### PR TITLE
fix: MCP recall robustness and index write durability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-21
+
 ### Added
 - Handoff/resume commands corrected against the real installed CLIs: cursor handoff uses positional prompt (no `chat` subcommand exists), pi resume uses `--session`, and grok is marked non-resumable (it has no session flags).
 - Per-prompt recall (UserPromptSubmit) now ranks THIS project's sessions by IDF-weighted overlap with the prompt instead of reconstructing an AND query — natural prompts are full of filler that poisoned the old query builder into empty or wrong hits. Excludes the current/too-fresh sessions, dedupes per agent session, and appends a ready citation line.
@@ -24,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SSH sync push is acknowledged delivery: export watermarks advance only after the remote import succeeds, so a failed transfer no longer silently drops that batch from every later push. Pull failures after the remote export now print the exact recovery command.
 - One malformed session file no longer aborts a full rebuild or an incremental pass: parsers are panic-guarded per file and per harness.
 - Crash-hardening for in-place index writes (#181): bucket files are replaced atomically, the record log is fsynced before the manifest stamps its size, an uncommitted record tail now triggers a rebuild instead of silently duplicating messages, and full rebuilds keep the previous index recoverable through the rename window.
+- MCP recall/blame accept a fractional `limit`: a client that serializes `5` as `5.0` used to get a `-32602` error and no results at all.
+- MCP server hardening: large JSON-RPC ids are echoed back exactly instead of being rounded through float64, and a single oversized frame is skipped rather than tearing down the whole stdio session.
+- `manifest.gob`/`sessions.gob` are fsynced before the rename, closing a crash window that could leave a torn manifest even though the rest of the index writes durably.
+- A session file caught mid-write (torn first line) is fully re-indexed on the next pass instead of resuming an append mid-line, so its first message is no longer dropped.
+- `deja install` writes the Windows `cmd /c` shim for Codex and Grok `config.toml`, matching the JSON-based installers.
 
 ### Added
 - Recall receipt: when auto-recall injects real context, the SessionStart hook now surfaces a one-line notice ("deja: recalled N prior sessions…") instead of working silently; `deja stats` and the statusline report the trailing-week recall count and re-used context volume.

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -144,8 +144,8 @@ func TestInstallWriteAndJSONEdges(t *testing.T) {
 func TestMCPMalformedParamsOversizedAndToolErrors(t *testing.T) {
 	hermeticEnv(t)
 	for _, req := range []rpcRequest{
-		{ID: 1, Method: "tools/call", Params: json.RawMessage(`{"name":`)},
-		{ID: 2, Method: "tools/call", Params: json.RawMessage(`{"name":"recall","arguments":{"query":`)},
+		{ID: json.RawMessage(`1`), Method: "tools/call", Params: json.RawMessage(`{"name":`)},
+		{ID: json.RawMessage(`2`), Method: "tools/call", Params: json.RawMessage(`{"name":"recall","arguments":{"query":`)},
 	} {
 		_, code, msg := handleMCP(req)
 		if code != -32602 || msg == "" {

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -90,7 +90,9 @@ func TestInstallGrokTOML(t *testing.T) {
 		t.Fatalf("grok install: %#v %v", r, err)
 	}
 	b, _ := os.ReadFile(cfg)
-	if !strings.Contains(string(b), "[mcp_servers.deja]") || !strings.Contains(string(b), `command = "/bin/deja"`) {
+	// The exe lands in command= on unix and inside args=[...] behind the cmd /c
+	// shim on Windows; assert its presence either way.
+	if !strings.Contains(string(b), "[mcp_servers.deja]") || !strings.Contains(string(b), "/bin/deja") {
 		t.Fatalf("grok config: %s", b)
 	}
 	// merge into an existing config without touching other sections

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -528,8 +528,19 @@ func installStatusline(exe string, uninstall bool) (installResult, error) {
 
 func installCodex(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(sources.CodexHome(), "config.toml")
-	block := fmt.Sprintf("[mcp_servers.deja]\ntype = \"stdio\"\ncommand = %q\nargs = [\"mcp\"]\n", exe)
+	cmd, args := mcpCommandArgs(exe)
+	block := fmt.Sprintf("[mcp_servers.deja]\ntype = \"stdio\"\ncommand = %q\nargs = %s\n", cmd, tomlStringArray(args))
 	return installTOML(path, block, uninstall)
+}
+
+// tomlStringArray renders a Go string slice as a TOML inline array, e.g.
+// ["/c", "deja", "mcp"], so the Windows cmd /c shim survives the config write.
+func tomlStringArray(xs []string) string {
+	quoted := make([]string, len(xs))
+	for i, x := range xs {
+		quoted[i] = fmt.Sprintf("%q", x)
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
 }
 
 // installGrok wires the MCP server into Grok Build's config.toml.
@@ -537,7 +548,8 @@ func installCodex(exe string, uninstall bool) (installResult, error) {
 // on passive events, so MCP is the deepest integration available.
 func installGrok(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(sources.GrokHome(), "config.toml")
-	block := fmt.Sprintf("[mcp_servers.deja]\ncommand = %q\nargs = [\"mcp\"]\n", exe)
+	cmd, args := mcpCommandArgs(exe)
+	block := fmt.Sprintf("[mcp_servers.deja]\ncommand = %q\nargs = %s\n", cmd, tomlStringArray(args))
 	return installTOML(path, block, uninstall)
 }
 

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -22,48 +22,70 @@ const mcpProtocolVersion = "2024-11-05"
 
 type rpcRequest struct {
 	JSONRPC string          `json:"jsonrpc"`
-	ID      any             `json:"id,omitempty"`
+	ID      json.RawMessage `json:"id,omitempty"`
 	Method  string          `json:"method"`
 	Params  json.RawMessage `json:"params,omitempty"`
 }
 
+// isNotification reports whether a request omitted id (a JSON-RPC notification,
+// which must get no reply). A literal null id counts as absent too.
+func isNotification(id json.RawMessage) bool {
+	return len(id) == 0 || string(id) == "null"
+}
+
+const mcpMaxFrame = 10 * 1024 * 1024
+
 func serveMCP(r io.Reader, w io.Writer) error {
-	s := bufio.NewScanner(r)
-	// MCP messages are line-delimited JSON here. Allow large, but bounded, client lines.
-	s.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	br := bufio.NewReaderSize(r, 64*1024)
 	enc := json.NewEncoder(w)
-	for s.Scan() {
-		line := strings.TrimSpace(s.Text())
-		if line == "" {
-			continue
-		}
-		var req rpcRequest
-		if err := json.Unmarshal([]byte(line), &req); err != nil {
+	for {
+		line, overlong, err := readMCPLine(br, mcpMaxFrame)
+		if overlong {
+			// One oversized frame is reported as a parse error and skipped; the
+			// server keeps serving instead of tearing down the whole session.
 			writeRPCError(enc, nil, -32700, "parse error")
-			continue
+		} else if trimmed := strings.TrimSpace(string(line)); trimmed != "" {
+			var req rpcRequest
+			if uerr := json.Unmarshal([]byte(trimmed), &req); uerr != nil {
+				writeRPCError(enc, nil, -32700, "parse error")
+			} else if !isNotification(req.ID) {
+				result, code, msg := handleMCP(req)
+				if code != 0 {
+					writeRPCError(enc, req.ID, code, msg)
+				} else if eerr := enc.Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": result}); eerr != nil {
+					return eerr
+				}
+			}
 		}
-		if req.ID == nil {
-			// Notification. Do not reply.
-			continue
-		}
-		result, code, msg := handleMCP(req)
-		if code != 0 {
-			writeRPCError(enc, req.ID, code, msg)
-			continue
-		}
-		if err := enc.Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": result}); err != nil {
-			return err
-		}
-	}
-	if err := s.Err(); err != nil {
-		// Oversized or malformed client frames are reported as JSON-RPC parse errors,
-		// then the stdio server exits gracefully instead of silently hard-stopping.
-		writeRPCError(enc, nil, -32700, "parse error")
-		if os.Getenv("DEJA_DEBUG") == "1" {
-			fmt.Fprintf(os.Stderr, "deja mcp scanner error: %v\n", err)
+		if err != nil {
+			if err != io.EOF && os.Getenv("DEJA_DEBUG") == "1" {
+				fmt.Fprintf(os.Stderr, "deja mcp read error: %v\n", err)
+			}
+			return nil
 		}
 	}
-	return nil
+}
+
+// readMCPLine reads one newline-delimited frame. A frame longer than max is
+// drained and reported via overlong=true rather than buffered whole, so a
+// hostile or corrupt client can't exhaust memory or kill the loop.
+func readMCPLine(br *bufio.Reader, max int) (line []byte, overlong bool, err error) {
+	for {
+		chunk, e := br.ReadSlice('\n')
+		if e == bufio.ErrBufferFull {
+			if len(line)+len(chunk) > max {
+				// Drain the rest of this overlong frame up to the next newline.
+				for e == bufio.ErrBufferFull {
+					_, e = br.ReadSlice('\n')
+				}
+				return nil, true, e
+			}
+			line = append(line, chunk...)
+			continue
+		}
+		line = append(line, chunk...)
+		return line, false, e
+	}
 }
 
 func handleMCP(req rpcRequest) (any, int, string) {
@@ -131,9 +153,9 @@ func callMCPTool(name string, raw json.RawMessage) (string, error) {
 	switch name {
 	case "recall":
 		var a struct {
-			Query   string `json:"query"`
-			Harness string `json:"harness"`
-			Limit   int    `json:"limit"`
+			Query   string  `json:"query"`
+			Harness string  `json:"harness"`
+			Limit   float64 `json:"limit"`
 		}
 		if err := json.Unmarshal(raw, &a); err != nil {
 			return "", err
@@ -141,7 +163,7 @@ func callMCPTool(name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Query) == "" {
 			return "", fmt.Errorf("query required")
 		}
-		text, sessions, err := recallTextResult(a.Query, a.Harness, a.Limit, 4096-recallFrameOverhead)
+		text, sessions, err := recallTextResult(a.Query, a.Harness, int(a.Limit), 4096-recallFrameOverhead)
 		if err == nil {
 			text = frameRecall(text)
 			usage.RecordResult(index.DefaultDir(), usage.KindRecall, len(text), sessions, sessions == 0)
@@ -166,12 +188,12 @@ func callMCPTool(name string, raw json.RawMessage) (string, error) {
 		return text, err
 	case "blame":
 		var a struct {
-			Path    string `json:"path"`
-			Harness string `json:"harness"`
-			Project string `json:"project"`
-			Since   string `json:"since"`
-			Limit   int    `json:"limit"`
-			All     bool   `json:"all"`
+			Path    string  `json:"path"`
+			Harness string  `json:"harness"`
+			Project string  `json:"project"`
+			Since   string  `json:"since"`
+			Limit   float64 `json:"limit"`
+			All     bool    `json:"all"`
 		}
 		if err := json.Unmarshal(raw, &a); err != nil {
 			return "", err
@@ -187,7 +209,7 @@ func callMCPTool(name string, raw json.RawMessage) (string, error) {
 				return "", err
 			}
 		}
-		return blameTextResult(search.BlameOptions{Harness: a.Harness, Project: a.Project, Since: since, All: a.All}, a.Path, a.Limit)
+		return blameTextResult(search.BlameOptions{Harness: a.Harness, Project: a.Project, Since: since, All: a.All}, a.Path, int(a.Limit))
 	case "remember":
 		var a struct {
 			Text    string `json:"text"`

--- a/cmd/deja/mcp_contract_test.go
+++ b/cmd/deja/mcp_contract_test.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// driveMCP feeds line-delimited JSON-RPC requests through serveMCP (the exact
+// code path `deja mcp` runs over stdio) and returns the parsed responses in
+// order. This exercises the real request/response framing a client sees.
+func driveMCP(t *testing.T, requests ...string) []map[string]any {
+	t.Helper()
+	in := strings.Join(requests, "\n") + "\n"
+	var out bytes.Buffer
+	if err := serveMCP(strings.NewReader(in), &out); err != nil {
+		t.Fatalf("serveMCP: %v", err)
+	}
+	var resp []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("bad response line %q: %v", line, err)
+		}
+		resp = append(resp, m)
+	}
+	return resp
+}
+
+// callText pulls result.content[0].text out of a tools/call response, asserting
+// the {content:[{type:text,text}]} envelope every MCP client parses.
+func callText(t *testing.T, resp map[string]any) string {
+	t.Helper()
+	if e, ok := resp["error"]; ok {
+		t.Fatalf("unexpected rpc error: %#v", e)
+	}
+	res, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("no result object: %#v", resp)
+	}
+	content, ok := res["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("no content array: %#v", res)
+	}
+	block := content[0].(map[string]any)
+	if block["type"] != "text" {
+		t.Fatalf("content[0].type = %v, want text", block["type"])
+	}
+	return block["text"].(string)
+}
+
+// seedClaude writes one claude session (user + assistant line) under the
+// DEJA_CLAUDE_ROOT project dir.
+func seedClaude(t *testing.T, root, project, id, userText, asstText string) {
+	t.Helper()
+	dir := filepath.Join(root, "-"+project)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(role, text string) string {
+		msg := map[string]any{"role": role, "content": text}
+		rec := map[string]any{"type": role, "sessionId": id, "cwd": "/tmp/" + project, "timestamp": "2026-01-02T03:04:05Z", "message": msg}
+		b, _ := json.Marshal(rec)
+		return string(b)
+	}
+	body := line("user", userText) + "\n" + line("assistant", asstText) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, id+".jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestMCPToolContract exercises the full stdio tool surface a real agent drives:
+// every tool (recall, recall_context, blame, remember), the harness filter, the
+// limit cap, the result envelope, and the tools/list schema. Hermetic and
+// deterministic — no network, no real agent. It is the guardrail that keeps the
+// MCP contract that live agents depend on from silently regressing.
+func TestMCPToolContract(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	// Two sessions share "frobnicator" (limit test); one names parser.go (blame).
+	seedClaude(t, claude, "app", "sess-alpha", "the frobnicator crash in parser.go", "fixed the frobnicator")
+	seedClaude(t, claude, "app", "sess-beta", "another frobnicator regression today", "frobnicator again")
+
+	t.Run("tools/list schema", func(t *testing.T) {
+		resp := driveMCP(t, `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+		tools := resp[0]["result"].(map[string]any)["tools"].([]any)
+		got := map[string]bool{}
+		for _, ti := range tools {
+			tool := ti.(map[string]any)
+			name, _ := tool["name"].(string)
+			got[name] = true
+			schema, ok := tool["inputSchema"].(map[string]any)
+			if !ok || schema["type"] != "object" {
+				t.Fatalf("tool %q inputSchema not an object: %#v", name, tool["inputSchema"])
+			}
+			if _, ok := schema["required"].([]any); !ok {
+				t.Fatalf("tool %q missing required[]: %#v", name, schema)
+			}
+		}
+		for _, want := range []string{"recall", "recall_context", "blame", "remember"} {
+			if !got[want] {
+				t.Fatalf("tools/list missing %q; got %v", want, got)
+			}
+		}
+	})
+
+	t.Run("recall envelope and hit", func(t *testing.T) {
+		resp := driveMCP(t, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"recall","arguments":{"query":"frobnicator","harness":"claude"}}}`)
+		text := callText(t, resp[0])
+		if !strings.Contains(text, "frobnicator") || !strings.Contains(text, "2 match(es)") {
+			t.Fatalf("recall text = %q, want 2 frobnicator matches", text)
+		}
+	})
+
+	t.Run("harness filter excludes", func(t *testing.T) {
+		// codex root is an empty temp dir, so filtering to codex must find nothing.
+		resp := driveMCP(t, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"recall","arguments":{"query":"frobnicator","harness":"codex"}}}`)
+		text := callText(t, resp[0])
+		if !strings.Contains(text, "No prior deja sessions matched") {
+			t.Fatalf("harness=codex should exclude claude session, got %q", text)
+		}
+	})
+
+	t.Run("limit caps results", func(t *testing.T) {
+		resp := driveMCP(t, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"recall","arguments":{"query":"frobnicator","harness":"claude","limit":1}}}`)
+		text := callText(t, resp[0])
+		if !strings.Contains(text, "1 match(es)") || strings.Contains(text, "2 match(es)") {
+			t.Fatalf("limit=1 should cap to one match, got %q", text)
+		}
+	})
+
+	t.Run("fractional limit is accepted", func(t *testing.T) {
+		// JSON has no int/float distinction; a client emitting 1.0 must not blow up
+		// the whole call. Schema advertises limit as "number".
+		resp := driveMCP(t, `{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"recall","arguments":{"query":"frobnicator","harness":"claude","limit":1.0}}}`)
+		if e, ok := resp[0]["error"]; ok {
+			t.Fatalf("fractional limit errored: %#v", e)
+		}
+		text := callText(t, resp[0])
+		if !strings.Contains(text, "1 match(es)") {
+			t.Fatalf("limit 1.0 should cap to one match, got %q", text)
+		}
+	})
+
+	t.Run("large integer id echoed exactly", func(t *testing.T) {
+		// Check raw wire bytes: parsing into map[string]any would itself round the
+		// id to float64, so assert on the encoded response string.
+		var out bytes.Buffer
+		if err := serveMCP(strings.NewReader(`{"jsonrpc":"2.0","id":9007199254740993,"method":"tools/list","params":{}}`+"\n"), &out); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out.String(), `"id":9007199254740993`) {
+			t.Fatalf("large id not echoed exactly: %s", out.String())
+		}
+	})
+
+	t.Run("oversized frame skipped then server keeps serving", func(t *testing.T) {
+		big := strings.Repeat("x", mcpMaxFrame+1)
+		resp := driveMCP(t,
+			`{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"recall","arguments":{"query":"nomatch"}}}`,
+			big,
+			`{"jsonrpc":"2.0","id":12,"method":"tools/list","params":{}}`,
+		)
+		// Three input frames -> a recall reply, one parse error, and a tools/list
+		// reply: the giant middle frame must not tear the session down.
+		if len(resp) != 3 {
+			t.Fatalf("want 3 responses (recall, parse-error, list), got %d: %#v", len(resp), resp)
+		}
+		if _, ok := resp[1]["error"]; !ok {
+			t.Fatalf("oversized frame should yield a parse error, got %#v", resp[1])
+		}
+		if _, ok := resp[2]["result"]; !ok {
+			t.Fatalf("server should still answer tools/list after oversized frame, got %#v", resp[2])
+		}
+	})
+
+	t.Run("blame finds file discussion", func(t *testing.T) {
+		resp := driveMCP(t, `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"blame","arguments":{"path":"parser.go"}}}`)
+		text := callText(t, resp[0])
+		var hits []map[string]any
+		if err := json.Unmarshal([]byte(text), &hits); err != nil {
+			t.Fatalf("blame result not a JSON array: %q (%v)", text, err)
+		}
+		if len(hits) == 0 {
+			t.Fatalf("blame parser.go found nothing; a session names it")
+		}
+	})
+
+	t.Run("remember then recall round-trips", func(t *testing.T) {
+		marker := "zebracricket advisory-lock decision"
+		save := driveMCP(t, fmt.Sprintf(`{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"remember","arguments":{"text":%q,"project":"notes"}}}`, marker))
+		if txt := callText(t, save[0]); !strings.Contains(txt, "Remembered") {
+			t.Fatalf("remember ack = %q", txt)
+		}
+		recall := driveMCP(t, `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"recall","arguments":{"query":"zebracricket"}}}`)
+		if txt := callText(t, recall[0]); !strings.Contains(txt, "zebracricket") {
+			t.Fatalf("stored note not recalled: %q", txt)
+		}
+	})
+
+	t.Run("missing required args error", func(t *testing.T) {
+		resp := driveMCP(t,
+			`{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"blame","arguments":{}}}`,
+			`{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"remember","arguments":{"text":""}}}`,
+		)
+		if e, ok := resp[0]["error"].(map[string]any); !ok || !strings.Contains(fmt.Sprint(e["message"]), "path required") {
+			t.Fatalf("blame without path should error path required, got %#v", resp[0])
+		}
+		if e, ok := resp[1]["error"].(map[string]any); !ok || !strings.Contains(fmt.Sprint(e["message"]), "text required") {
+			t.Fatalf("remember without text should error text required, got %#v", resp[1])
+		}
+	})
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="deja-vu — search every session your coding agents ever wrote">
-<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across ten coding agents, served back to them via MCP.">
+<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across eleven coding agents, served back to them via MCP.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -186,6 +186,26 @@ func TestExportDeferredCommitsWatermarkOnlyOnAck(t *testing.T) {
 	}
 }
 
+// A file indexed while its first line was still torn records SafeSize==0 with
+// bytes on disk. The next pass must NOT resume an append from that ambiguous 0
+// (which drops the first message or duplicates a lone line) — it must fall back
+// to a full re-index (#appendloss).
+func TestAppendSkipsIncrementalWhenNothingWasComplete(t *testing.T) {
+	claude := filepath.Join(t.TempDir(), "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	p := filepath.Join(claude, "-proj", "s1.jsonl") // harnessForPath -> "claude"
+	changed := map[string]FileState{p: {Path: p, Size: 120}}
+	old := map[string]FileState{p: {Path: p, Size: 40, SafeSize: 0}}
+	if canAppendIncremental(changed, old) {
+		t.Fatal("SafeSize==0 with bytes on disk must force full re-index, not append")
+	}
+	// A normal grown file with a real SafeSize still appends incrementally.
+	old[p] = FileState{Path: p, Size: 40, SafeSize: 40}
+	if !canAppendIncremental(changed, old) {
+		t.Fatal("a file with a complete prior line should still append incrementally")
+	}
+}
+
 func TestProjectRelevantRanksByIDFNotFiller(t *testing.T) {
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -1232,7 +1232,13 @@ func redactForIngest(m *Manifest, sourcePath, text string) string {
 	// boundary would otherwise lose its closing marker and store raw.
 	redacted, counts := redact.Text(text)
 	if len(redacted) > maxIndexedText {
-		redacted = redacted[:maxIndexedText]
+		// Cut on a rune boundary so a multibyte rune straddling the cap is not
+		// split, leaving an invalid tail byte in the stored text.
+		cut := maxIndexedText
+		for cut > 0 && !utf8.RuneStart(redacted[cut]) {
+			cut--
+		}
+		redacted = redacted[:cut]
 	}
 	n := counts.Total()
 	if n == 0 || m == nil {
@@ -1531,6 +1537,14 @@ func canAppendIncremental(changed map[string]FileState, old map[string]FileState
 	for p, f := range changed {
 		of, ok := old[p]
 		if !ok || f.Size <= of.Size {
+			return false
+		}
+		// A prior pass that indexed no complete line (a torn first line, or a lone
+		// line with no trailing newline) leaves SafeSize==0 with bytes on disk.
+		// Resuming an append from that ambiguous 0 would either re-read mid-line
+		// (dropping the first message) or duplicate an already-indexed lone line,
+		// so route these files through the full re-index path instead (#appendloss).
+		if of.SafeSize == 0 && of.Size > 0 {
 			return false
 		}
 		switch harnessForPath(p) {
@@ -3109,6 +3123,14 @@ func writeGobAtomic(p string, v any) error {
 		return err
 	}
 	if err := gob.NewEncoder(f).Encode(v); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	// fsync before rename: manifest.gob is the freshness/RecordsSize authority and
+	// must land durably last, like records.bin and the buckets. Skipping it left a
+	// window where a crash after rename but before flush yields a torn manifest.
+	if err := f.Sync(); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmp)
 		return err


### PR DESCRIPTION
Fixes surfaced by a graph-driven review of the hotspots.

- MCP: fractional `limit` (e.g. `5.0`) no longer fails the whole call; large JSON-RPC ids echo exactly; one oversized frame is skipped instead of ending the session.
- Index: `manifest.gob` fsynced before rename; a torn first line re-indexes instead of appending mid-line (no dropped first message); indexed-text cap cuts on a rune boundary.
- install: Codex/Grok `config.toml` get the Windows `cmd /c` shim like the JSON installers.

Adds a hermetic MCP stdio contract test (all four tools, harness filter, limit, error paths) with regression cases for the above. Cuts 0.14.0 (the #208-222 batch already on main + these fixes).