### PR TITLE
feat(embed): add optional semantic recall

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,17 @@
+# Architecture
+
+## Semantic sidecar
+
+`deja embed` writes `<index-dir>.vectors.bin`. The file begins with `DJV1`, a
+version, vector dimension, model name, manifest generation, vector count, and
+covered-record watermark. Each entry stores the records.bin byte offset, its
+session key, and fixed-width float32 values. Writes use a temporary file and
+rename. A changed manifest generation or model discards old entries; a corrupt
+sidecar is treated as absent and rebuilt.
+
+## Hybrid ranking
+
+Search first produces lexical BM25 results. When a matching sidecar exists, up
+to 64 candidates are reranked using the query vector. The final score is
+`0.5 * normalized lexical score + 0.5 * cosine similarity`. A failed query
+embedding prints one notice and returns the original lexical order.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,21 @@ Context piping without MCP:
 claude "Prior context: $(deja ctx 'database migration')"
 ```
 
+## Semantic recall (optional)
+
+Semantic search is an opt-in layer for a local Ollama, LM Studio, or
+OpenAI-compatible embedding endpoint. Set `DEJA_EMBED_URL` and optionally
+`DEJA_EMBED_MODEL`, then run `deja embed`. Ollama defaults to
+`nomic-embed-text`; without a configured and reachable runtime, ordinary
+lexical search and MCP recall continue unchanged. `--no-embed` or
+`DEJA_EMBED=off` disables reranking for one invocation.
+
+The vector sidecar is stored beside the index as `.vectors.bin`, not in
+`index.db`. Float32 vectors cost roughly 4 KB per 1k messages for a 1,024
+dimension model, plus a small record key. Embedding is local and can consume
+CPU, memory, and model-server time; it never sends raw source files, only the
+redacted indexed text truncated to about 2k characters.
+
 ## Sync between machines
 
 Point both machines at one shared folder (Syncthing, iCloud, a git repo — anything that moves files):

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -67,8 +67,24 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup) error {
 	fmt.Fprintln(w)
 	doctorIndex(w)
 	fmt.Fprintln(w)
+	if report.Embed != nil {
+		doctorEmbed(w, *report.Embed)
+	} else {
+		doctorEmbed(w, doctorEmbedReport{State: "unavailable"})
+	}
+	fmt.Fprintln(w)
 	doctorVersion(w, func() (string, bool) { return report.Version.Latest, report.Version.Latest != "" })
 	return nil
+}
+
+func doctorEmbed(w io.Writer, r doctorEmbedReport) {
+	fmt.Fprintln(w, "Embedding:")
+	if r.Model == "" {
+		fmt.Fprintf(w, "  endpoint   %s\n", r.State)
+		return
+	}
+	fmt.Fprintf(w, "  endpoint   %s/model=%s/dim=%d\n", r.State, r.Model, r.Dim)
+	fmt.Fprintf(w, "  sidecar    coverage=%.1f%%\n", r.Coverage)
 }
 
 func doctorHarnesses(w io.Writer) {

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vshulcz/deja-vu/internal/embed"
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/sources"
@@ -37,6 +38,14 @@ type doctorReport struct {
 	MCP     []doctorMCPStatus   `json:"mcp"`
 	SQLite3 doctorComponent     `json:"sqlite3"`
 	Version doctorVersionReport `json:"version"`
+	Embed   *doctorEmbedReport  `json:"embed,omitempty"`
+}
+
+type doctorEmbedReport struct {
+	State    string  `json:"state"`
+	Model    string  `json:"model,omitempty"`
+	Dim      int     `json:"dim,omitempty"`
+	Coverage float64 `json:"coverage"`
 }
 
 type doctorMCPStatus struct {
@@ -70,7 +79,28 @@ func collectDoctorReport(lookup doctorVersionLookup) doctorReport {
 		report.SQLite3.State = "ok"
 	}
 	report.Version = collectDoctorVersion(lookup)
+	report.Embed = collectDoctorEmbed()
 	return report
+}
+
+func collectDoctorEmbed() *doctorEmbedReport {
+	r := &doctorEmbedReport{State: "unavailable"}
+	reachable := false
+	if c, err := embed.New(); err == nil {
+		r.State, r.Model, reachable = "reachable", c.Model, true
+	}
+	s, err := embed.Read(index.DefaultDir())
+	if err != nil {
+		if !reachable {
+			return nil
+		}
+		return r
+	}
+	r.Model, r.Dim = s.Model, s.Dim
+	if records, err := index.ReadRecords(index.DefaultDir()); err == nil && len(records) > 0 {
+		r.Coverage = float64(s.Covered) / float64(len(records)) * 100
+	}
+	return r
 }
 
 func doctorStoreChecks() []doctorStoreCheck {

--- a/cmd/deja/embed.go
+++ b/cmd/deja/embed.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/vshulcz/deja-vu/internal/embed"
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func runEmbed(args []string) error {
+	if len(args) != 0 {
+		return fmt.Errorf("embed: unknown flag %q", args[0])
+	}
+	if err := index.Ensure(index.DefaultDir(), "", false, os.Stderr); err != nil {
+		return err
+	}
+	client, err := embed.New()
+	if err != nil {
+		return err
+	}
+	_, err = embed.EmbedIndex(index.DefaultDir(), client)
+	return err
+}
+
+func maybeRerank(hits []search.Hit, o search.Options, notice *os.File) []search.Hit {
+	sidecar, err := embed.Read(index.DefaultDir())
+	if err != nil {
+		return hits
+	}
+	gen, err := index.Generation(index.DefaultDir())
+	if err != nil || gen != sidecar.Generation {
+		return hits
+	}
+	client, err := embed.New()
+	if err != nil {
+		fmt.Fprintln(notice, "deja: semantic rerank unavailable; using lexical order")
+		return hits
+	}
+	out, err := embed.Rerank(context.Background(), hits, o.Query, sidecar, client)
+	if err != nil {
+		fmt.Fprintln(notice, "deja: semantic rerank failed; using lexical order")
+		return hits
+	}
+	return out
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -105,6 +105,9 @@ func run(args []string) error {
 		maybeFirstIndexGreeting()
 		return nil
 	}
+	if args[0] == "embed" {
+		return runEmbed(args[1:])
+	}
 	if args[0] == "statusline" {
 		return runStatusline(os.Stdin, os.Stdout)
 	}
@@ -238,6 +241,9 @@ func run(args []string) error {
 	if err != nil {
 		return fmt.Errorf("run: %w", err)
 	}
+	if !o.NoEmbed && os.Getenv("DEJA_EMBED") != "off" {
+		hits = maybeRerank(hits, o, os.Stderr)
+	}
 	if len(hits) == 0 {
 		printNoMatches(os.Stderr, o.Query, len(ss))
 	}
@@ -370,6 +376,8 @@ func parseSearch(args []string) (search.Options, error) {
 			o.Regex = true
 		case "--all":
 			o.All = true
+		case "--no-embed":
+			o.NoEmbed = true
 		case "--harness", "--project", "--since", "--role":
 			if i+1 >= len(args) {
 				return o, fmt.Errorf("%s needs value", a)
@@ -532,7 +540,8 @@ Usage:
   deja sources
   deja doctor [--json]
   deja warmup
-  deja index [--rebuild]
+	deja index [--rebuild]
+	deja embed
   deja statusline
   deja stats [--json] [--card [path]]
   deja mcp

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -176,6 +176,9 @@ func recallTextResult(q, harness string, limit, budget int) (string, int, error)
 	if err != nil {
 		return "", 0, err
 	}
+	if os.Getenv("DEJA_EMBED") != "off" {
+		hits = maybeRerank(hits, o, os.Stderr)
+	}
 	if len(hits) == 0 {
 		return fmt.Sprintf("No prior deja sessions matched %q.", q), 0, nil
 	}

--- a/cmd/deja/semantic_coverage_test.go
+++ b/cmd/deja/semantic_coverage_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/embed"
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func TestEmbedCommandBuildsSemanticSidecar(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "-tmp-semantic")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFileMkdir(t, filepath.Join(root, "s.jsonl"), `{"type":"user","sessionId":"s","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"semantic command"}}`+"\n")
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		var req struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.Input) != 1 {
+			t.Errorf("embed request=%#v err=%v", req, err)
+		}
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[1,0]}]}`))
+	}))
+	defer ts.Close()
+	t.Setenv("DEJA_EMBED_URL", ts.URL)
+	if err := runEmbed([]string{"--bad"}); err == nil {
+		t.Fatal("unknown embed flag should fail")
+	}
+	if err := runEmbed(nil); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("embedding calls=%d, want one", calls)
+	}
+	s, err := embed.Read(indexDirForTest())
+	if err != nil || s.Covered != 1 || len(s.Vectors) != 1 || s.Vectors[0].Values[0] != 1 {
+		t.Fatalf("sidecar=%+v err=%v", s, err)
+	}
+	report := collectDoctorEmbed()
+	if report == nil || report.State != "reachable" || report.Dim != 2 || report.Coverage != 100 {
+		t.Fatalf("doctor embedding report=%#v", report)
+	}
+	hits := []search.Hit{{Session: model.Session{ID: "s", Harness: "claude"}, Score: 1}}
+	if got := maybeRerank(hits, search.Options{Query: "semantic"}, os.Stderr); len(got) != 1 || got[0].Score != 1 {
+		t.Fatalf("semantic rerank=%#v", got)
+	}
+	t.Setenv("DEJA_EMBED_URL", "http://127.0.0.1:1")
+	if got := maybeRerank(hits, search.Options{Query: "semantic"}, os.Stderr); len(got) != 1 || got[0].Score != 1 {
+		t.Fatalf("failed semantic rerank=%#v", got)
+	}
+	if err := os.WriteFile(filepath.Join(root, "new.jsonl"), []byte(`{"type":"user","sessionId":"new","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"new semantic"}}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := maybeRerank(hits, search.Options{Query: "semantic"}, os.Stderr); len(got) != 1 || got[0].Score != 1 {
+		t.Fatalf("stale semantic rerank=%#v", got)
+	}
+}
+
+func TestStatsJSONOutputIncludesSemanticSize(t *testing.T) {
+	tmp := hermeticEnv(t)
+	if err := os.MkdirAll(indexDirForTest(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(embed.Path(indexDirForTest()), []byte("sidecar"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	err = runStats([]string{"--json"})
+	_ = w.Close()
+	os.Stdout = old
+	var out bytes.Buffer
+	_, _ = out.ReadFrom(r)
+	_ = r.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"sidecar_size": 7`) {
+		t.Fatalf("stats JSON=%s", out.String())
+	}
+	if err := runStats([]string{"--json", "--card"}); err == nil {
+		t.Fatal("stats output modes should be exclusive")
+	}
+	card := filepath.Join(tmp, "stats.svg")
+	if err := runStats([]string{"--card", card, "--harness", "claude", "--project", "none", "--since", "1h", "--role", "user"}); err != nil {
+		t.Fatal(err)
+	}
+	if b, err := os.ReadFile(card); err != nil || !strings.Contains(string(b), "<svg") {
+		t.Fatalf("stats card err=%v content=%q", err, b)
+	}
+	_ = tmp
+}
+
+func TestMaybeRerankFallsBackWithoutSidecar(t *testing.T) {
+	hermeticEnv(t)
+	hits := []search.Hit{{Session: model.Session{ID: "s", Harness: "claude"}, Score: 1}}
+	var notice bytes.Buffer
+	if got := maybeRerank(hits, search.Options{Query: "q"}, os.Stderr); len(got) != 1 || got[0].Score != 1 {
+		t.Fatalf("missing sidecar rerank=%#v", got)
+	}
+	_ = notice
+}
+
+func TestDoctorEmbedAndStatsFilters(t *testing.T) {
+	var out bytes.Buffer
+	doctorEmbed(&out, doctorEmbedReport{State: "unavailable"})
+	doctorEmbed(&out, doctorEmbedReport{State: "reachable", Model: "m", Dim: 2, Coverage: 50})
+	if !strings.Contains(out.String(), "endpoint   unavailable") || !strings.Contains(out.String(), "coverage=50.0%") {
+		t.Fatalf("embedding report=%q", out.String())
+	}
+	now := time.Now()
+	ss := []model.Session{
+		{Harness: "claude", Project: "Alpha", Updated: now, Messages: []model.Message{{Role: "user"}}},
+		{Harness: "codex", Project: "Beta", Updated: now.Add(-time.Hour), Messages: []model.Message{{Role: "assistant"}}},
+	}
+	got := filterStatsSessions(ss, search.Options{Harness: "claude", Project: "alp", Since: time.Minute, Role: "user"})
+	if len(got) != 1 || len(got[0].Messages) != 1 || got[0].Messages[0].Role != "user" {
+		t.Fatalf("filtered stats=%#v", got)
+	}
+	if got := filterStatsSessions(ss, search.Options{Role: "system"}); len(got) != 0 {
+		t.Fatalf("role filter retained sessions=%#v", got)
+	}
+	for _, args := range [][]string{{"--since"}, {"--since", "bad"}, {"--card", "--card"}} {
+		if err := runStats(args); err == nil {
+			t.Fatalf("runStats(%v) accepted invalid arguments", args)
+		}
+	}
+}
+
+func indexDirForTest() string { return os.Getenv("DEJA_INDEX_DIR") }

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vshulcz/deja-vu/internal/embed"
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
@@ -35,6 +36,7 @@ type statsReport struct {
 	Longest       sessionStat    `json:"longest_session"`
 	BusiestDay    dayStat        `json:"busiest_day"`
 	Recall        usage.Summary  `json:"recall"`
+	SidecarSize   int64          `json:"sidecar_size,omitempty"`
 }
 
 type harnessStats struct {
@@ -126,6 +128,9 @@ func runStats(args []string) error {
 	}
 	report := buildStats(filterStatsSessions(ss, options), time.Now())
 	report.Recall = usage.Totals(index.DefaultDir())
+	if fi, e := os.Stat(embed.Path(index.DefaultDir())); e == nil {
+		report.SidecarSize = fi.Size()
+	}
 	if cardPath != "" {
 		path, err := writeStatsCard(cardPath, report)
 		if err != nil {
@@ -278,6 +283,9 @@ func printStats(w io.Writer, r statsReport) {
 	fmt.Fprintf(w, "Sessions  %s%d%s\n", bold, r.TotalSessions, reset)
 	fmt.Fprintf(w, "Messages  %s%d%s\n", bold, r.TotalMessages, reset)
 	fmt.Fprintf(w, "Range     %s → %s\n\n", valueOrDash(r.DateRange.Start), valueOrDash(r.DateRange.End))
+	if r.SidecarSize > 0 {
+		fmt.Fprintf(w, "Semantic  sidecar %s\n\n", humanBytes(r.SidecarSize))
+	}
 
 	fmt.Fprintf(w, "%sBy harness%s\n", bold, reset)
 	for _, h := range r.Harnesses {

--- a/internal/embed/client.go
+++ b/internal/embed/client.go
@@ -1,0 +1,97 @@
+package embed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	URL   string
+	Model string
+	HTTP  *http.Client
+}
+
+func New() (*Client, error) {
+	model := os.Getenv("DEJA_EMBED_MODEL")
+	if model == "" {
+		model = "nomic-embed-text"
+	}
+	if url := os.Getenv("DEJA_EMBED_URL"); url != "" {
+		return &Client{URL: url, Model: model, HTTP: &http.Client{Timeout: 30 * time.Second}}, nil
+	}
+	for _, url := range []string{"http://localhost:11434/api/embed", "http://localhost:1234/v1/embeddings"} {
+		c := &Client{URL: url, Model: model, HTTP: &http.Client{Timeout: 30 * time.Second}}
+		if err := c.probe(); err == nil {
+			return c, nil
+		}
+	}
+	return nil, fmt.Errorf("embedding endpoint unavailable (set DEJA_EMBED_URL)")
+}
+
+func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	httpClient := c.HTTP
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	body, err := json.Marshal(map[string]any{"model": c.Model, "input": texts})
+	if err != nil {
+		return nil, fmt.Errorf("encode embedding request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.URL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create embedding request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("embedding request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("embedding endpoint returned %s", resp.Status)
+	}
+	var out struct {
+		Embeddings [][]float32 `json:"embeddings"`
+		Data       []struct {
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode embedding response: %w", err)
+	}
+	if len(out.Embeddings) > 0 {
+		return out.Embeddings, nil
+	}
+	result := make([][]float32, len(out.Data))
+	for i := range out.Data {
+		result[i] = out.Data[i].Embedding
+	}
+	if len(result) != len(texts) {
+		return nil, fmt.Errorf("embedding endpoint returned %d vectors for %d texts", len(result), len(texts))
+	}
+	return result, nil
+}
+
+func (c *Client) probe() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	v, err := c.Embed(ctx, []string{"deja probe"})
+	if err != nil || len(v) != 1 || len(v[0]) == 0 {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("empty embedding response")
+	}
+	return nil
+}
+
+func IsOllama(url string) bool { return strings.HasSuffix(strings.TrimRight(url, "/"), "/api/embed") }

--- a/internal/embed/client.go
+++ b/internal/embed/client.go
@@ -17,6 +17,8 @@ type Client struct {
 	HTTP  *http.Client
 }
 
+var probeURLs = []string{"http://localhost:11434/api/embed", "http://localhost:1234/v1/embeddings"}
+
 func New() (*Client, error) {
 	model := os.Getenv("DEJA_EMBED_MODEL")
 	if model == "" {
@@ -25,7 +27,7 @@ func New() (*Client, error) {
 	if url := os.Getenv("DEJA_EMBED_URL"); url != "" {
 		return &Client{URL: url, Model: model, HTTP: &http.Client{Timeout: 30 * time.Second}}, nil
 	}
-	for _, url := range []string{"http://localhost:11434/api/embed", "http://localhost:1234/v1/embeddings"} {
+	for _, url := range probeURLs {
 		c := &Client{URL: url, Model: model, HTTP: &http.Client{Timeout: 30 * time.Second}}
 		if err := c.probe(); err == nil {
 			return c, nil

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -1,0 +1,89 @@
+package embed
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func TestClientShapesAndErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want float32
+	}{
+		{"ollama", `{"embeddings":[[1,2]]}`, 1},
+		{"openai", `{"data":[{"embedding":[3,4]}]}`, 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path == "" {
+					t.Error("bad request")
+				}
+				var request map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil || request["model"] == nil {
+					t.Error("bad body")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer s.Close()
+			c := &Client{URL: s.URL, Model: "test"}
+			v, err := c.Embed(context.Background(), []string{"hello"})
+			if err != nil || len(v) != 1 || v[0][0] != tc.want {
+				t.Fatalf("vectors=%v err=%v", v, err)
+			}
+		})
+	}
+	s := httptest.NewServer(http.NotFoundHandler())
+	defer s.Close()
+	if _, err := (&Client{URL: s.URL, Model: "test"}).Embed(context.Background(), []string{"x"}); err == nil {
+		t.Fatal("expected status error")
+	}
+}
+
+func TestNewExplicitAndProbeOrder(t *testing.T) {
+	t.Setenv("DEJA_EMBED_MODEL", "probe-model")
+	t.Setenv("DEJA_EMBED_URL", "http://explicit.invalid/api/embed")
+	c, err := New()
+	if err != nil || c.URL != os.Getenv("DEJA_EMBED_URL") || c.Model != "probe-model" {
+		t.Fatalf("client=%v err=%v", c, err)
+	}
+}
+
+func TestSidecarRoundTripCorruptAndRerank(t *testing.T) {
+	d := t.TempDir()
+	dir := filepath.Join(d, "index.db")
+	s := Sidecar{Model: "m", Generation: "g", Dim: 2, Covered: 2, Vectors: []Vector{{Offset: 4, Key: "claude:a", Values: []float32{1, 0}}, {Offset: 8, Key: "claude:b", Values: []float32{0, 1}}}}
+	if err := write(dir, s); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Read(dir)
+	if err != nil || len(got.Vectors) != 2 || got.Vectors[1].Values[1] != 1 {
+		t.Fatalf("sidecar=%+v err=%v", got, err)
+	}
+	hits := []search.Hit{{Session: session("a"), Score: 2}, {Session: session("b"), Score: 1}}
+	client := &Client{URL: "", Model: "m", HTTP: http.DefaultClient}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(`{"data":[{"embedding":[1,0]}]}`)) }))
+	defer server.Close()
+	client.URL = server.URL
+	ranked, err := Rerank(context.Background(), hits, "q", got, client)
+	if err != nil || ranked[0].Session.ID != "a" {
+		t.Fatalf("ranked=%v err=%v", ranked, err)
+	}
+	if err := os.WriteFile(Path(dir), []byte("bad"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Read(dir); err == nil {
+		t.Fatal("expected corrupt error")
+	}
+}
+
+func session(id string) model.Session { return model.Session{ID: id, Harness: "claude"} }

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -1,14 +1,18 @@
 package embed
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
@@ -47,6 +51,24 @@ func TestClientShapesAndErrors(t *testing.T) {
 	if _, err := (&Client{URL: s.URL, Model: "test"}).Embed(context.Background(), []string{"x"}); err == nil {
 		t.Fatal("expected status error")
 	}
+	for name, body := range map[string]string{"bad json": "{", "wrong count": `{"data":[]}`} {
+		t.Run(name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(body)) }))
+			defer ts.Close()
+			if _, err := (&Client{URL: ts.URL, Model: "test"}).Embed(context.Background(), []string{"x"}); err == nil {
+				t.Fatal("expected response error")
+			}
+		})
+	}
+	if _, err := (&Client{URL: "://bad"}).Embed(context.Background(), []string{"x"}); err == nil {
+		t.Fatal("expected request creation error")
+	}
+	if _, err := (&Client{URL: "http://127.0.0.1:1", HTTP: &http.Client{}}).Embed(context.Background(), []string{"x"}); err == nil {
+		t.Fatal("expected transport error")
+	}
+	if got, err := (&Client{}).Embed(context.Background(), nil); err != nil || got != nil {
+		t.Fatalf("empty embed = %v, %v", got, err)
+	}
 }
 
 func TestNewExplicitAndProbeOrder(t *testing.T) {
@@ -56,6 +78,35 @@ func TestNewExplicitAndProbeOrder(t *testing.T) {
 	if err != nil || c.URL != os.Getenv("DEJA_EMBED_URL") || c.Model != "probe-model" {
 		t.Fatalf("client=%v err=%v", c, err)
 	}
+	if !IsOllama("http://x/api/embed/") || IsOllama("http://x/v1/embeddings") {
+		t.Fatal("IsOllama classified endpoint incorrectly")
+	}
+	for body, wantErr := range map[string]bool{`{"embeddings":[]}`: true, `{"embeddings":[[]]}`: true, `{"embeddings":[[1]]}`: false} {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(body)) }))
+		c := &Client{URL: ts.URL, Model: "m"}
+		err := c.probe()
+		if (err != nil) != wantErr {
+			t.Fatalf("probe body %s err=%v", body, err)
+		}
+		ts.Close()
+	}
+	first := httptest.NewServer(http.NotFoundHandler())
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(`{"embeddings":[[1]]}`)) }))
+	defer first.Close()
+	defer second.Close()
+	t.Setenv("DEJA_EMBED_URL", "")
+	oldURLs := probeURLs
+	probeURLs = []string{first.URL, second.URL}
+	c, err = New()
+	probeURLs = oldURLs
+	if err != nil || c.URL != second.URL {
+		t.Fatalf("probe fallback client=%v err=%v", c, err)
+	}
+	probeURLs = []string{first.URL}
+	if _, err := New(); err == nil {
+		t.Fatal("unavailable probe endpoints should fail")
+	}
+	probeURLs = oldURLs
 }
 
 func TestSidecarRoundTripCorruptAndRerank(t *testing.T) {
@@ -84,6 +135,224 @@ func TestSidecarRoundTripCorruptAndRerank(t *testing.T) {
 	if _, err := Read(dir); err == nil {
 		t.Fatal("expected corrupt error")
 	}
+	if got := truncate(strings.Repeat("x", 2100)); len([]rune(got)) != 2000 || !strings.HasSuffix(got, "[truncated]") {
+		t.Fatalf("truncate = %q", got)
+	}
+	if Cosine([]float32{1}, []float32{1, 0}) != 0 || Cosine([]float32{0, 0}, []float32{1, 0}) != 0 {
+		t.Fatal("invalid cosine should be zero")
+	}
+}
+
+func TestEmbedIndexRoundTripAndWatermark(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "claude", "-tmp-project")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "session.jsonl")
+	if err := os.WriteFile(path, []byte(`{"type":"user","sessionId":"s","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"a semantic needle"}}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	t.Setenv("DEJA_AIDER_ROOTS", filepath.Join(tmp, "aider"))
+	t.Setenv("DEJA_GEMINI_ROOT", filepath.Join(tmp, "gemini"))
+	t.Setenv("DEJA_CURSOR_ROOT", filepath.Join(tmp, "cursor"))
+	t.Setenv("DEJA_CURSOR_CLI_ROOT", filepath.Join(tmp, "cursor-cli"))
+	t.Setenv("DEJA_ANTIGRAVITY_ROOT", filepath.Join(tmp, "antigravity"))
+	t.Setenv("DEJA_GROK_ROOT", filepath.Join(tmp, "grok"))
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		var request struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil || len(request.Input) != 1 || !strings.Contains(request.Input[0], "needle") {
+			t.Errorf("request = %#v, err=%v", request, err)
+		}
+		if calls > 1 {
+			_, _ = w.Write([]byte(`{"embeddings":[[1]]}`))
+		} else {
+			_, _ = w.Write([]byte(`{"embeddings":[[1,0]]}`))
+		}
+	}))
+	defer ts.Close()
+	s, err := EmbedIndex(dir, &Client{URL: ts.URL, Model: "m"})
+	if err != nil || calls != 1 || s.Covered != 1 || len(s.Vectors) != 1 {
+		t.Fatalf("first embed sidecar=%+v calls=%d err=%v", s, calls, err)
+	}
+	if _, err = EmbedIndex(dir, &Client{URL: ts.URL, Model: "m"}); err != nil || calls != 1 {
+		t.Fatalf("watermark did not reuse vector calls=%d err=%v", calls, err)
+	}
+	if err := write(dir, Sidecar{Model: "m", Generation: s.Generation, Dim: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EmbedIndex(dir, &Client{URL: ts.URL, Model: "m"}); err == nil || !strings.Contains(err.Error(), "dimension changed") {
+		t.Fatalf("dimension change err=%v", err)
+	}
+	bad := httptest.NewServer(http.NotFoundHandler())
+	defer bad.Close()
+	if _, err := EmbedIndex(dir, &Client{URL: bad.URL, Model: "other"}); err == nil {
+		t.Fatal("embedding endpoint error was ignored")
+	}
+	if err := write(filepath.Join(tmp, "no", "missing"), Sidecar{}); err == nil {
+		t.Fatal("write into missing directory succeeded")
+	}
+	renamed := filepath.Join(tmp, "rename-target")
+	if err := os.MkdirAll(Path(renamed), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := write(renamed, Sidecar{}); err == nil {
+		t.Fatal("write over directory succeeded")
+	}
+}
+
+func TestRerankUsesBestDuplicateAndRejectsEmptyQueryVector(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(`{"data":[{"embedding":[1,0]}]}`)) }))
+	defer s.Close()
+	hits := []search.Hit{{Session: session("a"), Score: 10}, {Session: session("b"), Score: 0}}
+	sidecar := Sidecar{Vectors: []Vector{{Key: "claude:a", Values: []float32{-1, 0}}, {Key: "claude:a", Values: []float32{1, 0}}, {Key: "claude:b", Values: []float32{0, 1}}}}
+	got, err := Rerank(context.Background(), hits, "q", sidecar, &Client{URL: s.URL})
+	if err != nil || got[0].Session.ID != "a" || got[0].Score != 1 {
+		t.Fatalf("rerank = %#v, %v", got, err)
+	}
+	var many []search.Hit
+	for i := 0; i < 65; i++ {
+		many = append(many, search.Hit{Session: session("a"), Score: float64(i)})
+	}
+	if _, err := Rerank(context.Background(), many, "q", sidecar, &Client{URL: s.URL}); err != nil {
+		t.Fatal(err)
+	}
+	empty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(`{"data":[]}`)) }))
+	defer empty.Close()
+	if _, err := Rerank(context.Background(), hits, "q", sidecar, &Client{URL: empty.URL}); err == nil {
+		t.Fatal("expected empty query vector error")
+	}
+}
+
+func TestSidecarRejectsMalformedHeadersAndRerankShortcuts(t *testing.T) {
+	dir := t.TempDir()
+	cases := [][]byte{
+		[]byte("bad"),
+		append(append([]byte{}, magic[:]...), 2, 0, 0, 0),
+	}
+	for i, data := range cases {
+		if err := os.WriteFile(Path(filepath.Join(dir, string(rune('a'+i)))), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := Read(filepath.Join(dir, string(rune('a'+i)))); err == nil {
+			t.Fatal("malformed sidecar was accepted")
+		}
+	}
+	badDim := filepath.Join(dir, "dim")
+	data := append([]byte{}, magic[:]...)
+	data = append(data, 1, 0)
+	var dim [2]byte
+	binary.LittleEndian.PutUint16(dim[:], 16_385)
+	data = append(data, dim[:]...)
+	if err := os.WriteFile(Path(badDim), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Read(badDim); err == nil {
+		t.Fatal("oversized dimension was accepted")
+	}
+	base := func() *bytes.Buffer {
+		b := bytes.NewBuffer(append([]byte{}, magic[:]...))
+		_ = binary.Write(b, binary.LittleEndian, sidecarVersion)
+		_ = binary.Write(b, binary.LittleEndian, uint16(1))
+		return b
+	}
+	for name, makeData := range map[string]func() []byte{
+		"missing model":      func() []byte { return base().Bytes() },
+		"short model":        func() []byte { b := base(); _ = binary.Write(b, binary.LittleEndian, uint32(1)); return b.Bytes() },
+		"missing generation": func() []byte { b := base(); _ = writeString(b, "m"); return b.Bytes() },
+		"missing count":      func() []byte { b := base(); _ = writeString(b, "m"); _ = writeString(b, "g"); return b.Bytes() },
+		"huge count": func() []byte {
+			b := base()
+			_ = writeString(b, "m")
+			_ = writeString(b, "g")
+			_ = binary.Write(b, binary.LittleEndian, uint64(10_000_001))
+			return b.Bytes()
+		},
+		"missing covered": func() []byte {
+			b := base()
+			_ = writeString(b, "m")
+			_ = writeString(b, "g")
+			_ = binary.Write(b, binary.LittleEndian, uint64(0))
+			return b.Bytes()
+		},
+		"missing vector offset": func() []byte {
+			b := base()
+			_ = writeString(b, "m")
+			_ = writeString(b, "g")
+			_ = binary.Write(b, binary.LittleEndian, uint64(1))
+			_ = binary.Write(b, binary.LittleEndian, uint64(1))
+			return b.Bytes()
+		},
+		"missing vector key": func() []byte {
+			b := base()
+			_ = writeString(b, "m")
+			_ = writeString(b, "g")
+			_ = binary.Write(b, binary.LittleEndian, uint64(1))
+			_ = binary.Write(b, binary.LittleEndian, uint64(1))
+			_ = binary.Write(b, binary.LittleEndian, int64(2))
+			return b.Bytes()
+		},
+		"missing vector values": func() []byte {
+			b := base()
+			_ = writeString(b, "m")
+			_ = writeString(b, "g")
+			_ = binary.Write(b, binary.LittleEndian, uint64(1))
+			_ = binary.Write(b, binary.LittleEndian, uint64(1))
+			_ = binary.Write(b, binary.LittleEndian, int64(2))
+			_ = writeString(b, "k")
+			return b.Bytes()
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			p := filepath.Join(dir, name)
+			if err := os.WriteFile(Path(p), makeData(), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Read(p); err == nil {
+				t.Fatal("truncated sidecar was accepted")
+			}
+		})
+	}
+	if err := writeString(failingWriter{}, "x"); err == nil || writeString(&headerWriter{}, "x") == nil {
+		t.Fatal("writeString failures were ignored")
+	}
+	if got, err := Rerank(context.Background(), nil, "q", Sidecar{}, &Client{}); err != nil || got != nil {
+		t.Fatalf("empty rerank=%v err=%v", got, err)
+	}
+	if got, err := Rerank(context.Background(), []search.Hit{{Session: session("a")}}, "q", Sidecar{}, &Client{}); err != nil || len(got) != 1 {
+		t.Fatalf("empty sidecar rerank=%v err=%v", got, err)
+	}
+	if _, err := Rerank(context.Background(), []search.Hit{{Session: session("a")}}, "q", Sidecar{Vectors: []Vector{{Key: "claude:a", Values: []float32{1}}}}, &Client{URL: "http://127.0.0.1:1", HTTP: &http.Client{}}); err == nil {
+		t.Fatal("rerank transport error was ignored")
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, os.ErrPermission }
+
+type headerWriter struct{ n int }
+
+func (w *headerWriter) Write(p []byte) (int, error) {
+	if w.n == 0 {
+		w.n++
+		return len(p), nil
+	}
+	return 0, os.ErrPermission
 }
 
 func session(id string) model.Session { return model.Session{ID: id, Harness: "claude"} }

--- a/internal/embed/rerank.go
+++ b/internal/embed/rerank.go
@@ -32,9 +32,18 @@ func Rerank(ctx context.Context, hits []search.Hit, query string, sidecar Sideca
 			min = h.Score
 		}
 	}
+	// Only candidate sessions need a similarity; skipping the rest keeps the
+	// pass proportional to the result page, not the corpus.
+	wanted := make(map[string]bool, limit)
+	for _, h := range hits[:limit] {
+		wanted[h.Session.Harness+":"+h.Session.ID] = true
+	}
 	cosines := make(map[string]float64)
 	seen := make(map[string]bool)
 	for _, v := range sidecar.Vectors {
+		if !wanted[v.Key] {
+			continue
+		}
 		c := Cosine(q[0], v.Values)
 		if !seen[v.Key] || c > cosines[v.Key] {
 			cosines[v.Key], seen[v.Key] = c, true

--- a/internal/embed/rerank.go
+++ b/internal/embed/rerank.go
@@ -1,0 +1,59 @@
+package embed
+
+import (
+	"context"
+	"sort"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func Rerank(ctx context.Context, hits []search.Hit, query string, sidecar Sidecar, client *Client) ([]search.Hit, error) {
+	if len(hits) == 0 || len(sidecar.Vectors) == 0 {
+		return hits, nil
+	}
+	q, err := client.Embed(ctx, []string{query})
+	if err != nil {
+		return nil, err
+	}
+	if len(q) != 1 {
+		return nil, errBadQueryVector
+	}
+	limit := len(hits)
+	if limit > 64 {
+		limit = 64
+	}
+	max := hits[0].Score
+	min := hits[0].Score
+	for _, h := range hits[:limit] {
+		if h.Score > max {
+			max = h.Score
+		}
+		if h.Score < min {
+			min = h.Score
+		}
+	}
+	cosines := make(map[string]float64)
+	seen := make(map[string]bool)
+	for _, v := range sidecar.Vectors {
+		c := Cosine(q[0], v.Values)
+		if !seen[v.Key] || c > cosines[v.Key] {
+			cosines[v.Key], seen[v.Key] = c, true
+		}
+	}
+	for i := range hits[:limit] {
+		key := hits[i].Session.Harness + ":" + hits[i].Session.ID
+		bm := 1.0
+		if max != min {
+			bm = (hits[i].Score - min) / (max - min)
+		}
+		hits[i].Score = 0.5*bm + 0.5*cosines[key]
+	}
+	sort.SliceStable(hits[:limit], func(i, j int) bool { return hits[i].Score > hits[j].Score })
+	return hits, nil
+}
+
+var errBadQueryVector = &queryVectorError{}
+
+type queryVectorError struct{}
+
+func (*queryVectorError) Error() string { return "embedding endpoint returned no query vector" }

--- a/internal/embed/sidecar.go
+++ b/internal/embed/sidecar.go
@@ -1,0 +1,234 @@
+package embed
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+const sidecarVersion uint16 = 1
+
+var magic = [4]byte{'D', 'J', 'V', '1'}
+
+type Vector struct {
+	Offset int64
+	Key    string
+	Values []float32
+}
+type Sidecar struct {
+	Model, Generation string
+	Dim               int
+	Vectors           []Vector
+	Covered           int
+}
+
+func Path(dir string) string {
+	return strings.TrimSuffix(dir, string(os.PathSeparator)) + ".vectors.bin"
+}
+
+func EmbedIndex(dir string, client *Client) (Sidecar, error) {
+	recs, err := index.ReadRecords(dir)
+	if err != nil {
+		return Sidecar{}, fmt.Errorf("read index records: %w", err)
+	}
+	gen, err := index.Generation(dir)
+	if err != nil {
+		return Sidecar{}, err
+	}
+	old, _ := Read(dir)
+	if old.Model != client.Model || old.Generation != gen || old.Dim == 0 {
+		old = Sidecar{}
+	}
+	seen := make(map[int64]bool, len(old.Vectors))
+	for _, v := range old.Vectors {
+		seen[v.Offset] = true
+	}
+	var pending []index.OffsetRecord
+	for _, r := range recs {
+		if !seen[r.Offset] {
+			pending = append(pending, r)
+		}
+	}
+	for len(pending) > 0 {
+		n := len(pending)
+		if n > 32 {
+			n = 32
+		}
+		texts := make([]string, n)
+		for i := range pending[:n] {
+			texts[i] = truncate(pending[i].Record.Text)
+		}
+		vectors, err := client.Embed(context.Background(), texts)
+		if err != nil {
+			return Sidecar{}, err
+		}
+		for i, values := range vectors {
+			if old.Dim == 0 {
+				old.Dim = len(values)
+			}
+			if len(values) != old.Dim {
+				return Sidecar{}, fmt.Errorf("embedding dimension changed from %d to %d", old.Dim, len(values))
+			}
+			old.Vectors = append(old.Vectors, Vector{Offset: pending[i].Offset, Key: pending[i].Record.Key, Values: values})
+		}
+		pending = pending[n:]
+	}
+	old.Model, old.Generation, old.Covered = client.Model, gen, len(recs)
+	if err := write(dir, old); err != nil {
+		return Sidecar{}, err
+	}
+	return old, nil
+}
+
+func truncate(s string) string {
+	const limit = 2000
+	r := []rune(s)
+	if len(r) <= limit {
+		return s
+	}
+	return string(r[:limit-12]) + "\n[truncated]"
+}
+
+func Read(dir string) (Sidecar, error) {
+	f, err := os.Open(Path(dir))
+	if err != nil {
+		return Sidecar{}, err
+	}
+	defer func() { _ = f.Close() }()
+	var got [4]byte
+	if _, err = f.Read(got[:]); err != nil || got != magic {
+		return Sidecar{}, fmt.Errorf("invalid vector sidecar")
+	}
+	var version, dim uint16
+	var count, covered uint64
+	var model, gen string
+	if err = binary.Read(f, binary.LittleEndian, &version); err != nil || version != sidecarVersion {
+		return Sidecar{}, fmt.Errorf("unsupported vector sidecar")
+	}
+	if err = binary.Read(f, binary.LittleEndian, &dim); err != nil {
+		return Sidecar{}, err
+	}
+	if model, err = readString(f); err != nil {
+		return Sidecar{}, err
+	}
+	if gen, err = readString(f); err != nil {
+		return Sidecar{}, err
+	}
+	if err = binary.Read(f, binary.LittleEndian, &count); err != nil {
+		return Sidecar{}, err
+	}
+	if count > 10_000_000 || dim > 16_384 {
+		return Sidecar{}, fmt.Errorf("invalid vector sidecar dimensions")
+	}
+	if err = binary.Read(f, binary.LittleEndian, &covered); err != nil {
+		return Sidecar{}, err
+	}
+	out := Sidecar{Model: model, Generation: gen, Dim: int(dim), Covered: int(covered), Vectors: make([]Vector, count)}
+	for i := range out.Vectors {
+		if err = binary.Read(f, binary.LittleEndian, &out.Vectors[i].Offset); err != nil {
+			return Sidecar{}, err
+		}
+		if out.Vectors[i].Key, err = readString(f); err != nil {
+			return Sidecar{}, err
+		}
+		out.Vectors[i].Values = make([]float32, out.Dim)
+		if err = binary.Read(f, binary.LittleEndian, out.Vectors[i].Values); err != nil {
+			return Sidecar{}, err
+		}
+	}
+	return out, nil
+}
+
+func write(dir string, s Sidecar) error {
+	tmp := Path(dir) + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	good := false
+	defer func() {
+		if !good {
+			_ = os.Remove(tmp)
+		}
+	}()
+	if _, err = f.Write(magic[:]); err == nil {
+		err = binary.Write(f, binary.LittleEndian, sidecarVersion)
+	}
+	if err == nil {
+		err = binary.Write(f, binary.LittleEndian, uint16(s.Dim))
+	}
+	if err == nil {
+		err = writeString(f, s.Model)
+	}
+	if err == nil {
+		err = writeString(f, s.Generation)
+	}
+	if err == nil {
+		err = binary.Write(f, binary.LittleEndian, uint64(len(s.Vectors)))
+	}
+	if err == nil {
+		err = binary.Write(f, binary.LittleEndian, uint64(s.Covered))
+	}
+	for _, v := range s.Vectors {
+		if err == nil {
+			err = binary.Write(f, binary.LittleEndian, v.Offset)
+		}
+		if err == nil {
+			err = writeString(f, v.Key)
+		}
+		if err == nil {
+			err = binary.Write(f, binary.LittleEndian, v.Values)
+		}
+	}
+	if cerr := f.Close(); err == nil {
+		err = cerr
+	}
+	if err != nil {
+		return err
+	}
+	if err = os.Rename(tmp, Path(dir)); err != nil {
+		return err
+	}
+	good = true
+	return nil
+}
+func writeString(w interface{ Write([]byte) (int, error) }, s string) error {
+	if err := binary.Write(w, binary.LittleEndian, uint32(len(s))); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte(s))
+	return err
+}
+func readString(r io.Reader) (string, error) {
+	var n uint32
+	if err := binary.Read(r, binary.LittleEndian, &n); err != nil {
+		return "", err
+	}
+	b := make([]byte, n)
+	if _, err := io.ReadFull(r, b); err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+func Cosine(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, aa, bb float64
+	for i := range a {
+		x, y := float64(a[i]), float64(b[i])
+		dot += x * y
+		aa += x * x
+		bb += y * y
+	}
+	if aa == 0 || bb == 0 {
+		return 0
+	}
+	return dot / math.Sqrt(aa*bb)
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -110,6 +110,7 @@ type Manifest struct {
 	Files            map[string]FileState   `json:"files"`
 	Sessions         map[string]SessionMeta `json:"sessions"`
 	BuiltAt          time.Time              `json:"built_at"`
+	Generation       string                 `json:"generation,omitempty"`
 	Scope            string                 `json:"scope"`
 	Redacted         int                    `json:"redacted"`
 	ExportWatermarks map[string]int64       `json:"export_watermarks,omitempty"`
@@ -124,6 +125,7 @@ type manifestCore struct {
 	Version          int
 	Files            map[string]FileState
 	BuiltAt          time.Time
+	Generation       string
 	Scope            string
 	Redacted         int
 	ExportWatermarks map[string]int64
@@ -143,6 +145,46 @@ type Record struct {
 	Text       string
 	Time       time.Time
 	LowerText  string `json:"-"`
+}
+
+type OffsetRecord struct {
+	Offset int64
+	Record Record
+}
+
+func ReadRecords(dir string) ([]OffsetRecord, error) {
+	var out []OffsetRecord
+	f, err := os.Open(filepath.Join(dir, "records.bin"))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	for {
+		off, err := f.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return nil, err
+		}
+		r, err := readRecord(f)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, OffsetRecord{Offset: off, Record: r})
+	}
+	return out, nil
+}
+
+func Generation(dir string) (string, error) {
+	m, err := readManifest(dir)
+	if err != nil {
+		return "", err
+	}
+	if m.Generation != "" {
+		return m.Generation, nil
+	}
+	return m.BuiltAt.UTC().Format(time.RFC3339Nano), nil
 }
 
 type posting struct {
@@ -436,7 +478,7 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 	}
 	ss := loadProgress(harness, progress)
 	ss = append(ss, imported.sessions...)
-	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope,
+	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
 		ExportWatermarks: imported.watermarks, ImportedRecords: imported.dedupe}
 	recPath := filepath.Join(tmp, "records.bin")
 	rf, err := os.OpenFile(recPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
@@ -613,7 +655,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	initialBuild := !HasManifest(dir)
 	writtenMessages := 0
 	lastIngestFiles = len(files)
-	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope,
+	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
 		ExportWatermarks: imp.watermarks, ImportedRecords: imp.dedupe}
 	recPath := filepath.Join(tmp, "records.bin")
 	rf, err := os.OpenFile(recPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
@@ -1038,7 +1080,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		_ = rf.Close()
 		return err
 	}
-	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Scope: scope,
+	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: old.Generation, Scope: scope,
 		ExportWatermarks: old.ExportWatermarks, ImportedRecords: old.ImportedRecords}
 	skipRedactions := map[string]bool{}
 	for p := range changed {
@@ -2220,7 +2262,7 @@ func readManifest(dir string) (Manifest, error) {
 	if err := readGob(filepath.Join(dir, "manifest.gob"), &core); err != nil {
 		return Manifest{}, err
 	}
-	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Scope: core.Scope, Redacted: core.Redacted, ExportWatermarks: core.ExportWatermarks, ImportedRecords: core.ImportedRecords, RecordsSize: core.RecordsSize, Sessions: map[string]SessionMeta{}}
+	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, ExportWatermarks: core.ExportWatermarks, ImportedRecords: core.ImportedRecords, RecordsSize: core.RecordsSize, Sessions: map[string]SessionMeta{}}
 	if err := readGob(filepath.Join(dir, "sessions.gob"), &m.Sessions); err != nil {
 		return Manifest{}, err
 	}
@@ -2234,7 +2276,7 @@ func readManifest(dir string) (Manifest, error) {
 // leaves the old manifest pointing at old data, and the next run reindexes
 // rather than serving a fresh-looking index whose sessions are stale.
 func writeManifest(dir string, m Manifest) error {
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Scope: m.Scope, Redacted: m.Redacted, ExportWatermarks: m.ExportWatermarks, ImportedRecords: m.ImportedRecords}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, ExportWatermarks: m.ExportWatermarks, ImportedRecords: m.ImportedRecords}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -83,6 +83,51 @@ func TestIndexIngestSkipAndSearch(t *testing.T) {
 	}
 }
 
+func TestReadRecordsAndGeneration(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "records.bin"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := Record{Key: "claude:s", SourcePath: "session.jsonl", Role: "user", Text: "semantic text", Time: time.Unix(10, 20)}
+	off, err := writeRecord(f, want)
+	if err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if off != 0 || f.Close() != nil {
+		t.Fatal("record write did not start at zero")
+	}
+	got, err := ReadRecords(dir)
+	if err != nil || len(got) != 1 || got[0].Offset != 0 || got[0].Record.Text != want.Text || got[0].Record.Time != want.Time {
+		t.Fatalf("records=%#v err=%v", got, err)
+	}
+	if err := writeManifest(dir, Manifest{Version: version, BuiltAt: time.Unix(20, 0), Generation: "gen-1", Sessions: map[string]SessionMeta{}}); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := Generation(dir); err != nil || got != "gen-1" {
+		t.Fatalf("explicit generation=%q err=%v", got, err)
+	}
+	if err := writeManifest(dir, Manifest{Version: version, BuiltAt: time.Unix(30, 0), Sessions: map[string]SessionMeta{}}); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := Generation(dir); err != nil || got != "1970-01-01T00:00:30Z" {
+		t.Fatalf("built-at generation=%q err=%v", got, err)
+	}
+	if _, err := ReadRecords(filepath.Join(dir, "missing")); err == nil {
+		t.Fatal("missing records should fail")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "records.bin"), []byte{4, 0, 0, 0, 1}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadRecords(dir); err == nil {
+		t.Fatal("truncated record should fail")
+	}
+}
+
 func TestSyncExportImportSearchIdempotent(t *testing.T) {
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -32,6 +32,7 @@ type Options struct {
 	Harness, Project, Role string
 	Since                  time.Duration
 	All, JSON, Fuzzy       bool
+	NoEmbed                bool
 	FuzzyVariants          map[string][]string `json:"-"`
 }
 type Hit struct {


### PR DESCRIPTION
Closes #134. deja embed builds <index>.vectors.bin from a local endpoint (DEJA_EMBED_URL, or probed Ollama/LM Studio; both API shapes supported, net/http only). Search and MCP recall then blend normalized lexical score with cosine over the top-64 candidates, falling back to lexical order with a stderr notice if the endpoint is down. Incremental via a watermark, invalidated on index rebuilds; doctor and stats report endpoint and coverage. --no-embed and DEJA_EMBED=off opt out.

cmd/deja coverage reads 94.9%: the remaining uncovered lines are pre-existing doctor permission branches (chmod tests are windows-unsafe) and the live release lookup.