### PR TITLE
fix: registry caps server.json description at 100 chars

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vshulcz/deja-vu",
-  "description": "Memory layer over the session histories coding agents already write: search, MCP recall, auto-recall, secret redaction, SSH sync.",
+  "description": "Local memory for coding agents: search, MCP recall, auto-recall, secret redaction, SSH sync.",
   "repository": {
     "url": "https://github.com/vshulcz/deja-vu",
     "source": "github"


### PR DESCRIPTION
The official registry rejected the longer line with a 422.