### PR TITLE
chore: point windows manifests at v0.13.1

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.13.0",
+    "version": "0.13.1",
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.13.0/deja-vu_0.13.0_windows_amd64.zip",
-            "hash": "7a6221765221de74c1779a3cb921d55c6c42c601478b445b1a17547bd2ec529c"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.13.1/deja-vu_0.13.1_windows_amd64.zip",
+            "hash": "d31a8525e71cb7de21ec93e49a3b0b7345203209d6afc100ecae1d3cc4553d82"
         },
         "arm64": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.13.0/deja-vu_0.13.0_windows_arm64.zip",
-            "hash": "3a3bd81430bd119eb38775279adbf0b4f1c5ad0f78b529c5d29eaf7e091ab26c"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.13.1/deja-vu_0.13.1_windows_arm64.zip",
+            "hash": "39cceee8679ae07058a731959ee5a30a5a052e14dfaaa6dffb2f1b6af66e3c02"
         }
     },
     "bin": "deja.exe",

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.13.0
+PackageVersion: 0.13.1
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.13.0/deja-vu_0.13.0_windows_amd64.zip
-  InstallerSha256: 7A6221765221DE74C1779A3CB921D55C6C42C601478B445B1A17547BD2EC529C
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.13.1/deja-vu_0.13.1_windows_amd64.zip
+  InstallerSha256: D31A8525E71CB7DE21EC93E49A3B0B7345203209D6AFC100ECAE1D3CC4553D82
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.13.0/deja-vu_0.13.0_windows_arm64.zip
-  InstallerSha256: 3A3BD81430BD119EB38775279ADBF0B4F1C5AD0F78B529C5D29EAF7E091AB26C
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.13.1/deja-vu_0.13.1_windows_arm64.zip
+  InstallerSha256: 39CCEEE8679AE07058A731959EE5A30A5A052E14DFAAA6DFFB2F1B6AF66E3C02
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.13.0
+PackageVersion: 0.13.1
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.13.0/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.13.1/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider
@@ -17,6 +17,6 @@ Tags:
 - cursor
 - mcp
 - memory
-ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.13.0
+ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.13.1
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.13.0
+PackageVersion: 0.13.1
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Scoop and winget manifests bumped to 0.13.1 with hashes from the release checksums.txt.