### PR TITLE
feat(install): add user-level harness guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ deja install --all     # MCP recall for every agent it finds on this machine
 deja install --auto    # same, plus session-start auto-recall where supported
 ```
 
+Install also writes user-level guidance: `~/.claude/skills/deja-history/SKILL.md`, `~/.codex/AGENTS.md`, `~/.gemini/GEMINI.md`, and `~/.config/opencode/AGENTS.md` (or the configured `XDG_CONFIG_HOME`). Re-run rewrites deja's skill or marked block without changing surrounding user content. Use `deja install --all --no-guidance` to opt out; Cursor, Grok, and Antigravity have no documented user-level guidance location and are skipped.
+
 On a terminal, install reports whether it found local history and points to `deja index` when the first index still needs to be built.
 
 That's it. Next session, ask your agent:

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -25,6 +25,7 @@ func hermeticEnv(t *testing.T) string {
 	home := filepath.Join(tmp, "home")
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
 	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -585,6 +585,7 @@ func TestFallbackFindRecentAndMCPEnsureErrors(t *testing.T) {
 }
 
 func TestMoreErrorBranches(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
@@ -667,6 +668,7 @@ func TestSyncSSHPushMoreErrorBranches(t *testing.T) {
 }
 
 func TestInstallAdditionalBranches(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
 	h := t.TempDir()
 	t.Setenv("HOME", h)
 	t.Setenv("USERPROFILE", h)

--- a/cmd/deja/coverage_recover_test.go
+++ b/cmd/deja/coverage_recover_test.go
@@ -58,6 +58,7 @@ func TestDoctorAntigravityLocationFallback(t *testing.T) {
 }
 
 func TestDoctorOpencodeConfigPathJSONCFallback(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
 	tmp := hermeticEnv(t)
 	dir := filepath.Join(tmp, "home", ".config", "opencode")
 	if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -183,7 +183,7 @@ func doctorMCP(w io.Writer) {
 				status = "not wired"
 			}
 		}
-		fmt.Fprintf(w, "  %-12s %-14s %s\n", c.name, status, c.path)
+		fmt.Fprintf(w, "  %-12s %-14s guidance %-11s %s\n", c.name, status, guidanceStatus(guidanceHarness(c.name)), c.path)
 	}
 }
 
@@ -207,7 +207,7 @@ func doctorMCPConfigs() []doctorMCPConfig {
 }
 
 func doctorOpencodeConfigPath() string {
-	dir := filepath.Join(homeDir(), ".config", "opencode")
+	dir := filepath.Join(opencodeConfigHome(), "opencode")
 	path := filepath.Join(dir, "opencode.json")
 	if !doctorExists(path) {
 		if jsonc := filepath.Join(dir, "opencode.jsonc"); doctorExists(jsonc) {

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+const (
+	guidanceStart = "<!-- deja guidance:start -->"
+	guidanceEnd   = "<!-- deja guidance:end -->"
+)
+
+const guidanceBody = `Before re-deriving past work, search deja when the user refers to past work, previous sessions, or what was decided before. Use the deja MCP tools:
+
+- recall: search history with a specific error, function, or decision.
+- recall_context: get a concise digest of the best matching session.
+
+Example: for "what did we decide about token refresh?", call recall with query "token refresh decision", then call recall_context if the result needs more detail.`
+
+func guidancePath(harness string) string {
+	switch harness {
+	case "claude-code", "claude":
+		return filepath.Join(sources.ClaudeConfigDir(), "skills", "deja-history", "SKILL.md")
+	case "codex":
+		return filepath.Join(sources.CodexHome(), "AGENTS.md")
+	case "gemini":
+		return filepath.Join(sources.GeminiHome(), "GEMINI.md")
+	case "opencode":
+		return filepath.Join(opencodeConfigHome(), "opencode", "AGENTS.md")
+	default:
+		return ""
+	}
+}
+
+func opencodeConfigHome() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return xdg
+	}
+	return filepath.Join(homeDir(), ".config")
+}
+
+func guidanceText(harness string) string {
+	if harness == "claude-code" || harness == "claude" {
+		return "---\ntitle: deja-history\ndescription: Consult deja MCP history tools when the user refers to past work or previous decisions.\n---\n\n" + guidanceBody + "\n"
+	}
+	return guidanceStart + "\n" + guidanceBody + "\n" + guidanceEnd + "\n"
+}
+
+func installGuidance(harness string, uninstall bool) (installResult, error) {
+	path := guidancePath(harness)
+	if path == "" {
+		return installResult{}, nil
+	}
+	old, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return installResult{}, err
+	}
+	var next []byte
+	if harness == "claude-code" || harness == "claude" {
+		if uninstall {
+			if len(old) == 0 {
+				return installResult{Path: path, Action: "unchanged"}, nil
+			}
+			if err := os.Remove(path); err != nil {
+				return installResult{}, err
+			}
+			return installResult{Path: path, Action: "removed"}, nil
+		} else {
+			next = []byte(guidanceText(harness))
+		}
+	} else {
+		next = []byte(updateGuidanceBlock(string(old), uninstall))
+	}
+	a, err := writeIfChanged(path, old, next)
+	return installResult{Path: path, Action: a}, err
+}
+
+func updateGuidanceBlock(old string, uninstall bool) string {
+	newline := "\n"
+	if strings.Contains(old, "\r\n") {
+		newline = "\r\n"
+	}
+	start := strings.Index(old, guidanceStart)
+	if start >= 0 {
+		end := strings.Index(old[start+len(guidanceStart):], guidanceEnd)
+		if end >= 0 {
+			end += start + len(guidanceStart) + len(guidanceEnd)
+			old = old[:start] + old[end:]
+		}
+	}
+	if uninstall {
+		return old
+	}
+	old = strings.TrimRight(old, "\r\n")
+	if old != "" {
+		old += newline + newline
+	}
+	return old + strings.ReplaceAll(guidanceText("append"), "\n", newline)
+}
+
+func guidanceHarness(harness string) string {
+	switch harness {
+	case "claude-auto":
+		return "claude-code"
+	case "codex-auto":
+		return "codex"
+	case "opencode-auto":
+		return "opencode"
+	default:
+		return harness
+	}
+}
+
+func guidanceStatus(harness string) string {
+	path := guidancePath(harness)
+	if path == "" {
+		return "unsupported"
+	}
+	if _, err := os.Stat(path); err == nil {
+		return "written"
+	}
+	return "missing"
+}
+
+func guidanceResult(harness string, uninstall bool) (installResult, error) {
+	canonical := guidanceHarness(harness)
+	if canonical == "cursor" || canonical == "grok" || canonical == "antigravity" {
+		return installResult{}, nil
+	}
+	return installGuidance(canonical, uninstall)
+}
+
+func guidanceOutput(harness string, result installResult) string {
+	if result.Path == "" {
+		return fmt.Sprintf("%s: guidance unsupported", harness)
+	}
+	return fmt.Sprintf("%s: guidance %s %s", harness, result.Action, result.Path)
+}

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -45,7 +45,7 @@ func opencodeConfigHome() string {
 
 func guidanceText(harness string) string {
 	if harness == "claude-code" || harness == "claude" {
-		return "---\ntitle: deja-history\ndescription: Consult deja MCP history tools when the user refers to past work or previous decisions.\n---\n\n" + guidanceBody + "\n"
+		return "---\nname: deja-history\ndescription: Consult deja MCP history tools when the user refers to past work or previous decisions.\n---\n\n" + guidanceBody + "\n"
 	}
 	return guidanceStart + "\n" + guidanceBody + "\n" + guidanceEnd + "\n"
 }

--- a/cmd/deja/guidance_test.go
+++ b/cmd/deja/guidance_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGuidanceTargetsAreUserLevelAndRespectXDG(t *testing.T) {
+	home := t.TempDir()
+	xdg := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	if got := guidancePath("claude-code"); got != filepath.Join(home, ".claude", "skills", "deja-history", "SKILL.md") {
+		t.Fatalf("claude path = %q", got)
+	}
+	if got := guidancePath("opencode"); got != filepath.Join(xdg, "opencode", "AGENTS.md") {
+		t.Fatalf("opencode path = %q", got)
+	}
+	for _, harness := range []string{"cursor", "grok", "antigravity"} {
+		if got := guidancePath(harness); got != "" {
+			t.Fatalf("%s path = %q, want unsupported", harness, got)
+		}
+	}
+}
+
+func TestGuidanceAppendPreservesAndRewrites(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	path := guidancePath("codex")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("# Personal rules\n\nkeep this\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r, err := installGuidance("codex", false)
+	if err != nil || r.Action != "updated" {
+		t.Fatalf("install = %#v, %v", r, err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "keep this") || strings.Count(string(b), guidanceStart) != 1 {
+		t.Fatalf("surrounding content or marker lost: %s", b)
+	}
+	if r, err = installGuidance("codex", false); err != nil || r.Action != "unchanged" {
+		t.Fatalf("second install = %#v, %v", r, err)
+	}
+	if r, err = installGuidance("codex", true); err != nil || r.Action != "updated" {
+		t.Fatalf("uninstall = %#v, %v", r, err)
+	}
+	b, _ = os.ReadFile(path)
+	if strings.Contains(string(b), guidanceStart) || !strings.Contains(string(b), "keep this") {
+		t.Fatalf("uninstall changed user content: %s", b)
+	}
+}
+
+func TestClaudeGuidanceIsOwnedAndOptOutWorks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	path := guidancePath("claude-code")
+	r, err := installGuidance("claude-code", false)
+	if err != nil || r.Action != "created" || r.Path != path {
+		t.Fatalf("install = %#v, %v", r, err)
+	}
+	if got := guidanceStatus("claude-code"); got != "written" {
+		t.Fatalf("guidance status = %q", got)
+	}
+	if got := guidanceOutput("cursor", installResult{}); got != "cursor: guidance unsupported" {
+		t.Fatalf("unsupported output = %q", got)
+	}
+	b, _ := os.ReadFile(path)
+	if !strings.Contains(string(b), "deja-history") || !strings.Contains(string(b), "recall_context") {
+		t.Fatalf("skill content incomplete: %s", b)
+	}
+	if r, err = installGuidance("claude-code", false); err != nil || r.Action != "unchanged" {
+		t.Fatalf("second install = %#v, %v", r, err)
+	}
+	if r, err = installGuidance("claude-code", true); err != nil || r.Action != "removed" {
+		t.Fatalf("uninstall = %#v, %v", r, err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("owned skill still exists, err=%v", err)
+	}
+}
+
+func TestGuidanceBlockHandlesCRLFAndUnsupportedResult(t *testing.T) {
+	old := "# Rules\r\n\r\n" + guidanceStart + "\r\nold\r\n" + guidanceEnd + "\r\n"
+	got := updateGuidanceBlock(old, false)
+	if strings.Count(got, guidanceStart) != 1 || !strings.Contains(got, "\r\n") || strings.Contains(got, "old") {
+		t.Fatalf("CRLF rewrite = %q", got)
+	}
+	if r, err := guidanceResult("cursor", false); err != nil || r.Path != "" {
+		t.Fatalf("unsupported guidance = %#v, %v", r, err)
+	}
+}
+
+func TestInstallNoGuidanceOptOut(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	if err := runInstall([]string{"codex", "--no-guidance"}, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("guidance was written despite opt-out, err=%v", err)
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -16,14 +16,23 @@ import (
 type installResult struct{ Path, Action string }
 
 func runInstall(args []string, uninstall bool) error {
-	if len(args) != 1 {
+	guidance := true
+	var targetArgs []string
+	for _, arg := range args {
+		if arg == "--no-guidance" {
+			guidance = false
+			continue
+		}
+		targetArgs = append(targetArgs, arg)
+	}
+	if len(targetArgs) != 1 {
 		if uninstall {
 			return fmt.Errorf("uninstall needs target")
 		}
 		return fmt.Errorf("install needs target")
 	}
-	targets := []string{args[0]}
-	if args[0] == "--auto" {
+	targets := []string{targetArgs[0]}
+	if targetArgs[0] == "--auto" {
 		targets = nil
 		for _, t := range existingTargets() {
 			switch t {
@@ -44,7 +53,7 @@ func runInstall(args []string, uninstall bool) error {
 			return nil
 		}
 	}
-	if args[0] == "--all" {
+	if targetArgs[0] == "--all" {
 		targets = existingTargets()
 		if len(targets) == 0 {
 			fmt.Println("no known agent config directories found")
@@ -56,13 +65,22 @@ func runInstall(args []string, uninstall bool) error {
 		return err
 	}
 	exe, _ = filepath.Abs(exe)
-	banner := !uninstall && (args[0] == "--auto" || args[0] == "--all") && logoWanted(os.Stdout)
+	banner := !uninstall && (targetArgs[0] == "--auto" || targetArgs[0] == "--all") && logoWanted(os.Stdout)
 	type lineItem struct{ target, action, path string }
 	var done []lineItem
 	for _, t := range targets {
 		r, err := installTarget(t, exe, uninstall)
 		if err != nil {
 			return err
+		}
+		if guidance {
+			gr, err := guidanceResult(t, uninstall)
+			if err != nil {
+				return err
+			}
+			if gr.Path != "" && !banner {
+				fmt.Println(guidanceOutput(t, gr))
+			}
 		}
 		if banner {
 			done = append(done, lineItem{t, r.Action, shortHome(r.Path)})
@@ -132,7 +150,7 @@ func existingTargets() []string {
 	checks := map[string]string{
 		"claude-code": sources.ClaudeConfigDir(),
 		"codex":       sources.CodexHome(),
-		"opencode":    filepath.Join(h, ".config", "opencode"),
+		"opencode":    filepath.Join(opencodeConfigHome(), "opencode"),
 		"cursor":      sources.CursorCLIHome(),
 		"gemini":      filepath.Join(sources.GeminiHome(), "settings.json"),
 		"antigravity": filepath.Join(h, ".gemini", "config"),
@@ -457,8 +475,7 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 }
 
 func installOpencode(exe string, uninstall bool) (installResult, error) {
-	h, _ := os.UserHomeDir()
-	dir := filepath.Join(h, ".config", "opencode")
+	dir := filepath.Join(opencodeConfigHome(), "opencode")
 	path := filepath.Join(dir, "opencode.json")
 	if _, err := os.Stat(path); err != nil {
 		if _, e := os.Stat(filepath.Join(dir, "opencode.jsonc")); e == nil {

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -79,8 +79,7 @@ func entryHasCommand(entry map[string]any, cmd string) bool {
 // system prompt per request. The generated plugin shells out to
 // `deja hook-context --plain` once per session and caches the result.
 func installOpencodePlugin(exe string, uninstall bool) (installResult, error) {
-	h, _ := os.UserHomeDir()
-	dir := filepath.Join(h, ".config", "opencode", "plugins")
+	dir := filepath.Join(opencodeConfigHome(), "opencode", "plugins")
 	path := filepath.Join(dir, "deja.js")
 	if uninstall {
 		if _, err := os.Stat(path); err != nil {

--- a/cmd/deja/testmain_test.go
+++ b/cmd/deja/testmain_test.go
@@ -21,6 +21,8 @@ func TestMain(m *testing.M) {
 		"GEMINI_CLI_HOME":         "",
 		"CURSOR_CONFIG_DIR":       "",
 		"AIDER_CHAT_HISTORY_FILE": "",
+		"XDG_CONFIG_HOME":         "",
+		"XDG_DATA_HOME":           "",
 		"DEJA_CLAUDE_ROOT":        filepath.Join(root, "claude"),
 		"DEJA_CODEX_ROOT":         filepath.Join(root, "codex"),
 		"DEJA_OPENCODE_DB":        filepath.Join(root, "opencode.db"),


### PR DESCRIPTION
Closes #126. deja install now also writes user-level guidance: a deja-history skill for Claude Code and marked blocks in ~/.codex/AGENTS.md, ~/.gemini/GEMINI.md, and opencode's AGENTS.md, teaching agents to call recall / recall_context when the user refers to past work. --no-guidance opts out; doctor reports the state. Cursor, grok, antigravity skipped: no documented user-level rules file.