### PR TITLE
Add pi session support

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -173,6 +173,9 @@ func doctorHarnesses(w io.Writer) {
 
 	qwenRoot := filepath.Join(sources.QwenRoot(), "projects")
 	printRow("qwen", qwenRoot, doctorExists(qwenRoot), doctorCount(len(sources.QwenSessionFiles()), "file"))
+
+	piRoot := sources.PiRoot()
+	printRow("pi", piRoot, doctorExists(piRoot), doctorCount(len(sources.PiSessionFiles()), "file"))
 	printRow("deja", sources.NotesFile(), doctorFilePresent(sources.NotesFile()), "notes")
 }
 
@@ -270,6 +273,7 @@ func doctorMCPConfigs() []doctorMCPConfig {
 		{"antigravity", filepath.Join(antigravityConfigHome(), "mcp_config.json"), doctorJSONWired("mcpServers")},
 		{"grok", filepath.Join(sources.GrokHome(), "config.toml"), doctorTOMLWired},
 		{"qwen", filepath.Join(sources.QwenConfigDir(), "settings.json"), doctorJSONWired("mcpServers")},
+		{"pi", filepath.Join(sources.PiConfigDir(), "mcp.json"), doctorJSONWired("mcpServers")},
 		{"copilot", guidancePath("copilot"), doctorFileWired},
 	}
 }

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -117,6 +117,7 @@ func doctorStoreChecks() []doctorStoreCheck {
 		{"antigravity", sources.AntigravityRoots(), sources.AntigravityTranscripts(), sources.ParseAntigravityFile},
 		{"grok", []string{sources.GrokRoot()}, sources.GrokSessionFiles(), sources.ParseGrokFile},
 		{"qwen", []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.QwenSessionFiles(), sources.ParseQwenFile},
+		{"pi", []string{sources.PiRoot()}, sources.PiSessionFiles(), sources.ParsePiFile},
 		{"deja", []string{sources.NotesFile()}, presentDoctorFile(sources.NotesFile()), sources.ParseNotesFile},
 	}
 }

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -29,6 +29,8 @@ func guidancePath(harness string) string {
 		return filepath.Join(antigravityConfigHome(), "skills", "deja-history", "SKILL.md")
 	case "copilot":
 		return filepath.Join(homeDir(), ".copilot", "skills", "deja-history", "SKILL.md")
+	case "pi":
+		return filepath.Join(sources.PiConfigDir(), "skills", "deja-history", "SKILL.md")
 	case "qwen":
 		return filepath.Join(sources.QwenConfigDir(), "QWEN.md")
 	case "codex":
@@ -50,11 +52,27 @@ func opencodeConfigHome() string {
 }
 
 func guidanceText(harness string) string {
-	if harness == "claude-code" || harness == "claude" || harness == "antigravity" || harness == "copilot" {
+	if harness == "claude-code" || harness == "claude" || harness == "antigravity" || harness == "copilot" || harness == "pi" {
 		body := guidanceBody
 		if harness == "copilot" {
 			body = "deja does not index Copilot history. It is a consumer: use the deja MCP tools to search memory from the other harnesses.\n\n" + guidanceBody
 		}
+		if harness == "pi" {
+			body = `If the deja MCP tools are available (via pi-mcp-adapter), use them:
+
+- recall: search history with a specific error, function, or decision.
+- recall_context: get a concise digest of the best matching session.
+
+If MCP is not available, use the deja CLI via bash instead:
+
+- Search: bash("deja 'connection pool exhausted'")
+- Context: bash("deja context 'connection pool exhausted'")
+- Blame: bash("deja blame src/db.go")
+- Remember: bash("deja remember 'we use advisory locks because redis lost messages'")
+
+Example: for "what did we decide about token refresh?", try recall first; if unavailable, run bash("deja 'token refresh decision'").`
+		}
+
 		return "---\nname: deja-history\ndescription: Search the user's past AI coding sessions. Use when they say things like 'didn't we fix this before', 'what did we decide about X', or before re-debugging an error that may already be solved.\n---\n\n" + body + "\n"
 	}
 	return guidanceStart + "\n" + guidanceBody + "\n" + guidanceEnd + "\n"
@@ -70,7 +88,7 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 		return installResult{}, err
 	}
 	var next []byte
-	if harness == "claude-code" || harness == "claude" || harness == "antigravity" || harness == "copilot" {
+	if harness == "claude-code" || harness == "claude" || harness == "antigravity" || harness == "copilot" || harness == "pi" {
 		if uninstall {
 			if len(old) == 0 {
 				return installResult{Path: path, Action: "unchanged"}, nil

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -201,6 +201,7 @@ func existingTargets() []string {
 		"copilot":     filepath.Join(homeDir(), ".copilot"),
 		"grok":        sources.GrokRoot(),
 		"qwen":        sources.QwenConfigDir(),
+		"pi":          sources.PiConfigDir(),
 	}
 	var out []string
 	for name, p := range checks {
@@ -238,6 +239,8 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 		return installMCPJSON(filepath.Join(sources.QwenConfigDir(), "settings.json"), exe, uninstall)
 	case "copilot":
 		return installResult{Path: guidancePath("copilot"), Action: "guidance-only"}, nil
+	case "pi":
+		return installMCPJSON(filepath.Join(sources.PiConfigDir(), "mcp.json"), exe, uninstall)
 	case "opencode":
 		return installOpencode(exe, uninstall)
 	case "opencode-auto":

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -111,6 +111,8 @@ func resumeCommand(s model.Session) (string, string, error) {
 		return "", "", fmt.Errorf("cursor IDE chats reopen from the Cursor UI, not the terminal")
 	case "grok":
 		return sources.GrokCWDForSession(s.Path), "grok --resume " + s.ID, nil
+	case "pi":
+		return piProjectDirFor(s), "pi --resume " + s.ID, nil
 	default:
 		return "", "", fmt.Errorf("don't know how to resume %q sessions", s.Harness)
 	}
@@ -123,6 +125,19 @@ func claudeProjectDirFor(s model.Session) string {
 		return ""
 	}
 	base := sources.ClaudeProjectDirBase(s.Path)
+	if base == "" {
+		return ""
+	}
+	return sources.ResolveEncodedPath(base)
+}
+
+// piProjectDirFor recovers the original working directory from the
+// transcript location when the encoded project dir still exists on disk.
+func piProjectDirFor(s model.Session) string {
+	if s.Path == "" {
+		return ""
+	}
+	base := sources.PiProjectDirBase(s.Path)
 	if base == "" {
 		return ""
 	}

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -75,6 +75,14 @@
       "files": 0
     },
     {
+      "name": "pi",
+      "state": "missing",
+      "paths": [
+        "<tmp>/home/.pi/agent/sessions"
+      ],
+      "files": 0
+    },
+    {
       "name": "deja",
       "state": "missing",
       "paths": [
@@ -127,6 +135,11 @@
       "name": "qwen",
       "state": "config-missing",
       "path": "<tmp>/home/.qwen/settings.json"
+    },
+    {
+      "name": "pi",
+      "state": "config-missing",
+      "path": "<tmp>/home/.pi/agent/mcp.json"
     },
     {
       "name": "copilot",

--- a/docs/registry/README.md
+++ b/docs/registry/README.md
@@ -17,6 +17,7 @@ This registry records observed on-disk session formats for the harnesses that de
 | [Antigravity](antigravity.md) | JSONL transcript |
 | [Grok Build](grok.md) | ACP update JSONL with JSON metadata |
 | [Qwen Code](qwen.md) | JSONL transcript |
+| [pi](pi.md) | JSONL transcript |
 
 ## Reporting drift
 

--- a/docs/registry/pi.md
+++ b/docs/registry/pi.md
@@ -1,0 +1,78 @@
+# pi (pi.dev coding agent)
+
+| Field | Value |
+| --- | --- |
+| **Format** | JSONL transcript |
+| **Default store path** | `~/.pi/agent/sessions/<encoded-project>/<timestamp>_<uuid>.jsonl` |
+| **Env override** | `DEJA_PI_ROOT` |
+| **deja parser** | `internal/sources/pi.go` |
+| **Last verified** | 2026-07-19 |
+
+## Discovery
+
+pi stores session transcripts under `~/.pi/agent/sessions/`. Each project directory uses the same `--`-encoded path scheme as Claude Code, e.g. `--Users-max-code-deja-vu--` for `/Users/max/code/deja-vu`. Within each project directory, session files are named `<ISO-timestamp>_<UUID>.jsonl`.
+
+## File layout
+
+Each `.jsonl` file is a single session. The first line is always a session header:
+
+```json
+{"type":"session","version":3,"id":"<uuid>","timestamp":"<ISO-8601>","cwd":"<absolute-path>"}
+```
+
+Subsequent lines are typed events:
+
+| `type` | Description |
+| --- | --- |
+| `session` | Session header (first line only) |
+| `model_change` | Model/provider switch |
+| `thinking_level_change` | Thinking level adjustment |
+| `message` | User prompt, assistant response, or tool result |
+
+## Message records
+
+Messages use a wrapper envelope:
+
+```json
+{
+  "type": "message",
+  "id": "<hex>",
+  "parentId": "<hex-or-null>",
+  "timestamp": "<ISO-8601>",
+  "message": {
+    "role": "user|assistant|toolResult",
+    "content": [{"type": "text", "text": "..."}],
+    "timestamp": 1784448616190
+  }
+}
+```
+
+### Roles
+
+| `message.role` | deja maps to |
+| --- | --- |
+| `user` | `user` |
+| `assistant` | `assistant` |
+| `toolResult` | skipped (tool output, not conversational) |
+
+### Content
+
+`message.content` is an array of typed blocks. deja extracts `text` from blocks where `"type": "text"`. Blocks with `"type": "thinking"` or `"type": "toolCall"` are skipped.
+
+### Timestamps
+
+Both ISO-8601 strings (`"timestamp"` in the envelope) and Unix milliseconds (`"timestamp"` inside `message`) are observed. The parser uses the envelope timestamp.
+
+## Session identity
+
+The `id` field from the session header line is used as the session ID. The UUID also appears in the filename.
+
+## MCP
+
+pi does not include built-in MCP but supports it via the `pi-mcp-adapter` package (`pi install npm:pi-mcp-adapter`). The adapter reads `~/.pi/agent/mcp.json` with the standard `mcpServers` shape. `deja install pi` writes to that file.
+
+## Known quirks and drift
+
+- Project directory encoding uses `--` prefix and suffix (e.g. `--Users-max-code-foo--`) compared to Claude Code's single `-` prefix. The `resolveEncodedPath` function handles both.
+- Version field observed: `3`. No version migration behavior is known.
+- The `parentId` chain forms a tree, not a flat list; deja ignores the tree structure and processes messages in file order.

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -72,6 +72,14 @@
       "fixture_paths": ["fixtures/registry/qwen/projects/-workspace-registry-demo/chats/registry-qwen.jsonl"],
       "parser_source": "internal/sources/qwen.go",
       "last_verified": "2026-07-17"
+    },
+    {
+      "id": "pi",
+      "store_paths": ["${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl"],
+      "format_kind": "jsonl",
+      "fixture_paths": ["fixtures/registry/pi/session.jsonl"],
+      "parser_source": "internal/sources/pi.go",
+      "last_verified": "2026-07-19"
     }
   ]
 }

--- a/fixtures/registry/pi/session.jsonl
+++ b/fixtures/registry/pi/session.jsonl
@@ -1,0 +1,5 @@
+{"type":"session","version":3,"id":"reg-pi-001","timestamp":"2026-07-17T10:00:00Z","cwd":"/workspace/registry-demo"}
+{"type":"model_change","id":"mc1","parentId":null,"timestamp":"2026-07-17T10:00:01Z","provider":"anthropic","modelId":"claude-sonnet-4"}
+{"type":"thinking_level_change","id":"tl1","parentId":"mc1","timestamp":"2026-07-17T10:00:01Z","thinkingLevel":"medium"}
+{"type":"message","id":"u1","parentId":"tl1","timestamp":"2026-07-17T10:00:05Z","message":{"role":"user","content":[{"type":"text","text":"registry conformance question"}],"timestamp":1784386805000}}
+{"type":"message","id":"a1","parentId":"u1","timestamp":"2026-07-17T10:00:10Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"reasoning"},{"type":"text","text":"registry conformance answer"}],"api":"anthropic","model":"claude-sonnet-4","usage":{"input":5,"output":10},"stopReason":"endTurn","timestamp":1784386810000}}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -637,6 +637,7 @@ var harnessLoaders = []struct {
 	{"antigravity", sources.LoadAntigravity},
 	{"grok", sources.LoadGrok},
 	{"qwen", sources.LoadQwen},
+	{"pi", sources.LoadPi},
 }
 
 func load(h string) []model.Session { return loadProgress(h, nil) }
@@ -1275,7 +1276,7 @@ func canAppendIncremental(changed map[string]FileState, old map[string]FileState
 			return false
 		}
 		switch harnessForPath(p) {
-		case "claude", "codex", "codex-history", "opencode", "cursor-db", "deja":
+		case "claude", "codex", "codex-history", "opencode", "cursor-db", "deja", "pi":
 		default:
 			return false
 		}
@@ -1432,6 +1433,8 @@ func parseChangedFile(harness, p string, old FileState) ([]model.Session, error)
 		return sources.ParseGrokFile(p)
 	case "qwen":
 		return sources.ParseQwenFile(p)
+	case "pi":
+		return sources.ParsePiFile(p)
 	case "deja":
 		return sources.ParseNotesFile(p)
 	default:
@@ -1451,6 +1454,8 @@ func parseAppendedFile(harness, p string, old FileState) ([]model.Session, error
 		return sources.ParseCodexHistoryFromOffset(p, from)
 	case "qwen":
 		return sources.ParseQwenFileFromOffset(p, from)
+	case "pi":
+		return sources.ParsePiFileFromOffset(p, from)
 	case "deja":
 		return sources.ParseNotesFileFromOffset(p, from)
 	case "codex":
@@ -1507,6 +1512,9 @@ func harnessForPath(p string) string {
 	}
 	if strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, filepath.Join(sources.QwenRoot(), "projects")) {
 		return "qwen"
+	}
+	if strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, sources.PiRoot()) {
+		return "pi"
 	}
 	if p == sources.NotesFile() {
 		return "deja"
@@ -1590,6 +1598,11 @@ func currentFiles(h string) map[string]FileState {
 	}
 	if h == "" || h == "qwen" {
 		for _, p := range sources.QwenSessionFiles() {
+			paths[p] = true
+		}
+	}
+	if h == "" || h == "pi" {
+		for _, p := range sources.PiSessionFiles() {
 			paths[p] = true
 		}
 	}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -554,6 +554,8 @@ func harnessTag(h string, color bool) string {
 		return cGreen + tag + cReset + cBold
 	case "opencode":
 		return cBlue + tag + cReset + cBold
+	case "pi":
+		return cGreen + tag + cReset + cBold
 	}
 	return tag
 }

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -165,7 +165,13 @@ func resolveEncodedPath(base string) string {
 	if !strings.HasPrefix(base, "-") {
 		return ""
 	}
-	parts := strings.Split(strings.TrimPrefix(base, "-"), "-")
+	// pi uses "--" prefix/suffix (e.g. --Users-x-app--), Claude uses
+	// single "-" prefix. Strip both forms to get the segment list.
+	trimmed := strings.TrimPrefix(base, "-")
+	trimmed = strings.TrimPrefix(trimmed, "-")
+	trimmed = strings.TrimSuffix(trimmed, "-")
+	trimmed = strings.TrimSuffix(trimmed, "-")
+	parts := strings.Split(trimmed, "-")
 	if len(parts) == 0 || len(parts) > 24 {
 		return ""
 	}

--- a/internal/sources/pi.go
+++ b/internal/sources/pi.go
@@ -1,0 +1,92 @@
+package sources
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// PiConfigDir is the native pi coding agent configuration directory.
+func PiConfigDir() string { return filepath.Join(Home(), ".pi", "agent") }
+
+// PiRoot returns the session store root, overridable via DEJA_PI_ROOT.
+func PiRoot() string { return EnvPath("DEJA_PI_ROOT", filepath.Join(PiConfigDir(), "sessions")) }
+
+// PiSessionFiles lists transcript files under the pi session root.
+func PiSessionFiles() []string {
+	return walkFiles(PiRoot(), func(p string) bool {
+		return strings.HasSuffix(p, ".jsonl")
+	})
+}
+
+// LoadPi loads all pi sessions.
+func LoadPi() []model.Session { return parseFiles(PiSessionFiles(), ParsePiFile) }
+
+// ParsePiFile parses a single pi session transcript.
+func ParsePiFile(path string) ([]model.Session, error) {
+	return parsePiFileFromOffset(path, 0)
+}
+
+// ParsePiFileFromOffset parses a pi session transcript starting at a byte offset.
+func ParsePiFileFromOffset(path string, offset int64) ([]model.Session, error) {
+	return parsePiFileFromOffset(path, offset)
+}
+
+func parsePiFileFromOffset(path string, offset int64) ([]model.Session, error) {
+	s := model.Session{
+		Harness: "pi",
+		ID:      strings.TrimSuffix(filepath.Base(path), ".jsonl"),
+		Project: piProjectName(path),
+		Path:    path,
+	}
+	err := scanJSONLFromOffset(path, offset, func(m map[string]any) {
+		typ, _ := m["type"].(string)
+		switch typ {
+		case "session":
+			// First line: session header with id and timestamp.
+			if id, _ := m["id"].(string); id != "" {
+				s.ID = id
+			}
+			t := parseTimeAny(m["timestamp"])
+			s.Touch(t)
+		case "message":
+			msg, ok := m["message"].(map[string]any)
+			if !ok {
+				return
+			}
+			role, _ := msg["role"].(string)
+			if role != "user" && role != "assistant" {
+				return
+			}
+			t := parseTimeAny(m["timestamp"])
+			s.Touch(t)
+			txt := textFromContent(msg["content"])
+			if txt != "" {
+				s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
+			}
+		}
+	})
+	if len(s.Messages) == 0 {
+		return nil, err
+	}
+	return []model.Session{s}, err
+}
+
+// piProjectName derives the project display name from the encoded directory
+// name. pi uses the same "--" encoding as Claude Code.
+func piProjectName(path string) string {
+	dir := projectDir(PiRoot(), path)
+	return claudeProjectName(dir)
+}
+
+// PiProjectDirBase returns the encoded project dir name for a transcript
+// path, e.g. "--Users-x-projects-app--" for .../sessions/--Users-x-projects-app--/s.jsonl.
+func PiProjectDirBase(path string) string {
+	dir := projectDir(PiRoot(), path)
+	base := filepath.Base(dir)
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		return ""
+	}
+	return base
+}

--- a/internal/sources/pi_test.go
+++ b/internal/sources/pi_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -109,5 +110,45 @@ func TestParsePiFileEmpty(t *testing.T) {
 	}
 	if len(ss) != 0 {
 		t.Fatalf("expected no sessions from metadata-only file, got %d", len(ss))
+	}
+}
+
+func TestPiDiscoveryAndProjectBase(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("USERPROFILE", root)
+	t.Setenv("DEJA_PI_ROOT", "")
+	if got := PiRoot(); got != filepath.Join(root, ".pi", "agent", "sessions") {
+		t.Fatalf("default PiRoot = %q", got)
+	}
+	piRoot := filepath.Join(root, "pi-sessions")
+	t.Setenv("DEJA_PI_ROOT", piRoot)
+	proj := filepath.Join(piRoot, "--Users-max-app--")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(proj, "s.jsonl")
+	if err := os.WriteFile(path, []byte(`{"type":"session","id":"s1","timestamp":"2026-01-02T03:04:05Z"}
+{"type":"message","timestamp":"2026-01-02T03:04:06Z","message":{"role":"user","content":"pi discovery fact"}}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files := PiSessionFiles()
+	if len(files) != 1 || files[0] != path {
+		t.Fatalf("PiSessionFiles = %v", files)
+	}
+	ss := LoadPi()
+	if len(ss) != 1 || ss[0].ID != "s1" || ss[0].Harness != "pi" {
+		t.Fatalf("LoadPi = %#v", ss)
+	}
+	if !strings.HasSuffix(ss[0].Project, "app") {
+		t.Fatalf("pi project decode = %q, want …app", ss[0].Project)
+	}
+	if base := PiProjectDirBase(path); base != "--Users-max-app--" {
+		t.Fatalf("PiProjectDirBase = %q", base)
+	}
+	// A bare filename resolves to an empty encoded base.
+	if base := PiProjectDirBase("plain.jsonl"); base != "plain.jsonl" && base != "" {
+		t.Fatalf("bare PiProjectDirBase = %q", base)
 	}
 }

--- a/internal/sources/pi_test.go
+++ b/internal/sources/pi_test.go
@@ -1,0 +1,113 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParsePiFile(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_PI_ROOT", filepath.Join(root, "pi-sessions"))
+	project := filepath.Join(root, "pi-sessions", "--tmp-deja-vu--")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(project, "2026-01-02T03-04-05-000Z_abc-123.jsonl")
+	data := `{"type":"session","version":3,"id":"abc-123","timestamp":"2026-01-02T03:04:05Z","cwd":"/tmp/deja-vu"}
+{"type":"model_change","id":"m1","parentId":null,"timestamp":"2026-01-02T03:04:06Z","provider":"anthropic","modelId":"claude-sonnet-4"}
+{"type":"message","id":"u1","parentId":"m1","timestamp":"2026-01-02T03:04:10Z","message":{"role":"user","content":[{"type":"text","text":"what is pi?"}],"timestamp":1767337450000}}
+{"type":"message","id":"a1","parentId":"u1","timestamp":"2026-01-02T03:04:15Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"Let me think..."},{"type":"text","text":"pi is a coding agent"}],"api":"anthropic","model":"claude-sonnet-4","usage":{"input":10,"output":20},"stopReason":"endTurn","timestamp":1767337455000}}
+{"type":"message","id":"t1","parentId":"a1","timestamp":"2026-01-02T03:04:16Z","message":{"role":"toolResult","toolCallId":"call_1","toolName":"bash","content":[{"type":"text","text":"some output"}]}}
+{"type":"message","id":"a2","parentId":"t1","timestamp":"2026-01-02T03:04:20Z","message":{"role":"assistant","content":[{"type":"text","text":"here is the result"}],"timestamp":1767337460000}}
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParsePiFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("want 1 session, got %d", len(ss))
+	}
+	s := ss[0]
+	if s.Harness != "pi" {
+		t.Fatalf("harness = %q, want pi", s.Harness)
+	}
+	if s.ID != "abc-123" {
+		t.Fatalf("id = %q, want abc-123", s.ID)
+	}
+	if s.Project != filepath.Join("deja", "vu") {
+		t.Fatalf("project = %q, want deja/vu", s.Project)
+	}
+	if len(s.Messages) != 3 {
+		t.Fatalf("want 3 messages (user + 2 assistant), got %d: %#v", len(s.Messages), s.Messages)
+	}
+	if s.Messages[0].Role != "user" || s.Messages[0].Text != "what is pi?" {
+		t.Fatalf("message[0] = %#v", s.Messages[0])
+	}
+	if s.Messages[1].Role != "assistant" || s.Messages[1].Text != "pi is a coding agent" {
+		t.Fatalf("message[1] = %#v", s.Messages[1])
+	}
+	if s.Messages[2].Role != "assistant" || s.Messages[2].Text != "here is the result" {
+		t.Fatalf("message[2] = %#v", s.Messages[2])
+	}
+}
+
+func TestParsePiFileFromOffset(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_PI_ROOT", filepath.Join(root, "pi-sessions"))
+	project := filepath.Join(root, "pi-sessions", "--tmp-demo--")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line1 := `{"type":"session","version":3,"id":"off-1","timestamp":"2026-01-02T03:04:05Z","cwd":"/tmp/demo"}` + "\n"
+	line2 := `{"type":"message","id":"u1","parentId":null,"timestamp":"2026-01-02T03:04:10Z","message":{"role":"user","content":[{"type":"text","text":"first"}]}}` + "\n"
+	line3 := `{"type":"message","id":"a1","parentId":"u1","timestamp":"2026-01-02T03:04:15Z","message":{"role":"assistant","content":[{"type":"text","text":"reply"}]}}` + "\n"
+	path := filepath.Join(project, "session.jsonl")
+	if err := os.WriteFile(path, []byte(line1+line2+line3), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Parse from offset past the header + first message
+	offset := int64(len(line1) + len(line2))
+	ss, err := ParsePiFileFromOffset(path, offset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || len(ss[0].Messages) != 1 {
+		t.Fatalf("want 1 session with 1 message, got %#v", ss)
+	}
+	if ss[0].Messages[0].Text != "reply" {
+		t.Fatalf("message text = %q, want reply", ss[0].Messages[0].Text)
+	}
+}
+
+func TestParsePiFileEmpty(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_PI_ROOT", filepath.Join(root, "pi-sessions"))
+	project := filepath.Join(root, "pi-sessions", "--tmp-empty--")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(project, "session.jsonl")
+	data := `{"type":"session","version":3,"id":"empty-1","timestamp":"2026-01-02T03:04:05Z","cwd":"/tmp/empty"}
+{"type":"model_change","id":"m1","timestamp":"2026-01-02T03:04:06Z"}
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParsePiFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 0 {
+		t.Fatalf("expected no sessions from metadata-only file, got %d", len(ss))
+	}
+}

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -38,7 +38,7 @@ func TestFormatRegistryConformance(t *testing.T) {
 		"CURSOR_CONFIG_DIR", "DEJA_AIDER_ROOTS", "DEJA_ANTIGRAVITY_ROOT",
 		"DEJA_CLAUDE_ROOT", "DEJA_CODEX_ROOT", "DEJA_CURSOR_CLI_ROOT",
 		"DEJA_CURSOR_ROOT", "DEJA_GEMINI_ROOT", "DEJA_GROK_ROOT",
-		"DEJA_QWEN_ROOT",
+		"DEJA_PI_ROOT", "DEJA_QWEN_ROOT",
 		"DEJA_INCLUDE_SUBAGENTS", "DEJA_OPENCODE_DB", "GEMINI_CLI_HOME",
 		"GROK_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
 		"DEJA_NOTES_FILE",
@@ -145,6 +145,8 @@ func parseRegistryFixture(t *testing.T, id, path string) []model.Session {
 		sessions, err = ParseGrokFile(path)
 	case "qwen":
 		sessions, err = ParseQwenFile(path)
+	case "pi":
+		sessions, err = ParsePiFile(path)
 	default:
 		t.Fatalf("no conformance parser for %q", id)
 	}


### PR DESCRIPTION
I use pi.dev and wanted to try out deja-vu so below is pi's own attempt on adding support. seem to work :) 

## Summary
- add pi session discovery and parsing for `~/.pi/agent/sessions` JSONL transcripts
- wire pi into indexing, doctor, install/guidance, resume, search tags, and the registry docs/tests
- support both pi's `--encoded` project dirs and incremental append indexing

## Testing
- `go test ./...`

This adds support for indexing pi coding agent history, including existing sessions already on disk.
