### PR TITLE
feat(sources): Kimi Code is the twelfth harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center"><img src="assets/demo.gif" alt="deja demo"></p>
 
-Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, pi and Copilot CLI write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
+Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, pi and Copilot CLI write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
 
 | Feature | What it does |
 | --- | --- |
@@ -237,6 +237,7 @@ limits, trust assumptions, and release verification.
 | Antigravity | `~/.gemini/antigravity*/brain/*/.system_generated/logs/transcript.jsonl`<br>`${DEJA_ANTIGRAVITY_ROOT}/brain/*/.system_generated/logs/transcript.jsonl` | ✅ | — | ✅ | paste | — |
 | Grok Build | `${GROK_HOME:-~/.grok}/sessions/**/updates.jsonl`<br>`${DEJA_GROK_ROOT}/sessions/**/updates.jsonl` | ✅ | — | — | ✅ | — |
 | Qwen Code | `${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl` | ✅ | — | — | ✅ | — |
+| Kimi Code | `${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/main/wire.jsonl`<br>`${DEJA_KIMI_ROOT}/sessions/*/*/agents/main/wire.jsonl` | ✅ | — | ✅ | paste | — |
 | pi | `${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl` | ✅ | — | ✅ | ✅ | — |
 | Copilot CLI | `${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl` | ✅ | — | ✅ | ✅ | — |
 <!-- matrix:end -->
@@ -296,7 +297,7 @@ Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact cr
 **Does anything leave my machine?** Indexing and search are local. `deja update` downloads releases from GitHub, and user-invoked `deja sync ssh` transfers redacted batches through the system SSH client. Directory exports and shares go only to the destination you choose. See the [security model](docs/SECURITY-MODEL.md#data-flows) for the full data flow.
 
 **How is this different from cass?**
-[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, eleven harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
+[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, twelve harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
 
 [engram](https://github.com/Gentleman-Programming/engram) is the strongest of the record-forward memory tools: the agent calls `mem_save` and curated notes accumulate in SQLite. Curation buys it conflict detection deja doesn't attempt — but it starts empty, only knows what an agent decided to save, and can't answer for the months of sessions that happened before it was installed. deja starts full: the transcripts are the memory, no cooperation required.
 

--- a/cmd/deja/capability_drift_test.go
+++ b/cmd/deja/capability_drift_test.go
@@ -98,7 +98,7 @@ func TestCapabilityRegistryMatchesCode(t *testing.T) {
 			t.Fatalf("%s: unknown handoff kind %q", h.ID, c.Handoff)
 		}
 	}
-	if seen != len(handoffTargets())+1 { // +1: antigravity is paste-only
+	if seen != len(handoffTargets())+2 { // +2: antigravity and kimi are paste-only
 		t.Fatalf("registry covers %d harnesses, handoff targets %d", seen, len(handoffTargets()))
 	}
 

--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -37,7 +37,7 @@ _deja_completion() {
 
     local commands="blame bench completion ctx doctor embed forget handoff index install last log mcp remember resume share show sources stats statusline sync uninstall update version warmup"
     local harnesses="claude codex opencode aider gemini cursor antigravity grok qwen pi copilot deja"
-    local install_targets="claude-code codex opencode cursor gemini antigravity grok qwen copilot pi statusline --all --auto"
+    local install_targets="claude-code codex opencode cursor gemini antigravity grok qwen kimi copilot pi statusline --all --auto"
 
     if (( COMP_CWORD == 1 )); then
         COMPREPLY=( $(compgen -W "$commands --version -version --json --re --all --no-embed --harness --project --since --role --rebuild" -- "$cur") )
@@ -169,7 +169,7 @@ _deja() {
     'warmup:build or refresh the index'
   )
   harnesses=(claude codex opencode aider gemini cursor antigravity grok qwen pi copilot deja)
-  install_targets=(claude-code codex opencode cursor gemini antigravity grok qwen copilot pi statusline --all --auto)
+  install_targets=(claude-code codex opencode cursor gemini antigravity grok qwen kimi copilot pi statusline --all --auto)
 
   if (( CURRENT == 2 )); then
     _describe -t commands 'deja command' commands

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -175,6 +175,9 @@ func doctorHarnesses(w io.Writer) {
 	qwenRoot := filepath.Join(sources.QwenRoot(), "projects")
 	printRow("qwen", qwenRoot, doctorExists(qwenRoot), doctorCount(len(sources.QwenSessionFiles()), "file"))
 
+	kimiRoot := filepath.Join(sources.KimiRoot(), "sessions")
+	printRow("kimi", kimiRoot, doctorExists(kimiRoot), doctorCount(len(sources.KimiSessionFiles()), "file"))
+
 	piRoot := sources.PiRoot()
 	printRow("pi", piRoot, doctorExists(piRoot), doctorCount(len(sources.PiSessionFiles()), "file"))
 	copilotRoot := sources.CopilotRoot()
@@ -276,6 +279,7 @@ func doctorMCPConfigs() []doctorMCPConfig {
 		{"antigravity", filepath.Join(antigravityConfigHome(), "mcp_config.json"), doctorJSONWired("mcpServers")},
 		{"grok", filepath.Join(sources.GrokHome(), "config.toml"), doctorTOMLWired},
 		{"qwen", filepath.Join(sources.QwenConfigDir(), "settings.json"), doctorJSONWired("mcpServers")},
+		{"kimi", filepath.Join(sources.KimiConfigDir(), "mcp.json"), doctorJSONWired("mcpServers")},
 		{"pi", filepath.Join(sources.PiConfigDir(), "mcp.json"), doctorJSONWired("mcpServers")},
 		{"copilot", guidancePath("copilot"), doctorFileWired},
 	}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -120,6 +120,7 @@ func doctorStoreChecks() []doctorStoreCheck {
 		{"antigravity", sources.AntigravityRoots(), sources.AntigravityTranscripts(), sources.ParseAntigravityFile},
 		{"grok", []string{sources.GrokRoot()}, sources.GrokSessionFiles(), sources.ParseGrokFile},
 		{"qwen", []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.QwenSessionFiles(), sources.ParseQwenFile},
+		{"kimi", []string{filepath.Join(sources.KimiRoot(), "sessions")}, sources.KimiSessionFiles(), sources.ParseKimiFile},
 		{"pi", []string{sources.PiRoot()}, sources.PiSessionFiles(), sources.ParsePiFile},
 		{"copilot", []string{sources.CopilotRoot()}, sources.CopilotSessionFiles(), sources.ParseCopilotFile},
 		{"deja", []string{sources.NotesFile()}, presentDoctorFile(sources.NotesFile()), sources.ParseNotesFile},

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -37,6 +37,8 @@ func guidancePath(harness string) string {
 		return filepath.Join(sources.QwenConfigDir(), "QWEN.md")
 	case "codex":
 		return filepath.Join(sources.CodexHome(), "AGENTS.md")
+	case "kimi":
+		return filepath.Join(sources.KimiConfigDir(), "AGENTS.md")
 	case "gemini":
 		return filepath.Join(sources.GeminiHome(), "GEMINI.md")
 	case "opencode":

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -252,6 +252,7 @@ func existingTargets() []string {
 		"copilot":     filepath.Join(homeDir(), ".copilot"),
 		"grok":        sources.GrokRoot(),
 		"qwen":        sources.QwenConfigDir(),
+		"kimi":        sources.KimiConfigDir(),
 		"pi":          sources.PiConfigDir(),
 	}
 	var out []string
@@ -288,6 +289,8 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 		return installGrok(exe, uninstall)
 	case "qwen":
 		return installMCPJSON(filepath.Join(sources.QwenConfigDir(), "settings.json"), exe, uninstall)
+	case "kimi":
+		return installMCPJSON(filepath.Join(sources.KimiConfigDir(), "mcp.json"), exe, uninstall)
 	case "copilot":
 		return installCopilotMCP(exe, uninstall)
 	case "pi":

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -54,12 +54,15 @@ func loadAll(h string) []model.Session {
 	if h == "" || h == "qwen" {
 		ss = append(ss, sources.LoadQwen()...)
 	}
+	if h == "" || h == "kimi" {
+		ss = append(ss, sources.LoadKimi()...)
+	}
 	return ss
 }
 
 func loadFileSources() []model.Session {
 	var ss []model.Session
-	for _, harness := range []string{"claude", "codex", "aider", "gemini", "cursor", "antigravity", "grok", "qwen"} {
+	for _, harness := range []string{"claude", "codex", "aider", "gemini", "cursor", "antigravity", "grok", "qwen", "kimi"} {
 		ss = append(ss, loadAll(harness)...)
 	}
 	return ss
@@ -604,6 +607,7 @@ func printSources(dir string) {
 		{"antigravity", antigravityLocation, antigravityRoots, sources.LoadAntigravity},
 		{"grok", sources.GrokRoot(), []string{sources.GrokRoot()}, sources.LoadGrok},
 		{"qwen", filepath.Join(sources.QwenRoot(), "projects"), []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.LoadQwen},
+		{"kimi", filepath.Join(sources.KimiRoot(), "sessions"), []string{filepath.Join(sources.KimiRoot(), "sessions")}, sources.LoadKimi},
 		{"copilot", sources.CopilotRoot(), []string{sources.CopilotRoot()}, sources.LoadCopilot},
 		{"deja", sources.NotesFile(), []string{sources.NotesFile()}, sources.LoadNotes},
 	}
@@ -807,8 +811,8 @@ Usage:
   deja mcp
   deja version
   deja update
-  deja install <claude-code|codex|opencode|cursor|gemini|antigravity|grok|qwen|statusline|--all|--auto>
-  deja uninstall <claude-code|codex|opencode|cursor|gemini|antigravity|grok|qwen|statusline|--all|--auto>
+  deja install <claude-code|codex|opencode|cursor|gemini|antigravity|grok|qwen|kimi|statusline|--all|--auto>
+  deja uninstall <claude-code|codex|opencode|cursor|gemini|antigravity|grok|qwen|kimi|statusline|--all|--auto>
 
 Examples:
   deja "jwt refresh token bug"

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -112,6 +112,8 @@ func resumeCommand(s model.Session) (string, string, error) {
 		return "", "", fmt.Errorf("cursor IDE chats reopen from the Cursor UI, not the terminal")
 	case "grok":
 		return "", "", fmt.Errorf("grok has no session resume — start grok in %s to continue", sources.GrokCWDForSession(s.Path))
+	case "kimi":
+		return "", "kimi --session " + s.ID, nil
 	case "pi":
 		return piProjectDirFor(s), "pi --session " + s.ID, nil
 	case "copilot":

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -76,6 +76,14 @@
       "files": 0
     },
     {
+      "name": "kimi",
+      "state": "missing",
+      "paths": [
+        "<tmp>/home/.kimi-code/sessions"
+      ],
+      "files": 0
+    },
+    {
       "name": "pi",
       "state": "missing",
       "paths": [
@@ -144,6 +152,11 @@
       "name": "qwen",
       "state": "config-missing",
       "path": "<tmp>/home/.qwen/settings.json"
+    },
+    {
+      "name": "kimi",
+      "state": "config-missing",
+      "path": "<tmp>/home/.kimi-code/mcp.json"
     },
     {
       "name": "pi",

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -5,11 +5,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Harnesses — deja-vu docs</title>
-<meta name="description" content="The eleven coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta name="description" content="The twelve coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Harnesses — deja-vu docs">
-<meta property="og:description" content="The eleven coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta property="og:description" content="The twelve coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -25,12 +25,12 @@
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
 <meta name="twitter:title" content="Harnesses — deja-vu docs">
-<meta name="twitter:description" content="The eleven coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta name="twitter:description" content="The twelve coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
 <link rel="apple-touch-icon" href="../assets/favicon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Harnesses","description":"The eleven coding agents deja indexes today, where each stores its history, and how to add a new one.","url":"https://vshulcz.github.io/deja-vu/guide/harnesses.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Harnesses","description":"The twelve coding agents deja indexes today, where each stores its history, and how to add a new one.","url":"https://vshulcz.github.io/deja-vu/guide/harnesses.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Harnesses","item":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"}]}</script>
 </head>
 <body>
@@ -52,7 +52,7 @@
 <article>
 
 <h1>Harnesses</h1>
-<p>deja indexes eleven coding-agent histories into one retroactive index. A fix found in one agent is recalled inside another.</p>
+<p>deja indexes twelve coding-agent histories into one retroactive index. A fix found in one agent is recalled inside another.</p>
 <!-- matrix:start -->
 <table>
 <tr><th>Harness</th><th>Store</th><th>MCP recall</th><th>Auto-recall</th><th>Resume</th><th>Handoff</th><th>Needs</th></tr>
@@ -65,6 +65,7 @@
 <tr><td>Antigravity</td><td><code>~/.gemini/antigravity*/brain/*/.system_generated/logs/transcript.jsonl</code><br><code>${DEJA_ANTIGRAVITY_ROOT}/brain/*/.system_generated/logs/transcript.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>paste</td><td>—</td></tr>
 <tr><td>Grok Build</td><td><code>${GROK_HOME:-~/.grok}/sessions/**/updates.jsonl</code><br><code>${DEJA_GROK_ROOT}/sessions/**/updates.jsonl</code></td><td>✅</td><td>—</td><td>—</td><td>✅</td><td>—</td></tr>
 <tr><td>Qwen Code</td><td><code>${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl</code></td><td>✅</td><td>—</td><td>—</td><td>✅</td><td>—</td></tr>
+<tr><td>Kimi Code</td><td><code>${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/main/wire.jsonl</code><br><code>${DEJA_KIMI_ROOT}/sessions/*/*/agents/main/wire.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>paste</td><td>—</td></tr>
 <tr><td>pi</td><td><code>${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>✅</td><td>—</td></tr>
 <tr><td>Copilot CLI</td><td><code>${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>✅</td><td>—</td></tr>
 </table><!-- matrix:end -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>deja-vu — your agents already solved this. deja finds it.</title>
-<meta name="description" content="A memory layer for coding agents: search, MCP recall, auto-context, secret redaction, stats, share and sync over the session histories Claude Code, Codex, opencode, Cursor, Gemini CLI, aider, Antigravity, Grok Build, Qwen Code, pi and Copilot CLI already write. One zero-dependency binary, fully local.">
+<meta name="description" content="A memory layer for coding agents: search, MCP recall, auto-context, secret redaction, stats, share and sync over the session histories Claude Code, Codex, opencode, Cursor, Gemini CLI, aider, Antigravity, Grok Build, Qwen Code, Kimi Code, pi and Copilot CLI already write. One zero-dependency binary, fully local.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="deja-vu — search every session your coding agents ever wrote">
-<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across eleven coding agents, served back to them via MCP.">
+<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across twelve coding agents, served back to them via MCP.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -362,7 +362,7 @@ footer .spacer{flex:1}
     <table>
       <tr><td class="n">~200×</td><td class="c">fewer tokens to working context than grepping the raw logs, at equal fact coverage</td></tr>
       <tr><td class="n">~12 ms</td><td class="c">typical warm search over gigabytes of history</td></tr>
-      <tr><td class="n">11</td><td class="c">coding agents indexed into one retroactive memory</td></tr>
+      <tr><td class="n">12</td><td class="c">coding agents indexed into one retroactive memory</td></tr>
     </table>
     <p class="foot"><a href="guide/benchmarks.html">how it's measured →</a></p>
   </div>
@@ -387,7 +387,7 @@ footer .spacer{flex:1}
 </section>
 
 <section class="reveal">
-  <p class="shead"><span class="p">$</span> <span class="cmd">deja doctor</span> <span class="out"># eleven harnesses, one memory</span></p>
+  <p class="shead"><span class="p">$</span> <span class="cmd">deja doctor</span> <span class="out"># twelve harnesses, one memory</span></p>
   <div class="sources">
     <table class="mx">
       <tr><th></th><th>mcp recall</th><th>auto-recall</th><th>resume</th><th>handoff</th><th>needs</th></tr>
@@ -399,6 +399,7 @@ footer .spacer{flex:1}
       <tr><td class="nm">antigravity</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="am">paste</td><td class="pa">—</td></tr>
       <tr><td class="nm">grok build</td><td class="y">✓</td><td class="n">—</td><td class="n">—</td><td class="y">✓</td><td class="pa">—</td></tr>
       <tr><td class="nm">qwen code</td><td class="y">✓</td><td class="n">—</td><td class="n">—</td><td class="y">✓</td><td class="pa">—</td></tr>
+      <tr><td class="nm">kimi code</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="am">paste</td><td class="pa">—</td></tr>
       <tr><td class="nm">pi</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="y">✓</td><td class="pa">—</td></tr>
       <tr><td class="nm">copilot cli</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="y">✓</td><td class="pa">—</td></tr>
       <tr><td class="nm">aider</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="y">✓</td><td class="pa">no MCP client — history still indexed</td></tr>
@@ -439,7 +440,7 @@ footer .spacer{flex:1}
     <a href="guide/agents.html">agents-and-mcp<span>recall, blame, remember, auto-recall</span></a>
     <a href="guide/search.html">search<span>phrases, fuzzy, semantic, tiers</span></a>
     <a href="guide/commands.html">cli-reference<span>every subcommand and flag</span></a>
-    <a href="guide/harnesses.html">harnesses<span>eleven agents, and adding one</span></a>
+    <a href="guide/harnesses.html">harnesses<span>twelve agents, and adding one</span></a>
     <a href="guide/privacy.html">privacy<span>redaction, forget, exclude</span></a>
     <a href="guide/benchmarks.html">benchmarks<span>the ~200× number, reproducible</span></a>
     <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">architecture<span>index format, internals</span></a>
@@ -567,7 +568,7 @@ document.querySelectorAll('.reveal').forEach(function(el){io.observe(el)});
   }
   var COMMANDS={
     'help':'<p class="none">this input is a tiny deja: type words to search 16 demo sessions.\ncommands: <span class="t">sources</span> · <span class="t">stats</span> · <span class="t">version</span> · <span class="t">clear</span>\nthe real CLI does far more — see <a href="guide/commands.html">cli reference</a></p>',
-    'sources':'<p class="none">claude&nbsp;&nbsp;codex&nbsp;&nbsp;opencode&nbsp;&nbsp;cursor&nbsp;&nbsp;gemini&nbsp;&nbsp;aider&nbsp;&nbsp;antigravity&nbsp;&nbsp;grok&nbsp;&nbsp;qwen&nbsp;&nbsp;pi&nbsp;&nbsp;copilot\n11 harnesses, one index — real paths in the <a href="#proof">matrix below</a></p>',
+    'sources':'<p class="none">claude&nbsp;&nbsp;codex&nbsp;&nbsp;opencode&nbsp;&nbsp;cursor&nbsp;&nbsp;gemini&nbsp;&nbsp;aider&nbsp;&nbsp;antigravity&nbsp;&nbsp;grok&nbsp;&nbsp;qwen&nbsp;&nbsp;kimi&nbsp;&nbsp;pi&nbsp;&nbsp;copilot\n12 harnesses, one index — real paths in the <a href="#proof">matrix below</a></p>',
     'stats':'<p class="none">sessions 16 · messages 412 · top project api-gateway\nlast 12 months&nbsp;&nbsp;▁▁▂▃▂▅▆▄▇█▆▇\n(demo numbers — <span class="t">deja stats</span> wraps your real year)</p>',
     'version':'<p class="none">deja 0.14.1</p>',
     'clear':''

--- a/docs/registry/kimi.md
+++ b/docs/registry/kimi.md
@@ -1,0 +1,22 @@
+# Kimi Code
+
+- **ID**: `kimi`
+- **Store**: `${KIMI_CODE_HOME:-~/.kimi-code}/sessions/<workDirKey>/<sessionId>/agents/main/wire.jsonl`
+- **Read override**: `DEJA_KIMI_ROOT` (takes precedence over `KIMI_CODE_HOME` for reads)
+- **Format**: append-only JSONL wire protocol (observed `protocol_version` 1.1–1.4)
+
+`state.json` next to each session supplies title, workDir (project) and
+timestamps. User turns arrive as `context.append_message`; streamed assistant
+turns are reconstructed from `step.begin` → `content.part` (type `text` only;
+`think` parts are skipped) → `step.end`, with an end-of-file flush so a
+response that is mid-stream when indexing runs is not lost. Sub-agent
+histories under `agents/agent-*`, tool payloads and media are out of scope.
+
+- **MCP**: `deja install kimi` writes `mcpServers.deja` into
+  `$KIMI_CODE_HOME/mcp.json` (common JSON shape, existing entries preserved).
+- **Guidance**: global `AGENTS.md` in `$KIMI_CODE_HOME`.
+- **Resume**: `kimi --session <sessionId>` (verified live on 0.28.1).
+- **Handoff**: paste — the CLI has no documented start-with-prompt flag.
+
+Requested and specified by [@yearth](https://github.com/yearth) in
+[#248](https://github.com/vshulcz/deja-vu/issues/248).

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -196,6 +196,27 @@
       }
     },
     {
+      "id": "kimi",
+      "store_paths": [
+        "${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/main/wire.jsonl",
+        "${DEJA_KIMI_ROOT}/sessions/*/*/agents/main/wire.jsonl"
+      ],
+      "format_kind": "jsonl",
+      "fixture_paths": [
+        "fixtures/registry/kimi/sessions/wd_demo_0123456789ab/session_fixture01/agents/main/wire.jsonl"
+      ],
+      "parser_source": "internal/sources/kimi.go",
+      "last_verified": "2026-07-21",
+      "display_name": "Kimi Code",
+      "capabilities": {
+        "mcp": true,
+        "auto": false,
+        "resume": true,
+        "handoff": "paste",
+        "prereq": ""
+      }
+    },
+    {
       "id": "pi",
       "store_paths": [
         "${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl"

--- a/fixtures/registry/kimi/sessions/wd_demo_0123456789ab/session_fixture01/agents/main/wire.jsonl
+++ b/fixtures/registry/kimi/sessions/wd_demo_0123456789ab/session_fixture01/agents/main/wire.jsonl
@@ -1,0 +1,14 @@
+{"type":"metadata","protocol_version":"1.4","created_at":1782295200000}
+{"type":"config.update","profileName":"agent","systemPrompt":"You are Kimi Code CLI."}
+{"type":"turn.prompt","time":1782295200500}
+{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"why does the jwks cache go stale after rotation?"}],"toolCalls":[]},"time":1782295201000}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step_fx_01","turnId":"turn_fx_01","step":0},"time":1782295201100}
+{"type":"context.append_loop_event","event":{"type":"llm.request","uuid":"req_fx_01"},"time":1782295201150}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"part_fx_00","turnId":"turn_fx_01","step":0,"stepUuid":"step_fx_01","part":{"type":"think","text":"reasoning to be skipped"}},"time":1782295201180}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"part_fx_01","turnId":"turn_fx_01","step":0,"stepUuid":"step_fx_01","part":{"type":"text","text":"The cache keeps serving the old kid after rotateKey; "}},"time":1782295201200}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"part_fx_02","turnId":"turn_fx_01","step":0,"stepUuid":"step_fx_01","part":{"type":"text","text":"reload the jwks cache on rotation and add a clock-skew test."}},"time":1782295201300}
+{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"step_fx_01","turnId":"turn_fx_01","step":0,"finishReason":"end_turn"},"time":1782295201400}
+{"type":"usage.record","time":1782295201500}
+{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"and the mid-stream needle?"}],"toolCalls":[]},"time":1782295202000}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step_fx_02","turnId":"turn_fx_02","step":0},"time":1782295202100}
+{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"part_fx_03","turnId":"turn_fx_02","step":0,"stepUuid":"step_fx_02","part":{"type":"text","text":"torn-tail mid-stream answer survives"}},"time":1782295202200}

--- a/fixtures/registry/kimi/sessions/wd_demo_0123456789ab/session_fixture01/state.json
+++ b/fixtures/registry/kimi/sessions/wd_demo_0123456789ab/session_fixture01/state.json
@@ -1,0 +1,16 @@
+{
+  "createdAt": "2026-07-01T10:00:00.000Z",
+  "updatedAt": "2026-07-01T10:00:05.000Z",
+  "title": "Kimi fixture: jwks cache rotation needle",
+  "isCustomTitle": false,
+  "lastPrompt": "why does the jwks cache go stale after rotation?",
+  "workDir": "/home/example/work/demo-project",
+  "agents": {
+    "main": {
+      "homedir": "/home/example/.kimi-code/sessions/wd_demo_0123456789ab/session_fixture01/agents/main",
+      "type": "main",
+      "parentAgentId": null
+    }
+  },
+  "custom": {}
+}

--- a/internal/sources/kimi.go
+++ b/internal/sources/kimi.go
@@ -1,0 +1,166 @@
+package sources
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Kimi Code (github.com/MoonshotAI/kimi-code) keeps everything under
+// $KIMI_CODE_HOME (default ~/.kimi-code):
+//
+//	session_index.jsonl
+//	sessions/<workDirKey>/<sessionId>/state.json
+//	sessions/<workDirKey>/<sessionId>/agents/main/wire.jsonl
+//
+// wire.jsonl is the append-only main-agent transcript. User turns arrive as
+// context.append_message records; streamed assistant turns never do — they
+// have to be reconstructed from step.begin → content.part → step.end loop
+// events. Only the main agent is indexed; sub-agents, tool payloads and
+// think-parts are skipped by design (issue #248).
+
+// KimiConfigDir is the native Kimi Code home. DEJA_KIMI_ROOT intentionally
+// does not affect it because that variable only relocates reads.
+func KimiConfigDir() string { return EnvPath("KIMI_CODE_HOME", filepath.Join(Home(), ".kimi-code")) }
+
+func KimiRoot() string { return EnvPath("DEJA_KIMI_ROOT", KimiConfigDir()) }
+
+func KimiSessionFiles() []string {
+	return walkFiles(filepath.Join(KimiRoot(), "sessions"), func(p string) bool {
+		return filepath.Base(p) == "wire.jsonl" && filepath.Base(filepath.Dir(p)) == "main"
+	})
+}
+
+func LoadKimi() []model.Session { return parseFiles(KimiSessionFiles(), ParseKimiFile) }
+
+func ParseKimiFile(path string) ([]model.Session, error) {
+	return parseKimiFileFromOffset(path, 0)
+}
+
+func ParseKimiFileFromOffset(path string, offset int64) ([]model.Session, error) {
+	return parseKimiFileFromOffset(path, offset)
+}
+
+// kimiState is the slice of state.json deja cares about.
+type kimiState struct {
+	Title     string `json:"title"`
+	WorkDir   string `json:"workDir"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+func parseKimiFileFromOffset(path string, offset int64) ([]model.Session, error) {
+	// .../sessions/<workDirKey>/<sessionId>/agents/main/wire.jsonl
+	sessionDir := filepath.Dir(filepath.Dir(filepath.Dir(path)))
+	s := model.Session{
+		Harness: "kimi",
+		ID:      filepath.Base(sessionDir),
+		Path:    path,
+	}
+	var st kimiState
+	if b, err := os.ReadFile(filepath.Join(sessionDir, "state.json")); err == nil {
+		if json.Unmarshal(b, &st) == nil {
+			s.Title = strings.TrimSpace(st.Title)
+			s.Project = projectName(st.WorkDir)
+			s.Touch(parseTimeAny(st.CreatedAt))
+			s.Touch(parseTimeAny(st.UpdatedAt))
+		}
+	}
+	// Streamed assistant text accumulates across content.part events and is
+	// flushed on step.end — or at EOF, so a response mid-stream when the
+	// indexer runs is not lost (the remainder lands on the next incremental
+	// pass as its own message).
+	var pending strings.Builder
+	var pendingTime any
+	flush := func() {
+		if text := strings.TrimSpace(pending.String()); text != "" {
+			s.Messages = append(s.Messages, model.Message{Role: "assistant", Text: text, Time: parseTimeAny(pendingTime)})
+		}
+		pending.Reset()
+		pendingTime = nil
+	}
+	err := scanJSONLFromOffset(path, offset, func(m map[string]any) {
+		switch m["type"] {
+		case "context.append_message":
+			msg, _ := m["message"].(map[string]any)
+			if msg == nil {
+				return
+			}
+			role, _ := msg["role"].(string)
+			if role != "user" && role != "assistant" {
+				return
+			}
+			if role == "assistant" {
+				// Non-streamed assistant records exist in older protocols;
+				// close any open step first to keep message order stable.
+				flush()
+			}
+			text := kimiText(msg["content"])
+			t := parseTimeAny(m["time"])
+			s.Touch(t)
+			if text != "" {
+				s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: t})
+			}
+		case "context.append_loop_event":
+			e, _ := m["event"].(map[string]any)
+			if e == nil {
+				return
+			}
+			switch e["type"] {
+			case "step.begin":
+				flush()
+			case "content.part":
+				p, _ := e["part"].(map[string]any)
+				if p == nil || p["type"] != "text" {
+					return
+				}
+				text, _ := p["text"].(string)
+				if text == "" {
+					return
+				}
+				if t := parseTimeAny(m["time"]); !t.IsZero() {
+					s.Touch(t)
+					if pendingTime == nil {
+						pendingTime = m["time"]
+					}
+				}
+				pending.WriteString(text)
+			case "step.end":
+				flush()
+			}
+		}
+	})
+	flush()
+	if len(s.Messages) == 0 {
+		return nil, err
+	}
+	return []model.Session{s}, err
+}
+
+// kimiText joins the text parts of an append_message content array.
+func kimiText(v any) string {
+	parts, ok := v.([]any)
+	if !ok {
+		if s, ok := v.(string); ok {
+			return strings.TrimSpace(s)
+		}
+		return ""
+	}
+	var b strings.Builder
+	for _, pv := range parts {
+		p, ok := pv.(map[string]any)
+		if !ok || p["type"] != "text" {
+			continue
+		}
+		if t, _ := p["text"].(string); t != "" {
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(t)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/internal/sources/kimi_test.go
+++ b/internal/sources/kimi_test.go
@@ -1,0 +1,129 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func kimiFixture(t *testing.T) (root, wire string) {
+	t.Helper()
+	root = t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("USERPROFILE", root)
+	t.Setenv("KIMI_CODE_HOME", "")
+	t.Setenv("DEJA_KIMI_ROOT", filepath.Join(root, "kimi"))
+	dir := filepath.Join(root, "kimi", "sessions", "wd_demo_ab", "session_t01", "agents", "main")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	state := `{"createdAt":"2026-07-01T10:00:00.000Z","updatedAt":"2026-07-01T10:00:05.000Z","title":"t","workDir":"/home/u/work/proj"}`
+	if err := os.WriteFile(filepath.Join(root, "kimi", "sessions", "wd_demo_ab", "session_t01", "state.json"), []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root, filepath.Join(dir, "wire.jsonl")
+}
+
+const kimiWireHead = `{"type":"metadata","protocol_version":"1.4","created_at":1782295200000}
+{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"first question"}]},"time":1782295201000}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s1"},"time":1782295201100}
+{"type":"context.append_loop_event","event":{"type":"content.part","part":{"type":"think","text":"hidden"}},"time":1782295201150}
+{"type":"context.append_loop_event","event":{"type":"content.part","part":{"type":"text","text":"answer one, "}},"time":1782295201200}
+{"type":"context.append_loop_event","event":{"type":"content.part","part":{"type":"text","text":"joined"}},"time":1782295201300}
+{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"s1","finishReason":"end_turn"},"time":1782295201400}
+`
+
+func TestParseKimiReconstructsStreamedAssistant(t *testing.T) {
+	_, wire := kimiFixture(t)
+	if err := os.WriteFile(wire, []byte(kimiWireHead), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseKimiFile(wire)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v %d", err, len(ss))
+	}
+	s := ss[0]
+	if s.Harness != "kimi" || s.ID != "session_t01" || s.Project != "proj" || s.Title != "t" {
+		t.Fatalf("meta: %+v", s)
+	}
+	if len(s.Messages) != 2 {
+		t.Fatalf("messages = %d: %+v", len(s.Messages), s.Messages)
+	}
+	if s.Messages[0].Role != "user" || s.Messages[0].Text != "first question" {
+		t.Fatalf("user msg: %+v", s.Messages[0])
+	}
+	if s.Messages[1].Role != "assistant" || s.Messages[1].Text != "answer one, joined" {
+		t.Fatalf("assistant msg: %+v", s.Messages[1])
+	}
+	for _, m := range s.Messages {
+		if m.Text == "hidden" {
+			t.Fatal("think part leaked into the index")
+		}
+	}
+}
+
+func TestParseKimiMidStreamAndIncrementalAppend(t *testing.T) {
+	_, wire := kimiFixture(t)
+	// File ends mid-step: content.part written, no step.end yet.
+	head := kimiWireHead + `{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"second question"}]},"time":1782295202000}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s2"},"time":1782295202100}
+{"type":"context.append_loop_event","event":{"type":"content.part","part":{"type":"text","text":"partial answer"}},"time":1782295202200}
+`
+	if err := os.WriteFile(wire, []byte(head), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseKimiFile(wire)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v", err)
+	}
+	last := ss[0].Messages[len(ss[0].Messages)-1]
+	if last.Role != "assistant" || last.Text != "partial answer" {
+		t.Fatalf("mid-stream flush lost the response: %+v", ss[0].Messages)
+	}
+	// Append the rest and reparse from the previous offset.
+	offset := int64(len(head))
+	rest := `{"type":"context.append_loop_event","event":{"type":"content.part","part":{"type":"text","text":" continues"}},"time":1782295202300}
+{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"s2","finishReason":"end_turn"},"time":1782295202400}
+`
+	if err := os.WriteFile(wire, []byte(head+rest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	inc, err := ParseKimiFileFromOffset(wire, offset)
+	if err != nil || len(inc) != 1 {
+		t.Fatalf("incremental parse: %v %d", err, len(inc))
+	}
+	tail := inc[0].Messages[len(inc[0].Messages)-1]
+	if tail.Role != "assistant" || tail.Text != "continues" {
+		t.Fatalf("appended remainder: %+v", inc[0].Messages)
+	}
+}
+
+func TestParseKimiToleratesTornTail(t *testing.T) {
+	_, wire := kimiFixture(t)
+	torn := kimiWireHead + `{"type":"context.append_message","message":{"role":"user","co`
+	if err := os.WriteFile(wire, []byte(torn), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseKimiFile(wire)
+	if err != nil || len(ss) != 1 || len(ss[0].Messages) != 2 {
+		t.Fatalf("torn tail: err=%v sessions=%d", err, len(ss))
+	}
+}
+
+func TestKimiSessionFilesSkipsSubAgents(t *testing.T) {
+	root, wire := kimiFixture(t)
+	if err := os.WriteFile(wire, []byte(kimiWireHead), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(root, "kimi", "sessions", "wd_demo_ab", "session_t01", "agents", "agent-x1")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "wire.jsonl"), []byte(kimiWireHead), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files := KimiSessionFiles()
+	if len(files) != 1 || files[0] != wire {
+		t.Fatalf("sub-agent wire indexed: %v", files)
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -188,6 +188,17 @@ func Registry() []Harness {
 			}},
 		},
 		{
+			Name: "kimi", Load: LoadKimi, Files: KimiSessionFiles,
+			Kinds: []FileKind{{
+				Name: "kimi",
+				Match: func(p string) bool {
+					return hasBase(p, "wire.jsonl") && strings.HasPrefix(p, filepath.Join(KimiRoot(), "sessions"))
+				},
+				Parse:     fullParse(ParseKimiFile),
+				ParseFrom: offsetParse(ParseKimiFileFromOffset),
+			}},
+		},
+		{
 			Name: "pi", Load: LoadPi, Files: PiSessionFiles,
 			Kinds: []FileKind{{
 				Name:      "pi",

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -37,7 +37,7 @@ func TestFormatRegistryConformance(t *testing.T) {
 		"CURSOR_CONFIG_DIR", "DEJA_AIDER_ROOTS", "DEJA_ANTIGRAVITY_ROOT",
 		"DEJA_CLAUDE_ROOT", "DEJA_CODEX_ROOT", "DEJA_CURSOR_CLI_ROOT",
 		"DEJA_CURSOR_ROOT", "DEJA_GEMINI_ROOT", "DEJA_GROK_ROOT",
-		"DEJA_PI_ROOT", "DEJA_QWEN_ROOT",
+		"DEJA_PI_ROOT", "DEJA_QWEN_ROOT", "DEJA_KIMI_ROOT", "KIMI_CODE_HOME",
 		"DEJA_INCLUDE_SUBAGENTS", "DEJA_OPENCODE_DB", "GEMINI_CLI_HOME",
 		"GROK_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
 		"DEJA_NOTES_FILE",
@@ -133,6 +133,8 @@ func parseRegistryFixture(t *testing.T, id, path string) []model.Session {
 		sessions, err = ParseClaudeFile(path)
 	case "codex":
 		sessions, err = ParseCodexRollout(path)
+	case "kimi":
+		sessions, err = ParseKimiFile(path)
 	case "opencode":
 		if !SQLite3Available() {
 			t.Skip("sqlite3 not installed")


### PR DESCRIPTION
Closes #248 — spec by @yearth, and it was good enough to implement from almost verbatim.

Parser reconstructs streamed assistant turns from wire.jsonl loop events (step.begin → content.part → step.end), skips think parts, flushes at EOF so a mid-stream response survives incremental indexing, and tolerates torn tails. state.json supplies title/project/timestamps. Wired end to end: registry + conformance fixture (built against real 0.28.1 output, protocol 1.4), doctor, install (mcp.json + AGENTS.md guidance), resume via `kimi --session` (verified live — the resumed session kept context), completion, capability matrix, docs.

Live test: installed Kimi Code 0.28.1 driven by a free OpenRouter model, generated 8 real sessions, indexed them, searched, resumed, and had the kimi agent call deja's MCP recall — the calls are visible in `deja log`. Suite ran clean five times plus -race and e2e.