### PR TITLE
fix: warn in deja sources when sqlite3 CLI is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Claude Code, Codex and opencode write every conversation to local files — giga
 | **Share** | `deja share <id>` — hand a colleague a sanitized digest of a session, secrets already scrubbed |
 | **Sync** | `deja sync export/import` — move memory between machines, append-only, idempotent |
 
-One binary. No models to download, no services to run, nothing leaves your machine.
+One binary. No models to download, no services to run, nothing leaves your machine. (opencode indexing shells out to the `sqlite3` CLI, preinstalled on macOS and most Linux distros.)
 
 ## Install
 

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -293,7 +293,11 @@ func printSources() {
 		size = fi.Size()
 	}
 	s, m, _ := sources.OpencodeCounts()
-	fmt.Printf("opencode\t%s\tsessions=%d messages=%d size=%s redacted=%d\n", sources.OpencodeDB(), s, m, humanBytes(size), redactions[sources.OpencodeDB()])
+	note := ""
+	if size > 0 && !sources.SQLite3Available() {
+		note = "\t(sqlite3 CLI not found — opencode sessions unavailable)"
+	}
+	fmt.Printf("opencode\t%s\tsessions=%d messages=%d size=%s redacted=%d%s\n", sources.OpencodeDB(), s, m, humanBytes(size), redactions[sources.OpencodeDB()], note)
 }
 
 func redactionsUnder(files map[string]int, root string) int {

--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -13,6 +13,13 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
+// SQLite3Available reports whether the sqlite3 CLI the opencode parser
+// shells out to is on PATH.
+func SQLite3Available() bool {
+	_, err := exec.LookPath("sqlite3")
+	return err == nil
+}
+
 func OpencodeDB() string {
 	return EnvPath("DEJA_OPENCODE_DB", filepath.Join(Home(), ".local", "share", "opencode", "opencode.db"))
 }


### PR DESCRIPTION
opencode indexing shells out to sqlite3; without it the source silently contributes zero sessions. `deja sources` now says why, and the README mentions the dependency.

Closes #29