### PR TITLE
feat: index Grok Build chat history

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center"><img src="assets/demo.gif" alt="deja demo"></p>
 
-Claude Code, Codex and opencode write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
+Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity and Grok Build write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
 
 | | |
 | --- | --- |
@@ -26,7 +26,7 @@ Claude Code, Codex and opencode write every conversation to local files — giga
 | **Share** | `deja share <id>` — hand a colleague a sanitized digest of a session, secrets already scrubbed |
 | **Sync** | `deja sync export/import` — move memory between machines, append-only, idempotent |
 
-One binary. No models to download, no services to run, nothing leaves your machine. (opencode indexing shells out to the `sqlite3` CLI, preinstalled on macOS and most Linux distros.)
+One binary. No models to download, no services to run, nothing leaves your machine. (opencode and Cursor IDE indexing shell out to the `sqlite3` CLI, preinstalled on macOS and most Linux distros; Cursor CLI transcripts do not need it.)
 
 ## Install
 
@@ -74,7 +74,7 @@ $ deja "jwt refresh token"
 | `deja stats` | Totals, per-harness split, top projects, monthly sparkline. `--json` too. |
 | `deja sync export <dir> [--full]` / `import <dir>` / `ssh <host> [--pull]` | Move memory between machines — via a shared folder or one ssh command. Watermarked, append-only, idempotent. |
 | `deja show <id>` / `deja last [n]` | Read one session / list recent ones. |
-| `deja resume <id> [--exec]` | Reopen a found session in its native harness (`claude --resume`, `codex resume`, `opencode -s`). |
+| `deja resume <id> [--exec]` | Reopen a found session in its native harness (`claude --resume`, `codex resume`, `opencode -s`, `grok --resume`). |
 | `deja sources` | Discovered stores, sizes, message and redaction counts. |
 | `deja mcp` | The stdio MCP server (what `deja install` wires in). |
 | `deja warmup` | Build/refresh the index without searching — handy in cron or shell startup. |
@@ -114,7 +114,7 @@ the agent reach for memory on its own, add this to your `CLAUDE.md` /
 
 ```
 Before debugging or re-implementing something, run `deja "<query>"` (or the
-MCP recall tool) — past agent sessions across Claude Code, Codex and opencode
+MCP recall tool) — past agent sessions across Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity and Grok Build
 are indexed locally. Cite what you reuse.
 ```
 
@@ -140,9 +140,13 @@ Credentials are redacted at index time: AWS keys, generic `api_key=`/`token=` as
 | Claude Code | `~/.claude/projects/**/*.jsonl` | ✅ |
 | Codex CLI | `~/.codex/sessions/**` + `history.jsonl` | ✅ |
 | opencode | `~/.local/share/opencode/opencode.db` | ✅ |
-| aider, Gemini CLI, Antigravity | [#6](https://github.com/vshulcz/deja-vu/issues/6), [#7](https://github.com/vshulcz/deja-vu/issues/7) | planned |
+| aider | `.aider.chat.history.md` | ✅ |
+| Gemini CLI | `~/.gemini/tmp/*/chats/**` | ✅ |
+| Cursor | `state.vscdb` + `~/.cursor/projects/**/agent-transcripts/*.jsonl` | ✅ |
+| Antigravity | `~/.gemini/antigravity*/brain/*/.system_generated/logs/transcript.jsonl` | ✅ |
+| Grok Build | `~/.grok/sessions/**/updates.jsonl` | ✅ |
 
-Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_INDEX_DIR`.
+Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_AIDER_ROOTS`, `DEJA_GEMINI_ROOT`, `DEJA_CURSOR_ROOT`, `DEJA_CURSOR_CLI_ROOT`, `DEJA_ANTIGRAVITY_ROOT`, `DEJA_GROK_ROOT`, `DEJA_INDEX_DIR`. Grok's native `GROK_HOME` is also honored.
 
 ## Performance
 
@@ -167,7 +171,7 @@ Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact cr
 **Does anything leave my machine?** No. There is no network code in the tool. `sync` writes files to a directory you choose; moving them is up to you.
 
 **How is this different from cass?**
-[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, three harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
+[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, eight harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
 
 **And from MemPalace / Mem0 / Letta?**
 Those are memory *platforms*: embeddings, vector stores, capture hooks or APIs that record going forward. deja has no capture step at all — it indexes what your agents already wrote to disk, including months of history from before you installed it. They can coexist.

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -253,7 +253,7 @@ func TestMainHelpersFallbackAndSourcesBranches(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("DEJA_AIDER_ROOTS", aiderDir)
-	if got := pathSize("(home + DEJA_AIDER_ROOTS)"); got == 0 {
+	if got := pathSize(aiderDir); got != 5 {
 		t.Fatalf("aider pathSize = %d", got)
 	}
 	dir := t.TempDir()

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -47,6 +47,9 @@ func loadAll(h string) []model.Session {
 	if h == "" || h == "antigravity" {
 		ss = append(ss, sources.LoadAntigravity()...)
 	}
+	if h == "" || h == "grok" {
+		ss = append(ss, sources.LoadGrok()...)
+	}
 	return ss
 }
 

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -53,6 +53,14 @@ func loadAll(h string) []model.Session {
 	return ss
 }
 
+func loadFileSources() []model.Session {
+	var ss []model.Session
+	for _, harness := range []string{"claude", "codex", "aider", "gemini", "cursor", "antigravity", "grok"} {
+		ss = append(ss, loadAll(harness)...)
+	}
+	return ss
+}
+
 func run(args []string) error {
 	if len(args) == 0 {
 		printUsage()
@@ -201,7 +209,7 @@ func run(args []string) error {
 }
 
 func printNoMatches(w io.Writer, q string, n int) {
-	fmt.Fprintf(w, "deja: no matches for %q (searched %d sessions across claude/codex/opencode) — try fewer words or --re\n", q, n)
+	fmt.Fprintf(w, "deja: no matches for %q (searched %d sessions across claude/codex/opencode/aider/gemini/cursor/antigravity/grok) — try fewer words or --re\n", q, n)
 }
 
 func findByPrefix(p string) (model.Session, bool, error) {
@@ -210,7 +218,7 @@ func findByPrefix(p string) (model.Session, bool, error) {
 			return s, ok, nil
 		}
 	}
-	ss := append(loadAll("claude"), loadAll("codex")...)
+	ss := loadFileSources()
 	ss = append(ss, sources.LoadOpencodePrefix(p)...)
 	s, ok := search.FindByPrefix(ss, p)
 	return s, ok, nil
@@ -222,7 +230,7 @@ func recent(n int) ([]model.Session, error) {
 			return ss, nil
 		}
 	}
-	ss := append(loadAll("claude"), loadAll("codex")...)
+	ss := loadFileSources()
 	ss = append(ss, sources.LoadOpencodeRecent(n)...)
 	return search.Recent(ss, n), nil
 }
@@ -297,26 +305,60 @@ func printSources() {
 	if stats, err := index.Redactions(index.DefaultDir()); err == nil {
 		redactions = stats.Files
 	}
+	antigravityRoots := sources.AntigravityRoots()
+	antigravityLocation := strings.Join(antigravityRoots, string(os.PathListSeparator))
+	if antigravityLocation == "" {
+		antigravityLocation = filepath.Join(sources.Home(), ".gemini", "antigravity*")
+	}
 	items := []struct {
-		name, root string
-		load       func() []model.Session
+		name, location string
+		roots          []string
+		load           func() []model.Session
 	}{
-		{"claude", sources.ClaudeRoot(), sources.LoadClaude},
-		{"codex", sources.CodexRoot(), sources.LoadCodex},
-		{"cursor", sources.CursorUserRoot(), sources.LoadCursor},
-		{"gemini", filepath.Join(sources.GeminiRoot(), "tmp"), sources.LoadGemini},
-		{"antigravity", filepath.Join(sources.Home(), ".gemini"), sources.LoadAntigravity},
-		{"aider", "(home + DEJA_AIDER_ROOTS)", sources.LoadAider},
+		{"claude", sources.ClaudeRoot(), []string{sources.ClaudeRoot()}, sources.LoadClaude},
+		{"codex", sources.CodexRoot(), []string{sources.CodexRoot()}, sources.LoadCodex},
+		{"gemini", sources.GeminiRoot(), []string{filepath.Join(sources.GeminiRoot(), "tmp")}, sources.LoadGemini},
+		{"cursor", strings.Join([]string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, string(os.PathListSeparator)), []string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, sources.LoadCursor},
+		{"antigravity", antigravityLocation, antigravityRoots, sources.LoadAntigravity},
+		{"grok", sources.GrokRoot(), []string{sources.GrokRoot()}, sources.LoadGrok},
 	}
 	for _, it := range items {
-		size := pathSize(it.root)
+		var size int64
+		redacted := 0
+		for _, root := range it.roots {
+			size += pathSize(root)
+			redacted += redactionsUnder(redactions, root)
+		}
 		ss := it.load()
 		msg := 0
 		for _, s := range ss {
 			msg += len(s.Messages)
 		}
-		fmt.Printf("%s\t%s\tsessions=%d messages=%d size=%s redacted=%d\n", it.name, it.root, len(ss), msg, humanBytes(size), redactionsUnder(redactions, it.root))
+		note := ""
+		if it.name == "cursor" && len(sources.CursorDBs()) > 0 && !sources.SQLite3Available() {
+			note = "\t(sqlite3 CLI not found — Cursor IDE sessions unavailable)"
+		}
+		fmt.Printf("%s\t%s\tsessions=%d messages=%d size=%s redacted=%d%s\n", it.name, it.location, len(ss), msg, humanBytes(size), redacted, note)
 	}
+	aiderFiles := sources.AiderFiles()
+	var aiderSize int64
+	aiderRedactions := 0
+	for _, p := range aiderFiles {
+		if fi, err := os.Stat(p); err == nil {
+			aiderSize += fi.Size()
+		}
+		aiderRedactions += redactions[p]
+	}
+	aiderSessions := sources.LoadAider()
+	aiderMessages := 0
+	for _, s := range aiderSessions {
+		aiderMessages += len(s.Messages)
+	}
+	aiderLocation := filepath.Join(sources.Home(), ".aider.chat.history.md")
+	if roots := os.Getenv("DEJA_AIDER_ROOTS"); roots != "" {
+		aiderLocation += string(os.PathListSeparator) + roots
+	}
+	fmt.Printf("aider\t%s\tsessions=%d messages=%d size=%s redacted=%d\n", aiderLocation, len(aiderSessions), aiderMessages, humanBytes(aiderSize), aiderRedactions)
 	var size int64
 	if fi, err := os.Stat(sources.OpencodeDB()); err == nil {
 		size = fi.Size()
@@ -340,15 +382,6 @@ func redactionsUnder(files map[string]int, root string) int {
 }
 
 func pathSize(root string) int64 {
-	if strings.HasPrefix(root, "(") {
-		var total int64
-		for _, p := range sources.AiderFiles() {
-			if fi, err := os.Stat(p); err == nil {
-				total += fi.Size()
-			}
-		}
-		return total
-	}
 	var total int64
 	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
 		if err == nil && d.Type()&os.ModeSymlink == 0 && !d.IsDir() {
@@ -393,8 +426,8 @@ Usage:
   deja stats [--json]
   deja mcp
   deja version
-  deja install <claude-code|codex|opencode|cursor|gemini|antigravity|statusline|--all>
-  deja uninstall <claude-code|codex|opencode|cursor|gemini|antigravity|statusline|--all>
+  deja install <claude-code|codex|opencode|statusline|--all>
+  deja uninstall <claude-code|codex|opencode|statusline|--all>
 
 Examples:
   deja "jwt refresh token bug"

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -285,7 +285,7 @@ func TestPrintNoMatchesHelpfulMessage(t *testing.T) {
 	var b bytes.Buffer
 	printNoMatches(&b, "jwt refresh token", 3)
 	out := b.String()
-	if !strings.Contains(out, `deja: no matches for "jwt refresh token"`) || !strings.Contains(out, "searched 3 sessions across claude/codex/opencode") || !strings.Contains(out, "try fewer words or --re") {
+	if !strings.Contains(out, `deja: no matches for "jwt refresh token"`) || !strings.Contains(out, "searched 3 sessions across claude/codex/opencode/aider/gemini/cursor/antigravity/grok") || !strings.Contains(out, "try fewer words or --re") {
 		t.Fatalf("bad no-match message: %q", out)
 	}
 }
@@ -308,6 +308,8 @@ func TestLoadAllHermeticEmptySources(t *testing.T) {
 	t.Setenv("DEJA_GEMINI_ROOT", filepath.Join(tmp, "gemini"))
 	t.Setenv("DEJA_CURSOR_ROOT", filepath.Join(tmp, "cursor-workspaces"))
 	t.Setenv("DEJA_CURSOR_CLI_ROOT", filepath.Join(tmp, "cursor-cli"))
+	t.Setenv("DEJA_ANTIGRAVITY_ROOT", filepath.Join(tmp, "antigravity"))
+	t.Setenv("DEJA_GROK_ROOT", filepath.Join(tmp, "grok"))
 	if got := loadAll(""); len(got) != 0 {
 		t.Fatalf("loadAll empty sources = %#v", got)
 	}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -75,8 +75,8 @@ func handleMCP(req rpcRequest) (any, int, string) {
 		return map[string]any{"tools": []map[string]any{
 			{
 				"name":        "recall",
-				"description": "Search past coding-agent sessions (Claude Code, Codex, opencode) indexed on this machine and return the best matches as dense text under ~4KB. Use before debugging or re-implementing something: prior sessions often contain the exact fix, error message, or command. Query works best with specific tokens — an error string, function name, or flag.",
-				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "Search terms; specific tokens (error strings, function names, flags) match best. Multiple words are ANDed."}, "harness": map[string]any{"type": "string", "description": "Optional filter: claude, codex or opencode."}, "limit": map[string]any{"type": "number", "description": "Max sessions to return (default 5)."}}, "required": []string{"query"}},
+				"description": "Search past coding-agent sessions (Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build) indexed on this machine and return the best matches as dense text under ~4KB. Use before debugging or re-implementing something: prior sessions often contain the exact fix, error message, or command. Query works best with specific tokens — an error string, function name, or flag.",
+				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "Search terms; specific tokens (error strings, function names, flags) match best. Multiple words are ANDed."}, "harness": map[string]any{"type": "string", "description": "Optional filter: claude, codex, opencode, aider, gemini, cursor, antigravity or grok."}, "limit": map[string]any{"type": "number", "description": "Max sessions to return (default 5)."}}, "required": []string{"query"}},
 			},
 			{
 				"name":        "recall_context",

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -43,11 +44,7 @@ func runResume(args []string, stdout io.Writer) error {
 		return err
 	}
 	if !doExec {
-		if dir != "" {
-			fmt.Fprintf(stdout, "cd %s && %s\n", shellQuote(dir), cmdline)
-		} else {
-			fmt.Fprintln(stdout, cmdline)
-		}
+		fmt.Fprintln(stdout, formatResumeCommand(dir, cmdline))
 		return nil
 	}
 	parts := strings.Fields(cmdline)
@@ -57,6 +54,17 @@ func runResume(args []string, stdout io.Writer) error {
 	}
 	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return c.Run()
+}
+
+func formatResumeCommand(dir, cmdline string) string {
+	if dir == "" {
+		return cmdline
+	}
+	if runtime.GOOS == "windows" {
+		dir = "'" + strings.ReplaceAll(dir, "'", "''") + "'"
+		return fmt.Sprintf(`powershell.exe -NoProfile -Command "Set-Location -LiteralPath %s -ErrorAction Stop; %s"`, dir, cmdline)
+	}
+	return fmt.Sprintf("cd %s && %s", shellQuote(dir), cmdline)
 }
 
 // resumeCommand maps a session to (workdir, command). workdir is empty when
@@ -91,6 +99,8 @@ func resumeCommand(s model.Session) (string, string, error) {
 			return "", "", fmt.Errorf("cursor CLI transcripts have no documented resume command yet")
 		}
 		return "", "", fmt.Errorf("cursor IDE chats reopen from the Cursor UI, not the terminal")
+	case "grok":
+		return sources.GrokCWDForSession(s.Path), "grok --resume " + s.ID, nil
 	default:
 		return "", "", fmt.Errorf("don't know how to resume %q sessions", s.Harness)
 	}

--- a/cmd/deja/resume_test.go
+++ b/cmd/deja/resume_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -19,6 +20,7 @@ func TestResumeCommandPerHarness(t *testing.T) {
 	}
 	encoded := strings.ReplaceAll(real, string(filepath.Separator), "-")
 	claudePath := filepath.Join("/claude/projects", encoded, "abc.jsonl")
+	grokPath := filepath.Join(tmp, "grok-sessions", url.PathEscape(real), "019f-grok", "updates.jsonl")
 
 	cases := []struct {
 		name    string
@@ -31,6 +33,7 @@ func TestResumeCommandPerHarness(t *testing.T) {
 		{"codex rollout", model.Session{Harness: "codex", ID: "uuid-1", Project: "my-app"}, "", "codex resume uuid-1", ""},
 		{"codex history entry", model.Session{Harness: "codex", ID: "uuid-2", Project: "history"}, "", "", "nothing to resume"},
 		{"opencode with dir", model.Session{Harness: "opencode", ID: "ses_1", Project: "my-app", Path: real}, real, "opencode -s ses_1", ""},
+		{"grok with dir", model.Session{Harness: "grok", ID: "019f-grok", Project: "my-app", Path: grokPath}, real, "grok --resume 019f-grok", ""},
 		{"imported", model.Session{Harness: "claude", ID: "imported-9f5", Project: "imported:my-app"}, "", "", "another machine"},
 		{"unknown harness", model.Session{Harness: "mystery", ID: "x"}, "", "", "don't know how"},
 	}
@@ -51,6 +54,21 @@ func TestResumeCommandPerHarness(t *testing.T) {
 		if dir != c.wantDir || cmd != c.wantCmd {
 			t.Fatalf("%s: got (%q, %q), want (%q, %q)", c.name, dir, cmd, c.wantDir, c.wantCmd)
 		}
+	}
+}
+
+func TestFormatResumeCommand(t *testing.T) {
+	dir := filepath.Join("tmp", "project's dir")
+	got := formatResumeCommand(dir, "grok --resume 019f")
+	if runtime.GOOS == "windows" {
+		if !strings.HasPrefix(got, "powershell.exe -NoProfile") || !strings.Contains(got, "project''s dir") || !strings.Contains(got, "-ErrorAction Stop") || !strings.Contains(got, "grok --resume 019f") {
+			t.Fatalf("Windows resume command = %q", got)
+		}
+		return
+	}
+	want := "cd " + shellQuote(dir) + " && grok --resume 019f"
+	if got != want {
+		t.Fatalf("resume command = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/deja/testmain_test.go
+++ b/cmd/deja/testmain_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	root, err := os.MkdirTemp("", "deja-command-test-")
+	if err != nil {
+		panic(err)
+	}
+	stores := map[string]string{
+		"HOME":                  root,
+		"USERPROFILE":           root,
+		"DEJA_CLAUDE_ROOT":      filepath.Join(root, "claude"),
+		"DEJA_CODEX_ROOT":       filepath.Join(root, "codex"),
+		"DEJA_OPENCODE_DB":      filepath.Join(root, "opencode.db"),
+		"DEJA_AIDER_ROOTS":      filepath.Join(root, "aider"),
+		"DEJA_GEMINI_ROOT":      filepath.Join(root, "gemini"),
+		"DEJA_CURSOR_ROOT":      filepath.Join(root, "cursor"),
+		"DEJA_CURSOR_CLI_ROOT":  filepath.Join(root, "cursor-cli"),
+		"DEJA_ANTIGRAVITY_ROOT": filepath.Join(root, "antigravity"),
+		"DEJA_GROK_ROOT":        filepath.Join(root, "grok"),
+	}
+	for key, value := range stores {
+		if err := os.Setenv(key, value); err != nil {
+			panic(err)
+		}
+	}
+	code := m.Run()
+	_ = os.RemoveAll(root)
+	os.Exit(code)
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,10 +11,15 @@ Parsers live in `internal/sources` and return `[]model.Session`.
 | Claude Code | `claude.go` | JSONL files under `~/.claude/projects` |
 | Codex CLI | `codex.go` | rollout JSONL files plus `history.jsonl` under `~/.codex` |
 | opencode | `opencode.go` | SQLite database at `~/.local/share/opencode/opencode.db` |
+| aider | `aider.go` | `.aider.chat.history.md` files under configured project roots |
+| Gemini CLI | `gemini.go` | JSON and JSONL chats under `~/.gemini/tmp` |
+| Cursor | `cursor.go` | SQLite state stores plus CLI agent transcripts |
+| Antigravity | `antigravity.go` | JSONL transcripts under `~/.gemini/antigravity*` |
+| Grok Build | `grok.go` | ACP update streams and session summaries under `~/.grok/sessions` |
 
-Claude and Codex JSONL files are parsed with a worker pool sized to `runtime.NumCPU()`. Results are collected by input file index and then appended in sorted path order, so parsing can be parallel while index writes stay deterministic.
+File-based sources are parsed with a worker pool sized to `runtime.NumCPU()`. Results are collected by input file index and then appended in sorted path order, so parsing can be parallel while index writes stay deterministic.
 
-opencode is read through the local `sqlite3` command. There is no CGO SQLite dependency.
+opencode and Cursor IDE state are read through the local `sqlite3` command. Cursor CLI transcripts are plain JSONL. There is no CGO SQLite dependency.
 
 ## Index format
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -163,7 +163,7 @@ a:hover{text-decoration:underline}
     <div class="card">
       <div class="ic"><svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h10"/></svg></div>
       <h3>One index, every harness</h3>
-      <p>Seven harnesses — Claude Code, Codex, opencode, Cursor, Gemini CLI, aider, Antigravity — one index, retroactively. A fix found in Codex is recalled inside Claude Code.</p>
+      <p>Eight harnesses — Claude Code, Codex, opencode, Cursor, Gemini CLI, aider, Antigravity, Grok Build — one index, retroactively. A fix found in Codex is recalled inside Claude Code.</p>
     </div>
     <div class="card">
       <div class="ic"><svg viewBox="0 0 24 24"><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg></div>

--- a/internal/index/grok_test.go
+++ b/internal/index/grok_test.go
@@ -1,0 +1,186 @@
+package index
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func TestMain(m *testing.M) {
+	root, err := os.MkdirTemp("", "deja-index-test-")
+	if err != nil {
+		panic(err)
+	}
+	stores := map[string]string{
+		"HOME":                  root,
+		"USERPROFILE":           root,
+		"DEJA_CLAUDE_ROOT":      filepath.Join(root, "claude"),
+		"DEJA_CODEX_ROOT":       filepath.Join(root, "codex"),
+		"DEJA_OPENCODE_DB":      filepath.Join(root, "opencode.db"),
+		"DEJA_AIDER_ROOTS":      filepath.Join(root, "aider"),
+		"DEJA_GEMINI_ROOT":      filepath.Join(root, "gemini"),
+		"DEJA_CURSOR_ROOT":      filepath.Join(root, "cursor"),
+		"DEJA_CURSOR_CLI_ROOT":  filepath.Join(root, "cursor-cli"),
+		"DEJA_ANTIGRAVITY_ROOT": filepath.Join(root, "antigravity"),
+		"DEJA_GROK_ROOT":        filepath.Join(root, "grok"),
+	}
+	for key, value := range stores {
+		if err := os.Setenv(key, value); err != nil {
+			panic(err)
+		}
+	}
+	code := m.Run()
+	_ = os.RemoveAll(root)
+	os.Exit(code)
+}
+
+func TestGrokIndexGrowthRenameAndRewind(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	t.Setenv("DEJA_GROK_ROOT", filepath.Join(tmp, "grok"))
+
+	sessionDir := filepath.Join(tmp, "grok", "sessions", url.PathEscape("/work/grok-project"), "019f-grok-index")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	summary := `{"info":{"id":"019f-grok-index"},"generated_title":"Grok index test","created_at":"2026-07-01T10:00:00Z","updated_at":"2026-07-01T10:00:01Z"}`
+	summaryPath := filepath.Join(sessionDir, "summary.json")
+	if err := os.WriteFile(summaryPath, []byte(summary), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	updates := filepath.Join(sessionDir, "updates.jsonl")
+	first := `{"timestamp":1782900001,"params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"grokindexneedle question"},"_meta":{"promptIndex":0}}}}` + "\n"
+	if err := os.WriteFile(updates, []byte(first), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	indexDir := filepath.Join(tmp, "index.db")
+	if err := EnsureForSearch(indexDir, search.Options{Query: "grokindexneedle", Harness: "grok"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := Search(indexDir, search.Options{Query: "grokindexneedle", Harness: "grok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || ss[0].Harness != "grok" || ss[0].Project != "grok-project" {
+		t.Fatalf("bad indexed session: %#v", ss)
+	}
+	recent, err := Recent(indexDir, 1)
+	if err != nil || len(recent) != 1 || recent[0].Title != "Grok index test" {
+		t.Fatalf("bad indexed title: %#v err=%v", recent, err)
+	}
+	renamedSummary := `{"info":{"id":"019f-grok-index"},"generated_title":"Grok title test","created_at":"2026-07-01T10:00:00Z","updated_at":"2026-07-01T10:00:01Z"}`
+	if len(renamedSummary) != len(summary) {
+		t.Fatal("renamed summary must preserve size to exercise mtime freshness")
+	}
+	if err := os.WriteFile(summaryPath, []byte(renamedSummary), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tick := time.Now().Add(10 * time.Second)
+	if err := os.Chtimes(summaryPath, tick, tick); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureForSearch(indexDir, search.Options{Query: "grokindexneedle", Harness: "grok"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	recent, err = Recent(indexDir, 1)
+	if err != nil || len(recent) != 1 || recent[0].Title != "Grok title test" {
+		t.Fatalf("summary-only rename was not indexed: %#v err=%v", recent, err)
+	}
+
+	cwdPath := filepath.Join(filepath.Dir(sessionDir), ".cwd")
+	firstCWD := "/work/moved-project\n"
+	secondCWD := "/work/other-project\n"
+	if len(firstCWD) != len(secondCWD) {
+		t.Fatal("cwd fixtures must have equal size to exercise mtime freshness")
+	}
+	if err := os.WriteFile(cwdPath, []byte(firstCWD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tick = tick.Add(time.Second)
+	if err := os.Chtimes(cwdPath, tick, tick); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureForSearch(indexDir, search.Options{Query: "grokindexneedle", Harness: "grok"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	recent, err = Recent(indexDir, 1)
+	if err != nil || len(recent) != 1 || recent[0].Project != "moved-project" {
+		t.Fatalf("new Grok cwd marker was not indexed: %#v err=%v", recent, err)
+	}
+	if err := os.WriteFile(cwdPath, []byte(secondCWD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tick = tick.Add(time.Second)
+	if err := os.Chtimes(cwdPath, tick, tick); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureForSearch(indexDir, search.Options{Query: "grokindexneedle", Harness: "grok"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	ss, err = Search(indexDir, search.Options{Query: "grokindexneedle", Harness: "grok", Project: "other-project"})
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("changed Grok cwd marker was not indexed: %#v err=%v", ss, err)
+	}
+
+	f, err := os.OpenFile(updates, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second := `{"timestamp":1782900002,"params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"replacementneedle answer"}},"_meta":{"promptId":"p1"}}}` + "\n"
+	if _, err := f.WriteString(second); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	tick = tick.Add(time.Second)
+	if err := os.Chtimes(updates, tick, tick); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureForSearch(indexDir, search.Options{Query: "replacementneedle", Harness: "grok"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	ss, err = Search(indexDir, search.Options{Query: "replacementneedle", Harness: "grok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || len(ss[0].Messages) != 1 || ss[0].Messages[0].Text != "replacementneedle answer" {
+		t.Fatalf("Grok growth was not indexed cleanly: %#v", ss)
+	}
+	ss, err = Search(indexDir, search.Options{Query: "grokindexneedle", Harness: "grok"})
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("Grok growth lost existing records: %#v err=%v", ss, err)
+	}
+
+	rewound := first + `{"timestamp":1782900003,"params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"rewoundneedle replacement conversation that is longer than the removed assistant response"},"_meta":{"promptIndex":1}}}}` + "\n"
+	if len(rewound) <= len(first)+len(second) {
+		t.Fatal("rewound fixture must regrow past the previously indexed size")
+	}
+	if err := os.WriteFile(updates, []byte(rewound), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tick = tick.Add(time.Second)
+	if err := os.Chtimes(updates, tick, tick); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureForSearch(indexDir, search.Options{Query: "replacementneedle", Harness: "grok"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	ss, err = Search(indexDir, search.Options{Query: "replacementneedle", Harness: "grok"})
+	if err != nil || len(ss) != 0 {
+		t.Fatalf("Grok rewind retained truncated records: %#v err=%v", ss, err)
+	}
+	ss, err = Search(indexDir, search.Options{Query: "rewoundneedle", Harness: "grok"})
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("Grok rewind replacement was not indexed: %#v err=%v", ss, err)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -464,6 +464,9 @@ func load(h string) []model.Session {
 	if h == "" || h == "antigravity" {
 		ss = append(ss, sources.LoadAntigravity()...)
 	}
+	if h == "" || h == "grok" {
+		ss = append(ss, sources.LoadGrok()...)
+	}
 	return ss
 }
 
@@ -1131,6 +1134,8 @@ func parseChangedFile(harness, p string, old FileState) ([]model.Session, error)
 		return sources.ParseCursorTranscript(p)
 	case "antigravity":
 		return sources.ParseAntigravityFile(p)
+	case "grok":
+		return sources.ParseGrokFile(p)
 	default:
 		return nil, nil
 	}
@@ -1194,6 +1199,9 @@ func harnessForPath(p string) string {
 				return "antigravity"
 			}
 		}
+	}
+	if filepath.Base(p) == "updates.jsonl" && strings.HasPrefix(p, filepath.Join(sources.GrokRoot(), "sessions")) {
+		return "grok"
 	}
 	return ""
 }
@@ -1264,6 +1272,11 @@ func currentFiles(h string) map[string]FileState {
 	}
 	if h == "" || h == "antigravity" {
 		for _, p := range sources.AntigravityTranscripts() {
+			paths[p] = true
+		}
+	}
+	if h == "" || h == "grok" {
+		for _, p := range sources.GrokSessionFiles() {
 			paths[p] = true
 		}
 	}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -39,11 +39,15 @@ func IsCorrupt(err error) bool { return errors.Is(err, errCorruptIndex) }
 var lastIngestFiles int
 
 type FileState struct {
-	Path        string `json:"path"`
-	Size        int64  `json:"size"`
-	MTime       int64  `json:"mtime"`
-	LastUpdated int64  `json:"last_updated,omitempty"`
-	Redactions  int    `json:"redactions,omitempty"`
+	Path          string `json:"path"`
+	Size          int64  `json:"size"`
+	MTime         int64  `json:"mtime"`
+	MetadataSize  int64  `json:"metadata_size,omitempty"`
+	MetadataMTime int64  `json:"metadata_mtime,omitempty"`
+	CWDSize       int64  `json:"cwd_size,omitempty"`
+	CWDMTime      int64  `json:"cwd_mtime,omitempty"`
+	LastUpdated   int64  `json:"last_updated,omitempty"`
+	Redactions    int    `json:"redactions,omitempty"`
 	// SafeSize is the offset just past the last complete line at index time.
 	// A session file caught mid-write ends in a torn line; parsing skips it,
 	// and the next append must resume from here or that message is lost.
@@ -1106,7 +1110,11 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	return filesTouched, messages, nil
 }
 
-func sameFile(a, b FileState) bool { return a.Path == b.Path && a.Size == b.Size && a.MTime == b.MTime }
+func sameFile(a, b FileState) bool {
+	return a.Path == b.Path && a.Size == b.Size && a.MTime == b.MTime &&
+		a.MetadataSize == b.MetadataSize && a.MetadataMTime == b.MetadataMTime &&
+		a.CWDSize == b.CWDSize && a.CWDMTime == b.CWDMTime
+}
 
 func parseChangedFile(harness, p string, old FileState) ([]model.Session, error) {
 	switch harnessForPath(p) {
@@ -1286,6 +1294,16 @@ func currentFiles(h string) map[string]FileState {
 			fs := FileState{Path: p, Size: fi.Size(), MTime: fi.ModTime().UnixNano()}
 			if strings.HasSuffix(p, ".jsonl") {
 				fs.SafeSize = lastCompleteLineOffset(p, fi.Size())
+			}
+			if harnessForPath(p) == "grok" {
+				if summary, err := os.Lstat(filepath.Join(filepath.Dir(p), "summary.json")); err == nil && summary.Mode()&os.ModeSymlink == 0 && !summary.IsDir() {
+					fs.MetadataSize = summary.Size()
+					fs.MetadataMTime = summary.ModTime().UnixNano()
+				}
+				if cwd, err := os.Lstat(filepath.Join(filepath.Dir(filepath.Dir(p)), ".cwd")); err == nil && cwd.Mode()&os.ModeSymlink == 0 && !cwd.IsDir() {
+					fs.CWDSize = cwd.Size()
+					fs.CWDMTime = cwd.ModTime().UnixNano()
+				}
 			}
 			out[p] = fs
 		}

--- a/internal/sources/grok.go
+++ b/internal/sources/grok.go
@@ -1,0 +1,211 @@
+package sources
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Grok Build stores sessions by URL-encoded working directory. summary.json
+// carries metadata and updates.jsonl is the authoritative ACP conversation
+// stream. Grok can truncate and regrow the stream after a rewind, so changed
+// files are always reparsed in full.
+
+func GrokRoot() string {
+	if root := os.Getenv("DEJA_GROK_ROOT"); root != "" {
+		return root
+	}
+	return EnvPath("GROK_HOME", filepath.Join(Home(), ".grok"))
+}
+
+func GrokSessionFiles() []string {
+	return walkFiles(filepath.Join(GrokRoot(), "sessions"), func(p string) bool {
+		return filepath.Base(p) == "updates.jsonl"
+	})
+}
+
+func LoadGrok() []model.Session {
+	return parseFiles(GrokSessionFiles(), ParseGrokFile)
+}
+
+type grokSummary struct {
+	Info struct {
+		ID  string `json:"id"`
+		CWD string `json:"cwd"`
+	} `json:"info"`
+	SessionSummary string `json:"session_summary"`
+	GeneratedTitle string `json:"generated_title"`
+	CreatedAt      string `json:"created_at"`
+	UpdatedAt      string `json:"updated_at"`
+}
+
+func ParseGrokFile(path string) ([]model.Session, error) {
+	doc := readGrokSummary(path)
+	id := doc.Info.ID
+	if id == "" {
+		id = filepath.Base(filepath.Dir(path))
+	}
+	cwd := doc.Info.CWD
+	if cwd == "" {
+		cwd = grokCWDFromPath(path)
+	}
+	title := doc.GeneratedTitle
+	if title == "" {
+		title = doc.SessionSummary
+	}
+	s := model.Session{ID: id, Harness: "grok", Project: projectName(cwd), Path: path, Title: title}
+	if t, err := time.Parse(time.RFC3339Nano, doc.CreatedAt); err == nil {
+		s.Touch(t)
+	}
+	if t, err := time.Parse(time.RFC3339Nano, doc.UpdatedAt); err == nil {
+		s.Touch(t)
+	}
+
+	lastKey := ""
+	err := scanGrokUpdates(path, func(event grokUpdateEvent) {
+		role := ""
+		switch event.Params.Update.Kind {
+		case "user_message_chunk":
+			role = "user"
+		case "agent_message_chunk":
+			role = "assistant"
+		default:
+			return
+		}
+		text := grokContentText(event.Params.Update.Content)
+		if text == "" {
+			return
+		}
+		t := parseTimeAny(event.Timestamp)
+		if t.IsZero() {
+			t = parseTimeAny(event.Params.Meta.AgentTimestamp)
+		}
+		s.Touch(t)
+
+		key := grokMessageKey(role, event)
+		if key != "" && key == lastKey && len(s.Messages) > 0 {
+			s.Messages[len(s.Messages)-1].Text += text
+			return
+		}
+		s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: t})
+		lastKey = key
+	})
+	if len(s.Messages) == 0 {
+		return nil, err
+	}
+	return []model.Session{s}, err
+}
+
+type grokUpdateEvent struct {
+	Timestamp json.Number `json:"timestamp"`
+	Params    struct {
+		Update struct {
+			Kind    string          `json:"sessionUpdate"`
+			Content json.RawMessage `json:"content"`
+			Meta    struct {
+				PromptIndex *int `json:"promptIndex"`
+			} `json:"_meta"`
+		} `json:"update"`
+		Meta struct {
+			PromptID       string      `json:"promptId"`
+			AgentTimestamp json.Number `json:"agentTimestampMs"`
+		} `json:"_meta"`
+	} `json:"params"`
+}
+
+func grokMessageKey(role string, event grokUpdateEvent) string {
+	if role == "assistant" {
+		if event.Params.Meta.PromptID != "" {
+			return role + ":" + event.Params.Meta.PromptID
+		}
+		return ""
+	}
+	if event.Params.Update.Meta.PromptIndex != nil {
+		return role + ":" + strconv.Itoa(*event.Params.Update.Meta.PromptIndex)
+	}
+	return ""
+}
+
+func grokContentText(raw json.RawMessage) string {
+	var block struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &block) == nil && block.Text != "" {
+		if block.Type == "" || block.Type == "text" {
+			return block.Text
+		}
+		return ""
+	}
+	var v any
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.UseNumber()
+	_ = d.Decode(&v)
+	return textFromContent(v)
+}
+
+var grokUserChunk = []byte(`"user_message_chunk"`)
+var grokAgentChunk = []byte(`"agent_message_chunk"`)
+
+// Most update lines are large tool events. Filter them before JSON decoding so
+// indexing cost is dominated by reading the log rather than materializing tool
+// payloads that will be discarded.
+func scanGrokUpdates(path string, fn func(grokUpdateEvent)) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	r := bufio.NewReaderSize(f, 1024*1024)
+	for {
+		line, err := r.ReadBytes('\n')
+		if bytes.Contains(line, grokUserChunk) || bytes.Contains(line, grokAgentChunk) {
+			var event grokUpdateEvent
+			if json.Unmarshal(line, &event) == nil {
+				fn(event)
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func readGrokSummary(updatePath string) grokSummary {
+	var doc grokSummary
+	b, err := os.ReadFile(filepath.Join(filepath.Dir(updatePath), "summary.json"))
+	if err == nil {
+		_ = json.Unmarshal(b, &doc)
+	}
+	return doc
+}
+
+func grokCWDFromPath(updatePath string) string {
+	if updatePath == "" {
+		return ""
+	}
+	group := filepath.Dir(filepath.Dir(updatePath))
+	if b, err := os.ReadFile(filepath.Join(group, ".cwd")); err == nil {
+		if cwd := strings.TrimSpace(string(b)); cwd != "" {
+			return cwd
+		}
+	}
+	cwd, err := url.PathUnescape(filepath.Base(group))
+	if err != nil {
+		return ""
+	}
+	return cwd
+}

--- a/internal/sources/grok.go
+++ b/internal/sources/grok.go
@@ -193,6 +193,17 @@ func readGrokSummary(updatePath string) grokSummary {
 	return doc
 }
 
+// GrokCWDForSession recovers the working directory needed by grok --resume.
+func GrokCWDForSession(updatePath string) string {
+	if updatePath == "" {
+		return ""
+	}
+	if cwd := readGrokSummary(updatePath).Info.CWD; cwd != "" {
+		return cwd
+	}
+	return grokCWDFromPath(updatePath)
+}
+
 func grokCWDFromPath(updatePath string) string {
 	if updatePath == "" {
 		return ""

--- a/internal/sources/grok_test.go
+++ b/internal/sources/grok_test.go
@@ -78,14 +78,14 @@ func TestGrokDiscoveryAndRootOverrides(t *testing.T) {
 
 func TestGrokCWDFromEncodedGroupAndMarker(t *testing.T) {
 	_, updates := grokTree(t)
-	if got := grokCWDFromPath(updates); got != "/work/cool-app" {
+	if got := GrokCWDForSession(updates); got != "/work/cool-app" {
 		t.Fatalf("encoded cwd = %q", got)
 	}
 	group := filepath.Dir(filepath.Dir(updates))
 	if err := os.WriteFile(filepath.Join(group, ".cwd"), []byte("/a/very/long/project\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := grokCWDFromPath(updates); got != "/a/very/long/project" {
+	if got := GrokCWDForSession(updates); got != "/a/very/long/project" {
 		t.Fatalf("marker cwd = %q", got)
 	}
 }

--- a/internal/sources/grok_test.go
+++ b/internal/sources/grok_test.go
@@ -1,0 +1,91 @@
+package sources
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func grokTree(t *testing.T) (root, updates string) {
+	t.Helper()
+	root = t.TempDir()
+	t.Setenv("DEJA_GROK_ROOT", root)
+	group := url.PathEscape("/work/cool-app")
+	dir := filepath.Join(root, "sessions", group, "019f-grok-session")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root, filepath.Join(dir, "updates.jsonl")
+}
+
+func TestParseGrokFile(t *testing.T) {
+	_, updates := grokTree(t)
+	summary := `{"info":{"id":"019f-grok-session","cwd":"/work/cool-app"},"session_summary":"Fallback title","generated_title":"Fix the parser","created_at":"2026-07-01T10:00:00Z","updated_at":"2026-07-01T10:00:06Z"}`
+	if err := os.WriteFile(filepath.Join(filepath.Dir(updates), "summary.json"), []byte(summary), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lines := `{"timestamp":1782900001,"method":"session/update","params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"find grokneedle"},"_meta":{"promptIndex":0}}}}
+{"timestamp":1782900002,"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"first "}},"_meta":{"promptId":"p1"}}}
+{"timestamp":1782900003,"method":"session/update","params":{"update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"private reasoning"}}}}
+{"timestamp":1782900004,"method":"session/update","params":{"update":{"sessionUpdate":"tool_call","content":{"type":"text","text":"tool noise"}}}}
+{"timestamp":1782900005,"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"answer"}},"_meta":{"promptId":"p1"}}}
+{malformed
+`
+	if err := os.WriteFile(updates, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseGrokFile(updates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || ss[0].ID != "019f-grok-session" || ss[0].Harness != "grok" {
+		t.Fatalf("bad session: %#v", ss)
+	}
+	if ss[0].Project != "cool-app" || ss[0].Title != "Fix the parser" {
+		t.Fatalf("bad metadata: %#v", ss[0])
+	}
+	if len(ss[0].Messages) != 2 {
+		t.Fatalf("messages = %d, want 2: %#v", len(ss[0].Messages), ss[0].Messages)
+	}
+	if ss[0].Messages[0].Role != "user" || ss[0].Messages[0].Text != "find grokneedle" {
+		t.Fatalf("bad user message: %#v", ss[0].Messages[0])
+	}
+	if ss[0].Messages[1].Role != "assistant" || ss[0].Messages[1].Text != "first answer" {
+		t.Fatalf("assistant chunks not merged: %#v", ss[0].Messages[1])
+	}
+}
+
+func TestGrokDiscoveryAndRootOverrides(t *testing.T) {
+	root, updates := grokTree(t)
+	if err := os.WriteFile(updates, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(filepath.Dir(updates), "chat_history.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files := GrokSessionFiles()
+	if len(files) != 1 || files[0] != updates {
+		t.Fatalf("files = %v, want [%s]", files, updates)
+	}
+
+	t.Setenv("DEJA_GROK_ROOT", "")
+	t.Setenv("GROK_HOME", root)
+	if GrokRoot() != root {
+		t.Fatalf("GROK_HOME ignored: %q", GrokRoot())
+	}
+}
+
+func TestGrokCWDFromEncodedGroupAndMarker(t *testing.T) {
+	_, updates := grokTree(t)
+	if got := grokCWDFromPath(updates); got != "/work/cool-app" {
+		t.Fatalf("encoded cwd = %q", got)
+	}
+	group := filepath.Dir(filepath.Dir(updates))
+	if err := os.WriteFile(filepath.Join(group, ".cwd"), []byte("/a/very/long/project\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := grokCWDFromPath(updates); got != "/a/very/long/project" {
+		t.Fatalf("marker cwd = %q", got)
+	}
+}

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -7,9 +7,18 @@ fail() { echo "e2e FAIL: $*" >&2; exit 1; }
 
 go build -o /tmp/deja-e2e ./cmd/deja
 
+SOURCE_HOME="$(mktemp -d)"
+export HOME="$SOURCE_HOME"
+export USERPROFILE="$SOURCE_HOME"
 export DEJA_CLAUDE_ROOT="$PWD/fixtures/synthetic/claude"
 export DEJA_CODEX_ROOT="$PWD/fixtures/synthetic/codex"
 export DEJA_OPENCODE_DB="/tmp/deja-e2e-no.db"
+export DEJA_AIDER_ROOTS="$SOURCE_HOME/aider"
+export DEJA_GEMINI_ROOT="$SOURCE_HOME/gemini"
+export DEJA_CURSOR_ROOT="$SOURCE_HOME/cursor"
+export DEJA_CURSOR_CLI_ROOT="$SOURCE_HOME/cursor-cli"
+export DEJA_ANTIGRAVITY_ROOT="$SOURCE_HOME/antigravity"
+export DEJA_GROK_ROOT="$SOURCE_HOME/grok"
 DEJA_INDEX_DIR="$(mktemp -d)/index.db"
 export DEJA_INDEX_DIR
 export NO_COLOR=1


### PR DESCRIPTION
## Summary
- index Grok Build ACP update streams and summary metadata from `~/.grok/sessions`
- keep the index fresh across summary and `.cwd` metadata changes, appends, and rewinds
- add native `deja resume`, source/MCP reporting, documentation, and hermetic integration coverage

## Testing
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go mod verify`
- `sh scripts/e2e.sh`
- Linux, macOS, and Windows amd64 builds

Closes #63