### PR TITLE
perf(search): rare tokens reach the postings AND

### DIFF
--- a/internal/index/identparts_test.go
+++ b/internal/index/identparts_test.go
@@ -44,3 +44,48 @@ func TestIdentifierSplitRetrieval(t *testing.T) {
 		t.Fatalf("split retrieval missed camelCase: %+v", result.Sessions)
 	}
 }
+
+func TestRetrievalKeysFetchesMoreCandidates(t *testing.T) {
+	keys := []string{"k1", "k2", "k3", "k4", "k5", "k6", "k7", "k8", "k9"}
+	got := retrievalKeys(keys)
+	if len(got) != 8 {
+		t.Fatalf("retrievalKeys cap = %d, want 8", len(got))
+	}
+	short := []string{"a", "b"}
+	if len(retrievalKeys(short)) != 2 {
+		t.Fatal("short key lists must pass through")
+	}
+}
+
+func TestWiderKeyCapShrinksCandidateSet(t *testing.T) {
+	// 40 sessions share five long common words; one also has a rare short
+	// token. The old 3-longest cap fetched only common postings (40
+	// candidates for the scan); fetching the rare token's postings too
+	// collapses the AND to 1 before any record is read.
+	texts := make([]string, 0, 40)
+	for i := 0; i < 39; i++ {
+		texts = append(texts, "performance regression investigation deployment pipeline filler")
+	}
+	texts = append(texts, "performance regression investigation deployment pipeline zzq")
+	dir := nlIndex(t, texts...)
+
+	keys := queryKeys("performance regression investigation deployment pipeline zzq")
+	oldSel := keys
+	if len(oldSel) > 3 {
+		oldSel = oldSel[:3]
+	}
+	oldPosts, err := intersectPostings(dir, oldSel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newPosts, err := intersectPostings(dir, retrievalKeys(keys))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(oldPosts) < 30 {
+		t.Fatalf("fixture broken: old-cap candidates = %d, want ~40", len(oldPosts))
+	}
+	if len(newPosts) >= len(oldPosts)/10 {
+		t.Fatalf("wide cap did not narrow candidates: old=%d new=%d", len(oldPosts), len(newPosts))
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1232,10 +1232,15 @@ func splitCompound(word []rune, out *[]string) {
 }
 
 func retrievalKeys(keys []string) []string {
-	if len(keys) <= 3 {
+	// Fetch postings for up to 8 tokens: a bucket read is sub-millisecond and
+	// intersectPostings sorts the fetched lists rarest-first with an early
+	// exit, so more keys means a more selective AND, not a slower one. The old
+	// cap of 3 longest tokens guessed at rarity by length and guessed wrong on
+	// long-but-common words.
+	if len(keys) <= 8 {
 		return keys
 	}
-	return keys[:3] // tokens() sorts longest-first; long tokens are the most selective
+	return keys[:8]
 }
 
 func queryKeys(s string) []string {


### PR DESCRIPTION
Search v2, part 1/5. Bucket reads are sub-ms; the old cap of three longest tokens dropped exactly the tokens that narrow the AND. Candidate-set test pins the effect (40 -> 1); recall floor and full suite green.