### PR TITLE
feat(search): recall-worn ranking signal

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
+	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
 var version = "dev"
@@ -239,6 +240,7 @@ func runSearch(dir string, args []string) error {
 	if err != nil {
 		return err
 	}
+	o.RecallWorn = usage.WornSessions(dir)
 	prepareFirstIndexGreeting(dir)
 	if err := index.EnsureForSearch(dir, o, force, os.Stderr); err != nil {
 		return fmt.Errorf("ensure: %w", err)

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -164,10 +164,11 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Query) == "" {
 			return "", fmt.Errorf("query required")
 		}
-		text, sessions, raw, err := recallTextResult(dir, a.Query, a.Harness, int(a.Limit), 4096-recallFrameOverhead)
+		text, sessions, raw, ids, err := recallTextResult(dir, a.Query, a.Harness, int(a.Limit), 4096-recallFrameOverhead)
 		if err == nil {
 			text = frameRecall(text)
-			usage.RecordDigest(dir, usage.KindRecall, text, sessions, raw)
+			usage.RecordServedSessions(dir, usage.KindRecall, len(text), sessions, sessions == 0, raw, ids)
+			usage.SnapshotOnly(dir, usage.KindRecall, text, sessions)
 		}
 		return text, err
 	case "recall_context":
@@ -181,10 +182,11 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Query) == "" {
 			return "", fmt.Errorf("query required")
 		}
-		text, sessions, raw, err := recallContextResult(dir, a.Query, a.Harness)
+		text, sessions, raw, ids, err := recallContextResult(dir, a.Query, a.Harness)
 		if err == nil {
 			text = frameRecall(text)
-			usage.RecordDigest(dir, usage.KindContext, text, sessions, raw)
+			usage.RecordServedSessions(dir, usage.KindContext, len(text), sessions, sessions == 0, raw, ids)
+			usage.SnapshotOnly(dir, usage.KindContext, text, sessions)
 		}
 		return text, err
 	case "blame":
@@ -257,21 +259,21 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 }
 
 func recallText(dir, q, harness string, limit, budget int) (string, error) {
-	text, _, _, err := recallTextResult(dir, q, harness, limit, budget)
+	text, _, _, _, err := recallTextResult(dir, q, harness, limit, budget)
 	return text, err
 }
 
-func recallTextResult(dir, q, harness string, limit, budget int) (string, int, int64, error) {
+func recallTextResult(dir, q, harness string, limit, budget int) (string, int, int64, []string, error) {
 	if limit <= 0 {
 		limit = 5
 	}
-	o := search.Options{Query: q, Harness: harness, All: true}
+	o := search.Options{Query: q, Harness: harness, All: true, RecallWorn: usage.WornSessions(dir)}
 	if err := index.EnsureForSearch(dir, o, false, mcpProgress()); err != nil {
-		return "", 0, 0, err
+		return "", 0, 0, nil, err
 	}
 	result, err := index.SearchWithRecoveryDetailed(dir, o, mcpProgress())
 	if err != nil {
-		return "", 0, 0, err
+		return "", 0, 0, nil, err
 	}
 	ss := result.Sessions
 	o.Tier = result.Tier
@@ -286,7 +288,7 @@ func recallTextResult(dir, q, harness string, limit, budget int) (string, int, i
 	}
 	hits, err := search.Run(ss, o)
 	if err != nil {
-		return "", 0, 0, err
+		return "", 0, 0, nil, err
 	}
 	if os.Getenv("DEJA_EMBED") != "off" {
 		hits = maybeRerank(dir, hits, o, os.Stderr)
@@ -295,7 +297,7 @@ func recallTextResult(dir, q, harness string, limit, budget int) (string, int, i
 	hits, semantic = maybeSemantic(dir, hits, o, os.Stderr)
 	o.Semantic = semantic
 	if len(hits) == 0 {
-		return fmt.Sprintf("No prior deja sessions matched %q.", q), 0, 0, nil
+		return fmt.Sprintf("No prior deja sessions matched %q.", q), 0, 0, nil, nil
 	}
 	if len(hits) > limit {
 		hits = hits[:limit]
@@ -312,6 +314,9 @@ func recallTextResult(dir, q, harness string, limit, budget int) (string, int, i
 		fmt.Fprintf(&b, "\n%d. [%s] %s · %s · %d matches", i+1, h.Session.Harness, h.Session.Project, h.Session.ID, h.Count)
 		if !h.Session.Updated.IsZero() {
 			fmt.Fprintf(&b, " · updated %s (%s)", h.Session.Updated.Format("2006-01-02"), search.RelativeDate(h.Session.Updated))
+		}
+		if h.Reused > 1 {
+			fmt.Fprintf(&b, " · reused %d×", h.Reused)
 		}
 		fmt.Fprintln(&b)
 		if h.Superseded != "" {
@@ -333,15 +338,17 @@ func recallTextResult(dir, q, harness string, limit, budget int) (string, int, i
 		out = trimUTF8(out, budget)
 	}
 	var raw int64
+	var ids []string
 	for i, h := range hits {
 		if i >= served {
 			break
 		}
+		ids = append(ids, h.Session.ID)
 		for _, m := range h.Session.Messages {
 			raw += int64(len(m.Text))
 		}
 	}
-	return out, served, raw, nil
+	return out, served, raw, ids, nil
 }
 
 func trimUTF8(s string, budget int) string {
@@ -355,18 +362,18 @@ func trimUTF8(s string, budget int) string {
 }
 
 func recallContext(dir, q string) (string, error) {
-	text, _, _, err := recallContextResult(dir, q, "")
+	text, _, _, _, err := recallContextResult(dir, q, "")
 	return text, err
 }
 
-func recallContextResult(dir, q, harness string) (string, int, int64, error) {
-	o := search.Options{Query: q, Harness: harness, All: true}
+func recallContextResult(dir, q, harness string) (string, int, int64, []string, error) {
+	o := search.Options{Query: q, Harness: harness, All: true, RecallWorn: usage.WornSessions(dir)}
 	if err := index.EnsureForSearch(dir, o, false, mcpProgress()); err != nil {
-		return "", 0, 0, err
+		return "", 0, 0, nil, err
 	}
 	result, err := index.SearchWithRecoveryDetailed(dir, o, mcpProgress())
 	if err != nil {
-		return "", 0, 0, err
+		return "", 0, 0, nil, err
 	}
 	ss := result.Sessions
 	o.Tier = result.Tier
@@ -381,7 +388,7 @@ func recallContextResult(dir, q, harness string) (string, int, int64, error) {
 	}
 	hits, err := search.Run(ss, o)
 	if err != nil {
-		return "", 0, 0, err
+		return "", 0, 0, nil, err
 	}
 	var semantic bool
 	hits, semantic = maybeSemantic(dir, hits, o, os.Stderr)
@@ -389,7 +396,7 @@ func recallContextResult(dir, q, harness string) (string, int, int64, error) {
 		o.Tier = search.TierSemantic
 	}
 	if len(hits) == 0 {
-		return fmt.Sprintf("No prior deja sessions matched %q.", q), 0, 0, nil
+		return fmt.Sprintf("No prior deja sessions matched %q.", q), 0, 0, nil, nil
 	}
 	var b bytes.Buffer
 	search.PrintContext(&b, hits[0].Session, q)
@@ -397,7 +404,7 @@ func recallContextResult(dir, q, harness string) (string, int, int64, error) {
 	if hits[0].Tier != search.TierExact {
 		text = "[" + hits[0].Tier + "]\n" + text
 	}
-	return text, 1, rawSize([]model.Session{hits[0].Session}), nil
+	return text, 1, rawSize([]model.Session{hits[0].Session}), []string{hits[0].Session.ID}, nil
 }
 
 func mcpProgress() io.Writer {

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -56,8 +56,9 @@ envelope with `schema_version`:
 ```
 
 Stemmed search may also include `variants`; semantic search sets `semantic`.
-`superseded` (added in 0.15, optional) carries the date of a newer same-project
-session whose matches overlap this hit — an earlier-attempt signal.
+`superseded` (optional) carries the date of a newer same-project session whose
+matches overlap this hit — an earlier-attempt signal. `reused` (optional)
+counts recent agent recalls that served this session.
 
 ## `deja stats --json`
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -31,6 +31,9 @@ type Options struct {
 	Semantic                  bool                `json:"-"`
 	FuzzyVariants             map[string][]string `json:"-"`
 	Tier                      string              `json:"-"`
+	// RecallWorn maps session id -> agent recall count; filled by callers
+	// from the usage log, consumed as a bounded ranking boost.
+	RecallWorn map[string]int `json:"-"`
 }
 
 const (

--- a/internal/search/ranking_test.go
+++ b/internal/search/ranking_test.go
@@ -66,3 +66,28 @@ func TestBoostsAreBounded(t *testing.T) {
 		t.Fatal("neutral cases must not boost")
 	}
 }
+
+func TestWornBoostBreaksTiesButIsCapped(t *testing.T) {
+	a := rankSession("cold", "", "jwt refresh rotation fix applied")
+	b := rankSession("worn", "", "jwt refresh rotation fix applied")
+	hits, err := Run([]model.Session{a, b}, Options{Query: "jwt refresh rotation", All: true, RecallWorn: map[string]int{"worn": 4}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hits[0].Session.ID != "worn" || hits[0].Reused != 4 {
+		t.Fatalf("worn tie-break missing: %+v", hits[0])
+	}
+	if wornBoost(1000) != 1.2 {
+		t.Fatalf("worn boost uncapped: %f", wornBoost(1000))
+	}
+	// A clearly better match must beat a worn weak one: relevance > popularity.
+	strong := rankSession("strong", "jwt refresh rotation", "jwt refresh rotation everywhere jwt refresh rotation again")
+	weak := rankSession("weakworn", "", "jwt mentioned once, refresh later, rotation at the end of a long unrelated story about deployments")
+	hits2, err := Run([]model.Session{strong, weak}, Options{Query: "jwt refresh rotation", All: true, RecallWorn: map[string]int{"weakworn": 50}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hits2[0].Session.ID != "strong" {
+		t.Fatalf("popularity outranked relevance: %+v", hits2)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -67,6 +67,8 @@ type Hit struct {
 	// Superseded holds the date of a newer session in the same project whose
 	// matches overlap this one — a signal that this hit is an earlier attempt.
 	Superseded string `json:"superseded,omitempty"`
+	// Reused counts recent agent recalls that served this session.
+	Reused int `json:"reused,omitempty"`
 }
 
 const (
@@ -196,7 +198,7 @@ func Run(ss []model.Session, o Options) ([]Hit, error) {
 	if corpusDocuments > 0 {
 		avgLength = float64(corpusLength) / float64(corpusDocuments)
 	}
-	hits := scoreBM25(documents, df, corpusDocuments, avgLength, len(qtoks))
+	hits := scoreBM25(documents, df, corpusDocuments, avgLength, len(qtoks), o.RecallWorn)
 	markEarlierAttempts(hits)
 	if !o.All && len(hits) > 15 {
 		hits = hits[:15]
@@ -266,7 +268,7 @@ func snippetOverlap(a, b map[string]bool) float64 {
 // RelativeDate is the human "3w ago" form used in listings and digests.
 func RelativeDate(t time.Time) string { return relativeDate(t) }
 
-func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLength float64, queryTokenCount int) []Hit {
+func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLength float64, queryTokenCount int, worn map[string]int) []Hit {
 	emptyQuery := queryTokenCount == 0
 	now := time.Now()
 	hits := make([]Hit, 0, len(documents))
@@ -292,6 +294,10 @@ func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLengt
 		}
 		score *= proximityBoost(doc.minWindow, queryTokenCount)
 		score *= titleBoost(doc.titleHits, queryTokenCount)
+		if n := worn[doc.hit.Session.ID]; n > 0 {
+			doc.hit.Reused = n
+			score *= wornBoost(n)
+		}
 		score *= freshnessDecay(doc.hit.Session.Updated, now)
 		doc.hit.Score = score
 		hits = append(hits, doc.hit)
@@ -351,6 +357,16 @@ func proximityBoost(window, queryTokenCount int) float64 {
 	}
 	span := float64(window)
 	boost := 1 + 0.35*(200/(200+span))
+	return boost
+}
+
+// wornBoost rewards sessions agents keep recalling — capped hard at +20% so
+// popularity can never outrank relevance, only break near-ties.
+func wornBoost(n int) float64 {
+	boost := 1 + 0.05*math.Log2(float64(1+n))
+	if boost > 1.2 {
+		return 1.2
+	}
 	return boost
 }
 
@@ -472,6 +488,13 @@ func Print(w io.Writer, hits []Hit, o Options) {
 			fmt.Fprintf(w, "%s%s %-10s %s %s %s %s %s%s%d matches%s%s\n", cBold, harnessTag(h.Session.Harness, true), h.Session.Project, cDim+"·"+cReset+cBold, d, cDim+"·"+cReset+cBold, short(h.Session.ID), cDim+"— "+cReset, cBold, h.Count, cReset, tierLabel(h))
 		} else {
 			fmt.Fprintf(w, "[%s] %-10s · %s · %s — %d matches%s\n", h.Session.Harness, h.Session.Project, d, short(h.Session.ID), h.Count, tierLabel(h))
+		}
+		if h.Reused > 1 {
+			note := fmt.Sprintf("  reused %d× by agents recently", h.Reused)
+			if color {
+				note = cDim + note + cReset
+			}
+			fmt.Fprintln(w, note)
 		}
 		if h.Superseded != "" {
 			note := "  earlier attempt — this project has a newer session on the same ground (" + h.Superseded + ")"

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -585,7 +585,7 @@ func BenchmarkBM25Scoring1000Candidates(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		hits := scoreBM25(documents, []int{1000, 1000}, 1000, 6, 2)
+		hits := scoreBM25(documents, []int{1000, 1000}, 1000, 6, 2, nil)
 		if len(hits) != len(documents) {
 			b.Fatalf("hits=%d", len(hits))
 		}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -36,6 +36,12 @@ func SnapshotPath(indexDir string) string {
 // Best-effort like all usage recording.
 func RecordDigest(indexDir, kind, digest string, sessions int, raw int64) {
 	RecordResultRaw(indexDir, kind, len(digest), sessions, sessions == 0, raw)
+	SnapshotOnly(indexDir, kind, digest, sessions)
+}
+
+// SnapshotOnly stores the digest text without writing a counting event, for
+// callers that already recorded one with extra fields.
+func SnapshotOnly(indexDir, kind, digest string, sessions int) {
 	if digest == "" {
 		return
 	}

--- a/internal/usage/snapshots_test.go
+++ b/internal/usage/snapshots_test.go
@@ -65,3 +65,17 @@ func TestEventsLimitAndOrder(t *testing.T) {
 		t.Fatalf("events = %+v", events)
 	}
 }
+
+func TestWornSessionsCountsAgentRecalls(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	RecordServedSessions(dir, KindRecall, 100, 2, false, 5000, []string{"s1", "s2"})
+	RecordServedSessions(dir, KindContext, 80, 1, false, 3000, []string{"s1"})
+	RecordDigest(dir, KindHook, "hook digest", 3, 900) // hook pushes must not count
+	worn := WornSessions(dir)
+	if worn["s1"] != 2 || worn["s2"] != 1 {
+		t.Fatalf("worn = %v", worn)
+	}
+	if len(worn) != 2 {
+		t.Fatalf("hook injection leaked into worn: %v", worn)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -32,6 +32,9 @@ type Event struct {
 	// RawBytes is the size of the source transcripts the served digest was
 	// distilled from — what the agent would have had to replay without deja.
 	RawBytes int64 `json:"raw,omitempty"`
+	// SessionIDs lists the sessions served by an agent-initiated recall, so
+	// search can weigh what agents actually re-used.
+	SessionIDs []string `json:"ids,omitempty"`
 }
 
 type Summary struct {
@@ -69,6 +72,16 @@ func RecordResult(indexDir, kind string, bytes, sessions int, empty bool) {
 // RecordResultRaw additionally stores the source-transcript size the digest
 // was distilled from, for the served-vs-replayed ratio.
 func RecordResultRaw(indexDir, kind string, bytes, sessions int, empty bool, raw int64) {
+	recordFull(indexDir, kind, bytes, sessions, empty, raw, nil)
+}
+
+// RecordServedSessions is RecordResultRaw plus the ids of the sessions the
+// digest contained.
+func RecordServedSessions(indexDir, kind string, bytes, sessions int, empty bool, raw int64, ids []string) {
+	recordFull(indexDir, kind, bytes, sessions, empty, raw, ids)
+}
+
+func recordFull(indexDir, kind string, bytes, sessions int, empty bool, raw int64, ids []string) {
 	p := Path(indexDir)
 	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
 		return
@@ -79,7 +92,7 @@ func RecordResultRaw(indexDir, kind string, bytes, sessions int, empty bool, raw
 		return
 	}
 	defer func() { _ = f.Close() }()
-	b, err := json.Marshal(Event{Time: time.Now().UTC(), Kind: kind, Bytes: bytes, Sessions: sessions, Empty: empty, RawBytes: raw})
+	b, err := json.Marshal(Event{Time: time.Now().UTC(), Kind: kind, Bytes: bytes, Sessions: sessions, Empty: empty, RawBytes: raw, SessionIDs: ids})
 	if err != nil {
 		return
 	}
@@ -237,4 +250,23 @@ func rotate(p string) {
 		return
 	}
 	_ = os.Rename(tmp, p)
+}
+
+// WornSessions counts, per session id, how often agent-initiated recalls
+// served it inside the retention window. Search uses it as a small bounded
+// boost: what agents keep pulling is what the user keeps needing.
+func WornSessions(indexDir string) map[string]int {
+	out := map[string]int{}
+	for _, e := range read(Path(indexDir)) {
+		if e.Kind != KindRecall && e.Kind != KindContext {
+			continue
+		}
+		for _, id := range e.SessionIDs {
+			out[id]++
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }


### PR DESCRIPTION
Search v2, part 4/5. The usage log already knows what agents actually re-used; MCP recall events now carry served session ids (14-day window via existing rotation), WornSessions() aggregates them, and scoring applies a log-curve boost hard-capped at +20%. Hook injections deliberately do not count — a push is not a reuse signal. Tests: aggregation excludes hooks, tie-break works, cap holds, and a strong match still beats a heavily-worn weak one.