### PR TITLE
test: cover resume, statusline and install paths

### DIFF
--- a/cmd/deja/format_helpers_test.go
+++ b/cmd/deja/format_helpers_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestShareFilteringHelpers(t *testing.T) {
+	longProse := strings.Repeat("this readable sentence has enough words ", 4)
+	longDigits := strings.Repeat("1234567890", 10)
+	for _, tc := range []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"short", "fix parser", true},
+		{"prose", longProse, true},
+		{"mostly digits", longDigits, false},
+		{"empty", "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := looksLikeProse(tc.line); got != tc.want {
+				t.Fatalf("looksLikeProse = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	if !looksLikeDataDump("{" + strings.Repeat(`"k":"v",`, 80) + "}") {
+		t.Fatal("expected long json dump")
+	}
+	if !looksLikeDataDump(strings.Repeat("x", 201)) {
+		t.Fatal("expected long token dump")
+	}
+	if looksLikeDataDump("ordinary explanation with spaces") {
+		t.Fatal("ordinary prose marked as dump")
+	}
+
+	for _, s := range []string{"", "<task-notification x>", `{"tool_use":true}`, strings.Repeat("x", 201)} {
+		if !noisyShareMessage(s) {
+			t.Fatalf("expected noisy message %q", s)
+		}
+	}
+	if noisyShareMessage("user explains the regression") {
+		t.Fatal("plain message marked noisy")
+	}
+	if !noiseLine("file.go:18: match") || !noiseLine("  123 diff --git a b") {
+		t.Fatal("expected noisy lines")
+	}
+}
+
+func TestStatsFormattingHelpers(t *testing.T) {
+	if got := trimRunes("abcdef", 3); got != "ab…" {
+		t.Fatalf("trimRunes = %q", got)
+	}
+	if got := trimRunes("abcdef", 1); got != "a" {
+		t.Fatalf("trimRunes n=1 = %q", got)
+	}
+	if got := scaledBar(1, 100, 10); got != 1 {
+		t.Fatalf("scaledBar = %d", got)
+	}
+	if got := scaledBar(0, 100, 10); got != 0 {
+		t.Fatalf("scaledBar zero = %d", got)
+	}
+	if valueOrDash("") != "-" || valueOrDash("x") != "x" {
+		t.Fatal("valueOrDash mismatch")
+	}
+	if !statNoise("<local-command x>") || statNoise("real title") {
+		t.Fatal("statNoise mismatch")
+	}
+	if got := statTitle(model.Session{Title: "<command-noise>", Messages: []model.Message{{Role: "assistant", Text: "skip"}, {Role: "user", Text: strings.Repeat("word ", 20)}}}); !strings.HasSuffix(got, "…") {
+		t.Fatalf("statTitle = %q", got)
+	}
+	if got := statTitle(model.Session{Title: "Clean title"}); got != "Clean title" {
+		t.Fatalf("statTitle title = %q", got)
+	}
+	if got := statHarnessTag("claude", true); !strings.Contains(got, "[claude]") || !strings.Contains(got, statOrange) {
+		t.Fatalf("claude tag = %q", got)
+	}
+	if got := statHarnessTag("codex", true); !strings.Contains(got, statGreen) {
+		t.Fatalf("codex tag = %q", got)
+	}
+	if got := statHarnessTag("opencode", true); !strings.Contains(got, statBlue) {
+		t.Fatalf("opencode tag = %q", got)
+	}
+	if got := statHarnessTag("other", true); got != "[other]" {
+		t.Fatalf("other tag = %q", got)
+	}
+	t.Setenv("NO_COLOR", "1")
+	if statColorOK(os.Stdout) || statColorOK(&bytes.Buffer{}) {
+		t.Fatal("color should be disabled")
+	}
+}

--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -53,6 +53,37 @@ func TestInstallCodexHooksMergeAndUninstall(t *testing.T) {
 	}
 }
 
+func TestInstallCodexHooksErrorsAndMissingUninstall(t *testing.T) {
+	t.Run("malformed json", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		path := filepath.Join(home, ".codex", "hooks.json")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(`{"hooks":`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := installCodexHooks("/bin/deja", false); err == nil {
+			t.Fatal("expected malformed hooks.json error")
+		}
+	})
+
+	t.Run("uninstall missing file", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		r, err := installCodexHooks("/bin/deja", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if r.Path != filepath.Join(home, ".codex", "hooks.json") || r.Action != "created" {
+			t.Fatalf("result = %#v", r)
+		}
+	})
+}
+
 func TestInstallOpencodePlugin(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -79,5 +110,49 @@ func TestInstallOpencodePlugin(t *testing.T) {
 	}
 	if r, _ := installOpencodePlugin("/opt/deja", true); r.Action != "unchanged" {
 		t.Fatalf("second uninstall action = %s", r.Action)
+	}
+}
+
+func TestInstallOpencodePluginUninstallMissingDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	r, err := installOpencodePlugin("/opt/deja", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Action != "unchanged" || r.Path != filepath.Join(home, ".config", "opencode", "plugins", "deja.js") {
+		t.Fatalf("result = %#v", r)
+	}
+}
+
+func TestInstallAutoWrappers(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fn   func(string, bool) (installResult, error)
+		want string
+	}{
+		{"codex", installCodexAuto, filepath.Join(".codex", "hooks.json")},
+		{"opencode", installOpencodeAuto, filepath.Join(".config", "opencode", "plugins", "deja.js")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			r, err := tc.fn("/bin/deja", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if r.Action != "created" || r.Path != filepath.Join(home, tc.want) {
+				t.Fatalf("install result = %#v", r)
+			}
+			r, err = tc.fn("/bin/deja", true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if r.Path != filepath.Join(home, tc.want) {
+				t.Fatalf("uninstall result = %#v", r)
+			}
+		})
 	}
 }

--- a/cmd/deja/install_statusline_test.go
+++ b/cmd/deja/install_statusline_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallStatuslineErrorAndUninstallIdempotent(t *testing.T) {
+	t.Run("malformed settings", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		path := filepath.Join(home, ".claude", "settings.json")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(`{"statusLine":`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := installStatusline("/bin/deja", false); err == nil {
+			t.Fatal("expected malformed settings.json error")
+		}
+	})
+
+	t.Run("uninstall preserves foreign statusline", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		path := filepath.Join(home, ".claude", "settings.json")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		old := `{"statusLine":{"type":"command","command":"/bin/other status"}}`
+		if err := os.WriteFile(path, []byte(old), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		r, err := installStatusline("/bin/deja", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if r.Action != "unchanged" {
+			t.Fatalf("action = %q", r.Action)
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(b), "/bin/other status") || strings.Contains(string(b), "/bin/deja statusline") {
+			t.Fatalf("settings changed: %s", b)
+		}
+	})
+}
+
+func TestInstallStatuslineInstallConflictAndRemove(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	r, err := installStatusline("/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Action != "created" {
+		t.Fatalf("install result = %#v", r)
+	}
+	r, err = installStatusline("/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Action != "unchanged" {
+		t.Fatalf("second install = %#v", r)
+	}
+	r, err = installStatusline("/bin/deja", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Action != "updated" {
+		t.Fatalf("uninstall = %#v", r)
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "statusLine") {
+		t.Fatalf("statusline left in settings: %s", b)
+	}
+
+	if _, err := installStatusline("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".claude", "settings.json")
+	if err := os.WriteFile(path, []byte(`{"statusLine":{"type":"command","command":"/bin/other status"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installStatusline("/bin/deja", false); err == nil || !strings.Contains(err.Error(), "already configured") {
+		t.Fatalf("conflict err = %v", err)
+	}
+}
+
+func TestInstallTargetErrorsAndAliases(t *testing.T) {
+	if _, err := installTarget("missing", "/bin/deja", false); err == nil || !strings.Contains(err.Error(), "unknown target") {
+		t.Fatalf("unknown target err = %v", err)
+	}
+	for _, args := range [][]string{nil, []string{"a", "b"}} {
+		if err := runInstall(args, false); err == nil || !strings.Contains(err.Error(), "install needs target") {
+			t.Fatalf("install args %v err = %v", args, err)
+		}
+	}
+	if err := runInstall(nil, true); err == nil || !strings.Contains(err.Error(), "uninstall needs target") {
+		t.Fatalf("uninstall err = %v", err)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if _, err := installTarget("claude", "/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/deja/install_statusline_test.go
+++ b/cmd/deja/install_statusline_test.go
@@ -102,7 +102,7 @@ func TestInstallTargetErrorsAndAliases(t *testing.T) {
 	if _, err := installTarget("missing", "/bin/deja", false); err == nil || !strings.Contains(err.Error(), "unknown target") {
 		t.Fatalf("unknown target err = %v", err)
 	}
-	for _, args := range [][]string{nil, []string{"a", "b"}} {
+	for _, args := range [][]string{nil, {"a", "b"}} {
 		if err := runInstall(args, false); err == nil || !strings.Contains(err.Error(), "install needs target") {
 			t.Fatalf("install args %v err = %v", args, err)
 		}

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -296,6 +296,26 @@ func TestVersionDefaultIsDev(t *testing.T) {
 	}
 }
 
+func TestLoadAllHermeticEmptySources(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	t.Setenv("DEJA_AIDER_ROOTS", filepath.Join(tmp, "aider"))
+	t.Setenv("DEJA_GEMINI_ROOT", filepath.Join(tmp, "gemini"))
+	t.Setenv("DEJA_CURSOR_ROOT", filepath.Join(tmp, "cursor-workspaces"))
+	t.Setenv("DEJA_CURSOR_CLI_ROOT", filepath.Join(tmp, "cursor-cli"))
+	if got := loadAll(""); len(got) != 0 {
+		t.Fatalf("loadAll empty sources = %#v", got)
+	}
+	if got := loadAll("claude"); len(got) != 0 {
+		t.Fatalf("loadAll claude = %#v", got)
+	}
+}
+
 func TestMCPHandshakeListRecallRoundTrip(t *testing.T) {
 	root, err := filepath.Abs(filepath.Join("..", "..", "fixtures", "synthetic", "claude"))
 	if err != nil {

--- a/cmd/deja/resume_test.go
+++ b/cmd/deja/resume_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -50,5 +51,51 @@ func TestResumeCommandPerHarness(t *testing.T) {
 		if dir != c.wantDir || cmd != c.wantCmd {
 			t.Fatalf("%s: got (%q, %q), want (%q, %q)", c.name, dir, cmd, c.wantDir, c.wantCmd)
 		}
+	}
+}
+
+func TestRunResumePrintAndErrors(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-resume")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data := `{"type":"user","sessionId":"resume123","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"resume needle"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "resume123.jsonl"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+
+	var out bytes.Buffer
+	if err := runResume([]string{"resume"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); !strings.Contains(got, "claude --resume resume123") {
+		t.Fatalf("resume output = %q", got)
+	}
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing", nil, "resume needs id-prefix"},
+		{"exec without prefix", []string{"--exec"}, "resume needs id-prefix"},
+		{"not found", []string{"nope"}, `no session matches "nope"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var discard bytes.Buffer
+			err := runResume(tc.args, &discard)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }

--- a/cmd/deja/statusline_test.go
+++ b/cmd/deja/statusline_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -17,6 +18,42 @@ func TestStatuslineEmpty(t *testing.T) {
 	}
 	if got := out.String(); got != "deja · no recalls yet today" {
 		t.Fatalf("empty statusline = %q", got)
+	}
+}
+
+type chunkReader struct {
+	chunks []string
+	reads  int
+}
+
+func (r *chunkReader) Read(p []byte) (int, error) {
+	if r.reads >= len(r.chunks) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.chunks[r.reads])
+	r.reads++
+	return n, nil
+}
+
+func TestDrainStdinNonFileReader(t *testing.T) {
+	r := &chunkReader{chunks: []string{"{}", "ignored"}}
+	drainStdin(r)
+	if r.reads != len(r.chunks) {
+		t.Fatalf("reads = %d, want %d", r.reads, len(r.chunks))
+	}
+}
+
+func TestStatuslineMissingUsageFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	var out bytes.Buffer
+	if err := runStatusline(strings.NewReader(""), &out); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != "deja · no recalls yet today" {
+		t.Fatalf("statusline = %q", got)
 	}
 }
 

--- a/cmd/deja/sync_ssh_test.go
+++ b/cmd/deja/sync_ssh_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,9 @@ import (
 func setupLocalIndex(t *testing.T) string {
 	t.Helper()
 	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	claudeRoot := filepath.Join(tmp, "claude")
 	proj := filepath.Join(claudeRoot, "-tmp-sshsync")
 	if err := os.MkdirAll(proj, 0o755); err != nil {
@@ -29,6 +33,41 @@ func setupLocalIndex(t *testing.T) string {
 	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
 	return tmp
+}
+
+func TestSyncSSHPullFullAndScpFailure(t *testing.T) {
+	setupLocalIndex(t)
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	var exportCmd string
+	var cleanup bool
+	sshRunner = func(name string, args ...string) (string, error) {
+		if name == "ssh" && args[1] == "mktemp -d" {
+			return "/tmp/remote-out", nil
+		}
+		if name == "ssh" && strings.Contains(args[1], "sync export") {
+			exportCmd = args[1]
+			return "deja: exported 1 records", nil
+		}
+		if name == "ssh" && strings.Contains(args[1], "rm -rf") {
+			cleanup = true
+			return "", nil
+		}
+		if name == "scp" {
+			return "permission denied", errors.New("exit status 1")
+		}
+		return "", nil
+	}
+	err := runSyncSSH([]string{"minihost", "--pull", "--full"})
+	if err == nil || !strings.Contains(err.Error(), "scp: exit status 1: permission denied") {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.Contains(exportCmd, "sync export --full") {
+		t.Fatalf("export command = %q", exportCmd)
+	}
+	if !cleanup {
+		t.Fatal("expected remote cleanup after scp failure")
+	}
 }
 
 func TestSyncSSHPush(t *testing.T) {
@@ -136,5 +175,32 @@ func TestSyncSSHBadArgs(t *testing.T) {
 	}
 	if err := runSyncSSH([]string{"a", "b"}); err == nil {
 		t.Fatal("expected error for two hosts")
+	}
+}
+
+func TestRunSyncExportImport(t *testing.T) {
+	setupLocalIndex(t)
+	out := filepath.Join(t.TempDir(), "export")
+	if err := runSync([]string{"export", "--full", out}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected exported batch")
+	}
+	importDir := filepath.Join(t.TempDir(), "import.db")
+	t.Setenv("DEJA_INDEX_DIR", importDir)
+	if err := runSync([]string{"import", out}); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := index.Search(importDir, search.Options{Query: "sshneedle", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("imported sessions = %#v", ss)
 	}
 }


### PR DESCRIPTION
cmd/deja coverage 74.5% → 85.0%. Hermetic table-driven tests over the newer commands: resume print/error paths, statusline, install statusline conflict handling, codex/opencode auto targets, sync ssh failure paths.