### PR TITLE
feat(search): synonym and russian folds

### DIFF
--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -821,19 +821,23 @@ func hasStemToken(terms []string) bool {
 }
 
 func stemMatches(term string, catalog map[string]bool) []string {
+	var forms []string
 	if len([]rune(term)) < 5 {
-		var matches []string
 		for _, form := range []string{term, term + "s", term + "es", strings.TrimSuffix(term, "s")} {
-			if len(form) >= 3 && catalog[form] {
-				matches = append(matches, form)
+			if len(form) >= 3 {
+				forms = append(forms, form)
 			}
 		}
-		return matches
+	} else {
+		forms = suffixForms(term)
 	}
-	forms := suffixForms(term)
+	forms = append(forms, devSynonyms[term]...)
+	forms = append(forms, cyrSuffixForms(term)...)
 	matches := make([]string, 0, 8)
+	seen := map[string]bool{}
 	for _, form := range forms {
-		if catalog[form] {
+		if !seen[form] && catalog[form] {
+			seen[form] = true
 			matches = append(matches, form)
 		}
 	}
@@ -841,6 +845,72 @@ func stemMatches(term string, catalog map[string]bool) []string {
 		matches = matches[:8]
 	}
 	return matches
+}
+
+// devSynonyms is a small reviewed fold table for the abbreviations developers
+// actually type. Deterministic and shipped in the repo — no embeddings, no
+// guessing. Applied only in the stem tier (exact matches never consult it)
+// and narrated like any other variant.
+var devSynonyms = func() map[string][]string {
+	pairs := [][2]string{
+		{"auth", "authentication"}, {"auth", "authorization"},
+		{"db", "database"}, {"k8s", "kubernetes"},
+		{"env", "environment"}, {"config", "configuration"},
+		{"cfg", "config"}, {"repo", "repository"},
+		{"perm", "permission"}, {"cert", "certificate"},
+		{"dir", "directory"}, {"msg", "message"},
+		{"deps", "dependencies"}, {"prod", "production"},
+		{"param", "parameter"}, {"arg", "argument"},
+		{"docs", "documentation"}, {"err", "error"},
+		{"regex", "regexp"}, {"spec", "specification"},
+	}
+	m := map[string][]string{}
+	for _, p := range pairs {
+		m[p[0]] = append(m[p[0]], p[1])
+		m[p[1]] = append(m[p[1]], p[0])
+	}
+	return m
+}()
+
+// cyrEndings are common Russian inflection endings, longest first so the
+// stem strips greedily. A bounded fold, not a morphology engine.
+var cyrEndings = []string{
+	"иями", "ями", "ами", "ией", "иях", "ях", "ах", "ов", "ев", "ей",
+	"ой", "ий", "ия", "ию", "ии", "ие", "ый", "ая", "ое", "ые",
+	"ть", "л", "ла", "ло", "ли", "а", "я", "у", "ю", "ы", "и", "е", "о",
+}
+
+// cyrSuffixForms bridges Russian inflection: strip the longest known ending,
+// then re-attach each — миграция matches миграции and миграцию. ASCII terms
+// return nothing.
+func cyrSuffixForms(term string) []string {
+	runes := []rune(term)
+	if len(runes) < 5 {
+		return nil
+	}
+	cyr := false
+	for _, r := range runes {
+		if r >= 'а' && r <= 'я' || r == 'ё' {
+			cyr = true
+			break
+		}
+	}
+	if !cyr {
+		return nil
+	}
+	base := term
+	for _, end := range cyrEndings {
+		if strings.HasSuffix(term, end) && len([]rune(term))-len([]rune(end)) >= 4 {
+			base = strings.TrimSuffix(term, end)
+			break
+		}
+	}
+	forms := make([]string, 0, len(cyrEndings)+1)
+	forms = append(forms, base)
+	for _, end := range cyrEndings {
+		forms = append(forms, base+end)
+	}
+	return forms
 }
 
 func suffixForms(word string) []string {

--- a/internal/index/stemfolds_test.go
+++ b/internal/index/stemfolds_test.go
@@ -1,0 +1,63 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func TestDevSynonymFoldBridgesAbbreviations(t *testing.T) {
+	dir := nlIndex(t,
+		"the authentication middleware rejects rotated tokens",
+		"kubernetes ingress drops websocket upgrades",
+		"unrelated docker session filler",
+	)
+	// auth->authentication rides the substring tier (prefix); the synonym
+	// table exists for pairs with no substring bridge, like k8s->kubernetes.
+	for query, wantID := range map[string]string{
+		"auth middleware rejects": "a",
+		"k8s ingress websocket":   "b",
+	} {
+		result, err := SearchDetailed(dir, search.Options{Query: query, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result.Sessions) != 1 || result.Sessions[0].ID != wantID {
+			t.Fatalf("%q: sessions=%+v", query, result.Sessions)
+		}
+	}
+	k8s, err := SearchDetailed(dir, search.Options{Query: "k8s ingress websocket", All: true})
+	if err != nil || !k8s.Stemmed {
+		t.Fatalf("k8s must resolve via the stem tier: %+v %v", k8s, err)
+	}
+}
+
+func TestDevSynonymNeverTouchesExactTier(t *testing.T) {
+	dir := nlIndex(t,
+		"auth service config drift",
+		"authentication deep dive",
+	)
+	result, err := SearchDetailed(dir, search.Options{Query: "auth service", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Stemmed || len(result.Sessions) != 1 || result.Sessions[0].ID != "a" {
+		t.Fatalf("exact tier polluted: %+v", result)
+	}
+}
+
+func TestCyrillicSuffixFold(t *testing.T) {
+	dir := nlIndex(t,
+		"миграции таблиц падают на проде после отката",
+		"unrelated english session",
+	)
+	for _, q := range []string{"миграция падает", "миграцию откат"} {
+		result, err := SearchDetailed(dir, search.Options{Query: q, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result.Sessions) != 1 || result.Sessions[0].ID != "a" {
+			t.Fatalf("%q: sessions=%+v variants=%v", q, result.Sessions, result.Variants)
+		}
+	}
+}


### PR DESCRIPTION
Closes #261, closes #262. Stacked on #265. Substring expansion already bridges prefix abbreviations (auth->authentication) — the table covers the rest (k8s, deps, err...), shipped in the repo for review. Russian inflection gets the same treatment as English suffixes: longest known ending stripped, all endings re-tried against the token catalog. Deterministic, narrated, stem-tier only.