### PR TITLE
test: fuzz all parsers; crash-safe manifest commits

### DIFF
--- a/internal/index/crash_safe_test.go
+++ b/internal/index/crash_safe_test.go
@@ -1,0 +1,161 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func claudeLine(sid, ts, text string) string {
+	return `{"type":"user","sessionId":"` + sid + `","timestamp":"` + ts + `","message":{"role":"user","content":"` + text + `"}}` + "\n"
+}
+
+// A records.bin cut short by a crash must not read as a fresh index that
+// silently returns fewer messages: the size stamp catches the short file and
+// the next run rebuilds.
+func TestSearchRecoversFromTruncatedRecords(t *testing.T) {
+	root, dir := allHarnessEnv(t)
+	claudeFile := filepath.Join(root, "claude", "-tmp-p", "s.jsonl")
+	write(t, claudeFile, claudeLine("s1", "2026-01-02T03:04:05Z", "recneedle one")+claudeLine("s1", "2026-01-02T03:04:06Z", "recneedle two"))
+
+	o := search.Options{Query: "recneedle", All: true}
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if ss, err := Search(dir, o); err != nil || len(ss) != 1 || len(ss[0].Messages) != 2 {
+		t.Fatalf("baseline search wrong: %#v err=%v", ss, err)
+	}
+
+	// Truncate records.bin to simulate a torn write mid-record.
+	recs := filepath.Join(dir, "records.bin")
+	fi, err := os.Stat(recs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Truncate(recs, fi.Size()/2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Direct Search must flag corruption rather than return a half-scan.
+	if _, err := Search(dir, o); !IsCorrupt(err) {
+		t.Fatalf("Search over truncated records.bin err=%v, want corrupt index", err)
+	}
+	// The source files are unchanged, so the only way to heal is the size stamp
+	// forcing a rebuild.
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := Search(dir, o)
+	if err != nil || len(ss) != 1 || len(ss[0].Messages) != 2 {
+		t.Fatalf("not healed after rebuild: %#v err=%v", ss, err)
+	}
+}
+
+// A manifest.gob left half-written by a crash must fail to decode and trigger a
+// rebuild, never load as an empty-but-valid index.
+func TestEnsureRecoversFromTornManifest(t *testing.T) {
+	root, dir := allHarnessEnv(t)
+	claudeFile := filepath.Join(root, "claude", "-tmp-p", "s.jsonl")
+	write(t, claudeFile, claudeLine("s1", "2026-01-02T03:04:05Z", "manneedle here"))
+
+	o := search.Options{Query: "manneedle", All: true}
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	man := filepath.Join(dir, "manifest.gob")
+	fi, err := os.Stat(man)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Truncate(man, fi.Size()/2); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatalf("ensure did not heal torn manifest: %v", err)
+	}
+	if ss, err := Search(dir, o); err != nil || len(ss) != 1 {
+		t.Fatalf("not healed: %#v err=%v", ss, err)
+	}
+}
+
+// The incremental append path writes sessions.gob before manifest.gob so a
+// crash between them leaves the *old* manifest in place. This reconstructs that
+// exact crash state (old manifest, new sessions + records) and asserts the new
+// message is reindexed and found rather than silently dropped.
+func TestAppendCrashBetweenSessionsAndManifestReindexes(t *testing.T) {
+	root, dir := allHarnessEnv(t)
+	claudeFile := filepath.Join(root, "claude", "-tmp-p", "s.jsonl")
+	write(t, claudeFile, claudeLine("s1", "2026-01-02T03:04:05Z", "appendneedle first"))
+
+	o := search.Options{Query: "appendneedle", All: true}
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	oldManifest, err := os.ReadFile(filepath.Join(dir, "manifest.gob"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Append a second complete line and let the incremental path commit it.
+	f, err := os.OpenFile(claudeFile, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(claudeLine("s1", "2026-01-02T03:04:07Z", "appendneedle second")); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the crash: manifest.gob reverts to its pre-append contents while
+	// sessions.gob and records.bin already hold the new message.
+	if err := os.WriteFile(filepath.Join(dir, "manifest.gob"), oldManifest, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := Search(dir, search.Options{Query: "appendneedle second", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) == 0 {
+		t.Fatalf("appended message silently lost after simulated crash: %#v", ss)
+	}
+}
+
+// writeManifest must commit atomically: no leftover temp files, and the size
+// stamp must match records.bin exactly so recordsIntact never false-positives.
+func TestWriteManifestAtomicAndStamped(t *testing.T) {
+	root, dir := allHarnessEnv(t)
+	write(t, filepath.Join(root, "claude", "-tmp-p", "s.jsonl"),
+		claudeLine("s1", "2026-01-02T03:04:05Z", "stampneedle"))
+	if err := EnsureForSearch(dir, search.Options{Query: "stampneedle"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	leftovers, _ := filepath.Glob(filepath.Join(dir, "*.tmp"))
+	if len(leftovers) != 0 {
+		t.Fatalf("temp files left behind: %v", leftovers)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(filepath.Join(dir, "records.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.RecordsSize != fi.Size() {
+		t.Fatalf("RecordsSize=%d, records.bin=%d", m.RecordsSize, fi.Size())
+	}
+	if !recordsIntact(dir, m) {
+		t.Fatal("recordsIntact false on a clean index")
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -69,6 +69,10 @@ type Manifest struct {
 	Redacted         int                    `json:"redacted"`
 	ExportWatermarks map[string]int64       `json:"export_watermarks,omitempty"`
 	ImportedRecords  map[string]bool        `json:"imported_records,omitempty"`
+	// RecordsSize is records.bin's byte length when the manifest was committed.
+	// A live index whose records.bin is shorter than this lost its tail to a
+	// torn write and must be treated as corrupt.
+	RecordsSize int64 `json:"records_size,omitempty"`
 }
 
 type manifestCore struct {
@@ -79,6 +83,7 @@ type manifestCore struct {
 	Redacted         int
 	ExportWatermarks map[string]int64
 	ImportedRecords  map[string]bool
+	RecordsSize      int64
 }
 
 type RedactionStats struct {
@@ -119,7 +124,7 @@ func Ensure(dir string, harness string, force bool, progress io.Writer) error {
 	defer unlock()
 	want := currentFiles("")
 	m, err := readManifest(dir)
-	if !force && err == nil && manifestFresh(m, want, "") {
+	if !force && err == nil && manifestFresh(m, want, "") && recordsIntact(dir, m) {
 		return nil
 	}
 	return updateIndex(dir, "", "", want, force, progress)
@@ -137,10 +142,10 @@ func EnsureForSearch(dir string, o search.Options, force bool, progress io.Write
 	want := currentFiles("")
 	scope := ""
 	m, err := readManifest(dir)
-	if !force && err == nil && manifestFresh(m, want, scope) {
+	if !force && err == nil && manifestFresh(m, want, scope) && recordsIntact(dir, m) {
 		return nil
 	}
-	if force || err != nil || m.Version != version || m.Scope != scope {
+	if force || err != nil || m.Version != version || m.Scope != scope || !recordsIntact(dir, m) {
 		if progress != nil {
 			fmt.Fprintf(progress, "deja: indexing sessions into %s ...\n", dir)
 		}
@@ -164,6 +169,9 @@ func Search(dir string, o search.Options) ([]model.Session, error) {
 	m, err := readManifest(dir)
 	if err != nil {
 		return nil, fmt.Errorf("manifest: %w", err)
+	}
+	if !recordsIntact(dir, m) {
+		return nil, fmt.Errorf("%w: records.bin truncated", errCorruptIndex)
 	}
 	var posts []posting
 	usedPostings := false
@@ -834,6 +842,9 @@ func Redactions(dir string) (RedactionStats, error) {
 
 func updateIndex(dir, harness, scope string, files map[string]FileState, force bool, progress io.Writer) error {
 	old, err := readManifest(dir)
+	if err == nil && !recordsIntact(dir, old) {
+		force = true // records.bin lost its tail to a crash; only a rebuild is safe
+	}
 	if force || err != nil || old.Version != version || old.Scope != scope {
 		if progress != nil {
 			fmt.Fprintf(progress, "deja: indexing sessions into %s ...\n", dir)
@@ -1920,19 +1931,42 @@ func readManifest(dir string) (Manifest, error) {
 	if err := readGob(filepath.Join(dir, "manifest.gob"), &core); err != nil {
 		return Manifest{}, err
 	}
-	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Scope: core.Scope, Redacted: core.Redacted, ExportWatermarks: core.ExportWatermarks, ImportedRecords: core.ImportedRecords, Sessions: map[string]SessionMeta{}}
+	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Scope: core.Scope, Redacted: core.Redacted, ExportWatermarks: core.ExportWatermarks, ImportedRecords: core.ImportedRecords, RecordsSize: core.RecordsSize, Sessions: map[string]SessionMeta{}}
 	if err := readGob(filepath.Join(dir, "sessions.gob"), &m.Sessions); err != nil {
 		return Manifest{}, err
 	}
 	return m, nil
 }
 
+// writeManifest commits the two-file manifest crash-safely. sessions.gob is
+// written (and renamed into place) before manifest.gob, and both go through a
+// temp file + rename. manifest.gob carries the version/file sizes that decide
+// whether the index is fresh, so it must land last: a crash between the two
+// leaves the old manifest pointing at old data, and the next run reindexes
+// rather than serving a fresh-looking index whose sessions are stale.
 func writeManifest(dir string, m Manifest) error {
 	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Scope: m.Scope, Redacted: m.Redacted, ExportWatermarks: m.ExportWatermarks, ImportedRecords: m.ImportedRecords}
-	if err := writeGob(filepath.Join(dir, "manifest.gob"), core); err != nil {
+	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
+		core.RecordsSize = fi.Size()
+	}
+	if err := writeGobAtomic(filepath.Join(dir, "sessions.gob"), m.Sessions); err != nil {
 		return err
 	}
-	return writeGob(filepath.Join(dir, "sessions.gob"), m.Sessions)
+	return writeGobAtomic(filepath.Join(dir, "manifest.gob"), core)
+}
+
+// recordsIntact reports whether records.bin still holds everything the manifest
+// committed. A shorter file means a crash truncated the record log; the index
+// must rebuild rather than silently return fewer messages.
+func recordsIntact(dir string, m Manifest) bool {
+	if m.RecordsSize <= 0 {
+		return true // empty index, or one written before the size stamp existed
+	}
+	fi, err := os.Stat(filepath.Join(dir, "records.bin"))
+	if err != nil {
+		return false
+	}
+	return fi.Size() >= m.RecordsSize
 }
 
 type bucketEntry struct {
@@ -2125,6 +2159,26 @@ func writeGob(p string, v any) error {
 	}
 	defer func() { _ = f.Close() }()
 	return gob.NewEncoder(f).Encode(v)
+}
+
+// writeGobAtomic writes to a sibling temp file and renames it over p, so a
+// crash mid-write can never leave p half-decoded.
+func writeGobAtomic(p string, v any) error {
+	tmp := p + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	if err := gob.NewEncoder(f).Encode(v); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, p)
 }
 func readGob(p string, v any) error {
 	f, err := os.Open(p)

--- a/internal/sources/fuzz_test.go
+++ b/internal/sources/fuzz_test.go
@@ -1,0 +1,222 @@
+package sources
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// fuzzEnv points every source root at a throwaway temp dir so parsers that
+// resolve project names against the filesystem (claude/cursor encoded dirs,
+// grok cwd markers, gemini registry) never touch the real home directory.
+func fuzzEnv(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(root, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(root, "codex"))
+	t.Setenv("DEJA_GEMINI_ROOT", filepath.Join(root, "gemini"))
+	t.Setenv("DEJA_GROK_ROOT", filepath.Join(root, "grok"))
+	t.Setenv("GROK_HOME", filepath.Join(root, "grok"))
+	t.Setenv("DEJA_ANTIGRAVITY_ROOT", filepath.Join(root, "antigravity"))
+	return root
+}
+
+// checkSessions asserts the invariants every parser must uphold: it only
+// returns sessions with at least one message and a non-empty ID (each format
+// derives an ID from the filename or transcript, never leaving it blank).
+func checkSessions(t *testing.T, ss []model.Session) {
+	t.Helper()
+	for i := range ss {
+		if ss[i].Messages == nil {
+			t.Fatalf("session %d has nil Messages: %#v", i, ss[i])
+		}
+		if ss[i].ID == "" {
+			t.Fatalf("session %d has empty ID: %#v", i, ss[i])
+		}
+	}
+}
+
+func writeFuzzFile(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+const claudeSeed = `{"type":"user","sessionId":"claude-abc","cwd":"/tmp/demo","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"Find frobnicator bug"}}
+{"type":"assistant","sessionId":"claude-abc","cwd":"/tmp/demo","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"text","text":"in parser.go"}]}}
+`
+
+func FuzzParseClaudeFile(f *testing.F) {
+	f.Add([]byte(claudeSeed))
+	f.Add([]byte(`{"type":"user","sessionId":"c","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"hi"}}` + "\n"))
+	f.Add([]byte(`{"type":"summary","summary":"x"}` + "\n"))
+	f.Add([]byte(claudeSeed[:len(claudeSeed)/2])) // torn tail
+	f.Add([]byte("{\x00not json\n"))
+	f.Add([]byte(""))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzEnv(t)
+		p := writeFuzzFile(t, t.TempDir(), "s.jsonl", data)
+		ss, _ := ParseClaudeFile(p)
+		checkSessions(t, ss)
+	})
+}
+
+const codexRolloutSeed = `{"timestamp":"2026-01-02T03:04:05Z","type":"session_meta","payload":{"session_id":"codex-abc","cwd":"/tmp/codemo"}}
+{"timestamp":"2026-01-02T03:04:06Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello codex"}]}}
+{"timestamp":"2026-01-02T03:04:07Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"fixed"}]}}
+`
+
+func FuzzParseCodexRollout(f *testing.F) {
+	f.Add([]byte(codexRolloutSeed))
+	f.Add([]byte(`{"timestamp":"2026-01-02T03:04:06Z","payload":{"role":"assistant","content":"x"}}` + "\n"))
+	f.Add([]byte(`{"payload":{"message":"bare user text"}}` + "\n"))
+	f.Add([]byte(codexRolloutSeed[:len(codexRolloutSeed)/2]))
+	f.Add([]byte(`{"payload":null}` + "\n"))
+	f.Add([]byte(""))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzEnv(t)
+		p := writeFuzzFile(t, t.TempDir(), "rollout-fuzz.jsonl", data)
+		ss, _ := ParseCodexRollout(p)
+		checkSessions(t, ss)
+	})
+}
+
+func FuzzParseCodexHistory(f *testing.F) {
+	f.Add([]byte(`{"session_id":"hist-abc","ts":1767323045,"text":"history needle"}` + "\n"))
+	f.Add([]byte(`{"session_id":"","text":"no id"}` + "\n"))
+	f.Add([]byte(`{"session_id":"h","text":""}` + "\n"))
+	f.Add([]byte(`{"session_id":"h","ts":"2026-01-02T03:04:05Z","text":"a"}` + "\n{broken"))
+	f.Add([]byte(""))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzEnv(t)
+		p := writeFuzzFile(t, t.TempDir(), "history.jsonl", data)
+		ss, _ := ParseCodexHistory(p)
+		checkSessions(t, ss)
+	})
+}
+
+const geminiJSONSeed = `{"sessionId":"session-old-1","startTime":"2026-01-16T18:34:00.000Z","lastUpdated":"2026-01-16T18:35:00.000Z","messages":[{"id":"m1","timestamp":"2026-01-16T18:34:01.000Z","type":"user","content":"Hello"},{"id":"m2","timestamp":"2026-01-16T18:34:02.000Z","type":"gemini","content":"Hi!"}]}`
+
+const geminiJSONLSeed = `{"sessionId":"sess-new-1","startTime":"2026-07-01T10:00:00.000Z","lastUpdated":"2026-07-01T10:00:00.000Z","kind":"main"}
+{"id":"u1","timestamp":"2026-07-01T10:00:01.000Z","type":"user","content":[{"text":"first question"}]}
+{"id":"a1","timestamp":"2026-07-01T10:00:02.000Z","type":"gemini","content":"wrong answer"}
+{"$rewindTo":"a1"}
+{"id":"a2","timestamp":"2026-07-01T10:00:05.000Z","type":"gemini","content":"right answer"}
+{"$set":{"lastUpdated":"2026-07-01T10:00:06.000Z"}}
+`
+
+// ParseGeminiFile dispatches on extension, so each input is parsed as both a
+// whole-session .json and a streaming .jsonl.
+func FuzzParseGeminiFile(f *testing.F) {
+	f.Add([]byte(geminiJSONSeed))
+	f.Add([]byte(geminiJSONLSeed))
+	f.Add([]byte(`{"$rewindTo":"missing"}` + "\n"))
+	f.Add([]byte(geminiJSONLSeed[:len(geminiJSONLSeed)/2]))
+	f.Add([]byte(`{"sessionId":"s","messages":[{"type":"user","content":[{"text":"x"}]}]}`))
+	f.Add([]byte(""))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzEnv(t)
+		chats := filepath.Join(t.TempDir(), "tmp", "proj", "chats")
+		for _, ext := range []string{".json", ".jsonl"} {
+			p := writeFuzzFile(t, chats, "session-fuzz"+ext, data)
+			ss, _ := ParseGeminiFile(p)
+			checkSessions(t, ss)
+		}
+	})
+}
+
+const aiderSeed = "# aider chat started at 2026-07-16 10:32:01\n\n> aider v0.86.1\n\n#### fix the off-by-one\n#### keep tests green\n\nI'll fix the loop:\n\n```go\nfor i := 0; i < n; i++ {\n#### not a user line\n```\n\n> Applied edit\n\n# aider chat started at 2026-07-16 11:00:00\n\n#### second question\n\nSecond answer.\n"
+
+func FuzzParseAiderFile(f *testing.F) {
+	f.Add([]byte(aiderSeed))
+	f.Add([]byte("# aider chat started at 2026-01-01 00:00:00\n#### q\nans\n"))
+	f.Add([]byte("#### orphan user line with no session header\n"))
+	f.Add([]byte("# aider chat started at not-a-timestamp\n#### q\n```\nunclosed fence"))
+	f.Add([]byte(aiderSeed[:len(aiderSeed)/2]))
+	f.Add([]byte(""))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzEnv(t)
+		p := writeFuzzFile(t, t.TempDir(), ".aider.chat.history.md", data)
+		ss, _ := ParseAiderFile(p)
+		checkSessions(t, ss)
+	})
+}
+
+const antigravitySeed = `{"step_index":1,"source":"USER_EXPLICIT","type":"USER_INPUT","created_at":"2026-07-08T14:18:27Z","content":"<USER_REQUEST>\nBuild this\n</USER_REQUEST>"}
+{"step_index":2,"source":"SYSTEM","type":"SYSTEM","created_at":"2026-07-08T14:18:28Z","content":"noise"}
+{"step_index":3,"source":"MODEL","type":"PLANNER_RESPONSE","created_at":"2026-07-08T14:18:29Z","content":"I can help."}
+`
+
+func FuzzParseAntigravityFile(f *testing.F) {
+	f.Add([]byte(antigravitySeed))
+	f.Add([]byte(`{"source":"USER_EXPLICIT","created_at":"2026-07-08T14:18:27Z","content":"hi"}` + "\n"))
+	f.Add([]byte(`{"source":"MODEL","content":"<USER_REQUEST></USER_REQUEST>"}` + "\n"))
+	f.Add([]byte(antigravitySeed[:len(antigravitySeed)/2]))
+	f.Add([]byte(""))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		root := fuzzEnv(t)
+		dir := filepath.Join(root, "antigravity", "brain", "traj-1", ".system_generated", "logs")
+		p := writeFuzzFile(t, dir, "transcript.jsonl", data)
+		ss, _ := ParseAntigravityFile(p)
+		checkSessions(t, ss)
+	})
+}
+
+const grokSeed = `{"timestamp":1782900001,"method":"session/update","params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"find grokneedle"},"_meta":{"promptIndex":0}}}}
+{"timestamp":1782900002,"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"first "}},"_meta":{"promptId":"p1"}}}
+{"timestamp":1782900005,"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"answer"}},"_meta":{"promptId":"p1"}}}
+`
+
+func FuzzParseGrokFile(f *testing.F) {
+	f.Add([]byte(grokSeed))
+	f.Add([]byte(`{"timestamp":1,"params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"x"}}}}` + "\n"))
+	f.Add([]byte(`{"params":{"update":{"sessionUpdate":"user_message_chunk","content":"bare string"}}}` + "\n"))
+	f.Add([]byte(grokSeed + "{malformed\n"))
+	f.Add([]byte(grokSeed[:len(grokSeed)/2]))
+	f.Add([]byte(""))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		root := fuzzEnv(t)
+		group := url.PathEscape("/work/cool-app")
+		dir := filepath.Join(root, "grok", "sessions", group, "sess-1")
+		summary := `{"info":{"id":"sess-1","cwd":"/work/cool-app"},"generated_title":"t","created_at":"2026-07-01T10:00:00Z","updated_at":"2026-07-01T10:00:06Z"}`
+		writeFuzzFile(t, dir, "summary.json", []byte(summary))
+		p := writeFuzzFile(t, dir, "updates.jsonl", data)
+		ss, _ := ParseGrokFile(p)
+		checkSessions(t, ss)
+	})
+}
+
+const cursorTranscriptSeed = `{"role":"user","message":{"content":[{"type":"text","text":"transcriptneedle question"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"Running ls."},{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}
+{"type":"turn_ended","status":"success"}
+`
+
+func FuzzParseCursorTranscript(f *testing.F) {
+	f.Add([]byte(cursorTranscriptSeed))
+	f.Add([]byte(`{"role":"user","message":{"content":"hi"}}` + "\n"))
+	f.Add([]byte(`{"role":"assistant","message":null}` + "\n"))
+	f.Add([]byte(cursorTranscriptSeed[:len(cursorTranscriptSeed)/2]))
+	f.Add([]byte(""))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzEnv(t)
+		dir := filepath.Join(t.TempDir(), "projects", "Users-x-app", "agent-transcripts", "sess-1")
+		p := writeFuzzFile(t, dir, "sess-1.jsonl", data)
+		ss, _ := ParseCursorTranscript(p)
+		checkSessions(t, ss)
+	})
+}


### PR DESCRIPTION
Fuzzers for the eight parsers (no crashes found). The audit did find one real hole: manifest.gob committed before sessions.gob, so a crash mid-append left a fresh-looking index that silently dropped the new records. Manifest files now commit atomically in dependency order, and records.bin length is stamped so a truncated log reads as corrupt and rebuilds. Closes #87