### PR TITLE
feat: index Antigravity transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Credentials are redacted at index time: AWS keys, generic `api_key=`/`token=` as
 | Claude Code | `~/.claude/projects/**/*.jsonl` | ✅ |
 | Codex CLI | `~/.codex/sessions/**` + `history.jsonl` | ✅ |
 | opencode | `~/.local/share/opencode/opencode.db` | ✅ |
-| aider, Gemini CLI | [#6](https://github.com/vshulcz/deja-vu/issues/6), [#7](https://github.com/vshulcz/deja-vu/issues/7) | planned |
+| aider, Gemini CLI, Antigravity | [#6](https://github.com/vshulcz/deja-vu/issues/6), [#7](https://github.com/vshulcz/deja-vu/issues/7) | planned |
 
 Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_INDEX_DIR`.
 

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -44,6 +44,9 @@ func loadAll(h string) []model.Session {
 	if h == "" || h == "cursor" {
 		ss = append(ss, sources.LoadCursor()...)
 	}
+	if h == "" || h == "antigravity" {
+		ss = append(ss, sources.LoadAntigravity()...)
+	}
 	return ss
 }
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -457,6 +457,9 @@ func load(h string) []model.Session {
 	if h == "" || h == "cursor" {
 		ss = append(ss, sources.LoadCursor()...)
 	}
+	if h == "" || h == "antigravity" {
+		ss = append(ss, sources.LoadAntigravity()...)
+	}
 	return ss
 }
 
@@ -1073,6 +1076,8 @@ func parseChangedFile(harness, p string, old FileState) ([]model.Session, error)
 		return sources.ParseCursorDB(p)
 	case "cursor":
 		return sources.ParseCursorTranscript(p)
+	case "antigravity":
+		return sources.ParseAntigravityFile(p)
 	default:
 		return nil, nil
 	}
@@ -1124,6 +1129,13 @@ func harnessForPath(p string) string {
 	}
 	if strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, filepath.Join(sources.CursorCLIRoot(), "projects")) {
 		return "cursor"
+	}
+	if filepath.Base(p) == "transcript.jsonl" {
+		for _, root := range sources.AntigravityRoots() {
+			if strings.HasPrefix(p, root+string(filepath.Separator)) {
+				return "antigravity"
+			}
+		}
 	}
 	return ""
 }
@@ -1181,6 +1193,11 @@ func currentFiles(h string) map[string]FileState {
 			paths[p] = true
 		}
 		for _, p := range sources.CursorTranscripts() {
+			paths[p] = true
+		}
+	}
+	if h == "" || h == "antigravity" {
+		for _, p := range sources.AntigravityTranscripts() {
 			paths[p] = true
 		}
 	}

--- a/internal/sources/antigravity.go
+++ b/internal/sources/antigravity.go
@@ -1,0 +1,109 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+var (
+	antigravityRequestOpenRE  = regexp.MustCompile(`^\s*<USER_REQUEST>\s*`)
+	antigravityRequestCloseRE = regexp.MustCompile(`\s*</USER_REQUEST>\s*$`)
+)
+
+var antigravityUserBlockREs = []*regexp.Regexp{
+	regexp.MustCompile(`(?s)<ADDITIONAL_METADATA>.*?</ADDITIONAL_METADATA>`),
+	regexp.MustCompile(`(?s)<USER_SETTINGS_CHANGE>.*?</USER_SETTINGS_CHANGE>`),
+}
+
+func AntigravityRoots() []string {
+	if v := os.Getenv("DEJA_ANTIGRAVITY_ROOT"); v != "" {
+		return []string{v}
+	}
+	roots, err := filepath.Glob(filepath.Join(Home(), ".gemini", "antigravity*"))
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, root := range roots {
+		if fi, err := os.Stat(root); err == nil && fi.IsDir() {
+			out = append(out, root)
+		}
+	}
+	return out
+}
+
+func AntigravityTranscripts() []string {
+	var out []string
+	for _, root := range AntigravityRoots() {
+		matches, err := filepath.Glob(filepath.Join(root, "brain", "*", ".system_generated", "logs", "transcript.jsonl"))
+		if err == nil {
+			out = append(out, matches...)
+		}
+	}
+	return out
+}
+
+func LoadAntigravity() []model.Session {
+	return parseFiles(AntigravityTranscripts(), ParseAntigravityFile)
+}
+
+func ParseAntigravityFile(path string) ([]model.Session, error) {
+	id := antigravitySessionID(path)
+	if id == "" || id == "." || id == string(filepath.Separator) {
+		return nil, nil
+	}
+	s := model.Session{Harness: "antigravity", ID: id, Project: "-", Path: path}
+	err := scanJSONLFromOffset(path, 0, func(m map[string]any) {
+		role := ""
+		source, _ := m["source"].(string)
+		switch source {
+		case "USER_EXPLICIT":
+			role = "user"
+		case "MODEL":
+			role = "assistant"
+		default:
+			return
+		}
+		text, _ := m["content"].(string)
+		if strings.TrimSpace(text) == "" {
+			return
+		}
+		if role == "user" {
+			text = cleanAntigravityUserContent(text)
+		}
+		if strings.TrimSpace(text) == "" {
+			return
+		}
+		if len(text) > 64*1024 {
+			text = text[:64*1024]
+		}
+		t, _ := time.Parse(time.RFC3339Nano, str(m["created_at"]))
+		if t.IsZero() {
+			t = s.Started
+		}
+		s.Touch(t)
+		s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: t})
+	})
+	if len(s.Messages) == 0 {
+		return nil, err
+	}
+	return []model.Session{s}, err
+}
+
+func antigravitySessionID(path string) string {
+	return filepath.Base(filepath.Dir(filepath.Dir(filepath.Dir(path))))
+}
+
+func cleanAntigravityUserContent(text string) string {
+	for _, re := range antigravityUserBlockREs {
+		text = re.ReplaceAllString(text, "")
+	}
+	text = antigravityRequestOpenRE.ReplaceAllString(text, "")
+	text = antigravityRequestCloseRE.ReplaceAllString(text, "")
+	return strings.TrimSpace(text)
+}

--- a/internal/sources/antigravity_test.go
+++ b/internal/sources/antigravity_test.go
@@ -81,6 +81,7 @@ func TestAntigravityRootsGlob(t *testing.T) {
 	t.Setenv("DEJA_ANTIGRAVITY_ROOT", "")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	want := filepath.Join(home, ".gemini", "antigravity-cli")
 	if err := os.MkdirAll(want, 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/sources/antigravity_test.go
+++ b/internal/sources/antigravity_test.go
@@ -1,0 +1,95 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func antigravityTree(t *testing.T) (root, transcript string) {
+	t.Helper()
+	root = t.TempDir()
+	t.Setenv("DEJA_ANTIGRAVITY_ROOT", root)
+	transcript = filepath.Join(root, "brain", "traj-123", ".system_generated", "logs", "transcript.jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root, transcript
+}
+
+func TestParseAntigravityFile(t *testing.T) {
+	_, p := antigravityTree(t)
+	long := strings.Repeat("x", 70*1024)
+	lines := `{"step_index":1,"source":"USER_EXPLICIT","type":"USER_INPUT","created_at":"2026-07-08T14:18:27Z","content":"<USER_REQUEST>\nBuild this\n<USER_SETTINGS_CHANGE>{\"theme\":\"dark\"}</USER_SETTINGS_CHANGE>\n<ADDITIONAL_METADATA>{\"cwd\":\"/tmp\"}</ADDITIONAL_METADATA>\n</USER_REQUEST>"}
+{"step_index":2,"source":"SYSTEM","type":"SYSTEM","created_at":"2026-07-08T14:18:28Z","content":"system noise"}
+{"step_index":3,"source":"MODEL","type":"PLANNER_RESPONSE","created_at":"2026-07-08T14:18:29Z","thinking":"secret reasoning","content":"I can help."}
+{"step_index":4,"source":"MODEL","type":"CODE_ACTION","created_at":"2026-07-08T14:18:30Z","content":""}
+not-json
+{"step_index":5,"source":"MODEL","type":"PLANNER_RESPONSE","created_at":"2026-07-08T14:18:31Z","content":"` + long + `"}
+`
+	if err := os.WriteFile(p, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseAntigravityFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d, want 1: %#v", len(ss), ss)
+	}
+	s := ss[0]
+	if s.Harness != "antigravity" || s.ID != "traj-123" || s.Project != "-" {
+		t.Fatalf("bad meta: %#v", s)
+	}
+	if len(s.Messages) != 3 {
+		t.Fatalf("messages = %d, want 3: %#v", len(s.Messages), s.Messages)
+	}
+	if s.Messages[0].Role != "user" || s.Messages[0].Text != "Build this" {
+		t.Fatalf("user unwrap wrong: %#v", s.Messages[0])
+	}
+	if s.Messages[1].Role != "assistant" || s.Messages[1].Text != "I can help." || strings.Contains(s.Messages[1].Text, "secret") {
+		t.Fatalf("assistant wrong: %#v", s.Messages[1])
+	}
+	if s.Messages[0].Time.Format("2006-01-02T15:04:05Z") != "2026-07-08T14:18:27Z" {
+		t.Fatalf("timestamp wrong: %v", s.Messages[0].Time)
+	}
+	if s.Started != s.Messages[0].Time || s.Updated != s.Messages[2].Time {
+		t.Fatalf("session times wrong: started=%v updated=%v", s.Started, s.Updated)
+	}
+	if len(s.Messages[2].Text) != 64*1024 {
+		t.Fatalf("message cap = %d, want %d", len(s.Messages[2].Text), 64*1024)
+	}
+}
+
+func TestAntigravityTranscriptsEnvOverride(t *testing.T) {
+	root, p := antigravityTree(t)
+	if err := os.WriteFile(p, []byte(`{"source":"USER_EXPLICIT","created_at":"2026-07-08T14:18:27Z","content":"hi"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files := AntigravityTranscripts()
+	if len(files) != 1 || files[0] != p {
+		t.Fatalf("transcripts = %v, want %s", files, p)
+	}
+	roots := AntigravityRoots()
+	if len(roots) != 1 || roots[0] != root {
+		t.Fatalf("roots = %v, want %s", roots, root)
+	}
+}
+
+func TestAntigravityRootsGlob(t *testing.T) {
+	t.Setenv("DEJA_ANTIGRAVITY_ROOT", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	want := filepath.Join(home, ".gemini", "antigravity-cli")
+	if err := os.MkdirAll(want, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".gemini", "antigravity-file"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	roots := AntigravityRoots()
+	if len(roots) != 1 || roots[0] != want {
+		t.Fatalf("roots = %v, want %s", roots, want)
+	}
+}


### PR DESCRIPTION
Seventh harness. Antigravity keeps a plaintext transcript.jsonl per conversation under ~/.gemini/antigravity*/brain/ — the surface that stays readable even where its conversation db is encrypted. USER_REQUEST wrappers and metadata blocks are stripped from user messages; SYSTEM steps are skipped; message times fall back to session start like the other parsers.

Closes #67