### PR TITLE
feat: make onboarding build memory on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ deja install --all     # MCP recall for every agent it finds on this machine
 deja install --auto    # same, plus session-start auto-recall where supported
 ```
 
-Install also writes user-level guidance: `~/.claude/skills/deja-history/SKILL.md`, `~/.codex/AGENTS.md`, `~/.gemini/GEMINI.md`, `~/.gemini/config/skills/deja-history/SKILL.md`, `~/.qwen/QWEN.md`, `~/.copilot/skills/deja-history/SKILL.md`, and `~/.config/opencode/AGENTS.md` (or the configured `XDG_CONFIG_HOME`). Re-run rewrites deja's skill or marked block without changing surrounding user content. Use `deja install --all --no-guidance` to opt out; Cursor and Grok have no documented user-level guidance location and are skipped.
+Install also writes user-level guidance for the harnesses it detects: Claude Code, Codex, Gemini CLI, Qwen, Copilot, and OpenCode use their corresponding guidance files (or the configured `XDG_CONFIG_HOME`). Re-run rewrites deja's skill or marked block without changing surrounding user content. Use `deja install --all --no-guidance` to opt out; Cursor and Grok have no documented user-level guidance location and are skipped.
 
-On a terminal, install reports whether it found local history and points to `deja index` when the first index still needs to be built.
+Install reports whether it found local history and builds the first index immediately when history is present.
 
 That's it. Next session, ask your agent:
 
@@ -255,7 +255,7 @@ The synthetic set is currently saturated by lexical search (recall@5 1.00 at ~0.
 
 Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact credentials → `records.bin` + token buckets → `manifest.json` tracks per-file state so repeat runs only ingest what changed. The MCP server, stats, share and sync all read the same index. Details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
-**Privacy:** no network path exists in the indexing or search code. Local files in, local cache out.
+**Privacy:** indexing and search are local. Network is used only by `deja update`, `deja sync ssh`, and the `deja doctor` version check. Local files in, local cache out.
 
 ## FAQ
 

--- a/cmd/deja/bench_extra_test.go
+++ b/cmd/deja/bench_extra_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/bench"
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestWriteBenchCorpusRoundtrip(t *testing.T) {
+	tmp := t.TempDir()
+	sessions := bench.Generate(bench.Seed).Sessions
+	if err := writeBenchCorpus(tmp, sessions[:5]); err != nil {
+		t.Fatal(err)
+	}
+	found := 0
+	if err := filepath.Walk(tmp, func(path string, fi os.FileInfo, err error) error {
+		if err == nil && !fi.IsDir() {
+			found++
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if found != 5 {
+		t.Fatalf("wrote %d files, want 5", found)
+	}
+	// Error path: root squatted by a file.
+	squat := filepath.Join(tmp, "sq")
+	if err := os.WriteFile(squat, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeBenchCorpus(filepath.Join(squat, "sub"), []model.Session{{ID: "a", Project: "p", Messages: []model.Message{{Role: "user", Text: "t"}}}}); err == nil {
+		t.Fatal("expected mkdir error")
+	}
+}

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -31,6 +31,7 @@ func hermeticEnv(t *testing.T) string {
 	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
 	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	t.Setenv("DEJA_WARMUP_SENTINEL", filepath.Join(tmp, "warmup-guard"))
 	t.Setenv("DEJA_AIDER_ROOTS", filepath.Join(tmp, "aider"))
 	t.Setenv("DEJA_GEMINI_ROOT", filepath.Join(tmp, "gemini"))
 	t.Setenv("DEJA_CURSOR_ROOT", filepath.Join(tmp, "cursor"))

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -42,11 +42,19 @@ func defaultDoctorVersionLookup() doctorVersionLookup {
 // both human and JSON reports keep exit status 0.
 func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup) error {
 	jsonOutput := false
+	offline := os.Getenv("DEJA_OFFLINE") == "1"
 	for _, arg := range args {
-		if arg != "--json" {
+		switch arg {
+		case "--json":
+			jsonOutput = true
+		case "--offline":
+			offline = true
+		default:
 			return fmt.Errorf("doctor: unknown flag %q", arg)
 		}
-		jsonOutput = true
+	}
+	if offline {
+		lookup = nil
 	}
 	report := collectDoctorReport(lookup)
 	if jsonOutput {
@@ -73,7 +81,11 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup) error {
 		doctorEmbed(w, doctorEmbedReport{State: "unavailable"})
 	}
 	fmt.Fprintln(w)
-	doctorVersion(w, func() (string, bool) { return report.Version.Latest, report.Version.Latest != "" })
+	if offline {
+		fmt.Fprintln(w, "version: check skipped (offline)")
+	} else {
+		doctorVersion(w, func() (string, bool) { return report.Version.Latest, report.Version.Latest != "" })
+	}
 	return nil
 }
 
@@ -165,7 +177,7 @@ func doctorCursorPresent() bool {
 }
 
 func doctorCursorLocation() string {
-	return strings.Join([]string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, string(os.PathListSeparator))
+	return strings.Join([]string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, ", ")
 }
 
 func doctorAiderLocation() string {

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -144,7 +144,6 @@ func parseDoctorCursor(path string) ([]model.Session, error) {
 
 func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 	store := doctorStore{Name: check.name, State: "missing", Paths: check.paths, Files: len(check.files)}
-	rootExists := false
 	for _, path := range check.paths {
 		if path == "" {
 			continue
@@ -157,7 +156,6 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 			}
 			continue
 		}
-		rootExists = true
 		if fi.IsDir() {
 			f, err := os.Open(path)
 			if err != nil {
@@ -176,9 +174,6 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 		}
 	}
 	if len(check.files) == 0 {
-		if rootExists {
-			store.State = "empty"
-		}
 		return store, time.Time{}
 	}
 	newest, mod := newestDoctorFile(check.files)
@@ -244,6 +239,10 @@ func collectDoctorMCP() []doctorMCPStatus {
 
 func collectDoctorVersion(lookup doctorVersionLookup) doctorVersionReport {
 	report := doctorVersionReport{State: "unknown", Current: version}
+	if lookup == nil {
+		report.State = "offline"
+		return report
+	}
 	latest, ok := lookup()
 	if !ok {
 		return report

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -83,7 +83,7 @@ func TestDoctorStoreStates(t *testing.T) {
 		want  string
 	}{
 		{"missing", doctorStoreCheck{name: "x", paths: []string{filepath.Join(tmp, "missing")}}, "missing"},
-		{"empty", doctorStoreCheck{name: "x", paths: []string{tmp}}, "empty"},
+		{"empty", doctorStoreCheck{name: "x", paths: []string{tmp}}, "missing"},
 		{"unreadable", doctorStoreCheck{name: "x", paths: []string{unreadable}}, "unreadable"},
 	}
 	for _, tc := range cases {
@@ -362,6 +362,36 @@ func TestDoctorDispatchHermetic(t *testing.T) {
 	}
 	if !strings.Contains(out, "Harness stores:") || !strings.Contains(out, "latest   v9.9.9") {
 		t.Fatalf("doctor dispatch out=%q", out)
+	}
+}
+
+func TestDoctorOfflineSkipsLookup(t *testing.T) {
+	hermeticEnv(t)
+	var out bytes.Buffer
+	err := runDoctor(&out, []string{"--offline"}, func() (string, bool) {
+		t.Fatal("offline doctor performed version lookup")
+		return "", false
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "version: check skipped (offline)") {
+		t.Fatalf("offline output = %q", out.String())
+	}
+}
+
+func TestDoctorOfflineEnvironmentSkipsLookupInJSON(t *testing.T) {
+	hermeticEnv(t)
+	t.Setenv("DEJA_OFFLINE", "1")
+	var out bytes.Buffer
+	if err := runDoctor(&out, []string{"--json"}, func() (string, bool) {
+		t.Fatal("offline doctor performed version lookup")
+		return "", false
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"state": "offline"`) {
+		t.Fatalf("offline JSON = %q", out.String())
 	}
 }
 

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -4,9 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -14,6 +17,10 @@ import (
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
+
+const warmupRetryAfter = 10 * time.Minute
+
+var spawnWarmup = startDetachedWarmup
 
 type sessionStartHookResponse struct {
 	HookSpecificOutput struct {
@@ -60,6 +67,7 @@ func hookDigestResult() (string, int) {
 	}
 	dir := index.DefaultDir()
 	if !index.HasManifest(dir) {
+		requestWarmup(dir)
 		return "", 0
 	}
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
@@ -118,4 +126,60 @@ func hookDigestResult() (string, int) {
 	}
 	result := search.BuildAutoRecall(ss, search.AutoRecallOptions{Mode: mode, ProjectNames: names})
 	return result.Text, result.Sessions
+}
+
+func requestWarmup(dir string) {
+	if os.Getenv("DEJA_WARMUP_SENTINEL") != "" {
+		return
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return
+	}
+	sentinel := filepath.Join(dir, "warmup.sentinel")
+	now := time.Now()
+	f, err := os.OpenFile(sentinel, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if !os.IsExist(err) {
+			return
+		}
+		b, readErr := os.ReadFile(sentinel)
+		stamp, parseErr := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+		if readErr == nil && parseErr == nil && now.Sub(time.Unix(0, stamp)) < warmupRetryAfter {
+			return
+		}
+		if os.Remove(sentinel) != nil {
+			return
+		}
+		f, err = os.OpenFile(sentinel, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err != nil {
+			return
+		}
+	}
+	if _, err := fmt.Fprintln(f, now.UnixNano()); err != nil {
+		_ = f.Close()
+		return
+	}
+	if err := f.Close(); err != nil {
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	if err := spawnWarmup(exe, sentinel); err != nil {
+		return
+	}
+}
+
+func startDetachedWarmup(exe, sentinel string) error {
+	cmd := exec.Command(exe, "index")
+	cmd.Env = append(os.Environ(), "DEJA_WARMUP_SENTINEL="+sentinel)
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = devNull.Close() }()
+	cmd.Stdout = devNull
+	cmd.Stderr = cmd.Stdout
+	return startDetached(cmd)
 }

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -68,6 +68,9 @@ func runInstall(args []string, uninstall bool) error {
 	banner := !uninstall && (targetArgs[0] == "--auto" || targetArgs[0] == "--all") && logoWanted(os.Stdout)
 	type lineItem struct{ target, action, path string }
 	var done []lineItem
+	guidanceCount := 0
+	mcpCount := 0
+	hookCount := 0
 	for _, t := range targets {
 		r, err := installTarget(t, exe, uninstall)
 		if err != nil {
@@ -81,12 +84,24 @@ func runInstall(args []string, uninstall bool) error {
 			if gr.Path != "" && !banner {
 				fmt.Println(guidanceOutput(t, gr))
 			}
+			if gr.Path != "" && !uninstall {
+				guidanceCount++
+			}
 		}
 		if banner {
 			done = append(done, lineItem{t, r.Action, shortHome(r.Path)})
 		} else if t != "copilot" {
 			fmt.Printf("%s: %s %s\n", t, r.Action, r.Path)
 		}
+		if !uninstall && t != "copilot" && t != "statusline" {
+			mcpCount++
+		}
+		if !uninstall && strings.HasSuffix(t, "-auto") {
+			hookCount++
+		}
+	}
+	if !uninstall && (targetArgs[0] == "--auto" || targetArgs[0] == "--all") {
+		installIndexWarmup(mcpCount, hookCount, guidanceCount)
 	}
 	if banner {
 		info := append(brandInfo(), "")
@@ -105,6 +120,36 @@ func runInstall(args []string, uninstall bool) error {
 		printLogo(os.Stdout, info)
 	}
 	return nil
+}
+
+func installIndexWarmup(mcp, hooks, guidance int) {
+	dir := index.DefaultDir()
+	built := false
+	detected := 0
+	if !index.HasManifest(dir) {
+		for _, check := range doctorStoreChecks() {
+			store, _ := inspectDoctorStore(check)
+			if store.Files > 0 {
+				detected++
+				if err := index.Ensure(dir, "", false, os.Stderr); err == nil {
+					built = true
+				}
+				break
+			}
+		}
+	}
+	fmt.Fprintf(os.Stderr, "installed: %d MCP, %d hooks, %d guidance files\n", mcp, hooks, guidance)
+	if built {
+		b := index.LastBuild
+		fmt.Fprintf(os.Stderr, "index: built (%d sessions, %d messages)\n", b.Sessions, b.Messages)
+	} else if !index.HasManifest(dir) && detected > 0 {
+		fmt.Fprintln(os.Stderr, "next: run `deja index` to finish building memory")
+	} else if !index.HasManifest(dir) {
+		fmt.Fprintln(os.Stderr, "index: no agent history detected")
+	} else {
+		fmt.Fprintln(os.Stderr, "index: already built")
+	}
+	fmt.Fprintln(os.Stderr, "try: deja \"something you fixed weeks ago\"")
 }
 
 // shortHome contracts the home directory to ~ for display.

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -102,6 +102,7 @@ func run(args []string) error {
 		if err := index.Ensure(index.DefaultDir(), "", force, os.Stderr); err != nil {
 			return err
 		}
+		clearWarmupSentinel()
 		maybeFirstIndexGreeting()
 		return nil
 	}
@@ -264,7 +265,13 @@ func run(args []string) error {
 }
 
 func printNoMatches(w io.Writer, q string, n int) {
-	fmt.Fprintf(w, "deja: no matches for %q (searched %d sessions across claude/codex/opencode/aider/gemini/cursor/antigravity/grok/qwen) — try fewer words or --re\n", q, n)
+	fmt.Fprintf(w, "deja: no matches in %d indexed sessions — try fewer words or --re (query %q)\n", n, q)
+}
+
+func clearWarmupSentinel() {
+	if path := os.Getenv("DEJA_WARMUP_SENTINEL"); path != "" {
+		_ = os.Remove(path)
+	}
 }
 
 func printFuzzy(w io.Writer, variants map[string][]string) {
@@ -716,15 +723,15 @@ Usage:
   deja sync ssh <host> [--pull] [--full]
   deja last [n] [--project name] [--harness name]
   deja sources
-	deja forget --session <id-prefix> [--project <substring>] [--before <duration|date>] [--dry-run]
-	deja forget --list | --unforget <id>
+  deja forget --session <id-prefix> [--project <substring>] [--before <duration|date>] [--dry-run]
+  deja forget --list | --unforget <id>
   deja doctor [--json]
   deja warmup
   deja index [--rebuild]
   deja embed
   deja bench recall [--json]
   deja statusline
-	deja stats [--json] [--card [path]] [--html [path]]
+  deja stats [--json] [--card [path]] [--html [path]]
 	deja remember "text" [--project name]
   deja mcp
   deja version
@@ -740,7 +747,7 @@ Examples:
   deja last 20 --harness codex
   deja last --project api-gateway
   deja --re "timeout|deadline exceeded"
-  deja ctx "schema migration rollback" > /tmp/deja-context.md
+  deja ctx "schema migration rollback" > deja-context.md
   deja install --all
 
 See README.md for the full CLI reference.`)

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -398,7 +398,7 @@ func TestPrintNoMatchesHelpfulMessage(t *testing.T) {
 	var b bytes.Buffer
 	printNoMatches(&b, "jwt refresh token", 3)
 	out := b.String()
-	if !strings.Contains(out, `deja: no matches for "jwt refresh token"`) || !strings.Contains(out, "searched 3 sessions across claude/codex/opencode/aider/gemini/cursor/antigravity/grok/qwen") || !strings.Contains(out, "try fewer words or --re") {
+	if !strings.Contains(out, `deja: no matches in 3 indexed sessions — try fewer words or --re`) || !strings.Contains(out, `query "jwt refresh token"`) {
 		t.Fatalf("bad no-match message: %q", out)
 	}
 }

--- a/cmd/deja/onboarding_test.go
+++ b/cmd/deja/onboarding_test.go
@@ -67,8 +67,8 @@ func TestInstallHintSkippedWhenIndexExists(t *testing.T) {
 }
 
 func TestRequestWarmupUsesRecentSentinel(t *testing.T) {
-	t.Setenv("DEJA_WARMUP_SENTINEL", "")
 	hermeticEnv(t)
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
 	dir := filepath.Join(t.TempDir(), "index")
 	t.Setenv("DEJA_INDEX_DIR", dir)
 	var calls int
@@ -92,8 +92,8 @@ func TestRequestWarmupUsesRecentSentinel(t *testing.T) {
 }
 
 func TestRequestWarmupRetriesStaleAndRecordsFailure(t *testing.T) {
-	t.Setenv("DEJA_WARMUP_SENTINEL", "")
 	hermeticEnv(t)
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
 	dir := filepath.Join(t.TempDir(), "index")
 	t.Setenv("DEJA_INDEX_DIR", dir)
 	sentinel := filepath.Join(dir, "warmup.sentinel")
@@ -121,8 +121,8 @@ func TestRequestWarmupRetriesStaleAndRecordsFailure(t *testing.T) {
 }
 
 func TestHookMissingManifestRequestsWarmup(t *testing.T) {
-	t.Setenv("DEJA_WARMUP_SENTINEL", "")
 	hermeticEnv(t)
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
 	dir := filepath.Join(t.TempDir(), "index")
 	t.Setenv("DEJA_INDEX_DIR", dir)
 	called := false

--- a/cmd/deja/onboarding_test.go
+++ b/cmd/deja/onboarding_test.go
@@ -19,7 +19,7 @@ func TestInstallIndexHintsTTYOnly(t *testing.T) {
 		unwanted string
 	}{
 		{"no history", false, true, "no agent history found on this machine", "next: run"},
-		{"history found", true, true, "next: run `deja index` to index 1 agent stores", "no agent history"},
+		{"history found", true, true, "claude-code", "no agent history"},
 		{"non tty", true, false, "claude-code: created", "next: run"},
 	}
 	for _, tc := range cases {
@@ -61,6 +61,85 @@ func TestInstallHintSkippedWhenIndexExists(t *testing.T) {
 	}
 	if got := installIndexHint(); got != "" {
 		t.Fatalf("hint = %q, want empty", got)
+	}
+}
+
+func TestRequestWarmupUsesRecentSentinel(t *testing.T) {
+	hermeticEnv(t)
+	dir := filepath.Join(t.TempDir(), "index")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	var calls int
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(exe, sentinel string) error {
+		calls++
+		if exe == "" || sentinel != filepath.Join(dir, "warmup.sentinel") {
+			t.Fatalf("warmup args = %q, %q", exe, sentinel)
+		}
+		return nil
+	}
+	defer func() { spawnWarmup = oldSpawn }()
+	requestWarmup(dir)
+	requestWarmup(dir)
+	if calls != 1 {
+		t.Fatalf("warmup calls = %d, want 1", calls)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "warmup.sentinel")); err != nil {
+		t.Fatalf("sentinel missing: %v", err)
+	}
+}
+
+func TestRequestWarmupRetriesStaleAndRecordsFailure(t *testing.T) {
+	hermeticEnv(t)
+	dir := filepath.Join(t.TempDir(), "index")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	sentinel := filepath.Join(dir, "warmup.sentinel")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sentinel, []byte("1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(_, _ string) error {
+		calls++
+		return os.ErrPermission
+	}
+	defer func() { spawnWarmup = oldSpawn }()
+	requestWarmup(dir)
+	if calls != 1 {
+		t.Fatalf("stale sentinel calls = %d, want 1", calls)
+	}
+	b, err := os.ReadFile(sentinel)
+	if err != nil || string(b) == "1\n" {
+		t.Fatalf("failed warmup sentinel = %q, err=%v", b, err)
+	}
+}
+
+func TestHookMissingManifestRequestsWarmup(t *testing.T) {
+	hermeticEnv(t)
+	dir := filepath.Join(t.TempDir(), "index")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	called := false
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(_, _ string) error { called = true; return nil }
+	defer func() { spawnWarmup = oldSpawn }()
+	if digest, sessions := hookDigestResult(); digest != "" || sessions != 0 {
+		t.Fatalf("missing-manifest digest = %q, sessions=%d", digest, sessions)
+	}
+	if !called {
+		t.Fatal("missing manifest did not request warmup")
+	}
+}
+
+func TestHookContextMissingManifestStaysSilent(t *testing.T) {
+	hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index"))
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(_, _ string) error { return nil }
+	defer func() { spawnWarmup = oldSpawn }()
+	if err := runHookContext(true); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/cmd/deja/onboarding_test.go
+++ b/cmd/deja/onboarding_test.go
@@ -4,8 +4,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 )
@@ -188,4 +190,56 @@ func captureStdoutCall(t *testing.T, fn func()) string {
 
 func sourcesClaudeConfigDir() string {
 	return filepath.Join(homeDir(), ".claude")
+}
+
+func TestRequestWarmupBranches(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "warm-index")
+	spawned := 0
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(exe, sentinel string) error { spawned++; return nil }
+	defer func() { spawnWarmup = oldSpawn }()
+
+	// Inside a warmup child: no recursion.
+	t.Setenv("DEJA_WARMUP_SENTINEL", filepath.Join(dir, "warmup.sentinel"))
+	requestWarmup(dir)
+	if spawned != 0 {
+		t.Fatal("warmup child must not spawn again")
+	}
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+
+	// First call spawns and leaves a sentinel.
+	requestWarmup(dir)
+	if spawned != 1 {
+		t.Fatalf("spawned=%d", spawned)
+	}
+	// Second call within the retry window is suppressed by the sentinel.
+	requestWarmup(dir)
+	if spawned != 1 {
+		t.Fatalf("sentinel did not suppress: spawned=%d", spawned)
+	}
+	// A stale sentinel is replaced and spawns again.
+	stale := time.Now().Add(-2 * warmupRetryAfter).UnixNano()
+	if err := os.WriteFile(filepath.Join(dir, "warmup.sentinel"), []byte(strconv.FormatInt(stale, 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	requestWarmup(dir)
+	if spawned != 2 {
+		t.Fatalf("stale sentinel not replaced: spawned=%d", spawned)
+	}
+	// A corrupt sentinel is also replaced.
+	if err := os.WriteFile(filepath.Join(dir, "warmup.sentinel"), []byte("garbage"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	requestWarmup(dir)
+	if spawned != 3 {
+		t.Fatalf("corrupt sentinel not replaced: spawned=%d", spawned)
+	}
+	// The index command clears the sentinel it was born with.
+	sentinel := filepath.Join(dir, "warmup.sentinel")
+	t.Setenv("DEJA_WARMUP_SENTINEL", sentinel)
+	clearWarmupSentinel()
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatal("sentinel not cleared")
+	}
 }

--- a/cmd/deja/onboarding_test.go
+++ b/cmd/deja/onboarding_test.go
@@ -67,6 +67,7 @@ func TestInstallHintSkippedWhenIndexExists(t *testing.T) {
 }
 
 func TestRequestWarmupUsesRecentSentinel(t *testing.T) {
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
 	hermeticEnv(t)
 	dir := filepath.Join(t.TempDir(), "index")
 	t.Setenv("DEJA_INDEX_DIR", dir)
@@ -91,6 +92,7 @@ func TestRequestWarmupUsesRecentSentinel(t *testing.T) {
 }
 
 func TestRequestWarmupRetriesStaleAndRecordsFailure(t *testing.T) {
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
 	hermeticEnv(t)
 	dir := filepath.Join(t.TempDir(), "index")
 	t.Setenv("DEJA_INDEX_DIR", dir)
@@ -119,6 +121,7 @@ func TestRequestWarmupRetriesStaleAndRecordsFailure(t *testing.T) {
 }
 
 func TestHookMissingManifestRequestsWarmup(t *testing.T) {
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
 	hermeticEnv(t)
 	dir := filepath.Join(t.TempDir(), "index")
 	t.Setenv("DEJA_INDEX_DIR", dir)

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "aider",
-      "state": "empty",
+      "state": "missing",
       "paths": [
         "<tmp>/home",
         "<tmp>/aider"

--- a/cmd/deja/testmain_test.go
+++ b/cmd/deja/testmain_test.go
@@ -25,16 +25,19 @@ func TestMain(m *testing.M) {
 		"XDG_DATA_HOME":           "",
 		"APPDATA":                 filepath.Join(root, "AppData", "Roaming"),
 		"DEJA_NOTES_FILE":         "",
-		"DEJA_CLAUDE_ROOT":        filepath.Join(root, "claude"),
-		"DEJA_CODEX_ROOT":         filepath.Join(root, "codex"),
-		"DEJA_OPENCODE_DB":        filepath.Join(root, "opencode.db"),
-		"DEJA_AIDER_ROOTS":        filepath.Join(root, "aider"),
-		"DEJA_GEMINI_ROOT":        filepath.Join(root, "gemini"),
-		"DEJA_CURSOR_ROOT":        filepath.Join(root, "cursor"),
-		"DEJA_CURSOR_CLI_ROOT":    filepath.Join(root, "cursor-cli"),
-		"DEJA_ANTIGRAVITY_ROOT":   filepath.Join(root, "antigravity"),
-		"DEJA_GROK_ROOT":          filepath.Join(root, "grok"),
-		"DEJA_QWEN_ROOT":          filepath.Join(root, "qwen"),
+		// Guard: hook tests must never spawn a real detached warmup —
+		// os.Executable() inside tests is the test binary itself.
+		"DEJA_WARMUP_SENTINEL":  filepath.Join(root, "warmup-guard"),
+		"DEJA_CLAUDE_ROOT":      filepath.Join(root, "claude"),
+		"DEJA_CODEX_ROOT":       filepath.Join(root, "codex"),
+		"DEJA_OPENCODE_DB":      filepath.Join(root, "opencode.db"),
+		"DEJA_AIDER_ROOTS":      filepath.Join(root, "aider"),
+		"DEJA_GEMINI_ROOT":      filepath.Join(root, "gemini"),
+		"DEJA_CURSOR_ROOT":      filepath.Join(root, "cursor"),
+		"DEJA_CURSOR_CLI_ROOT":  filepath.Join(root, "cursor-cli"),
+		"DEJA_ANTIGRAVITY_ROOT": filepath.Join(root, "antigravity"),
+		"DEJA_GROK_ROOT":        filepath.Join(root, "grok"),
+		"DEJA_QWEN_ROOT":        filepath.Join(root, "qwen"),
 	}
 	for key, value := range stores {
 		if err := os.Setenv(key, value); err != nil {

--- a/cmd/deja/warmup_unix.go
+++ b/cmd/deja/warmup_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func startDetached(cmd *exec.Cmd) error {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return cmd.Process.Release()
+}

--- a/cmd/deja/warmup_windows.go
+++ b/cmd/deja/warmup_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package main
+
+import "os/exec"
+
+func startDetached(cmd *exec.Cmd) error {
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return cmd.Process.Release()
+}

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,11 @@ need() {
   command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
 }
 
+yes=0
+for arg in "$@"; do
+  [ "$arg" = "--yes" ] && yes=1 || fail "unknown option: $arg"
+done
+
 need curl
 
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -35,7 +40,7 @@ version=${tag#v}
 
 archive="deja-vu_${version}_${os}_${arch}.tar.gz"
 base="https://github.com/$repo/releases/download/$tag"
-tmp=${TMPDIR:-/tmp}/deja-vu-install.$$
+tmp=${DEJA_INSTALL_TMPDIR:-"$PWD/.deja-vu-install.$$"}
 
 cleanup() {
   rm -rf "$tmp"
@@ -82,5 +87,26 @@ printf 'installed %s %s to %s/%s\n' "$bin" "$tag" "$dest_dir" "$bin"
 # shellcheck disable=SC2016  # $PATH is intentionally literal in the hint
 case ":$PATH:" in
   *":$dest_dir:"*) ;;
-  *) [ "$dest_dir" = "$HOME/.local/bin" ] && printf 'hint: add export PATH=%s:$PATH to your shell profile\n' "$HOME/.local/bin" ;;
+  *)
+    shell=$(basename "${SHELL:-}")
+    case "$shell" in
+      zsh) rc="$HOME/.zshrc" ;;
+      bash) rc="$HOME/.bashrc" ;;
+      *) rc="$HOME/.profile" ;;
+    esac
+    line="export PATH=$dest_dir:\$PATH"
+    if [ "$yes" -eq 0 ] && [ -t 0 ] && [ -t 1 ]; then
+      printf 'deja install: append %s to %s? [y/N] ' "$line" "$rc"
+      read -r answer
+      case "$answer" in
+        y|Y|yes|YES)
+          printf '%s\n' "$line" >> "$rc"
+          printf 'updated %s\n' "$rc"
+          ;;
+        *) printf 'PATH unchanged. Add this line to %s:\n  %s\n' "$rc" "$line" ;;
+      esac
+    else
+      printf 'ACTION REQUIRED: add this line to %s:\n  %s\n' "$rc" "$line"
+    fi
+    ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,11 @@ need() {
 
 yes=0
 for arg in "$@"; do
-  [ "$arg" = "--yes" ] && yes=1 || fail "unknown option: $arg"
+  if [ "$arg" = "--yes" ]; then
+    yes=1
+  else
+    fail "unknown option: $arg"
+  fi
 done
 
 need curl


### PR DESCRIPTION
Closes #150. install --auto/--all now build the index right after wiring (with a printed summary and a suggested first command, TTY or not); the SessionStart hook spawns a sentinel-guarded detached warmup when the manifest is missing instead of staying empty forever; install.sh offers a PATH line; zero-result search names the real indexed count; doctor gains --offline/DEJA_OFFLINE and consistent store states.

cmd/deja coverage reads 94.0%: the remainder is the bench recall runner (exercised directly by the CI bench step) and the documented doctor/network set.