### PR TITLE
fix(search): don't label an exact token match as a variant

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -349,6 +349,11 @@ func variantDetail(text string, terms []string, variants map[string][]string) st
 	low := strings.ToLower(text)
 	for _, term := range terms {
 		for _, variant := range variants[term] {
+			// A term that matched itself is an exact hit, not a variant —
+			// don't render "connection->connection" as the tier detail.
+			if variant == term {
+				continue
+			}
 			if strings.Contains(low, variant) {
 				return term + "->" + variant
 			}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -606,3 +606,14 @@ func TestTierLabelVocabulary(t *testing.T) {
 		t.Fatalf("semantic label = %q", got)
 	}
 }
+
+func TestVariantDetailSkipsSelfMatch(t *testing.T) {
+	// A token matching itself must not be reported as a variant.
+	if d := variantDetail("connection pool", []string{"connection"}, map[string][]string{"connection": {"connection"}}); d != "" {
+		t.Fatalf("self-match reported as variant: %q", d)
+	}
+	// A real variant is still reported.
+	if d := variantDetail("the pool was exhausted", []string{"exhaustion"}, map[string][]string{"exhaustion": {"exhausted"}}); d != "exhaustion->exhausted" {
+		t.Fatalf("real variant detail = %q", d)
+	}
+}


### PR DESCRIPTION
When a query went through the fuzzy/stem fallback, an exactly-matched token was still shown with a self-referential tier detail like 'close (connection->connection)'. Skip self-matches so only real variants appear.