### PR TITLE
feat(search): earlier-attempt flags and age in recall

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -310,9 +310,12 @@ func recallTextResult(dir, q, harness string, limit, budget int) (string, int, e
 	for i, h := range hits {
 		fmt.Fprintf(&b, "\n%d. [%s] %s · %s · %d matches", i+1, h.Session.Harness, h.Session.Project, h.Session.ID, h.Count)
 		if !h.Session.Updated.IsZero() {
-			fmt.Fprintf(&b, " · updated %s", h.Session.Updated.Format("2006-01-02"))
+			fmt.Fprintf(&b, " · updated %s (%s)", h.Session.Updated.Format("2006-01-02"), search.RelativeDate(h.Session.Updated))
 		}
 		fmt.Fprintln(&b)
+		if h.Superseded != "" {
+			fmt.Fprintf(&b, "[earlier attempt — a newer session in this project covers the same ground, updated %s]\n", h.Superseded)
+		}
 		if h.Tier != search.TierExact {
 			fmt.Fprintf(&b, "[%s]\n", h.Tier)
 		}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -38,7 +38,8 @@ Default exact search returns a JSON array of hits:
     "snippets": ["matched text …"],
     "score": 1.5,
     "tier": "exact",
-    "tier_detail": ""
+    "tier_detail": "",
+    "superseded": "2026-07-19"
   }
 ]
 ```
@@ -55,6 +56,8 @@ envelope with `schema_version`:
 ```
 
 Stemmed search may also include `variants`; semantic search sets `semantic`.
+`superseded` (added in 0.15, optional) carries the date of a newer same-project
+session whose matches overlap this hit — an earlier-attempt signal.
 
 ## `deja stats --json`
 

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -64,6 +64,9 @@ type Hit struct {
 	Score      float64       `json:"score"`
 	Tier       string        `json:"tier"`
 	TierDetail string        `json:"tier_detail,omitempty"`
+	// Superseded holds the date of a newer session in the same project whose
+	// matches overlap this one — a signal that this hit is an earlier attempt.
+	Superseded string `json:"superseded,omitempty"`
 }
 
 const (
@@ -179,11 +182,74 @@ func Run(ss []model.Session, o Options) ([]Hit, error) {
 		avgLength = float64(corpusLength) / float64(corpusDocuments)
 	}
 	hits := scoreBM25(documents, df, corpusDocuments, avgLength, len(qtoks) == 0)
+	markEarlierAttempts(hits)
 	if !o.All && len(hits) > 15 {
 		hits = hits[:15]
 	}
 	return hits, nil
 }
+
+// markEarlierAttempts flags hits that look like older passes over the same
+// problem: same project, heavy overlap in what matched, and a newer session
+// above some margin. The old session stays in the results — history is the
+// product — but agents and readers see which one the project moved on to.
+func markEarlierAttempts(hits []Hit) {
+	n := len(hits)
+	if n > 50 {
+		n = 50
+	}
+	sets := make([]map[string]bool, n)
+	for i := 0; i < n; i++ {
+		set := map[string]bool{}
+		for _, sn := range hits[i].Snippets {
+			for _, w := range strings.Fields(strings.ToLower(sn)) {
+				if len(w) > 3 {
+					set[w] = true
+				}
+			}
+		}
+		sets[i] = set
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if i == j || hits[i].Superseded != "" {
+				continue
+			}
+			a, b := hits[i], hits[j]
+			if a.Session.Project == "" || a.Session.Project != b.Session.Project {
+				continue
+			}
+			// b must be meaningfully newer than a
+			if !b.Session.Updated.After(a.Session.Updated.Add(24 * time.Hour)) {
+				continue
+			}
+			if snippetOverlap(sets[i], sets[j]) < 0.6 {
+				continue
+			}
+			hits[i].Superseded = b.Session.Updated.Format("2006-01-02")
+		}
+	}
+}
+
+func snippetOverlap(a, b map[string]bool) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	small, large := a, b
+	if len(b) < len(a) {
+		small, large = b, a
+	}
+	shared := 0
+	for w := range small {
+		if large[w] {
+			shared++
+		}
+	}
+	return float64(shared) / float64(len(small))
+}
+
+// RelativeDate is the human "3w ago" form used in listings and digests.
+func RelativeDate(t time.Time) string { return relativeDate(t) }
 
 func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLength float64, emptyQuery bool) []Hit {
 	now := time.Now()
@@ -344,6 +410,13 @@ func Print(w io.Writer, hits []Hit, o Options) {
 			fmt.Fprintf(w, "%s%s %-10s %s %s %s %s %s%s%d matches%s%s\n", cBold, harnessTag(h.Session.Harness, true), h.Session.Project, cDim+"·"+cReset+cBold, d, cDim+"·"+cReset+cBold, short(h.Session.ID), cDim+"— "+cReset, cBold, h.Count, cReset, tierLabel(h))
 		} else {
 			fmt.Fprintf(w, "[%s] %-10s · %s · %s — %d matches%s\n", h.Session.Harness, h.Session.Project, d, short(h.Session.ID), h.Count, tierLabel(h))
+		}
+		if h.Superseded != "" {
+			note := "  earlier attempt — this project has a newer session on the same ground (" + h.Superseded + ")"
+			if color {
+				note = cDim + note + cReset
+			}
+			fmt.Fprintln(w, note)
 		}
 		for _, sn := range h.Snippets {
 			fmt.Fprintf(w, "  %s\n", highlight(sn, o.Query, o.Regex, color))

--- a/internal/search/staleness_test.go
+++ b/internal/search/staleness_test.go
@@ -1,0 +1,75 @@
+package search
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func stalenessSession(id, project, text string, updated time.Time) model.Session {
+	return model.Session{
+		ID: id, Harness: "claude", Project: project, Updated: updated,
+		Messages: []model.Message{{Role: "user", Text: text, Time: updated}},
+	}
+}
+
+func TestMarkEarlierAttempts(t *testing.T) {
+	now := time.Now()
+	old := stalenessSession("old1", "api", "connection pool exhausted under load, pgx acquire leak", now.AddDate(0, 0, -30))
+	fresh := stalenessSession("new1", "api", "connection pool exhausted under load fixed with acquire timeout", now.AddDate(0, 0, -1))
+	other := stalenessSession("oth1", "web", "connection pool exhausted under load in the browser", now.AddDate(0, 0, -30))
+
+	hits, err := Run([]model.Session{old, fresh, other}, Options{Query: "connection pool exhausted", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]Hit{}
+	for _, h := range hits {
+		byID[h.Session.ID] = h
+	}
+	if byID["old1"].Superseded == "" {
+		t.Fatalf("old same-project hit not marked: %+v", byID["old1"])
+	}
+	if byID["old1"].Superseded != fresh.Updated.Format("2006-01-02") {
+		t.Fatalf("superseded date = %q", byID["old1"].Superseded)
+	}
+	if byID["new1"].Superseded != "" {
+		t.Fatalf("newest hit marked superseded: %+v", byID["new1"])
+	}
+	if byID["oth1"].Superseded != "" {
+		t.Fatalf("different-project hit marked superseded: %+v", byID["oth1"])
+	}
+}
+
+func TestMarkEarlierAttemptsNeedsOverlap(t *testing.T) {
+	now := time.Now()
+	old := stalenessSession("old2", "api", "jwt refresh rotation broke login jwks cache stale", now.AddDate(0, 0, -30))
+	fresh := stalenessSession("new2", "api", "docker jwt oom killed the build runner memory limit", now.AddDate(0, 0, -1))
+	hits, err := Run([]model.Session{old, fresh}, Options{Query: "jwt", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hits {
+		if h.Superseded != "" {
+			t.Fatalf("low-overlap hit marked superseded: %+v", h)
+		}
+	}
+}
+
+func TestPrintShowsEarlierAttempt(t *testing.T) {
+	now := time.Now()
+	old := stalenessSession("old3", "api", "rate limiter lets bursts through token bucket clock", now.AddDate(0, 0, -20))
+	fresh := stalenessSession("new3", "api", "rate limiter lets bursts through fixed with monotonic token bucket", now.AddDate(0, 0, -1))
+	hits, err := Run([]model.Session{old, fresh}, Options{Query: "rate limiter bursts", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b bytes.Buffer
+	Print(&b, hits, Options{Query: "rate limiter bursts"})
+	if !strings.Contains(b.String(), "earlier attempt") {
+		t.Fatalf("print output missing earlier-attempt note: %q", b.String())
+	}
+}


### PR DESCRIPTION
Closes #240. Ranking already decays hard on age; what was missing is the signal when an old same-project session resurfaces next to the one that superseded it. Run() now marks the older of overlapping same-project hits, CLI prints an earlier-attempt note, MCP digests carry it plus a relative age. Additive `superseded` field documented in the JSON contract.