### PR TITLE
docs: agent strip on the site, current install targets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ brew install vshulcz/tap/deja-vu                        # Homebrew
 Wire it into the agents you use (edits config, keeps a `.bak`):
 
 ```sh
-deja install --all          # MCP recall for claude-code, codex, opencode
+deja install --all          # MCP recall for every agent it finds on this machine
 deja install claude-code --auto   # + SessionStart auto-recall hook
 ```
 
@@ -108,7 +108,7 @@ Batches are plain JSONL, redacted on the way out. Import is idempotent, so keep 
 
 ## Teach your agent to remember
 
-`deja install --all` wires up MCP recall; `deja install --auto` also adds session-start auto-recall on every harness it finds (Claude Code hook, Codex hooks.json, an opencode plugin). To make
+`deja install --all` wires up MCP recall (Claude Code, Codex, opencode, Cursor, Gemini CLI, Antigravity — aider has no MCP client, pipe `deja ctx` instead); `deja install --auto` also adds session-start auto-recall on every harness it finds (Claude Code hook, Codex hooks.json, an opencode plugin). To make
 the agent reach for memory on its own, add this to your `CLAUDE.md` /
 `AGENTS.md`:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -86,6 +86,16 @@ footer .spacer{flex:1}
 a{color:var(--a2);text-decoration:none}
 a:hover{text-decoration:underline}
 @media(max-width:600px){.hero-install{font-size:.78rem}}
+
+.agents{margin:34px auto 0;text-align:center}
+.agents .cap{font-size:.78rem;letter-spacing:.14em;text-transform:uppercase;color:#8a87a0;margin-bottom:14px}
+.agents .row{display:flex;flex-wrap:wrap;gap:22px;justify-content:center;align-items:flex-start}
+.agent{display:flex;flex-direction:column;align-items:center;gap:7px;width:76px;text-decoration:none}
+.agent .disc{width:46px;height:46px;border-radius:14px;background:#232134;border:1px solid #322f47;display:flex;align-items:center;justify-content:center;transition:transform .15s ease,border-color .15s ease}
+.agent:hover .disc{transform:translateY(-2px);border-color:#7c6cf0}
+.agent svg{width:22px;height:22px}
+.agent .mono{font-family:var(--mono);font-size:.82rem;font-weight:700;color:#9aa0b5}
+.agent .nm{font-size:.72rem;color:#8a87a0}
 </style>
 </head>
 <body>
@@ -112,6 +122,19 @@ a:hover{text-decoration:underline}
     <code id="cmd">curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</code>
     <button class="copy" data-copy="cmd">copy</button>
   </div>
+<div class="agents">
+  <div class="cap">one index &middot; seven agents</div>
+  <div class="row">
+    <span class="agent"><span class="disc"><svg fill="#9aa0b5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-label="Claude Code"><path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z"/></svg></span><span class="nm">Claude Code</span></span>
+    <span class="agent"><span class="disc"><span class="mono">cx</span></span><span class="nm">Codex CLI</span></span>
+    <span class="agent"><span class="disc"><span class="mono">&gt;_</span></span><span class="nm">opencode</span></span>
+    <span class="agent"><span class="disc"><svg fill="#9aa0b5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-label="Cursor"><path d="M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23"/></svg></span><span class="nm">Cursor</span></span>
+    <span class="agent"><span class="disc"><svg fill="#9aa0b5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-label="Gemini CLI"><path d="M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81"/></svg></span><span class="nm">Gemini CLI</span></span>
+    <span class="agent"><span class="disc"><span class="mono">ai</span></span><span class="nm">aider</span></span>
+    <span class="agent"><span class="disc"><span class="mono">ag</span></span><span class="nm">Antigravity</span></span>
+  </div>
+</div>
+
 </header>
 
 <div class="term">


### PR DESCRIPTION
Seven agent chips under the hero (real marks for Claude/Cursor/Gemini, matching monograms for the rest — no grok, it isn't supported yet). README stops claiming install --all covers only three harnesses.