### PR TITLE
feat: recall receipt and weekly recall numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Recall receipt: when auto-recall injects real context, the SessionStart hook now surfaces a one-line notice ("deja: recalled N prior sessions…") instead of working silently; `deja stats` and the statusline report the trailing-week recall count and re-used context volume.
 - GitHub Copilot CLI as the eleventh harness: sessions in `~/.copilot/session-state` are discovered, parsed and incrementally indexed; `copilot` is also a handoff target.
 - `deja handoff --to <agent> [id-prefix] [--exec]` — package the live context of a session (problem, conclusions, where it stopped) and continue it in a different agent. Composable: `codex "$(deja handoff --to codex)"`; `--exec` launches the target directly. Targets: claude, codex, opencode, gemini, qwen, aider, pi, grok.
 - Shareable stats card rebuilt around a trailing-year activity grid with a personal headline; `stats --card` now runs quietly and prints a paste-ready snippet.

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -23,6 +23,9 @@ const warmupRetryAfter = 10 * time.Minute
 var spawnWarmup = startDetachedWarmup
 
 type sessionStartHookResponse struct {
+	// SystemMessage surfaces a one-line receipt in the user's UI when memory
+	// actually landed; silent success builds no habit.
+	SystemMessage      string `json:"systemMessage,omitempty"`
 	HookSpecificOutput struct {
 		HookEventName     string `json:"hookEventName"`
 		AdditionalContext string `json:"additionalContext"`
@@ -76,6 +79,13 @@ func runHookContext(plain bool) error {
 	var resp sessionStartHookResponse
 	resp.HookSpecificOutput.HookEventName = "SessionStart"
 	resp.HookSpecificOutput.AdditionalContext = digest
+	if sessions > 0 {
+		plural := ""
+		if sessions > 1 {
+			plural = "s"
+		}
+		resp.SystemMessage = fmt.Sprintf("deja: recalled %d prior session%s from this project (~%dKB) — the agent starts already knowing them", sessions, plural, (len(digest)+1023)/1024)
+	}
 	b, err := json.Marshal(resp)
 	if err != nil {
 		return nil

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -638,6 +638,7 @@ func TestHookContextSyntheticFixtures(t *testing.T) {
 		t.Fatal(err)
 	}
 	var resp struct {
+		SystemMessage      string `json:"systemMessage"`
 		HookSpecificOutput struct {
 			HookEventName     string `json:"hookEventName"`
 			AdditionalContext string `json:"additionalContext"`
@@ -649,6 +650,10 @@ func TestHookContextSyntheticFixtures(t *testing.T) {
 	digest := resp.HookSpecificOutput.AdditionalContext
 	if resp.HookSpecificOutput.HookEventName != "SessionStart" || !strings.Contains(digest, "Find frobnicator bug") || !strings.Contains(digest, "parser.go") {
 		t.Fatalf("bad hook response: %#v", resp)
+	}
+	// A non-trivial injection must come with a visible receipt.
+	if !strings.Contains(resp.SystemMessage, "deja: recalled") || !strings.Contains(resp.SystemMessage, "prior session") {
+		t.Fatalf("receipt = %q", resp.SystemMessage)
 	}
 	if len(digest) > 2000 {
 		t.Fatalf("digest too large: %d", len(digest))

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -39,6 +39,8 @@ type statsReport struct {
 	Longest         sessionStat    `json:"longest_session"`
 	BusiestDay      dayStat        `json:"busiest_day"`
 	Recall          usage.Summary  `json:"recall"`
+	WeekRecalls     int            `json:"week_recalls"`
+	WeekBytes       int            `json:"week_bytes"`
 	SidecarSize     int64          `json:"sidecar_size,omitempty"`
 }
 
@@ -180,6 +182,7 @@ func runStats(args []string) error {
 	}
 	report := buildStats(filterStatsSessions(ss, options), time.Now())
 	report.Recall = usage.Totals(index.DefaultDir())
+	report.WeekRecalls, report.WeekBytes = usage.Week(index.DefaultDir())
 	if fi, e := os.Stat(embed.Path(index.DefaultDir())); e == nil {
 		report.SidecarSize = fi.Size()
 	}
@@ -457,6 +460,7 @@ func printStats(w io.Writer, r statsReport) {
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "%sRecall%s\n", bold, reset)
 	fmt.Fprintf(w, "  Recalls served   %d\n", r.Recall.Recalls)
+	fmt.Fprintf(w, "  This week        %d recalls · %s of context re-used\n", r.WeekRecalls, humanBytes(int64(r.WeekBytes)))
 	fmt.Fprintf(w, "  Injections       %d · %d sessions · %s\n", r.Recall.Injections, r.Recall.InjectedSessions, humanBytes(int64(r.Recall.InjectedBytes)))
 	fmt.Fprintf(w, "  Empty results    %.1f%%\n", r.Recall.EmptyResultRate*100)
 }

--- a/cmd/deja/statscard.go
+++ b/cmd/deja/statscard.go
@@ -93,6 +93,8 @@ func renderStatsCard(r statsReport) string {
 // cardPunchline picks one personal, shareable sentence for the card hero.
 func cardPunchline(r statsReport) string {
 	switch {
+	case r.WeekRecalls > 0:
+		return fmt.Sprintf("deja handed your agents memory %s times this week.", formatStatNumber(r.WeekRecalls))
 	case r.RepeatQuestions > 0:
 		return fmt.Sprintf("You asked the same thing %s times — deja remembered.", formatStatNumber(r.RepeatQuestions))
 	case r.Recall.Recalls > 0:

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -16,6 +16,10 @@ func runStatusline(stdin io.Reader, stdout io.Writer) error {
 	drainStdin(stdin)
 	recalls, bytes, injected := usage.TodayWithInjections(index.DefaultDir())
 	if recalls == 0 {
+		if wr, wb := usage.Week(index.DefaultDir()); wr > 0 {
+			fmt.Fprintf(stdout, "deja · quiet today · %d recalls, %s re-used this week", wr, humanBytes(int64(wb)))
+			return nil
+		}
 		fmt.Fprint(stdout, "deja · no recalls yet today · 0 B injected")
 		return nil
 	}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -132,6 +132,20 @@ func Totals(indexDir string) Summary {
 
 // Today sums events since local midnight: agent recalls (recall, context,
 // hook) and the context bytes they served.
+// Week aggregates recall activity over the trailing seven days — the number
+// a user can point at to see what the memory actually did for them.
+func Week(indexDir string) (recalls int, bytes int) {
+	cut := time.Now().Add(-7 * 24 * time.Hour)
+	for _, e := range read(Path(indexDir)) {
+		if e.Time.Before(cut) || e.Empty {
+			continue
+		}
+		recalls++
+		bytes += e.Bytes
+	}
+	return recalls, bytes
+}
+
 func Today(indexDir string) (recalls int, bytes int) {
 	recalls, bytes, _ = TodayWithInjections(indexDir)
 	return recalls, bytes

--- a/internal/usage/usage_week_test.go
+++ b/internal/usage/usage_week_test.go
@@ -1,0 +1,32 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWeekWindowAndEmptySkip(t *testing.T) {
+	idx := filepath.Join(t.TempDir(), "index.db")
+	var buf []byte
+	for _, e := range []Event{
+		{Time: time.Now().Add(-8 * 24 * time.Hour), Kind: KindHook, Bytes: 100},
+		{Time: time.Now().Add(-time.Hour), Kind: KindRecall, Bytes: 40},
+		{Time: time.Now().Add(-2 * time.Hour), Kind: KindRecall, Bytes: 7, Empty: true},
+	} {
+		b, _ := json.Marshal(e)
+		buf = append(append(buf, b...), '\n')
+	}
+	if err := os.WriteFile(Path(idx), buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	recalls, bytes := Week(idx)
+	if recalls != 1 || bytes != 40 {
+		t.Fatalf("Week = %d, %d; want 1, 40", recalls, bytes)
+	}
+	if r, b := Week(filepath.Join(t.TempDir(), "none")); r != 0 || b != 0 {
+		t.Fatalf("missing log Week = %d, %d", r, b)
+	}
+}


### PR DESCRIPTION
Auto-recall used to inject up to 2KB silently — users couldn't tell deja was working. The SessionStart hook now returns a `systemMessage` receipt (only when sessions actually matched), and the trailing-week recall count + re-used context volume show up in `deja stats`, the statusline (as a fallback line on quiet days) and the stats card punchline.