### PR TITLE
feat: handoff pull-pointer, honest recall metrics, panic-guarded parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Handoff digests now end with a pull pointer (source session id + how to recall deeper), turning a lossy one-shot push into push+pull; `deja stats` counts sessions started from a handoff.
+- The weekly recall headline counts only agent-initiated, non-empty recalls; auto-injections are reported separately. The recall receipt fires only when the recalled set changed, not on every session start.
+
 ### Fixed
+- One malformed session file no longer aborts a full rebuild or an incremental pass: parsers are panic-guarded per file and per harness.
 - Crash-hardening for in-place index writes (#181): bucket files are replaced atomically, the record log is fsynced before the manifest stamps its size, an uncommitted record tail now triggers a rebuild instead of silently duplicating messages, and full rebuilds keep the previous index recoverable through the rename window.
 
 ### Added

--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/sources"
+	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
 const handoffBudget = 6 * 1024
@@ -63,6 +64,7 @@ func runHandoff(args []string, stdout io.Writer) error {
 		return err
 	}
 	digest := handoffDigest(s, handoffBudget)
+	usage.Record(index.DefaultDir(), usage.KindHandoff, len(digest))
 	if !doExec {
 		printSanitized(stdout, digest)
 		if pasteOnly {
@@ -79,6 +81,11 @@ func runHandoff(args []string, stdout io.Writer) error {
 				strings.Join(head, " "), target, prefixArg(prefix), target, prefixArg(prefix))
 		}
 		return nil
+	}
+	// A prompt can never start with "-" today, but keep the invariant explicit
+	// so a future digest change cannot turn the prompt into a flag.
+	if strings.HasPrefix(digest, "-") {
+		digest = " " + digest
 	}
 	argv, _ := handoffCommand(target, digest)
 	if _, err := exec.LookPath(argv[0]); err != nil {
@@ -246,6 +253,10 @@ func handoffDigest(s model.Session, budget int) string {
 		b.WriteString("\n\n## Where it stopped\n\n")
 		b.WriteString(tail)
 	}
+	// The digest is a lossy slice by construction. Tell the receiving agent it
+	// can pull deeper instead of being stuck with the summary: push+pull, not
+	// one-shot push.
+	fmt.Fprintf(&b, "\n\nThis is a compact slice of session %s. If anything you need is missing — an exact error, a file, a decision — search the full history with `deja \"<term>\"` or `deja show %s`, or call the deja MCP tools recall / recall_context if available.\n", short(s.ID), short(s.ID))
 	return strings.TrimSpace(b.String()) + "\n"
 }
 

--- a/cmd/deja/handoff_test.go
+++ b/cmd/deja/handoff_test.go
@@ -191,3 +191,26 @@ func TestPrefixArgAndProjectCandidates(t *testing.T) {
 		t.Fatalf("candidates = %v", names)
 	}
 }
+
+func TestHandoffDigestHasPullPointer(t *testing.T) {
+	s := model.Session{ID: "abcdef123456xyz", Harness: "claude", Project: "p",
+		Messages: []model.Message{{Role: "user", Text: "real problem statement here"}}}
+	d := handoffDigest(s, handoffBudget)
+	if !strings.Contains(d, "compact slice of session abcdef123456") ||
+		!strings.Contains(d, "recall_context") || !strings.Contains(d, "deja show") {
+		t.Fatalf("pull pointer missing:\n%s", d)
+	}
+}
+
+func TestReceiptIsNewsDedupes(t *testing.T) {
+	hermeticEnv(t)
+	if !receiptIsNews("digest-a") {
+		t.Fatal("first announcement must be news")
+	}
+	if receiptIsNews("digest-a") {
+		t.Fatal("same digest within 24h must be suppressed")
+	}
+	if !receiptIsNews("digest-b") {
+		t.Fatal("changed digest must be news again")
+	}
+}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -79,7 +80,10 @@ func runHookContext(plain bool) error {
 	var resp sessionStartHookResponse
 	resp.HookSpecificOutput.HookEventName = "SessionStart"
 	resp.HookSpecificOutput.AdditionalContext = digest
-	if sessions > 0 {
+	// Announce only when the recalled set changed since the last announcement:
+	// injection is recency-ranked, so repeating the same receipt every session
+	// start is wallpaper, and wallpaper builds no habit.
+	if sessions > 0 && receiptIsNews(digest) {
 		plural := ""
 		if sessions > 1 {
 			plural = "s"
@@ -92,6 +96,25 @@ func runHookContext(plain bool) error {
 	}
 	fmt.Fprintln(os.Stdout, string(b))
 	return nil
+}
+
+// receiptIsNews reports whether this digest differs from the one last
+// announced (per index, 24h window). Best-effort: on any error, announce.
+func receiptIsNews(digest string) bool {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(digest))
+	sum := fmt.Sprintf("%x", h.Sum64())
+	p := index.DefaultDir() + ".receipt"
+	if b, err := os.ReadFile(p); err == nil {
+		parts := strings.Fields(string(b))
+		if len(parts) == 2 && parts[0] == sum {
+			if ts, err := strconv.ParseInt(parts[1], 10, 64); err == nil && time.Since(time.Unix(ts, 0)) < 24*time.Hour {
+				return false
+			}
+		}
+	}
+	_ = os.WriteFile(p, []byte(sum+" "+strconv.FormatInt(time.Now().Unix(), 10)), 0o600)
+	return true
 }
 
 func hookDigest() string {

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -41,6 +41,8 @@ type statsReport struct {
 	Recall          usage.Summary  `json:"recall"`
 	WeekRecalls     int            `json:"week_recalls"`
 	WeekBytes       int            `json:"week_bytes"`
+	WeekInjected    int            `json:"week_injected"`
+	HandoffsIn      int            `json:"handoffs_received"`
 	SidecarSize     int64          `json:"sidecar_size,omitempty"`
 }
 
@@ -182,7 +184,7 @@ func runStats(args []string) error {
 	}
 	report := buildStats(filterStatsSessions(ss, options), time.Now())
 	report.Recall = usage.Totals(index.DefaultDir())
-	report.WeekRecalls, report.WeekBytes = usage.Week(index.DefaultDir())
+	report.WeekRecalls, report.WeekBytes, report.WeekInjected, _ = usage.Week(index.DefaultDir())
 	if fi, e := os.Stat(embed.Path(index.DefaultDir())); e == nil {
 		report.SidecarSize = fi.Size()
 	}
@@ -368,6 +370,17 @@ func buildStats(ss []model.Session, now time.Time) statsReport {
 		out.DateRange.End = maxT.Format("2006-01-02")
 	}
 	out.RepeatQuestions = repeatQuestions(ss)
+	for _, s := range ss {
+		for _, msg := range s.Messages {
+			if msg.Role != "user" {
+				continue
+			}
+			if strings.Contains(msg.Text, "picking up work handed off from a") {
+				out.HandoffsIn++
+			}
+			break // only the opening user turn marks a handoff-seeded session
+		}
+	}
 	return out
 }
 
@@ -460,7 +473,10 @@ func printStats(w io.Writer, r statsReport) {
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "%sRecall%s\n", bold, reset)
 	fmt.Fprintf(w, "  Recalls served   %d\n", r.Recall.Recalls)
-	fmt.Fprintf(w, "  This week        %d recalls · %s of context re-used\n", r.WeekRecalls, humanBytes(int64(r.WeekBytes)))
+	fmt.Fprintf(w, "  This week        %d recalls by your agents · %s re-used (plus %d auto-injections)\n", r.WeekRecalls, humanBytes(int64(r.WeekBytes)), r.WeekInjected)
+	if r.HandoffsIn > 0 {
+		fmt.Fprintf(w, "  Handoffs         %d sessions started from a handoff\n", r.HandoffsIn)
+	}
 	fmt.Fprintf(w, "  Injections       %d · %d sessions · %s\n", r.Recall.Injections, r.Recall.InjectedSessions, humanBytes(int64(r.Recall.InjectedBytes)))
 	fmt.Fprintf(w, "  Empty results    %.1f%%\n", r.Recall.EmptyResultRate*100)
 }

--- a/cmd/deja/statscard_test.go
+++ b/cmd/deja/statscard_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
@@ -144,5 +145,17 @@ func TestStatsFlagValidation(t *testing.T) {
 		if err := runStats(args); err == nil {
 			t.Fatalf("runStats(%#v) returned nil", args)
 		}
+	}
+}
+
+func TestHandoffsReceivedCountedFromIndex(t *testing.T) {
+	ss := []model.Session{
+		{ID: "h1", Messages: []model.Message{{Role: "user", Text: "You are picking up work handed off from a claude session (project x)"}}},
+		{ID: "n1", Messages: []model.Message{{Role: "user", Text: "ordinary question"}}},
+		{ID: "n2", Messages: []model.Message{{Role: "assistant", Text: "picking up work handed off from a"}, {Role: "user", Text: "hi"}}},
+	}
+	r := buildStats(ss, time.Now())
+	if r.HandoffsIn != 1 {
+		t.Fatalf("HandoffsIn = %d, want 1", r.HandoffsIn)
 	}
 }

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -16,8 +16,8 @@ func runStatusline(stdin io.Reader, stdout io.Writer) error {
 	drainStdin(stdin)
 	recalls, bytes, injected := usage.TodayWithInjections(index.DefaultDir())
 	if recalls == 0 {
-		if wr, wb := usage.Week(index.DefaultDir()); wr > 0 {
-			fmt.Fprintf(stdout, "deja · quiet today · %d recalls, %s re-used this week", wr, humanBytes(int64(wb)))
+		if wr, wb, _, _ := usage.Week(index.DefaultDir()); wr > 0 {
+			fmt.Fprintf(stdout, "deja · quiet today · %d agent recalls, %s re-used this week", wr, humanBytes(int64(wb)))
 			return nil
 		}
 		fmt.Fprint(stdout, "deja · no recalls yet today · 0 B injected")

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -661,13 +661,27 @@ func load(h string) []model.Session { return loadProgress(h, nil) }
 
 // loadProgress narrates a full rebuild per harness: a cold pass over a large
 // corpus takes seconds and used to look hung.
+// safeLoad shields a cold rebuild from a panicking harness loader: one broken
+// store costs that harness's sessions this pass, not the whole index.
+func safeLoad(name string, load func() []model.Session, progress io.Writer) (ss []model.Session) {
+	defer func() {
+		if r := recover(); r != nil {
+			ss = nil
+			if progress != nil {
+				fmt.Fprintf(progress, "deja: %s: parser crashed (%v) — skipping this harness for now\n", name, r)
+			}
+		}
+	}()
+	return load()
+}
+
 func loadProgress(h string, progress io.Writer) []model.Session {
 	var ss []model.Session
 	for _, hl := range harnessLoaders {
 		if h != "" && h != hl.name {
 			continue
 		}
-		got := hl.load()
+		got := safeLoad(hl.name, hl.load, progress)
 		ss = append(ss, got...)
 		if progress != nil && len(got) > 0 && !SuppressHarnessNarration {
 			msgs := 0
@@ -1462,7 +1476,12 @@ func parseChangedFile(harness, p string, old FileState) ([]model.Session, error)
 	}
 }
 
-func parseAppendedFile(harness, p string, old FileState) ([]model.Session, error) {
+func parseAppendedFile(harness, p string, old FileState) (ss []model.Session, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			ss, err = nil, fmt.Errorf("parser panic on %s: %v", p, r)
+		}
+	}()
 	from := old.SafeSize
 	if from == 0 || from > old.Size {
 		from = old.Size

--- a/internal/index/lock_unix.go
+++ b/internal/index/lock_unix.go
@@ -10,7 +10,6 @@ import (
 )
 
 func lockDir(dir string) (func(), error) {
-	recoverIndexDir(dir)
 	lockPath := dir + ".lock"
 	// Tighten pre-existing indexes created before the 0700 default.
 	_ = os.Chmod(dir, 0o700)
@@ -25,6 +24,9 @@ func lockDir(dir string) (func(), error) {
 		f.Close()
 		return nil, fmt.Errorf("lock index: %w", err)
 	}
+	// Under the lock: finish any swap interrupted mid-rename. Running this
+	// before the flock raced a concurrent swap's missing-dir window (#181).
+	recoverIndexDir(dir)
 	return func() {
 		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 		_ = f.Close()

--- a/internal/index/lock_windows.go
+++ b/internal/index/lock_windows.go
@@ -19,7 +19,6 @@ var (
 )
 
 func lockDir(dir string) (func(), error) {
-	recoverIndexDir(dir)
 	lockPath := dir + ".lock"
 	// Tighten pre-existing indexes created before the 0700 default.
 	_ = os.Chmod(dir, 0o700)
@@ -36,6 +35,9 @@ func lockDir(dir string) (func(), error) {
 		f.Close()
 		return nil, fmt.Errorf("lock index: %w", err)
 	}
+	// Under the lock: finish any swap interrupted mid-rename. Running this
+	// before the lock raced a concurrent swap's missing-dir window (#181).
+	recoverIndexDir(dir)
 	return func() {
 		_ = unlockFileEx(h, 0, 1, 0, &ol)
 		_ = f.Close()

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -130,6 +131,17 @@ func walkFiles(root string, pred func(string) bool) []string {
 	return out
 }
 
+// safeParse shields the index from a panicking parser: one malformed session
+// file must cost one file, not the whole build.
+func safeParse(path string, parse func(string) ([]model.Session, error)) (ss []model.Session, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			ss, err = nil, fmt.Errorf("parser panic on %s: %v", path, r)
+		}
+	}()
+	return parse(path)
+}
+
 func parseFiles(files []string, parse func(string) ([]model.Session, error)) []model.Session {
 	files = append([]string(nil), files...)
 	sort.Strings(files)
@@ -155,7 +167,7 @@ func parseFiles(files []string, parse func(string) ([]model.Session, error)) []m
 		go func() {
 			defer wg.Done()
 			for j := range jobs {
-				ss, _ := parse(j.p)
+				ss, _ := safeParse(j.p, parse)
 				outs <- struct {
 					i  int
 					ss []model.Session

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -20,6 +20,7 @@ const (
 	KindContext = "recall_context"
 	KindHook    = "hook"
 	KindSearch  = "search"
+	KindHandoff = "handoff"
 )
 
 type Event struct {
@@ -132,18 +133,26 @@ func Totals(indexDir string) Summary {
 
 // Today sums events since local midnight: agent recalls (recall, context,
 // hook) and the context bytes they served.
-// Week aggregates recall activity over the trailing seven days — the number
-// a user can point at to see what the memory actually did for them.
-func Week(indexDir string) (recalls int, bytes int) {
+// Week aggregates the trailing seven days, split by who initiated: recalls
+// counts only what the AGENT asked for and got (non-empty recall/context
+// calls) — the honest demand-side number — while injected counts the hook
+// deliveries deja pushed unprompted.
+func Week(indexDir string) (recalls, bytes, injected, injectedBytes int) {
 	cut := time.Now().Add(-7 * 24 * time.Hour)
 	for _, e := range read(Path(indexDir)) {
 		if e.Time.Before(cut) || e.Empty {
 			continue
 		}
-		recalls++
-		bytes += e.Bytes
+		switch e.Kind {
+		case KindRecall, KindContext:
+			recalls++
+			bytes += e.Bytes
+		case KindHook:
+			injected++
+			injectedBytes += e.Bytes
+		}
 	}
-	return recalls, bytes
+	return recalls, bytes, injected, injectedBytes
 }
 
 func Today(indexDir string) (recalls int, bytes int) {

--- a/internal/usage/usage_week_test.go
+++ b/internal/usage/usage_week_test.go
@@ -12,7 +12,8 @@ func TestWeekWindowAndEmptySkip(t *testing.T) {
 	idx := filepath.Join(t.TempDir(), "index.db")
 	var buf []byte
 	for _, e := range []Event{
-		{Time: time.Now().Add(-8 * 24 * time.Hour), Kind: KindHook, Bytes: 100},
+		{Time: time.Now().Add(-2 * 24 * time.Hour), Kind: KindHook, Bytes: 100},
+		{Time: time.Now().Add(-9 * 24 * time.Hour), Kind: KindRecall, Bytes: 999},
 		{Time: time.Now().Add(-time.Hour), Kind: KindRecall, Bytes: 40},
 		{Time: time.Now().Add(-2 * time.Hour), Kind: KindRecall, Bytes: 7, Empty: true},
 	} {
@@ -22,11 +23,14 @@ func TestWeekWindowAndEmptySkip(t *testing.T) {
 	if err := os.WriteFile(Path(idx), buf, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	recalls, bytes := Week(idx)
+	recalls, bytes, injected, injBytes := Week(idx)
 	if recalls != 1 || bytes != 40 {
-		t.Fatalf("Week = %d, %d; want 1, 40", recalls, bytes)
+		t.Fatalf("Week demand = %d, %d; want 1, 40", recalls, bytes)
 	}
-	if r, b := Week(filepath.Join(t.TempDir(), "none")); r != 0 || b != 0 {
-		t.Fatalf("missing log Week = %d, %d", r, b)
+	if injected != 1 || injBytes != 100 {
+		t.Fatalf("Week injected = %d, %d; want 1, 100", injected, injBytes)
+	}
+	if r, b, i, _ := Week(filepath.Join(t.TempDir(), "none")); r != 0 || b != 0 || i != 0 {
+		t.Fatalf("missing log Week = %d, %d, %d", r, b, i)
 	}
 }


### PR DESCRIPTION
Batch of round-2 review outcomes:

- handoff digests end with the source session id and how to pull deeper (`deja show <id>`, MCP recall) — the receiving agent is no longer stuck with a lossy 6KB summary. `deja stats` now reports sessions that started from a handoff, and each packaged handoff is logged locally.
- the weekly headline counts only what agents actually asked for and got (non-empty recall/context calls); hook injections move to a secondary line. The session-start receipt fires only when the recalled set changed — announcing the same three sessions every start is wallpaper.
- every harness parser is panic-guarded per file (and per harness on cold rebuild): one malformed session file costs one file, not the whole index.
- index dir recovery now runs after the lock is held — running it before raced a concurrent rebuild's swap window.
- `--exec` prompts are guarded against ever starting with a dash.