### PR TITLE
security: close redaction gaps

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -545,11 +545,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 				if seenMsgs.dup(key, msg.Role, msg.Time, msg.Text) {
 					continue
 				}
-				text := msg.Text
-				if len(text) > maxIndexedText {
-					text = text[:maxIndexedText]
-				}
-				text = redactForIngest(&m, s.Path, text)
+				text := redactForIngest(&m, s.Path, msg.Text)
 				off, err := rw.write(Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
 				if err != nil {
 					return err
@@ -730,11 +726,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 			}
 			m.Sessions[key] = metaWithOrd(metaForSession(s), ord)
 			for _, msg := range s.Messages {
-				text := msg.Text
-				if len(text) > maxIndexedText {
-					text = text[:maxIndexedText]
-				}
-				text = redactForIngest(&m, s.Path, text)
+				text := redactForIngest(&m, s.Path, msg.Text)
 				off, err := rw.write(Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
 				if err != nil {
 					return err
@@ -975,7 +967,12 @@ func recordsForKey(path, key string) ([]Record, error) {
 }
 
 func redactForIngest(m *Manifest, sourcePath, text string) string {
+	// Redact the full text before capping: a secret straddling the cap
+	// boundary would otherwise lose its closing marker and store raw.
 	redacted, counts := redact.Text(text)
+	if len(redacted) > maxIndexedText {
+		redacted = redacted[:maxIndexedText]
+	}
 	n := counts.Total()
 	if n == 0 || m == nil {
 		return redacted
@@ -1240,11 +1237,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 			if seenMsgs.dup(key, msg.Role, msg.Time, msg.Text) {
 				continue
 			}
-			text := msg.Text
-			if len(text) > maxIndexedText {
-				text = text[:maxIndexedText]
-			}
-			text = redactForIngest(&m, s.Path, text)
+			text := redactForIngest(&m, s.Path, msg.Text)
 			if err := addRec(Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time}); err != nil {
 				_ = rw.Close()
 				return err
@@ -1358,11 +1351,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 			}
 			m.Sessions[key] = meta
 			for _, msg := range s.Messages {
-				text := msg.Text
-				if len(text) > maxIndexedText {
-					text = text[:maxIndexedText]
-				}
-				text = redactForIngest(&m, s.Path, text)
+				text := redactForIngest(&m, s.Path, msg.Text)
 				off, err := rw.write(Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
 				if err != nil {
 					return filesTouched, messages, err

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -30,19 +30,19 @@ var (
 	// delimiter ("api_key": "..."). Tolerate both so env-var and JSON forms are
 	// caught, not just a bare `api_key=`.
 	genericKVRE  = regexp.MustCompile(`(?i)\b([\w.-]{0,64}?(?:api[_-]?key|secret|token|passwd|password|authorization))(\s*['"]?\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=._-]{16,})(['"]?)`)
-	bearerRE     = regexp.MustCompile(`(?i)\b(Bearer)(\s+)([A-Za-z0-9._~+/=-]{16,})`)
-	pemPrivateRE = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`)
+	bearerRE     = regexp.MustCompile(`(?i)\b(Bearer|Basic)(\s+)([A-Za-z0-9._~+/=-]{16,})`)
+	pemPrivateRE = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----.*?-----END [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----`)
 	// Provider prefixes. sk- allows internal hyphens/underscores so modern
 	// hyphenated formats (sk-ant-…, sk-proj-…) are covered, not just legacy
 	// sk-<alnum> keys. xai- stays alphanumeric-only: real xAI keys have no
 	// internal hyphens, and allowing them makes every long kebab-case slug
 	// that happens to start with "xai-" (branch names, doc titles) a false
 	// positive.
-	providerRE = regexp.MustCompile(`\b(gh[opsur]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|glpat-[A-Za-z0-9_-]{20,}|(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}|sk-[A-Za-z0-9_-]{20,}|gsk_[A-Za-z0-9]{20,}|xai-[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|npm_[A-Za-z0-9]{30,}|xox[bpcs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{30,})\b`)
+	providerRE = regexp.MustCompile(`\b(gh[opsur]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|glpat-[A-Za-z0-9_-]{20,}|(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}|sk-[A-Za-z0-9_-]*[A-Za-z0-9]{20,}|gsk_[A-Za-z0-9]{20,}|xai-[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|npm_[A-Za-z0-9]{30,}|xox[bpcs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{30,})\b`)
 	jwtRE      = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\b`)
 	// Password is greedy so a password containing '@' (user:p@ss@host) splits on
 	// the last '@' and is redacted whole, not just up to the first '@'.
-	connURLRE = regexp.MustCompile(`\b([A-Za-z][A-Za-z0-9+.-]*://)([^\s/@:]+):([^\s]+)@([^\s]+)`) // scheme://user:pass@host
+	connURLRE = regexp.MustCompile(`\b([A-Za-z][A-Za-z0-9+.-]*://)([^\s/@:]*):([^\s]+)@([^\s]+)`) // scheme://[user]:pass@host
 )
 
 func Disabled() bool { return os.Getenv("DEJA_NO_REDACT") == "1" }
@@ -86,7 +86,7 @@ func Text(s string) (string, Counts) {
 	if strings.Contains(s, "AKIA") || strings.Contains(s, "ASIA") {
 		s = replaceWhole(s, awsAccessKeyRE, "aws-access-key", counts)
 	}
-	if strings.Contains(lower, "bearer") {
+	if strings.Contains(lower, "bearer") || strings.Contains(lower, "basic ") {
 		s = replaceSubmatch(s, bearerRE, "bearer-token", counts, func(m []string) string {
 			return m[1] + m[2] + "[redacted:bearer-token]"
 		})

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -135,3 +135,39 @@ func TestDisabledEscapeHatch(t *testing.T) {
 		t.Fatalf("escape hatch failed: out=%q counts=%#v", out, counts)
 	}
 }
+
+func TestRedactionGapFixes(t *testing.T) {
+	leaks := map[string]string{
+		"empty-user redis url":  "redis://:s3cr3tpassword@cache.example.com:6379",
+		"empty-user pg url":     "postgres://:mypassword123456@db:5432/app",
+		"http basic auth":       "Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQxMjM0",
+		"proxy basic auth":      "Proxy-Authorization: Basic YWJjZGVmZ2hpamtsbW5vcA==",
+		"pgp armored key block": "-----BEGIN PGP PRIVATE KEY BLOCK-----\nabcdefghij\n-----END PGP PRIVATE KEY BLOCK-----",
+	}
+	for name, in := range leaks {
+		if out, c := Text(in); out == in || c.Total() == 0 {
+			t.Errorf("%s: not redacted: %q", name, out)
+		}
+	}
+	realKeys := []string{
+		"sk-abcdefghijklmnopqrstuvwxyz012345",
+		"sk-proj-abcdefghijklmnopqrstuvwxyz012345",
+		"sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345",
+		"postgres://user:passw0rd1234567@host:5432/db",
+	}
+	for _, in := range realKeys {
+		if out, _ := Text(in); out == in {
+			t.Errorf("real secret missed: %q", in)
+		}
+	}
+	prose := []string{
+		"sk-my-really-long-feature-branch-name-here",
+		"rebased the xai-oauth-correction-loop-retry branch",
+		"just a basic english sentence with no secrets",
+	}
+	for _, in := range prose {
+		if out, c := Text(in); out != in || c.Total() != 0 {
+			t.Errorf("false positive on prose: %q -> %q", in, out)
+		}
+	}
+}


### PR DESCRIPTION
Closes #171. bearerRE also matches Basic (gated on "basic " too); connURLRE allows an empty username so scheme://:pass@host redacts; pemPrivateRE matches PGP armored blocks; the sk- provider rule requires a 20+ unbroken alnum run so kebab-case slugs are not destroyed while real keys still match; and redaction now runs on the full message before the 64KiB cap so a boundary-straddling secret can't be stored raw. Regression tests cover each leak, real-key retention, and prose survival.