### PR TITLE
feat: deja sync ssh <host> — one-command sync between machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ deja "jwt refresh token"
 | `deja ctx <query>` | Compact markdown digest of the best match — pipe it into a prompt. |
 | `deja share <id>` | Sanitized session digest for a colleague: secrets redacted, tool noise stripped. |
 | `deja stats` | Totals, per-harness split, top projects, monthly sparkline. `--json` too. |
-| `deja sync export <dir> [--full]` / `import <dir>` | Move memory between machines. Watermarked, append-only, idempotent. |
+| `deja sync export <dir> [--full]` / `import <dir>` / `ssh <host> [--pull]` | Move memory between machines — via a shared folder or one ssh command. Watermarked, append-only, idempotent. |
 | `deja show <id>` / `deja last [n]` | Read one session / list recent ones. |
 | `deja sources` | Discovered stores, sizes, message and redaction counts. |
 | `deja mcp` | The stdio MCP server (what `deja install` wires in). |
@@ -91,6 +91,15 @@ Point both machines at one shared folder (Syncthing, iCloud, a git repo — anyt
 deja sync export ~/Sync/deja   # machine A: appends new batches since last export
 deja sync import ~/Sync/deja   # machine B: picks up what it hasn't seen
 ```
+
+Or skip the shared folder when the other machine is a ssh hop away:
+
+```sh
+deja sync ssh mini          # push new records to mini and import them there
+deja sync ssh mini --pull   # fetch mini's new records into this machine
+```
+
+`ssh` mode uses your system ssh/scp and the `deja` binary on the remote (looked up on PATH, falling back to `~/.local/bin/deja`).
 
 Batches are plain JSONL, redacted on the way out. Import is idempotent, so keep the folder as an append-only log and run both commands from cron if you like. Records never echo back to their origin. `--full` re-exports everything regardless of watermarks — useful when adding a machine after old batches are gone. Synced sessions show up under `imported:<project>` in search, `recall`, and session-start auto-recall.
 

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -342,6 +342,7 @@ Usage:
   deja ctx <query|id-prefix>
   deja sync export <dir> [--full]
   deja sync import <dir>
+  deja sync ssh <host> [--pull] [--full]
   deja last [n]
   deja sources
   deja warmup

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -10,9 +10,11 @@ import (
 
 func runSync(args []string) error {
 	if len(args) < 2 {
-		return fmt.Errorf("sync needs export <dir> or import <dir>")
+		return fmt.Errorf("sync needs export <dir>, import <dir>, or ssh <host>")
 	}
 	switch args[0] {
+	case "ssh":
+		return runSyncSSH(args[1:])
 	case "export":
 		full := false
 		rest := args[1:]

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// sshRunner is swapped in tests.
+var sshRunner = func(name string, args ...string) (string, error) {
+	out, err := exec.Command(name, args...).CombinedOutput()
+	return string(out), err
+}
+
+func runSyncSSH(args []string) error {
+	host := ""
+	pull, full := false, false
+	for _, a := range args {
+		switch a {
+		case "--pull":
+			pull = true
+		case "--full":
+			full = true
+		default:
+			if strings.HasPrefix(a, "-") {
+				return fmt.Errorf("sync ssh: unknown flag %s", a)
+			}
+			if host != "" {
+				return fmt.Errorf("sync ssh takes one host")
+			}
+			host = a
+		}
+	}
+	if host == "" {
+		return fmt.Errorf("sync ssh needs a host (an ssh alias or user@host)")
+	}
+	if pull {
+		return syncSSHPull(host, full)
+	}
+	return syncSSHPush(host, full)
+}
+
+func syncSSHPush(host string, full bool) error {
+	if err := index.EnsureForSearch(index.DefaultDir(), search.Options{All: true}, false, os.Stderr); err != nil {
+		return err
+	}
+	tmp, err := os.MkdirTemp("", "deja-sync-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmp)
+	n, err := exportBatches(tmp, full)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "deja: exported %d records\n", n)
+	if n == 0 {
+		fmt.Fprintln(os.Stdout, "deja: nothing new to push")
+		return nil
+	}
+	batches, err := filepath.Glob(filepath.Join(tmp, "*.jsonl"))
+	if err != nil || len(batches) == 0 {
+		return fmt.Errorf("no batches produced")
+	}
+	rtmp, err := sshCapture(host, "mktemp -d")
+	if err != nil {
+		return err
+	}
+	scpArgs := append([]string{"-q"}, batches...)
+	scpArgs = append(scpArgs, host+":"+rtmp+"/")
+	if out, err := sshRunner("scp", scpArgs...); err != nil {
+		return fmt.Errorf("scp: %v: %s", err, strings.TrimSpace(out))
+	}
+	remote := fmt.Sprintf(`d=$(command -v deja || echo "$HOME/.local/bin/deja"); "$d" sync import %s; rc=$?; rm -rf %s; exit $rc`,
+		shellQuote(rtmp), shellQuote(rtmp))
+	out, err := sshRunner("ssh", host, "sh -lc "+shellQuote(remote))
+	out = strings.TrimSpace(out)
+	if err != nil {
+		return fmt.Errorf("remote import: %v: %s", err, out)
+	}
+	if out != "" {
+		fmt.Fprintf(os.Stdout, "%s: %s\n", host, out)
+	}
+	return nil
+}
+
+func syncSSHPull(host string, full bool) error {
+	rtmp, err := sshCapture(host, "mktemp -d")
+	if err != nil {
+		return err
+	}
+	exportCmd := "sync export"
+	if full {
+		exportCmd += " --full"
+	}
+	remote := fmt.Sprintf(`d=$(command -v deja || echo "$HOME/.local/bin/deja"); "$d" %s %s`, exportCmd, shellQuote(rtmp))
+	out, err := sshRunner("ssh", host, "sh -lc "+shellQuote(remote))
+	out = strings.TrimSpace(out)
+	if err != nil {
+		return fmt.Errorf("remote export: %v: %s", err, out)
+	}
+	if out != "" {
+		fmt.Fprintf(os.Stdout, "%s: %s\n", host, out)
+	}
+	cleanup := func() {
+		_, _ = sshRunner("ssh", host, "sh -lc "+shellQuote("rm -rf "+shellQuote(rtmp)))
+	}
+	if strings.Contains(out, "exported 0 records") {
+		cleanup()
+		fmt.Fprintln(os.Stdout, "deja: nothing new to pull")
+		return nil
+	}
+	ltmp, err := os.MkdirTemp("", "deja-sync-")
+	if err != nil {
+		cleanup()
+		return err
+	}
+	defer os.RemoveAll(ltmp)
+	if out, err := sshRunner("scp", "-q", host+":"+rtmp+"/*.jsonl", ltmp+"/"); err != nil {
+		cleanup()
+		return fmt.Errorf("scp: %v: %s", err, strings.TrimSpace(out))
+	}
+	cleanup()
+	n, err := index.Import(index.DefaultDir(), ltmp)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "deja: imported %d records\n", n)
+	return nil
+}
+
+func exportBatches(dir string, full bool) (int, error) {
+	if full {
+		return index.ExportFull(index.DefaultDir(), dir)
+	}
+	return index.Export(index.DefaultDir(), dir)
+}
+
+func sshCapture(host, cmd string) (string, error) {
+	out, err := sshRunner("ssh", host, cmd)
+	s := strings.TrimSpace(out)
+	if err != nil {
+		return "", fmt.Errorf("ssh %s: %v: %s", host, err, s)
+	}
+	if s == "" || strings.ContainsAny(s, "'\"\n") {
+		return "", fmt.Errorf("ssh %s: unexpected output %q", host, s)
+	}
+	return s, nil
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}

--- a/cmd/deja/sync_ssh_test.go
+++ b/cmd/deja/sync_ssh_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func setupLocalIndex(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-sshsync")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data := `{"type":"user","sessionId":"ssh1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"sshneedle question"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "ssh1.jsonl"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	return tmp
+}
+
+func TestSyncSSHPush(t *testing.T) {
+	setupLocalIndex(t)
+	var calls [][]string
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	sshRunner = func(name string, args ...string) (string, error) {
+		calls = append(calls, append([]string{name}, args...))
+		if name == "ssh" && args[1] == "mktemp -d" {
+			return "/tmp/remote-batch\n", nil
+		}
+		if name == "ssh" {
+			return "deja: imported 1 records", nil
+		}
+		return "", nil
+	}
+	if err := runSyncSSH([]string{"minihost"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 3 {
+		t.Fatalf("calls = %d, want mktemp+scp+import: %v", len(calls), calls)
+	}
+	if calls[1][0] != "scp" || !strings.HasSuffix(calls[1][len(calls[1])-1], ":/tmp/remote-batch/") {
+		t.Fatalf("bad scp call: %v", calls[1])
+	}
+	if !strings.Contains(calls[2][2], "sync import") || !strings.Contains(calls[2][2], "/tmp/remote-batch") {
+		t.Fatalf("bad remote import call: %v", calls[2])
+	}
+}
+
+func TestSyncSSHPushNothingNew(t *testing.T) {
+	setupLocalIndex(t)
+	var calls int
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	sshRunner = func(name string, args ...string) (string, error) {
+		calls++
+		return "/tmp/x", nil
+	}
+	// First push exports the one record; run it with a runner that accepts it.
+	full := sshRunner
+	sshRunner = func(name string, args ...string) (string, error) {
+		if name == "ssh" && args[1] == "mktemp -d" {
+			return "/tmp/remote-batch", nil
+		}
+		return "deja: imported 1 records", nil
+	}
+	if err := runSyncSSH([]string{"minihost"}); err != nil {
+		t.Fatal(err)
+	}
+	// Second push has nothing new: no ssh/scp calls at all.
+	sshRunner = full
+	calls = 0
+	if err := runSyncSSH([]string{"minihost"}); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected no remote calls on empty export, got %d", calls)
+	}
+}
+
+func TestSyncSSHPull(t *testing.T) {
+	setupLocalIndex(t)
+	base := time.Date(2026, 1, 3, 4, 5, 6, 0, time.UTC)
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	sshRunner = func(name string, args ...string) (string, error) {
+		if name == "ssh" && args[1] == "mktemp -d" {
+			return "/tmp/remote-out", nil
+		}
+		if name == "ssh" && strings.Contains(args[1], "sync export") {
+			return "deja: exported 1 records", nil
+		}
+		if name == "scp" {
+			dest := strings.TrimSuffix(args[len(args)-1], "/")
+			f, err := os.Create(filepath.Join(dest, "deja-sync-remote-1.jsonl"))
+			if err != nil {
+				return "", err
+			}
+			enc := json.NewEncoder(f)
+			_ = enc.Encode(index.SyncRecord{Harness: "claude", SessionID: "remote-ssh", Project: "otherbox", Role: "user", Text: "pullneedle from remote", Time: base})
+			return "", f.Close()
+		}
+		return "", nil
+	}
+	if err := runSyncSSH([]string{"minihost", "--pull"}); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := index.Search(os.Getenv("DEJA_INDEX_DIR"), search.Options{Query: "pullneedle", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || !strings.HasPrefix(ss[0].Project, "imported:") {
+		t.Fatalf("pulled session not searchable: %#v", ss)
+	}
+}
+
+func TestSyncSSHBadArgs(t *testing.T) {
+	if err := runSyncSSH(nil); err == nil {
+		t.Fatal("expected error for missing host")
+	}
+	if err := runSyncSSH([]string{"--evil"}); err == nil {
+		t.Fatal("expected error for flag-looking host")
+	}
+	if err := runSyncSSH([]string{"a", "b"}); err == nil {
+		t.Fatal("expected error for two hosts")
+	}
+}


### PR DESCRIPTION
`deja sync ssh mini` exports new records, copies the batch over ssh, and runs the remote import in one step; `--pull` fetches the remote's new records instead. Uses the system ssh/scp and the remote deja binary (PATH, falling back to ~/.local/bin/deja), so the zero-dependency story holds. `--full` composes with both directions.

Verified live between two machines: push moved 314 records, a second push sent only the delta, pull correctly reported nothing new. Unit tests fake the ssh runner and cover push, pull, empty-delta, and argument validation.

Closes #31