### PR TITLE
feat: deja handoff — continue a session in another agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `deja handoff --to <agent> [id-prefix] [--exec]` — package the live context of a session (problem, conclusions, where it stopped) and continue it in a different agent. Composable: `codex "$(deja handoff --to codex)"`; `--exec` launches the target directly. Targets: claude, codex, opencode, gemini, qwen, aider, pi, grok.
+- Shareable stats card rebuilt around a trailing-year activity grid with a personal headline; `stats --card` now runs quietly and prints a paste-ready snippet.
+
 ## [0.13.1] - 2026-07-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | **Search** | `deja "connection pool exhausted"` — ~12 ms over gigabytes, retroactive: months of logs from before you installed it |
 | **Agent recall** | MCP `recall` tool — the agent answers *"we fixed this three weeks ago"* instead of re-debugging, across harnesses: solve it in Codex, Claude remembers |
 | **Sync** | `deja sync ssh laptop` — your memory follows you between machines, append-only, idempotent, no cloud in the middle |
+| **Handoff** | `deja handoff --to codex` — stuck in one agent? package the live context and continue in another: `codex "$(deja handoff --to codex)"` |
 | **Auto-recall** | `install --auto` adds a SessionStart hook: relevant memory lands in context before you ask; Claude Code also captures the current transcript before compaction |
 | **Redaction** | API keys, JWTs, private keys are stripped at index time — the cache is safe to keep |
 | **Stats** | `deja stats` — your agent work, wrapped: harnesses, top projects, activity sparkline |

--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -35,7 +35,7 @@ _deja_completion() {
     command="${COMP_WORDS[1]}"
     action="${COMP_WORDS[2]}"
 
-    local commands="blame bench completion ctx doctor embed forget index install last mcp remember resume share show sources stats statusline sync uninstall update version warmup"
+    local commands="blame bench completion ctx doctor embed forget handoff index install last mcp remember resume share show sources stats statusline sync uninstall update version warmup"
     local harnesses="claude codex opencode aider gemini cursor antigravity grok qwen pi deja"
     local install_targets="claude-code codex opencode cursor gemini antigravity grok qwen copilot pi statusline --all --auto"
 
@@ -71,6 +71,13 @@ _deja_completion() {
             ;;
         forget)
             COMPREPLY=( $(compgen -W "--list --dry-run --session --project --before --unforget" -- "$cur") )
+            ;;
+        handoff)
+            if [[ "$prev" == "--to" ]]; then
+                COMPREPLY=( $(compgen -W "claude codex opencode gemini qwen aider pi grok" -- "$cur") )
+            else
+                COMPREPLY=( $(compgen -W "--to --exec" -- "$cur") )
+            fi
             ;;
         hook-context)
             COMPREPLY=( $(compgen -W "--plain" -- "$cur") )
@@ -140,6 +147,7 @@ _deja() {
     'doctor:diagnose local stores and wiring'
     'embed:build the semantic sidecar'
     'forget:remove indexed sessions'
+    'handoff:continue a session in another agent'
     'index:build or refresh the index'
     'install:wire deja into an agent'
     'last:list recent sessions'
@@ -186,6 +194,9 @@ _deja() {
       ;;
     forget)
       _arguments '--list[list tombstones]' '--dry-run[show changes without applying]' '--session=[session ID prefix]:session:' '--project=[project substring]:project:' '--before=[duration or date]:time:' '--unforget=[tombstone ID]:ID:'
+      ;;
+    handoff)
+      _arguments '--to=[target agent]:agent:(claude codex opencode gemini qwen aider pi grok)' '--exec[launch the target agent]' '1:session ID prefix:'
       ;;
     hook-context)
       _arguments '--plain[omit formatting]'
@@ -234,7 +245,7 @@ const fishCompletion = `function __deja_needs_command
     test (count (commandline -opc)) -eq 1
 end
 
-complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed forget index install last mcp remember resume share show sources stats statusline sync uninstall update version warmup'
+complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed forget handoff index install last mcp remember resume share show sources stats statusline sync uninstall update version warmup'
 complete -c deja -n '__deja_needs_command' -l json -d 'Print JSON'
 complete -c deja -n '__deja_needs_command' -l re -d 'Interpret query as a regular expression'
 complete -c deja -n '__deja_needs_command' -l all -d 'Include all results'
@@ -264,6 +275,8 @@ complete -c deja -n '__fish_seen_subcommand_from forget' -l session -r
 complete -c deja -n '__fish_seen_subcommand_from forget' -l project -r
 complete -c deja -n '__fish_seen_subcommand_from forget' -l before -r
 complete -c deja -n '__fish_seen_subcommand_from forget' -l unforget -r
+complete -c deja -n '__fish_seen_subcommand_from handoff' -l to -r -a 'claude codex opencode gemini qwen aider pi grok'
+complete -c deja -n '__fish_seen_subcommand_from handoff' -l exec
 complete -c deja -n '__fish_seen_subcommand_from hook-context' -l plain
 complete -c deja -n '__fish_seen_subcommand_from index' -l rebuild
 complete -c deja -n '__fish_seen_subcommand_from install uninstall' -a 'claude-code codex opencode cursor gemini antigravity grok qwen copilot pi statusline --all --auto'

--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+const handoffBudget = 6 * 1024
+
+// runHandoff packages the live context of a session — the problem, what was
+// concluded, where it stopped — and continues it in a different agent.
+// Default output is the digest itself so it composes into any CLI:
+//
+//	codex "$(deja handoff --to codex)"
+//
+// --exec launches the target agent directly with the digest as its first
+// prompt. The source is the newest session for the current project unless an
+// id-prefix picks one explicitly.
+func runHandoff(args []string, stdout io.Writer) error {
+	target := ""
+	prefix := ""
+	doExec := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--to":
+			if i+1 >= len(args) {
+				return fmt.Errorf("handoff: --to needs an agent name")
+			}
+			target = args[i+1]
+			i++
+		case "--exec":
+			doExec = true
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("handoff: unknown flag %s", args[i])
+			}
+			prefix = args[i]
+		}
+	}
+	if target == "" {
+		return fmt.Errorf("handoff needs --to <agent>: %s", strings.Join(handoffTargets(), ", "))
+	}
+	argv, ok := handoffCommand(target, "")
+	if !ok {
+		return fmt.Errorf("don't know how to hand off to %q; targets: %s", target, strings.Join(handoffTargets(), ", "))
+	}
+	s, err := handoffSource(prefix)
+	if err != nil {
+		return err
+	}
+	digest := handoffDigest(s, handoffBudget)
+	if !doExec {
+		printSanitized(stdout, digest)
+		fmt.Fprintf(os.Stderr, "\nhand it off:\n  %s \"$(deja handoff --to %s%s)\"\nor run it now: deja handoff --to %s%s --exec\n",
+			strings.Join(argv, " "), target, prefixArg(prefix), target, prefixArg(prefix))
+		return nil
+	}
+	argv, _ = handoffCommand(target, digest)
+	if _, err := exec.LookPath(argv[0]); err != nil {
+		return fmt.Errorf("handoff: %s is not installed (looked for %q in PATH)", target, argv[0])
+	}
+	c := exec.Command(argv[0], argv[1:]...)
+	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+	return c.Run()
+}
+
+func prefixArg(prefix string) string {
+	if prefix == "" {
+		return ""
+	}
+	return " " + prefix
+}
+
+// handoffSource resolves the session being handed off: an explicit id-prefix,
+// or the newest indexed session for the project in the current directory.
+func handoffSource(prefix string) (model.Session, error) {
+	if err := index.Ensure(index.DefaultDir(), "", false, os.Stderr); err != nil {
+		return model.Session{}, err
+	}
+	if prefix != "" {
+		s, ok, err := findByPrefix(prefix)
+		if err != nil {
+			return model.Session{}, err
+		}
+		if !ok {
+			return model.Session{}, fmt.Errorf("no session matches %q", prefix)
+		}
+		return s, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return model.Session{}, err
+	}
+	var newest model.Session
+	for _, name := range projectNameCandidates(cwd) {
+		ss, err := index.RecentProject(index.DefaultDir(), name, 1)
+		if err != nil || len(ss) == 0 {
+			continue
+		}
+		if ss[0].Updated.After(newest.Updated) {
+			newest = ss[0]
+		}
+	}
+	if newest.ID == "" {
+		return model.Session{}, fmt.Errorf("no indexed sessions for this project — pass a session id-prefix (see `deja last`)")
+	}
+	return newest, nil
+}
+
+func projectNameCandidates(cwd string) []string {
+	names := []string{sources.ClaudeProjectName(cwd)}
+	if base := filepath.Base(cwd); base != "" {
+		if two := filepath.Join(filepath.Base(filepath.Dir(cwd)), base); two != names[0] {
+			names = append(names, two)
+		}
+		if base != names[0] {
+			names = append(names, base)
+		}
+	}
+	return names
+}
+
+// agentArtifactMarkers flag transcript entries that are tool output or
+// harness plumbing recorded under a user/assistant role — noise that would
+// bury the actual problem statement in a handoff.
+var agentArtifactMarkers = []string{
+	"<system-reminder>",
+	"</teammate-message>",
+	"<task-notification>",
+	"<command-name>",
+	"Bash completed with no output",
+	"Shell cwd was reset",
+	"tool_use_error",
+	"no need to Read it back)",
+	"Called the Read tool with",
+	"[Request interrupted by user]",
+}
+
+func isAgentArtifact(text string) bool {
+	for _, m := range agentArtifactMarkers {
+		if strings.Contains(text, m) {
+			return true
+		}
+	}
+	trimmed := strings.TrimSpace(text)
+	// ls dumps recorded under a user role.
+	if strings.HasPrefix(trimmed, "total ") && strings.Contains(trimmed, "rwx") {
+		return true
+	}
+	// Tool echoes: file writes, diffs, command transcripts.
+	for _, p := range []string{"File created successfully at:", "The file ", "diff --git ", "$ "} {
+		if strings.HasPrefix(trimmed, p) {
+			return true
+		}
+	}
+	// Long dumps with almost no prose: measure letters vs symbols/digits in
+	// the first few hundred bytes — listings and tables sit far below prose.
+	if len(trimmed) > 400 {
+		letters, others := 0, 0
+		for _, r := range trimmed[:400] {
+			switch {
+			case r == ' ':
+			case ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z') || r >= 0x400: // latin + cyrillic
+				letters++
+			default:
+				others++
+			}
+		}
+		if others > letters {
+			return true
+		}
+	}
+	return false
+}
+
+// handoffClean drops agent artifacts so the digest carries conversation, not
+// tool output replayed under a user role.
+func handoffClean(s model.Session) model.Session {
+	out := s
+	out.Messages = nil
+	for _, m := range s.Messages {
+		if isAgentArtifact(m.Text) {
+			continue
+		}
+		out.Messages = append(out.Messages, m)
+	}
+	return out
+}
+
+// handoffDigest is the package the target agent starts from: framing header,
+// the user's problem statements, key conclusions, and the tail of the
+// conversation — the "where it stopped" part a plain summary loses.
+func handoffDigest(s model.Session, budget int) string {
+	s = handoffClean(s)
+	var b strings.Builder
+	date := "unknown"
+	if !s.Updated.IsZero() {
+		date = s.Updated.Format(time.RFC3339)
+	}
+	fmt.Fprintf(&b, "You are picking up work handed off from a %s session (project %s, %s). ", s.Harness, s.Project, date)
+	b.WriteString("Below is the packaged context: the problem, key conclusions so far, and where it stopped. Continue from there instead of re-deriving what is already done.\n\n")
+	body := shareDigest(s, budget*3/4)
+	// Drop the share header line; the framing above replaces it.
+	if i := strings.Index(body, "\n"); i > 0 && strings.HasPrefix(body, "# deja share:") {
+		body = strings.TrimSpace(body[i:])
+	}
+	b.WriteString(body)
+	if tail := handoffTail(s, budget-b.Len()); tail != "" {
+		b.WriteString("\n\n## Where it stopped\n\n")
+		b.WriteString(tail)
+	}
+	return strings.TrimSpace(b.String()) + "\n"
+}
+
+// handoffTail returns the last few substantive exchanges verbatim so the
+// target agent sees the live state, not just conclusions.
+func handoffTail(s model.Session, budget int) string {
+	if budget <= 0 {
+		return ""
+	}
+	var picked []model.Message
+	for i := len(s.Messages) - 1; i >= 0 && len(picked) < 4; i-- {
+		m := s.Messages[i]
+		if m.Role != "user" && m.Role != "assistant" {
+			continue
+		}
+		if noisyShareMessage(m.Text) || shareMessageText(m.Text) == "" {
+			continue
+		}
+		picked = append(picked, m)
+	}
+	var b strings.Builder
+	for i := len(picked) - 1; i >= 0; i-- {
+		m := picked[i]
+		chunk := fmt.Sprintf("**%s:** %s\n\n", m.Role, shareMessageText(m.Text))
+		if b.Len()+len(chunk) > budget {
+			chunk = utf8SafeCut(chunk, budget-b.Len())
+		}
+		b.WriteString(chunk)
+		if b.Len() >= budget {
+			break
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// handoffCommand maps a target agent to the argv that opens it with an
+// initial prompt. Prompt is passed as a single argv element — no shell.
+func handoffCommand(target, prompt string) ([]string, bool) {
+	switch target {
+	case "claude":
+		return []string{"claude", prompt}, true
+	case "codex":
+		return []string{"codex", prompt}, true
+	case "opencode":
+		return []string{"opencode", "run", prompt}, true
+	case "gemini":
+		return []string{"gemini", "-i", prompt}, true
+	case "qwen":
+		return []string{"qwen", "-i", prompt}, true
+	case "aider":
+		return []string{"aider", "--message", prompt}, true
+	case "pi":
+		return []string{"pi", prompt}, true
+	case "grok":
+		return []string{"grok", prompt}, true
+	default:
+		return nil, false
+	}
+}
+
+func handoffTargets() []string {
+	return []string{"claude", "codex", "opencode", "gemini", "qwen", "aider", "pi", "grok"}
+}

--- a/cmd/deja/handoff_test.go
+++ b/cmd/deja/handoff_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestHandoffFlagValidation(t *testing.T) {
+	for _, args := range [][]string{
+		{},
+		{"--to"},
+		{"--to", "notepad"},
+		{"--frobnicate"},
+	} {
+		if err := runHandoff(args, discardWriter{}); err == nil {
+			t.Fatalf("runHandoff(%#v) returned nil", args)
+		}
+	}
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestHandoffCommandTable(t *testing.T) {
+	cases := map[string][]string{
+		"claude":   {"claude", "P"},
+		"codex":    {"codex", "P"},
+		"opencode": {"opencode", "run", "P"},
+		"gemini":   {"gemini", "-i", "P"},
+		"qwen":     {"qwen", "-i", "P"},
+		"aider":    {"aider", "--message", "P"},
+		"pi":       {"pi", "P"},
+		"grok":     {"grok", "P"},
+	}
+	for target, want := range cases {
+		argv, ok := handoffCommand(target, "P")
+		if !ok || strings.Join(argv, "\x00") != strings.Join(want, "\x00") {
+			t.Fatalf("handoffCommand(%s) = %v, %v", target, argv, ok)
+		}
+	}
+	if _, ok := handoffCommand("cursor", "P"); ok {
+		t.Fatal("cursor has no CLI prompt entry point yet, must be rejected")
+	}
+	if len(handoffTargets()) != len(cases) {
+		t.Fatalf("handoffTargets() = %v out of sync with command table", handoffTargets())
+	}
+}
+
+func TestHandoffDigestShape(t *testing.T) {
+	s := model.Session{
+		ID: "abc123", Harness: "claude", Project: "gateway", Updated: time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC),
+		Messages: []model.Message{
+			{Role: "user", Text: "pool exhausted under load"},
+			{Role: "assistant", Text: "raised MaxIdleConns, real leak was rows.Close"},
+			{Role: "user", Text: "still failing on staging"},
+			{Role: "assistant", Text: "staging pgbouncer caps at 20, bump pool_size"},
+		},
+	}
+	d := handoffDigest(s, handoffBudget)
+	for _, want := range []string{
+		"picking up work handed off from a claude session",
+		"project gateway",
+		"## User problem statement(s)",
+		"## Where it stopped",
+		"**assistant:** staging pgbouncer caps at 20",
+	} {
+		if !strings.Contains(d, want) {
+			t.Fatalf("digest missing %q:\n%s", want, d)
+		}
+	}
+	if strings.Contains(d, "# deja share:") {
+		t.Fatalf("share header must be replaced by handoff framing:\n%s", d)
+	}
+	if len(d) > handoffBudget+256 {
+		t.Fatalf("digest exceeds budget: %d", len(d))
+	}
+}
+
+func TestHandoffTailEmptyAndBudget(t *testing.T) {
+	if got := handoffTail(model.Session{}, 100); got != "" {
+		t.Fatalf("empty session tail = %q", got)
+	}
+	s := model.Session{Messages: []model.Message{
+		{Role: "assistant", Text: strings.Repeat("x", 500)},
+	}}
+	if got := handoffTail(s, 40); len(got) > 40 {
+		t.Fatalf("tail ignored budget: %d bytes", len(got))
+	}
+	if got := handoffTail(s, 0); got != "" {
+		t.Fatalf("zero budget tail = %q", got)
+	}
+}
+
+func TestHandoffPrintsComposableDigest(t *testing.T) {
+	withStatsStores(t)
+	out, err := captureRun(t, "handoff", "--to", "codex", "c3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "picking up work handed off from a claude session") ||
+		!strings.Contains(out, "long beta session") {
+		t.Fatalf("handoff output = %q", out)
+	}
+}
+
+func TestHandoffSourceErrors(t *testing.T) {
+	withStatsStores(t)
+	if _, err := handoffSource("nope-prefix"); err == nil || !strings.Contains(err.Error(), "no session matches") {
+		t.Fatalf("bad prefix error = %v", err)
+	}
+	t.Chdir(t.TempDir())
+	if _, err := handoffSource(""); err == nil || !strings.Contains(err.Error(), "no indexed sessions for this project") {
+		t.Fatalf("empty project error = %v", err)
+	}
+}
+
+func TestHandoffSourcePicksNewestProjectSession(t *testing.T) {
+	withStatsStores(t)
+	cwd := filepath.Join(t.TempDir(), "tmp", "alpha")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	s, err := handoffSource("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// c2 (2026-03) is newer than c1 (2026-01) in project tmp/alpha.
+	if s.ID != "c2" {
+		t.Fatalf("picked session %s, want c2", s.ID)
+	}
+}
+
+func TestHandoffExecMissingBinary(t *testing.T) {
+	withStatsStores(t)
+	t.Setenv("PATH", t.TempDir())
+	err := runHandoff([]string{"--to", "grok", "c3", "--exec"}, discardWriter{})
+	if err == nil || !strings.Contains(err.Error(), "not installed") {
+		t.Fatalf("exec missing binary error = %v", err)
+	}
+}
+
+func TestPrefixArgAndProjectCandidates(t *testing.T) {
+	if prefixArg("") != "" || prefixArg("abc") != " abc" {
+		t.Fatal("prefixArg formatting")
+	}
+	names := projectNameCandidates("/tmp/alpha")
+	if len(names) == 0 || names[0] == "" {
+		t.Fatalf("candidates = %v", names)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -168,6 +168,9 @@ func run(args []string) error {
 	if args[0] == "resume" {
 		return runResume(args[1:], os.Stdout)
 	}
+	if args[0] == "handoff" {
+		return runHandoff(args[1:], os.Stdout)
+	}
 	if args[0] == "sync" {
 		return runSync(args[1:])
 	}
@@ -749,6 +752,7 @@ Usage:
   deja show <id-prefix>
   deja share <id-prefix>
   deja resume <id-prefix> [--exec]
+  deja handoff --to <agent> [id-prefix] [--exec]
   deja ctx <query|id-prefix>
   deja blame <path> [--all] [--json] [--project name] [--harness name] [--since 30d]
   deja sync export <dir> [--full]


### PR DESCRIPTION
Stuck in one agent, continue in another: `deja handoff --to codex` packages the newest session for the current project (or an explicit id-prefix) into a redacted digest — problem statements, key conclusions, and the last exchanges verbatim — and hands it to the target CLI. Default output is the digest itself so it composes (`codex "$(deja handoff --to codex)"`); `--exec` launches the agent with it directly. Targets: claude, codex, opencode, gemini, qwen, aider, pi, grok.

Known limitation: sessions heavy on tool dumps recorded under a user role can still leak fragments into the digest; the artifact filter catches the common shapes, the real fix is a tool role at parse time.