### PR TITLE
feat: honor upstream config-relocation variables

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -163,10 +163,10 @@ func doctorMCP(w io.Writer) {
 		wired func(string) bool
 	}{
 		{"claude-code", filepath.Join(h, ".claude.json"), doctorJSONWired("mcpServers")},
-		{"codex", filepath.Join(h, ".codex", "config.toml"), doctorTOMLWired},
+		{"codex", filepath.Join(sources.CodexRoot(), "config.toml"), doctorTOMLWired},
 		{"opencode", doctorOpencodeConfigPath(), doctorJSONWired("mcp")},
-		{"cursor", filepath.Join(h, ".cursor", "mcp.json"), doctorJSONWired("mcpServers")},
-		{"gemini", filepath.Join(h, ".gemini", "settings.json"), doctorJSONWired("mcpServers")},
+		{"cursor", filepath.Join(sources.CursorCLIRoot(), "mcp.json"), doctorJSONWired("mcpServers")},
+		{"gemini", filepath.Join(sources.GeminiRoot(), "settings.json"), doctorJSONWired("mcpServers")},
 		{"antigravity", filepath.Join(h, ".gemini", "config", "mcp_config.json"), doctorJSONWired("mcpServers")},
 		{"grok", filepath.Join(sources.GrokRoot(), "config.toml"), doctorTOMLWired},
 	}

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -163,10 +163,10 @@ func doctorMCP(w io.Writer) {
 		wired func(string) bool
 	}{
 		{"claude-code", filepath.Join(h, ".claude.json"), doctorJSONWired("mcpServers")},
-		{"codex", filepath.Join(sources.CodexRoot(), "config.toml"), doctorTOMLWired},
+		{"codex", filepath.Join(sources.CodexHome(), "config.toml"), doctorTOMLWired},
 		{"opencode", doctorOpencodeConfigPath(), doctorJSONWired("mcp")},
-		{"cursor", filepath.Join(sources.CursorCLIRoot(), "mcp.json"), doctorJSONWired("mcpServers")},
-		{"gemini", filepath.Join(sources.GeminiRoot(), "settings.json"), doctorJSONWired("mcpServers")},
+		{"cursor", filepath.Join(sources.CursorCLIHome(), "mcp.json"), doctorJSONWired("mcpServers")},
+		{"gemini", filepath.Join(sources.GeminiHome(), "settings.json"), doctorJSONWired("mcpServers")},
 		{"antigravity", filepath.Join(h, ".gemini", "config", "mcp_config.json"), doctorJSONWired("mcpServers")},
 		{"grok", filepath.Join(sources.GrokRoot(), "config.toml"), doctorTOMLWired},
 	}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -97,10 +97,10 @@ func existingTargets() []string {
 	h, _ := os.UserHomeDir()
 	checks := map[string]string{
 		"claude-code": filepath.Join(h, ".claude"),
-		"codex":       sources.CodexRoot(),
+		"codex":       sources.CodexHome(),
 		"opencode":    filepath.Join(h, ".config", "opencode"),
-		"cursor":      sources.CursorCLIRoot(),
-		"gemini":      filepath.Join(sources.GeminiRoot(), "settings.json"),
+		"cursor":      sources.CursorCLIHome(),
+		"gemini":      filepath.Join(sources.GeminiHome(), "settings.json"),
 		"antigravity": filepath.Join(h, ".gemini", "config"),
 		"grok":        sources.GrokRoot(),
 	}
@@ -131,7 +131,7 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 	case "cursor":
 		return installCursor(exe, uninstall)
 	case "gemini":
-		return installMCPJSON(filepath.Join(sources.GeminiRoot(), "settings.json"), exe, uninstall)
+		return installMCPJSON(filepath.Join(sources.GeminiHome(), "settings.json"), exe, uninstall)
 	case "antigravity":
 		return installMCPJSON(filepath.Join(homeDir(), ".gemini", "config", "mcp_config.json"), exe, uninstall)
 	case "grok":
@@ -339,7 +339,7 @@ func installStatusline(exe string, uninstall bool) (installResult, error) {
 }
 
 func installCodex(exe string, uninstall bool) (installResult, error) {
-	path := filepath.Join(sources.CodexRoot(), "config.toml")
+	path := filepath.Join(sources.CodexHome(), "config.toml")
 	block := fmt.Sprintf("[mcp_servers.deja]\ntype = \"stdio\"\ncommand = %q\nargs = [\"mcp\"]\n", exe)
 	return installTOML(path, block, uninstall)
 }
@@ -395,7 +395,7 @@ func homeDir() string {
 // (~/.cursor/mcp.json). Gemini CLI and Antigravity use the identical
 // mcpServers shape in their own files.
 func installCursor(exe string, uninstall bool) (installResult, error) {
-	return installMCPJSON(filepath.Join(sources.CursorCLIRoot(), "mcp.json"), exe, uninstall)
+	return installMCPJSON(filepath.Join(sources.CursorCLIHome(), "mcp.json"), exe, uninstall)
 }
 
 func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -97,10 +97,10 @@ func existingTargets() []string {
 	h, _ := os.UserHomeDir()
 	checks := map[string]string{
 		"claude-code": filepath.Join(h, ".claude"),
-		"codex":       filepath.Join(h, ".codex"),
+		"codex":       sources.CodexRoot(),
 		"opencode":    filepath.Join(h, ".config", "opencode"),
-		"cursor":      filepath.Join(h, ".cursor"),
-		"gemini":      filepath.Join(h, ".gemini", "settings.json"),
+		"cursor":      sources.CursorCLIRoot(),
+		"gemini":      filepath.Join(sources.GeminiRoot(), "settings.json"),
 		"antigravity": filepath.Join(h, ".gemini", "config"),
 		"grok":        sources.GrokRoot(),
 	}
@@ -131,7 +131,7 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 	case "cursor":
 		return installCursor(exe, uninstall)
 	case "gemini":
-		return installMCPJSON(filepath.Join(homeDir(), ".gemini", "settings.json"), exe, uninstall)
+		return installMCPJSON(filepath.Join(sources.GeminiRoot(), "settings.json"), exe, uninstall)
 	case "antigravity":
 		return installMCPJSON(filepath.Join(homeDir(), ".gemini", "config", "mcp_config.json"), exe, uninstall)
 	case "grok":
@@ -339,8 +339,7 @@ func installStatusline(exe string, uninstall bool) (installResult, error) {
 }
 
 func installCodex(exe string, uninstall bool) (installResult, error) {
-	h, _ := os.UserHomeDir()
-	path := filepath.Join(h, ".codex", "config.toml")
+	path := filepath.Join(sources.CodexRoot(), "config.toml")
 	block := fmt.Sprintf("[mcp_servers.deja]\ntype = \"stdio\"\ncommand = %q\nargs = [\"mcp\"]\n", exe)
 	return installTOML(path, block, uninstall)
 }
@@ -396,7 +395,7 @@ func homeDir() string {
 // (~/.cursor/mcp.json). Gemini CLI and Antigravity use the identical
 // mcpServers shape in their own files.
 func installCursor(exe string, uninstall bool) (installResult, error) {
-	return installMCPJSON(filepath.Join(homeDir(), ".cursor", "mcp.json"), exe, uninstall)
+	return installMCPJSON(filepath.Join(sources.CursorCLIRoot(), "mcp.json"), exe, uninstall)
 }
 
 func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -680,3 +680,26 @@ func TestRunIndexCommand(t *testing.T) {
 		t.Fatalf("index bogus err=%v", err)
 	}
 }
+
+// install must land in the profile the upstream variable points at.
+func TestInstallHonorsUpstreamHomes(t *testing.T) {
+	h := t.TempDir()
+	t.Setenv("HOME", h)
+	t.Setenv("USERPROFILE", h)
+	codexHome := filepath.Join(h, "profiles", "codex-work")
+	cursorCfg := filepath.Join(h, "profiles", "cursor-work")
+	t.Setenv("DEJA_CODEX_ROOT", "")
+	t.Setenv("DEJA_CURSOR_CLI_ROOT", "")
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("CURSOR_CONFIG_DIR", cursorCfg)
+
+	if r, err := installTarget("codex", "/bin/deja", false); err != nil || r.Path != filepath.Join(codexHome, "config.toml") {
+		t.Fatalf("codex install path=%q err=%v", r.Path, err)
+	}
+	if r, err := installTarget("cursor", "/bin/deja", false); err != nil || r.Path != filepath.Join(cursorCfg, "mcp.json") {
+		t.Fatalf("cursor install path=%q err=%v", r.Path, err)
+	}
+	if _, err := os.Stat(filepath.Join(h, ".codex")); !os.IsNotExist(err) {
+		t.Fatal("default ~/.codex must stay untouched")
+	}
+}

--- a/cmd/deja/testmain_test.go
+++ b/cmd/deja/testmain_test.go
@@ -12,17 +12,21 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	stores := map[string]string{
-		"HOME":                  root,
-		"USERPROFILE":           root,
-		"DEJA_CLAUDE_ROOT":      filepath.Join(root, "claude"),
-		"DEJA_CODEX_ROOT":       filepath.Join(root, "codex"),
-		"DEJA_OPENCODE_DB":      filepath.Join(root, "opencode.db"),
-		"DEJA_AIDER_ROOTS":      filepath.Join(root, "aider"),
-		"DEJA_GEMINI_ROOT":      filepath.Join(root, "gemini"),
-		"DEJA_CURSOR_ROOT":      filepath.Join(root, "cursor"),
-		"DEJA_CURSOR_CLI_ROOT":  filepath.Join(root, "cursor-cli"),
-		"DEJA_ANTIGRAVITY_ROOT": filepath.Join(root, "antigravity"),
-		"DEJA_GROK_ROOT":        filepath.Join(root, "grok"),
+		"HOME":                    root,
+		"USERPROFILE":             root,
+		"DEJA_CLAUDE_ROOT":        filepath.Join(root, "claude"),
+		"DEJA_CODEX_ROOT":         filepath.Join(root, "codex"),
+		"DEJA_OPENCODE_DB":        filepath.Join(root, "opencode.db"),
+		"DEJA_AIDER_ROOTS":        filepath.Join(root, "aider"),
+		"DEJA_GEMINI_ROOT":        filepath.Join(root, "gemini"),
+		"DEJA_CURSOR_ROOT":        filepath.Join(root, "cursor"),
+		"DEJA_CURSOR_CLI_ROOT":    filepath.Join(root, "cursor-cli"),
+		"DEJA_ANTIGRAVITY_ROOT":   filepath.Join(root, "antigravity"),
+		"DEJA_GROK_ROOT":          filepath.Join(root, "grok"),
+		"CODEX_HOME":              "",
+		"GEMINI_CLI_HOME":         "",
+		"CURSOR_CONFIG_DIR":       "",
+		"AIDER_CHAT_HISTORY_FILE": "",
 	}
 	for key, value := range stores {
 		if err := os.Setenv(key, value); err != nil {

--- a/internal/sources/aider.go
+++ b/internal/sources/aider.go
@@ -36,6 +36,11 @@ func AiderFiles() []string {
 		}
 	}
 	add(filepath.Join(Home(), aiderHistoryName))
+	// aider maps every flag to an env var; --chat-history-file is the
+	// documented way to move the history off the default name.
+	if p := os.Getenv("AIDER_CHAT_HISTORY_FILE"); p != "" {
+		add(p)
+	}
 	for _, root := range filepath.SplitList(os.Getenv("DEJA_AIDER_ROOTS")) {
 		if root == "" {
 			continue

--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -7,7 +7,11 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
-func CodexRoot() string { return EnvPath("DEJA_CODEX_ROOT", filepath.Join(Home(), ".codex")) }
+// CodexRoot honors Codex's own CODEX_HOME (it relocates the whole ~/.codex
+// tree: config.toml, sessions, history), with DEJA_CODEX_ROOT still winning.
+func CodexRoot() string {
+	return EnvPath("DEJA_CODEX_ROOT", EnvPath("CODEX_HOME", filepath.Join(Home(), ".codex")))
+}
 
 func LoadCodex() []model.Session {
 	root := CodexRoot()

--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -7,10 +7,16 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
-// CodexRoot honors Codex's own CODEX_HOME (it relocates the whole ~/.codex
-// tree: config.toml, sessions, history), with DEJA_CODEX_ROOT still winning.
+// CodexHome is where the Codex CLI itself keeps state; CODEX_HOME relocates
+// the whole tree (config.toml, sessions, history). Install and doctor use it.
+func CodexHome() string {
+	return EnvPath("CODEX_HOME", filepath.Join(Home(), ".codex"))
+}
+
+// CodexRoot is the session-reading root; DEJA_CODEX_ROOT overrides it without
+// affecting where install writes.
 func CodexRoot() string {
-	return EnvPath("DEJA_CODEX_ROOT", EnvPath("CODEX_HOME", filepath.Join(Home(), ".codex")))
+	return EnvPath("DEJA_CODEX_ROOT", CodexHome())
 }
 
 func LoadCodex() []model.Session {

--- a/internal/sources/cursor.go
+++ b/internal/sources/cursor.go
@@ -35,10 +35,16 @@ func CursorUserRoot() string {
 	return filepath.Join(h, ".config", "Cursor", "User")
 }
 
-// CursorCLIRoot honors Cursor CLI's documented CURSOR_CONFIG_DIR; the IDE's
+// CursorCLIHome honors Cursor CLI's documented CURSOR_CONFIG_DIR; the IDE's
 // global storage has no relocation variable and stays put.
+func CursorCLIHome() string {
+	return EnvPath("CURSOR_CONFIG_DIR", filepath.Join(Home(), ".cursor"))
+}
+
+// CursorCLIRoot is the transcript-reading root; DEJA_CURSOR_CLI_ROOT overrides
+// it without affecting where install writes.
 func CursorCLIRoot() string {
-	return EnvPath("DEJA_CURSOR_CLI_ROOT", EnvPath("CURSOR_CONFIG_DIR", filepath.Join(Home(), ".cursor")))
+	return EnvPath("DEJA_CURSOR_CLI_ROOT", CursorCLIHome())
 }
 
 // CursorDBs lists state.vscdb stores; modern chats live in globalStorage.

--- a/internal/sources/cursor.go
+++ b/internal/sources/cursor.go
@@ -35,8 +35,10 @@ func CursorUserRoot() string {
 	return filepath.Join(h, ".config", "Cursor", "User")
 }
 
+// CursorCLIRoot honors Cursor CLI's documented CURSOR_CONFIG_DIR; the IDE's
+// global storage has no relocation variable and stays put.
 func CursorCLIRoot() string {
-	return EnvPath("DEJA_CURSOR_CLI_ROOT", filepath.Join(Home(), ".cursor"))
+	return EnvPath("DEJA_CURSOR_CLI_ROOT", EnvPath("CURSOR_CONFIG_DIR", filepath.Join(Home(), ".cursor")))
 }
 
 // CursorDBs lists state.vscdb stores; modern chats live in globalStorage.

--- a/internal/sources/env_homes_test.go
+++ b/internal/sources/env_homes_test.go
@@ -1,0 +1,82 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// Each harness that documents a relocation variable gets the same contract:
+// the upstream variable moves the default, DEJA_* still wins.
+func TestUpstreamHomeVariables(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	t.Run("codex CODEX_HOME", func(t *testing.T) {
+		t.Setenv("DEJA_CODEX_ROOT", "")
+		t.Setenv("CODEX_HOME", filepath.Join(home, "codex-profile"))
+		if got := CodexRoot(); got != filepath.Join(home, "codex-profile") {
+			t.Fatalf("CodexRoot=%q", got)
+		}
+		t.Setenv("DEJA_CODEX_ROOT", filepath.Join(home, "override"))
+		if got := CodexRoot(); got != filepath.Join(home, "override") {
+			t.Fatalf("DEJA_CODEX_ROOT must win, got %q", got)
+		}
+	})
+
+	t.Run("gemini GEMINI_CLI_HOME appends .gemini", func(t *testing.T) {
+		t.Setenv("DEJA_GEMINI_ROOT", "")
+		t.Setenv("GEMINI_CLI_HOME", filepath.Join(home, "ghome"))
+		if got := GeminiRoot(); got != filepath.Join(home, "ghome", ".gemini") {
+			t.Fatalf("GeminiRoot=%q", got)
+		}
+		t.Setenv("DEJA_GEMINI_ROOT", filepath.Join(home, "gr"))
+		if got := GeminiRoot(); got != filepath.Join(home, "gr") {
+			t.Fatalf("DEJA_GEMINI_ROOT must win, got %q", got)
+		}
+	})
+
+	t.Run("cursor CURSOR_CONFIG_DIR", func(t *testing.T) {
+		t.Setenv("DEJA_CURSOR_CLI_ROOT", "")
+		t.Setenv("CURSOR_CONFIG_DIR", filepath.Join(home, "cursor-cfg"))
+		if got := CursorCLIRoot(); got != filepath.Join(home, "cursor-cfg") {
+			t.Fatalf("CursorCLIRoot=%q", got)
+		}
+	})
+
+	t.Run("opencode XDG_DATA_HOME linux only", func(t *testing.T) {
+		t.Setenv("DEJA_OPENCODE_DB", "")
+		t.Setenv("XDG_DATA_HOME", filepath.Join(home, "xdg"))
+		got := OpencodeDB()
+		want := filepath.Join(home, ".local", "share", "opencode", "opencode.db")
+		if runtime.GOOS == "linux" {
+			want = filepath.Join(home, "xdg", "opencode", "opencode.db")
+		}
+		if got != want {
+			t.Fatalf("OpencodeDB=%q want %q", got, want)
+		}
+	})
+
+	t.Run("aider AIDER_CHAT_HISTORY_FILE", func(t *testing.T) {
+		t.Setenv("DEJA_AIDER_ROOTS", "")
+		hist := filepath.Join(home, "elsewhere", "history.md")
+		if err := os.MkdirAll(filepath.Dir(hist), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(hist, []byte("# aider chat started at 2026-01-01 00:00:00\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("AIDER_CHAT_HISTORY_FILE", hist)
+		found := false
+		for _, f := range AiderFiles() {
+			if f == hist {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("AiderFiles missed AIDER_CHAT_HISTORY_FILE: %v", AiderFiles())
+		}
+	})
+}

--- a/internal/sources/gemini.go
+++ b/internal/sources/gemini.go
@@ -16,17 +16,20 @@ import (
 // "$rewindTo" truncation markers. Project ids are either path-hashes or
 // slugs; ~/.gemini/projects.json maps real paths to ids.
 
-// GeminiRoot honors GEMINI_CLI_HOME, the home-dir override Gemini CLI itself
-// implements (it appends .gemini to it). The often-cited GEMINI_CONFIG_DIR only
-// exists in upstream feature requests, so it is deliberately not read here.
-func GeminiRoot() string {
-	if root := os.Getenv("DEJA_GEMINI_ROOT"); root != "" {
-		return root
-	}
+// GeminiHome honors GEMINI_CLI_HOME, the home-dir override Gemini CLI itself
+// implements (it appends .gemini). The often-cited GEMINI_CONFIG_DIR only
+// exists in upstream feature requests and is deliberately not read.
+func GeminiHome() string {
 	if h := os.Getenv("GEMINI_CLI_HOME"); h != "" {
 		return filepath.Join(h, ".gemini")
 	}
 	return filepath.Join(Home(), ".gemini")
+}
+
+// GeminiRoot is the session-reading root; DEJA_GEMINI_ROOT overrides it
+// without affecting where install writes.
+func GeminiRoot() string {
+	return EnvPath("DEJA_GEMINI_ROOT", GeminiHome())
 }
 
 func GeminiChatFiles() []string {

--- a/internal/sources/gemini.go
+++ b/internal/sources/gemini.go
@@ -16,8 +16,17 @@ import (
 // "$rewindTo" truncation markers. Project ids are either path-hashes or
 // slugs; ~/.gemini/projects.json maps real paths to ids.
 
+// GeminiRoot honors GEMINI_CLI_HOME, the home-dir override Gemini CLI itself
+// implements (it appends .gemini to it). The often-cited GEMINI_CONFIG_DIR only
+// exists in upstream feature requests, so it is deliberately not read here.
 func GeminiRoot() string {
-	return EnvPath("DEJA_GEMINI_ROOT", filepath.Join(Home(), ".gemini"))
+	if root := os.Getenv("DEJA_GEMINI_ROOT"); root != "" {
+		return root
+	}
+	if h := os.Getenv("GEMINI_CLI_HOME"); h != "" {
+		return filepath.Join(h, ".gemini")
+	}
+	return filepath.Join(Home(), ".gemini")
 }
 
 func GeminiChatFiles() []string {

--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -20,8 +21,18 @@ func SQLite3Available() bool {
 	return err == nil
 }
 
+// OpencodeDB mirrors upstream's path logic: XDG_DATA_HOME is honored on Linux
+// only (opencode's xdg-basedir dependency ignores it elsewhere).
 func OpencodeDB() string {
-	return EnvPath("DEJA_OPENCODE_DB", filepath.Join(Home(), ".local", "share", "opencode", "opencode.db"))
+	if p := os.Getenv("DEJA_OPENCODE_DB"); p != "" {
+		return p
+	}
+	if runtime.GOOS == "linux" {
+		if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+			return filepath.Join(xdg, "opencode", "opencode.db")
+		}
+	}
+	return filepath.Join(Home(), ".local", "share", "opencode", "opencode.db")
 }
 
 func LoadOpencode() []model.Session {


### PR DESCRIPTION
Same contract #82 establishes for CLAUDE_CONFIG_DIR, applied to the rest of the fleet where upstream actually documents a variable: CODEX_HOME (moves the whole ~/.codex tree), GEMINI_CLI_HOME (home override, .gemini appended — GEMINI_CONFIG_DIR only exists in upstream feature requests and is deliberately not read), CURSOR_CONFIG_DIR (CLI only), XDG_DATA_HOME for opencode on Linux only (upstream's xdg-basedir ignores it elsewhere), AIDER_CHAT_HISTORY_FILE. DEJA_* always wins; install and doctor resolve through the same helpers. Antigravity and the Cursor IDE have no documented relocation and are left alone. Closes #101