### PR TITLE
feat: doctor --json and onboarding states

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           cache: false
       - run: go mod verify
       - run: go vet ./...
-      - run: go test -race -coverprofile=coverage.out -covermode=atomic -v -timeout 8m ./cmd/deja
+      - run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
         shell: bash
       - run: go build ./cmd/deja
       - name: Coverage summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           cache: false
       - run: go mod verify
       - run: go vet ./...
-      - run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+      - run: go test -race -coverprofile=coverage.out -covermode=atomic -v -timeout 8m ./cmd/deja
         shell: bash
       - run: go build ./cmd/deja
       - name: Coverage summary

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ deja install --all     # MCP recall for every agent it finds on this machine
 deja install --auto    # same, plus session-start auto-recall where supported
 ```
 
+On a terminal, install reports whether it found local history and points to `deja index` when the first index still needs to be built.
+
 That's it. Next session, ask your agent:
 
 > have we dealt with jwt refresh rotation before? check your memory
@@ -72,7 +74,7 @@ $ deja "jwt refresh token"
 | `deja ctx <query>` | Compact markdown digest of the best match — pipe it into a prompt. |
 | `deja share <id>` | Sanitized session digest for a colleague: secrets redacted, tool noise stripped. |
 | `deja stats` | Totals, per-harness split, top projects, monthly sparkline. `--json` too. |
-| `deja doctor` | Self-diagnosis: which stores were found, sqlite3 presence, MCP wiring per agent, index health, version. |
+| `deja doctor [--json]` | Self-diagnosis: store parse state, sqlite3 presence, MCP wiring per agent, index health, version; `--json` emits the same checks for scripts. |
 | `deja sync export <dir> [--full]` / `import <dir>` / `ssh <host> [--pull]` | Move memory between machines — via a shared folder or one ssh command. Watermarked, append-only, idempotent. |
 | `deja show <id>` / `deja last [n]` | Read one session / list recent ones. |
 | `deja resume <id> [--exec]` | Reopen a found session in its native harness (`claude --resume`, `codex resume`, `opencode -s`, `grok --resume`). |
@@ -84,6 +86,22 @@ $ deja "jwt refresh token"
 | `deja statusline` | One line for your status bar: recalls served to agents today. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
 
 `deja update` is for standalone installs. Homebrew and npm installs update through the package manager.
+
+### Doctor JSON
+
+`deja doctor --json` reports an explicit state for every check and exits 0 even when it finds a problem. Store states are `ok`, `missing`, `empty`, `unreadable`, or `parsed-zero`; the last state means session files exist but the newest file produced no sessions.
+
+```json
+{
+  "stores": [{"name": "claude", "state": "ok", "paths": ["/home/me/.claude/projects"], "files": 42}],
+  "index": {"state": "stale", "path": "/home/me/.cache/deja/index.db"},
+  "mcp": [{"name": "claude-code", "state": "wired", "path": "/home/me/.claude.json"}],
+  "sqlite3": {"state": "ok"},
+  "version": {"state": "ok", "current": "1.2.3", "latest": "1.2.3"}
+}
+```
+
+Index states are `ok`, `missing`, or `stale`; MCP states are `wired`, `not-wired`, or `config-missing`. The sqlite3 state is `ok` or `missing`. Version state is `ok`, `update-available`, `ahead`, `dev`, or `unknown`.
 
 Context piping without MCP:
 

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -33,7 +33,13 @@ func hermeticEnv(t *testing.T) string {
 	t.Setenv("DEJA_GEMINI_ROOT", filepath.Join(tmp, "gemini"))
 	t.Setenv("DEJA_CURSOR_ROOT", filepath.Join(tmp, "cursor"))
 	t.Setenv("DEJA_CURSOR_CLI_ROOT", filepath.Join(tmp, "cursor-cli"))
+	t.Setenv("DEJA_ANTIGRAVITY_ROOT", filepath.Join(tmp, "antigravity"))
 	t.Setenv("DEJA_GROK_ROOT", filepath.Join(tmp, "grok"))
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("GEMINI_CLI_HOME", "")
+	t.Setenv("CURSOR_CONFIG_DIR", "")
+	t.Setenv("AIDER_CHAT_HISTORY_FILE", "")
 	t.Setenv("NO_COLOR", "1")
 	return tmp
 }

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -38,10 +38,28 @@ func defaultDoctorVersionLookup() doctorVersionLookup {
 	}
 }
 
-// runDoctor prints a self-diagnosis report. It never fails: every section
-// degrades to a plain status line so the exit code stays 0.
-func runDoctor(w io.Writer, lookup doctorVersionLookup) error {
+// runDoctor prints a self-diagnosis report. Diagnosis itself never fails, so
+// both human and JSON reports keep exit status 0.
+func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup) error {
+	jsonOutput := false
+	for _, arg := range args {
+		if arg != "--json" {
+			return fmt.Errorf("doctor: unknown flag %q", arg)
+		}
+		jsonOutput = true
+	}
+	report := collectDoctorReport(lookup)
+	if jsonOutput {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
 	doctorHarnesses(w)
+	for _, store := range report.Stores {
+		if store.State == "parsed-zero" {
+			fmt.Fprintf(w, "  warning      %s files found but newest parsed to zero\n", store.Name)
+		}
+	}
 	fmt.Fprintln(w)
 	doctorTools(w)
 	fmt.Fprintln(w)
@@ -49,7 +67,7 @@ func runDoctor(w io.Writer, lookup doctorVersionLookup) error {
 	fmt.Fprintln(w)
 	doctorIndex(w)
 	fmt.Fprintln(w)
-	doctorVersion(w, lookup)
+	doctorVersion(w, func() (string, bool) { return report.Version.Latest, report.Version.Latest != "" })
 	return nil
 }
 
@@ -156,21 +174,7 @@ func doctorTools(w io.Writer) {
 
 func doctorMCP(w io.Writer) {
 	fmt.Fprintln(w, "MCP wiring:")
-	h := homeDir()
-	configs := []struct {
-		name  string
-		path  string
-		wired func(string) bool
-	}{
-		{"claude-code", sources.ClaudeJSONPath(), doctorJSONWired("mcpServers")},
-		{"codex", filepath.Join(sources.CodexHome(), "config.toml"), doctorTOMLWired},
-		{"opencode", doctorOpencodeConfigPath(), doctorJSONWired("mcp")},
-		{"cursor", filepath.Join(sources.CursorCLIHome(), "mcp.json"), doctorJSONWired("mcpServers")},
-		{"gemini", filepath.Join(sources.GeminiHome(), "settings.json"), doctorJSONWired("mcpServers")},
-		{"antigravity", filepath.Join(h, ".gemini", "config", "mcp_config.json"), doctorJSONWired("mcpServers")},
-		{"grok", filepath.Join(sources.GrokRoot(), "config.toml"), doctorTOMLWired},
-	}
-	for _, c := range configs {
+	for _, c := range doctorMCPConfigs() {
 		status := "config missing"
 		if doctorExists(c.path) {
 			if c.wired(c.path) {
@@ -180,6 +184,25 @@ func doctorMCP(w io.Writer) {
 			}
 		}
 		fmt.Fprintf(w, "  %-12s %-14s %s\n", c.name, status, c.path)
+	}
+}
+
+type doctorMCPConfig struct {
+	name  string
+	path  string
+	wired func(string) bool
+}
+
+func doctorMCPConfigs() []doctorMCPConfig {
+	h := homeDir()
+	return []doctorMCPConfig{
+		{"claude-code", sources.ClaudeJSONPath(), doctorJSONWired("mcpServers")},
+		{"codex", filepath.Join(sources.CodexHome(), "config.toml"), doctorTOMLWired},
+		{"opencode", doctorOpencodeConfigPath(), doctorJSONWired("mcp")},
+		{"cursor", filepath.Join(sources.CursorCLIHome(), "mcp.json"), doctorJSONWired("mcpServers")},
+		{"gemini", filepath.Join(sources.GeminiHome(), "settings.json"), doctorJSONWired("mcpServers")},
+		{"antigravity", filepath.Join(h, ".gemini", "config", "mcp_config.json"), doctorJSONWired("mcpServers")},
+		{"grok", filepath.Join(sources.GrokRoot(), "config.toml"), doctorTOMLWired},
 	}
 }
 

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+type doctorStore struct {
+	Name  string   `json:"name"`
+	State string   `json:"state"`
+	Paths []string `json:"paths"`
+	Files int      `json:"files"`
+}
+
+type doctorComponent struct {
+	State string `json:"state"`
+	Path  string `json:"path,omitempty"`
+}
+
+type doctorVersionReport struct {
+	State   string `json:"state"`
+	Current string `json:"current"`
+	Latest  string `json:"latest,omitempty"`
+}
+
+type doctorReport struct {
+	Stores  []doctorStore       `json:"stores"`
+	Index   doctorComponent     `json:"index"`
+	MCP     []doctorMCPStatus   `json:"mcp"`
+	SQLite3 doctorComponent     `json:"sqlite3"`
+	Version doctorVersionReport `json:"version"`
+}
+
+type doctorMCPStatus struct {
+	Name  string `json:"name"`
+	State string `json:"state"`
+	Path  string `json:"path"`
+}
+
+type doctorStoreCheck struct {
+	name  string
+	paths []string
+	files []string
+	parse func(string) ([]model.Session, error)
+}
+
+func collectDoctorReport(lookup doctorVersionLookup) doctorReport {
+	stores := doctorStoreChecks()
+	report := doctorReport{Stores: make([]doctorStore, 0, len(stores))}
+	var newest time.Time
+	for _, check := range stores {
+		store, mod := inspectDoctorStore(check)
+		report.Stores = append(report.Stores, store)
+		if mod.After(newest) {
+			newest = mod
+		}
+	}
+	report.Index = inspectDoctorIndex(newest)
+	report.MCP = collectDoctorMCP()
+	report.SQLite3.State = "missing"
+	if sources.SQLite3Available() {
+		report.SQLite3.State = "ok"
+	}
+	report.Version = collectDoctorVersion(lookup)
+	return report
+}
+
+func doctorStoreChecks() []doctorStoreCheck {
+	aiderPaths := []string{sources.Home()}
+	aiderPaths = append(aiderPaths, filepath.SplitList(os.Getenv("DEJA_AIDER_ROOTS"))...)
+	cursorFiles := append(sources.CursorTranscripts(), sources.CursorDBs()...)
+	return []doctorStoreCheck{
+		{"claude", []string{sources.ClaudeRoot()}, sources.ClaudeFiles(), sources.ParseClaudeFile},
+		{"codex", []string{sources.CodexRoot()}, sources.CodexFiles(), parseDoctorCodex},
+		{"opencode", []string{sources.OpencodeDB()}, presentDoctorFile(sources.OpencodeDB()), sources.ParseOpencodeDB},
+		{"aider", aiderPaths, sources.AiderFiles(), sources.ParseAiderFile},
+		{"gemini", []string{sources.GeminiRoot()}, sources.GeminiChatFiles(), sources.ParseGeminiFile},
+		{"cursor", []string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, cursorFiles, parseDoctorCursor},
+		{"antigravity", sources.AntigravityRoots(), sources.AntigravityTranscripts(), sources.ParseAntigravityFile},
+		{"grok", []string{sources.GrokRoot()}, sources.GrokSessionFiles(), sources.ParseGrokFile},
+	}
+}
+
+func presentDoctorFile(path string) []string {
+	if doctorExists(path) {
+		return []string{path}
+	}
+	return nil
+}
+
+func parseDoctorCodex(path string) ([]model.Session, error) {
+	if filepath.Base(path) == "history.jsonl" {
+		return sources.ParseCodexHistory(path)
+	}
+	return sources.ParseCodexRollout(path)
+}
+
+func parseDoctorCursor(path string) ([]model.Session, error) {
+	if filepath.Base(path) == "state.vscdb" {
+		return sources.ParseCursorDB(path)
+	}
+	return sources.ParseCursorTranscript(path)
+}
+
+func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
+	store := doctorStore{Name: check.name, State: "missing", Paths: check.paths, Files: len(check.files)}
+	rootExists := false
+	for _, path := range check.paths {
+		if path == "" {
+			continue
+		}
+		fi, err := os.Stat(path)
+		if err != nil {
+			if os.IsPermission(err) {
+				store.State = "unreadable"
+				return store, time.Time{}
+			}
+			continue
+		}
+		rootExists = true
+		if fi.IsDir() {
+			f, err := os.Open(path)
+			if err != nil {
+				if os.IsPermission(err) {
+					store.State = "unreadable"
+					return store, time.Time{}
+				}
+				continue
+			}
+			_, err = f.Readdirnames(1)
+			_ = f.Close()
+			if err != nil && err != io.EOF && os.IsPermission(err) {
+				store.State = "unreadable"
+				return store, time.Time{}
+			}
+		}
+	}
+	if len(check.files) == 0 {
+		if rootExists {
+			store.State = "empty"
+		}
+		return store, time.Time{}
+	}
+	newest, mod := newestDoctorFile(check.files)
+	f, err := os.Open(newest)
+	if err != nil {
+		if os.IsPermission(err) {
+			store.State = "unreadable"
+		} else {
+			store.State = "parsed-zero"
+		}
+		return store, mod
+	}
+	_ = f.Close()
+	sessions, _ := check.parse(newest)
+	store.State = "ok"
+	if len(sessions) == 0 {
+		store.State = "parsed-zero"
+	}
+	return store, mod
+}
+
+func newestDoctorFile(files []string) (string, time.Time) {
+	files = append([]string(nil), files...)
+	sort.Strings(files)
+	newest := files[0]
+	var newestMod time.Time
+	for _, path := range files {
+		if fi, err := os.Stat(path); err == nil && fi.ModTime().After(newestMod) {
+			newest, newestMod = path, fi.ModTime()
+		}
+	}
+	return newest, newestMod
+}
+
+func inspectDoctorIndex(newestStore time.Time) doctorComponent {
+	dir := index.DefaultDir()
+	result := doctorComponent{State: "missing", Path: dir}
+	if !index.HasManifest(dir) {
+		return result
+	}
+	result.State = "ok"
+	if fi, err := os.Stat(filepath.Join(dir, "manifest.gob")); err == nil && newestStore.After(fi.ModTime()) {
+		result.State = "stale"
+	}
+	return result
+}
+
+func collectDoctorMCP() []doctorMCPStatus {
+	configs := doctorMCPConfigs()
+	out := make([]doctorMCPStatus, 0, len(configs))
+	for _, config := range configs {
+		state := "config-missing"
+		if doctorExists(config.path) {
+			state = "not-wired"
+			if config.wired(config.path) {
+				state = "wired"
+			}
+		}
+		out = append(out, doctorMCPStatus{Name: config.name, State: state, Path: config.path})
+	}
+	return out
+}
+
+func collectDoctorVersion(lookup doctorVersionLookup) doctorVersionReport {
+	report := doctorVersionReport{State: "unknown", Current: version}
+	latest, ok := lookup()
+	if !ok {
+		return report
+	}
+	report.Latest = latest
+	current := normalizeUpdateVersion(version)
+	order, comparable := compareUpdateVersions(current, latest)
+	if !comparable {
+		if current == "dev" || current == "" {
+			report.State = "dev"
+		}
+		return report
+	}
+	switch {
+	case order < 0:
+		report.State = "update-available"
+	case order > 0:
+		report.State = "ahead"
+	default:
+		report.State = "ok"
+	}
+	return report
+}
+
+func doctorParsedZeroWarning() string {
+	var names []string
+	for _, check := range doctorStoreChecks() {
+		store, _ := inspectDoctorStore(check)
+		if store.State == "parsed-zero" {
+			names = append(names, store.Name)
+		}
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	return "warning: " + strings.Join(names, ", ") + " files found but newest parsed to zero"
+}

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -165,11 +165,13 @@ func TestDoctorJSONGolden(t *testing.T) {
 	got := strings.ReplaceAll(out.String(), `\\`, `/`)
 	got = filepath.ToSlash(got)
 	got = strings.ReplaceAll(got, filepath.ToSlash(tmp), "<tmp>")
-	want, err := os.ReadFile(filepath.Join("testdata", "doctor.json"))
+	wantRaw, err := os.ReadFile(filepath.Join("testdata", "doctor.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != string(want) {
+	// The golden may be checked out with CRLF on windows.
+	want := strings.ReplaceAll(string(wantRaw), "\r\n", "\n")
+	if got != want {
 		t.Fatalf("doctor JSON mismatch\n--- got ---\n%s--- want ---\n%s", got, want)
 	}
 }

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -3,10 +3,15 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
 )
 
 func mcpLine(name, status string) string {
@@ -39,7 +44,7 @@ func TestDoctorFullReport(t *testing.T) {
 	defer func() { version = old }()
 
 	var out bytes.Buffer
-	if err := runDoctor(&out, stubLookup("9.9.9", true)); err != nil {
+	if err := runDoctor(&out, nil, stubLookup("9.9.9", true)); err != nil {
 		t.Fatalf("runDoctor: %v", err)
 	}
 	got := out.String()
@@ -55,6 +60,207 @@ func TestDoctorFullReport(t *testing.T) {
 	}
 	if strings.Contains(got, "\x1b[") {
 		t.Fatalf("report contains color codes:\n%s", got)
+	}
+}
+
+func TestDoctorStoreStates(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod permissions are not meaningful on windows")
+	}
+	tmp := t.TempDir()
+	unreadable := filepath.Join(tmp, "unreadable")
+	if err := os.Mkdir(unreadable, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(unreadable, 0); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(unreadable, 0o700) }()
+
+	cases := []struct {
+		name  string
+		check doctorStoreCheck
+		want  string
+	}{
+		{"missing", doctorStoreCheck{name: "x", paths: []string{filepath.Join(tmp, "missing")}}, "missing"},
+		{"empty", doctorStoreCheck{name: "x", paths: []string{tmp}}, "empty"},
+		{"unreadable", doctorStoreCheck{name: "x", paths: []string{unreadable}}, "unreadable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := inspectDoctorStore(tc.check)
+			if got.State != tc.want {
+				t.Fatalf("state = %q, want %q", got.State, tc.want)
+			}
+		})
+	}
+
+	file := filepath.Join(tmp, "session.jsonl")
+	if err := os.WriteFile(file, []byte("fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name  string
+		parse func(string) ([]model.Session, error)
+		want  string
+	}{
+		{"ok", func(string) ([]model.Session, error) { return []model.Session{{ID: "1"}}, nil }, "ok"},
+		{"parsed-zero", func(string) ([]model.Session, error) { return nil, nil }, "parsed-zero"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := inspectDoctorStore(doctorStoreCheck{name: "x", paths: []string{tmp}, files: []string{file}, parse: tc.parse})
+			if got.State != tc.want {
+				t.Fatalf("state = %q, want %q", got.State, tc.want)
+			}
+		})
+	}
+}
+
+func TestDoctorParsesOnlyNewestFile(t *testing.T) {
+	tmp := t.TempDir()
+	oldPath := filepath.Join(tmp, "old")
+	newPath := filepath.Join(tmp, "new")
+	for _, path := range []string{oldPath, newPath} {
+		if err := os.WriteFile(path, []byte(path), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldTime := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(oldPath, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+	var parsed []string
+	check := doctorStoreCheck{
+		name: "x", paths: []string{tmp}, files: []string{newPath, oldPath},
+		parse: func(path string) ([]model.Session, error) {
+			parsed = append(parsed, path)
+			return []model.Session{{ID: "1"}}, nil
+		},
+	}
+	got, _ := inspectDoctorStore(check)
+	if got.State != "ok" || len(parsed) != 1 || parsed[0] != newPath {
+		t.Fatalf("state=%q parsed=%v, want newest only", got.State, parsed)
+	}
+}
+
+func TestDoctorJSONGolden(t *testing.T) {
+	tmp := hermeticEnv(t)
+	if err := os.MkdirAll(filepath.Join(tmp, "home"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "project", "session.jsonl"), "session", []string{
+		`{"type":"user","sessionId":"session","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"history"}}`,
+	})
+	t.Setenv("PATH", "")
+	oldVersion := version
+	version = "1.0.0"
+	defer func() { version = oldVersion }()
+
+	var out bytes.Buffer
+	if err := runDoctor(&out, []string{"--json"}, stubLookup("2.0.0", true)); err != nil {
+		t.Fatal(err)
+	}
+	got := filepath.ToSlash(out.String())
+	got = strings.ReplaceAll(got, filepath.ToSlash(tmp), "<tmp>")
+	want, err := os.ReadFile(filepath.Join("testdata", "doctor.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != string(want) {
+		t.Fatalf("doctor JSON mismatch\n--- got ---\n%s--- want ---\n%s", got, want)
+	}
+}
+
+func TestDoctorIndexStates(t *testing.T) {
+	hermeticEnv(t)
+	if got := inspectDoctorIndex(time.Time{}).State; got != "missing" {
+		t.Fatalf("missing index state = %q", got)
+	}
+	dir := os.Getenv("DEJA_INDEX_DIR")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"manifest.gob", "sessions.gob"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("fixture"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manifestTime := time.Now().Add(-time.Minute)
+	if err := os.Chtimes(filepath.Join(dir, "manifest.gob"), manifestTime, manifestTime); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name   string
+		newest time.Time
+		want   string
+	}{
+		{"ok", manifestTime.Add(-time.Minute), "ok"},
+		{"stale", manifestTime.Add(time.Minute), "stale"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := inspectDoctorIndex(tc.newest).State; got != tc.want {
+				t.Fatalf("state = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDoctorRejectsUnknownFlag(t *testing.T) {
+	if err := runDoctor(io.Discard, []string{"--yaml"}, stubLookup("", false)); err == nil {
+		t.Fatal("expected unknown flag error")
+	}
+}
+
+func TestDoctorParserDispatch(t *testing.T) {
+	tmp := t.TempDir()
+	history := filepath.Join(tmp, "history.jsonl")
+	writeFileMkdir(t, history, `{"session_id":"s","text":"hello","ts":1}`+"\n")
+	rollout := filepath.Join(tmp, "rollout-s.jsonl")
+	writeFileMkdir(t, rollout, `{"type":"response_item","timestamp":"2026-01-01T00:00:00Z","payload":{"role":"user","content":"hello"}}`+"\n")
+	transcript := filepath.Join(tmp, "cursor.jsonl")
+	writeFileMkdir(t, transcript, "not json\n")
+	db := filepath.Join(tmp, "state.vscdb")
+	writeFileMkdir(t, db, "")
+
+	for _, tc := range []struct {
+		name string
+		path string
+		fn   func(string) ([]model.Session, error)
+	}{
+		{"codex history", history, parseDoctorCodex},
+		{"codex rollout", rollout, parseDoctorCodex},
+		{"cursor transcript", transcript, parseDoctorCursor},
+		{"cursor db", db, parseDoctorCursor},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := tc.fn(tc.path); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestDoctorVersionReportStates(t *testing.T) {
+	cases := []struct {
+		current string
+		latest  string
+		ok      bool
+		want    string
+	}{
+		{"1.0.0", "", false, "unknown"},
+		{"dev", "2.0.0", true, "dev"},
+		{"1.0.0", "2.0.0", true, "update-available"},
+		{"2.0.0", "1.0.0", true, "ahead"},
+		{"1.0.0", "1.0.0", true, "ok"},
+	}
+	oldVersion := version
+	defer func() { version = oldVersion }()
+	for _, tc := range cases {
+		version = tc.current
+		got := collectDoctorVersion(stubLookup(tc.latest, tc.ok))
+		if got.State != tc.want {
+			t.Fatalf("version %q latest %q state = %q, want %q", tc.current, tc.latest, got.State, tc.want)
+		}
 	}
 }
 

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -160,7 +160,10 @@ func TestDoctorJSONGolden(t *testing.T) {
 	if err := runDoctor(&out, []string{"--json"}, stubLookup("2.0.0", true)); err != nil {
 		t.Fatal(err)
 	}
-	got := filepath.ToSlash(out.String())
+	// JSON escapes windows separators as \\, which ToSlash would turn
+	// into //; collapse them to / before substituting the temp dir.
+	got := strings.ReplaceAll(out.String(), `\\`, `/`)
+	got = filepath.ToSlash(got)
 	got = strings.ReplaceAll(got, filepath.ToSlash(tmp), "<tmp>")
 	want, err := os.ReadFile(filepath.Join("testdata", "doctor.json"))
 	if err != nil {

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
@@ -80,6 +81,9 @@ func runInstall(args []string, uninstall bool) error {
 		for _, d := range done {
 			info = append(info, fmt.Sprintf("%-*s  %s%-9s%s %s", nameW, d.target, logoBold, d.action, logoReset, logoDim+d.path+logoReset))
 		}
+		if hint := installIndexHint(); hint != "" {
+			info = append(info, "", hint)
+		}
 		printLogo(os.Stdout, info)
 	}
 	return nil
@@ -91,6 +95,36 @@ func shortHome(p string) string {
 		return "~" + strings.TrimPrefix(p, h)
 	}
 	return p
+}
+
+func installIndexHint() string {
+	if index.HasManifest(index.DefaultDir()) {
+		return ""
+	}
+	checks := doctorStoreChecks()
+	detected := 0
+	onlyMissingOrEmpty := true
+	var paths []string
+	seen := map[string]bool{}
+	for _, check := range checks {
+		store, _ := inspectDoctorStore(check)
+		if store.Files > 0 {
+			detected++
+		}
+		if store.State != "missing" && store.State != "empty" {
+			onlyMissingOrEmpty = false
+		}
+		for _, path := range store.Paths {
+			if path != "" && !seen[path] {
+				seen[path] = true
+				paths = append(paths, shortHome(path))
+			}
+		}
+	}
+	if onlyMissingOrEmpty {
+		return "no agent history found on this machine; checked " + strings.Join(paths, ", ")
+	}
+	return fmt.Sprintf("next: run `deja index` to index %d agent stores", detected)
 }
 
 func existingTargets() []string {

--- a/cmd/deja/logo.go
+++ b/cmd/deja/logo.go
@@ -49,7 +49,9 @@ var ansiRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
 
 func visibleLen(s string) int { return len([]rune(ansiRE.ReplaceAllString(s, ""))) }
 
-func logoWanted(f *os.File) bool {
+var logoWanted = defaultLogoWanted
+
+func defaultLogoWanted(f *os.File) bool {
 	if os.Getenv("NO_COLOR") != "" {
 		return false
 	}
@@ -130,5 +132,8 @@ func maybeFirstIndexGreeting() {
 		fmt.Sprintf("indexed %s%d%s messages across %s%d%s agents", logoBold, b.Messages, logoReset, logoBold, b.Harnesses, logoReset),
 		logoDim+`try: deja "something you fixed weeks ago"`+logoReset,
 	)
+	if warning := doctorParsedZeroWarning(); warning != "" {
+		info = append(info, warning)
+	}
 	printLogo(os.Stdout, info)
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -75,7 +75,7 @@ func run(args []string) error {
 		return nil
 	}
 	if args[0] == "doctor" {
-		return runDoctor(os.Stdout, doctorLookup)
+		return runDoctor(os.Stdout, args[1:], doctorLookup)
 	}
 	if args[0] == "warmup" {
 		prepareFirstIndexGreeting()
@@ -450,7 +450,7 @@ Usage:
   deja sync ssh <host> [--pull] [--full]
   deja last [n]
   deja sources
-  deja doctor
+  deja doctor [--json]
   deja warmup
   deja index [--rebuild]
   deja statusline

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -36,14 +36,17 @@ func captureRun(t *testing.T, args ...string) (string, error) {
 		t.Fatal(err)
 	}
 	os.Stdout = w
+	// Drain concurrently: windows anonymous pipes buffer only a few KB, so
+	// commands that print more would block a sequential read-after-run.
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
 	err = run(args)
 	_ = w.Close()
 	os.Stdout = old
-	b, readErr := io.ReadAll(r)
-	if readErr != nil {
-		t.Fatal(readErr)
-	}
-	return string(b), err
+	return <-done, err
 }
 
 func TestRunDispatcherSyntheticFixtures(t *testing.T) {

--- a/cmd/deja/onboarding_test.go
+++ b/cmd/deja/onboarding_test.go
@@ -92,15 +92,19 @@ func captureStdoutCall(t *testing.T, fn func()) string {
 		t.Fatal(err)
 	}
 	os.Stdout = w
+	// Drain concurrently: windows anonymous pipes buffer only a few KB, so
+	// callbacks that print more would block a sequential read-after-call.
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
 	fn()
 	_ = w.Close()
 	os.Stdout = old
-	b, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
+	out := <-done
 	_ = r.Close()
-	return string(b)
+	return out
 }
 
 func sourcesClaudeConfigDir() string {

--- a/cmd/deja/onboarding_test.go
+++ b/cmd/deja/onboarding_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+func TestInstallIndexHintsTTYOnly(t *testing.T) {
+	cases := []struct {
+		name     string
+		history  bool
+		tty      bool
+		want     string
+		unwanted string
+	}{
+		{"no history", false, true, "no agent history found on this machine", "next: run"},
+		{"history found", true, true, "next: run `deja index` to index 1 agent stores", "no agent history"},
+		{"non tty", true, false, "claude-code: created", "next: run"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hermeticEnv(t)
+			if err := os.MkdirAll(sourcesClaudeConfigDir(), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if tc.history {
+				writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "project", "session.jsonl"), "session", []string{
+					`{"type":"user","sessionId":"session","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"history"}}`,
+				})
+			}
+			oldLogoWanted := logoWanted
+			logoWanted = func(*os.File) bool { return tc.tty }
+			defer func() { logoWanted = oldLogoWanted }()
+
+			out, err := captureRun(t, "install", "--all")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(out, tc.want) || strings.Contains(out, tc.unwanted) {
+				t.Fatalf("output=%q, want %q without %q", out, tc.want, tc.unwanted)
+			}
+		})
+	}
+}
+
+func TestInstallHintSkippedWhenIndexExists(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"manifest.gob", "sessions.gob"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("present"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := installIndexHint(); got != "" {
+		t.Fatalf("hint = %q, want empty", got)
+	}
+}
+
+func TestFirstIndexGreetingIncludesParsedZeroWarning(t *testing.T) {
+	hermeticEnv(t)
+	bad := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "project", "bad.jsonl")
+	writeFileMkdir(t, bad, "not json\n")
+	oldLogoWanted := logoWanted
+	logoWanted = func(*os.File) bool { return true }
+	defer func() { logoWanted = oldLogoWanted }()
+	oldBuild := index.LastBuild
+	index.LastBuild = index.BuildSummary{
+		Initial: true, Messages: 1, Sessions: 1, Harnesses: 1,
+		PerHarness: []index.HarnessCount{{Name: "codex", Messages: 1, Sessions: 1}},
+	}
+	defer func() { index.LastBuild = oldBuild }()
+
+	out := captureStdoutCall(t, maybeFirstIndexGreeting)
+	if !strings.Contains(out, "warning: claude files found but newest parsed to zero") {
+		t.Fatalf("greeting missing parsed-zero warning: %q", out)
+	}
+}
+
+func captureStdoutCall(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	b, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = r.Close()
+	return string(b)
+}
+
+func sourcesClaudeConfigDir() string {
+	return filepath.Join(homeDir(), ".claude")
+}

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -1,0 +1,119 @@
+{
+  "stores": [
+    {
+      "name": "claude",
+      "state": "ok",
+      "paths": [
+        "<tmp>/claude"
+      ],
+      "files": 1
+    },
+    {
+      "name": "codex",
+      "state": "missing",
+      "paths": [
+        "<tmp>/codex"
+      ],
+      "files": 0
+    },
+    {
+      "name": "opencode",
+      "state": "missing",
+      "paths": [
+        "<tmp>/opencode.db"
+      ],
+      "files": 0
+    },
+    {
+      "name": "aider",
+      "state": "empty",
+      "paths": [
+        "<tmp>/home",
+        "<tmp>/aider"
+      ],
+      "files": 0
+    },
+    {
+      "name": "gemini",
+      "state": "missing",
+      "paths": [
+        "<tmp>/gemini"
+      ],
+      "files": 0
+    },
+    {
+      "name": "cursor",
+      "state": "missing",
+      "paths": [
+        "<tmp>/cursor",
+        "<tmp>/cursor-cli"
+      ],
+      "files": 0
+    },
+    {
+      "name": "antigravity",
+      "state": "missing",
+      "paths": [
+        "<tmp>/antigravity"
+      ],
+      "files": 0
+    },
+    {
+      "name": "grok",
+      "state": "missing",
+      "paths": [
+        "<tmp>/grok"
+      ],
+      "files": 0
+    }
+  ],
+  "index": {
+    "state": "missing",
+    "path": "<tmp>/index.db"
+  },
+  "mcp": [
+    {
+      "name": "claude-code",
+      "state": "config-missing",
+      "path": "<tmp>/home/.claude.json"
+    },
+    {
+      "name": "codex",
+      "state": "config-missing",
+      "path": "<tmp>/home/.codex/config.toml"
+    },
+    {
+      "name": "opencode",
+      "state": "config-missing",
+      "path": "<tmp>/home/.config/opencode/opencode.json"
+    },
+    {
+      "name": "cursor",
+      "state": "config-missing",
+      "path": "<tmp>/home/.cursor/mcp.json"
+    },
+    {
+      "name": "gemini",
+      "state": "config-missing",
+      "path": "<tmp>/home/.gemini/settings.json"
+    },
+    {
+      "name": "antigravity",
+      "state": "config-missing",
+      "path": "<tmp>/home/.gemini/config/mcp_config.json"
+    },
+    {
+      "name": "grok",
+      "state": "config-missing",
+      "path": "<tmp>/grok/config.toml"
+    }
+  ],
+  "sqlite3": {
+    "state": "missing"
+  },
+  "version": {
+    "state": "update-available",
+    "current": "1.0.0",
+    "latest": "2.0.0"
+  }
+}


### PR DESCRIPTION
doctor grows a --json mode with an explicit state per check: stores are ok/missing/empty/unreadable/parsed-zero (the last one — files exist, the newest parsed to nothing — is the case that used to look healthy), index ok/missing/stale, mcp wired/not-wired/config-missing, version states included. The human report surfaces parsed-zero as a warning, and a terminal install now says whether history was found and points at deja index when the first build is still pending. JSON shape documented in the README with a golden test. Closes #109