### PR TITLE
refactor: extract internal/query so index stops importing search

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -14,8 +14,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
 	"github.com/vshulcz/deja-vu/internal/redact"
-	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
@@ -114,7 +114,7 @@ func Ensure(dir string, harness string, force bool, progress io.Writer) error {
 	return updateIndex(dir, "", "", want, force, progress)
 }
 
-func EnsureForSearch(dir string, o search.Options, force bool, progress io.Writer) error {
+func EnsureForSearch(dir string, o query.Options, force bool, progress io.Writer) error {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -306,7 +306,7 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 	return ss
 }
 
-func rebuildForSearch(dir string, o search.Options, scope string, files map[string]FileState, progress io.Writer) error {
+func rebuildForSearch(dir string, o query.Options, scope string, files map[string]FileState, progress io.Writer) error {
 	tmp := dir + ".tmp"
 	_ = os.RemoveAll(tmp)
 	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o700); err != nil {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -14,15 +14,15 @@ import (
 	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/model"
-	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/query"
 )
 
-func Search(dir string, o search.Options) ([]model.Session, error) {
+func Search(dir string, o query.Options) ([]model.Session, error) {
 	r, err := SearchDetailed(dir, o)
 	return r.Sessions, err
 }
 
-func SearchDetailed(dir string, o search.Options) (SearchResult, error) {
+func SearchDetailed(dir string, o query.Options) (SearchResult, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -40,7 +40,7 @@ func SearchDetailed(dir string, o search.Options) (SearchResult, error) {
 	}
 	var posts []posting
 	var fallbackVariants map[string][]string
-	fallbackTier := search.TierExact
+	fallbackTier := query.TierExact
 	usedPostings := false
 	if !o.Regex {
 		if keys := queryKeys(o.Query); len(keys) > 0 {
@@ -60,7 +60,7 @@ func SearchDetailed(dir string, o search.Options) (SearchResult, error) {
 				}
 				if len(posts) > 0 {
 					fallbackVariants = variants
-					fallbackTier = search.TierClose
+					fallbackTier = query.TierClose
 				}
 			}
 		}
@@ -195,7 +195,7 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 
 // loadSessionRecords materializes one session's transcript from the index.
 func loadSessionRecords(dir string, m Manifest, meta SessionMeta) (model.Session, error) {
-	ss, err := scanRecords(dir, m, search.Options{All: true}, nil)
+	ss, err := scanRecords(dir, m, query.Options{All: true}, nil)
 	if err != nil {
 		return model.Session{}, err
 	}
@@ -237,7 +237,7 @@ func FirstMatch(dir string, queries []string, limit int) ([]model.Session, strin
 		if err != nil {
 			return nil, "", fmt.Errorf("postings: %w", err)
 		}
-		o := search.Options{Query: q}
+		o := query.Options{Query: q}
 		posts = cutPostingsBySession(posts, m, o)
 		if len(posts) == 0 {
 			continue
@@ -257,12 +257,12 @@ func FirstMatch(dir string, queries []string, limit int) ([]model.Session, strin
 // SearchWithRecovery is Search plus self-healing: a corrupt bucket (crash
 // mid-append) triggers one full rebuild instead of erroring until the user
 // runs --rebuild by hand.
-func SearchWithRecovery(dir string, o search.Options, progress io.Writer) ([]model.Session, error) {
+func SearchWithRecovery(dir string, o query.Options, progress io.Writer) ([]model.Session, error) {
 	r, err := SearchWithRecoveryDetailed(dir, o, progress)
 	return r.Sessions, err
 }
 
-func SearchWithRecoveryDetailed(dir string, o search.Options, progress io.Writer) (SearchResult, error) {
+func SearchWithRecoveryDetailed(dir string, o query.Options, progress io.Writer) (SearchResult, error) {
 	r, err := SearchDetailed(dir, o)
 	if err == nil || !IsCorrupt(err) {
 		return r, err
@@ -277,10 +277,10 @@ func SearchWithRecoveryDetailed(dir string, o search.Options, progress io.Writer
 }
 
 func Recent(dir string, n int) ([]model.Session, error) {
-	return RecentMatching(dir, n, search.Options{})
+	return RecentMatching(dir, n, query.Options{})
 }
 
-func RecentMatching(dir string, n int, o search.Options) ([]model.Session, error) {
+func RecentMatching(dir string, n int, o query.Options) ([]model.Session, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -390,11 +390,11 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 	return s, true, nil
 }
 
-func scanRecords(dir string, m Manifest, o search.Options, offsets []int64) ([]model.Session, error) {
+func scanRecords(dir string, m Manifest, o query.Options, offsets []int64) ([]model.Session, error) {
 	return scanRecordsWithVariants(dir, m, o, offsets, nil)
 }
 
-func scanRecordsWithVariants(dir string, m Manifest, o search.Options, offsets []int64, variants map[string][]string) ([]model.Session, error) {
+func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []int64, variants map[string][]string) ([]model.Session, error) {
 	by := map[string]*model.Session{}
 	add := func(r Record) {
 		meta, ok := m.Sessions[r.Key]
@@ -449,7 +449,7 @@ func scanRecordsWithVariants(dir string, m Manifest, o search.Options, offsets [
 	return out, nil
 }
 
-func cutPostingsBySession(posts []posting, m Manifest, o search.Options) []posting {
+func cutPostingsBySession(posts []posting, m Manifest, o query.Options) []posting {
 	metaByOrd := sessionMetaByOrd(m)
 	// Keep the complete posting-derived candidate set. Ranking needs the
 	// candidate records to calculate BM25 document frequency and length.
@@ -473,7 +473,7 @@ func sessionMetaByOrd(m Manifest) map[uint32]SessionMeta {
 	return out
 }
 
-func sessionMetaMatches(meta SessionMeta, o search.Options) bool {
+func sessionMetaMatches(meta SessionMeta, o query.Options) bool {
 	if o.Harness != "" && meta.Harness != o.Harness {
 		return false
 	}
@@ -680,8 +680,8 @@ func fuzzyPostings(dir string, terms, phrases []string) ([]posting, map[string][
 	return intersectPostingMaps(perToken), variants, nil
 }
 
-func fuzzySearch(dir string, m Manifest, o search.Options) (SearchResult, error) {
-	terms, phrases := search.QueryParts(o.Query)
+func fuzzySearch(dir string, m Manifest, o query.Options) (SearchResult, error) {
+	terms, phrases := query.QueryParts(o.Query)
 	posts, variants, err := fuzzyPostings(dir, terms, phrases)
 	if err != nil || len(posts) == 0 {
 		return SearchResult{}, err
@@ -694,11 +694,11 @@ func fuzzySearch(dir string, m Manifest, o search.Options) (SearchResult, error)
 	if err != nil || len(ss) == 0 {
 		return SearchResult{}, err
 	}
-	return SearchResult{Sessions: ss, Fuzzy: true, Variants: variants, Tier: search.TierClose}, nil
+	return SearchResult{Sessions: ss, Fuzzy: true, Variants: variants, Tier: query.TierClose}, nil
 }
 
-func stemSearch(dir string, m Manifest, o search.Options) (SearchResult, error) {
-	terms, phrases := search.QueryParts(o.Query)
+func stemSearch(dir string, m Manifest, o query.Options) (SearchResult, error) {
+	terms, phrases := query.QueryParts(o.Query)
 	posts, variants, err := stemPostings(dir, terms, phrases)
 	if err != nil || len(posts) == 0 {
 		return SearchResult{}, err
@@ -711,7 +711,7 @@ func stemSearch(dir string, m Manifest, o search.Options) (SearchResult, error) 
 	if err != nil || len(ss) == 0 {
 		return SearchResult{}, err
 	}
-	return SearchResult{Sessions: ss, Stemmed: true, Variants: variants, Tier: search.TierClose}, nil
+	return SearchResult{Sessions: ss, Stemmed: true, Variants: variants, Tier: query.TierClose}, nil
 }
 
 func stemPostings(dir string, terms, phrases []string) ([]posting, map[string][]string, error) {
@@ -1038,7 +1038,7 @@ func queryKeys(s string) []string {
 	// query is all stop words, keep them (odd results beat none).
 	content := make([]string, 0, len(toks))
 	for _, tok := range toks {
-		if !search.IsStopWord(tok) {
+		if !query.IsStopWord(tok) {
 			content = append(content, tok)
 		}
 	}
@@ -1052,19 +1052,19 @@ func queryKeys(s string) []string {
 	return out
 }
 
-func recordMatchesQuery(r Record, o search.Options) bool {
+func recordMatchesQuery(r Record, o query.Options) bool {
 	return recordMatchesQueryVariants(r, o, nil)
 }
 
-func recordMatchesQueryVariants(r Record, o search.Options, variants map[string][]string) bool {
+func recordMatchesQueryVariants(r Record, o query.Options, variants map[string][]string) bool {
 	if o.Regex {
 		return true
 	}
-	terms, phrases := search.QueryParts(o.Query)
+	terms, phrases := query.QueryParts(o.Query)
 	if len(terms) == 0 && len(phrases) == 0 {
 		return true
 	}
-	return search.MatchesParts(r.Text, terms, phrases, variants)
+	return query.MatchesParts(r.Text, terms, phrases, variants)
 }
 
 func bucket(tok string) string {

--- a/internal/index/stopword_retrieval_test.go
+++ b/internal/index/stopword_retrieval_test.go
@@ -1,12 +1,13 @@
 package index
 
 import (
-	"github.com/vshulcz/deja-vu/internal/model"
-	"github.com/vshulcz/deja-vu/internal/search"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
 )
 
 func TestStopWordsDoNotConstrainRetrieval(t *testing.T) {

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -1,7 +1,10 @@
-package search
+// Package query parses search queries and matches text against them.
+// It is a leaf: index and search both build on it.
+package query
 
 import (
 	"strings"
+	"time"
 	"unicode"
 )
 
@@ -18,11 +21,29 @@ var stopWords = map[string]bool{
 
 // QueryParts separates ordinary terms from quoted phrases without changing
 // the query syntax used by callers.
+type Options struct {
+	Query                     string
+	Regex                     bool
+	Harness, Project, Role    string
+	Since                     time.Duration
+	All, JSON, Fuzzy, Stemmed bool
+	NoEmbed                   bool
+	Semantic                  bool                `json:"-"`
+	FuzzyVariants             map[string][]string `json:"-"`
+	Tier                      string              `json:"-"`
+}
+
+const (
+	TierExact    = "exact"
+	TierClose    = "close"
+	TierSemantic = "semantic"
+)
+
 func QueryParts(q string) (terms []string, phrases []string) {
 	start := -1
 	var plain strings.Builder
 	flushPlain := func() {
-		terms = appendUnique(terms, queryTokens(plain.String())...)
+		terms = appendUnique(terms, Tokens(plain.String())...)
 		plain.Reset()
 	}
 	for i, r := range q {
@@ -40,13 +61,13 @@ func QueryParts(q string) (terms []string, phrases []string) {
 		content := q[start+1 : i]
 		if hasLetterOrDigit(content) {
 			phrases = appendUnique(phrases, strings.ToLower(strings.TrimSpace(content)))
-			terms = appendUnique(terms, queryTokens(content)...)
+			terms = appendUnique(terms, Tokens(content)...)
 		}
 		start = -1
 	}
 	if start >= 0 {
 		// An unfinished quote is just whitespace, as it was before phrases.
-		return withoutStopWords(queryTokens(q)), nil
+		return withoutStopWords(Tokens(q)), nil
 	}
 	flushPlain()
 	terms = withoutStopWords(terms)
@@ -118,4 +139,19 @@ func MatchesParts(text string, terms, phrases []string, variants map[string][]st
 		}
 	}
 	return len(terms) > 0 || len(phrases) > 0
+}
+
+// Tokens lowercases and dedupes whitespace-separated query tokens.
+func Tokens(s string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, tok := range strings.Fields(strings.ToLower(s)) {
+		tok = strings.Trim(tok, "\t\n\r .,;:!?()[]{}<>\"'`")
+		if len(tok) < 2 || seen[tok] {
+			continue
+		}
+		seen[tok] = true
+		out = append(out, tok)
+	}
+	return out
 }

--- a/internal/search/rank_fuzzy_test.go
+++ b/internal/search/rank_fuzzy_test.go
@@ -1,9 +1,10 @@
 package search
 
 import (
-	"github.com/vshulcz/deja-vu/internal/model"
 	"testing"
 	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
 )
 
 func TestFuzzyHitsScoreByFrequency(t *testing.T) {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -14,6 +14,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
 )
 
 const (
@@ -26,23 +27,25 @@ const (
 	cMatch  = "\x1b[48;5;236;38;5;230m"
 )
 
-type Options struct {
-	Query                     string
-	Regex                     bool
-	Harness, Project, Role    string
-	Since                     time.Duration
-	All, JSON, Fuzzy, Stemmed bool
-	NoEmbed                   bool
-	Semantic                  bool                `json:"-"`
-	FuzzyVariants             map[string][]string `json:"-"`
-	Tier                      string              `json:"-"`
-}
+// Options and the tier names live in internal/query so packages below
+// search (index) can use them without importing the ranking engine.
+type Options = query.Options
 
 const (
-	TierExact    = "exact"
-	TierClose    = "close"
-	TierSemantic = "semantic"
+	TierExact    = query.TierExact
+	TierClose    = query.TierClose
+	TierSemantic = query.TierSemantic
 )
+
+func QueryParts(q string) (terms []string, phrases []string) { return query.QueryParts(q) }
+
+func IsStopWord(term string) bool { return query.IsStopWord(term) }
+
+func MatchesQuery(text, q string) bool { return query.MatchesQuery(text, q) }
+
+func MatchesParts(text string, terms, phrases []string, variants map[string][]string) bool {
+	return query.MatchesParts(text, terms, phrases, variants)
+}
 
 type Hit struct {
 	Session    model.Session `json:"session"`
@@ -460,7 +463,7 @@ func snippet(s, q string, re *regexp.Regexp) string {
 		low := strings.ToLower(s)
 		b := strings.Index(low, strings.ToLower(q))
 		if b < 0 {
-			for _, tok := range queryTokens(q) {
+			for _, tok := range query.Tokens(q) {
 				if p := strings.Index(low, tok); p >= 0 && (b < 0 || p < b) {
 					b = p
 				}
@@ -491,20 +494,6 @@ func snippet(s, q string, re *regexp.Regexp) string {
 
 // Snippet formats a message for search results, including semantic matches.
 func Snippet(s, q string) string { return snippet(s, q, nil) }
-
-func queryTokens(s string) []string {
-	seen := map[string]bool{}
-	var out []string
-	for _, tok := range strings.Fields(strings.ToLower(s)) {
-		tok = strings.Trim(tok, "\t\n\r .,;:!?()[]{}<>\"'`")
-		if len(tok) < 2 || seen[tok] {
-			continue
-		}
-		seen[tok] = true
-		out = append(out, tok)
-	}
-	return out
-}
 
 func countAllTokens(low string, toks []string) int {
 	total := 0
@@ -551,7 +540,7 @@ func highlight(s, q string, isRe bool, color bool) string {
 	if strings.Contains(strings.ToLower(s), strings.ToLower(q)) {
 		return regexp.MustCompile(`(?i)`+regexp.QuoteMeta(q)).ReplaceAllStringFunc(s, func(x string) string { return cMatch + x + cReset })
 	}
-	toks := queryTokens(q)
+	toks := query.Tokens(q)
 	if len(toks) == 0 {
 		return s
 	}


### PR DESCRIPTION
Stage 6, last of the series. Query parsing, Options and tier names move to a leaf package; search re-exports them as aliases so cmd is untouched. index now depends on query, not the ranking engine.