### PR TITLE
fix(sync): acknowledged-delivery watermarks for ssh push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The weekly recall headline counts only agent-initiated, non-empty recalls; auto-injections are reported separately. The recall receipt fires only when the recalled set changed, not on every session start.
 
 ### Fixed
+- SSH sync push is acknowledged delivery: export watermarks advance only after the remote import succeeds, so a failed transfer no longer silently drops that batch from every later push. Pull failures after the remote export now print the exact recovery command.
 - One malformed session file no longer aborts a full rebuild or an incremental pass: parsers are panic-guarded per file and per harness.
 - Crash-hardening for in-place index writes (#181): bucket files are replaced atomically, the record log is fsynced before the manifest stamps its size, an uncommitted record tail now triggers a rebuild instead of silently duplicating messages, and full rebuilds keep the previous index recoverable through the rename window.
 

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -54,7 +54,17 @@ func syncSSHPush(host string, full bool) error {
 		return err
 	}
 	defer os.RemoveAll(tmp)
-	n, err := exportBatches(tmp, full)
+	// Watermarks advance only after the remote import succeeds: acknowledged
+	// delivery, so a failed scp or remote error cannot silently drop records
+	// from every later push.
+	var commit func() error
+	var n int
+	if full {
+		n, err = index.ExportFull(index.DefaultDir(), tmp)
+		commit = func() error { return nil }
+	} else {
+		n, commit, err = index.ExportDeferred(index.DefaultDir(), tmp)
+	}
 	if err != nil {
 		return err
 	}
@@ -82,6 +92,9 @@ func syncSSHPush(host string, full bool) error {
 	out = strings.TrimSpace(out)
 	if err != nil {
 		return fmt.Errorf("remote import: %v: %s", err, out)
+	}
+	if err := commit(); err != nil {
+		return fmt.Errorf("delivered, but recording watermarks failed (next push may resend; harmless — import dedupes): %w", err)
 	}
 	if out != "" {
 		fmt.Fprintf(os.Stdout, "%s: %s\n", host, out)
@@ -123,12 +136,12 @@ func syncSSHPull(host string, full bool) error {
 	defer os.RemoveAll(ltmp)
 	if out, err := sshRunner("scp", "-q", host+":"+rtmp+"/*.jsonl", ltmp+"/"); err != nil {
 		cleanup()
-		return fmt.Errorf("scp: %v: %s", err, strings.TrimSpace(out))
+		return fmt.Errorf("scp: %v: %s — the remote already advanced its watermark for this batch; recover it with `deja sync ssh %s --pull --full`", err, strings.TrimSpace(out), host)
 	}
 	cleanup()
 	n, err := index.Import(index.DefaultDir(), ltmp)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w — the remote already advanced its watermark for this batch; recover it with `deja sync ssh %s --pull --full`", err, host)
 	}
 	fmt.Fprintf(os.Stdout, "deja: imported %d records\n", n)
 	return nil

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -142,3 +142,46 @@ func TestIngestHealthPersistedToManifest(t *testing.T) {
 		t.Fatalf("ingest health = %#v, want claude malformed=1", h)
 	}
 }
+
+func TestExportDeferredCommitsWatermarkOnlyOnAck(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-x")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"watermark ack test"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(tmp, "out")
+	n, commit, err := ExportDeferred(dir, out)
+	if err != nil || n != 1 {
+		t.Fatalf("deferred export = %d, %v", n, err)
+	}
+	// Not committed: a re-export must still see the record.
+	n2, commit2, err := ExportDeferred(dir, filepath.Join(tmp, "out2"))
+	if err != nil || n2 != 1 {
+		t.Fatalf("pre-ack re-export = %d, %v — watermark advanced before ack", n2, err)
+	}
+	_ = commit2
+	if err := commit(); err != nil {
+		t.Fatal(err)
+	}
+	// Committed: nothing new.
+	n3, _, err := ExportDeferred(dir, filepath.Join(tmp, "out3"))
+	if err != nil || n3 != 0 {
+		t.Fatalf("post-ack export = %d, %v — watermark not persisted", n3, err)
+	}
+	// Sessions must survive the core-only manifest write.
+	ss, err := Recent(dir, 5)
+	if err != nil || len(ss) == 0 {
+		t.Fatalf("sessions clobbered by watermark commit: %v, %v", ss, err)
+	}
+}

--- a/internal/index/coverage_recover4_test.go
+++ b/internal/index/coverage_recover4_test.go
@@ -437,9 +437,10 @@ func TestExportRecordsErrorBranches(t *testing.T) {
 
 	dir3 := filepath.Join(tmp, "idx3")
 	writeTinyIndex(t, dir3)
-	// A directory squatting on sessions.gob.tmp makes writeGobAtomic fail
-	// regardless of directory permissions (lockDir re-tightens those).
-	if err := os.MkdirAll(filepath.Join(dir3, "sessions.gob.tmp", "block"), 0o700); err != nil {
+	// A directory squatting on manifest.gob.tmp makes writeGobAtomic fail
+	// regardless of directory permissions (lockDir re-tightens those). The
+	// watermark commit writes only manifest.gob, never sessions.gob.
+	if err := os.MkdirAll(filepath.Join(dir3, "manifest.gob.tmp", "block"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := Export(dir3, filepath.Join(tmp, "out3")); err == nil {

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -2671,6 +2671,17 @@ func readManifest(dir string) (Manifest, error) {
 // whether the index is fresh, so it must land last: a crash between the two
 // leaves the old manifest pointing at old data, and the next run reindexes
 // rather than serving a fresh-looking index whose sessions are stale.
+// writeManifestOnly persists manifest.gob without rewriting sessions.gob —
+// for updates that change only core fields (e.g. export watermarks) where the
+// caller has not loaded sessions and must not clobber them.
+func writeManifestOnly(dir string, m Manifest) error {
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ImportedRecords: m.ImportedRecords, IngestHealth: m.IngestHealth}
+	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
+		core.RecordsSize = fi.Size()
+	}
+	return writeGobAtomic(filepath.Join(dir, "manifest.gob"), core)
+}
+
 func writeManifest(dir string, m Manifest) error {
 	mergeIngestDiag(&m)
 	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ImportedRecords: m.ImportedRecords, IngestHealth: m.IngestHealth}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -38,21 +38,37 @@ func ExportFull(dir, outDir string) (int, error) {
 	return exportRecords(dir, outDir, true)
 }
 
+// ExportDeferred writes batches like Export but does not advance the
+// watermarks; the returned commit persists them once the receiver has
+// acknowledged the batch. Watermarked sync must be acknowledged delivery:
+// advancing on a failed transport silently drops records from the next push.
+func ExportDeferred(dir, outDir string) (int, func() error, error) {
+	return exportRecordsDeferred(dir, outDir, false)
+}
+
 func exportRecords(dir, outDir string, full bool) (int, error) {
+	n, commit, err := exportRecordsDeferred(dir, outDir, full)
+	if err != nil {
+		return n, err
+	}
+	return n, commit()
+}
+
+func exportRecordsDeferred(dir, outDir string, full bool) (int, func() error, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
 	unlock, err := lockDir(dir)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	defer unlock()
 	m, err := readManifest(dir)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	if err := os.MkdirAll(outDir, 0o700); err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	if m.ExportWatermarks == nil {
 		m.ExportWatermarks = map[string]int64{}
@@ -85,7 +101,7 @@ func exportRecords(dir, outDir string, full bool) (int, error) {
 		}
 	})
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	total := 0
 	for source, recs := range bySource {
@@ -95,27 +111,41 @@ func exportRecords(dir, outDir string, full bool) (int, error) {
 		name := fmt.Sprintf("deja-sync-%s-%d.jsonl", shortHash(source), time.Now().UnixNano())
 		f, err := os.Create(filepath.Join(outDir, name))
 		if err != nil {
-			return total, err
+			return total, nil, err
 		}
 		enc := json.NewEncoder(f)
 		for _, rec := range recs {
 			if err := enc.Encode(rec); err != nil {
 				_ = f.Close()
-				return total, err
+				return total, nil, err
 			}
 			total++
 		}
 		if err := f.Close(); err != nil {
-			return total, err
+			return total, nil, err
 		}
 	}
-	for source, wm := range nextWatermarks {
-		m.ExportWatermarks[source] = wm
+	commit := func() error {
+		unlock, err := lockDir(dir)
+		if err != nil {
+			return err
+		}
+		defer unlock()
+		cur, err := readManifest(dir)
+		if err != nil {
+			return err
+		}
+		if cur.ExportWatermarks == nil {
+			cur.ExportWatermarks = map[string]int64{}
+		}
+		for source, wm := range nextWatermarks {
+			if wm > cur.ExportWatermarks[source] {
+				cur.ExportWatermarks[source] = wm
+			}
+		}
+		return writeManifestOnly(dir, cur)
 	}
-	if err := writeManifest(dir, m); err != nil {
-		return total, err
-	}
-	return total, nil
+	return total, commit, nil
 }
 
 func Import(dir, inDir string) (int, error) {


### PR DESCRIPTION
Export advanced its watermarks before the transport ran: a failed `mktemp`, `scp` or remote import left the local manifest believing the batch was delivered, and every later push reported "nothing new". Push now uses `ExportDeferred` — batches are written, the remote imports them, and only then a commit closure persists the watermarks (re-reading the manifest under the lock and writing `manifest.gob` only, so sessions are never clobbered). If the commit itself fails the worst case is a resend, which import dedupes.

Pull's symmetric window (the remote export commits before local scp/import) can't be closed without a two-phase remote command and version-skew guarantees; instead both failure paths after the remote export now print the exact `--pull --full` recovery command. Regression test proves a deferred export re-exports until acked, stops after, and that sessions survive the core-only manifest write.