### PR TITLE
security: owner-only index permissions

### DIFF
--- a/internal/index/coverage_recover4_test.go
+++ b/internal/index/coverage_recover4_test.go
@@ -279,10 +279,11 @@ func TestAppendIncrementalBucketAndManifestWriteErrors(t *testing.T) {
 	if err := Ensure(dir2, "", false, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(dir2, 0o500); err != nil {
+	// Block the manifest tmp path instead of chmod: lockDir re-tightens the
+	// directory to 0700, so permission games no longer stick.
+	if err := os.MkdirAll(filepath.Join(dir2, "manifest.gob.tmp", "block"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = os.Chmod(dir2, 0o755) }()
 	f2, err := os.OpenFile(file2, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		t.Fatal(err)
@@ -436,11 +437,12 @@ func TestExportRecordsErrorBranches(t *testing.T) {
 
 	dir3 := filepath.Join(tmp, "idx3")
 	writeTinyIndex(t, dir3)
-	if err := os.Chmod(dir3, 0o500); err != nil {
+	// A directory squatting on sessions.gob.tmp makes writeGobAtomic fail
+	// regardless of directory permissions (lockDir re-tightens those).
+	if err := os.MkdirAll(filepath.Join(dir3, "sessions.gob.tmp", "block"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = os.Chmod(dir3, 0o755) }()
 	if _, err := Export(dir3, filepath.Join(tmp, "out3")); err == nil {
-		t.Fatal("Export with a read-only index dir (final writeManifest) returned nil error")
+		t.Fatal("Export with a blocked manifest tmp returned nil error")
 	}
 }

--- a/internal/index/crash_safe_test.go
+++ b/internal/index/crash_safe_test.go
@@ -3,6 +3,7 @@ package index
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -184,5 +185,41 @@ func TestSafeSizeTornLineLongerThanWindow(t *testing.T) {
 	fi2, _ := os.Stat(p2)
 	if got := lastCompleteLineOffset(p2, fi2.Size()); got != 0 {
 		t.Fatalf("SafeSize=%d want 0 for newline-free file", got)
+	}
+}
+
+// The index must not be wider-readable than the agent logs it derives from.
+func TestIndexPermissionsAreOwnerOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits")
+	}
+	root, dir := allHarnessEnv(t)
+	write(t, filepath.Join(root, "claude", "-p-app", "s1.jsonl"),
+		`{"type":"user","sessionId":"s1","timestamp":"2026-02-01T10:00:00Z","message":{"role":"user","content":"perm probe"}}`+"\n")
+	if err := EnsureForSearch(dir, search.Options{Query: "x", All: true}, true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if fi, err := os.Stat(dir); err != nil || fi.Mode().Perm() != 0o700 {
+		t.Fatalf("index dir perm=%v err=%v, want 0700", fi.Mode().Perm(), err)
+	}
+	err := filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		fi, err := os.Stat(p)
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if fi.Mode().Perm() != 0o700 {
+				t.Errorf("%s perm=%v want 0700", p, fi.Mode().Perm())
+			}
+		} else if fi.Mode().Perm() != 0o600 {
+			t.Errorf("%s perm=%v want 0600", p, fi.Mode().Perm())
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -393,7 +393,7 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 	imported := importedSessions(dir)
 	tmp := dir + ".tmp"
 	_ = os.RemoveAll(tmp)
-	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o700); err != nil {
 		return err
 	}
 	ss := loadProgress(harness, progress)
@@ -401,7 +401,7 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope,
 		ExportWatermarks: imported.watermarks, ImportedRecords: imported.dedupe}
 	recPath := filepath.Join(tmp, "records.bin")
-	rf, err := os.Create(recPath)
+	rf, err := os.OpenFile(recPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
@@ -557,7 +557,7 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 func rebuildForSearch(dir string, o search.Options, scope string, files map[string]FileState, progress io.Writer) error {
 	tmp := dir + ".tmp"
 	_ = os.RemoveAll(tmp)
-	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o700); err != nil {
 		return err
 	}
 	ss := loadProgress("", progress)
@@ -577,7 +577,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope,
 		ExportWatermarks: imp.watermarks, ImportedRecords: imp.dedupe}
 	recPath := filepath.Join(tmp, "records.bin")
-	rf, err := os.Create(recPath)
+	rf, err := os.OpenFile(recPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
@@ -987,10 +987,10 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	}
 	tmp := dir + ".tmp"
 	os.RemoveAll(tmp)
-	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o700); err != nil {
 		return err
 	}
-	rf, err := os.Create(filepath.Join(tmp, "records.bin"))
+	rf, err := os.OpenFile(filepath.Join(tmp, "records.bin"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
@@ -1123,7 +1123,7 @@ func canAppendIncremental(changed map[string]FileState, old map[string]FileState
 
 func appendIncremental(dir, harness, scope string, old Manifest, files map[string]FileState, changed map[string]FileState) (int, int, error) {
 	lastIngestFiles = len(changed)
-	rf, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	rf, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -2068,7 +2068,7 @@ func writeBucket(p string, data map[string][]posting) error {
 		entries = append(entries, bucketEntry{tok: tok, off: pos, n: uint32(len(b))})
 		pos += uint64(len(b))
 	}
-	f, err := os.Create(p)
+	f, err := os.OpenFile(p, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
@@ -2227,7 +2227,7 @@ func uvarintLen(v uint64) int {
 	return n
 }
 func writeGob(p string, v any) error {
-	f, err := os.Create(p)
+	f, err := os.OpenFile(p, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
@@ -2239,7 +2239,7 @@ func writeGob(p string, v any) error {
 // crash mid-write can never leave p half-decoded.
 func writeGobAtomic(p string, v any) error {
 	tmp := p + ".tmp"
-	f, err := os.Create(tmp)
+	f, err := os.OpenFile(tmp, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}

--- a/internal/index/lock_unix.go
+++ b/internal/index/lock_unix.go
@@ -11,10 +11,12 @@ import (
 
 func lockDir(dir string) (func(), error) {
 	lockPath := dir + ".lock"
-	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+	// Tighten pre-existing indexes created before the 0700 default.
+	_ = os.Chmod(dir, 0o700)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
 		return nil, err
 	}
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/index/lock_windows.go
+++ b/internal/index/lock_windows.go
@@ -20,10 +20,12 @@ var (
 
 func lockDir(dir string) (func(), error) {
 	lockPath := dir + ".lock"
-	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+	// Tighten pre-existing indexes created before the 0700 default.
+	_ = os.Chmod(dir, 0o700)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
 		return nil, err
 	}
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -51,7 +51,7 @@ func exportRecords(dir, outDir string, full bool) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
+	if err := os.MkdirAll(outDir, 0o700); err != nil {
 		return 0, err
 	}
 	if m.ExportWatermarks == nil {
@@ -196,7 +196,7 @@ func Import(dir, inDir string) (int, error) {
 }
 
 func initEmptyIndex(dir string) error {
-	if err := os.MkdirAll(filepath.Join(dir, "buckets"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(dir, "buckets"), 0o700); err != nil {
 		return err
 	}
 	f, err := os.Create(filepath.Join(dir, "records.bin"))
@@ -234,7 +234,7 @@ func readSyncFile(path string, fn func(SyncRecord) error) error {
 }
 
 func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Record, metas map[string]SessionMeta) error {
-	rf, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	rf, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return err
 	}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -42,11 +42,11 @@ func Path(indexDir string) string {
 // Record appends one event. Errors are swallowed on purpose.
 func Record(indexDir, kind string, bytes int) {
 	p := Path(indexDir)
-	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
 		return
 	}
 	rotate(p)
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Index and usage files were created world-readable (0644/0755) while the agent logs they derive from are often 0600. Directories now 0700, files 0600, gob temps included; existing indexes get chmod'ed on the next lock. Read-only failure-path tests switched to tmp-path squatting since permission games no longer stick.