### PR TITLE
docs: catch changelog and reference up to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-14
+
+### Added
+- `deja sync ssh <host>` — one-command sync between machines over system ssh/scp, `--pull` for the reverse direction.
+- `deja sync export --full` re-exports everything regardless of watermarks, for onboarding a new machine.
+- `deja warmup` builds the index without searching.
+- `deja sources` warns when the sqlite3 CLI is missing instead of silently showing zero opencode sessions.
+
+### Fixed
+- Sessions replaced during a non-append index update kept stale posting ordinals and dropped out of search.
+- A bucket file corrupted by a crash now triggers one automatic rebuild instead of erroring until a manual `--rebuild`.
+- Claude project names resolve against the filesystem, so `deja-vu` no longer displays as `deja/vu`.
+
+## [0.5.2] - 2026-07-14
+
+### Fixed
+- Sync-imported records survive full rebuilds and incremental index updates; re-import stays idempotent.
+- Redaction bookkeeping no longer creates phantom source-file entries that purged imported records.
+- Exports skip imported records, so bidirectional sync does not echo history back to its origin.
+- The first record of a sync import got a wrong posting offset and was unsearchable.
+
+## [0.5.1] - 2026-07-14
+
+### Changed
+- `deja share` filters pasted JSON, diff and CLI dumps out of digests.
+- Session titles and stats skip tool-wrapper and caveat noise.
+
 ## [0.5.0] - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ $ deja "jwt refresh token"
 | `deja show <id>` / `deja last [n]` | Read one session / list recent ones. |
 | `deja sources` | Discovered stores, sizes, message and redaction counts. |
 | `deja mcp` | The stdio MCP server (what `deja install` wires in). |
+| `deja warmup` | Build/refresh the index without searching — handy in cron or shell startup. |
 
 Context piping without MCP:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,7 +57,9 @@ Regex search scans records because arbitrary regex cannot use token postings saf
 
 The export watermark is per source path (falling back to session key for synthetic records) and is stored in `manifest.gob` as the max exported record timestamp. Re-running export emits only records with a newer timestamp for that source. Text is redacted again during export.
 
-`deja sync import <dir>` reads all `*.jsonl` batches, appends records to the local index, updates touched token buckets, and writes imported session metadata with the original harness and an `imported:` project prefix. Imported IDs are namespaced (`imported-<hash>`) so they do not clobber local sessions from the same harness. The manifest stores dedupe keys of `harness:session_id:time`, making re-import idempotent.
+`deja sync import <dir>` reads all `*.jsonl` batches, appends records to the local index, updates touched token buckets, and writes imported session metadata with the original harness and an `imported:` project prefix. Imported IDs are namespaced (`imported-<hash>`) so they do not clobber local sessions from the same harness. The manifest stores dedupe keys of `harness:session_id:time`, making re-import idempotent. Imported records live only in the index, so full rebuilds replay them from the old `records.bin` before regenerating from sources, and exports skip them to avoid echoing history back to its origin.
+
+`deja sync ssh <host>` wraps the same export/import in one command: export to a temp dir, scp the batches, run the remote import (system ssh/scp, remote binary from PATH or `~/.local/bin/deja`).
 
 ## Incremental algorithm
 


### PR DESCRIPTION
Changelog entries for 0.5.1–0.6.0, warmup in the CLI table, sync rebuild-survival and ssh transport notes in ARCHITECTURE.