### PR TITLE
refactor: source registry for harness dispatch

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -862,23 +862,6 @@ func importedSessions(dir string) importedState {
 	return out
 }
 
-var harnessLoaders = []struct {
-	name string
-	load func() []model.Session
-}{
-	{"claude", sources.LoadClaude},
-	{"codex", sources.LoadCodex},
-	{"opencode", sources.LoadOpencode},
-	{"aider", sources.LoadAider},
-	{"gemini", sources.LoadGemini},
-	{"cursor", sources.LoadCursor},
-	{"antigravity", sources.LoadAntigravity},
-	{"grok", sources.LoadGrok},
-	{"qwen", sources.LoadQwen},
-	{"pi", sources.LoadPi},
-	{"copilot", sources.LoadCopilot},
-}
-
 func load(h string) []model.Session { return loadProgress(h, nil) }
 
 // loadProgress narrates a full rebuild per harness: a cold pass over a large
@@ -899,29 +882,23 @@ func safeLoad(name string, load func() []model.Session, progress io.Writer) (ss 
 
 func loadProgress(h string, progress io.Writer) []model.Session {
 	var ss []model.Session
-	for _, hl := range harnessLoaders {
-		if h != "" && h != hl.name {
+	for _, hr := range sources.Registry() {
+		if h != "" && h != hr.Name {
 			continue
 		}
-		got := safeLoad(hl.name, hl.load, progress)
+		got := safeLoad(hr.Name, hr.Load, progress)
 		ss = append(ss, got...)
 		if progress != nil && len(got) > 0 && !SuppressHarnessNarration {
 			msgs := 0
 			for _, s := range got {
 				msgs += len(s.Messages)
 			}
-			fmt.Fprintf(progress, "deja: %s: %d sessions, %d messages\n", hl.name, len(got), msgs)
-		}
-	}
-	if h == "" || h == "deja" {
-		got := sources.LoadNotes()
-		ss = append(ss, got...)
-		if progress != nil && len(got) > 0 && !SuppressHarnessNarration {
-			msgs := 0
-			for _, s := range got {
-				msgs += len(s.Messages)
+			// "deja" is the notes pseudo-source; it narrates as "notes".
+			label := hr.Name
+			if label == "deja" {
+				label = "notes"
 			}
-			fmt.Fprintf(progress, "deja: notes: %d sessions, %d messages\n", len(got), msgs)
+			fmt.Fprintf(progress, "deja: %s: %d sessions, %d messages\n", label, len(got), msgs)
 		}
 	}
 	return ss
@@ -1671,45 +1648,24 @@ func sameFile(a, b FileState) bool {
 		a.CWDSize == b.CWDSize && a.CWDMTime == b.CWDMTime
 }
 
+// kindForPath returns the registry FileKind whose Match accepts p.
+func kindForPath(p string) (sources.FileKind, bool) {
+	for _, h := range sources.Registry() {
+		for _, k := range h.Kinds {
+			if k.Match(p) {
+				return k, true
+			}
+		}
+	}
+	return sources.FileKind{}, false
+}
+
 func parseChangedFile(harness, p string, old FileState) ([]model.Session, error) {
-	switch harnessForPath(p) {
-	case "claude":
-		return sources.ParseClaudeFile(p)
-	case "codex-history":
-		return sources.ParseCodexHistory(p)
-	case "codex":
-		return sources.ParseCodexRollout(p)
-	case "opencode":
-		if old.LastUpdated > 0 {
-			return sources.ParseOpencodeDBSince(p, time.Unix(0, old.LastUpdated))
-		}
-		return sources.ParseOpencodeDB(p)
-	case "cursor-db":
-		if old.LastUpdated > 0 {
-			return sources.ParseCursorDBSince(p, time.Unix(0, old.LastUpdated))
-		}
-		return sources.ParseCursorDB(p)
-	case "aider":
-		return sources.ParseAiderFile(p)
-	case "gemini":
-		return sources.ParseGeminiFile(p)
-	case "cursor":
-		return sources.ParseCursorTranscript(p)
-	case "antigravity":
-		return sources.ParseAntigravityFile(p)
-	case "grok":
-		return sources.ParseGrokFile(p)
-	case "qwen":
-		return sources.ParseQwenFile(p)
-	case "pi":
-		return sources.ParsePiFile(p)
-	case "copilot":
-		return sources.ParseCopilotFile(p)
-	case "deja":
-		return sources.ParseNotesFile(p)
-	default:
+	k, ok := kindForPath(p)
+	if !ok {
 		return nil, nil
 	}
+	return k.Parse(p, old.LastUpdated)
 }
 
 func parseAppendedFile(harness, p string, old FileState) (ss []model.Session, err error) {
@@ -1718,89 +1674,20 @@ func parseAppendedFile(harness, p string, old FileState) (ss []model.Session, er
 			ss, err = nil, fmt.Errorf("parser panic on %s: %v", p, r)
 		}
 	}()
+	k, ok := kindForPath(p)
+	if !ok || k.ParseFrom == nil {
+		return nil, nil
+	}
 	from := old.SafeSize
 	if from == 0 || from > old.Size {
 		from = old.Size
 	}
-	switch harnessForPath(p) {
-	case "claude":
-		return sources.ParseClaudeFileFromOffset(p, from)
-	case "codex-history":
-		return sources.ParseCodexHistoryFromOffset(p, from)
-	case "qwen":
-		return sources.ParseQwenFileFromOffset(p, from)
-	case "pi":
-		return sources.ParsePiFileFromOffset(p, from)
-	case "copilot":
-		return sources.ParseCopilotFileFromOffset(p, from)
-	case "deja":
-		return sources.ParseNotesFileFromOffset(p, from)
-	case "codex":
-		return sources.ParseCodexRolloutFromOffset(p, from)
-	case "opencode":
-		if old.LastUpdated > 0 {
-			return sources.ParseOpencodeDBSince(p, time.Unix(0, old.LastUpdated))
-		}
-		return sources.ParseOpencodeDB(p)
-	case "cursor-db":
-		if old.LastUpdated > 0 {
-			return sources.ParseCursorDBSince(p, time.Unix(0, old.LastUpdated))
-		}
-		return sources.ParseCursorDB(p)
-	default:
-		return nil, nil
-	}
+	return k.ParseFrom(p, from, old.LastUpdated)
 }
 
-func harnessForPath(p string) string {
-	if p == sources.OpencodeDB() {
-		return "opencode"
-	}
-	if filepath.Base(p) == "history.jsonl" && strings.HasPrefix(p, sources.CodexRoot()) {
-		return "codex-history"
-	}
-	if strings.HasSuffix(p, ".jsonl") && strings.Contains(filepath.Base(p), "rollout-") && strings.HasPrefix(p, filepath.Join(sources.CodexRoot(), "sessions")) {
-		return "codex"
-	}
-	if strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, sources.ClaudeRoot()) {
-		return "claude"
-	}
-	if filepath.Base(p) == ".aider.chat.history.md" {
-		return "aider"
-	}
-	if strings.HasPrefix(p, filepath.Join(sources.GeminiRoot(), "tmp")) && (strings.HasSuffix(p, ".json") || strings.HasSuffix(p, ".jsonl")) {
-		return "gemini"
-	}
-	if filepath.Base(p) == "state.vscdb" && strings.HasPrefix(p, sources.CursorUserRoot()) {
-		return "cursor-db"
-	}
-	if strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, filepath.Join(sources.CursorCLIRoot(), "projects")) {
-		return "cursor"
-	}
-	if filepath.Base(p) == "transcript.jsonl" {
-		for _, root := range sources.AntigravityRoots() {
-			if strings.HasPrefix(p, root+string(filepath.Separator)) {
-				return "antigravity"
-			}
-		}
-	}
-	if filepath.Base(p) == "updates.jsonl" && strings.HasPrefix(p, filepath.Join(sources.GrokRoot(), "sessions")) {
-		return "grok"
-	}
-	if strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, filepath.Join(sources.QwenRoot(), "projects")) {
-		return "qwen"
-	}
-	if strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, sources.PiRoot()) {
-		return "pi"
-	}
-	if filepath.Base(p) == "events.jsonl" && strings.HasPrefix(p, sources.CopilotRoot()) {
-		return "copilot"
-	}
-	if p == sources.NotesFile() {
-		return "deja"
-	}
-	return ""
-}
+// harnessForPath reports the fine-grained source kind for a path (claude,
+// codex-history, cursor-db, ...) via the sources registry, or "" if none.
+func harnessForPath(p string) string { return sources.KindForPath(p) }
 
 func setOpencodeLastUpdated(files map[string]FileState, sessions map[string]SessionMeta) {
 	setStoreLastUpdated(files, sessions, "opencode", sources.OpencodeDB())
@@ -1828,71 +1715,13 @@ func setStoreLastUpdated(files map[string]FileState, sessions map[string]Session
 
 func currentFiles(h string) map[string]FileState {
 	paths := map[string]bool{}
-	addWalk := func(root string, pred func(string) bool) {
-		_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
-			if err == nil && d.Type()&os.ModeSymlink == 0 && !d.IsDir() && pred(p) {
-				paths[p] = true
-			}
-			return nil
-		})
-	}
-	if h == "" || h == "claude" {
-		addWalk(sources.ClaudeRoot(), sources.ClaudeFileWanted)
-	}
-	if h == "" || h == "codex" {
-		addWalk(filepath.Join(sources.CodexRoot(), "sessions"), func(p string) bool {
-			return strings.HasSuffix(p, ".jsonl") && strings.Contains(filepath.Base(p), "rollout-")
-		})
-		paths[filepath.Join(sources.CodexRoot(), "history.jsonl")] = true
-	}
-	if h == "" || h == "opencode" {
-		paths[sources.OpencodeDB()] = true
-	}
-	if h == "" || h == "aider" {
-		for _, p := range sources.AiderFiles() {
+	for _, hr := range sources.Registry() {
+		if h != "" && h != hr.Name {
+			continue
+		}
+		for _, p := range hr.Files() {
 			paths[p] = true
 		}
-	}
-	if h == "" || h == "gemini" {
-		for _, p := range sources.GeminiChatFiles() {
-			paths[p] = true
-		}
-	}
-	if h == "" || h == "cursor" {
-		for _, p := range sources.CursorDBs() {
-			paths[p] = true
-		}
-		for _, p := range sources.CursorTranscripts() {
-			paths[p] = true
-		}
-	}
-	if h == "" || h == "antigravity" {
-		for _, p := range sources.AntigravityTranscripts() {
-			paths[p] = true
-		}
-	}
-	if h == "" || h == "grok" {
-		for _, p := range sources.GrokSessionFiles() {
-			paths[p] = true
-		}
-	}
-	if h == "" || h == "qwen" {
-		for _, p := range sources.QwenSessionFiles() {
-			paths[p] = true
-		}
-	}
-	if h == "" || h == "pi" {
-		for _, p := range sources.PiSessionFiles() {
-			paths[p] = true
-		}
-	}
-	if h == "" || h == "copilot" {
-		for _, p := range sources.CopilotSessionFiles() {
-			paths[p] = true
-		}
-	}
-	if h == "" || h == "deja" {
-		paths[sources.NotesFile()] = true
 	}
 	out := map[string]FileState{}
 	for p := range paths {

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -1,0 +1,230 @@
+package sources
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Harness is one AI tool deja ingests. Everything the index needs to discover,
+// load, match and parse a tool's sessions lives in a single registry entry, so
+// adding a harness is one entry here instead of edits scattered across the index
+// dispatch (load, path-match, full-parse, incremental-parse). Signatures use
+// primitives only (no index types) to keep sources a dependency-free leaf.
+type Harness struct {
+	Name  string                 // coarse name: claude, codex, cursor, ...
+	Load  func() []model.Session // full cold load of every session
+	Files func() []string        // current on-disk files to consider for indexing
+	Kinds []FileKind             // one or more on-disk file shapes to match+parse
+}
+
+// FileKind is one on-disk file shape belonging to a harness. A harness can have
+// several (codex has rollout logs and a history file; cursor has an IDE sqlite
+// db and CLI transcripts), each matched and parsed differently.
+type FileKind struct {
+	// Name is the fine-grained kind reported for a path (e.g. "codex-history").
+	Name  string
+	Match func(path string) bool
+	// Parse does a full parse. sinceNano>0 asks db-backed kinds to return only
+	// sessions newer than that instant; file kinds ignore it.
+	Parse func(path string, sinceNano int64) ([]model.Session, error)
+	// ParseFrom resumes an incremental parse: offset for append-only text logs,
+	// sinceNano for db-backed kinds. nil means the kind is not incremental.
+	ParseFrom func(path string, offset, sinceNano int64) ([]model.Session, error)
+}
+
+func sinceTime(nano int64) time.Time { return time.Unix(0, nano) }
+
+// fullParse/offsetParse adapt parsers that take no time cursor to the FileKind
+// signatures without a wrapper at every call site.
+func fullParse(f func(string) ([]model.Session, error)) func(string, int64) ([]model.Session, error) {
+	return func(p string, _ int64) ([]model.Session, error) { return f(p) }
+}
+
+func offsetParse(f func(string, int64) ([]model.Session, error)) func(string, int64, int64) ([]model.Session, error) {
+	return func(p string, off, _ int64) ([]model.Session, error) { return f(p, off) }
+}
+
+// dbParse/dbParseFrom handle the two db-backed kinds (opencode, cursor) that
+// filter by time rather than byte offset.
+func dbParse(full func(string) ([]model.Session, error), since func(string, time.Time) ([]model.Session, error)) func(string, int64) ([]model.Session, error) {
+	return func(p string, nano int64) ([]model.Session, error) {
+		if nano > 0 {
+			return since(p, sinceTime(nano))
+		}
+		return full(p)
+	}
+}
+
+func dbParseFrom(full func(string) ([]model.Session, error), since func(string, time.Time) ([]model.Session, error)) func(string, int64, int64) ([]model.Session, error) {
+	return func(p string, _ int64, nano int64) ([]model.Session, error) {
+		if nano > 0 {
+			return since(p, sinceTime(nano))
+		}
+		return full(p)
+	}
+}
+
+func hasBase(p, base string) bool { return filepath.Base(p) == base }
+
+// Registry returns every harness in load order. Flattening the kinds preserves
+// the original path-match precedence (matches are on disjoint roots/basenames,
+// so order only needs to stay deterministic).
+func Registry() []Harness {
+	return []Harness{
+		{
+			Name: "claude", Load: LoadClaude, Files: ClaudeFiles,
+			Kinds: []FileKind{{
+				Name:      "claude",
+				Match:     func(p string) bool { return strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, ClaudeRoot()) },
+				Parse:     fullParse(ParseClaudeFile),
+				ParseFrom: offsetParse(ParseClaudeFileFromOffset),
+			}},
+		},
+		{
+			Name: "codex", Load: LoadCodex, Files: CodexFiles,
+			Kinds: []FileKind{
+				{
+					Name:      "codex-history",
+					Match:     func(p string) bool { return hasBase(p, "history.jsonl") && strings.HasPrefix(p, CodexRoot()) },
+					Parse:     fullParse(ParseCodexHistory),
+					ParseFrom: offsetParse(ParseCodexHistoryFromOffset),
+				},
+				{
+					Name: "codex",
+					Match: func(p string) bool {
+						return strings.HasSuffix(p, ".jsonl") && strings.Contains(filepath.Base(p), "rollout-") && strings.HasPrefix(p, filepath.Join(CodexRoot(), "sessions"))
+					},
+					Parse:     fullParse(ParseCodexRollout),
+					ParseFrom: offsetParse(ParseCodexRolloutFromOffset),
+				},
+			},
+		},
+		{
+			Name: "opencode", Load: LoadOpencode, Files: func() []string { return []string{OpencodeDB()} },
+			Kinds: []FileKind{{
+				Name:      "opencode",
+				Match:     func(p string) bool { return p == OpencodeDB() },
+				Parse:     dbParse(ParseOpencodeDB, ParseOpencodeDBSince),
+				ParseFrom: dbParseFrom(ParseOpencodeDB, ParseOpencodeDBSince),
+			}},
+		},
+		{
+			Name: "aider", Load: LoadAider, Files: AiderFiles,
+			Kinds: []FileKind{{
+				Name:  "aider",
+				Match: func(p string) bool { return hasBase(p, ".aider.chat.history.md") },
+				Parse: fullParse(ParseAiderFile),
+			}},
+		},
+		{
+			Name: "gemini", Load: LoadGemini, Files: GeminiChatFiles,
+			Kinds: []FileKind{{
+				Name: "gemini",
+				Match: func(p string) bool {
+					return strings.HasPrefix(p, filepath.Join(GeminiRoot(), "tmp")) && (strings.HasSuffix(p, ".json") || strings.HasSuffix(p, ".jsonl"))
+				},
+				Parse: fullParse(ParseGeminiFile),
+			}},
+		},
+		{
+			Name: "cursor", Load: LoadCursor,
+			Files: func() []string { return append(append([]string{}, CursorDBs()...), CursorTranscripts()...) },
+			Kinds: []FileKind{
+				{
+					Name:      "cursor-db",
+					Match:     func(p string) bool { return hasBase(p, "state.vscdb") && strings.HasPrefix(p, CursorUserRoot()) },
+					Parse:     dbParse(ParseCursorDB, ParseCursorDBSince),
+					ParseFrom: dbParseFrom(ParseCursorDB, ParseCursorDBSince),
+				},
+				{
+					Name: "cursor",
+					Match: func(p string) bool {
+						return strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, filepath.Join(CursorCLIRoot(), "projects"))
+					},
+					Parse: fullParse(ParseCursorTranscript),
+				},
+			},
+		},
+		{
+			Name: "antigravity", Load: LoadAntigravity, Files: AntigravityTranscripts,
+			Kinds: []FileKind{{
+				Name: "antigravity",
+				Match: func(p string) bool {
+					if !hasBase(p, "transcript.jsonl") {
+						return false
+					}
+					for _, root := range AntigravityRoots() {
+						if strings.HasPrefix(p, root+string(filepath.Separator)) {
+							return true
+						}
+					}
+					return false
+				},
+				Parse: fullParse(ParseAntigravityFile),
+			}},
+		},
+		{
+			Name: "grok", Load: LoadGrok, Files: GrokSessionFiles,
+			Kinds: []FileKind{{
+				Name: "grok",
+				Match: func(p string) bool {
+					return hasBase(p, "updates.jsonl") && strings.HasPrefix(p, filepath.Join(GrokRoot(), "sessions"))
+				},
+				Parse: fullParse(ParseGrokFile),
+			}},
+		},
+		{
+			Name: "qwen", Load: LoadQwen, Files: QwenSessionFiles,
+			Kinds: []FileKind{{
+				Name: "qwen",
+				Match: func(p string) bool {
+					return strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, filepath.Join(QwenRoot(), "projects"))
+				},
+				Parse:     fullParse(ParseQwenFile),
+				ParseFrom: offsetParse(ParseQwenFileFromOffset),
+			}},
+		},
+		{
+			Name: "pi", Load: LoadPi, Files: PiSessionFiles,
+			Kinds: []FileKind{{
+				Name:      "pi",
+				Match:     func(p string) bool { return strings.HasSuffix(p, ".jsonl") && strings.HasPrefix(p, PiRoot()) },
+				Parse:     fullParse(ParsePiFile),
+				ParseFrom: offsetParse(ParsePiFileFromOffset),
+			}},
+		},
+		{
+			Name: "copilot", Load: LoadCopilot, Files: CopilotSessionFiles,
+			Kinds: []FileKind{{
+				Name:      "copilot",
+				Match:     func(p string) bool { return hasBase(p, "events.jsonl") && strings.HasPrefix(p, CopilotRoot()) },
+				Parse:     fullParse(ParseCopilotFile),
+				ParseFrom: offsetParse(ParseCopilotFileFromOffset),
+			}},
+		},
+		{
+			Name: "deja", Load: LoadNotes, Files: func() []string { return []string{NotesFile()} },
+			Kinds: []FileKind{{
+				Name:      "deja",
+				Match:     func(p string) bool { return p == NotesFile() },
+				Parse:     fullParse(ParseNotesFile),
+				ParseFrom: offsetParse(ParseNotesFileFromOffset),
+			}},
+		},
+	}
+}
+
+// KindForPath returns the fine-grained kind whose Match accepts p, or "".
+func KindForPath(p string) string {
+	for _, h := range Registry() {
+		for _, k := range h.Kinds {
+			if k.Match(p) {
+				return k.Name
+			}
+		}
+	}
+	return ""
+}

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -73,11 +72,25 @@ func TestFormatRegistryConformance(t *testing.T) {
 		})
 	}
 
-	loaders := harnessLoaderIDs(t, filepath.Join(root, "internal", "index", "index.go"))
+	loaders := registryHarnessIDs()
 	sort.Strings(registered)
 	if strings.Join(registered, ",") != strings.Join(loaders, ",") {
-		t.Fatalf("registry harnesses = %v, harnessLoaders = %v", registered, loaders)
+		t.Fatalf("format registry harnesses = %v, source registry = %v", registered, loaders)
 	}
+}
+
+// registryHarnessIDs lists the real harnesses in the source registry (excluding
+// the notes pseudo-source) to compare against the published format registry.
+func registryHarnessIDs() []string {
+	var ids []string
+	for _, h := range Registry() {
+		if h.Name == "deja" {
+			continue
+		}
+		ids = append(ids, h.Name)
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 func readFormatRegistry(t *testing.T, path string) formatRegistry {
@@ -176,23 +189,4 @@ func validateRegistrySessions(t *testing.T, id string, sessions []model.Session)
 			}
 		}
 	}
-}
-
-func harnessLoaderIDs(t *testing.T, path string) []string {
-	t.Helper()
-	b, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	re := regexp.MustCompile(`\{"([a-z0-9-]+)", sources\.Load[A-Za-z]+\}`)
-	matches := re.FindAllSubmatch(b, -1)
-	ids := make([]string, 0, len(matches))
-	for _, match := range matches {
-		ids = append(ids, string(match[1]))
-	}
-	if len(ids) == 0 {
-		t.Fatal("no harnessLoaders entries found")
-	}
-	sort.Strings(ids)
-	return ids
 }


### PR DESCRIPTION
First stage of the pragmatic DDD refactor. Collapses the five scattered harness-dispatch points in index.go (load, path-match, full-parse, incremental-parse, discovery) into one `sources.Registry()`. Adding a harness is now one entry instead of edits across index.go. No behavior change — same parsers, same order, same tests; the conformance test now enumerates the registry instead of regex-parsing index.go source. Net −177 lines.