### PR TITLE
fix: split Grok config home from session root

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -76,7 +76,9 @@ func TestInstallMCPJSONTargetsAndErrors(t *testing.T) {
 
 func TestInstallGrokTOML(t *testing.T) {
 	tmp := hermeticEnv(t)
-	cfg := filepath.Join(tmp, "grok", "config.toml")
+	home := filepath.Join(tmp, "grok-home")
+	t.Setenv("GROK_HOME", home)
+	cfg := filepath.Join(home, "config.toml")
 
 	r, err := installTarget("grok", "/bin/deja", false)
 	if err != nil || r.Action != "created" || r.Path != cfg {

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -202,7 +202,7 @@ func doctorMCPConfigs() []doctorMCPConfig {
 		{"cursor", filepath.Join(sources.CursorCLIHome(), "mcp.json"), doctorJSONWired("mcpServers")},
 		{"gemini", filepath.Join(sources.GeminiHome(), "settings.json"), doctorJSONWired("mcpServers")},
 		{"antigravity", filepath.Join(h, ".gemini", "config", "mcp_config.json"), doctorJSONWired("mcpServers")},
-		{"grok", filepath.Join(sources.GrokRoot(), "config.toml"), doctorTOMLWired},
+		{"grok", filepath.Join(sources.GrokHome(), "config.toml"), doctorTOMLWired},
 	}
 }
 

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -298,13 +298,15 @@ func TestDoctorMCPWiringStates(t *testing.T) {
 	home := filepath.Join(tmp, "home")
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	grokHome := filepath.Join(tmp, "grok-home")
+	t.Setenv("GROK_HOME", grokHome)
 
 	// wired via JSON
 	writeFileMkdir(t, filepath.Join(home, ".claude.json"), `{"mcpServers":{"deja":{}}}`)
 	// present but not wired (TOML without our block)
 	writeFileMkdir(t, filepath.Join(home, ".codex", "config.toml"), "[cli]\nauto_update = false\n")
-	// wired via TOML at the grok root
-	writeFileMkdir(t, filepath.Join(os.Getenv("DEJA_GROK_ROOT"), "config.toml"), "[mcp_servers.deja]\ncommand = \"x\"\n")
+	// wired via TOML at the Grok home, separate from the session read root
+	writeFileMkdir(t, filepath.Join(grokHome, "config.toml"), "[mcp_servers.deja]\ncommand = \"x\"\n")
 	// gemini settings.json left absent -> config missing
 
 	var out bytes.Buffer

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -375,11 +375,11 @@ func installCodex(exe string, uninstall bool) (installResult, error) {
 	return installTOML(path, block, uninstall)
 }
 
-// installGrok wires the MCP server into Grok Build's ~/.grok/config.toml.
+// installGrok wires the MCP server into Grok Build's config.toml.
 // Same [mcp_servers.NAME] TOML shape as Codex; Grok's hook stdout is ignored
 // on passive events, so MCP is the deepest integration available.
 func installGrok(exe string, uninstall bool) (installResult, error) {
-	path := filepath.Join(sources.GrokRoot(), "config.toml")
+	path := filepath.Join(sources.GrokHome(), "config.toml")
 	block := fmt.Sprintf("[mcp_servers.deja]\ncommand = %q\nargs = [\"mcp\"]\n", exe)
 	return installTOML(path, block, uninstall)
 }

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -105,7 +105,7 @@
     {
       "name": "grok",
       "state": "config-missing",
-      "path": "<tmp>/grok/config.toml"
+      "path": "<tmp>/home/.grok/config.toml"
     }
   ],
   "sqlite3": {

--- a/docs/registry/grok.md
+++ b/docs/registry/grok.md
@@ -2,7 +2,7 @@
 
 ## Store and files
 
-Grok Build stores sessions below `${GROK_HOME:-~/.grok}/sessions/<encoded-cwd>/<session-id>/`. `DEJA_GROK_ROOT` overrides the read root. `updates.jsonl` is the conversation stream and sibling `summary.json` carries metadata. A `.cwd` file beside session directories can recover the working directory when summary metadata is absent.
+Grok Build stores sessions below `${GROK_HOME:-~/.grok}/sessions/<encoded-cwd>/<session-id>/`. `DEJA_GROK_ROOT` overrides where deja reads sessions; `GROK_HOME` relocates the whole Grok tree, including `config.toml`. `updates.jsonl` is the conversation stream and sibling `summary.json` carries metadata. A `.cwd` file beside session directories can recover the working directory when summary metadata is absent.
 
 The working-directory group is URL-encoded, although observed names are not always encoded consistently. deja prefers `summary.json` and `.cwd` over decoding the directory name.
 

--- a/internal/sources/grok.go
+++ b/internal/sources/grok.go
@@ -16,17 +16,22 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
+// GrokHome is where Grok Build itself keeps state; GROK_HOME relocates the
+// whole tree (config.toml, sessions). Install and doctor use it.
+func GrokHome() string {
+	return EnvPath("GROK_HOME", filepath.Join(Home(), ".grok"))
+}
+
+// GrokRoot is the session-reading root; DEJA_GROK_ROOT overrides it without
+// affecting where install writes.
+func GrokRoot() string {
+	return EnvPath("DEJA_GROK_ROOT", GrokHome())
+}
+
 // Grok Build stores sessions by URL-encoded working directory. summary.json
 // carries metadata and updates.jsonl is the authoritative ACP conversation
 // stream. Grok can truncate and regrow the stream after a rewind, so changed
 // files are always reparsed in full.
-
-func GrokRoot() string {
-	if root := os.Getenv("DEJA_GROK_ROOT"); root != "" {
-		return root
-	}
-	return EnvPath("GROK_HOME", filepath.Join(Home(), ".grok"))
-}
 
 func GrokSessionFiles() []string {
 	return walkFiles(filepath.Join(GrokRoot(), "sessions"), func(p string) bool {

--- a/internal/sources/grok_test.go
+++ b/internal/sources/grok_test.go
@@ -69,10 +69,17 @@ func TestGrokDiscoveryAndRootOverrides(t *testing.T) {
 		t.Fatalf("files = %v, want [%s]", files, updates)
 	}
 
-	t.Setenv("DEJA_GROK_ROOT", "")
-	t.Setenv("GROK_HOME", root)
+	home := t.TempDir()
+	t.Setenv("GROK_HOME", home)
+	if GrokHome() != home {
+		t.Fatalf("GROK_HOME ignored: %q", GrokHome())
+	}
 	if GrokRoot() != root {
-		t.Fatalf("GROK_HOME ignored: %q", GrokRoot())
+		t.Fatalf("DEJA_GROK_ROOT ignored: %q", GrokRoot())
+	}
+	t.Setenv("DEJA_GROK_ROOT", "")
+	if GrokRoot() != home {
+		t.Fatalf("GrokRoot fallback = %q, want %q", GrokRoot(), home)
 	}
 }
 


### PR DESCRIPTION
Closes #120. GrokHome (GROK_HOME) now carries config.toml for install and doctor; GrokRoot (DEJA_GROK_ROOT) stays a session-read override, matching the codex split.