### PR TITLE
feat: add shareable stats card

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ $ deja "jwt refresh token"
 | `deja update` | Download the latest GitHub release, verify its checksum, and replace the current binary. |
 | `deja statusline` | One line for your status bar: recalls served to agents today. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
 
+### Share your stats
+
+Run `deja stats --card` to write a self-contained `deja-stats.svg` for a README or social post.
+
 `deja update` is for standalone installs. Homebrew and npm installs update through the package manager.
 
 ### Doctor JSON

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -454,7 +454,7 @@ Usage:
   deja warmup
   deja index [--rebuild]
   deja statusline
-  deja stats [--json]
+  deja stats [--json] [--card [path]]
   deja mcp
   deja version
   deja update

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -73,13 +73,49 @@ type dayStat struct {
 
 func runStats(args []string) error {
 	jsonOut := false
-	for _, a := range args {
-		switch a {
+	cardPath := ""
+	card := false
+	var options search.Options
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
 		case "--json":
 			jsonOut = true
+		case "--card":
+			if card {
+				return fmt.Errorf("stats: --card specified twice")
+			}
+			card = true
+			cardPath = "deja-stats.svg"
+			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				cardPath = args[i+1]
+				i++
+			}
+		case "--harness", "--project", "--since", "--role":
+			if i+1 >= len(args) {
+				return fmt.Errorf("stats: %s needs value", args[i])
+			}
+			v := args[i+1]
+			i++
+			switch args[i-1] {
+			case "--harness":
+				options.Harness = v
+			case "--project":
+				options.Project = v
+			case "--role":
+				options.Role = v
+			case "--since":
+				d, err := parseDur(v)
+				if err != nil {
+					return err
+				}
+				options.Since = d
+			}
 		default:
-			return fmt.Errorf("stats: unknown flag %s", a)
+			return fmt.Errorf("stats: unknown flag %s", args[i])
 		}
+	}
+	if jsonOut && card {
+		return fmt.Errorf("stats: choose one output")
 	}
 	if err := index.Ensure(index.DefaultDir(), "", false, os.Stderr); err != nil {
 		return err
@@ -88,8 +124,16 @@ func runStats(args []string) error {
 	if err != nil {
 		return err
 	}
-	report := buildStats(ss, time.Now())
+	report := buildStats(filterStatsSessions(ss, options), time.Now())
 	report.Recall = usage.Totals(index.DefaultDir())
+	if cardPath != "" {
+		path, err := writeStatsCard(cardPath, report)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stdout, path)
+		return nil
+	}
 	if jsonOut {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -97,6 +141,43 @@ func runStats(args []string) error {
 	}
 	printStats(os.Stdout, report)
 	return nil
+}
+
+func filterStatsSessions(ss []model.Session, o search.Options) []model.Session {
+	if o.Harness == "" && o.Project == "" && o.Since <= 0 && o.Role == "" {
+		return ss
+	}
+	cut := time.Time{}
+	if o.Since > 0 {
+		cut = time.Now().Add(-o.Since)
+	}
+	out := make([]model.Session, 0, len(ss))
+	for _, s := range ss {
+		if o.Harness != "" && s.Harness != o.Harness {
+			continue
+		}
+		if o.Project != "" && !strings.Contains(strings.ToLower(s.Project), strings.ToLower(o.Project)) {
+			continue
+		}
+		if !cut.IsZero() && s.Updated.Before(cut) {
+			continue
+		}
+		if o.Role != "" {
+			cp := s
+			cp.Messages = nil
+			for _, m := range s.Messages {
+				if m.Role == o.Role {
+					cp.Messages = append(cp.Messages, m)
+				}
+			}
+			if len(cp.Messages) == 0 {
+				continue
+			}
+			s = cp
+		}
+		out = append(out, s)
+	}
+	return out
 }
 
 func buildStats(ss []model.Session, now time.Time) statsReport {

--- a/cmd/deja/statscard.go
+++ b/cmd/deja/statscard.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const statsCardFont = "ui-monospace, SFMono-Regular, Menlo, monospace"
+
+func writeStatsCard(path string, report statsReport) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("stats card path: %w", err)
+	}
+	if err := os.WriteFile(abs, []byte(renderStatsCard(report)), 0o644); err != nil {
+		return "", fmt.Errorf("write stats card: %w", err)
+	}
+	return abs, nil
+}
+
+func renderStatsCard(r statsReport) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	b.WriteString(`<svg xmlns="http://www.w3.org/2000/svg" width="800" height="420" viewBox="0 0 800 420">` + "\n")
+	b.WriteString(`<rect width="800" height="420" rx="24" fill="#0d1117"/>` + "\n")
+	b.WriteString(`<g font-family="` + statsCardFont + `" fill="#f0f6fc">` + "\n")
+	cardText(&b, 40, 48, 25, "700", "deja", "#f78166")
+	cardText(&b, 112, 47, 13, "400", "agent history", "#8b949e")
+	cardText(&b, 760, 47, 13, "400", valueOrDash(r.DateRange.Start)+" - "+valueOrDash(r.DateRange.End), "#8b949e", "text-anchor=\"end\"")
+	cardText(&b, 40, 91, 11, "400", "INDEXED WORK", "#8b949e", "letter-spacing=\"2\"")
+	cardText(&b, 40, 132, 32, "700", fmt.Sprintf("%d", r.TotalSessions), "#f0f6fc")
+	cardText(&b, 40, 153, 12, "400", "sessions", "#8b949e")
+	cardText(&b, 190, 132, 32, "700", fmt.Sprintf("%d", r.TotalMessages), "#f0f6fc")
+	cardText(&b, 190, 153, 12, "400", "messages", "#8b949e")
+	cardText(&b, 340, 132, 32, "700", fmt.Sprintf("%d", len(r.Harnesses)), "#f0f6fc")
+	cardText(&b, 340, 153, 12, "400", "harnesses", "#8b949e")
+
+	cardText(&b, 40, 190, 11, "700", "ACTIVITY / LAST 12 MONTHS", "#8b949e", "letter-spacing=\"1.5\"")
+	maxMonth := 0
+	for _, m := range r.Monthly {
+		if m.Messages > maxMonth {
+			maxMonth = m.Messages
+		}
+	}
+	for i, m := range r.Monthly {
+		x := 40 + i*43
+		h := 8
+		opacity := 0.35
+		if maxMonth > 0 && m.Messages > 0 {
+			h = 8 + 52*m.Messages/maxMonth
+			opacity = 0.35 + 0.65*float64(m.Messages)/float64(maxMonth)
+		}
+		fmt.Fprintf(&b, `<rect x="%d" y="%d" width="27" height="%d" rx="4" fill="#58a6ff" opacity="%.2f"/>`+"\n", x, 255-h, h, opacity)
+		label := m.Month
+		if len(label) >= 7 {
+			label = label[5:]
+		}
+		cardText(&b, x+13, 276, 10, "400", label, "#8b949e", "text-anchor=\"middle\"")
+	}
+
+	cardText(&b, 40, 312, 11, "700", "BY HARNESS", "#8b949e", "letter-spacing=\"1.5\"")
+	harnesses := append([]harnessStats(nil), r.Harnesses...)
+	sort.SliceStable(harnesses, func(i, j int) bool {
+		if harnesses[i].Sessions == harnesses[j].Sessions {
+			return harnesses[i].Harness < harnesses[j].Harness
+		}
+		return harnesses[i].Sessions > harnesses[j].Sessions
+	})
+	if len(harnesses) > 6 {
+		other := harnessStats{Harness: "other"}
+		for _, h := range harnesses[6:] {
+			other.Sessions += h.Sessions
+		}
+		harnesses = append(harnesses[:6], other)
+	}
+	maxHarness := 1
+	for _, h := range harnesses {
+		if h.Sessions > maxHarness {
+			maxHarness = h.Sessions
+		}
+	}
+	for i, h := range harnesses {
+		y := 322 + i*11
+		cardText(&b, 40, y+9, 10, "400", h.Harness, "#c9d1d9")
+		width := 100 * h.Sessions / maxHarness
+		fmt.Fprintf(&b, `<rect x="145" y="%d" width="%d" height="8" rx="4" fill="#3fb950"/>`+"\n", y+1, width)
+		cardText(&b, 255, y+9, 10, "700", fmt.Sprintf("%d", h.Sessions), "#c9d1d9")
+	}
+	if len(r.TopProjects) > 0 {
+		cardText(&b, 500, 312, 11, "700", "TOP PROJECT", "#8b949e", "letter-spacing=\"1.5\"")
+		cardText(&b, 500, 335, 13, "400", r.TopProjects[0].Project, "#c9d1d9")
+	}
+	cardText(&b, 40, 410, 11, "400", "deja v"+version, "#8b949e")
+	b.WriteString("</g>\n</svg>\n")
+	return b.String()
+}
+
+func cardText(b *strings.Builder, x, y, size int, weight, text, fill string, attrs ...string) {
+	attr := ""
+	if len(attrs) > 0 {
+		attr = " " + strings.Join(attrs, " ")
+	}
+	fmt.Fprintf(b, `<text x="%d" y="%d" font-size="%d" font-weight="%s" fill="%s"%s>`, x, y, size, weight, fill, attr)
+	var escaped strings.Builder
+	_ = xml.EscapeText(&escaped, []byte(text))
+	b.WriteString(escaped.String())
+	b.WriteString("</text>\n")
+}

--- a/cmd/deja/statscard_test.go
+++ b/cmd/deja/statscard_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func TestRenderStatsCardDeterministicAndEscaped(t *testing.T) {
+	r := statsReport{
+		TotalSessions: 9,
+		TotalMessages: 27,
+		Harnesses: []harnessStats{
+			{Harness: "<&>", Sessions: 4}, {Harness: "codex", Sessions: 3},
+			{Harness: "a", Sessions: 2},
+		},
+		TopProjects: []projectStats{{Project: "<&>", Sessions: 2}},
+		Monthly:     []monthStats{{Month: "2026-07", Messages: 4}},
+		DateRange:   dateRangeStats{Start: "2026-01-01", End: "2026-07-01"},
+	}
+	one := renderStatsCard(r)
+	if one != renderStatsCard(r) {
+		t.Fatal("card rendering is not deterministic")
+	}
+	if strings.Contains(one, "<script") || !strings.Contains(one, "&lt;&amp;&gt;") {
+		t.Fatalf("card escaping or script check failed: %s", one)
+	}
+	decoder := xml.NewDecoder(strings.NewReader(one))
+	for {
+		if _, err := decoder.Token(); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("card is not XML: %v", err)
+		}
+	}
+	if !strings.Contains(one, `viewBox="0 0 800 420"`) || !strings.Contains(one, ">9</text>") || !strings.Contains(one, ">27</text>") {
+		t.Fatalf("card missing fixed layout or hero values")
+	}
+}
+
+func TestRenderStatsCardHarnessAggregation(t *testing.T) {
+	r := statsReport{Harnesses: []harnessStats{
+		{Harness: "z", Sessions: 1}, {Harness: "y", Sessions: 2}, {Harness: "x", Sessions: 3},
+		{Harness: "w", Sessions: 4}, {Harness: "v", Sessions: 5}, {Harness: "u", Sessions: 6}, {Harness: "t", Sessions: 7},
+	}}
+	card := renderStatsCard(r)
+	if !strings.Contains(card, ">other</text>") || !strings.Contains(card, `height="8"`) {
+		t.Fatalf("aggregated harness card = %s", card)
+	}
+}
+
+func TestWriteStatsCardAndStatsFlagConflict(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "card.svg")
+	written, err := writeStatsCard(path, statsReport{Monthly: []monthStats{{Month: "2026-01"}}})
+	if err != nil || written != path {
+		t.Fatalf("writeStatsCard = %q, %v", written, err)
+	}
+	if b, err := os.ReadFile(path); err != nil || !bytes.HasPrefix(b, []byte("<?xml")) {
+		t.Fatalf("card file = %q, %v", b, err)
+	}
+	if err := runStats([]string{"--card", "--json"}); err == nil || !strings.Contains(err.Error(), "choose one output") {
+		t.Fatalf("conflict error = %v", err)
+	}
+	if _, err := writeStatsCard(filepath.Join(path, "nested.svg"), statsReport{}); err == nil {
+		t.Fatal("expected path error")
+	}
+}
+
+func TestStatsCardCommand(t *testing.T) {
+	withStatsStores(t)
+	path := filepath.Join(t.TempDir(), "stats.svg")
+	out, err := captureRun(t, "stats", "--card", path, "--harness", "claude", "--project", "alpha", "--since", "365000d", "--role", "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	abs, _ := filepath.Abs(path)
+	if strings.TrimSpace(out) != abs {
+		t.Fatalf("card output = %q, want %q", out, abs)
+	}
+	if b, err := os.ReadFile(path); err != nil || !strings.Contains(string(b), ">deja</text>") {
+		t.Fatalf("card contents = %q, %v", b, err)
+	}
+}
+
+func TestFilterStatsSessions(t *testing.T) {
+	ss := []model.Session{
+		{Harness: "claude", Project: "alpha", Messages: []model.Message{{Role: "user"}, {Role: "assistant"}}},
+		{Harness: "codex", Project: "beta", Messages: []model.Message{{Role: "user"}}},
+	}
+	got := filterStatsSessions(ss, search.Options{Harness: "claude", Role: "user"})
+	if len(got) != 1 || len(got[0].Messages) != 1 || got[0].Messages[0].Role != "user" {
+		t.Fatalf("filtered sessions = %#v", got)
+	}
+	if got := filterStatsSessions(ss, search.Options{Project: "missing", Since: 1}); len(got) != 0 {
+		t.Fatalf("missing project filter = %#v", got)
+	}
+}


### PR DESCRIPTION
Closes #124. deja stats --card [path] writes a deterministic 800x420 SVG built from the same aggregates as the text report: totals, 12-month activity bars, per-harness breakdown. Self-contained, no external assets; XML-escapes user-derived names.