### PR TITLE
feat: registry-generated capability matrix, copilot resume

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,7 +84,7 @@ release:
     ```sh
     curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
     go install github.com/vshulcz/deja-vu/cmd/deja@{{ .Tag }}
-    brew install vshulcz/homebrew-tap/deja-vu
+    brew install vshulcz/tap/deja-vu
     ```
 
 # The tap repository (github.com/vshulcz/homebrew-tap) must exist before tagged releases run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Harness capability matrix (MCP / auto-recall / resume / handoff / prerequisites) generated from the format registry into README and the site; a conformance test pins the published matrix to actual code behavior.
+- `deja resume` reopens Copilot CLI sessions (`copilot --resume=<id>`).
 - Copilot CLI is now a full MCP target: `deja install` writes `~/.copilot/mcp-config.json` (verified live — Copilot calls deja's recall over MCP), replacing the guidance-only stub.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -224,18 +224,21 @@ limits, trust assumptions, and release verification.
 
 ## Supported harnesses
 
-| Harness | Store | Status |
-| --- | --- | --- |
-| Claude Code | `~/.claude/projects/**/*.jsonl` | ✅ |
-| Codex CLI | `~/.codex/sessions/**` + `history.jsonl` | ✅ |
-| opencode | `~/.local/share/opencode/opencode.db` | ✅ |
-| aider | `.aider.chat.history.md` | ✅ |
-| Gemini CLI | `~/.gemini/tmp/*/chats/**` | ✅ |
-| Cursor | `state.vscdb` + `~/.cursor/projects/**/agent-transcripts/*.jsonl` | ✅ |
-| Antigravity | `~/.gemini/antigravity*/brain/*/.system_generated/logs/transcript.jsonl` | ✅ |
-| Grok Build | `~/.grok/sessions/**/updates.jsonl` | ✅ |
-| Qwen Code | `~/.qwen/projects/**/chats/*.jsonl` | ✅ |
-| pi | `~/.pi/agent/sessions/**/*.jsonl` | ✅ |
+<!-- matrix:start -->
+| Harness | Store | MCP recall | Auto-recall | Resume | Handoff | Needs |
+| --- | --- | :-: | :-: | :-: | :-: | --- |
+| Claude Code | `${CLAUDE_CONFIG_DIR:-~/.claude}/projects/**/*.jsonl`<br>`${DEJA_CLAUDE_ROOT}/**/*.jsonl` | ✅ | ✅ | ✅ | ✅ | — |
+| Codex CLI | `${CODEX_HOME:-~/.codex}/sessions/**/rollout-*.jsonl`<br>`${CODEX_HOME:-~/.codex}/history.jsonl`<br>`${DEJA_CODEX_ROOT}/sessions/**/rollout-*.jsonl` | ✅ | ✅ | ✅ | ✅ | — |
+| opencode | `~/.local/share/opencode/opencode.db`<br>`${XDG_DATA_HOME}/opencode/opencode.db`<br>`${DEJA_OPENCODE_DB}` | ✅ | ✅ | ✅ | ✅ | sqlite3 |
+| aider | `~/.aider.chat.history.md`<br>`${AIDER_CHAT_HISTORY_FILE}`<br>`${DEJA_AIDER_ROOTS}/**/.aider.chat.history.md` | — | — | — | ✅ | — |
+| Gemini CLI | `${GEMINI_CLI_HOME:-~}/.gemini/tmp/*/chats/**/*.{json,jsonl}`<br>`${DEJA_GEMINI_ROOT}/tmp/*/chats/**/*.{json,jsonl}` | ✅ | — | — | ✅ | — |
+| Cursor | `~/Library/Application Support/Cursor/User/{globalStorage,workspaceStorage/*}/state.vscdb`<br>`~/.config/Cursor/User/{globalStorage,workspaceStorage/*}/state.vscdb`<br>`${CURSOR_CONFIG_DIR:-~/.cursor}/projects/**/agent-transcripts/**/*.jsonl`<br>`${DEJA_CURSOR_ROOT}`<br>`${DEJA_CURSOR_CLI_ROOT}` | ✅ | — | — | ✅ | sqlite3 (IDE chats) |
+| Antigravity | `~/.gemini/antigravity*/brain/*/.system_generated/logs/transcript.jsonl`<br>`${DEJA_ANTIGRAVITY_ROOT}/brain/*/.system_generated/logs/transcript.jsonl` | ✅ | — | ✅ | paste | — |
+| Grok Build | `${GROK_HOME:-~/.grok}/sessions/**/updates.jsonl`<br>`${DEJA_GROK_ROOT}/sessions/**/updates.jsonl` | ✅ | — | ✅ | ✅ | — |
+| Qwen Code | `${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl` | ✅ | — | — | ✅ | — |
+| pi | `${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl` | ✅ | — | ✅ | ✅ | — |
+| Copilot CLI | `${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl` | ✅ | — | ✅ | ✅ | — |
+<!-- matrix:end -->
 
 Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_AIDER_ROOTS`, `DEJA_GEMINI_ROOT`, `DEJA_CURSOR_ROOT`, `DEJA_CURSOR_CLI_ROOT`, `DEJA_ANTIGRAVITY_ROOT`, `DEJA_GROK_ROOT`, `DEJA_QWEN_ROOT`, `DEJA_INDEX_DIR`. Each agent's own relocation variable is honored too: `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `GEMINI_CLI_HOME`, `CURSOR_CONFIG_DIR`, `GROK_HOME`, `AIDER_CHAT_HISTORY_FILE`, and `XDG_DATA_HOME` for opencode on Linux.
 

--- a/cmd/deja/capability_drift_test.go
+++ b/cmd/deja/capability_drift_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+type capRegistry struct {
+	Harnesses []struct {
+		ID           string `json:"id"`
+		DisplayName  string `json:"display_name"`
+		Capabilities *struct {
+			MCP     bool   `json:"mcp"`
+			Auto    bool   `json:"auto"`
+			Resume  bool   `json:"resume"`
+			Handoff string `json:"handoff"`
+		} `json:"capabilities"`
+	} `json:"harnesses"`
+}
+
+// The capability matrix in README/site is generated from the registry; this
+// test pins the registry to what the code actually does, so the published
+// matrix cannot drift from behavior.
+func TestCapabilityRegistryMatchesCode(t *testing.T) {
+	hermeticEnv(t)
+	b, err := os.ReadFile(filepath.Join("..", "..", "docs", "registry", "registry.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reg capRegistry
+	if err := json.Unmarshal(b, &reg); err != nil {
+		t.Fatal(err)
+	}
+	installID := map[string]string{"claude": "claude-code"}
+	autoCapable := map[string]bool{"claude": true, "codex": true, "opencode": true}
+	seen := 0
+	for _, h := range reg.Harnesses {
+		if h.ID == "deja" {
+			continue
+		}
+		if h.Capabilities == nil {
+			t.Fatalf("registry entry %q has no capabilities block", h.ID)
+		}
+		if h.DisplayName == "" {
+			t.Fatalf("registry entry %q has no display_name", h.ID)
+		}
+		seen++
+		c := h.Capabilities
+
+		// MCP: an install target must exist and write real wiring.
+		id := h.ID
+		if v, ok := installID[h.ID]; ok {
+			id = v
+		}
+		r, err := installTarget(id, "/bin/deja", false)
+		gotMCP := err == nil && r.Action != "" && r.Action != "guidance-only"
+		if h.ID == "aider" {
+			gotMCP = false // aider has no MCP client and no install target
+			if _, err := installTarget("aider", "/bin/deja", false); err == nil {
+				t.Fatal("aider unexpectedly grew an install target — update the registry")
+			}
+		}
+		if gotMCP != c.MCP {
+			t.Fatalf("%s: registry mcp=%v, code says %v", h.ID, c.MCP, gotMCP)
+		}
+
+		// Auto-recall hooks exist only where an -auto target installs.
+		if c.Auto != autoCapable[h.ID] {
+			if _, err := installTarget(h.ID+"-auto", "/bin/deja", false); (err == nil) != c.Auto {
+				t.Fatalf("%s: registry auto=%v disagrees with install targets", h.ID, c.Auto)
+			}
+		}
+
+		// Resume: resumeCommand must succeed for a plausible session.
+		s := model.Session{ID: "abc123", Harness: h.ID, Project: "p", Path: "/tmp/x.jsonl"}
+		_, _, rerr := resumeCommand(s)
+		if (rerr == nil) != c.Resume {
+			t.Fatalf("%s: registry resume=%v, resumeCommand err=%v", h.ID, c.Resume, rerr)
+		}
+
+		// Handoff: exec targets come from the command table; paste-only is the rest.
+		_, execOK := handoffCommand(h.ID, "P")
+		switch c.Handoff {
+		case "exec":
+			if !execOK {
+				t.Fatalf("%s: registry says handoff exec, command table disagrees", h.ID)
+			}
+		case "paste":
+			if execOK {
+				t.Fatalf("%s: registry says paste-only, but an exec entry exists", h.ID)
+			}
+		default:
+			t.Fatalf("%s: unknown handoff kind %q", h.ID, c.Handoff)
+		}
+	}
+	if seen != len(handoffTargets())+1 { // +1: antigravity is paste-only
+		t.Fatalf("registry covers %d harnesses, handoff targets %d", seen, len(handoffTargets()))
+	}
+
+	// The published README matrix must contain a row for every harness.
+	readme, err := os.ReadFile(filepath.Join("..", "..", "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range reg.Harnesses {
+		if h.ID == "deja" {
+			continue
+		}
+		if !strings.Contains(string(readme), "| "+h.DisplayName+" |") {
+			t.Fatalf("README matrix missing row for %s — run `go run ./scripts/genmatrix`", h.DisplayName)
+		}
+	}
+}

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -113,6 +113,8 @@ func resumeCommand(s model.Session) (string, string, error) {
 		return sources.GrokCWDForSession(s.Path), "grok --resume " + s.ID, nil
 	case "pi":
 		return piProjectDirFor(s), "pi --resume " + s.ID, nil
+	case "copilot":
+		return "", "copilot --resume=" + s.ID, nil
 	default:
 		return "", "", fmt.Errorf("don't know how to resume %q sessions", s.Harness)
 	}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,6 +16,10 @@ Parsers live in `internal/sources` and return `[]model.Session`.
 | Cursor | `cursor.go` | SQLite state stores plus CLI agent transcripts |
 | Antigravity | `antigravity.go` | JSONL transcripts under `~/.gemini/antigravity*` |
 | Grok Build | `grok.go` | ACP update streams and session summaries under `~/.grok/sessions` |
+| Qwen Code | `qwen.go` | JSONL chats under `~/.qwen/projects/*/chats` |
+| pi | `pi.go` | JSONL transcripts under `~/.pi/agent/sessions` |
+| Copilot CLI | `copilot.go` | `events.jsonl` per session under `~/.copilot/session-state` |
+| deja notes | `notes.go` | `deja remember` entries in `notes.jsonl` |
 
 File-based sources are parsed with a worker pool sized to `runtime.NumCPU()`. Results are collected by input file index and then appended in sorted path order, so parsing can be parallel while index writes stay deterministic.
 

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -53,19 +53,21 @@
 
 <h1>Harnesses</h1>
 <p>deja indexes eleven coding-agent histories into one retroactive index. A fix found in one agent is recalled inside another.</p>
-<table><thead><tr><th>Harness</th><th>Store</th></tr></thead><tbody>
-<tr><td>Claude Code</td><td><code>~/.claude/projects/**</code></td></tr>
-<tr><td>Codex CLI</td><td><code>~/.codex/sessions/**</code>, <code>history.jsonl</code></td></tr>
-<tr><td>opencode</td><td>SQLite store</td></tr>
-<tr><td>Cursor</td><td><code>state.vscdb</code> + CLI transcripts</td></tr>
-<tr><td>Gemini CLI</td><td><code>~/.gemini/tmp/**</code></td></tr>
-<tr><td>aider</td><td><code>.aider.chat.history.md</code></td></tr>
-<tr><td>Antigravity</td><td><code>~/.gemini/antigravity*/**</code></td></tr>
-<tr><td>Grok Build</td><td><code>~/.grok/sessions/**</code></td></tr>
-<tr><td>Qwen Code</td><td><code>~/.qwen/projects/**/chats/*.jsonl</code></td></tr>
-<tr><td>pi</td><td><code>~/.pi/agent/sessions/**/*.jsonl</code></td></tr>
-<tr><td>Copilot CLI</td><td><code>~/.copilot/session-state/*/events.jsonl</code></td></tr>
-</tbody></table>
+<!-- matrix:start -->
+<table>
+<tr><th>Harness</th><th>Store</th><th>MCP recall</th><th>Auto-recall</th><th>Resume</th><th>Handoff</th><th>Needs</th></tr>
+<tr><td>Claude Code</td><td><code>${CLAUDE_CONFIG_DIR:-~/.claude}/projects/**/*.jsonl</code><br><code>${DEJA_CLAUDE_ROOT}/**/*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
+<tr><td>Codex CLI</td><td><code>${CODEX_HOME:-~/.codex}/sessions/**/rollout-*.jsonl</code><br><code>${CODEX_HOME:-~/.codex}/history.jsonl</code><br><code>${DEJA_CODEX_ROOT}/sessions/**/rollout-*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
+<tr><td>opencode</td><td><code>~/.local/share/opencode/opencode.db</code><br><code>${XDG_DATA_HOME}/opencode/opencode.db</code><br><code>${DEJA_OPENCODE_DB}</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>sqlite3</td></tr>
+<tr><td>aider</td><td><code>~/.aider.chat.history.md</code><br><code>${AIDER_CHAT_HISTORY_FILE}</code><br><code>${DEJA_AIDER_ROOTS}/**/.aider.chat.history.md</code></td><td>—</td><td>—</td><td>—</td><td>✅</td><td>—</td></tr>
+<tr><td>Gemini CLI</td><td><code>${GEMINI_CLI_HOME:-~}/.gemini/tmp/*/chats/**/*.{json,jsonl}</code><br><code>${DEJA_GEMINI_ROOT}/tmp/*/chats/**/*.{json,jsonl}</code></td><td>✅</td><td>—</td><td>—</td><td>✅</td><td>—</td></tr>
+<tr><td>Cursor</td><td><code>~/Library/Application Support/Cursor/User/{globalStorage,workspaceStorage/*}/state.vscdb</code><br><code>~/.config/Cursor/User/{globalStorage,workspaceStorage/*}/state.vscdb</code><br><code>${CURSOR_CONFIG_DIR:-~/.cursor}/projects/**/agent-transcripts/**/*.jsonl</code><br><code>${DEJA_CURSOR_ROOT}</code><br><code>${DEJA_CURSOR_CLI_ROOT}</code></td><td>✅</td><td>—</td><td>—</td><td>✅</td><td>sqlite3 (IDE chats)</td></tr>
+<tr><td>Antigravity</td><td><code>~/.gemini/antigravity*/brain/*/.system_generated/logs/transcript.jsonl</code><br><code>${DEJA_ANTIGRAVITY_ROOT}/brain/*/.system_generated/logs/transcript.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>paste</td><td>—</td></tr>
+<tr><td>Grok Build</td><td><code>${GROK_HOME:-~/.grok}/sessions/**/updates.jsonl</code><br><code>${DEJA_GROK_ROOT}/sessions/**/updates.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>✅</td><td>—</td></tr>
+<tr><td>Qwen Code</td><td><code>${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl</code></td><td>✅</td><td>—</td><td>—</td><td>✅</td><td>—</td></tr>
+<tr><td>pi</td><td><code>${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>✅</td><td>—</td></tr>
+<tr><td>Copilot CLI</td><td><code>${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>✅</td><td>—</td></tr>
+</table><!-- matrix:end -->
 <p>Each format is documented in the <a href="../registry/README.md">session format registry</a>, with synthetic fixtures and a conformance test that catches upstream drift.</p>
 <h2>Adding a harness</h2>
 <p>A new parser is one file in <code>internal/sources/</code> modeled on an existing one, plus wiring at the discovery, doctor, install and registry points. See the open harness issues on GitHub if you'd like to add yours.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -205,7 +205,7 @@ a:hover{text-decoration:underline}
 
 <section>
   <h2>Memory your agent actually uses</h2>
-  <p class="lead">After <code style="font-family:var(--mono);font-size:.9em">deja install --all</code>, every agent on your machine gets a <span style="font-family:var(--mono);font-size:.9em">recall</span> tool over MCP — add <span style="font-family:var(--mono);font-size:.9em">--auto</span> for session-start auto-recall where the agent supports it.</p>
+  <p class="lead">After <code style="font-family:var(--mono);font-size:.9em">deja install --all</code>, every agent with an MCP client gets a <span style="font-family:var(--mono);font-size:.9em">recall</span> tool (aider's CLI has none — its history is still indexed) — add <span style="font-family:var(--mono);font-size:.9em">--auto</span> for session-start auto-recall where the agent supports it.</p>
   <div class="chat">
     <div class="msg you"><span class="who">you</span><div class="bubble">have we dealt with jwt refresh rotation before? check your memory</div></div>
     <div class="msg ai"><span class="who">AI</span><div class="bubble"><div class="tool">→ recall("jwt refresh rotation")</div>Yes — three weeks ago in the <code>api-gateway</code> project (a Codex session). Login broke after key rotation: the jwks cache wasn't reloaded after <code>rotateKey</code>. You fixed it by reloading the cache and adding a clock-skew test. Want me to apply the same pattern here?</div></div>

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -12,7 +12,15 @@
         "fixtures/registry/claude-code/session.jsonl"
       ],
       "parser_source": "internal/sources/claude.go",
-      "last_verified": "2026-07-17"
+      "last_verified": "2026-07-17",
+      "display_name": "Claude Code",
+      "capabilities": {
+        "mcp": true,
+        "auto": true,
+        "resume": true,
+        "handoff": "exec",
+        "prereq": ""
+      }
     },
     {
       "id": "codex",
@@ -26,7 +34,15 @@
         "fixtures/registry/codex/rollout-2026-07-17T09-00-00-registry-codex.jsonl"
       ],
       "parser_source": "internal/sources/codex.go",
-      "last_verified": "2026-07-17"
+      "last_verified": "2026-07-17",
+      "display_name": "Codex CLI",
+      "capabilities": {
+        "mcp": true,
+        "auto": true,
+        "resume": true,
+        "handoff": "exec",
+        "prereq": ""
+      }
     },
     {
       "id": "opencode",
@@ -40,7 +56,15 @@
         "fixtures/registry/opencode/opencode.sql"
       ],
       "parser_source": "internal/sources/opencode.go",
-      "last_verified": "2026-07-17"
+      "last_verified": "2026-07-17",
+      "display_name": "opencode",
+      "capabilities": {
+        "mcp": true,
+        "auto": true,
+        "resume": true,
+        "handoff": "exec",
+        "prereq": "sqlite3"
+      }
     },
     {
       "id": "aider",
@@ -54,7 +78,15 @@
         "fixtures/registry/aider/.aider.chat.history.md"
       ],
       "parser_source": "internal/sources/aider.go",
-      "last_verified": "2026-07-17"
+      "last_verified": "2026-07-17",
+      "display_name": "aider",
+      "capabilities": {
+        "mcp": false,
+        "auto": false,
+        "resume": false,
+        "handoff": "exec",
+        "prereq": ""
+      }
     },
     {
       "id": "gemini",
@@ -67,7 +99,15 @@
         "fixtures/registry/gemini/session.jsonl"
       ],
       "parser_source": "internal/sources/gemini.go",
-      "last_verified": "2026-07-17"
+      "last_verified": "2026-07-17",
+      "display_name": "Gemini CLI",
+      "capabilities": {
+        "mcp": true,
+        "auto": false,
+        "resume": false,
+        "handoff": "exec",
+        "prereq": ""
+      }
     },
     {
       "id": "cursor",
@@ -83,7 +123,15 @@
         "fixtures/registry/cursor/projects/registry-demo/agent-transcripts/registry-cursor.jsonl"
       ],
       "parser_source": "internal/sources/cursor.go",
-      "last_verified": "2026-07-17"
+      "last_verified": "2026-07-17",
+      "display_name": "Cursor",
+      "capabilities": {
+        "mcp": true,
+        "auto": false,
+        "resume": false,
+        "handoff": "exec",
+        "prereq": "sqlite3 (IDE chats)"
+      }
     },
     {
       "id": "antigravity",
@@ -96,7 +144,15 @@
         "fixtures/registry/antigravity/brain/registry-antigravity/.system_generated/logs/transcript.jsonl"
       ],
       "parser_source": "internal/sources/antigravity.go",
-      "last_verified": "2026-07-17"
+      "last_verified": "2026-07-17",
+      "display_name": "Antigravity",
+      "capabilities": {
+        "mcp": true,
+        "auto": false,
+        "resume": true,
+        "handoff": "paste",
+        "prereq": ""
+      }
     },
     {
       "id": "grok",
@@ -109,7 +165,15 @@
         "fixtures/registry/grok/sessions/workspace%2Fregistry-demo/registry-grok/updates.jsonl"
       ],
       "parser_source": "internal/sources/grok.go",
-      "last_verified": "2026-07-17"
+      "last_verified": "2026-07-17",
+      "display_name": "Grok Build",
+      "capabilities": {
+        "mcp": true,
+        "auto": false,
+        "resume": true,
+        "handoff": "exec",
+        "prereq": ""
+      }
     },
     {
       "id": "qwen",
@@ -121,7 +185,15 @@
         "fixtures/registry/qwen/projects/-workspace-registry-demo/chats/registry-qwen.jsonl"
       ],
       "parser_source": "internal/sources/qwen.go",
-      "last_verified": "2026-07-17"
+      "last_verified": "2026-07-17",
+      "display_name": "Qwen Code",
+      "capabilities": {
+        "mcp": true,
+        "auto": false,
+        "resume": false,
+        "handoff": "exec",
+        "prereq": ""
+      }
     },
     {
       "id": "pi",
@@ -133,7 +205,15 @@
         "fixtures/registry/pi/session.jsonl"
       ],
       "parser_source": "internal/sources/pi.go",
-      "last_verified": "2026-07-19"
+      "last_verified": "2026-07-19",
+      "display_name": "pi",
+      "capabilities": {
+        "mcp": true,
+        "auto": false,
+        "resume": true,
+        "handoff": "exec",
+        "prereq": ""
+      }
     },
     {
       "id": "copilot",
@@ -145,7 +225,15 @@
         "fixtures/registry/copilot/7cf44517-55ca-435c-893a-3fde1973a44e/events.jsonl"
       ],
       "parser_source": "internal/sources/copilot.go",
-      "last_verified": "2026-07-20"
+      "last_verified": "2026-07-20",
+      "display_name": "Copilot CLI",
+      "capabilities": {
+        "mcp": true,
+        "auto": false,
+        "resume": true,
+        "handoff": "exec",
+        "prereq": ""
+      }
     }
   ]
 }

--- a/scripts/genmatrix/main.go
+++ b/scripts/genmatrix/main.go
@@ -1,0 +1,127 @@
+// Command genmatrix renders the harness capability matrix from
+// docs/registry/registry.json into README.md and docs/guide/harnesses.html,
+// between matrix markers. One source of truth; a CI test fails on drift.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type entry struct {
+	ID           string   `json:"id"`
+	DisplayName  string   `json:"display_name"`
+	StorePaths   []string `json:"store_paths"`
+	Capabilities struct {
+		MCP     bool   `json:"mcp"`
+		Auto    bool   `json:"auto"`
+		Resume  bool   `json:"resume"`
+		Handoff string `json:"handoff"`
+		Prereq  string `json:"prereq"`
+	} `json:"capabilities"`
+}
+
+type registry struct {
+	Harnesses []entry `json:"harnesses"`
+}
+
+func mark(b bool) string {
+	if b {
+		return "✅"
+	}
+	return "—"
+}
+
+func handoffMark(kind string) string {
+	switch kind {
+	case "exec":
+		return "✅"
+	case "paste":
+		return "paste"
+	default:
+		return "—"
+	}
+}
+
+func markdownTable(r registry) string {
+	var b strings.Builder
+	b.WriteString("| Harness | Store | MCP recall | Auto-recall | Resume | Handoff | Needs |\n")
+	b.WriteString("| --- | --- | :-: | :-: | :-: | :-: | --- |\n")
+	for _, e := range r.Harnesses {
+		if e.ID == "deja" {
+			continue
+		}
+		quoted := make([]string, 0, len(e.StorePaths))
+		for _, sp := range e.StorePaths {
+			quoted = append(quoted, "`"+sp+"`")
+		}
+		store := strings.Join(quoted, "<br>")
+		prereq := e.Capabilities.Prereq
+		if prereq == "" {
+			prereq = "—"
+		}
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s | %s |\n",
+			e.DisplayName, store, mark(e.Capabilities.MCP), mark(e.Capabilities.Auto),
+			mark(e.Capabilities.Resume), handoffMark(e.Capabilities.Handoff), prereq)
+	}
+	return b.String()
+}
+
+func htmlTable(r registry) string {
+	var b strings.Builder
+	b.WriteString("<table>\n<tr><th>Harness</th><th>Store</th><th>MCP recall</th><th>Auto-recall</th><th>Resume</th><th>Handoff</th><th>Needs</th></tr>\n")
+	for _, e := range r.Harnesses {
+		if e.ID == "deja" {
+			continue
+		}
+		prereq := e.Capabilities.Prereq
+		if prereq == "" {
+			prereq = "—"
+		}
+		fmt.Fprintf(&b, "<tr><td>%s</td><td><code>%s</code></td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>\n",
+			e.DisplayName, strings.Join(e.StorePaths, "</code><br><code>"),
+			mark(e.Capabilities.MCP), mark(e.Capabilities.Auto), mark(e.Capabilities.Resume),
+			handoffMark(e.Capabilities.Handoff), prereq)
+	}
+	b.WriteString("</table>")
+	return b.String()
+}
+
+func replaceBetween(path, start, end, content string) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	s := string(b)
+	i := strings.Index(s, start)
+	j := strings.Index(s, end)
+	if i < 0 || j < 0 || j < i {
+		return fmt.Errorf("%s: markers %q/%q not found", path, start, end)
+	}
+	out := s[:i+len(start)] + "\n" + content + s[j:]
+	return os.WriteFile(path, []byte(out), 0o644)
+}
+
+func main() {
+	b, err := os.ReadFile("docs/registry/registry.json")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	var r registry
+	if err := json.Unmarshal(b, &r); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := replaceBetween("README.md", "<!-- matrix:start -->", "<!-- matrix:end -->", markdownTable(r)); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := replaceBetween("docs/guide/harnesses.html", "<!-- matrix:start -->", "<!-- matrix:end -->", htmlTable(r)); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println("matrix rendered")
+}


### PR DESCRIPTION
One support number hides five support levels. The registry now records per-harness capabilities (MCP, auto-recall, resume, handoff, prerequisites), `go run ./scripts/genmatrix` renders the README and site tables from it, and a test pins every registry claim to what the code actually does — installTarget, resumeCommand and the handoff table are called directly, so the published matrix cannot drift from behavior. The test caught its first bug before the PR: the registry said copilot was resumable and the code disagreed — copilot now resumes (`copilot --resume=<id>`, verified against a live session). Also: architecture parser table extended to all twelve sources, the site's "every agent gets MCP" claim now excludes aider honestly, brew tap name unified.