### PR TITLE
security: last two scorecard warnings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,13 +9,15 @@ on:
     - cron: '31 6 * * 2'
 
 permissions:
-  security-events: write
   contents: read
 
 jobs:
   analyze:
     name: analyze (go)
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/deja ./cmd/deja
 
 # Runtime: sqlite3 is only needed when an opencode store is mounted in
-FROM alpine:3.20
+FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
 RUN apk add --no-cache sqlite
 COPY --from=build /out/deja /usr/local/bin/deja
 ENTRYPOINT ["deja"]


### PR DESCRIPTION
security-events:write moves from workflow to job level in codeql.yml; the runtime alpine stage in the Dockerfile gets digest-pinned like the build stage.