### PR TITLE
feat: add session format registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, 
 
 `DEJA_RECALL=safe` is the default: SessionStart recall stays in the current project, filters weak or duplicate results, prefers the last 90 days, and injects at most 2KB. `DEJA_RECALL=aggressive` searches across projects and raises the injection cap to 4KB. `DEJA_RECALL=off` disables SessionStart recall output.
 
+### Session format registry
+
+The [session format registry](docs/registry/README.md) documents the observed store paths, record schemas, role mapping, timestamps, and compatibility notes for each supported harness. Synthetic fixtures keep those descriptions checked against the parsers.
+
 ## Performance
 
 Measured on a real corpus — 1,250+ sessions, ~3.3GB across three harnesses:

--- a/docs/registry/README.md
+++ b/docs/registry/README.md
@@ -1,0 +1,32 @@
+# Session format registry
+
+This registry records observed on-disk session formats for the harnesses that deja parses. Each entry describes store discovery, file layout, message records, role and timestamp handling, and known compatibility behavior. These are observations of upstream output, not specifications published by the harness vendors.
+
+[`registry.json`](registry.json) is the machine-readable index. The files under [`fixtures/registry`](../../fixtures/registry) are synthetic conformance samples shaped like upstream records. `internal/sources/registry_test.go` checks the index against deja's loader list and runs each fixture through its parser.
+
+## Entries
+
+| Harness | Format |
+| --- | --- |
+| [Claude Code](claude-code.md) | JSONL transcript |
+| [Codex CLI](codex.md) | rollout and history JSONL |
+| [opencode](opencode.md) | SQLite relational store |
+| [Cursor](cursor.md) | SQLite key-value store and JSONL transcript |
+| [Gemini CLI](gemini.md) | session JSON and replayable JSONL |
+| [aider](aider.md) | append-only Markdown |
+| [Antigravity](antigravity.md) | JSONL transcript |
+| [Grok Build](grok.md) | ACP update JSONL with JSON metadata |
+
+## Reporting drift
+
+Open an issue with the harness name and version, operating system, observed store path, and the smallest redacted record that shows the difference. State whether the change affects discovery, session metadata, roles, content, or timestamps. Do not attach a real session database or unredacted transcript.
+
+## Adding or updating a format
+
+1. Update the harness reference page from observed records and note the drift under **Known quirks and drift**.
+2. Add a synthetic fixture that contains no user data or credentials.
+3. Add or update the `registry.json` entry. Paths are repository-relative; store paths use environment-variable placeholders where applicable.
+4. Update the parser and its focused tests, then run the registry conformance test and the full suite.
+5. Set **Last verified** to the observation date and **deja parser version** to the version used for verification.
+
+SQLite fixture sources are stored as SQL so changes remain reviewable. The conformance test materializes them in a temporary directory before parsing.

--- a/docs/registry/aider.md
+++ b/docs/registry/aider.md
@@ -1,0 +1,34 @@
+# aider session format
+
+## Store and files
+
+aider appends Markdown to `.aider.chat.history.md` in its launch directory. The default home file is `~/.aider.chat.history.md`; `AIDER_CHAT_HISTORY_FILE` relocates it. deja also scans each directory in the platform path-list variable `DEJA_AIDER_ROOTS`, to two levels below each root.
+
+One history file contains multiple sessions. A session begins with:
+
+```markdown
+# aider chat started at 2026-07-17 09:00:00
+
+#### Show me the failing query
+
+The query misses the tenant predicate.
+
+> Applied edit to query.go
+```
+
+## Message mapping
+
+Outside fenced code blocks, `#### ` starts or continues a user message. Plain Markdown is assistant output. Lines beginning with `> ` are tool or system output and are not indexed. Blank lines remain part of the current message.
+
+The header timestamp uses local time with layout `YYYY-MM-DD HH:MM:SS`. aider does not store message timestamps, so every message receives the session start. It does not store a session ID; deja derives a stable ID from the history path and the session's ordinal in that file.
+
+## Known quirks and drift
+
+- The file is append-only and can contain many launches.
+- Markdown fences may contain lines beginning with `#### ` or `>`; these are content, not role markers. The parser tracks triple-backtick fences.
+- `<blank>` after the user prefix represents an empty line.
+- Tool output terminates an assistant block but does not become a message.
+- Moving a history file changes deja's derived session IDs because the path is part of the ID.
+
+**Last verified:** 2026-07-17
+**deja parser version:** v0.12.0-1-g9e2088c

--- a/docs/registry/antigravity.md
+++ b/docs/registry/antigravity.md
@@ -1,0 +1,27 @@
+# Antigravity session format
+
+## Store and files
+
+Antigravity stores transcripts at `~/.gemini/antigravity*/brain/<session-id>/.system_generated/logs/transcript.jsonl`. The wildcard reflects observed versioned or profile-specific roots. `DEJA_ANTIGRAVITY_ROOT` replaces root discovery.
+
+## Records
+
+Each line has a source, content, and creation time:
+
+```json
+{"source":"USER_EXPLICIT","created_at":"2026-07-17T09:00:00Z","content":"<USER_REQUEST>Check the build.<ADDITIONAL_METADATA>{\"cwd\":\"/work/api\"}</ADDITIONAL_METADATA></USER_REQUEST>"}
+```
+
+`USER_EXPLICIT` maps to `user` and `MODEL` maps to `assistant`. Other sources are ignored. `created_at` is RFC 3339. The directory below `brain` is the session ID; the transcript does not currently provide project metadata, so deja records `-`.
+
+Before indexing user text, deja removes the outer `<USER_REQUEST>` wrapper and complete `<ADDITIONAL_METADATA>` and `<USER_SETTINGS_CHANGE>` blocks. Assistant content is retained as written. Content is capped at 64 KiB.
+
+## Known quirks and drift
+
+- User-visible content and machine metadata share one string field.
+- System events and other source values can be interleaved with conversation records.
+- A malformed or partially written JSONL line is skipped.
+- If a timestamp is absent, later messages fall back to the session start when one has already been observed.
+
+**Last verified:** 2026-07-17
+**deja parser version:** v0.12.0-1-g9e2088c

--- a/docs/registry/claude-code.md
+++ b/docs/registry/claude-code.md
@@ -1,0 +1,27 @@
+# Claude Code session format
+
+## Store and files
+
+Claude Code writes transcripts below `${CLAUDE_CONFIG_DIR:-~/.claude}/projects/`. deja can point only session reads elsewhere with `DEJA_CLAUDE_ROOT`. Files are JSONL and normally named for a session ID. A project directory encodes an absolute path by replacing both separators and literal hyphens with `-`; nested `subagents/*.jsonl` files are excluded unless `DEJA_INCLUDE_SUBAGENTS=1`.
+
+The top-level `~/.claude.json` is not a transcript. When `CLAUDE_CONFIG_DIR` is set, Claude moves that file to `$CLAUDE_CONFIG_DIR/.claude.json`.
+
+## Records
+
+Message records have `type`, `sessionId`, `timestamp`, and a `message` object. `message.content` is either a string or an array whose useful parts have `text` or `content`.
+
+```json
+{"type":"assistant","sessionId":"session-7","timestamp":"2026-07-17T09:00:01Z","message":{"role":"assistant","content":[{"type":"text","text":"The failing check is in parser.go."}]}}
+```
+
+`type: "user"` maps to `user` and `type: "assistant"` maps to `assistant`; a non-empty `message.role` takes precedence. Timestamps are RFC 3339 strings in observed files. deja also accepts numeric Unix seconds or milliseconds.
+
+## Known quirks and drift
+
+- JSONL can end in a partial line while Claude is writing. Malformed lines are skipped; a later indexing pass reads the completed tail.
+- Tool and control records use other `type` values and do not become messages.
+- Project path encoding is ambiguous because `-` represents both a separator and a hyphen. deja checks the local filesystem before using a two-segment fallback.
+- Subagent logs largely duplicate parent content and are opt-in.
+
+**Last verified:** 2026-07-17
+**deja parser version:** v0.12.0-1-g9e2088c

--- a/docs/registry/codex.md
+++ b/docs/registry/codex.md
@@ -1,0 +1,36 @@
+# Codex CLI session format
+
+## Store and files
+
+Codex stores state under `${CODEX_HOME:-~/.codex}`. deja's read-only override is `DEJA_CODEX_ROOT`. Rollouts are `sessions/YYYY/MM/DD/rollout-*.jsonl`; a separate `history.jsonl` contains prompt history.
+
+## Rollout records
+
+A rollout begins with session metadata and then event records. The parser reads `payload.role`, `payload.content`, and the older `payload.message` fallback.
+
+```json
+{"timestamp":"2026-07-17T09:00:00Z","type":"session_meta","payload":{"session_id":"session-7","cwd":"/work/api"}}
+{"timestamp":"2026-07-17T09:00:01Z","type":"response_item","payload":{"role":"assistant","content":[{"type":"output_text","text":"The migration is complete."}]}}
+```
+
+`payload.role` is retained. When only `payload.message` is present, deja treats it as a user message. Content may be a string or an array of text-bearing parts. `session_meta` supplies the stable ID and project working directory. Timestamps accept RFC 3339, Unix seconds, or Unix milliseconds.
+
+## Prompt history
+
+Each history line is independent:
+
+```json
+{"session_id":"session-7","ts":1784278801,"text":"check the migration"}
+```
+
+History entries map to one-message sessions with role `user` and project `history`. The same prompt may also occur in its rollout; consumers should expect this duplication.
+
+## Known quirks and drift
+
+- Rollout files are append-only JSONL and may have a torn final line.
+- Events without a payload and non-message payloads are ignored.
+- `history.jsonl` duplicates user prompts but lacks assistant responses and project metadata.
+- Older records use `payload.message`; current records generally use structured `payload.content`.
+
+**Last verified:** 2026-07-17
+**deja parser version:** v0.12.0-1-g9e2088c

--- a/docs/registry/cursor.md
+++ b/docs/registry/cursor.md
@@ -1,0 +1,36 @@
+# Cursor session format
+
+## Stores and files
+
+Cursor IDE stores chats in `state.vscdb` under `globalStorage/` and `workspaceStorage/*/`. The user root is `~/Library/Application Support/Cursor/User` on macOS and `~/.config/Cursor/User` on other systems; an existing `$XDG_CONFIG_HOME/Cursor/User` is used when available. `DEJA_CURSOR_ROOT` overrides IDE discovery.
+
+Cursor CLI writes `projects/<encoded-path>/agent-transcripts/**/*.jsonl` below `${CURSOR_CONFIG_DIR:-~/.cursor}`. `DEJA_CURSOR_CLI_ROOT` overrides transcript reads. Subagent transcripts are excluded unless `DEJA_INCLUDE_SUBAGENTS=1`.
+
+## IDE SQLite records
+
+The `cursorDiskKV(key, value)` table has session values at `composerData:<id>` and message values at `bubbleId:<composer-id>:<bubble-id>`.
+
+```json
+{"composerId":"composer-7","name":"Fix cache invalidation","createdAt":1784278800000,"lastUpdatedAt":1784278802000}
+{"type":1,"text":"Why is this stale?","timestamp":1784278801000,"workspaceProjectDir":"/work/api"}
+```
+
+Bubble `type: 1` maps to `user`; other numeric types map to `assistant`. Text uses `text`, falling back to `rawText`. Timestamps are Unix milliseconds. The first bubble with `workspaceProjectDir` supplies the project. Reading SQLite requires the `sqlite3` CLI.
+
+## CLI JSONL records
+
+```json
+{"role":"assistant","message":{"content":[{"type":"text","text":"The cache key omitted the locale."}]}}
+```
+
+Only `user` and `assistant` roles are retained. Content follows the Anthropic string-or-parts shape. Control records such as `turn_ended` are ignored. The transcript has no message timestamps, so deja uses file modification time.
+
+## Known quirks and drift
+
+- Cursor moved modern IDE chats toward global storage while older versions used workspace databases; both are scanned.
+- SQLite values are JSON inside a key-value table and malformed or null entries occur.
+- CLI project path encoding has the same separator-versus-hyphen ambiguity as Claude Code.
+- SQLite text is capped at 64 KiB. CLI subagent duplication is opt-in.
+
+**Last verified:** 2026-07-17
+**deja parser version:** v0.12.0-1-g9e2088c

--- a/docs/registry/gemini.md
+++ b/docs/registry/gemini.md
@@ -1,0 +1,29 @@
+# Gemini CLI session format
+
+## Store and files
+
+Gemini CLI stores chats under `~/.gemini/tmp/<project-id>/chats/`. If `GEMINI_CLI_HOME` is set, Gemini appends `.gemini` to that directory. deja can override only session reads with `DEJA_GEMINI_ROOT`.
+
+Two generations coexist: whole-session `.json` files and replayable `.jsonl` files. `projects.json` maps working directories to project IDs; a per-project `.project_root` file is another observed source for the project name.
+
+## Records
+
+Whole-session JSON has `sessionId`, `startTime`, `lastUpdated`, and a `messages` array. JSONL puts the session fields on its first metadata line, followed by message and control lines.
+
+```json
+{"sessionId":"session-7","startTime":"2026-07-17T09:00:00Z","lastUpdated":"2026-07-17T09:00:02Z"}
+{"id":"message-1","timestamp":"2026-07-17T09:00:01Z","type":"gemini","content":[{"text":"The configuration is valid."}]}
+```
+
+`type: "user"` maps to `user`; `gemini` and `model` map to `assistant`. Other types, including informational and error events, are ignored. Content is a string or an array of parts with `text`. All documented timestamps are RFC 3339; a missing message timestamp falls back to session start.
+
+## Known quirks and drift
+
+- A resumed legacy `.json` session can be rewritten as `.jsonl`. deja deduplicates by session ID and prefers JSONL.
+- JSONL `$set.lastUpdated` patches session metadata.
+- `$rewindTo` replays history by removing the referenced message and everything after it before later records are applied.
+- The chats tree also contains non-session JSON such as checkpoints; files without a valid session ID and messages are ignored.
+- Nested subagent chat files occur below a parent chat directory.
+
+**Last verified:** 2026-07-17
+**deja parser version:** v0.12.0-1-g9e2088c

--- a/docs/registry/grok.md
+++ b/docs/registry/grok.md
@@ -1,0 +1,30 @@
+# Grok Build session format
+
+## Store and files
+
+Grok Build stores sessions below `${GROK_HOME:-~/.grok}/sessions/<encoded-cwd>/<session-id>/`. `DEJA_GROK_ROOT` overrides the read root. `updates.jsonl` is the conversation stream and sibling `summary.json` carries metadata. A `.cwd` file beside session directories can recover the working directory when summary metadata is absent.
+
+The working-directory group is URL-encoded, although observed names are not always encoded consistently. deja prefers `summary.json` and `.cwd` over decoding the directory name.
+
+## Records
+
+`summary.json` includes `info.id`, `info.cwd`, titles, and RFC 3339 creation/update times. Conversation lines use ACP session updates:
+
+```json
+{"timestamp":1784278802,"params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"The first chunk "}},"_meta":{"promptId":"prompt-1"}}}
+```
+
+`user_message_chunk` maps to `user` and `agent_message_chunk` maps to `assistant`. Content is usually `{ "type": "text", "text": "..." }`; arrays of text-bearing parts are also accepted. Timestamps accept Unix seconds or milliseconds. `_meta.agentTimestampMs` is the fallback.
+
+Consecutive assistant chunks with the same `promptId` are joined. Consecutive user chunks with the same `promptIndex` are joined.
+
+## Known quirks and drift
+
+- The ACP stream contains large tool updates. deja filters lines for message chunk kinds before decoding JSON.
+- Rewind can truncate and regrow `updates.jsonl`; changed streams are reparsed in full.
+- `generated_title` takes precedence over `session_summary`.
+- Missing summary files fall back to directory IDs and the `.cwd` or URL-decoded path.
+- Path encoding is ambiguous when upstream leaves separators or percent escapes in different forms.
+
+**Last verified:** 2026-07-17
+**deja parser version:** v0.12.0-1-g9e2088c

--- a/docs/registry/opencode.md
+++ b/docs/registry/opencode.md
@@ -1,0 +1,35 @@
+# opencode session format
+
+## Store and files
+
+opencode stores sessions in `~/.local/share/opencode/opencode.db`. On Linux it honors `XDG_DATA_HOME`, producing `$XDG_DATA_HOME/opencode/opencode.db`; deja also accepts `DEJA_OPENCODE_DB`. The store is SQLite and deja reads it through the `sqlite3` command-line tool.
+
+## Schema
+
+The parser joins three tables:
+
+```sql
+session(id, directory, time_created, time_updated)
+message(id, session_id, time_created, data)
+part(id, message_id, data)
+```
+
+`message.data` and `part.data` are JSON. A real-shaped pair is:
+
+```json
+{"role":"assistant","time":{"created":"2026-07-17T09:00:01Z"}}
+{"type":"text","text":"The query now uses the index.","time":{"start":"2026-07-17T09:00:01Z"}}
+```
+
+Only parts with `type: "text"` are messages. The role comes from `message.data.role`. Message time prefers `part.data.time.start`, then `message.data.time.created`; session times come from the `session` row. Strings in RFC 3339 form and numeric Unix seconds or milliseconds are accepted. `session.directory` supplies the project.
+
+## Known quirks and drift
+
+- The database can be several gigabytes. deja projects JSON scalars in SQL instead of streaming complete blobs.
+- Message content is split across `message` and `part`; one message can have several parts.
+- Non-text parts, including tool data, are ignored. Text is capped at 64 KiB per part.
+- A missing database must not be passed to SQLite because the CLI would create it.
+- The committed conformance fixture is SQL rather than a binary database; the test creates a temporary SQLite file.
+
+**Last verified:** 2026-07-17
+**deja parser version:** v0.12.0-1-g9e2088c

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "harnesses": [
+    {
+      "id": "claude",
+      "store_paths": ["${CLAUDE_CONFIG_DIR:-~/.claude}/projects/**/*.jsonl", "${DEJA_CLAUDE_ROOT}/**/*.jsonl"],
+      "format_kind": "jsonl",
+      "fixture_paths": ["fixtures/registry/claude-code/session.jsonl"],
+      "parser_source": "internal/sources/claude.go",
+      "last_verified": "2026-07-17"
+    },
+    {
+      "id": "codex",
+      "store_paths": ["${CODEX_HOME:-~/.codex}/sessions/**/rollout-*.jsonl", "${CODEX_HOME:-~/.codex}/history.jsonl", "${DEJA_CODEX_ROOT}/sessions/**/rollout-*.jsonl"],
+      "format_kind": "jsonl-rollout-and-history",
+      "fixture_paths": ["fixtures/registry/codex/rollout-2026-07-17T09-00-00-registry-codex.jsonl"],
+      "parser_source": "internal/sources/codex.go",
+      "last_verified": "2026-07-17"
+    },
+    {
+      "id": "opencode",
+      "store_paths": ["~/.local/share/opencode/opencode.db", "${XDG_DATA_HOME}/opencode/opencode.db", "${DEJA_OPENCODE_DB}"],
+      "format_kind": "sqlite",
+      "fixture_paths": ["fixtures/registry/opencode/opencode.sql"],
+      "parser_source": "internal/sources/opencode.go",
+      "last_verified": "2026-07-17"
+    },
+    {
+      "id": "aider",
+      "store_paths": ["~/.aider.chat.history.md", "${AIDER_CHAT_HISTORY_FILE}", "${DEJA_AIDER_ROOTS}/**/.aider.chat.history.md"],
+      "format_kind": "markdown-log",
+      "fixture_paths": ["fixtures/registry/aider/.aider.chat.history.md"],
+      "parser_source": "internal/sources/aider.go",
+      "last_verified": "2026-07-17"
+    },
+    {
+      "id": "gemini",
+      "store_paths": ["${GEMINI_CLI_HOME:-~}/.gemini/tmp/*/chats/**/*.{json,jsonl}", "${DEJA_GEMINI_ROOT}/tmp/*/chats/**/*.{json,jsonl}"],
+      "format_kind": "json-or-jsonl",
+      "fixture_paths": ["fixtures/registry/gemini/session.jsonl"],
+      "parser_source": "internal/sources/gemini.go",
+      "last_verified": "2026-07-17"
+    },
+    {
+      "id": "cursor",
+      "store_paths": ["~/Library/Application Support/Cursor/User/{globalStorage,workspaceStorage/*}/state.vscdb", "~/.config/Cursor/User/{globalStorage,workspaceStorage/*}/state.vscdb", "${CURSOR_CONFIG_DIR:-~/.cursor}/projects/**/agent-transcripts/**/*.jsonl", "${DEJA_CURSOR_ROOT}", "${DEJA_CURSOR_CLI_ROOT}"],
+      "format_kind": "sqlite-kv-or-jsonl",
+      "fixture_paths": ["fixtures/registry/cursor/projects/registry-demo/agent-transcripts/registry-cursor.jsonl"],
+      "parser_source": "internal/sources/cursor.go",
+      "last_verified": "2026-07-17"
+    },
+    {
+      "id": "antigravity",
+      "store_paths": ["~/.gemini/antigravity*/brain/*/.system_generated/logs/transcript.jsonl", "${DEJA_ANTIGRAVITY_ROOT}/brain/*/.system_generated/logs/transcript.jsonl"],
+      "format_kind": "jsonl",
+      "fixture_paths": ["fixtures/registry/antigravity/brain/registry-antigravity/.system_generated/logs/transcript.jsonl"],
+      "parser_source": "internal/sources/antigravity.go",
+      "last_verified": "2026-07-17"
+    },
+    {
+      "id": "grok",
+      "store_paths": ["${GROK_HOME:-~/.grok}/sessions/**/updates.jsonl", "${DEJA_GROK_ROOT}/sessions/**/updates.jsonl"],
+      "format_kind": "acp-jsonl-with-json-metadata",
+      "fixture_paths": ["fixtures/registry/grok/sessions/workspace%2Fregistry-demo/registry-grok/updates.jsonl"],
+      "parser_source": "internal/sources/grok.go",
+      "last_verified": "2026-07-17"
+    }
+  ]
+}

--- a/fixtures/registry/aider/.aider.chat.history.md
+++ b/fixtures/registry/aider/.aider.chat.history.md
@@ -1,0 +1,5 @@
+# aider chat started at 2026-07-17 09:00:00
+
+#### inspect the markdown history
+
+The history is readable.

--- a/fixtures/registry/antigravity/brain/registry-antigravity/.system_generated/logs/transcript.jsonl
+++ b/fixtures/registry/antigravity/brain/registry-antigravity/.system_generated/logs/transcript.jsonl
@@ -1,0 +1,2 @@
+{"source":"USER_EXPLICIT","created_at":"2026-07-17T09:00:00Z","content":"<USER_REQUEST>inspect the antigravity transcript<ADDITIONAL_METADATA>{\"cwd\":\"/workspace/registry-demo\"}</ADDITIONAL_METADATA></USER_REQUEST>"}
+{"source":"MODEL","created_at":"2026-07-17T09:00:01Z","content":"the transcript is readable"}

--- a/fixtures/registry/claude-code/session.jsonl
+++ b/fixtures/registry/claude-code/session.jsonl
@@ -1,0 +1,2 @@
+{"type":"user","sessionId":"registry-claude","timestamp":"2026-07-17T09:00:00Z","message":{"role":"user","content":"inspect the registry fixture"}}
+{"type":"assistant","sessionId":"registry-claude","timestamp":"2026-07-17T09:00:01Z","message":{"role":"assistant","content":[{"type":"text","text":"the fixture has a valid message pair"}]}}

--- a/fixtures/registry/codex/rollout-2026-07-17T09-00-00-registry-codex.jsonl
+++ b/fixtures/registry/codex/rollout-2026-07-17T09-00-00-registry-codex.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":"2026-07-17T09:00:00Z","type":"session_meta","payload":{"session_id":"registry-codex","cwd":"/workspace/registry-demo"}}
+{"timestamp":"2026-07-17T09:00:01Z","type":"response_item","payload":{"role":"user","content":[{"type":"input_text","text":"inspect the rollout"}]}}
+{"timestamp":"2026-07-17T09:00:02Z","type":"response_item","payload":{"role":"assistant","content":[{"type":"output_text","text":"the rollout is readable"}]}}

--- a/fixtures/registry/cursor/projects/registry-demo/agent-transcripts/registry-cursor.jsonl
+++ b/fixtures/registry/cursor/projects/registry-demo/agent-transcripts/registry-cursor.jsonl
@@ -1,0 +1,3 @@
+{"role":"user","message":{"content":[{"type":"text","text":"inspect the cursor transcript"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"the transcript is readable"}]}}
+{"type":"turn_ended","status":"success"}

--- a/fixtures/registry/gemini/session.jsonl
+++ b/fixtures/registry/gemini/session.jsonl
@@ -1,0 +1,3 @@
+{"sessionId":"registry-gemini","startTime":"2026-07-17T09:00:00Z","lastUpdated":"2026-07-17T09:00:02Z"}
+{"id":"message-user","timestamp":"2026-07-17T09:00:01Z","type":"user","content":"inspect the gemini session"}
+{"id":"message-assistant","timestamp":"2026-07-17T09:00:02Z","type":"gemini","content":[{"text":"the session is readable"}]}

--- a/fixtures/registry/grok/sessions/workspace%2Fregistry-demo/registry-grok/summary.json
+++ b/fixtures/registry/grok/sessions/workspace%2Fregistry-demo/registry-grok/summary.json
@@ -1,0 +1,1 @@
+{"info":{"id":"registry-grok","cwd":"/workspace/registry-demo"},"session_summary":"Registry fixture","generated_title":"Inspect registry fixture","created_at":"2026-07-17T09:00:00Z","updated_at":"2026-07-17T09:00:03Z"}

--- a/fixtures/registry/grok/sessions/workspace%2Fregistry-demo/registry-grok/updates.jsonl
+++ b/fixtures/registry/grok/sessions/workspace%2Fregistry-demo/registry-grok/updates.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":1784278801,"params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"inspect the grok stream"},"_meta":{"promptIndex":0}}}}
+{"timestamp":1784278802,"params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"the stream "}},"_meta":{"promptId":"prompt-1"}}}
+{"timestamp":1784278803,"params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"is readable"}},"_meta":{"promptId":"prompt-1"}}}

--- a/fixtures/registry/opencode/opencode.sql
+++ b/fixtures/registry/opencode/opencode.sql
@@ -1,0 +1,8 @@
+create table session (id text primary key, directory text, time_created any, time_updated any);
+create table message (id text primary key, session_id text, time_created any, data text);
+create table part (id text primary key, message_id text, data text);
+insert into session values ('registry-opencode', '/workspace/registry-demo', '2026-07-17T09:00:00Z', '2026-07-17T09:00:02Z');
+insert into message values ('message-user', 'registry-opencode', 1784278801000, '{"role":"user","time":{"created":"2026-07-17T09:00:01Z"}}');
+insert into message values ('message-assistant', 'registry-opencode', 1784278802000, '{"role":"assistant","time":{"created":"2026-07-17T09:00:02Z"}}');
+insert into part values ('part-user', 'message-user', '{"type":"text","text":"inspect the sqlite fixture","time":{"start":"2026-07-17T09:00:01Z"}}');
+insert into part values ('part-assistant', 'message-assistant', '{"type":"text","text":"the sqlite rows are readable","time":{"start":"2026-07-17T09:00:02Z"}}');

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -1,0 +1,190 @@
+package sources
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+type formatRegistry struct {
+	SchemaVersion int                   `json:"schema_version"`
+	Harnesses     []formatRegistryEntry `json:"harnesses"`
+}
+
+type formatRegistryEntry struct {
+	ID           string   `json:"id"`
+	StorePaths   []string `json:"store_paths"`
+	FormatKind   string   `json:"format_kind"`
+	FixturePaths []string `json:"fixture_paths"`
+	ParserSource string   `json:"parser_source"`
+	LastVerified string   `json:"last_verified"`
+}
+
+func TestFormatRegistryConformance(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	for _, key := range []string{
+		"AIDER_CHAT_HISTORY_FILE", "CLAUDE_CONFIG_DIR", "CODEX_HOME",
+		"CURSOR_CONFIG_DIR", "DEJA_AIDER_ROOTS", "DEJA_ANTIGRAVITY_ROOT",
+		"DEJA_CLAUDE_ROOT", "DEJA_CODEX_ROOT", "DEJA_CURSOR_CLI_ROOT",
+		"DEJA_CURSOR_ROOT", "DEJA_GEMINI_ROOT", "DEJA_GROK_ROOT",
+		"DEJA_INCLUDE_SUBAGENTS", "DEJA_OPENCODE_DB", "GEMINI_CLI_HOME",
+		"GROK_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+	} {
+		t.Setenv(key, "")
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(home, "claude"))
+	t.Setenv("DEJA_GEMINI_ROOT", filepath.Join(home, "gemini"))
+
+	registry := readFormatRegistry(t, filepath.Join(root, "docs", "registry", "registry.json"))
+	if registry.SchemaVersion != 1 {
+		t.Fatalf("schema_version = %d, want 1", registry.SchemaVersion)
+	}
+
+	registered := make([]string, 0, len(registry.Harnesses))
+	seen := map[string]bool{}
+	for _, entry := range registry.Harnesses {
+		if entry.ID == "" || seen[entry.ID] {
+			t.Fatalf("invalid or duplicate harness id %q", entry.ID)
+		}
+		seen[entry.ID] = true
+		registered = append(registered, entry.ID)
+		validateRegistryEntry(t, root, entry)
+
+		entry := entry
+		t.Run(entry.ID, func(t *testing.T) {
+			for _, fixture := range entry.FixturePaths {
+				fixture := filepath.Join(root, filepath.FromSlash(fixture))
+				sessions := parseRegistryFixture(t, entry.ID, fixture)
+				validateRegistrySessions(t, entry.ID, sessions)
+			}
+		})
+	}
+
+	loaders := harnessLoaderIDs(t, filepath.Join(root, "internal", "index", "index.go"))
+	sort.Strings(registered)
+	if strings.Join(registered, ",") != strings.Join(loaders, ",") {
+		t.Fatalf("registry harnesses = %v, harnessLoaders = %v", registered, loaders)
+	}
+}
+
+func readFormatRegistry(t *testing.T, path string) formatRegistry {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var registry formatRegistry
+	if err := json.Unmarshal(b, &registry); err != nil {
+		t.Fatal(err)
+	}
+	return registry
+}
+
+func validateRegistryEntry(t *testing.T, root string, entry formatRegistryEntry) {
+	t.Helper()
+	if len(entry.StorePaths) == 0 || entry.FormatKind == "" || len(entry.FixturePaths) == 0 || entry.ParserSource == "" {
+		t.Fatalf("incomplete registry entry for %q: %#v", entry.ID, entry)
+	}
+	if _, err := time.Parse("2006-01-02", entry.LastVerified); err != nil {
+		t.Fatalf("%s last_verified: %v", entry.ID, err)
+	}
+	paths := append(append([]string(nil), entry.FixturePaths...), entry.ParserSource)
+	for _, path := range paths {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(path))); err != nil {
+			t.Fatalf("%s path %q: %v", entry.ID, path, err)
+		}
+	}
+}
+
+func parseRegistryFixture(t *testing.T, id, path string) []model.Session {
+	t.Helper()
+	var (
+		sessions []model.Session
+		err      error
+	)
+	switch id {
+	case "claude":
+		sessions, err = ParseClaudeFile(path)
+	case "codex":
+		sessions, err = ParseCodexRollout(path)
+	case "opencode":
+		if !SQLite3Available() {
+			t.Skip("sqlite3 not installed")
+		}
+		sql, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		db := filepath.Join(t.TempDir(), "opencode.db")
+		if out, runErr := exec.Command("sqlite3", db, string(sql)).CombinedOutput(); runErr != nil {
+			t.Fatalf("create sqlite fixture: %v: %s", runErr, out)
+		}
+		sessions, err = ParseOpencodeDB(db)
+	case "aider":
+		sessions, err = ParseAiderFile(path)
+	case "gemini":
+		sessions, err = ParseGeminiFile(path)
+	case "cursor":
+		sessions, err = ParseCursorTranscript(path)
+	case "antigravity":
+		sessions, err = ParseAntigravityFile(path)
+	case "grok":
+		sessions, err = ParseGrokFile(path)
+	default:
+		t.Fatalf("no conformance parser for %q", id)
+	}
+	if err != nil {
+		t.Fatalf("parse %s fixture: %v", id, err)
+	}
+	return sessions
+}
+
+func validateRegistrySessions(t *testing.T, id string, sessions []model.Session) {
+	t.Helper()
+	if len(sessions) == 0 {
+		t.Fatalf("%s fixture produced no sessions", id)
+	}
+	for _, session := range sessions {
+		if session.Harness != id || session.ID == "" || session.Project == "" || session.Path == "" {
+			t.Fatalf("%s fixture produced invalid session: %#v", id, session)
+		}
+		if session.Started.IsZero() || session.Updated.IsZero() || len(session.Messages) == 0 {
+			t.Fatalf("%s fixture produced incomplete session: %#v", id, session)
+		}
+		for _, message := range session.Messages {
+			if (message.Role != "user" && message.Role != "assistant") || strings.TrimSpace(message.Text) == "" || message.Time.IsZero() {
+				t.Fatalf("%s fixture produced invalid message: %#v", id, message)
+			}
+		}
+	}
+}
+
+func harnessLoaderIDs(t *testing.T, path string) []string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	re := regexp.MustCompile(`\{"([a-z0-9-]+)", sources\.Load[A-Za-z]+\}`)
+	matches := re.FindAllSubmatch(b, -1)
+	ids := make([]string, 0, len(matches))
+	for _, match := range matches {
+		ids = append(ids, string(match[1]))
+	}
+	if len(ids) == 0 {
+		t.Fatal("no harnessLoaders entries found")
+	}
+	sort.Strings(ids)
+	return ids
+}


### PR DESCRIPTION
Closes #115. Adds docs/registry/ with one doc per harness format, a registry.json index, synthetic fixtures, and a conformance test that runs each fixture through its parser.