### PR TITLE
fix(search): score fuzzy/stem hits and keep stop words out of retrieval

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -2460,8 +2460,20 @@ func queryKeys(s string) []string {
 	if len(toks) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(toks))
+	// Drop stop words so retrievalKeys picks selective content tokens; a
+	// long stop word like "before" must not over-constrain the AND. If the
+	// query is all stop words, keep them (odd results beat none).
+	content := make([]string, 0, len(toks))
 	for _, tok := range toks {
+		if !search.IsStopWord(tok) {
+			content = append(content, tok)
+		}
+	}
+	if len(content) == 0 {
+		content = toks
+	}
+	out := make([]string, 0, len(content))
+	for _, tok := range content {
 		out = append(out, "t"+tok)
 	}
 	return out

--- a/internal/index/stopword_retrieval_test.go
+++ b/internal/index/stopword_retrieval_test.go
@@ -1,0 +1,33 @@
+package index
+
+import (
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStopWordsDoNotConstrainRetrieval(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "idx")
+	// The record does NOT contain the stop word "before".
+	sessions := []model.Session{{ID: "s", Harness: "claude", Project: "p", Updated: time.Now(),
+		Messages: []model.Message{{Role: "user", Text: "fix the race condition on commit"}}}}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	// Natural-language query with a stop word ("before") that is NOT in the
+	// record. The content tokens race+commit must still find it.
+	hits, err := Search(dir, search.Options{Query: "race before commit", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("stop word over-constrained retrieval: got %d hits", len(hits))
+	}
+}

--- a/internal/search/query.go
+++ b/internal/search/query.go
@@ -53,6 +53,11 @@ func QueryParts(q string) (terms []string, phrases []string) {
 	return terms, phrases
 }
 
+// IsStopWord reports whether a token is a query-time stop word. Retrieval
+// key selection uses it so a long stop word like "before" cannot displace a
+// short content token in the AND intersection.
+func IsStopWord(term string) bool { return stopWords[term] }
+
 func withoutStopWords(terms []string) []string {
 	kept := make([]string, 0, len(terms))
 	for _, term := range terms {

--- a/internal/search/rank_fuzzy_test.go
+++ b/internal/search/rank_fuzzy_test.go
@@ -1,0 +1,31 @@
+package search
+
+import (
+	"github.com/vshulcz/deja-vu/internal/model"
+	"testing"
+	"time"
+)
+
+func TestFuzzyHitsScoreByFrequency(t *testing.T) {
+	ts := time.Now().Add(-time.Hour) // same recency for both -> isolates BM25
+	dense := model.Session{ID: "dense", Updated: ts, Messages: []model.Message{
+		{Role: "user", Text: "receive receive receive the packet, receive again"},
+	}}
+	sparse := model.Session{ID: "sparse", Updated: ts, Messages: []model.Message{
+		{Role: "user", Text: "receive one packet"},
+	}}
+	o := Options{Query: "recieve", All: true, FuzzyVariants: map[string][]string{"recieve": {"receive"}}}
+	hits, err := Run([]model.Session{sparse, dense}, o)
+	if err != nil || len(hits) != 2 {
+		t.Fatalf("hits=%d err=%v", len(hits), err)
+	}
+	for _, h := range hits {
+		if h.Score <= 0 {
+			t.Fatalf("fuzzy hit %s scored zero (variant not counted)", h.Session.ID)
+		}
+	}
+	if hits[0].Session.ID != "dense" {
+		t.Fatalf("equal recency but frequency ignored: %s(%.3f) before %s(%.3f)",
+			hits[0].Session.ID, hits[0].Score, hits[1].Session.ID, hits[1].Score)
+	}
+}

--- a/internal/search/rank_fuzzy_test.go
+++ b/internal/search/rank_fuzzy_test.go
@@ -9,12 +9,12 @@ import (
 func TestFuzzyHitsScoreByFrequency(t *testing.T) {
 	ts := time.Now().Add(-time.Hour) // same recency for both -> isolates BM25
 	dense := model.Session{ID: "dense", Updated: ts, Messages: []model.Message{
-		{Role: "user", Text: "receive receive receive the packet, receive again"},
+		{Role: "user", Text: "frobnicator frobnicator frobnicator crashed, frobnicator again"},
 	}}
 	sparse := model.Session{ID: "sparse", Updated: ts, Messages: []model.Message{
-		{Role: "user", Text: "receive one packet"},
+		{Role: "user", Text: "frobnicator crashed once"},
 	}}
-	o := Options{Query: "recieve", All: true, FuzzyVariants: map[string][]string{"recieve": {"receive"}}}
+	o := Options{Query: "frobnicatr", All: true, FuzzyVariants: map[string][]string{"frobnicatr": {"frobnicator"}}}
 	hits, err := Run([]model.Session{sparse, dense}, o)
 	if err != nil || len(hits) != 2 {
 		t.Fatalf("hits=%d err=%v", len(hits), err)

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -141,7 +141,7 @@ func Run(ss []model.Session, o Options) ([]Hit, error) {
 				}
 			}
 			low := strings.ToLower(m.Text)
-			doc.length += countDocumentWords(low, qtoks, doc.termCount, doc.userCount, m.Role == "user")
+			doc.length += countDocumentWords(low, qtoks, o.FuzzyVariants, doc.termCount, doc.userCount, m.Role == "user")
 			if len(qtoks) == 1 && doc.termCount[0] == 0 && strings.Contains(low, qlow) {
 				n := strings.Count(low, qlow)
 				doc.termCount[0] += n
@@ -222,7 +222,7 @@ func freshnessDecay(updated, now time.Time) float64 {
 	return 1 / (1 + age)
 }
 
-func countDocumentWords(s string, terms []string, counts, userCounts []int, user bool) int {
+func countDocumentWords(s string, terms []string, variants map[string][]string, counts, userCounts []int, user bool) int {
 	length := 0
 	start := -1
 	for i := 0; i <= len(s); {
@@ -239,7 +239,19 @@ func countDocumentWords(s string, terms []string, counts, userCounts []int, user
 			word := s[start:i]
 			length++
 			for j, term := range terms {
-				if word == term {
+				matched := word == term
+				if !matched {
+					// A word matching a fuzzy/stem variant of this term counts
+					// toward its term frequency so BM25 ranks the hit instead of
+					// falling back to recency-only order.
+					for _, v := range variants[term] {
+						if word == v {
+							matched = true
+							break
+						}
+					}
+				}
+				if matched {
 					counts[j]++
 					if user {
 						userCounts[j]++

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -99,7 +99,7 @@ func TestBM25HelperSignals(t *testing.T) {
 	}
 	counts := make([]int, 2)
 	userCounts := make([]int, 2)
-	if got := countDocumentWords("one needle, needle-two", []string{"needle", "needle-two"}, counts, userCounts, true); got != 3 || counts[0] != 1 || counts[1] != 1 || userCounts[1] != 1 {
+	if got := countDocumentWords("one needle, needle-two", []string{"needle", "needle-two"}, nil, counts, userCounts, true); got != 3 || counts[0] != 1 || counts[1] != 1 || userCounts[1] != 1 {
 		t.Fatalf("word counts len=%d counts=%v user=%v", got, counts, userCounts)
 	}
 }


### PR DESCRIPTION
Closes #178. countDocumentWords now counts fuzzy/stem variant matches toward BM25 term frequency, so those hits rank by relevance rather than recency-only; queryKeys drops stop words before retrievalKeys picks the selective tokens, so a long stop word cannot over-constrain the postings intersection. Regression tests: a denser fuzzy match outranks a sparse one at equal recency, and a natural-language query with a non-present stop word still finds its record.