### PR TITLE
feat(last): add --since and --role filters matching search

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ deja "jwt refresh token"
 | `deja stats` | Headline counts, totals, per-harness split, top projects, monthly sparkline. `--json` too. |
 | `deja doctor [--json]` | Self-diagnosis: store parse state, sqlite3 presence, MCP wiring per agent, index health, version; `--json` emits the same checks for scripts. |
 | `deja sync export <dir> [--full]` / `import <dir>` / `ssh <host> [--pull]` | Move memory between machines — via a shared folder or one ssh command. Watermarked, append-only, idempotent. |
-| `deja show <id>` / `deja last [n]` | Read one session / list recent ones. |
+| `deja show <id>` / `deja last [n]` | Read one session / list recent ones (`--project`, `--harness`, `--since`, `--role`). |
 | `deja resume <id> [--exec]` | Reopen a found session in its native harness (`claude --resume`, `codex resume`, `opencode -s`, `grok --resume`). |
 | `deja sources` | Discovered stores, sizes, message and redaction counts. |
 | `deja mcp` | The stdio MCP server (what `deja install` wires in). |

--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -91,8 +91,10 @@ _deja_completion() {
         last)
             if [[ "$prev" == "--harness" ]]; then
                 COMPREPLY=( $(compgen -W "$harnesses" -- "$cur") )
+            elif [[ "$prev" == "--role" ]]; then
+                COMPREPLY=( $(compgen -W "user assistant tool" -- "$cur") )
             else
-                COMPREPLY=( $(compgen -W "--harness --project" -- "$cur") )
+                COMPREPLY=( $(compgen -W "--harness --project --since --role" -- "$cur") )
             fi
             ;;
         remember)
@@ -208,7 +210,7 @@ _deja() {
       _arguments '--no-guidance[skip guidance files]' "1:target:($install_targets)"
       ;;
     last)
-      _arguments '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '1:count:'
+      _arguments '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(user assistant tool)' '1:count:'
       ;;
     remember)
       _arguments '--project=[note project]:project:' '1:text:'
@@ -283,6 +285,8 @@ complete -c deja -n '__fish_seen_subcommand_from install uninstall' -a 'claude-c
 complete -c deja -n '__fish_seen_subcommand_from install uninstall' -l no-guidance
 complete -c deja -n '__fish_seen_subcommand_from last' -l harness -r -a 'claude codex opencode aider gemini cursor antigravity grok qwen pi copilot deja'
 complete -c deja -n '__fish_seen_subcommand_from last' -l project -r
+complete -c deja -n '__fish_seen_subcommand_from last' -l since -r
+complete -c deja -n '__fish_seen_subcommand_from last' -l role -r -a 'user assistant tool'
 complete -c deja -n '__fish_seen_subcommand_from remember' -l project -r
 complete -c deja -n '__fish_seen_subcommand_from resume' -l exec
 complete -c deja -n '__fish_seen_subcommand_from stats' -l json

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -343,7 +343,13 @@ func recent(n int) ([]model.Session, error) {
 
 func recentMatching(n int, o search.Options) ([]model.Session, error) {
 	if err := index.Ensure(index.DefaultDir(), "", false, os.Stderr); err == nil {
-		if ss, err := index.RecentMatching(index.DefaultDir(), n, o); err == nil {
+		if o.Role != "" {
+			ss, err := index.SearchWithRecovery(index.DefaultDir(), search.Options{All: true}, io.Discard)
+			if err == nil {
+				ss = filterRecentSources(ss, o)
+				return search.Recent(ss, n), nil
+			}
+		} else if ss, err := index.RecentMatching(index.DefaultDir(), n, o); err == nil {
 			return ss, nil
 		}
 	}
@@ -361,15 +367,25 @@ func parseLast(args []string) (int, search.Options, error) {
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		switch a {
-		case "--harness", "--project":
+		case "--harness", "--project", "--since", "--role":
 			if i+1 >= len(args) {
 				return n, o, fmt.Errorf("%s needs value", a)
 			}
 			i++
-			if a == "--harness" {
-				o.Harness = args[i]
-			} else {
-				o.Project = args[i]
+			v := args[i]
+			switch a {
+			case "--harness":
+				o.Harness = v
+			case "--project":
+				o.Project = v
+			case "--role":
+				o.Role = v
+			default:
+				d, err := parseDur(v)
+				if err != nil {
+					return n, o, err
+				}
+				o.Since = d
 			}
 		default:
 			if strings.HasPrefix(a, "-") {
@@ -387,10 +403,14 @@ func parseLast(args []string) (int, search.Options, error) {
 }
 
 func filterRecentSources(ss []model.Session, o search.Options) []model.Session {
-	if o.Harness == "" && o.Project == "" {
+	if o.Harness == "" && o.Project == "" && o.Since <= 0 && o.Role == "" {
 		return ss
 	}
-	out := ss[:0]
+	cut := time.Time{}
+	if o.Since > 0 {
+		cut = time.Now().Add(-o.Since)
+	}
+	out := make([]model.Session, 0, len(ss))
 	project := strings.ToLower(o.Project)
 	for _, s := range ss {
 		if o.Harness != "" && s.Harness != o.Harness {
@@ -399,9 +419,24 @@ func filterRecentSources(ss []model.Session, o search.Options) []model.Session {
 		if project != "" && !strings.Contains(strings.ToLower(s.Project), project) {
 			continue
 		}
+		if !cut.IsZero() && s.Updated.Before(cut) {
+			continue
+		}
+		if o.Role != "" && !sessionHasRole(s, o.Role) {
+			continue
+		}
 		out = append(out, s)
 	}
 	return out
+}
+
+func sessionHasRole(s model.Session, role string) bool {
+	for _, m := range s.Messages {
+		if m.Role == role {
+			return true
+		}
+	}
+	return false
 }
 
 func firstUserTitle(s model.Session) string {
@@ -759,7 +794,7 @@ Usage:
   deja sync export <dir> [--full]
   deja sync import <dir>
   deja sync ssh <host> [--pull] [--full]
-  deja last [n] [--project name] [--harness name]
+  deja last [n] [--project name] [--harness name] [--since duration] [--role user|assistant|tool]
   deja sources
   deja completion <bash|zsh|fish>
   deja forget --session <id-prefix> [--project <substring>] [--before <duration|date>] [--dry-run]
@@ -785,6 +820,7 @@ Examples:
   deja --harness claude --since 30d "panic in indexer"
   deja last 20 --harness codex
   deja last --project api-gateway
+  deja last --since 7d --role user
   deja --re "timeout|deadline exceeded"
   deja ctx "schema migration rollback" > deja-context.md
   deja install --all

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -210,10 +210,75 @@ func TestLastFiltersProjectAndHarness(t *testing.T) {
 	}
 }
 
+func TestLastFiltersSinceAndRole(t *testing.T) {
+	hermeticEnv(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "alpha", "claude-alpha.jsonl"), "claude-alpha", []string{
+		`{"type":"user","sessionId":"claude-alpha","timestamp":"2026-01-03T10:00:00Z","message":{"role":"user","content":"alpha claude memory"}}`,
+	})
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "claude-beta.jsonl"), "claude-beta", []string{
+		`{"type":"user","sessionId":"claude-beta","timestamp":"2026-01-02T10:00:00Z","message":{"role":"user","content":"beta claude memory"}}`,
+	})
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "gamma", "claude-gamma.jsonl"), "claude-gamma", []string{
+		`{"type":"assistant","sessionId":"claude-gamma","timestamp":"2026-01-05T10:00:00Z","message":{"role":"assistant","content":"assistant-only memory"}}`,
+	})
+
+	out, err := captureRun(t, "last", "--since", "365000d")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "alpha claude memory") || !strings.Contains(out, "beta claude memory") || !strings.Contains(out, "claude-gamma") {
+		t.Fatalf("since-filtered last output = %q", out)
+	}
+
+	out, err = captureRun(t, "last", "--since", "1d")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "alpha claude memory") || strings.Contains(out, "beta claude memory") || strings.Contains(out, "claude-gamma") {
+		t.Fatalf("recent-only last output = %q", out)
+	}
+
+	out, err = captureRun(t, "last", "--since", "365000d", "--role", "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "alpha claude memory") || !strings.Contains(out, "beta claude memory") || strings.Contains(out, "claude-gamma") {
+		t.Fatalf("role-filtered last output = %q", out)
+	}
+
+	out, err = captureRun(t, "last", "--role", "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "alpha claude memory") || strings.Contains(out, "claude-gamma") {
+		t.Fatalf("role-only last output = %q", out)
+	}
+
+	out, err = captureRun(t, "last", "--since", "365000d", "--role", "assistant", "--project", "gamma")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "claude-gamma") || strings.Contains(out, "alpha claude memory") {
+		t.Fatalf("combined last filters output = %q", out)
+	}
+
+	if _, err := captureRun(t, "last", "--since"); err == nil || !strings.Contains(err.Error(), "--since needs value") {
+		t.Fatalf("missing last since value err=%v", err)
+	}
+	if _, err := captureRun(t, "last", "--role"); err == nil || !strings.Contains(err.Error(), "--role needs value") {
+		t.Fatalf("missing last role value err=%v", err)
+	}
+}
+
 func TestLastParserAndSourceFilters(t *testing.T) {
 	n, o, err := parseLast([]string{"25", "--harness", "codex", "--project", "api"})
 	if err != nil || n != 25 || o.Harness != "codex" || o.Project != "api" {
 		t.Fatalf("parseLast = n:%d options:%#v err:%v", n, o, err)
+	}
+	n, o, err = parseLast([]string{"5", "--since", "7d", "--role", "assistant"})
+	if err != nil || n != 5 || o.Since != 7*24*time.Hour || o.Role != "assistant" {
+		t.Fatalf("parseLast since/role = n:%d options:%#v err:%v", n, o, err)
 	}
 	n, o, err = parseLast([]string{"bad"})
 	if err != nil || n != 10 || o.Harness != "" || o.Project != "" {
@@ -225,11 +290,14 @@ func TestLastParserAndSourceFilters(t *testing.T) {
 	if _, _, err := parseLast([]string{"--harness"}); err == nil || !strings.Contains(err.Error(), "--harness needs value") {
 		t.Fatalf("parseLast missing harness err=%v", err)
 	}
+	if _, _, err := parseLast([]string{"--since", "bad"}); err == nil {
+		t.Fatalf("parseLast bad since err=%v", err)
+	}
 
 	sessions := []model.Session{
-		{ID: "c1", Harness: "codex", Project: "api-gateway"},
-		{ID: "c2", Harness: "claude", Project: "api-gateway"},
-		{ID: "c3", Harness: "codex", Project: "frontend"},
+		{ID: "c1", Harness: "codex", Project: "api-gateway", Updated: time.Now(), Messages: []model.Message{{Role: "user", Text: "hi"}}},
+		{ID: "c2", Harness: "claude", Project: "api-gateway", Updated: time.Now(), Messages: []model.Message{{Role: "assistant", Text: "ok"}}},
+		{ID: "c3", Harness: "codex", Project: "frontend", Updated: time.Now().Add(-48 * time.Hour), Messages: []model.Message{{Role: "user", Text: "old"}}},
 	}
 	if got := filterRecentSources(sessions, search.Options{}); len(got) != 3 {
 		t.Fatalf("unfiltered sources = %#v", got)
@@ -237,6 +305,22 @@ func TestLastParserAndSourceFilters(t *testing.T) {
 	got := filterRecentSources(sessions, search.Options{Harness: "codex", Project: "API"})
 	if len(got) != 1 || got[0].ID != "c1" {
 		t.Fatalf("filtered sources = %#v", got)
+	}
+	got = filterRecentSources(sessions, search.Options{Since: time.Hour})
+	if len(got) != 2 || got[0].ID != "c1" || got[1].ID != "c2" {
+		t.Fatalf("since-filtered sources = %#v", got)
+	}
+	got = filterRecentSources(sessions, search.Options{Role: "user"})
+	if len(got) != 2 || got[0].ID != "c1" || got[1].ID != "c3" {
+		t.Fatalf("role-filtered sources = %#v", got)
+	}
+	got = filterRecentSources(sessions, search.Options{Role: "assistant"})
+	if len(got) != 1 || got[0].ID != "c2" {
+		t.Fatalf("assistant role filter = %#v", got)
+	}
+	got = filterRecentSources([]model.Session{{ID: "empty", Messages: nil}}, search.Options{Role: "user"})
+	if len(got) != 0 {
+		t.Fatalf("empty messages role filter = %#v", got)
 	}
 }
 

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -59,7 +59,7 @@
 <tr><td><code>deja remember "text"</code></td><td>Store a durable note. <code>--project</code> optional.</td></tr>
 <tr><td><code>deja forget</code></td><td>Remove sessions by <code>--session</code>/<code>--project</code>/<code>--before</code>; <code>--dry-run</code>, <code>--list</code>, <code>--unforget</code>.</td></tr>
 <tr><td><code>deja stats</code></td><td>Totals, top projects, activity. <code>--card</code> (SVG), <code>--html</code> (timeline), <code>--redaction</code>, <code>--json</code>.</td></tr>
-<tr><td><code>deja last [n]</code></td><td>Recent sessions. <code>--project</code>, <code>--harness</code>.</td></tr>
+<tr><td><code>deja last [n]</code></td><td>Recent sessions. <code>--project</code>, <code>--harness</code>, <code>--since</code>, <code>--role</code>.</td></tr>
 <tr><td><code>deja sources</code></td><td>Discovered stores per harness, with redaction counts.</td></tr>
 <tr><td><code>deja install &lt;target|--all|--auto&gt;</code></td><td>Wire MCP recall (and hooks) into your agents.</td></tr>
 <tr><td><code>deja embed</code></td><td>Build the semantic vector sidecar from a local endpoint.</td></tr>


### PR DESCRIPTION
## Summary
Add `--since` and `--role` flags to `deja last`, using the same duration parsing and filter semantics as `deja search` and `deja stats`.

## Motivation
Users often want recent sessions from a time window or role (e.g. "sessions from this week with user messages") without running a full search. Issue #187.

## Changes
- Extend `parseLast` to accept `--since` and `--role`
- Apply since/role filtering in `filterRecentSources` (indexed path uses `SearchWithRecovery` when role is set, matching stats)
- Update bash/zsh/fish completions, usage text, README, and docs guide
- Add unit and integration tests for the new filters and combinations

## Tests
- `go test ./cmd/deja/ -race -count=1 -run TestLast` — pass
- `go test ./... -race -count=1` — pass
- `go vet ./...` — pass
- `go build ./cmd/deja` — pass

## Notes
- Role filtering on the indexed path loads full session records (same trade-off as `deja stats --role`)
- Fixed in-place slice reuse in `filterRecentSources` that could corrupt the input slice during filtering

Fixes #187