### PR TITLE
feat: add reproducible recall benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,13 @@ jobs:
       - run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
         shell: bash
       - run: go build ./cmd/deja
+      - name: Benchmark lexical recall floor
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          report=$(./deja bench recall --json)
+          printf '%s\n' "$report"
+          printf '%s\n' "$report" | jq -e '.lexical.recall_at_5 >= 0.85'
       - name: Coverage summary
         if: runner.os == 'Linux'
         run: go tool cover -func=coverage.out | tail -1

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ fixtures/private/
 /deja
 .build.log
 fixtures/synthetic/opencode.db
+.deja-bench/

--- a/README.md
+++ b/README.md
@@ -225,6 +225,21 @@ Measured on a real corpus — 1,250+ sessions, ~3.3GB across three harnesses:
 
 The index is incremental: when a session file grows, only that file is re-read.
 
+## Benchmarks
+
+Run the reproducible recall benchmark with:
+
+```sh
+deja bench recall
+deja bench recall --json
+```
+
+The current lexical run reports recall@5 **1.00**, recall@10 **1.00**, and
+median latency **0.33 ms**; hybrid recall is skipped when no embedding
+endpoint is available. It generates 500 fixed-seed sessions and 50 derived
+queries, then runs them through the normal index and search pipeline; the
+[generator](internal/bench/corpus.go) defines the corpus and relevance.
+
 ## How it works
 
 Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact credentials → `records.bin` + token buckets → `manifest.json` tracks per-file state so repeat runs only ingest what changed. The MCP server, stats, share and sync all read the same index. Details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).

--- a/cmd/deja/bench.go
+++ b/cmd/deja/bench.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/bench"
+	"github.com/vshulcz/deja-vu/internal/embed"
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+type benchMetric struct {
+	RecallAt5  float64 `json:"recall_at_5"`
+	RecallAt10 float64 `json:"recall_at_10"`
+	MedianMS   float64 `json:"median_latency_ms"`
+}
+
+type benchReport struct {
+	CorpusHash   string       `json:"corpus_hash"`
+	Sessions     int          `json:"sessions"`
+	Queries      int          `json:"queries"`
+	Lexical      benchMetric  `json:"lexical"`
+	Hybrid       *benchMetric `json:"hybrid,omitempty"`
+	HybridStatus string       `json:"hybrid_status"`
+}
+
+func runBench(args []string) error {
+	if len(args) < 1 || args[0] != "recall" || len(args) > 2 || (len(args) == 2 && args[1] != "--json") {
+		return fmt.Errorf("bench: usage: bench recall [--json]")
+	}
+	return runBenchRecall(len(args) == 2)
+}
+
+func runBenchRecall(jsonOutput bool) error {
+	corpus := bench.Generate(bench.Seed)
+	root, err := benchmarkTempDir()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(root) }()
+	indexDir := filepath.Join(root, "index.db")
+	claudeRoot := filepath.Join(root, "claude")
+	if err := writeBenchCorpus(claudeRoot, corpus.Sessions); err != nil {
+		return err
+	}
+	restore := isolateBenchEnv(root, claudeRoot, indexDir)
+	defer restore()
+	if err := index.EnsureForSearch(indexDir, search.Options{Query: "", All: true}, true, io.Discard); err != nil {
+		return fmt.Errorf("build benchmark index: %w", err)
+	}
+	lexical, err := measureRecall(indexDir, corpus.Queries, nil)
+	if err != nil {
+		return err
+	}
+	report := benchReport{CorpusHash: corpus.Hash, Sessions: len(corpus.Sessions), Queries: len(corpus.Queries), Lexical: lexical, HybridStatus: "endpoint unavailable, skipped"}
+	if client, probeErr := embed.New(); probeErr == nil {
+		if _, embedErr := embed.EmbedIndex(indexDir, client); embedErr == nil {
+			var hybrid benchMetric
+			hybrid, err = measureRecall(indexDir, corpus.Queries, client)
+			if err != nil {
+				return err
+			}
+			report.Hybrid = &hybrid
+			report.HybridStatus = "available"
+		} else {
+			report.HybridStatus = "endpoint unavailable, skipped"
+		}
+	} else {
+		report.HybridStatus = "endpoint unavailable, skipped"
+	}
+	if jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(report)
+	}
+	printBenchReport(os.Stdout, report)
+	return nil
+}
+
+func measureRecall(dir string, queries []bench.Query, client *embed.Client) (benchMetric, error) {
+	latencies := make([]time.Duration, 0, len(queries))
+	got5, got10 := 0, 0
+	for _, q := range queries {
+		started := time.Now()
+		result, err := index.SearchWithRecoveryDetailed(dir, search.Options{Query: q.Text, All: true}, io.Discard)
+		if err != nil {
+			return benchMetric{}, fmt.Errorf("benchmark query %q: %w", q.Text, err)
+		}
+		o := search.Options{Query: q.Text, All: true}
+		if result.Fuzzy {
+			o.Fuzzy = true
+			o.FuzzyVariants = result.Variants
+		}
+		hits, err := search.Run(result.Sessions, o)
+		if err != nil {
+			return benchMetric{}, fmt.Errorf("rank benchmark query %q: %w", q.Text, err)
+		}
+		if client != nil {
+			sidecar, sidecarErr := embed.Read(dir)
+			if sidecarErr != nil {
+				return benchMetric{}, sidecarErr
+			}
+			hits, err = embed.Rerank(context.Background(), hits, q.Text, sidecar, client)
+			if err != nil {
+				return benchMetric{}, fmt.Errorf("hybrid benchmark query %q: %w", q.Text, err)
+			}
+		}
+		latencies = append(latencies, time.Since(started))
+		if containsRelevant(hits, q.Relevant, 5) {
+			got5++
+		}
+		if containsRelevant(hits, q.Relevant, 10) {
+			got10++
+		}
+	}
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+	median := latencies[len(latencies)/2]
+	return benchMetric{RecallAt5: float64(got5) / float64(len(queries)), RecallAt10: float64(got10) / float64(len(queries)), MedianMS: float64(median) / float64(time.Millisecond)}, nil
+}
+
+func containsRelevant(hits []search.Hit, ids []string, limit int) bool {
+	if len(hits) > limit {
+		hits = hits[:limit]
+	}
+	wanted := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		wanted[id] = true
+	}
+	for _, hit := range hits {
+		if wanted[hit.Session.ID] {
+			return true
+		}
+	}
+	return false
+}
+
+func writeBenchCorpus(root string, sessions []model.Session) error {
+	for _, s := range sessions {
+		path := filepath.Join(root, s.Project, s.ID+".jsonl")
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return err
+		}
+		f, err := os.Create(path)
+		if err != nil {
+			return err
+		}
+		for _, m := range s.Messages {
+			line := struct {
+				Type    string `json:"type"`
+				ID      string `json:"sessionId"`
+				Time    string `json:"timestamp"`
+				Message struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				} `json:"message"`
+			}{Type: m.Role, ID: s.ID, Time: m.Time.UTC().Format(time.RFC3339), Message: struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			}{Role: m.Role, Content: m.Text}}
+			b, marshalErr := json.Marshal(line)
+			if marshalErr != nil {
+				_ = f.Close()
+				return marshalErr
+			}
+			if _, writeErr := fmt.Fprintln(f, string(b)); writeErr != nil {
+				_ = f.Close()
+				return writeErr
+			}
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isolateBenchEnv(root, claudeRoot, indexDir string) func() {
+	values := map[string]string{
+		"HOME": root, "USERPROFILE": root, "DEJA_INDEX_DIR": indexDir,
+		"DEJA_CLAUDE_ROOT": claudeRoot, "DEJA_CODEX_ROOT": filepath.Join(root, "codex"),
+		"DEJA_OPENCODE_DB": filepath.Join(root, "opencode.db"), "DEJA_AIDER_ROOTS": filepath.Join(root, "aider"),
+		"DEJA_GEMINI_ROOT": filepath.Join(root, "gemini"), "DEJA_CURSOR_ROOT": filepath.Join(root, "cursor"),
+		"DEJA_CURSOR_CLI_ROOT": filepath.Join(root, "cursor-cli"), "DEJA_ANTIGRAVITY_ROOT": filepath.Join(root, "antigravity"),
+		"DEJA_GROK_ROOT": filepath.Join(root, "grok"), "DEJA_QWEN_ROOT": filepath.Join(root, "qwen"),
+		"DEJA_NOTES_FILE": filepath.Join(root, "notes.jsonl"), "CLAUDE_CONFIG_DIR": filepath.Join(root, "claude-config"),
+		"CODEX_HOME": filepath.Join(root, "codex-home"), "GEMINI_CLI_HOME": filepath.Join(root, "gemini-home"),
+		"CURSOR_CONFIG_DIR": filepath.Join(root, "cursor-config"), "GROK_HOME": filepath.Join(root, "grok-home"),
+		"AIDER_CHAT_HISTORY_FILE": filepath.Join(root, "aider-history.md"), "XDG_CONFIG_HOME": filepath.Join(root, "config"),
+		"XDG_DATA_HOME": filepath.Join(root, "data"), "APPDATA": filepath.Join(root, "appdata"),
+	}
+	old := make(map[string]string)
+	for key, value := range values {
+		old[key] = os.Getenv(key)
+		_ = os.Setenv(key, value)
+	}
+	return func() {
+		for key, value := range old {
+			_ = os.Setenv(key, value)
+		}
+	}
+}
+
+func benchmarkTempDir() (string, error) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	parent := filepath.Join(workingDir, ".deja-bench")
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return "", err
+	}
+	return os.MkdirTemp(parent, "run-")
+}
+
+func printBenchReport(w io.Writer, report benchReport) {
+	fmt.Fprintf(w, "deja bench recall\ncorpus: %d sessions, %d queries\n", report.Sessions, report.Queries)
+	fmt.Fprintln(w, "mode    recall@5  recall@10  median latency")
+	fmt.Fprintf(w, "lexical %.2f      %.2f       %.2f ms\n", report.Lexical.RecallAt5, report.Lexical.RecallAt10, report.Lexical.MedianMS)
+	if report.Hybrid != nil {
+		fmt.Fprintf(w, "hybrid  %.2f      %.2f       %.2f ms\n", report.Hybrid.RecallAt5, report.Hybrid.RecallAt10, report.Hybrid.MedianMS)
+	} else {
+		fmt.Fprintln(w, "hybrid: endpoint unavailable, skipped")
+	}
+}

--- a/cmd/deja/bench_test.go
+++ b/cmd/deja/bench_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/bench"
+	"github.com/vshulcz/deja-vu/internal/embed"
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func TestBenchRecallJSONAndIsolation(t *testing.T) {
+	outside := t.TempDir()
+	t.Setenv("HOME", outside)
+	t.Setenv("USERPROFILE", outside)
+	t.Setenv("DEJA_EMBED_URL", "http://127.0.0.1:1")
+	out, err := captureRun(t, "bench", "recall", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		CorpusHash string `json:"corpus_hash"`
+		Sessions   int    `json:"sessions"`
+		Queries    int    `json:"queries"`
+		Lexical    struct {
+			RecallAt5  float64 `json:"recall_at_5"`
+			RecallAt10 float64 `json:"recall_at_10"`
+			MedianMS   float64 `json:"median_latency_ms"`
+		} `json:"lexical"`
+		HybridStatus string `json:"hybrid_status"`
+	}
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("invalid benchmark JSON %q: %v", out, err)
+	}
+	if len(report.CorpusHash) != 64 || report.Sessions != 500 || report.Queries != 50 || report.Lexical.RecallAt5 < 0.85 || report.Lexical.RecallAt10 < report.Lexical.RecallAt5 || report.Lexical.MedianMS < 0 || report.HybridStatus == "" {
+		t.Fatalf("unexpected benchmark report: %#v", report)
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("benchmark wrote outside its temp directory: %v", entries)
+	}
+}
+
+func TestBenchRecallHumanAndInvalidArgs(t *testing.T) {
+	t.Setenv("DEJA_EMBED_URL", "http://127.0.0.1:1")
+	out, err := captureRun(t, "bench", "recall")
+	if err != nil || !strings.Contains(out, "recall@5") || !strings.Contains(out, "hybrid: endpoint unavailable, skipped") {
+		t.Fatalf("human benchmark output=%q err=%v", out, err)
+	}
+	if _, err := captureRun(t, "bench", "other"); err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Fatal("invalid benchmark command did not fail")
+	}
+	if _, err := captureRun(t, "bench", "recall", "--bad"); err == nil {
+		t.Fatal("invalid benchmark flag did not fail")
+	}
+	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), "index.db")); !os.IsNotExist(err) {
+		t.Fatalf("unexpected real index path state: %v", err)
+	}
+}
+
+func TestBenchHelpers(t *testing.T) {
+	hits := []search.Hit{{Session: model.Session{ID: "one"}}, {Session: model.Session{ID: "two"}}}
+	if !containsRelevant(hits, []string{"one"}, 1) || containsRelevant(hits, []string{"two"}, 1) {
+		t.Fatal("relevance cutoff is wrong")
+	}
+	var out bytes.Buffer
+	printBenchReport(&out, benchReport{Sessions: 1, Queries: 1, Lexical: benchMetric{RecallAt5: 1}, Hybrid: &benchMetric{RecallAt10: 1}, HybridStatus: "available"})
+	if !strings.Contains(out.String(), "hybrid") {
+		t.Fatalf("hybrid report missing: %q", out.String())
+	}
+	if _, err := measureRecall(filepath.Join(t.TempDir(), "missing"), []bench.Query{{Text: "missing"}}, nil); err == nil {
+		t.Fatal("missing benchmark index did not fail")
+	}
+	root := t.TempDir()
+	when := time.Date(2099, time.January, 1, 0, 0, 0, 0, time.UTC)
+	session := model.Session{ID: "helper", Project: "project", Messages: []model.Message{{Role: "user", Text: "helper", Time: when}}}
+	if err := writeBenchCorpus(root, []model.Session{session}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "project", "helper.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+	badRoot := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(badRoot, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeBenchCorpus(badRoot, []model.Session{session}); err == nil {
+		t.Fatal("writing under a file did not fail")
+	}
+}
+
+func TestBenchmarkTempDirStaysInWorkspace(t *testing.T) {
+	dir, err := benchmarkTempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rel, err := filepath.Rel(workingDir, dir)
+	if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		t.Fatalf("benchmark temp dir escaped workspace: %q", dir)
+	}
+}
+
+func TestBenchmarkTempDirRejectsSquattedParent(t *testing.T) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(workingDir) }()
+	if err := os.WriteFile(filepath.Join(root, ".deja-bench"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := benchmarkTempDir(); err == nil {
+		t.Fatal("benchmark accepted a squatted scratch path")
+	}
+	if err := runBenchRecall(false); err == nil {
+		t.Fatal("benchmark ignored a squatted scratch path")
+	}
+}
+
+func TestMeasureRecallUsesFuzzyVariants(t *testing.T) {
+	root := t.TempDir()
+	corpus := bench.Generate(bench.Seed)
+	claudeRoot := filepath.Join(root, "claude")
+	if err := writeBenchCorpus(claudeRoot, corpus.Sessions); err != nil {
+		t.Fatal(err)
+	}
+	indexDir := filepath.Join(root, "index.db")
+	restore := isolateBenchEnv(root, claudeRoot, indexDir)
+	defer restore()
+	if err := index.EnsureForSearch(indexDir, search.Options{Query: "", All: true}, true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := measureRecall(indexDir, []bench.Query{{Text: "invaldtion", Relevant: []string{"session-000"}}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := measureRecall(indexDir, []bench.Query{{Text: "cache", Relevant: []string{"session-000"}}}, &embed.Client{}); err == nil {
+		t.Fatal("missing hybrid sidecar did not fail")
+	}
+}
+
+func TestBenchHybridWhenEndpointIsAvailable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("embedding request: %v", err)
+			return
+		}
+		vectors := make([][]float32, len(request.Input))
+		for i := range vectors {
+			vectors[i] = []float32{1}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"embeddings": vectors})
+	}))
+	defer server.Close()
+	t.Setenv("DEJA_EMBED_URL", server.URL)
+	if _, err := captureRun(t, "bench", "recall", "--json"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -108,6 +108,9 @@ func run(args []string) error {
 	if args[0] == "embed" {
 		return runEmbed(args[1:])
 	}
+	if args[0] == "bench" {
+		return runBench(args[1:])
+	}
 	if args[0] == "statusline" {
 		return runStatusline(os.Stdin, os.Stdout)
 	}
@@ -629,8 +632,9 @@ Usage:
   deja sources
   deja doctor [--json]
   deja warmup
-	deja index [--rebuild]
-	deja embed
+  deja index [--rebuild]
+  deja embed
+  deja bench recall [--json]
   deja statusline
 	deja stats [--json] [--card [path]]
 	deja remember "text" [--project name]

--- a/internal/bench/corpus.go
+++ b/internal/bench/corpus.go
@@ -11,10 +11,11 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
+const Seed int64 = 1
+
 const (
-	Seed         int64 = 1
-	SessionCount       = 500
-	QueryCount         = 50
+	SessionCount = 500
+	QueryCount   = 50
 )
 
 type Query struct {
@@ -43,7 +44,7 @@ var topics = []topic{
 	{name: "pool", exact: "connection pool exhausted", rephrased: "database clients ran out", typo: "exhaustd", phrase: "connection pool exhausted", code: "db/pool.go"},
 	{name: "oauth", exact: "refresh token rotation", rephrased: "renewing credentials after rotation", typo: "rotaton", phrase: "refresh token rotation", code: "auth/tokens.go"},
 	{name: "queue", exact: "duplicate job delivery", rephrased: "the worker received one task twice", typo: "delivry", phrase: "duplicate job delivery", code: "jobs/worker.go"},
-	{name: "parser", exact: "parser boundary error", rephrased: "the decoder crossed a record boundary", typo: "boundry", phrase: "parser boundary error", code: "internal/parse.go"},
+	{name: "parser", exact: "parser boundary error", rephrased: "the decoder crossed a record boundary", typo: "boundray", phrase: "parser boundary error", code: "internal/parse.go"},
 	{name: "timeout", exact: "request deadline timeout", rephrased: "the upstream call exceeded its deadline", typo: "deadine", phrase: "request deadline timeout", code: "net/client.go"},
 	{name: "locking", exact: "file lock contention", rephrased: "writers waited on the same lock", typo: "contetion", phrase: "file lock contention", code: "internal/lock.go"},
 	{name: "redaction", exact: "credential redaction", rephrased: "secrets are removed before indexing", typo: "redacton", phrase: "credential redaction", code: "security/redact.go"},

--- a/internal/bench/corpus.go
+++ b/internal/bench/corpus.go
@@ -1,0 +1,113 @@
+package bench
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+const (
+	Seed         int64 = 1
+	SessionCount       = 500
+	QueryCount         = 50
+)
+
+type Query struct {
+	Text     string
+	Relevant []string
+}
+
+type Corpus struct {
+	Sessions []model.Session
+	Queries  []Query
+	Hash     string
+}
+
+type topic struct {
+	name      string
+	exact     string
+	rephrased string
+	typo      string
+	phrase    string
+	code      string
+}
+
+var topics = []topic{
+	{name: "cache", exact: "cache invalidation", rephrased: "refreshing stale cache entries", typo: "invaldation", phrase: "cache invalidation race", code: "cache/refresh.go"},
+	{name: "migration", exact: "idempotent migration", rephrased: "safe repeatable schema upgrade", typo: "idempotnt", phrase: "idempotent migration", code: "db/migrate.go"},
+	{name: "pool", exact: "connection pool exhausted", rephrased: "database clients ran out", typo: "exhaustd", phrase: "connection pool exhausted", code: "db/pool.go"},
+	{name: "oauth", exact: "refresh token rotation", rephrased: "renewing credentials after rotation", typo: "rotaton", phrase: "refresh token rotation", code: "auth/tokens.go"},
+	{name: "queue", exact: "duplicate job delivery", rephrased: "the worker received one task twice", typo: "delivry", phrase: "duplicate job delivery", code: "jobs/worker.go"},
+	{name: "parser", exact: "parser boundary error", rephrased: "the decoder crossed a record boundary", typo: "boundry", phrase: "parser boundary error", code: "internal/parse.go"},
+	{name: "timeout", exact: "request deadline timeout", rephrased: "the upstream call exceeded its deadline", typo: "deadine", phrase: "request deadline timeout", code: "net/client.go"},
+	{name: "locking", exact: "file lock contention", rephrased: "writers waited on the same lock", typo: "contetion", phrase: "file lock contention", code: "internal/lock.go"},
+	{name: "redaction", exact: "credential redaction", rephrased: "secrets are removed before indexing", typo: "redacton", phrase: "credential redaction", code: "security/redact.go"},
+	{name: "recovery", exact: "crash recovery replay", rephrased: "rebuilding after an interrupted write", typo: "replai", phrase: "crash recovery replay", code: "index/recover.go"},
+}
+
+// Generate is the benchmark fixture. Every value, including timestamps and
+// IDs, comes from the fixed seed or the constants above.
+func Generate(seed int64) Corpus {
+	rng := rand.New(rand.NewSource(seed))
+	base := time.Date(2099, time.January, 2, 3, 4, 5, 0, time.UTC)
+	sessions := make([]model.Session, 0, SessionCount)
+	queries := make([]Query, 0, QueryCount)
+	for i := 0; i < SessionCount; i++ {
+		t := topics[i%len(topics)]
+		id := fmt.Sprintf("session-%03d", i)
+		project := fmt.Sprintf("project-%02d", i%25)
+		text := fmt.Sprintf("routine %s session %d recorded a harmless status update", t.name, i)
+		if i < QueryCount {
+			variant := i % 5
+			switch variant {
+			case 0:
+				text = fmt.Sprintf("decision: investigate %s; code reference %s", t.exact, t.code)
+			case 1:
+				text = fmt.Sprintf("error log: %s; decision: %s", t.exact, t.rephrased)
+			case 2:
+				text = fmt.Sprintf("error log mentions %s; the correct term is %s", t.typo, t.exact)
+			case 3:
+				text = fmt.Sprintf("decision recorded for %q in %s", t.phrase, t.code)
+			case 4:
+				text = fmt.Sprintf("code review for %s found the %s behavior", t.code, t.exact)
+			}
+			queries = append(queries, Query{Text: queryText(t, variant), Relevant: []string{id}})
+		}
+		noise := rng.Intn(1000)
+		sessions = append(sessions, model.Session{
+			ID: id, Harness: "claude", Project: project,
+			Started: base.Add(time.Duration(i) * time.Minute),
+			Updated: base.Add(time.Duration(i) * time.Minute),
+			Messages: []model.Message{
+				{Role: "user", Text: text, Time: base.Add(time.Duration(i) * time.Minute)},
+				{Role: "assistant", Text: fmt.Sprintf("reviewed result %d and kept the change local", noise), Time: base.Add(time.Duration(i)*time.Minute + time.Minute)},
+			},
+		})
+	}
+	b, _ := json.Marshal(struct {
+		Sessions []model.Session
+		Queries  []Query
+	}{sessions, queries})
+	h := sha256.Sum256(b)
+	return Corpus{Sessions: sessions, Queries: queries, Hash: hex.EncodeToString(h[:])}
+}
+
+func queryText(t topic, variant int) string {
+	switch variant {
+	case 0:
+		return t.exact
+	case 1:
+		return t.rephrased
+	case 2:
+		return t.typo
+	case 3:
+		return fmt.Sprintf("%q", t.phrase)
+	default:
+		return t.code
+	}
+}

--- a/internal/bench/corpus_test.go
+++ b/internal/bench/corpus_test.go
@@ -1,0 +1,27 @@
+package bench
+
+import "testing"
+
+func TestGenerateIsDeterministic(t *testing.T) {
+	a := Generate(Seed)
+	b := Generate(Seed)
+	if a.Hash != b.Hash || len(a.Sessions) != SessionCount || len(a.Queries) != QueryCount {
+		t.Fatalf("generator changed: hash %q/%q sessions=%d queries=%d", a.Hash, b.Hash, len(a.Sessions), len(a.Queries))
+	}
+	if a.Hash == Generate(2).Hash {
+		t.Fatal("different seeds produced the same corpus")
+	}
+}
+
+func TestQueriesHaveRelevantSessions(t *testing.T) {
+	c := Generate(Seed)
+	byID := make(map[string]bool, len(c.Sessions))
+	for _, s := range c.Sessions {
+		byID[s.ID] = true
+	}
+	for _, q := range c.Queries {
+		if len(q.Relevant) != 1 || !byID[q.Relevant[0]] {
+			t.Fatalf("invalid query relevance: %#v", q)
+		}
+	}
+}


### PR DESCRIPTION
Closes #144. deja bench recall generates a seeded 500-session corpus and 50 queries in a temp dir, runs them through the real pipeline, and reports recall@5/@10 with median latency (--json for scripting; hybrid column when an embedding endpoint is reachable). CI runs it on linux with a recall floor. The command never touches the user's real index.