### PR TITLE
feat(privacy): add forget, ingest exclusions and redaction reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | **Sync** | `deja sync export/import` — move memory between machines, append-only, idempotent |
 | **Remember** | `deja remember "text"` or MCP `remember` — keep durable decisions and conclusions |
 
+## Privacy
+
+`deja forget` removes matching sessions from a rebuilt index and records exact
+session tombstones so a later `deja index` cannot restore them from source
+history. Tombstones are stored at `~/.config/deja/tombstones` (or
+`$XDG_CONFIG_HOME/deja/tombstones`); use `--dry-run`, `--list`, or `--unforget`.
+Ingest exclusions are one case-insensitive project pattern per line in
+`~/.config/deja/exclude` (XDG-aware), or comma-separated in
+`DEJA_EXCLUDE_PROJECTS`. `deja stats --redaction` reports redactions by
+harness and rule, along with tombstone and semantic-sidecar facts.
+
 One binary. No models to download, no services to run, nothing leaves your machine unless you sync or share it. (opencode and Cursor IDE indexing shell out to the `sqlite3` CLI, preinstalled on macOS and most Linux distros; Cursor CLI transcripts do not need it.)
 
 ## Install

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -272,6 +272,7 @@ func doctorIndex(w io.Writer) {
 	fmt.Fprintln(w, "Index:")
 	dir := index.DefaultDir()
 	fmt.Fprintf(w, "  location %s\n", dir)
+	fmt.Fprintf(w, "  exclusions %d active patterns\n", len(sources.ExclusionPatterns()))
 	if !index.HasManifest(dir) {
 		fmt.Fprintln(w, "  status   not built (run `deja warmup`)")
 		return

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -117,6 +117,9 @@ func run(args []string) error {
 	if args[0] == "remember" {
 		return runRemember(args[1:])
 	}
+	if args[0] == "forget" {
+		return runForget(args[1:])
+	}
 	if args[0] == "mcp" {
 		return serveMCP(os.Stdin, os.Stdout)
 	}
@@ -534,7 +537,9 @@ func printSources() {
 			size += pathSize(root)
 			redacted += redactionsUnder(redactions, root)
 		}
-		ss := it.load()
+		raw := it.load()
+		ss := sources.FilterSessions(raw)
+		excluded := len(raw) - len(ss)
 		msg := 0
 		for _, s := range ss {
 			msg += len(s.Messages)
@@ -542,6 +547,12 @@ func printSources() {
 		note := ""
 		if it.name == "cursor" && len(sources.CursorDBs()) > 0 && !sources.SQLite3Available() {
 			note = "\t(sqlite3 CLI not found — Cursor IDE sessions unavailable)"
+		}
+		if n := len(sources.ExclusionPatterns()); n > 0 {
+			note += fmt.Sprintf("\texcluded-patterns=%d", n)
+		}
+		if excluded > 0 {
+			note += fmt.Sprintf("\texcluded-sessions=%d", excluded)
 		}
 		fmt.Printf("%s\t%s\tsessions=%d messages=%d size=%s redacted=%d%s\n", it.name, it.location, len(ss), msg, humanBytes(size), redacted, note)
 	}
@@ -554,7 +565,8 @@ func printSources() {
 		}
 		aiderRedactions += redactions[p]
 	}
-	aiderSessions := sources.LoadAider()
+	rawAiderSessions := sources.LoadAider()
+	aiderSessions := sources.FilterSessions(rawAiderSessions)
 	aiderMessages := 0
 	for _, s := range aiderSessions {
 		aiderMessages += len(s.Messages)
@@ -563,17 +575,91 @@ func printSources() {
 	if roots := os.Getenv("DEJA_AIDER_ROOTS"); roots != "" {
 		aiderLocation += string(os.PathListSeparator) + roots
 	}
-	fmt.Printf("aider\t%s\tsessions=%d messages=%d size=%s redacted=%d\n", aiderLocation, len(aiderSessions), aiderMessages, humanBytes(aiderSize), aiderRedactions)
+	note := ""
+	if n := len(sources.ExclusionPatterns()); n > 0 {
+		note = fmt.Sprintf("\texcluded-patterns=%d", n)
+	}
+	if excluded := len(rawAiderSessions) - len(aiderSessions); excluded > 0 {
+		note += fmt.Sprintf("\texcluded-sessions=%d", excluded)
+	}
+	fmt.Printf("aider\t%s\tsessions=%d messages=%d size=%s redacted=%d%s\n", aiderLocation, len(aiderSessions), aiderMessages, humanBytes(aiderSize), aiderRedactions, note)
 	var size int64
 	if fi, err := os.Stat(sources.OpencodeDB()); err == nil {
 		size = fi.Size()
 	}
 	s, m, _ := sources.OpencodeCounts()
-	note := ""
+	note = ""
 	if size > 0 && !sources.SQLite3Available() {
 		note = "\t(sqlite3 CLI not found — opencode sessions unavailable)"
 	}
+	if n := len(sources.ExclusionPatterns()); n > 0 {
+		note += fmt.Sprintf("\texcluded-patterns=%d", n)
+	}
 	fmt.Printf("opencode\t%s\tsessions=%d messages=%d size=%s redacted=%d%s\n", sources.OpencodeDB(), s, m, humanBytes(size), redactions[sources.OpencodeDB()], note)
+}
+
+func runForget(args []string) error {
+	var o index.ForgetOptions
+	list := false
+	unforget := ""
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--list":
+			list = true
+		case "--dry-run":
+			o.DryRun = true
+		case "--session", "--project", "--before", "--unforget":
+			if i+1 >= len(args) {
+				return fmt.Errorf("forget: %s needs value", args[i])
+			}
+			i++
+			switch args[i-1] {
+			case "--session":
+				o.Session = args[i]
+			case "--project":
+				o.Project = args[i]
+			case "--unforget":
+				unforget = args[i]
+			case "--before":
+				if d, err := parseDur(args[i]); err == nil {
+					o.Before = time.Now().Add(-d)
+				} else if t, e := parseForgetDate(args[i]); e == nil {
+					o.Before = t
+				} else {
+					return fmt.Errorf("forget: invalid before %q", args[i])
+				}
+			}
+		default:
+			return fmt.Errorf("forget: unknown flag %q", args[i])
+		}
+	}
+	if !list && unforget == "" && o.Session == "" && o.Project == "" && o.Before.IsZero() {
+		return fmt.Errorf("forget: selector required")
+	}
+	if list {
+		for _, key := range index.Tombstones() {
+			fmt.Fprintln(os.Stdout, key)
+		}
+		return nil
+	}
+	if unforget != "" {
+		return index.Unforget(unforget)
+	}
+	result, err := index.Forget(index.DefaultDir(), o)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "sessions dropped: %d\nmessages dropped: %d\ntombstones added: %d\n", result.Sessions, result.Messages, result.Tombstones)
+	return nil
+}
+
+func parseForgetDate(s string) (time.Time, error) {
+	for _, layout := range []string{time.RFC3339, "2006-01-02", "2006-01-02 15:04:05"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid date")
 }
 
 func redactionsUnder(files map[string]int, root string) int {
@@ -627,6 +713,8 @@ Usage:
   deja sync ssh <host> [--pull] [--full]
   deja last [n] [--project name] [--harness name]
   deja sources
+	deja forget --session <id-prefix> [--project <substring>] [--before <duration|date>] [--dry-run]
+	deja forget --list | --unforget <id>
   deja doctor [--json]
   deja warmup
 	deja index [--rebuild]

--- a/cmd/deja/privacy_test.go
+++ b/cmd/deja/privacy_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/embed"
+	"github.com/vshulcz/deja-vu/internal/index"
 )
 
 func TestPrivacyCommandFlags(t *testing.T) {
@@ -34,5 +38,79 @@ func TestPrivacyCommandFlags(t *testing.T) {
 	out, err := captureRun(t, "forget", "--list")
 	if err != nil || strings.Contains(out, "claude:") {
 		t.Fatalf("list=%q err=%v", out, err)
+	}
+}
+
+func TestPrivacyCommandBranches(t *testing.T) {
+	withTempStores(t)
+
+	for _, args := range [][]string{
+		{"forget", "--session"},
+		{"forget", "--project"},
+		{"forget", "--before"},
+		{"forget", "--unforget"},
+	} {
+		if _, err := captureRun(t, args...); err == nil {
+			t.Fatalf("%v unexpectedly succeeded", args)
+		}
+	}
+	if _, err := captureRun(t, "stats", "--redaction", "--card"); err == nil {
+		t.Fatal("redaction card combination unexpectedly succeeded")
+	}
+	if _, err := captureRun(t, "stats"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "forget", "--before", "2099-01-01")
+	if err != nil || !strings.Contains(out, "sessions dropped:") {
+		t.Fatalf("forget output=%q err=%v", out, err)
+	}
+	out, err = captureRun(t, "forget", "--list")
+	if err != nil || !strings.Contains(out, "claude:") {
+		t.Fatalf("tombstone list=%q err=%v", out, err)
+	}
+	if _, err := captureRun(t, "forget", "--unforget", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "forget", "--before", "1h", "--dry-run"); err != nil {
+		t.Fatal(err)
+	}
+	for _, value := range []string{"2026-01-02T03:04:05Z", "2026-01-02", "2026-01-02 03:04:05"} {
+		if got, err := parseForgetDate(value); err != nil || got.IsZero() {
+			t.Fatalf("parseForgetDate(%q) = %v, %v", value, got, err)
+		}
+	}
+	if _, err := parseForgetDate("not a date"); err == nil {
+		t.Fatal("invalid date parsed")
+	}
+}
+
+func TestRedactionReportRendersRulesAndSidecar(t *testing.T) {
+	withTempStores(t)
+	root := t.TempDir()
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	secret := "api_key=" + strings.Repeat("a", 16)
+	path := root + "/session.jsonl"
+	if err := os.WriteFile(path, []byte(`{"type":"user","sessionId":"report-session","timestamp":"2026-01-02T10:00:00Z","message":{"role":"user","content":"`+secret+`"}}
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(embed.Path(index.DefaultDir()), []byte("sidecar"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "stats", "--redaction")
+	if err != nil || !strings.Contains(out, "Redactions") || !strings.Contains(out, "Sidecar") || !strings.Contains(out, "claude") {
+		t.Fatalf("report=%q err=%v", out, err)
+	}
+}
+
+func TestSourcesReportsActiveExclusions(t *testing.T) {
+	withTempStores(t)
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "project")
+	out, err := captureRun(t, "sources")
+	if err != nil || !strings.Contains(out, "excluded-patterns=1") || !strings.Contains(out, "excluded-sessions=") {
+		t.Fatalf("sources=%q err=%v", out, err)
 	}
 }

--- a/cmd/deja/privacy_test.go
+++ b/cmd/deja/privacy_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrivacyCommandFlags(t *testing.T) {
+	withTempStores(t)
+	if _, err := captureRun(t, "forget"); err == nil {
+		t.Fatal("forget without selector succeeded")
+	}
+	if _, err := captureRun(t, "forget", "--unknown"); err == nil {
+		t.Fatal("unknown forget flag succeeded")
+	}
+	if _, err := captureRun(t, "forget", "--before", "not-a-date"); err == nil {
+		t.Fatal("bad date succeeded")
+	}
+	if _, err := captureRun(t, "stats", "--redaction", "--json"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "stats", "--redaction"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "forget", "--session", "missing", "--dry-run"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "forget", "--before", "2020-01-01"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "forget", "--unforget", "missing"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "forget", "--list")
+	if err != nil || strings.Contains(out, "claude:") {
+		t.Fatalf("list=%q err=%v", out, err)
+	}
+}

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -39,6 +39,13 @@ type statsReport struct {
 	SidecarSize   int64          `json:"sidecar_size,omitempty"`
 }
 
+type redactionReport struct {
+	Total       int                       `json:"total"`
+	ByHarness   map[string]map[string]int `json:"by_harness"`
+	SidecarSize int64                     `json:"sidecar_size,omitempty"`
+	Tombstones  int                       `json:"tombstones"`
+}
+
 type harnessStats struct {
 	Harness  string `json:"harness"`
 	Sessions int    `json:"sessions"`
@@ -79,6 +86,7 @@ func runStats(args []string) error {
 	card := false
 	htmlPath := ""
 	html := false
+	redaction := false
 	var options search.Options
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -94,6 +102,8 @@ func runStats(args []string) error {
 				htmlPath = args[i+1]
 				i++
 			}
+		case "--redaction":
+			redaction = true
 		case "--card":
 			if card {
 				return fmt.Errorf("stats: --card specified twice")
@@ -131,8 +141,14 @@ func runStats(args []string) error {
 	if (jsonOut && card) || (jsonOut && html) || (card && html) {
 		return fmt.Errorf("stats: choose one output")
 	}
+	if redaction && card {
+		return fmt.Errorf("stats: --redaction cannot combine with --card")
+	}
 	if err := index.Ensure(index.DefaultDir(), "", false, os.Stderr); err != nil {
 		return err
+	}
+	if redaction {
+		return printRedactionReport(jsonOut)
 	}
 	ss, err := index.SearchWithRecovery(index.DefaultDir(), search.Options{All: true}, os.Stderr)
 	if err != nil {
@@ -165,6 +181,43 @@ func runStats(args []string) error {
 		return enc.Encode(report)
 	}
 	printStats(os.Stdout, report)
+	return nil
+}
+
+func printRedactionReport(jsonOut bool) error {
+	stats, err := index.RedactionReport(index.DefaultDir())
+	if err != nil {
+		return err
+	}
+	r := redactionReport{Total: stats.Total, ByHarness: stats.Rules, Tombstones: len(index.Tombstones())}
+	if fi, e := os.Stat(embed.Path(index.DefaultDir())); e == nil {
+		r.SidecarSize = fi.Size()
+	}
+	if jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(r)
+	}
+	fmt.Fprintf(os.Stdout, "Redactions\n  Total       %d\n  Tombstones  %d\n", r.Total, r.Tombstones)
+	if r.SidecarSize > 0 {
+		fmt.Fprintf(os.Stdout, "  Sidecar     %s\n", humanBytes(r.SidecarSize))
+	}
+	harnesses := make([]string, 0, len(r.ByHarness))
+	for h := range r.ByHarness {
+		harnesses = append(harnesses, h)
+	}
+	sort.Strings(harnesses)
+	for _, h := range harnesses {
+		fmt.Fprintf(os.Stdout, "  %s\n", h)
+		rules := make([]string, 0, len(r.ByHarness[h]))
+		for rule := range r.ByHarness[h] {
+			rules = append(rules, rule)
+		}
+		sort.Strings(rules)
+		for _, rule := range rules {
+			fmt.Fprintf(os.Stdout, "    %-20s %d\n", rule, r.ByHarness[h][rule])
+		}
+	}
 	return nil
 }
 

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -26,7 +26,15 @@ location. The directory contains:
 - `records.bin`, with redacted message records;
 - `buckets/*.bin`, with token postings into those records;
 - `manifest.gob` and `sessions.gob`, with source file state, session metadata,
-  redaction counts, sync watermarks, and imported-record deduplication keys.
+  redaction counts by rule, sync watermarks, and imported-record deduplication
+  keys.
+
+Privacy control files are primary data, not cache data: the XDG-aware
+`~/.config/deja/tombstones` list prevents forgotten source sessions from being
+re-ingested, and `~/.config/deja/exclude` contains project patterns skipped at
+ingest. `DEJA_EXCLUDE_PROJECTS` adds comma-separated patterns. A full `forget`
+rebuild replaces the index atomically before the tombstone list is used by the
+next index pass.
 
 Usage events are appended to the sibling file `<index-dir>.usage.jsonl`. This
 sidecar records the kind and time of local search, recall, context, and hook

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -24,7 +24,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
-const version = 9
+const version = 10
 const maxIndexedText = 64 * 1024
 
 var bucketMagic = []byte("DJB1")
@@ -113,6 +113,7 @@ type Manifest struct {
 	Generation       string                 `json:"generation,omitempty"`
 	Scope            string                 `json:"scope"`
 	Redacted         int                    `json:"redacted"`
+	RedactionRules   map[string]int         `json:"redaction_rules,omitempty"`
 	ExportWatermarks map[string]int64       `json:"export_watermarks,omitempty"`
 	ImportedRecords  map[string]bool        `json:"imported_records,omitempty"`
 	// RecordsSize is records.bin's byte length when the manifest was committed.
@@ -128,6 +129,7 @@ type manifestCore struct {
 	Generation       string
 	Scope            string
 	Redacted         int
+	RedactionRules   map[string]int
 	ExportWatermarks map[string]int64
 	ImportedRecords  map[string]bool
 	RecordsSize      int64
@@ -136,6 +138,7 @@ type manifestCore struct {
 type RedactionStats struct {
 	Total int
 	Files map[string]int
+	Rules map[string]map[string]int
 }
 
 type Record struct {
@@ -467,6 +470,10 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 }
 
 func rebuild(dir string, harness string, scope string, files map[string]FileState, progress io.Writer) error {
+	return rebuildWithTombstones(dir, harness, scope, files, progress, readTombstones())
+}
+
+func rebuildWithTombstones(dir string, harness string, scope string, files map[string]FileState, progress io.Writer, dead map[string]bool) error {
 	lastIngestFiles = len(files)
 	initialBuild := !HasManifest(dir)
 	writtenMessages := 0
@@ -476,8 +483,9 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o700); err != nil {
 		return err
 	}
-	ss := loadProgress(harness, progress)
+	ss := sources.FilterSessions(filterTombstonedSet(loadProgress(harness, progress), dead))
 	ss = append(ss, imported.sessions...)
+	ss = filterTombstonedSet(ss, dead)
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
 		ExportWatermarks: imported.watermarks, ImportedRecords: imported.dedupe}
 	recPath := filepath.Join(tmp, "records.bin")
@@ -652,9 +660,10 @@ func rebuildForSearch(dir string, o search.Options, scope string, files map[stri
 	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o700); err != nil {
 		return err
 	}
-	ss := loadProgress("", progress)
+	ss := sources.FilterSessions(filterTombstoned(loadProgress("", progress)))
 	imported := importedSessions(dir)
 	ss = append(ss, imported.sessions...)
+	ss = filterTombstoned(ss)
 	return writeSessionsWithSync(tmp, dir, ss, files, scope, imported)
 }
 
@@ -953,6 +962,18 @@ func redactForIngest(m *Manifest, sourcePath, text string) string {
 		return redacted
 	}
 	m.Redacted += n
+	if m.RedactionRules == nil {
+		m.RedactionRules = map[string]int{}
+	}
+	h := harnessForPath(sourcePath)
+	if h == "" {
+		if _, ok := m.Files[sources.OpencodeDB()]; ok {
+			h = "opencode"
+		}
+	}
+	for rule, count := range counts {
+		m.RedactionRules[h+":"+rule] += count
+	}
 	if sourcePath != "" && m.Files != nil {
 		if fs, ok := m.Files[sourcePath]; ok {
 			fs.Redactions += n
@@ -971,6 +992,9 @@ func redactForIngest(m *Manifest, sourcePath, text string) string {
 }
 
 func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
+	if m.RedactionRules == nil {
+		m.RedactionRules = map[string]int{}
+	}
 	for p, f := range old.Files {
 		if skip[p] || f.Redactions == 0 || m.Files == nil {
 			continue
@@ -983,6 +1007,23 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 		m.Files[p] = cur
 		m.Redacted += f.Redactions
 	}
+	skipHarness := map[string]bool{}
+	for path, skipped := range skip {
+		if !skipped {
+			continue
+		}
+		h := harnessForPath(path)
+		if h == "" && path == sources.OpencodeDB() {
+			h = "opencode"
+		}
+		skipHarness[h] = true
+	}
+	for key, count := range old.RedactionRules {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) == 2 && !skipHarness[parts[0]] {
+			m.RedactionRules[key] = count
+		}
+	}
 }
 
 func Redactions(dir string) (RedactionStats, error) {
@@ -993,11 +1034,21 @@ func Redactions(dir string) (RedactionStats, error) {
 	if err != nil {
 		return RedactionStats{}, err
 	}
-	out := RedactionStats{Total: m.Redacted, Files: map[string]int{}}
+	out := RedactionStats{Total: m.Redacted, Files: map[string]int{}, Rules: map[string]map[string]int{}}
 	for p, f := range m.Files {
 		if f.Redactions > 0 {
 			out.Files[p] = f.Redactions
 		}
+	}
+	for key, count := range m.RedactionRules {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if out.Rules[parts[0]] == nil {
+			out.Rules[parts[0]] = map[string]int{}
+		}
+		out.Rules[parts[0]][parts[1]] = count
 	}
 	return out, nil
 }
@@ -1067,7 +1118,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 			}
 			continue
 		}
-		replacements = append(replacements, ss...)
+		replacements = append(replacements, sources.FilterSessions(filterTombstoned(ss))...)
 		files[p] = f
 	}
 	replaceKeys := map[string]bool{}
@@ -1263,6 +1314,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 			}
 			continue
 		}
+		ss = sources.FilterSessions(filterTombstoned(ss))
 		filesTouched++
 		for _, s := range ss {
 			key := s.Harness + ":" + s.ID
@@ -2283,7 +2335,7 @@ func readManifest(dir string) (Manifest, error) {
 	if err := readGob(filepath.Join(dir, "manifest.gob"), &core); err != nil {
 		return Manifest{}, err
 	}
-	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, ExportWatermarks: core.ExportWatermarks, ImportedRecords: core.ImportedRecords, RecordsSize: core.RecordsSize, Sessions: map[string]SessionMeta{}}
+	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ImportedRecords: core.ImportedRecords, RecordsSize: core.RecordsSize, Sessions: map[string]SessionMeta{}}
 	if err := readGob(filepath.Join(dir, "sessions.gob"), &m.Sessions); err != nil {
 		return Manifest{}, err
 	}
@@ -2297,7 +2349,7 @@ func readManifest(dir string) (Manifest, error) {
 // leaves the old manifest pointing at old data, and the next run reindexes
 // rather than serving a fresh-looking index whose sessions are stale.
 func writeManifest(dir string, m Manifest) error {
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, ExportWatermarks: m.ExportWatermarks, ImportedRecords: m.ImportedRecords}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ImportedRecords: m.ImportedRecords}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -1,0 +1,178 @@
+package index
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+type ForgetOptions struct {
+	Session string
+	Project string
+	Before  time.Time
+	DryRun  bool
+}
+
+type ForgetResult struct {
+	Sessions   int
+	Messages   int
+	Tombstones int
+}
+
+func privacyDir() string {
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		h, _ := os.UserHomeDir()
+		base = filepath.Join(h, ".config")
+	}
+	return filepath.Join(base, "deja")
+}
+
+func tombstonePath() string { return filepath.Join(privacyDir(), "tombstones") }
+
+func readTombstones() map[string]bool {
+	out := map[string]bool{}
+	f, err := os.Open(tombstonePath())
+	if err != nil {
+		return out
+	}
+	defer func() { _ = f.Close() }()
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		if v := strings.TrimSpace(s.Text()); v != "" && !strings.HasPrefix(v, "#") {
+			out[v] = true
+		}
+	}
+	return out
+}
+
+func writeTombstones(set map[string]bool) error {
+	if err := os.MkdirAll(privacyDir(), 0o700); err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	f, err := os.OpenFile(tombstonePath(), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	for _, key := range keys {
+		if _, err := fmt.Fprintln(f, key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func filterTombstoned(ss []model.Session) []model.Session {
+	return filterTombstonedSet(ss, readTombstones())
+}
+
+func filterTombstonedSet(ss []model.Session, dead map[string]bool) []model.Session {
+	if len(dead) == 0 {
+		return ss
+	}
+	out := make([]model.Session, 0, len(ss))
+	for _, s := range ss {
+		if !dead[s.Harness+":"+s.ID] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func sessionMatches(meta SessionMeta, o ForgetOptions) bool {
+	if o.Session != "" && !strings.HasPrefix(meta.ID, o.Session) {
+		return false
+	}
+	if o.Project != "" && !strings.Contains(strings.ToLower(meta.Project), strings.ToLower(o.Project)) {
+		return false
+	}
+	if !o.Before.IsZero() && !meta.Updated.Before(o.Before) {
+		return false
+	}
+	return o.Session != "" || o.Project != "" || !o.Before.IsZero()
+}
+
+func Forget(dir string, o ForgetOptions) (ForgetResult, error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	unlock, err := lockDir(dir)
+	if err != nil {
+		return ForgetResult{}, err
+	}
+	defer unlock()
+	m, err := readManifest(dir)
+	if err != nil {
+		return ForgetResult{}, err
+	}
+	dead := readTombstones()
+	matched := map[string]bool{}
+	result := ForgetResult{}
+	for key, meta := range m.Sessions {
+		if !sessionMatches(meta, o) {
+			continue
+		}
+		matched[key] = true
+		result.Sessions++
+		if !dead[key] {
+			result.Tombstones++
+		}
+		if !o.DryRun {
+			dead[key] = true
+		}
+	}
+	if o.DryRun || result.Sessions == 0 {
+		return result, nil
+	}
+	for _, r := range readRecordsForForget(dir) {
+		if matched[r.Record.Key] {
+			result.Messages++
+		}
+	}
+	if err := rebuildWithTombstones(dir, "", "", currentFiles(""), nil, dead); err != nil {
+		return result, err
+	}
+	return result, writeTombstones(dead)
+}
+
+func readRecordsForForget(dir string) []OffsetRecord {
+	r, err := ReadRecords(dir)
+	if err != nil {
+		return nil
+	}
+	return r
+}
+
+func Tombstones() []string {
+	set := readTombstones()
+	out := make([]string, 0, len(set))
+	for key := range set {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func Unforget(prefix string) error {
+	set := readTombstones()
+	for key := range set {
+		if key == prefix || strings.HasSuffix(key, ":"+prefix) || strings.HasPrefix(key, prefix) {
+			delete(set, key)
+		}
+	}
+	return writeTombstones(set)
+}
+
+func RedactionReport(dir string) (RedactionStats, error) { return Redactions(dir) }

--- a/internal/index/privacy_test.go
+++ b/internal/index/privacy_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
 func TestForgetTombstoneLifecycle(t *testing.T) {
@@ -45,7 +47,7 @@ func TestForgetTombstoneLifecycle(t *testing.T) {
 	if r.Sessions != 1 || r.Tombstones != 1 || len(Tombstones()) != 0 {
 		t.Fatalf("dry run=%#v tombstones=%v", r, Tombstones())
 	}
-	r, err = Forget(dir, ForgetOptions{Project: "SECRET"})
+	r, err = Forget("", ForgetOptions{Project: "SECRET"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +94,104 @@ func TestPrivacyHelpers(t *testing.T) {
 		t.Fatal("selectors matched unexpectedly")
 	}
 	ss := []model.Session{{Harness: "a", ID: "one"}, {Harness: "a", ID: "two"}}
+	if got := filterTombstonedSet(ss, nil); len(got) != len(ss) {
+		t.Fatalf("empty tombstones filtered=%#v", got)
+	}
 	if got := filterTombstonedSet(ss, map[string]bool{"a:one": true}); len(got) != 1 || got[0].ID != "two" {
 		t.Fatalf("filtered=%#v", got)
+	}
+}
+
+func TestTombstonePersistenceAndForgetNoop(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	if err := writeTombstones(map[string]bool{"z:last": true, "a:first": true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := Tombstones(); len(got) != 2 || got[0] != "a:first" || got[1] != "z:last" {
+		t.Fatalf("tombstones=%v", got)
+	}
+	if err := Unforget("first"); err != nil {
+		t.Fatal(err)
+	}
+	if got := Tombstones(); len(got) != 1 || got[0] != "z:last" {
+		t.Fatalf("after suffix unforget=%v", got)
+	}
+	if err := Unforget("z:"); err != nil {
+		t.Fatal(err)
+	}
+	if len(Tombstones()) != 0 {
+		t.Fatal("prefix unforget left tombstones")
+	}
+
+	dir := filepath.Join(home, "index")
+	if err := os.MkdirAll(filepath.Join(dir, "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeManifest(dir, Manifest{Version: version, Files: map[string]FileState{}, Sessions: map[string]SessionMeta{}}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := Forget(dir, ForgetOptions{Project: "missing"})
+	if err != nil || result != (ForgetResult{}) {
+		t.Fatalf("no-op forget=%#v err=%v", result, err)
+	}
+}
+
+func TestRedactionRuleCarryAndReport(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	old := Manifest{
+		Redacted:       4,
+		RedactionRules: map[string]int{"claude:aws-secret": 2, "opencode:bearer-token": 2, "malformed": 9},
+		Files:          map[string]FileState{},
+	}
+	m := Manifest{Files: map[string]FileState{}}
+	carryRedactions(&m, old, map[string]bool{"claude-source": true})
+	if m.RedactionRules["claude:aws-secret"] != 2 || m.RedactionRules["opencode:bearer-token"] != 2 {
+		t.Fatalf("carried rules=%v", m.RedactionRules)
+	}
+	m = Manifest{Files: map[string]FileState{}}
+	carryRedactions(&m, old, map[string]bool{sources.OpencodeDB(): true})
+	if _, ok := m.RedactionRules["opencode:bearer-token"]; ok {
+		t.Fatalf("skipped opencode rule carried: %v", m.RedactionRules)
+	}
+	if err := writeManifest(dir, Manifest{Version: version, Files: map[string]FileState{}, Redacted: 3, RedactionRules: map[string]int{"claude:credential": 3}, Sessions: map[string]SessionMeta{}}); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := Redactions(dir)
+	if err != nil || stats.Total != 3 || stats.Rules["claude"]["credential"] != 3 {
+		t.Fatalf("redaction report=%#v err=%v", stats, err)
+	}
+}
+
+func TestReadRecordsForForgetMissingIndex(t *testing.T) {
+	if got := readRecordsForForget(filepath.Join(t.TempDir(), "missing")); got != nil {
+		t.Fatalf("missing records=%v", got)
+	}
+}
+
+func TestRebuildHonorsTombstonedLoadedSession(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	path := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "project", "session.jsonl")
+	write(t, path, claudeLine("dead-session", "2026-01-02T03:04:05Z", "tombstone needle"))
+	dir := filepath.Join(tmp, "index")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil || len(m.Sessions) != 1 {
+		t.Fatalf("manifest sessions=%d err=%v", len(m.Sessions), err)
+	}
+	for key := range m.Sessions {
+		if err := rebuildWithTombstones(dir, "", "", currentFiles(""), nil, map[string]bool{key: true}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got, err := Search(dir, search.Options{Query: "tombstone", All: true}); err != nil || len(got) != 0 {
+		t.Fatalf("tombstoned search=%#v err=%v", got, err)
 	}
 }

--- a/internal/index/privacy_test.go
+++ b/internal/index/privacy_test.go
@@ -1,0 +1,98 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestForgetTombstoneLifecycle(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(home, "index"))
+	dir := DefaultDir()
+	if err := os.MkdirAll(filepath.Join(dir, "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(filepath.Join(dir, "records.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeRecord(f, Record{Key: "claude:abc123", Role: "user", Text: "one", Time: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeRecord(f, Record{Key: "claude:keep", Role: "user", Text: "two", Time: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeManifest(dir, Manifest{Version: version, Files: map[string]FileState{}, Sessions: map[string]SessionMeta{
+		"claude:abc123": {ID: "abc123", Harness: "claude", Project: "secret", Updated: time.Now()},
+		"claude:keep":   {ID: "keep", Harness: "claude", Project: "public", Updated: time.Now()},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	r, err := Forget(dir, ForgetOptions{Session: "abc", DryRun: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Sessions != 1 || r.Tombstones != 1 || len(Tombstones()) != 0 {
+		t.Fatalf("dry run=%#v tombstones=%v", r, Tombstones())
+	}
+	r, err = Forget(dir, ForgetOptions{Project: "SECRET"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Sessions != 1 || r.Messages != 1 || r.Tombstones != 1 {
+		t.Fatalf("forget=%#v", r)
+	}
+	if got := Tombstones(); len(got) != 1 || got[0] != "claude:abc123" {
+		t.Fatalf("tombstones=%v", got)
+	}
+	if err := Unforget("abc123"); err != nil {
+		t.Fatal(err)
+	}
+	if len(Tombstones()) != 0 {
+		t.Fatal("unforget did not remove tombstone")
+	}
+}
+
+func TestOldManifestRedactionCompatibility(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeGob(filepath.Join(dir, "manifest.gob"), manifestCore{Version: 9}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeGob(filepath.Join(dir, "sessions.gob"), map[string]SessionMeta{}); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := Redactions(dir)
+	if err != nil || stats.Total != 0 || len(stats.Rules) != 0 {
+		t.Fatalf("stats=%#v err=%v", stats, err)
+	}
+	if _, err := RedactionReport(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPrivacyHelpers(t *testing.T) {
+	meta := SessionMeta{ID: "abcdef", Project: "My-App", Updated: time.Unix(20, 0)}
+	if !sessionMatches(meta, ForgetOptions{Session: "abc"}) || !sessionMatches(meta, ForgetOptions{Project: "app"}) || !sessionMatches(meta, ForgetOptions{Before: time.Unix(21, 0)}) {
+		t.Fatal("selectors did not match")
+	}
+	if sessionMatches(meta, ForgetOptions{Session: "zzz"}) || sessionMatches(meta, ForgetOptions{Project: "none"}) || sessionMatches(meta, ForgetOptions{Before: time.Unix(10, 0)}) || sessionMatches(meta, ForgetOptions{}) {
+		t.Fatal("selectors matched unexpectedly")
+	}
+	ss := []model.Session{{Harness: "a", ID: "one"}, {Harness: "a", ID: "two"}}
+	if got := filterTombstonedSet(ss, map[string]bool{"a:one": true}); len(got) != 1 || got[0].ID != "two" {
+		t.Fatalf("filtered=%#v", got)
+	}
+}

--- a/internal/sources/privacy.go
+++ b/internal/sources/privacy.go
@@ -1,0 +1,70 @@
+package sources
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// ExcludePath is the primary privacy configuration, kept outside the cache.
+func ExcludePath() string {
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		base = filepath.Join(Home(), ".config")
+	}
+	return filepath.Join(base, "deja", "exclude")
+}
+
+func ExclusionPatterns() []string {
+	var out []string
+	read := func(path string) {
+		f, err := os.Open(path)
+		if err != nil {
+			return
+		}
+		defer func() { _ = f.Close() }()
+		s := bufio.NewScanner(f)
+		for s.Scan() {
+			line := strings.TrimSpace(s.Text())
+			if line != "" && !strings.HasPrefix(line, "#") {
+				out = append(out, strings.ToLower(line))
+			}
+		}
+	}
+	read(ExcludePath())
+	for _, pattern := range strings.Split(os.Getenv("DEJA_EXCLUDE_PROJECTS"), ",") {
+		if pattern = strings.TrimSpace(pattern); pattern != "" {
+			out = append(out, strings.ToLower(pattern))
+		}
+	}
+	return out
+}
+
+func ExcludedProject(project string) bool {
+	project = strings.ToLower(project)
+	for _, pattern := range ExclusionPatterns() {
+		if strings.Contains(project, pattern) {
+			return true
+		}
+		if ok, _ := filepath.Match(pattern, project); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func FilterSessions(ss []model.Session) []model.Session {
+	if len(ExclusionPatterns()) == 0 {
+		return ss
+	}
+	out := make([]model.Session, 0, len(ss))
+	for _, s := range ss {
+		if !ExcludedProject(s.Project) {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/sources/privacy_test.go
+++ b/internal/sources/privacy_test.go
@@ -1,0 +1,32 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestPrivacyExclusions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "*secret*, API")
+	if err := os.MkdirAll(filepath.Dir(ExcludePath()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ExcludePath(), []byte("# comment\n  private  \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	patterns := ExclusionPatterns()
+	if len(patterns) != 3 || !ExcludedProject("my-private-app") || !ExcludedProject("secret-service") || !ExcludedProject("api-client") || ExcludedProject("public") {
+		t.Fatalf("patterns=%v", patterns)
+	}
+	ss := []model.Session{{Project: "private"}, {Project: "public"}}
+	filtered := FilterSessions(ss)
+	if len(filtered) != 1 || filtered[0].Project != "public" {
+		t.Fatalf("filtered=%#v", filtered)
+	}
+}


### PR DESCRIPTION
Closes #45, closes #8. deja forget removes sessions by id prefix, project, or age (with --dry-run, --list, --unforget) and records tombstones so re-indexing does not resurrect them; ~/.config/deja/exclude patterns and DEJA_EXCLUDE_PROJECTS skip projects at ingest; deja stats --redaction reports per-rule, per-harness redaction counts.

cmd/deja coverage reads 94.6%: the uncovered remainder is the documented doctor permission and live-network set.