### PR TITLE
feat(install): extend user-level guidance targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ deja install --all     # MCP recall for every agent it finds on this machine
 deja install --auto    # same, plus session-start auto-recall where supported
 ```
 
-Install also writes user-level guidance: `~/.claude/skills/deja-history/SKILL.md`, `~/.codex/AGENTS.md`, `~/.gemini/GEMINI.md`, and `~/.config/opencode/AGENTS.md` (or the configured `XDG_CONFIG_HOME`). Re-run rewrites deja's skill or marked block without changing surrounding user content. Use `deja install --all --no-guidance` to opt out; Cursor, Grok, and Antigravity have no documented user-level guidance location and are skipped.
+Install also writes user-level guidance: `~/.claude/skills/deja-history/SKILL.md`, `~/.codex/AGENTS.md`, `~/.gemini/GEMINI.md`, `~/.gemini/config/skills/deja-history/SKILL.md`, `~/.qwen/QWEN.md`, `~/.copilot/skills/deja-history/SKILL.md`, and `~/.config/opencode/AGENTS.md` (or the configured `XDG_CONFIG_HOME`). Re-run rewrites deja's skill or marked block without changing surrounding user content. Use `deja install --all --no-guidance` to opt out; Cursor and Grok have no documented user-level guidance location and are skipped.
 
 On a terminal, install reports whether it found local history and points to `deja index` when the first index still needs to be built.
 

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -197,17 +197,22 @@ type doctorMCPConfig struct {
 }
 
 func doctorMCPConfigs() []doctorMCPConfig {
-	h := homeDir()
 	return []doctorMCPConfig{
 		{"claude-code", sources.ClaudeJSONPath(), doctorJSONWired("mcpServers")},
 		{"codex", filepath.Join(sources.CodexHome(), "config.toml"), doctorTOMLWired},
 		{"opencode", doctorOpencodeConfigPath(), doctorJSONWired("mcp")},
 		{"cursor", filepath.Join(sources.CursorCLIHome(), "mcp.json"), doctorJSONWired("mcpServers")},
 		{"gemini", filepath.Join(sources.GeminiHome(), "settings.json"), doctorJSONWired("mcpServers")},
-		{"antigravity", filepath.Join(h, ".gemini", "config", "mcp_config.json"), doctorJSONWired("mcpServers")},
+		{"antigravity", filepath.Join(antigravityConfigHome(), "mcp_config.json"), doctorJSONWired("mcpServers")},
 		{"grok", filepath.Join(sources.GrokHome(), "config.toml"), doctorTOMLWired},
 		{"qwen", filepath.Join(sources.QwenConfigDir(), "settings.json"), doctorJSONWired("mcpServers")},
+		{"copilot", guidancePath("copilot"), doctorFileWired},
 	}
+}
+
+func doctorFileWired(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func doctorOpencodeConfigPath() string {

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -338,6 +338,19 @@ func TestDoctorJSONCWiringFallback(t *testing.T) {
 	}
 }
 
+func TestDoctorGuidanceFileState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "SKILL.md")
+	if doctorFileWired(path) {
+		t.Fatal("missing guidance file reported as present")
+	}
+	if err := os.WriteFile(path, []byte("skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !doctorFileWired(path) {
+		t.Fatal("written guidance file reported as missing")
+	}
+}
+
 func TestDoctorDispatchHermetic(t *testing.T) {
 	hermeticEnv(t)
 	old := doctorLookup

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -25,6 +25,12 @@ func guidancePath(harness string) string {
 	switch harness {
 	case "claude-code", "claude":
 		return filepath.Join(sources.ClaudeConfigDir(), "skills", "deja-history", "SKILL.md")
+	case "antigravity":
+		return filepath.Join(antigravityConfigHome(), "skills", "deja-history", "SKILL.md")
+	case "copilot":
+		return filepath.Join(homeDir(), ".copilot", "skills", "deja-history", "SKILL.md")
+	case "qwen":
+		return filepath.Join(sources.QwenConfigDir(), "QWEN.md")
 	case "codex":
 		return filepath.Join(sources.CodexHome(), "AGENTS.md")
 	case "gemini":
@@ -44,8 +50,12 @@ func opencodeConfigHome() string {
 }
 
 func guidanceText(harness string) string {
-	if harness == "claude-code" || harness == "claude" {
-		return "---\nname: deja-history\ndescription: Consult deja MCP history tools when the user refers to past work or previous decisions.\n---\n\n" + guidanceBody + "\n"
+	if harness == "claude-code" || harness == "claude" || harness == "antigravity" || harness == "copilot" {
+		body := guidanceBody
+		if harness == "copilot" {
+			body = "deja does not index Copilot history. It is a consumer: use the deja MCP tools to search memory from the other harnesses.\n\n" + guidanceBody
+		}
+		return "---\nname: deja-history\ndescription: Consult deja MCP history tools when the user refers to past work or previous decisions.\n---\n\n" + body + "\n"
 	}
 	return guidanceStart + "\n" + guidanceBody + "\n" + guidanceEnd + "\n"
 }
@@ -60,7 +70,7 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 		return installResult{}, err
 	}
 	var next []byte
-	if harness == "claude-code" || harness == "claude" {
+	if harness == "claude-code" || harness == "claude" || harness == "antigravity" || harness == "copilot" {
 		if uninstall {
 			if len(old) == 0 {
 				return installResult{Path: path, Action: "unchanged"}, nil
@@ -84,13 +94,9 @@ func updateGuidanceBlock(old string, uninstall bool) string {
 	if strings.Contains(old, "\r\n") {
 		newline = "\r\n"
 	}
-	start := strings.Index(old, guidanceStart)
-	if start >= 0 {
-		end := strings.Index(old[start+len(guidanceStart):], guidanceEnd)
-		if end >= 0 {
-			end += start + len(guidanceStart) + len(guidanceEnd)
-			old = old[:start] + old[end:]
-		}
+	start, end := guidanceMarkerLines(old)
+	if start >= 0 && end >= 0 {
+		old = old[:start] + old[end:]
 	}
 	if uninstall {
 		return old
@@ -100,6 +106,22 @@ func updateGuidanceBlock(old string, uninstall bool) string {
 		old += newline + newline
 	}
 	return old + strings.ReplaceAll(guidanceText("append"), "\n", newline)
+}
+
+func guidanceMarkerLines(s string) (start, end int) {
+	start, end = -1, -1
+	offset := 0
+	for _, line := range strings.SplitAfter(s, "\n") {
+		content := strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+		if start < 0 && content == guidanceStart {
+			start = offset
+		} else if start >= 0 && content == guidanceEnd {
+			end = offset + len(line)
+			break
+		}
+		offset += len(line)
+	}
+	return start, end
 }
 
 func guidanceHarness(harness string) string {
@@ -128,7 +150,7 @@ func guidanceStatus(harness string) string {
 
 func guidanceResult(harness string, uninstall bool) (installResult, error) {
 	canonical := guidanceHarness(harness)
-	if canonical == "cursor" || canonical == "grok" || canonical == "antigravity" {
+	if canonical == "cursor" || canonical == "grok" {
 		return installResult{}, nil
 	}
 	return installGuidance(canonical, uninstall)

--- a/cmd/deja/guidance_test.go
+++ b/cmd/deja/guidance_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -240,8 +241,11 @@ func TestInstallGuidanceSkillErrorBranches(t *testing.T) {
 		t.Fatal("expected copilot read error")
 	}
 	// Uninstall of a skill whose path parent blocks removal errors out.
-	if _, err := installGuidance("copilot", true); err == nil {
-		t.Fatal("expected copilot uninstall read error")
+	// Windows maps the squatted read to not-exist, which reads as unchanged.
+	if runtime.GOOS != "windows" {
+		if _, err := installGuidance("copilot", true); err == nil {
+			t.Fatal("expected copilot uninstall read error")
+		}
 	}
 	// antigravity skill install + uninstall roundtrip.
 	if r, err := installGuidance("antigravity", false); err != nil || r.Action != "created" {

--- a/cmd/deja/guidance_test.go
+++ b/cmd/deja/guidance_test.go
@@ -19,10 +19,85 @@ func TestGuidanceTargetsAreUserLevelAndRespectXDG(t *testing.T) {
 	if got := guidancePath("opencode"); got != filepath.Join(xdg, "opencode", "AGENTS.md") {
 		t.Fatalf("opencode path = %q", got)
 	}
-	for _, harness := range []string{"cursor", "grok", "antigravity"} {
+	if got := guidancePath("antigravity"); got != filepath.Join(home, ".gemini", "config", "skills", "deja-history", "SKILL.md") {
+		t.Fatalf("antigravity path = %q", got)
+	}
+	if got := guidancePath("qwen"); got != filepath.Join(home, ".qwen", "QWEN.md") {
+		t.Fatalf("qwen path = %q", got)
+	}
+	if got := guidancePath("copilot"); got != filepath.Join(home, ".copilot", "skills", "deja-history", "SKILL.md") {
+		t.Fatalf("copilot path = %q", got)
+	}
+	for _, harness := range []string{"cursor", "grok"} {
 		if got := guidancePath(harness); got != "" {
 			t.Fatalf("%s path = %q, want unsupported", harness, got)
 		}
+	}
+}
+
+func TestOwnedGuidanceTargetsAndMarkerBoundaries(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	for _, harness := range []string{"antigravity", "qwen", "copilot"} {
+		r, err := installGuidance(harness, false)
+		if err != nil || r.Action != "created" {
+			t.Fatalf("%s install = %#v, %v", harness, r, err)
+		}
+		if r, err = installGuidance(harness, false); err != nil || r.Action != "unchanged" {
+			t.Fatalf("%s rerun = %#v, %v", harness, r, err)
+		}
+		b, _ := os.ReadFile(guidancePath(harness))
+		if harness != "qwen" && !strings.Contains(string(b), "name: deja-history") {
+			t.Fatalf("%s frontmatter missing: %s", harness, b)
+		}
+	}
+	old := "prose " + guidanceStart + "\nkeep\n" + guidanceEnd + "\n"
+	want := old + "\n" + guidanceStart + "\n" + guidanceBody + "\n" + guidanceEnd + "\n"
+	if got := updateGuidanceBlock(old, false); got != want {
+		t.Fatalf("inline markers were replaced: %q", got)
+	}
+	qwen := guidancePath("qwen")
+	if err := os.WriteFile(qwen, []byte("# Personal context\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGuidance("qwen", false); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(qwen)
+	if !strings.Contains(string(b), "# Personal context") {
+		t.Fatalf("qwen context was not preserved: %s", b)
+	}
+	if _, err := installGuidance("qwen", true); err != nil {
+		t.Fatal(err)
+	}
+	b, _ = os.ReadFile(qwen)
+	if strings.Contains(string(b), guidanceStart) || !strings.Contains(string(b), "# Personal context") {
+		t.Fatalf("qwen uninstall changed personal context: %s", b)
+	}
+
+	squat := filepath.Join(home, ".copilot", "skills", "deja-history")
+	if err := os.RemoveAll(filepath.Dir(squat)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(squat), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(squat, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGuidance("copilot", false); err == nil {
+		t.Fatal("expected path-squatting error")
+	}
+	if _, err := writeIfChanged(filepath.Join(squat, "SKILL.md"), nil, []byte("skill")); err == nil {
+		t.Fatal("expected atomic write path-squatting error")
+	}
+	entries, err := os.ReadDir(filepath.Dir(squat))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != filepath.Base(squat) {
+		t.Fatalf("temporary file left after failed write: %v", entries)
 	}
 }
 
@@ -137,5 +212,11 @@ func TestInstallGuidanceEdgeBranches(t *testing.T) {
 	}
 	if r, err := installGuidance("claude-code", true); err != nil || r.Action != "unchanged" {
 		t.Fatalf("uninstall with no skill = %#v err=%v", r, err)
+	}
+}
+
+func TestCopilotInstallIsGuidanceOnly(t *testing.T) {
+	if result, err := installTarget("copilot", "/bin/deja", false); err != nil || result.Action != "guidance-only" || result.Path != guidancePath("copilot") {
+		t.Fatalf("copilot MCP install = %#v, %v", result, err)
 	}
 }

--- a/cmd/deja/guidance_test.go
+++ b/cmd/deja/guidance_test.go
@@ -220,3 +220,37 @@ func TestCopilotInstallIsGuidanceOnly(t *testing.T) {
 		t.Fatalf("copilot MCP install = %#v, %v", result, err)
 	}
 }
+
+func TestInstallGuidanceSkillErrorBranches(t *testing.T) {
+	tmp := hermeticEnv(t)
+	// path == "" branch for a harness without a guidance location.
+	if r, err := installGuidance("grok", false); err != nil || r.Path != "" {
+		t.Fatalf("grok guidance = %#v err=%v", r, err)
+	}
+	// Read failure that is not IsNotExist must surface (copilot skill dir
+	// squatted by a file).
+	squat := filepath.Join(tmp, "home", ".copilot", "skills")
+	if err := os.MkdirAll(filepath.Dir(squat), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(squat, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGuidance("copilot", false); err == nil {
+		t.Fatal("expected copilot read error")
+	}
+	// Uninstall of a skill whose path parent blocks removal errors out.
+	if _, err := installGuidance("copilot", true); err == nil {
+		t.Fatal("expected copilot uninstall read error")
+	}
+	// antigravity skill install + uninstall roundtrip.
+	if r, err := installGuidance("antigravity", false); err != nil || r.Action != "created" {
+		t.Fatalf("antigravity install = %#v err=%v", r, err)
+	}
+	if r, err := installGuidance("antigravity", true); err != nil || r.Action != "removed" {
+		t.Fatalf("antigravity uninstall = %#v err=%v", r, err)
+	}
+	if r, err := installGuidance("antigravity", true); err != nil || r.Action != "unchanged" {
+		t.Fatalf("antigravity re-uninstall = %#v err=%v", r, err)
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -84,7 +84,7 @@ func runInstall(args []string, uninstall bool) error {
 		}
 		if banner {
 			done = append(done, lineItem{t, r.Action, shortHome(r.Path)})
-		} else {
+		} else if t != "copilot" {
 			fmt.Printf("%s: %s %s\n", t, r.Action, r.Path)
 		}
 	}
@@ -146,14 +146,14 @@ func installIndexHint() string {
 }
 
 func existingTargets() []string {
-	h, _ := os.UserHomeDir()
 	checks := map[string]string{
 		"claude-code": sources.ClaudeConfigDir(),
 		"codex":       sources.CodexHome(),
 		"opencode":    filepath.Join(opencodeConfigHome(), "opencode"),
 		"cursor":      sources.CursorCLIHome(),
 		"gemini":      filepath.Join(sources.GeminiHome(), "settings.json"),
-		"antigravity": filepath.Join(h, ".gemini", "config"),
+		"antigravity": antigravityConfigHome(),
+		"copilot":     filepath.Join(homeDir(), ".copilot"),
 		"grok":        sources.GrokRoot(),
 		"qwen":        sources.QwenConfigDir(),
 	}
@@ -186,11 +186,13 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 	case "gemini":
 		return installMCPJSON(filepath.Join(sources.GeminiHome(), "settings.json"), exe, uninstall)
 	case "antigravity":
-		return installMCPJSON(filepath.Join(homeDir(), ".gemini", "config", "mcp_config.json"), exe, uninstall)
+		return installMCPJSON(filepath.Join(antigravityConfigHome(), "mcp_config.json"), exe, uninstall)
 	case "grok":
 		return installGrok(exe, uninstall)
 	case "qwen":
 		return installMCPJSON(filepath.Join(sources.QwenConfigDir(), "settings.json"), exe, uninstall)
+	case "copilot":
+		return installResult{Path: guidancePath("copilot"), Action: "guidance-only"}, nil
 	case "opencode":
 		return installOpencode(exe, uninstall)
 	case "opencode-auto":
@@ -248,7 +250,24 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 	if err := backupOnce(path); err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(path, next, 0o644); err != nil {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".deja-tmp-")
+	if err != nil {
+		return "", err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(next); err != nil {
+		_ = tmp.Close()
+		return "", err
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
 		return "", err
 	}
 	if len(old) == 0 {
@@ -441,6 +460,10 @@ func removeCodexDejaBlock(s string) string {
 func homeDir() string {
 	h, _ := os.UserHomeDir()
 	return h
+}
+
+func antigravityConfigHome() string {
+	return filepath.Join(homeDir(), ".gemini", "config")
 }
 
 // installCursor wires the MCP server into Cursor's global config

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -119,6 +119,11 @@
       "name": "qwen",
       "state": "config-missing",
       "path": "<tmp>/home/.qwen/settings.json"
+    },
+    {
+      "name": "copilot",
+      "state": "config-missing",
+      "path": "<tmp>/home/.copilot/skills/deja-history/SKILL.md"
     }
   ],
   "sqlite3": {


### PR DESCRIPTION
Extends #126 coverage: a deja-history skill for Antigravity (~/.gemini/config/skills) and Copilot (~/.copilot/skills, serving both the CLI and VS Code Chat, framed as a memory consumer since deja does not index Copilot history), and a marked block in the global ~/.qwen/QWEN.md. Marker matching is now whole-line only. Cursor and grok stay skipped: no documented user-level location.

Package coverage reads 94.8%: the remaining uncovered lines are doctor's permission-error branches (chmod-based tests are excluded as windows-unsafe) and the live release lookup.