### PR TITLE
fix: skip unreadable sources for a pass instead of failing the update

### DIFF
--- a/internal/index/graceful_test.go
+++ b/internal/index/graceful_test.go
@@ -3,6 +3,7 @@ package index
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/search"
@@ -12,6 +13,9 @@ import (
 // is skipped for the pass, its old records survive, and it is retried once
 // readable again.
 func TestUnreadableSourceSkippedNotFatal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0 does not make files unreadable on windows")
+	}
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")
 	proj := filepath.Join(claudeRoot, "-tmp-grace")

--- a/internal/index/graceful_test.go
+++ b/internal/index/graceful_test.go
@@ -1,0 +1,75 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// One unreadable source file must not fail the whole index update: the file
+// is skipped for the pass, its old records survive, and it is retried once
+// readable again.
+func TestUnreadableSourceSkippedNotFatal(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-grace")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	good := filepath.Join(proj, "good.jsonl")
+	bad := filepath.Join(proj, "bad.jsonl")
+	line := func(sid, text string) string {
+		return `{"type":"user","sessionId":"` + sid + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+	}
+	if err := os.WriteFile(good, []byte(line("g1", "goodneedle stays")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bad, []byte(line("b1", "badneedle original")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	o := search.Options{Query: "badneedle", All: true}
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rewrite bad.jsonl shorter (forces the non-append replace path) and make
+	// it unreadable, then also shrink good.jsonl so the same pass has real work.
+	if err := os.WriteFile(bad, []byte(line("b1", "badneedle updated")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(bad, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(bad, 0o644) }()
+	if err := os.WriteFile(good, []byte(line("g1", "goodneedle v2")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureForSearch(dir, search.Options{Query: "goodneedle"}, false, nil); err != nil {
+		t.Fatalf("update failed instead of skipping unreadable file: %v", err)
+	}
+	if ss, err := Search(dir, search.Options{Query: "goodneedle", All: true}); err != nil || len(ss) != 1 || ss[0].Messages[0].Text != "goodneedle v2" {
+		t.Fatalf("good file not reindexed: %#v err=%v", ss, err)
+	}
+	// old records of the unreadable file survive
+	if ss, err := Search(dir, search.Options{Query: "badneedle", All: true}); err != nil || len(ss) != 1 || ss[0].Messages[0].Text != "badneedle original" {
+		t.Fatalf("old records lost for skipped file: %#v err=%v", ss, err)
+	}
+
+	// readable again → retried and updated
+	if err := os.Chmod(bad, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureForSearch(dir, search.Options{Query: "badneedle"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if ss, err := Search(dir, search.Options{Query: "badneedle", All: true}); err != nil || len(ss) != 1 || ss[0].Messages[0].Text != "badneedle updated" {
+		t.Fatalf("skipped file not retried: %#v err=%v", ss, err)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -809,7 +809,19 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	for p, f := range changed {
 		ss, err := parseChangedFile(harness, p, old.Files[p])
 		if err != nil {
-			return fmt.Errorf("changed %s: %w", p, err)
+			// A live-locked or half-written store (Cursor holds its sqlite
+			// under WAL) must not fail every search. Keep the old records
+			// and the old FileState so the next run retries this file.
+			if progress != nil {
+				fmt.Fprintf(progress, "deja: skipping %s this pass: %v\n", filepath.Base(p), err)
+			}
+			delete(changed, p)
+			if of, ok := old.Files[p]; ok {
+				files[p] = of
+			} else {
+				delete(files, p)
+			}
+			continue
 		}
 		replacements = append(replacements, ss...)
 		files[p] = f
@@ -989,7 +1001,12 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	for p := range changed {
 		ss, err := parseAppendedFile(harness, p, old.Files[p])
 		if err != nil {
-			return filesTouched, messages, fmt.Errorf("parse %s: %w", filepath.Base(p), err)
+			if of, ok := old.Files[p]; ok {
+				m.Files[p] = of // retry this file on the next pass
+			} else {
+				delete(m.Files, p)
+			}
+			continue
 		}
 		filesTouched++
 		for _, s := range ss {


### PR DESCRIPTION
One unreadable file — a permission error, or Cursor holding its sqlite mid-write — was failing the whole index update, which reads as "deja is broken" to the user. Now the file is skipped for the pass with a note on stderr, its existing records stay searchable, and the old FileState is kept so the next run retries it. Regression test covers skip, survival of old records, and the retry.