### PR TITLE
feat: respect CLAUDE_CONFIG_DIR for read and install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Credentials are redacted at index time: AWS keys, generic `api_key=`/`token=` as
 | Antigravity | `~/.gemini/antigravity*/brain/*/.system_generated/logs/transcript.jsonl` | ✅ |
 | Grok Build | `~/.grok/sessions/**/updates.jsonl` | ✅ |
 
-Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_AIDER_ROOTS`, `DEJA_GEMINI_ROOT`, `DEJA_CURSOR_ROOT`, `DEJA_CURSOR_CLI_ROOT`, `DEJA_ANTIGRAVITY_ROOT`, `DEJA_GROK_ROOT`, `DEJA_INDEX_DIR`. Grok's native `GROK_HOME` is also honored.
+Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_AIDER_ROOTS`, `DEJA_GEMINI_ROOT`, `DEJA_CURSOR_ROOT`, `DEJA_CURSOR_CLI_ROOT`, `DEJA_ANTIGRAVITY_ROOT`, `DEJA_GROK_ROOT`, `DEJA_INDEX_DIR`. Grok's native `GROK_HOME` and Claude Code's native `CLAUDE_CONFIG_DIR` are also honored.
 
 ## Performance
 

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -162,7 +162,7 @@ func doctorMCP(w io.Writer) {
 		path  string
 		wired func(string) bool
 	}{
-		{"claude-code", filepath.Join(h, ".claude.json"), doctorJSONWired("mcpServers")},
+		{"claude-code", sources.ClaudeJSONPath(), doctorJSONWired("mcpServers")},
 		{"codex", filepath.Join(sources.CodexHome(), "config.toml"), doctorTOMLWired},
 		{"opencode", doctorOpencodeConfigPath(), doctorJSONWired("mcp")},
 		{"cursor", filepath.Join(sources.CursorCLIHome(), "mcp.json"), doctorJSONWired("mcpServers")},

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -96,7 +96,7 @@ func shortHome(p string) string {
 func existingTargets() []string {
 	h, _ := os.UserHomeDir()
 	checks := map[string]string{
-		"claude-code": filepath.Join(h, ".claude"),
+		"claude-code": sources.ClaudeConfigDir(),
 		"codex":       sources.CodexHome(),
 		"opencode":    filepath.Join(h, ".config", "opencode"),
 		"cursor":      sources.CursorCLIHome(),
@@ -109,7 +109,7 @@ func existingTargets() []string {
 		if _, err := os.Stat(p); err == nil {
 			out = append(out, name)
 		} else if name == "claude-code" {
-			if _, err := os.Stat(filepath.Join(h, ".claude.json")); err == nil {
+			if _, err := os.Stat(sources.ClaudeJSONPath()); err == nil {
 				out = append(out, name)
 			}
 		}
@@ -203,8 +203,7 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 }
 
 func installClaude(exe string, uninstall bool) (installResult, error) {
-	h, _ := os.UserHomeDir()
-	path := filepath.Join(h, ".claude.json")
+	path := sources.ClaudeJSONPath()
 	old, _ := os.ReadFile(path)
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {
@@ -232,8 +231,7 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 }
 
 func installClaudeHook(exe string, uninstall bool) (installResult, error) {
-	h, _ := os.UserHomeDir()
-	path := filepath.Join(h, ".claude", "settings.json")
+	path := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
 	old, _ := os.ReadFile(path)
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {
@@ -307,8 +305,7 @@ func updateClaudeSessionStartHook(root map[string]any, exe string, uninstall boo
 // It refuses to replace a statusline the user already configured (many run
 // ccstatusline or their own script) — printing how to combine instead.
 func installStatusline(exe string, uninstall bool) (installResult, error) {
-	h, _ := os.UserHomeDir()
-	path := filepath.Join(h, ".claude", "settings.json")
+	path := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
 	old, _ := os.ReadFile(path)
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {

--- a/cmd/deja/install_config_dir_test.go
+++ b/cmd/deja/install_config_dir_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// When CLAUDE_CONFIG_DIR points Claude Code at a non-default profile, deja must
+// wire the MCP server, SessionStart hook and statusline into that profile
+// rather than the default ~/.claude.json and ~/.claude/settings.json.
+func TestInstallClaudeHonorsConfigDir(t *testing.T) {
+	home := t.TempDir()
+	cfg := filepath.Join(home, "custom-claude")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", cfg)
+
+	if _, err := installClaude("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installClaudeHook("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installStatusline("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+
+	mcp := filepath.Join(cfg, ".claude.json")
+	settings := filepath.Join(cfg, "settings.json")
+	for _, p := range []string{mcp, settings} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("expected %s to be written: %v", p, err)
+		}
+	}
+	if b, err := os.ReadFile(mcp); err != nil || !strings.Contains(string(b), `"deja"`) {
+		t.Fatalf("mcp server not in %s: %s (%v)", mcp, b, err)
+	}
+	if b, err := os.ReadFile(settings); err != nil || !strings.Contains(string(b), "deja hook-context") || !strings.Contains(string(b), "deja statusline") {
+		t.Fatalf("hook/statusline not in %s: %s (%v)", settings, b, err)
+	}
+
+	// The default ~/.claude location must be left untouched.
+	for _, p := range []string{filepath.Join(home, ".claude.json"), filepath.Join(home, ".claude", "settings.json")} {
+		if _, err := os.Stat(p); err == nil {
+			t.Fatalf("default location %s should not have been written", p)
+		}
+	}
+}

--- a/cmd/deja/testmain_test.go
+++ b/cmd/deja/testmain_test.go
@@ -12,8 +12,15 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	stores := map[string]string{
-		"HOME":                    root,
-		"USERPROFILE":             root,
+		"HOME":        root,
+		"USERPROFILE": root,
+		// Neutralize ambient profile overrides so install/read paths resolve
+		// under the temp HOME instead of the developer's real agent profiles.
+		"CLAUDE_CONFIG_DIR":       "",
+		"CODEX_HOME":              "",
+		"GEMINI_CLI_HOME":         "",
+		"CURSOR_CONFIG_DIR":       "",
+		"AIDER_CHAT_HISTORY_FILE": "",
 		"DEJA_CLAUDE_ROOT":        filepath.Join(root, "claude"),
 		"DEJA_CODEX_ROOT":         filepath.Join(root, "codex"),
 		"DEJA_OPENCODE_DB":        filepath.Join(root, "opencode.db"),
@@ -23,10 +30,6 @@ func TestMain(m *testing.M) {
 		"DEJA_CURSOR_CLI_ROOT":    filepath.Join(root, "cursor-cli"),
 		"DEJA_ANTIGRAVITY_ROOT":   filepath.Join(root, "antigravity"),
 		"DEJA_GROK_ROOT":          filepath.Join(root, "grok"),
-		"CODEX_HOME":              "",
-		"GEMINI_CLI_HOME":         "",
-		"CURSOR_CONFIG_DIR":       "",
-		"AIDER_CHAT_HISTORY_FILE": "",
 	}
 	for key, value := range stores {
 		if err := os.Setenv(key, value); err != nil {

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -9,8 +9,25 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
+// ClaudeConfigDir is the directory Claude Code keeps its state in
+// (settings.json, projects/, ...). Claude Code lets users relocate it with the
+// CLAUDE_CONFIG_DIR environment variable — common when juggling separate
+// personal/work profiles — so we honor the same variable to read from and
+// install into whichever profile is active. Falls back to the default
+// ~/.claude.
+func ClaudeConfigDir() string {
+	return EnvPath("CLAUDE_CONFIG_DIR", filepath.Join(Home(), ".claude"))
+}
+
+// ClaudeJSONPath is Claude Code's top-level state file (holds mcpServers). By
+// default it lives at ~/.claude.json, a sibling of ~/.claude, but when
+// CLAUDE_CONFIG_DIR is set Claude Code moves it inside that directory.
+func ClaudeJSONPath() string {
+	return filepath.Join(EnvPath("CLAUDE_CONFIG_DIR", Home()), ".claude.json")
+}
+
 func ClaudeRoot() string {
-	return EnvPath("DEJA_CLAUDE_ROOT", filepath.Join(Home(), ".claude", "projects"))
+	return EnvPath("DEJA_CLAUDE_ROOT", filepath.Join(ClaudeConfigDir(), "projects"))
 }
 
 func LoadClaude() []model.Session {

--- a/internal/sources/claude_config_test.go
+++ b/internal/sources/claude_config_test.go
@@ -1,0 +1,54 @@
+package sources
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// Claude Code lets users relocate its state directory with CLAUDE_CONFIG_DIR
+// (commonly to keep personal and work profiles apart). These tests pin down
+// that ClaudeConfigDir/ClaudeJSONPath/ClaudeRoot follow that variable and fall
+// back to the default ~/.claude layout when it is unset.
+func TestClaudeConfigDirRespectsEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	t.Run("unset falls back to ~/.claude", func(t *testing.T) {
+		t.Setenv("CLAUDE_CONFIG_DIR", "")
+		t.Setenv("DEJA_CLAUDE_ROOT", "")
+		if got, want := ClaudeConfigDir(), filepath.Join(home, ".claude"); got != want {
+			t.Fatalf("ClaudeConfigDir()=%q want %q", got, want)
+		}
+		if got, want := ClaudeJSONPath(), filepath.Join(home, ".claude.json"); got != want {
+			t.Fatalf("ClaudeJSONPath()=%q want %q", got, want)
+		}
+		if got, want := ClaudeRoot(), filepath.Join(home, ".claude", "projects"); got != want {
+			t.Fatalf("ClaudeRoot()=%q want %q", got, want)
+		}
+	})
+
+	t.Run("set relocates config, json and projects", func(t *testing.T) {
+		cfg := filepath.Join(home, "profiles", "personal")
+		t.Setenv("CLAUDE_CONFIG_DIR", cfg)
+		t.Setenv("DEJA_CLAUDE_ROOT", "")
+		if got := ClaudeConfigDir(); got != cfg {
+			t.Fatalf("ClaudeConfigDir()=%q want %q", got, cfg)
+		}
+		if got, want := ClaudeJSONPath(), filepath.Join(cfg, ".claude.json"); got != want {
+			t.Fatalf("ClaudeJSONPath()=%q want %q", got, want)
+		}
+		if got, want := ClaudeRoot(), filepath.Join(cfg, "projects"); got != want {
+			t.Fatalf("ClaudeRoot()=%q want %q", got, want)
+		}
+	})
+
+	t.Run("DEJA_CLAUDE_ROOT still wins over CLAUDE_CONFIG_DIR", func(t *testing.T) {
+		override := filepath.Join(home, "explicit-projects")
+		t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, "profiles", "work"))
+		t.Setenv("DEJA_CLAUDE_ROOT", override)
+		if got := ClaudeRoot(); got != override {
+			t.Fatalf("ClaudeRoot()=%q want %q", got, override)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`deja` hard-coded `~/.claude`, ignoring Claude Code's `CLAUDE_CONFIG_DIR` — the standard way to run separate profiles (personal/work).
With `CLAUDE_CONFIG_DIR` set, `deja install` writes the MCP server, hook and statusline into the wrong (inactive) profile, and indexing reads an empty `~/.claude/projects`.

This honors `CLAUDE_CONFIG_DIR` for both the read and install paths, falling back to `~/.claude`. `DEJA_CLAUDE_ROOT` still takes precedence — the same pattern `grok.go` already uses for `GROK_HOME`. Existing setups are unaffected.

## Test plan

- New tests: the path helpers follow `CLAUDE_CONFIG_DIR` (with `DEJA_CLAUDE_ROOT` still winning); `install` lands in the configured profile and leaves the default `~/.claude*` untouched.
- `go build ./cmd/deja`, `go test -race ./...`, `gofmt -l`, `go vet ./...` — all clean.
