### PR TITLE
fix(search): stem fallback recovers NL queries instead of returning zero

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -284,6 +284,10 @@ func printStemmed(w io.Writer, variants map[string][]string) {
 	sort.Strings(keys)
 	for _, token := range keys {
 		for _, variant := range variants[token] {
+			if variant == "" {
+				fmt.Fprintf(w, "deja: ignoring %q — no session matches it together with the rest\n", token)
+				continue
+			}
 			if variant != token {
 				fmt.Fprintf(w, "deja: no exact match, trying word forms: %s -> %s\n", token, variant)
 			}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -401,6 +401,10 @@ func fuzzySummary(variants map[string][]string) []string {
 	var out []string
 	for token, values := range variants {
 		for _, value := range values {
+			if value == "" {
+				out = append(out, token+" (ignored: no session matches it with the rest)")
+				continue
+			}
 			if value != token {
 				out = append(out, token+" -> "+value)
 			}

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -335,8 +335,13 @@ func TestMultiWordSearchUsesAllPostingsAndDoesNotFullScan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ss) != 0 {
-		t.Fatalf("search fell back to full scan despite indexed query tokens: %#v", ss)
+	// The stem fallback may drop a token and return posted sessions at the
+	// close tier; the invariant this test guards is narrower — a record with
+	// no postings must never surface, because that would mean a full scan.
+	for _, s := range ss {
+		if s.ID == "unposted" {
+			t.Fatalf("search fell back to full scan despite indexed query tokens: %#v", ss)
+		}
 	}
 }
 

--- a/internal/index/nl_fallback_test.go
+++ b/internal/index/nl_fallback_test.go
@@ -1,0 +1,104 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func nlIndex(t *testing.T, texts ...string) string {
+	t.Helper()
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "idx")
+	var sessions []model.Session
+	for i, text := range texts {
+		sessions = append(sessions, model.Session{
+			ID: string(rune('a' + i)), Harness: "claude", Project: "p", Updated: time.Now(),
+			Messages: []model.Message{{Role: "user", Text: text}},
+		})
+	}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestStemFallbackIngToSPair(t *testing.T) {
+	dir := nlIndex(t, "staging domain fails CORS but prod works")
+	result, err := SearchDetailed(dir, search.Options{Query: "cors failing staging", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Sessions) != 1 || !result.Stemmed {
+		t.Fatalf("failing->fails not recovered: sessions=%d stemmed=%v", len(result.Sessions), result.Stemmed)
+	}
+	if vs := result.Variants["failing"]; len(vs) == 0 {
+		t.Fatalf("variants missing failing: %v", result.Variants)
+	}
+}
+
+func TestStemFallbackShortTermPlural(t *testing.T) {
+	dir := nlIndex(t, "rate limiter lets short bursts through the bucket")
+	result, err := SearchDetailed(dir, search.Options{Query: "limiter let bursts", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Sessions) != 1 {
+		t.Fatalf("let->lets not recovered: %+v", result)
+	}
+}
+
+func TestStemFallbackDropsFillerToken(t *testing.T) {
+	dir := nlIndex(t,
+		"rate limiter lets short bursts through the bucket",
+		"why do refresh tokens die after rotation",
+	)
+	// "why" matches only the other session; no session holds all tokens.
+	result, err := SearchDetailed(dir, search.Options{Query: "why limiter lets bursts through", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Sessions) != 1 || result.Sessions[0].ID != "a" {
+		t.Fatalf("filler token still constrains the AND: %+v", result.Sessions)
+	}
+	if vs, ok := result.Variants["why"]; !ok || len(vs) != 1 || vs[0] != "" {
+		t.Fatalf("dropped token not marked optional: %v", result.Variants)
+	}
+}
+
+func TestStemFallbackKeepsAndWhenFullMatchExists(t *testing.T) {
+	dir := nlIndex(t,
+		"rate limiter lets short bursts through the bucket",
+		"why does the rate limiter lets bursts pass in this trace",
+	)
+	result, err := SearchDetailed(dir, search.Options{Query: "why limiter lets bursts", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range result.Sessions {
+		if s.ID == "b" {
+			return
+		}
+	}
+	t.Fatalf("full-coverage session missing from results: %+v", result.Sessions)
+}
+
+func TestStemFallbackNeedsTwoAnchors(t *testing.T) {
+	dir := nlIndex(t, "rate limiter lets short bursts through")
+	// Only one token exists in the corpus — dropping the rest would leave a
+	// single-term query the user did not ask for.
+	result, err := SearchDetailed(dir, search.Options{Query: "zzqx wwvv limiter", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Sessions) != 0 {
+		t.Fatalf("single anchor produced results: %+v", result.Sessions)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -722,27 +722,93 @@ func stemPostings(dir string, terms, phrases []string) ([]posting, map[string][]
 	if err != nil {
 		return nil, nil, err
 	}
-	perToken := make([]map[int64]posting, len(terms))
-	variants := map[string][]string{}
+	matchesPer := make([][]string, len(terms))
+	anchored := 0
 	for i, term := range terms {
-		matches := stemMatches(term, catalog)
-		if len(matches) == 0 {
-			return nil, nil, nil
+		matchesPer[i] = stemMatches(term, catalog)
+		if len(matchesPer[i]) > 0 {
+			anchored++
 		}
-		variants[term] = matches
-		perToken[i] = map[int64]posting{}
-		for _, variant := range matches {
+	}
+	if anchored == 0 {
+		return nil, nil, nil
+	}
+	// A token with no occurrences anywhere in the corpus cannot anchor the
+	// AND — natural-language queries are full of them. Drop such tokens when
+	// at least two anchored terms remain; the empty-string variant marks the
+	// token optional for the scan-time matcher.
+	variants := map[string][]string{}
+	type anchor struct {
+		term string
+		set  map[int64]posting
+	}
+	anchors := make([]anchor, 0, len(terms))
+	for i, term := range terms {
+		if len(matchesPer[i]) == 0 {
+			if anchored < 2 {
+				return nil, nil, nil
+			}
+			variants[term] = []string{""}
+			continue
+		}
+		variants[term] = matchesPer[i]
+		set := map[int64]posting{}
+		for _, variant := range matchesPer[i] {
 			posts, err := postingsFor(dir, "t"+variant)
 			if err != nil {
 				return nil, nil, err
 			}
 			for _, p := range posts {
-				perToken[i][p.Off] = p
+				set[p.Off] = p
+			}
+		}
+		anchors = append(anchors, anchor{term: term, set: set})
+	}
+	_ = phrases
+	sets := func(skip map[int]bool) []map[int64]posting {
+		out := make([]map[int64]posting, 0, len(anchors))
+		for i, a := range anchors {
+			if !skip[i] {
+				out = append(out, a.set)
+			}
+		}
+		return out
+	}
+	if posts := intersectPostingMaps(sets(nil)); len(posts) > 0 {
+		return posts, variants, nil
+	}
+	// Best-effort AND: no single session holds every anchored token. Natural
+	// queries carry filler ("why", "let") — try dropping up to two tokens,
+	// shortest first, and keep the first combination that matches anything.
+	if len(anchors) < 3 {
+		return nil, variants, nil
+	}
+	order := make([]int, len(anchors))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(a, b int) bool {
+		return len(anchors[order[a]].term) < len(anchors[order[b]].term)
+	})
+	for _, i := range order {
+		if posts := intersectPostingMaps(sets(map[int]bool{i: true})); len(posts) > 0 {
+			variants[anchors[i].term] = []string{""}
+			return posts, variants, nil
+		}
+	}
+	if len(anchors) >= 4 {
+		for x := 0; x < len(order); x++ {
+			for y := x + 1; y < len(order); y++ {
+				i, j := order[x], order[y]
+				if posts := intersectPostingMaps(sets(map[int]bool{i: true, j: true})); len(posts) > 0 {
+					variants[anchors[i].term] = []string{""}
+					variants[anchors[j].term] = []string{""}
+					return posts, variants, nil
+				}
 			}
 		}
 	}
-	_ = phrases
-	return intersectPostingMaps(perToken), variants, nil
+	return nil, variants, nil
 }
 
 func hasStemToken(terms []string) bool {
@@ -756,10 +822,13 @@ func hasStemToken(terms []string) bool {
 
 func stemMatches(term string, catalog map[string]bool) []string {
 	if len([]rune(term)) < 5 {
-		if catalog[term] {
-			return []string{term}
+		var matches []string
+		for _, form := range []string{term, term + "s", term + "es", strings.TrimSuffix(term, "s")} {
+			if len(form) >= 3 && catalog[form] {
+				matches = append(matches, form)
+			}
 		}
-		return nil
+		return matches
 	}
 	forms := suffixForms(term)
 	matches := make([]string, 0, 8)
@@ -834,6 +903,15 @@ func oneSuffixStep(word string) []string {
 		add(base + "ing")
 		add(base + "ed")
 		add(strings.TrimSuffix(word, "te") + "tion")
+	}
+	// expansions: fail->fails, fail->failing/failed. The catalog filter keeps
+	// nonsense forms from ever reaching a lookup.
+	if !strings.HasSuffix(word, "s") {
+		add(word + "s")
+	}
+	if !strings.HasSuffix(word, "e") && !strings.HasSuffix(word, "ing") && !strings.HasSuffix(word, "ed") {
+		add(word + "ing")
+		add(word + "ed")
 	}
 	return out
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -440,7 +440,7 @@ func variantDetail(text string, terms []string, variants map[string][]string) st
 		for _, variant := range variants[term] {
 			// A term that matched itself is an exact hit, not a variant —
 			// don't render "connection->connection" as the tier detail.
-			if variant == term {
+			if variant == term || variant == "" {
 				continue
 			}
 			if strings.Contains(low, variant) {
@@ -596,11 +596,19 @@ func countAllTokens(low string, toks []string) int {
 func countAllVariants(low string, toks []string, variants map[string][]string) int {
 	total := 0
 	for _, tok := range toks {
+		optional := false
 		count := strings.Count(low, tok)
 		for _, variant := range variants[tok] {
+			if variant == "" {
+				optional = true
+				continue
+			}
 			count += strings.Count(low, variant)
 		}
 		if count == 0 {
+			if optional {
+				continue
+			}
 			return 0
 		}
 		total += count


### PR DESCRIPTION
Closes #236. Three changes: suffix forms expand in both directions (-ing/-s pairs), short tokens get plural forms, and the stem tier's AND drops up to two unanchorable or uncoverable tokens (>=3 anchors required) with explicit narration. One regression test re-pinned to its actual invariant (no full scan) rather than strict-AND zero results.