### PR TITLE
chore: publish to the MCP registry on release

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -1,0 +1,48 @@
+name: MCP Registry
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Wait for the npm package to land
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          for _ in $(seq 1 30); do
+            if curl -fsSL "https://registry.npmjs.org/@vshulcz/deja-vu/${version}" >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 30
+          done
+          echo "npm package ${version} not visible yet" >&2
+          exit 1
+      - name: Stamp the release version into server.json
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          python3 - "$version" <<'PY'
+          import json, sys
+          version = sys.argv[1]
+          with open("server.json") as f:
+              manifest = json.load(f)
+          manifest["version"] = version
+          for pkg in manifest.get("packages", []):
+              pkg["version"] = version
+          with open("server.json", "w") as f:
+              json.dump(manifest, f, indent=2)
+          PY
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz | tar xz
+          sudo mv mcp-publisher /usr/local/bin/
+      - name: Publish to the MCP registry
+        run: |
+          mcp-publisher login github-oidc
+          mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,26 +1,28 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.vshulcz/deja-vu",
-  "description": "Local memory for coding agents: search, MCP recall, auto-recall, secret redaction, SSH sync.",
+  "description": "Local memory layer over your coding-agent histories: search, recall, blame and notes across Claude Code, Codex, Cursor, opencode, aider, Gemini CLI, Antigravity, Grok Build and Qwen Code. Zero-dependency binary, nothing leaves the machine.",
   "repository": {
     "url": "https://github.com/vshulcz/deja-vu",
     "source": "github"
   },
-  "version": "0.7.1",
+  "version": "0.13.0",
   "packages": [
     {
       "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@vshulcz/deja-vu",
-      "version": "0.7.1",
+      "version": "0.13.0",
       "transport": {
         "type": "stdio"
       },
       "runtimeHint": "npx",
+      "runtimeArguments": [],
       "packageArguments": [
         {
           "type": "positional",
           "value": "mcp",
-          "description": "run the stdio MCP server"
+          "description": "Run the MCP server over stdio."
         }
       ]
     }


### PR DESCRIPTION
Adds server.json (io.github.vshulcz/deja-vu, npm package, stdio transport) and a release-triggered workflow that stamps the tag version and publishes via mcp-publisher with GitHub OIDC — no secrets. The npm package already carries the matching mcpName.