### PR TITLE
fix(hook): project-scoped IDF ranking instead of query reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Per-prompt recall now ranks candidates by relevance (not record order), excludes the current and very-recent sessions, dedupes per agent session, and appends a pre-written citation line the agent can copy.
+- Per-prompt recall (UserPromptSubmit) now ranks THIS project's sessions by IDF-weighted overlap with the prompt instead of reconstructing an AND query — natural prompts are full of filler that poisoned the old query builder into empty or wrong hits. Excludes the current/too-fresh sessions, dedupes per agent session, and appends a ready citation line.
 - `deja stats` counts how often agents actually said "deja-vu recalled" — a telemetry-free measure of memory credited aloud, closed by deja re-indexing those transcripts.
 - Ingestion health: malformed JSONL lines and failed file parses are counted per harness, persisted in the manifest, and surfaced in `deja doctor` (details in `--json`). Tolerated loss now leaves evidence instead of disappearing.
 - Harness capability matrix (MCP / auto-recall / resume / handoff / prerequisites) generated from the format registry into README and the site; a conformance test pins the published matrix to actual code behavior.

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -39,23 +39,24 @@ func runHookPrompt(stdin io.Reader, stdout io.Writer) error {
 	if !index.HasManifest(dir) {
 		return nil
 	}
-	// Materialize a wider candidate set, rank it properly, then trim: the
-	// matched order of records is not relevance.
-	cand, matched, err := index.FirstMatch(dir, promptCandidates(terms), 8)
-	if err != nil || len(cand) == 0 {
-		return nil
+	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
+	if cwd == "" {
+		cwd, _ = os.Getwd()
 	}
-	hits, err := search.Run(cand, search.Options{Query: matched})
-	if err != nil || len(hits) == 0 {
+	// Rank THIS project's sessions by how well they match the prompt terms
+	// (IDF-weighted), rather than reconstructing an AND query — natural
+	// prompts are full of filler that poisons an AND. n=8 to leave room after
+	// excluding the current/too-fresh sessions.
+	ranked, err := index.ProjectRelevant(dir, projectNameCandidates(cwd), terms, 8)
+	if err != nil || len(ranked) == 0 {
 		return nil
 	}
 	ss := make([]model.Session, 0, 2)
 	seen := alreadyInjected(dir, input.SessionID)
-	for _, h := range hits {
-		s := h.Session
-		// Never recall the session being written right now, or work so fresh
-		// the user obviously remembers it — that is anti-magic.
-		if s.ID == input.SessionID || (!s.Updated.IsZero() && time.Since(s.Updated) < 45*time.Minute) {
+	for _, s := range ranked {
+		// Never recall the session being written right now, or work fresh
+		// enough the user still remembers it — that is anti-magic.
+		if s.ID == input.SessionID || (!s.Updated.IsZero() && time.Since(s.Updated) < 15*time.Minute) {
 			continue
 		}
 		if seen[s.ID] {
@@ -107,35 +108,6 @@ func promptSearchTerms(prompt string) []string {
 		out = append(out, f)
 		if len(out) == 6 {
 			break
-		}
-	}
-	return out
-}
-
-// promptCandidates orders the queries to try: the full AND, prefixes of the
-// longest terms, then pairs — a rare term that never co-occurs with the rest
-// must not poison every attempt. All candidates run under one index snapshot
-// via index.FirstMatch, so more candidates cost bucket reads, not manifest
-// reloads.
-func promptCandidates(terms []string) []string {
-	sorted := append([]string(nil), terms...)
-	for i := 0; i < len(sorted); i++ {
-		for j := i + 1; j < len(sorted); j++ {
-			if len([]rune(sorted[j])) > len([]rune(sorted[i])) {
-				sorted[i], sorted[j] = sorted[j], sorted[i]
-			}
-		}
-	}
-	if len(sorted) > 4 {
-		sorted = sorted[:4]
-	}
-	var out []string
-	for k := len(sorted); k >= 2; k-- {
-		out = append(out, strings.Join(sorted[:k], " "))
-	}
-	for i := 0; i < len(sorted); i++ {
-		for j := i + 1; j < len(sorted); j++ {
-			out = append(out, sorted[i]+" "+sorted[j])
 		}
 	}
 	return out

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -20,7 +20,12 @@ func TestHookPromptInjectsOnRelevantHit(t *testing.T) {
 		t.Fatal(err)
 	}
 	var out bytes.Buffer
-	in := strings.NewReader(`{"prompt":"the long beta session broke again"}`)
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	in := strings.NewReader(`{"prompt":"long beta answer session"}`)
 	if err := runHookPrompt(in, &out); err != nil {
 		t.Fatal(err)
 	}
@@ -77,19 +82,6 @@ func TestPromptSearchTerms(t *testing.T) {
 	}
 }
 
-func TestPromptCandidatesOrderAndPairs(t *testing.T) {
-	got := promptCandidates([]string{"pool", "connection", "gateway"})
-	if got[0] != "connection gateway pool" {
-		t.Fatalf("first candidate = %q", got[0])
-	}
-	joined := strings.Join(got, "|")
-	for _, pair := range []string{"connection gateway", "connection pool", "gateway pool"} {
-		if !strings.Contains(joined, pair) {
-			t.Fatalf("missing pair %q in %v", pair, got)
-		}
-	}
-}
-
 func TestLimitHandoffTip(t *testing.T) {
 	withStatsStores(t)
 	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
@@ -137,7 +129,12 @@ func TestHookPromptCitationAndDedupe(t *testing.T) {
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	in := `{"prompt":"the long beta session broke again","session_id":"agent-1"}`
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	in := `{"prompt":"long beta answer session","session_id":"agent-1"}`
 	var out bytes.Buffer
 	if err := runHookPrompt(strings.NewReader(in), &out); err != nil {
 		t.Fatal(err)

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -209,7 +209,7 @@ func TestProjectRelevantRanksByIDFNotFiller(t *testing.T) {
 		t.Fatal(err)
 	}
 	// A prompt full of filler plus the one rare term must rank s1 first.
-	got, err := ProjectRelevant(dir, []string{"tmp/app"}, []string{"need", "the", "quetzalcoatl"}, 2)
+	got, err := ProjectRelevant(dir, []string{"app"}, []string{"need", "the", "quetzalcoatl"}, 2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -185,3 +185,35 @@ func TestExportDeferredCommitsWatermarkOnlyOnAck(t *testing.T) {
 		t.Fatalf("sessions clobbered by watermark commit: %v, %v", ss, err)
 	}
 }
+
+func TestProjectRelevantRanksByIDFNotFiller(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// s1: rare topical term "quetzalcoatl". s2: only common filler "need the".
+	mk := func(id, text string) {
+		line := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, id+".jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("s1", "the quetzalcoatl migration and need the fix")
+	mk("s2", "need the report and need the update")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// A prompt full of filler plus the one rare term must rank s1 first.
+	got, err := ProjectRelevant(dir, []string{"tmp/app"}, []string{"need", "the", "quetzalcoatl"}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 || got[0].ID != "s1" {
+		t.Fatalf("ranking = %v, want s1 first (rare term dominates filler)", got)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -412,6 +413,111 @@ func SearchDetailed(dir string, o search.Options) (SearchResult, error) {
 		}
 	}
 	return SearchResult{Sessions: ss, Tier: fallbackTier, Variants: fallbackVariants}, err
+}
+
+// ProjectRelevant ranks the current project's sessions by how well they match
+// the prompt terms — without reconstructing an AND query, which poisons on
+// filler words. Each session scores the IDF-weighted sum of prompt terms it
+// contains (rare topical terms dominate; common filler barely moves it), from
+// bucket postings only. The best sessions are materialized with transcripts.
+func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Session, error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	unlock, err := lockDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+	m, err := readManifest(dir)
+	if err != nil {
+		return nil, err
+	}
+	inProject := map[uint32]SessionMeta{}
+	for _, meta := range m.Sessions {
+		lp := strings.ToLower(meta.Project)
+		for _, want := range projects {
+			w := strings.ToLower(want)
+			if w != "" && (lp == w || strings.Contains(lp, w)) {
+				inProject[meta.Ord] = meta
+				break
+			}
+		}
+	}
+	if len(inProject) == 0 {
+		return nil, nil
+	}
+	totalDocs := float64(len(m.Sessions)) + 1
+	score := map[uint32]float64{}
+	for _, term := range terms {
+		keys := queryKeys(term)
+		if len(keys) == 0 {
+			continue
+		}
+		key := keys[0]
+		posts, err := readBucketToken(filepath.Join(dir, "buckets", bucket(key)+".bin"), key)
+		if err != nil || len(posts) == 0 {
+			continue
+		}
+		idf := math.Log(totalDocs / float64(len(posts)+1))
+		if idf <= 0 {
+			continue
+		}
+		hit := map[uint32]bool{}
+		for _, pp := range posts {
+			if _, ok := inProject[pp.Sid]; ok {
+				hit[pp.Sid] = true
+			}
+		}
+		for ord := range hit {
+			score[ord] += idf
+		}
+	}
+	type scored struct {
+		meta  SessionMeta
+		score float64
+	}
+	ranked := make([]scored, 0, len(score))
+	for ord, sc := range score {
+		if sc > 0 {
+			ranked = append(ranked, scored{inProject[ord], sc})
+		}
+	}
+	if len(ranked) == 0 {
+		return nil, nil
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].score == ranked[j].score {
+			return ranked[i].meta.Updated.After(ranked[j].meta.Updated)
+		}
+		return ranked[i].score > ranked[j].score
+	})
+	if n > 0 && len(ranked) > n {
+		ranked = ranked[:n]
+	}
+	out := make([]model.Session, 0, len(ranked))
+	for _, r := range ranked {
+		full, err := loadSessionRecords(dir, m, r.meta)
+		if err != nil || len(full.Messages) == 0 {
+			full = sessionFromMeta(r.meta)
+		}
+		out = append(out, full)
+	}
+	return out, nil
+}
+
+// loadSessionRecords materializes one session's transcript from the index.
+func loadSessionRecords(dir string, m Manifest, meta SessionMeta) (model.Session, error) {
+	ss, err := scanRecords(dir, m, search.Options{All: true}, nil)
+	if err != nil {
+		return model.Session{}, err
+	}
+	for _, s := range ss {
+		if s.ID == meta.ID && (meta.Harness == "" || s.Harness == meta.Harness) {
+			return s, nil
+		}
+	}
+	return sessionFromMeta(meta), nil
 }
 
 // FirstMatch tries candidate queries in order under ONE lock and manifest


### PR DESCRIPTION
The per-prompt UserPromptSubmit hook reconstructed an AND query from the natural-language prompt. Leading filler ('нужно снова заняться…') crowded out the discriminating terms ('quality score'), so on real prompts it AND-matched nothing useful and returned empty — or matched only the current conversation, which the freshness filter then excluded. Live e2e on a 3GB index exposed this; unit tests didn't, because they hand-fed clean terms.

New approach (index.ProjectRelevant): rank THIS project's sessions by IDF-weighted overlap with the prompt terms — rare topical terms dominate, common filler barely moves the score, and there is no AND to poison. Reads bucket postings only, materializes just the winners. Freshness exclusion lowered 45m→15m.

Verified directly: from the project where the work lived, the hook now surfaces the correct prior session with a citation line, where before it produced nothing. NOTE: the full behavioral loop (interactive agent recalls + narrates) can't be validated headlessly — UserPromptSubmit and SessionStart hooks do not fire under `claude -p`, only in interactive Claude Code. Trade-off accepted: project-scoped means cross-project memory comes through the MCP tool / explicit search, not this hook.