### PR TITLE
docs: add security model and contributor guidance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 * @vshulcz
+
+# Parser ownership template; uncomment and replace the owner when delegated.
+# /internal/sources/claude.go @parser-maintainer
+# /internal/sources/claude_test.go @parser-maintainer

--- a/.github/ISSUE_TEMPLATE/format-drift.yml
+++ b/.github/ISSUE_TEMPLATE/format-drift.yml
@@ -1,0 +1,67 @@
+name: Session format drift
+description: Report an existing harness whose sessions stopped indexing correctly
+title: "format drift: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Do not include credentials, private source code, or an unreviewed session
+        file. Replace identifying values in all pasted output.
+  - type: dropdown
+    id: harness
+    attributes:
+      label: Harness
+      options:
+        - Claude Code
+        - Codex CLI
+        - opencode
+        - aider
+        - Gemini CLI
+        - Cursor
+        - Antigravity
+        - Grok Build
+    validations:
+      required: true
+  - type: input
+    id: agent-version
+    attributes:
+      label: Agent version
+      description: Exact version and installation method, if known.
+      placeholder: "1.2.3 installed with Homebrew"
+    validations:
+      required: true
+  - type: textarea
+    id: sample
+    attributes:
+      label: Minimal redacted sample
+      description: >-
+        Paste the smallest session fragment that demonstrates the new shape.
+        Preserve field names and nesting, but replace message text, paths, IDs,
+        account data, and credentials.
+      render: json
+    validations:
+      required: true
+  - type: textarea
+    id: doctor
+    attributes:
+      label: deja doctor output
+      description: Run `deja doctor` and redact local paths before pasting.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Observed behavior
+      description: State what stopped indexing and when it last worked.
+    validations:
+      required: true
+  - type: checkboxes
+    id: redaction
+    attributes:
+      label: Data review
+      options:
+        - label: I reviewed the sample and doctor output for secrets and private data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/parser-request.yml
+++ b/.github/ISSUE_TEMPLATE/parser-request.yml
@@ -1,0 +1,56 @@
+name: New harness parser
+description: Request indexing support for another coding agent
+title: "parser: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Do not upload a complete private history. Provide a minimal synthetic or
+        reviewed sample with credentials, source code, paths, and IDs replaced.
+  - type: input
+    id: harness
+    attributes:
+      label: Harness
+      placeholder: Agent name and version
+    validations:
+      required: true
+  - type: textarea
+    id: locations
+    attributes:
+      label: Session locations
+      description: >-
+        List default paths on each supported OS and any documented environment
+        variable that relocates the store.
+      placeholder: "Linux/macOS: ~/.example/sessions/*.jsonl"
+    validations:
+      required: true
+  - type: textarea
+    id: sample
+    attributes:
+      label: Minimal redacted sample
+      description: Preserve the fields and nesting needed to parse one exchange.
+      render: json
+    validations:
+      required: true
+  - type: input
+    id: resume
+    attributes:
+      label: Resume command
+      description: Command that reopens a session by ID, or "none".
+      placeholder: "example --resume <session-id>"
+    validations:
+      required: true
+  - type: textarea
+    id: integration
+    attributes:
+      label: Integration notes
+      description: Documented MCP configuration, hooks, and SQLite CLI requirements, if any.
+  - type: checkboxes
+    id: redaction
+    attributes:
+      label: Data review
+      options:
+        - label: I reviewed the sample for secrets and private data.
+          required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
         with:
           go-version: '1.25.x'
           cache: false
+      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
 
       - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
+      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
+
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X main.version={{ .Version }}
+      - -s -w -trimpath -X main.version={{ .Version }}
 
 archives:
   - id: default
@@ -34,6 +34,12 @@ archives:
 
 checksum:
   name_template: checksums.txt
+
+sboms:
+  - id: archives
+    artifacts: archive
+    documents:
+      - "${artifact}.spdx.json"
 
 # Keyless cosign signature over the checksum file; the .sig and .pem land in
 # the release assets so consumers (and scorecards) can verify without keys.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,8 +15,10 @@ builds:
     goarch:
       - amd64
       - arm64
+    flags:
+      - -trimpath
     ldflags:
-      - -s -w -trimpath -X main.version={{ .Version }}
+      - -s -w -X main.version={{ .Version }}
 
 archives:
   - id: default

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,23 +2,81 @@
 
 ## Build and test
 
+deja requires Go 1.25 and has no runtime Go dependencies. Before opening a pull
+request, run:
+
 ```sh
-go test ./...
+go test ./... -race -count=1
 go vet ./...
 go build ./cmd/deja
 ```
 
-Useful local checks:
+Run `gofmt -s` on changed Go files. Every package touched by a change must keep
+at least 95% statement coverage. Measure each package directly so aggregate
+coverage does not hide a regression:
 
 ```sh
-go test ./internal/index ./internal/sources ./cmd/deja
-go test -run TestMCP ./cmd/deja
+go test ./internal/sources/ -coverprofile=coverage.out
+go tool cover -func=coverage.out
 ```
 
-## Pull requests
+Replace `internal/sources` with each package changed. Do not add low-value tests
+only to move the number; explain a genuinely unreachable branch in the pull
+request instead.
+
+## Hermetic tests
+
+Tests must not read or modify a contributor's real agent configuration or
+history.
+
+- Use `t.TempDir()` for files and directories.
+- Set both `HOME` and `USERPROFILE` with `t.Setenv`.
+- Also set every location variable the code path reads: relevant `DEJA_*`
+  variables and, when applicable, `CODEX_HOME`, `GEMINI_CLI_HOME`,
+  `CURSOR_CONFIG_DIR`, `CLAUDE_CONFIG_DIR`, or
+  `AIDER_CHAT_HISTORY_FILE`.
+- Keep paths valid on Windows. Guard Unix-only behavior with `runtime.GOOS` and
+  skip it on unsupported platforms.
+- Check cleanup errors where practical. In particular, do not leave a bare
+  error-returning call in a `defer`.
+
+Use table-driven tests from the standard library. The project does not use
+testify or other test frameworks.
+
+## Adding or updating a harness parser
+
+The [source parser registry](docs/ARCHITECTURE.md#source-parsers) maps harnesses
+to their implementation under `internal/sources`. Follow the integration steps
+in [Add a new harness](docs/ARCHITECTURE.md#add-a-new-harness); a parser alone is
+not enough because discovery, incremental indexing, install support, and user
+documentation are separate paths.
+
+Fixtures must be synthetic and minimal. Put reusable cross-package samples
+under `fixtures/synthetic`; keep parser-specific cases near their tests. Use
+stable IDs and timestamps, retain only fields needed to exercise the format,
+and replace credentials and identifying paths. SQLite fixtures should be built
+from a checked-in script such as `fixtures/synthetic/make_opencode_db.sh`, not
+copied from a local agent database.
+
+A parser change should cover discovery, normal parsing, malformed or truncated
+input, and incremental behavior where the format is append-only. Add an index
+integration test and install/doctor coverage when those commands recognize the
+harness.
+
+If an upstream format changed, use the
+[format drift report](https://github.com/vshulcz/deja-vu/issues/new?template=format-drift.yml).
+For a new harness, use the
+[parser request](https://github.com/vshulcz/deja-vu/issues/new?template=parser-request.yml)
+before contributing real session data.
+
+## Pull requests and review
 
 - Keep changes small and explain the user-visible behavior.
-- Add or update tests for parser, index, CLI, or MCP changes.
-- Run `gofmt` on changed Go files.
+- Add or update tests and documentation with the implementation.
 - Do not commit private history, generated local indexes, or machine-specific logs.
 - No CLA.
+
+A pull request is ready to merge when CI is green, affected packages meet the
+coverage bar, tests are hermetic on supported platforms, documentation matches
+the behavior, and review comments are resolved. Maintainers may ask for a
+smaller change when unrelated refactoring makes behavior difficult to review.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ Subagent transcripts are skipped by default (they mostly duplicate the parent se
 
 Credentials are redacted at index time: AWS keys, generic `api_key=`/`token=` assignments, bearer tokens and raw JWTs, PEM private key blocks, provider tokens (`ghp_`, `sk-`, `npm_`, `xox.`, `AIza`), and `scheme://user:pass@host` URLs. The value is replaced with `[redacted:<kind>]`; surrounding text stays searchable. `deja sources` shows per-store counts. Opt out with `DEJA_NO_REDACT=1` (unsafe). `deja share` and `deja sync export` re-apply redaction on the way out.
 
+The [security model](docs/SECURITY-MODEL.md) documents data flows, redaction
+limits, trust assumptions, and release verification.
+
 ## Supported harnesses
 
 | Harness | Store | Status |
@@ -173,7 +176,7 @@ Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact cr
 
 ## FAQ
 
-**Does anything leave my machine?** No. Indexing and search are fully local. `sync` writes files to a directory you choose, moving them is up to you. The only network call is `deja update`, which downloads releases from GitHub.
+**Does anything leave my machine?** Indexing and search are local. `deja update` downloads releases from GitHub, and user-invoked `deja sync ssh` transfers redacted batches through the system SSH client. Directory exports and shares go only to the destination you choose. See the [security model](docs/SECURITY-MODEL.md#data-flows) for the full data flow.
 
 **How is this different from cass?**
 [cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, eight harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
@@ -196,7 +199,7 @@ rm -rf ~/.cache/deja
 
 ## Contributing
 
-`make build test lint` — see [CONTRIBUTING.md](CONTRIBUTING.md). Adding a harness is one parser file: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#adding-a-harness). Good first issues are labeled.
+`make build test lint` — see [CONTRIBUTING.md](CONTRIBUTING.md). Adding a harness starts in the [parser registry](docs/ARCHITECTURE.md#source-parsers). Current priorities and non-goals are in [ROADMAP.md](ROADMAP.md). Good first issues are labeled.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,42 @@
+# Roadmap
+
+This roadmap records direction, not release commitments. Linked issues contain
+the current scope and are the place to discuss design changes.
+
+## Now
+
+- Add ingest-time project exclusions so selected histories never enter the
+  index ([#8](https://github.com/vshulcz/deja-vu/issues/8)).
+- Add `deja forget` for deleting sessions, projects, or age ranges from records
+  and postings ([#45](https://github.com/vshulcz/deja-vu/issues/45)).
+- Validate path discovery, terminal output, install configuration, and locking
+  on real Windows installations ([#9](https://github.com/vshulcz/deja-vu/issues/9)).
+- Maintain the security model, signed checksums, provenance, release SBOMs, and
+  structured parser-format reports as release and harness formats change.
+
+## Next
+
+- Add project and harness filters to `deja last`
+  ([#10](https://github.com/vshulcz/deja-vu/issues/10)).
+- Derive canonical project identity from a repository remote when available so
+  same-named repositories and worktrees do not collide
+  ([#44](https://github.com/vshulcz/deja-vu/issues/44)).
+- Improve share selection around decisions in tool-heavy sessions without
+  exposing raw tool dumps ([#22](https://github.com/vshulcz/deja-vu/issues/22)).
+
+## Later
+
+- Add a typo-tolerant fallback only when exact and substring search return no
+  results, while keeping the normal search path unchanged
+  ([#11](https://github.com/vshulcz/deja-vu/issues/11)).
+- Expose recent sessions as an MCP resource and add bounded recall pagination
+  ([#12](https://github.com/vshulcz/deja-vu/issues/12)).
+
+## Not planned
+
+- **Capture daemons:** deja indexes histories already written by each harness;
+  a recorder would add a persistent process and a second source of truth.
+- **Cloud sync by default:** implicit upload conflicts with local-only indexing;
+  sync remains an explicit export or SSH operation.
+- **Embeddings in the base binary:** model files and vector runtimes would break
+  the zero-runtime-dependency distribution and increase index cost.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,6 +18,9 @@ update` (fetches releases from GitHub) and `deja sync ssh` (your own SSH
 connection). Reports about secrets surviving redaction in indexed or shared
 output are in scope and appreciated.
 
+See the [security model](docs/SECURITY-MODEL.md) for data flows, redaction
+limits, trust assumptions, and release verification.
+
 ## Supported versions
 
 Only the latest release receives fixes.

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -1,0 +1,150 @@
+# Security model
+
+deja indexes existing coding-agent histories on the same machine. This document
+describes the data it handles, the boundaries around that data, and the release
+artifacts available for verification.
+
+## Data flows
+
+### Local reads
+
+deja discovers and parses the session stores documented in the
+[source parser table](ARCHITECTURE.md#source-parsers): JSON, JSONL, Markdown, and
+SQLite data written by Claude Code, Codex CLI, opencode, aider, Gemini CLI,
+Cursor, Antigravity, and Grok Build. For opencode and Cursor IDE stores it runs
+the local `sqlite3` executable rather than opening a network connection.
+
+Indexing reads session messages and metadata needed for search, including
+session IDs, project paths, titles, roles, and timestamps. It does not modify
+the source session stores.
+
+### Local writes
+
+The default index is `~/.cache/deja/index.db`; `DEJA_INDEX_DIR` changes that
+location. The directory contains:
+
+- `records.bin`, with redacted message records;
+- `buckets/*.bin`, with token postings into those records;
+- `manifest.gob` and `sessions.gob`, with source file state, session metadata,
+  redaction counts, sync watermarks, and imported-record deduplication keys.
+
+Usage events are appended to the sibling file `<index-dir>.usage.jsonl`. This
+sidecar records the kind and time of local search, recall, context, and hook
+use. It rotates at 1 MiB and retains 14 days; it does not contain session text
+or queries.
+
+The index and sidecar never leave the machine through indexing, search, MCP,
+stats, or hook operation. The MCP server uses JSON-RPC over standard input and
+output and does not listen on a network socket.
+
+### Explicit exports and network paths
+
+deja has no background network traffic. Network access happens only after one
+of these commands is run:
+
+- `deja update` connects to GitHub over HTTPS to read release metadata and
+  download the selected archive and `checksums.txt`. It verifies the archive's
+  SHA-256 checksum before replacing the binary.
+- `deja sync ssh <host>` runs the system `ssh` and `scp` clients against the
+  host supplied by the user. The remote peer receives redacted JSONL sync
+  batches and imports them into its own index. `--pull` reverses that flow.
+
+`deja sync export <dir>` and `deja share <id>` write data to a path or output
+chosen by the user. They do not transmit it themselves. Exported batches and
+shared digests can leave the machine if the destination directory, shell
+pipeline, or later user action sends them elsewhere.
+
+## Redaction boundary
+
+Redaction runs before session messages and titles are stored in the index and
+runs again for share and sync export output. It replaces matched values while
+leaving surrounding text searchable. The current patterns cover:
+
+- AWS access key IDs and secret-key assignments;
+- generic credential assignments such as `api_key=`, `token=`, `secret=`,
+  `password=`, and `authorization=`;
+- bearer tokens and JWTs;
+- PEM private-key blocks;
+- known GitHub, GitLab, OpenAI/Anthropic-style, Groq, xAI, Hugging Face, npm,
+  Slack, and Google token prefixes;
+- URLs containing `scheme://user:password@host` credentials.
+
+Pattern matching is not secret detection. A new provider's token shape, an
+unlabelled credential, encoded or transformed data, and a secret split across
+lines can pass through unchanged. Redaction also cannot remove sensitive prose
+that does not look like a credential. Review every share or export before
+sending it to another person or system.
+
+Setting `DEJA_NO_REDACT=1` disables this boundary. Plaintext credentials may
+then be written to the local index and may appear in search, share, and sync
+output. Do not use it with histories that contain secrets.
+
+## Non-goals and trust assumptions
+
+- deja is not an access-control system. Anyone who can read the index files can
+  inspect the data stored in them.
+- The index and usage sidecar inherit the permissions and protections of their
+  directory and filesystem. deja does not encrypt them at rest.
+- Sync trusts the SSH host, account, and keys selected by the user. deja does
+  not authenticate peers beyond the system SSH client's checks and does not
+  revoke data after a peer imports it.
+- Redaction reduces accidental credential disclosure; it does not prove that
+  output is free of secrets or other private information.
+
+## Release integrity
+
+Each GitHub release includes `checksums.txt`, `checksums.txt.sig`, and
+`checksums.txt.pem`. The release workflow creates a keyless cosign signature
+over `checksums.txt` and publishes a GitHub build-provenance attestation for the
+same checksum set. Releases also include an SPDX JSON SBOM for each archive.
+
+After downloading those three checksum files, verify the signature with:
+
+```sh
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp '^https://github.com/vshulcz/deja-vu/.github/workflows/release.yml@refs/tags/v[0-9].*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  checksums.txt
+```
+
+Then verify the downloaded archive against the signed checksum list:
+
+```sh
+sha256sum --ignore-missing --check checksums.txt
+```
+
+On macOS, use `shasum -a 256 -c checksums.txt` instead.
+
+## Rebuilding a release
+
+Release binaries are built with Go 1.25.x, `CGO_ENABLED=0`, and `-trimpath`.
+To compare one target, check out its tag, use the exact Go patch version shown
+in the release workflow logs, and set the version embedded by GoReleaser:
+
+```sh
+git checkout vX.Y.Z
+export CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS=-trimpath
+go build -ldflags='-s -w -trimpath -X main.version=X.Y.Z' -o deja ./cmd/deja
+sha256sum deja
+```
+
+Run the equivalent target for the archive being checked and compare the binary
+inside that archive. Go patch version, target OS and architecture, environment,
+and build flags must match.
+
+For a local archive build, use the same GoReleaser and Syft versions as the
+release job and derive the archive timestamp from the tag commit:
+
+```sh
+export GOFLAGS=-trimpath
+export SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
+goreleaser release --snapshot --clean --skip=publish
+```
+
+The Go binaries are intended to be reproducible when those inputs match.
+Release archives are not claimed to be byte-reproducible today: the workflow
+does not pin the GoReleaser version, snapshot builds carry a different version,
+and archive/SBOM metadata can vary with tool versions. `SOURCE_DATE_EPOCH`
+stabilizes timestamps but does not remove those differences.


### PR DESCRIPTION
Closes #118. Adds docs/SECURITY-MODEL.md (data flows, redaction limits, trust boundaries, release verification), SPDX SBOMs and -trimpath in goreleaser, a roadmap, CODEOWNERS, and parser-focused issue templates. Expands CONTRIBUTING with the hermetic-test rules the suite already follows.