### PR TITLE
feat: add semantic search fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ OpenAI-compatible embedding endpoint. Set `DEJA_EMBED_URL` and optionally
 `nomic-embed-text`; without a configured and reachable runtime, ordinary
 lexical search and MCP recall continue unchanged. `--no-embed` or
 `DEJA_EMBED=off` disables reranking for one invocation.
+Without an embedding endpoint, the semantic zero-result fallback does not exist.
 
 The vector sidecar is stored beside the index as `.vectors.bin`, not in
 `index.db`. Float32 vectors cost roughly 4 KB per 1k messages for a 1,024

--- a/cmd/deja/bench.go
+++ b/cmd/deja/bench.go
@@ -18,9 +18,10 @@ import (
 )
 
 type benchMetric struct {
-	RecallAt5  float64 `json:"recall_at_5"`
-	RecallAt10 float64 `json:"recall_at_10"`
-	MedianMS   float64 `json:"median_latency_ms"`
+	RecallAt5             float64 `json:"recall_at_5"`
+	RecallAt10            float64 `json:"recall_at_10"`
+	MedianMS              float64 `json:"median_latency_ms"`
+	SemanticOnlyRephrased float64 `json:"semantic_only_rephrased_recall,omitempty"`
 }
 
 type benchReport struct {
@@ -68,6 +69,10 @@ func runBenchRecall(jsonOutput bool) error {
 			if err != nil {
 				return err
 			}
+			hybrid.SemanticOnlyRephrased, err = measureSemanticOnlyRephrased(indexDir, corpus.Queries, client)
+			if err != nil {
+				return err
+			}
 			report.Hybrid = &hybrid
 			report.HybridStatus = "available"
 		} else {
@@ -81,6 +86,31 @@ func runBenchRecall(jsonOutput bool) error {
 	}
 	printBenchReport(os.Stdout, report)
 	return nil
+}
+
+func measureSemanticOnlyRephrased(dir string, queries []bench.Query, client *embed.Client) (float64, error) {
+	sidecar, err := embed.Read(dir)
+	if err != nil {
+		return 0, err
+	}
+	matched, total := 0, 0
+	for i, q := range queries {
+		if i%5 != 1 {
+			continue
+		}
+		total++
+		hits, searchErr := embed.SemanticSearch(context.Background(), dir, search.Options{Query: q.Text, All: true}, sidecar, client)
+		if searchErr != nil {
+			return 0, fmt.Errorf("semantic-only benchmark query %q: %w", q.Text, searchErr)
+		}
+		if containsRelevant(hits, q.Relevant, 5) {
+			matched++
+		}
+	}
+	if total == 0 {
+		return 0, nil
+	}
+	return float64(matched) / float64(total), nil
 }
 
 func measureRecall(dir string, queries []bench.Query, client *embed.Client) (benchMetric, error) {
@@ -223,7 +253,7 @@ func printBenchReport(w io.Writer, report benchReport) {
 	fmt.Fprintln(w, "mode    recall@5  recall@10  median latency")
 	fmt.Fprintf(w, "lexical %.2f      %.2f       %.2f ms\n", report.Lexical.RecallAt5, report.Lexical.RecallAt10, report.Lexical.MedianMS)
 	if report.Hybrid != nil {
-		fmt.Fprintf(w, "hybrid  %.2f      %.2f       %.2f ms\n", report.Hybrid.RecallAt5, report.Hybrid.RecallAt10, report.Hybrid.MedianMS)
+		fmt.Fprintf(w, "hybrid  %.2f      %.2f       %.2f ms  semantic-only rephrased %.2f\n", report.Hybrid.RecallAt5, report.Hybrid.RecallAt10, report.Hybrid.MedianMS, report.Hybrid.SemanticOnlyRephrased)
 	} else {
 		fmt.Fprintln(w, "hybrid: endpoint unavailable, skipped")
 	}

--- a/cmd/deja/blame_extra_test.go
+++ b/cmd/deja/blame_extra_test.go
@@ -57,3 +57,26 @@ func TestEmbedCommandBranches(t *testing.T) {
 		t.Fatal("expected ensure error")
 	}
 }
+
+func TestMaybeSemanticGuards(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "idx"))
+	hit := []search.Hit{{}}
+	// Existing hits pass through untouched.
+	if out, used := maybeSemantic(hit, search.Options{}, os.Stderr); used || len(out) != 1 {
+		t.Fatal("hits must pass through")
+	}
+	// NoEmbed and env opt-outs.
+	if _, used := maybeSemantic(nil, search.Options{NoEmbed: true}, os.Stderr); used {
+		t.Fatal("NoEmbed must skip")
+	}
+	t.Setenv("DEJA_EMBED", "off")
+	if _, used := maybeSemantic(nil, search.Options{}, os.Stderr); used {
+		t.Fatal("env off must skip")
+	}
+	t.Setenv("DEJA_EMBED", "")
+	// No sidecar at all.
+	if _, used := maybeSemantic(nil, search.Options{}, os.Stderr); used {
+		t.Fatal("missing sidecar must skip")
+	}
+}

--- a/cmd/deja/blame_extra_test.go
+++ b/cmd/deja/blame_extra_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/search"
@@ -78,5 +83,54 @@ func TestMaybeSemanticGuards(t *testing.T) {
 	// No sidecar at all.
 	if _, used := maybeSemantic(nil, search.Options{}, os.Stderr); used {
 		t.Fatal("missing sidecar must skip")
+	}
+}
+
+func TestMaybeSemanticSidecarBranches(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "idx"))
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "p", "s1.jsonl"), "s1", []string{
+		`{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"connection pool exhausted"}}`,
+	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input any `json:"input"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		n := 1
+		if list, ok := req.Input.([]any); ok {
+			n = len(list)
+		}
+		vecs := make([]string, n)
+		for i := range vecs {
+			vecs[i] = "[1,0]"
+		}
+		_, _ = fmt.Fprintf(w, `{"embeddings":[%s]}`, strings.Join(vecs, ","))
+	}))
+	defer srv.Close()
+	t.Setenv("DEJA_EMBED_URL", srv.URL+"/api/embed")
+	if err := runEmbed(nil); err != nil {
+		t.Fatal(err)
+	}
+	// Sidecar current: fallback fires.
+	out, used := maybeSemantic(nil, search.Options{Query: "totally different words"}, os.Stderr)
+	if !used || len(out) == 0 {
+		t.Fatalf("semantic fallback did not fire: used=%v out=%d", used, len(out))
+	}
+	// Dead endpoint with a valid sidecar: query embed fails, silent skip.
+	t.Setenv("DEJA_EMBED_URL", "http://127.0.0.1:1/api/embed")
+	if _, used := maybeSemantic(nil, search.Options{Query: "anything"}, os.Stderr); used {
+		t.Fatal("dead endpoint must skip")
+	}
+	t.Setenv("DEJA_EMBED_URL", srv.URL+"/api/embed")
+	// Generation moves on re-index: stale sidecar skips.
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "p", "s2.jsonl"), "s2", []string{
+		`{"type":"user","sessionId":"s2","timestamp":"2026-01-03T03:04:05Z","message":{"role":"user","content":"another session"}}`,
+	})
+	if err := run([]string{"index", "--rebuild"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, used := maybeSemantic(nil, search.Options{Query: "anything"}, os.Stderr); used {
+		t.Fatal("stale sidecar generation must skip")
 	}
 }

--- a/cmd/deja/embed.go
+++ b/cmd/deja/embed.go
@@ -46,3 +46,27 @@ func maybeRerank(hits []search.Hit, o search.Options, notice *os.File) []search.
 	}
 	return out
 }
+
+func maybeSemantic(hits []search.Hit, o search.Options, notice *os.File) ([]search.Hit, bool) {
+	if len(hits) != 0 || o.NoEmbed || os.Getenv("DEJA_EMBED") == "off" {
+		return hits, false
+	}
+	sidecar, err := embed.Read(index.DefaultDir())
+	if err != nil {
+		return hits, false
+	}
+	gen, err := index.Generation(index.DefaultDir())
+	if err != nil || gen != sidecar.Generation {
+		return hits, false
+	}
+	client, err := embed.New()
+	if err != nil {
+		return hits, false
+	}
+	out, err := embed.SemanticSearch(context.Background(), index.DefaultDir(), o, sidecar, client)
+	if err != nil || len(out) == 0 {
+		return hits, false
+	}
+	fmt.Fprintln(notice, "deja: no lexical match, semantic results:")
+	return out, true
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -261,6 +261,9 @@ func run(args []string) error {
 	if !o.NoEmbed && os.Getenv("DEJA_EMBED") != "off" {
 		hits = maybeRerank(hits, o, os.Stderr)
 	}
+	var semantic bool
+	hits, semantic = maybeSemantic(hits, o, os.Stderr)
+	o.Semantic = semantic
 	if len(hits) == 0 {
 		printNoMatches(os.Stderr, o.Query, len(ss))
 	}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -260,6 +260,9 @@ func recallTextResult(q, harness string, limit, budget int) (string, int, error)
 	if os.Getenv("DEJA_EMBED") != "off" {
 		hits = maybeRerank(hits, o, os.Stderr)
 	}
+	var semantic bool
+	hits, semantic = maybeSemantic(hits, o, os.Stderr)
+	o.Semantic = semantic
 	if len(hits) == 0 {
 		return fmt.Sprintf("No prior deja sessions matched %q.", q), 0, nil
 	}
@@ -330,6 +333,7 @@ func recallContextResult(q, harness string) (string, int, error) {
 	if err != nil {
 		return "", 0, err
 	}
+	hits, _ = maybeSemantic(hits, o, os.Stderr)
 	if len(hits) == 0 {
 		return fmt.Sprintf("No prior deja sessions matched %q.", q), 0, nil
 	}

--- a/cmd/deja/semantic_coverage_test.go
+++ b/cmd/deja/semantic_coverage_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/vshulcz/deja-vu/internal/bench"
 	"github.com/vshulcz/deja-vu/internal/embed"
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -54,6 +55,24 @@ func TestEmbedCommandBuildsSemanticSidecar(t *testing.T) {
 	if report == nil || report.State != "reachable" || report.Dim != 2 || report.Coverage != 100 {
 		t.Fatalf("doctor embedding report=%#v", report)
 	}
+	var notice bytes.Buffer
+	semanticHits, semantic := maybeSemantic(nil, search.Options{Query: "rephrased"}, os.Stderr)
+	if !semantic || len(semanticHits) != 1 || semanticHits[0].Count != 0 {
+		t.Fatalf("semantic fallback hits=%#v semantic=%v", semanticHits, semantic)
+	}
+	var jsonOut bytes.Buffer
+	search.Print(&jsonOut, semanticHits, search.Options{JSON: true, Semantic: true})
+	if !strings.Contains(jsonOut.String(), `"semantic":true`) {
+		t.Fatalf("semantic JSON=%q", jsonOut.String())
+	}
+	metric, err := measureSemanticOnlyRephrased(indexDirForTest(), []bench.Query{{Text: "ignored"}, {Text: "rephrased", Relevant: []string{"s"}}}, &embed.Client{URL: ts.URL})
+	if err != nil || metric != 1 {
+		t.Fatalf("semantic-only metric=%v err=%v", metric, err)
+	}
+	if metric, err := measureSemanticOnlyRephrased(indexDirForTest(), nil, &embed.Client{URL: ts.URL}); err != nil || metric != 0 {
+		t.Fatalf("empty semantic-only metric=%v err=%v", metric, err)
+	}
+	_ = notice
 	hits := []search.Hit{{Session: model.Session{ID: "s", Harness: "claude"}, Score: 1}}
 	if got := maybeRerank(hits, search.Options{Query: "semantic"}, os.Stderr); len(got) != 1 || got[0].Score != 1 {
 		t.Fatalf("semantic rerank=%#v", got)

--- a/internal/embed/client.go
+++ b/internal/embed/client.go
@@ -70,12 +70,12 @@ func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error)
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, fmt.Errorf("decode embedding response: %w", err)
 	}
-	if len(out.Embeddings) > 0 {
-		return out.Embeddings, nil
-	}
-	result := make([][]float32, len(out.Data))
-	for i := range out.Data {
-		result[i] = out.Data[i].Embedding
+	result := out.Embeddings
+	if len(result) == 0 {
+		result = make([][]float32, len(out.Data))
+		for i := range out.Data {
+			result[i] = out.Data[i].Embedding
+		}
 	}
 	if len(result) != len(texts) {
 		return nil, fmt.Errorf("embedding endpoint returned %d vectors for %d texts", len(result), len(texts))

--- a/internal/embed/embed_extra_test.go
+++ b/internal/embed/embed_extra_test.go
@@ -1,0 +1,19 @@
+package embed
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEmbedRejectsCountMismatchOnOllamaShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"embeddings":[[1,0],[1,0],[1,0]]}`))
+	}))
+	defer srv.Close()
+	c := &Client{URL: srv.URL, Model: "m"}
+	if _, err := c.Embed(context.Background(), []string{"one"}); err == nil {
+		t.Fatal("expected count-mismatch error for the embeddings shape")
+	}
+}

--- a/internal/embed/embed_extra_test.go
+++ b/internal/embed/embed_extra_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
 )
 
 func TestEmbedRejectsCountMismatchOnOllamaShape(t *testing.T) {
@@ -15,5 +17,17 @@ func TestEmbedRejectsCountMismatchOnOllamaShape(t *testing.T) {
 	c := &Client{URL: srv.URL, Model: "m"}
 	if _, err := c.Embed(context.Background(), []string{"one"}); err == nil {
 		t.Fatal("expected count-mismatch error for the embeddings shape")
+	}
+}
+
+func TestSemanticSearchBadQueryVector(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Two vectors for a single query text: len(query) != 1 downstream.
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[1,0]},{"embedding":[0,1]}]}`))
+	}))
+	defer srv.Close()
+	c := &Client{URL: srv.URL, Model: "m"}
+	if _, err := SemanticSearch(context.Background(), t.TempDir(), search.Options{Query: "q"}, Sidecar{Vectors: []Vector{{Key: "k", Values: []float32{1, 0}}}}, c); err == nil {
+		t.Fatal("expected bad query vector error")
 	}
 }

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -235,6 +236,94 @@ func TestRerankUsesBestDuplicateAndRejectsEmptyQueryVector(t *testing.T) {
 	defer empty.Close()
 	if _, err := Rerank(context.Background(), hits, "q", sidecar, &Client{URL: empty.URL}); err == nil {
 		t.Fatal("expected empty query vector error")
+	}
+}
+
+func TestSemanticSearchFiltersRanksAndCaps(t *testing.T) {
+	if errBadQueryVector.Error() != "embedding endpoint returned no query vector" {
+		t.Fatal("unexpected query vector error")
+	}
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "claude")
+	if err := os.MkdirAll(filepath.Join(root, "project"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(id, text string) string {
+		return fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":%q}}`+"\n", id, text)
+	}
+	if err := os.WriteFile(filepath.Join(root, "project", "a.jsonl"), []byte(line("a", "semantic answer")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "project", "b.jsonl"), []byte(line("b", "weak answer")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for key, value := range map[string]string{
+		"HOME": tmp, "USERPROFILE": tmp, "DEJA_CLAUDE_ROOT": root,
+		"DEJA_CODEX_ROOT": filepath.Join(tmp, "codex"), "DEJA_OPENCODE_DB": filepath.Join(tmp, "open.db"),
+		"DEJA_AIDER_ROOTS": filepath.Join(tmp, "aider"), "DEJA_GEMINI_ROOT": filepath.Join(tmp, "gemini"),
+		"DEJA_CURSOR_ROOT": filepath.Join(tmp, "cursor"), "DEJA_CURSOR_CLI_ROOT": filepath.Join(tmp, "cursor-cli"),
+		"DEJA_ANTIGRAVITY_ROOT": filepath.Join(tmp, "antigravity"), "DEJA_GROK_ROOT": filepath.Join(tmp, "grok"),
+		"DEJA_QWEN_ROOT": filepath.Join(tmp, "qwen"),
+	} {
+		t.Setenv(key, value)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	records, err := index.ReadRecords(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen, err := index.Generation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := write(dir, Sidecar{Generation: gen, Dim: 2, Vectors: []Vector{
+		{Offset: records[0].Offset, Key: records[0].Record.Key, Values: []float32{1, 0}},
+		{Offset: records[1].Offset, Key: records[1].Record.Key, Values: []float32{0.8, 0.6}},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"embeddings":[[1,0]]}`))
+	}))
+	defer ts.Close()
+	hits, err := SemanticSearch(context.Background(), dir, search.Options{Query: "rephrased", All: true}, Sidecar{Generation: gen, Dim: 2, Vectors: []Vector{
+		{Offset: records[0].Offset, Key: records[0].Record.Key, Values: []float32{1, 0}},
+		{Offset: records[1].Offset, Key: records[1].Record.Key, Values: []float32{0, 1}},
+	}}, &Client{URL: ts.URL})
+	if err != nil || len(hits) != 1 || hits[0].Session.ID != "a" || hits[0].Count != 0 || hits[0].Score != 1 || !strings.Contains(hits[0].Snippets[0], "semantic answer") {
+		t.Fatalf("semantic hits=%#v err=%v", hits, err)
+	}
+	if _, err := SemanticSearch(context.Background(), dir, search.Options{Query: "q", All: true}, Sidecar{}, &Client{URL: "http://127.0.0.1:1", HTTP: &http.Client{}}); err == nil {
+		t.Fatal("endpoint failure was ignored")
+	}
+	badVector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"embeddings":[[1],[2]]}`))
+	}))
+	defer badVector.Close()
+	if _, err := SemanticSearch(context.Background(), dir, search.Options{Query: "q", All: true}, Sidecar{}, &Client{URL: badVector.URL}); err == nil {
+		t.Fatal("multiple query vectors were accepted")
+	}
+	if _, err := SemanticSearch(context.Background(), filepath.Join(tmp, "missing"), search.Options{Query: "q", All: true}, Sidecar{}, &Client{URL: ts.URL}); err == nil {
+		t.Fatal("missing records were accepted")
+	}
+	if got, err := SemanticSearch(context.Background(), dir, search.Options{Query: "q", Role: "assistant"}, Sidecar{Vectors: []Vector{
+		{Offset: 999, Key: records[0].Record.Key, Values: []float32{1, 0}},
+		{Offset: records[0].Offset, Key: "claude:missing", Values: []float32{1, 0}},
+	}}, &Client{URL: ts.URL}); err != nil || len(got) != 0 {
+		t.Fatalf("filtered semantic results=%#v err=%v", got, err)
+	}
+	noManifest := filepath.Join(tmp, "no-manifest")
+	if err := os.MkdirAll(noManifest, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(noManifest, "records.bin"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SemanticSearch(context.Background(), noManifest, search.Options{Query: "q", All: true}, Sidecar{}, &Client{URL: ts.URL}); err == nil {
+		t.Fatal("missing manifest was accepted")
 	}
 }
 

--- a/internal/embed/semantic.go
+++ b/internal/embed/semantic.go
@@ -1,0 +1,87 @@
+package embed
+
+import (
+	"context"
+	"sort"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// semanticFloor avoids turning unrelated vectors into search results.
+const semanticFloor = 0.55
+
+// SemanticSearch searches every covered record and returns the best vector
+// match per session. The caller is responsible for checking generation and
+// endpoint availability before calling it.
+func SemanticSearch(ctx context.Context, dir string, o search.Options, sidecar Sidecar, client *Client) ([]search.Hit, error) {
+	query, err := client.Embed(ctx, []string{o.Query})
+	if err != nil {
+		return nil, err
+	}
+	if len(query) != 1 {
+		return nil, errBadQueryVector
+	}
+	records, err := index.ReadRecords(dir)
+	if err != nil {
+		return nil, err
+	}
+	metaSessions, err := index.RecentMatching(dir, 0, o)
+	if err != nil {
+		return nil, err
+	}
+	byKey := make(map[string]model.Session, len(metaSessions))
+	for _, s := range metaSessions {
+		byKey[s.Harness+":"+s.ID] = s
+	}
+	byOffset := make(map[int64]index.Record, len(records))
+	for _, record := range records {
+		byOffset[record.Offset] = record.Record
+	}
+	type match struct {
+		session model.Session
+		record  index.Record
+		score   float64
+	}
+	best := make(map[string]match)
+	for _, vector := range sidecar.Vectors {
+		session, ok := byKey[vector.Key]
+		if !ok {
+			continue
+		}
+		record, ok := byOffset[vector.Offset]
+		if !ok || (o.Role != "" && record.Role != o.Role) {
+			continue
+		}
+		score := Cosine(query[0], vector.Values)
+		if score < semanticFloor {
+			continue
+		}
+		if old, ok := best[vector.Key]; !ok || score > old.score {
+			best[vector.Key] = match{session: session, record: record, score: score}
+		}
+	}
+	out := make([]search.Hit, 0, len(best))
+	for _, found := range best {
+		out = append(out, search.Hit{
+			Session:  found.session,
+			Count:    0,
+			Snippets: []string{search.Snippet(found.record.Text, o.Query)},
+			Score:    found.score,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		if !out[i].Session.Updated.Equal(out[j].Session.Updated) {
+			return out[i].Session.Updated.After(out[j].Session.Updated)
+		}
+		return out[i].Session.ID < out[j].Session.ID
+	})
+	if len(out) > 10 {
+		out = out[:10]
+	}
+	return out, nil
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -33,6 +33,7 @@ type Options struct {
 	Since                     time.Duration
 	All, JSON, Fuzzy, Stemmed bool
 	NoEmbed                   bool
+	Semantic                  bool                `json:"-"`
 	FuzzyVariants             map[string][]string `json:"-"`
 }
 type Hit struct {
@@ -262,7 +263,12 @@ func mergeSessions(in []model.Session) []model.Session {
 
 func Print(w io.Writer, hits []Hit, o Options) {
 	if o.JSON {
-		if o.Stemmed {
+		if o.Semantic {
+			_ = json.NewEncoder(w).Encode(struct {
+				Hits     []Hit `json:"hits"`
+				Semantic bool  `json:"semantic"`
+			}{hits, true})
+		} else if o.Stemmed {
 			_ = json.NewEncoder(w).Encode(struct {
 				Hits     []Hit               `json:"hits"`
 				Stemmed  bool                `json:"stemmed"`
@@ -403,6 +409,9 @@ func snippet(s, q string, re *regexp.Regexp) string {
 	}
 	return out
 }
+
+// Snippet formats a message for search results, including semantic matches.
+func Snippet(s, q string) string { return snippet(s, q, nil) }
 
 func queryTokens(s string) []string {
 	seen := map[string]bool{}


### PR DESCRIPTION
Closes #152. When the whole lexical chain (substring, stem, typo) finds nothing and a current-generation sidecar exists, embed the query and cosine-search the vectors (floor 0.55, top 10 sessions), with an stderr notice and a semantic flag in JSON; MCP recall inherits. Endpoint failures silently keep the plain no-match path. bench recall gains a semantic-only figure for the rephrased class when an endpoint is up. Also fixes a robustness hole found while testing: the Ollama response shape skipped the vector-count validation, so a misbehaving endpoint could panic the embed pass.

cmd/deja coverage reads 93.3%: the remainder is the bench runner (exercised by the CI bench step) and the documented doctor/network set.