### PR TITLE
feat(index): ingestion health — silent loss leaves evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Ingestion health: malformed JSONL lines and failed file parses are counted per harness, persisted in the manifest, and surfaced in `deja doctor` (details in `--json`). Tolerated loss now leaves evidence instead of disappearing.
 - Harness capability matrix (MCP / auto-recall / resume / handoff / prerequisites) generated from the format registry into README and the site; a conformance test pins the published matrix to actual code behavior.
 - `deja resume` reopens Copilot CLI sessions (`copilot --resume=<id>`).
 - Copilot CLI is now a full MCP target: `deja install` writes `~/.copilot/mcp-config.json` (verified live — Copilot calls deja's recall over MCP), replacing the guidance-only stub.

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -347,6 +348,18 @@ func doctorIndex(w io.Writer, idx doctorComponent) {
 		}
 	default:
 		fmt.Fprintln(w, "  freshness up to date")
+	}
+	health := index.IngestHealth(dir)
+	names := make([]string, 0, len(health))
+	for h, e := range health {
+		if e.MalformedLines > 0 || e.FailedFiles > 0 {
+			names = append(names, h)
+		}
+	}
+	sort.Strings(names)
+	for _, h := range names {
+		e := health[h]
+		fmt.Fprintf(w, "  ingest   %s: %d malformed lines skipped, %d files failed — see `deja doctor --json`\n", h, e.MalformedLines, e.FailedFiles)
 	}
 }
 

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -34,12 +34,13 @@ type doctorVersionReport struct {
 }
 
 type doctorReport struct {
-	Stores  []doctorStore       `json:"stores"`
-	Index   doctorComponent     `json:"index"`
-	MCP     []doctorMCPStatus   `json:"mcp"`
-	SQLite3 doctorComponent     `json:"sqlite3"`
-	Version doctorVersionReport `json:"version"`
-	Embed   *doctorEmbedReport  `json:"embed,omitempty"`
+	Stores  []doctorStore                  `json:"stores"`
+	Index   doctorComponent                `json:"index"`
+	MCP     []doctorMCPStatus              `json:"mcp"`
+	SQLite3 doctorComponent                `json:"sqlite3"`
+	Version doctorVersionReport            `json:"version"`
+	Embed   *doctorEmbedReport             `json:"embed,omitempty"`
+	Ingest  map[string]index.HarnessIngest `json:"ingest_health,omitempty"`
 }
 
 type doctorEmbedReport struct {
@@ -72,6 +73,7 @@ func collectDoctorReport(lookup doctorVersionLookup) doctorReport {
 		storeMods = append(storeMods, mod)
 	}
 	report.Index = inspectDoctorIndex(storeMods)
+	report.Ingest = index.IngestHealth(index.DefaultDir())
 	report.MCP = collectDoctorMCP()
 	report.SQLite3.State = "missing"
 	if sources.SQLite3Available() {

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -118,3 +118,27 @@ func TestWriteTombstonesAtomicNoTemp(t *testing.T) {
 		t.Fatalf("after shrink = %#v", got)
 	}
 }
+
+func TestIngestHealthPersistedToManifest(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	dir := filepath.Join(tmp, "index.db")
+	proj := filepath.Join(claudeRoot, "-tmp-x")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data := `{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"good line"}}` + "\n" +
+		`{"broken json` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	h := IngestHealth(dir)
+	if h["claude"].MalformedLines != 1 {
+		t.Fatalf("ingest health = %#v, want claude malformed=1", h)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -125,6 +125,74 @@ type Manifest struct {
 	// A live index whose records.bin is shorter than this lost its tail to a
 	// torn write and must be treated as corrupt.
 	RecordsSize int64 `json:"records_size,omitempty"`
+	// IngestHealth records, per harness, what ingestion skipped on the pass
+	// that last touched it: malformed JSONL lines and files that failed to
+	// parse. Silent loss must be diagnosable (`deja doctor --json`).
+	IngestHealth map[string]HarnessIngest `json:"ingest_health,omitempty"`
+}
+
+// IngestHealth returns the per-harness ingestion health persisted by the
+// last indexing passes, or nil when the index has none recorded.
+func IngestHealth(dir string) map[string]HarnessIngest {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		return nil
+	}
+	return m.IngestHealth
+}
+
+// HarnessIngest is one harness's ingestion health from its last indexing pass.
+type HarnessIngest struct {
+	MalformedLines int    `json:"malformed_lines,omitempty"`
+	FailedFiles    int    `json:"failed_files,omitempty"`
+	LastError      string `json:"last_error,omitempty"`
+}
+
+// mergeIngestDiag folds the sources side-channel counters into the manifest,
+// keyed by harness. Harnesses untouched this pass keep their previous entry.
+func mergeIngestDiag(m *Manifest) {
+	malformed, failed := sources.DiagSnapshot()
+	if len(malformed) == 0 && len(failed) == 0 {
+		return
+	}
+	if m.IngestHealth == nil {
+		m.IngestHealth = map[string]HarnessIngest{}
+	}
+	touched := map[string]bool{}
+	for p := range malformed {
+		touched[harnessForPath(p)] = true
+	}
+	for p := range failed {
+		touched[harnessForPath(p)] = true
+	}
+	for h := range touched {
+		if h == "" {
+			continue
+		}
+		m.IngestHealth[h] = HarnessIngest{}
+	}
+	for p, n := range malformed {
+		h := harnessForPath(p)
+		if h == "" {
+			continue
+		}
+		e := m.IngestHealth[h]
+		e.MalformedLines += n
+		m.IngestHealth[h] = e
+	}
+	for p, msg := range failed {
+		h := harnessForPath(p)
+		if h == "" {
+			continue
+		}
+		e := m.IngestHealth[h]
+		e.FailedFiles++
+		e.LastError = msg
+		m.IngestHealth[h] = e
+	}
 }
 
 type manifestCore struct {
@@ -138,6 +206,7 @@ type manifestCore struct {
 	ExportWatermarks map[string]int64
 	ImportedRecords  map[string]bool
 	RecordsSize      int64
+	IngestHealth     map[string]HarnessIngest
 }
 
 type RedactionStats struct {
@@ -2589,7 +2658,7 @@ func readManifest(dir string) (Manifest, error) {
 	if err := readGob(filepath.Join(dir, "manifest.gob"), &core); err != nil {
 		return Manifest{}, err
 	}
-	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ImportedRecords: core.ImportedRecords, RecordsSize: core.RecordsSize, Sessions: map[string]SessionMeta{}}
+	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ImportedRecords: core.ImportedRecords, RecordsSize: core.RecordsSize, IngestHealth: core.IngestHealth, Sessions: map[string]SessionMeta{}}
 	if err := readGob(filepath.Join(dir, "sessions.gob"), &m.Sessions); err != nil {
 		return Manifest{}, err
 	}
@@ -2603,7 +2672,8 @@ func readManifest(dir string) (Manifest, error) {
 // leaves the old manifest pointing at old data, and the next run reindexes
 // rather than serving a fresh-looking index whose sessions are stale.
 func writeManifest(dir string, m Manifest) error {
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ImportedRecords: m.ImportedRecords}
+	mergeIngestDiag(&m)
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ImportedRecords: m.ImportedRecords, IngestHealth: m.IngestHealth}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}

--- a/internal/sources/diag.go
+++ b/internal/sources/diag.go
@@ -1,0 +1,39 @@
+package sources
+
+import "sync"
+
+// Ingest diagnostics are a side channel, not a parser API change: scanners and
+// file loaders report what they skipped, the index aggregates it per harness
+// and persists it, and doctor makes it visible. "Not found because it never
+// happened" and "not found because ingestion skipped it" must not look
+// identical in a memory tool.
+var diagMu sync.Mutex
+var diagMalformed = map[string]int{}
+var diagFailed = map[string]string{}
+
+func diagMalformedLine(path string) {
+	diagMu.Lock()
+	diagMalformed[path]++
+	diagMu.Unlock()
+}
+
+func diagFileError(path string, err error) {
+	if err == nil {
+		return
+	}
+	diagMu.Lock()
+	diagFailed[path] = err.Error()
+	diagMu.Unlock()
+}
+
+// DiagSnapshot returns and clears the counters accumulated since the last
+// snapshot: malformed JSONL lines per file, and files whose parse failed
+// outright with the error text.
+func DiagSnapshot() (malformed map[string]int, failed map[string]string) {
+	diagMu.Lock()
+	defer diagMu.Unlock()
+	malformed, failed = diagMalformed, diagFailed
+	diagMalformed = map[string]int{}
+	diagFailed = map[string]string{}
+	return malformed, failed
+}

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -241,6 +241,11 @@ func TestScanJSONLSkipsMalformedLines(t *testing.T) {
 	if len(ss) != 1 || len(ss[0].Messages) != 2 || ss[0].Messages[1].Text != "after bad" {
 		t.Fatalf("bad malformed-line parse: %#v", ss)
 	}
+	// Tolerated loss must leave evidence: the skip is counted, not silent.
+	malformed, _ := DiagSnapshot()
+	if malformed[p] != 1 {
+		t.Fatalf("malformed counter = %#v, want 1 for %s", malformed, p)
+	}
 }
 
 func TestSQLQuoteDoublesSingleQuotes(t *testing.T) {

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -109,6 +109,8 @@ func scanJSONLFromOffset(path string, offset int64, fn func(map[string]any)) err
 			d.UseNumber()
 			if d.Decode(&m) == nil {
 				fn(m)
+			} else if len(strings.TrimSpace(string(line))) > 0 {
+				diagMalformedLine(path)
 			}
 		}
 		if errors.Is(err, io.EOF) {
@@ -167,7 +169,8 @@ func parseFiles(files []string, parse func(string) ([]model.Session, error)) []m
 		go func() {
 			defer wg.Done()
 			for j := range jobs {
-				ss, _ := safeParse(j.p, parse)
+				ss, err := safeParse(j.p, parse)
+				diagFileError(j.p, err)
 				outs <- struct {
 					i  int
 					ss []model.Session


### PR DESCRIPTION
"Not found because it never happened" and "not found because ingestion skipped it" used to look identical: the JSONL scanner dropped malformed lines invisibly and `parseFiles` discarded every parser error. A side-channel collector (no parser API changes) now counts malformed lines per file and failed file parses, `writeManifest` folds them into per-harness aggregates, and `deja doctor` prints a terse ingest line for any harness with loss (full detail in `--json`). The test that explicitly blessed a malformed line disappearing without a trace now asserts the counter instead.