### PR TITLE
chore: manifests for MCP registry, Glama and Smithery

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "vshulcz"
+  ]
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -37,5 +37,6 @@
     "@vshulcz/deja-vu-linux-amd64": "0.0.0",
     "@vshulcz/deja-vu-windows-arm64": "0.0.0",
     "@vshulcz/deja-vu-windows-amd64": "0.0.0"
-  }
+  },
+  "mcpName": "io.github.vshulcz/deja-vu"
 }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.vshulcz/deja-vu",
+  "description": "Memory layer over the session histories coding agents already write: search, MCP recall, auto-recall, secret redaction, SSH sync.",
+  "repository": {
+    "url": "https://github.com/vshulcz/deja-vu",
+    "source": "github"
+  },
+  "version": "0.7.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@vshulcz/deja-vu",
+      "version": "0.7.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeHint": "npx",
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp",
+          "description": "run the stdio MCP server"
+        }
+      ]
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,7 @@
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties: {}
+  commandFunction: |-
+    (config) => ({ command: "npx", args: ["-y", "@vshulcz/deja-vu", "mcp"] })


### PR DESCRIPTION
server.json for the official MCP registry, mcpName ownership marker in the npm package, glama.json and smithery.yaml. Directory listings feed off these.