### PR TITLE
docs: changelog, README and site for 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-16
+
+### Added
+- Three new harnesses: Cursor (IDE chats from state.vscdb plus CLI agent transcripts), Gemini CLI (both storage generations, including $rewindTo replay) and aider (markdown chat history with fence-aware parsing). deja now indexes six coding agents into one memory.
+- `DEJA_AUTORECALL_LOCAL_ONLY=1` keeps synced sessions out of session-start auto-recall.
+
 ## [0.8.0] - 2026-07-16
 
 ### Added

--- a/docs/index.html
+++ b/docs/index.html
@@ -138,7 +138,7 @@ a:hover{text-decoration:underline}
     <div class="card">
       <div class="ic"><svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h10"/></svg></div>
       <h3>One index, every harness</h3>
-      <p>All your harnesses write session logs to disk. deja indexes them together, retroactively — a fix found in Codex is recalled inside Claude Code.</p>
+      <p>Six harnesses — Claude Code, Codex, opencode, Cursor, Gemini CLI, aider — one index, retroactively. A fix found in Codex is recalled inside Claude Code.</p>
     </div>
     <div class="card">
       <div class="ic"><svg viewBox="0 0 24 24"><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg></div>


### PR DESCRIPTION
Six harnesses in the copy.