### PR TITLE
fix(search): quote context messages per-term, never return a bare header

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -84,7 +84,7 @@ func handleMCP(req rpcRequest) (any, int, string) {
 			},
 			{
 				"name":        "recall_context",
-				"description": "Return a full markdown digest (~8KB) of the single best-matching prior session — problem, decisions, outcome — when a bare recall hit is not enough and you need the reasoning behind it. Use after recall, or directly when the user asks 'remind me how we handled X' or 'what was the whole story with Y'. Query with the error string, function name, or flag that identifies the session. Not for browsing many sessions — use recall for that; this returns one deep digest.",
+				"description": "Return a full markdown digest (~8KB) of the single best-matching prior session — problem, decisions, outcome — when a bare recall hit is not enough and you need the reasoning behind it. Use after recall, or directly when the user asks 'remind me how we handled X' or 'what was the whole story with Y'. Query terms are matched against transcript text, so use tokens likely to appear verbatim: an error string, function name, or flag. Not for browsing many sessions — use recall for that; this returns one deep digest.",
 				"annotations": map[string]any{"title": "Digest one past session", "readOnlyHint": true, "openWorldHint": false},
 				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "Search terms identifying the session to digest."}, "harness": map[string]any{"type": "string", "description": "Optional harness filter."}}, "required": []string{"query"}},
 			},

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -376,14 +376,31 @@ func PrintContext(w io.Writer, s model.Session, query string) {
 	}
 	fmt.Fprintln(w)
 	qlow := strings.ToLower(query)
+	terms, phrases := QueryParts(query)
 	budget := 8000
+	written := printContextChunks(w, s, budget, func(m model.Message) (bool, bool) {
+		matched := qlow != "" && (strings.Contains(strings.ToLower(m.Text), qlow) || MatchesParts(m.Text, terms, phrases, nil))
+		return matched || m.Role == "user", matched
+	})
+	if written > 0 {
+		return
+	}
+	// The session can match with query terms spread across messages, so no
+	// single message qualifies above; show an overview instead of a bare header.
+	if qlow != "" {
+		fmt.Fprintf(w, "\nNo single message contains the full query; showing the session's opening exchange.\n")
+	}
+	printContextChunks(w, s, budget, func(m model.Message) (bool, bool) { return true, false })
+}
+
+func printContextChunks(w io.Writer, s model.Session, budget int, include func(m model.Message) (ok, matched bool)) int {
 	written := 0
 	for _, m := range s.Messages {
 		if written >= budget {
 			break
 		}
-		matched := qlow != "" && strings.Contains(strings.ToLower(m.Text), qlow)
-		if !matched && m.Role != "user" {
+		ok, matched := include(m)
+		if !ok {
 			continue
 		}
 		text := contextText(m.Text, matched)
@@ -401,6 +418,7 @@ func PrintContext(w io.Writer, s model.Session, query string) {
 		fmt.Fprint(w, chunk)
 		written += len(chunk)
 	}
+	return written
 }
 
 func Recent(ss []model.Session, n int) []model.Session {

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -216,6 +216,31 @@ func TestPrintSessionContextAndDigestBudgetEdges(t *testing.T) {
 	}
 }
 
+func TestPrintContextTokenMatchAndFallback(t *testing.T) {
+	s := model.Session{ID: "ctxtok", Harness: "claude", Project: "p", Messages: []model.Message{
+		{Role: "assistant", Text: "rotated the turso token and redeployed on vercel"},
+	}}
+	var b bytes.Buffer
+	// Tokens out of order relative to the query: the old full-phrase match
+	// dropped this message and returned a bare header.
+	PrintContext(&b, s, "turso vercel token")
+	if !strings.Contains(b.String(), "redeployed") {
+		t.Fatalf("token-matched assistant message missing: %q", b.String())
+	}
+	spread := model.Session{ID: "ctxspread", Harness: "claude", Project: "p", Messages: []model.Message{
+		{Role: "assistant", Text: "first we rotated the turso token"},
+		{Role: "assistant", Text: "then we redeployed on vercel"},
+	}}
+	b.Reset()
+	// Terms spread across messages: no single message qualifies, so the
+	// digest falls back to an overview instead of a header-only result.
+	PrintContext(&b, spread, "turso vercel")
+	out := b.String()
+	if !strings.Contains(out, "opening exchange") || !strings.Contains(out, "turso token") || !strings.Contains(out, "redeployed") {
+		t.Fatalf("fallback overview missing: %q", out)
+	}
+}
+
 func TestHighlightDateSnippetAndColorBranches(t *testing.T) {
 	if got := highlight("Needle and thread", "needle", false, true); !strings.Contains(got, cMatch+"Needle"+cReset) {
 		t.Fatalf("highlight literal=%q", got)


### PR DESCRIPTION
Fixes #157

## Problem

`PrintContext` quotes a non-user message only when the **entire query** appears as one contiguous substring of that message, while session selection (`search.Run` → `MatchesParts`) matches ANDed terms. A multi-word query like `Turso Platform API rotate token Vercel` therefore selects a session but drops every assistant/tool message from the digest, and when the session's user messages have no printable prose (agent sessions are often mostly pasted terminal output), `recall_context` returns literally one header line. Reproduced on a real v0.12.0 corpus; details in #157.

## Fix

- `PrintContext` now qualifies a message via `QueryParts` + `MatchesParts` — the same term semantics search used to pick the session — keeping the old full-phrase `strings.Contains` as a fast path.
- If the message loop writes nothing, fall back to a session overview (opening messages, any role) with an explicit note, so a header-only digest is structurally impossible. The empty-query CLI path (`deja context` on a session with no query) keeps its current behavior and gains the same fallback without the note.
- The `recall_context` MCP tool description now tells the calling model to query with tokens that appear verbatim in the transcript.

## Tests

`TestPrintContextTokenMatchAndFallback` covers both halves: out-of-order tokens in one message (fails on the old regex-free full-phrase check with exactly the bare-header output) and terms spread across messages (expects the overview fallback). Verified the new test fails against the old implementation before applying the fix. `go test ./...`: 566 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)