### PR TITLE
fix: default message time to session start when timestamps are absent

### DIFF
--- a/internal/sources/cursor.go
+++ b/internal/sources/cursor.go
@@ -157,6 +157,9 @@ func ParseCursorDB(db string) ([]model.Session, error) {
 				role = "user"
 			}
 			t := epochMS(b["ts"])
+			if t.IsZero() {
+				t = s.Started
+			}
 			s.Touch(t)
 			s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: t})
 			if s.Project == "-" {

--- a/internal/sources/gemini.go
+++ b/internal/sources/gemini.go
@@ -182,6 +182,9 @@ func appendGeminiMessages(s *model.Session, msgs []geminiMessage) {
 			continue
 		}
 		t, _ := time.Parse(time.RFC3339Nano, m.Timestamp)
+		if t.IsZero() {
+			t = s.Started
+		}
 		s.Touch(t)
 		s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: t})
 	}

--- a/internal/sources/gemini_test.go
+++ b/internal/sources/gemini_test.go
@@ -113,3 +113,19 @@ func TestGeminiDedupePrefersJSONL(t *testing.T) {
 		t.Fatalf("jsonl not preferred: %#v", out[0])
 	}
 }
+
+func TestGeminiMessageTimeFallback(t *testing.T) {
+	_, chats := geminiTree(t)
+	doc := `{"sessionId":"s1","startTime":"2026-07-15T10:00:00.000Z","lastUpdated":"2026-07-15T10:00:00.000Z","messages":[{"id":"m1","type":"user","content":"no timestamp here"}]}`
+	p := filepath.Join(chats, "session-s1.json")
+	if err := os.WriteFile(p, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseGeminiFile(p)
+	if err != nil || len(ss) != 1 || len(ss[0].Messages) != 1 {
+		t.Fatalf("ss=%#v err=%v", ss, err)
+	}
+	if ss[0].Messages[0].Time.IsZero() || ss[0].Messages[0].Time != ss[0].Started {
+		t.Fatalf("message time not defaulted to start: %v vs %v", ss[0].Messages[0].Time, ss[0].Started)
+	}
+}


### PR DESCRIPTION
Cursor bubbles and some Gemini messages have no per-message timestamp; show/ctx rendered a zero-value date for them. Found during real-data e2e of the new parsers.