### PR TITLE
Redact credentials at ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-14
+
+### Added
+
+- Secret redaction at ingest before records are written to the local index, with manifest counters and `deja sources` redaction totals.
+
 ## [0.1.1] - 2026-07-14
 
 ### Fixed
@@ -32,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stdio MCP memory server with `recall` and `recall_context` tools.
 - Idempotent installers for claude-code, codex, and opencode MCP config.
 
-[Unreleased]: https://github.com/vshulcz/deja-vu/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/vshulcz/deja-vu/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/vshulcz/deja-vu/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/vshulcz/deja-vu/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/vshulcz/deja-vu/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -107,13 +107,23 @@ The index is incremental: when a session file grows, only that file is re-read.
 
 ## How it works
 
-Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → `records.bin` + token buckets → `manifest.json` tracks per-file size/mtime so repeat runs only ingest what changed. The MCP server is the same index behind two tools. Details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact secrets → `records.bin` + token buckets → manifest tracks per-file size/mtime so repeat runs only ingest what changed. The MCP server is the same index behind two tools. Details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 **Privacy:** no network path exists in the indexing or search code. Local files in, local cache out.
+
+## Security
+
+deja redacts secrets at ingest before writing `~/.cache/deja/index.db/records.bin`. It keeps surrounding text searchable and replaces only the secret value with `[redacted:<kind>]`.
+
+Redacted classes: AWS access keys and AWS secret assignments, generic `api_key`/`secret`/`token`/`passwd`/`password`/`authorization` assignments with long base64/hex-ish values, bearer tokens, PEM private key blocks, GitHub/OpenAI/npm/Slack/Google provider tokens, and connection URLs with `user:pass@host` credentials.
+
+`deja sources` reports a `redacted=` count from the manifest. Unsafe escape hatch: set `DEJA_NO_REDACT=1` to disable ingest redaction for users who intentionally want plaintext secrets in the local index.
 
 ## FAQ
 
 **Does anything leave my machine?** No. There is no network code in the tool.
+
+**Are secrets stored in the index?** By default, no for supported patterns: secrets are redacted before index writes. If older indexes predate redaction, v0.2.0 bumps the index version and rebuilds transparently. `DEJA_NO_REDACT=1` disables this and is unsafe.
 
 **How is this different from `/resume` or a history viewer?** Those are per-harness and per-project. `deja` is one index across every harness and project on the machine, plus an MCP tool so the *agent* can search it.
 

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -255,6 +255,10 @@ func parseDur(s string) (time.Duration, error) {
 }
 
 func printSources() {
+	redactions := map[string]int{}
+	if stats, err := index.Redactions(index.DefaultDir()); err == nil {
+		redactions = stats.Files
+	}
 	items := []struct {
 		name, root string
 		load       func() []model.Session
@@ -266,14 +270,24 @@ func printSources() {
 		for _, s := range ss {
 			msg += len(s.Messages)
 		}
-		fmt.Printf("%s\t%s\tsessions=%d messages=%d size=%s\n", it.name, it.root, len(ss), msg, humanBytes(size))
+		fmt.Printf("%s\t%s\tsessions=%d messages=%d size=%s redacted=%d\n", it.name, it.root, len(ss), msg, humanBytes(size), redactionsUnder(redactions, it.root))
 	}
 	var size int64
 	if fi, err := os.Stat(sources.OpencodeDB()); err == nil {
 		size = fi.Size()
 	}
 	s, m, _ := sources.OpencodeCounts()
-	fmt.Printf("opencode\t%s\tsessions=%d messages=%d size=%s\n", sources.OpencodeDB(), s, m, humanBytes(size))
+	fmt.Printf("opencode\t%s\tsessions=%d messages=%d size=%s redacted=%d\n", sources.OpencodeDB(), s, m, humanBytes(size), redactions[sources.OpencodeDB()])
+}
+
+func redactionsUnder(files map[string]int, root string) int {
+	total := 0
+	for p, n := range files {
+		if p == root || strings.HasPrefix(p, root+string(os.PathSeparator)) {
+			total += n
+		}
+	}
+	return total
 }
 
 func pathSize(root string) int64 {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,7 +24,15 @@ Files:
 
 - `records.bin`: length-prefixed records. Each record stores session key, source path, role, text, and timestamp.
 - `buckets/*.bin`: token bucket files. A token maps to compact postings: record offset plus session ordinal.
-- `manifest.gob` / `sessions.gob`: index version, source file state, session metadata (including ordinals), build time, and search scope.
+- `manifest.gob` / `sessions.gob`: index version, source file state, redaction counters, session metadata (including ordinals), build time, and search scope.
+
+## Secret redaction
+
+`internal/redact` runs before every `writeRecord` path: cold rebuild, `writeSessions`, non-append incremental replacement, and append-only incremental ingest. The pass is disabled only when `DEJA_NO_REDACT=1` is set; that escape hatch is unsafe because plaintext credentials will be written to the local index.
+
+The redactor replaces only secret values, keeping keys and surrounding prose searchable. It covers AWS access keys and AWS secret assignments, generic credential assignments, bearer tokens, PEM private key blocks, GitHub/OpenAI/npm/Slack/Google provider prefixes, and connection URLs with `scheme://user:pass@host` credentials.
+
+Redaction counts are accumulated per source file in `FileState.Redactions` and as a manifest total. `deja sources` reads those counters and prints `redacted=` per harness.
 
 Search flow:
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -17,11 +17,12 @@ import (
 	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/redact"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
-const version = 7
+const version = 8
 const maxIndexedText = 64 * 1024
 
 var bucketMagic = []byte("DJB1")
@@ -33,6 +34,7 @@ type FileState struct {
 	Size        int64  `json:"size"`
 	MTime       int64  `json:"mtime"`
 	LastUpdated int64  `json:"last_updated,omitempty"`
+	Redactions  int    `json:"redactions,omitempty"`
 }
 
 type SessionMeta struct {
@@ -47,13 +49,20 @@ type Manifest struct {
 	Sessions map[string]SessionMeta `json:"sessions"`
 	BuiltAt  time.Time              `json:"built_at"`
 	Scope    string                 `json:"scope"`
+	Redacted int                    `json:"redacted"`
 }
 
 type manifestCore struct {
-	Version int
-	Files   map[string]FileState
-	BuiltAt time.Time
-	Scope   string
+	Version  int
+	Files    map[string]FileState
+	BuiltAt  time.Time
+	Scope    string
+	Redacted int
+}
+
+type RedactionStats struct {
+	Total int
+	Files map[string]int
 }
 
 type Record struct {
@@ -269,6 +278,7 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 				if len(text) > maxIndexedText {
 					text = text[:maxIndexedText]
 				}
+				text = redactForIngest(&m, s.Path, text)
 				off, err := writeRecord(rf, Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
 				if err != nil {
 					return err
@@ -356,6 +366,7 @@ func writeSessions(tmp, dir string, ss []model.Session, files map[string]FileSta
 				if len(text) > maxIndexedText {
 					text = text[:maxIndexedText]
 				}
+				text = redactForIngest(&m, s.Path, text)
 				off, err := writeRecord(rf, Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
 				if err != nil {
 					return err
@@ -552,6 +563,56 @@ func recordsForKey(path, key string) ([]Record, error) {
 	return out, err
 }
 
+func redactForIngest(m *Manifest, sourcePath, text string) string {
+	redacted, counts := redact.Text(text)
+	n := counts.Total()
+	if n == 0 || m == nil {
+		return redacted
+	}
+	m.Redacted += n
+	if sourcePath != "" && m.Files != nil {
+		fs := m.Files[sourcePath]
+		if fs.Path == "" {
+			fs.Path = sourcePath
+		}
+		fs.Redactions += n
+		m.Files[sourcePath] = fs
+	}
+	return redacted
+}
+
+func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
+	for p, f := range old.Files {
+		if skip[p] || f.Redactions == 0 || m.Files == nil {
+			continue
+		}
+		cur, ok := m.Files[p]
+		if !ok {
+			continue
+		}
+		cur.Redactions = f.Redactions
+		m.Files[p] = cur
+		m.Redacted += f.Redactions
+	}
+}
+
+func Redactions(dir string) (RedactionStats, error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		return RedactionStats{}, err
+	}
+	out := RedactionStats{Total: m.Redacted, Files: map[string]int{}}
+	for p, f := range m.Files {
+		if f.Redactions > 0 {
+			out.Files[p] = f.Redactions
+		}
+	}
+	return out, nil
+}
+
 func updateIndex(dir, harness, scope string, files map[string]FileState, force bool, progress io.Writer) error {
 	old, err := readManifest(dir)
 	if force || err != nil || old.Version != version || old.Scope != scope {
@@ -613,6 +674,14 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		return err
 	}
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope}
+	skipRedactions := map[string]bool{}
+	for p := range changed {
+		skipRedactions[p] = true
+	}
+	for p := range removed {
+		skipRedactions[p] = true
+	}
+	carryRedactions(&m, old, skipRedactions)
 	buckets := bucketPostings{}
 	addRec := func(r Record) error {
 		if r.SourcePath == "" {
@@ -625,6 +694,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		if !ok {
 			return nil
 		}
+		r.Text = redactForIngest(&m, r.SourcePath, r.Text)
 		off, err := writeRecord(rf, r)
 		if err != nil {
 			return err
@@ -672,6 +742,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 			if len(text) > maxIndexedText {
 				text = text[:maxIndexedText]
 			}
+			text = redactForIngest(&m, s.Path, text)
 			if err := addRec(Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time}); err != nil {
 				rf.Close()
 				return err
@@ -742,6 +813,8 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	m.Scope = scope
 	m.BuiltAt = time.Now()
 	m.Files = files
+	m.Redacted = 0
+	carryRedactions(&m, old, map[string]bool{})
 	if m.Sessions == nil {
 		m.Sessions = map[string]SessionMeta{}
 	}
@@ -779,6 +852,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 				if len(text) > maxIndexedText {
 					text = text[:maxIndexedText]
 				}
+				text = redactForIngest(&m, s.Path, text)
 				off, err := writeRecord(rf, Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
 				if err != nil {
 					return filesTouched, messages, err
@@ -1404,7 +1478,7 @@ func readManifest(dir string) (Manifest, error) {
 	if err := readGob(filepath.Join(dir, "manifest.gob"), &core); err != nil {
 		return Manifest{}, err
 	}
-	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Scope: core.Scope, Sessions: map[string]SessionMeta{}}
+	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Scope: core.Scope, Redacted: core.Redacted, Sessions: map[string]SessionMeta{}}
 	if err := readGob(filepath.Join(dir, "sessions.gob"), &m.Sessions); err != nil {
 		return Manifest{}, err
 	}
@@ -1412,7 +1486,7 @@ func readManifest(dir string) (Manifest, error) {
 }
 
 func writeManifest(dir string, m Manifest) error {
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Scope: m.Scope}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Scope: m.Scope, Redacted: m.Redacted}
 	if err := writeGob(filepath.Join(dir, "manifest.gob"), core); err != nil {
 		return err
 	}

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -576,3 +576,73 @@ func TestOldJSONManifestRebuildsTransparently(t *testing.T) {
 		t.Fatalf("old index was not rebuilt: %#v", ss)
 	}
 }
+
+func TestRedactsSecretsAtIngest(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "project")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	secrets := []string{
+		"AKIA" + "ABCDEFGHIJKLMNOP",
+		"aws_secret_access_key=abcdEFGH12345678abcdEFGH12345678",
+		"api_key=0123456789abcdef",
+		"password=abcdefabcdefabcd",
+		"Authorization: abcdefabcdefabcd",
+		"Bearer eyJhbGciOiJIUzI1NiJ9abcdef",
+		"-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAfakefakefakefakefake\n-----END RSA PRIVATE KEY-----",
+		"ghp_" + "1234567890abcdefghijklmnop",
+		"gho_1234567890abcdefghijklmnop",
+		"gith" + "ub_pat_1234567890abcdefghijklmnop",
+		"sk-1" + "2345678901234567890",
+		"npm_" + "123456789012345678901234567890",
+		"xoxb" + "-123456789012-123456789012-abcdefghijkl",
+		"xoxp" + "-123456789012-123456789012-abcdefghijkl",
+		"AIza123456789012345678901234567890",
+		"postgres://user:pass1234567890@localhost/db",
+	}
+	text := "redactionmarker before " + strings.Join(secrets, " middle ") + " after"
+	data := fmt.Sprintf(`{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":%q}}`+"\n", text)
+	p := filepath.Join(proj, "s1.jsonl")
+	if err := os.WriteFile(p, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "no-codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "no-opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	if err := EnsureForSearch(dir, search.Options{Query: "redactionmarker", Harness: "claude"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	recordBytes, err := os.ReadFile(filepath.Join(dir, "records.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range secrets {
+		if bytes.Contains(recordBytes, []byte(secret)) {
+			t.Fatalf("records.bin contains secret %q", secret)
+		}
+		ss, err := Search(dir, search.Options{Query: secret, Harness: "claude"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ss) != 0 {
+			t.Fatalf("search for secret %q returned %#v", secret, ss)
+		}
+	}
+	ss, err := Search(dir, search.Options{Query: "redactionmarker", Harness: "claude"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || !strings.Contains(ss[0].Messages[0].Text, "[redacted:") || !strings.Contains(ss[0].Messages[0].Text, "before") || !strings.Contains(ss[0].Messages[0].Text, "after") {
+		t.Fatalf("surrounding words not searchable/redacted: %#v", ss)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Redacted < len(secrets) || m.Files[p].Redactions < len(secrets) {
+		t.Fatalf("redaction counters not reported: total=%d file=%d", m.Redacted, m.Files[p].Redactions)
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,107 @@
+package redact
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+type Counts map[string]int
+
+func (c Counts) Add(kind string, n int) {
+	if n > 0 {
+		c[kind] += n
+	}
+}
+
+func (c Counts) Total() int {
+	total := 0
+	for _, n := range c {
+		total += n
+	}
+	return total
+}
+
+var (
+	awsAccessKeyRE = regexp.MustCompile(`AKIA[0-9A-Z]{16}`)
+	awsSecretRE    = regexp.MustCompile(`(?i)\b(aws[_-]?secret[_-]?access[_-]?key)(\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=_-]{32,})(['"]?)`)
+	genericKVRE    = regexp.MustCompile(`(?i)\b(api[_-]?key|secret|token|passwd|password|authorization)(\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=._-]{16,})(['"]?)`)
+	bearerRE       = regexp.MustCompile(`(?i)\b(Bearer)(\s+)([A-Za-z0-9._~+/=-]{16,})`)
+	pemPrivateRE   = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`)
+	providerRE     = regexp.MustCompile(`\b(ghp_[A-Za-z0-9_]{20,}|gho_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9]{20,}|npm_[A-Za-z0-9]{30,}|xox[bpcs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{30,})\b`)
+	jwtRE          = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b`)
+	connURLRE      = regexp.MustCompile(`\b([A-Za-z][A-Za-z0-9+.-]*://)([^\s/@:]+):([^\s/@]+)@([^\s]+)`) // scheme://user:pass@host
+)
+
+func Disabled() bool { return os.Getenv("DEJA_NO_REDACT") == "1" }
+
+func Text(s string) (string, Counts) {
+	counts := Counts{}
+	if Disabled() || s == "" {
+		return s, counts
+	}
+	s = replaceWhole(s, pemPrivateRE, "private-key", counts)
+	s = replaceSubmatch(s, connURLRE, "url-credentials", counts, func(m []string) string {
+		return m[1] + m[2] + ":[redacted:url-credentials]@" + m[4]
+	})
+	s = replaceSubmatch(s, awsSecretRE, "aws-secret", counts, func(m []string) string {
+		return m[1] + m[2] + m[3] + "[redacted:aws-secret]" + closingQuote(m[3], m[5])
+	})
+	s = replaceWhole(s, awsAccessKeyRE, "aws-access-key", counts)
+	s = replaceSubmatch(s, bearerRE, "bearer-token", counts, func(m []string) string {
+		return m[1] + m[2] + "[redacted:bearer-token]"
+	})
+	s = replaceWhole(s, jwtRE, "jwt", counts)
+	s = replaceSubmatch(s, genericKVRE, "credential", counts, func(m []string) string {
+		return m[1] + m[2] + m[3] + "[redacted:credential]" + closingQuote(m[3], m[5])
+	})
+	s = replaceProvider(s, counts)
+	return s, counts
+}
+
+func replaceWhole(s string, re *regexp.Regexp, kind string, counts Counts) string {
+	n := 0
+	out := re.ReplaceAllStringFunc(s, func(_ string) string {
+		n++
+		return "[redacted:" + kind + "]"
+	})
+	counts.Add(kind, n)
+	return out
+}
+
+func replaceSubmatch(s string, re *regexp.Regexp, kind string, counts Counts, repl func([]string) string) string {
+	n := 0
+	out := re.ReplaceAllStringFunc(s, func(match string) string {
+		n++
+		return repl(re.FindStringSubmatch(match))
+	})
+	counts.Add(kind, n)
+	return out
+}
+
+func replaceProvider(s string, counts Counts) string {
+	return providerRE.ReplaceAllStringFunc(s, func(v string) string {
+		kind := "provider-token"
+		switch {
+		case strings.HasPrefix(v, "ghp_"), strings.HasPrefix(v, "gho_"), strings.HasPrefix(v, "github_pat_"):
+			kind = "github-token"
+		case strings.HasPrefix(v, "sk-"):
+			kind = "openai-key"
+		case strings.HasPrefix(v, "npm_"):
+			kind = "npm-token"
+		case strings.HasPrefix(v, "xoxb-"), strings.HasPrefix(v, "xoxp-"):
+			kind = "slack-token"
+		case strings.HasPrefix(v, "AIza"):
+			kind = "google-api-key"
+		}
+		counts.Add(kind, 1)
+		return "[redacted:" + kind + "]"
+	})
+}
+
+func closingQuote(open, close string) string {
+	if open == "" {
+		return ""
+	}
+	return close
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,60 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+// Secret-shaped fixtures are assembled at runtime so this file never contains
+// token literals — GitHub push protection (rightly) blocks those.
+func fake(prefix string, n int) string { return prefix + strings.Repeat("a1B2", n/4+1)[:n] }
+
+func TestTextRedactsSupportedPatterns(t *testing.T) {
+	jwt := "eyJ" + strings.Repeat("hA9", 8) + "." + "eyJ" + strings.Repeat("zQ4", 8) + "." + strings.Repeat("Kf7", 10)
+	samples := []string{
+		"AKIA" + strings.Repeat("ABCD", 4),
+		"aws_secret_access_key=" + fake("", 32),
+		"api_key=" + fake("", 16),
+		"Bearer " + fake("", 24),
+		"-----BEGIN RSA PRIVATE KEY-----\nabc\n-----END RSA PRIVATE KEY-----",
+		fake("ghp_", 24),
+		fake("gho_", 24),
+		fake("github_pat_", 24),
+		fake("sk-", 24),
+		fake("npm_", 32),
+		"xoxb-123456789012-" + fake("", 12),
+		"xoxp-123456789012-" + fake("", 12),
+		"xoxc-123456789012-" + fake("", 12),
+		fake("AIza", 32),
+		jwt,
+		"mysql://user:" + fake("", 13) + "@host/db",
+	}
+	in := strings.Join(samples, " ")
+	out, counts := Text("before " + in + " after")
+	if counts.Total() < 16 {
+		t.Fatalf("counts=%#v out=%s", counts, out)
+	}
+	secrets := []string{
+		"AKIA" + strings.Repeat("ABCD", 4), fake("", 32), fake("ghp_", 24),
+		strings.Repeat("Kf7", 10), "xoxc-123456789012-" + fake("", 12),
+	}
+	for _, sec := range secrets {
+		if strings.Contains(out, sec) {
+			t.Fatalf("secret %q was not redacted from %q", sec, out)
+		}
+	}
+	for _, keep := range []string{"before", "api_key=", "Bearer ", "mysql://user:", "@host/db", "after"} {
+		if !strings.Contains(out, keep) {
+			t.Fatalf("surrounding text %q missing from %q", keep, out)
+		}
+	}
+}
+
+func TestDisabledEscapeHatch(t *testing.T) {
+	t.Setenv("DEJA_NO_REDACT", "1")
+	in := "api_key=" + fake("", 16)
+	out, counts := Text(in)
+	if out != in || counts.Total() != 0 || !Disabled() {
+		t.Fatalf("escape hatch failed: out=%q counts=%#v", out, counts)
+	}
+}


### PR DESCRIPTION
Closes #13

Redaction pass over every record before it is written, in all ingest paths. Counters in deja sources, DEJA_NO_REDACT escape hatch, index version bump. JWT and xoxc/xoxs classes added after review.