### PR TITLE
feat(handoff): cursor as an exec target via cursor-agent

### DIFF
--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -46,7 +46,7 @@ func runHandoff(args []string, stdout io.Writer) error {
 			prefix = args[i]
 		}
 	}
-	pasteOnly := target == "" || target == "antigravity" || target == "cursor"
+	pasteOnly := target == "" || target == "antigravity"
 	if !pasteOnly {
 		if _, ok := handoffCommand(target, ""); !ok {
 			return fmt.Errorf("don't know how to hand off to %q; targets: %s (or omit --to and paste the digest anywhere)", target, strings.Join(handoffTargets(), ", "))
@@ -301,11 +301,13 @@ func handoffCommand(target, prompt string) ([]string, bool) {
 		return []string{"pi", prompt}, true
 	case "grok":
 		return []string{"grok", prompt}, true
+	case "cursor":
+		return []string{"cursor-agent", "chat", prompt}, true
 	default:
 		return nil, false
 	}
 }
 
 func handoffTargets() []string {
-	return []string{"claude", "codex", "opencode", "gemini", "qwen", "aider", "pi", "grok"}
+	return []string{"claude", "codex", "opencode", "cursor", "gemini", "qwen", "aider", "pi", "grok"}
 }

--- a/cmd/deja/handoff_test.go
+++ b/cmd/deja/handoff_test.go
@@ -36,6 +36,7 @@ func TestHandoffCommandTable(t *testing.T) {
 		"aider":    {"aider", "--message", "P"},
 		"pi":       {"pi", "P"},
 		"grok":     {"grok", "P"},
+		"cursor":   {"cursor-agent", "chat", "P"},
 	}
 	for target, want := range cases {
 		argv, ok := handoffCommand(target, "P")
@@ -43,8 +44,8 @@ func TestHandoffCommandTable(t *testing.T) {
 			t.Fatalf("handoffCommand(%s) = %v, %v", target, argv, ok)
 		}
 	}
-	if _, ok := handoffCommand("cursor", "P"); ok {
-		t.Fatal("cursor has no CLI prompt entry point yet, must be rejected")
+	if _, ok := handoffCommand("antigravity", "P"); ok {
+		t.Fatal("antigravity has no CLI prompt entry point, must stay paste-only")
 	}
 	if len(handoffTargets()) != len(cases) {
 		t.Fatalf("handoffTargets() = %v out of sync with command table", handoffTargets())


### PR DESCRIPTION
Cursor sessions are already indexed, so it should be a first-class handoff target too: `deja handoff --to cursor --exec` opens `cursor-agent chat` with the digest (syntax per Cursor's CLI docs). All ten indexed harnesses are now covered — nine launchable, antigravity paste-only (no CLI prompt entry).