### PR TITLE
docs: refresh copy before the release

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ $ deja "jwt refresh token"
 | `deja ctx <query>` | Compact markdown digest of the best match — pipe it into a prompt. |
 | `deja share <id>` | Sanitized session digest for a colleague: secrets redacted, tool noise stripped. |
 | `deja stats` | Totals, per-harness split, top projects, monthly sparkline. `--json` too. |
+| `deja doctor` | Self-diagnosis: which stores were found, sqlite3 presence, MCP wiring per agent, index health, version. |
 | `deja sync export <dir> [--full]` / `import <dir>` / `ssh <host> [--pull]` | Move memory between machines — via a shared folder or one ssh command. Watermarked, append-only, idempotent. |
 | `deja show <id>` / `deja last [n]` | Read one session / list recent ones. |
 | `deja resume <id> [--exec]` | Reopen a found session in its native harness (`claude --resume`, `codex resume`, `opencode -s`, `grok --resume`). |
@@ -150,7 +151,7 @@ Credentials are redacted at index time: AWS keys, generic `api_key=`/`token=` as
 | Antigravity | `~/.gemini/antigravity*/brain/*/.system_generated/logs/transcript.jsonl` | ✅ |
 | Grok Build | `~/.grok/sessions/**/updates.jsonl` | ✅ |
 
-Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_AIDER_ROOTS`, `DEJA_GEMINI_ROOT`, `DEJA_CURSOR_ROOT`, `DEJA_CURSOR_CLI_ROOT`, `DEJA_ANTIGRAVITY_ROOT`, `DEJA_GROK_ROOT`, `DEJA_INDEX_DIR`. Grok's native `GROK_HOME` and Claude Code's native `CLAUDE_CONFIG_DIR` are also honored.
+Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_AIDER_ROOTS`, `DEJA_GEMINI_ROOT`, `DEJA_CURSOR_ROOT`, `DEJA_CURSOR_CLI_ROOT`, `DEJA_ANTIGRAVITY_ROOT`, `DEJA_GROK_ROOT`, `DEJA_INDEX_DIR`. Each agent's own relocation variable is honored too: `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `GEMINI_CLI_HOME`, `CURSOR_CONFIG_DIR`, `GROK_HOME`, `AIDER_CHAT_HISTORY_FILE`, and `XDG_DATA_HOME` for opencode on Linux.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity and Grok Bu
 
 | | |
 | --- | --- |
-| **Search** | `deja "connection pool exhausted"` — 7–9 ms over gigabytes, retroactive: months of logs from before you installed it |
+| **Search** | `deja "connection pool exhausted"` — ~12 ms over gigabytes, retroactive: months of logs from before you installed it |
 | **Agent recall** | MCP `recall` tool — the agent answers *"we fixed this three weeks ago"* instead of re-debugging, across harnesses |
 | **Auto-recall** | `install --auto` adds a SessionStart hook: relevant memory lands in context before you ask |
 | **Redaction** | API keys, JWTs, private keys are stripped at index time — the cache is safe to keep |
@@ -159,7 +159,7 @@ Measured on a real corpus — 1,250+ sessions, ~3.3GB across three harnesses:
 
 | | |
 | --- | --- |
-| Warm search | **7–9 ms** typical, ~40 ms worst-case |
+| Warm search | **~12 ms** typical, ~25 ms worst-case |
 | Cold index (once) | ~10 s |
 | Index size | ~2.4% of corpus |
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,11 +4,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>deja-vu — your agents already solved this. deja finds it.</title>
-<meta name="description" content="A memory layer for coding agents: search, MCP recall, auto-context, secret redaction, stats, share and sync over the session histories Claude Code, Codex and opencode already write. One zero-dependency binary, fully local.">
+<meta name="description" content="A memory layer for coding agents: search, MCP recall, auto-context, secret redaction, stats, share and sync over the session histories Claude Code, Codex, opencode, Cursor, Gemini CLI, aider, Antigravity and Grok Build already write. One zero-dependency binary, fully local.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="deja-vu — search every session your coding agents ever wrote">
-<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across Claude Code, Codex and opencode, served back to agents via MCP.">
+<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across eight coding agents, served back to them via MCP.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -116,7 +116,7 @@ a:hover{text-decoration:underline}
 
 <header>
   <h1>Your agents already solved this.<br><span class="grad">deja finds it.</span></h1>
-  <p class="sub">Claude Code, Codex and opencode write every session to disk — gigabytes of solved problems nobody can search. <code>deja</code> turns them into a memory layer: search, agent recall, auto-context, redaction, stats, share and sync. One zero-dependency binary.</p>
+  <p class="sub">Eight coding agents write every session to disk — gigabytes of solved problems nobody can search. <code>deja</code> turns them into a memory layer: search, agent recall, auto-context, redaction, stats, share and sync. One zero-dependency binary.</p>
   <div class="cta">
     <a class="btn primary" href="#install">Get started</a>
     <a class="btn" href="https://github.com/vshulcz/deja-vu">Star on GitHub</a>
@@ -149,7 +149,7 @@ a:hover{text-decoration:underline}
 
 <section>
   <h2>Memory your agent actually uses</h2>
-  <p class="lead">After <code style="font-family:var(--mono);font-size:.9em">deja install --all</code>, every agent on your machine gets a <span style="font-family:var(--mono);font-size:.9em">recall</span> tool over MCP — add <span style="font-family:var(--mono);font-size:.9em">--auto</span> for session-start auto-recall on Claude Code, Codex and opencode.</p>
+  <p class="lead">After <code style="font-family:var(--mono);font-size:.9em">deja install --all</code>, every agent on your machine gets a <span style="font-family:var(--mono);font-size:.9em">recall</span> tool over MCP — add <span style="font-family:var(--mono);font-size:.9em">--auto</span> for session-start auto-recall where the agent supports it.</p>
   <div class="chat">
     <div class="msg you"><span class="who">you</span><div class="bubble">have we dealt with jwt refresh rotation before? check your memory</div></div>
     <div class="msg ai"><span class="who">AI</span><div class="bubble"><div class="tool">→ recall("jwt refresh rotation")</div>Yes — three weeks ago in the <code>api-gateway</code> project (a Codex session). Login broke after key rotation: the jwks cache wasn't reloaded after <code>rotateKey</code>. You fixed it by reloading the cache and adding a clock-skew test. Want me to apply the same pattern here?</div></div>
@@ -161,7 +161,7 @@ a:hover{text-decoration:underline}
     <div class="card">
       <div class="ic"><svg viewBox="0 0 24 24"><path d="M12 3a9 9 0 1 0 9 9"/><path d="M21 12l-4-3M21 12l-4 2"/></svg></div>
       <h3>Agent memory via MCP</h3>
-      <p><code>recall</code> and <code>recall_context</code> tools, answers under ~4KB. Add <code>--auto</code> and project memory lands in Claude Code, Codex and opencode before you ask.</p>
+      <p><code>recall</code> and <code>recall_context</code> tools, answers under ~4KB. Add <code>--auto</code> and project memory lands in your agent before you ask.</p>
     </div>
     <div class="card">
       <div class="ic"><svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h10"/></svg></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -193,7 +193,7 @@ a:hover{text-decoration:underline}
 
 <section>
   <div class="stats">
-    <div class="stat"><b>7–9 ms</b><span>warm search over ~3.3GB</span></div>
+    <div class="stat"><b>~12 ms</b><span>warm search over ~3.3GB</span></div>
     <div class="stat"><b>~10 s</b><span>cold index, once</span></div>
     <div class="stat"><b>~2.4%</b><span>index size vs corpus</span></div>
     <div class="stat"><b>0</b><span>runtime dependencies</span></div>


### PR DESCRIPTION
Site meta/hero still said three agents; the CLI table was missing doctor; the env-var note now lists every honored relocation variable.