### PR TITLE
fix(sources): resolve Claude project dirs encoded with a Windows drive letter

### DIFF
--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -162,7 +162,13 @@ func decodeProjectBase(base string) string {
 // at. Segments are re-joined with "/" or "-" and pruned by checking each
 // completed directory prefix on disk.
 func resolveEncodedPath(base string) string {
-	if !strings.HasPrefix(base, "-") {
+	// Windows encodes the drive root too: C:\Users\x\app becomes
+	// "C--Users-x-app". Peel the drive off and let the shared segment walk
+	// resolve the rest from "C:" instead of from an empty root.
+	root := ""
+	if drive, rest, ok := splitEncodedWindowsDrive(base); ok {
+		root, base = drive, rest
+	} else if !strings.HasPrefix(base, "-") {
 		return ""
 	}
 	// pi uses "--" prefix/suffix (e.g. --Users-x-app--), Claude uses
@@ -198,7 +204,21 @@ func resolveEncodedPath(base string) string {
 	if parts[0] == "" {
 		return ""
 	}
-	return try("", parts[0], 1)
+	return try(root, parts[0], 1)
+}
+
+// splitEncodedWindowsDrive recognises the "C--Users-x-app" form Claude Code
+// writes on Windows and returns the drive root ("C:") plus the remainder in
+// the unix-style encoding the resolver already understands ("-Users-x-app").
+func splitEncodedWindowsDrive(base string) (root, rest string, ok bool) {
+	if len(base) < 4 || base[1] != '-' || base[2] != '-' {
+		return "", "", false
+	}
+	c := base[0]
+	if (c < 'A' || c > 'Z') && (c < 'a' || c > 'z') {
+		return "", "", false
+	}
+	return string(c) + ":", base[2:], true
 }
 
 // ClaudeProjectName derives the display project name using the same rules as

--- a/internal/sources/claude_drive_split_test.go
+++ b/internal/sources/claude_drive_split_test.go
@@ -1,0 +1,30 @@
+package sources
+
+import "testing"
+
+// splitEncodedWindowsDrive's whole job is to fire on the Windows "C--…" form
+// and NEVER on unix or pi encodings — a false positive would rewrite good
+// project paths. This runs on every platform (unlike the windows-gated
+// resolver tests) because that invariant is what regresses silently.
+func TestSplitEncodedWindowsDrive(t *testing.T) {
+	cases := []struct {
+		in   string
+		root string
+		rest string
+		ok   bool
+	}{
+		{"C--Users-x-app", "C:", "-Users-x-app", true},
+		{"d--Users-y", "d:", "-Users-y", true},
+		{"-Users-x-app", "", "", false},    // unix: leading slash
+		{"--Users-x-app--", "", "", false}, // pi prefix/suffix
+		{"1--Users", "", "", false},        // not a drive letter
+		{"C-Users", "", "", false},         // single dash, no separator
+		{"C--", "", "", false},             // too short to carry a path
+	}
+	for _, c := range cases {
+		root, rest, ok := splitEncodedWindowsDrive(c.in)
+		if ok != c.ok || root != c.root || rest != c.rest {
+			t.Errorf("split(%q) = (%q,%q,%v), want (%q,%q,%v)", c.in, root, rest, ok, c.root, c.rest, c.ok)
+		}
+	}
+}

--- a/internal/sources/claude_windows_path_test.go
+++ b/internal/sources/claude_windows_path_test.go
@@ -1,0 +1,61 @@
+//go:build windows
+
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Claude Code on Windows encodes the drive root as well, so a project dir is
+// named "C--Users-x-app", not "-Users-x-app". Before this was handled,
+// resolveEncodedPath bailed on the missing "-" prefix and the caller fell
+// back to the dash heuristic, which turns "domain-manage" into
+// "domain\manage" and splits one project across two display names.
+func TestResolveEncodedPathWindowsDriveLetter(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "Downloads", "domain-manage")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	vol := filepath.VolumeName(target) // "C:"
+	if vol == "" {
+		t.Skip("target has no volume name")
+	}
+	trimmed := strings.TrimPrefix(target, vol)
+	encoded := strings.TrimSuffix(vol, ":") + "-" +
+		strings.ReplaceAll(strings.ReplaceAll(trimmed, "\\", "-"), "/", "-")
+
+	got := resolveEncodedPath(encoded)
+	if got == "" {
+		t.Fatalf("resolveEncodedPath(%q) = \"\" — drive-letter form not resolved", encoded)
+	}
+	if !strings.EqualFold(got, target) {
+		t.Fatalf("resolveEncodedPath(%q) = %q, want %q", encoded, got, target)
+	}
+}
+
+// The hyphenated leaf must survive: "domain-manage" is one directory, not
+// "domain/manage".
+func TestClaudeProjectNameWindowsKeepsHyphenatedLeaf(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "Downloads", "domain-manage")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	vol := filepath.VolumeName(target)
+	if vol == "" {
+		t.Skip("target has no volume name")
+	}
+	trimmed := strings.TrimPrefix(target, vol)
+	encoded := strings.TrimSuffix(vol, ":") + "-" +
+		strings.ReplaceAll(strings.ReplaceAll(trimmed, "\\", "-"), "/", "-")
+
+	got := decodeProjectBase(encoded)
+	if !strings.Contains(got, "domain-manage") {
+		t.Fatalf("decodeProjectBase(%q) = %q, want it to keep \"domain-manage\"", encoded, got)
+	}
+}


### PR DESCRIPTION
Fixes #216.

## Problem

Claude Code on Windows encodes the drive root too, so a project directory is
named `C--Users-x-Downloads-domain-manage`, not `-Users-x-...`.
`resolveEncodedPath` required a leading `-` and returned `""` for that form,
so `decodeProjectBase` fell through to the dash heuristic — which cannot tell
an encoded separator from a literal hyphen and renders `domain-manage` as
`domain\manage`.

On a real corpus (445 sessions / 144,752 messages) this split one project
across two entries in `deja stats`:

```
domain-manage   ################## 180    <- codex source (real cwd paths)
domain\manage   #####  54                 <- claude source (Windows)
```

## Fix

Peel the encoded drive off and hand the remainder to the existing segment
walk with `C:` as the root, so the on-disk probe recovers hyphenated names on
Windows exactly as it already does on unix. Non-Windows encodings take the
unchanged code path.

## Verification (Windows 11, go 1.25, windows/amd64)

- `ResolveEncodedPath("C--Users-daoti-Downloads-domain-manage")` before: `""`;
  after: the real directory.
- Re-indexed the corpus with the patched binary: the claude sessions resolve
  to the real path and `domain-manage` keeps its hyphen.
- Added windows-gated regression tests for the resolver and for the decoded
  display name.
- `go test ./...` green (cmd/deja, index, search, sources, redact, embed,
  bench, usage).

## Note on #54

#54 skipped the resolution test on Windows on the grounds that "claude
encodes unix absolute paths, so directory recovery is a no-op on windows".
That assumption does not hold on a Windows host — Claude Code does create
encoded project dirs there — which is why the resolver has had no Windows
coverage. The tests added here are windows-gated and exercise it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
