### PR TITLE
docs: document JSON output schemas and add schema_version

### DIFF
--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/embed"
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
@@ -34,13 +35,14 @@ type doctorVersionReport struct {
 }
 
 type doctorReport struct {
-	Stores  []doctorStore                  `json:"stores"`
-	Index   doctorComponent                `json:"index"`
-	MCP     []doctorMCPStatus              `json:"mcp"`
-	SQLite3 doctorComponent                `json:"sqlite3"`
-	Version doctorVersionReport            `json:"version"`
-	Embed   *doctorEmbedReport             `json:"embed,omitempty"`
-	Ingest  map[string]index.HarnessIngest `json:"ingest_health,omitempty"`
+	SchemaVersion int                            `json:"schema_version"`
+	Stores        []doctorStore                  `json:"stores"`
+	Index         doctorComponent                `json:"index"`
+	MCP           []doctorMCPStatus              `json:"mcp"`
+	SQLite3       doctorComponent                `json:"sqlite3"`
+	Version       doctorVersionReport            `json:"version"`
+	Embed         *doctorEmbedReport             `json:"embed,omitempty"`
+	Ingest        map[string]index.HarnessIngest `json:"ingest_health,omitempty"`
 }
 
 type doctorEmbedReport struct {
@@ -65,7 +67,7 @@ type doctorStoreCheck struct {
 
 func collectDoctorReport(lookup doctorVersionLookup, dir string) doctorReport {
 	stores := doctorStoreChecks()
-	report := doctorReport{Stores: make([]doctorStore, 0, len(stores))}
+	report := doctorReport{SchemaVersion: jsonout.Version, Stores: make([]doctorStore, 0, len(stores))}
 	storeMods := make([]time.Time, 0, len(stores))
 	for _, check := range stores {
 		store, mod := inspectDoctorStore(check)

--- a/cmd/deja/json_schema_test.go
+++ b/cmd/deja/json_schema_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/jsonout"
+	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/stats"
+)
+
+func TestJSONSchemaVersionPresent(t *testing.T) {
+	t.Run("search", func(t *testing.T) {
+		var b bytes.Buffer
+		search.Print(&b, nil, search.Options{JSON: true, Fuzzy: true})
+		assertSchemaVersion(t, b.Bytes())
+	})
+	t.Run("search-semantic", func(t *testing.T) {
+		var b bytes.Buffer
+		search.Print(&b, nil, search.Options{JSON: true, Semantic: true})
+		assertSchemaVersion(t, b.Bytes())
+	})
+	t.Run("stats", func(t *testing.T) {
+		report := stats.Build(nil, time.Now())
+		b, err := json.Marshal(report)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertSchemaVersion(t, b)
+	})
+	t.Run("doctor", func(t *testing.T) {
+		tmp := hermeticEnv(t)
+		if err := os.MkdirAll(filepath.Join(tmp, "home"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		var out bytes.Buffer
+		if err := runDoctor(&out, []string{"--json"}, nil, indexDirForTest()); err != nil {
+			t.Fatal(err)
+		}
+		assertSchemaVersion(t, out.Bytes())
+	})
+}
+
+func assertSchemaVersion(t *testing.T, raw []byte) {
+	t.Helper()
+	var env struct {
+		SchemaVersion int             `json:"schema_version"`
+		Hits          json.RawMessage `json:"hits"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, raw)
+	}
+	if env.SchemaVersion != jsonout.Version {
+		t.Fatalf("schema_version = %d, want %d", env.SchemaVersion, jsonout.Version)
+	}
+}
+
+func TestJSONSchemaRequiredFields(t *testing.T) {
+	withStatsStores(t)
+	out, err := captureRun(t, "stats", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{`"schema_version"`, `"total_sessions"`, `"total_messages"`, `"harnesses"`, `"date_range"`} {
+		if !strings.Contains(out, key) {
+			t.Fatalf("stats json missing %s: %s", key, out)
+		}
+	}
+	out, err = captureRun(t, "blame", "--json", "parser.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(out), "[") {
+		t.Fatalf("blame json should remain a top-level array: %s", out)
+	}
+}

--- a/cmd/deja/json_schema_test.go
+++ b/cmd/deja/json_schema_test.go
@@ -66,7 +66,7 @@ func TestJSONSchemaRequiredFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, key := range []string{`"schema_version"`, `"total_sessions"`, `"total_messages"`, `"harnesses"`, `"date_range"`} {
+	for _, key := range []string{`"schema_version"`, `"total_sessions"`, `"total_messages"`, `"harnesses"`, `"date_range"`, `"recalls_served"`} {
 		if !strings.Contains(out, key) {
 			t.Fatalf("stats json missing %s: %s", key, out)
 		}

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "stores": [
     {
       "name": "claude",

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -30,7 +30,9 @@ Default exact search returns a JSON array of hits:
       "path": "/home/user/.claude/projects/.../session.jsonl",
       "started": "2026-01-02T03:04:05Z",
       "updated": "2026-01-02T03:10:00Z",
-      "messages": []
+      "messages": [
+        {"role": "user", "text": "why does the parser fail on …", "time": "2026-01-02T03:04:05Z"}
+      ]
     },
     "count": 2,
     "snippets": ["matched text …"],
@@ -82,9 +84,12 @@ Stemmed search may also include `variants`; semantic search sets `semantic`.
   },
   "busiest_day": {"date": "2026-07-04", "messages": 22},
   "recall": {
-    "recalls": 10,
+    "recalls_served": 10,
     "injections": 4,
+    "recall_sessions": 8,
     "injected_sessions": 3,
+    "bytes": 40960,
+    "injected_bytes": 12288,
     "empty_result_rate": 0.1
   },
   "week_recalls": 2,
@@ -115,7 +120,7 @@ Optional fields are omitted when zero or empty. The heatmap grid used by
   ],
   "index": {
     "state": "ok",
-    "path": "/home/user/.deja/index.db",
+    "path": "/home/user/.cache/deja/index.db",
     "stale_stores": 0
   },
   "mcp": [
@@ -160,8 +165,10 @@ Returns a JSON array of blame hits (same stability rules as exact search):
       "updated": "2026-01-02T03:10:00Z"
     },
     "title": "Fix parser edge case",
-    "tier": "exact",
-    "snippets": ["… parser.go …"]
+    "count": 3,
+    "snippets": ["… parser.go …"],
+    "score": 1.5,
+    "tier": "exact"
   }
 ]
 ```

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -1,0 +1,169 @@
+# JSON output contract
+
+Several `deja` commands accept `--json` and print machine-readable output for
+scripting, dashboards, and editor integrations. Object-shaped responses include
+a `schema_version` field so consumers can detect breaking changes.
+
+## Stability policy
+
+- **Within a `schema_version`**, changes are additive only: new optional fields
+  may appear, but existing field names, types, and meanings stay the same.
+- **Bumping `schema_version`** signals a breaking change (field removal, rename,
+  or type change). Consumers should branch on `schema_version` before parsing
+  the rest of the envelope.
+- The current version is **1** (constant in `internal/jsonout`).
+- **Exact `deja search --json` and `deja blame --json`** return a top-level JSON
+  array (not an object envelope). Their element shapes are stable; only additive
+  fields inside `session` or hit objects are permitted.
+
+## `deja search --json`
+
+Default exact search returns a JSON array of hits:
+
+```json
+[
+  {
+    "session": {
+      "harness": "claude",
+      "id": "abc123",
+      "project": "myapp",
+      "path": "/home/user/.claude/projects/.../session.jsonl",
+      "started": "2026-01-02T03:04:05Z",
+      "updated": "2026-01-02T03:10:00Z",
+      "messages": []
+    },
+    "count": 2,
+    "snippets": ["matched text …"],
+    "score": 1.5,
+    "tier": "exact",
+    "tier_detail": ""
+  }
+]
+```
+
+When fuzzy, stemmed, or semantic reranking is active, the output is an object
+envelope with `schema_version`:
+
+```json
+{
+  "schema_version": 1,
+  "hits": [ … ],
+  "fuzzy": true
+}
+```
+
+Stemmed search may also include `variants`; semantic search sets `semantic`.
+
+## `deja stats --json`
+
+```json
+{
+  "schema_version": 1,
+  "total_sessions": 42,
+  "total_messages": 318,
+  "repeat_questions": 3,
+  "harnesses": [
+    {"harness": "claude", "sessions": 30, "messages": 240}
+  ],
+  "top_projects": [
+    {"project": "myapp", "sessions": 12}
+  ],
+  "monthly": [
+    {"month": "2026-01", "messages": 45}
+  ],
+  "sparkline": "▁▂▅▇█",
+  "date_range": {"start": "2026-01-02", "end": "2026-07-04"},
+  "longest_session": {
+    "id": "c3",
+    "harness": "claude",
+    "project": "myapp",
+    "title": "Refactor parser",
+    "messages": 48
+  },
+  "busiest_day": {"date": "2026-07-04", "messages": 22},
+  "recall": {
+    "recalls": 10,
+    "injections": 4,
+    "injected_sessions": 3,
+    "empty_result_rate": 0.1
+  },
+  "week_recalls": 2,
+  "week_bytes": 4096,
+  "week_injected": 1,
+  "handoffs_received": 0,
+  "agent_credits": 1,
+  "week_agent_credits": 0,
+  "sidecar_size": 12345
+}
+```
+
+Optional fields are omitted when zero or empty. The heatmap grid used by
+`--card` is intentionally excluded from `--json` output.
+
+## `deja doctor --json`
+
+```json
+{
+  "schema_version": 1,
+  "stores": [
+    {
+      "name": "claude",
+      "state": "ok",
+      "paths": ["/home/user/.claude/projects"],
+      "files": 12
+    }
+  ],
+  "index": {
+    "state": "ok",
+    "path": "/home/user/.deja/index.db",
+    "stale_stores": 0
+  },
+  "mcp": [
+    {
+      "name": "claude-code",
+      "state": "wired",
+      "path": "/home/user/.claude.json"
+    }
+  ],
+  "sqlite3": {"state": "ok"},
+  "version": {
+    "state": "ok",
+    "current": "0.14.1",
+    "latest": "0.14.1"
+  },
+  "embed": {
+    "state": "reachable",
+    "model": "text-embedding-3-small",
+    "dim": 1536,
+    "coverage": 87.5
+  },
+  "ingest_health": {
+    "claude": {"malformed_lines": 0, "failed_files": 0}
+  }
+}
+```
+
+`embed` and `ingest_health` are omitted when unavailable. Store `state` values
+include `ok`, `missing`, `empty`, `unreadable`, and `parsed-zero`.
+
+## `deja blame <path> --json`
+
+Returns a JSON array of blame hits (same stability rules as exact search):
+
+```json
+[
+  {
+    "session": {
+      "harness": "claude",
+      "id": "abc123",
+      "project": "myapp",
+      "updated": "2026-01-02T03:10:00Z"
+    },
+    "title": "Fix parser edge case",
+    "tier": "exact",
+    "snippets": ["… parser.go …"]
+  }
+]
+```
+
+The MCP `blame` tool returns the same array shape.

--- a/internal/jsonout/version.go
+++ b/internal/jsonout/version.go
@@ -1,0 +1,4 @@
+// Package jsonout defines the stable schema version for deja CLI JSON envelopes.
+package jsonout
+
+const Version = 1

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -13,6 +13,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/query"
 )
@@ -45,6 +46,15 @@ func MatchesQuery(text, q string) bool { return query.MatchesQuery(text, q) }
 
 func MatchesParts(text string, terms, phrases []string, variants map[string][]string) bool {
 	return query.MatchesParts(text, terms, phrases, variants)
+}
+
+type searchJSONEnvelope struct {
+	SchemaVersion int                 `json:"schema_version"`
+	Hits          []Hit               `json:"hits"`
+	Fuzzy         bool                `json:"fuzzy,omitempty"`
+	Stemmed       bool                `json:"stemmed,omitempty"`
+	Semantic      bool                `json:"semantic,omitempty"`
+	Variants      map[string][]string `json:"variants,omitempty"`
 }
 
 type Hit struct {
@@ -301,21 +311,24 @@ func Print(w io.Writer, hits []Hit, o Options) {
 	}
 	if o.JSON {
 		if o.Semantic {
-			_ = json.NewEncoder(w).Encode(struct {
-				Hits     []Hit `json:"hits"`
-				Semantic bool  `json:"semantic"`
-			}{hits, true})
+			_ = json.NewEncoder(w).Encode(searchJSONEnvelope{
+				SchemaVersion: jsonout.Version,
+				Hits:          hits,
+				Semantic:      true,
+			})
 		} else if o.Stemmed {
-			_ = json.NewEncoder(w).Encode(struct {
-				Hits     []Hit               `json:"hits"`
-				Stemmed  bool                `json:"stemmed"`
-				Variants map[string][]string `json:"variants,omitempty"`
-			}{hits, true, o.FuzzyVariants})
+			_ = json.NewEncoder(w).Encode(searchJSONEnvelope{
+				SchemaVersion: jsonout.Version,
+				Hits:          hits,
+				Stemmed:       true,
+				Variants:      o.FuzzyVariants,
+			})
 		} else if o.Fuzzy {
-			_ = json.NewEncoder(w).Encode(struct {
-				Hits  []Hit `json:"hits"`
-				Fuzzy bool  `json:"fuzzy"`
-			}{hits, true})
+			_ = json.NewEncoder(w).Encode(searchJSONEnvelope{
+				SchemaVersion: jsonout.Version,
+				Hits:          hits,
+				Fuzzy:         true,
+			})
 		} else {
 			_ = json.NewEncoder(w).Encode(hits)
 		}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -344,7 +344,7 @@ func TestQueryPartsDropsStopWordsButKeepsAllStopQueries(t *testing.T) {
 func TestFuzzyJSONEnvelope(t *testing.T) {
 	var b bytes.Buffer
 	Print(&b, []Hit{{Count: 1}}, Options{JSON: true, Fuzzy: true})
-	if !strings.Contains(b.String(), `"fuzzy":true`) || !strings.Contains(b.String(), `"hits"`) {
+	if !strings.Contains(b.String(), `"schema_version":1`) || !strings.Contains(b.String(), `"fuzzy":true`) || !strings.Contains(b.String(), `"hits"`) {
 		t.Fatalf("fuzzy json = %q", b.String())
 	}
 }
@@ -352,7 +352,7 @@ func TestFuzzyJSONEnvelope(t *testing.T) {
 func TestStemmedJSONEnvelope(t *testing.T) {
 	var b bytes.Buffer
 	Print(&b, []Hit{{Count: 1}}, Options{JSON: true, Stemmed: true, FuzzyVariants: map[string][]string{"rotation": {"rotated"}}})
-	if !strings.Contains(b.String(), `"stemmed":true`) || !strings.Contains(b.String(), `"rotation":["rotated"]`) {
+	if !strings.Contains(b.String(), `"schema_version":1`) || !strings.Contains(b.String(), `"stemmed":true`) || !strings.Contains(b.String(), `"rotation":["rotated"]`) {
 		t.Fatalf("stemmed json = %q", b.String())
 	}
 }

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -8,12 +8,14 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
 type Report struct {
+	SchemaVersion   int            `json:"schema_version"`
 	TotalSessions   int            `json:"total_sessions"`
 	TotalMessages   int            `json:"total_messages"`
 	RepeatQuestions int            `json:"repeat_questions,omitempty"`
@@ -134,7 +136,7 @@ func Build(ss []model.Session, now time.Time) Report {
 		monthIndex[label] = i
 	}
 
-	var out Report
+	out := Report{SchemaVersion: jsonout.Version}
 	var minT, maxT time.Time
 	for _, s := range ss {
 		out.TotalSessions++


### PR DESCRIPTION
## Summary

Document the stable JSON shapes for `deja search --json`, `stats --json`, `doctor --json`, and `blame --json` in `docs/json-output.md`, and add a `schema_version` field to object-shaped CLI JSON envelopes.

## Motivation

Fixes #186. Scripting against `--json` output was fragile because the shapes were undocumented and had no version marker for breaking changes.

## Changes

- Add `docs/json-output.md` with examples per command and a stability policy
- Introduce `internal/jsonout.Version` (currently `1`)
- Emit `schema_version` on object envelopes: `stats --json`, `doctor --json`, and fuzzy/stemmed/semantic `search --json`
- Keep exact `search --json` and `blame --json` as top-level JSON arrays for backward compatibility
- Add schema contract tests; update doctor JSON golden fixture

## Tests

```sh
go test ./... -race -count=1
go vet ./...
go build ./cmd/deja
```

All pass locally.

## Notes

Exact search and blame intentionally remain arrays (not object envelopes) so existing `jq` scripts and MCP consumers keep working. Only additive fields inside hit/session objects are permitted within schema version 1.