### PR TITLE
feat: deja index command, rebuild progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ $ deja "jwt refresh token"
 | `deja sources` | Discovered stores, sizes, message and redaction counts. |
 | `deja mcp` | The stdio MCP server (what `deja install` wires in). |
 | `deja warmup` | Build/refresh the index without searching — handy in cron or shell startup. |
+| `deja index [--rebuild]` | Same as warmup; `--rebuild` forces a full rebuild. Cold builds narrate per-harness progress. |
 | `deja update` | Download the latest GitHub release, verify its checksum, and replace the current binary. |
 | `deja statusline` | One line for your status bar: recalls served to agents today. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
 

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -77,6 +77,17 @@ func run(args []string) error {
 	if args[0] == "warmup" {
 		return index.Ensure(index.DefaultDir(), "", false, os.Stderr)
 	}
+	if args[0] == "index" {
+		force := false
+		for _, a := range args[1:] {
+			if a == "--rebuild" || a == "-rebuild" {
+				force = true
+				continue
+			}
+			return fmt.Errorf("index: unknown flag %q", a)
+		}
+		return index.Ensure(index.DefaultDir(), "", force, os.Stderr)
+	}
 	if args[0] == "statusline" {
 		return runStatusline(os.Stdin, os.Stdout)
 	}
@@ -425,6 +436,7 @@ Usage:
   deja last [n]
   deja sources
   deja warmup
+  deja index [--rebuild]
   deja statusline
   deja stats [--json]
   deja mcp

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -667,3 +667,16 @@ func TestRunInstallAllExistingAndJSONCEdges(t *testing.T) {
 		})
 	}
 }
+
+func TestRunIndexCommand(t *testing.T) {
+	withTempStores(t)
+	if out, err := captureRun(t, "index"); err != nil || out != "" {
+		t.Fatalf("index out=%q err=%v", out, err)
+	}
+	if _, err := captureRun(t, "index", "--rebuild"); err != nil {
+		t.Fatalf("index --rebuild err=%v", err)
+	}
+	if _, err := captureRun(t, "index", "--bogus"); err == nil || !strings.Contains(err.Error(), "unknown flag") {
+		t.Fatalf("index bogus err=%v", err)
+	}
+}

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -372,7 +372,7 @@ func TestDuplicateSessionBranchesAndAdditionalParsers(t *testing.T) {
 		}
 	}
 	dir := filepath.Join(tmp, "dup-index")
-	if err := rebuild(dir, "claude", "", currentFiles("claude")); err != nil {
+	if err := rebuild(dir, "claude", "", currentFiles("claude"), nil); err != nil {
 		t.Fatal(err)
 	}
 	if ss, err := Search(dir, search.Options{Query: "duplicate", All: true}); err != nil || len(ss) != 1 {

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -716,7 +716,7 @@ func TestIndexErrorBranches(t *testing.T) {
 	if err := writeSessions(filepath.Join(tmp, "missing-tmp"), filepath.Join(tmp, "out"), nil, nil, ""); err == nil {
 		t.Fatal("writeSessions missing tmp returned nil")
 	}
-	if _, err := indexTextParallel(func(chan<- tokenJob) error { return errors.New("feed") }); err == nil {
+	if _, err := indexTextParallel(func(func(tokenJob)) error { return errors.New("feed") }); err == nil {
 		t.Fatal("indexTextParallel feed error returned nil")
 	}
 	if err := writeBucketsConcurrent(badWriteDir, bucketPostings{"ta": {"talpha": {{Off: 1, Sid: 1}}}}); err == nil {

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -343,8 +343,13 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 	if err != nil {
 		return err
 	}
+	rw, err := newRecordWriter(rf)
+	if err != nil {
+		_ = rf.Close()
+		return err
+	}
 	seenMsgs := msgSeen{}
-	buckets, err := indexTextParallel(func(jobs chan<- tokenJob) error {
+	buckets, err := indexTextParallel(func(push func(tokenJob)) error {
 		for _, s := range ss {
 			key := s.Harness + ":" + s.ID
 			ord := uint32(0)
@@ -376,20 +381,20 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 					text = text[:maxIndexedText]
 				}
 				text = redactForIngest(&m, s.Path, text)
-				off, err := writeRecord(rf, Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
+				off, err := rw.write(Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
 				if err != nil {
 					return err
 				}
-				jobs <- tokenJob{text: text, offset: off, sid: m.Sessions[key].Ord}
+				push(tokenJob{text: text, offset: off, sid: m.Sessions[key].Ord})
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		_ = rf.Close()
+		_ = rw.Close()
 		return err
 	}
-	if err := rf.Close(); err != nil {
+	if err := rw.Close(); err != nil {
 		return err
 	}
 	if err := writeBucketsConcurrent(filepath.Join(tmp, "buckets"), buckets); err != nil {
@@ -499,7 +504,12 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	if err != nil {
 		return err
 	}
-	buckets, err := indexTextParallel(func(jobs chan<- tokenJob) error {
+	rw, err := newRecordWriter(rf)
+	if err != nil {
+		_ = rf.Close()
+		return err
+	}
+	buckets, err := indexTextParallel(func(push func(tokenJob)) error {
 		for _, s := range ss {
 			key := s.Harness + ":" + s.ID
 			ord := uint32(0)
@@ -528,20 +538,20 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 					text = text[:maxIndexedText]
 				}
 				text = redactForIngest(&m, s.Path, text)
-				off, err := writeRecord(rf, Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
+				off, err := rw.write(Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
 				if err != nil {
 					return err
 				}
-				jobs <- tokenJob{text: text, offset: off, sid: m.Sessions[key].Ord}
+				push(tokenJob{text: text, offset: off, sid: m.Sessions[key].Ord})
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		_ = rf.Close()
+		_ = rw.Close()
 		return err
 	}
-	if err := rf.Close(); err != nil {
+	if err := rw.Close(); err != nil {
 		return err
 	}
 	if err := writeBucketsConcurrent(filepath.Join(tmp, "buckets"), buckets); err != nil {
@@ -563,12 +573,16 @@ type tokenJob struct {
 
 type bucketPostings map[string]map[string][]posting
 
-func indexTextParallel(feed func(chan<- tokenJob) error) (bucketPostings, error) {
+// indexTextParallel hands the feed a push callback and moves jobs to the
+// workers in batches: one channel send per message caused enough scheduler
+// wakeups to show up as ~20% of a cold rebuild profile.
+func indexTextParallel(feed func(push func(tokenJob)) error) (bucketPostings, error) {
 	workers := runtime.NumCPU()
 	if workers < 1 {
 		workers = 1
 	}
-	jobs := make(chan tokenJob, workers*256)
+	const batchSize = 512
+	jobs := make(chan []tokenJob, workers*4)
 	partials := make([]bucketPostings, workers)
 	var wg sync.WaitGroup
 	for i := 0; i < workers; i++ {
@@ -577,12 +591,25 @@ func indexTextParallel(feed func(chan<- tokenJob) error) (bucketPostings, error)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for job := range jobs {
-				addIndexKeys(partials[i], job.text, job.offset, job.sid)
+			for batch := range jobs {
+				for _, job := range batch {
+					addIndexKeys(partials[i], job.text, job.offset, job.sid)
+				}
 			}
 		}()
 	}
-	err := feed(jobs)
+	batch := make([]tokenJob, 0, batchSize)
+	push := func(j tokenJob) {
+		batch = append(batch, j)
+		if len(batch) == batchSize {
+			jobs <- batch
+			batch = make([]tokenJob, 0, batchSize)
+		}
+	}
+	err := feed(push)
+	if len(batch) > 0 {
+		jobs <- batch
+	}
 	close(jobs)
 	wg.Wait()
 	if err != nil {
@@ -878,6 +905,11 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	if err != nil {
 		return err
 	}
+	rw, err := newRecordWriter(rf)
+	if err != nil {
+		_ = rf.Close()
+		return err
+	}
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope,
 		ExportWatermarks: old.ExportWatermarks, ImportedRecords: old.ImportedRecords}
 	skipRedactions := map[string]bool{}
@@ -901,7 +933,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 			return nil
 		}
 		r.Text = redactForIngest(&m, r.SourcePath, r.Text)
-		off, err := writeRecord(rf, r)
+		off, err := rw.write(r)
 		if err != nil {
 			return err
 		}
@@ -933,11 +965,11 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		}
 		recErr = addRec(r)
 	}); err != nil {
-		_ = rf.Close()
+		_ = rw.Close()
 		return err
 	}
 	if recErr != nil {
-		rf.Close()
+		_ = rw.Close()
 		return recErr
 	}
 	seenMsgs := msgSeen{}
@@ -963,12 +995,12 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 			}
 			text = redactForIngest(&m, s.Path, text)
 			if err := addRec(Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time}); err != nil {
-				rf.Close()
+				_ = rw.Close()
 				return err
 			}
 		}
 	}
-	if err := rf.Close(); err != nil {
+	if err := rw.Close(); err != nil {
 		return err
 	}
 	if err := writeBucketsConcurrent(filepath.Join(tmp, "buckets"), buckets); err != nil {
@@ -1006,10 +1038,12 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	if err != nil {
 		return 0, 0, err
 	}
-	defer rf.Close()
-	if _, err := rf.Seek(0, io.SeekEnd); err != nil {
+	rw, err := newRecordWriter(rf)
+	if err != nil {
+		_ = rf.Close()
 		return 0, 0, err
 	}
+	defer func() { _ = rw.Close() }()
 	buckets := bucketPostings{}
 	loadBucket := func(tok string) (map[string][]posting, error) {
 		b := bucket(tok)
@@ -1077,7 +1111,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 					text = text[:maxIndexedText]
 				}
 				text = redactForIngest(&m, s.Path, text)
-				off, err := writeRecord(rf, Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
+				off, err := rw.write(Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
 				if err != nil {
 					return filesTouched, messages, err
 				}
@@ -1097,7 +1131,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 			}
 		}
 	}
-	if err := rf.Close(); err != nil {
+	if err := rw.Close(); err != nil {
 		return filesTouched, messages, err
 	}
 	if err := writeBucketsConcurrent(filepath.Join(dir, "buckets"), buckets); err != nil {
@@ -1523,6 +1557,50 @@ func sortedUniquePostings(posts []posting) []posting {
 	return out[:n]
 }
 
+// recordWriter appends length-prefixed records through one buffer, tracking
+// the file offset in memory: the hot rebuild path used to pay a Seek syscall
+// per record, which dominated cold-rebuild profiles.
+type recordWriter struct {
+	f   *os.File
+	w   *bufio.Writer
+	off int64
+}
+
+func newRecordWriter(f *os.File) (*recordWriter, error) {
+	off, err := f.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, err
+	}
+	return &recordWriter{f: f, w: bufio.NewWriterSize(f, 1<<20), off: off}, nil
+}
+
+func (rw *recordWriter) write(r Record) (int64, error) {
+	b := encodeRecord(r)
+	if len(b) > 1<<31 {
+		return 0, fmt.Errorf("record too large")
+	}
+	var hdr [4]byte
+	binary.LittleEndian.PutUint32(hdr[:], uint32(len(b)))
+	if _, err := rw.w.Write(hdr[:]); err != nil {
+		return 0, err
+	}
+	if _, err := rw.w.Write(b); err != nil {
+		return 0, err
+	}
+	off := rw.off
+	rw.off += int64(len(hdr)) + int64(len(b))
+	return off, nil
+}
+
+func (rw *recordWriter) Close() error {
+	ferr := rw.w.Flush()
+	cerr := rw.f.Close()
+	if ferr != nil {
+		return ferr
+	}
+	return cerr
+}
+
 func writeRecord(f *os.File, r Record) (int64, error) {
 	off, err := f.Seek(0, io.SeekCurrent)
 	if err != nil {
@@ -1879,35 +1957,36 @@ func writeBucket(p string, data map[string][]posting) error {
 		return err
 	}
 	defer func() { _ = f.Close() }()
-	if _, err := f.Write(bucketMagic); err != nil {
+	w := bufio.NewWriterSize(f, 1<<20)
+	if _, err := w.Write(bucketMagic); err != nil {
 		return err
 	}
 	var scratch [binary.MaxVarintLen64]byte
 	n := binary.PutUvarint(scratch[:], uint64(len(entries)))
-	if _, err := f.Write(scratch[:n]); err != nil {
+	if _, err := w.Write(scratch[:n]); err != nil {
 		return err
 	}
 	for _, e := range entries {
 		n = binary.PutUvarint(scratch[:], uint64(len(e.tok)))
-		if _, err := f.Write(scratch[:n]); err != nil {
+		if _, err := w.Write(scratch[:n]); err != nil {
 			return err
 		}
-		if _, err := f.Write([]byte(e.tok)); err != nil {
+		if _, err := w.Write([]byte(e.tok)); err != nil {
 			return err
 		}
 		var fixed [12]byte
 		binary.LittleEndian.PutUint64(fixed[:8], e.off)
 		binary.LittleEndian.PutUint32(fixed[8:], e.n)
-		if _, err := f.Write(fixed[:]); err != nil {
+		if _, err := w.Write(fixed[:]); err != nil {
 			return err
 		}
 	}
 	for _, tok := range toks {
-		if _, err := f.Write(encoded[tok]); err != nil {
+		if _, err := w.Write(encoded[tok]); err != nil {
 			return err
 		}
 	}
-	return nil
+	return w.Flush()
 }
 
 func readBucket(p string) (map[string][]posting, error) {

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -144,7 +144,7 @@ func EnsureForSearch(dir string, o search.Options, force bool, progress io.Write
 		if progress != nil {
 			fmt.Fprintf(progress, "deja: indexing sessions into %s ...\n", dir)
 		}
-		return rebuildForSearch(dir, o, scope, want)
+		return rebuildForSearch(dir, o, scope, want, progress)
 	}
 	if err := updateIndex(dir, o.Harness, scope, want, force, progress); err != nil {
 		return fmt.Errorf("update: %w", err)
@@ -326,7 +326,7 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 	return s, true, nil
 }
 
-func rebuild(dir string, harness string, scope string, files map[string]FileState) error {
+func rebuild(dir string, harness string, scope string, files map[string]FileState, progress io.Writer) error {
 	lastIngestFiles = len(files)
 	imported := importedSessions(dir)
 	tmp := dir + ".tmp"
@@ -334,7 +334,7 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o755); err != nil {
 		return err
 	}
-	ss := load(harness)
+	ss := loadProgress(harness, progress)
 	ss = append(ss, imported.sessions...)
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope,
 		ExportWatermarks: imported.watermarks, ImportedRecords: imported.dedupe}
@@ -450,42 +450,50 @@ func importedSessions(dir string) importedState {
 	return out
 }
 
-func load(h string) []model.Session {
+var harnessLoaders = []struct {
+	name string
+	load func() []model.Session
+}{
+	{"claude", sources.LoadClaude},
+	{"codex", sources.LoadCodex},
+	{"opencode", sources.LoadOpencode},
+	{"aider", sources.LoadAider},
+	{"gemini", sources.LoadGemini},
+	{"cursor", sources.LoadCursor},
+	{"antigravity", sources.LoadAntigravity},
+	{"grok", sources.LoadGrok},
+}
+
+func load(h string) []model.Session { return loadProgress(h, nil) }
+
+// loadProgress narrates a full rebuild per harness: a cold pass over a large
+// corpus takes seconds and used to look hung.
+func loadProgress(h string, progress io.Writer) []model.Session {
 	var ss []model.Session
-	if h == "" || h == "claude" {
-		ss = append(ss, sources.LoadClaude()...)
-	}
-	if h == "" || h == "codex" {
-		ss = append(ss, sources.LoadCodex()...)
-	}
-	if h == "" || h == "opencode" {
-		ss = append(ss, sources.LoadOpencode()...)
-	}
-	if h == "" || h == "aider" {
-		ss = append(ss, sources.LoadAider()...)
-	}
-	if h == "" || h == "gemini" {
-		ss = append(ss, sources.LoadGemini()...)
-	}
-	if h == "" || h == "cursor" {
-		ss = append(ss, sources.LoadCursor()...)
-	}
-	if h == "" || h == "antigravity" {
-		ss = append(ss, sources.LoadAntigravity()...)
-	}
-	if h == "" || h == "grok" {
-		ss = append(ss, sources.LoadGrok()...)
+	for _, hl := range harnessLoaders {
+		if h != "" && h != hl.name {
+			continue
+		}
+		got := hl.load()
+		ss = append(ss, got...)
+		if progress != nil && len(got) > 0 {
+			msgs := 0
+			for _, s := range got {
+				msgs += len(s.Messages)
+			}
+			fmt.Fprintf(progress, "deja: %s: %d sessions, %d messages\n", hl.name, len(got), msgs)
+		}
 	}
 	return ss
 }
 
-func rebuildForSearch(dir string, o search.Options, scope string, files map[string]FileState) error {
+func rebuildForSearch(dir string, o search.Options, scope string, files map[string]FileState, progress io.Writer) error {
 	tmp := dir + ".tmp"
 	_ = os.RemoveAll(tmp)
 	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o755); err != nil {
 		return err
 	}
-	ss := load("")
+	ss := loadProgress("", progress)
 	imported := importedSessions(dir)
 	ss = append(ss, imported.sessions...)
 	return writeSessionsWithSync(tmp, dir, ss, files, scope, imported)
@@ -830,7 +838,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		if progress != nil {
 			fmt.Fprintf(progress, "deja: indexing sessions into %s ...\n", dir)
 		}
-		return rebuild(dir, harness, scope, files)
+		return rebuild(dir, harness, scope, files, progress)
 	}
 	changed := map[string]FileState{}
 	removed := map[string]bool{}
@@ -857,7 +865,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 			if progress != nil {
 				fmt.Fprintf(progress, "deja: index damaged (%v), rebuilding ...\n", err)
 			}
-			return rebuild(dir, harness, scope, files)
+			return rebuild(dir, harness, scope, files, progress)
 		}
 		if err != nil {
 			return fmt.Errorf("append: %w", err)

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -238,7 +238,8 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 	if err != nil {
 		return err
 	}
-	if _, err := rf.Seek(0, io.SeekEnd); err != nil {
+	rw, err := newRecordWriter(rf)
+	if err != nil {
 		_ = rf.Close()
 		return err
 	}
@@ -280,22 +281,22 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 		}
 		m.Sessions[key] = meta
 		for _, r := range recsByKey[key] {
-			off, err := writeRecord(rf, r)
+			off, err := rw.write(r)
 			if err != nil {
-				_ = rf.Close()
+				_ = rw.Close()
 				return err
 			}
 			for _, tok := range indexKeys(r.Text) {
 				data, err := loadBucket(tok)
 				if err != nil {
-					_ = rf.Close()
+					_ = rw.Close()
 					return err
 				}
 				data[tok] = append(data[tok], posting{Off: off, Sid: meta.Ord})
 			}
 		}
 	}
-	if err := rf.Close(); err != nil {
+	if err := rw.Close(); err != nil {
 		return err
 	}
 	if err := writeBucketsConcurrent(filepath.Join(dir, "buckets"), buckets); err != nil {

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -44,27 +44,61 @@ var (
 
 func Disabled() bool { return os.Getenv("DEJA_NO_REDACT") == "1" }
 
+// kvHints are the substrings genericKVRE can anchor on; providerHints the
+// literal prefixes of providerRE. Checking them first keeps the regexes off
+// the vast majority of messages, which contain no credentials at all.
+var kvHints = []string{"key", "secret", "token", "passw", "authorization"}
+
+// "github_pat_" is listed on its own: "gh" is not a substring of "github".
+var providerHints = []string{"gh", "github_pat_", "glpat-", "sk_", "rk_", "sk-", "gsk_", "xai-", "hf_", "npm_", "xox", "AIza"}
+
+func containsAnyFold(s string, hints []string) bool {
+	for _, h := range hints {
+		if strings.Contains(s, h) {
+			return true
+		}
+	}
+	return false
+}
+
 func Text(s string) (string, Counts) {
 	counts := Counts{}
 	if Disabled() || s == "" {
 		return s, counts
 	}
-	s = replaceWhole(s, pemPrivateRE, "private-key", counts)
-	s = replaceSubmatch(s, connURLRE, "url-credentials", counts, func(m []string) string {
-		return m[1] + m[2] + ":[redacted:url-credentials]@" + m[4]
-	})
-	s = replaceSubmatch(s, awsSecretRE, "aws-secret", counts, func(m []string) string {
-		return m[1] + m[2] + m[3] + "[redacted:aws-secret]" + closingQuote(m[3], m[5])
-	})
-	s = replaceWhole(s, awsAccessKeyRE, "aws-access-key", counts)
-	s = replaceSubmatch(s, bearerRE, "bearer-token", counts, func(m []string) string {
-		return m[1] + m[2] + "[redacted:bearer-token]"
-	})
-	s = replaceWhole(s, jwtRE, "jwt", counts)
-	s = replaceSubmatch(s, genericKVRE, "credential", counts, func(m []string) string {
-		return m[1] + m[2] + m[3] + "[redacted:credential]" + closingQuote(m[3], m[5])
-	})
-	s = replaceProvider(s, counts)
+	lower := strings.ToLower(s)
+	if strings.Contains(s, "-----BEGIN") {
+		s = replaceWhole(s, pemPrivateRE, "private-key", counts)
+	}
+	if strings.Contains(s, "://") {
+		s = replaceSubmatch(s, connURLRE, "url-credentials", counts, func(m []string) string {
+			return m[1] + m[2] + ":[redacted:url-credentials]@" + m[4]
+		})
+	}
+	if strings.Contains(lower, "aws") {
+		s = replaceSubmatch(s, awsSecretRE, "aws-secret", counts, func(m []string) string {
+			return m[1] + m[2] + m[3] + "[redacted:aws-secret]" + closingQuote(m[3], m[5])
+		})
+	}
+	if strings.Contains(s, "AKIA") || strings.Contains(s, "ASIA") {
+		s = replaceWhole(s, awsAccessKeyRE, "aws-access-key", counts)
+	}
+	if strings.Contains(lower, "bearer") {
+		s = replaceSubmatch(s, bearerRE, "bearer-token", counts, func(m []string) string {
+			return m[1] + m[2] + "[redacted:bearer-token]"
+		})
+	}
+	if strings.Contains(s, "eyJ") {
+		s = replaceWhole(s, jwtRE, "jwt", counts)
+	}
+	if containsAnyFold(lower, kvHints) {
+		s = replaceSubmatch(s, genericKVRE, "credential", counts, func(m []string) string {
+			return m[1] + m[2] + m[3] + "[redacted:credential]" + closingQuote(m[3], m[5])
+		})
+	}
+	if containsAnyFold(s, providerHints) {
+		s = replaceProvider(s, counts)
+	}
 	return s, counts
 }
 


### PR DESCRIPTION
Real `index` subcommand instead of the accidental fall-through to a search for the word "index", plus per-harness progress lines during cold rebuilds. Closes #84