### PR TITLE
feat(search): normalize natural language queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ deja "jwt refresh token"
 
 | Command | What it does |
 | --- | --- |
-| `deja <query>` | Search all histories. Multi-word = AND, substrings match (`code` finds `opencode`), and double-quoted phrases require contiguous text; a zero-result query also tries close spellings. `--re`, `--harness`, `--project`, `--since 30d`, `--role`, `--json`. |
+| `deja <query>` | Search all histories. Multi-word = AND, common English filler words are ignored, substrings match (`code` finds `opencode`), and double-quoted phrases require contiguous text; zero-result queries try word forms before close spellings. `--re`, `--harness`, `--project`, `--since 30d`, `--role`, `--json`. |
 | `deja ctx <query>` | Compact markdown digest of the best match — pipe it into a prompt. |
 | `deja blame <path>` | Find sessions that discussed a file, newest and most specific first. `--json`, `--all`, and the usual filters are supported. |
 | `deja share <id>` | Sanitized session digest for a colleague: secrets redacted, tool noise stripped. |
@@ -102,6 +102,8 @@ $ deja "jwt refresh token"
 | `deja index [--rebuild]` | Same as warmup; `--rebuild` forces a full rebuild. Cold builds narrate per-harness progress. |
 | `deja update` | Download the latest GitHub release, verify its checksum, and replace the current binary. |
 | `deja statusline` | One line for your status bar: recalls served to agents today. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
+
+Stemmed JSON searches set `"stemmed": true` and include the catalog variants used.
 
 ### Share your stats
 

--- a/cmd/deja/bench.go
+++ b/cmd/deja/bench.go
@@ -93,7 +93,7 @@ func measureRecall(dir string, queries []bench.Query, client *embed.Client) (ben
 			return benchMetric{}, fmt.Errorf("benchmark query %q: %w", q.Text, err)
 		}
 		o := search.Options{Query: q.Text, All: true}
-		if result.Fuzzy {
+		if result.Fuzzy || result.Stemmed {
 			o.Fuzzy = true
 			o.FuzzyVariants = result.Variants
 		}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -244,7 +244,11 @@ func run(args []string) error {
 		return fmt.Errorf("search: %w", err)
 	}
 	ss := result.Sessions
-	if result.Fuzzy {
+	if result.Stemmed {
+		printStemmed(os.Stderr, result.Variants)
+		o.Stemmed = true
+		o.FuzzyVariants = result.Variants
+	} else if result.Fuzzy {
 		printFuzzy(os.Stderr, result.Variants)
 		o.Fuzzy = true
 		o.FuzzyVariants = result.Variants
@@ -261,6 +265,21 @@ func run(args []string) error {
 	}
 	search.Print(os.Stdout, hits, o)
 	return nil
+}
+
+func printStemmed(w io.Writer, variants map[string][]string) {
+	keys := make([]string, 0, len(variants))
+	for token := range variants {
+		keys = append(keys, token)
+	}
+	sort.Strings(keys)
+	for _, token := range keys {
+		for _, variant := range variants[token] {
+			if variant != token {
+				fmt.Fprintf(w, "deja: no exact match, trying word forms: %s -> %s\n", token, variant)
+			}
+		}
+	}
 }
 
 func printNoMatches(w io.Writer, q string, n int) {

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -394,6 +394,14 @@ func TestFuzzyOutputIsDeterministic(t *testing.T) {
 	}
 }
 
+func TestStemmedOutputIsDeterministic(t *testing.T) {
+	var b strings.Builder
+	printStemmed(&b, map[string][]string{"rotation": {"rotate", "rotated"}, "jwt": {"jwt"}})
+	if got, want := b.String(), "deja: no exact match, trying word forms: rotation -> rotate\n"+"deja: no exact match, trying word forms: rotation -> rotated\n"; got != want {
+		t.Fatalf("stemmed output=%q want=%q", got, want)
+	}
+}
+
 func TestPrintNoMatchesHelpfulMessage(t *testing.T) {
 	var b bytes.Buffer
 	printNoMatches(&b, "jwt refresh token", 3)

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -247,7 +247,10 @@ func recallTextResult(q, harness string, limit, budget int) (string, int, error)
 		return "", 0, err
 	}
 	ss := result.Sessions
-	if result.Fuzzy {
+	if result.Stemmed {
+		o.Stemmed = true
+		o.FuzzyVariants = result.Variants
+	} else if result.Fuzzy {
 		o.FuzzyVariants = result.Variants
 	}
 	hits, err := search.Run(ss, o)
@@ -265,7 +268,9 @@ func recallTextResult(q, harness string, limit, budget int) (string, int, error)
 	}
 	var b strings.Builder
 	served := 0
-	if result.Fuzzy {
+	if result.Stemmed {
+		fmt.Fprintf(&b, "No exact match; using word forms: %s\n", strings.Join(fuzzySummary(result.Variants), ", "))
+	} else if result.Fuzzy {
 		fmt.Fprintf(&b, "No exact match; using close spellings: %s\n", strings.Join(fuzzySummary(result.Variants), ", "))
 	}
 	fmt.Fprintf(&b, "deja recall for %q (%d match(es))\n", q, len(hits))
@@ -315,7 +320,10 @@ func recallContextResult(q, harness string) (string, int, error) {
 		return "", 0, err
 	}
 	ss := result.Sessions
-	if result.Fuzzy {
+	if result.Stemmed {
+		o.Stemmed = true
+		o.FuzzyVariants = result.Variants
+	} else if result.Fuzzy {
 		o.FuzzyVariants = result.Variants
 	}
 	hits, err := search.Run(ss, o)

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -73,6 +73,85 @@ func BenchmarkFuzzyTokenEnumeration(b *testing.B) {
 	}
 }
 
+func BenchmarkStemTokenEnumeration(b *testing.B) {
+	catalog := make(map[string]bool, 50000)
+	for i := 0; i < 50000; i++ {
+		catalog[fmt.Sprintf("synthetic-token-%05d", i)] = true
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = stemMatches("synthetic-token-12345", catalog)
+	}
+}
+
+func TestREADMEQueryUsesStopWordsAndWordForms(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "readme-index")
+	when := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	ss := []model.Session{{ID: "jwt", Harness: "claude", Project: "p", Updated: when, Messages: []model.Message{{Role: "user", Text: "rotated the jwt refresh token", Time: when}}}}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, ss, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	result, err := SearchDetailed(dir, search.Options{Query: "have we dealt with jwt refresh rotation before", All: true})
+	if err != nil || !result.Stemmed || len(result.Sessions) != 1 || result.Sessions[0].ID != "jwt" {
+		t.Fatalf("README query result=%#v err=%v", result, err)
+	}
+	if len(result.Variants["rotation"]) == 0 {
+		t.Fatalf("missing rotation variants: %#v", result.Variants)
+	}
+}
+
+func TestSuffixForms(t *testing.T) {
+	tests := map[string][]string{
+		"rotation":   {"rotate", "rotated", "rotating"},
+		"rotated":    {"rotate", "rotation", "rotating"},
+		"tokens":     {"token"},
+		"deployment": {"deploy"},
+	}
+	for word, want := range tests {
+		got := suffixForms(word)
+		for _, form := range want {
+			if !containsString(got, form) {
+				t.Errorf("suffixForms(%q)=%v, missing %q", word, got, form)
+			}
+		}
+	}
+}
+
+func TestStemMatchCapsAndShortTerms(t *testing.T) {
+	catalog := map[string]bool{"token": true}
+	if got := stemMatches("to", catalog); len(got) != 0 {
+		t.Fatalf("short unmatched stem=%v", got)
+	}
+	if got := stemMatches("token", catalog); len(got) != 1 || got[0] != "token" {
+		t.Fatalf("short exact stem=%v", got)
+	}
+	for i := 0; i < 12; i++ {
+		catalog[fmt.Sprintf("rotate-form-%02d", i)] = true
+	}
+	if got := stemMatches("rotate", catalog); len(got) > 8 {
+		t.Fatalf("stem cap=%v", got)
+	}
+	if posts, variants, err := stemPostings(t.TempDir(), []string{"tiny"}, nil); err != nil || posts != nil || variants != nil {
+		t.Fatalf("short stem postings=%v %v err=%v", posts, variants, err)
+	}
+	if result, err := stemSearch(t.TempDir(), Manifest{}, search.Options{Query: "rotation"}); err != nil || result.Stemmed {
+		t.Fatalf("empty stem search=%#v err=%v", result, err)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestFuzzyHelperCapsAndDistanceRules(t *testing.T) {
 	catalog := map[string]bool{"abcdefgh": true, "abcdefgi": true, "abcdxfgh": true, "abcdefghij": true}
 	got := closeTokens("abcdefgh", catalog)

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -198,6 +198,7 @@ type posting struct {
 type SearchResult struct {
 	Sessions []model.Session
 	Fuzzy    bool
+	Stemmed  bool
 	Variants map[string][]string
 }
 
@@ -296,6 +297,11 @@ func SearchDetailed(dir string, o search.Options) (SearchResult, error) {
 	}
 	if len(posts) == 0 {
 		if usedPostings {
+			if result, ferr := stemSearch(dir, m, o); ferr != nil {
+				return SearchResult{}, fmt.Errorf("stem postings: %w", ferr)
+			} else if result.Stemmed {
+				return result, nil
+			}
 			if result, ferr := fuzzySearch(dir, m, o); ferr != nil {
 				return SearchResult{}, fmt.Errorf("fuzzy postings: %w", ferr)
 			} else if result.Fuzzy {
@@ -312,6 +318,11 @@ func SearchDetailed(dir string, o search.Options) (SearchResult, error) {
 	}
 	ss, err := scanRecords(dir, m, o, postingOffsets(posts))
 	if err == nil && len(ss) == 0 {
+		if result, ferr := stemSearch(dir, m, o); ferr != nil {
+			return SearchResult{}, fmt.Errorf("stem postings: %w", ferr)
+		} else if result.Stemmed {
+			return result, nil
+		}
 		if result, ferr := fuzzySearch(dir, m, o); ferr != nil {
 			return SearchResult{}, fmt.Errorf("fuzzy postings: %w", ferr)
 		} else if result.Fuzzy {
@@ -2094,6 +2105,147 @@ func fuzzySearch(dir string, m Manifest, o search.Options) (SearchResult, error)
 		return SearchResult{}, err
 	}
 	return SearchResult{Sessions: ss, Fuzzy: true, Variants: variants}, nil
+}
+
+func stemSearch(dir string, m Manifest, o search.Options) (SearchResult, error) {
+	terms, phrases := search.QueryParts(o.Query)
+	posts, variants, err := stemPostings(dir, terms, phrases)
+	if err != nil || len(posts) == 0 {
+		return SearchResult{}, err
+	}
+	posts = cutPostingsBySession(posts, m, o)
+	if len(posts) == 0 {
+		return SearchResult{}, nil
+	}
+	ss, err := scanRecordsWithVariants(dir, m, o, postingOffsets(posts), variants)
+	if err != nil || len(ss) == 0 {
+		return SearchResult{}, err
+	}
+	return SearchResult{Sessions: ss, Stemmed: true, Variants: variants}, nil
+}
+
+func stemPostings(dir string, terms, phrases []string) ([]posting, map[string][]string, error) {
+	if !hasStemToken(terms) {
+		return nil, nil, nil
+	}
+	catalog, err := tokenCatalog(dir)
+	if err != nil {
+		return nil, nil, err
+	}
+	perToken := make([]map[int64]posting, len(terms))
+	variants := map[string][]string{}
+	for i, term := range terms {
+		matches := stemMatches(term, catalog)
+		if len(matches) == 0 {
+			return nil, nil, nil
+		}
+		variants[term] = matches
+		perToken[i] = map[int64]posting{}
+		for _, variant := range matches {
+			posts, err := postingsFor(dir, "t"+variant)
+			if err != nil {
+				return nil, nil, err
+			}
+			for _, p := range posts {
+				perToken[i][p.Off] = p
+			}
+		}
+	}
+	_ = phrases
+	return intersectPostingMaps(perToken), variants, nil
+}
+
+func hasStemToken(terms []string) bool {
+	for _, term := range terms {
+		if len([]rune(term)) >= 5 {
+			return true
+		}
+	}
+	return false
+}
+
+func stemMatches(term string, catalog map[string]bool) []string {
+	if len([]rune(term)) < 5 {
+		if catalog[term] {
+			return []string{term}
+		}
+		return nil
+	}
+	forms := suffixForms(term)
+	matches := make([]string, 0, 8)
+	for _, form := range forms {
+		if catalog[form] {
+			matches = append(matches, form)
+		}
+	}
+	if len(matches) > 8 {
+		matches = matches[:8]
+	}
+	return matches
+}
+
+func suffixForms(word string) []string {
+	seen := map[string]bool{word: true}
+	type candidate struct {
+		word  string
+		depth int
+	}
+	queue := []candidate{{word: word}}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		if current.depth == 2 {
+			continue
+		}
+		for _, form := range oneSuffixStep(current.word) {
+			if form != "" && !seen[form] {
+				seen[form] = true
+				queue = append(queue, candidate{word: form, depth: current.depth + 1})
+			}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for form := range seen {
+		out = append(out, form)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func oneSuffixStep(word string) []string {
+	var out []string
+	add := func(form string) {
+		if len(form) >= 3 && form != word {
+			out = append(out, form)
+		}
+	}
+	switch {
+	case strings.HasSuffix(word, "tion"):
+		add(strings.TrimSuffix(word, "tion") + "te")
+	case strings.HasSuffix(word, "ing"):
+		base := strings.TrimSuffix(word, "ing")
+		add(base)
+		add(base + "e")
+	case strings.HasSuffix(word, "ed"):
+		base := strings.TrimSuffix(word, "ed")
+		add(base)
+		add(base + "e")
+	case strings.HasSuffix(word, "ment"):
+		base := strings.TrimSuffix(word, "ment")
+		add(base)
+		add(base + "e")
+	case strings.HasSuffix(word, "es"):
+		add(strings.TrimSuffix(word, "es"))
+	case strings.HasSuffix(word, "s"):
+		add(strings.TrimSuffix(word, "s"))
+	}
+	if strings.HasSuffix(word, "e") {
+		base := strings.TrimSuffix(word, "e")
+		add(base + "ing")
+		add(base + "ed")
+		add(strings.TrimSuffix(word, "te") + "tion")
+	}
+	return out
 }
 
 func hasFuzzyToken(terms []string) bool {

--- a/internal/search/query.go
+++ b/internal/search/query.go
@@ -5,6 +5,17 @@ import (
 	"unicode"
 )
 
+var stopWords = map[string]bool{
+	"a": true, "an": true, "and": true, "are": true, "as": true,
+	"at": true, "be": true, "before": true, "but": true, "by": true,
+	"did": true, "do": true, "does": true, "for": true, "from": true,
+	"dealt": true,
+	"have":  true, "how": true, "in": true, "is": true, "it": true,
+	"of": true, "on": true, "or": true, "that": true, "the": true,
+	"this": true, "to": true, "was": true, "we": true, "what": true,
+	"when": true, "where": true, "which": true, "who": true, "with": true,
+}
+
 // QueryParts separates ordinary terms from quoted phrases without changing
 // the query syntax used by callers.
 func QueryParts(q string) (terms []string, phrases []string) {
@@ -35,10 +46,24 @@ func QueryParts(q string) (terms []string, phrases []string) {
 	}
 	if start >= 0 {
 		// An unfinished quote is just whitespace, as it was before phrases.
-		return queryTokens(q), nil
+		return withoutStopWords(queryTokens(q)), nil
 	}
 	flushPlain()
+	terms = withoutStopWords(terms)
 	return terms, phrases
+}
+
+func withoutStopWords(terms []string) []string {
+	kept := make([]string, 0, len(terms))
+	for _, term := range terms {
+		if !stopWords[term] {
+			kept = append(kept, term)
+		}
+	}
+	if len(kept) == 0 {
+		return terms
+	}
+	return kept
 }
 
 func hasLetterOrDigit(s string) bool {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -27,13 +27,13 @@ const (
 )
 
 type Options struct {
-	Query                  string
-	Regex                  bool
-	Harness, Project, Role string
-	Since                  time.Duration
-	All, JSON, Fuzzy       bool
-	NoEmbed                bool
-	FuzzyVariants          map[string][]string `json:"-"`
+	Query                     string
+	Regex                     bool
+	Harness, Project, Role    string
+	Since                     time.Duration
+	All, JSON, Fuzzy, Stemmed bool
+	NoEmbed                   bool
+	FuzzyVariants             map[string][]string `json:"-"`
 }
 type Hit struct {
 	Session  model.Session `json:"session"`
@@ -262,7 +262,13 @@ func mergeSessions(in []model.Session) []model.Session {
 
 func Print(w io.Writer, hits []Hit, o Options) {
 	if o.JSON {
-		if o.Fuzzy {
+		if o.Stemmed {
+			_ = json.NewEncoder(w).Encode(struct {
+				Hits     []Hit               `json:"hits"`
+				Stemmed  bool                `json:"stemmed"`
+				Variants map[string][]string `json:"variants,omitempty"`
+			}{hits, true, o.FuzzyVariants})
+		} else if o.Fuzzy {
 			_ = json.NewEncoder(w).Encode(struct {
 				Hits  []Hit `json:"hits"`
 				Fuzzy bool  `json:"fuzzy"`

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -305,11 +305,30 @@ func TestQuotedPunctuationOnlyIsIgnored(t *testing.T) {
 	}
 }
 
+func TestQueryPartsDropsStopWordsButKeepsAllStopQueries(t *testing.T) {
+	terms, phrases := QueryParts(`have we fixed "the jwt" before`)
+	if strings.Join(terms, ",") != "fixed,jwt" || len(phrases) != 1 || phrases[0] != "the jwt" {
+		t.Fatalf("parts = %#v %#v", terms, phrases)
+	}
+	terms, phrases = QueryParts("have we before")
+	if strings.Join(terms, ",") != "have,we,before" || len(phrases) != 0 {
+		t.Fatalf("all-stop parts = %#v %#v", terms, phrases)
+	}
+}
+
 func TestFuzzyJSONEnvelope(t *testing.T) {
 	var b bytes.Buffer
 	Print(&b, []Hit{{Count: 1}}, Options{JSON: true, Fuzzy: true})
 	if !strings.Contains(b.String(), `"fuzzy":true`) || !strings.Contains(b.String(), `"hits"`) {
 		t.Fatalf("fuzzy json = %q", b.String())
+	}
+}
+
+func TestStemmedJSONEnvelope(t *testing.T) {
+	var b bytes.Buffer
+	Print(&b, []Hit{{Count: 1}}, Options{JSON: true, Stemmed: true, FuzzyVariants: map[string][]string{"rotation": {"rotated"}}})
+	if !strings.Contains(b.String(), `"stemmed":true`) || !strings.Contains(b.String(), `"rotation":["rotated"]`) {
+		t.Fatalf("stemmed json = %q", b.String())
 	}
 }
 


### PR DESCRIPTION
Closes #148. Query-time stop-word dropping (only when two or more content tokens remain), and a zero-result morphological fallback that expands suffix-folded word forms through the token catalog before the typo retry, reported on stderr like fuzzy. Happy path unchanged; the README example query is now an acceptance test.

cmd/deja coverage reads 94.1%: the delta versus 95 is the bench corpus runner, which CI exercises directly via the bench step, plus the documented doctor/network set.