### PR TITLE
fix(privacy): atomic tombstone writes

### DIFF
--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -96,3 +96,25 @@ func TestWriteBucketLeavesNoTemp(t *testing.T) {
 		}
 	}
 }
+
+func TestWriteTombstonesAtomicNoTemp(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	if err := writeTombstones(map[string]bool{"claude:s1": true, "codex:s2": true}); err != nil {
+		t.Fatal(err)
+	}
+	got := Tombstones()
+	if !got["claude:s1"] || !got["codex:s2"] {
+		t.Fatalf("tombstones = %#v", got)
+	}
+	if _, err := os.Stat(tombstonePath() + ".tmp"); !os.IsNotExist(err) {
+		t.Fatal("temp file left behind")
+	}
+	// Overwrite shrinks the set — rename must fully replace, not append.
+	if err := writeTombstones(map[string]bool{"claude:s1": true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := Tombstones(); got["codex:s2"] || !got["claude:s1"] {
+		t.Fatalf("after shrink = %#v", got)
+	}
+}

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -103,7 +103,7 @@ func TestWriteTombstonesAtomicNoTemp(t *testing.T) {
 	if err := writeTombstones(map[string]bool{"claude:s1": true, "codex:s2": true}); err != nil {
 		t.Fatal(err)
 	}
-	got := Tombstones()
+	got := readTombstones()
 	if !got["claude:s1"] || !got["codex:s2"] {
 		t.Fatalf("tombstones = %#v", got)
 	}
@@ -114,7 +114,7 @@ func TestWriteTombstonesAtomicNoTemp(t *testing.T) {
 	if err := writeTombstones(map[string]bool{"claude:s1": true}); err != nil {
 		t.Fatal(err)
 	}
-	if got := Tombstones(); got["codex:s2"] || !got["claude:s1"] {
+	if got := readTombstones(); got["codex:s2"] || !got["claude:s1"] {
 		t.Fatalf("after shrink = %#v", got)
 	}
 }

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -61,17 +61,28 @@ func writeTombstones(set map[string]bool) error {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	f, err := os.OpenFile(tombstonePath(), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	// Tombstones are privacy policy, not cache: a crash mid-write must never
+	// truncate the set and let a later rebuild resurrect forgotten sessions.
+	// Write a sibling temp file, fsync, then rename over the live one.
+	tmp := tombstonePath() + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = f.Close() }()
 	for _, key := range keys {
 		if _, err := fmt.Fprintln(f, key); err != nil {
+			_ = f.Close()
 			return err
 		}
 	}
-	return nil
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp, tombstonePath())
 }
 
 func filterTombstoned(ss []model.Session) []model.Session {


### PR DESCRIPTION
Tombstones are privacy policy, not cache, but writeTombstones truncated the live file in place — a crash mid-write could erase the set and let the next rebuild resurrect sessions the user explicitly forgot. Now written to a sibling temp file, fsynced and renamed, same pattern as the index-side hardening.