### PR TITLE
fix(redact): stop xai- pattern matching kebab-case prose

### DIFF
--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -34,8 +34,11 @@ var (
 	pemPrivateRE = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`)
 	// Provider prefixes. sk- allows internal hyphens/underscores so modern
 	// hyphenated formats (sk-ant-…, sk-proj-…) are covered, not just legacy
-	// sk-<alnum> keys.
-	providerRE = regexp.MustCompile(`\b(gh[opsur]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|glpat-[A-Za-z0-9_-]{20,}|(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}|sk-[A-Za-z0-9_-]{20,}|gsk_[A-Za-z0-9]{20,}|xai-[A-Za-z0-9-]{20,}|hf_[A-Za-z0-9]{20,}|npm_[A-Za-z0-9]{30,}|xox[bpcs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{30,})\b`)
+	// sk-<alnum> keys. xai- stays alphanumeric-only: real xAI keys have no
+	// internal hyphens, and allowing them makes every long kebab-case slug
+	// that happens to start with "xai-" (branch names, doc titles) a false
+	// positive.
+	providerRE = regexp.MustCompile(`\b(gh[opsur]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|glpat-[A-Za-z0-9_-]{20,}|(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}|sk-[A-Za-z0-9_-]{20,}|gsk_[A-Za-z0-9]{20,}|xai-[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|npm_[A-Za-z0-9]{30,}|xox[bpcs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{30,})\b`)
 	jwtRE      = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\b`)
 	// Password is greedy so a password containing '@' (user:p@ss@host) splits on
 	// the last '@' and is redacted whole, not just up to the first '@'.

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -117,6 +117,8 @@ func TestTextKeepsOrdinaryProse(t *testing.T) {
 		"the secret to success is grit",
 		"password reset link sent to your inbox",
 		"authorization is pending review",
+		"rebase the xai-oauth-correction-loop-retry branch first",
+		"see docs/xai-rate-limit-troubleshooting-notes.md for details",
 	} {
 		out, counts := Text(s)
 		if out != s || counts.Total() != 0 {


### PR DESCRIPTION
## Problem

`providerRE`'s xAI arm — `xai-[A-Za-z0-9-]{20,}` — allows internal hyphens, so any long kebab-case slug that happens to start with `xai-` is redacted as a key: branch names (`xai-oauth-correction-loop-retry`), doc file names (`xai-rate-limit-troubleshooting-notes.md`), issue titles, and similar prose.

This isn't hypothetical: running this exact pattern over my real agent-transcript corpus produced **35 xai- redactions, and all 35 were false positives** (hyphenated prose, zero real keys).

## Fix

Real xAI keys are alphanumeric after the `xai-` prefix, so drop `-` from the character class: `xai-[A-Za-z0-9]{20,}`. The `sk-` arm keeps its hyphens intentionally (sk-ant-…, sk-proj-… are real formats) — a comment now records why the two differ.

Added two kebab-case slugs to `TestTextKeepsOrdinaryProse`; they fail against the old regex and pass with the fix. The existing positive case (`fake("xai-", 32)`, alphanumeric) still passes. `go test ./...`: 565 passed.

## Context (partial field report for #9)

Found while verifying deja v0.12.0 on a real Windows 11 machine, which may be useful for #9:
- store discovery: `%USERPROFILE%\.claude\projects` (138 sessions), `.codex` (328), `.grok` (101), `.gemini\antigravity-cli` (7) — all found, index built fine
- search/doctor/stats work in Git Bash and PowerShell (Windows Terminal)
- MCP `deja mcp` handshake + `recall` verified over stdio (registered via `cmd /c deja mcp` in Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)