### PR TITLE
refactor: move stats computation to internal/stats

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/stats"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
@@ -211,7 +212,7 @@ func TestStatsHelperBranches(t *testing.T) {
 		sessions = append(sessions, model.Session{ID: p, Harness: "claude", Project: p, Updated: now.Add(time.Duration(i) * time.Hour), Messages: []model.Message{{Role: "user", Text: p, Time: now}}})
 	}
 	sessions = append(sessions, model.Session{ID: "empty-project", Harness: "aider", Title: "<local-command noisy>", Messages: []model.Message{{Role: "assistant", Text: "skip"}}})
-	r := buildStats(sessions, now)
+	r := stats.Build(sessions, now)
 	if len(r.TopProjects) != 5 || r.TopProjects[0].Project != "-" || r.TopProjects[1].Project != "a" || r.DateRange.Start != "2026-07-16" {
 		t.Fatalf("stats = %#v", r)
 	}
@@ -225,8 +226,8 @@ func TestStatsHelperBranches(t *testing.T) {
 			t.Fatalf("statHarnessTag(%q)", h)
 		}
 	}
-	if statTitle(model.Session{Title: "good"}) != "good" || statTitle(model.Session{Messages: []model.Message{{Role: "user", Text: "<bash-noise"}}}) != "" {
-		t.Fatal("statTitle branches failed")
+	if stats.Title(model.Session{Title: "good"}) != "good" || stats.Title(model.Session{Messages: []model.Message{{Role: "user", Text: "<bash-noise"}}}) != "" {
+		t.Fatal("stats.Title branches failed")
 	}
 	if err := runStats(index.DefaultDir(), []string{"--bad"}); err == nil || !strings.Contains(err.Error(), "unknown flag") {
 		t.Fatalf("runStats bad flag err=%v", err)
@@ -531,7 +532,7 @@ func TestShareStatsResumeAndSyncEdgeBranches(t *testing.T) {
 		t.Fatal("closed file reported color")
 	}
 	var b bytes.Buffer
-	printStats(&b, statsReport{Harnesses: []harnessStats{{Harness: strings.Repeat("h", 20), Sessions: 1}}, TopProjects: []projectStats{{Project: "p", Sessions: 0}}, Monthly: []monthStats{{Month: "bad"}}})
+	printStats(&b, stats.Report{Harnesses: []stats.HarnessStats{{Harness: strings.Repeat("h", 20), Sessions: 1}}, TopProjects: []stats.ProjectStats{{Project: "p", Sessions: 0}}, Monthly: []stats.MonthStats{{Month: "bad"}}})
 	if !strings.Contains(b.String(), "deja stats") {
 		t.Fatalf("stats output = %q", b.String())
 	}

--- a/cmd/deja/coverage_final_test.go
+++ b/cmd/deja/coverage_final_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/stats"
 )
 
 // --- install.go ---
@@ -139,10 +140,10 @@ func TestPrintStatsColorEnabledBranch(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = devNull.Close() }()
-	r := statsReport{
-		Harnesses:   []harnessStats{{Harness: "claude", Sessions: 1, Messages: 2}},
-		TopProjects: []projectStats{{Project: "p", Sessions: 1}},
-		Monthly:     []monthStats{{Month: "2026-01", Messages: 1}},
+	r := stats.Report{
+		Harnesses:   []stats.HarnessStats{{Harness: "claude", Sessions: 1, Messages: 2}},
+		TopProjects: []stats.ProjectStats{{Project: "p", Sessions: 1}},
+		Monthly:     []stats.MonthStats{{Month: "2026-01", Messages: 1}},
 	}
 	printStats(devNull, r)
 }

--- a/cmd/deja/format_helpers_test.go
+++ b/cmd/deja/format_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/stats"
 )
 
 func TestShareFilteringHelpers(t *testing.T) {
@@ -53,29 +54,29 @@ func TestShareFilteringHelpers(t *testing.T) {
 }
 
 func TestStatsFormattingHelpers(t *testing.T) {
-	if got := trimRunes("abcdef", 3); got != "ab…" {
-		t.Fatalf("trimRunes = %q", got)
+	if got := stats.TrimRunes("abcdef", 3); got != "ab…" {
+		t.Fatalf("stats.TrimRunes = %q", got)
 	}
-	if got := trimRunes("abcdef", 1); got != "a" {
-		t.Fatalf("trimRunes n=1 = %q", got)
+	if got := stats.TrimRunes("abcdef", 1); got != "a" {
+		t.Fatalf("stats.TrimRunes n=1 = %q", got)
 	}
-	if got := scaledBar(1, 100, 10); got != 1 {
-		t.Fatalf("scaledBar = %d", got)
+	if got := stats.ScaledBar(1, 100, 10); got != 1 {
+		t.Fatalf("stats.ScaledBar = %d", got)
 	}
-	if got := scaledBar(0, 100, 10); got != 0 {
-		t.Fatalf("scaledBar zero = %d", got)
+	if got := stats.ScaledBar(0, 100, 10); got != 0 {
+		t.Fatalf("stats.ScaledBar zero = %d", got)
 	}
 	if valueOrDash("") != "-" || valueOrDash("x") != "x" {
 		t.Fatal("valueOrDash mismatch")
 	}
-	if !statNoise("<local-command x>") || statNoise("real title") {
-		t.Fatal("statNoise mismatch")
+	if !stats.Noise("<local-command x>") || stats.Noise("real title") {
+		t.Fatal("stats.Noise mismatch")
 	}
-	if got := statTitle(model.Session{Title: "<command-noise>", Messages: []model.Message{{Role: "assistant", Text: "skip"}, {Role: "user", Text: strings.Repeat("word ", 20)}}}); !strings.HasSuffix(got, "…") {
-		t.Fatalf("statTitle = %q", got)
+	if got := stats.Title(model.Session{Title: "<command-noise>", Messages: []model.Message{{Role: "assistant", Text: "skip"}, {Role: "user", Text: strings.Repeat("word ", 20)}}}); !strings.HasSuffix(got, "…") {
+		t.Fatalf("stats.Title = %q", got)
 	}
-	if got := statTitle(model.Session{Title: "Clean title"}); got != "Clean title" {
-		t.Fatalf("statTitle title = %q", got)
+	if got := stats.Title(model.Session{Title: "Clean title"}); got != "Clean title" {
+		t.Fatalf("stats.Title title = %q", got)
 	}
 	if got := statHarnessTag("claude", true); !strings.Contains(got, "[claude]") || !strings.Contains(got, statOrange) {
 		t.Fatalf("claude tag = %q", got)

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/stats"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 )
@@ -168,7 +169,7 @@ func TestAgentCreditsCountedFromIndex(t *testing.T) {
 		{Role: "assistant", Text: "deja-vu recalled: old one", Time: now.Add(-9 * 24 * time.Hour)},
 		{Role: "user", Text: "deja-vu recalled should not count from users"},
 	}}}
-	r := buildStats(ss, now)
+	r := stats.Build(ss, now)
 	if r.AgentCredits != 2 || r.WeekCredits != 1 {
 		t.Fatalf("credits = %d/%d, want 2/1", r.AgentCredits, r.WeekCredits)
 	}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -593,8 +593,8 @@ func parseDur(s string) (time.Duration, error) {
 
 func printSources(dir string) {
 	redactions := map[string]int{}
-	if stats, err := index.Redactions(dir); err == nil {
-		redactions = stats.Files
+	if red, err := index.Redactions(dir); err == nil {
+		redactions = red.Files
 	}
 	antigravityRoots := sources.AntigravityRoots()
 	antigravityLocation := strings.Join(antigravityRoots, string(os.PathListSeparator))

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/stats"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
@@ -413,7 +414,7 @@ func TestStatsCommandJSONAndNoColor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var report statsReport
+	var report stats.Report
 	if err := json.Unmarshal([]byte(out), &report); err != nil {
 		t.Fatalf("json: %v\n%s", err, out)
 	}
@@ -435,7 +436,7 @@ func TestStatsCommandJSONAndNoColor(t *testing.T) {
 	if report.Recall.Recalls != 3 || report.Recall.Injections != 1 || report.Recall.InjectedSessions != 2 || report.Recall.EmptyResultRate != 0.5 {
 		t.Fatalf("recall = %#v", report.Recall)
 	}
-	byHarness := map[string]harnessStats{}
+	byHarness := map[string]stats.HarnessStats{}
 	for _, h := range report.Harnesses {
 		byHarness[h.Harness] = h
 	}
@@ -464,7 +465,7 @@ func TestBuildStatsMonthlyDistribution(t *testing.T) {
 			{Role: "user", Text: "jul", Time: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)},
 		},
 	}}
-	report := buildStats(ss, time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC))
+	report := stats.Build(ss, time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC))
 	if len(report.Monthly) != 12 || report.Monthly[0].Month != "2025-08" || report.Monthly[11].Month != "2026-07" {
 		t.Fatalf("months = %#v", report.Monthly)
 	}

--- a/cmd/deja/semantic_coverage_test.go
+++ b/cmd/deja/semantic_coverage_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/stats"
 )
 
 func TestEmbedCommandBuildsSemanticSidecar(t *testing.T) {
@@ -153,11 +154,11 @@ func TestDoctorEmbedAndStatsFilters(t *testing.T) {
 		{Harness: "claude", Project: "Alpha", Updated: now, Messages: []model.Message{{Role: "user"}}},
 		{Harness: "codex", Project: "Beta", Updated: now.Add(-time.Hour), Messages: []model.Message{{Role: "assistant"}}},
 	}
-	got := filterStatsSessions(ss, search.Options{Harness: "claude", Project: "alp", Since: time.Minute, Role: "user"})
+	got := stats.Filter(ss, search.Options{Harness: "claude", Project: "alp", Since: time.Minute, Role: "user"})
 	if len(got) != 1 || len(got[0].Messages) != 1 || got[0].Messages[0].Role != "user" {
 		t.Fatalf("filtered stats=%#v", got)
 	}
-	if got := filterStatsSessions(ss, search.Options{Role: "system"}); len(got) != 0 {
+	if got := stats.Filter(ss, search.Options{Role: "system"}); len(got) != 0 {
 		t.Fatalf("role filter retained sessions=%#v", got)
 	}
 	for _, args := range [][]string{{"--since"}, {"--since", "bad"}, {"--card", "--card"}} {

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/embed"
 	"github.com/vshulcz/deja-vu/internal/index"
-	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/stats"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
@@ -26,81 +26,11 @@ const (
 	statBlue   = "\x1b[34m"
 )
 
-type statsReport struct {
-	TotalSessions   int            `json:"total_sessions"`
-	TotalMessages   int            `json:"total_messages"`
-	RepeatQuestions int            `json:"repeat_questions,omitempty"`
-	Harnesses       []harnessStats `json:"harnesses"`
-	TopProjects     []projectStats `json:"top_projects"`
-	Monthly         []monthStats   `json:"monthly"`
-	Heatmap         heatmapStats   `json:"-"` // card-only presentation data; kept out of the stable --json schema
-	Sparkline       string         `json:"sparkline"`
-	DateRange       dateRangeStats `json:"date_range"`
-	Longest         sessionStat    `json:"longest_session"`
-	BusiestDay      dayStat        `json:"busiest_day"`
-	Recall          usage.Summary  `json:"recall"`
-	WeekRecalls     int            `json:"week_recalls"`
-	WeekBytes       int            `json:"week_bytes"`
-	WeekInjected    int            `json:"week_injected"`
-	HandoffsIn      int            `json:"handoffs_received"`
-	AgentCredits    int            `json:"agent_credits"`
-	WeekCredits     int            `json:"week_agent_credits"`
-	SidecarSize     int64          `json:"sidecar_size,omitempty"`
-}
-
 type redactionReport struct {
 	Total       int                       `json:"total"`
 	ByHarness   map[string]map[string]int `json:"by_harness"`
 	SidecarSize int64                     `json:"sidecar_size,omitempty"`
 	Tombstones  int                       `json:"tombstones"`
-}
-
-type harnessStats struct {
-	Harness  string `json:"harness"`
-	Sessions int    `json:"sessions"`
-	Messages int    `json:"messages"`
-}
-
-type projectStats struct {
-	Project  string `json:"project"`
-	Sessions int    `json:"sessions"`
-}
-
-type monthStats struct {
-	Month    string `json:"month"`
-	Messages int    `json:"messages"`
-}
-
-// heatmapStats is a GitHub-style trailing-year grid: one column per week,
-// seven rows (Sun–Sat). A day count of -1 means the cell falls outside the
-// covered range and is not drawn.
-type heatmapStats struct {
-	Weeks  [][7]int    `json:"weeks"`
-	Max    int         `json:"max"`
-	Months []heatMonth `json:"months"`
-}
-
-type heatMonth struct {
-	Col   int    `json:"col"`
-	Label string `json:"label"`
-}
-
-type dateRangeStats struct {
-	Start string `json:"start,omitempty"`
-	End   string `json:"end,omitempty"`
-}
-
-type sessionStat struct {
-	ID       string `json:"id,omitempty"`
-	Harness  string `json:"harness,omitempty"`
-	Project  string `json:"project,omitempty"`
-	Title    string `json:"title,omitempty"`
-	Messages int    `json:"messages"`
-}
-
-type dayStat struct {
-	Date     string `json:"date,omitempty"`
-	Messages int    `json:"messages"`
 }
 
 func runStats(dir string, args []string) error {
@@ -184,7 +114,7 @@ func runStats(dir string, args []string) error {
 	if err != nil {
 		return err
 	}
-	report := buildStats(filterStatsSessions(ss, options), time.Now())
+	report := stats.Build(stats.Filter(ss, options), time.Now())
 	sshTip := sshSyncTip(dir, ss)
 	report.Recall = usage.Totals(dir)
 	report.WeekRecalls, report.WeekBytes, report.WeekInjected, _ = usage.Week(dir)
@@ -201,7 +131,7 @@ func runStats(dir string, args []string) error {
 		return nil
 	}
 	if htmlPath != "" {
-		path, err := writeStatsHTML(htmlPath, report, filterStatsSessions(ss, options))
+		path, err := writeStatsHTML(htmlPath, report, stats.Filter(ss, options))
 		if err != nil {
 			return err
 		}
@@ -221,11 +151,11 @@ func runStats(dir string, args []string) error {
 }
 
 func printRedactionReport(dir string, jsonOut bool) error {
-	stats, err := index.RedactionReport(dir)
+	report, err := index.RedactionReport(dir)
 	if err != nil {
 		return err
 	}
-	r := redactionReport{Total: stats.Total, ByHarness: stats.Rules, Tombstones: len(index.Tombstones())}
+	r := redactionReport{Total: report.Total, ByHarness: report.Rules, Tombstones: len(index.Tombstones())}
 	if fi, e := os.Stat(embed.Path(dir)); e == nil {
 		r.SidecarSize = fi.Size()
 	}
@@ -257,187 +187,7 @@ func printRedactionReport(dir string, jsonOut bool) error {
 	return nil
 }
 
-func filterStatsSessions(ss []model.Session, o search.Options) []model.Session {
-	if o.Harness == "" && o.Project == "" && o.Since <= 0 && o.Role == "" {
-		return ss
-	}
-	cut := time.Time{}
-	if o.Since > 0 {
-		cut = time.Now().Add(-o.Since)
-	}
-	out := make([]model.Session, 0, len(ss))
-	for _, s := range ss {
-		if o.Harness != "" && s.Harness != o.Harness {
-			continue
-		}
-		if o.Project != "" && !strings.Contains(strings.ToLower(s.Project), strings.ToLower(o.Project)) {
-			continue
-		}
-		if !cut.IsZero() && s.Updated.Before(cut) {
-			continue
-		}
-		if o.Role != "" {
-			cp := s
-			cp.Messages = nil
-			for _, m := range s.Messages {
-				if m.Role == o.Role {
-					cp.Messages = append(cp.Messages, m)
-				}
-			}
-			if len(cp.Messages) == 0 {
-				continue
-			}
-			s = cp
-		}
-		out = append(out, s)
-	}
-	return out
-}
-
-func buildStats(ss []model.Session, now time.Time) statsReport {
-	byHarness := map[string]*harnessStats{}
-	byProject := map[string]int{}
-	byDay := map[string]int{}
-	monthStart := firstMonth(now).AddDate(0, -11, 0)
-	months := make([]monthStats, 12)
-	monthIndex := map[string]int{}
-	for i := range months {
-		m := monthStart.AddDate(0, i, 0)
-		label := m.Format("2006-01")
-		months[i] = monthStats{Month: label}
-		monthIndex[label] = i
-	}
-
-	var out statsReport
-	var minT, maxT time.Time
-	for _, s := range ss {
-		out.TotalSessions++
-		msgCount := len(s.Messages)
-		out.TotalMessages += msgCount
-		hs := byHarness[s.Harness]
-		if hs == nil {
-			hs = &harnessStats{Harness: s.Harness}
-			byHarness[s.Harness] = hs
-		}
-		hs.Sessions++
-		hs.Messages += msgCount
-		project := s.Project
-		if project == "" {
-			project = "-"
-		}
-		byProject[project]++
-		if msgCount > out.Longest.Messages {
-			out.Longest = sessionStat{ID: s.ID, Harness: s.Harness, Project: project, Title: statTitle(s), Messages: msgCount}
-		}
-		considerTime(&minT, &maxT, s.Started)
-		considerTime(&minT, &maxT, s.Updated)
-		for _, m := range s.Messages {
-			t := m.Time
-			if t.IsZero() {
-				t = s.Updated
-			}
-			considerTime(&minT, &maxT, t)
-			if !t.IsZero() {
-				day := t.Format("2006-01-02")
-				byDay[day]++
-				if i, ok := monthIndex[firstMonth(t).Format("2006-01")]; ok {
-					months[i].Messages++
-				}
-			}
-		}
-	}
-	out.Harnesses = make([]harnessStats, 0, len(byHarness))
-	for _, hs := range byHarness {
-		out.Harnesses = append(out.Harnesses, *hs)
-	}
-	sort.Slice(out.Harnesses, func(i, j int) bool { return out.Harnesses[i].Harness < out.Harnesses[j].Harness })
-	for project, count := range byProject {
-		out.TopProjects = append(out.TopProjects, projectStats{Project: project, Sessions: count})
-	}
-	sort.Slice(out.TopProjects, func(i, j int) bool {
-		if out.TopProjects[i].Sessions == out.TopProjects[j].Sessions {
-			return out.TopProjects[i].Project < out.TopProjects[j].Project
-		}
-		return out.TopProjects[i].Sessions > out.TopProjects[j].Sessions
-	})
-	if len(out.TopProjects) > 5 {
-		out.TopProjects = out.TopProjects[:5]
-	}
-	for day, count := range byDay {
-		if count > out.BusiestDay.Messages || (count == out.BusiestDay.Messages && (out.BusiestDay.Date == "" || day < out.BusiestDay.Date)) {
-			out.BusiestDay = dayStat{Date: day, Messages: count}
-		}
-	}
-	out.Monthly = months
-	out.Heatmap = buildHeatmap(byDay, now)
-	out.Sparkline = sparkline(months)
-	if !minT.IsZero() {
-		out.DateRange.Start = minT.Format("2006-01-02")
-		out.DateRange.End = maxT.Format("2006-01-02")
-	}
-	out.RepeatQuestions = repeatQuestions(ss)
-	weekCut := now.Add(-7 * 24 * time.Hour)
-	for _, s := range ss {
-		for _, msg := range s.Messages {
-			// The attribution loop: agents saying "deja-vu recalled" end up in
-			// the very transcripts deja indexes, so the next pass can count how
-			// often memory was credited out loud — a measured magic metric with
-			// zero telemetry.
-			if msg.Role == "assistant" && strings.Contains(msg.Text, "deja-vu recalled") {
-				out.AgentCredits++
-				if !msg.Time.IsZero() && msg.Time.After(weekCut) {
-					out.WeekCredits++
-				}
-			}
-		}
-		for _, msg := range s.Messages {
-			if msg.Role != "user" {
-				continue
-			}
-			if strings.Contains(msg.Text, "picking up work handed off from a") {
-				out.HandoffsIn++
-			}
-			break // only the opening user turn marks a handoff-seeded session
-		}
-	}
-	return out
-}
-
-// buildHeatmap turns per-day message counts into a Sunday-aligned trailing-year
-// grid (~53 week columns) with month ticks, for the shareable stats card.
-func buildHeatmap(byDay map[string]int, now time.Time) heatmapStats {
-	end := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	start := end.AddDate(0, 0, -370)
-	for start.Weekday() != time.Sunday {
-		start = start.AddDate(0, 0, -1)
-	}
-	var hm heatmapStats
-	lastMonth := ""
-	for cur := start; !cur.After(end); {
-		var week [7]int
-		colDate := cur
-		for d := 0; d < 7; d++ {
-			if cur.After(end) {
-				week[d] = -1
-			} else {
-				c := byDay[cur.Format("2006-01-02")]
-				week[d] = c
-				if c > hm.Max {
-					hm.Max = c
-				}
-			}
-			cur = cur.AddDate(0, 0, 1)
-		}
-		if mon := colDate.Format("Jan"); mon != lastMonth {
-			hm.Months = append(hm.Months, heatMonth{Col: len(hm.Weeks), Label: mon})
-			lastMonth = mon
-		}
-		hm.Weeks = append(hm.Weeks, week)
-	}
-	return hm
-}
-
-func printStats(w io.Writer, r statsReport) {
+func printStats(w io.Writer, r stats.Report) {
 	color := statColorOK(w)
 	barGlyph := "#"
 	if color {
@@ -478,7 +228,7 @@ func printStats(w io.Writer, r statsReport) {
 		}
 	}
 	for _, p := range r.TopProjects {
-		fmt.Fprintf(w, "  %-18s %s %d\n", trimRunes(p.Project, 18), strings.Repeat(barGlyph, scaledBar(p.Sessions, maxProject, 18)), p.Sessions)
+		fmt.Fprintf(w, "  %-18s %s %d\n", stats.TrimRunes(p.Project, 18), strings.Repeat(barGlyph, stats.ScaledBar(p.Sessions, maxProject, 18)), p.Sessions)
 	}
 	fmt.Fprintln(w)
 
@@ -501,28 +251,6 @@ func printStats(w io.Writer, r statsReport) {
 	}
 	fmt.Fprintf(w, "  Injections       %d · %d sessions · %s\n", r.Recall.Injections, r.Recall.InjectedSessions, humanBytes(int64(r.Recall.InjectedBytes)))
 	fmt.Fprintf(w, "  Empty results    %.1f%%\n", r.Recall.EmptyResultRate*100)
-}
-
-func statTitle(s model.Session) string {
-	if s.Title != "" && !statNoise(s.Title) {
-		return s.Title
-	}
-	for _, m := range s.Messages {
-		if m.Role == "user" && !statNoise(m.Text) {
-			return trimRunes(strings.Join(strings.Fields(m.Text), " "), 60)
-		}
-	}
-	return ""
-}
-
-func statNoise(s string) bool {
-	t := strings.TrimSpace(s)
-	for _, p := range []string{"<local-command", "<command-", "<task-notification", "<teammate-message", "<bash-", "Caveat:", "<system-reminder"} {
-		if strings.HasPrefix(t, p) {
-			return true
-		}
-	}
-	return false
 }
 
 func statColorOK(w io.Writer) bool {

--- a/cmd/deja/stats_helpers.go
+++ b/cmd/deja/stats_helpers.go
@@ -7,45 +7,10 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/stats"
 )
 
-func considerTime(minT, maxT *time.Time, t time.Time) {
-	if t.IsZero() {
-		return
-	}
-	if minT.IsZero() || t.Before(*minT) {
-		*minT = t
-	}
-	if maxT.IsZero() || t.After(*maxT) {
-		*maxT = t
-	}
-}
-
-func firstMonth(t time.Time) time.Time {
-	y, m, _ := t.Date()
-	return time.Date(y, m, 1, 0, 0, 0, 0, t.Location())
-}
-
-func sparkline(months []monthStats) string {
-	blocks := []rune("▁▂▃▄▅▆▇█")
-	maxMessages := 0
-	for _, m := range months {
-		if m.Messages > maxMessages {
-			maxMessages = m.Messages
-		}
-	}
-	var b strings.Builder
-	for _, m := range months {
-		idx := 0
-		if maxMessages > 0 && m.Messages > 0 {
-			idx = ((m.Messages - 1) * (len(blocks) - 1) / maxMessages) + 1
-		}
-		b.WriteRune(blocks[idx])
-	}
-	return b.String()
-}
-
-func monthLabels(months []monthStats) string {
+func monthLabels(months []stats.MonthStats) string {
 	labels := make([]string, 0, len(months))
 	for _, m := range months {
 		if t, err := time.Parse("2006-01", m.Month); err == nil {
@@ -55,33 +20,11 @@ func monthLabels(months []monthStats) string {
 	return strings.Join(labels, " ")
 }
 
-func scaledBar(n, maxN, width int) int {
-	if n <= 0 || maxN <= 0 {
-		return 0
-	}
-	scaled := n * width / maxN
-	if scaled == 0 {
-		return 1
-	}
-	return scaled
-}
-
 func valueOrDash(s string) string {
 	if s == "" {
 		return "-"
 	}
 	return s
-}
-
-func trimRunes(s string, n int) string {
-	r := []rune(s)
-	if len(r) <= n {
-		return s
-	}
-	if n <= 1 {
-		return string(r[:n])
-	}
-	return string(r[:n-1]) + "…"
 }
 
 // sshSyncTip suggests `deja sync ssh` once when the history shows the user

--- a/cmd/deja/stats_metrics.go
+++ b/cmd/deja/stats_metrics.go
@@ -3,12 +3,11 @@ package main
 import (
 	"fmt"
 	"strings"
-	"unicode"
 
-	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/stats"
 )
 
-func statsHeadline(r statsReport) string {
+func statsHeadline(r stats.Report) string {
 	parts := make([]string, 0, 3)
 	if r.TotalSessions > 0 {
 		parts = append(parts, fmt.Sprintf("%s sessions indexed", formatStatNumber(r.TotalSessions)))
@@ -28,50 +27,4 @@ func formatStatNumber(n int) string {
 		s = s[:i] + "," + s[i:]
 	}
 	return s
-}
-
-// repeatQuestions is a corpus proxy because the usage sidecar does not store query text.
-func repeatQuestions(ss []model.Session) int {
-	// Exact stem match only: questionStemFor already folds case and
-	// punctuation, and a pairwise similarity pass is quadratic in corpora
-	// with tens of thousands of user messages.
-	counts := map[string]int{}
-	for _, s := range ss {
-		seen := map[string]bool{}
-		for _, m := range s.Messages {
-			if m.Role != "user" {
-				continue
-			}
-			stem := questionStemFor(m.Text)
-			// Short acknowledgements ("ok", "continue") repeat across every
-			// session; only substantial messages count as questions.
-			if stem == "" || len(strings.Fields(stem)) < 4 || seen[stem] {
-				continue
-			}
-			seen[stem] = true
-			counts[stem]++
-		}
-	}
-	count := 0
-	for _, n := range counts {
-		if n > 1 {
-			count++
-		}
-	}
-	return count
-}
-
-func questionStemFor(text string) string {
-	if statNoise(text) {
-		return ""
-	}
-	var b strings.Builder
-	for _, r := range strings.ToLower(text) {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' {
-			b.WriteRune(r)
-		} else {
-			b.WriteByte(' ')
-		}
-	}
-	return strings.Join(strings.Fields(b.String()), " ")
 }

--- a/cmd/deja/statscard.go
+++ b/cmd/deja/statscard.go
@@ -7,11 +7,13 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/stats"
 )
 
 const statsCardFont = "ui-monospace, SFMono-Regular, Menlo, monospace"
 
-func writeStatsCard(path string, report statsReport) (string, error) {
+func writeStatsCard(path string, report stats.Report) (string, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("stats card path: %w", err)
@@ -22,7 +24,7 @@ func writeStatsCard(path string, report statsReport) (string, error) {
 	return abs, nil
 }
 
-func renderStatsCard(r statsReport) string {
+func renderStatsCard(r stats.Report) string {
 	var b strings.Builder
 	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
 	b.WriteString(`<svg xmlns="http://www.w3.org/2000/svg" width="800" height="420" viewBox="0 0 800 420">` + "\n")
@@ -56,7 +58,7 @@ func renderStatsCard(r statsReport) string {
 
 	// top agents, right column
 	cardText(&b, 470, 276, 11, "700", "TOP AGENTS", "#78788c", "letter-spacing=\"1.5\"")
-	harnesses := append([]harnessStats(nil), r.Harnesses...)
+	harnesses := append([]stats.HarnessStats(nil), r.Harnesses...)
 	sort.SliceStable(harnesses, func(i, j int) bool {
 		if harnesses[i].Sessions == harnesses[j].Sessions {
 			return harnesses[i].Harness < harnesses[j].Harness
@@ -64,7 +66,7 @@ func renderStatsCard(r statsReport) string {
 		return harnesses[i].Sessions > harnesses[j].Sessions
 	})
 	if len(harnesses) > 4 {
-		other := harnessStats{Harness: "other"}
+		other := stats.HarnessStats{Harness: "other"}
 		for _, h := range harnesses[4:] {
 			other.Sessions += h.Sessions
 		}
@@ -91,7 +93,7 @@ func renderStatsCard(r statsReport) string {
 }
 
 // cardPunchline picks one personal, shareable sentence for the card hero.
-func cardPunchline(r statsReport) string {
+func cardPunchline(r stats.Report) string {
 	switch {
 	case r.WeekRecalls > 0:
 		return fmt.Sprintf("deja handed your agents memory %s times this week.", formatStatNumber(r.WeekRecalls))
@@ -107,7 +109,7 @@ func cardPunchline(r statsReport) string {
 }
 
 // renderHeatmap draws a GitHub-style week-by-day grid with month ticks.
-func renderHeatmap(b *strings.Builder, hm heatmapStats, x0, y0 int) {
+func renderHeatmap(b *strings.Builder, hm stats.HeatmapStats, x0, y0 int) {
 	const step = 13
 	for _, mt := range hm.Months {
 		cardText(b, x0+mt.Col*step, y0-6, 10, "400", mt.Label, "#78788c")

--- a/cmd/deja/statscard_test.go
+++ b/cmd/deja/statscard_test.go
@@ -13,19 +13,20 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/stats"
 )
 
 func TestRenderStatsCardDeterministicAndEscaped(t *testing.T) {
-	r := statsReport{
+	r := stats.Report{
 		TotalSessions: 9,
 		TotalMessages: 27,
-		Harnesses: []harnessStats{
+		Harnesses: []stats.HarnessStats{
 			{Harness: "<&>", Sessions: 4}, {Harness: "codex", Sessions: 3},
 			{Harness: "a", Sessions: 2},
 		},
-		TopProjects: []projectStats{{Project: "<&>", Sessions: 2}},
-		Monthly:     []monthStats{{Month: "2026-07", Messages: 4}},
-		DateRange:   dateRangeStats{Start: "2026-01-01", End: "2026-07-01"},
+		TopProjects: []stats.ProjectStats{{Project: "<&>", Sessions: 2}},
+		Monthly:     []stats.MonthStats{{Month: "2026-07", Messages: 4}},
+		DateRange:   stats.DateRangeStats{Start: "2026-01-01", End: "2026-07-01"},
 	}
 	one := renderStatsCard(r)
 	if one != renderStatsCard(r) {
@@ -49,7 +50,7 @@ func TestRenderStatsCardDeterministicAndEscaped(t *testing.T) {
 }
 
 func TestRenderStatsCardHarnessAggregation(t *testing.T) {
-	r := statsReport{Harnesses: []harnessStats{
+	r := stats.Report{Harnesses: []stats.HarnessStats{
 		{Harness: "z", Sessions: 1}, {Harness: "y", Sessions: 2}, {Harness: "x", Sessions: 3},
 		{Harness: "w", Sessions: 4}, {Harness: "v", Sessions: 5}, {Harness: "u", Sessions: 6}, {Harness: "t", Sessions: 7},
 	}}
@@ -61,7 +62,7 @@ func TestRenderStatsCardHarnessAggregation(t *testing.T) {
 
 func TestWriteStatsCardAndStatsFlagConflict(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "card.svg")
-	written, err := writeStatsCard(path, statsReport{Monthly: []monthStats{{Month: "2026-01"}}})
+	written, err := writeStatsCard(path, stats.Report{Monthly: []stats.MonthStats{{Month: "2026-01"}}})
 	if err != nil || written != path {
 		t.Fatalf("writeStatsCard = %q, %v", written, err)
 	}
@@ -71,7 +72,7 @@ func TestWriteStatsCardAndStatsFlagConflict(t *testing.T) {
 	if err := runStats(index.DefaultDir(), []string{"--card", "--json"}); err == nil || !strings.Contains(err.Error(), "choose one output") {
 		t.Fatalf("conflict error = %v", err)
 	}
-	if _, err := writeStatsCard(filepath.Join(path, "nested.svg"), statsReport{}); err == nil {
+	if _, err := writeStatsCard(filepath.Join(path, "nested.svg"), stats.Report{}); err == nil {
 		t.Fatal("expected path error")
 	}
 }
@@ -97,11 +98,11 @@ func TestFilterStatsSessions(t *testing.T) {
 		{Harness: "claude", Project: "alpha", Messages: []model.Message{{Role: "user"}, {Role: "assistant"}}},
 		{Harness: "codex", Project: "beta", Messages: []model.Message{{Role: "user"}}},
 	}
-	got := filterStatsSessions(ss, search.Options{Harness: "claude", Role: "user"})
+	got := stats.Filter(ss, search.Options{Harness: "claude", Role: "user"})
 	if len(got) != 1 || len(got[0].Messages) != 1 || got[0].Messages[0].Role != "user" {
 		t.Fatalf("filtered sessions = %#v", got)
 	}
-	if got := filterStatsSessions(ss, search.Options{Project: "missing", Since: 1}); len(got) != 0 {
+	if got := stats.Filter(ss, search.Options{Project: "missing", Since: 1}); len(got) != 0 {
 		t.Fatalf("missing project filter = %#v", got)
 	}
 }
@@ -112,18 +113,18 @@ func TestStatsHeadlineAndRepeatQuestions(t *testing.T) {
 		{ID: "two", Messages: []model.Message{{Role: "user", Text: "how do I fix auth"}}},
 		{ID: "three", Messages: []model.Message{{Role: "assistant", Text: "How do I fix auth?"}}},
 	}
-	if got := repeatQuestions(ss); got != 1 {
-		t.Fatalf("repeatQuestions = %d, want 1", got)
+	if got := stats.RepeatQuestions(ss); got != 1 {
+		t.Fatalf("stats.RepeatQuestions = %d, want 1", got)
 	}
-	if got := statsHeadline(statsReport{TotalSessions: 1240, RepeatQuestions: 17}); got != "1,240 sessions indexed · 17 questions asked more than once" {
+	if got := statsHeadline(stats.Report{TotalSessions: 1240, RepeatQuestions: 17}); got != "1,240 sessions indexed · 17 questions asked more than once" {
 		t.Fatalf("headline = %q", got)
 	}
-	if got := statsHeadline(statsReport{}); got != "" {
+	if got := statsHeadline(stats.Report{}); got != "" {
 		t.Fatalf("empty headline = %q", got)
 	}
 	// Near-repeats with different wording no longer count: the metric is
 	// exact-stem only so it stays linear on large corpora.
-	if got := repeatQuestions([]model.Session{{Messages: []model.Message{
+	if got := stats.RepeatQuestions([]model.Session{{Messages: []model.Message{
 		{Role: "user", Text: "<local-command-caveat>"},
 		{Role: "user", Text: "   "},
 	}}, {Messages: []model.Message{{Role: "user", Text: "fix auth timeout in service now"}}}, {Messages: []model.Message{{Role: "user", Text: "fix auth timeout in service"}}}}); got != 0 {
@@ -155,7 +156,7 @@ func TestHandoffsReceivedCountedFromIndex(t *testing.T) {
 		{ID: "n1", Messages: []model.Message{{Role: "user", Text: "ordinary question"}}},
 		{ID: "n2", Messages: []model.Message{{Role: "assistant", Text: "picking up work handed off from a"}, {Role: "user", Text: "hi"}}},
 	}
-	r := buildStats(ss, time.Now())
+	r := stats.Build(ss, time.Now())
 	if r.HandoffsIn != 1 {
 		t.Fatalf("HandoffsIn = %d, want 1", r.HandoffsIn)
 	}

--- a/cmd/deja/statshtml.go
+++ b/cmd/deja/statshtml.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/stats"
 )
 
 const statsHTMLCap = 5000
@@ -28,13 +29,13 @@ type statsHTMLPage struct {
 	Harnesses     int
 	DateStart     string
 	DateEnd       string
-	Monthly       []monthStats
+	Monthly       []stats.MonthStats
 	SessionsJSON  template.JS
 	SessionCount  int
 	Truncated     bool
 }
 
-func writeStatsHTML(path string, report statsReport, sessions []model.Session) (string, error) {
+func writeStatsHTML(path string, report stats.Report, sessions []model.Session) (string, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("stats html path: %w", err)
@@ -53,7 +54,7 @@ func writeStatsHTML(path string, report statsReport, sessions []model.Session) (
 	return abs, nil
 }
 
-func newStatsHTMLPage(report statsReport, sessions []model.Session) (statsHTMLPage, error) {
+func newStatsHTMLPage(report stats.Report, sessions []model.Session) (statsHTMLPage, error) {
 	sessions = append([]model.Session(nil), sessions...)
 	sort.SliceStable(sessions, func(i, j int) bool {
 		left := sessions[i].Updated
@@ -81,7 +82,7 @@ func newStatsHTMLPage(report statsReport, sessions []model.Session) (statsHTMLPa
 		}
 		rows = append(rows, htmlSession{
 			Date: date.Format("2006-01-02"), Harness: s.Harness, Project: project,
-			Title: statTitle(s), Messages: len(s.Messages),
+			Title: stats.Title(s), Messages: len(s.Messages),
 		})
 	}
 	truncated := len(rows) > statsHTMLCap
@@ -117,7 +118,7 @@ const sessions={{.SessionsJSON}};const tbody=document.getElementById('sessions')
 function esc(value){const node=document.createElement('span');node.textContent=value;return node.innerHTML}function render(){const q=input.value.toLowerCase().trim();tbody.innerHTML='';let n=0;sessions.forEach((s,i)=>{const hay=[s.date,s.harness,s.project,s.title].join(' ').toLowerCase();if(q&&!hay.includes(q))return;n++;const row=document.createElement('tr');row.innerHTML='<td>'+esc(s.date)+'</td><td><span class="badge clickable" data-value="'+esc(s.harness)+'">'+esc(s.harness)+'</span></td><td><span class="clickable" data-value="'+esc(s.project)+'">'+esc(s.project)+'</span></td><td class="title">'+esc(s.title||'-')+'</td><td>'+s.messages+'</td>';row.querySelectorAll('.clickable').forEach(e=>e.onclick=()=>{input.value=e.dataset.value;render()});tbody.appendChild(row)});empty.hidden=n!==0}input.oninput=render;render();
 </script></body></html>`))
 
-func barHeight(n int, months []monthStats) int {
+func barHeight(n int, months []stats.MonthStats) int {
 	max := 1
 	for _, m := range months {
 		if m.Messages > max {

--- a/cmd/deja/statshtml_test.go
+++ b/cmd/deja/statshtml_test.go
@@ -10,10 +10,11 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/stats"
 )
 
 func TestStatsHTMLMetadataEscapingAndPrivacy(t *testing.T) {
-	report := statsReport{TotalSessions: 1, TotalMessages: 2, Harnesses: []harnessStats{{Harness: "claude"}}, DateRange: dateRangeStats{Start: "2026-01-01", End: "2026-01-02"}, Monthly: []monthStats{{Month: "2026-01", Messages: 2}}}
+	report := stats.Report{TotalSessions: 1, TotalMessages: 2, Harnesses: []stats.HarnessStats{{Harness: "claude"}}, DateRange: stats.DateRangeStats{Start: "2026-01-01", End: "2026-01-02"}, Monthly: []stats.MonthStats{{Month: "2026-01", Messages: 2}}}
 	sessions := []model.Session{{Harness: "claude", Project: `<script>alert(1)</script>`, Title: "redacted title", Updated: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC), Messages: []model.Message{{Role: "user", Text: "secret message body"}}}}
 	page, err := newStatsHTMLPage(report, sessions)
 	if err != nil {
@@ -44,25 +45,25 @@ func TestStatsHTMLCapAndWrite(t *testing.T) {
 	for i := range sessions {
 		sessions[i] = model.Session{Harness: "h", Project: "p", Updated: time.Date(2020, 1, 1, 0, 0, i, 0, time.UTC)}
 	}
-	page, err := newStatsHTMLPage(statsReport{}, sessions)
+	page, err := newStatsHTMLPage(stats.Report{}, sessions)
 	if err != nil || !page.Truncated || page.SessionCount != statsHTMLCap {
 		t.Fatalf("cap page=%#v err=%v", page, err)
 	}
 	path := filepath.Join(t.TempDir(), "timeline.html")
-	written, err := writeStatsHTML(path, statsReport{}, sessions[:1])
+	written, err := writeStatsHTML(path, stats.Report{}, sessions[:1])
 	if err != nil || written != path {
 		t.Fatalf("write HTML=%q err=%v", written, err)
 	}
 	if b, err := os.ReadFile(path); err != nil || !strings.HasPrefix(string(b), "<!doctype html>") {
 		t.Fatalf("HTML file err=%v content=%q", err, b)
 	}
-	if _, err := writeStatsHTML(filepath.Join(path, "nested.html"), statsReport{}, nil); err == nil {
+	if _, err := writeStatsHTML(filepath.Join(path, "nested.html"), stats.Report{}, nil); err == nil {
 		t.Fatal("expected path error")
 	}
 }
 
 func TestStatsHTMLHelpers(t *testing.T) {
-	months := []monthStats{{Messages: 0}, {Messages: 10}}
+	months := []stats.MonthStats{{Messages: 0}, {Messages: 10}}
 	if barHeight(0, months) != 4 || barHeight(5, months) != 56 || monthShort("2026-02") != "02" || monthShort("x") != "x" {
 		t.Fatal("unexpected HTML helper output")
 	}
@@ -100,7 +101,7 @@ func TestStatsHTMLEdgeBranches(t *testing.T) {
 		{ID: "b", Harness: "claude", Started: started, Messages: []model.Message{{Role: "user", Text: "hello"}}},
 		{ID: "a", Harness: "claude", Started: started},
 	}
-	page, err := newStatsHTMLPage(statsReport{}, sessions)
+	page, err := newStatsHTMLPage(stats.Report{}, sessions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +113,7 @@ func TestStatsHTMLEdgeBranches(t *testing.T) {
 	if err := os.WriteFile(squat, []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := writeStatsHTML(filepath.Join(squat, "out.html"), statsReport{}, nil); err == nil {
+	if _, err := writeStatsHTML(filepath.Join(squat, "out.html"), stats.Report{}, nil); err == nil {
 		t.Fatal("expected write error")
 	}
 }

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -1,0 +1,390 @@
+// Package stats computes the corpus statistics behind `deja stats`:
+// per-harness/project counts, activity heatmap, and repeat-question metric.
+package stats
+
+import (
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+type Report struct {
+	TotalSessions   int            `json:"total_sessions"`
+	TotalMessages   int            `json:"total_messages"`
+	RepeatQuestions int            `json:"repeat_questions,omitempty"`
+	Harnesses       []HarnessStats `json:"harnesses"`
+	TopProjects     []ProjectStats `json:"top_projects"`
+	Monthly         []MonthStats   `json:"monthly"`
+	Heatmap         HeatmapStats   `json:"-"` // card-only presentation data; kept out of the stable --json schema
+	Sparkline       string         `json:"sparkline"`
+	DateRange       DateRangeStats `json:"date_range"`
+	Longest         SessionStat    `json:"longest_session"`
+	BusiestDay      DayStat        `json:"busiest_day"`
+	Recall          usage.Summary  `json:"recall"`
+	WeekRecalls     int            `json:"week_recalls"`
+	WeekBytes       int            `json:"week_bytes"`
+	WeekInjected    int            `json:"week_injected"`
+	HandoffsIn      int            `json:"handoffs_received"`
+	AgentCredits    int            `json:"agent_credits"`
+	WeekCredits     int            `json:"week_agent_credits"`
+	SidecarSize     int64          `json:"sidecar_size,omitempty"`
+}
+
+type HarnessStats struct {
+	Harness  string `json:"harness"`
+	Sessions int    `json:"sessions"`
+	Messages int    `json:"messages"`
+}
+
+type ProjectStats struct {
+	Project  string `json:"project"`
+	Sessions int    `json:"sessions"`
+}
+
+type MonthStats struct {
+	Month    string `json:"month"`
+	Messages int    `json:"messages"`
+}
+
+// HeatmapStats is a GitHub-style trailing-year grid: one column per week,
+// seven rows (Sun–Sat). A day count of -1 means the cell falls outside the
+// covered range and is not drawn.
+type HeatmapStats struct {
+	Weeks  [][7]int    `json:"weeks"`
+	Max    int         `json:"max"`
+	Months []HeatMonth `json:"months"`
+}
+
+type HeatMonth struct {
+	Col   int    `json:"col"`
+	Label string `json:"label"`
+}
+
+type DateRangeStats struct {
+	Start string `json:"start,omitempty"`
+	End   string `json:"end,omitempty"`
+}
+
+type SessionStat struct {
+	ID       string `json:"id,omitempty"`
+	Harness  string `json:"harness,omitempty"`
+	Project  string `json:"project,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Messages int    `json:"messages"`
+}
+
+type DayStat struct {
+	Date     string `json:"date,omitempty"`
+	Messages int    `json:"messages"`
+}
+
+func Filter(ss []model.Session, o search.Options) []model.Session {
+	if o.Harness == "" && o.Project == "" && o.Since <= 0 && o.Role == "" {
+		return ss
+	}
+	cut := time.Time{}
+	if o.Since > 0 {
+		cut = time.Now().Add(-o.Since)
+	}
+	out := make([]model.Session, 0, len(ss))
+	for _, s := range ss {
+		if o.Harness != "" && s.Harness != o.Harness {
+			continue
+		}
+		if o.Project != "" && !strings.Contains(strings.ToLower(s.Project), strings.ToLower(o.Project)) {
+			continue
+		}
+		if !cut.IsZero() && s.Updated.Before(cut) {
+			continue
+		}
+		if o.Role != "" {
+			cp := s
+			cp.Messages = nil
+			for _, m := range s.Messages {
+				if m.Role == o.Role {
+					cp.Messages = append(cp.Messages, m)
+				}
+			}
+			if len(cp.Messages) == 0 {
+				continue
+			}
+			s = cp
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func Build(ss []model.Session, now time.Time) Report {
+	byHarness := map[string]*HarnessStats{}
+	byProject := map[string]int{}
+	byDay := map[string]int{}
+	monthStart := firstMonth(now).AddDate(0, -11, 0)
+	months := make([]MonthStats, 12)
+	monthIndex := map[string]int{}
+	for i := range months {
+		m := monthStart.AddDate(0, i, 0)
+		label := m.Format("2006-01")
+		months[i] = MonthStats{Month: label}
+		monthIndex[label] = i
+	}
+
+	var out Report
+	var minT, maxT time.Time
+	for _, s := range ss {
+		out.TotalSessions++
+		msgCount := len(s.Messages)
+		out.TotalMessages += msgCount
+		hs := byHarness[s.Harness]
+		if hs == nil {
+			hs = &HarnessStats{Harness: s.Harness}
+			byHarness[s.Harness] = hs
+		}
+		hs.Sessions++
+		hs.Messages += msgCount
+		project := s.Project
+		if project == "" {
+			project = "-"
+		}
+		byProject[project]++
+		if msgCount > out.Longest.Messages {
+			out.Longest = SessionStat{ID: s.ID, Harness: s.Harness, Project: project, Title: Title(s), Messages: msgCount}
+		}
+		considerTime(&minT, &maxT, s.Started)
+		considerTime(&minT, &maxT, s.Updated)
+		for _, m := range s.Messages {
+			t := m.Time
+			if t.IsZero() {
+				t = s.Updated
+			}
+			considerTime(&minT, &maxT, t)
+			if !t.IsZero() {
+				day := t.Format("2006-01-02")
+				byDay[day]++
+				if i, ok := monthIndex[firstMonth(t).Format("2006-01")]; ok {
+					months[i].Messages++
+				}
+			}
+		}
+	}
+	out.Harnesses = make([]HarnessStats, 0, len(byHarness))
+	for _, hs := range byHarness {
+		out.Harnesses = append(out.Harnesses, *hs)
+	}
+	sort.Slice(out.Harnesses, func(i, j int) bool { return out.Harnesses[i].Harness < out.Harnesses[j].Harness })
+	for project, count := range byProject {
+		out.TopProjects = append(out.TopProjects, ProjectStats{Project: project, Sessions: count})
+	}
+	sort.Slice(out.TopProjects, func(i, j int) bool {
+		if out.TopProjects[i].Sessions == out.TopProjects[j].Sessions {
+			return out.TopProjects[i].Project < out.TopProjects[j].Project
+		}
+		return out.TopProjects[i].Sessions > out.TopProjects[j].Sessions
+	})
+	if len(out.TopProjects) > 5 {
+		out.TopProjects = out.TopProjects[:5]
+	}
+	for day, count := range byDay {
+		if count > out.BusiestDay.Messages || (count == out.BusiestDay.Messages && (out.BusiestDay.Date == "" || day < out.BusiestDay.Date)) {
+			out.BusiestDay = DayStat{Date: day, Messages: count}
+		}
+	}
+	out.Monthly = months
+	out.Heatmap = buildHeatmap(byDay, now)
+	out.Sparkline = sparkline(months)
+	if !minT.IsZero() {
+		out.DateRange.Start = minT.Format("2006-01-02")
+		out.DateRange.End = maxT.Format("2006-01-02")
+	}
+	out.RepeatQuestions = RepeatQuestions(ss)
+	weekCut := now.Add(-7 * 24 * time.Hour)
+	for _, s := range ss {
+		for _, msg := range s.Messages {
+			// The attribution loop: agents saying "deja-vu recalled" end up in
+			// the very transcripts deja indexes, so the next pass can count how
+			// often memory was credited out loud — a measured magic metric with
+			// zero telemetry.
+			if msg.Role == "assistant" && strings.Contains(msg.Text, "deja-vu recalled") {
+				out.AgentCredits++
+				if !msg.Time.IsZero() && msg.Time.After(weekCut) {
+					out.WeekCredits++
+				}
+			}
+		}
+		for _, msg := range s.Messages {
+			if msg.Role != "user" {
+				continue
+			}
+			if strings.Contains(msg.Text, "picking up work handed off from a") {
+				out.HandoffsIn++
+			}
+			break // only the opening user turn marks a handoff-seeded session
+		}
+	}
+	return out
+}
+
+// buildHeatmap turns per-day message counts into a Sunday-aligned trailing-year
+// grid (~53 week columns) with month ticks, for the shareable stats card.
+func buildHeatmap(byDay map[string]int, now time.Time) HeatmapStats {
+	end := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	start := end.AddDate(0, 0, -370)
+	for start.Weekday() != time.Sunday {
+		start = start.AddDate(0, 0, -1)
+	}
+	var hm HeatmapStats
+	lastMonth := ""
+	for cur := start; !cur.After(end); {
+		var week [7]int
+		colDate := cur
+		for d := 0; d < 7; d++ {
+			if cur.After(end) {
+				week[d] = -1
+			} else {
+				c := byDay[cur.Format("2006-01-02")]
+				week[d] = c
+				if c > hm.Max {
+					hm.Max = c
+				}
+			}
+			cur = cur.AddDate(0, 0, 1)
+		}
+		if mon := colDate.Format("Jan"); mon != lastMonth {
+			hm.Months = append(hm.Months, HeatMonth{Col: len(hm.Weeks), Label: mon})
+			lastMonth = mon
+		}
+		hm.Weeks = append(hm.Weeks, week)
+	}
+	return hm
+}
+
+func Title(s model.Session) string {
+	if s.Title != "" && !Noise(s.Title) {
+		return s.Title
+	}
+	for _, m := range s.Messages {
+		if m.Role == "user" && !Noise(m.Text) {
+			return TrimRunes(strings.Join(strings.Fields(m.Text), " "), 60)
+		}
+	}
+	return ""
+}
+
+func Noise(s string) bool {
+	t := strings.TrimSpace(s)
+	for _, p := range []string{"<local-command", "<command-", "<task-notification", "<teammate-message", "<bash-", "Caveat:", "<system-reminder"} {
+		if strings.HasPrefix(t, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func considerTime(minT, maxT *time.Time, t time.Time) {
+	if t.IsZero() {
+		return
+	}
+	if minT.IsZero() || t.Before(*minT) {
+		*minT = t
+	}
+	if maxT.IsZero() || t.After(*maxT) {
+		*maxT = t
+	}
+}
+
+func firstMonth(t time.Time) time.Time {
+	y, m, _ := t.Date()
+	return time.Date(y, m, 1, 0, 0, 0, 0, t.Location())
+}
+
+func sparkline(months []MonthStats) string {
+	blocks := []rune("▁▂▃▄▅▆▇█")
+	maxMessages := 0
+	for _, m := range months {
+		if m.Messages > maxMessages {
+			maxMessages = m.Messages
+		}
+	}
+	var b strings.Builder
+	for _, m := range months {
+		idx := 0
+		if maxMessages > 0 && m.Messages > 0 {
+			idx = ((m.Messages - 1) * (len(blocks) - 1) / maxMessages) + 1
+		}
+		b.WriteRune(blocks[idx])
+	}
+	return b.String()
+}
+
+func ScaledBar(n, maxN, width int) int {
+	if n <= 0 || maxN <= 0 {
+		return 0
+	}
+	scaled := n * width / maxN
+	if scaled == 0 {
+		return 1
+	}
+	return scaled
+}
+
+func TrimRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	if n <= 1 {
+		return string(r[:n])
+	}
+	return string(r[:n-1]) + "…"
+}
+
+// RepeatQuestions is a corpus proxy because the usage sidecar does not store query text.
+func RepeatQuestions(ss []model.Session) int {
+	// Exact stem match only: questionStemFor already folds case and
+	// punctuation, and a pairwise similarity pass is quadratic in corpora
+	// with tens of thousands of user messages.
+	counts := map[string]int{}
+	for _, s := range ss {
+		seen := map[string]bool{}
+		for _, m := range s.Messages {
+			if m.Role != "user" {
+				continue
+			}
+			stem := questionStemFor(m.Text)
+			// Short acknowledgements ("ok", "continue") repeat across every
+			// session; only substantial messages count as questions.
+			if stem == "" || len(strings.Fields(stem)) < 4 || seen[stem] {
+				continue
+			}
+			seen[stem] = true
+			counts[stem]++
+		}
+	}
+	count := 0
+	for _, n := range counts {
+		if n > 1 {
+			count++
+		}
+	}
+	return count
+}
+
+func questionStemFor(text string) string {
+	if Noise(text) {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range strings.ToLower(text) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte(' ')
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}


### PR DESCRIPTION
Stage 5a. Domain side of deja stats (report building, session filtering, heatmap, repeat-question metric) moves to internal/stats; cmd keeps flag parsing and rendering. JSON schema unchanged.