### PR TITLE
feat: windows path audit, scoop and winget manifests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+packaging/** text eol=lf

--- a/internal/sources/cursor.go
+++ b/internal/sources/cursor.go
@@ -75,18 +75,31 @@ func CursorTranscripts() []string {
 		if err != nil || d.IsDir() {
 			return nil
 		}
-		if !strings.HasSuffix(p, ".jsonl") {
+		if !strings.EqualFold(filepath.Ext(p), ".jsonl") {
 			return nil
 		}
-		if strings.Contains(p, string(filepath.Separator)+"subagents"+string(filepath.Separator)) && os.Getenv("DEJA_INCLUDE_SUBAGENTS") != "1" {
+		if cursorPathHasDir(p, "subagents") && os.Getenv("DEJA_INCLUDE_SUBAGENTS") != "1" {
 			return nil
 		}
-		if strings.Contains(p, string(filepath.Separator)+"agent-transcripts"+string(filepath.Separator)) {
+		if cursorPathHasDir(p, "agent-transcripts") {
 			out = append(out, p)
 		}
 		return nil
 	})
 	return out
+}
+
+func cursorPathHasDir(path, want string) bool {
+	for dir := filepath.Dir(path); ; {
+		if strings.EqualFold(filepath.Base(dir), want) {
+			return true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
+	}
 }
 
 func fileExists(p string) bool {
@@ -274,16 +287,16 @@ func ParseCursorTranscript(path string) ([]model.Session, error) {
 // back to a path with a greedy existence-checked walk; hyphens in real dir
 // names survive because the literal branch is tried when the split fails.
 func cursorTranscriptProject(path string) string {
-	dir := path
-	for filepath.Base(filepath.Dir(dir)) != "projects" && dir != "/" && dir != "." {
+	dir := filepath.Clean(path)
+	for !strings.EqualFold(filepath.Base(filepath.Dir(dir)), "projects") {
 		parent := filepath.Dir(dir)
-		if parent == dir { // reached a root like C:\ on Windows
-			break
+		if parent == dir {
+			return "-"
 		}
 		dir = parent
 	}
 	encoded := filepath.Base(dir)
-	if encoded == "" || encoded == "/" || encoded == "." || encoded == string(filepath.Separator) {
+	if encoded == "" || encoded == "." {
 		return "-"
 	}
 	if resolved := resolveEncodedPath("-" + encoded); resolved != "" {

--- a/internal/sources/cursor_test.go
+++ b/internal/sources/cursor_test.go
@@ -87,6 +87,54 @@ func TestParseCursorTranscript(t *testing.T) {
 	}
 }
 
+func TestCursorTranscriptProjectWalkUp(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "project directory",
+			path: filepath.Join("root", "projects", "Users-me-work-app", "agent-transcripts", "session", "session.jsonl"),
+			want: filepath.Join("work", "app"),
+		},
+		{
+			name: "project directory case",
+			path: filepath.Join("root", "Projects", "Users-me-work-app", "agent-transcripts", "session", "session.jsonl"),
+			want: filepath.Join("work", "app"),
+		},
+		{
+			name: "filesystem root",
+			path: filepath.Join(string(filepath.Separator), "session.jsonl"),
+			want: "-",
+		},
+		{
+			name: "relative path without projects directory",
+			path: filepath.Join("agent-transcripts", "session.jsonl"),
+			want: "-",
+		},
+	}
+	if runtime.GOOS == "windows" {
+		tests = append(tests, struct {
+			name string
+			path string
+			want string
+		}{
+			name: "windows drive root",
+			path: filepath.Join(`C:\`, "session.jsonl"),
+			want: "-",
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cursorTranscriptProject(tt.path); got != tt.want {
+				t.Fatalf("cursorTranscriptProject(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCursorTranscriptsSkipSubagents(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("DEJA_CURSOR_CLI_ROOT", root)
@@ -104,5 +152,25 @@ func TestCursorTranscriptsSkipSubagents(t *testing.T) {
 	files := CursorTranscripts()
 	if len(files) != 1 || !strings.HasSuffix(files[0], "s1.jsonl") {
 		t.Fatalf("discovery wrong: %v", files)
+	}
+}
+
+func TestCursorTranscriptsPathMatchingIsCaseInsensitive(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DEJA_CURSOR_CLI_ROOT", root)
+	dir := filepath.Join(root, "projects", "Users-x-app", "Agent-Transcripts", "s1", "SubAgents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "child.JSONL")
+	if err := os.WriteFile(path, []byte(`{"role":"user","message":{"content":"hi"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := CursorTranscripts(); len(got) != 0 {
+		t.Fatalf("subagent transcript discovered: %v", got)
+	}
+	t.Setenv("DEJA_INCLUDE_SUBAGENTS", "1")
+	if got := CursorTranscripts(); len(got) != 1 || got[0] != path {
+		t.Fatalf("case-insensitive transcript discovery = %v, want %q", got, path)
 	}
 }

--- a/internal/sources/windows_packaging_test.go
+++ b/internal/sources/windows_packaging_test.go
@@ -119,7 +119,7 @@ func TestWinGetManifestSet(t *testing.T) {
 	if strings.Count(installer, "  InstallerSha256: ") != 2 || strings.Count(installer, "- RelativeFilePath: deja.exe\n") != 1 {
 		t.Error("installer must have two hashes and one portable deja.exe entry")
 	}
-	for _, line := range strings.Split(installer, "\n") {
+	for _, line := range strings.Split(strings.ReplaceAll(installer, "\r\n", "\n"), "\n") {
 		if hash, ok := strings.CutPrefix(line, "  InstallerSha256: "); ok && !hashRE.MatchString(hash) {
 			t.Errorf("invalid InstallerSha256 %q", hash)
 		}

--- a/internal/sources/windows_packaging_test.go
+++ b/internal/sources/windows_packaging_test.go
@@ -1,0 +1,155 @@
+package sources
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const (
+	packageID      = "vshulcz.deja-vu"
+	manifestSchema = "1.12.0"
+)
+
+var (
+	semverRE = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+	hashRE   = regexp.MustCompile(`^[A-Fa-f0-9]{64}$`)
+)
+
+type scoopDownload struct {
+	URL  string `json:"url"`
+	Hash string `json:"hash"`
+}
+
+type scoopManifest struct {
+	Version      string                   `json:"version"`
+	Description  string                   `json:"description"`
+	Homepage     string                   `json:"homepage"`
+	License      string                   `json:"license"`
+	Architecture map[string]scoopDownload `json:"architecture"`
+	Bin          string                   `json:"bin"`
+	Checkver     string                   `json:"checkver"`
+	Autoupdate   struct {
+		Architecture map[string]scoopDownload `json:"architecture"`
+	} `json:"autoupdate"`
+}
+
+func TestScoopManifest(t *testing.T) {
+	b, err := os.ReadFile("../../packaging/scoop/deja-vu.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest scoopManifest
+	if err := json.Unmarshal(b, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if !semverRE.MatchString(manifest.Version) {
+		t.Errorf("version = %q, want stable semantic version", manifest.Version)
+	}
+	if manifest.Description == "" || manifest.Homepage != "https://github.com/vshulcz/deja-vu" || manifest.License != "MIT" {
+		t.Error("description, homepage, or license is missing")
+	}
+	if manifest.Bin != "deja.exe" || manifest.Checkver != "github" {
+		t.Errorf("bin/checkver = %q/%q", manifest.Bin, manifest.Checkver)
+	}
+	for architecture, assetArchitecture := range map[string]string{"64bit": "amd64", "arm64": "arm64"} {
+		download, ok := manifest.Architecture[architecture]
+		if !ok {
+			t.Errorf("missing %s download", architecture)
+			continue
+		}
+		wantURL := releaseURL(manifest.Version, assetArchitecture)
+		if download.URL != wantURL || !hashRE.MatchString(download.Hash) {
+			t.Errorf("%s download = %#v, want URL %q and SHA-256", architecture, download, wantURL)
+		}
+		update, ok := manifest.Autoupdate.Architecture[architecture]
+		wantUpdate := releaseURL("$version", assetArchitecture)
+		if !ok || update.URL != wantUpdate {
+			t.Errorf("%s autoupdate URL = %q, want %q", architecture, update.URL, wantUpdate)
+		}
+	}
+}
+
+func TestWinGetManifestSet(t *testing.T) {
+	files := []struct {
+		path         string
+		manifestType string
+	}{
+		{"../../packaging/winget/vshulcz.deja-vu.yaml", "version"},
+		{"../../packaging/winget/vshulcz.deja-vu.locale.en-US.yaml", "defaultLocale"},
+		{"../../packaging/winget/vshulcz.deja-vu.installer.yaml", "installer"},
+	}
+	var version string
+	for _, file := range files {
+		values := topLevelYAML(t, file.path)
+		if values["PackageIdentifier"] != packageID || values["ManifestType"] != file.manifestType || values["ManifestVersion"] != manifestSchema {
+			t.Errorf("%s has inconsistent identity or manifest metadata: %#v", file.path, values)
+		}
+		if version == "" {
+			version = values["PackageVersion"]
+		}
+		if values["PackageVersion"] != version {
+			t.Errorf("%s version = %q, want %q", file.path, values["PackageVersion"], version)
+		}
+	}
+	if !semverRE.MatchString(version) {
+		t.Fatalf("PackageVersion = %q, want stable semantic version", version)
+	}
+
+	locale := topLevelYAML(t, files[1].path)
+	for _, key := range []string{"PackageLocale", "Publisher", "PackageName", "License", "ShortDescription"} {
+		if locale[key] == "" {
+			t.Errorf("defaultLocale is missing %s", key)
+		}
+	}
+
+	b, err := os.ReadFile(files[2].path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installer := string(b)
+	for architecture, assetArchitecture := range map[string]string{"x64": "amd64", "arm64": "arm64"} {
+		if !strings.Contains(installer, "- Architecture: "+architecture+"\n") || !strings.Contains(installer, "  InstallerUrl: "+releaseURL(version, assetArchitecture)+"\n") {
+			t.Errorf("installer is missing %s release URL", architecture)
+		}
+	}
+	if strings.Count(installer, "  InstallerSha256: ") != 2 || strings.Count(installer, "- RelativeFilePath: deja.exe\n") != 1 {
+		t.Error("installer must have two hashes and one portable deja.exe entry")
+	}
+	for _, line := range strings.Split(installer, "\n") {
+		if hash, ok := strings.CutPrefix(line, "  InstallerSha256: "); ok && !hashRE.MatchString(hash) {
+			t.Errorf("invalid InstallerSha256 %q", hash)
+		}
+	}
+}
+
+func topLevelYAML(t *testing.T, path string) map[string]string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	values := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "-") {
+			continue
+		}
+		if key, value, ok := strings.Cut(line, ":"); ok {
+			values[key] = strings.TrimSpace(value)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return values
+}
+
+func releaseURL(version, architecture string) string {
+	return "https://github.com/vshulcz/deja-vu/releases/download/v" + version + "/deja-vu_" + version + "_windows_" + architecture + ".zip"
+}

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,51 @@
+# Windows package manifests
+
+This directory keeps the source manifests for Scoop and WinGet. They are
+pinned to a published release so their URLs and SHA-256 values can be checked
+before submission.
+
+## Update checklist
+
+After GoReleaser publishes a tag:
+
+1. Download `checksums.txt` from the GitHub release and confirm both Windows
+   zip assets are listed.
+2. In `scoop/deja-vu.json`, set `version`, the two initial download URLs, and
+   their hashes. Leave the `$version` autoupdate URLs unchanged.
+3. In all three files under `winget/`, set `PackageVersion`. Update the release
+   URLs, `InstallerSha256` values, `LicenseUrl`, and `ReleaseNotesUrl`.
+4. Download both archives and confirm each contains `deja.exe` at its root.
+5. On Windows, validate the WinGet set:
+
+   ```powershell
+   winget validate --manifest packaging\winget
+   winget install --manifest packaging\winget
+   ```
+
+6. In a Scoop development checkout, copy the Scoop manifest into a bucket and
+   validate it:
+
+   ```powershell
+   scoop checkver deja-vu
+   scoop audit deja-vu
+   ```
+
+7. Run `go test ./...` to check local version, URL, architecture, and hash
+   consistency across the manifests.
+
+## Publish
+
+For the first Scoop publication, copy `scoop/deja-vu.json` to
+`bucket/deja-vu.json` in a fork of `ScoopInstaller/Main`, run the checks above,
+and open a pull request there. After acceptance, Scoop's checkver automation
+can propose routine version updates; keep this source copy in sync.
+
+For WinGet, copy the three files into
+`manifests/v/vshulcz/deja-vu/<version>/` in a fork of
+`microsoft/winget-pkgs`. Run `winget validate` against that directory, install
+from the local manifests, and then open a pull request. Do not replace the
+previous version directory.
+
+Add package-manager commands to the project README only after each upstream
+manifest is accepted. Until then, the checked-in manifests are publication
+sources, not working install channels.

--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.12.0",
+    "description": "Persistent memory for coding agents",
+    "homepage": "https://github.com/vshulcz/deja-vu",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.12.0/deja-vu_0.12.0_windows_amd64.zip",
+            "hash": "fd32a9d1ef0ba07407b3045c84b5596893999028300c9e1c37c973e85be8f209"
+        },
+        "arm64": {
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.12.0/deja-vu_0.12.0_windows_arm64.zip",
+            "hash": "84d1bb250e59b9f07ea535cfde08dd10985ab4db953e64fbe5b5a081a7cb81cd"
+        }
+    },
+    "bin": "deja.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/vshulcz/deja-vu/releases/download/v$version/deja-vu_$version_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/vshulcz/deja-vu/releases/download/v$version/deja-vu_$version_windows_arm64.zip"
+            }
+        }
+    }
+}

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: vshulcz.deja-vu
+PackageVersion: 0.12.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: deja.exe
+  PortableCommandAlias: deja
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.12.0/deja-vu_0.12.0_windows_amd64.zip
+  InstallerSha256: FD32A9D1EF0BA07407B3045C84B5596893999028300C9E1C37C973E85BE8F209
+- Architecture: arm64
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.12.0/deja-vu_0.12.0_windows_arm64.zip
+  InstallerSha256: 84D1BB250E59B9F07EA535CFDE08DD10985AB4DB953E64FBE5B5A081A7CB81CD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,0 +1,22 @@
+PackageIdentifier: vshulcz.deja-vu
+PackageVersion: 0.12.0
+PackageLocale: en-US
+Publisher: vshulcz
+PublisherUrl: https://github.com/vshulcz
+PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
+PackageName: deja-vu
+PackageUrl: https://github.com/vshulcz/deja-vu
+License: MIT
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.12.0/LICENSE
+ShortDescription: Persistent memory for coding agents
+Tags:
+- aider
+- claude-code
+- cli
+- codex
+- cursor
+- mcp
+- memory
+ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.12.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: vshulcz.deja-vu
+PackageVersion: 0.12.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Case-insensitive extension and directory matching where Windows filesystems need it, path-component checks instead of separator-substring games, and a cleaner root-terminated walk in the cursor transcript resolver, each with a regression test. packaging/ gains a scoop manifest and a three-file winget set for the portable zip — hashes match the v0.12.0 checksums.txt — plus a release-time checklist. Closes #113