### PR TITLE
fix: dedup search builds, safe forget ordering, unbounded aider reader

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -702,6 +702,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 		_ = rf.Close()
 		return err
 	}
+	seenMsgs := msgSeen{}
 	buckets, err := indexTextParallel(func(push func(tokenJob)) error {
 		for _, s := range ss {
 			key := s.Harness + ":" + s.ID
@@ -726,6 +727,9 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 			}
 			m.Sessions[key] = metaWithOrd(metaForSession(s), ord)
 			for _, msg := range s.Messages {
+				if seenMsgs.dup(key, msg.Role, msg.Time, msg.Text) {
+					continue
+				}
 				text := redactForIngest(&m, s.Path, msg.Text)
 				off, err := rw.write(Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
 				if err != nil {

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -141,10 +141,12 @@ func Forget(dir string, o ForgetOptions) (ForgetResult, error) {
 			result.Messages++
 		}
 	}
-	if err := rebuildWithTombstones(dir, "", "", currentFiles(""), nil, dead); err != nil {
+	// Persist tombstones before the rebuild: a crash between the two must
+	// leave sessions forgotten, not resurrect them on the next index pass.
+	if err := writeTombstones(dead); err != nil {
 		return result, err
 	}
-	return result, writeTombstones(dead)
+	return result, rebuildWithTombstones(dir, "", "", currentFiles(""), nil, dead)
 }
 
 func readRecordsForForget(dir string) []OffsetRecord {
@@ -167,8 +169,22 @@ func Tombstones() []string {
 
 func Unforget(prefix string) error {
 	set := readTombstones()
+	// A prefix containing ':' is a key/harness-scoped prefix (claude:abc,
+	// z:); a bare prefix is an id-prefix symmetric with forget --session, so
+	// "c" cannot resurrect every claude/codex/cursor session at once.
+	scoped := strings.ContainsRune(prefix, ':')
 	for key := range set {
-		if key == prefix || strings.HasSuffix(key, ":"+prefix) || strings.HasPrefix(key, prefix) {
+		var match bool
+		if scoped {
+			match = strings.HasPrefix(key, prefix)
+		} else {
+			id := key
+			if i := strings.IndexByte(key, ':'); i >= 0 {
+				id = key[i+1:]
+			}
+			match = key == prefix || strings.HasPrefix(id, prefix)
+		}
+		if match {
 			delete(set, key)
 		}
 	}

--- a/internal/index/privacy_test.go
+++ b/internal/index/privacy_test.go
@@ -195,3 +195,34 @@ func TestRebuildHonorsTombstonedLoadedSession(t *testing.T) {
 		t.Fatalf("tombstoned search=%#v err=%v", got, err)
 	}
 }
+
+func TestUnforgetDoesNotOverMatchHarness(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	if err := writeTombstones(map[string]bool{"claude:abc": true, "codex:abc": true, "cursor:xyz": true}); err != nil {
+		t.Fatal(err)
+	}
+	// A bare "c" is an id-prefix: it must NOT resurrect whole harnesses.
+	if err := Unforget("c"); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(Tombstones()); got != 3 {
+		t.Fatalf("bare prefix c wrongly matched harnesses: %v", Tombstones())
+	}
+	// An id-prefix that really matches an id works.
+	if err := Unforget("ab"); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(Tombstones()); got != 1 {
+		t.Fatalf("id-prefix ab: %v", Tombstones())
+	}
+	// A harness-scoped prefix still works.
+	if err := Unforget("cursor:"); err != nil {
+		t.Fatal(err)
+	}
+	if len(Tombstones()) != 0 {
+		t.Fatalf("harness scope left: %v", Tombstones())
+	}
+}

--- a/internal/sources/aider.go
+++ b/internal/sources/aider.go
@@ -109,10 +109,16 @@ func ParseAiderFile(path string) ([]model.Session, error) {
 		cur = nil
 	}
 
-	s := bufio.NewScanner(f)
-	s.Buffer(make([]byte, 64*1024), 8*1024*1024)
-	for s.Scan() {
-		line := strings.TrimRight(s.Text(), " \t")
+	// Unbounded line reader: a single pasted blob can exceed any fixed
+	// scanner cap, which would silently drop every session after it. Read
+	// line by line with no cap, matching the other parsers.
+	r := bufio.NewReader(f)
+	for {
+		raw, readErr := r.ReadString('\n')
+		if raw == "" && readErr != nil {
+			break
+		}
+		line := strings.TrimRight(raw, " \t\r\n")
 		if !inFence && strings.HasPrefix(line, aiderSessionMark) {
 			endSession()
 			idx++
@@ -162,9 +168,6 @@ func ParseAiderFile(path string) ([]model.Session, error) {
 		}
 	}
 	endSession()
-	if err := s.Err(); err != nil {
-		return out, err
-	}
 	return out, nil
 }
 

--- a/internal/sources/coverage_extra_test.go
+++ b/internal/sources/coverage_extra_test.go
@@ -336,12 +336,20 @@ func TestMoreSourceEdgeBranches(t *testing.T) {
 	if ss, err := ParseAiderFile(hist); err != nil || len(ss) != 1 || ss[0].Messages[0].Role != "assistant" {
 		t.Fatalf("aider fence-first ss=%#v err=%v", ss, err)
 	}
-	tooLong := filepath.Join(tmp, "too-long.md")
-	if err := os.WriteFile(tooLong, []byte("# aider chat started at 2026-01-01 00:00:00\n"+strings.Repeat("x", 9*1024*1024)), 0o644); err != nil {
+	// A single line larger than any fixed scanner cap must be read, not drop
+	// every session after it. The huge user line parses and a later session
+	// still appears.
+	huge := filepath.Join(tmp, "huge-line.md")
+	content := "# aider chat started at 2026-01-01 00:00:00\n#### " + strings.Repeat("x", 9*1024*1024) + "\n# aider chat started at 2026-01-02 00:00:00\n#### later question\n"
+	if err := os.WriteFile(huge, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ParseAiderFile(tooLong); err == nil {
-		t.Fatal("aider scanner error branch not hit")
+	ss, err := ParseAiderFile(huge)
+	if err != nil {
+		t.Fatalf("aider huge line errored: %v", err)
+	}
+	if len(ss) != 2 {
+		t.Fatalf("aider huge line dropped sessions: got %d, want 2", len(ss))
 	}
 
 	claude := filepath.Join(tmp, "claude.jsonl")


### PR DESCRIPTION
Closes #173. Adds message dedup to writeSessionsWithSync (the search/MCP/sync cold-build path) so duplicate-store sessions are not double-indexed; forget now persists tombstones before rebuilding and unforget matches by id-prefix (bare) or an explicit harness:-scoped key-prefix, so a single letter cannot resurrect whole harnesses; the aider parser reads unbounded lines so a large pasted blob no longer drops later sessions. Regression tests for each.