### PR TITLE
feat: deja log — audit trail of served context

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ $ deja "jwt refresh token"
 | `deja index [--rebuild]` | Same as warmup; `--rebuild` forces a full rebuild. Cold builds narrate per-harness progress. |
 | `deja update` | Download the latest GitHub release, verify its checksum, and replace the current binary. |
 | `deja statusline` | One line for your status bar: recalls served to agents today. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
+| `deja log [n] [--last] [--json]` | Audit what deja actually served: recent recalls and injections, or the exact text of the last injected digest with `--last`. |
 
 Stemmed JSON searches set `"stemmed": true` and include the catalog variants used.
 

--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -35,7 +35,7 @@ _deja_completion() {
     command="${COMP_WORDS[1]}"
     action="${COMP_WORDS[2]}"
 
-    local commands="blame bench completion ctx doctor embed forget handoff index install last mcp remember resume share show sources stats statusline sync uninstall update version warmup"
+    local commands="blame bench completion ctx doctor embed forget handoff index install last log mcp remember resume share show sources stats statusline sync uninstall update version warmup"
     local harnesses="claude codex opencode aider gemini cursor antigravity grok qwen pi copilot deja"
     local install_targets="claude-code codex opencode cursor gemini antigravity grok qwen copilot pi statusline --all --auto"
 
@@ -153,6 +153,7 @@ _deja() {
     'index:build or refresh the index'
     'install:wire deja into an agent'
     'last:list recent sessions'
+    'log:show what deja served to agents'
     'mcp:serve the MCP protocol'
     'remember:store a durable note'
     'resume:reopen a session'
@@ -247,7 +248,7 @@ const fishCompletion = `function __deja_needs_command
     test (count (commandline -opc)) -eq 1
 end
 
-complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed forget handoff index install last mcp remember resume share show sources stats statusline sync uninstall update version warmup'
+complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed forget handoff index install last log mcp remember resume share show sources stats statusline sync uninstall update version warmup'
 complete -c deja -n '__deja_needs_command' -l json -d 'Print JSON'
 complete -c deja -n '__deja_needs_command' -l re -d 'Interpret query as a regular expression'
 complete -c deja -n '__deja_needs_command' -l all -d 'Include all results'

--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -73,7 +73,7 @@ func runHandoff(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprintf(os.Stderr, "deja: note — this session is %s old; if you meant newer work, pass an id-prefix (see `deja last`)\n", age)
 	}
 	digest := digest.Handoff(s, handoffBudget)
-	usage.Record(dir, usage.KindHandoff, len(digest))
+	usage.RecordDigest(dir, usage.KindHandoff, digest, 1)
 	if !doExec {
 		printSanitized(stdout, digest)
 		if pasteOnly {

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -75,7 +75,7 @@ func runHookContext(dir string, plain bool) error {
 		digest += "\n" + tip
 	}
 	digest = frameRecall(digest)
-	usage.RecordResult(dir, usage.KindHook, len(digest), sessions, false)
+	usage.RecordDigest(dir, usage.KindHook, digest, sessions)
 	if plain {
 		fmt.Fprintln(os.Stdout, digest)
 		return nil

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -78,7 +78,7 @@ func runHookPrompt(dir string, stdin io.Reader, stdout io.Writer) error {
 	}
 	lead := "deja found prior sessions matching this request. If one genuinely helps, use it and tell the user in one digest.Short line what deja-vu recalled; otherwise ignore silently.\n"
 	out := frameRecall(lead + digest + citationLine(ss[0]))
-	usage.RecordResult(dir, usage.KindHook, len(out), len(ss), false)
+	usage.RecordDigest(dir, usage.KindHook, out, len(ss))
 	var resp sessionStartHookResponse
 	resp.HookSpecificOutput.HookEventName = "UserPromptSubmit"
 	resp.HookSpecificOutput.AdditionalContext = out

--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// runLog answers "what did deja actually feed my agents": recent usage events
+// as a table, or the verbatim text of the last served digest with --last.
+func runLog(dir string, args []string) error {
+	return runLogTo(os.Stdout, dir, args)
+}
+
+func runLogTo(w io.Writer, dir string, args []string) error {
+	n := 20
+	jsonOut := false
+	last := false
+	for _, a := range args {
+		switch a {
+		case "--json":
+			jsonOut = true
+		case "--last":
+			last = true
+		default:
+			x, err := strconv.Atoi(a)
+			if err != nil || x <= 0 {
+				return fmt.Errorf("log: unknown flag %q", a)
+			}
+			n = x
+		}
+	}
+	if last {
+		snaps := usage.Snapshots(dir, 1)
+		if len(snaps) == 0 {
+			fmt.Fprintln(w, "deja: no injected digests recorded yet — they appear after a hook or MCP recall fires")
+			return nil
+		}
+		s := snaps[0]
+		if jsonOut {
+			enc := json.NewEncoder(w)
+			enc.SetIndent("", "  ")
+			return enc.Encode(s)
+		}
+		fmt.Fprintf(w, "# %s · %s · %d sessions · %s\n\n", s.Kind, s.Time.Local().Format("2006-01-02 15:04"), s.Sessions, humanBytes(int64(s.Bytes)))
+		fmt.Fprintln(w, s.Digest)
+		return nil
+	}
+	events := usage.Events(dir, n)
+	if jsonOut {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(events)
+	}
+	if len(events) == 0 {
+		fmt.Fprintln(w, "deja: no usage recorded yet — events appear when agents search, recall, or receive injected context")
+		return nil
+	}
+	for _, e := range events {
+		mark := ""
+		if e.Empty {
+			mark = "  (empty result)"
+		}
+		sess := ""
+		if e.Sessions > 0 {
+			sess = fmt.Sprintf(" · %d sessions", e.Sessions)
+		}
+		fmt.Fprintf(w, "%s  %-14s %s%s%s\n", e.Time.Local().Format("2006-01-02 15:04"), e.Kind, humanBytes(int64(e.Bytes)), sess, mark)
+	}
+	fmt.Fprintln(w, "\nuse `deja log --last` to see the exact text of the most recent injected digest")
+	return nil
+}

--- a/cmd/deja/log_test.go
+++ b/cmd/deja/log_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+func TestLogEmptyState(t *testing.T) {
+	hermeticEnv(t)
+	var out bytes.Buffer
+	if err := runLogTo(&out, index.DefaultDir(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "no usage recorded yet") {
+		t.Fatalf("empty log output = %q", out.String())
+	}
+	out.Reset()
+	if err := runLogTo(&out, index.DefaultDir(), []string{"--last"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "no injected digests") {
+		t.Fatalf("empty --last output = %q", out.String())
+	}
+}
+
+func TestLogListsEventsAndLastDigest(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	usage.RecordDigest(dir, usage.KindHook, "the injected context body", 3)
+	usage.RecordResult(dir, usage.KindRecall, 42, 0, true)
+
+	var out bytes.Buffer
+	if err := runLogTo(&out, dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "hook") || !strings.Contains(s, "recall") || !strings.Contains(s, "(empty result)") || !strings.Contains(s, "3 sessions") {
+		t.Fatalf("log output = %q", s)
+	}
+
+	out.Reset()
+	if err := runLogTo(&out, dir, []string{"--last"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "the injected context body") || !strings.Contains(out.String(), "# hook") {
+		t.Fatalf("--last output = %q", out.String())
+	}
+
+	out.Reset()
+	if err := runLogTo(&out, dir, []string{"--json", "1"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"kind"`) {
+		t.Fatalf("json output = %q", out.String())
+	}
+	if err := runLogTo(&out, dir, []string{"--nope"}); err == nil {
+		t.Fatal("unknown flag accepted")
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -93,6 +93,7 @@ var commands = map[string]command{
 	"share":           func(dir string, rest []string) error { return runShare(dir, rest, os.Stdout) },
 	"resume":          func(dir string, rest []string) error { return runResume(dir, rest, os.Stdout) },
 	"handoff":         func(dir string, rest []string) error { return runHandoff(dir, rest, os.Stdout) },
+	"log":             runLog,
 	"sync":            runSync,
 	"ctx":             cmdCtx,
 	"blame":           runBlame,
@@ -795,6 +796,7 @@ Usage:
   deja index [--rebuild]
   deja embed
   deja bench recall [--json]
+  deja log [n] [--last] [--json]
   deja statusline
   deja stats [--json] [--card [path]] [--html [path]]
 	deja remember "text" [--project name]

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -166,7 +166,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		text, sessions, err := recallTextResult(dir, a.Query, a.Harness, int(a.Limit), 4096-recallFrameOverhead)
 		if err == nil {
 			text = frameRecall(text)
-			usage.RecordResult(dir, usage.KindRecall, len(text), sessions, sessions == 0)
+			usage.RecordDigest(dir, usage.KindRecall, text, sessions)
 		}
 		return text, err
 	case "recall_context":
@@ -183,7 +183,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		text, sessions, err := recallContextResult(dir, a.Query, a.Harness)
 		if err == nil {
 			text = frameRecall(text)
-			usage.RecordResult(dir, usage.KindContext, len(text), sessions, sessions == 0)
+			usage.RecordDigest(dir, usage.KindContext, text, sessions)
 		}
 		return text, err
 	case "blame":

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -1,0 +1,132 @@
+package usage
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// A Snapshot is the full text of one served digest, kept so `deja log` can
+// show after the fact exactly what an agent received. Text comes from the
+// index, so it is already redacted.
+type Snapshot struct {
+	Time     time.Time `json:"t"`
+	Kind     string    `json:"kind"`
+	Sessions int       `json:"sessions,omitempty"`
+	Bytes    int       `json:"bytes"`
+	Digest   string    `json:"digest"`
+}
+
+const (
+	snapshotsToKeep  = 20
+	snapshotRotateAt = 512 << 10
+)
+
+// SnapshotPath returns the injection-snapshot log for an index dir; a sibling
+// file like the usage log, so it survives full rebuilds.
+func SnapshotPath(indexDir string) string {
+	return strings.TrimSuffix(indexDir, string(filepath.Separator)) + ".injections.jsonl"
+}
+
+// RecordDigest records a served digest: the counting event plus a snapshot of
+// the text. Best-effort like all usage recording.
+func RecordDigest(indexDir, kind, digest string, sessions int) {
+	RecordResult(indexDir, kind, len(digest), sessions, sessions == 0)
+	if digest == "" {
+		return
+	}
+	p := SnapshotPath(indexDir)
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		return
+	}
+	rotateSnapshots(p)
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	b, err := json.Marshal(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions, Bytes: len(digest), Digest: digest})
+	if err != nil {
+		return
+	}
+	_, _ = f.Write(append(b, '\n'))
+}
+
+func rotateSnapshots(p string) {
+	fi, err := os.Stat(p)
+	if err != nil || fi.Size() < snapshotRotateAt {
+		return
+	}
+	snaps := snapshotsFrom(p, snapshotsToKeep) // newest first
+	tmp := p + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return
+	}
+	for i := len(snaps) - 1; i >= 0; i-- {
+		if b, err := json.Marshal(snaps[i]); err == nil {
+			_, _ = f.Write(append(b, '\n'))
+		}
+	}
+	_ = f.Close()
+	_ = os.Rename(tmp, p)
+}
+
+// snapshotsFrom reads a snapshot file and returns up to n entries, newest
+// first. n <= 0 means all.
+func snapshotsFrom(p string, n int) []Snapshot {
+	f, err := os.Open(p)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+	var out []Snapshot
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64<<10), 4<<20)
+	for sc.Scan() {
+		var s Snapshot
+		if json.Unmarshal(sc.Bytes(), &s) == nil && s.Digest != "" {
+			out = append(out, s)
+		}
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	if n > 0 && len(out) > n {
+		out = out[:n]
+	}
+	return out
+}
+
+// Snapshots returns up to n recorded digests for an index dir, newest first.
+func Snapshots(indexDir string, n int) []Snapshot {
+	return snapshotsFrom(SnapshotPath(indexDir), n)
+}
+
+// Events returns up to n usage events, newest first. n <= 0 means all.
+func Events(indexDir string, n int) []Event {
+	f, err := os.Open(Path(indexDir))
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+	var out []Event
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64<<10), 4<<20)
+	for sc.Scan() {
+		var e Event
+		if json.Unmarshal(sc.Bytes(), &e) == nil && e.Kind != "" {
+			out = append(out, e)
+		}
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	if n > 0 && len(out) > n {
+		out = out[:n]
+	}
+	return out
+}

--- a/internal/usage/snapshots_test.go
+++ b/internal/usage/snapshots_test.go
@@ -1,0 +1,67 @@
+package usage
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRecordDigestAndSnapshots(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	RecordDigest(dir, KindHook, "first digest", 2)
+	RecordDigest(dir, KindRecall, "second digest", 1)
+
+	snaps := Snapshots(dir, 10)
+	if len(snaps) != 2 {
+		t.Fatalf("snapshots = %d, want 2", len(snaps))
+	}
+	if snaps[0].Digest != "second digest" || snaps[0].Kind != KindRecall || snaps[0].Sessions != 1 {
+		t.Fatalf("newest snapshot = %+v", snaps[0])
+	}
+	if snaps[1].Digest != "first digest" {
+		t.Fatalf("oldest snapshot = %+v", snaps[1])
+	}
+
+	events := Events(dir, 10)
+	if len(events) != 2 || events[0].Kind != KindRecall || events[0].Bytes != len("second digest") {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
+func TestRecordDigestEmptySkipsSnapshot(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	RecordDigest(dir, KindRecall, "", 0)
+	if snaps := Snapshots(dir, 10); len(snaps) != 0 {
+		t.Fatalf("empty digest recorded a snapshot: %+v", snaps)
+	}
+	events := Events(dir, 10)
+	if len(events) != 1 || !events[0].Empty {
+		t.Fatalf("empty event = %+v", events)
+	}
+}
+
+func TestSnapshotRotationKeepsNewest(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	big := strings.Repeat("x", 60<<10)
+	for i := 0; i < 12; i++ {
+		RecordDigest(dir, KindHook, big+string(rune('a'+i)), 1)
+	}
+	snaps := Snapshots(dir, 0)
+	if len(snaps) == 0 || len(snaps) > snapshotsToKeep+2 {
+		t.Fatalf("rotation kept %d snapshots", len(snaps))
+	}
+	if !strings.HasSuffix(snaps[0].Digest, "l") {
+		t.Fatalf("newest snapshot lost after rotation, tail = %q", snaps[0].Digest[len(snaps[0].Digest)-1:])
+	}
+}
+
+func TestEventsLimitAndOrder(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	for i := 0; i < 5; i++ {
+		RecordResult(dir, KindSearch, i, 0, false)
+	}
+	events := Events(dir, 3)
+	if len(events) != 3 || events[0].Bytes != 4 || events[2].Bytes != 2 {
+		t.Fatalf("events = %+v", events)
+	}
+}


### PR DESCRIPTION
Closes #239. `deja log` lists recent usage events; `deja log --last` prints the verbatim digest most recently injected (hook, per-prompt, MCP recall/context, handoff), from a size-capped snapshot file next to the usage sidecar. Snapshot text comes from the index, so it is already redacted.