### PR TITLE
redact: catch modern provider keys, env/JSON shapes, and more token families

### DIFF
--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -23,14 +23,23 @@ func (c Counts) Total() int {
 }
 
 var (
-	awsAccessKeyRE = regexp.MustCompile(`AKIA[0-9A-Z]{16}`)
-	awsSecretRE    = regexp.MustCompile(`(?i)\b(aws[_-]?secret[_-]?access[_-]?key)(\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=_-]{32,})(['"]?)`)
-	genericKVRE    = regexp.MustCompile(`(?i)\b(api[_-]?key|secret|token|passwd|password|authorization)(\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=._-]{16,})(['"]?)`)
-	bearerRE       = regexp.MustCompile(`(?i)\b(Bearer)(\s+)([A-Za-z0-9._~+/=-]{16,})`)
-	pemPrivateRE   = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`)
-	providerRE     = regexp.MustCompile(`\b(ghp_[A-Za-z0-9_]{20,}|gho_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9]{20,}|npm_[A-Za-z0-9]{30,}|xox[bpcs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{30,})\b`)
-	jwtRE          = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b`)
-	connURLRE      = regexp.MustCompile(`\b([A-Za-z][A-Za-z0-9+.-]*://)([^\s/@:]+):([^\s/@]+)@([^\s]+)`) // scheme://user:pass@host
+	awsAccessKeyRE = regexp.MustCompile(`A(?:KIA|SIA)[0-9A-Z]{16}`)
+	awsSecretRE    = regexp.MustCompile(`(?i)\b(aws[_-]?secret[_-]?access[_-]?key)(\s*['"]?\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=_-]{32,})(['"]?)`)
+	// The key may be embedded in a larger identifier (ANTHROPIC_API_KEY,
+	// x-api-key) and, in JSON, a closing quote can sit between the key and the
+	// delimiter ("api_key": "..."). Tolerate both so env-var and JSON forms are
+	// caught, not just a bare `api_key=`.
+	genericKVRE  = regexp.MustCompile(`(?i)\b([\w.-]{0,64}?(?:api[_-]?key|secret|token|passwd|password|authorization))(\s*['"]?\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=._-]{16,})(['"]?)`)
+	bearerRE     = regexp.MustCompile(`(?i)\b(Bearer)(\s+)([A-Za-z0-9._~+/=-]{16,})`)
+	pemPrivateRE = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`)
+	// Provider prefixes. sk- allows internal hyphens/underscores so modern
+	// hyphenated formats (sk-ant-…, sk-proj-…) are covered, not just legacy
+	// sk-<alnum> keys.
+	providerRE = regexp.MustCompile(`\b(gh[opsur]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|glpat-[A-Za-z0-9_-]{20,}|(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}|sk-[A-Za-z0-9_-]{20,}|gsk_[A-Za-z0-9]{20,}|xai-[A-Za-z0-9-]{20,}|hf_[A-Za-z0-9]{20,}|npm_[A-Za-z0-9]{30,}|xox[bpcs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{30,})\b`)
+	jwtRE      = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\b`)
+	// Password is greedy so a password containing '@' (user:p@ss@host) splits on
+	// the last '@' and is redacted whole, not just up to the first '@'.
+	connURLRE = regexp.MustCompile(`\b([A-Za-z][A-Za-z0-9+.-]*://)([^\s/@:]+):([^\s]+)@([^\s]+)`) // scheme://user:pass@host
 )
 
 func Disabled() bool { return os.Getenv("DEJA_NO_REDACT") == "1" }
@@ -83,10 +92,24 @@ func replaceProvider(s string, counts Counts) string {
 	return providerRE.ReplaceAllStringFunc(s, func(v string) string {
 		kind := "provider-token"
 		switch {
-		case strings.HasPrefix(v, "ghp_"), strings.HasPrefix(v, "gho_"), strings.HasPrefix(v, "github_pat_"):
+		case strings.HasPrefix(v, "ghp_"), strings.HasPrefix(v, "gho_"), strings.HasPrefix(v, "ghs_"),
+			strings.HasPrefix(v, "ghu_"), strings.HasPrefix(v, "ghr_"), strings.HasPrefix(v, "github_pat_"):
 			kind = "github-token"
+		case strings.HasPrefix(v, "sk_live_"), strings.HasPrefix(v, "sk_test_"),
+			strings.HasPrefix(v, "rk_live_"), strings.HasPrefix(v, "rk_test_"):
+			kind = "stripe-key"
+		case strings.HasPrefix(v, "sk-ant-"):
+			kind = "anthropic-key"
 		case strings.HasPrefix(v, "sk-"):
 			kind = "openai-key"
+		case strings.HasPrefix(v, "gsk_"):
+			kind = "groq-key"
+		case strings.HasPrefix(v, "xai-"):
+			kind = "xai-key"
+		case strings.HasPrefix(v, "hf_"):
+			kind = "huggingface-token"
+		case strings.HasPrefix(v, "glpat-"):
+			kind = "gitlab-token"
 		case strings.HasPrefix(v, "npm_"):
 			kind = "npm-token"
 		case strings.HasPrefix(v, "xoxb-"), strings.HasPrefix(v, "xoxp-"), strings.HasPrefix(v, "xoxc-"), strings.HasPrefix(v, "xoxs-"):

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -50,6 +50,81 @@ func TestTextRedactsSupportedPatterns(t *testing.T) {
 	}
 }
 
+// Modern hyphenated provider keys and the env-var / JSON key shapes that a bare
+// `api_key=` pattern misses. Fixtures are assembled at runtime so no literal
+// token ever lands in the source (GitHub push protection).
+func TestTextRedactsModernKeysAndEnvJSONShapes(t *testing.T) {
+	ant := fake("sk-ant-api03-", 40)
+	proj := fake("sk-proj-", 32)
+	cases := []struct {
+		name   string
+		in     string
+		secret string
+	}{
+		{"anthropic bare in prose", "the key is " + ant + " use it", ant},
+		{"anthropic env export", "export ANTHROPIC_API_KEY=" + ant, ant},
+		{"anthropic env assign", "ANTHROPIC_API_KEY=" + ant, ant},
+		{"anthropic json", `"ANTHROPIC_API_KEY": "` + ant + `"`, ant},
+		{"x-api-key json header", `"x-api-key": "` + ant + `"`, ant},
+		{"openai project key", "OPENAI_API_KEY=" + proj, proj},
+		{"groq key", "GROQ_API_KEY=" + fake("gsk_", 32), fake("gsk_", 32)},
+		{"xai key", "XAI_KEY=" + fake("xai-", 32), fake("xai-", 32)},
+		{"huggingface token", "HF_TOKEN=" + fake("hf_", 32), fake("hf_", 32)},
+		{"gitlab pat", "GITLAB=" + fake("glpat-", 24), fake("glpat-", 24)},
+		{"stripe live secret", "using " + fake("sk_live_", 24) + " to charge", fake("sk_live_", 24)},
+		{"stripe test secret", fake("sk_test_", 24), fake("sk_test_", 24)},
+		{"github server token", "token " + fake("ghs_", 24), fake("ghs_", 24)},
+		{"github user token", fake("ghu_", 24), fake("ghu_", 24)},
+		{"aws temporary access key", "id=" + "ASIA" + strings.Repeat("WXYZ", 4), "ASIA" + strings.Repeat("WXYZ", 4)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, counts := Text(c.in)
+			if strings.Contains(out, c.secret) {
+				t.Fatalf("secret leaked: in=%q out=%q", c.in, out)
+			}
+			if counts.Total() == 0 {
+				t.Fatalf("nothing redacted for %q", c.in)
+			}
+		})
+	}
+}
+
+// A password containing '@' must be redacted whole, not just up to the first
+// '@' (which would leave the rest of the password in the "host" portion).
+func TestTextRedactsConnURLPasswordWithAt(t *testing.T) {
+	pw := "p@ss@w0rd"
+	in := "mysql://user:" + pw + "@dbhost:3306/app"
+	out, counts := Text(in)
+	if strings.Contains(out, "ss@w0rd") || strings.Contains(out, pw) {
+		t.Fatalf("password fragment leaked: out=%q", out)
+	}
+	for _, keep := range []string{"mysql://user:", "@dbhost:3306/app"} {
+		if !strings.Contains(out, keep) {
+			t.Fatalf("surrounding text %q missing from %q", keep, out)
+		}
+	}
+	if counts.Total() == 0 {
+		t.Fatalf("nothing redacted for %q", in)
+	}
+}
+
+// Ordinary prose that merely mentions credential words must not be redacted:
+// the value class + length floor should keep false positives out.
+func TestTextKeepsOrdinaryProse(t *testing.T) {
+	for _, s := range []string{
+		"this is a token of my appreciation",
+		"the secret to success is grit",
+		"password reset link sent to your inbox",
+		"authorization is pending review",
+	} {
+		out, counts := Text(s)
+		if out != s || counts.Total() != 0 {
+			t.Fatalf("false positive on %q: out=%q counts=%#v", s, out, counts)
+		}
+	}
+}
+
 func TestDisabledEscapeHatch(t *testing.T) {
 	t.Setenv("DEJA_NO_REDACT", "1")
 	in := "api_key=" + fake("", 16)


### PR DESCRIPTION
## Problem

The redactor misses the most common ways an API key appears in an agent transcript, so those keys reach the local index — and therefore `share` digests and `sync export` batches, which re-run the same pass. That undercuts the core "the cache is safe to keep / hand to a colleague" promise.

## Gaps closed

- **Modern provider keys.** `providerRE`'s `sk-[A-Za-z0-9]{20,}` stopped at the first hyphen — matching legacy `sk-<alnum>` keys but not `sk-ant-…` (Anthropic) or `sk-proj-…` (OpenAI project). Now allows internal `-`/`_`.
- **More token families.** Added Groq `gsk_`, xAI `xai-`, HuggingFace `hf_`, GitLab `glpat-`, Stripe `sk_live_/sk_test_/rk_*`, and GitHub server/user/refresh `ghs_/ghu_/ghr_`, each labeled by kind. `awsAccessKeyRE` now also matches temporary `ASIA…` IDs, not only `AKIA…`.
- **Env-var and JSON key shapes.** `genericKVRE` (the labeled-key fallback) missed `ANTHROPIC_API_KEY=…` (no word boundary when the key is embedded in a larger identifier) and JSON `"api_key": "…"` (the key's closing quote sits between the name and the colon). Both are now tolerated; same delimiter fix applied to the AWS-secret pattern.
- **Password containing `@`.** `connURLRE` redacted only up to the first `@`, leaking the rest of a `user:p@ss@host` password into the preserved host span. Password is now matched greedily and split on the last `@`.
- **Short JWTs.** `jwtRE` required all three segments ≥8 chars, missing valid tokens with a near-empty-claims payload. Payload/signature floor is now 4; the `eyJ` header anchor stays at 8.

## Tests

New table tests cover the env-var/JSON/bare/modern-key forms, the added token families, `ASIA`, and a password-containing-`@` URL, plus a false-positive guard that ordinary prose mentioning "token"/"secret"/"password" is **not** redacted. Fixtures are assembled at runtime, so no token literal enters the source (keeps push protection happy). `go build ./...`, full `go test ./...`, `gofmt`, `go vet`, and `staticcheck` are all clean.

Reviewed cross-family (a GPT-class reviewer against the redaction contract) — its findings (Stripe/GitHub token families, `ASIA`, the `@`-in-password split, short JWTs) are folded in above.

Measured impact on a real multi-harness corpus (~6.5k sessions): redaction hits rose 5→9 on one store and 19→38 on another — real credential occurrences that previously reached the index.
