### PR TITLE
feat(search): add confidence tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ $ deja "jwt refresh token"
 
 Stemmed JSON searches set `"stemmed": true` and include the catalog variants used.
 
+Search hits carry `exact`, `close`, or `semantic` confidence tiers; close hits include the matched variant and semantic hits include cosine.
+
 ### Share your stats
 
 Run `deja stats --card` to write a self-contained `deja-stats.svg` for a README or social post.

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -245,6 +245,7 @@ func run(args []string) error {
 		return fmt.Errorf("search: %w", err)
 	}
 	ss := result.Sessions
+	o.Tier = result.Tier
 	if result.Stemmed {
 		printStemmed(os.Stderr, result.Variants)
 		o.Stemmed = true
@@ -252,6 +253,9 @@ func run(args []string) error {
 	} else if result.Fuzzy {
 		printFuzzy(os.Stderr, result.Variants)
 		o.Fuzzy = true
+		o.FuzzyVariants = result.Variants
+	}
+	if result.Tier == search.TierClose && o.FuzzyVariants == nil {
 		o.FuzzyVariants = result.Variants
 	}
 	hits, err := search.Run(ss, o)

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -251,10 +251,14 @@ func recallTextResult(q, harness string, limit, budget int) (string, int, error)
 		return "", 0, err
 	}
 	ss := result.Sessions
+	o.Tier = result.Tier
 	if result.Stemmed {
 		o.Stemmed = true
 		o.FuzzyVariants = result.Variants
 	} else if result.Fuzzy {
+		o.FuzzyVariants = result.Variants
+	}
+	if o.Tier == search.TierClose && o.FuzzyVariants == nil {
 		o.FuzzyVariants = result.Variants
 	}
 	hits, err := search.Run(ss, o)
@@ -287,6 +291,9 @@ func recallTextResult(q, harness string, limit, budget int) (string, int, error)
 			fmt.Fprintf(&b, " · updated %s", h.Session.Updated.Format("2006-01-02"))
 		}
 		fmt.Fprintln(&b)
+		if h.Tier != search.TierExact {
+			fmt.Fprintf(&b, "[%s]\n", h.Tier)
+		}
 		for _, sn := range h.Snippets {
 			fmt.Fprintf(&b, "- %s\n", sn)
 		}
@@ -327,23 +334,35 @@ func recallContextResult(q, harness string) (string, int, error) {
 		return "", 0, err
 	}
 	ss := result.Sessions
+	o.Tier = result.Tier
 	if result.Stemmed {
 		o.Stemmed = true
 		o.FuzzyVariants = result.Variants
 	} else if result.Fuzzy {
 		o.FuzzyVariants = result.Variants
 	}
+	if o.Tier == search.TierClose && o.FuzzyVariants == nil {
+		o.FuzzyVariants = result.Variants
+	}
 	hits, err := search.Run(ss, o)
 	if err != nil {
 		return "", 0, err
 	}
-	hits, _ = maybeSemantic(hits, o, os.Stderr)
+	var semantic bool
+	hits, semantic = maybeSemantic(hits, o, os.Stderr)
+	if semantic {
+		o.Tier = search.TierSemantic
+	}
 	if len(hits) == 0 {
 		return fmt.Sprintf("No prior deja sessions matched %q.", q), 0, nil
 	}
 	var b bytes.Buffer
 	search.PrintContext(&b, hits[0].Session, q)
-	return b.String(), 1, nil
+	text := b.String()
+	if hits[0].Tier != search.TierExact {
+		text = "[" + hits[0].Tier + "]\n" + text
+	}
+	return text, 1, nil
 }
 
 func mcpProgress() io.Writer {

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -293,7 +293,7 @@ func TestSemanticSearchFiltersRanksAndCaps(t *testing.T) {
 		{Offset: records[0].Offset, Key: records[0].Record.Key, Values: []float32{1, 0}},
 		{Offset: records[1].Offset, Key: records[1].Record.Key, Values: []float32{0, 1}},
 	}}, &Client{URL: ts.URL})
-	if err != nil || len(hits) != 1 || hits[0].Session.ID != "a" || hits[0].Count != 0 || hits[0].Score != 1 || !strings.Contains(hits[0].Snippets[0], "semantic answer") {
+	if err != nil || len(hits) != 1 || hits[0].Session.ID != "a" || hits[0].Count != 0 || hits[0].Score != 1 || hits[0].Tier != search.TierSemantic || hits[0].TierDetail != "1.00" || !strings.Contains(hits[0].Snippets[0], "semantic answer") {
 		t.Fatalf("semantic hits=%#v err=%v", hits, err)
 	}
 	if _, err := SemanticSearch(context.Background(), dir, search.Options{Query: "q", All: true}, Sidecar{}, &Client{URL: "http://127.0.0.1:1", HTTP: &http.Client{}}); err == nil {

--- a/internal/embed/semantic.go
+++ b/internal/embed/semantic.go
@@ -2,6 +2,7 @@ package embed
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -65,10 +66,12 @@ func SemanticSearch(ctx context.Context, dir string, o search.Options, sidecar S
 	out := make([]search.Hit, 0, len(best))
 	for _, found := range best {
 		out = append(out, search.Hit{
-			Session:  found.session,
-			Count:    0,
-			Snippets: []string{search.Snippet(found.record.Text, o.Query)},
-			Score:    found.score,
+			Session:    found.session,
+			Count:      0,
+			Snippets:   []string{search.Snippet(found.record.Text, o.Query)},
+			Score:      found.score,
+			Tier:       search.TierSemantic,
+			TierDetail: fmt.Sprintf("%.2f", found.score),
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -52,13 +52,20 @@ func TestPhraseAndFuzzyIndexedSearch(t *testing.T) {
 		t.Fatalf("phrase result=%#v err=%v", result, err)
 	}
 	result, err = SearchDetailed(dir, search.Options{Query: "exhaustd", All: true})
-	if err != nil || !result.Fuzzy || len(result.Sessions) != 2 {
+	if err != nil || !result.Fuzzy || result.Tier != search.TierClose || len(result.Sessions) != 2 {
 		t.Fatalf("fuzzy result=%#v err=%v", result, err)
 	}
-	o := search.Options{Query: "exhaustd", All: true, FuzzyVariants: result.Variants}
+	o := search.Options{Query: "exhaustd", All: true, Tier: result.Tier, FuzzyVariants: result.Variants}
 	hits, err := search.Run(result.Sessions, o)
 	if err != nil || len(hits) != 2 || hits[0].Count == 0 {
 		t.Fatalf("fuzzy pipeline hits=%#v err=%v", hits, err)
+	}
+	if hits[0].Tier != search.TierClose || hits[0].TierDetail == "" {
+		t.Fatalf("fuzzy tier=%#v", hits)
+	}
+	result, err = SearchDetailed(dir, search.Options{Query: "haust", All: true})
+	if err != nil || result.Tier != search.TierClose || len(result.Variants["haust"]) == 0 {
+		t.Fatalf("substring tier=%#v err=%v", result, err)
 	}
 }
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -200,6 +200,7 @@ type SearchResult struct {
 	Fuzzy    bool
 	Stemmed  bool
 	Variants map[string][]string
+	Tier     string
 }
 
 func DefaultDir() string {
@@ -276,6 +277,8 @@ func SearchDetailed(dir string, o search.Options) (SearchResult, error) {
 		return SearchResult{}, fmt.Errorf("%w: records.bin truncated", errCorruptIndex)
 	}
 	var posts []posting
+	var fallbackVariants map[string][]string
+	fallbackTier := search.TierExact
 	usedPostings := false
 	if !o.Regex {
 		if keys := queryKeys(o.Query); len(keys) > 0 {
@@ -288,9 +291,14 @@ func SearchDetailed(dir string, o search.Options) (SearchResult, error) {
 				// grep expectation: "code" should find "opencode". Expand each query
 				// token to all indexed tokens containing it (bucket directories only,
 				// no record scan), then intersect.
-				posts, err = intersectSubstringPostings(dir, tokens(o.Query))
+				var variants map[string][]string
+				posts, variants, err = intersectSubstringPostingsDetailed(dir, tokens(o.Query))
 				if err != nil {
 					return SearchResult{}, fmt.Errorf("substr postings: %w", err)
+				}
+				if len(posts) > 0 {
+					fallbackVariants = variants
+					fallbackTier = search.TierClose
 				}
 			}
 		}
@@ -310,7 +318,7 @@ func SearchDetailed(dir string, o search.Options) (SearchResult, error) {
 			return SearchResult{}, nil
 		}
 		ss, err := scanRecords(dir, m, o, nil)
-		return SearchResult{Sessions: ss}, err
+		return SearchResult{Sessions: ss, Tier: fallbackTier, Variants: fallbackVariants}, err
 	}
 	posts = cutPostingsBySession(posts, m, o)
 	if len(posts) == 0 {
@@ -329,7 +337,7 @@ func SearchDetailed(dir string, o search.Options) (SearchResult, error) {
 			return result, nil
 		}
 	}
-	return SearchResult{Sessions: ss}, err
+	return SearchResult{Sessions: ss, Tier: fallbackTier, Variants: fallbackVariants}, err
 }
 
 // SearchWithRecovery is Search plus self-healing: a corrupt bucket (crash
@@ -1993,8 +2001,13 @@ func intersectPostings(dir string, keys []string) ([]posting, error) {
 }
 
 func intersectSubstringPostings(dir string, bare []string) ([]posting, error) {
+	posts, _, err := intersectSubstringPostingsDetailed(dir, bare)
+	return posts, err
+}
+
+func intersectSubstringPostingsDetailed(dir string, bare []string) ([]posting, map[string][]string, error) {
 	if len(bare) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if len(bare) > 3 {
 		bare = bare[:3] // longest-first; keep the expansion bounded
@@ -2002,11 +2015,12 @@ func intersectSubstringPostings(dir string, bare []string) ([]posting, error) {
 	buckets, err := os.ReadDir(filepath.Join(dir, "buckets"))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, nil, nil
 		}
-		return nil, err
+		return nil, nil, err
 	}
 	perTok := make([]map[int64]posting, len(bare))
+	variants := make(map[string][]string, len(bare))
 	for i := range perTok {
 		perTok[i] = map[int64]posting{}
 	}
@@ -2025,6 +2039,7 @@ func intersectSubstringPostings(dir string, bare []string) ([]posting, error) {
 				if !strings.Contains(tok, b) {
 					continue
 				}
+				variants[b] = append(variants[b], tok)
 				buf := make([]byte, e.n)
 				if _, err := f.ReadAt(buf, int64(e.off)); err != nil {
 					continue
@@ -2046,7 +2061,7 @@ func intersectSubstringPostings(dir string, bare []string) ([]posting, error) {
 		}
 		set = next
 		if len(set) == 0 {
-			return nil, nil
+			return nil, nil, nil
 		}
 	}
 	out := make([]posting, 0, len(set))
@@ -2054,7 +2069,10 @@ func intersectSubstringPostings(dir string, bare []string) ([]posting, error) {
 		out = append(out, p)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Off < out[j].Off })
-	return out, nil
+	for token := range variants {
+		sort.Strings(variants[token])
+	}
+	return out, variants, nil
 }
 
 func fuzzyPostings(dir string, terms, phrases []string) ([]posting, map[string][]string, error) {
@@ -2104,7 +2122,7 @@ func fuzzySearch(dir string, m Manifest, o search.Options) (SearchResult, error)
 	if err != nil || len(ss) == 0 {
 		return SearchResult{}, err
 	}
-	return SearchResult{Sessions: ss, Fuzzy: true, Variants: variants}, nil
+	return SearchResult{Sessions: ss, Fuzzy: true, Variants: variants, Tier: search.TierClose}, nil
 }
 
 func stemSearch(dir string, m Manifest, o search.Options) (SearchResult, error) {
@@ -2121,7 +2139,7 @@ func stemSearch(dir string, m Manifest, o search.Options) (SearchResult, error) 
 	if err != nil || len(ss) == 0 {
 		return SearchResult{}, err
 	}
-	return SearchResult{Sessions: ss, Stemmed: true, Variants: variants}, nil
+	return SearchResult{Sessions: ss, Stemmed: true, Variants: variants, Tier: search.TierClose}, nil
 }
 
 func stemPostings(dir string, terms, phrases []string) ([]posting, map[string][]string, error) {

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -33,6 +33,7 @@ type BlameHit struct {
 	Count    int           `json:"count"`
 	Snippets []string      `json:"snippets"`
 	Score    float64       `json:"score"`
+	Tier     string        `json:"tier"`
 }
 
 func ResolveBlamePath(name string) (BlameTarget, error) {
@@ -74,7 +75,7 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 		if !cut.IsZero() && session.Updated.Before(cut) {
 			continue
 		}
-		hit := BlameHit{Session: session, Title: sessionTitle(session)}
+		hit := BlameHit{Session: session, Title: sessionTitle(session), Tier: TierExact}
 		specificity := 0.0
 		for _, message := range session.Messages {
 			count, level := mentionScore(message.Text, base, forms)
@@ -212,6 +213,11 @@ func sessionTitle(s model.Session) string {
 }
 
 func PrintBlame(w io.Writer, hits []BlameHit, jsonOutput bool) {
+	for i := range hits {
+		if hits[i].Tier == "" {
+			hits[i].Tier = TierExact
+		}
+	}
 	if jsonOutput {
 		_ = json.NewEncoder(w).Encode(hits)
 		return

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -35,12 +35,22 @@ type Options struct {
 	NoEmbed                   bool
 	Semantic                  bool                `json:"-"`
 	FuzzyVariants             map[string][]string `json:"-"`
+	Tier                      string              `json:"-"`
 }
+
+const (
+	TierExact    = "exact"
+	TierClose    = "close"
+	TierSemantic = "semantic"
+)
+
 type Hit struct {
-	Session  model.Session `json:"session"`
-	Count    int           `json:"count"`
-	Snippets []string      `json:"snippets"`
-	Score    float64       `json:"score"`
+	Session    model.Session `json:"session"`
+	Count      int           `json:"count"`
+	Snippets   []string      `json:"snippets"`
+	Score      float64       `json:"score"`
+	Tier       string        `json:"tier"`
+	TierDetail string        `json:"tier_detail,omitempty"`
 }
 
 const (
@@ -86,7 +96,11 @@ func Run(ss []model.Session, o Options) ([]Hit, error) {
 		if !cut.IsZero() && s.Updated.Before(cut) {
 			continue
 		}
-		doc := bm25Document{hit: Hit{Session: s}, termCount: make([]int, len(qtoks)), userCount: make([]int, len(qtoks))}
+		tier := o.Tier
+		if tier == "" {
+			tier = TierExact
+		}
+		doc := bm25Document{hit: Hit{Session: s, Tier: tier}, termCount: make([]int, len(qtoks)), userCount: make([]int, len(qtoks))}
 		if len(qtoks) == 0 {
 			doc.termCount = []int{0}
 			doc.userCount = []int{0}
@@ -119,6 +133,9 @@ func Run(ss []model.Session, o Options) ([]Hit, error) {
 			}
 			if c > 0 {
 				doc.hit.Count += c
+				if doc.hit.Tier == TierClose && doc.hit.TierDetail == "" {
+					doc.hit.TierDetail = variantDetail(m.Text, qtoks, o.FuzzyVariants)
+				}
 				if len(doc.hit.Snippets) < 3 {
 					doc.hit.Snippets = append(doc.hit.Snippets, snippet(m.Text, o.Query, re))
 				}
@@ -262,6 +279,11 @@ func mergeSessions(in []model.Session) []model.Session {
 }
 
 func Print(w io.Writer, hits []Hit, o Options) {
+	for i := range hits {
+		if hits[i].Tier == "" {
+			hits[i].Tier = TierExact
+		}
+	}
 	if o.JSON {
 		if o.Semantic {
 			_ = json.NewEncoder(w).Encode(struct {
@@ -291,14 +313,36 @@ func Print(w io.Writer, hits []Hit, o Options) {
 			d = relativeDate(h.Session.Updated)
 		}
 		if color {
-			fmt.Fprintf(w, "%s%s %-10s %s %s %s %s %s%s%d matches%s\n", cBold, harnessTag(h.Session.Harness, true), h.Session.Project, cDim+"·"+cReset+cBold, d, cDim+"·"+cReset+cBold, short(h.Session.ID), cDim+"— "+cReset, cBold, h.Count, cReset)
+			fmt.Fprintf(w, "%s%s %-10s %s %s %s %s %s%s%d matches%s%s\n", cBold, harnessTag(h.Session.Harness, true), h.Session.Project, cDim+"·"+cReset+cBold, d, cDim+"·"+cReset+cBold, short(h.Session.ID), cDim+"— "+cReset, cBold, h.Count, cReset, tierLabel(h))
 		} else {
-			fmt.Fprintf(w, "[%s] %-10s · %s · %s — %d matches\n", h.Session.Harness, h.Session.Project, d, short(h.Session.ID), h.Count)
+			fmt.Fprintf(w, "[%s] %-10s · %s · %s — %d matches%s\n", h.Session.Harness, h.Session.Project, d, short(h.Session.ID), h.Count, tierLabel(h))
 		}
 		for _, sn := range h.Snippets {
 			fmt.Fprintf(w, "  %s\n", highlight(sn, o.Query, o.Regex, color))
 		}
 	}
+}
+
+func tierLabel(h Hit) string {
+	if h.Tier == "" || h.Tier == TierExact {
+		return ""
+	}
+	if h.TierDetail == "" {
+		return " · " + h.Tier
+	}
+	return " · " + h.Tier + " (" + h.TierDetail + ")"
+}
+
+func variantDetail(text string, terms []string, variants map[string][]string) string {
+	low := strings.ToLower(text)
+	for _, term := range terms {
+		for _, variant := range variants[term] {
+			if strings.Contains(low, variant) {
+				return term + "->" + variant
+			}
+		}
+	}
+	return ""
 }
 
 func FindByPrefix(ss []model.Session, p string) (model.Session, bool) {

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -541,3 +541,18 @@ func BenchmarkBM25Scoring1000Candidates(b *testing.B) {
 		}
 	}
 }
+
+func TestTierLabelVocabulary(t *testing.T) {
+	if got := tierLabel(Hit{}); got != "" {
+		t.Fatalf("empty tier label = %q", got)
+	}
+	if got := tierLabel(Hit{Tier: TierExact}); got != "" {
+		t.Fatalf("exact tier label = %q", got)
+	}
+	if got := tierLabel(Hit{Tier: TierClose}); got != " · close" {
+		t.Fatalf("close no-detail label = %q", got)
+	}
+	if got := tierLabel(Hit{Tier: TierSemantic, TierDetail: "0.71"}); got != " · semantic (0.71)" {
+		t.Fatalf("semantic label = %q", got)
+	}
+}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -342,6 +342,29 @@ func TestFuzzyMatchingUsesVariants(t *testing.T) {
 	if err != nil || len(hits) != 1 || hits[0].Count == 0 {
 		t.Fatalf("fuzzy hits=%#v err=%v", hits, err)
 	}
+	if hits[0].Tier != TierExact {
+		t.Fatalf("direct search tier=%q", hits[0].Tier)
+	}
+	hits, err = Run([]model.Session{{ID: "close", Updated: time.Now(), Messages: []model.Message{{Text: "connection exhausted"}}}}, Options{
+		Query: "connecton exhaustd", All: true, Tier: TierClose,
+		FuzzyVariants: map[string][]string{"connecton": {"connection"}, "exhaustd": {"exhausted"}},
+	})
+	if err != nil || len(hits) != 1 || hits[0].TierDetail != "connecton->connection" {
+		t.Fatalf("close tier=%#v err=%v", hits, err)
+	}
+}
+
+func TestPrintAlwaysEmitsTierAndLabelsFallback(t *testing.T) {
+	var b bytes.Buffer
+	Print(&b, []Hit{{Count: 1}}, Options{JSON: true})
+	if !strings.Contains(b.String(), `"tier":"exact"`) {
+		t.Fatalf("exact JSON=%q", b.String())
+	}
+	b.Reset()
+	Print(&b, []Hit{{Count: 1, Tier: TierClose, TierDetail: "rotaton->rotation"}}, Options{})
+	if !strings.Contains(b.String(), "close (rotaton->rotation)") {
+		t.Fatalf("close output=%q", b.String())
+	}
 }
 
 func BenchmarkPhraseVerification(b *testing.B) {


### PR DESCRIPTION
Closes #159. Every hit carries tier (exact/close/semantic) and tier_detail (matched variant or cosine): CLI appends it to the header only when not exact, JSON always includes it, MCP digests mark non-exact blocks, blame inherits through the shared Hit type.