### PR TITLE
feat(search): support quoted phrases and fuzzy fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ deja "jwt refresh token"
 
 | Command | What it does |
 | --- | --- |
-| `deja <query>` | Search all histories. Multi-word = AND, substrings match (`code` finds `opencode`). `--re`, `--harness`, `--project`, `--since 30d`, `--role`, `--json`. |
+| `deja <query>` | Search all histories. Multi-word = AND, substrings match (`code` finds `opencode`), and double-quoted phrases require contiguous text; a zero-result query also tries close spellings. `--re`, `--harness`, `--project`, `--since 30d`, `--role`, `--json`. |
 | `deja ctx <query>` | Compact markdown digest of the best match — pipe it into a prompt. |
 | `deja share <id>` | Sanitized session digest for a colleague: secrets redacted, tool noise stripped. |
 | `deja stats` | Totals, per-harness split, top projects, monthly sparkline. `--json` too. |

--- a/cmd/deja/guidance_test.go
+++ b/cmd/deja/guidance_test.go
@@ -113,3 +113,29 @@ func TestInstallNoGuidanceOptOut(t *testing.T) {
 		t.Fatalf("guidance was written despite opt-out, err=%v", err)
 	}
 }
+
+func TestInstallGuidanceReadFailureSurfaces(t *testing.T) {
+	tmp := hermeticEnv(t)
+	// Squat the skill directory path with a regular file so reading the
+	// skill file fails with a non-NotExist error.
+	skills := filepath.Join(tmp, "home", ".claude", "skills")
+	if err := os.MkdirAll(filepath.Dir(skills), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(skills, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGuidance("claude-code", false); err == nil {
+		t.Fatal("expected guidance install error when skills path is a file")
+	}
+}
+
+func TestInstallGuidanceEdgeBranches(t *testing.T) {
+	hermeticEnv(t)
+	if r, err := installGuidance("nope", false); err != nil || r.Path != "" {
+		t.Fatalf("unknown harness = %#v err=%v", r, err)
+	}
+	if r, err := installGuidance("claude-code", true); err != nil || r.Action != "unchanged" {
+		t.Fatalf("uninstall with no skill = %#v err=%v", r, err)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -223,9 +224,15 @@ func run(args []string) error {
 		return fmt.Errorf("ensure: %w", err)
 	}
 	maybeFirstIndexGreeting()
-	ss, err := index.SearchWithRecovery(index.DefaultDir(), o, os.Stderr)
+	result, err := index.SearchWithRecoveryDetailed(index.DefaultDir(), o, os.Stderr)
 	if err != nil {
 		return fmt.Errorf("search: %w", err)
+	}
+	ss := result.Sessions
+	if result.Fuzzy {
+		printFuzzy(os.Stderr, result.Variants)
+		o.Fuzzy = true
+		o.FuzzyVariants = result.Variants
 	}
 	hits, err := search.Run(ss, o)
 	if err != nil {
@@ -240,6 +247,21 @@ func run(args []string) error {
 
 func printNoMatches(w io.Writer, q string, n int) {
 	fmt.Fprintf(w, "deja: no matches for %q (searched %d sessions across claude/codex/opencode/aider/gemini/cursor/antigravity/grok/qwen) — try fewer words or --re\n", q, n)
+}
+
+func printFuzzy(w io.Writer, variants map[string][]string) {
+	keys := make([]string, 0, len(variants))
+	for token := range variants {
+		keys = append(keys, token)
+	}
+	sort.Strings(keys)
+	for _, token := range keys {
+		for _, variant := range variants[token] {
+			if variant != token {
+				fmt.Fprintf(w, "deja: no exact match, trying close spellings: %s -> %s\n", token, variant)
+			}
+		}
+	}
 }
 
 func findByPrefix(p string) (model.Session, bool, error) {
@@ -521,6 +543,8 @@ Usage:
 
 Examples:
   deja "jwt refresh token bug"
+  deja '"connection pool exhausted"'
+  deja "conection"  # zero exact results try close spellings
   deja --harness claude --since 30d "panic in indexer"
   deja last 20 --harness codex
   deja last --project api-gateway

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -544,7 +544,7 @@ Usage:
 Examples:
   deja "jwt refresh token bug"
   deja '"connection pool exhausted"'
-  deja "conection"  # zero exact results try close spellings
+  deja "exhaustd"  # zero exact results try close spellings
   deja --harness claude --since 30d "panic in indexer"
   deja last 20 --harness codex
   deja last --project api-gateway

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -378,6 +378,22 @@ func TestParseSearchAndSmallHelpers(t *testing.T) {
 	}
 }
 
+func TestFuzzyOutputIsDeterministic(t *testing.T) {
+	var b strings.Builder
+	printFuzzy(&b, map[string][]string{"zebra": {"zebar"}, "alpha": {"alpha", "alphi"}})
+	if got, want := b.String(), "deja: no exact match, trying close spellings: alpha -> alphi\n"+"deja: no exact match, trying close spellings: zebra -> zebar\n"; got != want {
+		t.Fatalf("fuzzy output=%q want=%q", got, want)
+	}
+	if got := fuzzySummary(map[string][]string{"b": {"a"}, "a": {"a", "c"}}); strings.Join(got, ",") != "a -> c,b -> a" {
+		t.Fatalf("fuzzy summary=%v", got)
+	}
+	var empty strings.Builder
+	printFuzzy(&empty, nil)
+	if empty.Len() != 0 || fuzzySummary(nil) != nil {
+		t.Fatal("empty fuzzy output was not empty")
+	}
+}
+
 func TestPrintNoMatchesHelpfulMessage(t *testing.T) {
 	var b bytes.Buffer
 	printNoMatches(&b, "jwt refresh token", 3)

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"unicode/utf8"
 
@@ -163,9 +164,13 @@ func recallTextResult(q, harness string, limit, budget int) (string, int, error)
 	if err := index.EnsureForSearch(index.DefaultDir(), o, false, mcpProgress()); err != nil {
 		return "", 0, err
 	}
-	ss, err := index.SearchWithRecovery(index.DefaultDir(), o, mcpProgress())
+	result, err := index.SearchWithRecoveryDetailed(index.DefaultDir(), o, mcpProgress())
 	if err != nil {
 		return "", 0, err
+	}
+	ss := result.Sessions
+	if result.Fuzzy {
+		o.FuzzyVariants = result.Variants
 	}
 	hits, err := search.Run(ss, o)
 	if err != nil {
@@ -179,6 +184,9 @@ func recallTextResult(q, harness string, limit, budget int) (string, int, error)
 	}
 	var b strings.Builder
 	served := 0
+	if result.Fuzzy {
+		fmt.Fprintf(&b, "No exact match; using close spellings: %s\n", strings.Join(fuzzySummary(result.Variants), ", "))
+	}
 	fmt.Fprintf(&b, "deja recall for %q (%d match(es))\n", q, len(hits))
 	for i, h := range hits {
 		fmt.Fprintf(&b, "\n%d. [%s] %s · %s · %d matches", i+1, h.Session.Harness, h.Session.Project, h.Session.ID, h.Count)
@@ -221,9 +229,13 @@ func recallContextResult(q, harness string) (string, int, error) {
 	if err := index.EnsureForSearch(index.DefaultDir(), o, false, mcpProgress()); err != nil {
 		return "", 0, err
 	}
-	ss, err := index.SearchWithRecovery(index.DefaultDir(), o, mcpProgress())
+	result, err := index.SearchWithRecoveryDetailed(index.DefaultDir(), o, mcpProgress())
 	if err != nil {
 		return "", 0, err
+	}
+	ss := result.Sessions
+	if result.Fuzzy {
+		o.FuzzyVariants = result.Variants
 	}
 	hits, err := search.Run(ss, o)
 	if err != nil {
@@ -242,4 +254,17 @@ func mcpProgress() io.Writer {
 		return os.Stderr
 	}
 	return io.Discard
+}
+
+func fuzzySummary(variants map[string][]string) []string {
+	var out []string
+	for token, values := range variants {
+		for _, value := range values {
+			if value != token {
+				out = append(out, token+" -> "+value)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -35,6 +35,83 @@ func hermeticIndexEnv(t *testing.T) string {
 	return tmp
 }
 
+func TestPhraseAndFuzzyIndexedSearch(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "fuzzy-index")
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	sessions := []model.Session{{ID: "phrase", Harness: "claude", Project: "p", Updated: base, Messages: []model.Message{{Role: "user", Text: "connection pool exhausted"}}}, {ID: "apart", Harness: "claude", Project: "p", Updated: base, Messages: []model.Message{{Role: "user", Text: "connection pool was exhausted"}}}}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	result, err := SearchDetailed(dir, search.Options{Query: `"connection pool exhausted"`, All: true})
+	if err != nil || len(result.Sessions) != 1 || result.Sessions[0].ID != "phrase" {
+		t.Fatalf("phrase result=%#v err=%v", result, err)
+	}
+	result, err = SearchDetailed(dir, search.Options{Query: "exhaustd", All: true})
+	if err != nil || !result.Fuzzy || len(result.Sessions) != 2 {
+		t.Fatalf("fuzzy result=%#v err=%v", result, err)
+	}
+	o := search.Options{Query: "exhaustd", All: true, FuzzyVariants: result.Variants}
+	hits, err := search.Run(result.Sessions, o)
+	if err != nil || len(hits) != 2 || hits[0].Count == 0 {
+		t.Fatalf("fuzzy pipeline hits=%#v err=%v", hits, err)
+	}
+}
+
+func BenchmarkFuzzyTokenEnumeration(b *testing.B) {
+	catalog := make(map[string]bool, 50000)
+	for i := 0; i < 50000; i++ {
+		catalog[fmt.Sprintf("synthetic-token-%05d", i)] = true
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = closeTokens("synthetic-token-12345", catalog)
+	}
+}
+
+func TestFuzzyHelperCapsAndDistanceRules(t *testing.T) {
+	catalog := map[string]bool{"abcdefgh": true, "abcdefgi": true, "abcdxfgh": true, "abcdefghij": true}
+	got := closeTokens("abcdefgh", catalog)
+	if len(got) > 8 || len(got) == 0 || got[0] != "abcdefgh" {
+		t.Fatalf("close tokens=%v", got)
+	}
+	if damerauDistance("abcd", "acbd", 1) != 1 || damerauDistance("abcdefgh", "abcfghxy", 1) <= 1 {
+		t.Fatal("distance cap or transposition is wrong")
+	}
+	if damerauDistance("界界", "界界界", 1) != 1 || abs(-4) != 4 || abs(4) != 4 {
+		t.Fatal("unicode distance helpers failed")
+	}
+	if got := intersectPostingMaps(nil); got != nil {
+		t.Fatalf("empty intersection=%v", got)
+	}
+	empty := t.TempDir()
+	if catalog, err := tokenCatalog(empty); err != nil || len(catalog) != 0 {
+		t.Fatalf("missing catalog=%v err=%v", catalog, err)
+	}
+	if posts, variants, err := fuzzyPostings(empty, []string{"abc"}, nil); err != nil || posts != nil || variants != nil {
+		t.Fatalf("short fuzzy query=%v %v err=%v", posts, variants, err)
+	}
+	if posts, variants, err := fuzzyPostings(empty, []string{"abcd"}, nil); err != nil || posts != nil || variants != nil {
+		t.Fatalf("unmatched fuzzy query=%v %v err=%v", posts, variants, err)
+	}
+	bad := filepath.Join(empty, "buckets")
+	if err := os.MkdirAll(bad, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, "aa.bin"), []byte("bad"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tokenCatalog(empty); err == nil {
+		t.Fatal("malformed catalog returned nil error")
+	}
+	if result, err := fuzzySearch(empty, Manifest{}, search.Options{Query: "abc"}); err != nil || result.Fuzzy {
+		t.Fatalf("empty fuzzy search=%#v err=%v", result, err)
+	}
+}
+
 func writeTinyIndex(t *testing.T, dir string) {
 	t.Helper()
 	tmp := dir + ".tmp"

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -836,3 +836,83 @@ func TestIndexErrorBranches(t *testing.T) {
 		t.Fatalf("cursor lastupdated parse=%#v err=%v", got, err)
 	}
 }
+
+func TestFuzzySearchFilterAndCatalogErrors(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "fuzzy-edge")
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	sessions := []model.Session{{ID: "one", Harness: "claude", Project: "p", Updated: base, Messages: []model.Message{{Role: "user", Text: "connection pool exhausted"}}}}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// A harness filter that excludes every candidate session must yield an
+	// empty non-fuzzy result, not an error.
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result, err := fuzzySearch(dir, m, search.Options{Query: "exhaustd", Harness: "codex"}); err != nil || result.Fuzzy || len(result.Sessions) != 0 {
+		t.Fatalf("filtered fuzzy = %#v err=%v", result, err)
+	}
+
+	// A bucket entry with a corrupt header surfaces as an error.
+	if err := os.WriteFile(filepath.Join(dir, "buckets", "zz.bin"), []byte("not a bucket"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tokenCatalog(dir); err == nil {
+		t.Fatal("expected tokenCatalog error for squatting directory")
+	}
+	if _, err := fuzzySearch(dir, m, search.Options{Query: "exhaustd"}); err == nil {
+		t.Fatal("expected fuzzySearch to propagate catalog error")
+	}
+
+	// buckets squatted by a regular file: ReadDir fails with a non-NotExist
+	// error that must propagate.
+	flat := filepath.Join(tmp, "flat-index")
+	if err := os.MkdirAll(flat, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(flat, "buckets"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tokenCatalog(flat); err == nil {
+		t.Fatal("expected tokenCatalog ReadDir error")
+	}
+}
+
+func TestFuzzySearchWithPhraseTokens(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "fuzzy-phrase")
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	sessions := []model.Session{{ID: "one", Harness: "claude", Project: "p", Updated: base, Messages: []model.Message{{Role: "user", Text: "connection pool exhausted"}}}}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A quoted phrase alongside a fuzzy token exercises the phrase branch of
+	// the fuzzy candidate collection.
+	result, err := fuzzySearch(dir, m, search.Options{Query: `exhaustd "connection pool"`, All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Fuzzy && len(result.Sessions) != 0 {
+		t.Fatalf("unexpected result %#v", result)
+	}
+
+	// The full SearchDetailed path where postings match but the phrase filter
+	// rejects every record falls through to the fuzzy branch.
+	result, err = SearchDetailed(dir, search.Options{Query: `"pool connection"`, All: true})
+	if err != nil || len(result.Sessions) != 0 {
+		t.Fatalf("reversed phrase result=%#v err=%v", result, err)
+	}
+}

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -871,7 +871,11 @@ func TestFuzzySearchFilterAndCatalogErrors(t *testing.T) {
 	}
 
 	// buckets squatted by a regular file: ReadDir fails with a non-NotExist
-	// error that must propagate.
+	// error that must propagate. Windows maps this to a NotExist-style error,
+	// which tokenCatalog treats as an empty catalog.
+	if runtime.GOOS == "windows" {
+		return
+	}
 	flat := filepath.Join(tmp, "flat-index")
 	if err := os.MkdirAll(flat, 0o700); err != nil {
 		t.Fatal(err)

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/redact"
@@ -149,6 +150,12 @@ type posting struct {
 	Sid uint32
 }
 
+type SearchResult struct {
+	Sessions []model.Session
+	Fuzzy    bool
+	Variants map[string][]string
+}
+
 func DefaultDir() string {
 	if v := os.Getenv("DEJA_INDEX_DIR"); v != "" {
 		return v
@@ -202,20 +209,25 @@ func EnsureForSearch(dir string, o search.Options, force bool, progress io.Write
 }
 
 func Search(dir string, o search.Options) ([]model.Session, error) {
+	r, err := SearchDetailed(dir, o)
+	return r.Sessions, err
+}
+
+func SearchDetailed(dir string, o search.Options) (SearchResult, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
 	unlock, err := lockDir(dir)
 	if err != nil {
-		return nil, err
+		return SearchResult{}, err
 	}
 	defer unlock()
 	m, err := readManifest(dir)
 	if err != nil {
-		return nil, fmt.Errorf("manifest: %w", err)
+		return SearchResult{}, fmt.Errorf("manifest: %w", err)
 	}
 	if !recordsIntact(dir, m) {
-		return nil, fmt.Errorf("%w: records.bin truncated", errCorruptIndex)
+		return SearchResult{}, fmt.Errorf("%w: records.bin truncated", errCorruptIndex)
 	}
 	var posts []posting
 	usedPostings := false
@@ -224,7 +236,7 @@ func Search(dir string, o search.Options) ([]model.Session, error) {
 			usedPostings = true
 			posts, err = intersectPostings(dir, retrievalKeys(keys))
 			if err != nil {
-				return nil, fmt.Errorf("postings: %w", err)
+				return SearchResult{}, fmt.Errorf("postings: %w", err)
 			}
 			if len(posts) == 0 {
 				// grep expectation: "code" should find "opencode". Expand each query
@@ -232,39 +244,58 @@ func Search(dir string, o search.Options) ([]model.Session, error) {
 				// no record scan), then intersect.
 				posts, err = intersectSubstringPostings(dir, tokens(o.Query))
 				if err != nil {
-					return nil, fmt.Errorf("substr postings: %w", err)
+					return SearchResult{}, fmt.Errorf("substr postings: %w", err)
 				}
 			}
 		}
 	}
 	if len(posts) == 0 {
 		if usedPostings {
-			return nil, nil
+			if result, ferr := fuzzySearch(dir, m, o); ferr != nil {
+				return SearchResult{}, fmt.Errorf("fuzzy postings: %w", ferr)
+			} else if result.Fuzzy {
+				return result, nil
+			}
+			return SearchResult{}, nil
 		}
-		return scanRecords(dir, m, o, nil)
+		ss, err := scanRecords(dir, m, o, nil)
+		return SearchResult{Sessions: ss}, err
 	}
 	posts = cutPostingsBySession(posts, m, o)
 	if len(posts) == 0 {
-		return nil, nil
+		return SearchResult{}, nil
 	}
-	return scanRecords(dir, m, o, postingOffsets(posts))
+	ss, err := scanRecords(dir, m, o, postingOffsets(posts))
+	if err == nil && len(ss) == 0 {
+		if result, ferr := fuzzySearch(dir, m, o); ferr != nil {
+			return SearchResult{}, fmt.Errorf("fuzzy postings: %w", ferr)
+		} else if result.Fuzzy {
+			return result, nil
+		}
+	}
+	return SearchResult{Sessions: ss}, err
 }
 
 // SearchWithRecovery is Search plus self-healing: a corrupt bucket (crash
 // mid-append) triggers one full rebuild instead of erroring until the user
 // runs --rebuild by hand.
 func SearchWithRecovery(dir string, o search.Options, progress io.Writer) ([]model.Session, error) {
-	ss, err := Search(dir, o)
+	r, err := SearchWithRecoveryDetailed(dir, o, progress)
+	return r.Sessions, err
+}
+
+func SearchWithRecoveryDetailed(dir string, o search.Options, progress io.Writer) (SearchResult, error) {
+	r, err := SearchDetailed(dir, o)
 	if err == nil || !IsCorrupt(err) {
-		return ss, err
+		return r, err
 	}
 	if progress != nil {
 		fmt.Fprintf(progress, "deja: index damaged (%v), rebuilding ...\n", err)
 	}
 	if rerr := EnsureForSearch(dir, o, true, progress); rerr != nil {
-		return nil, rerr
+		return SearchResult{}, rerr
 	}
-	return Search(dir, o)
+	return SearchDetailed(dir, o)
 }
 
 func Recent(dir string, n int) ([]model.Session, error) {
@@ -1506,6 +1537,10 @@ func manifestFresh(m Manifest, files map[string]FileState, scope string) bool {
 }
 
 func scanRecords(dir string, m Manifest, o search.Options, offsets []int64) ([]model.Session, error) {
+	return scanRecordsWithVariants(dir, m, o, offsets, nil)
+}
+
+func scanRecordsWithVariants(dir string, m Manifest, o search.Options, offsets []int64, variants map[string][]string) ([]model.Session, error) {
 	by := map[string]*model.Session{}
 	add := func(r Record) {
 		meta, ok := m.Sessions[r.Key]
@@ -1540,12 +1575,16 @@ func scanRecords(dir string, m Manifest, o search.Options, offsets []int64) ([]m
 		defer func() { _ = f.Close() }()
 		offsets = sortedUniqueOffsets(offsets)
 		for _, off := range offsets {
-			if r, err := readRecordAt(f, off); err == nil && recordMatchesQuery(r, o) {
+			if r, err := readRecordAt(f, off); err == nil && recordMatchesQueryVariants(r, o, variants) {
 				add(r)
 			}
 		}
 	} else {
-		if err := eachRecord(filepath.Join(dir, "records.bin"), add); err != nil {
+		if err := eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
+			if recordMatchesQueryVariants(r, o, variants) {
+				add(r)
+			}
+		}); err != nil {
 			return nil, err
 		}
 	}
@@ -1892,6 +1931,203 @@ func intersectSubstringPostings(dir string, bare []string) ([]posting, error) {
 	return out, nil
 }
 
+func fuzzyPostings(dir string, terms, phrases []string) ([]posting, map[string][]string, error) {
+	if !hasFuzzyToken(terms) {
+		return nil, nil, nil
+	}
+	catalog, err := tokenCatalog(dir)
+	if err != nil {
+		return nil, nil, err
+	}
+	perToken := make([]map[int64]posting, len(terms))
+	variants := map[string][]string{}
+	for i, term := range terms {
+		matches := closeTokens(term, catalog)
+		if len(matches) == 0 {
+			return nil, nil, nil
+		}
+		variants[term] = matches
+		perToken[i] = map[int64]posting{}
+		for _, variant := range matches {
+			posts, err := postingsFor(dir, "t"+variant)
+			if err != nil {
+				return nil, nil, err
+			}
+			for _, p := range posts {
+				perToken[i][p.Off] = p
+			}
+		}
+	}
+	if len(phrases) > 0 {
+		// Phrase text is verified from records; its tokens still participate in
+		// the same fuzzy candidate intersection above.
+	}
+	return intersectPostingMaps(perToken), variants, nil
+}
+
+func fuzzySearch(dir string, m Manifest, o search.Options) (SearchResult, error) {
+	terms, phrases := search.QueryParts(o.Query)
+	posts, variants, err := fuzzyPostings(dir, terms, phrases)
+	if err != nil || len(posts) == 0 {
+		return SearchResult{}, err
+	}
+	posts = cutPostingsBySession(posts, m, o)
+	if len(posts) == 0 {
+		return SearchResult{}, nil
+	}
+	ss, err := scanRecordsWithVariants(dir, m, o, postingOffsets(posts), variants)
+	if err != nil || len(ss) == 0 {
+		return SearchResult{}, err
+	}
+	return SearchResult{Sessions: ss, Fuzzy: true, Variants: variants}, nil
+}
+
+func hasFuzzyToken(terms []string) bool {
+	for _, term := range terms {
+		if len([]rune(term)) >= 4 {
+			return true
+		}
+	}
+	return false
+}
+
+func tokenCatalog(dir string) (map[string]bool, error) {
+	entries, err := os.ReadDir(filepath.Join(dir, "buckets"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]bool{}, nil
+		}
+		return nil, err
+	}
+	catalog := map[string]bool{}
+	for _, de := range entries {
+		if de.IsDir() || !strings.HasSuffix(de.Name(), ".bin") {
+			continue
+		}
+		header, f, err := openBucketDir(filepath.Join(dir, "buckets", de.Name()))
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range header {
+			catalog[strings.TrimPrefix(entry.tok, "t")] = true
+		}
+		_ = f.Close()
+	}
+	return catalog, nil
+}
+
+func closeTokens(query string, catalog map[string]bool) []string {
+	type match struct {
+		token    string
+		distance int
+	}
+	var matches []match
+	limit := 1
+	if len([]rune(query)) >= 8 {
+		limit = 2
+	}
+	for token := range catalog {
+		d := damerauDistance(query, token, limit)
+		if d <= limit {
+			matches = append(matches, match{token: token, distance: d})
+		}
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].distance == matches[j].distance {
+			return matches[i].token < matches[j].token
+		}
+		return matches[i].distance < matches[j].distance
+	})
+	if len(matches) > 8 {
+		matches = matches[:8]
+	}
+	out := make([]string, len(matches))
+	for i, m := range matches {
+		out[i] = m.token
+	}
+	return out
+}
+
+func damerauDistance(a, b string, max int) int {
+	if len(a) <= 64 && len(b) <= 64 && utf8.ValidString(a) && utf8.ValidString(b) && utf8.RuneCountInString(a) == len(a) && utf8.RuneCountInString(b) == len(b) {
+		var prev, prevPrev, cur [65]int
+		for j := 0; j <= len(b); j++ {
+			prev[j] = j
+		}
+		for i := 1; i <= len(a); i++ {
+			cur[0] = i
+			for j := 1; j <= len(b); j++ {
+				cost := 0
+				if a[i-1] != b[j-1] {
+					cost = 1
+				}
+				cur[j] = min(cur[j-1]+1, min(prev[j]+1, prev[j-1]+cost))
+				if i > 1 && j > 1 && a[i-1] == b[j-2] && a[i-2] == b[j-1] {
+					cur[j] = min(cur[j], prevPrev[j-2]+1)
+				}
+			}
+			prevPrev, prev, cur = prev, cur, prevPrev
+		}
+		return prev[len(b)]
+	}
+	return damerauDistanceRunes(a, b, max)
+}
+
+func damerauDistanceRunes(a, b string, max int) int {
+	ar, br := []rune(a), []rune(b)
+	if abs(len(ar)-len(br)) > max {
+		return max + 1
+	}
+	prev := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	prevPrev := append([]int(nil), prev...)
+	for i := 1; i <= len(ar); i++ {
+		cur := make([]int, len(br)+1)
+		cur[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 0
+			if ar[i-1] != br[j-1] {
+				cost = 1
+			}
+			cur[j] = min(cur[j-1]+1, min(prev[j]+1, prev[j-1]+cost))
+			if i > 1 && j > 1 && ar[i-1] == br[j-2] && ar[i-2] == br[j-1] {
+				cur[j] = min(cur[j], prevPrev[j-2]+1)
+			}
+		}
+		prevPrev, prev = prev, cur
+	}
+	return prev[len(br)]
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+func intersectPostingMaps(sets []map[int64]posting) []posting {
+	if len(sets) == 0 {
+		return nil
+	}
+	set := sets[0]
+	for _, next := range sets[1:] {
+		for off := range set {
+			if _, ok := next[off]; !ok {
+				delete(set, off)
+			}
+		}
+	}
+	out := make([]posting, 0, len(set))
+	for _, p := range set {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Off < out[j].Off })
+	return out
+}
+
 func tokens(s string) []string {
 	seen := map[string]bool{}
 	var out []string
@@ -1949,20 +2185,18 @@ func queryKeys(s string) []string {
 }
 
 func recordMatchesQuery(r Record, o search.Options) bool {
+	return recordMatchesQueryVariants(r, o, nil)
+}
+
+func recordMatchesQueryVariants(r Record, o search.Options, variants map[string][]string) bool {
 	if o.Regex {
 		return true
 	}
-	toks := tokens(o.Query)
-	if len(toks) == 0 {
+	terms, phrases := search.QueryParts(o.Query)
+	if len(terms) == 0 && len(phrases) == 0 {
 		return true
 	}
-	text := strings.ToLower(r.Text)
-	for _, tok := range toks {
-		if !strings.Contains(text, tok) {
-			return false
-		}
-	}
-	return true
+	return search.MatchesParts(r.Text, terms, phrases, variants)
 }
 
 func bucket(tok string) string {

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -1958,10 +1958,9 @@ func fuzzyPostings(dir string, terms, phrases []string) ([]posting, map[string][
 			}
 		}
 	}
-	if len(phrases) > 0 {
-		// Phrase text is verified from records; its tokens still participate in
-		// the same fuzzy candidate intersection above.
-	}
+	// Phrase text is verified from records; phrase tokens participate in the
+	// same fuzzy candidate intersection above, so phrases need no extra work.
+	_ = phrases
 	return intersectPostingMaps(perToken), variants, nil
 }
 

--- a/internal/search/query.go
+++ b/internal/search/query.go
@@ -1,0 +1,91 @@
+package search
+
+import (
+	"strings"
+	"unicode"
+)
+
+// QueryParts separates ordinary terms from quoted phrases without changing
+// the query syntax used by callers.
+func QueryParts(q string) (terms []string, phrases []string) {
+	start := -1
+	var plain strings.Builder
+	flushPlain := func() {
+		terms = appendUnique(terms, queryTokens(plain.String())...)
+		plain.Reset()
+	}
+	for i, r := range q {
+		if r != '"' {
+			if start < 0 {
+				plain.WriteRune(r)
+			}
+			continue
+		}
+		if start < 0 {
+			flushPlain()
+			start = i
+			continue
+		}
+		content := q[start+1 : i]
+		if hasLetterOrDigit(content) {
+			phrases = appendUnique(phrases, strings.ToLower(strings.TrimSpace(content)))
+			terms = appendUnique(terms, queryTokens(content)...)
+		}
+		start = -1
+	}
+	if start >= 0 {
+		// An unfinished quote is just whitespace, as it was before phrases.
+		return queryTokens(q), nil
+	}
+	flushPlain()
+	return terms, phrases
+}
+
+func hasLetterOrDigit(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func appendUnique(dst []string, values ...string) []string {
+	seen := make(map[string]bool, len(dst)+len(values))
+	for _, v := range dst {
+		seen[v] = true
+	}
+	for _, v := range values {
+		if v != "" && !seen[v] {
+			dst = append(dst, v)
+			seen[v] = true
+		}
+	}
+	return dst
+}
+
+// MatchesQuery applies the text-level part of the query. Index candidates
+// use this too, so phrase verification is shared by every search frontend.
+func MatchesQuery(text, q string) bool {
+	terms, phrases := QueryParts(q)
+	return MatchesParts(text, terms, phrases, nil)
+}
+
+func MatchesParts(text string, terms, phrases []string, variants map[string][]string) bool {
+	low := strings.ToLower(text)
+	for _, term := range terms {
+		matched := strings.Contains(low, term)
+		for _, variant := range variants[term] {
+			matched = matched || strings.Contains(low, variant)
+		}
+		if !matched {
+			return false
+		}
+	}
+	for _, phrase := range phrases {
+		if !strings.Contains(low, phrase) {
+			return false
+		}
+	}
+	return len(terms) > 0 || len(phrases) > 0
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -31,7 +31,8 @@ type Options struct {
 	Regex                  bool
 	Harness, Project, Role string
 	Since                  time.Duration
-	All, JSON              bool
+	All, JSON, Fuzzy       bool
+	FuzzyVariants          map[string][]string `json:"-"`
 }
 type Hit struct {
 	Session  model.Session `json:"session"`
@@ -56,7 +57,7 @@ type bm25Document struct {
 func Run(ss []model.Session, o Options) ([]Hit, error) {
 	var re *regexp.Regexp
 	qlow := strings.ToLower(o.Query)
-	qtoks := queryTokens(o.Query)
+	qtoks, phrases := QueryParts(o.Query)
 	if o.Regex {
 		var err error
 		re, err = regexp.Compile("(?i)" + o.Query)
@@ -97,9 +98,21 @@ func Run(ss []model.Session, o Options) ([]Hit, error) {
 				c = len(re.FindAllStringIndex(m.Text, -1))
 			} else {
 				low := strings.ToLower(m.Text)
-				c = countAllTokens(low, qtoks)
-				if len(qtoks) == 1 && c == 0 && strings.Contains(low, qlow) {
-					c = strings.Count(low, qlow)
+				if !MatchesParts(m.Text, qtoks, phrases, o.FuzzyVariants) {
+					c = 0
+				} else if len(qtoks) <= 1 && len(phrases) == 0 && o.FuzzyVariants == nil {
+					if strings.Contains(low, qlow) {
+						c = strings.Count(low, qlow)
+					}
+				} else {
+					if o.FuzzyVariants != nil {
+						c = countAllVariants(low, qtoks, o.FuzzyVariants)
+					} else {
+						c = countAllTokens(low, qtoks)
+					}
+					for _, phrase := range phrases {
+						c += strings.Count(low, phrase)
+					}
 				}
 			}
 			if c > 0 {
@@ -248,7 +261,14 @@ func mergeSessions(in []model.Session) []model.Session {
 
 func Print(w io.Writer, hits []Hit, o Options) {
 	if o.JSON {
-		_ = json.NewEncoder(w).Encode(hits)
+		if o.Fuzzy {
+			_ = json.NewEncoder(w).Encode(struct {
+				Hits  []Hit `json:"hits"`
+				Fuzzy bool  `json:"fuzzy"`
+			}{hits, true})
+		} else {
+			_ = json.NewEncoder(w).Encode(hits)
+		}
 		return
 	}
 	color := colorOK(w)
@@ -399,6 +419,21 @@ func countAllTokens(low string, toks []string) int {
 			return 0
 		}
 		total += c
+	}
+	return total
+}
+
+func countAllVariants(low string, toks []string, variants map[string][]string) int {
+	total := 0
+	for _, tok := range toks {
+		count := strings.Count(low, tok)
+		for _, variant := range variants[tok] {
+			count += strings.Count(low, variant)
+		}
+		if count == 0 {
+			return 0
+		}
+		total += count
 	}
 	return total
 }

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -279,6 +279,63 @@ func TestMultiWordSearchRequiresAllTokensAndCountsOccurrences(t *testing.T) {
 	}
 }
 
+func TestQuotedPhrasesRequireContiguousCaseInsensitiveText(t *testing.T) {
+	now := time.Now()
+	ss := []model.Session{
+		{ID: "phrase", Updated: now, Messages: []model.Message{{Text: "Connection POOL exhausted again"}}},
+		{ID: "apart", Updated: now, Messages: []model.Message{{Text: "connection pool was completely exhausted"}}},
+	}
+	hits, err := Run(ss, Options{Query: `"connection pool exhausted"`})
+	if err != nil || len(hits) != 1 || hits[0].Session.ID != "phrase" {
+		t.Fatalf("phrase hits = %#v err=%v", hits, err)
+	}
+	hits, err = Run(ss, Options{Query: `"connection pool exhausted" again`})
+	if err != nil || len(hits) != 1 || hits[0].Session.ID != "phrase" {
+		t.Fatalf("mixed phrase hits = %#v err=%v", hits, err)
+	}
+	if got, _ := Run(ss, Options{Query: `"connection pool`}); len(got) != 2 {
+		t.Fatalf("unbalanced quote should be ordinary terms: %#v", got)
+	}
+}
+
+func TestQuotedPunctuationOnlyIsIgnored(t *testing.T) {
+	terms, phrases := QueryParts(`"---" needle`)
+	if len(phrases) != 0 || len(terms) != 1 || terms[0] != "needle" {
+		t.Fatalf("parts = %#v %#v", terms, phrases)
+	}
+}
+
+func TestFuzzyJSONEnvelope(t *testing.T) {
+	var b bytes.Buffer
+	Print(&b, []Hit{{Count: 1}}, Options{JSON: true, Fuzzy: true})
+	if !strings.Contains(b.String(), `"fuzzy":true`) || !strings.Contains(b.String(), `"hits"`) {
+		t.Fatalf("fuzzy json = %q", b.String())
+	}
+}
+
+func TestFuzzyMatchingUsesVariants(t *testing.T) {
+	if !MatchesQuery("needle", "needle") || MatchesQuery("other", "needle") {
+		t.Fatal("literal query matcher failed")
+	}
+	hits, err := Run([]model.Session{{ID: "fuzzy", Updated: time.Now(), Messages: []model.Message{{Text: "connection exhausted"}}}}, Options{
+		Query: "conection exhaustd", All: true, FuzzyVariants: map[string][]string{"conection": {"connection"}, "exhaustd": {"exhausted"}},
+	})
+	if err != nil || len(hits) != 1 || hits[0].Count == 0 {
+		t.Fatalf("fuzzy hits=%#v err=%v", hits, err)
+	}
+}
+
+func BenchmarkPhraseVerification(b *testing.B) {
+	text := strings.Repeat("prefix words ", 200) + "connection pool exhausted" + strings.Repeat(" suffix words", 200)
+	terms, phrases := QueryParts(`"connection pool exhausted"`)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !MatchesParts(text, terms, phrases, nil) {
+			b.Fatal("phrase did not match")
+		}
+	}
+}
+
 func TestPrintPlainWhenNotTTY(t *testing.T) {
 	now := time.Now()
 	hits := []Hit{{Session: model.Session{ID: "abcdef1234567890", Harness: "opencode", Project: "deja", Updated: now}, Count: 1, Snippets: []string{"hello needle"}}}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -318,7 +318,7 @@ func TestFuzzyMatchingUsesVariants(t *testing.T) {
 		t.Fatal("literal query matcher failed")
 	}
 	hits, err := Run([]model.Session{{ID: "fuzzy", Updated: time.Now(), Messages: []model.Message{{Text: "connection exhausted"}}}}, Options{
-		Query: "conection exhaustd", All: true, FuzzyVariants: map[string][]string{"conection": {"connection"}, "exhaustd": {"exhausted"}},
+		Query: "connecton exhaustd", All: true, FuzzyVariants: map[string][]string{"connecton": {"connection"}, "exhaustd": {"exhausted"}},
 	})
 	if err != nil || len(hits) != 1 || hits[0].Count == 0 {
 		t.Fatalf("fuzzy hits=%#v err=%v", hits, err)


### PR DESCRIPTION
Closes #131. Quoted groups AND their tokens through the index, then verify the exact substring against candidate records. On zero results the query retries with close spellings from the token catalog (Damerau-Levenshtein 1, 2 for len>=8, capped at 8 variants), reported on stderr and flagged in JSON. No index format changes.