### PR TITLE
fix(install): spawn the MCP server through cmd on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ deja install --all     # MCP recall for every agent it finds on this machine
 deja install --auto    # same, plus session-start auto-recall where supported
 ```
 
+On Windows, register the MCP server through the shell wrapper most stdio servers need there: `cmd /c deja mcp` (deja install writes this form automatically; use it if you wire configs by hand).
+
 Install also writes user-level guidance for the harnesses it detects: Claude Code, Codex, Gemini CLI, Qwen, Copilot, and OpenCode use their corresponding guidance files (or the configured `XDG_CONFIG_HOME`). Re-run rewrites deja's skill or marked block without changing surrounding user content. Use `deja install --all --no-guidance` to opt out; Cursor and Grok have no documented user-level guidance location and are skipped.
 
 Install reports whether it found local history and builds the first index immediately when history is present.

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -346,7 +347,7 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 	if uninstall {
 		delete(m, "deja")
 	} else {
-		m["deja"] = map[string]any{"type": "stdio", "command": exe, "args": []string{"mcp"}}
+		m["deja"] = mcpServerEntry(exe)
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
@@ -530,6 +531,21 @@ func antigravityConfigHome() string {
 
 // installCursor wires the MCP server into Cursor's global config
 // (~/.cursor/mcp.json). Gemini CLI and Antigravity use the identical
+// mcpServerEntry is the JSON mcpServers value for deja. Windows stdio MCP
+// clients (Claude Code among them) spawn through cmd, so the entry uses the
+// cmd /c wrapper there; elsewhere it is the executable directly.
+func mcpServerEntry(exe string) map[string]any {
+	command, args := mcpCommandArgs(exe)
+	return map[string]any{"type": "stdio", "command": command, "args": args}
+}
+
+func mcpCommandArgs(exe string) (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", []string{"/c", exe, "mcp"}
+	}
+	return exe, []string{"mcp"}
+}
+
 // mcpServers shape in their own files.
 func installCursor(exe string, uninstall bool) (installResult, error) {
 	return installMCPJSON(filepath.Join(sources.CursorCLIHome(), "mcp.json"), exe, uninstall)
@@ -551,7 +567,8 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 	if uninstall {
 		delete(m, "deja")
 	} else {
-		m["deja"] = map[string]any{"command": exe, "args": []string{"mcp"}}
+		command, args := mcpCommandArgs(exe)
+		m["deja"] = map[string]any{"command": command, "args": args}
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {

--- a/cmd/deja/install_windows_note_test.go
+++ b/cmd/deja/install_windows_note_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestMCPCommandArgsPerOS(t *testing.T) {
+	command, args := mcpCommandArgs("/usr/local/bin/deja")
+	if runtime.GOOS == "windows" {
+		if command != "cmd" || len(args) != 3 || args[0] != "/c" || args[2] != "mcp" {
+			t.Fatalf("windows form = %q %v", command, args)
+		}
+	} else {
+		if command != "/usr/local/bin/deja" || len(args) != 1 || args[0] != "mcp" {
+			t.Fatalf("unix form = %q %v", command, args)
+		}
+	}
+	entry := mcpServerEntry("/usr/local/bin/deja")
+	if entry["type"] != "stdio" || entry["command"] != command {
+		t.Fatalf("entry = %#v", entry)
+	}
+}

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -542,7 +542,8 @@ func TestInstallClaudeTempHome(t *testing.T) {
 		t.Fatalf("install: %#v %v", r, err)
 	}
 	b, _ := os.ReadFile(path)
-	if !strings.Contains(string(b), `"mcpServers"`) || !strings.Contains(string(b), `"command": "/bin/deja"`) {
+	wantCommand, _ := mcpCommandArgs("/bin/deja")
+	if !strings.Contains(string(b), `"mcpServers"`) || !strings.Contains(string(b), `"command": "`+wantCommand+`"`) || !strings.Contains(string(b), "/bin/deja") {
 		t.Fatalf("bad claude config: %s", b)
 	}
 	if _, err := os.Stat(path + ".bak"); err != nil {


### PR DESCRIPTION
Closes #9. A full checklist verification on a real Windows 11 machine (thanks @Sora-bluesky — 6.5GB of real stores, byte-level color checks, concurrent index builds) surfaced one real defect: install wrote the MCP command as the bare executable, which Claude Code on Windows cannot spawn without the cmd /c wrapper. Both JSON writers now emit the wrapper form on windows, and the README documents it.