### PR TITLE
feat: add self-update command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.22.x'
+          go-version: '1.25.x'
           cache: false
       - run: go mod verify
       - run: go vet ./...
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.22.x'
+          go-version: '1.25.x'
           cache: false
       - run: sh scripts/e2e.sh
 
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.22.x'
+          go-version: '1.25.x'
           cache: false
       - name: Build all release targets
         run: |
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: '1.25.x'
           cache: false
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck ./...
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.22.x'
+          go-version: '1.25.x'
           cache: false
       - uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.22.x'
+          go-version: '1.25.x'
           cache: false
 
       - name: Run golangci-lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.22.x'
+          go-version: '1.25.x'
           cache: false
 
       - uses: goreleaser/goreleaser-action@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.22-alpine AS build
+FROM golang:1.25-alpine AS build
 WORKDIR /src
 COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/deja ./cmd/deja

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity and Grok Bu
 | **Share** | `deja share <id>` — hand a colleague a sanitized digest of a session, secrets already scrubbed |
 | **Sync** | `deja sync export/import` — move memory between machines, append-only, idempotent |
 
-One binary. No models to download, no services to run, nothing leaves your machine. (opencode and Cursor IDE indexing shell out to the `sqlite3` CLI, preinstalled on macOS and most Linux distros; Cursor CLI transcripts do not need it.)
+One binary. No models to download, no services to run, and deja never uploads your session data. (Explicit sync and recalled context remain under your control; opencode and Cursor IDE indexing shell out to the `sqlite3` CLI, preinstalled on macOS and most Linux distros; Cursor CLI transcripts do not need it.)
 
 ## Install
 
@@ -78,7 +78,10 @@ $ deja "jwt refresh token"
 | `deja sources` | Discovered stores, sizes, message and redaction counts. |
 | `deja mcp` | The stdio MCP server (what `deja install` wires in). |
 | `deja warmup` | Build/refresh the index without searching — handy in cron or shell startup. |
+| `deja update` | Download the latest GitHub release, verify its checksum, and replace the current binary. |
 | `deja statusline` | One line for your status bar: recalls served to agents today. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
+
+`deja update` is for standalone binary installs. For Homebrew or npm installations, use the package manager so its installed-version metadata stays consistent.
 
 Context piping without MCP:
 
@@ -168,7 +171,7 @@ Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact cr
 
 ## FAQ
 
-**Does anything leave my machine?** No. There is no network code in the tool. `sync` writes files to a directory you choose; moving them is up to you.
+**Does anything leave my machine?** Indexing and search are fully local, and deja makes no session-data upload requests. Explicit sync moves sanitized records; recalled context passed to an agent follows that harness/provider's data policy. `deja update` only downloads release metadata and binaries from GitHub.
 
 **How is this different from cass?**
 [cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, eight harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ deja "jwt refresh token"
 | `deja update` | Download the latest GitHub release, verify its checksum, and replace the current binary. |
 | `deja statusline` | One line for your status bar: recalls served to agents today. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
 
-`deja update` is for standalone installs. Homebrew and npm installs update through the package manager.
+`deja update` is for standalone installs and uses `curl` to download releases. Homebrew and npm installs update through the package manager.
 
 Context piping without MCP:
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ deja "jwt refresh token"
 | `deja update` | Download the latest GitHub release, verify its checksum, and replace the current binary. |
 | `deja statusline` | One line for your status bar: recalls served to agents today. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
 
-`deja update` is for standalone installs and uses `curl` to download releases. Homebrew and npm installs update through the package manager.
+`deja update` is for standalone installs. Homebrew and npm installs update through the package manager.
 
 Context piping without MCP:
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity and Grok Bu
 | **Share** | `deja share <id>` — hand a colleague a sanitized digest of a session, secrets already scrubbed |
 | **Sync** | `deja sync export/import` — move memory between machines, append-only, idempotent |
 
-One binary. No models to download, no services to run, and deja never uploads your session data. (Explicit sync and recalled context remain under your control; opencode and Cursor IDE indexing shell out to the `sqlite3` CLI, preinstalled on macOS and most Linux distros; Cursor CLI transcripts do not need it.)
+One binary. No models to download, no services to run, nothing leaves your machine unless you sync or share it. (opencode and Cursor IDE indexing shell out to the `sqlite3` CLI, preinstalled on macOS and most Linux distros; Cursor CLI transcripts do not need it.)
 
 ## Install
 
@@ -81,7 +81,7 @@ $ deja "jwt refresh token"
 | `deja update` | Download the latest GitHub release, verify its checksum, and replace the current binary. |
 | `deja statusline` | One line for your status bar: recalls served to agents today. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
 
-`deja update` is for standalone binary installs. For Homebrew or npm installations, use the package manager so its installed-version metadata stays consistent.
+`deja update` is for standalone installs. Homebrew and npm installs update through the package manager.
 
 Context piping without MCP:
 
@@ -171,7 +171,7 @@ Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact cr
 
 ## FAQ
 
-**Does anything leave my machine?** Indexing and search are fully local, and deja makes no session-data upload requests. Explicit sync moves sanitized records; recalled context passed to an agent follows that harness/provider's data policy. `deja update` only downloads release metadata and binaries from GitHub.
+**Does anything leave my machine?** No. Indexing and search are fully local. `sync` writes files to a directory you choose, moving them is up to you. The only network call is `deja update`, which downloads releases from GitHub.
 
 **How is this different from cass?**
 [cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, eight harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -97,6 +97,9 @@ func run(args []string) error {
 	if args[0] == "uninstall" {
 		return runInstall(args[1:], true)
 	}
+	if args[0] == "update" {
+		return runUpdate(args[1:], os.Stdout)
+	}
 	if args[0] == "show" {
 		if len(args) < 2 {
 			return fmt.Errorf("show needs id-prefix")
@@ -426,6 +429,7 @@ Usage:
   deja stats [--json]
   deja mcp
   deja version
+  deja update
   deja install <claude-code|codex|opencode|cursor|gemini|antigravity|grok|statusline|--all|--auto>
   deja uninstall <claude-code|codex|opencode|cursor|gemini|antigravity|grok|statusline|--all|--auto>
 

--- a/cmd/deja/update.go
+++ b/cmd/deja/update.go
@@ -1,0 +1,430 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	latestReleaseURL = "https://api.github.com/repos/vshulcz/deja-vu/releases/latest"
+	maxReleaseJSON   = 2 << 20
+	maxChecksums     = 2 << 20
+	maxArchive       = 128 << 20
+	maxExecutable    = 128 << 20
+)
+
+type updateAsset struct {
+	Name string `json:"name"`
+	URL  string `json:"browser_download_url"`
+}
+
+type updateRelease struct {
+	TagName string        `json:"tag_name"`
+	Assets  []updateAsset `json:"assets"`
+}
+
+type updateConfig struct {
+	currentVersion string
+	goos           string
+	goarch         string
+	executable     string
+	latestURL      string
+	client         *http.Client
+}
+
+func runUpdate(args []string, out io.Writer) error {
+	if len(args) != 0 {
+		return fmt.Errorf("update takes no arguments")
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate executable: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(executable); err == nil {
+		executable = resolved
+	}
+	return performUpdate(updateConfig{
+		currentVersion: version,
+		goos:           runtime.GOOS,
+		goarch:         runtime.GOARCH,
+		executable:     executable,
+		latestURL:      latestReleaseURL,
+		client:         &http.Client{Timeout: 2 * time.Minute},
+	}, out)
+}
+
+func performUpdate(cfg updateConfig, out io.Writer) error {
+	if cfg.client == nil {
+		return fmt.Errorf("update HTTP client is required")
+	}
+	if cfg.executable == "" {
+		return fmt.Errorf("update executable path is required")
+	}
+	if _, _, err := updateAssetNames("version", cfg.goos, cfg.goarch); err != nil {
+		return err
+	}
+
+	body, err := fetchUpdateURL(cfg.client, cfg.latestURL, maxReleaseJSON, "latest release")
+	if err != nil {
+		return err
+	}
+	var release updateRelease
+	if err := json.Unmarshal(body, &release); err != nil {
+		return fmt.Errorf("decode latest release: %w", err)
+	}
+	latest := normalizeUpdateVersion(release.TagName)
+	if latest == "" {
+		return fmt.Errorf("latest release did not include a tag")
+	}
+	current := normalizeUpdateVersion(cfg.currentVersion)
+	if current != "" && current != "dev" {
+		if order, ok := compareUpdateVersions(current, latest); ok {
+			switch {
+			case order == 0:
+				fmt.Fprintf(out, "deja is already up to date (v%s)\n", latest)
+				return nil
+			case order > 0:
+				fmt.Fprintf(out, "deja v%s is newer than the latest stable release (v%s)\n", current, latest)
+				return nil
+			}
+		} else if current == latest {
+			fmt.Fprintf(out, "deja is already up to date (v%s)\n", latest)
+			return nil
+		}
+	}
+
+	archiveName, binaryName, err := updateAssetNames(latest, cfg.goos, cfg.goarch)
+	if err != nil {
+		return err
+	}
+	archiveAsset, ok := findUpdateAsset(release.Assets, archiveName)
+	if !ok {
+		return fmt.Errorf("release v%s has no asset for %s/%s", latest, cfg.goos, cfg.goarch)
+	}
+	checksumsAsset, ok := findUpdateAsset(release.Assets, "checksums.txt")
+	if !ok {
+		return fmt.Errorf("release v%s has no checksums.txt", latest)
+	}
+
+	checksums, err := fetchUpdateURL(cfg.client, checksumsAsset.URL, maxChecksums, "checksums.txt")
+	if err != nil {
+		return err
+	}
+	want, err := checksumForArchive(checksums, archiveName)
+	if err != nil {
+		return err
+	}
+	archive, err := fetchUpdateURL(cfg.client, archiveAsset.URL, maxArchive, archiveName)
+	if err != nil {
+		return err
+	}
+	actual := sha256.Sum256(archive)
+	if !strings.EqualFold(hex.EncodeToString(actual[:]), want) {
+		return fmt.Errorf("checksum mismatch for %s", archiveName)
+	}
+
+	binary, err := extractUpdateBinary(archive, binaryName, cfg.goos)
+	if err != nil {
+		return fmt.Errorf("extract %s: %w", archiveName, err)
+	}
+	if err := installUpdateBinary(cfg.executable, binary); err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return fmt.Errorf("replace %s: %w; rerun with permission to write its install directory or use your package manager", cfg.executable, err)
+		}
+		return fmt.Errorf("replace %s: %w", cfg.executable, err)
+	}
+	from := current
+	if from == "" {
+		from = "unknown"
+	}
+	if from != "dev" && from != "unknown" {
+		from = "v" + from
+	}
+	fmt.Fprintf(out, "updated deja %s -> v%s at %s\n", from, latest, cfg.executable)
+	return nil
+}
+
+func normalizeUpdateVersion(v string) string {
+	return strings.TrimPrefix(strings.TrimSpace(v), "v")
+}
+
+type parsedUpdateVersion struct {
+	core       [3]int
+	prerelease []string
+}
+
+// compareUpdateVersions returns -1, 0, or 1 when a is older, equal to, or
+// newer than b. Release tags use SemVer, so refusing a downgrade is safe.
+func compareUpdateVersions(a, b string) (int, bool) {
+	left, ok := parseUpdateVersion(a)
+	if !ok {
+		return 0, false
+	}
+	right, ok := parseUpdateVersion(b)
+	if !ok {
+		return 0, false
+	}
+	for i := range left.core {
+		if left.core[i] < right.core[i] {
+			return -1, true
+		}
+		if left.core[i] > right.core[i] {
+			return 1, true
+		}
+	}
+	if len(left.prerelease) == 0 && len(right.prerelease) == 0 {
+		return 0, true
+	}
+	if len(left.prerelease) == 0 {
+		return 1, true
+	}
+	if len(right.prerelease) == 0 {
+		return -1, true
+	}
+	for i := 0; i < len(left.prerelease) && i < len(right.prerelease); i++ {
+		if left.prerelease[i] == right.prerelease[i] {
+			continue
+		}
+		ln, lerr := strconv.Atoi(left.prerelease[i])
+		rn, rerr := strconv.Atoi(right.prerelease[i])
+		switch {
+		case lerr == nil && rerr == nil:
+			if ln < rn {
+				return -1, true
+			}
+			return 1, true
+		case lerr == nil:
+			return -1, true
+		case rerr == nil:
+			return 1, true
+		case left.prerelease[i] < right.prerelease[i]:
+			return -1, true
+		default:
+			return 1, true
+		}
+	}
+	if len(left.prerelease) < len(right.prerelease) {
+		return -1, true
+	}
+	if len(left.prerelease) > len(right.prerelease) {
+		return 1, true
+	}
+	return 0, true
+}
+
+func parseUpdateVersion(v string) (parsedUpdateVersion, bool) {
+	var parsed parsedUpdateVersion
+	v = normalizeUpdateVersion(v)
+	v = strings.SplitN(v, "+", 2)[0]
+	parts := strings.SplitN(v, "-", 2)
+	core := strings.Split(parts[0], ".")
+	if len(core) != len(parsed.core) {
+		return parsed, false
+	}
+	for i, part := range core {
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 {
+			return parsed, false
+		}
+		parsed.core[i] = n
+	}
+	if len(parts) == 2 {
+		if parts[1] == "" {
+			return parsed, false
+		}
+		parsed.prerelease = strings.Split(parts[1], ".")
+		for _, identifier := range parsed.prerelease {
+			if identifier == "" {
+				return parsedUpdateVersion{}, false
+			}
+		}
+	}
+	return parsed, true
+}
+
+func updateAssetNames(version, goos, goarch string) (archive, binary string, err error) {
+	if goos != "darwin" && goos != "linux" && goos != "windows" {
+		return "", "", fmt.Errorf("updates are not available for %s/%s", goos, goarch)
+	}
+	if goarch != "amd64" && goarch != "arm64" {
+		return "", "", fmt.Errorf("updates are not available for %s/%s", goos, goarch)
+	}
+	ext := ".tar.gz"
+	binary = "deja"
+	if goos == "windows" {
+		ext = ".zip"
+		binary = "deja.exe"
+	}
+	return fmt.Sprintf("deja-vu_%s_%s_%s%s", version, goos, goarch, ext), binary, nil
+}
+
+func findUpdateAsset(assets []updateAsset, name string) (updateAsset, bool) {
+	for _, asset := range assets {
+		if asset.Name == name && asset.URL != "" {
+			return asset, true
+		}
+	}
+	return updateAsset{}, false
+}
+
+func fetchUpdateURL(client *http.Client, url string, limit int64, label string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("request %s: %w", label, err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "deja/"+normalizeUpdateVersion(version))
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", label, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("download %s: HTTP %s", label, resp.Status)
+	}
+	if resp.ContentLength > limit {
+		return nil, fmt.Errorf("download %s: response exceeds %d bytes", label, limit)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", label, err)
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("download %s: response exceeds %d bytes", label, limit)
+	}
+	return body, nil
+}
+
+func checksumForArchive(checksums []byte, archiveName string) (string, error) {
+	for _, line := range strings.Split(string(checksums), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || strings.TrimPrefix(fields[1], "*") != archiveName {
+			continue
+		}
+		if len(fields[0]) != sha256.Size*2 {
+			return "", fmt.Errorf("invalid checksum for %s", archiveName)
+		}
+		if _, err := hex.DecodeString(fields[0]); err != nil {
+			return "", fmt.Errorf("invalid checksum for %s", archiveName)
+		}
+		return fields[0], nil
+	}
+	return "", fmt.Errorf("checksum entry not found for %s", archiveName)
+}
+
+func extractUpdateBinary(archive []byte, binaryName, goos string) ([]byte, error) {
+	if goos == "windows" {
+		zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+		if err != nil {
+			return nil, err
+		}
+		for _, file := range zr.File {
+			if path.Base(file.Name) != binaryName || file.FileInfo().IsDir() {
+				continue
+			}
+			if file.UncompressedSize64 > maxExecutable {
+				return nil, fmt.Errorf("%s exceeds %d bytes", binaryName, maxExecutable)
+			}
+			r, err := file.Open()
+			if err != nil {
+				return nil, err
+			}
+			binary, readErr := readUpdateBinary(r, binaryName)
+			closeErr := r.Close()
+			if readErr != nil {
+				return nil, readErr
+			}
+			if closeErr != nil {
+				return nil, closeErr
+			}
+			return binary, nil
+		}
+		return nil, fmt.Errorf("archive did not contain %s", binaryName)
+	}
+
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if path.Base(header.Name) != binaryName || !header.FileInfo().Mode().IsRegular() {
+			continue
+		}
+		if header.Size > maxExecutable {
+			return nil, fmt.Errorf("%s exceeds %d bytes", binaryName, maxExecutable)
+		}
+		return readUpdateBinary(tr, binaryName)
+	}
+	return nil, fmt.Errorf("archive did not contain %s", binaryName)
+}
+
+func readUpdateBinary(r io.Reader, name string) ([]byte, error) {
+	binary, err := io.ReadAll(io.LimitReader(r, maxExecutable+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(binary) == 0 {
+		return nil, fmt.Errorf("%s is empty", name)
+	}
+	if len(binary) > maxExecutable {
+		return nil, fmt.Errorf("%s exceeds %d bytes", name, maxExecutable)
+	}
+	return binary, nil
+}
+
+func installUpdateBinary(destination string, binary []byte) (err error) {
+	info, err := os.Stat(destination)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("destination is not a regular file")
+	}
+	staged, err := os.CreateTemp(filepath.Dir(destination), ".deja-update-*")
+	if err != nil {
+		return err
+	}
+	stagedPath := staged.Name()
+	defer func() {
+		_ = staged.Close()
+		_ = os.Remove(stagedPath)
+	}()
+	if _, err := staged.Write(binary); err != nil {
+		return err
+	}
+	if err := staged.Chmod(info.Mode().Perm()); err != nil {
+		return err
+	}
+	if err := staged.Sync(); err != nil {
+		return err
+	}
+	if err := staged.Close(); err != nil {
+		return err
+	}
+	return replaceExecutable(stagedPath, destination)
+}

--- a/cmd/deja/update.go
+++ b/cmd/deja/update.go
@@ -5,14 +5,15 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -39,13 +40,57 @@ type updateRelease struct {
 	Assets  []updateAsset `json:"assets"`
 }
 
+type updateDownloader func(url string, limit int64, label string) ([]byte, error)
+
+func defaultUpdateDownloader() updateDownloader {
+	return func(url string, limit int64, label string) ([]byte, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "curl",
+			"--disable", "--fail", "--silent", "--show-error", "--location",
+			"--proto", "=https", "--proto-redir", "=https",
+			"--header", "Accept: application/vnd.github+json",
+			"--user-agent", "deja/"+normalizeUpdateVersion(version), url)
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return nil, fmt.Errorf("download %s: %w", label, err)
+		}
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Start(); err != nil {
+			return nil, fmt.Errorf("download %s: %w", label, err)
+		}
+		body, readErr := io.ReadAll(io.LimitReader(stdout, limit+1))
+		if int64(len(body)) > limit {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			return nil, fmt.Errorf("download %s: response exceeds %d bytes", label, limit)
+		}
+		waitErr := cmd.Wait()
+		if readErr != nil {
+			return nil, fmt.Errorf("download %s: %w", label, readErr)
+		}
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("download %s: %w", label, ctx.Err())
+		}
+		if waitErr != nil {
+			message := strings.TrimSpace(stderr.String())
+			if message != "" {
+				return nil, fmt.Errorf("download %s: %s", label, message)
+			}
+			return nil, fmt.Errorf("download %s: %w", label, waitErr)
+		}
+		return body, nil
+	}
+}
+
 type updateConfig struct {
 	currentVersion string
 	goos           string
 	goarch         string
 	executable     string
 	latestURL      string
-	client         *http.Client
+	download       updateDownloader
 }
 
 func runUpdate(args []string, out io.Writer) error {
@@ -65,13 +110,13 @@ func runUpdate(args []string, out io.Writer) error {
 		goarch:         runtime.GOARCH,
 		executable:     executable,
 		latestURL:      latestReleaseURL,
-		client:         &http.Client{Timeout: 2 * time.Minute},
+		download:       defaultUpdateDownloader(),
 	}, out)
 }
 
 func performUpdate(cfg updateConfig, out io.Writer) error {
-	if cfg.client == nil {
-		return fmt.Errorf("update HTTP client is required")
+	if cfg.download == nil {
+		return fmt.Errorf("update downloader is required")
 	}
 	if cfg.executable == "" {
 		return fmt.Errorf("update executable path is required")
@@ -80,7 +125,7 @@ func performUpdate(cfg updateConfig, out io.Writer) error {
 		return err
 	}
 
-	body, err := fetchUpdateURL(cfg.client, cfg.latestURL, maxReleaseJSON, "latest release")
+	body, err := cfg.download(cfg.latestURL, maxReleaseJSON, "latest release")
 	if err != nil {
 		return err
 	}
@@ -122,7 +167,7 @@ func performUpdate(cfg updateConfig, out io.Writer) error {
 		return fmt.Errorf("release v%s has no checksums.txt", latest)
 	}
 
-	checksums, err := fetchUpdateURL(cfg.client, checksumsAsset.URL, maxChecksums, "checksums.txt")
+	checksums, err := cfg.download(checksumsAsset.URL, maxChecksums, "checksums.txt")
 	if err != nil {
 		return err
 	}
@@ -130,7 +175,7 @@ func performUpdate(cfg updateConfig, out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	archive, err := fetchUpdateURL(cfg.client, archiveAsset.URL, maxArchive, archiveName)
+	archive, err := cfg.download(archiveAsset.URL, maxArchive, archiveName)
 	if err != nil {
 		return err
 	}
@@ -281,34 +326,6 @@ func findUpdateAsset(assets []updateAsset, name string) (updateAsset, bool) {
 		}
 	}
 	return updateAsset{}, false
-}
-
-func fetchUpdateURL(client *http.Client, url string, limit int64, label string) ([]byte, error) {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("request %s: %w", label, err)
-	}
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("User-Agent", "deja/"+normalizeUpdateVersion(version))
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("download %s: %w", label, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("download %s: HTTP %s", label, resp.Status)
-	}
-	if resp.ContentLength > limit {
-		return nil, fmt.Errorf("download %s: response exceeds %d bytes", label, limit)
-	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
-	if err != nil {
-		return nil, fmt.Errorf("download %s: %w", label, err)
-	}
-	if int64(len(body)) > limit {
-		return nil, fmt.Errorf("download %s: response exceeds %d bytes", label, limit)
-	}
-	return body, nil
 }
 
 func checksumForArchive(checksums []byte, archiveName string) (string, error) {

--- a/cmd/deja/update.go
+++ b/cmd/deja/update.go
@@ -5,15 +5,14 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -43,42 +42,52 @@ type updateRelease struct {
 type updateDownloader func(url string, limit int64, label string) ([]byte, error)
 
 func defaultUpdateDownloader() updateDownloader {
+	return newHTTPUpdateDownloader(&http.Client{Timeout: 2 * time.Minute})
+}
+
+func newHTTPUpdateDownloader(client *http.Client) updateDownloader {
+	configured := *client
+	previousRedirect := configured.CheckRedirect
+	configured.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req.URL.Scheme != "https" {
+			return fmt.Errorf("refusing non-HTTPS redirect")
+		}
+		if previousRedirect != nil {
+			return previousRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		return nil
+	}
+	client = &configured
 	return func(url string, limit int64, label string) ([]byte, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-		defer cancel()
-		cmd := exec.CommandContext(ctx, "curl",
-			"--disable", "--fail", "--silent", "--show-error", "--location",
-			"--proto", "=https", "--proto-redir", "=https",
-			"--header", "Accept: application/vnd.github+json",
-			"--user-agent", "deja/"+normalizeUpdateVersion(version), url)
-		stdout, err := cmd.StdoutPipe()
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("request %s: %w", label, err)
+		}
+		if req.URL.Scheme != "https" {
+			return nil, fmt.Errorf("download %s: URL must use HTTPS", label)
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("User-Agent", "deja/"+normalizeUpdateVersion(version))
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("download %s: %w", label, err)
 		}
-		var stderr bytes.Buffer
-		cmd.Stderr = &stderr
-		if err := cmd.Start(); err != nil {
-			return nil, fmt.Errorf("download %s: %w", label, err)
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("download %s: HTTP %s", label, resp.Status)
 		}
-		body, readErr := io.ReadAll(io.LimitReader(stdout, limit+1))
-		if int64(len(body)) > limit {
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
+		if resp.ContentLength > limit {
 			return nil, fmt.Errorf("download %s: response exceeds %d bytes", label, limit)
 		}
-		waitErr := cmd.Wait()
-		if readErr != nil {
-			return nil, fmt.Errorf("download %s: %w", label, readErr)
+		body, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+		if err != nil {
+			return nil, fmt.Errorf("download %s: %w", label, err)
 		}
-		if ctx.Err() != nil {
-			return nil, fmt.Errorf("download %s: %w", label, ctx.Err())
-		}
-		if waitErr != nil {
-			message := strings.TrimSpace(stderr.String())
-			if message != "" {
-				return nil, fmt.Errorf("download %s: %s", label, message)
-			}
-			return nil, fmt.Errorf("download %s: %w", label, waitErr)
+		if int64(len(body)) > limit {
+			return nil, fmt.Errorf("download %s: response exceeds %d bytes", label, limit)
 		}
 		return body, nil
 	}

--- a/cmd/deja/update.go
+++ b/cmd/deja/update.go
@@ -294,7 +294,7 @@ func fetchUpdateURL(client *http.Client, url string, limit int64, label string) 
 	if err != nil {
 		return nil, fmt.Errorf("download %s: %w", label, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("download %s: HTTP %s", label, resp.Status)
 	}
@@ -362,7 +362,7 @@ func extractUpdateBinary(archive []byte, binaryName, goos string) ([]byte, error
 	if err != nil {
 		return nil, err
 	}
-	defer gz.Close()
+	defer func() { _ = gz.Close() }()
 	tr := tar.NewReader(gz)
 	for {
 		header, err := tr.Next()

--- a/cmd/deja/update_test.go
+++ b/cmd/deja/update_test.go
@@ -9,8 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -18,6 +16,8 @@ import (
 	"sync/atomic"
 	"testing"
 )
+
+const testLatestReleaseURL = "test://latest"
 
 func TestPerformUpdate(t *testing.T) {
 	for _, goos := range []string{"linux", "windows"} {
@@ -33,8 +33,7 @@ func TestPerformUpdate(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			server, requests := newUpdateServer(t, "1.2.0", goos, "amd64", []byte("new binary"), false)
-			defer server.Close()
+			download, requests := newUpdateDownloader(t, "1.2.0", goos, "amd64", []byte("new binary"), false)
 
 			var out bytes.Buffer
 			err = performUpdate(updateConfig{
@@ -42,8 +41,8 @@ func TestPerformUpdate(t *testing.T) {
 				goos:           goos,
 				goarch:         "amd64",
 				executable:     target,
-				latestURL:      server.URL + "/latest",
-				client:         server.Client(),
+				latestURL:      testLatestReleaseURL,
+				download:       download,
 			}, &out)
 			if err != nil {
 				t.Fatal(err)
@@ -79,8 +78,7 @@ func TestPerformUpdateAlreadyCurrent(t *testing.T) {
 	if err := os.WriteFile(target, []byte("current binary"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	server, requests := newUpdateServer(t, "1.2.0", "linux", "amd64", []byte("unused"), false)
-	defer server.Close()
+	download, requests := newUpdateDownloader(t, "1.2.0", "linux", "amd64", []byte("unused"), false)
 
 	var out bytes.Buffer
 	err := performUpdate(updateConfig{
@@ -88,8 +86,8 @@ func TestPerformUpdateAlreadyCurrent(t *testing.T) {
 		goos:           "linux",
 		goarch:         "amd64",
 		executable:     target,
-		latestURL:      server.URL + "/latest",
-		client:         server.Client(),
+		latestURL:      testLatestReleaseURL,
+		download:       download,
 	}, &out)
 	if err != nil {
 		t.Fatal(err)
@@ -108,8 +106,7 @@ func TestPerformUpdateDoesNotDowngrade(t *testing.T) {
 	if err := os.WriteFile(target, []byte("newer binary"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	server, requests := newUpdateServer(t, "1.2.0", "linux", "amd64", []byte("older binary"), false)
-	defer server.Close()
+	download, requests := newUpdateDownloader(t, "1.2.0", "linux", "amd64", []byte("older binary"), false)
 
 	var out bytes.Buffer
 	err := performUpdate(updateConfig{
@@ -117,8 +114,8 @@ func TestPerformUpdateDoesNotDowngrade(t *testing.T) {
 		goos:           "linux",
 		goarch:         "amd64",
 		executable:     target,
-		latestURL:      server.URL + "/latest",
-		client:         server.Client(),
+		latestURL:      testLatestReleaseURL,
+		download:       download,
 	}, &out)
 	if err != nil {
 		t.Fatal(err)
@@ -137,16 +134,15 @@ func TestPerformUpdateChecksumFailurePreservesBinary(t *testing.T) {
 	if err := os.WriteFile(target, []byte("old binary"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	server, _ := newUpdateServer(t, "1.2.0", "linux", "amd64", []byte("new binary"), true)
-	defer server.Close()
+	download, _ := newUpdateDownloader(t, "1.2.0", "linux", "amd64", []byte("new binary"), true)
 
 	err := performUpdate(updateConfig{
 		currentVersion: "dev",
 		goos:           "linux",
 		goarch:         "amd64",
 		executable:     target,
-		latestURL:      server.URL + "/latest",
-		client:         server.Client(),
+		latestURL:      testLatestReleaseURL,
+		download:       download,
 	}, io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
 		t.Fatalf("error = %v", err)
@@ -157,25 +153,22 @@ func TestPerformUpdateChecksumFailurePreservesBinary(t *testing.T) {
 	}
 }
 
-func TestPerformUpdateHTTPFailurePreservesBinary(t *testing.T) {
+func TestPerformUpdateDownloadFailurePreservesBinary(t *testing.T) {
 	target := filepath.Join(t.TempDir(), "deja")
 	if err := os.WriteFile(target, []byte("old binary"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, "unavailable", http.StatusServiceUnavailable)
-	}))
-	defer server.Close()
-
 	err := performUpdate(updateConfig{
 		currentVersion: "1.1.0",
 		goos:           "linux",
 		goarch:         "amd64",
 		executable:     target,
-		latestURL:      server.URL,
-		client:         server.Client(),
+		latestURL:      testLatestReleaseURL,
+		download: func(_ string, _ int64, _ string) ([]byte, error) {
+			return nil, fmt.Errorf("service unavailable")
+		},
 	}, io.Discard)
-	if err == nil || !strings.Contains(err.Error(), "HTTP 503") {
+	if err == nil || !strings.Contains(err.Error(), "service unavailable") {
 		t.Fatalf("error = %v", err)
 	}
 	got, _ := os.ReadFile(target)
@@ -231,7 +224,15 @@ func TestUpdateCommandShapeAndPlatforms(t *testing.T) {
 	}
 }
 
-func newUpdateServer(t *testing.T, version, goos, goarch string, binary []byte, badChecksum bool) (*httptest.Server, *atomic.Int32) {
+func TestUpdateDownloaderReportsMissingCurl(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	_, err := defaultUpdateDownloader()("https://example.invalid", 1024, "test asset")
+	if err == nil || !strings.Contains(err.Error(), "curl") {
+		t.Fatalf("missing curl error = %v", err)
+	}
+}
+
+func newUpdateDownloader(t *testing.T, version, goos, goarch string, binary []byte, badChecksum bool) (updateDownloader, *atomic.Int32) {
 	t.Helper()
 	archiveName, binaryName, err := updateAssetNames(version, goos, goarch)
 	if err != nil {
@@ -244,28 +245,34 @@ func newUpdateServer(t *testing.T, version, goos, goarch string, binary []byte, 
 		checksum = strings.Repeat("0", sha256.Size*2) + "  " + archiveName + "\n"
 	}
 
+	release, err := json.Marshal(updateRelease{
+		TagName: "v" + version,
+		Assets: []updateAsset{
+			{Name: archiveName, URL: "test://archive"},
+			{Name: "checksums.txt", URL: "test://checksums"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	responses := map[string][]byte{
+		testLatestReleaseURL: release,
+		"test://archive":     archive,
+		"test://checksums":   []byte(checksum),
+	}
 	requests := &atomic.Int32{}
-	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	download := func(url string, limit int64, label string) ([]byte, error) {
 		requests.Add(1)
-		switch r.URL.Path {
-		case "/latest":
-			_ = json.NewEncoder(w).Encode(updateRelease{
-				TagName: "v" + version,
-				Assets: []updateAsset{
-					{Name: archiveName, URL: server.URL + "/archive"},
-					{Name: "checksums.txt", URL: server.URL + "/checksums"},
-				},
-			})
-		case "/archive":
-			_, _ = w.Write(archive)
-		case "/checksums":
-			_, _ = io.WriteString(w, checksum)
-		default:
-			http.NotFound(w, r)
+		body, ok := responses[url]
+		if !ok {
+			return nil, fmt.Errorf("download %s: unexpected URL %s", label, url)
 		}
-	}))
-	return server, requests
+		if int64(len(body)) > limit {
+			return nil, fmt.Errorf("download %s: response exceeds %d bytes", label, limit)
+		}
+		return append([]byte(nil), body...), nil
+	}
+	return download, requests
 }
 
 func makeUpdateArchive(t *testing.T, goos, binaryName string, binary []byte) []byte {

--- a/cmd/deja/update_test.go
+++ b/cmd/deja/update_test.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -224,11 +226,43 @@ func TestUpdateCommandShapeAndPlatforms(t *testing.T) {
 	}
 }
 
-func TestUpdateDownloaderReportsMissingCurl(t *testing.T) {
-	t.Setenv("PATH", t.TempDir())
-	_, err := defaultUpdateDownloader()("https://example.invalid", 1024, "test asset")
-	if err == nil || !strings.Contains(err.Error(), "curl") {
-		t.Fatalf("missing curl error = %v", err)
+func TestHTTPUpdateDownloader(t *testing.T) {
+	insecure := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "non-HTTPS redirect was followed", http.StatusInternalServerError)
+	}))
+	defer insecure.Close()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") != "application/vnd.github+json" || !strings.HasPrefix(r.Header.Get("User-Agent"), "deja/") {
+			t.Errorf("headers = %#v", r.Header)
+		}
+		switch r.URL.Path {
+		case "/ok":
+			_, _ = io.WriteString(w, "release")
+		case "/error":
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+		case "/redirect":
+			http.Redirect(w, r, insecure.URL, http.StatusFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	download := newHTTPUpdateDownloader(server.Client())
+	body, err := download(server.URL+"/ok", 32, "test asset")
+	if err != nil || string(body) != "release" {
+		t.Fatalf("download body=%q err=%v", body, err)
+	}
+	if _, err := download(server.URL+"/ok", 3, "test asset"); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("size limit error = %v", err)
+	}
+	if _, err := download(server.URL+"/error", 32, "test asset"); err == nil || !strings.Contains(err.Error(), "HTTP 503") {
+		t.Fatalf("HTTP status error = %v", err)
+	}
+	if _, err := download("http://example.invalid", 32, "test asset"); err == nil || !strings.Contains(err.Error(), "HTTPS") {
+		t.Fatalf("insecure URL error = %v", err)
+	}
+	if _, err := download(server.URL+"/redirect", 32, "test asset"); err == nil || !strings.Contains(err.Error(), "non-HTTPS") {
+		t.Fatalf("insecure redirect error = %v", err)
 	}
 }
 

--- a/cmd/deja/update_test.go
+++ b/cmd/deja/update_test.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestPerformUpdate(t *testing.T) {
+	for _, goos := range []string{"linux", "windows"} {
+		t.Run(goos, func(t *testing.T) {
+			target := filepath.Join(t.TempDir(), "deja")
+			if goos == "windows" {
+				target += ".exe"
+			}
+			if err := os.WriteFile(target, []byte("old binary"), 0o750); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.Stat(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			server, requests := newUpdateServer(t, "1.2.0", goos, "amd64", []byte("new binary"), false)
+			defer server.Close()
+
+			var out bytes.Buffer
+			err = performUpdate(updateConfig{
+				currentVersion: "1.1.0",
+				goos:           goos,
+				goarch:         "amd64",
+				executable:     target,
+				latestURL:      server.URL + "/latest",
+				client:         server.Client(),
+			}, &out)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != "new binary" {
+				t.Fatalf("installed binary = %q", got)
+			}
+			if requests.Load() != 3 {
+				t.Fatalf("requests = %d, want release + checksum + archive", requests.Load())
+			}
+			if !strings.Contains(out.String(), "v1.1.0 -> v1.2.0") || !strings.Contains(out.String(), target) {
+				t.Fatalf("output = %q", out.String())
+			}
+			if runtime.GOOS != "windows" {
+				info, err := os.Stat(target)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if info.Mode().Perm() != before.Mode().Perm() {
+					t.Fatalf("installed mode = %o, want %o", info.Mode().Perm(), before.Mode().Perm())
+				}
+			}
+		})
+	}
+}
+
+func TestPerformUpdateAlreadyCurrent(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "deja")
+	if err := os.WriteFile(target, []byte("current binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	server, requests := newUpdateServer(t, "1.2.0", "linux", "amd64", []byte("unused"), false)
+	defer server.Close()
+
+	var out bytes.Buffer
+	err := performUpdate(updateConfig{
+		currentVersion: "v1.2.0",
+		goos:           "linux",
+		goarch:         "amd64",
+		executable:     target,
+		latestURL:      server.URL + "/latest",
+		client:         server.Client(),
+	}, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("requests = %d, downloaded an unnecessary asset", requests.Load())
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "current binary" || !strings.Contains(out.String(), "already up to date") {
+		t.Fatalf("binary=%q output=%q", got, out.String())
+	}
+}
+
+func TestPerformUpdateDoesNotDowngrade(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "deja")
+	if err := os.WriteFile(target, []byte("newer binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	server, requests := newUpdateServer(t, "1.2.0", "linux", "amd64", []byte("older binary"), false)
+	defer server.Close()
+
+	var out bytes.Buffer
+	err := performUpdate(updateConfig{
+		currentVersion: "1.3.0-alpha.1",
+		goos:           "linux",
+		goarch:         "amd64",
+		executable:     target,
+		latestURL:      server.URL + "/latest",
+		client:         server.Client(),
+	}, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requests.Load() != 1 || !strings.Contains(out.String(), "newer than") {
+		t.Fatalf("requests=%d output=%q", requests.Load(), out.String())
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "newer binary" {
+		t.Fatalf("downgrade installed %q", got)
+	}
+}
+
+func TestPerformUpdateChecksumFailurePreservesBinary(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "deja")
+	if err := os.WriteFile(target, []byte("old binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	server, _ := newUpdateServer(t, "1.2.0", "linux", "amd64", []byte("new binary"), true)
+	defer server.Close()
+
+	err := performUpdate(updateConfig{
+		currentVersion: "dev",
+		goos:           "linux",
+		goarch:         "amd64",
+		executable:     target,
+		latestURL:      server.URL + "/latest",
+		client:         server.Client(),
+	}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("error = %v", err)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "old binary" {
+		t.Fatalf("failed update replaced binary with %q", got)
+	}
+}
+
+func TestPerformUpdateHTTPFailurePreservesBinary(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "deja")
+	if err := os.WriteFile(target, []byte("old binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	err := performUpdate(updateConfig{
+		currentVersion: "1.1.0",
+		goos:           "linux",
+		goarch:         "amd64",
+		executable:     target,
+		latestURL:      server.URL,
+		client:         server.Client(),
+	}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "HTTP 503") {
+		t.Fatalf("error = %v", err)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "old binary" {
+		t.Fatalf("failed update replaced binary with %q", got)
+	}
+}
+
+func TestUpdateCommandShapeAndPlatforms(t *testing.T) {
+	if err := runUpdate([]string{"unexpected"}, io.Discard); err == nil || !strings.Contains(err.Error(), "takes no arguments") {
+		t.Fatalf("runUpdate error = %v", err)
+	}
+	if err := run([]string{"update", "unexpected"}); err == nil || !strings.Contains(err.Error(), "takes no arguments") {
+		t.Fatalf("dispatcher error = %v", err)
+	}
+	out, err := captureRun(t)
+	if err != nil || !strings.Contains(out, "deja update") {
+		t.Fatalf("usage output = %q, error = %v", out, err)
+	}
+
+	for _, tc := range []struct {
+		goos, goarch string
+		archive      string
+		binary       string
+		wantErr      bool
+	}{
+		{"linux", "amd64", "deja-vu_2.0.0_linux_amd64.tar.gz", "deja", false},
+		{"darwin", "arm64", "deja-vu_2.0.0_darwin_arm64.tar.gz", "deja", false},
+		{"windows", "amd64", "deja-vu_2.0.0_windows_amd64.zip", "deja.exe", false},
+		{"freebsd", "amd64", "", "", true},
+		{"linux", "386", "", "", true},
+	} {
+		archive, binary, err := updateAssetNames("2.0.0", tc.goos, tc.goarch)
+		if (err != nil) != tc.wantErr || archive != tc.archive || binary != tc.binary {
+			t.Fatalf("updateAssetNames(%s/%s) = %q, %q, %v", tc.goos, tc.goarch, archive, binary, err)
+		}
+	}
+
+	for _, tc := range []struct {
+		left, right string
+		want        int
+	}{
+		{"0.9.2", "0.9.2", 0},
+		{"0.10.0", "0.9.9", 1},
+		{"1.0.0-alpha.2", "1.0.0-alpha.10", -1},
+		{"1.0.0-alpha", "1.0.0", -1},
+		{"2.0.0", "1.99.99", 1},
+	} {
+		got, ok := compareUpdateVersions(tc.left, tc.right)
+		if !ok || got != tc.want {
+			t.Fatalf("compareUpdateVersions(%q, %q) = %d, %v", tc.left, tc.right, got, ok)
+		}
+	}
+}
+
+func newUpdateServer(t *testing.T, version, goos, goarch string, binary []byte, badChecksum bool) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	archiveName, binaryName, err := updateAssetNames(version, goos, goarch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive := makeUpdateArchive(t, goos, binaryName, binary)
+	sum := sha256.Sum256(archive)
+	checksum := fmt.Sprintf("%x  %s\n", sum, archiveName)
+	if badChecksum {
+		checksum = strings.Repeat("0", sha256.Size*2) + "  " + archiveName + "\n"
+	}
+
+	requests := &atomic.Int32{}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		switch r.URL.Path {
+		case "/latest":
+			_ = json.NewEncoder(w).Encode(updateRelease{
+				TagName: "v" + version,
+				Assets: []updateAsset{
+					{Name: archiveName, URL: server.URL + "/archive"},
+					{Name: "checksums.txt", URL: server.URL + "/checksums"},
+				},
+			})
+		case "/archive":
+			_, _ = w.Write(archive)
+		case "/checksums":
+			_, _ = io.WriteString(w, checksum)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return server, requests
+}
+
+func makeUpdateArchive(t *testing.T, goos, binaryName string, binary []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if goos == "windows" {
+		zw := zip.NewWriter(&buf)
+		file, err := zw.Create(binaryName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := file.Write(binary); err != nil {
+			t.Fatal(err)
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return buf.Bytes()
+	}
+
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: binaryName, Mode: 0o755, Size: int64(len(binary))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(binary); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}

--- a/cmd/deja/update_unix.go
+++ b/cmd/deja/update_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+import "os"
+
+func replaceExecutable(staged, destination string) error {
+	return os.Rename(staged, destination)
+}

--- a/cmd/deja/update_windows.go
+++ b/cmd/deja/update_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func replaceExecutable(staged, destination string) error {
+	removeStaleUpdateBackups(destination)
+	// A long-running process can keep its old image locked after an update.
+	// Use this update's random staging suffix so that lock cannot block the next one.
+	backup := filepath.Join(filepath.Dir(destination), "."+filepath.Base(destination)+".old-"+filepath.Base(staged))
+	if err := os.Rename(destination, backup); err != nil {
+		return err
+	}
+	if err := os.Rename(staged, destination); err != nil {
+		if rollbackErr := os.Rename(backup, destination); rollbackErr != nil {
+			return fmt.Errorf("install update: %v (rollback failed: %v)", err, rollbackErr)
+		}
+		return err
+	}
+	// Windows may keep the running old executable locked until this process exits.
+	_ = os.Remove(backup)
+	return nil
+}
+
+func removeStaleUpdateBackups(destination string) {
+	pattern := filepath.Join(filepath.Dir(destination), "."+filepath.Base(destination)+".old-.deja-update-*")
+	backups, _ := filepath.Glob(pattern)
+	for _, backup := range backups {
+		// A still-running old process keeps its image locked; a later update retries.
+		_ = os.Remove(backup)
+	}
+}

--- a/cmd/deja/update_windows_test.go
+++ b/cmd/deja/update_windows_test.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoveStaleUpdateBackups(t *testing.T) {
+	dir := t.TempDir()
+	destination := filepath.Join(dir, "deja.exe")
+	backups := []string{
+		filepath.Join(dir, ".deja.exe.old-.deja-update-one"),
+		filepath.Join(dir, ".deja.exe.old-.deja-update-two"),
+	}
+	for _, backup := range backups {
+		if err := os.WriteFile(backup, []byte("old"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	unrelated := filepath.Join(dir, "keep.exe")
+	if err := os.WriteFile(unrelated, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manualBackup := filepath.Join(dir, ".deja.exe.old-manual")
+	if err := os.WriteFile(manualBackup, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	removeStaleUpdateBackups(destination)
+	for _, backup := range backups {
+		if _, err := os.Stat(backup); !os.IsNotExist(err) {
+			t.Fatalf("backup still exists: %s", backup)
+		}
+	}
+	if _, err := os.Stat(unrelated); err != nil {
+		t.Fatal("cleanup removed unrelated file", err)
+	}
+	if _, err := os.Stat(manualBackup); err != nil {
+		t.Fatal("cleanup removed manual backup", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/vshulcz/deja-vu
 
-go 1.22
+go 1.25


### PR DESCRIPTION
## Summary

- add `deja update` for standalone installations using the latest stable GitHub release for the current OS and architecture
- download with Go's native HTTPS client, enforce HTTPS redirects and response limits, and remove the external `curl` dependency
- verify `checksums.txt`, preserve executable permissions, avoid downgrades, and replace binaries with Unix atomic rename or Windows rollback/backup handling
- build and test with Go 1.25, the oldest supported Go line that emits the Darwin `LC_UUID` required by current macOS

## Test plan

- Go 1.25.12: `go mod verify`, `go vet ./...`, and race tests with coverage
- Go 1.25.12: `sh scripts/e2e.sh`
- golangci-lint 2.12.2 and actionlint 1.7.12
- all six release cross-builds plus Darwin and Windows test-binary compilation
- verify `LC_UUID` in both Darwin release architectures
- GoReleaser 2.17.0 snapshot release
- source and release-binary `govulncheck`
- live update from v0.9.2 to v0.10.0 with an empty `PATH`, plus an already-current v0.10.0 check

## Notes

Go 1.24 is the technical `LC_UUID` boundary, but it is end-of-life and its final patch has reachable standard-library vulnerabilities. Go 1.25 is therefore the oldest safe supported build line.

The updater intentionally targets standalone binaries. Homebrew and npm installations should continue updating through their package managers so installed-version metadata remains consistent.

Closes #79
