### PR TITLE
brand: per-agent breakdown in the first-index greeting

### DIFF
--- a/cmd/deja/logo.go
+++ b/cmd/deja/logo.go
@@ -96,17 +96,38 @@ func brandInfo() []string {
 	}
 }
 
+// prepareFirstIndexGreeting silences the per-harness narration when the
+// greeting is about to show the same numbers in its info column.
+func prepareFirstIndexGreeting() {
+	if !index.HasManifest(index.DefaultDir()) && logoWanted(os.Stdout) {
+		index.SuppressHarnessNarration = true
+	}
+}
+
 func maybeFirstIndexGreeting() {
+	index.SuppressHarnessNarration = false
 	b := index.LastBuild
 	if !b.Initial || b.Messages == 0 || !logoWanted(os.Stdout) {
 		return
 	}
-	info := append(brandInfo(),
+	info := brandInfo()
+	info = append(info, "")
+	nameW := 0
+	for _, h := range b.PerHarness {
+		if h.Messages > 0 && len(h.Name) > nameW {
+			nameW = len(h.Name)
+		}
+	}
+	for _, h := range b.PerHarness {
+		if h.Messages == 0 {
+			continue
+		}
+		info = append(info, fmt.Sprintf("%-*s  %s%6d%s messages · %d sessions",
+			nameW, h.Name, logoBold, h.Messages, logoReset, h.Sessions))
+	}
+	info = append(info,
 		"",
-		fmt.Sprintf("messages   %s%d%s", logoBold, b.Messages, logoReset),
-		fmt.Sprintf("sessions   %s%d%s", logoBold, b.Sessions, logoReset),
-		fmt.Sprintf("agents     %s%d%s", logoBold, b.Harnesses, logoReset),
-		"",
+		fmt.Sprintf("indexed %s%d%s messages across %s%d%s agents", logoBold, b.Messages, logoReset, logoBold, b.Harnesses, logoReset),
 		logoDim+`try: deja "something you fixed weeks ago"`+logoReset,
 	)
 	printLogo(os.Stdout, info)

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -78,6 +78,7 @@ func run(args []string) error {
 		return runDoctor(os.Stdout, doctorLookup)
 	}
 	if args[0] == "warmup" {
+		prepareFirstIndexGreeting()
 		if err := index.Ensure(index.DefaultDir(), "", false, os.Stderr); err != nil {
 			return err
 		}
@@ -93,6 +94,7 @@ func run(args []string) error {
 			}
 			return fmt.Errorf("index: unknown flag %q", a)
 		}
+		prepareFirstIndexGreeting()
 		if err := index.Ensure(index.DefaultDir(), "", force, os.Stderr); err != nil {
 			return err
 		}
@@ -215,6 +217,7 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
+	prepareFirstIndexGreeting()
 	if err := index.EnsureForSearch(index.DefaultDir(), o, force, os.Stderr); err != nil {
 		return fmt.Errorf("ensure: %w", err)
 	}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -40,21 +40,46 @@ var lastIngestFiles int
 
 // BuildSummary describes the most recent (re)build in this process; the CLI
 // uses it to greet a first-ever index with a summary instead of silence.
+type HarnessCount struct {
+	Name     string
+	Sessions int
+	Messages int
+}
+
 type BuildSummary struct {
-	Initial   bool
-	Sessions  int
-	Messages  int
-	Harnesses int
+	Initial    bool
+	Sessions   int
+	Messages   int
+	Harnesses  int
+	PerHarness []HarnessCount
 }
 
 var LastBuild BuildSummary
 
+// SuppressHarnessNarration silences the per-harness progress lines for one
+// build; the CLI sets it when it is about to greet a first index with the
+// same numbers in the summary block.
+var SuppressHarnessNarration bool
+
 func summarizeBuild(initial bool, sessions int, messages int, ss []model.Session) {
-	hs := map[string]bool{}
+	counts := map[string]*HarnessCount{}
+	order := []string{}
 	for _, s := range ss {
-		hs[s.Harness] = true
+		c := counts[s.Harness]
+		if c == nil {
+			c = &HarnessCount{Name: s.Harness}
+			counts[s.Harness] = c
+			order = append(order, s.Harness)
+		}
+		c.Sessions++
+		c.Messages += len(s.Messages)
 	}
-	LastBuild = BuildSummary{Initial: initial, Sessions: sessions, Messages: messages, Harnesses: len(hs)}
+	sort.Strings(order)
+	per := make([]HarnessCount, 0, len(order))
+	for _, name := range order {
+		per = append(per, *counts[name])
+	}
+	LastBuild = BuildSummary{Initial: initial, Sessions: sessions, Messages: messages, Harnesses: len(order), PerHarness: per}
 }
 
 type FileState struct {
@@ -510,7 +535,7 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 		}
 		got := hl.load()
 		ss = append(ss, got...)
-		if progress != nil && len(got) > 0 {
+		if progress != nil && len(got) > 0 && !SuppressHarnessNarration {
 			msgs := 0
 			for _, s := range got {
 				msgs += len(s.Messages)


### PR DESCRIPTION
First index used to narrate per-harness counts above the mark and then repeat totals beside it. The narration is now suppressed for that one build and the breakdown lives in the info column: agent rows with message/session counts, total line, try hint.