### PR TITLE
fix: deterministic greeting-suggestion tie-break

### DIFF
--- a/cmd/deja/suggest.go
+++ b/cmd/deja/suggest.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -37,6 +38,9 @@ func suggestFirstQuery(dir string) string {
 	total := float64(len(ss))
 	best := ""
 	bestScore := 0.0
+	// Newest first, so an IDF tie resolves to the most recent phrase instead
+	// of map iteration order.
+	sort.SliceStable(ss, func(i, j int) bool { return ss[i].Updated.After(ss[j].Updated) })
 	for _, s := range ss {
 		if s.Updated.Before(cut) {
 			continue
@@ -54,7 +58,7 @@ func suggestFirstQuery(dir string) string {
 					continue
 				}
 				score := math.Log(total/float64(df[a])) + math.Log(total/float64(df[b]))
-				if score > bestScore {
+				if score > bestScore+1e-9 {
 					bestScore = score
 					best = a + " " + b
 				}

--- a/cmd/deja/suggest_test.go
+++ b/cmd/deja/suggest_test.go
@@ -26,6 +26,7 @@ func TestSuggestFirstQueryPicksDistinctiveRecentPhrase(t *testing.T) {
 		"s2": mk("s2", "jwks rotation cache still stale after deploy"),
 		"s3": mk("s3", "please update readme wording and typos"),
 		"s4": mk("s4", "update readme header image"),
+		"s5": mk("s5", "update readme badges"),
 	}
 	for id, body := range files {
 		if err := os.WriteFile(filepath.Join(root, id+".jsonl"), []byte(body), 0o644); err != nil {


### PR DESCRIPTION
TestSuggestFirstQueryPicksDistinctiveRecentPhrase flaked on macOS: two bigrams tied on IDF and map iteration order picked the winner. Sessions now scan newest-first with a strict-improvement comparison; the fixture corpus is tie-free.