### PR TITLE
feat: index Gemini CLI chat history

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -38,6 +38,9 @@ func loadAll(h string) []model.Session {
 	if h == "" || h == "aider" {
 		ss = append(ss, sources.LoadAider()...)
 	}
+	if h == "" || h == "gemini" {
+		ss = append(ss, sources.LoadGemini()...)
+	}
 	return ss
 }
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -451,6 +451,9 @@ func load(h string) []model.Session {
 	if h == "" || h == "aider" {
 		ss = append(ss, sources.LoadAider()...)
 	}
+	if h == "" || h == "gemini" {
+		ss = append(ss, sources.LoadGemini()...)
+	}
 	return ss
 }
 
@@ -1061,6 +1064,8 @@ func parseChangedFile(harness, p string, old FileState) ([]model.Session, error)
 		return sources.ParseOpencodeDB(p)
 	case "aider":
 		return sources.ParseAiderFile(p)
+	case "gemini":
+		return sources.ParseGeminiFile(p)
 	default:
 		return nil, nil
 	}
@@ -1103,6 +1108,9 @@ func harnessForPath(p string) string {
 	}
 	if filepath.Base(p) == ".aider.chat.history.md" {
 		return "aider"
+	}
+	if strings.HasPrefix(p, filepath.Join(sources.GeminiRoot(), "tmp")) && (strings.HasSuffix(p, ".json") || strings.HasSuffix(p, ".jsonl")) {
+		return "gemini"
 	}
 	return ""
 }
@@ -1147,6 +1155,11 @@ func currentFiles(h string) map[string]FileState {
 	}
 	if h == "" || h == "aider" {
 		for _, p := range sources.AiderFiles() {
+			paths[p] = true
+		}
+	}
+	if h == "" || h == "gemini" {
+		for _, p := range sources.GeminiChatFiles() {
 			paths[p] = true
 		}
 	}

--- a/internal/sources/gemini.go
+++ b/internal/sources/gemini.go
@@ -1,0 +1,253 @@
+package sources
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Gemini CLI records chats under ~/.gemini/tmp/<projectId>/chats/ in two
+// generations: whole-session JSON files and newer JSONL logs where the first
+// line is metadata and later lines are messages, "$set" metadata patches, or
+// "$rewindTo" truncation markers. Project ids are either path-hashes or
+// slugs; ~/.gemini/projects.json maps real paths to ids.
+
+func GeminiRoot() string {
+	return EnvPath("DEJA_GEMINI_ROOT", filepath.Join(Home(), ".gemini"))
+}
+
+func GeminiChatFiles() []string {
+	root := filepath.Join(GeminiRoot(), "tmp")
+	var out []string
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		chats := filepath.Join(root, e.Name(), "chats")
+		_ = filepath.WalkDir(chats, func(p string, d os.DirEntry, err error) error {
+			if err == nil && !d.IsDir() && (strings.HasSuffix(p, ".json") || strings.HasSuffix(p, ".jsonl")) {
+				out = append(out, p)
+			}
+			return nil
+		})
+	}
+	return out
+}
+
+func LoadGemini() []model.Session {
+	ss := parseFiles(GeminiChatFiles(), ParseGeminiFile)
+	return dedupeGeminiSessions(ss)
+}
+
+// A session resumed from an old .json gets rewritten as .jsonl — keep the
+// jsonl (richer, current) when both exist.
+func dedupeGeminiSessions(ss []model.Session) []model.Session {
+	best := map[string]int{}
+	var out []model.Session
+	for _, s := range ss {
+		key := s.Harness + ":" + s.ID
+		if i, ok := best[key]; ok {
+			if strings.HasSuffix(s.Path, ".jsonl") {
+				out[i] = s
+			}
+			continue
+		}
+		best[key] = len(out)
+		out = append(out, s)
+	}
+	return out
+}
+
+func ParseGeminiFile(path string) ([]model.Session, error) {
+	if strings.HasSuffix(path, ".jsonl") {
+		return parseGeminiJSONL(path)
+	}
+	return parseGeminiJSON(path)
+}
+
+type geminiMessage struct {
+	ID        string          `json:"id"`
+	Timestamp string          `json:"timestamp"`
+	Type      string          `json:"type"`
+	Content   json.RawMessage `json:"content"`
+	Model     string          `json:"model"`
+}
+
+func parseGeminiJSON(path string) ([]model.Session, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var doc struct {
+		SessionID   string          `json:"sessionId"`
+		StartTime   string          `json:"startTime"`
+		LastUpdated string          `json:"lastUpdated"`
+		Messages    []geminiMessage `json:"messages"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return nil, nil // not a session file (e.g. checkpoint) — skip quietly
+	}
+	if doc.SessionID == "" {
+		return nil, nil
+	}
+	s := geminiSessionShell(path, doc.SessionID, doc.StartTime, doc.LastUpdated)
+	appendGeminiMessages(&s, doc.Messages)
+	if len(s.Messages) == 0 {
+		return nil, nil
+	}
+	return []model.Session{s}, nil
+}
+
+func parseGeminiJSONL(path string) ([]model.Session, error) {
+	var s model.Session
+	started := false
+	var msgs []geminiMessage
+	err := scanJSONLFromOffset(path, 0, func(m map[string]any) {
+		if !started {
+			id, _ := m["sessionId"].(string)
+			if id == "" {
+				return
+			}
+			st, _ := m["startTime"].(string)
+			lu, _ := m["lastUpdated"].(string)
+			s = geminiSessionShell(path, id, st, lu)
+			started = true
+			return
+		}
+		if patch, ok := m["$set"].(map[string]any); ok {
+			if lu, _ := patch["lastUpdated"].(string); lu != "" {
+				if t, err := time.Parse(time.RFC3339Nano, lu); err == nil {
+					s.Touch(t)
+				}
+			}
+			return
+		}
+		if rid, ok := m["$rewindTo"].(string); ok {
+			for i := len(msgs) - 1; i >= 0; i-- {
+				if msgs[i].ID == rid {
+					msgs = msgs[:i]
+					break
+				}
+			}
+			return
+		}
+		raw, _ := json.Marshal(m)
+		var gm geminiMessage
+		if json.Unmarshal(raw, &gm) == nil && gm.Type != "" {
+			msgs = append(msgs, gm)
+		}
+	})
+	if !started {
+		return nil, err
+	}
+	appendGeminiMessages(&s, msgs)
+	if len(s.Messages) == 0 {
+		return nil, err
+	}
+	return []model.Session{s}, err
+}
+
+func geminiSessionShell(path, id, startTime, lastUpdated string) model.Session {
+	s := model.Session{Harness: "gemini", ID: id, Project: geminiProjectName(path), Path: path}
+	if t, err := time.Parse(time.RFC3339Nano, startTime); err == nil {
+		s.Touch(t)
+	}
+	if t, err := time.Parse(time.RFC3339Nano, lastUpdated); err == nil {
+		s.Touch(t)
+	}
+	return s
+}
+
+func appendGeminiMessages(s *model.Session, msgs []geminiMessage) {
+	for _, m := range msgs {
+		role := ""
+		switch m.Type {
+		case "user":
+			role = "user"
+		case "gemini", "model":
+			role = "assistant"
+		default:
+			continue // info/error/warning noise
+		}
+		text := geminiContentText(m.Content)
+		if text == "" {
+			continue
+		}
+		t, _ := time.Parse(time.RFC3339Nano, m.Timestamp)
+		s.Touch(t)
+		s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: t})
+	}
+}
+
+// content is a string or an array of Part objects ({"text": ...} и др.)
+func geminiContentText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var str string
+	if json.Unmarshal(raw, &str) == nil {
+		return str
+	}
+	var parts []map[string]any
+	if json.Unmarshal(raw, &parts) == nil {
+		var b strings.Builder
+		for _, p := range parts {
+			if t, _ := p["text"].(string); t != "" {
+				if b.Len() > 0 {
+					b.WriteByte('\n')
+				}
+				b.WriteString(t)
+			}
+		}
+		return b.String()
+	}
+	return ""
+}
+
+// geminiProjectName resolves .gemini/tmp/<id>/chats/x -> a display name:
+// projects.json reverse mapping first, then a .project_root marker, then the
+// raw id (slug or hash).
+func geminiProjectName(path string) string {
+	idDir := filepath.Dir(filepath.Dir(path)) // .../tmp/<id>
+	// subagent files nest one deeper: chats/<parent>/<sid>.jsonl
+	if filepath.Base(filepath.Dir(path)) != "chats" && filepath.Base(idDir) == "chats" {
+		idDir = filepath.Dir(idDir)
+	}
+	id := filepath.Base(idDir)
+	if mapped := geminiProjectFromRegistry(id); mapped != "" {
+		return mapped
+	}
+	if b, err := os.ReadFile(filepath.Join(idDir, ".project_root")); err == nil {
+		if p := strings.TrimSpace(string(b)); p != "" {
+			return projectName(p)
+		}
+	}
+	return id
+}
+
+func geminiProjectFromRegistry(id string) string {
+	b, err := os.ReadFile(filepath.Join(GeminiRoot(), "projects.json"))
+	if err != nil {
+		return ""
+	}
+	var doc struct {
+		Projects map[string]string `json:"projects"`
+	}
+	if json.Unmarshal(b, &doc) != nil {
+		return ""
+	}
+	for path, pid := range doc.Projects {
+		if pid == id {
+			return projectName(path)
+		}
+	}
+	return ""
+}

--- a/internal/sources/gemini_test.go
+++ b/internal/sources/gemini_test.go
@@ -1,0 +1,115 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func geminiTree(t *testing.T) (root, chats string) {
+	t.Helper()
+	root = t.TempDir()
+	t.Setenv("DEJA_GEMINI_ROOT", root)
+	chats = filepath.Join(root, "tmp", "my-proj", "chats")
+	if err := os.MkdirAll(chats, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root, chats
+}
+
+func TestParseGeminiOldJSON(t *testing.T) {
+	_, chats := geminiTree(t)
+	doc := `{"sessionId":"session-old-1","projectHash":"abc","startTime":"2026-01-16T18:34:00.000Z","lastUpdated":"2026-01-16T18:35:00.000Z","messages":[
+	 {"id":"m1","timestamp":"2026-01-16T18:34:01.000Z","type":"user","content":"Hello gemneedle"},
+	 {"id":"m2","timestamp":"2026-01-16T18:34:02.000Z","type":"gemini","model":"gemini-3-flash","content":"Hi there!"},
+	 {"id":"m3","timestamp":"2026-01-16T18:34:03.000Z","type":"info","content":"noise"}]}`
+	p := filepath.Join(chats, "session-old-1.json")
+	if err := os.WriteFile(p, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseGeminiFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || ss[0].ID != "session-old-1" || ss[0].Harness != "gemini" {
+		t.Fatalf("bad session: %#v", ss)
+	}
+	if len(ss[0].Messages) != 2 {
+		t.Fatalf("messages = %d, want 2 (info skipped): %#v", len(ss[0].Messages), ss[0].Messages)
+	}
+	if ss[0].Messages[1].Role != "assistant" || ss[0].Messages[1].Text != "Hi there!" {
+		t.Fatalf("assistant wrong: %#v", ss[0].Messages[1])
+	}
+	if ss[0].Project != "my-proj" {
+		t.Fatalf("project = %q", ss[0].Project)
+	}
+}
+
+func TestParseGeminiJSONLWithRewind(t *testing.T) {
+	_, chats := geminiTree(t)
+	lines := `{"sessionId":"sess-new-1","projectHash":"abc","startTime":"2026-07-01T10:00:00.000Z","lastUpdated":"2026-07-01T10:00:00.000Z","kind":"main"}
+{"id":"u1","timestamp":"2026-07-01T10:00:01.000Z","type":"user","content":[{"text":"first question"}]}
+{"id":"a1","timestamp":"2026-07-01T10:00:02.000Z","type":"gemini","content":"wrong answer","model":"gemini-3"}
+{"$rewindTo":"a1"}
+{"id":"a2","timestamp":"2026-07-01T10:00:05.000Z","type":"gemini","content":"right answer","model":"gemini-3"}
+{"$set":{"lastUpdated":"2026-07-01T10:00:06.000Z"}}
+`
+	p := filepath.Join(chats, "session-2026-07-01T10-00-sess-new-1.jsonl")
+	if err := os.WriteFile(p, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseGeminiFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || ss[0].ID != "sess-new-1" {
+		t.Fatalf("bad session: %#v", ss)
+	}
+	m := ss[0].Messages
+	if len(m) != 2 {
+		t.Fatalf("messages = %d, want 2 (rewind dropped wrong answer): %#v", len(m), m)
+	}
+	if m[0].Text != "first question" || m[1].Text != "right answer" {
+		t.Fatalf("rewind replay wrong: %#v", m)
+	}
+	if ss[0].Updated.Second() != 6 {
+		t.Fatalf("$set lastUpdated not applied: %v", ss[0].Updated)
+	}
+}
+
+func TestGeminiProjectFromRegistry(t *testing.T) {
+	root, chats := geminiTree(t)
+	if err := os.WriteFile(filepath.Join(root, "projects.json"), []byte(`{"projects":{"/Users/x/work/cool-app":"my-proj"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	doc := `{"sessionId":"s1","startTime":"2026-01-16T18:34:00.000Z","lastUpdated":"2026-01-16T18:34:00.000Z","messages":[{"id":"m1","timestamp":"2026-01-16T18:34:01.000Z","type":"user","content":"q"}]}`
+	p := filepath.Join(chats, "session-s1.json")
+	if err := os.WriteFile(p, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseGeminiFile(p)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("ss=%v err=%v", ss, err)
+	}
+	if ss[0].Project != "cool-app" {
+		t.Fatalf("project = %q, want cool-app", ss[0].Project)
+	}
+}
+
+func TestGeminiDedupePrefersJSONL(t *testing.T) {
+	in := []model.Session{
+		{Harness: "gemini", ID: "dup1", Path: "/a/session-dup1.json"},
+		{Harness: "gemini", ID: "dup1", Path: "/a/session-dup1.jsonl"},
+		{Harness: "gemini", ID: "solo", Path: "/a/session-solo.json"},
+	}
+	out := dedupeGeminiSessions(in)
+	if len(out) != 2 {
+		t.Fatalf("deduped to %d, want 2", len(out))
+	}
+	if out[0].ID != "dup1" || !strings.HasSuffix(out[0].Path, ".jsonl") {
+		t.Fatalf("jsonl not preferred: %#v", out[0])
+	}
+}


### PR DESCRIPTION
Fifth harness. Handles both storage generations — the old whole-session JSON files and the current JSONL logs, including $set metadata patches and $rewindTo markers (replayed so rewound messages don't resurface in search). When a session exists in both formats the JSONL wins. Project display names come from ~/.gemini/projects.json with .project_root and slug fallbacks.

Closes #7