### PR TITLE
fix: resolve claude project names against the filesystem

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -51,8 +51,13 @@ func hookDigest() string {
 		}
 	}
 	names := []string{sources.ClaudeProjectName(cwd)}
-	if base := filepath.Base(cwd); base != "" && base != names[0] {
-		names = append(names, base)
+	if base := filepath.Base(cwd); base != "" {
+		if two := filepath.Join(filepath.Base(filepath.Dir(cwd)), base); two != names[0] {
+			names = append(names, two)
+		}
+		if base != names[0] {
+			names = append(names, base)
+		}
 	}
 	var ss []model.Session
 	seen := map[string]bool{}

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -1,8 +1,10 @@
 package sources
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/vshulcz/deja-vu/internal/model"
 )
@@ -73,10 +75,35 @@ func claudeProjectDir(path string) string {
 	return dir
 }
 
+var projectNameCache sync.Map // encoded base -> display name
+
 func claudeProjectName(dir string) string {
 	base := filepath.Base(dir)
 	if base == "" || base == "." || base == string(filepath.Separator) {
 		return "-"
+	}
+	if v, ok := projectNameCache.Load(base); ok {
+		return v.(string)
+	}
+	name := decodeProjectBase(base)
+	projectNameCache.Store(base, name)
+	return name
+}
+
+// decodeProjectBase turns a Claude Code project dir name back into a display
+// name. Claude encodes both "/" and "-" as "-", so "-Users-x-deja-vu" is
+// ambiguous; resolving against the filesystem recovers hyphenated project
+// names ("deja-vu", not "deja/vu"). Falls back to the dash heuristic when the
+// path no longer exists (deleted projects, dirs imported from other machines).
+func decodeProjectBase(base string) string {
+	if resolved := resolveEncodedPath(base); resolved != "" {
+		segs := strings.Split(strings.Trim(resolved, string(filepath.Separator)), string(filepath.Separator))
+		if len(segs) >= 2 {
+			return filepath.Join(segs[len(segs)-2], segs[len(segs)-1])
+		}
+		if len(segs) == 1 {
+			return segs[0]
+		}
 	}
 	parts := strings.Split(base, "-")
 	var clean []string
@@ -92,6 +119,43 @@ func claudeProjectName(dir string) string {
 		return clean[0]
 	}
 	return filepath.Join(clean[len(clean)-2], clean[len(clean)-1])
+}
+
+// resolveEncodedPath finds the real directory an encoded project name points
+// at. Segments are re-joined with "/" or "-" and pruned by checking each
+// completed directory prefix on disk.
+func resolveEncodedPath(base string) string {
+	if !strings.HasPrefix(base, "-") {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(base, "-"), "-")
+	if len(parts) == 0 || len(parts) > 24 {
+		return ""
+	}
+	var try func(done, seg string, i int) string
+	try = func(done, seg string, i int) string {
+		if i == len(parts) {
+			p := done + string(filepath.Separator) + seg
+			if fi, err := os.Stat(p); err == nil && fi.IsDir() {
+				return p
+			}
+			return ""
+		}
+		// close the current segment with "/" first (most path characters are
+		// separators), pruning when the prefix does not exist
+		p := done + string(filepath.Separator) + seg
+		if fi, err := os.Stat(p); err == nil && fi.IsDir() {
+			if r := try(p, parts[i], i+1); r != "" {
+				return r
+			}
+		}
+		// or keep extending it with a literal hyphen
+		return try(done, seg+"-"+parts[i], i+1)
+	}
+	if parts[0] == "" {
+		return ""
+	}
+	return try("", parts[0], 1)
 }
 
 // ClaudeProjectName derives the display project name using the same rules as

--- a/internal/sources/name_test.go
+++ b/internal/sources/name_test.go
@@ -1,0 +1,27 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Claude Code encodes "/" and "-" identically; resolving against the
+// filesystem must recover hyphenated project names instead of mangling
+// deja-vu into deja/vu.
+func TestClaudeProjectNameResolvesHyphenatedDirs(t *testing.T) {
+	tmp := t.TempDir()
+	real := filepath.Join(tmp, "projects", "deja-vu")
+	if err := os.MkdirAll(real, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	encoded := strings.ReplaceAll(real, string(filepath.Separator), "-")
+	if got := claudeProjectName(filepath.Join("/claude/projects", encoded)); got != filepath.Join("projects", "deja-vu") {
+		t.Fatalf("resolved name = %q, want projects/deja-vu", got)
+	}
+	// Non-existent paths keep the old heuristic.
+	if got := claudeProjectName("/claude/projects/-no-such-root-deja-vu"); got != filepath.Join("deja", "vu") {
+		t.Fatalf("fallback name = %q, want deja/vu", got)
+	}
+}

--- a/internal/sources/name_test.go
+++ b/internal/sources/name_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -11,6 +12,9 @@ import (
 // filesystem must recover hyphenated project names instead of mangling
 // deja-vu into deja/vu.
 func TestClaudeProjectNameResolvesHyphenatedDirs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("claude encodes unix-style absolute paths; resolution is a no-op on windows")
+	}
 	tmp := t.TempDir()
 	real := filepath.Join(tmp, "projects", "deja-vu")
 	if err := os.MkdirAll(real, 0o755); err != nil {


### PR DESCRIPTION
Claude Code encodes both / and - as - in project dir names, so a repo called deja-vu displayed as deja/vu and never matched the opencode/codex name for the same project (filters, hook auto-recall). Encoded names are now resolved against the filesystem with pruned backtracking and a per-name cache; paths that no longer exist keep the old heuristic. The session-start hook also tries the parent/base form of the cwd.

Closes #28