### PR TITLE
feat: personal greeting query and distilled-context ratio

### DIFF
--- a/cmd/deja/coverage_recover_test.go
+++ b/cmd/deja/coverage_recover_test.go
@@ -154,15 +154,15 @@ func TestMaybeFirstIndexGreetingPrints(t *testing.T) {
 
 	// Just needs to run without panicking; output goes to /dev/null and
 	// there is nothing to assert on, but the branch executes.
-	maybeFirstIndexGreeting()
+	maybeFirstIndexGreeting(index.DefaultDir())
 
 	// A zero-message initial build digest.Short circuits before printing.
 	index.LastBuild = index.BuildSummary{Initial: true, Sessions: 1, Messages: 0, Harnesses: 1}
-	maybeFirstIndexGreeting()
+	maybeFirstIndexGreeting(index.DefaultDir())
 
 	// Non-initial build must digest.Short circuit before printing.
 	index.LastBuild = index.BuildSummary{Initial: false, Sessions: 1, Messages: 1, Harnesses: 1}
-	maybeFirstIndexGreeting()
+	maybeFirstIndexGreeting(index.DefaultDir())
 }
 
 // --- resume.go ---

--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -73,7 +73,7 @@ func runHandoff(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprintf(os.Stderr, "deja: note — this session is %s old; if you meant newer work, pass an id-prefix (see `deja last`)\n", age)
 	}
 	digest := digest.Handoff(s, handoffBudget)
-	usage.RecordDigest(dir, usage.KindHandoff, digest, 1)
+	usage.RecordDigest(dir, usage.KindHandoff, digest, 1, rawSize([]model.Session{s}))
 	if !doExec {
 		printSanitized(stdout, digest)
 		if pasteOnly {

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -60,7 +60,7 @@ func runHookContext(dir string, plain bool) error {
 		Source string `json:"source"`
 	}
 	_ = json.NewDecoder(os.Stdin).Decode(&input)
-	digest, sessions := hookDigestResult(dir)
+	digest, sessions, raw := hookDigestResult(dir)
 	if digest == "" {
 		return nil
 	}
@@ -75,7 +75,7 @@ func runHookContext(dir string, plain bool) error {
 		digest += "\n" + tip
 	}
 	digest = frameRecall(digest)
-	usage.RecordDigest(dir, usage.KindHook, digest, sessions)
+	usage.RecordDigest(dir, usage.KindHook, digest, sessions, raw)
 	if plain {
 		fmt.Fprintln(os.Stdout, digest)
 		return nil
@@ -121,26 +121,26 @@ func receiptIsNews(dir, digest string) bool {
 }
 
 func hookDigest(dir string) string {
-	digest, _ := hookDigestResult(dir)
+	digest, _, _ := hookDigestResult(dir)
 	return digest
 }
 
-func hookDigestResult(dir string) (string, int) {
+func hookDigestResult(dir string) (string, int, int64) {
 	defer func() { _ = recover() }()
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL")))
 	if mode == search.RecallOff {
-		return "", 0
+		return "", 0, 0
 	}
 	if !index.HasManifest(dir) {
 		requestWarmup(dir)
-		return "", 0
+		return "", 0, 0
 	}
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
 	if cwd == "" {
 		var err error
 		cwd, err = os.Getwd()
 		if err != nil {
-			return "", 0
+			return "", 0, 0
 		}
 	}
 	names := []string{sources.ClaudeProjectName(cwd)}
@@ -183,14 +183,14 @@ func hookDigestResult(dir string) (string, int) {
 		}
 	}
 	if len(ss) == 0 {
-		return "", 0
+		return "", 0, 0
 	}
 	sort.Slice(ss, func(i, j int) bool { return ss[i].Updated.After(ss[j].Updated) })
 	if len(ss) > 12 {
 		ss = ss[:12]
 	}
 	result := search.BuildAutoRecall(ss, search.AutoRecallOptions{Mode: mode, ProjectNames: names})
-	return result.Text, result.Sessions
+	return result.Text, result.Sessions, rawSize(ss)
 }
 
 func requestWarmup(dir string) {

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -78,7 +78,7 @@ func runHookPrompt(dir string, stdin io.Reader, stdout io.Writer) error {
 	}
 	lead := "deja found prior sessions matching this request. If one genuinely helps, use it and tell the user in one digest.Short line what deja-vu recalled; otherwise ignore silently.\n"
 	out := frameRecall(lead + digest + citationLine(ss[0]))
-	usage.RecordDigest(dir, usage.KindHook, out, len(ss))
+	usage.RecordDigest(dir, usage.KindHook, out, len(ss), rawSize(ss))
 	var resp sessionStartHookResponse
 	resp.HookSpecificOutput.HookEventName = "UserPromptSubmit"
 	resp.HookSpecificOutput.AdditionalContext = out

--- a/cmd/deja/log_test.go
+++ b/cmd/deja/log_test.go
@@ -30,7 +30,7 @@ func TestLogEmptyState(t *testing.T) {
 func TestLogListsEventsAndLastDigest(t *testing.T) {
 	hermeticEnv(t)
 	dir := index.DefaultDir()
-	usage.RecordDigest(dir, usage.KindHook, "the injected context body", 3)
+	usage.RecordDigest(dir, usage.KindHook, "the injected context body", 3, 1024)
 	usage.RecordResult(dir, usage.KindRecall, 42, 0, true)
 
 	var out bytes.Buffer
@@ -59,5 +59,18 @@ func TestLogListsEventsAndLastDigest(t *testing.T) {
 	}
 	if err := runLogTo(&out, dir, []string{"--nope"}); err == nil {
 		t.Fatal("unknown flag accepted")
+	}
+}
+
+func TestStatuslineShowsDistillRatio(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	usage.RecordDigest(dir, usage.KindRecall, strings.Repeat("d", 1000), 2, 250000)
+	var out bytes.Buffer
+	if err := runStatusline(dir, strings.NewReader(""), &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "less than replaying") {
+		t.Fatalf("statusline missing ratio: %q", out.String())
 	}
 }

--- a/cmd/deja/logo.go
+++ b/cmd/deja/logo.go
@@ -106,7 +106,7 @@ func prepareFirstIndexGreeting(dir string) {
 	}
 }
 
-func maybeFirstIndexGreeting() {
+func maybeFirstIndexGreeting(dir string) {
 	index.SuppressHarnessNarration = false
 	b := index.LastBuild
 	if !b.Initial || b.Messages == 0 || !logoWanted(os.Stdout) {
@@ -127,10 +127,14 @@ func maybeFirstIndexGreeting() {
 		info = append(info, fmt.Sprintf("%-*s  %s%6d%s messages · %d sessions",
 			nameW, h.Name, logoBold, h.Messages, logoReset, h.Sessions))
 	}
+	tryLine := logoDim + `try: deja "something you fixed weeks ago"` + logoReset
+	if q := suggestFirstQuery(dir); q != "" {
+		tryLine = "try it on your own history:  " + logoBold + `deja "` + q + `"` + logoReset
+	}
 	info = append(info,
 		"",
 		fmt.Sprintf("indexed %s%d%s messages across %s%d%s agents", logoBold, b.Messages, logoReset, logoBold, b.Harnesses, logoReset),
-		logoDim+`try: deja "something you fixed weeks ago"`+logoReset,
+		tryLine,
 	)
 	if warning := doctorParsedZeroWarning(); warning != "" {
 		info = append(info, warning)

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -125,7 +125,7 @@ func cmdWarmup(dir string, _ []string) error {
 	if err := index.Ensure(dir, "", false, os.Stderr); err != nil {
 		return err
 	}
-	maybeFirstIndexGreeting()
+	maybeFirstIndexGreeting(dir)
 	return nil
 }
 
@@ -143,7 +143,7 @@ func cmdIndex(dir string, rest []string) error {
 		return err
 	}
 	clearWarmupSentinel()
-	maybeFirstIndexGreeting()
+	maybeFirstIndexGreeting(dir)
 	return nil
 }
 
@@ -243,7 +243,7 @@ func runSearch(dir string, args []string) error {
 	if err := index.EnsureForSearch(dir, o, force, os.Stderr); err != nil {
 		return fmt.Errorf("ensure: %w", err)
 	}
-	maybeFirstIndexGreeting()
+	maybeFirstIndexGreeting(dir)
 	result, err := index.SearchWithRecoveryDetailed(dir, o, os.Stderr)
 	if err != nil {
 		return fmt.Errorf("search: %w", err)

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -163,10 +164,10 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Query) == "" {
 			return "", fmt.Errorf("query required")
 		}
-		text, sessions, err := recallTextResult(dir, a.Query, a.Harness, int(a.Limit), 4096-recallFrameOverhead)
+		text, sessions, raw, err := recallTextResult(dir, a.Query, a.Harness, int(a.Limit), 4096-recallFrameOverhead)
 		if err == nil {
 			text = frameRecall(text)
-			usage.RecordDigest(dir, usage.KindRecall, text, sessions)
+			usage.RecordDigest(dir, usage.KindRecall, text, sessions, raw)
 		}
 		return text, err
 	case "recall_context":
@@ -180,10 +181,10 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Query) == "" {
 			return "", fmt.Errorf("query required")
 		}
-		text, sessions, err := recallContextResult(dir, a.Query, a.Harness)
+		text, sessions, raw, err := recallContextResult(dir, a.Query, a.Harness)
 		if err == nil {
 			text = frameRecall(text)
-			usage.RecordDigest(dir, usage.KindContext, text, sessions)
+			usage.RecordDigest(dir, usage.KindContext, text, sessions, raw)
 		}
 		return text, err
 	case "blame":
@@ -256,21 +257,21 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 }
 
 func recallText(dir, q, harness string, limit, budget int) (string, error) {
-	text, _, err := recallTextResult(dir, q, harness, limit, budget)
+	text, _, _, err := recallTextResult(dir, q, harness, limit, budget)
 	return text, err
 }
 
-func recallTextResult(dir, q, harness string, limit, budget int) (string, int, error) {
+func recallTextResult(dir, q, harness string, limit, budget int) (string, int, int64, error) {
 	if limit <= 0 {
 		limit = 5
 	}
 	o := search.Options{Query: q, Harness: harness, All: true}
 	if err := index.EnsureForSearch(dir, o, false, mcpProgress()); err != nil {
-		return "", 0, err
+		return "", 0, 0, err
 	}
 	result, err := index.SearchWithRecoveryDetailed(dir, o, mcpProgress())
 	if err != nil {
-		return "", 0, err
+		return "", 0, 0, err
 	}
 	ss := result.Sessions
 	o.Tier = result.Tier
@@ -285,7 +286,7 @@ func recallTextResult(dir, q, harness string, limit, budget int) (string, int, e
 	}
 	hits, err := search.Run(ss, o)
 	if err != nil {
-		return "", 0, err
+		return "", 0, 0, err
 	}
 	if os.Getenv("DEJA_EMBED") != "off" {
 		hits = maybeRerank(dir, hits, o, os.Stderr)
@@ -294,7 +295,7 @@ func recallTextResult(dir, q, harness string, limit, budget int) (string, int, e
 	hits, semantic = maybeSemantic(dir, hits, o, os.Stderr)
 	o.Semantic = semantic
 	if len(hits) == 0 {
-		return fmt.Sprintf("No prior deja sessions matched %q.", q), 0, nil
+		return fmt.Sprintf("No prior deja sessions matched %q.", q), 0, 0, nil
 	}
 	if len(hits) > limit {
 		hits = hits[:limit]
@@ -331,7 +332,16 @@ func recallTextResult(dir, q, harness string, limit, budget int) (string, int, e
 	if len(out) > budget {
 		out = trimUTF8(out, budget)
 	}
-	return out, served, nil
+	var raw int64
+	for i, h := range hits {
+		if i >= served {
+			break
+		}
+		for _, m := range h.Session.Messages {
+			raw += int64(len(m.Text))
+		}
+	}
+	return out, served, raw, nil
 }
 
 func trimUTF8(s string, budget int) string {
@@ -345,18 +355,18 @@ func trimUTF8(s string, budget int) string {
 }
 
 func recallContext(dir, q string) (string, error) {
-	text, _, err := recallContextResult(dir, q, "")
+	text, _, _, err := recallContextResult(dir, q, "")
 	return text, err
 }
 
-func recallContextResult(dir, q, harness string) (string, int, error) {
+func recallContextResult(dir, q, harness string) (string, int, int64, error) {
 	o := search.Options{Query: q, Harness: harness, All: true}
 	if err := index.EnsureForSearch(dir, o, false, mcpProgress()); err != nil {
-		return "", 0, err
+		return "", 0, 0, err
 	}
 	result, err := index.SearchWithRecoveryDetailed(dir, o, mcpProgress())
 	if err != nil {
-		return "", 0, err
+		return "", 0, 0, err
 	}
 	ss := result.Sessions
 	o.Tier = result.Tier
@@ -371,7 +381,7 @@ func recallContextResult(dir, q, harness string) (string, int, error) {
 	}
 	hits, err := search.Run(ss, o)
 	if err != nil {
-		return "", 0, err
+		return "", 0, 0, err
 	}
 	var semantic bool
 	hits, semantic = maybeSemantic(dir, hits, o, os.Stderr)
@@ -379,7 +389,7 @@ func recallContextResult(dir, q, harness string) (string, int, error) {
 		o.Tier = search.TierSemantic
 	}
 	if len(hits) == 0 {
-		return fmt.Sprintf("No prior deja sessions matched %q.", q), 0, nil
+		return fmt.Sprintf("No prior deja sessions matched %q.", q), 0, 0, nil
 	}
 	var b bytes.Buffer
 	search.PrintContext(&b, hits[0].Session, q)
@@ -387,7 +397,7 @@ func recallContextResult(dir, q, harness string) (string, int, error) {
 	if hits[0].Tier != search.TierExact {
 		text = "[" + hits[0].Tier + "]\n" + text
 	}
-	return text, 1, nil
+	return text, 1, rawSize([]model.Session{hits[0].Session}), nil
 }
 
 func mcpProgress() io.Writer {

--- a/cmd/deja/onboarding_test.go
+++ b/cmd/deja/onboarding_test.go
@@ -129,7 +129,7 @@ func TestHookMissingManifestRequestsWarmup(t *testing.T) {
 	oldSpawn := spawnWarmup
 	spawnWarmup = func(_, _ string) error { called = true; return nil }
 	defer func() { spawnWarmup = oldSpawn }()
-	if digest, sessions := hookDigestResult(index.DefaultDir()); digest != "" || sessions != 0 {
+	if digest, sessions, _ := hookDigestResult(index.DefaultDir()); digest != "" || sessions != 0 {
 		t.Fatalf("missing-manifest digest = %q, sessions=%d", digest, sessions)
 	}
 	if !called {
@@ -162,7 +162,7 @@ func TestFirstIndexGreetingIncludesParsedZeroWarning(t *testing.T) {
 	}
 	defer func() { index.LastBuild = oldBuild }()
 
-	out := captureStdoutCall(t, maybeFirstIndexGreeting)
+	out := captureStdoutCall(t, func() { maybeFirstIndexGreeting(index.DefaultDir()) })
 	if !strings.Contains(out, "warning: claude files found but newest parsed to zero") {
 		t.Fatalf("greeting missing parsed-zero warning: %q", out)
 	}

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -242,6 +242,12 @@ func printStats(w io.Writer, r stats.Report) {
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "%sRecall%s\n", bold, reset)
 	fmt.Fprintf(w, "  Recalls served   %d\n", r.Recall.Recalls)
+	if r.Recall.RawBytes > 0 && r.Recall.Bytes > 0 {
+		ratio := r.Recall.RawBytes / int64(r.Recall.Bytes)
+		if ratio >= 2 {
+			fmt.Fprintf(w, "  Distilled        %s served from %s of transcripts — ~%d× less context\n", humanBytes(int64(r.Recall.Bytes)), humanBytes(r.Recall.RawBytes), ratio)
+		}
+	}
 	fmt.Fprintf(w, "  This week        %d recalls by your agents · %s re-used (plus %d auto-injections)\n", r.WeekRecalls, humanBytes(int64(r.WeekBytes)), r.WeekInjected)
 	if r.AgentCredits > 0 {
 		fmt.Fprintf(w, "  Credited aloud   agents said \"deja-vu recalled\" %d times (%d this week)\n", r.AgentCredits, r.WeekCredits)

--- a/cmd/deja/stats_helpers.go
+++ b/cmd/deja/stats_helpers.go
@@ -51,3 +51,15 @@ func sshSyncTip(dir string, ss []model.Session) string {
 	_ = os.WriteFile(sentinel, []byte("shown"), 0o600)
 	return fmt.Sprintf("tip: %d sessions mention ssh — if you work across machines, `deja sync ssh <host>` carries this memory along (shown once)", sshSessions)
 }
+
+// rawSize is the transcript volume a set of served sessions represents — the
+// denominator of the served-vs-replayed ratio.
+func rawSize(ss []model.Session) int64 {
+	var n int64
+	for _, s := range ss {
+		for _, m := range s.Messages {
+			n += int64(len(m.Text))
+		}
+	}
+	return n
+}

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -26,7 +26,11 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 	if recalls == 1 {
 		noun = "recall"
 	}
-	fmt.Fprintf(stdout, "deja · %d %s · %s ctx today · %s injected", recalls, noun, humanBytes(int64(bytes)), humanBytes(int64(injected)))
+	line := fmt.Sprintf("deja · %d %s · %s ctx today · %s injected", recalls, noun, humanBytes(int64(bytes)), humanBytes(int64(injected)))
+	if raw := usage.TodayRaw(dir); bytes > 0 && raw/int64(bytes) >= 2 {
+		line += fmt.Sprintf(" · ~%d× less than replaying", raw/int64(bytes))
+	}
+	fmt.Fprint(stdout, line)
 	return nil
 }
 

--- a/cmd/deja/suggest.go
+++ b/cmd/deja/suggest.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"math"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/digest"
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// suggestFirstQuery picks a short phrase from the user's own recent history to
+// print after the first index build: counts impress, but seeing your own
+// three-week-old problem come back is the argument. Empty string means "use
+// the generic hint" — a thin corpus never gets a made-up suggestion.
+func suggestFirstQuery(dir string) string {
+	ss, err := index.SearchWithRecovery(dir, query.Options{All: true}, nil)
+	if err != nil || len(ss) < 3 {
+		return ""
+	}
+	// Document frequency over every session; candidate phrases only from
+	// recent, human-typed messages.
+	df := map[string]int{}
+	for _, s := range ss {
+		seen := map[string]bool{}
+		for _, m := range s.Messages {
+			for _, tok := range suggestTokens(m.Text) {
+				if !seen[tok] {
+					seen[tok] = true
+					df[tok]++
+				}
+			}
+		}
+	}
+	cut := time.Now().AddDate(0, -2, 0)
+	total := float64(len(ss))
+	best := ""
+	bestScore := 0.0
+	for _, s := range ss {
+		if s.Updated.Before(cut) {
+			continue
+		}
+		for _, m := range s.Messages {
+			if m.Role != "user" || digest.IsAgentArtifact(m.Text) {
+				continue
+			}
+			toks := suggestTokens(m.Text)
+			for i := 0; i+1 < len(toks); i++ {
+				a, b := toks[i], toks[i+1]
+				// Both words must recur (a search should hit more than this
+				// one session) yet stay rare enough to be distinctive.
+				if df[a] < 2 || df[b] < 2 {
+					continue
+				}
+				score := math.Log(total/float64(df[a])) + math.Log(total/float64(df[b]))
+				if score > bestScore {
+					bestScore = score
+					best = a + " " + b
+				}
+			}
+		}
+	}
+	if bestScore < 1.0 {
+		return ""
+	}
+	return best
+}
+
+// suggestTokens keeps the informative words of a message: lowercase, no stop
+// words, no redaction markers, no digits-only noise.
+func suggestTokens(text string) []string {
+	if strings.Contains(text, "[redacted:") {
+		return nil
+	}
+	raw := query.Tokens(text)
+	out := make([]string, 0, len(raw))
+	for _, tok := range raw {
+		if len(tok) < 4 || len(tok) > 24 || query.IsStopWord(tok) {
+			continue
+		}
+		letters := 0
+		for _, r := range tok {
+			if r >= 'a' && r <= 'z' || r >= 'а' && r <= 'я' {
+				letters++
+			}
+		}
+		if letters*2 < len(tok) {
+			continue
+		}
+		out = append(out, tok)
+	}
+	return out
+}

--- a/cmd/deja/suggest_test.go
+++ b/cmd/deja/suggest_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+func TestSuggestFirstQueryPicksDistinctiveRecentPhrase(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-a")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	now := "2026-07-20T10:00:00Z"
+	mk := func(id, text string) string {
+		return `{"type":"user","sessionId":"` + id + `","cwd":"/w/a","timestamp":"` + now + `","message":{"role":"user","content":"` + text + `"}}` + "\n"
+	}
+	// "jwks rotation" recurs in two sessions; filler words dominate the rest.
+	files := map[string]string{
+		"s1": mk("s1", "the jwks rotation broke login again today"),
+		"s2": mk("s2", "jwks rotation cache still stale after deploy"),
+		"s3": mk("s3", "please update readme wording and typos"),
+		"s4": mk("s4", "update readme header image"),
+	}
+	for id, body := range files {
+		if err := os.WriteFile(filepath.Join(root, id+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	got := suggestFirstQuery(dir)
+	if !strings.Contains(got, "jwks") {
+		t.Fatalf("suggestion = %q, want the distinctive recurring phrase", got)
+	}
+}
+
+func TestSuggestFirstQueryEmptyOnThinCorpus(t *testing.T) {
+	hermeticEnv(t)
+	if got := suggestFirstQuery(index.DefaultDir()); got != "" {
+		t.Fatalf("thin corpus suggested %q", got)
+	}
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -32,9 +32,10 @@ func SnapshotPath(indexDir string) string {
 }
 
 // RecordDigest records a served digest: the counting event plus a snapshot of
-// the text. Best-effort like all usage recording.
-func RecordDigest(indexDir, kind, digest string, sessions int) {
-	RecordResult(indexDir, kind, len(digest), sessions, sessions == 0)
+// the text. raw is the size of the source transcripts the digest distilled.
+// Best-effort like all usage recording.
+func RecordDigest(indexDir, kind, digest string, sessions int, raw int64) {
+	RecordResultRaw(indexDir, kind, len(digest), sessions, sessions == 0, raw)
 	if digest == "" {
 		return
 	}

--- a/internal/usage/snapshots_test.go
+++ b/internal/usage/snapshots_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestRecordDigestAndSnapshots(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "index.db")
-	RecordDigest(dir, KindHook, "first digest", 2)
-	RecordDigest(dir, KindRecall, "second digest", 1)
+	RecordDigest(dir, KindHook, "first digest", 2, 1024)
+	RecordDigest(dir, KindRecall, "second digest", 1, 1024)
 
 	snaps := Snapshots(dir, 10)
 	if len(snaps) != 2 {
@@ -30,7 +30,7 @@ func TestRecordDigestAndSnapshots(t *testing.T) {
 
 func TestRecordDigestEmptySkipsSnapshot(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "index.db")
-	RecordDigest(dir, KindRecall, "", 0)
+	RecordDigest(dir, KindRecall, "", 0, 1024)
 	if snaps := Snapshots(dir, 10); len(snaps) != 0 {
 		t.Fatalf("empty digest recorded a snapshot: %+v", snaps)
 	}
@@ -44,7 +44,7 @@ func TestSnapshotRotationKeepsNewest(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "index.db")
 	big := strings.Repeat("x", 60<<10)
 	for i := 0; i < 12; i++ {
-		RecordDigest(dir, KindHook, big+string(rune('a'+i)), 1)
+		RecordDigest(dir, KindHook, big+string(rune('a'+i)), 1, 2048)
 	}
 	snaps := Snapshots(dir, 0)
 	if len(snaps) == 0 || len(snaps) > snapshotsToKeep+2 {

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -29,6 +29,9 @@ type Event struct {
 	Bytes    int       `json:"bytes"`
 	Sessions int       `json:"sessions,omitempty"`
 	Empty    bool      `json:"empty,omitempty"`
+	// RawBytes is the size of the source transcripts the served digest was
+	// distilled from — what the agent would have had to replay without deja.
+	RawBytes int64 `json:"raw,omitempty"`
 }
 
 type Summary struct {
@@ -38,6 +41,7 @@ type Summary struct {
 	InjectedSessions int     `json:"injected_sessions"`
 	Bytes            int     `json:"bytes"`
 	InjectedBytes    int     `json:"injected_bytes"`
+	RawBytes         int64   `json:"raw_bytes,omitempty"`
 	EmptyResultRate  float64 `json:"empty_result_rate"`
 }
 
@@ -59,6 +63,12 @@ func Record(indexDir, kind string, bytes int) {
 
 // RecordResult appends an event with result accounting. Errors are swallowed.
 func RecordResult(indexDir, kind string, bytes, sessions int, empty bool) {
+	RecordResultRaw(indexDir, kind, bytes, sessions, empty, 0)
+}
+
+// RecordResultRaw additionally stores the source-transcript size the digest
+// was distilled from, for the served-vs-replayed ratio.
+func RecordResultRaw(indexDir, kind string, bytes, sessions int, empty bool, raw int64) {
 	p := Path(indexDir)
 	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
 		return
@@ -69,7 +79,7 @@ func RecordResult(indexDir, kind string, bytes, sessions int, empty bool) {
 		return
 	}
 	defer func() { _ = f.Close() }()
-	b, err := json.Marshal(Event{Time: time.Now().UTC(), Kind: kind, Bytes: bytes, Sessions: sessions, Empty: empty})
+	b, err := json.Marshal(Event{Time: time.Now().UTC(), Kind: kind, Bytes: bytes, Sessions: sessions, Empty: empty, RawBytes: raw})
 	if err != nil {
 		return
 	}
@@ -104,6 +114,23 @@ func TodayWithInjections(indexDir string) (recalls, bytes, injected int) {
 	return recalls, bytes, injected
 }
 
+// TodayRaw sums the source-transcript volume behind today's served digests.
+func TodayRaw(indexDir string) int64 {
+	now := time.Now()
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	var raw int64
+	for _, e := range read(Path(indexDir)) {
+		if e.Time.Before(midnight) {
+			continue
+		}
+		switch e.Kind {
+		case KindRecall, KindContext, KindHook:
+			raw += e.RawBytes
+		}
+	}
+	return raw
+}
+
 // Totals summarizes the retained usage log.
 func Totals(indexDir string) Summary {
 	var out Summary
@@ -114,6 +141,7 @@ func Totals(indexDir string) Summary {
 			out.Recalls++
 			out.RecallSessions += e.Sessions
 			out.Bytes += e.Bytes
+			out.RawBytes += e.RawBytes
 			if e.Empty {
 				empty++
 			}
@@ -123,6 +151,7 @@ func Totals(indexDir string) Summary {
 			out.InjectedSessions += e.Sessions
 			out.InjectedBytes += e.Bytes
 			out.Bytes += e.Bytes
+			out.RawBytes += e.RawBytes
 		}
 	}
 	if served := out.Recalls - out.Injections; served > 0 {


### PR DESCRIPTION
Closes #256, closes #257. The first-index greeting now ends with `try it on your own history: deja "<phrase from their corpus>"` — highest-IDF recurring bigram from recent user messages, redaction-aware, generic fallback on thin corpora. Every served digest records the raw transcript volume it distilled; `deja stats` prints "X served from Y of transcripts — ~N× less context" and the statusline appends the daily ratio. Strictly measured from real events — no estimates.