### PR TITLE
feat(handoff): paste mode, cleaner digests, opencode TUI prompt

### DIFF
--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -46,12 +46,17 @@ func runHandoff(args []string, stdout io.Writer) error {
 			prefix = args[i]
 		}
 	}
-	if target == "" {
-		return fmt.Errorf("handoff needs --to <agent>: %s", strings.Join(handoffTargets(), ", "))
+	pasteOnly := target == "" || target == "antigravity" || target == "cursor"
+	if !pasteOnly {
+		if _, ok := handoffCommand(target, ""); !ok {
+			return fmt.Errorf("don't know how to hand off to %q; targets: %s (or omit --to and paste the digest anywhere)", target, strings.Join(handoffTargets(), ", "))
+		}
 	}
-	argv, ok := handoffCommand(target, "")
-	if !ok {
-		return fmt.Errorf("don't know how to hand off to %q; targets: %s", target, strings.Join(handoffTargets(), ", "))
+	if pasteOnly && doExec {
+		if target == "" {
+			return fmt.Errorf("handoff --exec needs --to <agent>: %s", strings.Join(handoffTargets(), ", "))
+		}
+		return fmt.Errorf("%s has no CLI prompt entry — run `deja handoff --to %s` and paste the digest into a new chat", target, target)
 	}
 	s, err := handoffSource(prefix)
 	if err != nil {
@@ -60,11 +65,22 @@ func runHandoff(args []string, stdout io.Writer) error {
 	digest := handoffDigest(s, handoffBudget)
 	if !doExec {
 		printSanitized(stdout, digest)
-		fmt.Fprintf(os.Stderr, "\nhand it off:\n  %s \"$(deja handoff --to %s%s)\"\nor run it now: deja handoff --to %s%s --exec\n",
-			strings.Join(argv, " "), target, prefixArg(prefix), target, prefixArg(prefix))
+		if pasteOnly {
+			fmt.Fprintf(os.Stderr, "\npaste this into a new chat, or hand off directly: deja handoff --to <%s> [--exec]\n", strings.Join(handoffTargets(), "|"))
+		} else {
+			argv, _ := handoffCommand(target, "")
+			head := make([]string, 0, len(argv))
+			for _, a := range argv {
+				if a != "" {
+					head = append(head, a)
+				}
+			}
+			fmt.Fprintf(os.Stderr, "\nhand it off:\n  %s \"$(deja handoff --to %s%s)\"\nor run it now: deja handoff --to %s%s --exec\n",
+				strings.Join(head, " "), target, prefixArg(prefix), target, prefixArg(prefix))
+		}
 		return nil
 	}
-	argv, _ = handoffCommand(target, digest)
+	argv, _ := handoffCommand(target, digest)
 	if _, err := exec.LookPath(argv[0]); err != nil {
 		return fmt.Errorf("handoff: %s is not installed (looked for %q in PATH)", target, argv[0])
 	}
@@ -143,6 +159,7 @@ var agentArtifactMarkers = []string{
 	"no need to Read it back)",
 	"Called the Read tool with",
 	"[Request interrupted by user]",
+	"Comments on artifact URI:",
 }
 
 func isAgentArtifact(text string) bool {
@@ -152,6 +169,11 @@ func isAgentArtifact(text string) bool {
 		}
 	}
 	trimmed := strings.TrimSpace(text)
+	// Harness preambles injected as user turns: <environment_context>,
+	// <user_instructions> and similar XML-wrapped plumbing.
+	if strings.HasPrefix(trimmed, "<") && strings.Contains(trimmed, "</") {
+		return true
+	}
 	// ls dumps recorded under a user role.
 	if strings.HasPrefix(trimmed, "total ") && strings.Contains(trimmed, "rwx") {
 		return true
@@ -182,15 +204,21 @@ func isAgentArtifact(text string) bool {
 	return false
 }
 
-// handoffClean drops agent artifacts so the digest carries conversation, not
-// tool output replayed under a user role.
+// handoffClean drops agent artifacts and exact repeats so the digest carries
+// conversation, not tool output replayed under a user role.
 func handoffClean(s model.Session) model.Session {
 	out := s
 	out.Messages = nil
+	seen := map[string]bool{}
 	for _, m := range s.Messages {
 		if isAgentArtifact(m.Text) {
 			continue
 		}
+		key := m.Role + "\x00" + strings.TrimSpace(m.Text)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
 		out.Messages = append(out.Messages, m)
 	}
 	return out
@@ -262,7 +290,7 @@ func handoffCommand(target, prompt string) ([]string, bool) {
 	case "codex":
 		return []string{"codex", prompt}, true
 	case "opencode":
-		return []string{"opencode", "run", prompt}, true
+		return []string{"opencode", "--prompt", prompt}, true
 	case "gemini":
 		return []string{"gemini", "-i", prompt}, true
 	case "qwen":

--- a/cmd/deja/handoff_test.go
+++ b/cmd/deja/handoff_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestHandoffFlagValidation(t *testing.T) {
 	for _, args := range [][]string{
-		{},
 		{"--to"},
 		{"--to", "notepad"},
 		{"--frobnicate"},
@@ -31,7 +30,7 @@ func TestHandoffCommandTable(t *testing.T) {
 	cases := map[string][]string{
 		"claude":   {"claude", "P"},
 		"codex":    {"codex", "P"},
-		"opencode": {"opencode", "run", "P"},
+		"opencode": {"opencode", "--prompt", "P"},
 		"gemini":   {"gemini", "-i", "P"},
 		"qwen":     {"qwen", "-i", "P"},
 		"aider":    {"aider", "--message", "P"},
@@ -106,6 +105,41 @@ func TestHandoffPrintsComposableDigest(t *testing.T) {
 	if !strings.Contains(out, "picking up work handed off from a claude session") ||
 		!strings.Contains(out, "long beta session") {
 		t.Fatalf("handoff output = %q", out)
+	}
+}
+
+func TestHandoffPasteModes(t *testing.T) {
+	withStatsStores(t)
+	// no --to: universal paste digest
+	out, err := captureRun(t, "handoff", "c3")
+	if err != nil || !strings.Contains(out, "picking up work handed off") {
+		t.Fatalf("bare handoff = %q, %v", out, err)
+	}
+	// GUI-only target prints the digest too
+	out, err = captureRun(t, "handoff", "--to", "antigravity", "c3")
+	if err != nil || !strings.Contains(out, "picking up work handed off") {
+		t.Fatalf("antigravity handoff = %q, %v", out, err)
+	}
+	// but cannot --exec
+	if err := runHandoff([]string{"--to", "antigravity", "c3", "--exec"}, discardWriter{}); err == nil || !strings.Contains(err.Error(), "no CLI prompt entry") {
+		t.Fatalf("antigravity exec error = %v", err)
+	}
+	if err := runHandoff([]string{"c3", "--exec"}, discardWriter{}); err == nil || !strings.Contains(err.Error(), "--exec needs --to") {
+		t.Fatalf("bare exec error = %v", err)
+	}
+}
+
+func TestHandoffCleanDropsPreamblesAndRepeats(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "<environment_context><cwd>/x</cwd></environment_context>"},
+		{Role: "user", Text: "hi"},
+		{Role: "user", Text: "hi"},
+		{Role: "user", Text: "Comments on artifact URI: file:///brain/plan.md approved"},
+		{Role: "user", Text: "real question about retries"},
+	}}
+	got := handoffClean(s)
+	if len(got.Messages) != 2 || got.Messages[0].Text != "hi" || got.Messages[1].Text != "real question about retries" {
+		t.Fatalf("cleaned = %#v", got.Messages)
 	}
 }
 

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -752,7 +752,7 @@ Usage:
   deja show <id-prefix>
   deja share <id-prefix>
   deja resume <id-prefix> [--exec]
-  deja handoff --to <agent> [id-prefix] [--exec]
+  deja handoff [--to <agent>] [id-prefix] [--exec]
   deja ctx <query|id-prefix>
   deja blame <path> [--all] [--json] [--project name] [--harness name] [--since 30d]
   deja sync export <dir> [--full]


### PR DESCRIPTION
Round of fixes from a live end-to-end pass against installed claude, codex and opencode (plus antigravity as a GUI-only case):

- `--to` is now optional: bare `deja handoff` prints the digest for pasting anywhere; GUI-only agents (antigravity, cursor) get the digest plus a clear message instead of an error, and refuse `--exec` with guidance.
- digest cleanup: codex `<environment_context>` preambles and antigravity artifact-URI plumbing are filtered, exact repeated turns dedupe.
- opencode target opens the TUI with `--prompt` instead of one-shot `run`.
- composable-hint formatting fix.

Transport verified live in all three CLIs (each agent correctly restated the project and where the previous session stopped), and the `--exec` loop confirmed end-to-end: the launched claude session's first message is the digest — indexed back by deja itself.