### PR TITLE
feat(stats): activity-grid stats card

### DIFF
--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -32,6 +33,7 @@ type statsReport struct {
 	Harnesses       []harnessStats `json:"harnesses"`
 	TopProjects     []projectStats `json:"top_projects"`
 	Monthly         []monthStats   `json:"monthly"`
+	Heatmap         heatmapStats   `json:"heatmap"`
 	Sparkline       string         `json:"sparkline"`
 	DateRange       dateRangeStats `json:"date_range"`
 	Longest         sessionStat    `json:"longest_session"`
@@ -61,6 +63,20 @@ type projectStats struct {
 type monthStats struct {
 	Month    string `json:"month"`
 	Messages int    `json:"messages"`
+}
+
+// heatmapStats is a GitHub-style trailing-year grid: one column per week,
+// seven rows (Sun–Sat). A day count of -1 means the cell falls outside the
+// covered range and is not drawn.
+type heatmapStats struct {
+	Weeks  [][7]int    `json:"weeks"`
+	Max    int         `json:"max"`
+	Months []heatMonth `json:"months"`
+}
+
+type heatMonth struct {
+	Col   int    `json:"col"`
+	Label string `json:"label"`
 }
 
 type dateRangeStats struct {
@@ -145,13 +161,20 @@ func runStats(args []string) error {
 	if redaction && card {
 		return fmt.Errorf("stats: --redaction cannot combine with --card")
 	}
-	if err := index.Ensure(index.DefaultDir(), "", false, os.Stderr); err != nil {
+	// A card is a shareable artifact, not a build log: keep the per-harness
+	// indexing chatter off stdout/stderr and show one quiet status line instead.
+	progress := io.Writer(os.Stderr)
+	if cardPath != "" {
+		fmt.Fprintln(os.Stderr, "deja: preparing your stats card …")
+		progress = io.Discard
+	}
+	if err := index.Ensure(index.DefaultDir(), "", false, progress); err != nil {
 		return err
 	}
 	if redaction {
 		return printRedactionReport(jsonOut)
 	}
-	ss, err := index.SearchWithRecovery(index.DefaultDir(), search.Options{All: true}, os.Stderr)
+	ss, err := index.SearchWithRecovery(index.DefaultDir(), search.Options{All: true}, progress)
 	if err != nil {
 		return err
 	}
@@ -165,9 +188,8 @@ func runStats(args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(os.Stdout, path)
-		fmt.Fprintln(os.Stdout, "![deja](deja-stats.svg)")
-		fmt.Fprintln(os.Stdout, "Commit the SVG to your profile or repository if you want.")
+		base := filepath.Base(path)
+		fmt.Fprintf(os.Stdout, "saved %s\n\nshare it — paste into a README or post:\n  ![deja](%s)\n", path, base)
 		return nil
 	}
 	if htmlPath != "" {
@@ -336,6 +358,7 @@ func buildStats(ss []model.Session, now time.Time) statsReport {
 		}
 	}
 	out.Monthly = months
+	out.Heatmap = buildHeatmap(byDay, now)
 	out.Sparkline = sparkline(months)
 	if !minT.IsZero() {
 		out.DateRange.Start = minT.Format("2006-01-02")
@@ -343,6 +366,40 @@ func buildStats(ss []model.Session, now time.Time) statsReport {
 	}
 	out.RepeatQuestions = repeatQuestions(ss)
 	return out
+}
+
+// buildHeatmap turns per-day message counts into a Sunday-aligned trailing-year
+// grid (~53 week columns) with month ticks, for the shareable stats card.
+func buildHeatmap(byDay map[string]int, now time.Time) heatmapStats {
+	end := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	start := end.AddDate(0, 0, -370)
+	for start.Weekday() != time.Sunday {
+		start = start.AddDate(0, 0, -1)
+	}
+	var hm heatmapStats
+	lastMonth := ""
+	for cur := start; !cur.After(end); {
+		var week [7]int
+		colDate := cur
+		for d := 0; d < 7; d++ {
+			if cur.After(end) {
+				week[d] = -1
+			} else {
+				c := byDay[cur.Format("2006-01-02")]
+				week[d] = c
+				if c > hm.Max {
+					hm.Max = c
+				}
+			}
+			cur = cur.AddDate(0, 0, 1)
+		}
+		if mon := colDate.Format("Jan"); mon != lastMonth {
+			hm.Months = append(hm.Months, heatMonth{Col: len(hm.Weeks), Label: mon})
+			lastMonth = mon
+		}
+		hm.Weeks = append(hm.Weeks, week)
+	}
+	return hm
 }
 
 func printStats(w io.Writer, r statsReport) {

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -33,7 +33,7 @@ type statsReport struct {
 	Harnesses       []harnessStats `json:"harnesses"`
 	TopProjects     []projectStats `json:"top_projects"`
 	Monthly         []monthStats   `json:"monthly"`
-	Heatmap         heatmapStats   `json:"heatmap"`
+	Heatmap         heatmapStats   `json:"-"` // card-only presentation data; kept out of the stable --json schema
 	Sparkline       string         `json:"sparkline"`
 	DateRange       dateRangeStats `json:"date_range"`
 	Longest         sessionStat    `json:"longest_session"`

--- a/cmd/deja/statscard.go
+++ b/cmd/deja/statscard.go
@@ -26,43 +26,36 @@ func renderStatsCard(r statsReport) string {
 	var b strings.Builder
 	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
 	b.WriteString(`<svg xmlns="http://www.w3.org/2000/svg" width="800" height="420" viewBox="0 0 800 420">` + "\n")
-	b.WriteString(`<rect width="800" height="420" rx="24" fill="#0d1117"/>` + "\n")
-	b.WriteString(`<g font-family="` + statsCardFont + `" fill="#f0f6fc">` + "\n")
-	cardText(&b, 40, 54, 27, "700", statsHeadline(r), "#f0f6fc")
-	cardText(&b, 40, 80, 13, "400", "deja · agent history", "#f78166")
-	cardText(&b, 760, 80, 13, "400", valueOrDash(r.DateRange.Start)+" - "+valueOrDash(r.DateRange.End), "#8b949e", "text-anchor=\"end\"")
-	cardText(&b, 40, 112, 11, "400", "INDEXED WORK", "#8b949e", "letter-spacing=\"2\"")
-	cardText(&b, 40, 145, 28, "700", fmt.Sprintf("%d", r.TotalSessions), "#f0f6fc")
-	cardText(&b, 40, 163, 12, "400", "sessions", "#8b949e")
-	cardText(&b, 190, 145, 28, "700", fmt.Sprintf("%d", r.TotalMessages), "#f0f6fc")
-	cardText(&b, 190, 163, 12, "400", "messages", "#8b949e")
-	cardText(&b, 340, 145, 28, "700", fmt.Sprintf("%d", len(r.Harnesses)), "#f0f6fc")
-	cardText(&b, 340, 163, 12, "400", "harnesses", "#8b949e")
-
-	cardText(&b, 40, 201, 11, "700", "ACTIVITY / LAST 12 MONTHS", "#8b949e", "letter-spacing=\"1.5\"")
-	maxMonth := 0
-	for _, m := range r.Monthly {
-		if m.Messages > maxMonth {
-			maxMonth = m.Messages
+	b.WriteString(`<rect width="800" height="420" rx="20" fill="#0d0b16"/>` + "\n")
+	b.WriteString(`<rect x="0.5" y="0.5" width="799" height="419" rx="19.5" fill="none" stroke="#26233a"/>` + "\n")
+	b.WriteString(`<g font-family="` + statsCardFont + `" fill="#e6e6f0">` + "\n")
+	// brand line (kept verbatim so the card is unmistakably deja) + active range
+	b.WriteString(`<circle cx="46" cy="43" r="6" fill="#7c6cf0"/>` + "\n")
+	cardText(&b, 62, 48, 15, "700", "deja · agent history", "#4ecdc4", "letter-spacing=\"0.5\"")
+	cardText(&b, 760, 48, 13, "400", valueOrDash(r.DateRange.Start)+" – "+valueOrDash(r.DateRange.End), "#78788c", "text-anchor=\"end\"")
+	// the punch line — one personal sentence, sized to fit the card width
+	head := cardPunchline(r)
+	headSize := 25
+	if n := len(head); n > 0 && 1150/n < headSize {
+		if headSize = 1150 / n; headSize < 14 {
+			headSize = 14
 		}
 	}
-	for i, m := range r.Monthly {
-		x := 40 + i*43
-		h := 8
-		opacity := 0.35
-		if maxMonth > 0 && m.Messages > 0 {
-			h = 8 + 52*m.Messages/maxMonth
-			opacity = 0.35 + 0.65*float64(m.Messages)/float64(maxMonth)
-		}
-		fmt.Fprintf(&b, `<rect x="%d" y="%d" width="27" height="%d" rx="4" fill="#58a6ff" opacity="%.2f"/>`+"\n", x, 266-h, h, opacity)
-		label := m.Month
-		if len(label) >= 7 {
-			label = label[5:]
-		}
-		cardText(&b, x+13, 287, 10, "400", label, "#8b949e", "text-anchor=\"middle\"")
-	}
+	cardText(&b, 40, 90, headSize, "800", head, "#ffffff")
 
-	cardText(&b, 40, 312, 11, "700", "BY HARNESS", "#8b949e", "letter-spacing=\"1.5\"")
+	// hero: a GitHub-style trailing-year activity grid
+	renderHeatmap(&b, r.Heatmap, 44, 128)
+
+	// supporting counts (sessions/messages kept as their own text nodes)
+	cardText(&b, 44, 300, 30, "800", formatStatNumber(r.TotalSessions), "#4ecdc4")
+	cardText(&b, 44, 320, 12, "400", "sessions", "#78788c")
+	cardText(&b, 196, 300, 30, "700", formatStatNumber(r.TotalMessages), "#e6e6f0")
+	cardText(&b, 196, 320, 12, "400", "messages", "#78788c")
+	cardText(&b, 348, 300, 30, "700", fmt.Sprintf("%d", len(r.Harnesses)), "#e6e6f0")
+	cardText(&b, 348, 320, 12, "400", "agents", "#78788c")
+
+	// top agents, right column
+	cardText(&b, 470, 276, 11, "700", "TOP AGENTS", "#78788c", "letter-spacing=\"1.5\"")
 	harnesses := append([]harnessStats(nil), r.Harnesses...)
 	sort.SliceStable(harnesses, func(i, j int) bool {
 		if harnesses[i].Sessions == harnesses[j].Sessions {
@@ -70,12 +63,12 @@ func renderStatsCard(r statsReport) string {
 		}
 		return harnesses[i].Sessions > harnesses[j].Sessions
 	})
-	if len(harnesses) > 6 {
+	if len(harnesses) > 4 {
 		other := harnessStats{Harness: "other"}
-		for _, h := range harnesses[6:] {
+		for _, h := range harnesses[4:] {
 			other.Sessions += h.Sessions
 		}
-		harnesses = append(harnesses[:6], other)
+		harnesses = append(harnesses[:4], other)
 	}
 	maxHarness := 1
 	for _, h := range harnesses {
@@ -84,21 +77,70 @@ func renderStatsCard(r statsReport) string {
 		}
 	}
 	for i, h := range harnesses {
-		y := 322 + i*11
-		cardText(&b, 40, y+9, 10, "400", h.Harness, "#c9d1d9")
-		width := 100 * h.Sessions / maxHarness
-		fmt.Fprintf(&b, `<rect x="145" y="%d" width="%d" height="8" rx="4" fill="#3fb950"/>`+"\n", y+1, width)
-		cardText(&b, 255, y+9, 10, "700", fmt.Sprintf("%d", h.Sessions), "#c9d1d9")
+		y := 290 + i*13
+		cardText(&b, 470, y+9, 10, "400", h.Harness, "#c9d1d9")
+		width := 90 * h.Sessions / maxHarness
+		fmt.Fprintf(&b, `<rect x="570" y="%d" width="%d" height="8" rx="4" fill="#4ecdc4"/>`+"\n", y+1, width)
+		cardText(&b, 672, y+9, 10, "700", fmt.Sprintf("%d", h.Sessions), "#c9d1d9")
 	}
-	// No project names on the card: it is meant to be committed to public
-	// READMEs, and project names are private. Show the active range instead.
-	if r.DateRange.Start != "" {
-		cardText(&b, 500, 312, 11, "700", "ACTIVE SINCE", "#8b949e", "letter-spacing=\"1.5\"")
-		cardText(&b, 500, 335, 13, "400", r.DateRange.Start, "#c9d1d9")
-	}
-	cardText(&b, 40, 410, 11, "400", "deja v"+version, "#8b949e")
+
+	cardText(&b, 40, 402, 11, "400", "deja v"+version, "#78788c")
+	cardText(&b, 760, 402, 12, "700", "vshulcz.github.io/deja-vu", "#4ecdc4", "text-anchor=\"end\"")
 	b.WriteString("</g>\n</svg>\n")
 	return b.String()
+}
+
+// cardPunchline picks one personal, shareable sentence for the card hero.
+func cardPunchline(r statsReport) string {
+	switch {
+	case r.RepeatQuestions > 0:
+		return fmt.Sprintf("You asked the same thing %s times — deja remembered.", formatStatNumber(r.RepeatQuestions))
+	case r.Recall.Recalls > 0:
+		return fmt.Sprintf("deja handed your agents memory %s times.", formatStatNumber(r.Recall.Recalls))
+	case r.TotalSessions > 0:
+		return fmt.Sprintf("%s sessions of agent history, all searchable.", formatStatNumber(r.TotalSessions))
+	default:
+		return "Your coding-agent memory, indexed and searchable."
+	}
+}
+
+// renderHeatmap draws a GitHub-style week-by-day grid with month ticks.
+func renderHeatmap(b *strings.Builder, hm heatmapStats, x0, y0 int) {
+	const step = 13
+	for _, mt := range hm.Months {
+		cardText(b, x0+mt.Col*step, y0-6, 10, "400", mt.Label, "#78788c")
+	}
+	for col, week := range hm.Weeks {
+		for d := 0; d < 7; d++ {
+			c := week[d]
+			if c < 0 {
+				continue
+			}
+			fill, op := heatFill(c, hm.Max)
+			fmt.Fprintf(b, `<rect x="%d" y="%d" width="11" height="11" rx="2" fill="%s" opacity="%.2f"/>`+"\n",
+				x0+col*step, y0+d*step, fill, op)
+		}
+	}
+}
+
+func heatFill(c, max int) (string, float64) {
+	if c <= 0 {
+		return "#1b1926", 1
+	}
+	ratio := 1.0
+	if max > 0 {
+		ratio = float64(c) / float64(max)
+	}
+	switch {
+	case ratio <= 0.25:
+		return "#4ecdc4", 0.28
+	case ratio <= 0.5:
+		return "#4ecdc4", 0.5
+	case ratio <= 0.75:
+		return "#4ecdc4", 0.72
+	default:
+		return "#4ecdc4", 1
+	}
 }
 
 func cardText(b *strings.Builder, x, y, size int, weight, text, fill string, attrs ...string) {

--- a/cmd/deja/statscard_test.go
+++ b/cmd/deja/statscard_test.go
@@ -82,9 +82,8 @@ func TestStatsCardCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 	abs, _ := filepath.Abs(path)
-	lines := strings.Split(strings.TrimSpace(out), "\n")
-	if len(lines) != 3 || lines[0] != abs || lines[1] != "![deja](deja-stats.svg)" {
-		t.Fatalf("card output = %q, want %q", out, abs)
+	if !strings.Contains(out, "saved "+abs) || !strings.Contains(out, "![deja]("+filepath.Base(path)+")") {
+		t.Fatalf("card output = %q, want saved %q + share snippet", out, abs)
 	}
 	if b, err := os.ReadFile(path); err != nil || !strings.Contains(string(b), "deja · agent history") {
 		t.Fatalf("card contents = %q, %v", b, err)


### PR DESCRIPTION
The card hero is now a GitHub-style trailing-year activity grid with one personal line (repeat questions / recalls served). `--card` runs quietly instead of dumping per-harness indexing logs, and prints a paste-ready markdown snippet with the actual filename.