### PR TITLE
chore: Dockerfile and richer MCP tool descriptions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/deja ./cmd/deja
+
+# Runtime: sqlite3 is only needed when an opencode store is mounted in
+FROM alpine:3.20
+RUN apk add --no-cache sqlite
+COPY --from=build /out/deja /usr/local/bin/deja
+ENTRYPOINT ["deja"]
+CMD ["mcp"]

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -75,13 +75,13 @@ func handleMCP(req rpcRequest) (any, int, string) {
 		return map[string]any{"tools": []map[string]any{
 			{
 				"name":        "recall",
-				"description": "Recall prior coding-agent sessions matching a query as dense text under about 4KB by default.",
-				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string"}, "harness": map[string]any{"type": "string"}, "limit": map[string]any{"type": "number"}}, "required": []string{"query"}},
+				"description": "Search past coding-agent sessions (Claude Code, Codex, opencode) indexed on this machine and return the best matches as dense text under ~4KB. Use before debugging or re-implementing something: prior sessions often contain the exact fix, error message, or command. Query works best with specific tokens — an error string, function name, or flag.",
+				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "Search terms; specific tokens (error strings, function names, flags) match best. Multiple words are ANDed."}, "harness": map[string]any{"type": "string", "description": "Optional filter: claude, codex or opencode."}, "limit": map[string]any{"type": "number", "description": "Max sessions to return (default 5)."}}, "required": []string{"query"}},
 			},
 			{
 				"name":        "recall_context",
-				"description": "Return the deja ctx markdown digest for the best matching prior session.",
-				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string"}}, "required": []string{"query"}},
+				"description": "Return a markdown digest (~8KB) of the single best-matching prior session — the full problem/solution arc, not just snippets. Use after recall points at a session and more detail is needed.",
+				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "Search terms identifying the session to digest."}}, "required": []string{"query"}},
 			},
 		}}, 0, ""
 	case "tools/call":


### PR DESCRIPTION
Glama builds a release from a Dockerfile to run security and coherence checks; verified locally that the image builds and the MCP server answers initialize. Tool and parameter descriptions now carry when-to-use guidance, which is also what their tool-quality scoring reads.