### PR TITLE
deja stats: your agent work, summarized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-14
+
+### Added
+
+- `deja stats` shareable indexed-work summary with totals, harness breakdown, top projects, 12-month activity sparkline, date range, longest session, busiest day, and `--json` output.
+
 ## [0.3.0] - 2026-07-14
 
 ### Added
@@ -44,7 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stdio MCP memory server with `recall` and `recall_context` tools.
 - Idempotent installers for claude-code, codex, and opencode MCP config.
 
-[Unreleased]: https://github.com/vshulcz/deja-vu/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/vshulcz/deja-vu/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/vshulcz/deja-vu/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/vshulcz/deja-vu/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/vshulcz/deja-vu/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/vshulcz/deja-vu/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -75,12 +75,44 @@ $ deja "jwt refresh token"
 | `deja show <id>` | Print one session, tool noise collapsed. |
 | `deja last [n]` | Recent sessions across all harnesses. |
 | `deja sources` | What stores were found, sizes, message counts. |
+| `deja stats [--json]` | Shareable summary: totals, harness split, top projects, activity sparkline, longest session, busiest day. |
 | `deja mcp` | Run the stdio MCP server (what `deja install` wires in). |
 
 Context piping without MCP:
 
 ```sh
 claude "Prior context: $(deja ctx 'database migration')"
+```
+
+## Stats
+
+`deja stats` renders a screenshot-ready summary entirely from the local index. Use `--json` for the same numbers in machine-readable form.
+
+```text
+$ deja stats
+deja stats
+indexed agent work, wrapped for sharing
+
+Sessions  1284
+Messages  58391
+Range     2025-08-03 → 2026-07-14
+
+By harness
+  [claude]              884 sessions  42110 messages
+  [codex]               291 sessions  11142 messages
+  [opencode]            109 sessions   5139 messages
+
+Top projects
+  deja/vu            ################## 312
+  api                ############ 211
+  web                ######### 164
+
+Last 12 months
+  ▁▁▂▃▄▅▆▇██▇█  Aug Sep Oct Nov Dec Jan Feb Mar Apr May Jun Jul
+
+Highlights
+  Longest session  642 messages · [claude] · index append race in records.bin
+  Busiest day      2026-07-08 · 1831 messages
 ```
 
 ## MCP tools

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -51,6 +51,9 @@ func run(args []string) error {
 		printSources()
 		return nil
 	}
+	if args[0] == "stats" {
+		return runStats(args[1:])
+	}
 	if args[0] == "mcp" {
 		return serveMCP(os.Stdin, os.Stdout)
 	}
@@ -329,6 +332,7 @@ Usage:
   deja ctx <query|id-prefix>
   deja last [n]
   deja sources
+  deja stats [--json]
   deja mcp
   deja version
   deja install <claude-code|codex|opencode|--all>

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -62,6 +62,7 @@ func TestRunDispatcherSyntheticFixtures(t *testing.T) {
 		{"ctx", []string{"ctx", "frobnicator"}, "# deja context:", ""},
 		{"last", []string{"last", "1"}, "claude", ""},
 		{"sources", []string{"sources"}, "opencode", ""},
+		{"stats", []string{"stats"}, "deja stats", ""},
 		{"ctx missing", []string{"ctx"}, "", "ctx needs query"},
 		{"show missing", []string{"show"}, "", "show needs id-prefix"},
 		{"bad duration", []string{"--since", "nope", "needle"}, "", "invalid duration"},
@@ -83,6 +84,119 @@ func TestRunDispatcherSyntheticFixtures(t *testing.T) {
 				t.Fatalf("out %q does not contain %q", out, tc.want)
 			}
 		})
+	}
+}
+
+func withStatsStores(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	claudeRoot := filepath.Join(tmp, "claude")
+	codexRoot := filepath.Join(tmp, "codex")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", codexRoot)
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	t.Setenv("NO_COLOR", "1")
+
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-alpha", "c1.jsonl"), "c1", []string{
+		`{"type":"user","sessionId":"c1","timestamp":"2026-01-02T10:00:00Z","message":{"role":"user","content":"alpha plan"}}`,
+		`{"type":"assistant","sessionId":"c1","timestamp":"2026-01-02T10:01:00Z","message":{"role":"assistant","content":"alpha answer"}}`,
+	})
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-alpha", "c2.jsonl"), "c2", []string{
+		`{"type":"user","sessionId":"c2","timestamp":"2026-03-05T11:00:00Z","message":{"role":"user","content":"march alpha"}}`,
+	})
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-beta", "c3.jsonl"), "c3", []string{
+		`{"type":"user","sessionId":"c3","timestamp":"2026-07-04T12:00:00Z","message":{"role":"user","content":"long beta session"}}`,
+		`{"type":"assistant","sessionId":"c3","timestamp":"2026-07-04T12:01:00Z","message":{"role":"assistant","content":"beta answer one"}}`,
+		`{"type":"assistant","sessionId":"c3","timestamp":"2026-07-04T12:02:00Z","message":{"role":"assistant","content":"beta answer two"}}`,
+	})
+	codexFile := filepath.Join(codexRoot, "sessions", "2026", "02", "02", "rollout-2026-02-02T09-00-00-codex1.jsonl")
+	if err := os.MkdirAll(filepath.Dir(codexFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codex := strings.Join([]string{
+		`{"type":"session_meta","timestamp":"2026-02-02T09:00:00Z","payload":{"session_id":"codex1","cwd":"/tmp/gamma"}}`,
+		`{"type":"message","timestamp":"2026-02-02T09:01:00Z","payload":{"role":"user","content":"gamma question"}}`,
+		`{"type":"message","timestamp":"2026-02-02T09:02:00Z","payload":{"role":"assistant","content":"gamma answer"}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(codexFile, []byte(codex), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeClaudeFixture(t *testing.T, path, sessionID string, lines []string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_ = sessionID
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStatsCommandJSONAndNoColor(t *testing.T) {
+	withStatsStores(t)
+	out, err := captureRun(t, "stats", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report statsReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	if report.TotalSessions != 4 || report.TotalMessages != 8 {
+		t.Fatalf("totals = %d/%d", report.TotalSessions, report.TotalMessages)
+	}
+	if len([]rune(report.Sparkline)) != 12 {
+		t.Fatalf("sparkline length = %d (%q)", len([]rune(report.Sparkline)), report.Sparkline)
+	}
+	if report.DateRange.Start != "2026-01-02" || report.DateRange.End != "2026-07-04" {
+		t.Fatalf("range = %#v", report.DateRange)
+	}
+	if report.Longest.ID != "c3" || report.Longest.Messages != 3 {
+		t.Fatalf("longest = %#v", report.Longest)
+	}
+	if report.BusiestDay.Date != "2026-07-04" || report.BusiestDay.Messages != 3 {
+		t.Fatalf("busiest = %#v", report.BusiestDay)
+	}
+	byHarness := map[string]harnessStats{}
+	for _, h := range report.Harnesses {
+		byHarness[h.Harness] = h
+	}
+	if byHarness["claude"].Sessions != 3 || byHarness["claude"].Messages != 6 || byHarness["codex"].Sessions != 1 || byHarness["codex"].Messages != 2 {
+		t.Fatalf("harnesses = %#v", report.Harnesses)
+	}
+	if len(report.TopProjects) == 0 || report.TopProjects[0].Project != filepath.Join("tmp", "alpha") || report.TopProjects[0].Sessions != 2 {
+		t.Fatalf("top projects = %#v", report.TopProjects)
+	}
+
+	out, err = captureRun(t, "stats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "\x1b[") || strings.Contains(out, "█") || !strings.Contains(out, "##") || !strings.Contains(out, "[claude]") {
+		t.Fatalf("NO_COLOR/plain output wrong: %q", out)
+	}
+}
+
+func TestBuildStatsMonthlyDistribution(t *testing.T) {
+	ss := []model.Session{{
+		ID: "s", Harness: "claude", Project: "p", Started: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), Updated: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+		Messages: []model.Message{
+			{Role: "user", Text: "jan", Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+			{Role: "user", Text: "jan", Time: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)},
+			{Role: "user", Text: "jul", Time: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)},
+		},
+	}}
+	report := buildStats(ss, time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC))
+	if len(report.Monthly) != 12 || report.Monthly[0].Month != "2025-08" || report.Monthly[11].Month != "2026-07" {
+		t.Fatalf("months = %#v", report.Monthly)
+	}
+	if report.Monthly[5].Messages != 2 || report.Monthly[11].Messages != 1 || len([]rune(report.Sparkline)) != 12 {
+		t.Fatalf("monthly counts/sparkline = %#v %q", report.Monthly, report.Sparkline)
 	}
 }
 

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -1,0 +1,351 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+const (
+	statReset  = "\x1b[0m"
+	statDim    = "\x1b[2m"
+	statBold   = "\x1b[1m"
+	statOrange = "\x1b[38;5;208m"
+	statGreen  = "\x1b[32m"
+	statBlue   = "\x1b[34m"
+)
+
+type statsReport struct {
+	TotalSessions int            `json:"total_sessions"`
+	TotalMessages int            `json:"total_messages"`
+	Harnesses     []harnessStats `json:"harnesses"`
+	TopProjects   []projectStats `json:"top_projects"`
+	Monthly       []monthStats   `json:"monthly"`
+	Sparkline     string         `json:"sparkline"`
+	DateRange     dateRangeStats `json:"date_range"`
+	Longest       sessionStat    `json:"longest_session"`
+	BusiestDay    dayStat        `json:"busiest_day"`
+}
+
+type harnessStats struct {
+	Harness  string `json:"harness"`
+	Sessions int    `json:"sessions"`
+	Messages int    `json:"messages"`
+}
+
+type projectStats struct {
+	Project  string `json:"project"`
+	Sessions int    `json:"sessions"`
+}
+
+type monthStats struct {
+	Month    string `json:"month"`
+	Messages int    `json:"messages"`
+}
+
+type dateRangeStats struct {
+	Start string `json:"start,omitempty"`
+	End   string `json:"end,omitempty"`
+}
+
+type sessionStat struct {
+	ID       string `json:"id,omitempty"`
+	Harness  string `json:"harness,omitempty"`
+	Project  string `json:"project,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Messages int    `json:"messages"`
+}
+
+type dayStat struct {
+	Date     string `json:"date,omitempty"`
+	Messages int    `json:"messages"`
+}
+
+func runStats(args []string) error {
+	jsonOut := false
+	for _, a := range args {
+		switch a {
+		case "--json":
+			jsonOut = true
+		default:
+			return fmt.Errorf("stats: unknown flag %s", a)
+		}
+	}
+	if err := index.Ensure(index.DefaultDir(), "", false, os.Stderr); err != nil {
+		return err
+	}
+	ss, err := index.Search(index.DefaultDir(), search.Options{All: true})
+	if err != nil {
+		return err
+	}
+	report := buildStats(ss, time.Now())
+	if jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+	printStats(os.Stdout, report)
+	return nil
+}
+
+func buildStats(ss []model.Session, now time.Time) statsReport {
+	byHarness := map[string]*harnessStats{}
+	byProject := map[string]int{}
+	byDay := map[string]int{}
+	monthStart := firstMonth(now).AddDate(0, -11, 0)
+	months := make([]monthStats, 12)
+	monthIndex := map[string]int{}
+	for i := range months {
+		m := monthStart.AddDate(0, i, 0)
+		label := m.Format("2006-01")
+		months[i] = monthStats{Month: label}
+		monthIndex[label] = i
+	}
+
+	var out statsReport
+	var minT, maxT time.Time
+	for _, s := range ss {
+		out.TotalSessions++
+		msgCount := len(s.Messages)
+		out.TotalMessages += msgCount
+		hs := byHarness[s.Harness]
+		if hs == nil {
+			hs = &harnessStats{Harness: s.Harness}
+			byHarness[s.Harness] = hs
+		}
+		hs.Sessions++
+		hs.Messages += msgCount
+		project := s.Project
+		if project == "" {
+			project = "-"
+		}
+		byProject[project]++
+		if msgCount > out.Longest.Messages {
+			out.Longest = sessionStat{ID: s.ID, Harness: s.Harness, Project: project, Title: statTitle(s), Messages: msgCount}
+		}
+		considerTime(&minT, &maxT, s.Started)
+		considerTime(&minT, &maxT, s.Updated)
+		for _, m := range s.Messages {
+			t := m.Time
+			if t.IsZero() {
+				t = s.Updated
+			}
+			considerTime(&minT, &maxT, t)
+			if !t.IsZero() {
+				day := t.Format("2006-01-02")
+				byDay[day]++
+				if i, ok := monthIndex[firstMonth(t).Format("2006-01")]; ok {
+					months[i].Messages++
+				}
+			}
+		}
+	}
+	out.Harnesses = make([]harnessStats, 0, len(byHarness))
+	for _, hs := range byHarness {
+		out.Harnesses = append(out.Harnesses, *hs)
+	}
+	sort.Slice(out.Harnesses, func(i, j int) bool { return out.Harnesses[i].Harness < out.Harnesses[j].Harness })
+	for project, count := range byProject {
+		out.TopProjects = append(out.TopProjects, projectStats{Project: project, Sessions: count})
+	}
+	sort.Slice(out.TopProjects, func(i, j int) bool {
+		if out.TopProjects[i].Sessions == out.TopProjects[j].Sessions {
+			return out.TopProjects[i].Project < out.TopProjects[j].Project
+		}
+		return out.TopProjects[i].Sessions > out.TopProjects[j].Sessions
+	})
+	if len(out.TopProjects) > 5 {
+		out.TopProjects = out.TopProjects[:5]
+	}
+	for day, count := range byDay {
+		if count > out.BusiestDay.Messages || (count == out.BusiestDay.Messages && (out.BusiestDay.Date == "" || day < out.BusiestDay.Date)) {
+			out.BusiestDay = dayStat{Date: day, Messages: count}
+		}
+	}
+	out.Monthly = months
+	out.Sparkline = sparkline(months)
+	if !minT.IsZero() {
+		out.DateRange.Start = minT.Format("2006-01-02")
+		out.DateRange.End = maxT.Format("2006-01-02")
+	}
+	return out
+}
+
+func printStats(w io.Writer, r statsReport) {
+	color := statColorOK(w)
+	barGlyph := "#"
+	if color {
+		barGlyph = "█"
+	}
+	faint, bold, reset := "", "", ""
+	if color {
+		faint, bold, reset = statDim, statBold, statReset
+	}
+	fmt.Fprintf(w, "%sdeja stats%s\n", bold, reset)
+	fmt.Fprintf(w, "%sindexed agent work, wrapped for sharing%s\n\n", faint, reset)
+	fmt.Fprintf(w, "Sessions  %s%d%s\n", bold, r.TotalSessions, reset)
+	fmt.Fprintf(w, "Messages  %s%d%s\n", bold, r.TotalMessages, reset)
+	fmt.Fprintf(w, "Range     %s → %s\n\n", valueOrDash(r.DateRange.Start), valueOrDash(r.DateRange.End))
+
+	fmt.Fprintf(w, "%sBy harness%s\n", bold, reset)
+	for _, h := range r.Harnesses {
+		fmt.Fprintf(w, "  %-20s %4d sessions  %5d messages\n", statHarnessTag(h.Harness, color), h.Sessions, h.Messages)
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, "%sTop projects%s\n", bold, reset)
+	maxProject := 0
+	for _, p := range r.TopProjects {
+		if p.Sessions > maxProject {
+			maxProject = p.Sessions
+		}
+	}
+	for _, p := range r.TopProjects {
+		fmt.Fprintf(w, "  %-18s %s %d\n", trimRunes(p.Project, 18), strings.Repeat(barGlyph, scaledBar(p.Sessions, maxProject, 18)), p.Sessions)
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, "%sLast 12 months%s\n", bold, reset)
+	fmt.Fprintf(w, "  %s  %s\n", r.Sparkline, monthLabels(r.Monthly))
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, "%sHighlights%s\n", bold, reset)
+	fmt.Fprintf(w, "  Longest session  %d messages · %s · %s\n", r.Longest.Messages, statHarnessTag(r.Longest.Harness, color), valueOrDash(r.Longest.Title))
+	fmt.Fprintf(w, "  Busiest day      %s · %d messages\n", valueOrDash(r.BusiestDay.Date), r.BusiestDay.Messages)
+}
+
+func considerTime(minT, maxT *time.Time, t time.Time) {
+	if t.IsZero() {
+		return
+	}
+	if minT.IsZero() || t.Before(*minT) {
+		*minT = t
+	}
+	if maxT.IsZero() || t.After(*maxT) {
+		*maxT = t
+	}
+}
+
+func firstMonth(t time.Time) time.Time {
+	y, m, _ := t.Date()
+	return time.Date(y, m, 1, 0, 0, 0, 0, t.Location())
+}
+
+func sparkline(months []monthStats) string {
+	blocks := []rune("▁▂▃▄▅▆▇█")
+	maxMessages := 0
+	for _, m := range months {
+		if m.Messages > maxMessages {
+			maxMessages = m.Messages
+		}
+	}
+	var b strings.Builder
+	for _, m := range months {
+		idx := 0
+		if maxMessages > 0 && m.Messages > 0 {
+			idx = ((m.Messages - 1) * (len(blocks) - 1) / maxMessages) + 1
+		}
+		b.WriteRune(blocks[idx])
+	}
+	return b.String()
+}
+
+func monthLabels(months []monthStats) string {
+	labels := make([]string, 0, len(months))
+	for _, m := range months {
+		if t, err := time.Parse("2006-01", m.Month); err == nil {
+			labels = append(labels, t.Format("Jan"))
+		}
+	}
+	return strings.Join(labels, " ")
+}
+
+func scaledBar(n, maxN, width int) int {
+	if n <= 0 || maxN <= 0 {
+		return 0
+	}
+	scaled := n * width / maxN
+	if scaled == 0 {
+		return 1
+	}
+	return scaled
+}
+
+func statTitle(s model.Session) string {
+	if s.Title != "" && !statNoise(s.Title) {
+		return s.Title
+	}
+	for _, m := range s.Messages {
+		if m.Role == "user" && !statNoise(m.Text) {
+			return trimRunes(strings.Join(strings.Fields(m.Text), " "), 60)
+		}
+	}
+	return ""
+}
+
+func statNoise(s string) bool {
+	t := strings.TrimSpace(s)
+	for _, p := range []string{"<local-command", "<command-", "<task-notification", "<teammate-message", "<bash-", "Caveat:", "<system-reminder"} {
+		if strings.HasPrefix(t, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func valueOrDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func trimRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	if n <= 1 {
+		return string(r[:n])
+	}
+	return string(r[:n-1]) + "…"
+}
+
+func statColorOK(w io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	st, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return st.Mode()&os.ModeCharDevice != 0
+}
+
+func statHarnessTag(h string, color bool) string {
+	tag := "[" + h + "]"
+	if !color {
+		return tag
+	}
+	switch h {
+	case "claude":
+		return statOrange + tag + statReset + statBold
+	case "codex":
+		return statGreen + tag + statReset + statBold
+	case "opencode":
+		return statBlue + tag + statReset + statBold
+	}
+	return tag
+}


### PR DESCRIPTION
Closes #17

Reviewed line-by-line; longest-session title now skips caveat/tool-wrapper noise (caught on live data). Sparkline, --json and NO_COLOR verified.