### PR TITLE
fix(index): bound record allocation on a corrupt length prefix

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -27,6 +27,11 @@ import (
 const version = 10
 const maxIndexedText = 64 * 1024
 
+// maxRecordSize bounds a single serialized record. A record is one message
+// (text capped at maxIndexedText) plus small metadata, so anything larger is
+// a corrupt length prefix — reject it rather than allocate up to 4 GiB.
+const maxRecordSize = 8 << 20
+
 var bucketMagic = []byte("DJB1")
 
 // errCorruptIndex marks unreadable index structures (e.g. a bucket file cut
@@ -1910,7 +1915,11 @@ func readRecord(r io.Reader) (Record, error) {
 	if _, err := io.ReadFull(r, hdr[:]); err != nil {
 		return Record{}, err
 	}
-	b := make([]byte, binary.LittleEndian.Uint32(hdr[:]))
+	n := binary.LittleEndian.Uint32(hdr[:])
+	if n > maxRecordSize {
+		return Record{}, fmt.Errorf("%w: record length %d exceeds cap", errCorruptIndex, n)
+	}
+	b := make([]byte, n)
 	if _, err := io.ReadFull(r, b); err != nil {
 		return Record{}, err
 	}

--- a/internal/index/record_alloc_test.go
+++ b/internal/index/record_alloc_test.go
@@ -1,0 +1,21 @@
+package index
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadRecordRejectsHugeLengthPrefix(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "records.bin")
+	var hdr [4]byte
+	binary.LittleEndian.PutUint32(hdr[:], 0xFFFFFFFF) // ~4GiB claimed
+	if err := os.WriteFile(p, append(hdr[:], 'x'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := eachRecord(p, func(Record) { t.Fatal("should not decode a corrupt record") })
+	if err == nil || !IsCorrupt(err) {
+		t.Fatalf("expected corrupt-index error, got %v", err)
+	}
+}


### PR DESCRIPTION
A record's 4-byte length prefix was trusted directly, so a bit-flip could allocate up to 4 GiB before the read failed. Records are single messages capped well under 8 MiB; anything larger is now rejected as a corrupt index so recovery rebuilds. Test writes a 0xFFFFFFFF length prefix and asserts a corrupt-index error.