### PR TITLE
feat: add durable notes via deja remember

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,14 @@
 # Architecture
 
+## Notes source
+
+Explicit notes are stored as one JSON object per line in
+`~/.local/share/deja/notes.jsonl`, or under `XDG_DATA_HOME`; `DEJA_NOTES_FILE`
+overrides the path. Each record contains an RFC3339 `ts`, `project`, and
+`text`. Notes are grouped into one user-message session per project and UTC
+calendar day, then redacted and indexed like every other source. The file is
+primary data; the index remains a rebuildable cache.
+
 ## Semantic sidecar
 
 `deja embed` writes `<index-dir>.vectors.bin`. The file begins with `DJV1`, a

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | **Stats** | `deja stats` — your agent work, wrapped: harnesses, top projects, activity sparkline |
 | **Share** | `deja share <id>` — hand a colleague a sanitized digest of a session, secrets already scrubbed |
 | **Sync** | `deja sync export/import` — move memory between machines, append-only, idempotent |
+| **Remember** | `deja remember "text"` or MCP `remember` — keep durable decisions and conclusions |
 
 One binary. No models to download, no services to run, nothing leaves your machine unless you sync or share it. (opencode and Cursor IDE indexing shell out to the `sqlite3` CLI, preinstalled on macOS and most Linux distros; Cursor CLI transcripts do not need it.)
 
@@ -83,6 +84,7 @@ $ deja "jwt refresh token"
 | `deja resume <id> [--exec]` | Reopen a found session in its native harness (`claude --resume`, `codex resume`, `opencode -s`, `grok --resume`). |
 | `deja sources` | Discovered stores, sizes, message and redaction counts. |
 | `deja mcp` | The stdio MCP server (what `deja install` wires in). |
+| `deja remember "text" [--project name]` | Store an explicit fact in the notes source. |
 | `deja warmup` | Build/refresh the index without searching — handy in cron or shell startup. |
 | `deja index [--rebuild]` | Same as warmup; `--rebuild` forces a full rebuild. Cold builds narrate per-harness progress. |
 | `deja update` | Download the latest GitHub release, verify its checksum, and replace the current binary. |
@@ -176,6 +178,7 @@ are indexed locally. Cite what you reuse.
 | `recall` | `query`, `harness?`, `limit?` | Dense matching snippets, ≤4KB — cheap on context. |
 | `recall_context` | `query`, `harness?` | Markdown digest of the best-matching session. |
 | `blame` | `path`, `harness?`, `project?`, `since?`, `limit?` | Sessions that discussed a file, with titles and matched context. |
+| `remember` | `text`, `project?` | Stores a durable decision or conclusion for later recall. |
 
 With `--auto`, a SessionStart hook also feeds the current project's recent memory in automatically — read-only, capped at 2KB, and it never delays or breaks agent startup.
 

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -30,6 +30,7 @@ func hermeticEnv(t *testing.T) string {
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
 	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
 	t.Setenv("DEJA_AIDER_ROOTS", filepath.Join(tmp, "aider"))
 	t.Setenv("DEJA_GEMINI_ROOT", filepath.Join(tmp, "gemini"))
 	t.Setenv("DEJA_CURSOR_ROOT", filepath.Join(tmp, "cursor"))

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -126,6 +126,7 @@ func doctorHarnesses(w io.Writer) {
 
 	qwenRoot := filepath.Join(sources.QwenRoot(), "projects")
 	printRow("qwen", qwenRoot, doctorExists(qwenRoot), doctorCount(len(sources.QwenSessionFiles()), "file"))
+	printRow("deja", sources.NotesFile(), doctorFilePresent(sources.NotesFile()), "notes")
 }
 
 func doctorSQLiteDetail(db string, sqlite bool) string {

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -117,6 +117,7 @@ func doctorStoreChecks() []doctorStoreCheck {
 		{"antigravity", sources.AntigravityRoots(), sources.AntigravityTranscripts(), sources.ParseAntigravityFile},
 		{"grok", []string{sources.GrokRoot()}, sources.GrokSessionFiles(), sources.ParseGrokFile},
 		{"qwen", []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.QwenSessionFiles(), sources.ParseQwenFile},
+		{"deja", []string{sources.NotesFile()}, presentDoctorFile(sources.NotesFile()), sources.ParseNotesFile},
 	}
 }
 

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -114,6 +114,9 @@ func run(args []string) error {
 	if args[0] == "stats" {
 		return runStats(args[1:])
 	}
+	if args[0] == "remember" {
+		return runRemember(args[1:])
+	}
 	if args[0] == "mcp" {
 		return serveMCP(os.Stdin, os.Stdout)
 	}
@@ -522,6 +525,7 @@ func printSources() {
 		{"antigravity", antigravityLocation, antigravityRoots, sources.LoadAntigravity},
 		{"grok", sources.GrokRoot(), []string{sources.GrokRoot()}, sources.LoadGrok},
 		{"qwen", filepath.Join(sources.QwenRoot(), "projects"), []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.LoadQwen},
+		{"deja", sources.NotesFile(), []string{sources.NotesFile()}, sources.LoadNotes},
 	}
 	for _, it := range items {
 		var size int64
@@ -628,7 +632,8 @@ Usage:
 	deja index [--rebuild]
 	deja embed
   deja statusline
-  deja stats [--json] [--card [path]]
+	deja stats [--json] [--card [path]]
+	deja remember "text" [--project name]
   deja mcp
   deja version
   deja update

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
@@ -89,6 +90,11 @@ func handleMCP(req rpcRequest) (any, int, string) {
 				"name":        "blame",
 				"description": "Before changing a file, see why it is the way it is. Find prior sessions that discussed a path, with the most specific mentions first.",
 				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"path": map[string]any{"type": "string", "description": "Absolute, relative, or bare filename."}, "harness": map[string]any{"type": "string"}, "project": map[string]any{"type": "string"}, "since": map[string]any{"type": "string", "description": "Age such as 30d or 24h."}, "limit": map[string]any{"type": "number"}, "all": map[string]any{"type": "boolean"}}, "required": []string{"path"}},
+			},
+			{
+				"name":        "remember",
+				"description": "Store a durable decision or conclusion for later recall. Do not store transcripts or routine conversation; text is required and project is optional.",
+				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"text": map[string]any{"type": "string", "description": "A durable fact, decision, or conclusion to remember."}, "project": map[string]any{"type": "string", "description": "Optional project name; defaults to notes."}}, "required": []string{"text"}},
 			},
 		}}, 0, ""
 	case "tools/call":
@@ -176,6 +182,27 @@ func callMCPTool(name string, raw json.RawMessage) (string, error) {
 			}
 		}
 		return blameTextResult(search.BlameOptions{Harness: a.Harness, Project: a.Project, Since: since, All: a.All}, a.Path, a.Limit)
+	case "remember":
+		var a struct {
+			Text    string `json:"text"`
+			Project string `json:"project"`
+		}
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return "", err
+		}
+		if strings.TrimSpace(a.Text) == "" {
+			return "", fmt.Errorf("text required")
+		}
+		if strings.TrimSpace(a.Project) == "" {
+			a.Project = "notes"
+		}
+		if err := sources.AppendNote(a.Project, a.Text, time.Now()); err != nil {
+			return "", err
+		}
+		if err := index.EnsureForSearch(index.DefaultDir(), search.Options{All: true}, false, mcpProgress()); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Remembered under %s.", strings.TrimSpace(a.Project)), nil
 	default:
 		return "", fmt.Errorf("unknown tool %q", name)
 	}

--- a/cmd/deja/remember.go
+++ b/cmd/deja/remember.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+func runRemember(args []string) error {
+	var text, project string
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--project" {
+			if i+1 >= len(args) {
+				return fmt.Errorf("remember: --project needs value")
+			}
+			project = args[i+1]
+			i++
+			continue
+		}
+		if strings.HasPrefix(args[i], "-") {
+			return fmt.Errorf("remember: unknown flag %q", args[i])
+		}
+		if text != "" {
+			return fmt.Errorf("remember: expected one text argument")
+		}
+		text = args[i]
+	}
+	if strings.TrimSpace(text) == "" {
+		return fmt.Errorf("remember: text required")
+	}
+	if strings.TrimSpace(project) == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		project = sources.ClaudeProjectName(cwd)
+	}
+	if err := sources.AppendNote(project, text, time.Now()); err != nil {
+		return err
+	}
+	if err := index.EnsureForSearch(index.DefaultDir(), search.Options{All: true}, false, os.Stderr); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "deja: remembered under %s\n", strings.TrimSpace(project))
+	return nil
+}

--- a/cmd/deja/remember_test.go
+++ b/cmd/deja/remember_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func TestRememberCLIAndMCP(t *testing.T) {
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(t.TempDir(), "notes.jsonl"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+	if err := runRemember([]string{"--project", "cli-project", "durable cli decision"}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := callMCPTool("remember", []byte(`{"text":"durable mcp conclusion"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "notes") {
+		t.Fatalf("mcp result=%q", result)
+	}
+	if err := index.EnsureForSearch(index.DefaultDir(), search.Options{All: true}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := index.Search(index.DefaultDir(), search.Options{Query: "durable", All: true})
+	if err != nil || len(ss) != 2 {
+		t.Fatalf("search=%#v err=%v", ss, err)
+	}
+}
+
+func TestRememberValidation(t *testing.T) {
+	if err := run([]string{"version"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := run([]string{"sources"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := run([]string{"remember"}); err == nil {
+		t.Fatal("dispatch accepted missing text")
+	}
+	for _, args := range [][]string{{}, {""}, {"--project"}, {"--bad", "text"}, {"one", "two"}} {
+		if err := runRemember(args); err == nil {
+			t.Fatalf("args=%v accepted", args)
+		}
+	}
+}
+
+func TestRememberDefaultProjectAndAppendError(t *testing.T) {
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(t.TempDir(), "notes.jsonl"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+	if err := runRemember([]string{"defaulted project note"}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_NOTES_FILE", t.TempDir())
+	if err := runRemember([]string{"cannot append"}); err == nil {
+		t.Fatal("append to directory accepted")
+	}
+}
+
+func TestRememberMCPValidation(t *testing.T) {
+	if _, err := callMCPTool("remember", []byte("{")); err == nil {
+		t.Fatal("malformed remember arguments accepted")
+	}
+	t.Setenv("DEJA_NOTES_FILE", t.TempDir())
+	if _, err := callMCPTool("remember", []byte(`{"text":"stored"}`)); err == nil {
+		t.Fatal("MCP append error ignored")
+	}
+}

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -78,7 +78,7 @@
       "name": "deja",
       "state": "missing",
       "paths": [
-        "<tmp>/home/.local/share/deja/notes.jsonl"
+        "<tmp>/notes.jsonl"
       ],
       "files": 0
     }

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -73,6 +73,14 @@
         "<tmp>/qwen/projects"
       ],
       "files": 0
+    },
+    {
+      "name": "deja",
+      "state": "missing",
+      "paths": [
+        "<tmp>/home/.local/share/deja/notes.jsonl"
+      ],
+      "files": 0
     }
   ],
   "index": {

--- a/cmd/deja/testmain_test.go
+++ b/cmd/deja/testmain_test.go
@@ -34,7 +34,6 @@ func TestMain(m *testing.M) {
 		"DEJA_CURSOR_CLI_ROOT":    filepath.Join(root, "cursor-cli"),
 		"DEJA_ANTIGRAVITY_ROOT":   filepath.Join(root, "antigravity"),
 		"DEJA_GROK_ROOT":          filepath.Join(root, "grok"),
-		"DEJA_NOTES_FILE":         filepath.Join(root, "notes.jsonl"),
 		"DEJA_QWEN_ROOT":          filepath.Join(root, "qwen"),
 	}
 	for key, value := range stores {

--- a/cmd/deja/testmain_test.go
+++ b/cmd/deja/testmain_test.go
@@ -23,6 +23,7 @@ func TestMain(m *testing.M) {
 		"AIDER_CHAT_HISTORY_FILE": "",
 		"XDG_CONFIG_HOME":         "",
 		"XDG_DATA_HOME":           "",
+		"DEJA_NOTES_FILE":         "",
 		"DEJA_CLAUDE_ROOT":        filepath.Join(root, "claude"),
 		"DEJA_CODEX_ROOT":         filepath.Join(root, "codex"),
 		"DEJA_OPENCODE_DB":        filepath.Join(root, "opencode.db"),

--- a/cmd/deja/testmain_test.go
+++ b/cmd/deja/testmain_test.go
@@ -23,6 +23,7 @@ func TestMain(m *testing.M) {
 		"AIDER_CHAT_HISTORY_FILE": "",
 		"XDG_CONFIG_HOME":         "",
 		"XDG_DATA_HOME":           "",
+		"APPDATA":                 filepath.Join(root, "AppData", "Roaming"),
 		"DEJA_NOTES_FILE":         "",
 		"DEJA_CLAUDE_ROOT":        filepath.Join(root, "claude"),
 		"DEJA_CODEX_ROOT":         filepath.Join(root, "codex"),
@@ -33,6 +34,7 @@ func TestMain(m *testing.M) {
 		"DEJA_CURSOR_CLI_ROOT":    filepath.Join(root, "cursor-cli"),
 		"DEJA_ANTIGRAVITY_ROOT":   filepath.Join(root, "antigravity"),
 		"DEJA_GROK_ROOT":          filepath.Join(root, "grok"),
+		"DEJA_NOTES_FILE":         filepath.Join(root, "notes.jsonl"),
 		"DEJA_QWEN_ROOT":          filepath.Join(root, "qwen"),
 	}
 	for key, value := range stores {

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -32,6 +32,7 @@ func hermeticIndexEnv(t *testing.T) string {
 	t.Setenv("DEJA_CURSOR_CLI_ROOT", filepath.Join(tmp, "cursor-cli"))
 	t.Setenv("DEJA_ANTIGRAVITY_ROOT", filepath.Join(tmp, "antigravity"))
 	t.Setenv("DEJA_INCLUDE_SUBAGENTS", "")
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
 	return tmp
 }
 
@@ -391,6 +392,10 @@ func TestDefaultDirQueriesFiltersAndCorruptBucketBranches(t *testing.T) {
 
 func TestCurrentFilesAllHarnessesAndRecordEdgeCases(t *testing.T) {
 	tmp := hermeticIndexEnv(t)
+	notes := os.Getenv("DEJA_NOTES_FILE")
+	if err := os.WriteFile(notes, []byte(`{"ts":"2026-01-02T03:04:05Z","project":"notes-app","text":"first durable note"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	claude := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "proj", "s.jsonl")
 	codexHist := filepath.Join(os.Getenv("DEJA_CODEX_ROOT"), "history.jsonl")
 	codexRoll := filepath.Join(os.Getenv("DEJA_CODEX_ROOT"), "sessions", "2026", "01", "02", "rollout-2026-01-02T00-00-00-r.jsonl")
@@ -400,7 +405,7 @@ func TestCurrentFilesAllHarnessesAndRecordEdgeCases(t *testing.T) {
 	cursorDB := filepath.Join(os.Getenv("DEJA_CURSOR_ROOT"), "globalStorage", "state.vscdb")
 	cursorTr := filepath.Join(os.Getenv("DEJA_CURSOR_CLI_ROOT"), "projects", "p", "agent-transcripts", "c", "c.jsonl")
 	ag := filepath.Join(os.Getenv("DEJA_ANTIGRAVITY_ROOT"), "brain", "traj", ".system_generated", "logs", "transcript.jsonl")
-	for _, p := range []string{claude, codexHist, codexRoll, aider, gemini, cursorDB, cursorTr, ag, os.Getenv("DEJA_OPENCODE_DB")} {
+	for _, p := range []string{claude, codexHist, codexRoll, aider, gemini, cursorDB, cursorTr, ag, os.Getenv("DEJA_OPENCODE_DB"), notes} {
 		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -409,7 +414,7 @@ func TestCurrentFilesAllHarnessesAndRecordEdgeCases(t *testing.T) {
 		}
 	}
 	files := currentFiles("")
-	for _, p := range []string{claude, codexHist, codexRoll, aider, gemini, cursorDB, cursorTr, ag, os.Getenv("DEJA_OPENCODE_DB")} {
+	for _, p := range []string{claude, codexHist, codexRoll, aider, gemini, cursorDB, cursorTr, ag, os.Getenv("DEJA_OPENCODE_DB"), notes} {
 		if _, ok := files[p]; !ok {
 			t.Fatalf("currentFiles missing %s in %#v", p, files)
 		}
@@ -439,6 +444,37 @@ func TestCurrentFilesAllHarnessesAndRecordEdgeCases(t *testing.T) {
 	}
 	if _, err := scanRecords(filepath.Join(tmp, "missing-index"), Manifest{}, search.Options{}, nil); err == nil {
 		t.Fatal("scanRecords missing records returned nil")
+	}
+}
+
+func TestNotesIncrementalIndex(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	notes := os.Getenv("DEJA_NOTES_FILE")
+	if err := os.WriteFile(notes, []byte(`{"ts":"2026-01-02T03:04:05Z","project":"notes-app","text":"first durable note"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "notes-index")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	var progress strings.Builder
+	if got := loadProgress("deja", &progress); len(got) != 1 || !strings.Contains(progress.String(), "notes") {
+		t.Fatalf("notes loader=%#v progress=%q", got, progress.String())
+	}
+	if got, err := Search(dir, search.Options{Query: "first", All: true}); err != nil || len(got) != 1 || got[0].Harness != "deja" {
+		t.Fatalf("first note=%#v err=%v", got, err)
+	}
+	f, err := os.OpenFile(notes, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString(`{"ts":"2026-01-02T04:04:05Z","project":"notes-app","text":"second durable note"}` + "\n")
+	_ = f.Close()
+	if err := EnsureForSearch(dir, search.Options{All: true}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := Search(dir, search.Options{Query: "second", All: true}); err != nil || len(got) != 1 {
+		t.Fatalf("second note=%#v err=%v", got, err)
 	}
 }
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -632,6 +632,17 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 			fmt.Fprintf(progress, "deja: %s: %d sessions, %d messages\n", hl.name, len(got), msgs)
 		}
 	}
+	if h == "" || h == "deja" {
+		got := sources.LoadNotes()
+		ss = append(ss, got...)
+		if progress != nil && len(got) > 0 && !SuppressHarnessNarration {
+			msgs := 0
+			for _, s := range got {
+				msgs += len(s.Messages)
+			}
+			fmt.Fprintf(progress, "deja: notes: %d sessions, %d messages\n", len(got), msgs)
+		}
+	}
 	return ss
 }
 
@@ -1194,7 +1205,7 @@ func canAppendIncremental(changed map[string]FileState, old map[string]FileState
 			return false
 		}
 		switch harnessForPath(p) {
-		case "claude", "codex", "codex-history", "opencode", "cursor-db":
+		case "claude", "codex", "codex-history", "opencode", "cursor-db", "deja":
 		default:
 			return false
 		}
@@ -1350,6 +1361,8 @@ func parseChangedFile(harness, p string, old FileState) ([]model.Session, error)
 		return sources.ParseGrokFile(p)
 	case "qwen":
 		return sources.ParseQwenFile(p)
+	case "deja":
+		return sources.ParseNotesFile(p)
 	default:
 		return nil, nil
 	}
@@ -1367,6 +1380,8 @@ func parseAppendedFile(harness, p string, old FileState) ([]model.Session, error
 		return sources.ParseCodexHistoryFromOffset(p, from)
 	case "qwen":
 		return sources.ParseQwenFileFromOffset(p, from)
+	case "deja":
+		return sources.ParseNotesFileFromOffset(p, from)
 	case "codex":
 		return sources.ParseCodexRolloutFromOffset(p, from)
 	case "opencode":
@@ -1421,6 +1436,9 @@ func harnessForPath(p string) string {
 	}
 	if strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, filepath.Join(sources.QwenRoot(), "projects")) {
 		return "qwen"
+	}
+	if p == sources.NotesFile() {
+		return "deja"
 	}
 	return ""
 }
@@ -1503,6 +1521,9 @@ func currentFiles(h string) map[string]FileState {
 		for _, p := range sources.QwenSessionFiles() {
 			paths[p] = true
 		}
+	}
+	if h == "" || h == "deja" {
+		paths[sources.NotesFile()] = true
 	}
 	out := map[string]FileState{}
 	for p := range paths {

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -1,0 +1,112 @@
+package sources
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+type note struct {
+	TS      string `json:"ts"`
+	Project string `json:"project"`
+	Text    string `json:"text"`
+}
+
+func NotesFile() string {
+	if p := os.Getenv("DEJA_NOTES_FILE"); p != "" {
+		return p
+	}
+	if runtime.GOOS == "windows" {
+		if dir, err := os.UserConfigDir(); err == nil && dir != "" {
+			return filepath.Join(dir, "deja", "notes.jsonl")
+		}
+		return filepath.Join(Home(), "AppData", "Roaming", "deja", "notes.jsonl")
+	}
+	dir := os.Getenv("XDG_DATA_HOME")
+	if dir == "" {
+		dir = filepath.Join(Home(), ".local", "share")
+	}
+	return filepath.Join(dir, "deja", "notes.jsonl")
+}
+
+func AppendNote(project, text string, now time.Time) error {
+	project = strings.TrimSpace(project)
+	if project == "" {
+		return fmt.Errorf("project required")
+	}
+	if strings.TrimSpace(text) == "" {
+		return fmt.Errorf("text required")
+	}
+	path := NotesFile()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("notes file is a symlink")
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	if err := f.Chmod(0o600); err != nil && runtime.GOOS != "windows" {
+		return err
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	return json.NewEncoder(f).Encode(note{TS: now.UTC().Format(time.RFC3339Nano), Project: project, Text: text})
+}
+
+func LoadNotes() []model.Session {
+	ss, _ := ParseNotesFile(NotesFile())
+	return ss
+}
+
+func ParseNotesFile(path string) ([]model.Session, error) {
+	return ParseNotesFileFromOffset(path, 0)
+}
+
+func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error) {
+	byDay := map[string]*model.Session{}
+	err := scanJSONLFromOffset(path, offset, func(m map[string]any) {
+		ts, _ := m["ts"].(string)
+		project, _ := m["project"].(string)
+		text, _ := m["text"].(string)
+		t, parseErr := time.Parse(time.RFC3339Nano, ts)
+		if parseErr != nil || strings.TrimSpace(project) == "" || strings.TrimSpace(text) == "" {
+			return
+		}
+		project = strings.TrimSpace(project)
+		day := t.UTC().Format("2006-01-02")
+		key := project + "\x00" + day
+		s := byDay[key]
+		if s == nil {
+			s = &model.Session{ID: "deja-" + day + "-" + project, Harness: "deja", Project: project, Path: path}
+			byDay[key] = s
+		}
+		s.Touch(t)
+		s.Messages = append(s.Messages, model.Message{Role: "user", Text: text, Time: t})
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]model.Session, 0, len(byDay))
+	for _, s := range byDay {
+		out = append(out, *s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Project == out[j].Project {
+			return out[i].Started.Before(out[j].Started)
+		}
+		return out[i].Project < out[j].Project
+	})
+	return out, nil
+}

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -23,17 +23,18 @@ func NotesFile() string {
 	if p := os.Getenv("DEJA_NOTES_FILE"); p != "" {
 		return p
 	}
+	// An explicit XDG_DATA_HOME wins on every platform so relocation and
+	// hermetic tests behave the same everywhere.
+	if dir := os.Getenv("XDG_DATA_HOME"); dir != "" {
+		return filepath.Join(dir, "deja", "notes.jsonl")
+	}
 	if runtime.GOOS == "windows" {
 		if dir, err := os.UserConfigDir(); err == nil && dir != "" {
 			return filepath.Join(dir, "deja", "notes.jsonl")
 		}
 		return filepath.Join(Home(), "AppData", "Roaming", "deja", "notes.jsonl")
 	}
-	dir := os.Getenv("XDG_DATA_HOME")
-	if dir == "" {
-		dir = filepath.Join(Home(), ".local", "share")
-	}
-	return filepath.Join(dir, "deja", "notes.jsonl")
+	return filepath.Join(Home(), ".local", "share", "deja", "notes.jsonl")
 }
 
 func AppendNote(project, text string, now time.Time) error {

--- a/internal/sources/notes_test.go
+++ b/internal/sources/notes_test.go
@@ -1,0 +1,96 @@
+package sources
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNotesPathAndAppendParse(t *testing.T) {
+	home := t.TempDir()
+	xdg := filepath.Join(home, "xdg")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_NOTES_FILE", "")
+	t.Setenv("XDG_DATA_HOME", xdg)
+	if got, want := NotesFile(), filepath.Join(xdg, "deja", "notes.jsonl"); got != want {
+		t.Fatalf("NotesFile=%q want %q", got, want)
+	}
+	path := filepath.Join(t.TempDir(), "private", "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", path)
+	when := time.Date(2026, 1, 2, 3, 4, 5, 0, time.FixedZone("x", 3600))
+	if err := AppendNote("app", "decision one", when); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, appendMustRead(t, path, `{"ts":"2026-01-02T03:04:05Z","project":"app","text":"decision two"}`+"\n"+`{"ts":"bad","project":"app","text":"ignored"}`+"\n"+`{"ts":"2026-01-03T00:00:00Z","project":"other","text":"other"}`+"\n"+`{"ts":"2026-01-03T00:00:00Z","project":"app","text":"torn`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseNotesFile(path)
+	if err != nil || len(ss) != 2 {
+		t.Fatalf("notes=%#v err=%v", ss, err)
+	}
+	if ss[0].Project != "app" || len(ss[0].Messages) != 2 || ss[1].Project != "other" {
+		t.Fatalf("grouped notes=%#v", ss)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	offset := bytes.IndexByte(data, '\n') + 1
+	if got, err := ParseNotesFileFromOffset(path, int64(offset)); err != nil || len(got) != 2 {
+		t.Fatalf("offset notes=%#v err=%v", got, err)
+	}
+	if err := AppendNote("", "x", when); err == nil {
+		t.Fatal("empty project accepted")
+	}
+	if err := AppendNote("app", "", when); err == nil {
+		t.Fatal("empty text accepted")
+	}
+	if err := AppendNote("app", "  preserved  ", time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" {
+		for _, p := range []string{filepath.Dir(path), path} {
+			info, statErr := os.Stat(p)
+			if statErr != nil {
+				t.Fatal(statErr)
+			}
+			if info.Mode().Perm() != map[bool]os.FileMode{true: 0o600, false: 0o700}[p == path] {
+				t.Fatalf("%s mode=%o", p, info.Mode().Perm())
+			}
+		}
+	}
+}
+
+func TestNotesSymlinkAndMissingFile(t *testing.T) {
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(t.TempDir(), "missing", "notes.jsonl"))
+	if got := LoadNotes(); got != nil {
+		t.Fatalf("missing notes=%#v", got)
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skip("symlinks unavailable")
+	}
+	t.Setenv("DEJA_NOTES_FILE", link)
+	if err := AppendNote("p", "x", time.Now()); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("symlink append err=%v", err)
+	}
+}
+
+func appendMustRead(t *testing.T, path, suffix string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(b, suffix...)
+}

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -41,6 +41,7 @@ func TestFormatRegistryConformance(t *testing.T) {
 		"DEJA_QWEN_ROOT",
 		"DEJA_INCLUDE_SUBAGENTS", "DEJA_OPENCODE_DB", "GEMINI_CLI_HOME",
 		"GROK_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+		"DEJA_NOTES_FILE",
 	} {
 		t.Setenv(key, "")
 	}


### PR DESCRIPTION
Closes #138. Notes live in ~/.local/share/deja/notes.jsonl (XDG-aware, DEJA_NOTES_FILE override), appended by deja remember or the MCP remember tool, and flow through the pipeline as a tenth source: redacted at index time, searchable immediately, exported by sync, shown with [deja] provenance. Project defaults to the current directory identity.

cmd/deja coverage reads 94.7%: the uncovered remainder is the documented doctor permission and live-network set.