### PR TITLE
fix: torn lines longer than the SafeSize window lost messages

### DIFF
--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -581,8 +581,8 @@ func TestRequestedCodecLineAndSubstringBranches(t *testing.T) {
 	if err := os.WriteFile(largeNoNL, []byte(large), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := lastCompleteLineOffset(largeNoNL, int64(len(large))); got != int64(len(large)) {
-		t.Fatalf("large no newline offset=%d", got)
+	if got := lastCompleteLineOffset(largeNoNL, int64(len(large))); got != 0 {
+		t.Fatalf("large no newline offset=%d, want 0: no complete line exists yet", got)
 	}
 	exact := filepath.Join(tmp, "exact-window")
 	exactData := strings.Repeat("x", 64*1024-1) + "\n"

--- a/internal/index/crash_safe_test.go
+++ b/internal/index/crash_safe_test.go
@@ -3,6 +3,7 @@ package index
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/search"
@@ -157,5 +158,31 @@ func TestWriteManifestAtomicAndStamped(t *testing.T) {
 	}
 	if !recordsIntact(dir, m) {
 		t.Fatal("recordsIntact false on a clean index")
+	}
+}
+
+// A torn trailing line longer than the scan window used to make SafeSize
+// fall back to the file size, silently skipping the message once completed.
+func TestSafeSizeTornLineLongerThanWindow(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "big.jsonl")
+	complete := `{"type":"user","sessionId":"s","message":{"role":"user","content":"ok"}}` + "\n"
+	torn := `{"type":"user","sessionId":"s","message":{"role":"user","content":"` + strings.Repeat("x", 100*1024)
+	if err := os.WriteFile(p, []byte(complete+torn), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fi, _ := os.Stat(p)
+	got := lastCompleteLineOffset(p, fi.Size())
+	if got != int64(len(complete)) {
+		t.Fatalf("SafeSize=%d want %d (end of last complete line)", got, len(complete))
+	}
+	// no newline at all -> nothing is safe yet
+	p2 := filepath.Join(dir, "noline.jsonl")
+	if err := os.WriteFile(p2, []byte(strings.Repeat("y", 70*1024)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fi2, _ := os.Stat(p2)
+	if got := lastCompleteLineOffset(p2, fi2.Size()); got != 0 {
+		t.Fatalf("SafeSize=%d want 0 for newline-free file", got)
 	}
 }

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -1446,24 +1446,28 @@ func lastCompleteLineOffset(p string, size int64) int64 {
 		return size
 	}
 	defer func() { _ = f.Close() }()
+	// Walk backwards window by window: a torn line longer than one window
+	// (a fat tool result caught mid-write) must not fool us into treating
+	// the whole file as complete, or its message is lost after completion.
 	const window = 64 * 1024
-	start := size - window
-	if start < 0 {
-		start = 0
-	}
-	buf := make([]byte, size-start)
-	if _, err := f.ReadAt(buf, start); err != nil {
-		return size
-	}
-	for i := len(buf) - 1; i >= 0; i-- {
-		if buf[i] == '\n' {
-			return start + int64(i) + 1
+	end := size
+	for end > 0 {
+		start := end - window
+		if start < 0 {
+			start = 0
 		}
+		buf := make([]byte, end-start)
+		if _, err := f.ReadAt(buf, start); err != nil {
+			return size
+		}
+		for i := len(buf) - 1; i >= 0; i-- {
+			if buf[i] == '\n' {
+				return start + int64(i) + 1
+			}
+		}
+		end = start
 	}
-	if start == 0 {
-		return 0
-	}
-	return size
+	return 0
 }
 
 func manifestFresh(m Manifest, files map[string]FileState, scope string) bool {


### PR DESCRIPTION
lastCompleteLineOffset only looked at the final 64KB; a mid-write line fatter than that (large tool results qualify) made it treat the whole file as complete, so the message vanished after the write finished. The scan now walks back window by window. Regression test with a 100KB torn tail.