### PR TITLE
feat: deja statusline — recalls served to agents, at a glance

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $ deja "jwt refresh token"
 | `deja sources` | Discovered stores, sizes, message and redaction counts. |
 | `deja mcp` | The stdio MCP server (what `deja install` wires in). |
 | `deja warmup` | Build/refresh the index without searching — handy in cron or shell startup. |
+| `deja statusline` | One line for your status bar: recalls served to agents today. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
 
 Context piping without MCP:
 

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
+	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
 type sessionStartHookResponse struct {
@@ -25,6 +26,7 @@ func runHookContext() error {
 	if digest == "" {
 		return nil
 	}
+	usage.Record(index.DefaultDir(), usage.KindHook, len(digest))
 	var resp sessionStartHookResponse
 	resp.HookSpecificOutput.HookEventName = "SessionStart"
 	resp.HookSpecificOutput.AdditionalContext = digest

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -76,6 +76,8 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 		return installCodex(exe, uninstall)
 	case "opencode":
 		return installOpencode(exe, uninstall)
+	case "statusline":
+		return installStatusline(exe, uninstall)
 	default:
 		return installResult{}, fmt.Errorf("unknown target %q", target)
 	}
@@ -221,6 +223,41 @@ func updateClaudeSessionStartHook(root map[string]any, exe string, uninstall boo
 		delete(root, "hooks")
 	}
 	return root
+}
+
+// installStatusline wires `deja statusline` as the Claude Code status bar.
+// It refuses to replace a statusline the user already configured (many run
+// ccstatusline or their own script) — printing how to combine instead.
+func installStatusline(exe string, uninstall bool) (installResult, error) {
+	h, _ := os.UserHomeDir()
+	path := filepath.Join(h, ".claude", "settings.json")
+	old, _ := os.ReadFile(path)
+	var root map[string]any
+	if len(bytes.TrimSpace(old)) == 0 {
+		root = map[string]any{}
+	} else if err := json.Unmarshal(old, &root); err != nil {
+		return installResult{}, err
+	}
+	cmd := exe + " statusline"
+	existing, _ := root["statusLine"].(map[string]any)
+	if uninstall {
+		if existing == nil || existing["command"] != cmd {
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
+		delete(root, "statusLine")
+	} else {
+		if existing != nil && existing["command"] != cmd {
+			return installResult{}, fmt.Errorf("a statusline is already configured (%v) — append `deja statusline` output to it instead of replacing it", existing["command"])
+		}
+		root["statusLine"] = map[string]any{"type": "command", "command": cmd}
+	}
+	next, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return installResult{}, err
+	}
+	next = append(next, '\n')
+	a, err := writeIfChanged(path, old, next)
+	return installResult{Path: path, Action: a}, err
 }
 
 func installCodex(exe string, uninstall bool) (installResult, error) {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -40,7 +40,7 @@ func loadAll(h string) []model.Session {
 
 func run(args []string) error {
 	if len(args) == 0 {
-		usage()
+		printUsage()
 		return nil
 	}
 	if args[0] == "version" || args[0] == "--version" || args[0] == "-version" {
@@ -53,6 +53,9 @@ func run(args []string) error {
 	}
 	if args[0] == "warmup" {
 		return index.Ensure(index.DefaultDir(), "", false, os.Stderr)
+	}
+	if args[0] == "statusline" {
+		return runStatusline(os.Stdin, os.Stdout)
 	}
 	if args[0] == "stats" {
 		return runStats(args[1:])
@@ -336,7 +339,7 @@ func humanBytes(n int64) string {
 	}
 	return fmt.Sprintf("%.1f %s", f, units[i])
 }
-func usage() {
+func printUsage() {
 	fmt.Println(`deja - persistent memory for coding agents
 
 Usage:
@@ -350,11 +353,12 @@ Usage:
   deja last [n]
   deja sources
   deja warmup
+  deja statusline
   deja stats [--json]
   deja mcp
   deja version
-  deja install <claude-code|codex|opencode|--all>
-  deja uninstall <claude-code|codex|opencode|--all>
+  deja install <claude-code|codex|opencode|statusline|--all>
+  deja uninstall <claude-code|codex|opencode|statusline|--all>
 
 Examples:
   deja "jwt refresh token bug"

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
 const mcpProtocolVersion = "2024-11-05"
@@ -123,7 +124,11 @@ func callMCPTool(name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Query) == "" {
 			return "", fmt.Errorf("query required")
 		}
-		return recallText(a.Query, a.Harness, a.Limit, 4096)
+		text, err := recallText(a.Query, a.Harness, a.Limit, 4096)
+		if err == nil {
+			usage.Record(index.DefaultDir(), usage.KindRecall, len(text))
+		}
+		return text, err
 	case "recall_context":
 		var a struct {
 			Query string `json:"query"`
@@ -134,7 +139,11 @@ func callMCPTool(name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Query) == "" {
 			return "", fmt.Errorf("query required")
 		}
-		return recallContext(a.Query)
+		text, err := recallContext(a.Query)
+		if err == nil {
+			usage.Record(index.DefaultDir(), usage.KindContext, len(text))
+		}
+		return text, err
 	default:
 		return "", fmt.Errorf("unknown tool %q", name)
 	}

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// runStatusline prints one line for a status bar: how much memory deja served
+// to agents today. It must stay fast and quiet — no index access, no locks —
+// because status bars call it constantly.
+func runStatusline(stdin io.Reader, stdout io.Writer) error {
+	drainStdin(stdin)
+	recalls, bytes := usage.Today(index.DefaultDir())
+	if recalls == 0 {
+		fmt.Fprint(stdout, "deja · no recalls yet today")
+		return nil
+	}
+	noun := "recalls"
+	if recalls == 1 {
+		noun = "recall"
+	}
+	fmt.Fprintf(stdout, "deja · %d %s · %s ctx today", recalls, noun, humanBytes(int64(bytes)))
+	return nil
+}
+
+// Claude Code pipes session JSON to statusline commands. We don't need it,
+// but leaving the pipe unread can block the caller on some platforms.
+func drainStdin(r io.Reader) {
+	if f, ok := r.(*os.File); ok {
+		if fi, err := f.Stat(); err != nil || fi.Mode()&os.ModeCharDevice != 0 {
+			return // interactive terminal: nothing piped, don't block
+		}
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(r, 1<<20))
+}

--- a/cmd/deja/statusline_test.go
+++ b/cmd/deja/statusline_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+func TestStatuslineEmpty(t *testing.T) {
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+	var out bytes.Buffer
+	if err := runStatusline(strings.NewReader("{}"), &out); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != "deja · no recalls yet today" {
+		t.Fatalf("empty statusline = %q", got)
+	}
+}
+
+func TestStatuslineCountsRecalls(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	usage.Record(dir, usage.KindRecall, 2048)
+	usage.Record(dir, usage.KindHook, 1024)
+	usage.Record(dir, usage.KindSearch, 4096) // human search, excluded
+	var out bytes.Buffer
+	if err := runStatusline(strings.NewReader(`{"session_id":"x"}`), &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "2 recalls") || !strings.Contains(got, "3.0 KB ctx") {
+		t.Fatalf("statusline = %q", got)
+	}
+}
+
+func TestStatuslineSingular(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	usage.Record(dir, usage.KindContext, 100)
+	var out bytes.Buffer
+	if err := runStatusline(strings.NewReader(""), &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "1 recall ·") {
+		t.Fatalf("statusline = %q", out.String())
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -1,0 +1,127 @@
+// Package usage records when deja serves memory to an agent — MCP recalls
+// and session-start hook injections — so `deja statusline` can show activity.
+// Recording is best-effort by design: a failure to write a usage event must
+// never break the recall path itself.
+package usage
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Event kinds. Search is tracked too but statusline only counts memory
+// served to agents (recall, context, hook).
+const (
+	KindRecall  = "recall"
+	KindContext = "recall_context"
+	KindHook    = "hook"
+	KindSearch  = "search"
+)
+
+type Event struct {
+	Time  time.Time `json:"t"`
+	Kind  string    `json:"kind"`
+	Bytes int       `json:"bytes"`
+}
+
+const (
+	rotateAt   = 1 << 20 // rewrite the log when it grows past 1MB
+	keepWindow = 14 * 24 * time.Hour
+)
+
+// Path returns the usage log location for an index dir: a sibling file, like
+// the .lock file, so it survives full index rebuilds.
+func Path(indexDir string) string {
+	return strings.TrimSuffix(indexDir, string(filepath.Separator)) + ".usage.jsonl"
+}
+
+// Record appends one event. Errors are swallowed on purpose.
+func Record(indexDir, kind string, bytes int) {
+	p := Path(indexDir)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return
+	}
+	rotate(p)
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	b, err := json.Marshal(Event{Time: time.Now().UTC(), Kind: kind, Bytes: bytes})
+	if err != nil {
+		return
+	}
+	_, _ = f.Write(append(b, '\n'))
+}
+
+// Today sums events since local midnight: agent recalls (recall, context,
+// hook) and the context bytes they served.
+func Today(indexDir string) (recalls int, bytes int) {
+	now := time.Now()
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	for _, e := range read(Path(indexDir)) {
+		if e.Time.Before(midnight) {
+			continue
+		}
+		switch e.Kind {
+		case KindRecall, KindContext, KindHook:
+			recalls++
+			bytes += e.Bytes
+		}
+	}
+	return recalls, bytes
+}
+
+func read(p string) []Event {
+	f, err := os.Open(p)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	var out []Event
+	s := bufio.NewScanner(f)
+	s.Buffer(make([]byte, 4096), 1<<20)
+	for s.Scan() {
+		var e Event
+		if json.Unmarshal(s.Bytes(), &e) == nil && !e.Time.IsZero() {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// rotate rewrites the log keeping only the recent window once it grows past
+// rotateAt. Concurrent writers may lose an event during the swap; usage data
+// is advisory, so that trade keeps the hot path lock-free.
+func rotate(p string) {
+	fi, err := os.Stat(p)
+	if err != nil || fi.Size() < rotateAt {
+		return
+	}
+	cutoff := time.Now().UTC().Add(-keepWindow)
+	var keep []Event
+	for _, e := range read(p) {
+		if e.Time.After(cutoff) {
+			keep = append(keep, e)
+		}
+	}
+	tmp := p + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return
+	}
+	for _, e := range keep {
+		if b, err := json.Marshal(e); err == nil {
+			_, _ = f.Write(append(b, '\n'))
+		}
+	}
+	if f.Close() != nil {
+		_ = os.Remove(tmp)
+		return
+	}
+	_ = os.Rename(tmp, p)
+}

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -1,0 +1,79 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRecordAndToday(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	Record(dir, KindRecall, 1000)
+	Record(dir, KindHook, 500)
+	Record(dir, KindSearch, 9999) // human search, not counted
+	recalls, bytes := Today(dir)
+	if recalls != 2 || bytes != 1500 {
+		t.Fatalf("today = %d recalls %d bytes, want 2/1500", recalls, bytes)
+	}
+	if _, err := os.Stat(Path(dir)); err != nil {
+		t.Fatalf("usage log missing: %v", err)
+	}
+}
+
+func TestTodayIgnoresYesterday(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	old := Event{Time: time.Now().UTC().Add(-48 * time.Hour), Kind: KindRecall, Bytes: 700}
+	b, _ := json.Marshal(old)
+	if err := os.WriteFile(Path(dir), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	Record(dir, KindRecall, 300)
+	recalls, bytes := Today(dir)
+	if recalls != 1 || bytes != 300 {
+		t.Fatalf("today = %d/%d, want 1/300", recalls, bytes)
+	}
+}
+
+func TestCorruptLinesIgnored(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	if err := os.WriteFile(Path(dir), []byte("{broken\n\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	Record(dir, KindContext, 42)
+	recalls, bytes := Today(dir)
+	if recalls != 1 || bytes != 42 {
+		t.Fatalf("today = %d/%d, want 1/42", recalls, bytes)
+	}
+}
+
+func TestRotateKeepsRecentWindow(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	p := Path(dir)
+	var sb strings.Builder
+	oldEvent, _ := json.Marshal(Event{Time: time.Now().UTC().Add(-30 * 24 * time.Hour), Kind: KindRecall, Bytes: 1})
+	newEvent, _ := json.Marshal(Event{Time: time.Now().UTC(), Kind: KindRecall, Bytes: 2})
+	for sb.Len() < rotateAt {
+		sb.Write(oldEvent)
+		sb.WriteByte('\n')
+	}
+	sb.Write(newEvent)
+	sb.WriteByte('\n')
+	if err := os.WriteFile(p, []byte(sb.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	Record(dir, KindHook, 3) // triggers rotation
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size() >= rotateAt {
+		t.Fatalf("log not rotated, size %d", fi.Size())
+	}
+	recalls, bytes := Today(dir)
+	if recalls != 2 || bytes != 5 {
+		t.Fatalf("today after rotate = %d/%d, want 2/5", recalls, bytes)
+	}
+}


### PR DESCRIPTION
One line for the status bar: how many times deja fed memory to an agent today and how much context that was. MCP recalls and hook injections append to a sidecar jsonl (best-effort, never blocks the recall path, auto-rotated); `deja statusline` reads it in ~3ms with no index access. `deja install statusline` wires it into Claude Code settings and refuses to touch an existing statusline setup.

Closes #40