### PR TITLE
fix(index): crash-harden in-place writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Crash-hardening for in-place index writes (#181): bucket files are replaced atomically, the record log is fsynced before the manifest stamps its size, an uncommitted record tail now triggers a rebuild instead of silently duplicating messages, and full rebuilds keep the previous index recoverable through the rename window.
+
 ### Added
 - GitHub Copilot CLI as the eleventh harness: sessions in `~/.copilot/session-state` are discovered, parsed and incrementally indexed; `copilot` is also a handoff target.
 - `deja handoff --to <agent> [id-prefix] [--exec]` — package the live context of a session (problem, conclusions, where it stopped) and continue it in a different agent. Composable: `codex "$(deja handoff --to codex)"`; `--exec` launches the target directly. Targets: claude, codex, opencode, gemini, qwen, aider, pi, grok.

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -1,0 +1,98 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A crash after records flushed but before the manifest committed leaves an
+// orphan tail; re-appending it used to duplicate messages silently (#181).
+func TestRecordsIntactRejectsOrphanTail(t *testing.T) {
+	dir := t.TempDir()
+	m := Manifest{RecordsSize: 10}
+	if err := os.WriteFile(filepath.Join(dir, "records.bin"), make([]byte, 10), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !recordsIntact(dir, m) {
+		t.Fatal("exact size must be intact")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "records.bin"), make([]byte, 14), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if recordsIntact(dir, m) {
+		t.Fatal("orphan tail must not count as intact")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "records.bin"), make([]byte, 6), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if recordsIntact(dir, m) {
+		t.Fatal("truncated log must not count as intact")
+	}
+}
+
+func TestSwapIndexDirAndRecovery(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "index.db")
+	tmp := filepath.Join(base, "tmp-build")
+	for _, d := range []string{dir, tmp} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "marker"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "marker"), []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := swapIndexDir(dir, tmp); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(filepath.Join(dir, "marker"))
+	if string(b) != "new" {
+		t.Fatalf("marker = %q", b)
+	}
+	if _, err := os.Stat(dir + ".old"); !os.IsNotExist(err) {
+		t.Fatal(".old must be cleaned up after a completed swap")
+	}
+	// Interrupted swap: dir gone, .old parked — recovery restores it.
+	if err := os.Rename(dir, dir+".old"); err != nil {
+		t.Fatal(err)
+	}
+	recoverIndexDir(dir)
+	b, _ = os.ReadFile(filepath.Join(dir, "marker"))
+	if string(b) != "new" {
+		t.Fatalf("recovered marker = %q", b)
+	}
+	// With a healthy dir, recovery only clears leftovers.
+	if err := os.MkdirAll(dir+".old", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	recoverIndexDir(dir)
+	if _, err := os.Stat(dir + ".old"); !os.IsNotExist(err) {
+		t.Fatal("stale .old must be removed when dir is healthy")
+	}
+}
+
+func TestWriteBucketLeavesNoTemp(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "ab.bin")
+	if err := writeBucket(p, map[string][]posting{"tok": {{Off: 1, Sid: 2}}}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readBucket(p)
+	if err != nil || len(got["tok"]) != 1 {
+		t.Fatalf("bucket roundtrip = %#v, %v", got, err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Fatalf("temp file left behind: %s", e.Name())
+		}
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -279,7 +279,7 @@ func SearchDetailed(dir string, o search.Options) (SearchResult, error) {
 		return SearchResult{}, fmt.Errorf("manifest: %w", err)
 	}
 	if !recordsIntact(dir, m) {
-		return SearchResult{}, fmt.Errorf("%w: records.bin truncated", errCorruptIndex)
+		return SearchResult{}, fmt.Errorf("%w: records.bin size does not match the manifest (crash-truncated or uncommitted tail)", errCorruptIndex)
 	}
 	var posts []posting
 	var fallbackVariants map[string][]string
@@ -591,8 +591,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	if err := writeManifest(tmp, m); err != nil {
 		return err
 	}
-	_ = os.RemoveAll(dir)
-	if err := os.Rename(tmp, dir); err != nil {
+	if err := swapIndexDir(dir, tmp); err != nil {
 		return err
 	}
 	summarizeBuild(initialBuild, len(m.Sessions), writtenMessages, ss)
@@ -778,8 +777,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	if err := writeManifest(tmp, m); err != nil {
 		return err
 	}
-	os.RemoveAll(dir)
-	if err := os.Rename(tmp, dir); err != nil {
+	if err := swapIndexDir(dir, tmp); err != nil {
 		return err
 	}
 	summarizeBuild(initialBuild, len(m.Sessions), writtenMessages, ss)
@@ -1287,8 +1285,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	if err := writeManifest(tmp, m); err != nil {
 		return err
 	}
-	os.RemoveAll(dir)
-	return os.Rename(tmp, dir)
+	return swapIndexDir(dir, tmp)
 }
 
 func canAppendIncremental(changed map[string]FileState, old map[string]FileState) bool {
@@ -1888,9 +1885,15 @@ func (rw *recordWriter) write(r Record) (int64, error) {
 
 func (rw *recordWriter) Close() error {
 	ferr := rw.w.Flush()
+	// The manifest stamps the record-log size on commit; sync data first so a
+	// crash cannot leave a manifest that promises records the disk never got.
+	serr := rw.f.Sync()
 	cerr := rw.f.Close()
 	if ferr != nil {
 		return ferr
+	}
+	if serr != nil {
+		return serr
 	}
 	return cerr
 }
@@ -2591,6 +2594,39 @@ func writeManifest(dir string, m Manifest) error {
 	return writeGobAtomic(filepath.Join(dir, "manifest.gob"), core)
 }
 
+// swapIndexDir replaces dir with tmp without a destructive window: the old
+// dir is parked as dir.old until the new one is in place, so a crash between
+// steps leaves a recoverable copy instead of nothing (#181).
+func swapIndexDir(dir, tmp string) error {
+	old := dir + ".old"
+	_ = os.RemoveAll(old)
+	if err := os.Rename(dir, old); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Rename(tmp, dir); err != nil {
+		// Put the previous index back rather than leaving nothing.
+		_ = os.Rename(old, dir)
+		return err
+	}
+	_ = os.RemoveAll(old)
+	return nil
+}
+
+// recoverIndexDir finishes an interrupted swapIndexDir: if the index dir is
+// missing but its .old sibling survives, restore it.
+func recoverIndexDir(dir string) {
+	if dir == "" {
+		return
+	}
+	if _, err := os.Stat(dir); err == nil {
+		_ = os.RemoveAll(dir + ".old")
+		return
+	}
+	if _, err := os.Stat(dir + ".old"); err == nil {
+		_ = os.Rename(dir+".old", dir)
+	}
+}
+
 // recordsIntact reports whether records.bin still holds everything the manifest
 // committed. A shorter file means a crash truncated the record log; the index
 // must rebuild rather than silently return fewer messages.
@@ -2602,7 +2638,9 @@ func recordsIntact(dir string, m Manifest) bool {
 	if err != nil {
 		return false
 	}
-	return fi.Size() >= m.RecordsSize
+	// Shorter: a crash truncated the log. Longer: a crash landed records the
+	// manifest never committed; re-appending them would duplicate messages.
+	return fi.Size() == m.RecordsSize
 }
 
 type bucketEntry struct {
@@ -2630,7 +2668,8 @@ func writeBucket(p string, data map[string][]posting) error {
 		entries = append(entries, bucketEntry{tok: tok, off: pos, n: uint32(len(b))})
 		pos += uint64(len(b))
 	}
-	f, err := os.OpenFile(p, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	tmp := p + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
@@ -2664,7 +2703,18 @@ func writeBucket(p string, data map[string][]posting) error {
 			return err
 		}
 	}
-	return w.Flush()
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	// Rename over the live bucket: readers see the old file or the new one,
+	// never a torn write (#181).
+	return os.Rename(tmp, p)
 }
 
 func readBucket(p string) (map[string][]posting, error) {

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -316,9 +316,6 @@ func TestMultiWordSearchUsesAllPostingsAndDoesNotFullScan(t *testing.T) {
 		t.Fatal(err)
 	}
 	m.Sessions["claude:unposted"] = SessionMeta{ID: "unposted", Harness: "claude", Project: filepath.Join("deja", "vu"), Path: "manual", Updated: time.Now()}
-	if err := writeManifest(dir, m); err != nil {
-		t.Fatal(err)
-	}
 	rec, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_APPEND|os.O_WRONLY, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -328,6 +325,11 @@ func TestMultiWordSearchUsesAllPostingsAndDoesNotFullScan(t *testing.T) {
 		t.Fatal(err)
 	} else if closeErr != nil {
 		t.Fatal(closeErr)
+	}
+	// Manifest committed after the append: the size stamp covers the record,
+	// but no posting points at it — the full-scan bait stays in place.
+	if err := writeManifest(dir, m); err != nil {
+		t.Fatal(err)
 	}
 	ss, err = Search(dir, search.Options{Query: "jwt only refresh", Harness: "claude"})
 	if err != nil {

--- a/internal/index/lock_unix.go
+++ b/internal/index/lock_unix.go
@@ -10,6 +10,7 @@ import (
 )
 
 func lockDir(dir string) (func(), error) {
+	recoverIndexDir(dir)
 	lockPath := dir + ".lock"
 	// Tighten pre-existing indexes created before the 0700 default.
 	_ = os.Chmod(dir, 0o700)

--- a/internal/index/lock_windows.go
+++ b/internal/index/lock_windows.go
@@ -19,6 +19,7 @@ var (
 )
 
 func lockDir(dir string) (func(), error) {
+	recoverIndexDir(dir)
 	lockPath := dir + ".lock"
 	// Tighten pre-existing indexes created before the 0700 default.
 	_ = os.Chmod(dir, 0o700)


### PR DESCRIPTION
Closes the #181 crash cluster at the write layer:

- `writeBucket` writes to a temp file, fsyncs and renames — a crash mid-write can no longer leave a torn bucket that breaks search until `--rebuild`.
- the record log is fsynced before the manifest commits its size stamp.
- `recordsIntact` now requires an exact size match: a crash that flushed records the manifest never committed used to re-append them as silent duplicates; it now triggers a clean rebuild.
- full rebuilds swap through `dir.old` instead of `RemoveAll`+rename, and every entry point recovers a parked `dir.old` — the window that could permanently destroy sync-imported sessions is gone.