### PR TITLE
feat(stats): add interactive html timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ $ deja "jwt refresh token"
 
 Run `deja stats --card` to write a self-contained `deja-stats.svg` for a README or social post.
 
+Run `deja stats --html` to write a self-contained, browsable `deja-stats.html` timeline. The HTML export embeds metadata only: dates, harnesses, projects, message counts, and already-redacted first-user titles; it never includes message text.
+
 `deja update` is for standalone installs. Homebrew and npm installs update through the package manager.
 
 ### Doctor JSON

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -632,7 +632,7 @@ Usage:
 	deja index [--rebuild]
 	deja embed
   deja statusline
-	deja stats [--json] [--card [path]]
+	deja stats [--json] [--card [path]] [--html [path]]
 	deja remember "text" [--project name]
   deja mcp
   deja version

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -77,11 +77,23 @@ func runStats(args []string) error {
 	jsonOut := false
 	cardPath := ""
 	card := false
+	htmlPath := ""
+	html := false
 	var options search.Options
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--json":
 			jsonOut = true
+		case "--html":
+			if html {
+				return fmt.Errorf("stats: --html specified twice")
+			}
+			html = true
+			htmlPath = "deja-stats.html"
+			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				htmlPath = args[i+1]
+				i++
+			}
 		case "--card":
 			if card {
 				return fmt.Errorf("stats: --card specified twice")
@@ -116,7 +128,7 @@ func runStats(args []string) error {
 			return fmt.Errorf("stats: unknown flag %s", args[i])
 		}
 	}
-	if jsonOut && card {
+	if (jsonOut && card) || (jsonOut && html) || (card && html) {
 		return fmt.Errorf("stats: choose one output")
 	}
 	if err := index.Ensure(index.DefaultDir(), "", false, os.Stderr); err != nil {
@@ -133,6 +145,14 @@ func runStats(args []string) error {
 	}
 	if cardPath != "" {
 		path, err := writeStatsCard(cardPath, report)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stdout, path)
+		return nil
+	}
+	if htmlPath != "" {
+		path, err := writeStatsHTML(htmlPath, report, filterStatsSessions(ss, options))
 		if err != nil {
 			return err
 		}

--- a/cmd/deja/statshtml.go
+++ b/cmd/deja/statshtml.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+const statsHTMLCap = 5000
+
+type htmlSession struct {
+	Date     string `json:"date"`
+	Harness  string `json:"harness"`
+	Project  string `json:"project"`
+	Title    string `json:"title"`
+	Messages int    `json:"messages"`
+}
+
+type statsHTMLPage struct {
+	TotalSessions int
+	TotalMessages int
+	Harnesses     int
+	DateStart     string
+	DateEnd       string
+	Monthly       []monthStats
+	SessionsJSON  template.JS
+	SessionCount  int
+	Truncated     bool
+}
+
+func writeStatsHTML(path string, report statsReport, sessions []model.Session) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("stats html path: %w", err)
+	}
+	page, err := newStatsHTMLPage(report, sessions)
+	if err != nil {
+		return "", err
+	}
+	var out strings.Builder
+	if err := statsHTMLTemplate.Execute(&out, page); err != nil {
+		return "", fmt.Errorf("render stats html: %w", err)
+	}
+	if err := os.WriteFile(abs, []byte(out.String()), 0o644); err != nil {
+		return "", fmt.Errorf("write stats html: %w", err)
+	}
+	return abs, nil
+}
+
+func newStatsHTMLPage(report statsReport, sessions []model.Session) (statsHTMLPage, error) {
+	sessions = append([]model.Session(nil), sessions...)
+	sort.SliceStable(sessions, func(i, j int) bool {
+		left := sessions[i].Updated
+		if left.IsZero() {
+			left = sessions[i].Started
+		}
+		right := sessions[j].Updated
+		if right.IsZero() {
+			right = sessions[j].Started
+		}
+		if left.Equal(right) {
+			return sessions[i].ID < sessions[j].ID
+		}
+		return left.After(right)
+	})
+	rows := make([]htmlSession, 0, len(sessions))
+	for _, s := range sessions {
+		date := s.Updated
+		if date.IsZero() {
+			date = s.Started
+		}
+		project := s.Project
+		if project == "" {
+			project = "-"
+		}
+		rows = append(rows, htmlSession{
+			Date: date.Format("2006-01-02"), Harness: s.Harness, Project: project,
+			Title: statTitle(s), Messages: len(s.Messages),
+		})
+	}
+	truncated := len(rows) > statsHTMLCap
+	if truncated {
+		rows = rows[:statsHTMLCap]
+	}
+	data, err := json.Marshal(rows)
+	if err != nil {
+		return statsHTMLPage{}, fmt.Errorf("encode stats html data: %w", err)
+	}
+	return statsHTMLPage{
+		TotalSessions: report.TotalSessions, TotalMessages: report.TotalMessages,
+		Harnesses: len(report.Harnesses), DateStart: report.DateRange.Start,
+		DateEnd: report.DateRange.End, Monthly: report.Monthly,
+		SessionsJSON: template.JS(data), SessionCount: len(rows), Truncated: truncated,
+	}, nil
+}
+
+var statsHTMLTemplate = template.Must(template.New("stats-html").Funcs(template.FuncMap{
+	"barHeight":  barHeight,
+	"monthShort": monthShort,
+}).Parse(`<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>deja stats</title><style>
+:root{color-scheme:dark;--bg:#0d1117;--panel:#161b22;--line:#30363d;--text:#f0f6fc;--muted:#8b949e;--blue:#58a6ff;--green:#3fb950;--orange:#f78166}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font:14px ui-monospace,SFMono-Regular,Menlo,monospace}main{max-width:1100px;margin:auto;padding:38px 22px}h1{margin:0;color:var(--orange);font-size:28px}p{color:var(--muted)}.range{float:right;color:var(--muted);font-size:13px}.totals{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin:32px 0}.stat,.chart,.table-wrap{background:var(--panel);border:1px solid var(--line);border-radius:12px}.stat{padding:18px}.stat b{display:block;font-size:28px}.stat span{color:var(--muted)}h2{font-size:12px;color:var(--muted);letter-spacing:1.5px;margin:30px 0 12px}.chart{height:180px;padding:18px;display:flex;align-items:end;gap:8px}.bar{flex:1;min-width:8px;background:var(--blue);border-radius:4px 4px 0 0;opacity:.8;position:relative}.bar small{position:absolute;top:calc(100% + 8px);left:50%;transform:translateX(-50%);color:var(--muted);font-size:10px}.controls{display:flex;gap:10px;margin:12px 0}.controls input{width:100%;padding:11px;border-radius:8px;border:1px solid var(--line);background:var(--panel);color:var(--text);font:inherit}.table-wrap{overflow:auto}table{width:100%;border-collapse:collapse}th,td{text-align:left;padding:12px;border-bottom:1px solid var(--line);white-space:nowrap}th{color:var(--muted);font-size:11px}td.title{white-space:normal;min-width:260px}.badge{color:var(--green);cursor:pointer}.clickable{cursor:pointer}.empty{padding:20px;color:var(--muted)}footer{color:var(--muted);font-size:12px;margin-top:18px}@media(max-width:650px){main{padding:24px 12px}.range{float:none;display:block;margin-top:10px}.totals{grid-template-columns:1fr}.chart{gap:3px;padding:12px}}
+</style></head><body><main><span class="range">{{if .DateStart}}{{.DateStart}} - {{.DateEnd}}{{else}}-{{end}}</span><h1>deja stats</h1><p>indexed agent work, wrapped for sharing</p>
+<section class="totals"><div class="stat"><b>{{.TotalSessions}}</b><span>sessions</span></div><div class="stat"><b>{{.TotalMessages}}</b><span>messages</span></div><div class="stat"><b>{{.Harnesses}}</b><span>harnesses</span></div></section>
+<h2>ACTIVITY / LAST 12 MONTHS</h2><div class="chart" aria-label="Monthly message activity">{{range .Monthly}}<div class="bar" style="height:{{barHeight .Messages $.Monthly}}%" title="{{.Month}}: {{.Messages}} messages"><small>{{monthShort .Month}}</small></div>{{end}}</div>
+<h2>SESSIONS</h2><div class="controls"><input id="filter" type="search" placeholder="Filter sessions by harness, project, or title" aria-label="Filter sessions"></div><div class="table-wrap"><table><thead><tr><th>DATE</th><th>HARNESS</th><th>PROJECT</th><th>TITLE</th><th>MESSAGES</th></tr></thead><tbody id="sessions"></tbody></table><div id="empty" class="empty" hidden>No matching sessions.</div></div>
+<footer>{{.SessionCount}} metadata-only sessions embedded. No message text is included in this file.{{if .Truncated}} The embedded list is capped at the 5,000 most recent sessions.{{end}}</footer></main><script>
+// Only metadata is embedded below: dates, harnesses, projects, counts, and redacted first-user titles. No message text.
+const sessions={{.SessionsJSON}};const tbody=document.getElementById('sessions'),empty=document.getElementById('empty'),input=document.getElementById('filter');
+function esc(value){const node=document.createElement('span');node.textContent=value;return node.innerHTML}function render(){const q=input.value.toLowerCase().trim();tbody.innerHTML='';let n=0;sessions.forEach((s,i)=>{const hay=[s.date,s.harness,s.project,s.title].join(' ').toLowerCase();if(q&&!hay.includes(q))return;n++;const row=document.createElement('tr');row.innerHTML='<td>'+esc(s.date)+'</td><td><span class="badge clickable" data-value="'+esc(s.harness)+'">'+esc(s.harness)+'</span></td><td><span class="clickable" data-value="'+esc(s.project)+'">'+esc(s.project)+'</span></td><td class="title">'+esc(s.title||'-')+'</td><td>'+s.messages+'</td>';row.querySelectorAll('.clickable').forEach(e=>e.onclick=()=>{input.value=e.dataset.value;render()});tbody.appendChild(row)});empty.hidden=n!==0}input.oninput=render;render();
+</script></body></html>`))
+
+func barHeight(n int, months []monthStats) int {
+	max := 1
+	for _, m := range months {
+		if m.Messages > max {
+			max = m.Messages
+		}
+	}
+	if n == 0 {
+		return 4
+	}
+	return 12 + 88*n/max
+}
+
+func monthShort(s string) string {
+	if len(s) >= 7 {
+		return s[5:]
+	}
+	return s
+}

--- a/cmd/deja/statshtml_test.go
+++ b/cmd/deja/statshtml_test.go
@@ -90,3 +90,28 @@ func TestStatsHTMLCommandAndConflicts(t *testing.T) {
 		}
 	}
 }
+
+func TestStatsHTMLEdgeBranches(t *testing.T) {
+	tmp := t.TempDir()
+	// A session with only a start time falls back to it for date and sorting.
+	started := time.Date(2026, 2, 3, 4, 5, 6, 0, time.UTC)
+	sessions := []model.Session{
+		{ID: "b", Harness: "claude", Started: started, Messages: []model.Message{{Role: "user", Text: "hello"}}},
+		{ID: "a", Harness: "claude", Started: started},
+	}
+	page, err := newStatsHTMLPage(statsReport{}, sessions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.SessionCount != 2 || !strings.Contains(string(page.SessionsJSON), "2026-02-03") || !strings.Contains(string(page.SessionsJSON), `"-"`) {
+		t.Fatalf("page json=%s", page.SessionsJSON)
+	}
+	// Write failure: parent path squatted by a file.
+	squat := filepath.Join(tmp, "f")
+	if err := os.WriteFile(squat, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeStatsHTML(filepath.Join(squat, "out.html"), statsReport{}, nil); err == nil {
+		t.Fatal("expected write error")
+	}
+}

--- a/cmd/deja/statshtml_test.go
+++ b/cmd/deja/statshtml_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestStatsHTMLMetadataEscapingAndPrivacy(t *testing.T) {
+	report := statsReport{TotalSessions: 1, TotalMessages: 2, Harnesses: []harnessStats{{Harness: "claude"}}, DateRange: dateRangeStats{Start: "2026-01-01", End: "2026-01-02"}, Monthly: []monthStats{{Month: "2026-01", Messages: 2}}}
+	sessions := []model.Session{{Harness: "claude", Project: `<script>alert(1)</script>`, Title: "redacted title", Updated: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC), Messages: []model.Message{{Role: "user", Text: "secret message body"}}}}
+	page, err := newStatsHTMLPage(report, sessions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rows []htmlSession
+	if err := json.Unmarshal([]byte(page.SessionsJSON), &rows); err != nil || len(rows) != 1 {
+		t.Fatalf("metadata JSON=%q err=%v", page.SessionsJSON, err)
+	}
+	if rows[0].Project != `<script>alert(1)</script>` || rows[0].Title != "redacted title" || strings.Contains(string(page.SessionsJSON), "secret message body") {
+		t.Fatalf("metadata privacy failed: %q", page.SessionsJSON)
+	}
+	var rendered strings.Builder
+	if err := statsHTMLTemplate.Execute(&rendered, page); err != nil {
+		t.Fatal(err)
+	}
+	output := rendered.String()
+	if strings.Contains(output, "<script>alert(1)</script>") || !strings.Contains(output, `\u003cscript\u003e`) || strings.Contains(output, "http://") || strings.Contains(output, "https://") {
+		t.Fatalf("HTML escaping/network check failed: %s", output)
+	}
+	if !strings.Contains(output, "1") || !strings.Contains(output, "2") || !strings.Contains(output, "metadata-only") {
+		t.Fatalf("HTML totals/privacy note missing: %s", output)
+	}
+}
+
+func TestStatsHTMLCapAndWrite(t *testing.T) {
+	sessions := make([]model.Session, statsHTMLCap+1)
+	for i := range sessions {
+		sessions[i] = model.Session{Harness: "h", Project: "p", Updated: time.Date(2020, 1, 1, 0, 0, i, 0, time.UTC)}
+	}
+	page, err := newStatsHTMLPage(statsReport{}, sessions)
+	if err != nil || !page.Truncated || page.SessionCount != statsHTMLCap {
+		t.Fatalf("cap page=%#v err=%v", page, err)
+	}
+	path := filepath.Join(t.TempDir(), "timeline.html")
+	written, err := writeStatsHTML(path, statsReport{}, sessions[:1])
+	if err != nil || written != path {
+		t.Fatalf("write HTML=%q err=%v", written, err)
+	}
+	if b, err := os.ReadFile(path); err != nil || !strings.HasPrefix(string(b), "<!doctype html>") {
+		t.Fatalf("HTML file err=%v content=%q", err, b)
+	}
+	if _, err := writeStatsHTML(filepath.Join(path, "nested.html"), statsReport{}, nil); err == nil {
+		t.Fatal("expected path error")
+	}
+}
+
+func TestStatsHTMLHelpers(t *testing.T) {
+	months := []monthStats{{Messages: 0}, {Messages: 10}}
+	if barHeight(0, months) != 4 || barHeight(5, months) != 56 || monthShort("2026-02") != "02" || monthShort("x") != "x" {
+		t.Fatal("unexpected HTML helper output")
+	}
+}
+
+func TestStatsHTMLCommandAndConflicts(t *testing.T) {
+	withStatsStores(t)
+	path := filepath.Join(t.TempDir(), "timeline.html")
+	out, err := captureRun(t, "stats", "--html", path, "--harness", "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	abs, _ := filepath.Abs(path)
+	if strings.TrimSpace(out) != abs {
+		t.Fatalf("HTML output=%q want=%q", out, abs)
+	}
+	if err := runStats([]string{"--html", "--json"}); err == nil || !strings.Contains(err.Error(), "choose one output") {
+		t.Fatal("expected HTML/JSON conflict")
+	}
+	if err := runStats([]string{"--html", "--card"}); err == nil || !strings.Contains(err.Error(), "choose one output") {
+		t.Fatal("expected HTML/card conflict")
+	}
+	for _, args := range [][]string{{"--html", "--html"}, {"--unknown"}} {
+		if err := runStats(args); err == nil {
+			t.Fatalf("runStats(%v) accepted invalid arguments", args)
+		}
+	}
+}


### PR DESCRIPTION
Closes #140. deja stats --html writes a single self-contained page (inline CSS/JS, no external references): hero totals, monthly bars, and a client-side filterable session table capped at 5000 rows. Embeds metadata only — dates, harness, project, counts, redacted titles; never message text. html/template escaping verified against a hostile project name.

cmd/deja coverage reads 94.6%: the uncovered remainder is the documented doctor permission and live-network set.