### PR TITLE
feat: limit-aware handoff tip, one-time ssh sync tip

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -71,6 +71,9 @@ func runHookContext(plain bool) error {
 		lead = "Context was just compacted. The project memory below is from deja's index and survived the compaction; call recall_context with a term from it to restore any details you lost.\n"
 	}
 	digest = lead + digest
+	if tip := limitHandoffTip(); tip != "" {
+		digest += "\n" + tip
+	}
 	digest = frameRecall(digest)
 	usage.RecordResult(index.DefaultDir(), usage.KindHook, len(digest), sessions, false)
 	if plain {
@@ -245,4 +248,49 @@ func startDetachedWarmup(exe, sentinel string) error {
 	cmd.Stdout = devNull
 	cmd.Stderr = cmd.Stdout
 	return startDetached(cmd)
+}
+
+// limitMarkers are the strings harnesses print when a session dies on quota.
+var limitMarkers = []string{
+	"usage limit reached",
+	"rate limit reached",
+	"You've reached your usage limit",
+	"usage limit will reset",
+	"quota exceeded",
+	"out of free quota",
+	"upgrade to continue",
+	"5-hour limit",
+	"weekly limit",
+}
+
+// limitHandoffTip checks whether the newest indexed session ended on a usage
+// limit and, if so, suggests continuing in a different agent via handoff —
+// the cross-agent escape hatch is exactly what limits are for.
+func limitHandoffTip() string {
+	recent, err := index.Recent(index.DefaultDir(), 1)
+	if err != nil || len(recent) == 0 {
+		return ""
+	}
+	s := recent[0]
+	// Only a fresh limit matters; an old one is stale advice.
+	if s.Updated.IsZero() || time.Since(s.Updated) > 6*time.Hour {
+		return ""
+	}
+	// Recent returns metadata only; the tail scan needs the transcript.
+	if full, ok, err := findByPrefix(s.ID); err == nil && ok {
+		s = full
+	}
+	tail := s.Messages
+	if len(tail) > 4 {
+		tail = tail[len(tail)-4:]
+	}
+	for _, m := range tail {
+		lower := strings.ToLower(m.Text)
+		for _, marker := range limitMarkers {
+			if strings.Contains(lower, strings.ToLower(marker)) {
+				return fmt.Sprintf("Note: the most recent %s session appears to have hit a usage limit. If that blocks the user again, suggest `deja handoff --to <agent>` — it packages the live context and continues the work in another agent.", s.Harness)
+			}
+		}
+	}
+	return ""
 }

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -3,8 +3,13 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 )
@@ -82,5 +87,47 @@ func TestPromptCandidatesOrderAndPairs(t *testing.T) {
 		if !strings.Contains(joined, pair) {
 			t.Fatalf("missing pair %q in %v", pair, got)
 		}
+	}
+}
+
+func TestLimitHandoffTip(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	now := time.Now().UTC().Format("2006-01-02T15:04:05Z")
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-alpha", "lim.jsonl"), "lim", []string{
+		`{"type":"user","sessionId":"lim","timestamp":"` + now + `","message":{"role":"user","content":"continue please"}}`,
+		`{"type":"assistant","sessionId":"lim","timestamp":"` + now + `","message":{"role":"assistant","content":"You have reached your usage limit reached for today"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	recent, err := index.Recent(index.DefaultDir(), 1)
+	if err != nil || len(recent) == 0 {
+		t.Fatalf("recent: %v %v", recent, err)
+	}
+	t.Logf("newest: id=%s updated=%v msgs=%d", recent[0].ID, recent[0].Updated, len(recent[0].Messages))
+	tip := limitHandoffTip()
+	if !strings.Contains(tip, "usage limit") || !strings.Contains(tip, "deja handoff") {
+		t.Fatalf("tip = %q", tip)
+	}
+}
+
+func TestSSHSyncTipThresholdAndOnce(t *testing.T) {
+	withStatsStores(t)
+	var ss []model.Session
+	for i := 0; i < 6; i++ {
+		ss = append(ss, model.Session{ID: strconv.Itoa(i), Messages: []model.Message{{Role: "user", Text: "run ssh mini and check"}}})
+	}
+	tip := sshSyncTip(ss)
+	if !strings.Contains(tip, "deja sync ssh") {
+		t.Fatalf("tip = %q", tip)
+	}
+	if again := sshSyncTip(ss); again != "" {
+		t.Fatalf("tip must show once, got %q", again)
+	}
+	// Below threshold: silent (fresh sentinel dir).
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "idx"))
+	if tip := sshSyncTip(ss[:2]); tip != "" {
+		t.Fatalf("below threshold tip = %q", tip)
 	}
 }

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -183,6 +183,7 @@ func runStats(args []string) error {
 		return err
 	}
 	report := buildStats(filterStatsSessions(ss, options), time.Now())
+	sshTip := sshSyncTip(ss)
 	report.Recall = usage.Totals(index.DefaultDir())
 	report.WeekRecalls, report.WeekBytes, report.WeekInjected, _ = usage.Week(index.DefaultDir())
 	if fi, e := os.Stat(embed.Path(index.DefaultDir())); e == nil {
@@ -211,6 +212,9 @@ func runStats(args []string) error {
 		return enc.Encode(report)
 	}
 	printStats(os.Stdout, report)
+	if sshTip != "" {
+		fmt.Fprintln(os.Stdout, sshTip)
+	}
 	return nil
 }
 

--- a/cmd/deja/stats_helpers.go
+++ b/cmd/deja/stats_helpers.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"fmt"
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"os"
 	"strings"
 	"time"
 )
@@ -78,4 +82,29 @@ func trimRunes(s string, n int) string {
 		return string(r[:n])
 	}
 	return string(r[:n-1]) + "…"
+}
+
+// sshSyncTip suggests `deja sync ssh` once when the history shows the user
+// working across machines — many sessions mentioning ssh is the signal that
+// their memory is fragmented over hosts. One-time: a sentinel next to the
+// index suppresses repeats, and any sync usage counts as "already knows".
+func sshSyncTip(ss []model.Session) string {
+	sentinel := index.DefaultDir() + ".synctip"
+	if _, err := os.Stat(sentinel); err == nil {
+		return ""
+	}
+	sshSessions := 0
+	for _, s := range ss {
+		for _, m := range s.Messages {
+			if strings.Contains(m.Text, "ssh ") || strings.Contains(m.Text, "ssh-") {
+				sshSessions++
+				break
+			}
+		}
+	}
+	if sshSessions < 5 {
+		return ""
+	}
+	_ = os.WriteFile(sentinel, []byte("shown"), 0o600)
+	return fmt.Sprintf("tip: %d sessions mention ssh — if you work across machines, `deja sync ssh <host>` carries this memory along (shown once)", sshSessions)
 }


### PR DESCRIPTION
Items 5 and 6 of the magic program, plus the item-4 audit:

- **Limit → handoff**: when the newest indexed session (fresh, <6h) ends with a usage-limit message, the next session's auto-recall injection carries one line telling the agent to suggest `deja handoff --to <agent>` if the user gets blocked again. Recent() returns metadata only, so the tail scan loads the full session first.
- **SSH → sync**: `deja stats` suggests `deja sync ssh <host>` exactly once (sentinel-guarded) when ≥5 sessions mention ssh — the signal that memory is fragmented across machines.
- **Hook-analog audit (item 4)**: Claude Code has UserPromptSubmit (shipped); opencode's documented plugin events don't expose per-message text/injection, so its session-level system transform remains the deepest available wiring; codex has our SessionStart entry; the remaining harnesses have no hook systems — MCP + guidance is their ceiling. Both tips above reach opencode/codex automatically because their integrations call the shared `hook-context`.