### PR TITLE
feat(search): split compound identifiers at index time

### DIFF
--- a/internal/index/identparts_test.go
+++ b/internal/index/identparts_test.go
@@ -1,0 +1,46 @@
+package index
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func TestIdentifierParts(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"call getUserById now", []string{"get", "user"}}, // "by","id" < 3 runes
+		{"refresh_token_rotation broke", []string{"refresh", "token", "rotation"}},
+		{"JSONDataReader failed", []string{"json", "data", "reader"}},
+		{"kebab-case-slug", []string{"kebab", "case", "slug"}},
+		{"plain words only here", nil},
+		{"short a_b", nil},
+	}
+	for _, tc := range cases {
+		got := identifierParts(tc.in)
+		sort.Strings(got)
+		want := append([]string(nil), tc.want...)
+		sort.Strings(want)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("identifierParts(%q) = %v, want %v", tc.in, got, want)
+		}
+	}
+}
+
+func TestIdentifierSplitRetrieval(t *testing.T) {
+	dir := nlIndex(t,
+		"the bug is in getUserProfile handler",
+		"unrelated session about docker",
+	)
+	result, err := SearchDetailed(dir, search.Options{Query: "user profile", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Sessions) != 1 || result.Sessions[0].ID != "a" {
+		t.Fatalf("split retrieval missed camelCase: %+v", result.Sessions)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1096,7 +1096,69 @@ func indexKeys(s string) []string {
 	for _, tok := range tokens(s) {
 		out = append(out, "t"+tok)
 	}
+	for _, part := range identifierParts(s) {
+		out = append(out, "t"+part)
+	}
 	return out
+}
+
+// identifierParts emits the lowered inner words of compound identifiers so
+// `deja "user profile"` finds getUserProfile and refresh_token_rotation.
+// It walks the original-cased text: case humps are gone after lowering.
+// Only words of 6+ runes with a real boundary produce parts, and only parts
+// of 3+ runes are kept — short fragments ride the substring tier instead.
+func identifierParts(s string) []string {
+	var out []string
+	var word []rune
+	flushWord := func() {
+		if len(word) >= 6 {
+			splitCompound(word, &out)
+		}
+		word = word[:0]
+	}
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' {
+			word = append(word, r)
+			if len(word) > 64 {
+				flushWord()
+			}
+			continue
+		}
+		flushWord()
+	}
+	flushWord()
+	return out
+}
+
+func splitCompound(word []rune, out *[]string) {
+	start := 0
+	boundaries := 0
+	emit := func(end int) {
+		if end-start >= 3 {
+			*out = append(*out, strings.ToLower(string(word[start:end])))
+		}
+		start = end
+	}
+	for i := 1; i < len(word); i++ {
+		c, p := word[i], word[i-1]
+		switch {
+		case c == '_' || c == '-':
+			emit(i)
+			start = i + 1
+			boundaries++
+		case unicode.IsUpper(c) && (unicode.IsLower(p) || unicode.IsDigit(p)):
+			// getUser | getUserById: hump boundary
+			emit(i)
+			boundaries++
+		case unicode.IsLower(c) && unicode.IsUpper(p) && i-1 > start:
+			// JSONData -> JSON | Data: break before the last upper
+			emit(i - 1)
+			boundaries++
+		}
+	}
+	if boundaries > 0 {
+		emit(len(word))
+	}
 }
 
 func retrievalKeys(keys []string) []string {


### PR DESCRIPTION
Closes #260. indexKeys additionally emits the inner words of camelCase / snake_case / kebab-case compounds (split before lowercasing — humps are unrecoverable after), parts of 3+ runes from words of 6+ with a real boundary; shorter fragments already ride the substring tier. Query side unchanged.

Measured on the real 3.3 GB corpus: index 59 MB -> 60 MB (+1.7%), cold build 16.0s -> 15.5s median (noise), warm search unchanged, bench recall floor 1.0. Live check: "record writer seek" went from 75 to 113 matches by picking up recordWriter/recordsForKey humps.