### PR TITLE
feat: capture before compaction and re-inject after

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ are indexed locally. Cite what you reuse.
 | `blame` | `path`, `harness?`, `project?`, `since?`, `limit?` | Sessions that discussed a file, with titles and matched context. |
 | `remember` | `text`, `project?` | Stores a durable decision or conclusion for later recall. |
 
-With `--auto`, a SessionStart hook also feeds the current project's recent memory in automatically — read-only, capped at 2KB, and it never delays or breaks agent startup.
+With `--auto`, a SessionStart hook also feeds the current project's recent memory in automatically — read-only, capped at 2KB, and it never delays or breaks agent startup. Because SessionStart also fires after every context compaction, the same memory is re-injected right after Claude Code compacts — and a PreCompact hook captures the transcript into the index beforehand.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | --- | --- |
 | **Search** | `deja "connection pool exhausted"` — ~12 ms over gigabytes, retroactive: months of logs from before you installed it |
 | **Agent recall** | MCP `recall` tool — the agent answers *"we fixed this three weeks ago"* instead of re-debugging, across harnesses |
-| **Auto-recall** | `install --auto` adds a SessionStart hook: relevant memory lands in context before you ask |
+| **Auto-recall** | `install --auto` adds a SessionStart hook: relevant memory lands in context before you ask; Claude Code also captures the current transcript before compaction |
 | **Redaction** | API keys, JWTs, private keys are stripped at index time — the cache is safe to keep |
 | **Stats** | `deja stats` — your agent work, wrapped: harnesses, top projects, activity sparkline |
 | **Share** | `deja share <id>` — hand a colleague a sanitized digest of a session, secrets already scrubbed |

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -73,6 +73,8 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup) error {
 	fmt.Fprintln(w)
 	doctorMCP(w)
 	fmt.Fprintln(w)
+	doctorHooks(w)
+	fmt.Fprintln(w)
 	doctorIndex(w)
 	fmt.Fprintln(w)
 	if report.Embed != nil {
@@ -87,6 +89,39 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup) error {
 		doctorVersion(w, func() (string, bool) { return report.Version.Latest, report.Version.Latest != "" })
 	}
 	return nil
+}
+
+func doctorHooks(w io.Writer) {
+	fmt.Fprintln(w, "Hooks:")
+	path := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(w, "  %-12s missing      %s\n", "claude-code", path)
+		return
+	}
+	var root map[string]any
+	if json.Unmarshal(b, &root) != nil {
+		fmt.Fprintf(w, "  %-12s unreadable   %s\n", "claude-code", path)
+		return
+	}
+	hooks, _ := root["hooks"].(map[string]any)
+	precompact := hookEventWired(hooks, "PreCompact", "hook-precompact")
+	status := "missing"
+	if precompact {
+		status = "wired"
+	}
+	fmt.Fprintf(w, "  %-12s %-11s %s\n", "precompact", status, path)
+}
+
+func hookEventWired(hooks map[string]any, event, command string) bool {
+	entries, _ := hooks[event].([]any)
+	for _, entryAny := range entries {
+		entry, _ := entryAny.(map[string]any)
+		if entry != nil && entryHasCommand(entry, command) {
+			return true
+		}
+	}
+	return false
 }
 
 func doctorEmbed(w io.Writer, r doctorEmbedReport) {

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -38,6 +38,13 @@ func TestDoctorFullReport(t *testing.T) {
 	if err := os.WriteFile(claudeJSON, []byte(`{"mcpServers":{"deja":{"command":"/bin/deja","args":["mcp"]}}}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	claudeSettings := filepath.Join(tmp, "home", ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(claudeSettings), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(claudeSettings, []byte(`{"hooks":{"PreCompact":[{"matcher":"manual|auto","hooks":[{"type":"command","command":"/bin/deja hook-precompact"}]}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	old := version
 	version = "1.0.0"
@@ -49,7 +56,7 @@ func TestDoctorFullReport(t *testing.T) {
 	}
 	got := out.String()
 	for _, want := range []string{
-		"Harness stores:", "Tools:", "MCP wiring:", "Index:", "Version:",
+		"Harness stores:", "Tools:", "MCP wiring:", "Hooks:", "precompact", "Index:", "Version:",
 		"claude", "opencode", "aider", "gemini", "cursor", "antigravity", "grok",
 		"1 file", mcpLine("claude-code", "wired"), "config missing",
 		"not built", "current  1.0.0", "latest   v9.9.9", "update available",

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -29,6 +29,22 @@ type sessionStartHookResponse struct {
 	} `json:"hookSpecificOutput"`
 }
 
+type precompactHookInput struct {
+	SessionID      string `json:"session_id"`
+	TranscriptPath string `json:"transcript_path"`
+	CWD            string `json:"cwd"`
+	HookEventName  string `json:"hook_event_name"`
+	Trigger        string `json:"trigger"`
+}
+
+// runHookPrecompact is deliberately best effort: Claude must be able to
+// compact even when the input is incomplete or the index cannot start.
+func runHookPrecompact() {
+	var input precompactHookInput
+	_ = json.NewDecoder(os.Stdin).Decode(&input)
+	requestWarmup(index.DefaultDir())
+}
+
 // runHookContext prints session-start context. plain=false emits the Claude
 // Code / Codex hook JSON envelope; plain=true prints the bare digest for
 // hosts that inject raw text (the opencode plugin).

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -49,13 +49,24 @@ func runHookPrecompact() {
 // Code / Codex hook JSON envelope; plain=true prints the bare digest for
 // hosts that inject raw text (the opencode plugin).
 func runHookContext(plain bool) error {
+	// SessionStart fires for startup, resume, clear and compact; the payload
+	// says which. After a compaction the model just lost its working context,
+	// so the lead line changes to say the memory below survived it.
+	var input struct {
+		Source string `json:"source"`
+	}
+	_ = json.NewDecoder(os.Stdin).Decode(&input)
 	digest, sessions := hookDigestResult()
 	if digest == "" {
 		return nil
 	}
 	// One actionable line so injected memory leads somewhere: models that see
 	// bare data tend to ignore it.
-	digest = "The sessions below are from this project's recent history. If any is relevant to what the user asks next, call recall_context with a term from it to pull the full details before acting.\n" + digest
+	lead := "The sessions below are from this project's recent history. If any is relevant to what the user asks next, call recall_context with a term from it to pull the full details before acting.\n"
+	if input.Source == "compact" {
+		lead = "Context was just compacted. The project memory below is from deja's index and survived the compaction; call recall_context with a term from it to restore any details you lost.\n"
+	}
+	digest = lead + digest
 	digest = frameRecall(digest)
 	usage.RecordResult(index.DefaultDir(), usage.KindHook, len(digest), sessions, false)
 	if plain {

--- a/cmd/deja/hook_precompact_test.go
+++ b/cmd/deja/hook_precompact_test.go
@@ -40,6 +40,9 @@ func TestHookContextCompactLead(t *testing.T) {
 	if !strings.Contains(out, "Context was just compacted") {
 		t.Fatalf("compact lead missing: %q", out)
 	}
+	if !strings.Contains(out, "✓ recalled from claude session") {
+		t.Fatalf("provenance marker missing: %q", out)
+	}
 
 	withHookStdin(t, `{"source":"startup"}`)
 	out = captureStdout(t, func() { _ = runHookContext(true) })

--- a/cmd/deja/hook_precompact_test.go
+++ b/cmd/deja/hook_precompact_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func withHookStdin(t *testing.T, payload string) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.WriteString(payload); err != nil {
+		t.Fatal(err)
+	}
+	_ = w.Close()
+	old := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = old; _ = r.Close() })
+}
+
+func TestHookContextCompactLead(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "idx"))
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-tmp-p", "s.jsonl"), "s", []string{
+		`{"type":"user","sessionId":"s","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"compact survivor fact"}}`,
+	})
+	if err := run([]string{"index"}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", "/tmp/p")
+
+	withHookStdin(t, `{"source":"compact","session_id":"x"}`)
+	out := captureStdout(t, func() { _ = runHookContext(true) })
+	if !strings.Contains(out, "Context was just compacted") {
+		t.Fatalf("compact lead missing: %q", out)
+	}
+
+	withHookStdin(t, `{"source":"startup"}`)
+	out = captureStdout(t, func() { _ = runHookContext(true) })
+	if strings.Contains(out, "Context was just compacted") || !strings.Contains(out, "recent history") {
+		t.Fatalf("startup lead wrong: %q", out)
+	}
+
+	// Malformed stdin must not break the hook.
+	withHookStdin(t, `{not json`)
+	out = captureStdout(t, func() { _ = runHookContext(true) })
+	if out == "" {
+		t.Fatal("hook produced nothing on malformed stdin")
+	}
+}
+
+func TestRunHookPrecompactParsesAndGuards(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "idx"))
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	spawned := 0
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(exe, sentinel string) error { spawned++; return nil }
+	defer func() { spawnWarmup = oldSpawn }()
+
+	payload, _ := json.Marshal(map[string]any{"session_id": "abc", "trigger": "auto"})
+	withHookStdin(t, string(payload))
+	runHookPrecompact()
+	if spawned != 1 {
+		t.Fatalf("spawned=%d, want 1", spawned)
+	}
+	// Malformed stdin still triggers the guarded warmup path.
+	withHookStdin(t, "garbage")
+	runHookPrecompact()
+	if spawned != 1 {
+		t.Fatalf("sentinel must suppress the second spawn, got %d", spawned)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var b bytes.Buffer
+		_, _ = b.ReadFrom(r)
+		done <- b.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	return <-done
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -367,6 +367,7 @@ func installClaudeHook(exe string, uninstall bool) (installResult, error) {
 		return installResult{}, err
 	}
 	nextRoot := updateClaudeSessionStartHook(root, exe, uninstall)
+	nextRoot = updateClaudeHook(nextRoot, "PreCompact", exe+" hook-precompact", "manual|auto", uninstall)
 	next, err := json.MarshalIndent(nextRoot, "", "  ")
 	if err != nil {
 		return installResult{}, err
@@ -377,13 +378,17 @@ func installClaudeHook(exe string, uninstall bool) (installResult, error) {
 }
 
 func updateClaudeSessionStartHook(root map[string]any, exe string, uninstall bool) map[string]any {
+	root = updateClaudeHook(root, "SessionStart", exe+" hook-context", "", uninstall)
+	return root
+}
+
+func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall bool) map[string]any {
 	hooks, _ := root["hooks"].(map[string]any)
 	if hooks == nil {
 		hooks = map[string]any{}
 		root["hooks"] = hooks
 	}
-	cmd := exe + " hook-context"
-	entries, _ := hooks["SessionStart"].([]any)
+	entries, _ := hooks[event].([]any)
 	var out []any
 	found := false
 	for _, entryAny := range entries {
@@ -415,12 +420,16 @@ func updateClaudeSessionStartHook(root map[string]any, exe string, uninstall boo
 		out = append(out, entry)
 	}
 	if !uninstall && !found {
-		out = append(out, map[string]any{"hooks": []any{map[string]any{"type": "command", "command": cmd}}})
+		entry := map[string]any{"hooks": []any{map[string]any{"type": "command", "command": cmd}}}
+		if matcher != "" {
+			entry["matcher"] = matcher
+		}
+		out = append(out, entry)
 	}
 	if len(out) == 0 {
-		delete(hooks, "SessionStart")
+		delete(hooks, event)
 	} else {
-		hooks["SessionStart"] = out
+		hooks[event] = out
 	}
 	if len(hooks) == 0 {
 		delete(root, "hooks")

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -132,6 +132,10 @@ func run(args []string) error {
 		_ = runHookContext(plain)
 		return nil
 	}
+	if args[0] == "hook-precompact" {
+		runHookPrecompact()
+		return nil
+	}
 	if args[0] == "install" {
 		return runInstall(args[1:], false)
 	}

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -592,6 +592,34 @@ func TestHookContextSyntheticFixtures(t *testing.T) {
 	}
 }
 
+func TestHookPrecompactIsQuietAndBestEffort(t *testing.T) {
+	withTempStores(t)
+	t.Setenv("DEJA_WARMUP_SENTINEL", filepath.Join(t.TempDir(), "guard"))
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.WriteString(`{"session_id":"s","transcript_path":"/missing.jsonl","trigger":"auto"}`); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdin = r
+	defer func() {
+		os.Stdin = oldStdin
+		_ = r.Close()
+	}()
+	out, err := captureRun(t, "hook-precompact")
+	if err != nil || out != "" {
+		t.Fatalf("hook output=%q err=%v", out, err)
+	}
+	if out, err := captureRun(t, "hook-precompact"); err != nil || out != "" {
+		t.Fatalf("malformed hook output=%q err=%v", out, err)
+	}
+}
+
 func TestInstallAutoClaudeHookIdempotentPreservesHooks(t *testing.T) {
 	h := t.TempDir()
 	t.Setenv("HOME", h)
@@ -614,7 +642,7 @@ func TestInstallAutoClaudeHookIdempotentPreservesHooks(t *testing.T) {
 	}
 	b, _ = os.ReadFile(settingsPath)
 	s := string(b)
-	if strings.Count(s, "hook-context") != 1 || !strings.Contains(s, "/bin/user-hook") || !strings.Contains(s, `"Stop"`) {
+	if strings.Count(s, "hook-context") != 1 || strings.Count(s, "hook-precompact") != 1 || !strings.Contains(s, "/bin/user-hook") || !strings.Contains(s, `"Stop"`) {
 		t.Fatalf("bad auto settings: %s", s)
 	}
 	if _, err := os.Stat(settingsPath + ".bak"); err != nil {
@@ -624,14 +652,14 @@ func TestInstallAutoClaudeHookIdempotentPreservesHooks(t *testing.T) {
 		t.Fatalf("idempotent out=%q err=%v", out, err)
 	}
 	b, _ = os.ReadFile(settingsPath)
-	if strings.Count(string(b), "hook-context") != 1 {
+	if strings.Count(string(b), "hook-context") != 1 || strings.Count(string(b), "hook-precompact") != 1 {
 		t.Fatalf("duplicate hook: %s", b)
 	}
 	if out, err := captureRun(t, "uninstall", "--auto"); err != nil || !strings.Contains(out, "claude-auto:") {
 		t.Fatalf("uninstall --auto out=%q err=%v", out, err)
 	}
 	b, _ = os.ReadFile(settingsPath)
-	if strings.Contains(string(b), "hook-context") || !strings.Contains(string(b), "/bin/user-hook") {
+	if strings.Contains(string(b), "hook-context") || strings.Contains(string(b), "hook-precompact") || !strings.Contains(string(b), "/bin/user-hook") {
 		t.Fatalf("bad uninstall settings: %s", b)
 	}
 	b, _ = os.ReadFile(mcpPath)

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -37,7 +37,7 @@ func AutoRecallDigest(ss []model.Session, budget int) string {
 		if b.Len() >= budget {
 			break
 		}
-		section := autoRecallSession(s)
+		section := autoRecallSession(s, time.Now(), false)
 		if section == "" {
 			continue
 		}
@@ -88,7 +88,7 @@ func BuildAutoRecall(ss []model.Session, o AutoRecallOptions) AutoRecallResult {
 		if mode == RecallSafe && !projectMatches(s.Project, o.ProjectNames) {
 			continue
 		}
-		section := autoRecallSession(s)
+		section := autoRecallSession(s, o.Now, true)
 		if section == "" || (mode == RecallSafe && relevanceWords(s) < 3) {
 			continue
 		}
@@ -170,7 +170,7 @@ func nearDuplicate(candidate map[string]bool, prior []map[string]bool) bool {
 	return false
 }
 
-func autoRecallSession(s model.Session) string {
+func autoRecallSession(s model.Session, now time.Time, provenance bool) string {
 	var problem string
 	var conclusions []string
 	for _, m := range s.Messages {
@@ -192,12 +192,17 @@ func autoRecallSession(s model.Session) string {
 	if problem == "" && len(conclusions) == 0 {
 		return ""
 	}
-	date := ""
-	if !s.Updated.IsZero() {
-		date = " · " + s.Updated.Format("2006-01-02")
-	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "- **%s** `%s`%s\n", s.Project, short(s.ID), date)
+	if provenance {
+		fmt.Fprintf(&b, "✓ recalled from %s session · %s\n", s.Harness, relativeDay(s.Updated, now))
+		fmt.Fprintf(&b, "  - Session: **%s** `%s`\n", s.Project, short(s.ID))
+	} else {
+		date := ""
+		if !s.Updated.IsZero() {
+			date = " · " + s.Updated.Format("2006-01-02")
+		}
+		fmt.Fprintf(&b, "- **%s** `%s`%s\n", s.Project, short(s.ID), date)
+	}
 	if problem != "" {
 		fmt.Fprintf(&b, "  - User: %s\n", problem)
 	}
@@ -205,6 +210,35 @@ func autoRecallSession(s model.Session) string {
 		fmt.Fprintf(&b, "  - Assistant: %s\n", c)
 	}
 	return b.String()
+}
+
+func relativeDay(updated, now time.Time) string {
+	if updated.IsZero() {
+		return "unknown date"
+	}
+	location := now.Location()
+	updatedDate := updated.In(location)
+	nowDate := now.In(location)
+	y, m, d := nowDate.Date()
+	today := time.Date(y, m, d, 0, 0, 0, 0, location)
+	uy, um, ud := updatedDate.Date()
+	updatedDay := time.Date(uy, um, ud, 0, 0, 0, 0, location)
+	calendarDay := func(t time.Time) time.Time {
+		y, m, d := t.Date()
+		return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+	}
+	days := int(calendarDay(today).Sub(calendarDay(updatedDay)) / (24 * time.Hour))
+	switch days {
+	case 0:
+		return "today"
+	case 1:
+		return "yesterday"
+	default:
+		if days < 0 {
+			return "today"
+		}
+		return fmt.Sprintf("%d days ago", days)
+	}
 }
 
 func noiseMessage(s string) bool {

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -512,6 +512,31 @@ func TestBuildAutoRecallPolicy(t *testing.T) {
 	}
 }
 
+func TestAutoRecallProvenanceDates(t *testing.T) {
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name string
+		when time.Time
+		want string
+	}{
+		{"today", now, "today"},
+		{"yesterday", now.AddDate(0, 0, -1), "yesterday"},
+		{"days", now.AddDate(0, 0, -4), "4 days ago"},
+		{"future", now.AddDate(0, 0, 1), "today"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := model.Session{ID: tc.name, Harness: "claude", Project: "p", Updated: tc.when, Messages: []model.Message{{Role: "user", Text: "enough useful context"}}}
+			got := BuildAutoRecall([]model.Session{s}, AutoRecallOptions{Mode: RecallAggressive, Now: now})
+			if !strings.Contains(got.Text, "✓ recalled from claude session · "+tc.want) {
+				t.Fatalf("provenance = %q", got.Text)
+			}
+		})
+	}
+	if got := relativeDay(time.Time{}, now); got != "unknown date" {
+		t.Fatalf("zero date = %q", got)
+	}
+}
+
 func TestSnippetPrefersProseOverToolDump(t *testing.T) {
 	text := "netcat output noise needle\n1: package main\n2: func main() {}\nUser asked about needle migration strategy and we concluded use small batches."
 	hits, err := Run([]model.Session{{ID: "s", Harness: "claude", Project: "p", Updated: time.Now(), Messages: []model.Message{{Role: "assistant", Text: text}}}}, Options{Query: "needle"})


### PR DESCRIPTION
Closes #161. install --auto registers a PreCompact hook running deja hook-precompact, which triggers the sentinel-guarded incremental index (reusing the warmup machinery) so pre-compaction transcript content is captured immediately. The SessionStart hook now reads the payload source and, on compact, leads the injected digest with an explicit re-anchoring line; recalled sessions carry a visible provenance marker with a relative date.

cmd/deja coverage reads 93.1%: the remainder is the documented bench-runner and doctor/network set.