### PR TITLE
feat(search): rank candidates with BM25

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,11 +44,16 @@ Search flow:
 1. Tokenize the query.
 2. Read posting lists from the token buckets.
 3. Intersect posting lists for multi-word searches.
-4. Aggregate posting counts per session and pre-rank by count × recency using session metadata.
-5. Read matching records from `records.bin` only for the top sessions (`--all` keeps all candidates).
-6. Group records back into sessions and rank in `internal/search`.
+4. Filter postings by session metadata and read every matching candidate record.
+5. Group records back into sessions and score them in `internal/search` with BM25
+   (`k1=1.2`, `b=0.75`). Document frequency and document length are measured
+   over the candidate records at search time. User-message term contributions
+   receive a 1.3 multiplier, and the score is multiplied by `1/(1+age_days)`.
+6. Sort by score, then updated time descending, then session ID ascending; the
+   normal result limit is applied after ranking.
 
-`--harness`, `--project`, and `--since` are applied during pre-rank from session metadata. `--role` needs record data, so it is applied after the pre-rank cut; pre-rank counts may include other roles.
+`--harness`, `--project`, and `--since` are applied from session metadata before
+scoring. `--role` is applied while reading candidate records.
 
 Regex search scans records because arbitrary regex cannot use token postings safely.
 

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -268,8 +268,8 @@ func TestDefaultDirQueriesFiltersAndCorruptBucketBranches(t *testing.T) {
 		many = append(many, posting{Off: int64(i), Sid: uint32(i)})
 		manyManifest.Sessions[fmt.Sprintf("h:%d", i)] = SessionMeta{ID: fmt.Sprint(i), Harness: "h", Project: "p", Ord: uint32(i), Updated: time.Now().Add(time.Duration(i) * time.Second)}
 	}
-	if got := cutPostingsBySession(many, manyManifest, search.Options{}); len(got) != 15 {
-		t.Fatalf("top15 cut len=%d", len(got))
+	if got := cutPostingsBySession(many, manyManifest, search.Options{}); len(got) != 20 {
+		t.Fatalf("candidate cut len=%d", len(got))
 	}
 
 	for name, data := range map[string][]byte{

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -1557,50 +1557,17 @@ func scanRecords(dir string, m Manifest, o search.Options, offsets []int64) ([]m
 }
 
 func cutPostingsBySession(posts []posting, m Manifest, o search.Options) []posting {
-	// Rank from posting counts before reading record text. Harness/project/since are
-	// session metadata filters; role is record-level, so search.Run applies it after
-	// the cut and pre-rank counts may include other roles.
-	type candidate struct {
-		sid     uint32
-		count   int
-		updated time.Time
-	}
 	metaByOrd := sessionMetaByOrd(m)
-	counts := map[uint32]int{}
-	for _, p := range sortedUniquePostings(posts) {
-		meta, ok := metaByOrd[p.Sid]
-		if !ok || !sessionMetaMatches(meta, o) {
-			continue
-		}
-		counts[p.Sid]++
-	}
-	if len(counts) == 0 {
-		return nil
-	}
-	candidates := make([]candidate, 0, len(counts))
-	for sid, count := range counts {
-		candidates = append(candidates, candidate{sid: sid, count: count, updated: metaByOrd[sid].Updated})
-	}
-	sort.Slice(candidates, func(i, j int) bool {
-		si := preRankScore(candidates[i].count, candidates[i].updated)
-		sj := preRankScore(candidates[j].count, candidates[j].updated)
-		if si == sj {
-			return candidates[i].updated.After(candidates[j].updated)
-		}
-		return si > sj
-	})
-	if !o.All && len(candidates) > 15 {
-		candidates = candidates[:15]
-	}
-	keep := make(map[uint32]bool, len(candidates))
-	for _, c := range candidates {
-		keep[c.sid] = true
-	}
+	// Keep the complete posting-derived candidate set. Ranking needs the
+	// candidate records to calculate BM25 document frequency and length.
 	out := make([]posting, 0, len(posts))
 	for _, p := range posts {
-		if keep[p.Sid] {
+		if meta, ok := metaByOrd[p.Sid]; ok && sessionMetaMatches(meta, o) {
 			out = append(out, p)
 		}
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }
@@ -1624,11 +1591,6 @@ func sessionMetaMatches(meta SessionMeta, o search.Options) bool {
 		return false
 	}
 	return true
-}
-
-func preRankScore(count int, updated time.Time) float64 {
-	age := time.Since(updated).Hours() / 24
-	return float64(count) * 1000 / (1 + age)
 }
 
 func postingOffsets(posts []posting) []int64 {

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -451,9 +451,6 @@ func TestIndexRecentFindRecordsAndBranches(t *testing.T) {
 	if got, err := parseChangedFile("", p, FileState{}); err != nil || len(got) != 1 {
 		t.Fatalf("parse changed=%#v err=%v", got, err)
 	}
-	if preRankScore(2, time.Now()) <= 0 {
-		t.Fatalf("preRankScore not positive")
-	}
 	if !strings.HasPrefix(bucket("a"), "x") || bucket("ab") != "ab" {
 		t.Fatalf("short bucket failed")
 	}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -38,6 +40,19 @@ type Hit struct {
 	Score    float64       `json:"score"`
 }
 
+const (
+	bm25K1        = 1.2
+	bm25B         = 0.75
+	userRoleBoost = 1.3
+)
+
+type bm25Document struct {
+	hit       Hit
+	termCount []int
+	userCount []int
+	length    int
+}
+
 func Run(ss []model.Session, o Options) ([]Hit, error) {
 	var re *regexp.Regexp
 	qlow := strings.ToLower(o.Query)
@@ -53,8 +68,12 @@ func Run(ss []model.Session, o Options) ([]Hit, error) {
 	if o.Since > 0 {
 		cut = time.Now().Add(-o.Since)
 	}
-	var hits []Hit
-	for _, s := range mergeSessions(ss) {
+	merged := mergeSessions(ss)
+	documents := make([]bm25Document, 0, len(merged))
+	df := make([]int, len(qtoks))
+	corpusDocuments := 0
+	corpusLength := 0
+	for _, s := range merged {
 		if o.Harness != "" && s.Harness != o.Harness {
 			continue
 		}
@@ -64,7 +83,11 @@ func Run(ss []model.Session, o Options) ([]Hit, error) {
 		if !cut.IsZero() && s.Updated.Before(cut) {
 			continue
 		}
-		h := Hit{Session: s}
+		doc := bm25Document{hit: Hit{Session: s}, termCount: make([]int, len(qtoks)), userCount: make([]int, len(qtoks))}
+		if len(qtoks) == 0 {
+			doc.termCount = []int{0}
+			doc.userCount = []int{0}
+		}
 		for _, m := range s.Messages {
 			if o.Role != "" && m.Role != o.Role {
 				continue
@@ -74,37 +97,131 @@ func Run(ss []model.Session, o Options) ([]Hit, error) {
 				c = len(re.FindAllStringIndex(m.Text, -1))
 			} else {
 				low := strings.ToLower(m.Text)
-				if len(qtoks) <= 1 {
-					if strings.Contains(low, qlow) {
-						c = strings.Count(low, qlow)
-					}
-				} else {
-					c = countAllTokens(low, qtoks)
+				c = countAllTokens(low, qtoks)
+				if len(qtoks) == 1 && c == 0 && strings.Contains(low, qlow) {
+					c = strings.Count(low, qlow)
 				}
 			}
 			if c > 0 {
-				h.Count += c
-				if len(h.Snippets) < 3 {
-					h.Snippets = append(h.Snippets, snippet(m.Text, o.Query, re))
+				doc.hit.Count += c
+				if len(doc.hit.Snippets) < 3 {
+					doc.hit.Snippets = append(doc.hit.Snippets, snippet(m.Text, o.Query, re))
+				}
+			}
+			low := strings.ToLower(m.Text)
+			doc.length += countDocumentWords(low, qtoks, doc.termCount, doc.userCount, m.Role == "user")
+			if len(qtoks) == 1 && doc.termCount[0] == 0 && strings.Contains(low, qlow) {
+				n := strings.Count(low, qlow)
+				doc.termCount[0] += n
+				if m.Role == "user" {
+					doc.userCount[0] += n
 				}
 			}
 		}
-		if h.Count > 0 {
-			age := time.Since(s.Updated).Hours() / 24
-			h.Score = float64(h.Count) * 1000 / (1 + age)
-			hits = append(hits, h)
+		corpusDocuments++
+		corpusLength += doc.length
+		for i, n := range doc.termCount {
+			if n > 0 {
+				df[i]++
+			}
+		}
+		if doc.hit.Count > 0 {
+			documents = append(documents, doc)
 		}
 	}
-	sort.Slice(hits, func(i, j int) bool {
-		if hits[i].Score == hits[j].Score {
-			return hits[i].Session.Updated.After(hits[j].Session.Updated)
-		}
-		return hits[i].Score > hits[j].Score
-	})
+	avgLength := 0.0
+	if corpusDocuments > 0 {
+		avgLength = float64(corpusLength) / float64(corpusDocuments)
+	}
+	hits := scoreBM25(documents, df, corpusDocuments, avgLength, len(qtoks) == 0)
 	if !o.All && len(hits) > 15 {
 		hits = hits[:15]
 	}
 	return hits, nil
+}
+
+func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLength float64, emptyQuery bool) []Hit {
+	now := time.Now()
+	hits := make([]Hit, 0, len(documents))
+	for _, doc := range documents {
+		score := 0.0
+		for i, tf := range doc.termCount {
+			if tf == 0 {
+				continue
+			}
+			idf := math.Log(1 + (float64(corpusDocuments-df[i])+.5)/(float64(df[i])+.5))
+			norm := 1 - bm25B
+			if avgLength > 0 {
+				norm += bm25B * float64(doc.length) / avgLength
+			}
+			term := idf * (float64(tf) * (bm25K1 + 1)) / (float64(tf) + bm25K1*norm)
+			if doc.userCount[i] > 0 {
+				term += idf * (float64(doc.userCount[i]) * (bm25K1 + 1)) / (float64(tf) + bm25K1*norm) * (userRoleBoost - 1)
+			}
+			score += term
+		}
+		if emptyQuery {
+			score = float64(doc.hit.Count)
+		}
+		score *= freshnessDecay(doc.hit.Session.Updated, now)
+		doc.hit.Score = score
+		hits = append(hits, doc.hit)
+	}
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].Score == hits[j].Score {
+			if hits[i].Session.Updated.Equal(hits[j].Session.Updated) {
+				return hits[i].Session.ID < hits[j].Session.ID
+			}
+			return hits[i].Session.Updated.After(hits[j].Session.Updated)
+		}
+		return hits[i].Score > hits[j].Score
+	})
+	return hits
+}
+
+func freshnessDecay(updated, now time.Time) float64 {
+	if updated.IsZero() {
+		return 0
+	}
+	age := now.Sub(updated).Hours() / 24
+	if age <= 0 {
+		return 1
+	}
+	return 1 / (1 + age)
+}
+
+func countDocumentWords(s string, terms []string, counts, userCounts []int, user bool) int {
+	length := 0
+	start := -1
+	for i := 0; i <= len(s); {
+		isWord := false
+		size := 0
+		if i < len(s) {
+			r, n := utf8.DecodeRuneInString(s[i:])
+			size = n
+			isWord = unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-'
+		}
+		if isWord && start < 0 {
+			start = i
+		} else if !isWord && start >= 0 {
+			word := s[start:i]
+			length++
+			for j, term := range terms {
+				if word == term {
+					counts[j]++
+					if user {
+						userCounts[j]++
+					}
+				}
+			}
+			start = -1
+		}
+		if i == len(s) {
+			break
+		}
+		i += size
+	}
+	return length
 }
 
 func mergeSessions(in []model.Session) []model.Session {

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -29,6 +30,77 @@ func TestSearchRanksAndFilters(t *testing.T) {
 	}
 	if len(hits) != 1 || hits[0].Session.ID != "b" {
 		t.Fatalf("bad filter: %#v", hits)
+	}
+}
+
+func TestRunBM25Signals(t *testing.T) {
+	now := time.Now()
+	session := func(id, role, text string, updated time.Time) model.Session {
+		return model.Session{ID: id, Harness: "claude", Project: "p", Updated: updated, Messages: []model.Message{{Role: role, Text: text}}}
+	}
+	tests := []struct {
+		name  string
+		query string
+		ss    []model.Session
+		want  string
+	}{
+		{"term frequency", "needle", []model.Session{
+			session("padding", "user", "needle "+strings.Repeat("padding ", 100), now),
+			session("frequency", "user", "needle needle needle", now),
+		}, "frequency"},
+		{"rare term", "common rare", []model.Session{
+			session("common", "user", "common rare common common", now),
+			session("rare", "user", "common rare", now),
+			session("noise", "user", "common common", now),
+		}, "rare"},
+		{"user role", "needle", []model.Session{
+			session("assistant", "assistant", "needle", now),
+			session("user", "user", "needle", now),
+		}, "user"},
+		{"recency", "needle", []model.Session{
+			session("new", "user", "needle", now),
+			session("old", "user", "needle", now.Add(-24*time.Hour)),
+		}, "new"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hits, err := Run(tc.ss, Options{Query: tc.query, All: true})
+			if err != nil || len(hits) < 2 || hits[0].Session.ID != tc.want {
+				t.Fatalf("hits=%#v err=%v", hits, err)
+			}
+		})
+	}
+}
+
+func TestRunBM25DeterministicIDTieBreak(t *testing.T) {
+	when := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	ss := []model.Session{
+		{ID: "z", Updated: when, Messages: []model.Message{{Role: "user", Text: "needle"}}},
+		{ID: "a", Updated: when, Messages: []model.Message{{Role: "user", Text: "needle"}}},
+	}
+	for i := 0; i < 5; i++ {
+		hits, err := Run(ss, Options{Query: "needle", All: true})
+		if err != nil || len(hits) != 2 || hits[0].Session.ID != "a" || hits[1].Session.ID != "z" {
+			t.Fatalf("iteration %d hits=%#v err=%v", i, hits, err)
+		}
+	}
+}
+
+func TestBM25HelperSignals(t *testing.T) {
+	now := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	if got := freshnessDecay(time.Time{}, now); got != 0 {
+		t.Fatalf("zero decay=%v", got)
+	}
+	if got := freshnessDecay(now.Add(time.Hour), now); got != 1 {
+		t.Fatalf("future decay=%v", got)
+	}
+	if got := freshnessDecay(now.Add(-24*time.Hour), now); got != 0.5 {
+		t.Fatalf("one-day decay=%v", got)
+	}
+	counts := make([]int, 2)
+	userCounts := make([]int, 2)
+	if got := countDocumentWords("one needle, needle-two", []string{"needle", "needle-two"}, counts, userCounts, true); got != 3 || counts[0] != 1 || counts[1] != 1 || userCounts[1] != 1 {
+		t.Fatalf("word counts len=%d counts=%v user=%v", got, counts, userCounts)
 	}
 }
 
@@ -352,5 +424,21 @@ func TestSnippetPrefersProseOverToolDump(t *testing.T) {
 	}
 	if !strings.Contains(hits[0].Snippets[0], "migration strategy") {
 		t.Fatalf("missing prose snippet: %#v", hits[0].Snippets[0])
+	}
+}
+
+func BenchmarkBM25Scoring1000Candidates(b *testing.B) {
+	now := time.Now()
+	documents := make([]bm25Document, 1000)
+	for i := range documents {
+		documents[i] = bm25Document{hit: Hit{Session: model.Session{ID: fmt.Sprintf("session-%04d", i), Updated: now}}, termCount: []int{1, 1}, userCount: []int{1, 1}, length: 6}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		hits := scoreBM25(documents, []int{1000, 1000}, 1000, 6, false)
+		if len(hits) != len(documents) {
+			b.Fatalf("hits=%d", len(hits))
+		}
 	}
 }


### PR DESCRIPTION
Closes #129. BM25 (k1=1.2, b=0.75) over the candidate set with df from the merged corpus, a 1.3x boost for user-message matches, and the existing freshness decay as a multiplier. Deterministic tie-break on updated time then id. Scoring benchmark included; no index format changes.