### PR TITLE
feat: deja resume — reopen a found session in its native harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ $ deja "jwt refresh token"
 | `deja stats` | Totals, per-harness split, top projects, monthly sparkline. `--json` too. |
 | `deja sync export <dir> [--full]` / `import <dir>` / `ssh <host> [--pull]` | Move memory between machines — via a shared folder or one ssh command. Watermarked, append-only, idempotent. |
 | `deja show <id>` / `deja last [n]` | Read one session / list recent ones. |
+| `deja resume <id> [--exec]` | Reopen a found session in its native harness (`claude --resume`, `codex resume`, `opencode -s`). |
 | `deja sources` | Discovered stores, sizes, message and redaction counts. |
 | `deja mcp` | The stdio MCP server (what `deja install` wires in). |
 | `deja warmup` | Build/refresh the index without searching — handy in cron or shell startup. |

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -91,6 +91,9 @@ func run(args []string) error {
 	if args[0] == "share" {
 		return runShare(args[1:], os.Stdout)
 	}
+	if args[0] == "resume" {
+		return runResume(args[1:], os.Stdout)
+	}
 	if args[0] == "sync" {
 		return runSync(args[1:])
 	}
@@ -347,6 +350,7 @@ Usage:
   deja [flags] <query>
   deja show <id-prefix>
   deja share <id-prefix>
+  deja resume <id-prefix> [--exec]
   deja ctx <query|id-prefix>
   deja sync export <dir> [--full]
   deja sync import <dir>

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// runResume turns a found session into the command that reopens it in its
+// native harness. Prints the command by default; --exec runs it with the
+// terminal attached.
+func runResume(args []string, stdout io.Writer) error {
+	if len(args) < 1 {
+		return fmt.Errorf("resume needs id-prefix")
+	}
+	doExec := false
+	prefix := ""
+	for _, a := range args {
+		if a == "--exec" {
+			doExec = true
+			continue
+		}
+		prefix = a
+	}
+	if prefix == "" {
+		return fmt.Errorf("resume needs id-prefix")
+	}
+	s, ok, err := findByPrefix(prefix)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("no session matches %q", prefix)
+	}
+	dir, cmdline, err := resumeCommand(s)
+	if err != nil {
+		return err
+	}
+	if !doExec {
+		if dir != "" {
+			fmt.Fprintf(stdout, "cd %s && %s\n", shellQuote(dir), cmdline)
+		} else {
+			fmt.Fprintln(stdout, cmdline)
+		}
+		return nil
+	}
+	parts := strings.Fields(cmdline)
+	c := exec.Command(parts[0], parts[1:]...)
+	if dir != "" {
+		c.Dir = dir
+	}
+	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+	return c.Run()
+}
+
+// resumeCommand maps a session to (workdir, command). workdir is empty when
+// the harness resumes globally or the original directory is unknown.
+func resumeCommand(s model.Session) (string, string, error) {
+	if strings.HasPrefix(s.Project, "imported:") {
+		return "", "", fmt.Errorf("session %s was synced from another machine — resume it there", short(s.ID))
+	}
+	switch s.Harness {
+	case "claude":
+		return claudeProjectDirFor(s), "claude --resume " + s.ID, nil
+	case "codex":
+		if s.Project == "history" {
+			return "", "", fmt.Errorf("session %s is a one-off codex exec entry, nothing to resume", short(s.ID))
+		}
+		return "", "codex resume " + s.ID, nil
+	case "opencode":
+		dir := ""
+		if s.Path != "" && s.Path != sources.OpencodeDB() {
+			dir = s.Path // opencode sessions carry their project directory
+		}
+		return dir, "opencode -s " + s.ID, nil
+	default:
+		return "", "", fmt.Errorf("don't know how to resume %q sessions", s.Harness)
+	}
+}
+
+// claudeProjectDirFor recovers the original working directory from the
+// transcript location when the encoded project dir still exists on disk.
+func claudeProjectDirFor(s model.Session) string {
+	if s.Path == "" {
+		return ""
+	}
+	base := sources.ClaudeProjectDirBase(s.Path)
+	if base == "" {
+		return ""
+	}
+	return sources.ResolveEncodedPath(base)
+}
+
+func short(s string) string {
+	if len(s) > 12 {
+		return s[:12]
+	}
+	return s
+}

--- a/cmd/deja/resume_test.go
+++ b/cmd/deja/resume_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestResumeCommandPerHarness(t *testing.T) {
+	tmp := t.TempDir()
+	real := filepath.Join(tmp, "projects", "my-app")
+	if err := os.MkdirAll(real, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	encoded := strings.ReplaceAll(real, string(filepath.Separator), "-")
+	claudePath := filepath.Join("/claude/projects", encoded, "abc.jsonl")
+
+	cases := []struct {
+		name    string
+		s       model.Session
+		wantDir string
+		wantCmd string
+		wantErr string
+	}{
+		{"claude with resolvable dir", model.Session{Harness: "claude", ID: "abc-123", Project: "projects/my-app", Path: claudePath}, real, "claude --resume abc-123", ""},
+		{"codex rollout", model.Session{Harness: "codex", ID: "uuid-1", Project: "my-app"}, "", "codex resume uuid-1", ""},
+		{"codex history entry", model.Session{Harness: "codex", ID: "uuid-2", Project: "history"}, "", "", "nothing to resume"},
+		{"opencode with dir", model.Session{Harness: "opencode", ID: "ses_1", Project: "my-app", Path: real}, real, "opencode -s ses_1", ""},
+		{"imported", model.Session{Harness: "claude", ID: "imported-9f5", Project: "imported:my-app"}, "", "", "another machine"},
+		{"unknown harness", model.Session{Harness: "mystery", ID: "x"}, "", "", "don't know how"},
+	}
+	for _, c := range cases {
+		dir, cmd, err := resumeCommand(c.s)
+		if c.wantErr != "" {
+			if err == nil || !strings.Contains(err.Error(), c.wantErr) {
+				t.Fatalf("%s: err = %v, want %q", c.name, err, c.wantErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		if dir != c.wantDir || cmd != c.wantCmd {
+			t.Fatalf("%s: got (%q, %q), want (%q, %q)", c.name, dir, cmd, c.wantDir, c.wantCmd)
+		}
+	}
+}

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -174,3 +174,18 @@ func resolveEncodedPath(base string) string {
 // ClaudeProjectName derives the display project name using the same rules as
 // the Claude source parser.
 func ClaudeProjectName(dir string) string { return claudeProjectName(dir) }
+
+// ClaudeProjectDirBase returns the encoded project dir name for a transcript
+// path, e.g. "-Users-x-projects-app" for .../projects/-Users-x-projects-app/s.jsonl.
+func ClaudeProjectDirBase(path string) string {
+	dir := claudeProjectDir(path)
+	base := filepath.Base(dir)
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		return ""
+	}
+	return base
+}
+
+// ResolveEncodedPath maps an encoded project dir name back to the real
+// directory when it still exists on disk; empty string otherwise.
+func ResolveEncodedPath(base string) string { return resolveEncodedPath(base) }


### PR DESCRIPTION
Search finds the session; resume continues it. `deja resume <id-prefix>` prints the right command per harness — `claude --resume`, `codex resume`, `opencode -s` — with the original working directory recovered from the encoded transcript path when it still exists. `--exec` runs it with the terminal attached. Synced sessions from another machine get a clear error instead of a broken command.

Closes #42