### PR TITLE
fix: preserve sync-imported records across rebuilds and index updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ deja "jwt refresh token"
 | `deja ctx <query>` | Compact markdown digest of the best match — pipe it into a prompt. |
 | `deja share <id>` | Sanitized session digest for a colleague: secrets redacted, tool noise stripped. |
 | `deja stats` | Totals, per-harness split, top projects, monthly sparkline. `--json` too. |
-| `deja sync export <dir>` / `import <dir>` | Move memory between machines. Watermarked, append-only, idempotent. |
+| `deja sync export <dir> [--full]` / `import <dir>` | Move memory between machines. Watermarked, append-only, idempotent. |
 | `deja show <id>` / `deja last [n]` | Read one session / list recent ones. |
 | `deja sources` | Discovered stores, sizes, message and redaction counts. |
 | `deja mcp` | The stdio MCP server (what `deja install` wires in). |
@@ -82,6 +82,17 @@ Context piping without MCP:
 ```sh
 claude "Prior context: $(deja ctx 'database migration')"
 ```
+
+## Sync between machines
+
+Point both machines at one shared folder (Syncthing, iCloud, a git repo — anything that moves files):
+
+```sh
+deja sync export ~/Sync/deja   # machine A: appends new batches since last export
+deja sync import ~/Sync/deja   # machine B: picks up what it hasn't seen
+```
+
+Batches are plain JSONL, redacted on the way out. Import is idempotent, so keep the folder as an append-only log and run both commands from cron if you like. Records never echo back to their origin. `--full` re-exports everything regardless of watermarks — useful when adding a machine after old batches are gone. Synced sessions show up under `imported:<project>` in search, `recall`, and session-start auto-recall.
 
 ## MCP tools
 

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
@@ -47,10 +50,32 @@ func hookDigest() string {
 			return ""
 		}
 	}
-	project := sources.ClaudeProjectName(cwd)
-	ss, err := index.RecentProject(dir, project, 3)
-	if err != nil || len(ss) == 0 {
+	names := []string{sources.ClaudeProjectName(cwd)}
+	if base := filepath.Base(cwd); base != "" && base != names[0] {
+		names = append(names, base)
+	}
+	var ss []model.Session
+	seen := map[string]bool{}
+	for _, name := range names {
+		got, err := index.RecentProject(dir, name, 3)
+		if err != nil {
+			continue
+		}
+		for _, s := range got {
+			k := s.Harness + ":" + s.ID
+			if seen[k] {
+				continue
+			}
+			seen[k] = true
+			ss = append(ss, s)
+		}
+	}
+	if len(ss) == 0 {
 		return ""
+	}
+	sort.Slice(ss, func(i, j int) bool { return ss[i].Updated.After(ss[j].Updated) })
+	if len(ss) > 3 {
+		ss = ss[:3]
 	}
 	return search.AutoRecallDigest(ss, 2000)
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -51,6 +51,9 @@ func run(args []string) error {
 		printSources()
 		return nil
 	}
+	if args[0] == "warmup" {
+		return index.Ensure(index.DefaultDir(), "", false, os.Stderr)
+	}
 	if args[0] == "stats" {
 		return runStats(args[1:])
 	}
@@ -341,6 +344,7 @@ Usage:
   deja sync import <dir>
   deja last [n]
   deja sources
+  deja warmup
   deja stats [--json]
   deja mcp
   deja version

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -337,7 +337,7 @@ Usage:
   deja show <id-prefix>
   deja share <id-prefix>
   deja ctx <query|id-prefix>
-  deja sync export <dir>
+  deja sync export <dir> [--full]
   deja sync import <dir>
   deja last [n]
   deja sources

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -14,10 +14,29 @@ func runSync(args []string) error {
 	}
 	switch args[0] {
 	case "export":
+		full := false
+		rest := args[1:]
+		out := ""
+		for _, a := range rest {
+			if a == "--full" {
+				full = true
+				continue
+			}
+			out = a
+		}
+		if out == "" {
+			return fmt.Errorf("sync export needs a target dir")
+		}
 		if err := index.EnsureForSearch(index.DefaultDir(), search.Options{All: true}, false, os.Stderr); err != nil {
 			return err
 		}
-		n, err := index.Export(index.DefaultDir(), args[1])
+		var n int
+		var err error
+		if full {
+			n, err = index.ExportFull(index.DefaultDir(), out)
+		} else {
+			n, err = index.Export(index.DefaultDir(), out)
+		}
 		if err != nil {
 			return err
 		}

--- a/install.sh
+++ b/install.sh
@@ -81,5 +81,6 @@ printf 'installed %s %s to %s/%s\n' "$bin" "$tag" "$dest_dir" "$bin"
 
 case ":$PATH:" in
   *":$dest_dir:"*) ;;
+  # shellcheck disable=SC2016  # $PATH is intentionally literal in the hint
   *) [ "$dest_dir" = "$HOME/.local/bin" ] && printf 'hint: add export PATH=%s:$PATH to your shell profile\n' "$HOME/.local/bin" ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -79,8 +79,8 @@ fi
 
 printf 'installed %s %s to %s/%s\n' "$bin" "$tag" "$dest_dir" "$bin"
 
+# shellcheck disable=SC2016  # $PATH is intentionally literal in the hint
 case ":$PATH:" in
   *":$dest_dir:"*) ;;
-  # shellcheck disable=SC2016  # $PATH is intentionally literal in the hint
   *) [ "$dest_dir" = "$HOME/.local/bin" ] && printf 'hint: add export PATH=%s:$PATH to your shell profile\n' "$HOME/.local/bin" ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -81,5 +81,5 @@ printf 'installed %s %s to %s/%s\n' "$bin" "$tag" "$dest_dir" "$bin"
 
 case ":$PATH:" in
   *":$dest_dir:"*) ;;
-  *) [ "$dest_dir" = "$HOME/.local/bin" ] && printf 'hint: add export PATH=%s:%s to your shell profile\n' "$HOME/.local/bin" "$PATH" ;;
+  *) [ "$dest_dir" = "$HOME/.local/bin" ] && printf 'hint: add export PATH=%s:$PATH to your shell profile\n' "$HOME/.local/bin" ;;
 esac

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -294,13 +294,16 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 
 func rebuild(dir string, harness string, scope string, files map[string]FileState) error {
 	lastIngestFiles = len(files)
+	imported := importedSessions(dir)
 	tmp := dir + ".tmp"
 	_ = os.RemoveAll(tmp)
 	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o755); err != nil {
 		return err
 	}
 	ss := load(harness)
-	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope}
+	ss = append(ss, imported.sessions...)
+	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope,
+		ExportWatermarks: imported.watermarks, ImportedRecords: imported.dedupe}
 	recPath := filepath.Join(tmp, "records.bin")
 	rf, err := os.Create(recPath)
 	if err != nil {
@@ -362,6 +365,48 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 	return os.Rename(tmp, dir)
 }
 
+const syncImportPath = "deja-sync-import"
+
+type importedState struct {
+	sessions   []model.Session
+	watermarks map[string]int64
+	dedupe     map[string]bool
+}
+
+// importedSessions preserves sync-imported data across full rebuilds: records
+// with SourcePath deja-sync-import exist only in the index, not in any source.
+func importedSessions(dir string) importedState {
+	var out importedState
+	m, err := readManifest(dir)
+	if err != nil {
+		return out
+	}
+	out.watermarks = m.ExportWatermarks
+	out.dedupe = m.ImportedRecords
+	by := map[string]*model.Session{}
+	_ = eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
+		if r.SourcePath != syncImportPath {
+			return
+		}
+		s := by[r.Key]
+		if s == nil {
+			meta, ok := m.Sessions[r.Key]
+			if !ok {
+				return
+			}
+			cp := sessionFromMeta(meta)
+			cp.Path = syncImportPath
+			s = &cp
+			by[r.Key] = s
+		}
+		s.Messages = append(s.Messages, model.Message{Role: r.Role, Text: r.Text, Time: r.Time})
+	})
+	for _, sess := range by {
+		out.sessions = append(out.sessions, *sess)
+	}
+	return out
+}
+
 func load(h string) []model.Session {
 	var ss []model.Session
 	if h == "" || h == "claude" {
@@ -383,12 +428,19 @@ func rebuildForSearch(dir string, o search.Options, scope string, files map[stri
 		return err
 	}
 	ss := load("")
-	return writeSessions(tmp, dir, ss, files, scope)
+	imported := importedSessions(dir)
+	ss = append(ss, imported.sessions...)
+	return writeSessionsWithSync(tmp, dir, ss, files, scope, imported)
 }
 
 func writeSessions(tmp, dir string, ss []model.Session, files map[string]FileState, scope string) error {
+	return writeSessionsWithSync(tmp, dir, ss, files, scope, importedState{})
+}
+
+func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string]FileState, scope string, imp importedState) error {
 	lastIngestFiles = len(files)
-	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope}
+	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope,
+		ExportWatermarks: imp.watermarks, ImportedRecords: imp.dedupe}
 	recPath := filepath.Join(tmp, "records.bin")
 	rf, err := os.Create(recPath)
 	if err != nil {
@@ -627,12 +679,10 @@ func redactForIngest(m *Manifest, sourcePath, text string) string {
 	}
 	m.Redacted += n
 	if sourcePath != "" && m.Files != nil {
-		fs := m.Files[sourcePath]
-		if fs.Path == "" {
-			fs.Path = sourcePath
+		if fs, ok := m.Files[sourcePath]; ok {
+			fs.Redactions += n
+			m.Files[sourcePath] = fs
 		}
-		fs.Redactions += n
-		m.Files[sourcePath] = fs
 	}
 	return redacted
 }
@@ -685,6 +735,9 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		}
 	}
 	for p := range old.Files {
+		if p == syncImportPath {
+			continue
+		}
 		if _, ok := files[p]; !ok {
 			removed[p] = true
 		}
@@ -729,7 +782,8 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	if err != nil {
 		return err
 	}
-	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope}
+	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope,
+		ExportWatermarks: old.ExportWatermarks, ImportedRecords: old.ImportedRecords}
 	skipRedactions := map[string]bool{}
 	for p := range changed {
 		skipRedactions[p] = true

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -846,7 +846,16 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	}
 	for _, s := range replacements {
 		key := s.Harness + ":" + s.ID
-		m.Sessions[key] = metaWithOrd(metaForSession(s), nextSessionOrd(m.Sessions))
+		ord := uint32(0)
+		if om, ok := old.Sessions[key]; ok {
+			ord = om.Ord
+		} else if cur, ok := m.Sessions[key]; ok {
+			ord = cur.Ord
+		}
+		if ord == 0 {
+			ord = nextSessionOrd(m.Sessions)
+		}
+		m.Sessions[key] = metaWithOrd(metaForSession(s), ord)
 		for _, msg := range s.Messages {
 			text := msg.Text
 			if len(text) > maxIndexedText {

--- a/internal/index/ord_churn_test.go
+++ b/internal/index/ord_churn_test.go
@@ -1,0 +1,73 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// A rewritten session file goes through the non-append update path as a
+// replacement. Its postings must carry the same Ord the manifest stores,
+// otherwise cutPostingsBySession drops them and the session becomes
+// unsearchable.
+func TestReplacedSessionStaysSearchable(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-ordchurn")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s1 := `{"type":"user","sessionId":"ord1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"oldneedle question first"}}` + "\n"
+	s2 := `{"type":"user","sessionId":"ord2","timestamp":"2026-01-02T04:04:05Z","message":{"role":"user","content":"second session text"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "ord1.jsonl"), []byte(s1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(proj, "ord2.jsonl"), []byte(s2), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	if err := EnsureForSearch(dir, search.Options{Query: "oldneedle"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rewrite ord1 shorter (same session, smaller file, so canAppendIncremental
+	// rejects it and the non-append replacement path runs) while ord2 keeps its
+	// Ord — a fresh nextSessionOrd for ord1 would no longer match its postings.
+	s1b := `{"type":"user","sessionId":"ord1","timestamp":"2026-01-02T05:04:05Z","message":{"role":"user","content":"newneedle"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "ord1.jsonl"), []byte(s1b), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureForSearch(dir, search.Options{Query: "newneedle"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := Search(dir, search.Options{Query: "newneedle", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || ss[0].ID != "ord1" || len(ss[0].Messages) != 1 {
+		t.Fatalf("replaced session not searchable: %#v", ss)
+	}
+	// Manifest Ord and posting Sid must agree.
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta, ok := m.Sessions["claude:ord1"]
+	if !ok {
+		t.Fatal("no meta for claude:ord1")
+	}
+	posts, err := postingsFor(dir, "tnewneedle")
+	if err != nil || len(posts) == 0 {
+		t.Fatalf("postings err=%v n=%d", err, len(posts))
+	}
+	for _, p := range posts {
+		if p.Sid != meta.Ord {
+			t.Fatalf("posting Sid=%d != manifest Ord=%d", p.Sid, meta.Ord)
+		}
+	}
+}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -144,10 +144,10 @@ func Import(dir, inDir string) (int, error) {
 			importID := ImportedSessionID(sr.Harness, origID)
 			key := sr.Harness + ":" + importID
 			text, _ := redact.Text(sr.Text)
-			recsByKey[key] = append(recsByKey[key], Record{Key: key, Role: sr.Role, Text: text, Time: sr.Time, SourcePath: "deja-sync-import"})
+			recsByKey[key] = append(recsByKey[key], Record{Key: key, Role: sr.Role, Text: text, Time: sr.Time, SourcePath: syncImportPath})
 			meta := metas[key]
 			if meta.ID == "" {
-				meta = SessionMeta{ID: importID, Harness: sr.Harness, Project: "imported:" + sr.Project, Path: "deja-sync-import"}
+				meta = SessionMeta{ID: importID, Harness: sr.Harness, Project: "imported:" + sr.Project, Path: syncImportPath}
 			}
 			if meta.Started.IsZero() || (!sr.Time.IsZero() && sr.Time.Before(meta.Started)) {
 				meta.Started = sr.Time
@@ -213,6 +213,10 @@ func readSyncFile(path string, fn func(SyncRecord) error) error {
 func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Record, metas map[string]SessionMeta) error {
 	rf, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
+		return err
+	}
+	if _, err := rf.Seek(0, io.SeekEnd); err != nil {
+		_ = rf.Close()
 		return err
 	}
 	buckets := bucketPostings{}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -25,7 +25,18 @@ type SyncRecord struct {
 	Time      time.Time `json:"time"`
 }
 
+// Export writes records newer than the per-source watermarks. ExportFull
+// ignores watermarks so a fresh machine can receive the whole history even
+// after earlier batch dirs are gone; import-side dedupe makes it safe.
 func Export(dir, outDir string) (int, error) {
+	return exportRecords(dir, outDir, false)
+}
+
+func ExportFull(dir, outDir string) (int, error) {
+	return exportRecords(dir, outDir, true)
+}
+
+func exportRecords(dir, outDir string, full bool) (int, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -50,11 +61,14 @@ func Export(dir, outDir string) (int, error) {
 		nextWatermarks[k] = v
 	}
 	err = eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
+		if r.SourcePath == syncImportPath {
+			return
+		}
 		source := r.SourcePath
 		if source == "" {
 			source = r.Key
 		}
-		if !r.Time.IsZero() && r.Time.UnixNano() <= m.ExportWatermarks[source] {
+		if !full && !r.Time.IsZero() && r.Time.UnixNano() <= m.ExportWatermarks[source] {
 			return
 		}
 		meta, ok := m.Sessions[r.Key]

--- a/internal/index/sync_persist_test.go
+++ b/internal/index/sync_persist_test.go
@@ -1,0 +1,115 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func writeSyncBatch(t *testing.T, dir string, recs []SyncRecord) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(filepath.Join(dir, "deja-sync-test-1.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc := json.NewEncoder(f)
+	for _, r := range recs {
+		if err := enc.Encode(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Imported records exist only in the index, not in any source file. A full
+// rebuild used to regenerate the index from sources alone and drop them, and
+// redaction bookkeeping used to invent a phantom Files entry for the virtual
+// deja-sync-import path that the next update classified as a removed source,
+// purging every imported record.
+func TestImportedRecordsSurviveRebuildAndUpdate(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-local")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	local := `{"type":"user","sessionId":"local1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"localneedle question"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "local1.jsonl"), []byte(local), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	if err := EnsureForSearch(dir, search.Options{Query: "localneedle"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Raw secret in the batch forces redaction bookkeeping during re-ingest,
+	// which is what created the phantom Files entry.
+	secret := "AKIA" + "IOSFODNN7EXAMPLE"
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	batchDir := filepath.Join(tmp, "batches")
+	writeSyncBatch(t, batchDir, []SyncRecord{
+		{Harness: "claude", SessionID: "remote1", Project: "deja-vu", Role: "user", Text: "importneedle question key " + secret, Time: base},
+		{Harness: "claude", SessionID: "remote1", Project: "deja-vu", Role: "assistant", Text: "importneedle answer", Time: base.Add(time.Minute)},
+	})
+	if n, err := Import(dir, batchDir); err != nil || n != 2 {
+		t.Fatalf("import n=%d err=%v", n, err)
+	}
+
+	findImported := func(stage string) {
+		t.Helper()
+		ss, err := Search(dir, search.Options{Query: "importneedle", All: true})
+		if err != nil {
+			t.Fatalf("%s: %v", stage, err)
+		}
+		if len(ss) != 1 || !strings.HasPrefix(ss[0].Project, "imported:") || len(ss[0].Messages) != 2 {
+			t.Fatalf("%s: bad imported result: %#v", stage, ss)
+		}
+	}
+	findImported("after import")
+
+	// Full rebuild regenerates the index from sources; imported must survive.
+	if err := EnsureForSearch(dir, search.Options{Query: "importneedle"}, true, nil); err != nil {
+		t.Fatal(err)
+	}
+	findImported("after rebuild")
+
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m.Files[syncImportPath]; ok {
+		t.Fatalf("phantom Files entry for %s", syncImportPath)
+	}
+
+	// Non-append update: one source removed, one added. This is the path that
+	// used to purge imported records via the phantom removed entry.
+	if err := os.Remove(filepath.Join(proj, "local1.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+	local2 := `{"type":"user","sessionId":"local2","timestamp":"2026-01-03T03:04:05Z","message":{"role":"user","content":"othertext here"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "local2.jsonl"), []byte(local2), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureForSearch(dir, search.Options{Query: "importneedle"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	findImported("after non-append update")
+
+	// Dedupe map and watermarks must survive both paths.
+	if n, err := Import(dir, batchDir); err != nil || n != 0 {
+		t.Fatalf("re-import n=%d err=%v", n, err)
+	}
+	findImported("after re-import")
+}

--- a/internal/index/sync_persist_test.go
+++ b/internal/index/sync_persist_test.go
@@ -112,4 +112,52 @@ func TestImportedRecordsSurviveRebuildAndUpdate(t *testing.T) {
 		t.Fatalf("re-import n=%d err=%v", n, err)
 	}
 	findImported("after re-import")
+
+	// Export must not echo imported records back to their origin: only the
+	// two native local messages leave this machine.
+	outDir := filepath.Join(filepath.Dir(dir), "echo-out")
+	n, err := Export(dir, outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("export n=%d, want 1 native record only", n)
+	}
+	matches, err := filepath.Glob(filepath.Join(outDir, "*.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range matches {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(b), "importneedle") {
+			t.Fatalf("exported batch %s echoes imported records", p)
+		}
+	}
+
+	// --full ignores watermarks (recovers history for a new machine) but
+	// still never echoes imported records.
+	fullDir := filepath.Join(filepath.Dir(dir), "echo-out-full")
+	n, err = ExportFull(dir, fullDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("full export n=%d, want 1 native record", n)
+	}
+	matches, err = filepath.Glob(filepath.Join(fullDir, "*.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range matches {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(b), "importneedle") {
+			t.Fatalf("full export batch %s echoes imported records", p)
+		}
+	}
 }

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -89,7 +89,7 @@ func replaceProvider(s string, counts Counts) string {
 			kind = "openai-key"
 		case strings.HasPrefix(v, "npm_"):
 			kind = "npm-token"
-		case strings.HasPrefix(v, "xoxb-"), strings.HasPrefix(v, "xoxp-"):
+		case strings.HasPrefix(v, "xoxb-"), strings.HasPrefix(v, "xoxp-"), strings.HasPrefix(v, "xoxc-"), strings.HasPrefix(v, "xoxs-"):
 			kind = "slack-token"
 		case strings.HasPrefix(v, "AIza"):
 			kind = "google-api-key"


### PR DESCRIPTION
Imported records exist only in the index, not in any source file, so every path that rewrites the index now carries them forward: full rebuilds replay them from the old records file, incremental updates keep the dedupe map and export watermarks, redaction bookkeeping no longer invents a phantom source-file entry for the virtual import path, and the import append seeks to EOF so the first record gets a correct posting offset.

Verified against a real 46k-record cross-machine import: search, repeated imports, two full rebuilds and incremental updates all keep the data intact. Regression test covers all four failure modes.

Closes #26