### PR TITLE
feat: skip subagent transcripts, never lose a torn tail line

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ With `--auto`, a SessionStart hook also feeds the current project's recent memor
 
 ## Security
 
+Subagent transcripts are skipped by default (they mostly duplicate the parent session); set `DEJA_INCLUDE_SUBAGENTS=1` to index them. Files caught mid-write are handled safely — the torn tail line is picked up on the next pass.
+
 Credentials are redacted at index time: AWS keys, generic `api_key=`/`token=` assignments, bearer tokens and raw JWTs, PEM private key blocks, provider tokens (`ghp_`, `sk-`, `npm_`, `xox.`, `AIza`), and `scheme://user:pass@host` URLs. The value is replaced with `[redacted:<kind>]`; surrounding text stays searchable. `deja sources` shows per-store counts. Opt out with `DEJA_NO_REDACT=1` (unsafe). `deja share` and `deja sync export` re-apply redaction on the way out.
 
 ## Supported harnesses

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -44,6 +44,10 @@ type FileState struct {
 	MTime       int64  `json:"mtime"`
 	LastUpdated int64  `json:"last_updated,omitempty"`
 	Redactions  int    `json:"redactions,omitempty"`
+	// SafeSize is the offset just past the last complete line at index time.
+	// A session file caught mid-write ends in a torn line; parsing skips it,
+	// and the next append must resume from here or that message is lost.
+	SafeSize int64 `json:"safe_size,omitempty"`
 }
 
 type SessionMeta struct {
@@ -1058,13 +1062,17 @@ func parseChangedFile(harness, p string, old FileState) ([]model.Session, error)
 }
 
 func parseAppendedFile(harness, p string, old FileState) ([]model.Session, error) {
+	from := old.SafeSize
+	if from == 0 || from > old.Size {
+		from = old.Size
+	}
 	switch harnessForPath(p) {
 	case "claude":
-		return sources.ParseClaudeFileFromOffset(p, old.Size)
+		return sources.ParseClaudeFileFromOffset(p, from)
 	case "codex-history":
-		return sources.ParseCodexHistoryFromOffset(p, old.Size)
+		return sources.ParseCodexHistoryFromOffset(p, from)
 	case "codex":
-		return sources.ParseCodexRolloutFromOffset(p, old.Size)
+		return sources.ParseCodexRolloutFromOffset(p, from)
 	case "opencode":
 		if old.LastUpdated > 0 {
 			return sources.ParseOpencodeDBSince(p, time.Unix(0, old.LastUpdated))
@@ -1118,7 +1126,7 @@ func currentFiles(h string) map[string]FileState {
 		})
 	}
 	if h == "" || h == "claude" {
-		addWalk(sources.ClaudeRoot(), func(p string) bool { return strings.HasSuffix(p, ".jsonl") })
+		addWalk(sources.ClaudeRoot(), sources.ClaudeFileWanted)
 	}
 	if h == "" || h == "codex" {
 		addWalk(filepath.Join(sources.CodexRoot(), "sessions"), func(p string) bool {
@@ -1132,10 +1140,46 @@ func currentFiles(h string) map[string]FileState {
 	out := map[string]FileState{}
 	for p := range paths {
 		if fi, err := os.Lstat(p); err == nil && fi.Mode()&os.ModeSymlink == 0 && !fi.IsDir() {
-			out[p] = FileState{Path: p, Size: fi.Size(), MTime: fi.ModTime().UnixNano()}
+			fs := FileState{Path: p, Size: fi.Size(), MTime: fi.ModTime().UnixNano()}
+			if strings.HasSuffix(p, ".jsonl") {
+				fs.SafeSize = lastCompleteLineOffset(p, fi.Size())
+			}
+			out[p] = fs
 		}
 	}
 	return out
+}
+
+// lastCompleteLineOffset finds the offset just past the final newline, so an
+// append can resume without re-reading or losing a torn tail line. Reads at
+// most the last 64KB; a longer unterminated tail falls back to full size.
+func lastCompleteLineOffset(p string, size int64) int64 {
+	if size == 0 {
+		return 0
+	}
+	f, err := os.Open(p)
+	if err != nil {
+		return size
+	}
+	defer func() { _ = f.Close() }()
+	const window = 64 * 1024
+	start := size - window
+	if start < 0 {
+		start = 0
+	}
+	buf := make([]byte, size-start)
+	if _, err := f.ReadAt(buf, start); err != nil {
+		return size
+	}
+	for i := len(buf) - 1; i >= 0; i-- {
+		if buf[i] == '\n' {
+			return start + int64(i) + 1
+		}
+	}
+	if start == 0 {
+		return 0
+	}
+	return size
 }
 
 func manifestFresh(m Manifest, files map[string]FileState, scope string) bool {

--- a/internal/index/ingest_safety_test.go
+++ b/internal/index/ingest_safety_test.go
@@ -1,0 +1,127 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func writeClaudeLine(t *testing.T, path, sid, text string, partial bool) {
+	t.Helper()
+	line := `{"type":"user","sessionId":"` + sid + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}`
+	if !partial {
+		line += "\n"
+	} else {
+		line = line[:len(line)/2] // torn mid-write
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(line); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A session file caught mid-write must not lose the torn line: the next
+// index pass picks it up exactly once.
+func TestTornTailLineIndexedOnce(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-torn")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(proj, "t1.jsonl")
+	writeClaudeLine(t, file, "t1", "first tornneedle message", false)
+	// torn second line: writer got interrupted mid-json
+	writeClaudeLine(t, file, "t1", "second tornneedle message", true)
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	o := search.Options{Query: "tornneedle", All: true}
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := Search(dir, o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || len(ss[0].Messages) != 1 {
+		t.Fatalf("initial index: %#v", ss)
+	}
+
+	// writer finishes the line: complete the torn json and append a newline
+	full := `{"type":"user","sessionId":"t1","timestamp":"2026-01-02T03:06:05Z","message":{"role":"user","content":"second tornneedle message"}}`
+	b, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	safe := 0
+	for i := len(b) - 1; i >= 0; i-- {
+		if b[i] == '\n' {
+			safe = i + 1
+			break
+		}
+	}
+	if err := os.WriteFile(file, append(b[:safe], []byte(full+"\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	ss, err = Search(dir, o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || len(ss[0].Messages) != 2 {
+		t.Fatalf("after completing torn line: want 2 messages exactly once, got %#v", ss)
+	}
+}
+
+// Subagent transcripts are skipped by default and included with the env flag.
+func TestSubagentTranscriptsSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-sub")
+	sub := filepath.Join(proj, "subagents")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	main := `{"type":"user","sessionId":"m1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"mainneedle question"}}` + "\n"
+	agent := `{"type":"user","sessionId":"a1","timestamp":"2026-01-02T03:04:06Z","message":{"role":"user","content":"subneedle question"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "m1.jsonl"), []byte(main), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "a1.jsonl"), []byte(agent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	if err := EnsureForSearch(dir, search.Options{Query: "subneedle"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if ss, err := Search(dir, search.Options{Query: "subneedle", All: true}); err != nil || len(ss) != 0 {
+		t.Fatalf("subagent indexed by default: %#v err=%v", ss, err)
+	}
+	if ss, err := Search(dir, search.Options{Query: "mainneedle", All: true}); err != nil || len(ss) != 1 {
+		t.Fatalf("main session missing: %#v err=%v", ss, err)
+	}
+
+	t.Setenv("DEJA_INCLUDE_SUBAGENTS", "1")
+	dir2 := filepath.Join(tmp, "index2.db")
+	if err := EnsureForSearch(dir2, search.Options{Query: "subneedle"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if ss, err := Search(dir2, search.Options{Query: "subneedle", All: true}); err != nil || len(ss) != 1 {
+		t.Fatalf("opt-in did not index subagent: %#v err=%v", ss, err)
+	}
+}

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -15,8 +15,21 @@ func ClaudeRoot() string {
 
 func LoadClaude() []model.Session {
 	root := ClaudeRoot()
-	files := walkFiles(root, func(p string) bool { return strings.HasSuffix(p, ".jsonl") })
+	files := walkFiles(root, ClaudeFileWanted)
 	return parseFiles(files, ParseClaudeFile)
+}
+
+// ClaudeFileWanted reports whether a path under the Claude root belongs in
+// the index. Subagent transcripts mostly duplicate their parent session, so
+// they are skipped unless DEJA_INCLUDE_SUBAGENTS=1.
+func ClaudeFileWanted(p string) bool {
+	if !strings.HasSuffix(p, ".jsonl") {
+		return false
+	}
+	if os.Getenv("DEJA_INCLUDE_SUBAGENTS") == "1" {
+		return true
+	}
+	return !strings.Contains(p, string(filepath.Separator)+"subagents"+string(filepath.Separator))
 }
 
 func ParseClaudeFile(path string) ([]model.Session, error) {


### PR DESCRIPTION
Two ingest-safety changes. Subagent transcripts are skipped by default (they mostly duplicate the parent session; DEJA_INCLUDE_SUBAGENTS=1 opts in). And instead of skipping actively-written files, the manifest now records the offset of the last complete line — a session file caught mid-write parses cleanly and the torn line is picked up exactly once on the next pass. Previously that message was silently lost because the next append resumed past it.

Both covered by regression tests; the torn-tail test fails on the old code.

Closes #43