### PR TITLE
feat: index aider chat history

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -35,6 +35,9 @@ func loadAll(h string) []model.Session {
 	if h == "" || h == "opencode" {
 		ss = append(ss, sources.LoadOpencode()...)
 	}
+	if h == "" || h == "aider" {
+		ss = append(ss, sources.LoadAider()...)
+	}
 	return ss
 }
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -448,6 +448,9 @@ func load(h string) []model.Session {
 	if h == "" || h == "opencode" {
 		ss = append(ss, sources.LoadOpencode()...)
 	}
+	if h == "" || h == "aider" {
+		ss = append(ss, sources.LoadAider()...)
+	}
 	return ss
 }
 
@@ -1056,6 +1059,8 @@ func parseChangedFile(harness, p string, old FileState) ([]model.Session, error)
 			return sources.ParseOpencodeDBSince(p, time.Unix(0, old.LastUpdated))
 		}
 		return sources.ParseOpencodeDB(p)
+	case "aider":
+		return sources.ParseAiderFile(p)
 	default:
 		return nil, nil
 	}
@@ -1095,6 +1100,9 @@ func harnessForPath(p string) string {
 	}
 	if strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, sources.ClaudeRoot()) {
 		return "claude"
+	}
+	if filepath.Base(p) == ".aider.chat.history.md" {
+		return "aider"
 	}
 	return ""
 }
@@ -1136,6 +1144,11 @@ func currentFiles(h string) map[string]FileState {
 	}
 	if h == "" || h == "opencode" {
 		paths[sources.OpencodeDB()] = true
+	}
+	if h == "" || h == "aider" {
+		for _, p := range sources.AiderFiles() {
+			paths[p] = true
+		}
 	}
 	out := map[string]FileState{}
 	for p := range paths {

--- a/internal/sources/aider.go
+++ b/internal/sources/aider.go
@@ -1,0 +1,184 @@
+package sources
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// aider writes one markdown file per launch directory, appending forever:
+// sessions start with "# aider chat started at <ts>", user input lines are
+// prefixed "#### ", tool/system output "> ", and assistant output is raw
+// markdown in between. Fenced code blocks may contain any of those prefixes,
+// so the parser tracks fences.
+
+const aiderHistoryName = ".aider.chat.history.md"
+
+// AiderFiles returns history files to index: $HOME plus any directories
+// listed in DEJA_AIDER_ROOTS (colon-separated, scanned two levels deep —
+// scanning all of $HOME would make warmup unusable).
+func AiderFiles() []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(p string) {
+		if seen[p] {
+			return
+		}
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	add(filepath.Join(Home(), aiderHistoryName))
+	for _, root := range filepath.SplitList(os.Getenv("DEJA_AIDER_ROOTS")) {
+		if root == "" {
+			continue
+		}
+		add(filepath.Join(root, aiderHistoryName))
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			add(filepath.Join(root, e.Name(), aiderHistoryName))
+			sub, err := os.ReadDir(filepath.Join(root, e.Name()))
+			if err != nil {
+				continue
+			}
+			for _, s := range sub {
+				if s.IsDir() {
+					add(filepath.Join(root, e.Name(), s.Name(), aiderHistoryName))
+				}
+			}
+		}
+	}
+	return out
+}
+
+func LoadAider() []model.Session {
+	return parseFiles(AiderFiles(), ParseAiderFile)
+}
+
+const aiderSessionMark = "# aider chat started at "
+
+func ParseAiderFile(path string) ([]model.Session, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	project := projectName(filepath.Dir(path))
+	var out []model.Session
+	var cur *model.Session
+	var role string
+	var buf []string
+	inFence := false
+	idx := 0
+
+	flush := func() {
+		if cur == nil || len(buf) == 0 {
+			role, buf = "", nil
+			return
+		}
+		text := strings.TrimSpace(strings.Join(buf, "\n"))
+		if text != "" && role != "" {
+			cur.Messages = append(cur.Messages, model.Message{Role: role, Text: text, Time: cur.Started})
+		}
+		role, buf = "", nil
+	}
+	endSession := func() {
+		flush()
+		if cur != nil && len(cur.Messages) > 0 {
+			out = append(out, *cur)
+		}
+		cur = nil
+	}
+
+	s := bufio.NewScanner(f)
+	s.Buffer(make([]byte, 64*1024), 8*1024*1024)
+	for s.Scan() {
+		line := strings.TrimRight(s.Text(), " \t")
+		if !inFence && strings.HasPrefix(line, aiderSessionMark) {
+			endSession()
+			idx++
+			ts, _ := time.ParseInLocation("2006-01-02 15:04:05", strings.TrimSpace(strings.TrimPrefix(line, aiderSessionMark)), time.Local)
+			id := aiderSessionID(path, idx)
+			cur = &model.Session{Harness: "aider", ID: id, Project: project, Path: path, Started: ts, Updated: ts}
+			inFence = false
+			continue
+		}
+		if cur == nil {
+			continue
+		}
+		if strings.HasPrefix(line, "```") {
+			inFence = !inFence
+			if role == "" {
+				role = "assistant"
+			}
+			buf = append(buf, line)
+			continue
+		}
+		if inFence {
+			buf = append(buf, line)
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "#### "):
+			if role != "user" {
+				flush()
+				role = "user"
+			}
+			t := strings.TrimPrefix(line, "#### ")
+			if t == "<blank>" {
+				t = ""
+			}
+			buf = append(buf, t)
+		case strings.HasPrefix(line, "> "), line == ">":
+			// tool/system output: ends any assistant block, not indexed as a message
+			flush()
+		case strings.TrimSpace(line) == "":
+			buf = append(buf, "")
+		default:
+			if role != "assistant" {
+				flush()
+				role = "assistant"
+			}
+			buf = append(buf, line)
+		}
+	}
+	endSession()
+	if err := s.Err(); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+// aider has no session ids; derive a stable one from file path + ordinal.
+func aiderSessionID(path string, idx int) string {
+	h := sha1.Sum([]byte(path))
+	return "aider-" + hex.EncodeToString(h[:6]) + "-" + itoa(idx)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [8]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/internal/sources/aider_test.go
+++ b/internal/sources/aider_test.go
@@ -1,0 +1,103 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const aiderFixture = `# aider chat started at 2026-07-16 10:32:01
+
+> /usr/local/bin/aider --model sonnet
+> Aider v0.86.1
+
+#### fix the off-by-one in pager.go
+#### keep the tests green
+
+I'll fix the loop bound:
+
+` + "```go" + `
+for i := 0; i < n; i++ {
+#### this is code, not a user line
+> and this is not tool output
+` + "```" + `
+
+> Applied edit to pager.go
+> Commit a1b2c3d fix: off-by-one
+
+#### <blank>
+
+# aider chat started at 2026-07-16 11:00:00
+
+#### second session question
+
+Second session answer here.
+`
+
+func TestParseAiderFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".aider.chat.history.md")
+	if err := os.WriteFile(p, []byte(aiderFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseAiderFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 2 {
+		t.Fatalf("sessions = %d, want 2", len(ss))
+	}
+	s1 := ss[0]
+	if s1.Harness != "aider" || s1.Started.Hour() != 10 {
+		t.Fatalf("bad session meta: %#v", s1)
+	}
+	if len(s1.Messages) != 2 {
+		t.Fatalf("s1 messages = %d, want user+assistant: %#v", len(s1.Messages), s1.Messages)
+	}
+	if s1.Messages[0].Role != "user" || s1.Messages[0].Text != "fix the off-by-one in pager.go\nkeep the tests green" {
+		t.Fatalf("user message wrong: %#v", s1.Messages[0])
+	}
+	a := s1.Messages[1]
+	if a.Role != "assistant" {
+		t.Fatalf("assistant role wrong: %#v", a)
+	}
+	// fence content preserved verbatim, prefixes inside not treated as boundaries
+	for _, want := range []string{"loop bound", "#### this is code", "> and this is not tool output"} {
+		if !strings.Contains(a.Text, want) {
+			t.Fatalf("assistant text missing %q: %q", want, a.Text)
+		}
+	}
+	s2 := ss[1]
+	if len(s2.Messages) != 2 || s2.Messages[0].Text != "second session question" || s2.Messages[1].Text != "Second session answer here." {
+		t.Fatalf("s2 wrong: %#v", s2.Messages)
+	}
+	if s1.ID == s2.ID || s1.ID == "" {
+		t.Fatalf("session ids not distinct: %q %q", s1.ID, s2.ID)
+	}
+}
+
+func TestAiderFilesDiscovery(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	roots := t.TempDir()
+	proj := filepath.Join(roots, "group", "proj")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{
+		filepath.Join(home, ".aider.chat.history.md"),
+		filepath.Join(roots, ".aider.chat.history.md"),
+		filepath.Join(proj, ".aider.chat.history.md"),
+	} {
+		if err := os.WriteFile(p, []byte("# aider chat started at 2026-01-01 00:00:00\n#### q\nans\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_AIDER_ROOTS", roots)
+	files := AiderFiles()
+	if len(files) != 3 {
+		t.Fatalf("discovered %d files, want 3: %v", len(files), files)
+	}
+}


### PR DESCRIPTION
Fourth harness. aider appends markdown per launch directory: sessions split on the started-at header, #### lines are user input, > lines are tool output, everything else is the assistant. The parser tracks code fences so those prefixes inside snippets stay content — the reference implementation in another tool gets the roles backwards, so this one follows aider's own io.py. Discovery covers $HOME plus DEJA_AIDER_ROOTS (scanning all of home would wreck warmup).

Closes #6