### PR TITLE
chore(packaging): pin scoop/winget manifests to 0.14.1

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.13.1",
+    "version": "0.14.1",
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.13.1/deja-vu_0.13.1_windows_amd64.zip",
-            "hash": "d31a8525e71cb7de21ec93e49a3b0b7345203209d6afc100ecae1d3cc4553d82"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.14.1/deja-vu_0.14.1_windows_amd64.zip",
+            "hash": "7db9df5eb7e5c4cc65fc5388a3d50e590b2751ea381ccf4098268b1162bd651d"
         },
         "arm64": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.13.1/deja-vu_0.13.1_windows_arm64.zip",
-            "hash": "39cceee8679ae07058a731959ee5a30a5a052e14dfaaa6dffb2f1b6af66e3c02"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.14.1/deja-vu_0.14.1_windows_arm64.zip",
+            "hash": "310d3f130a58be6e2b325f12f08d593380db2053cef1c06028cd062d0f15f29a"
         }
     },
     "bin": "deja.exe",

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.13.1
+PackageVersion: 0.14.1
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.13.1/deja-vu_0.13.1_windows_amd64.zip
-  InstallerSha256: D31A8525E71CB7DE21EC93E49A3B0B7345203209D6AFC100ECAE1D3CC4553D82
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.14.1/deja-vu_0.14.1_windows_amd64.zip
+  InstallerSha256: 7DB9DF5EB7E5C4CC65FC5388A3D50E590B2751EA381CCF4098268B1162BD651D
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.13.1/deja-vu_0.13.1_windows_arm64.zip
-  InstallerSha256: 39CCEEE8679AE07058A731959EE5A30A5A052E14DFAAA6DFFB2F1B6AF66E3C02
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.14.1/deja-vu_0.14.1_windows_arm64.zip
+  InstallerSha256: 310D3F130A58BE6E2B325F12F08D593380DB2053CEF1C06028CD062D0F15F29A
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.13.1
+PackageVersion: 0.14.1
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.13.1/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.14.1/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider
@@ -17,6 +17,6 @@ Tags:
 - cursor
 - mcp
 - memory
-ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.13.1
+ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.14.1
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.13.1
+PackageVersion: 0.14.1
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Hashes from the signed checksums.txt; amd64 zip re-verified locally, deja.exe at archive root.