### PR TITLE
share: filter JSON, diff and CLI dumps from digests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,19 @@
 
 <p align="center"><img src="assets/demo.gif" alt="deja demo"></p>
 
-Claude Code, Codex and opencode write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that indexes those histories, retroactively, in about ten seconds.
+Claude Code, Codex and opencode write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
 
-`deja` indexes those histories and serves them back:
+| | |
+| --- | --- |
+| **Search** | `deja "connection pool exhausted"` — 7–9 ms over gigabytes, retroactive: months of logs from before you installed it |
+| **Agent recall** | MCP `recall` tool — the agent answers *"we fixed this three weeks ago"* instead of re-debugging, across harnesses |
+| **Auto-recall** | `install --auto` adds a SessionStart hook: relevant memory lands in context before you ask |
+| **Redaction** | API keys, JWTs, private keys are stripped at index time — the cache is safe to keep |
+| **Stats** | `deja stats` — your agent work, wrapped: harnesses, top projects, activity sparkline |
+| **Share** | `deja share <id>` — hand a colleague a sanitized digest of a session, secrets already scrubbed |
+| **Sync** | `deja sync export/import` — move memory between machines, append-only, idempotent |
 
-- **to your agent** — an MCP `recall` tool, so the agent can answer *"we fixed this three weeks ago — worker.py:87 leaked sessions on cancel"* instead of re-debugging it;
-- **to you** — a fast CLI: `deja "connection pool exhausted"`.
-
-One binary, no dependencies, everything stays on your machine.
+One binary. No models to download, no services to run, nothing leaves your machine.
 
 ## Install
 
@@ -40,22 +45,15 @@ brew install vshulcz/tap/deja-vu                        # Homebrew
 Wire it into the agents you use (edits config, keeps a `.bak`):
 
 ```sh
-deja install --all        # or: claude-code | codex | opencode
-```
-
-## Auto-recall (optional)
-
-For Claude Code, `deja install --auto` does the normal MCP install and also adds a read-only `SessionStart` hook. When a session starts, Claude receives a tiny (<2KB) markdown digest of the most recent sessions for the current project, so it can remember prior fixes without being asked; if the local index is missing or stale, the hook prints nothing and startup continues.
-
-```sh
-deja install --auto
+deja install --all          # MCP recall for claude-code, codex, opencode
+deja install claude-code --auto   # + SessionStart auto-recall hook
 ```
 
 That's it. Next session, ask your agent:
 
 > have we dealt with jwt refresh rotation before? check your memory
 
-The agent calls `recall` and gets back the sessions where you solved it — including ones from a *different* harness.
+— or with `--auto`, don't ask: the agent starts each session already knowing what you solved in that project.
 
 ## CLI
 
@@ -70,76 +68,19 @@ $ deja "jwt refresh token"
 
 | Command | What it does |
 | --- | --- |
-| `deja <query>` | Search all histories. Multi-word = AND. `--re` for regex, `--harness`, `--project`, `--since 30d`, `--role`, `--json`. |
+| `deja <query>` | Search all histories. Multi-word = AND, substrings match (`code` finds `opencode`). `--re`, `--harness`, `--project`, `--since 30d`, `--role`, `--json`. |
 | `deja ctx <query>` | Compact markdown digest of the best match — pipe it into a prompt. |
-| `deja show <id>` | Print one session, tool noise collapsed. |
-| `deja share <id>` | Sanitized markdown digest for a colleague: project/harness/date, user problem, key assistant conclusions/code. |
-| `deja sync export <dir>` / `deja sync import <dir>` | Append-only JSONL batches for moving indexed memory between machines. |
-| `deja last [n]` | Recent sessions across all harnesses. |
-| `deja sources` | What stores were found, sizes, message counts. |
-| `deja stats [--json]` | Shareable summary: totals, harness split, top projects, activity sparkline, longest session, busiest day. |
-| `deja mcp` | Run the stdio MCP server (what `deja install` wires in). |
+| `deja share <id>` | Sanitized session digest for a colleague: secrets redacted, tool noise stripped. |
+| `deja stats` | Totals, per-harness split, top projects, monthly sparkline. `--json` too. |
+| `deja sync export <dir>` / `import <dir>` | Move memory between machines. Watermarked, append-only, idempotent. |
+| `deja show <id>` / `deja last [n]` | Read one session / list recent ones. |
+| `deja sources` | Discovered stores, sizes, message and redaction counts. |
+| `deja mcp` | The stdio MCP server (what `deja install` wires in). |
 
 Context piping without MCP:
 
 ```sh
 claude "Prior context: $(deja ctx 'database migration')"
-```
-
-## Share
-
-`deja share <id-prefix>` prints a pasteable markdown digest of one session. It is more complete than `ctx`, skips tool-wrapper noise, and every output line is redacted again before printing.
-
-```sh
-deja last 5
-deja share 8f31c0a9 > session-digest.md
-```
-
-## Sync
-
-`deja sync` moves indexed, redacted records between machines with append-only JSONL batches. Export tracks per-source watermarks in the index manifest, so repeated exports only write new records. Import marks sessions as imported and dedupes by `harness:id:time`, so re-importing the same batch is safe.
-
-Laptop → server workflow:
-
-```sh
-# laptop
-deja sync export ~/deja-batches
-rsync -a ~/deja-batches/ server:~/deja-batches/
-
-# server
-deja sync import ~/deja-batches
-deja "jwt refresh token"
-```
-
-## Stats
-
-`deja stats` renders a screenshot-ready summary entirely from the local index. Use `--json` for the same numbers in machine-readable form.
-
-```text
-$ deja stats
-deja stats
-indexed agent work, wrapped for sharing
-
-Sessions  1284
-Messages  58391
-Range     2025-08-03 → 2026-07-14
-
-By harness
-  [claude]              884 sessions  42110 messages
-  [codex]               291 sessions  11142 messages
-  [opencode]            109 sessions   5139 messages
-
-Top projects
-  deja/vu            ################## 312
-  api                ############ 211
-  web                ######### 164
-
-Last 12 months
-  ▁▁▂▃▄▅▆▇██▇█  Aug Sep Oct Nov Dec Jan Feb Mar Apr May Jun Jul
-
-Highlights
-  Longest session  642 messages · [claude] · index append race in records.bin
-  Busiest day      2026-07-08 · 1831 messages
 ```
 
 ## MCP tools
@@ -149,6 +90,12 @@ Highlights
 | `recall` | `query`, `harness?`, `limit?` | Dense matching snippets, ≤4KB — cheap on context. |
 | `recall_context` | `query` | Markdown digest of the best-matching session. |
 
+With `--auto`, a SessionStart hook also feeds the current project's recent memory in automatically — read-only, capped at 2KB, and it never delays or breaks agent startup.
+
+## Security
+
+Credentials are redacted at index time: AWS keys, generic `api_key=`/`token=` assignments, bearer tokens and raw JWTs, PEM private key blocks, provider tokens (`ghp_`, `sk-`, `npm_`, `xox.`, `AIza`), and `scheme://user:pass@host` URLs. The value is replaced with `[redacted:<kind>]`; surrounding text stays searchable. `deja sources` shows per-store counts. Opt out with `DEJA_NO_REDACT=1` (unsafe). `deja share` and `deja sync export` re-apply redaction on the way out.
+
 ## Supported harnesses
 
 | Harness | Store | Status |
@@ -156,7 +103,7 @@ Highlights
 | Claude Code | `~/.claude/projects/**/*.jsonl` | ✅ |
 | Codex CLI | `~/.codex/sessions/**` + `history.jsonl` | ✅ |
 | opencode | `~/.local/share/opencode/opencode.db` | ✅ |
-| aider, Gemini CLI | — | planned |
+| aider, Gemini CLI | [#6](https://github.com/vshulcz/deja-vu/issues/6), [#7](https://github.com/vshulcz/deja-vu/issues/7) | planned |
 
 Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_INDEX_DIR`.
 
@@ -174,37 +121,25 @@ The index is incremental: when a session file grows, only that file is re-read.
 
 ## How it works
 
-Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact secrets → `records.bin` + token buckets → manifest tracks per-file size/mtime so repeat runs only ingest what changed. The MCP server is the same index behind two tools. Details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact credentials → `records.bin` + token buckets → `manifest.json` tracks per-file state so repeat runs only ingest what changed. The MCP server, stats, share and sync all read the same index. Details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 **Privacy:** no network path exists in the indexing or search code. Local files in, local cache out.
 
-## Security
-
-deja redacts secrets at ingest before writing `~/.cache/deja/index.db/records.bin`. It keeps surrounding text searchable and replaces only the secret value with `[redacted:<kind>]`.
-
-Redacted classes: AWS access keys and AWS secret assignments, generic `api_key`/`secret`/`token`/`passwd`/`password`/`authorization` assignments with long base64/hex-ish values, bearer tokens, PEM private key blocks, GitHub/OpenAI/npm/Slack/Google provider tokens, and connection URLs with `user:pass@host` credentials.
-
-`deja sources` reports a `redacted=` count from the manifest. Unsafe escape hatch: set `DEJA_NO_REDACT=1` to disable ingest redaction for users who intentionally want plaintext secrets in the local index.
-
 ## FAQ
 
-**Does anything leave my machine?** No. There is no network code in the tool.
-
-**Are secrets stored in the index?** By default, no for supported patterns: secrets are redacted before index writes. If older indexes predate redaction, v0.2.0 bumps the index version and rebuilds transparently. `DEJA_NO_REDACT=1` disables this and is unsafe.
-
-**What does the auto-recall hook do?** It is read-only: it only checks the warm local index for the current Claude project and returns a capped (<2KB) summary. It never builds the index from the hook, and on any error it exits successfully with no output.
-
-**How is this different from `/resume` or a history viewer?** Those are per-harness and per-project. `deja` is one index across every harness and project on the machine, plus an MCP tool so the *agent* can search it.
+**Does anything leave my machine?** No. There is no network code in the tool. `sync` writes files to a directory you choose; moving them is up to you.
 
 **How is this different from cass?**
-[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on the same idea: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, the three harnesses I actually run, zero things to configure or download. If you want hybrid search over everything, use cass. If you want grep-fast recall that installs in ten seconds, that's deja.
+[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, three harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
 
 **And from MemPalace / Mem0 / Letta?**
-Those are memory *platforms*: embeddings, vector stores, capture hooks or APIs that record sessions going forward. deja has no capture step at all — it indexes what your agents already wrote to disk, including months of history from before you installed it. They can coexist.
+Those are memory *platforms*: embeddings, vector stores, capture hooks or APIs that record going forward. deja has no capture step at all — it indexes what your agents already wrote to disk, including months of history from before you installed it. They can coexist.
 
-**What about Windows?** Builds exist and file locking is implemented; macOS/Linux are the tested paths today.
+**What about secrets already in my logs?** They stay in the original harness files (that's your agent's data), but they don't enter deja's index, digests, shares or sync exports.
 
-**Can I exclude a project?** Not yet — planned as `--exclude`. Today you can point `DEJA_*_ROOT` at a filtered copy.
+**What about Windows?** Builds exist, CI runs the suite on Windows; macOS/Linux are the battle-tested paths. Field reports welcome: [#9](https://github.com/vshulcz/deja-vu/issues/9).
+
+**Can I exclude a project?** Not yet — planned as `--exclude` ([#8](https://github.com/vshulcz/deja-vu/issues/8)). Today you can point `DEJA_*_ROOT` at a filtered copy.
 
 **How do I wipe everything?**
 
@@ -215,7 +150,7 @@ rm -rf ~/.cache/deja
 
 ## Contributing
 
-`make build test lint` — see [CONTRIBUTING.md](CONTRIBUTING.md). Adding a harness is one parser file: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#adding-a-harness).
+`make build test lint` — see [CONTRIBUTING.md](CONTRIBUTING.md). Adding a harness is one parser file: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#adding-a-harness). Good first issues are labeled.
 
 ## License
 

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -118,6 +118,11 @@ var (
 )
 
 func looksLikeProse(line string) bool {
+	// Short lines are kept: dumps are long. The prose gate exists to drop
+	// pasted JSON/CLI walls, not three-word problem statements.
+	if len(line) < 80 {
+		return true
+	}
 	letters, total, wordish := 0, 0, 0
 	for _, f := range strings.Fields(line) {
 		hasLetter := false

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -100,7 +101,7 @@ func shareMessageText(s string) string {
 	var keep []string
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
-		if line == "" || noisyShareMessage(line) {
+		if line == "" || noisyShareMessage(line) || noiseLine(line) || !looksLikeProse(line) {
 			continue
 		}
 		keep = append(keep, line)
@@ -109,6 +110,41 @@ func shareMessageText(s string) string {
 		}
 	}
 	return strings.Join(strings.Fields(strings.Join(keep, " ")), " ")
+}
+
+var (
+	shareLineNumRE = regexp.MustCompile(`^\s*\d{1,6}\s`)            // "1 diff --git", numbered dumps
+	shareGrepRE    = regexp.MustCompile(`^\S+\.[a-z]{1,5}:\d+[:)]`) // path/file.go:18: grep output
+)
+
+func looksLikeProse(line string) bool {
+	letters, total, wordish := 0, 0, 0
+	for _, f := range strings.Fields(line) {
+		hasLetter := false
+		for _, r := range f {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r >= 0x80 {
+				hasLetter = true
+			}
+		}
+		if hasLetter && len(f) >= 2 {
+			wordish++
+		}
+	}
+	for _, r := range line {
+		total++
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r >= 0x80 {
+			letters++
+		}
+	}
+	if total == 0 {
+		return false
+	}
+	// enough real words, and letters are a real share of the characters
+	return wordish >= 4 && letters*100/total >= 45
+}
+
+func noiseLine(line string) bool {
+	return shareLineNumRE.MatchString(line) || shareGrepRE.MatchString(line)
 }
 
 func noisyShareMessage(s string) bool {
@@ -121,7 +157,33 @@ func noisyShareMessage(s string) bool {
 			return true
 		}
 	}
-	return strings.Contains(t, "tool_use") || strings.Contains(t, "tool_result")
+	if strings.Contains(t, "tool_use") || strings.Contains(t, "tool_result") {
+		return true
+	}
+	return looksLikeDataDump(t)
+}
+
+// looksLikeDataDump flags pasted JSON, CLI output, or blobs with very long
+// unbroken tokens — content that would make a shared digest unreadable.
+func looksLikeDataDump(t string) bool {
+	if len(t) > 400 {
+		if (strings.HasPrefix(t, "{") || strings.HasPrefix(t, "[")) && strings.Contains(t, "\":\"") {
+			return true
+		}
+	}
+	longestRun := 0
+	run := 0
+	for _, r := range t {
+		if r == ' ' || r == '\n' || r == '\t' {
+			run = 0
+			continue
+		}
+		run++
+		if run > longestRun {
+			longestRun = run
+		}
+	}
+	return longestRun > 200
 }
 
 func stripANSI(s string) string {

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>deja-vu — your agents already solved this. deja finds it.</title>
-<meta name="description" content="deja indexes every session Claude Code, Codex CLI and opencode wrote on your machine and serves it back — to you and to your agents via MCP. Local, fast, zero dependencies.">
+<meta name="description" content="A memory layer for coding agents: search, MCP recall, auto-context, secret redaction, stats, share and sync over the session histories Claude Code, Codex and opencode already write. One zero-dependency binary, fully local.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="deja-vu — search every session your coding agents ever wrote">
@@ -100,7 +100,7 @@ a:hover{text-decoration:underline}
 
 <header>
   <h1>Your agents already solved this.<br><span class="grad">deja finds it.</span></h1>
-  <p class="sub">Claude Code, Codex and opencode forget everything between sessions — but the solutions are still on your disk. <code>deja</code> indexes those histories and serves them back, to you and to the agent.</p>
+  <p class="sub">Claude Code, Codex and opencode write every session to disk — gigabytes of solved problems nobody can search. <code>deja</code> turns them into a memory layer: search, agent recall, auto-context, redaction, stats, share and sync. One zero-dependency binary.</p>
   <div class="cta">
     <a class="btn primary" href="#install">Get started</a>
     <a class="btn" href="https://github.com/vshulcz/deja-vu">Star on GitHub</a>
@@ -131,19 +131,34 @@ a:hover{text-decoration:underline}
     <div class="card">
       <div class="ic"><svg viewBox="0 0 24 24"><path d="M12 3a9 9 0 1 0 9 9"/><path d="M21 12l-4-3M21 12l-4 2"/></svg></div>
       <h3>Agent memory via MCP</h3>
-      <p>Two tools — <code>recall</code> and <code>recall_context</code> — answers stay under ~4KB, cheap on context. One command wires it into Claude Code, Codex and opencode.</p>
+      <p><code>recall</code> and <code>recall_context</code> tools, answers under ~4KB. Add <code>--auto</code> and a SessionStart hook feeds project memory in before you ask.</p>
     </div>
     <div class="card">
       <div class="ic"><svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h10"/></svg></div>
       <h3>One index, every harness</h3>
-      <p>All your harnesses write session logs to disk. deja indexes them together — a fix found in Codex is recalled inside Claude Code.</p>
+      <p>All your harnesses write session logs to disk. deja indexes them together, retroactively — a fix found in Codex is recalled inside Claude Code.</p>
     </div>
     <div class="card">
       <div class="ic"><svg viewBox="0 0 24 24"><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg></div>
-      <h3>Local and private</h3>
-      <p>No network code exists in the tool. Local files in, local cache out. A single Go binary with zero dependencies.</p>
+      <h3>Secrets redacted</h3>
+      <p>API keys, JWTs and private-key blocks are stripped at index time — the cache is safe to keep, shares and exports are safe to send.</p>
     </div>
-  </div>
+    <div class="card">
+      <div class="ic"><svg viewBox="0 0 24 24"><path d="M4 20V10M10 20V4M16 20v-8M22 20H2"/></svg></div>
+      <h3>Stats, wrapped</h3>
+      <p><code>deja stats</code> — sessions, top projects, a monthly activity sparkline. Your agent year, one screenshot.</p>
+    </div>
+    <div class="card">
+      <div class="ic"><svg viewBox="0 0 24 24"><path d="M12 5v9M8 8l4-4 4 4"/><rect x="4" y="14" width="16" height="6" rx="2"/></svg></div>
+      <h3>Share a session</h3>
+      <p><code>deja share &lt;id&gt;</code> hands a colleague a sanitized digest — problem, key conclusions, secrets already scrubbed.</p>
+    </div>
+    <div class="card">
+      <div class="ic"><svg viewBox="0 0 24 24"><path d="M7 8h10M7 8l3-3M7 8l3 3M17 16H7M17 16l-3-3M17 16l-3 3"/></svg></div>
+      <h3>Sync between machines</h3>
+      <p><code>deja sync export/import</code> moves memory laptop&nbsp;↔&nbsp;server. Watermarked, append-only, idempotent.</p>
+    </div>
+  </div></div>
 </section>
 
 <section>


### PR DESCRIPTION
Improves share output on tool-heavy sessions (follow-up: #22)

Reviewed line-by-line; redaction applied in all ingest paths, JWT and xoxc/xoxs classes added after review.