### PR TITLE
feat(install): Copilot CLI as a full MCP target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Copilot CLI is now a full MCP target: `deja install` writes `~/.copilot/mcp-config.json` (verified live — Copilot calls deja's recall over MCP), replacing the guidance-only stub.
+
 ### Changed
 - Handoff digests now end with a pull pointer (source session id + how to recall deeper), turning a lossy one-shot push into push+pull; `deja stats` counts sessions started from a handoff.
 - The weekly recall headline counts only agent-initiated, non-empty recalls; auto-injections are reported separately. The recall receipt fires only when the recalled set changed, not on every session start.

--- a/cmd/deja/guidance_test.go
+++ b/cmd/deja/guidance_test.go
@@ -216,9 +216,28 @@ func TestInstallGuidanceEdgeBranches(t *testing.T) {
 	}
 }
 
-func TestCopilotInstallIsGuidanceOnly(t *testing.T) {
-	if result, err := installTarget("copilot", "/bin/deja", false); err != nil || result.Action != "guidance-only" || result.Path != guidancePath("copilot") {
+func TestCopilotInstallWritesMCPConfig(t *testing.T) {
+	tmp := hermeticEnv(t)
+	result, err := installTarget("copilot", "/bin/deja", false)
+	if err != nil || result.Action != "created" {
 		t.Fatalf("copilot MCP install = %#v, %v", result, err)
+	}
+	b, err := os.ReadFile(filepath.Join(tmp, "home", ".copilot", "mcp-config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"deja"`, `"type": "local"`, `"tools"`, `"mcp"`} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("mcp-config missing %s: %s", want, b)
+		}
+	}
+	// Uninstall removes only our entry.
+	if r, err := installTarget("copilot", "/bin/deja", true); err != nil || r.Action == "" {
+		t.Fatalf("copilot uninstall = %#v, %v", r, err)
+	}
+	b, _ = os.ReadFile(filepath.Join(tmp, "home", ".copilot", "mcp-config.json"))
+	if strings.Contains(string(b), `"deja"`) {
+		t.Fatalf("deja entry not removed: %s", b)
 	}
 }
 

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -91,10 +91,10 @@ func runInstall(args []string, uninstall bool) error {
 		}
 		if banner {
 			done = append(done, lineItem{t, r.Action, shortHome(r.Path)})
-		} else if t != "copilot" {
+		} else {
 			fmt.Printf("%s: %s %s\n", t, r.Action, r.Path)
 		}
-		if !uninstall && t != "copilot" && t != "statusline" {
+		if !uninstall && t != "statusline" {
 			mcpCount++
 		}
 		if !uninstall && strings.HasSuffix(t, "-auto") {
@@ -239,7 +239,7 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 	case "qwen":
 		return installMCPJSON(filepath.Join(sources.QwenConfigDir(), "settings.json"), exe, uninstall)
 	case "copilot":
-		return installResult{Path: guidancePath("copilot"), Action: "guidance-only"}, nil
+		return installCopilotMCP(exe, uninstall)
 	case "pi":
 		return installMCPJSON(filepath.Join(sources.PiConfigDir(), "mcp.json"), exe, uninstall)
 	case "opencode":
@@ -552,6 +552,38 @@ func mcpCommandArgs(exe string) (string, []string) {
 // mcpServers shape in their own files.
 func installCursor(exe string, uninstall bool) (installResult, error) {
 	return installMCPJSON(filepath.Join(sources.CursorCLIHome(), "mcp.json"), exe, uninstall)
+}
+
+// installCopilotMCP wires deja into GitHub Copilot CLI's MCP registry
+// (~/.copilot/mcp-config.json). Copilot's schema differs from the common
+// mcpServers shape: entries carry a type and an enabled-tools list.
+func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
+	path := filepath.Join(sources.Home(), ".copilot", "mcp-config.json")
+	old, _ := os.ReadFile(path)
+	var root map[string]any
+	if len(bytes.TrimSpace(old)) == 0 {
+		root = map[string]any{}
+	} else if err := json.Unmarshal(old, &root); err != nil {
+		return installResult{}, err
+	}
+	m, _ := root["mcpServers"].(map[string]any)
+	if m == nil {
+		m = map[string]any{}
+		root["mcpServers"] = m
+	}
+	if uninstall {
+		delete(m, "deja")
+	} else {
+		command, args := mcpCommandArgs(exe)
+		m["deja"] = map[string]any{"type": "local", "command": command, "args": args, "tools": []string{"*"}}
+	}
+	next, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return installResult{}, err
+	}
+	next = append(next, '\n')
+	a, err := writeIfChanged(path, old, next)
+	return installResult{Path: path, Action: a}, err
 }
 
 func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {


### PR DESCRIPTION
Copilot CLI reads MCP servers from `~/.copilot/mcp-config.json` (its schema adds `type` and an enabled-`tools` list to the usual shape). `deja install` now writes a real entry there instead of treating copilot as guidance-only, and copilot counts toward the MCP summary. Verified live: a copilot session called deja's `recall` tool over MCP and got results back. First step of the capability-parity pass — every harness at full support where the vendor allows it.