### PR TITLE
fix(doctor): warn when index is stale relative to source stores

### DIFF
--- a/cmd/deja/coverage_recover_test.go
+++ b/cmd/deja/coverage_recover_test.go
@@ -99,10 +99,14 @@ func TestDoctorIndexBuiltBranch(t *testing.T) {
 		t.Fatal(err)
 	}
 	var out bytes.Buffer
-	doctorIndex(&out)
+	report := collectDoctorReport(nil)
+	doctorIndex(&out, report.Index)
 	got := out.String()
 	if !strings.Contains(got, "status   built") || !strings.Contains(got, "size=") || !strings.Contains(got, "updated=") {
 		t.Fatalf("doctorIndex built = %q", got)
+	}
+	if !strings.Contains(got, "freshness up to date") {
+		t.Fatalf("doctorIndex freshness = %q", got)
 	}
 }
 

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -75,7 +75,7 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup) error {
 	fmt.Fprintln(w)
 	doctorHooks(w)
 	fmt.Fprintln(w)
-	doctorIndex(w)
+	doctorIndex(w, report.Index)
 	fmt.Fprintln(w)
 	if report.Embed != nil {
 		doctorEmbed(w, *report.Embed)
@@ -319,12 +319,15 @@ func doctorTOMLWired(path string) bool {
 	return strings.Contains(string(b), "[mcp_servers.deja]")
 }
 
-func doctorIndex(w io.Writer) {
+func doctorIndex(w io.Writer, idx doctorComponent) {
 	fmt.Fprintln(w, "Index:")
-	dir := index.DefaultDir()
+	dir := idx.Path
+	if dir == "" {
+		dir = index.DefaultDir()
+	}
 	fmt.Fprintf(w, "  location %s\n", dir)
 	fmt.Fprintf(w, "  exclusions %d active patterns\n", len(sources.ExclusionPatterns()))
-	if !index.HasManifest(dir) {
+	if idx.State == "missing" {
 		fmt.Fprintln(w, "  status   not built (run `deja warmup`)")
 		return
 	}
@@ -333,6 +336,16 @@ func doctorIndex(w io.Writer) {
 		updated = fi.ModTime().Format("2006-01-02 15:04")
 	}
 	fmt.Fprintf(w, "  status   built (size=%s, updated=%s)\n", humanBytes(pathSize(dir)), updated)
+	switch idx.State {
+	case "stale":
+		if idx.StaleStores == 1 {
+			fmt.Fprintln(w, "  freshness 1 store changed since last build — run `deja index`")
+		} else {
+			fmt.Fprintf(w, "  freshness %d stores changed since last build — run `deja index`\n", idx.StaleStores)
+		}
+	default:
+		fmt.Fprintln(w, "  freshness up to date")
+	}
 }
 
 func doctorVersion(w io.Writer, lookup doctorVersionLookup) {

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -22,8 +22,9 @@ type doctorStore struct {
 }
 
 type doctorComponent struct {
-	State string `json:"state"`
-	Path  string `json:"path,omitempty"`
+	State       string `json:"state"`
+	Path        string `json:"path,omitempty"`
+	StaleStores int    `json:"stale_stores,omitempty"`
 }
 
 type doctorVersionReport struct {
@@ -64,15 +65,13 @@ type doctorStoreCheck struct {
 func collectDoctorReport(lookup doctorVersionLookup) doctorReport {
 	stores := doctorStoreChecks()
 	report := doctorReport{Stores: make([]doctorStore, 0, len(stores))}
-	var newest time.Time
+	storeMods := make([]time.Time, 0, len(stores))
 	for _, check := range stores {
 		store, mod := inspectDoctorStore(check)
 		report.Stores = append(report.Stores, store)
-		if mod.After(newest) {
-			newest = mod
-		}
+		storeMods = append(storeMods, mod)
 	}
-	report.Index = inspectDoctorIndex(newest)
+	report.Index = inspectDoctorIndex(storeMods)
 	report.MCP = collectDoctorMCP()
 	report.SQLite3.State = "missing"
 	if sources.SQLite3Available() {
@@ -209,14 +208,20 @@ func newestDoctorFile(files []string) (string, time.Time) {
 	return newest, newestMod
 }
 
-func inspectDoctorIndex(newestStore time.Time) doctorComponent {
+func inspectDoctorIndex(storeMods []time.Time) doctorComponent {
 	dir := index.DefaultDir()
 	result := doctorComponent{State: "missing", Path: dir}
 	if !index.HasManifest(dir) {
 		return result
 	}
 	result.State = "ok"
-	if fi, err := os.Stat(filepath.Join(dir, "manifest.gob")); err == nil && newestStore.After(fi.ModTime()) {
+	builtAt := index.ManifestBuiltAt(dir)
+	for _, mod := range storeMods {
+		if !mod.IsZero() && mod.After(builtAt) {
+			result.StaleStores++
+		}
+	}
+	if result.StaleStores > 0 {
 		result.State = "stale"
 	}
 	return result

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -185,7 +185,7 @@ func TestDoctorJSONGolden(t *testing.T) {
 
 func TestDoctorIndexStates(t *testing.T) {
 	hermeticEnv(t)
-	if got := inspectDoctorIndex(time.Time{}).State; got != "missing" {
+	if got := inspectDoctorIndex(nil).State; got != "missing" {
 		t.Fatalf("missing index state = %q", got)
 	}
 	dir := os.Getenv("DEJA_INDEX_DIR")
@@ -202,18 +202,44 @@ func TestDoctorIndexStates(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, tc := range []struct {
-		name   string
-		newest time.Time
-		want   string
+		name      string
+		storeMods []time.Time
+		want      string
+		stale     int
 	}{
-		{"ok", manifestTime.Add(-time.Minute), "ok"},
-		{"stale", manifestTime.Add(time.Minute), "stale"},
+		{"ok", []time.Time{manifestTime.Add(-time.Minute)}, "ok", 0},
+		{"stale-one", []time.Time{manifestTime.Add(time.Minute)}, "stale", 1},
+		{"stale-two", []time.Time{manifestTime.Add(time.Minute), manifestTime.Add(2 * time.Minute)}, "stale", 2},
+		{"mixed", []time.Time{manifestTime.Add(-time.Minute), manifestTime.Add(time.Minute), time.Time{}}, "stale", 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := inspectDoctorIndex(tc.newest).State; got != tc.want {
-				t.Fatalf("state = %q, want %q", got, tc.want)
+			got := inspectDoctorIndex(tc.storeMods)
+			if got.State != tc.want {
+				t.Fatalf("state = %q, want %q", got.State, tc.want)
+			}
+			if got.StaleStores != tc.stale {
+				t.Fatalf("stale stores = %d, want %d", got.StaleStores, tc.stale)
 			}
 		})
+	}
+}
+
+func TestDoctorIndexFreshnessOutput(t *testing.T) {
+	var out bytes.Buffer
+	doctorIndex(&out, doctorComponent{State: "ok", Path: "/tmp/index"})
+	if !strings.Contains(out.String(), "freshness up to date") {
+		t.Fatalf("fresh output = %q", out.String())
+	}
+	out.Reset()
+	doctorIndex(&out, doctorComponent{State: "stale", Path: "/tmp/index", StaleStores: 3})
+	got := out.String()
+	if !strings.Contains(got, "freshness 3 stores changed since last build") {
+		t.Fatalf("stale output = %q", got)
+	}
+	out.Reset()
+	doctorIndex(&out, doctorComponent{State: "stale", Path: "/tmp/index", StaleStores: 1})
+	if !strings.Contains(out.String(), "freshness 1 store changed since last build") {
+		t.Fatalf("singular stale output = %q", out.String())
 	}
 }
 

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -210,7 +210,7 @@ func TestDoctorIndexStates(t *testing.T) {
 		{"ok", []time.Time{manifestTime.Add(-time.Minute)}, "ok", 0},
 		{"stale-one", []time.Time{manifestTime.Add(time.Minute)}, "stale", 1},
 		{"stale-two", []time.Time{manifestTime.Add(time.Minute), manifestTime.Add(2 * time.Minute)}, "stale", 2},
-		{"mixed", []time.Time{manifestTime.Add(-time.Minute), manifestTime.Add(time.Minute), time.Time{}}, "stale", 1},
+		{"mixed", []time.Time{manifestTime.Add(-time.Minute), manifestTime.Add(time.Minute), {}}, "stale", 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := inspectDoctorIndex(tc.storeMods)

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -418,6 +418,22 @@ func HasManifest(dir string) bool {
 	return err == nil
 }
 
+// ManifestBuiltAt returns when the index was last built. Older manifests may
+// omit BuiltAt; in that case manifest.gob's mtime is used.
+func ManifestBuiltAt(dir string) time.Time {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifest(dir)
+	if err == nil && !m.BuiltAt.IsZero() {
+		return m.BuiltAt
+	}
+	if fi, err := os.Stat(filepath.Join(dir, "manifest.gob")); err == nil {
+		return fi.ModTime()
+	}
+	return time.Time{}
+}
+
 func RecentProject(dir, project string, n int) ([]model.Session, error) {
 	if dir == "" {
 		dir = DefaultDir()

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -128,6 +128,33 @@ func TestReadRecordsAndGeneration(t *testing.T) {
 	}
 }
 
+func TestManifestBuiltAt(t *testing.T) {
+	dir := t.TempDir()
+	if got := ManifestBuiltAt(dir); !got.IsZero() {
+		t.Fatalf("missing manifest = %v, want zero", got)
+	}
+	builtAt := time.Unix(42, 0)
+	mtime := time.Unix(99, 0)
+	if err := writeManifest(dir, Manifest{Version: version, BuiltAt: builtAt, Sessions: map[string]SessionMeta{}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(filepath.Join(dir, "manifest.gob"), mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	if got := ManifestBuiltAt(dir); !got.Equal(builtAt) {
+		t.Fatalf("BuiltAt = %v, want %v", got, builtAt)
+	}
+	if err := writeManifest(dir, Manifest{Version: version, Sessions: map[string]SessionMeta{}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(filepath.Join(dir, "manifest.gob"), mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	if got := ManifestBuiltAt(dir); !got.Equal(mtime) {
+		t.Fatalf("zero BuiltAt fallback = %v, want mtime %v", got, mtime)
+	}
+}
+
 func TestSyncExportImportSearchIdempotent(t *testing.T) {
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")


### PR DESCRIPTION
## Summary

`deja doctor` now compares each harness store's newest source file against the index manifest build time and reports whether the index is up to date.

## Motivation

Users often search and get stale results because the index was not rebuilt after new sessions landed. The doctor report already gathered store paths and manifest metadata, but did not surface freshness.

Fixes #184

## Changes

- Add `index.ManifestBuiltAt` to read the manifest `BuiltAt` timestamp (fallback: `manifest.gob` mtime).
- Count stores whose newest file is newer than the manifest build time.
- Human output: `freshness up to date` or `N store(s) changed since last build — run deja index`.
- JSON output: `index.state` (`ok` / `stale`) and `index.stale_stores`.

## Tests

- `go test ./cmd/deja/... ./internal/index/...`
- Added `TestManifestBuiltAt`, expanded `TestDoctorIndexStates`, and `TestDoctorIndexFreshnessOutput`.

## Notes

Read-only and offline: only mtime comparison against the on-disk manifest, no network or index rebuild.