### PR TITLE
docs: changelog and site for 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-16
+
+### Added
+- `deja statusline` — one line for your status bar: recalls served to agents today and how much context that was. `deja install statusline` wires it into Claude Code without touching an existing statusline.
+- Session-start auto-recall for Codex (hooks.json) and opencode (generated plugin). `deja install --auto` now covers every harness it finds.
+- `deja hook-context --plain` prints the bare digest for hosts that inject raw text.
+
 ## [0.6.0] - 2026-07-14
 
 ### Added

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,7 +121,7 @@ a:hover{text-decoration:underline}
 
 <section>
   <h2>Memory your agent actually uses</h2>
-  <p class="lead">After <code style="font-family:var(--mono);font-size:.9em">deja install --all</code>, every agent on your machine gets a <span style="font-family:var(--mono);font-size:.9em">recall</span> tool over MCP — add <span style="font-family:var(--mono);font-size:.9em">--auto</span> for a SessionStart hook that feeds relevant memory in on its own.</p>
+  <p class="lead">After <code style="font-family:var(--mono);font-size:.9em">deja install --all</code>, every agent on your machine gets a <span style="font-family:var(--mono);font-size:.9em">recall</span> tool over MCP — add <span style="font-family:var(--mono);font-size:.9em">--auto</span> for session-start auto-recall on Claude Code, Codex and opencode.</p>
   <div class="chat">
     <div class="msg you"><span class="who">you</span><div class="bubble">have we dealt with jwt refresh rotation before? check your memory</div></div>
     <div class="msg ai"><span class="who">AI</span><div class="bubble"><div class="tool">→ recall("jwt refresh rotation")</div>Yes — three weeks ago in the <code>api-gateway</code> project (a Codex session). Login broke after key rotation: the jwks cache wasn't reloaded after <code>rotateKey</code>. You fixed it by reloading the cache and adding a clock-skew test. Want me to apply the same pattern here?</div></div>
@@ -133,7 +133,7 @@ a:hover{text-decoration:underline}
     <div class="card">
       <div class="ic"><svg viewBox="0 0 24 24"><path d="M12 3a9 9 0 1 0 9 9"/><path d="M21 12l-4-3M21 12l-4 2"/></svg></div>
       <h3>Agent memory via MCP</h3>
-      <p><code>recall</code> and <code>recall_context</code> tools, answers under ~4KB. Add <code>--auto</code> and a SessionStart hook feeds project memory in before you ask.</p>
+      <p><code>recall</code> and <code>recall_context</code> tools, answers under ~4KB. Add <code>--auto</code> and project memory lands in Claude Code, Codex and opencode before you ask.</p>
     </div>
     <div class="card">
       <div class="ic"><svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h10"/></svg></div>


### PR DESCRIPTION
Statusline and cross-harness auto-recall in the changelog; site copy mentions all three harnesses.