### PR TITLE
docs: prepare 0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.3] - 2026-07-21
+
+### Added
+- Kimi Code is the twelfth harness: `wire.jsonl` transcripts are indexed retroactively (streamed assistant turns reconstructed from loop events, mid-stream responses survive incremental indexing), `deja install kimi` wires MCP through `$KIMI_CODE_HOME/mcp.json` plus an `AGENTS.md` guidance file, and `deja resume` reopens sessions via `kimi --session`. Spec contributed by @yearth (#248).
+
 ## [0.14.2] - 2026-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -193,13 +193,13 @@ Batches are plain JSONL, redacted on the way out. Import is idempotent, so keep 
 
 ## Teach your agent to remember
 
-`deja install --all` wires up MCP recall (Claude Code, Codex, opencode, Cursor, Gemini CLI, Antigravity, Grok Build, Qwen Code, pi — aider has no MCP client, pipe `deja ctx` instead); `deja install --auto` does the same and adds session-start auto-recall where the harness supports it (Claude Code hook, Codex hooks.json, an opencode plugin — Cursor, Gemini CLI, Antigravity, Grok Build, Qwen Code and pi have no hook that can inject context, so MCP is their full install). To make
+`deja install --all` wires up MCP recall (Claude Code, Codex, opencode, Cursor, Gemini CLI, Antigravity, Grok Build, Qwen Code, Kimi Code, Copilot CLI, pi — aider has no MCP client, pipe `deja ctx` instead); `deja install --auto` does the same and adds session-start auto-recall where the harness supports it (Claude Code hook, Codex hooks.json, an opencode plugin — Cursor, Gemini CLI, Antigravity, Grok Build, Qwen Code, Kimi Code, Copilot CLI and pi have no hook that can inject context, so MCP is their full install). To make
 the agent reach for memory on its own, add this to your `CLAUDE.md` /
 `AGENTS.md`:
 
 ```
 Before debugging or re-implementing something, run `deja "<query>"` (or the
- MCP recall tool) — past agent sessions across Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code and pi
+ MCP recall tool) — past agent sessions across Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, Copilot CLI and pi
 are indexed locally. Cite what you reuse.
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -532,7 +532,7 @@ document.querySelectorAll('.reveal').forEach(function(el){io.observe(el)});
     {h:'claude',p:'billing',a:'4mo ago',t:'float rounding breaks invoice totals',s:'money as float64 — move to integer cents, property tests over samples',k:'float rounding money invoice cents decimal precision'},
     {h:'copilot',p:'ml-pipeline',a:'5w ago',t:'CUDA OOM on batch 512 only in prod',s:'gradient accumulation misconfigured; effective batch was 4x — fix config',k:'cuda oom gpu batch training memory pytorch'},
     {h:'codex',p:'infra',a:'1mo ago',t:'TLS cert renewal silently failing',s:'certbot renewed but nginx never reloaded — deploy hook + expiry alert',k:'tls certificate renewal certbot nginx expiry https'},
-    {h:'opencode',p:'cli-tools',a:'2mo ago',t:'windows path join bug in installer',s:'filepath.Dir("C:\\\\")=="C:\\\\" loops forever — parent==dir break guard',k:'windows path filepath installer loop walk'}
+    {h:'kimi',p:'cli-tools',a:'2mo ago',t:'windows path join bug in installer',s:'filepath.Dir("C:\\\\")=="C:\\\\" loops forever — parent==dir break guard',k:'windows path filepath installer loop walk'}
   ];
   var input=document.getElementById('dq'),res=document.getElementById('dres');
   function esc(s){return s.replace(/[&<>"]/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]})}


### PR DESCRIPTION
Changelog for the Kimi Code release; README install/guidance enumerations catch up (they were also missing Copilot CLI), one demo-corpus entry now shows the kimi harness tag.