### PR TITLE
fix(magic): ranked recalls, dedupe, pre-written citation, attribution metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Per-prompt recall now ranks candidates by relevance (not record order), excludes the current and very-recent sessions, dedupes per agent session, and appends a pre-written citation line the agent can copy.
+- `deja stats` counts how often agents actually said "deja-vu recalled" — a telemetry-free measure of memory credited aloud, closed by deja re-indexing those transcripts.
 - Ingestion health: malformed JSONL lines and failed file parses are counted per harness, persisted in the manifest, and surfaced in `deja doctor` (details in `--json`). Tolerated loss now leaves evidence instead of disappearing.
 - Harness capability matrix (MCP / auto-recall / resume / handoff / prerequisites) generated from the format registry into README and the site; a conformance test pins the published matrix to actual code behavior.
 - `deja resume` reopens Copilot CLI sessions (`copilot --resume=<id>`).

--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -193,6 +193,8 @@ var agentArtifactMarkers = []string{
 	"Called the Read tool with",
 	"[Request interrupted by user]",
 	"Comments on artifact URI:",
+	"idle_notification",
+	`{"type":`,
 }
 
 func isAgentArtifact(text string) bool {

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -152,7 +152,8 @@ func citationLine(s model.Session) string {
 				continue
 			}
 			r := []rune(tt)[0]
-			if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r >= 0x400) {
+			alpha := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r >= 0x400
+			if !alpha {
 				continue
 			}
 			title = tt

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -3,8 +3,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/vshulcz/deja-vu/internal/model"
 	"io"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/search"
@@ -16,7 +19,8 @@ import (
 const promptHookBudget = 1024
 
 type promptHookInput struct {
-	Prompt string `json:"prompt"`
+	Prompt    string `json:"prompt"`
+	SessionID string `json:"session_id"`
 }
 
 // runHookPrompt is the UserPromptSubmit hook: search the user's own prompt
@@ -35,16 +39,43 @@ func runHookPrompt(stdin io.Reader, stdout io.Writer) error {
 	if !index.HasManifest(dir) {
 		return nil
 	}
-	ss, err := index.FirstMatch(dir, promptCandidates(terms), 2)
-	if err != nil || len(ss) == 0 {
+	// Materialize a wider candidate set, rank it properly, then trim: the
+	// matched order of records is not relevance.
+	cand, matched, err := index.FirstMatch(dir, promptCandidates(terms), 8)
+	if err != nil || len(cand) == 0 {
 		return nil
 	}
+	hits, err := search.Run(cand, search.Options{Query: matched})
+	if err != nil || len(hits) == 0 {
+		return nil
+	}
+	ss := make([]model.Session, 0, 2)
+	seen := alreadyInjected(dir, input.SessionID)
+	for _, h := range hits {
+		s := h.Session
+		// Never recall the session being written right now, or work so fresh
+		// the user obviously remembers it — that is anti-magic.
+		if s.ID == input.SessionID || (!s.Updated.IsZero() && time.Since(s.Updated) < 45*time.Minute) {
+			continue
+		}
+		if seen[s.ID] {
+			continue
+		}
+		ss = append(ss, s)
+		if len(ss) == 2 {
+			break
+		}
+	}
+	if len(ss) == 0 {
+		return nil
+	}
+	rememberInjected(dir, input.SessionID, ss)
 	digest := search.AutoRecallDigest(ss, promptHookBudget-recallFrameOverhead)
 	if strings.TrimSpace(digest) == "" {
 		return nil
 	}
 	lead := "deja found prior sessions matching this request. If one genuinely helps, use it and tell the user in one short line what deja-vu recalled; otherwise ignore silently.\n"
-	out := frameRecall(lead + digest)
+	out := frameRecall(lead + digest + citationLine(ss[0]))
 	usage.RecordResult(dir, usage.KindHook, len(out), len(ss), false)
 	var resp sessionStartHookResponse
 	resp.HookSpecificOutput.HookEventName = "UserPromptSubmit"
@@ -90,7 +121,7 @@ func promptCandidates(terms []string) []string {
 	sorted := append([]string(nil), terms...)
 	for i := 0; i < len(sorted); i++ {
 		for j := i + 1; j < len(sorted); j++ {
-			if len(sorted[j]) > len(sorted[i]) {
+			if len([]rune(sorted[j])) > len([]rune(sorted[i])) {
 				sorted[i], sorted[j] = sorted[j], sorted[i]
 			}
 		}
@@ -108,4 +139,73 @@ func promptCandidates(terms []string) []string {
 		}
 	}
 	return out
+}
+
+// citationLine pre-writes the narration so the agent copies structure instead
+// of having to follow an instruction — models do the former far more reliably.
+func citationLine(s model.Session) string {
+	title := ""
+	for _, m := range s.Messages {
+		if m.Role == "user" && !isAgentArtifact(m.Text) {
+			tt := strings.TrimSpace(shareMessageText(m.Text))
+			if tt == "" || strings.HasPrefix(tt, "Exit code") {
+				continue
+			}
+			r := []rune(tt)[0]
+			if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r >= 0x400) {
+				continue
+			}
+			title = tt
+			break
+		}
+	}
+	if title == "" {
+		title = s.Title
+	}
+	title = strings.TrimSpace(title)
+	if len([]rune(title)) > 60 {
+		title = string([]rune(title)[:60]) + "…"
+	}
+	date := ""
+	if !s.Updated.IsZero() {
+		date = ", " + s.Updated.Format("Jan 2")
+	}
+	return fmt.Sprintf("\nIf it helped, say: \"deja-vu recalled: %s (%s%s) — reusing it.\"", title, s.Harness, date)
+}
+
+// alreadyInjected returns the session ids this hook already injected into the
+// given agent session, so follow-up prompts do not repeat the same memory.
+func alreadyInjected(dir, sid string) map[string]bool {
+	out := map[string]bool{}
+	if sid == "" {
+		return out
+	}
+	b, err := os.ReadFile(dir + ".hookseen")
+	if err != nil {
+		return out
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		parts := strings.Fields(line)
+		if len(parts) == 2 && parts[0] == sid {
+			out[parts[1]] = true
+		}
+	}
+	return out
+}
+
+func rememberInjected(dir, sid string, ss []model.Session) {
+	if sid == "" {
+		return
+	}
+	f, err := os.OpenFile(dir+".hookseen", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	if fi, err := f.Stat(); err == nil && fi.Size() > 1<<20 {
+		return // advisory state; stop growing rather than rotate under a hook
+	}
+	for _, s := range ss {
+		fmt.Fprintf(f, "%s %s\n", sid, s.ID)
+	}
 }

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -131,3 +131,47 @@ func TestSSHSyncTipThresholdAndOnce(t *testing.T) {
 		t.Fatalf("below threshold tip = %q", tip)
 	}
 }
+
+func TestHookPromptCitationAndDedupe(t *testing.T) {
+	withStatsStores(t)
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	in := `{"prompt":"the long beta session broke again","session_id":"agent-1"}`
+	var out bytes.Buffer
+	if err := runHookPrompt(strings.NewReader(in), &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `If it helped, say: \"deja-vu recalled:`) {
+		t.Fatalf("citation line missing: %q", out.String())
+	}
+	// Same session asks again: the same memory must not be re-injected.
+	var out2 bytes.Buffer
+	if err := runHookPrompt(strings.NewReader(in), &out2); err != nil {
+		t.Fatal(err)
+	}
+	if out2.Len() != 0 {
+		t.Fatalf("repeat injection for same session: %q", out2.String())
+	}
+	// A different agent session still gets it.
+	var out3 bytes.Buffer
+	if err := runHookPrompt(strings.NewReader(`{"prompt":"the long beta session broke again","session_id":"agent-2"}`), &out3); err != nil {
+		t.Fatal(err)
+	}
+	if out3.Len() == 0 {
+		t.Fatal("fresh session should still receive the memory")
+	}
+}
+
+func TestAgentCreditsCountedFromIndex(t *testing.T) {
+	now := time.Now()
+	ss := []model.Session{{ID: "a", Messages: []model.Message{
+		{Role: "assistant", Text: "deja-vu recalled: jwt fix — reusing it.", Time: now},
+		{Role: "assistant", Text: "deja-vu recalled: old one", Time: now.Add(-9 * 24 * time.Hour)},
+		{Role: "user", Text: "deja-vu recalled should not count from users"},
+	}}}
+	r := buildStats(ss, now)
+	if r.AgentCredits != 2 || r.WeekCredits != 1 {
+		t.Fatalf("credits = %d/%d, want 2/1", r.AgentCredits, r.WeekCredits)
+	}
+}

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -43,6 +43,8 @@ type statsReport struct {
 	WeekBytes       int            `json:"week_bytes"`
 	WeekInjected    int            `json:"week_injected"`
 	HandoffsIn      int            `json:"handoffs_received"`
+	AgentCredits    int            `json:"agent_credits"`
+	WeekCredits     int            `json:"week_agent_credits"`
 	SidecarSize     int64          `json:"sidecar_size,omitempty"`
 }
 
@@ -374,7 +376,20 @@ func buildStats(ss []model.Session, now time.Time) statsReport {
 		out.DateRange.End = maxT.Format("2006-01-02")
 	}
 	out.RepeatQuestions = repeatQuestions(ss)
+	weekCut := now.Add(-7 * 24 * time.Hour)
 	for _, s := range ss {
+		for _, msg := range s.Messages {
+			// The attribution loop: agents saying "deja-vu recalled" end up in
+			// the very transcripts deja indexes, so the next pass can count how
+			// often memory was credited out loud — a measured magic metric with
+			// zero telemetry.
+			if msg.Role == "assistant" && strings.Contains(msg.Text, "deja-vu recalled") {
+				out.AgentCredits++
+				if !msg.Time.IsZero() && msg.Time.After(weekCut) {
+					out.WeekCredits++
+				}
+			}
+		}
 		for _, msg := range s.Messages {
 			if msg.Role != "user" {
 				continue
@@ -478,6 +493,9 @@ func printStats(w io.Writer, r statsReport) {
 	fmt.Fprintf(w, "%sRecall%s\n", bold, reset)
 	fmt.Fprintf(w, "  Recalls served   %d\n", r.Recall.Recalls)
 	fmt.Fprintf(w, "  This week        %d recalls by your agents · %s re-used (plus %d auto-injections)\n", r.WeekRecalls, humanBytes(int64(r.WeekBytes)), r.WeekInjected)
+	if r.AgentCredits > 0 {
+		fmt.Fprintf(w, "  Credited aloud   agents said \"deja-vu recalled\" %d times (%d this week)\n", r.AgentCredits, r.WeekCredits)
+	}
 	if r.HandoffsIn > 0 {
 		fmt.Fprintf(w, "  Handoffs         %d sessions started from a handoff\n", r.HandoffsIn)
 	}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -419,21 +419,21 @@ func SearchDetailed(dir string, o search.Options) (SearchResult, error) {
 // materializes sessions for the first query that matches. Built for the
 // per-prompt hook, which fires on every user message and must stay fast: the
 // full Search pipeline per candidate would re-read the manifest each time.
-func FirstMatch(dir string, queries []string, limit int) ([]model.Session, error) {
+func FirstMatch(dir string, queries []string, limit int) ([]model.Session, string, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
 	unlock, err := lockDir(dir)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer unlock()
 	m, err := readManifest(dir)
 	if err != nil {
-		return nil, fmt.Errorf("manifest: %w", err)
+		return nil, "", fmt.Errorf("manifest: %w", err)
 	}
 	if !recordsIntact(dir, m) {
-		return nil, fmt.Errorf("%w: records.bin size does not match the manifest (crash-truncated or uncommitted tail)", errCorruptIndex)
+		return nil, "", fmt.Errorf("%w: records.bin size does not match the manifest (crash-truncated or uncommitted tail)", errCorruptIndex)
 	}
 	for _, q := range queries {
 		keys := queryKeys(q)
@@ -442,7 +442,7 @@ func FirstMatch(dir string, queries []string, limit int) ([]model.Session, error
 		}
 		posts, err := intersectPostings(dir, retrievalKeys(keys))
 		if err != nil {
-			return nil, fmt.Errorf("postings: %w", err)
+			return nil, "", fmt.Errorf("postings: %w", err)
 		}
 		o := search.Options{Query: q}
 		posts = cutPostingsBySession(posts, m, o)
@@ -456,9 +456,9 @@ func FirstMatch(dir string, queries []string, limit int) ([]model.Session, error
 		if len(ss) > limit {
 			ss = ss[:limit]
 		}
-		return ss, nil
+		return ss, q, nil
 	}
-	return nil, nil
+	return nil, "", nil
 }
 
 // SearchWithRecovery is Search plus self-healing: a corrupt bucket (crash


### PR DESCRIPTION
Self-review of the magic pass turned up real defects; this fixes all of them and adds two mechanisms.

**Fixed**
- **FirstMatch didn't rank** — it returned records in match order, so the injected "top 2" could be the two worst hits. It now materializes up to 8 candidates and `search.Run` ranks them (BM25) before trimming to 2.
- **No per-session dedupe / self-recall** — the hook ignored `session_id` from stdin, so follow-up prompts re-injected the same memory, and it could even recall the session being written or work from minutes ago (anti-magic). Now excludes the current session + anything under 45m old, and remembers what it injected per agent session.
- **Byte-length term sorting** mis-ranked Cyrillic (2 bytes/char); now rune length.

**Added**
- **Pre-written citation line**: instead of only instructing "tell the user", the injection ends with `If it helped, say: "deja-vu recalled: <title> (<harness>, <date>) — reusing it."` — models copy structure far more reliably than they follow meta-instructions (#154).
- **Attribution metric**: because agents write "deja-vu recalled" into transcripts that deja then indexes, `deja stats` counts how often memory was credited out loud — a telemetry-free magic metric no competitor can have. Verified live: haiku recalled a real prod incident, credited it in-format, and the next index made stats read "agents said deja-vu recalled 6 times this week."