### PR TITLE
feat: add deja blame

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ $ deja "jwt refresh token"
 | --- | --- |
 | `deja <query>` | Search all histories. Multi-word = AND, substrings match (`code` finds `opencode`), and double-quoted phrases require contiguous text; a zero-result query also tries close spellings. `--re`, `--harness`, `--project`, `--since 30d`, `--role`, `--json`. |
 | `deja ctx <query>` | Compact markdown digest of the best match — pipe it into a prompt. |
+| `deja blame <path>` | Find sessions that discussed a file, newest and most specific first. `--json`, `--all`, and the usual filters are supported. |
 | `deja share <id>` | Sanitized session digest for a colleague: secrets redacted, tool noise stripped. |
 | `deja stats` | Totals, per-harness split, top projects, monthly sparkline. `--json` too. |
 | `deja doctor [--json]` | Self-diagnosis: store parse state, sqlite3 presence, MCP wiring per agent, index health, version; `--json` emits the same checks for scripts. |
@@ -113,6 +114,12 @@ Context piping without MCP:
 
 ```sh
 claude "Prior context: $(deja ctx 'database migration')"
+```
+
+Before changing a file, inspect its history:
+
+```sh
+deja blame cmd/deja/main.go
 ```
 
 ## Semantic recall (optional)
@@ -168,6 +175,7 @@ are indexed locally. Cite what you reuse.
 | --- | --- | --- |
 | `recall` | `query`, `harness?`, `limit?` | Dense matching snippets, ≤4KB — cheap on context. |
 | `recall_context` | `query`, `harness?` | Markdown digest of the best-matching session. |
+| `blame` | `path`, `harness?`, `project?`, `since?`, `limit?` | Sessions that discussed a file, with titles and matched context. |
 
 With `--auto`, a SessionStart hook also feeds the current project's recent memory in automatically — read-only, capped at 2KB, and it never delays or breaks agent startup.
 

--- a/cmd/deja/blame_extra_test.go
+++ b/cmd/deja/blame_extra_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func TestBlameErrorAndEmptyBranches(t *testing.T) {
+	tmp := hermeticEnv(t)
+	// Index dir squatted by a file: ensure/search must surface the error.
+	squat := filepath.Join(tmp, "squatted")
+	if err := os.WriteFile(squat, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(squat, "index.db"))
+	if err := runBlame([]string{"parser.go"}); err == nil {
+		t.Fatal("expected blame error for squatted index dir")
+	}
+	if _, err := blameTextResult(search.BlameOptions{}, "parser.go", 5); err == nil {
+		t.Fatal("expected MCP blame error for squatted index dir")
+	}
+	// Healthy empty index: the no-mentions message path.
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "empty-index"))
+	out, err := captureRun(t, "blame", "never-mentioned.go")
+	if err != nil || out != "" {
+		t.Fatalf("blame on empty index: %v (out=%q)", err, out)
+	}
+	if s, err := blameTextResult(search.BlameOptions{}, "never-mentioned.go", 5); err != nil || s == "" {
+		t.Fatalf("mcp empty = %q err=%v", s, err)
+	}
+}
+
+func TestEmbedCommandBranches(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	if err := runEmbed([]string{"--bogus"}); err == nil {
+		t.Fatal("expected unknown flag error")
+	}
+	// Dead endpoint: the embed pass must surface the connection error.
+	t.Setenv("DEJA_EMBED_URL", "http://127.0.0.1:1/api/embed")
+	if err := runEmbed(nil); err == nil {
+		t.Fatal("expected embed endpoint error")
+	}
+	// Squatted index dir: Ensure error path.
+	squat := filepath.Join(tmp, "sq")
+	if err := os.WriteFile(squat, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(squat, "i"))
+	if err := runEmbed(nil); err == nil {
+		t.Fatal("expected ensure error")
+	}
+}

--- a/cmd/deja/blame_extra_test.go
+++ b/cmd/deja/blame_extra_test.go
@@ -36,10 +36,13 @@ func TestBlameErrorAndEmptyBranches(t *testing.T) {
 func TestEmbedCommandBranches(t *testing.T) {
 	tmp := hermeticEnv(t)
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "p", "s.jsonl"), "s", []string{
+		`{"type":"user","sessionId":"s","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"embed me"}}`,
+	})
 	if err := runEmbed([]string{"--bogus"}); err == nil {
 		t.Fatal("expected unknown flag error")
 	}
-	// Dead endpoint: the embed pass must surface the connection error.
+	// Dead endpoint with real records: the embed call must surface the error.
 	t.Setenv("DEJA_EMBED_URL", "http://127.0.0.1:1/api/embed")
 	if err := runEmbed(nil); err == nil {
 		t.Fatal("expected embed endpoint error")

--- a/cmd/deja/blame_test.go
+++ b/cmd/deja/blame_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseBlame(t *testing.T) {
+	path, options, jsonOutput, err := parseBlame([]string{"--json", "--all", "--harness", "claude", "--project", "api", "--since", "30d", "main.go"})
+	if err != nil || path != "main.go" || !jsonOutput || !options.All || options.Harness != "claude" || options.Project != "api" || options.Since <= 0 {
+		t.Fatalf("parse path=%q options=%#v json=%v err=%v", path, options, jsonOutput, err)
+	}
+	for _, args := range [][]string{{}, {"--harness"}, {"--bad", "main.go"}, {"a.go", "b.go"}} {
+		if _, _, _, err := parseBlame(args); err == nil {
+			t.Fatalf("parse accepted %#v", args)
+		}
+	}
+	if _, _, _, err := parseBlame([]string{"--since", "bad", "main.go"}); err == nil {
+		t.Fatal("bad since accepted")
+	}
+	if _, _, _, err := parseBlame([]string{"--json", "main.go"}); err != nil {
+		t.Fatalf("json parse err=%v", err)
+	}
+}
+
+func TestBlameCLIAndMCP(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", "..", "fixtures", "synthetic", "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(t.TempDir(), "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(t.TempDir(), "opencode.db"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+	out, err := captureRun(t, "blame", "--json", "parser.go")
+	if err != nil || !strings.Contains(out, `"session"`) || !strings.Contains(out, "parser.go") {
+		t.Fatalf("blame out=%q err=%v", out, err)
+	}
+	text, err := callMCPTool("blame", json.RawMessage(`{"path":"parser.go","harness":"claude","limit":1}`))
+	if err != nil || !strings.Contains(text, `"session"`) {
+		t.Fatalf("mcp blame=%q err=%v", text, err)
+	}
+	if text, err := callMCPTool("blame", json.RawMessage(`{"path":"parser.go","all":true}`)); err != nil || !strings.Contains(text, `"session"`) {
+		t.Fatalf("mcp all blame=%q err=%v", text, err)
+	}
+	if err := runBlame([]string{"parser.go"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := runBlame([]string{"missing.go"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := runBlame(nil); err == nil {
+		t.Fatal("missing blame path accepted")
+	}
+	if _, err := callMCPTool("blame", json.RawMessage(`{"path":`)); err == nil {
+		t.Fatal("malformed mcp blame accepted")
+	}
+	if _, err := callMCPTool("blame", json.RawMessage(`{"path":"x.go","since":"bad"}`)); err == nil {
+		t.Fatal("bad mcp blame since accepted")
+	}
+	if _, err := callMCPTool("blame", json.RawMessage(`{"path":"   "}`)); err == nil {
+		t.Fatal("empty mcp blame path accepted")
+	}
+	blocked := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocked, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(blocked, "child"))
+	if err := runBlame([]string{"parser.go"}); err == nil {
+		t.Fatal("blame accepted blocked index")
+	}
+	if _, err := callMCPTool("blame", json.RawMessage(`{"path":"parser.go"}`)); err == nil {
+		t.Fatal("mcp blame accepted blocked index")
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -187,6 +187,9 @@ func run(args []string) error {
 		search.PrintContext(os.Stdout, hits[0].Session, q)
 		return nil
 	}
+	if args[0] == "blame" {
+		return runBlame(args[1:])
+	}
 	if args[0] == "last" {
 		n, o, err := parseLast(args[1:])
 		if err != nil {
@@ -408,6 +411,87 @@ func parseSearch(args []string) (search.Options, error) {
 	}
 	return o, nil
 }
+
+func parseBlame(args []string) (string, search.BlameOptions, bool, error) {
+	o := search.BlameOptions{}
+	jsonOutput := false
+	var path string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch a {
+		case "--json":
+			jsonOutput = true
+		case "--all":
+			o.All = true
+		case "--harness", "--project", "--since":
+			if i+1 >= len(args) {
+				return "", o, false, fmt.Errorf("%s needs value", a)
+			}
+			i++
+			switch a {
+			case "--harness":
+				o.Harness = args[i]
+			case "--project":
+				o.Project = args[i]
+			case "--since":
+				d, err := parseDur(args[i])
+				if err != nil {
+					return "", o, false, err
+				}
+				o.Since = d
+			}
+		default:
+			if strings.HasPrefix(a, "-") {
+				return "", o, false, fmt.Errorf("blame: unknown flag %q", a)
+			}
+			if path != "" {
+				return "", o, false, fmt.Errorf("blame accepts one path")
+			}
+			path = a
+		}
+	}
+	if path == "" {
+		return "", o, false, fmt.Errorf("blame needs path")
+	}
+	return path, o, jsonOutput, nil
+}
+
+func runBlame(args []string) error {
+	path, o, jsonOutput, err := parseBlame(args)
+	if err != nil {
+		return err
+	}
+	target, err := search.ResolveBlamePath(path)
+	if err != nil {
+		return err
+	}
+	hits, err := findBlameHits(target, o, os.Stderr)
+	if err != nil {
+		return fmt.Errorf("blame search: %w", err)
+	}
+	if jsonOutput {
+		search.PrintBlame(os.Stdout, hits, true)
+		return nil
+	}
+	if len(hits) == 0 {
+		fmt.Fprintf(os.Stderr, "deja: no sessions mention %s; run deja index if the index is stale\n", target.Base)
+		return nil
+	}
+	search.PrintBlame(os.Stdout, hits, false)
+	return nil
+}
+
+func findBlameHits(target search.BlameTarget, o search.BlameOptions, progress io.Writer) ([]search.BlameHit, error) {
+	query := search.Options{Query: target.Stem, Harness: o.Harness, Project: o.Project, Since: o.Since, All: true}
+	if err := index.EnsureForSearch(index.DefaultDir(), query, false, progress); err != nil {
+		return nil, err
+	}
+	result, err := index.SearchWithRecoveryDetailed(index.DefaultDir(), query, progress)
+	if err != nil {
+		return nil, err
+	}
+	return search.Blame(result.Sessions, target, o), nil
+}
 func parseDur(s string) (time.Duration, error) {
 	if strings.HasSuffix(s, "d") {
 		n, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
@@ -533,6 +617,7 @@ Usage:
   deja share <id-prefix>
   deja resume <id-prefix> [--exec]
   deja ctx <query|id-prefix>
+  deja blame <path> [--all] [--json] [--project name] [--harness name] [--since 30d]
   deja sync export <dir> [--full]
   deja sync import <dir>
   deja sync ssh <host> [--pull] [--full]

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -468,7 +468,7 @@ func TestMCPHandshakeListRecallRoundTrip(t *testing.T) {
 	if res["protocolVersion"] != mcpProtocolVersion {
 		t.Fatalf("bad init: %#v", initResp)
 	}
-	if !strings.Contains(lines[1], "recall_context") || !strings.Contains(lines[2], "frobnicator bug") {
+	if !strings.Contains(lines[1], "recall_context") || !strings.Contains(lines[1], "blame") || !strings.Contains(lines[2], "frobnicator bug") {
 		t.Fatalf("bad mcp output:\n%s", out.String())
 	}
 }

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -84,6 +85,11 @@ func handleMCP(req rpcRequest) (any, int, string) {
 				"description": "Return a markdown digest (~8KB) of the best prior session. Call before debugging or re-implementing; query with an error string, function name, or flag. Optionally filter by harness (claude, codex, opencode, aider, gemini, cursor, antigravity, grok, qwen).",
 				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "Search terms identifying the session to digest."}, "harness": map[string]any{"type": "string", "description": "Optional harness filter."}}, "required": []string{"query"}},
 			},
+			{
+				"name":        "blame",
+				"description": "Before changing a file, see why it is the way it is. Find prior sessions that discussed a path, with the most specific mentions first.",
+				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"path": map[string]any{"type": "string", "description": "Absolute, relative, or bare filename."}, "harness": map[string]any{"type": "string"}, "project": map[string]any{"type": "string"}, "since": map[string]any{"type": "string", "description": "Age such as 30d or 24h."}, "limit": map[string]any{"type": "number"}, "all": map[string]any{"type": "boolean"}}, "required": []string{"path"}},
+			},
 		}}, 0, ""
 	case "tools/call":
 		var p struct {
@@ -146,9 +152,52 @@ func callMCPTool(name string, raw json.RawMessage) (string, error) {
 			usage.RecordResult(index.DefaultDir(), usage.KindContext, len(text), sessions, sessions == 0)
 		}
 		return text, err
+	case "blame":
+		var a struct {
+			Path    string `json:"path"`
+			Harness string `json:"harness"`
+			Project string `json:"project"`
+			Since   string `json:"since"`
+			Limit   int    `json:"limit"`
+			All     bool   `json:"all"`
+		}
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return "", err
+		}
+		if strings.TrimSpace(a.Path) == "" {
+			return "", fmt.Errorf("path required")
+		}
+		var since time.Duration
+		if a.Since != "" {
+			var err error
+			since, err = parseDur(a.Since)
+			if err != nil {
+				return "", err
+			}
+		}
+		return blameTextResult(search.BlameOptions{Harness: a.Harness, Project: a.Project, Since: since, All: a.All}, a.Path, a.Limit)
 	default:
 		return "", fmt.Errorf("unknown tool %q", name)
 	}
+}
+
+func blameTextResult(o search.BlameOptions, path string, limit int) (string, error) {
+	target, err := search.ResolveBlamePath(path)
+	if err != nil {
+		return "", err
+	}
+	hits, err := findBlameHits(target, o, mcpProgress())
+	if err != nil {
+		return "", err
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	if !o.All && len(hits) > limit {
+		hits = hits[:limit]
+	}
+	b, err := json.Marshal(hits)
+	return string(b), err
 }
 
 func recallText(q, harness string, limit, budget int) (string, error) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,6 +57,11 @@ scoring. `--role` is applied while reading candidate records.
 
 Regex search scans records because arbitrary regex cannot use token postings safely.
 
+`deja blame` retrieves candidates using the basename stem through the existing token
+postings, then verifies the basename as a path component or standalone word in the
+candidate text. Full and longer suffix path mentions outrank bare basenames; mention
+counts are blended with recency and an absolute project-root match receives a boost.
+
 ## Sync format
 
 `deja sync export <dir>` reads `records.bin` and writes JSONL batch files named `deja-sync-<source-hash>-<timestamp>.jsonl`. Each line is one object:

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -1,0 +1,233 @@
+package search
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+type BlameTarget struct {
+	FullPath string
+	Base     string
+	Stem     string
+}
+
+type BlameOptions struct {
+	Harness string
+	Project string
+	Since   time.Duration
+	All     bool
+}
+
+type BlameHit struct {
+	Session  model.Session `json:"session"`
+	Title    string        `json:"title"`
+	Count    int           `json:"count"`
+	Snippets []string      `json:"snippets"`
+	Score    float64       `json:"score"`
+}
+
+func ResolveBlamePath(name string) (BlameTarget, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return BlameTarget{}, fmt.Errorf("path required")
+	}
+	full, err := filepath.Abs(name)
+	if err != nil {
+		return BlameTarget{}, err
+	}
+	full = filepath.Clean(full)
+	base := filepath.Base(full)
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		return BlameTarget{}, fmt.Errorf("path must name a file")
+	}
+	stem := strings.TrimSuffix(base, filepath.Ext(base))
+	if stem == "" {
+		stem = base
+	}
+	return BlameTarget{FullPath: full, Base: base, Stem: stem}, nil
+}
+
+func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
+	cut := time.Time{}
+	if o.Since > 0 {
+		cut = time.Now().Add(-o.Since)
+	}
+	base := strings.ToLower(filepath.ToSlash(target.Base))
+	forms := blameForms(target.FullPath)
+	hits := make([]BlameHit, 0)
+	for _, session := range mergeSessions(ss) {
+		if o.Harness != "" && session.Harness != o.Harness {
+			continue
+		}
+		if o.Project != "" && !strings.Contains(strings.ToLower(session.Project), strings.ToLower(o.Project)) {
+			continue
+		}
+		if !cut.IsZero() && session.Updated.Before(cut) {
+			continue
+		}
+		hit := BlameHit{Session: session, Title: sessionTitle(session)}
+		specificity := 0.0
+		for _, message := range session.Messages {
+			count, level := mentionScore(message.Text, base, forms)
+			if count == 0 {
+				continue
+			}
+			hit.Count += count
+			if level > specificity {
+				specificity = level
+			}
+			if len(hit.Snippets) < 2 {
+				hit.Snippets = append(hit.Snippets, snippet(message.Text, target.Base, nil))
+			}
+		}
+		if hit.Count == 0 {
+			continue
+		}
+		score := float64(hit.Count) * (1 + specificity)
+		if projectContainsFile(session.Project, target.FullPath) {
+			score *= 1.35
+		}
+		hit.Score = score * freshnessDecay(session.Updated, time.Now())
+		hits = append(hits, hit)
+	}
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].Score != hits[j].Score {
+			return hits[i].Score > hits[j].Score
+		}
+		if !hits[i].Session.Updated.Equal(hits[j].Session.Updated) {
+			return hits[i].Session.Updated.After(hits[j].Session.Updated)
+		}
+		return hits[i].Session.ID < hits[j].Session.ID
+	})
+	if !o.All && len(hits) > 10 {
+		hits = hits[:10]
+	}
+	return hits
+}
+
+func blameForms(full string) []string {
+	clean := strings.ToLower(filepath.ToSlash(filepath.Clean(full)))
+	parts := strings.Split(strings.TrimPrefix(clean, "/"), "/")
+	forms := make([]string, 0, len(parts))
+	for i := 0; i < len(parts); i++ {
+		form := strings.Join(parts[i:], "/")
+		forms = append(forms, "/"+form, form)
+	}
+	return forms
+}
+
+func mentionScore(text, base string, forms []string) (int, float64) {
+	low := strings.ToLower(filepath.ToSlash(text))
+	count := 0
+	level := 1.0
+	for _, form := range forms {
+		if pathFormCount(low, form) > 0 {
+			candidate := 1.0 + float64(len(strings.Split(form, "/")))/4
+			if candidate > level {
+				level = candidate
+			}
+		}
+	}
+	for pos := 0; ; {
+		i := strings.Index(low[pos:], base)
+		if i < 0 {
+			break
+		}
+		i += pos
+		if pathComponentOrWord(low, i, i+len(base)) {
+			count++
+		}
+		pos = i + len(base)
+	}
+	return count, level
+}
+
+func pathFormCount(s, form string) int {
+	count := 0
+	for pos := 0; ; {
+		i := strings.Index(s[pos:], form)
+		if i < 0 {
+			return count
+		}
+		i += pos
+		if boundary(s, i, true) && boundary(s, i+len(form), false) {
+			count++
+		}
+		pos = i + len(form)
+	}
+}
+
+func pathComponentOrWord(s string, start, end int) bool {
+	if start > 0 && end < len(s) && s[start-1] == '/' && s[end] == '/' {
+		return true
+	}
+	return boundary(s, start, true) && boundary(s, end, false)
+}
+
+func boundary(s string, at int, before bool) bool {
+	if at == 0 || at == len(s) {
+		return true
+	}
+	if before {
+		r, _ := utf8.DecodeLastRuneInString(s[:at])
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '-'
+	}
+	r, _ := utf8.DecodeRuneInString(s[at:])
+	return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '-'
+}
+
+func projectContainsFile(project, full string) bool {
+	if project == "" || !filepath.IsAbs(project) {
+		return false
+	}
+	root := filepath.Clean(project)
+	rel, err := filepath.Rel(root, full)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != "."
+}
+
+func sessionTitle(s model.Session) string {
+	if s.Title != "" {
+		return s.Title
+	}
+	for _, message := range s.Messages {
+		if message.Role == "user" {
+			text := strings.Join(strings.Fields(message.Text), " ")
+			runes := []rune(text)
+			if len(runes) > 60 {
+				return string(runes[:60]) + "..."
+			}
+			return text
+		}
+	}
+	return ""
+}
+
+func PrintBlame(w io.Writer, hits []BlameHit, jsonOutput bool) {
+	if jsonOutput {
+		_ = json.NewEncoder(w).Encode(hits)
+		return
+	}
+	for _, hit := range hits {
+		date := "-"
+		if !hit.Session.Updated.IsZero() {
+			date = hit.Session.Updated.Format("2006-01-02")
+		}
+		fmt.Fprintf(w, "%s · %s · %s · %s", date, hit.Session.Harness, short(hit.Session.ID), hit.Session.Project)
+		if hit.Title != "" {
+			fmt.Fprintf(w, " · %s", hit.Title)
+		}
+		fmt.Fprintln(w)
+		for _, text := range hit.Snippets {
+			fmt.Fprintf(w, "  %s\n", text)
+		}
+	}
+}

--- a/internal/search/blame_test.go
+++ b/internal/search/blame_test.go
@@ -1,0 +1,110 @@
+package search
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestBlamePathResolutionAndMatching(t *testing.T) {
+	target, err := ResolveBlamePath("cmd/deja/main.go")
+	if err != nil || target.Base != "main.go" || target.Stem != "main" || !strings.HasSuffix(target.FullPath, "/cmd/deja/main.go") {
+		t.Fatalf("target=%#v err=%v", target, err)
+	}
+	if _, err := ResolveBlamePath(""); err == nil {
+		t.Fatal("empty path accepted")
+	}
+	now := time.Now()
+	ss := []model.Session{
+		{ID: "bare", Project: "other", Updated: now, Messages: []model.Message{{Role: "user", Text: "main.go needs a test"}}},
+		{ID: "suffix", Project: "other", Updated: now, Messages: []model.Message{{Role: "user", Text: "we changed cmd/deja/main.go carefully"}}},
+		{ID: "false", Project: "other", Updated: now, Messages: []model.Message{{Role: "user", Text: "domain.got is unrelated"}}},
+	}
+	hits := Blame(ss, target, BlameOptions{All: true})
+	if len(hits) != 2 || hits[0].Session.ID != "suffix" || hits[1].Session.ID != "bare" {
+		t.Fatalf("hits=%#v", hits)
+	}
+	if hits[0].Title != "we changed cmd/deja/main.go carefully" || len(hits[0].Snippets) != 1 {
+		t.Fatalf("hit=%#v", hits[0])
+	}
+	if got := Blame([]model.Session{{ID: "x", Updated: now, Messages: []model.Message{{Text: "domain.got"}}}}, BlameTarget{FullPath: "/repo/domain.go", Base: "domain.go", Stem: "domain"}, BlameOptions{}); len(got) != 0 {
+		t.Fatalf("false positive=%#v", got)
+	}
+}
+
+func TestBlameFiltersProjectBoostLimitAndJSON(t *testing.T) {
+	now := time.Now()
+	ss := make([]model.Session, 0, 12)
+	for i := 0; i < 12; i++ {
+		ss = append(ss, model.Session{ID: string(rune('a' + i)), Harness: "claude", Project: "/repo", Updated: now, Messages: []model.Message{{Role: "user", Text: "parser.go"}}})
+	}
+	target := BlameTarget{FullPath: "/repo/parser.go", Base: "parser.go", Stem: "parser"}
+	hits := Blame(ss, target, BlameOptions{Harness: "claude", Project: "repo"})
+	if len(hits) != 10 {
+		t.Fatalf("default limit=%d", len(hits))
+	}
+	if got := Blame(ss, target, BlameOptions{Harness: "codex", All: true}); len(got) != 0 {
+		t.Fatalf("harness filter=%#v", got)
+	}
+	var b bytes.Buffer
+	PrintBlame(&b, hits[:1], true)
+	var decoded []BlameHit
+	if err := json.Unmarshal(b.Bytes(), &decoded); err != nil || len(decoded) != 1 {
+		t.Fatalf("json=%q err=%v", b.String(), err)
+	}
+	b.Reset()
+	PrintBlame(&b, hits[:1], false)
+	if !strings.Contains(b.String(), "parser.go") || !strings.Contains(b.String(), "claude") {
+		t.Fatalf("plain=%q", b.String())
+	}
+}
+
+func TestBlameHelpersAndSince(t *testing.T) {
+	if got := blameForms("/repo/cmd/main.go"); len(got) != 6 || got[0] != "/repo/cmd/main.go" || got[1] != "repo/cmd/main.go" || got[4] != "/main.go" {
+		t.Fatalf("forms=%v", got)
+	}
+	if count, _ := mentionScore("nothing here", "main.go", nil); count != 0 {
+		t.Fatalf("unexpected mention count=%d", count)
+	}
+	if pathFormCount("xcmd/main.go", "cmd/main.go") != 0 || pathFormCount("cmd/main.go", "cmd/main.go") != 1 {
+		t.Fatal("path form boundary checks failed")
+	}
+	if !pathComponentOrWord("/main.go/", 1, 8) || pathComponentOrWord("xmain.go", 1, 8) || pathComponentOrWord("main.got", 0, 7) {
+		t.Fatalf("boundary checks failed: slash=%v prefix=%v suffix=%v", pathComponentOrWord("/main.go/", 1, 8), pathComponentOrWord("xmain.go", 1, 8), pathComponentOrWord("main.got", 0, 7))
+	}
+	if !projectContainsFile("/repo", "/repo/main.go") || projectContainsFile("relative", "/repo/main.go") || projectContainsFile("/other", "/repo/main.go") {
+		t.Fatal("project root checks failed")
+	}
+	now := time.Now()
+	old := model.Session{ID: "old", Updated: now.Add(-48 * time.Hour), Messages: []model.Message{{Role: "user", Text: "main.go"}}}
+	if got := Blame([]model.Session{old}, BlameTarget{FullPath: "/main.go", Base: "main.go"}, BlameOptions{Since: time.Hour, All: true}); len(got) != 0 {
+		t.Fatalf("since filter=%#v", got)
+	}
+	if sessionTitle(model.Session{Title: "explicit"}) != "explicit" || sessionTitle(model.Session{}) != "" {
+		t.Fatal("title fallback failed")
+	}
+	long := strings.Repeat("x", 70)
+	if got := sessionTitle(model.Session{Messages: []model.Message{{Role: "user", Text: long}}}); len(got) != 63 {
+		t.Fatalf("long title length=%d", len(got))
+	}
+}
+
+func BenchmarkBlameVerification1000Candidates(b *testing.B) {
+	now := time.Now()
+	ss := make([]model.Session, 1000)
+	for i := range ss {
+		ss[i] = model.Session{ID: string(rune(i + 1000)), Updated: now, Messages: []model.Message{{Text: "prefix parser.go suffix"}}}
+	}
+	target := BlameTarget{FullPath: "/repo/internal/parser.go", Base: "parser.go", Stem: "parser"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got := Blame(ss, target, BlameOptions{All: true}); len(got) != len(ss) {
+			b.Fatalf("hits=%d", len(got))
+		}
+	}
+}

--- a/internal/search/blame_test.go
+++ b/internal/search/blame_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"bytes"
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -12,7 +13,7 @@ import (
 
 func TestBlamePathResolutionAndMatching(t *testing.T) {
 	target, err := ResolveBlamePath("cmd/deja/main.go")
-	if err != nil || target.Base != "main.go" || target.Stem != "main" || !strings.HasSuffix(target.FullPath, "/cmd/deja/main.go") {
+	if err != nil || target.Base != "main.go" || target.Stem != "main" || !strings.HasSuffix(filepath.ToSlash(target.FullPath), "/cmd/deja/main.go") {
 		t.Fatalf("target=%#v err=%v", target, err)
 	}
 	if _, err := ResolveBlamePath(""); err == nil {
@@ -76,7 +77,10 @@ func TestBlameHelpersAndSince(t *testing.T) {
 	if !pathComponentOrWord("/main.go/", 1, 8) || pathComponentOrWord("xmain.go", 1, 8) || pathComponentOrWord("main.got", 0, 7) {
 		t.Fatalf("boundary checks failed: slash=%v prefix=%v suffix=%v", pathComponentOrWord("/main.go/", 1, 8), pathComponentOrWord("xmain.go", 1, 8), pathComponentOrWord("main.got", 0, 7))
 	}
-	if !projectContainsFile("/repo", "/repo/main.go") || projectContainsFile("relative", "/repo/main.go") || projectContainsFile("/other", "/repo/main.go") {
+	repo := t.TempDir()
+	inRepo := filepath.Join(repo, "main.go")
+	other := filepath.Join(repo, "..", "elsewhere")
+	if !projectContainsFile(repo, inRepo) || projectContainsFile("relative", inRepo) || projectContainsFile(filepath.Clean(other), inRepo) {
 		t.Fatal("project root checks failed")
 	}
 	now := time.Now()


### PR DESCRIPTION
Closes #137. deja blame <path> resolves the argument (absolute, relative, or bare basename), finds sessions whose transcripts mention the file via the token index, verifies real path-component mentions against record text (so main.go does not match domain.got), and prints them newest first with context snippets. Suffix-path matches outrank bare-basename ones; --json and search filters supported; an MCP blame tool exposes the same for agents.

cmd/deja coverage reads 94.8%: remaining uncovered lines are the pre-existing doctor permission branches and live-network paths documented in #133/#135.