### PR TITLE
feat: add qwen-code session support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center"><img src="assets/demo.gif" alt="deja demo"></p>
 
-Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity and Grok Build write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
+Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build and Qwen Code write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
 
 | | |
 | --- | --- |
@@ -135,13 +135,13 @@ Batches are plain JSONL, redacted on the way out. Import is idempotent, so keep 
 
 ## Teach your agent to remember
 
-`deja install --all` wires up MCP recall (Claude Code, Codex, opencode, Cursor, Gemini CLI, Antigravity, Grok Build — aider has no MCP client, pipe `deja ctx` instead); `deja install --auto` does the same and adds session-start auto-recall where the harness supports it (Claude Code hook, Codex hooks.json, an opencode plugin — Cursor, Gemini CLI, Antigravity and Grok Build have no hook that can inject context, so MCP is their full install). To make
+`deja install --all` wires up MCP recall (Claude Code, Codex, opencode, Cursor, Gemini CLI, Antigravity, Grok Build, Qwen Code — aider has no MCP client, pipe `deja ctx` instead); `deja install --auto` does the same and adds session-start auto-recall where the harness supports it (Claude Code hook, Codex hooks.json, an opencode plugin — Cursor, Gemini CLI, Antigravity, Grok Build and Qwen Code have no hook that can inject context, so MCP is their full install). To make
 the agent reach for memory on its own, add this to your `CLAUDE.md` /
 `AGENTS.md`:
 
 ```
 Before debugging or re-implementing something, run `deja "<query>"` (or the
-MCP recall tool) — past agent sessions across Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity and Grok Build
+ MCP recall tool) — past agent sessions across Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build and Qwen Code
 are indexed locally. Cite what you reuse.
 ```
 
@@ -175,8 +175,9 @@ limits, trust assumptions, and release verification.
 | Cursor | `state.vscdb` + `~/.cursor/projects/**/agent-transcripts/*.jsonl` | ✅ |
 | Antigravity | `~/.gemini/antigravity*/brain/*/.system_generated/logs/transcript.jsonl` | ✅ |
 | Grok Build | `~/.grok/sessions/**/updates.jsonl` | ✅ |
+| Qwen Code | `~/.qwen/projects/**/chats/*.jsonl` | ✅ |
 
-Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_AIDER_ROOTS`, `DEJA_GEMINI_ROOT`, `DEJA_CURSOR_ROOT`, `DEJA_CURSOR_CLI_ROOT`, `DEJA_ANTIGRAVITY_ROOT`, `DEJA_GROK_ROOT`, `DEJA_INDEX_DIR`. Each agent's own relocation variable is honored too: `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `GEMINI_CLI_HOME`, `CURSOR_CONFIG_DIR`, `GROK_HOME`, `AIDER_CHAT_HISTORY_FILE`, and `XDG_DATA_HOME` for opencode on Linux.
+Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_AIDER_ROOTS`, `DEJA_GEMINI_ROOT`, `DEJA_CURSOR_ROOT`, `DEJA_CURSOR_CLI_ROOT`, `DEJA_ANTIGRAVITY_ROOT`, `DEJA_GROK_ROOT`, `DEJA_QWEN_ROOT`, `DEJA_INDEX_DIR`. Each agent's own relocation variable is honored too: `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `GEMINI_CLI_HOME`, `CURSOR_CONFIG_DIR`, `GROK_HOME`, `AIDER_CHAT_HISTORY_FILE`, and `XDG_DATA_HOME` for opencode on Linux.
 
 `DEJA_RECALL=safe` is the default: SessionStart recall stays in the current project, filters weak or duplicate results, prefers the last 90 days, and injects at most 2KB. `DEJA_RECALL=aggressive` searches across projects and raises the injection cap to 4KB. `DEJA_RECALL=off` disables SessionStart recall output.
 

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -35,6 +35,7 @@ func hermeticEnv(t *testing.T) string {
 	t.Setenv("DEJA_CURSOR_CLI_ROOT", filepath.Join(tmp, "cursor-cli"))
 	t.Setenv("DEJA_ANTIGRAVITY_ROOT", filepath.Join(tmp, "antigravity"))
 	t.Setenv("DEJA_GROK_ROOT", filepath.Join(tmp, "grok"))
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 	t.Setenv("CODEX_HOME", "")
 	t.Setenv("GEMINI_CLI_HOME", "")
@@ -49,7 +50,7 @@ func TestInstallMCPJSONTargetsAndErrors(t *testing.T) {
 	if got := homeDir(); got == "" {
 		t.Fatal("homeDir empty")
 	}
-	for _, target := range []string{"cursor", "gemini", "antigravity"} {
+	for _, target := range []string{"cursor", "gemini", "antigravity", "qwen"} {
 		t.Run(target, func(t *testing.T) {
 			r, err := installTarget(target, "/bin/deja", false)
 			if err != nil || r.Action != "created" {

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -107,6 +107,9 @@ func doctorHarnesses(w io.Writer) {
 
 	grokRoot := sources.GrokRoot()
 	printRow("grok", grokRoot, doctorExists(grokRoot), doctorCount(len(sources.GrokSessionFiles()), "file"))
+
+	qwenRoot := filepath.Join(sources.QwenRoot(), "projects")
+	printRow("qwen", qwenRoot, doctorExists(qwenRoot), doctorCount(len(sources.QwenSessionFiles()), "file"))
 }
 
 func doctorSQLiteDetail(db string, sqlite bool) string {
@@ -203,6 +206,7 @@ func doctorMCPConfigs() []doctorMCPConfig {
 		{"gemini", filepath.Join(sources.GeminiHome(), "settings.json"), doctorJSONWired("mcpServers")},
 		{"antigravity", filepath.Join(h, ".gemini", "config", "mcp_config.json"), doctorJSONWired("mcpServers")},
 		{"grok", filepath.Join(sources.GrokHome(), "config.toml"), doctorTOMLWired},
+		{"qwen", filepath.Join(sources.QwenConfigDir(), "settings.json"), doctorJSONWired("mcpServers")},
 	}
 }
 

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -86,6 +86,7 @@ func doctorStoreChecks() []doctorStoreCheck {
 		{"cursor", []string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, cursorFiles, parseDoctorCursor},
 		{"antigravity", sources.AntigravityRoots(), sources.AntigravityTranscripts(), sources.ParseAntigravityFile},
 		{"grok", []string{sources.GrokRoot()}, sources.GrokSessionFiles(), sources.ParseGrokFile},
+		{"qwen", []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.QwenSessionFiles(), sources.ParseQwenFile},
 	}
 }
 

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -137,6 +137,7 @@ func existingTargets() []string {
 		"gemini":      filepath.Join(sources.GeminiHome(), "settings.json"),
 		"antigravity": filepath.Join(h, ".gemini", "config"),
 		"grok":        sources.GrokRoot(),
+		"qwen":        sources.QwenConfigDir(),
 	}
 	var out []string
 	for name, p := range checks {
@@ -170,6 +171,8 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 		return installMCPJSON(filepath.Join(homeDir(), ".gemini", "config", "mcp_config.json"), exe, uninstall)
 	case "grok":
 		return installGrok(exe, uninstall)
+	case "qwen":
+		return installMCPJSON(filepath.Join(sources.QwenConfigDir(), "settings.json"), exe, uninstall)
 	case "opencode":
 		return installOpencode(exe, uninstall)
 	case "opencode-auto":

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -50,12 +50,15 @@ func loadAll(h string) []model.Session {
 	if h == "" || h == "grok" {
 		ss = append(ss, sources.LoadGrok()...)
 	}
+	if h == "" || h == "qwen" {
+		ss = append(ss, sources.LoadQwen()...)
+	}
 	return ss
 }
 
 func loadFileSources() []model.Session {
 	var ss []model.Session
-	for _, harness := range []string{"claude", "codex", "aider", "gemini", "cursor", "antigravity", "grok"} {
+	for _, harness := range []string{"claude", "codex", "aider", "gemini", "cursor", "antigravity", "grok", "qwen"} {
 		ss = append(ss, loadAll(harness)...)
 	}
 	return ss
@@ -238,7 +241,7 @@ func run(args []string) error {
 }
 
 func printNoMatches(w io.Writer, q string, n int) {
-	fmt.Fprintf(w, "deja: no matches for %q (searched %d sessions across claude/codex/opencode/aider/gemini/cursor/antigravity/grok) — try fewer words or --re\n", q, n)
+	fmt.Fprintf(w, "deja: no matches for %q (searched %d sessions across claude/codex/opencode/aider/gemini/cursor/antigravity/grok/qwen) — try fewer words or --re\n", q, n)
 }
 
 func findByPrefix(p string) (model.Session, bool, error) {
@@ -350,6 +353,7 @@ func printSources() {
 		{"cursor", strings.Join([]string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, string(os.PathListSeparator)), []string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, sources.LoadCursor},
 		{"antigravity", antigravityLocation, antigravityRoots, sources.LoadAntigravity},
 		{"grok", sources.GrokRoot(), []string{sources.GrokRoot()}, sources.LoadGrok},
+		{"qwen", filepath.Join(sources.QwenRoot(), "projects"), []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.LoadQwen},
 	}
 	for _, it := range items {
 		var size int64
@@ -458,8 +462,8 @@ Usage:
   deja mcp
   deja version
   deja update
-  deja install <claude-code|codex|opencode|cursor|gemini|antigravity|grok|statusline|--all|--auto>
-  deja uninstall <claude-code|codex|opencode|cursor|gemini|antigravity|grok|statusline|--all|--auto>
+  deja install <claude-code|codex|opencode|cursor|gemini|antigravity|grok|qwen|statusline|--all|--auto>
+  deja uninstall <claude-code|codex|opencode|cursor|gemini|antigravity|grok|qwen|statusline|--all|--auto>
 
 Examples:
   deja "jwt refresh token bug"

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -295,7 +295,7 @@ func TestPrintNoMatchesHelpfulMessage(t *testing.T) {
 	var b bytes.Buffer
 	printNoMatches(&b, "jwt refresh token", 3)
 	out := b.String()
-	if !strings.Contains(out, `deja: no matches for "jwt refresh token"`) || !strings.Contains(out, "searched 3 sessions across claude/codex/opencode/aider/gemini/cursor/antigravity/grok") || !strings.Contains(out, "try fewer words or --re") {
+	if !strings.Contains(out, `deja: no matches for "jwt refresh token"`) || !strings.Contains(out, "searched 3 sessions across claude/codex/opencode/aider/gemini/cursor/antigravity/grok/qwen") || !strings.Contains(out, "try fewer words or --re") {
 		t.Fatalf("bad no-match message: %q", out)
 	}
 }

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -75,12 +75,12 @@ func handleMCP(req rpcRequest) (any, int, string) {
 		return map[string]any{"tools": []map[string]any{
 			{
 				"name":        "recall",
-				"description": "Search past coding-agent sessions and return the best matches as dense text under ~4KB. Call before debugging or re-implementing: use a specific error string, function name, or flag. Optionally filter by harness (claude, codex, opencode, aider, gemini, cursor, antigravity, grok).",
-				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "Search terms; specific tokens (error strings, function names, flags) match best. Multiple words are ANDed."}, "harness": map[string]any{"type": "string", "description": "Optional filter: claude, codex, opencode, aider, gemini, cursor, antigravity or grok."}, "limit": map[string]any{"type": "number", "description": "Max sessions to return (default 5)."}}, "required": []string{"query"}},
+				"description": "Search past coding-agent sessions and return the best matches as dense text under ~4KB. Call before debugging or re-implementing: use a specific error string, function name, or flag. Optionally filter by harness (claude, codex, opencode, aider, gemini, cursor, antigravity, grok, qwen).",
+				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "Search terms; specific tokens (error strings, function names, flags) match best. Multiple words are ANDed."}, "harness": map[string]any{"type": "string", "description": "Optional filter: claude, codex, opencode, aider, gemini, cursor, antigravity, grok or qwen."}, "limit": map[string]any{"type": "number", "description": "Max sessions to return (default 5)."}}, "required": []string{"query"}},
 			},
 			{
 				"name":        "recall_context",
-				"description": "Return a markdown digest (~8KB) of the best prior session. Call before debugging or re-implementing; query with an error string, function name, or flag. Optionally filter by harness (claude, codex, opencode, aider, gemini, cursor, antigravity, grok).",
+				"description": "Return a markdown digest (~8KB) of the best prior session. Call before debugging or re-implementing; query with an error string, function name, or flag. Optionally filter by harness (claude, codex, opencode, aider, gemini, cursor, antigravity, grok, qwen).",
 				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "Search terms identifying the session to digest."}, "harness": map[string]any{"type": "string", "description": "Optional harness filter."}}, "required": []string{"query"}},
 			},
 		}}, 0, ""

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -65,6 +65,14 @@
         "<tmp>/grok"
       ],
       "files": 0
+    },
+    {
+      "name": "qwen",
+      "state": "missing",
+      "paths": [
+        "<tmp>/qwen/projects"
+      ],
+      "files": 0
     }
   ],
   "index": {
@@ -106,6 +114,11 @@
       "name": "grok",
       "state": "config-missing",
       "path": "<tmp>/home/.grok/config.toml"
+    },
+    {
+      "name": "qwen",
+      "state": "config-missing",
+      "path": "<tmp>/home/.qwen/settings.json"
     }
   ],
   "sqlite3": {

--- a/cmd/deja/testmain_test.go
+++ b/cmd/deja/testmain_test.go
@@ -30,6 +30,7 @@ func TestMain(m *testing.M) {
 		"DEJA_CURSOR_CLI_ROOT":    filepath.Join(root, "cursor-cli"),
 		"DEJA_ANTIGRAVITY_ROOT":   filepath.Join(root, "antigravity"),
 		"DEJA_GROK_ROOT":          filepath.Join(root, "grok"),
+		"DEJA_QWEN_ROOT":          filepath.Join(root, "qwen"),
 	}
 	for key, value := range stores {
 		if err := os.Setenv(key, value); err != nil {

--- a/docs/registry/README.md
+++ b/docs/registry/README.md
@@ -16,6 +16,7 @@ This registry records observed on-disk session formats for the harnesses that de
 | [aider](aider.md) | append-only Markdown |
 | [Antigravity](antigravity.md) | JSONL transcript |
 | [Grok Build](grok.md) | ACP update JSONL with JSON metadata |
+| [Qwen Code](qwen.md) | JSONL transcript |
 
 ## Reporting drift
 

--- a/docs/registry/qwen.md
+++ b/docs/registry/qwen.md
@@ -1,0 +1,26 @@
+# Qwen Code session format
+
+## Store and files
+
+Qwen Code writes sessions below `${DEJA_QWEN_ROOT:-~/.qwen}/projects/<encoded-project>/chats/*.jsonl`. The project directory uses the same slash-and-hyphen encoding as Claude Code. The `chats/` directory is part of Qwen's layout; only JSONL files directly inside it are session streams.
+
+The Qwen configuration directory remains `~/.qwen` for installer settings. `DEJA_QWEN_ROOT` relocates session reads only.
+
+## Records
+
+Each line is a JSON object with `type`, `sessionId`, `timestamp`, and a `message` object. Message text is in `message.parts`; parts marked `thought: true` are reasoning and are excluded.
+
+```json
+{"type":"assistant","sessionId":"session-7","timestamp":"2026-07-17T09:00:01Z","message":{"role":"model","parts":[{"text":"The failing check is in parser.go."}]}}
+```
+
+`message.role` `model` maps to `assistant` and `user` maps to `user`; when it is absent, the top-level `type` is used. Parts with text are joined with newlines. RFC 3339 and numeric Unix timestamps are accepted.
+
+## Known quirks and drift
+
+- JSONL can end in a partial line while Qwen is writing. Malformed lines are skipped.
+- System, tool-result, and other control records do not become messages.
+- Project path encoding is ambiguous because `-` represents both a separator and a hyphen. deja checks the local filesystem before using a two-segment fallback.
+
+**Last verified:** 2026-07-17
+**deja parser version:** v0.12.0-1-g9e2088c

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -64,6 +64,14 @@
       "fixture_paths": ["fixtures/registry/grok/sessions/workspace%2Fregistry-demo/registry-grok/updates.jsonl"],
       "parser_source": "internal/sources/grok.go",
       "last_verified": "2026-07-17"
+    },
+    {
+      "id": "qwen",
+      "store_paths": ["${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl"],
+      "format_kind": "jsonl",
+      "fixture_paths": ["fixtures/registry/qwen/projects/-workspace-registry-demo/chats/registry-qwen.jsonl"],
+      "parser_source": "internal/sources/qwen.go",
+      "last_verified": "2026-07-17"
     }
   ]
 }

--- a/fixtures/registry/qwen/projects/-workspace-registry-demo/chats/registry-qwen.jsonl
+++ b/fixtures/registry/qwen/projects/-workspace-registry-demo/chats/registry-qwen.jsonl
@@ -1,0 +1,2 @@
+{"type":"user","sessionId":"registry-qwen","timestamp":"2026-07-17T09:00:00Z","message":{"role":"user","parts":[{"text":"Inspect the sample parser."}]}}
+{"type":"assistant","sessionId":"registry-qwen","timestamp":"2026-07-17T09:00:01Z","message":{"role":"model","parts":[{"text":"I found the parser fixture."}]}}

--- a/internal/index/grok_test.go
+++ b/internal/index/grok_test.go
@@ -27,6 +27,7 @@ func TestMain(m *testing.M) {
 		"DEJA_CURSOR_CLI_ROOT":  filepath.Join(root, "cursor-cli"),
 		"DEJA_ANTIGRAVITY_ROOT": filepath.Join(root, "antigravity"),
 		"DEJA_GROK_ROOT":        filepath.Join(root, "grok"),
+		"DEJA_QWEN_ROOT":        filepath.Join(root, "qwen"),
 	}
 	for key, value := range stores {
 		if err := os.Setenv(key, value); err != nil {

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -529,6 +529,7 @@ var harnessLoaders = []struct {
 	{"cursor", sources.LoadCursor},
 	{"antigravity", sources.LoadAntigravity},
 	{"grok", sources.LoadGrok},
+	{"qwen", sources.LoadQwen},
 }
 
 func load(h string) []model.Session { return loadProgress(h, nil) }
@@ -1267,6 +1268,8 @@ func parseChangedFile(harness, p string, old FileState) ([]model.Session, error)
 		return sources.ParseAntigravityFile(p)
 	case "grok":
 		return sources.ParseGrokFile(p)
+	case "qwen":
+		return sources.ParseQwenFile(p)
 	default:
 		return nil, nil
 	}
@@ -1282,6 +1285,8 @@ func parseAppendedFile(harness, p string, old FileState) ([]model.Session, error
 		return sources.ParseClaudeFileFromOffset(p, from)
 	case "codex-history":
 		return sources.ParseCodexHistoryFromOffset(p, from)
+	case "qwen":
+		return sources.ParseQwenFileFromOffset(p, from)
 	case "codex":
 		return sources.ParseCodexRolloutFromOffset(p, from)
 	case "opencode":
@@ -1333,6 +1338,9 @@ func harnessForPath(p string) string {
 	}
 	if filepath.Base(p) == "updates.jsonl" && strings.HasPrefix(p, filepath.Join(sources.GrokRoot(), "sessions")) {
 		return "grok"
+	}
+	if strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, filepath.Join(sources.QwenRoot(), "projects")) {
+		return "qwen"
 	}
 	return ""
 }
@@ -1408,6 +1416,11 @@ func currentFiles(h string) map[string]FileState {
 	}
 	if h == "" || h == "grok" {
 		for _, p := range sources.GrokSessionFiles() {
+			paths[p] = true
+		}
+	}
+	if h == "" || h == "qwen" {
+		for _, p := range sources.QwenSessionFiles() {
 			paths[p] = true
 		}
 	}

--- a/internal/index/integration_test.go
+++ b/internal/index/integration_test.go
@@ -28,6 +28,7 @@ func allHarnessEnv(t *testing.T) (root, dir string) {
 	t.Setenv("DEJA_ANTIGRAVITY_ROOT", filepath.Join(root, "antigravity"))
 	t.Setenv("DEJA_AIDER_ROOTS", filepath.Join(root, "aiderroot"))
 	t.Setenv("DEJA_GROK_ROOT", filepath.Join(root, "grok"))
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(root, "qwen"))
 	if err := os.MkdirAll(filepath.Join(root, "home"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/qwen_test.go
+++ b/internal/index/qwen_test.go
@@ -1,0 +1,28 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestQwenChangedAndAppendedFiles(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(root, "qwen"))
+	path := filepath.Join(root, "qwen", "projects", "-tmp-index", "chats", "session.jsonl")
+	line := `{"type":"user","sessionId":"q","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","parts":[{"text":"index text"}]}}` + "\n"
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := parseChangedFile("qwen", path, FileState{}); err != nil || len(got) != 1 {
+		t.Fatalf("changed qwen = %#v, %v", got, err)
+	}
+	if got, err := parseAppendedFile("qwen", path, FileState{}); err != nil || len(got) != 1 {
+		t.Fatalf("appended qwen = %#v, %v", got, err)
+	}
+}

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -92,7 +92,10 @@ func parseClaudeFileFromOffset(path string, offset int64) ([]model.Session, erro
 }
 
 func claudeProjectDir(path string) string {
-	root := ClaudeRoot()
+	return projectDir(ClaudeRoot(), path)
+}
+
+func projectDir(root, path string) string {
 	if rel, err := filepath.Rel(root, path); err == nil && rel != "." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".." {
 		parts := strings.Split(rel, string(filepath.Separator))
 		if len(parts) > 1 && parts[0] != "" {

--- a/internal/sources/env_homes_test.go
+++ b/internal/sources/env_homes_test.go
@@ -79,4 +79,14 @@ func TestUpstreamHomeVariables(t *testing.T) {
 			t.Fatalf("AiderFiles missed AIDER_CHAT_HISTORY_FILE: %v", AiderFiles())
 		}
 	})
+
+	t.Run("qwen DEJA_QWEN_ROOT", func(t *testing.T) {
+		t.Setenv("DEJA_QWEN_ROOT", filepath.Join(home, "qwen-read"))
+		if got := QwenRoot(); got != filepath.Join(home, "qwen-read") {
+			t.Fatalf("QwenRoot=%q", got)
+		}
+		if got := QwenConfigDir(); got != filepath.Join(home, ".qwen") {
+			t.Fatalf("QwenConfigDir=%q", got)
+		}
+	})
 }

--- a/internal/sources/fuzz_test.go
+++ b/internal/sources/fuzz_test.go
@@ -25,6 +25,7 @@ func fuzzEnv(t *testing.T) string {
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(root, "codex"))
 	t.Setenv("DEJA_GEMINI_ROOT", filepath.Join(root, "gemini"))
 	t.Setenv("DEJA_GROK_ROOT", filepath.Join(root, "grok"))
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(root, "qwen"))
 	t.Setenv("GROK_HOME", filepath.Join(root, "grok"))
 	t.Setenv("DEJA_ANTIGRAVITY_ROOT", filepath.Join(root, "antigravity"))
 	return root

--- a/internal/sources/qwen.go
+++ b/internal/sources/qwen.go
@@ -1,0 +1,99 @@
+package sources
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// QwenConfigDir is the native Qwen Code configuration directory. DEJA_QWEN_ROOT
+// intentionally does not affect it because that variable only relocates reads.
+func QwenConfigDir() string { return filepath.Join(Home(), ".qwen") }
+
+func QwenRoot() string { return EnvPath("DEJA_QWEN_ROOT", QwenConfigDir()) }
+
+func QwenSessionFiles() []string {
+	return walkFiles(filepath.Join(QwenRoot(), "projects"), func(p string) bool {
+		return strings.HasSuffix(p, ".jsonl") && filepath.Base(filepath.Dir(p)) == "chats"
+	})
+}
+
+func LoadQwen() []model.Session { return parseFiles(QwenSessionFiles(), ParseQwenFile) }
+
+func ParseQwenFile(path string) ([]model.Session, error) {
+	return parseQwenFileFromOffset(path, 0)
+}
+
+func ParseQwenFileFromOffset(path string, offset int64) ([]model.Session, error) {
+	return parseQwenFileFromOffset(path, offset)
+}
+
+func parseQwenFileFromOffset(path string, offset int64) ([]model.Session, error) {
+	project := projectDir(filepath.Join(QwenRoot(), "projects"), path)
+	s := model.Session{
+		Harness: "qwen",
+		ID:      strings.TrimSuffix(filepath.Base(path), ".jsonl"),
+		Project: claudeProjectName(project),
+		Path:    path,
+	}
+	err := scanJSONLFromOffset(path, offset, func(m map[string]any) {
+		typ, _ := m["type"].(string)
+		if typ != "user" && typ != "assistant" {
+			return
+		}
+		if id, _ := m["sessionId"].(string); id != "" {
+			s.ID = id
+		}
+		t := parseTimeAny(m["timestamp"])
+		s.Touch(t)
+		role := typ
+		text := ""
+		if msg, ok := m["message"].(map[string]any); ok {
+			if r, _ := msg["role"].(string); r != "" {
+				switch r {
+				case "model":
+					role = "assistant"
+				case "user":
+					role = "user"
+				default:
+					role = typ
+				}
+			}
+			text = qwenText(msg["parts"])
+		}
+		if text != "" {
+			s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: t})
+		}
+	})
+	if len(s.Messages) == 0 {
+		return nil, err
+	}
+	return []model.Session{s}, err
+}
+
+func qwenText(v any) string {
+	parts, ok := v.([]any)
+	if !ok {
+		return ""
+	}
+	var b strings.Builder
+	for _, part := range parts {
+		m, ok := part.(map[string]any)
+		if !ok {
+			continue
+		}
+		if thought, _ := m["thought"].(bool); thought {
+			continue
+		}
+		text, _ := m["text"].(string)
+		if text == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(text)
+	}
+	return b.String()
+}

--- a/internal/sources/qwen_test.go
+++ b/internal/sources/qwen_test.go
@@ -1,0 +1,37 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseQwenFile(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(root, "qwen"))
+	project := filepath.Join(root, "qwen", "projects", "-tmp-deja-vu", "chats")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(project, "session.jsonl")
+	data := `{"type":"user","sessionId":"q-1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","parts":[{"text":"first"},{"text":" question"}]}}
+{"type":"assistant","sessionId":"q-1","timestamp":1767337505,"message":{"role":"model","parts":[{"text":"private reasoning","thought":true},{"text":"surface"},{"text":" answer"}]}}
+{"type":"system","sessionId":"q-1","timestamp":"2026-01-02T03:06:05Z","message":{"role":"model","parts":[{"text":"skip"}]}}
+{"type":"assistant","sessionId":"q-1","timestamp":"2026-01-02T03:07:05Z","message":{"parts":[{"text":"fallback"}]}}
+{"type":"assistant",`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseQwenFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || ss[0].Project != filepath.Join("deja", "vu") || len(ss[0].Messages) != 3 {
+		t.Fatalf("parsed sessions = %#v", ss)
+	}
+	if ss[0].Messages[0].Text != "first\n question" || ss[0].Messages[1].Text != "surface\n answer" || ss[0].Messages[2].Role != "assistant" {
+		t.Fatalf("parsed messages = %#v", ss[0].Messages)
+	}
+}

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -38,6 +38,7 @@ func TestFormatRegistryConformance(t *testing.T) {
 		"CURSOR_CONFIG_DIR", "DEJA_AIDER_ROOTS", "DEJA_ANTIGRAVITY_ROOT",
 		"DEJA_CLAUDE_ROOT", "DEJA_CODEX_ROOT", "DEJA_CURSOR_CLI_ROOT",
 		"DEJA_CURSOR_ROOT", "DEJA_GEMINI_ROOT", "DEJA_GROK_ROOT",
+		"DEJA_QWEN_ROOT",
 		"DEJA_INCLUDE_SUBAGENTS", "DEJA_OPENCODE_DB", "GEMINI_CLI_HOME",
 		"GROK_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
 	} {
@@ -141,6 +142,8 @@ func parseRegistryFixture(t *testing.T, id, path string) []model.Session {
 		sessions, err = ParseAntigravityFile(path)
 	case "grok":
 		sessions, err = ParseGrokFile(path)
+	case "qwen":
+		sessions, err = ParseQwenFile(path)
 	default:
 		t.Fatalf("no conformance parser for %q", id)
 	}


### PR DESCRIPTION
Closes #117. Reads ~/.qwen/projects/**/chats/*.jsonl (same project-dir encoding as Claude Code), maps role model to assistant, concatenates message.parts text and skips thought parts. Adds doctor/sources/install wiring, a registry entry with fixtures, and DEJA_QWEN_ROOT for read relocation.