### PR TITLE
ci: trigger MCP registry publish on tag push

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -1,8 +1,11 @@
 name: MCP Registry
 
 on:
-  release:
-    types: [published]
+  # goreleaser creates the release with GITHUB_TOKEN, whose events do not
+  # trigger other workflows; key off the tag push instead, plus a manual run.
+  push:
+    tags: ['v*']
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
The registry publish keyed on `release: published`, but goreleaser creates the release with GITHUB_TOKEN and those events don't trigger workflows — so it never ran for v0.13.1. Trigger on the tag push (a real event) and add workflow_dispatch for manual re-runs.