### PR TITLE
chore: point windows manifests at v0.13.0

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.12.0",
+    "version": "0.13.0",
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.12.0/deja-vu_0.12.0_windows_amd64.zip",
-            "hash": "fd32a9d1ef0ba07407b3045c84b5596893999028300c9e1c37c973e85be8f209"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.13.0/deja-vu_0.13.0_windows_amd64.zip",
+            "hash": "7a6221765221de74c1779a3cb921d55c6c42c601478b445b1a17547bd2ec529c"
         },
         "arm64": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.12.0/deja-vu_0.12.0_windows_arm64.zip",
-            "hash": "84d1bb250e59b9f07ea535cfde08dd10985ab4db953e64fbe5b5a081a7cb81cd"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.13.0/deja-vu_0.13.0_windows_arm64.zip",
+            "hash": "3a3bd81430bd119eb38775279adbf0b4f1c5ad0f78b529c5d29eaf7e091ab26c"
         }
     },
     "bin": "deja.exe",

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.12.0
+PackageVersion: 0.13.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.12.0/deja-vu_0.12.0_windows_amd64.zip
-  InstallerSha256: FD32A9D1EF0BA07407B3045C84B5596893999028300C9E1C37C973E85BE8F209
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.13.0/deja-vu_0.13.0_windows_amd64.zip
+  InstallerSha256: 7A6221765221DE74C1779A3CB921D55C6C42C601478B445B1A17547BD2EC529C
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.12.0/deja-vu_0.12.0_windows_arm64.zip
-  InstallerSha256: 84D1BB250E59B9F07EA535CFDE08DD10985AB4DB953E64FBE5B5A081A7CB81CD
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.13.0/deja-vu_0.13.0_windows_arm64.zip
+  InstallerSha256: 3A3BD81430BD119EB38775279ADBF0B4F1C5AD0F78B529C5D29EAF7E091AB26C
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.12.0
+PackageVersion: 0.13.0
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.12.0/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.13.0/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider
@@ -17,6 +17,6 @@ Tags:
 - cursor
 - mcp
 - memory
-ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.12.0
+ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.13.0
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.12.0
+PackageVersion: 0.13.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Scoop and winget manifests bumped to 0.13.0 with hashes from the release checksums.txt.