### PR TITLE
feat: wordmark on install and first index

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -62,6 +62,9 @@ func runInstall(args []string, uninstall bool) error {
 		}
 		fmt.Printf("%s: %s %s\n", t, r.Action, r.Path)
 	}
+	if !uninstall && (args[0] == "--auto" || args[0] == "--all") && logoWanted(os.Stdout) {
+		printLogo(os.Stdout, "memory for coding agents")
+	}
 	return nil
 }
 

--- a/cmd/deja/logo.go
+++ b/cmd/deja/logo.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The wordmark prints on exactly two occasions: the end of a successful
+// install and the first index build. Everywhere else deja lives in pipes,
+// hooks and status bars, where a banner is noise.
+const logoAccent = "\x1b[38;5;141m"
+const logoDim = "\x1b[2m"
+const logoReset = "\x1b[0m"
+
+var logoLines = []string{
+	`┌┬┐┌─┐ ┬┌─┐   ┬  ┬┬ ┬`,
+	` ││├┤  │├─┤───└┐┌┘│ │`,
+	`─┴┘└─┘└┘┴ ┴    └┘ └─┘`,
+}
+
+func logoWanted(f *os.File) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+func printLogo(w io.Writer, tagline string) {
+	fmt.Fprintln(w)
+	for _, l := range logoLines {
+		fmt.Fprintf(w, "  %s%s%s\n", logoAccent, l, logoReset)
+	}
+	if tagline != "" {
+		fmt.Fprintf(w, "  %s%s%s\n", logoDim, tagline, logoReset)
+	}
+	fmt.Fprintln(w)
+}
+
+func maybeFirstIndexGreeting() {
+	b := index.LastBuild
+	if !b.Initial || b.Messages == 0 || !logoWanted(os.Stdout) {
+		return
+	}
+	printLogo(os.Stdout, "memory for coding agents")
+	fmt.Printf("  indexed %d messages from %d sessions across %d agents\n", b.Messages, b.Sessions, b.Harnesses)
+	fmt.Printf("  try: deja \"something you fixed weeks ago\"\n\n")
+}

--- a/cmd/deja/logo_test.go
+++ b/cmd/deja/logo_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPrintLogo(t *testing.T) {
+	var b bytes.Buffer
+	printLogo(&b, "memory for coding agents")
+	out := b.String()
+	if !strings.Contains(out, "┌┬┐") || !strings.Contains(out, "memory for coding agents") {
+		t.Fatalf("logo output: %q", out)
+	}
+	if len(strings.Split(strings.TrimSpace(out), "\n")) != 4 {
+		t.Fatalf("logo should be 3 glyph lines + tagline: %q", out)
+	}
+}
+
+func TestLogoWanted(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "notatty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	if logoWanted(f) {
+		t.Fatal("regular file must not want a logo")
+	}
+	t.Setenv("NO_COLOR", "1")
+	if logoWanted(os.Stdout) {
+		t.Fatal("NO_COLOR must suppress the logo")
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -78,7 +78,11 @@ func run(args []string) error {
 		return runDoctor(os.Stdout, doctorLookup)
 	}
 	if args[0] == "warmup" {
-		return index.Ensure(index.DefaultDir(), "", false, os.Stderr)
+		if err := index.Ensure(index.DefaultDir(), "", false, os.Stderr); err != nil {
+			return err
+		}
+		maybeFirstIndexGreeting()
+		return nil
 	}
 	if args[0] == "index" {
 		force := false
@@ -89,7 +93,11 @@ func run(args []string) error {
 			}
 			return fmt.Errorf("index: unknown flag %q", a)
 		}
-		return index.Ensure(index.DefaultDir(), "", force, os.Stderr)
+		if err := index.Ensure(index.DefaultDir(), "", force, os.Stderr); err != nil {
+			return err
+		}
+		maybeFirstIndexGreeting()
+		return nil
 	}
 	if args[0] == "statusline" {
 		return runStatusline(os.Stdin, os.Stdout)
@@ -210,6 +218,7 @@ func run(args []string) error {
 	if err := index.EnsureForSearch(index.DefaultDir(), o, force, os.Stderr); err != nil {
 		return fmt.Errorf("ensure: %w", err)
 	}
+	maybeFirstIndexGreeting()
 	ss, err := index.SearchWithRecovery(index.DefaultDir(), o, os.Stderr)
 	if err != nil {
 		return fmt.Errorf("search: %w", err)

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -38,6 +38,25 @@ func IsCorrupt(err error) bool { return errors.Is(err, errCorruptIndex) }
 
 var lastIngestFiles int
 
+// BuildSummary describes the most recent (re)build in this process; the CLI
+// uses it to greet a first-ever index with a summary instead of silence.
+type BuildSummary struct {
+	Initial   bool
+	Sessions  int
+	Messages  int
+	Harnesses int
+}
+
+var LastBuild BuildSummary
+
+func summarizeBuild(initial bool, sessions int, messages int, ss []model.Session) {
+	hs := map[string]bool{}
+	for _, s := range ss {
+		hs[s.Harness] = true
+	}
+	LastBuild = BuildSummary{Initial: initial, Sessions: sessions, Messages: messages, Harnesses: len(hs)}
+}
+
 type FileState struct {
 	Path          string `json:"path"`
 	Size          int64  `json:"size"`
@@ -336,6 +355,8 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 
 func rebuild(dir string, harness string, scope string, files map[string]FileState, progress io.Writer) error {
 	lastIngestFiles = len(files)
+	initialBuild := !HasManifest(dir)
+	writtenMessages := 0
 	imported := importedSessions(dir)
 	tmp := dir + ".tmp"
 	_ = os.RemoveAll(tmp)
@@ -393,6 +414,7 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 				if err != nil {
 					return err
 				}
+				writtenMessages++
 				push(tokenJob{text: text, offset: off, sid: m.Sessions[key].Ord})
 			}
 		}
@@ -413,7 +435,11 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 		return err
 	}
 	_ = os.RemoveAll(dir)
-	return os.Rename(tmp, dir)
+	if err := os.Rename(tmp, dir); err != nil {
+		return err
+	}
+	summarizeBuild(initialBuild, len(m.Sessions), writtenMessages, ss)
+	return nil
 }
 
 const syncImportPath = "deja-sync-import"
@@ -512,6 +538,8 @@ func writeSessions(tmp, dir string, ss []model.Session, files map[string]FileSta
 }
 
 func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string]FileState, scope string, imp importedState) error {
+	initialBuild := !HasManifest(dir)
+	writtenMessages := 0
 	lastIngestFiles = len(files)
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope,
 		ExportWatermarks: imp.watermarks, ImportedRecords: imp.dedupe}
@@ -558,6 +586,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 				if err != nil {
 					return err
 				}
+				writtenMessages++
 				push(tokenJob{text: text, offset: off, sid: m.Sessions[key].Ord})
 			}
 		}
@@ -578,7 +607,11 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 		return err
 	}
 	os.RemoveAll(dir)
-	return os.Rename(tmp, dir)
+	if err := os.Rename(tmp, dir); err != nil {
+		return err
+	}
+	summarizeBuild(initialBuild, len(m.Sessions), writtenMessages, ss)
+	return nil
 }
 
 type tokenJob struct {


### PR DESCRIPTION
Prints the deja-vu wordmark after install --auto/--all and after the very first index build, with indexed counts. TTY-only, suppressed by NO_COLOR. Stacked on #89. Closes #85