### PR TITLE
fix: rebuild automatically when a bucket file is corrupt

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -109,7 +109,7 @@ func run(args []string) error {
 		if err := index.EnsureForSearch(index.DefaultDir(), o, false, os.Stderr); err != nil {
 			return err
 		}
-		ss, err := index.Search(index.DefaultDir(), o)
+		ss, err := index.SearchWithRecovery(index.DefaultDir(), o, os.Stderr)
 		if err != nil {
 			return err
 		}
@@ -163,7 +163,7 @@ func run(args []string) error {
 	if err := index.EnsureForSearch(index.DefaultDir(), o, force, os.Stderr); err != nil {
 		return fmt.Errorf("ensure: %w", err)
 	}
-	ss, err := index.Search(index.DefaultDir(), o)
+	ss, err := index.SearchWithRecovery(index.DefaultDir(), o, os.Stderr)
 	if err != nil {
 		return fmt.Errorf("search: %w", err)
 	}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -148,7 +148,7 @@ func recallText(q, harness string, limit, budget int) (string, error) {
 	if err := index.EnsureForSearch(index.DefaultDir(), o, false, mcpProgress()); err != nil {
 		return "", err
 	}
-	ss, err := index.Search(index.DefaultDir(), o)
+	ss, err := index.SearchWithRecovery(index.DefaultDir(), o, mcpProgress())
 	if err != nil {
 		return "", err
 	}
@@ -199,7 +199,7 @@ func recallContext(q string) (string, error) {
 	if err := index.EnsureForSearch(index.DefaultDir(), o, false, mcpProgress()); err != nil {
 		return "", err
 	}
-	ss, err := index.Search(index.DefaultDir(), o)
+	ss, err := index.SearchWithRecovery(index.DefaultDir(), o, mcpProgress())
 	if err != nil {
 		return "", err
 	}

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -82,7 +82,7 @@ func runStats(args []string) error {
 	if err := index.Ensure(index.DefaultDir(), "", false, os.Stderr); err != nil {
 		return err
 	}
-	ss, err := index.Search(index.DefaultDir(), search.Options{All: true})
+	ss, err := index.SearchWithRecovery(index.DefaultDir(), search.Options{All: true}, os.Stderr)
 	if err != nil {
 		return err
 	}

--- a/internal/index/heal_test.go
+++ b/internal/index/heal_test.go
@@ -1,0 +1,54 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// A bucket file cut short by a crash must read as "corrupt index" and
+// SearchWithRecovery must rebuild and answer instead of erroring.
+func TestSearchRecoversFromCorruptBucket(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-heal")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data := `{"type":"user","sessionId":"h1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"healneedle question"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "h1.jsonl"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	o := search.Options{Query: "healneedle", All: true}
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Truncate every bucket to simulate a crash mid-write.
+	buckets, err := filepath.Glob(filepath.Join(dir, "buckets", "*.bin"))
+	if err != nil || len(buckets) == 0 {
+		t.Fatalf("buckets glob err=%v n=%d", err, len(buckets))
+	}
+	for _, b := range buckets {
+		if err := os.Truncate(b, 3); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := Search(dir, o); !IsCorrupt(err) {
+		t.Fatalf("Search error = %v, want corrupt index", err)
+	}
+	ss, err := SearchWithRecovery(dir, o, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || ss[0].ID != "h1" {
+		t.Fatalf("recovery search bad result: %#v", ss)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/binary"
 	"encoding/gob"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -26,6 +27,14 @@ const version = 9
 const maxIndexedText = 64 * 1024
 
 var bucketMagic = []byte("DJB1")
+
+// errCorruptIndex marks unreadable index structures (e.g. a bucket file cut
+// short by a crash). Callers treat it as a cache miss and rebuild.
+var errCorruptIndex = errors.New("corrupt index")
+
+// IsCorrupt reports whether err means the on-disk index is damaged and a
+// rebuild will heal it.
+func IsCorrupt(err error) bool { return errors.Is(err, errCorruptIndex) }
 
 var lastIngestFiles int
 
@@ -179,6 +188,23 @@ func Search(dir string, o search.Options) ([]model.Session, error) {
 		return nil, nil
 	}
 	return scanRecords(dir, m, o, postingOffsets(posts))
+}
+
+// SearchWithRecovery is Search plus self-healing: a corrupt bucket (crash
+// mid-append) triggers one full rebuild instead of erroring until the user
+// runs --rebuild by hand.
+func SearchWithRecovery(dir string, o search.Options, progress io.Writer) ([]model.Session, error) {
+	ss, err := Search(dir, o)
+	if err == nil || !IsCorrupt(err) {
+		return ss, err
+	}
+	if progress != nil {
+		fmt.Fprintf(progress, "deja: index damaged (%v), rebuilding ...\n", err)
+	}
+	if rerr := EnsureForSearch(dir, o, true, progress); rerr != nil {
+		return nil, rerr
+	}
+	return Search(dir, o)
 }
 
 func Recent(dir string, n int) ([]model.Session, error) {
@@ -748,6 +774,12 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	}
 	if len(removed) == 0 && canAppendIncremental(changed, old.Files) {
 		filesTouched, messages, err := appendIncremental(dir, harness, scope, old, files, changed)
+		if IsCorrupt(err) {
+			if progress != nil {
+				fmt.Fprintf(progress, "deja: index damaged (%v), rebuilding ...\n", err)
+			}
+			return rebuild(dir, harness, scope, files)
+		}
 		if err != nil {
 			return fmt.Errorf("append: %w", err)
 		}
@@ -1718,33 +1750,33 @@ func openBucketDir(p string) ([]bucketEntry, *os.File, error) {
 	magic := make([]byte, len(bucketMagic))
 	if _, err := io.ReadFull(r, magic); err != nil {
 		f.Close()
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("%w: %v", errCorruptIndex, err)
 	}
 	if string(magic) != string(bucketMagic) {
 		f.Close()
-		return nil, nil, fmt.Errorf("bad bucket format")
+		return nil, nil, fmt.Errorf("%w: bad bucket magic", errCorruptIndex)
 	}
 	count, err := binary.ReadUvarint(r)
 	if err != nil {
 		f.Close()
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("%w: %v", errCorruptIndex, err)
 	}
 	entries := make([]bucketEntry, 0, count)
 	for i := uint64(0); i < count; i++ {
 		ln, err := binary.ReadUvarint(r)
 		if err != nil {
 			f.Close()
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("%w: %v", errCorruptIndex, err)
 		}
 		tb := make([]byte, ln)
 		if _, err := io.ReadFull(r, tb); err != nil {
 			f.Close()
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("%w: %v", errCorruptIndex, err)
 		}
 		var fixed [12]byte
 		if _, err := io.ReadFull(r, fixed[:]); err != nil {
 			f.Close()
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("%w: %v", errCorruptIndex, err)
 		}
 		entries = append(entries, bucketEntry{tok: string(tb), off: binary.LittleEndian.Uint64(fixed[:8]), n: binary.LittleEndian.Uint32(fixed[8:])})
 	}


### PR DESCRIPTION
A crash mid-append (or kill -9 during sync import) can truncate a bucket file. Search then errored on every call until the user ran `--rebuild` by hand. Corrupt buckets are now tagged with a sentinel error; SearchWithRecovery and the incremental updater treat them as a cache miss and rebuild once. Covered by a truncated-bucket regression test.

Closes #30