### PR TITLE
docs: release prep for 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-19
+
+### Added
+- BM25 ranking with a user-message boost, quoted phrase queries, and a typo fallback that only runs on zero results.
+- Optional semantic recall: `deja embed` builds a vector sidecar from a local Ollama/LM Studio endpoint; search and MCP recall blend it with the lexical score.
+- `deja blame <path>` and an MCP `blame` tool: sessions that discussed a file, newest and most specific first.
+- `deja remember` and an MCP `remember` tool: durable notes stored as a tenth source with full redaction, sync and provenance.
+- Privacy set: `deja forget` with persistent tombstones, ingest exclusion patterns, and `deja stats --redaction` per-rule reports.
+- `deja stats --card` (shareable SVG) and `deja stats --html` (self-contained, metadata-only timeline).
+- Qwen Code as the ninth harness, `deja last --project/--harness` filters, a session format registry with conformance fixtures, and a reproducible `deja bench recall`.
+- User-level agent guidance written by install for Claude Code, Codex, Gemini, opencode, Antigravity, Qwen and Copilot.
+
+### Fixed
+- Torn lines longer than one scan window no longer lose messages.
+- `GROK_HOME`/`DEJA_GROK_ROOT` split: session-read overrides no longer move where install writes config.
+
+### Security
+- Index and usage files are created owner-only; install backups and new agent configs are 0600.
+- `deja resume` refuses session ids with shell-unsafe characters.
+- Agent-facing recall output is framed as untrusted historical data.
+
+## [0.12.0] - 2026-07-17
+
+See the release notes: harness coverage through Grok Build, `deja update`, signed checksums, npm and install-script distribution.
+
+## [0.11.0] - 2026-07-16
+
+See the release notes.
+
+## [0.10.0] - 2026-07-16
+
+See the release notes: Antigravity harness, share redaction hardening.
+
 ## [0.9.2] - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build and Qwen Code write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
 
-| | |
+| Feature | What it does |
 | --- | --- |
 | **Search** | `deja "connection pool exhausted"` — ~12 ms over gigabytes, retroactive: months of logs from before you installed it |
 | **Agent recall** | MCP `recall` tool — the agent answers *"we fixed this three weeks ago"* instead of re-debugging, across harnesses |
@@ -26,6 +26,8 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | **Share** | `deja share <id>` — hand a colleague a sanitized digest of a session, secrets already scrubbed |
 | **Sync** | `deja sync export/import` — move memory between machines, append-only, idempotent |
 | **Remember** | `deja remember "text"` or MCP `remember` — keep durable decisions and conclusions |
+| **Blame** | `deja blame <path>` — which sessions touched this file, what was decided and why |
+| **Semantic** | optional: point `deja embed` at a local Ollama/LM Studio and rephrased queries still hit |
 
 ## Privacy
 
@@ -230,7 +232,7 @@ The [session format registry](docs/registry/README.md) documents the observed st
 
 Measured on a real corpus — 1,250+ sessions, ~3.3GB across three harnesses:
 
-| | |
+| Measurement | Result |
 | --- | --- |
 | Warm search | **~12 ms** typical, ~25 ms worst-case |
 | Cold index (once) | ~10 s |

--- a/README.md
+++ b/README.md
@@ -249,11 +249,7 @@ deja bench recall
 deja bench recall --json
 ```
 
-The current lexical run reports recall@5 **1.00**, recall@10 **1.00**, and
-median latency **0.33 ms**; hybrid recall is skipped when no embedding
-endpoint is available. It generates 500 fixed-seed sessions and 50 derived
-queries, then runs them through the normal index and search pipeline; the
-[generator](internal/bench/corpus.go) defines the corpus and relevance.
+The synthetic set is currently saturated by lexical search (recall@5 1.00 at ~0.7 ms median), so it serves as a regression floor for ranking changes rather than a bragging number; CI fails if recall drops. The corpus generator and the relevance labels are ordinary reviewed Go — audit what "relevant" means before trusting any figure, ours included. With a local embedding endpoint up, the same command reports the hybrid column.
 
 ## How it works
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -170,6 +170,16 @@ a:hover{text-decoration:underline}
       <p>Nine harnesses — Claude Code, Codex, opencode, Cursor, Gemini CLI, aider, Antigravity, Grok Build, Qwen Code — one index, retroactively. A fix found in Codex is recalled inside Claude Code.</p>
     </div>
     <div class="card">
+      <div class="ic"><svg viewBox="0 0 24 24"><path d="M6 3v18M6 8h12l-3-3M18 8l-3 3"/></svg></div>
+      <h3>Blame for conversations</h3>
+      <p><code>deja blame &lt;path&gt;</code> — which sessions touched this file, what was decided and why. git blame, but for the discussions behind the code.</p>
+    </div>
+    <div class="card">
+      <div class="ic"><svg viewBox="0 0 24 24"><path d="M5 4h14v16l-7-4-7 4z"/></svg></div>
+      <h3>Notes that persist</h3>
+      <p><code>deja remember</code> and the MCP <code>remember</code> tool keep explicit decisions next to the recalled history — same index, same redaction, same provenance.</p>
+    </div>
+    <div class="card">
       <div class="ic"><svg viewBox="0 0 24 24"><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg></div>
       <h3>Secrets redacted</h3>
       <p>API keys, JWTs and private-key blocks are stripped at index time — the cache is safe to keep, shares and exports are safe to send.</p>


### PR DESCRIPTION
Feature-table and performance-table headers (they rendered as an empty first row), Blame and Semantic rows, two site cards, an honest wording of the saturated bench set, and the 0.13.0 changelog entry.