### PR TITLE
docs: reposition hero, honest bench baseline, release-note cleanup

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,6 +57,7 @@ snapshot:
 
 changelog:
   sort: asc
+  format: "{{ .Message }}"
   groups:
     - title: Features
       regexp: '^feat(\(.+\))?:'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,11 @@ go test ./internal/sources/ -coverprofile=coverage.out
 go tool cover -func=coverage.out
 ```
 
-Replace `internal/sources` with each package changed. Do not add low-value tests
-only to move the number; explain a genuinely unreachable branch in the pull
-request instead.
+Replace `internal/sources` with each package changed. CI prints only the
+aggregate number, so the two commands above are how you check the figure review
+actually looks at — run them before opening the PR and there will be no
+surprises. Do not add low-value tests only to move the number; explain a
+genuinely unreachable branch in the pull request instead.
 
 ## Hermetic tests
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="assets/logo.svg" width="340" alt="deja-vu"></p>
 
-<p align="center"><strong>Your agents already solved this. deja finds it.</strong><br>Search 3.3&nbsp;GB of agent history in ~12&nbsp;ms &mdash; and reach working context for ~60&times; fewer tokens than replaying it. One zero-dependency binary, fully local.</p>
+<p align="center"><strong>Your agents already solved this. deja finds it.</strong><br>Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk &mdash; months of history from before you installed it &mdash; searches 3.3&nbsp;GB in ~12&nbsp;ms, serves it back to any agent over MCP, and moves with you between machines over SSH. One zero-dependency binary, fully local.</p>
 
 <p align="center"><a href="https://vshulcz.github.io/deja-vu/">vshulcz.github.io/deja-vu</a></p>
 
@@ -19,12 +19,12 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | Feature | What it does |
 | --- | --- |
 | **Search** | `deja "connection pool exhausted"` — ~12 ms over gigabytes, retroactive: months of logs from before you installed it |
-| **Agent recall** | MCP `recall` tool — the agent answers *"we fixed this three weeks ago"* instead of re-debugging, across harnesses |
+| **Agent recall** | MCP `recall` tool — the agent answers *"we fixed this three weeks ago"* instead of re-debugging, across harnesses: solve it in Codex, Claude remembers |
+| **Sync** | `deja sync ssh laptop` — your memory follows you between machines, append-only, idempotent, no cloud in the middle |
 | **Auto-recall** | `install --auto` adds a SessionStart hook: relevant memory lands in context before you ask; Claude Code also captures the current transcript before compaction |
 | **Redaction** | API keys, JWTs, private keys are stripped at index time — the cache is safe to keep |
 | **Stats** | `deja stats` — your agent work, wrapped: harnesses, top projects, activity sparkline |
 | **Share** | `deja share <id>` — hand a colleague a sanitized digest of a session, secrets already scrubbed |
-| **Sync** | `deja sync export/import` — move memory between machines, append-only, idempotent |
 | **Remember** | `deja remember "text"` or MCP `remember` — keep durable decisions and conclusions |
 | **Blame** | `deja blame <path>` — which sessions touched this file, what was decided and why |
 | **Semantic** | optional: point `deja embed` at a local Ollama/LM Studio and rephrased queries still hit |
@@ -278,7 +278,7 @@ Run with the default seed (`1`):
 | naive-grep | 57,489 | 40,413-74,837 | 1.00 | 0 |
 | cold | 0 | 0-0 | 0.00 | 0 |
 
-Prior sessions in the generated corpus carry realistic log-noise bulk; without it the full-history arm looks artificially cheap and the comparison is meaningless. On this corpus the recall digest reaches the same fact coverage as replaying the full history for about 60x fewer tokens, and injects nothing on the negative-control chains where no prior fact is relevant.
+Prior sessions in the generated corpus carry realistic log-noise bulk; without it the full-history arm looks artificially cheap and the comparison is meaningless. On this corpus the recall digest reaches the same fact coverage as grepping the raw logs for about 200x fewer tokens — and about 60x fewer than replaying the matched sessions in full — while injecting nothing on the negative-control chains where no prior fact is relevant.
 
 ## How it works
 
@@ -291,10 +291,10 @@ Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact cr
 **Does anything leave my machine?** Indexing and search are local. `deja update` downloads releases from GitHub, and user-invoked `deja sync ssh` transfers redacted batches through the system SSH client. Directory exports and shares go only to the destination you choose. See the [security model](docs/SECURITY-MODEL.md#data-flows) for the full data flow.
 
 **How is this different from cass?**
-[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, eight harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
+[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, ten harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
 
 **And from MemPalace / Mem0 / Letta?**
-Those are memory *platforms*: embeddings, vector stores, capture hooks or APIs that record going forward. deja has no capture step at all — it indexes what your agents already wrote to disk, including months of history from before you installed it. They can coexist.
+Those are memory *platforms*: a Python runtime, embedding models, a vector store, and capture hooks that only remember what happens after you adopt them. deja has no capture step and no stack — one binary over the logs your agents already wrote, so it knows your history from day one, including everything from before you installed it.
 
 **What about secrets already in my logs?** They stay in the original harness files (that's your agent's data), but they don't enter deja's index, digests, shares or sync exports.
 

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -58,7 +58,7 @@
 <p>Builds a seeded multi-session corpus and query set, runs them through the real search pipeline, and reports recall@5/@10 with median latency (plus a hybrid column when an embedding endpoint is up). CI fails if recall regresses.</p>
 <h2>Context readiness</h2>
 <pre>deja bench context</pre>
-<p>The interesting number. Across seeded multi-session task chains, it compares four ways to assemble the context a task needs — deja recall, replaying full history, naive grep, and cold — reporting median tokens with spread and verbatim fact coverage. On the default corpus, deja reaches the same fact coverage as replaying the full history for roughly <b>60× fewer tokens</b>, and injects nothing on the negative-control chains where no prior fact is relevant.</p>
+<p>The interesting number. Across seeded multi-session task chains, it compares four ways to assemble the context a task needs — deja recall, replaying full history, naive grep, and cold — reporting median tokens with spread and verbatim fact coverage. On the default corpus, deja reaches the same fact coverage as grepping the raw logs for roughly <b>200× fewer tokens</b> — and about 60× fewer than replaying the matched sessions in full — while injecting nothing on the negative-control chains where no prior fact is relevant.</p>
 <div class="note">The comparison is ablation-matched (same pipeline, memory on/off) with naive baselines, so the number isolates deja's contribution rather than "more context helps". Run it and read the distribution.</div>
 
 </article>

--- a/docs/index.html
+++ b/docs/index.html
@@ -162,14 +162,14 @@ a:hover{text-decoration:underline}
 
 <header>
   <h1>Your agents already solved this.<br><span class="grad">deja finds it.</span></h1>
-  <p class="sub">Your agents forget everything between sessions. Every fix, every rejected approach, every decision — written to disk, never searched again. <code>deja</code> indexes it all and hands it back over MCP, so the agent recalls what it already figured out instead of re-solving it.</p>
+  <p class="sub">Memory tools start empty and record forward. <code>deja</code> starts full: it indexes the sessions your agents already wrote to disk — months of history from before you installed it — hands it back over MCP so any agent recalls what any other solved, and follows you between machines over SSH.</p>
   <div class="cta">
     <a class="btn primary" href="#install">Get started</a>
     <a class="btn" href="https://github.com/vshulcz/deja-vu">Star on GitHub</a>
   </div>
   <div class="chips">
     <span class="chip"><b>10</b> coding agents</span>
-    <span class="chip"><b>~60&times;</b> fewer tokens to context</span>
+    <span class="chip"><b>0</b> capture step — indexes retroactively</span>
     <span class="chip"><b>0</b> config, 0 cloud</span>
     <span class="chip">MIT &middot; fully local</span>
   </div>
@@ -215,7 +215,7 @@ a:hover{text-decoration:underline}
   <h2>Measured, not claimed</h2>
   <p class="lead">Reaching the context a task needs, with deja recall vs replaying the whole history — a seeded benchmark anyone can run with <code style="font-family:var(--mono)">deja bench context</code>.</p>
   <div class="proof-grid">
-    <div class="proof-cell"><div class="big grad">~60&times;</div><div class="cap2">fewer tokens to working context than replaying history, at equal fact coverage</div></div>
+    <div class="proof-cell"><div class="big grad">~200&times;</div><div class="cap2">fewer tokens to working context than grepping the raw logs, at equal fact coverage</div></div>
     <div class="proof-cell"><div class="big grad">~12 ms</div><div class="cap2">typical warm search over gigabytes of history</div></div>
     <div class="proof-cell"><div class="big grad">10</div><div class="cap2">coding agents indexed into one retroactive memory</div></div>
   </div>
@@ -296,7 +296,7 @@ a:hover{text-decoration:underline}
     <a href="guide/commands.html">CLI reference<span>every subcommand and flag</span></a>
     <a href="guide/harnesses.html">Harnesses<span>ten agents, and adding one</span></a>
     <a href="guide/privacy.html">Privacy<span>redaction, forget, exclude</span></a>
-    <a href="guide/benchmarks.html">Benchmarks<span>the ~60&times; number, reproducible</span></a>
+    <a href="guide/benchmarks.html">Benchmarks<span>the ~200&times; number, reproducible</span></a>
     <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture<span>index format, internals</span></a>
   </div>
 </section>


### PR DESCRIPTION
Repositions the README and site around what only deja does: starts full (retroactive), cross-agent recall, SSH-portable. The headline token figure now uses the grep baseline (~200x) with replay (~60x) secondary — grep is what people actually do with logs. Sync moves up the feature table, the MemPalace FAQ states the contrast instead of shrugging, goreleaser changelog drops raw SHAs, CONTRIBUTING explains how to self-check the per-package coverage figure.