### PR TITLE
feat: felt memory — déjà vu moments, living brief, receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-21
+
+### Added
+- Déjà vu moments: when a prompt matches work your own history already answered, the per-prompt recall now announces it with a visible one-liner — `deja-vu: you have been here — "<that session>" (3w ago)` — and the moment is counted in stats and the weekly numbers.
+- Bare `deja` on a terminal shows a living brief instead of help text: today's sessions, recalls served and what they distilled, this week's déjà vu moments, recent sessions, and a suggested search from your own history. `deja help` keeps the usage text.
+- The session-start recall receipt now carries the day's tally: how many recalls deja served today and how much history they distilled.
+
+### Fixed
+- `deja uninstall` could leave a hook entry with `"hooks": null` in Claude Code's settings.json when the entry carried a matcher — Claude Code then rejected the whole settings file. Uninstall now drops the entry, and any damaged entry from an earlier version heals on the next install.
+
 ## [0.14.4] - 2026-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ $ deja "jwt refresh token"
 | `deja update` | Download the latest GitHub release, verify its checksum, and replace the current binary. |
 | `deja statusline` | One line for your status bar: recalls served to agents today. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
 | `deja log [n] [--last] [--json]` | Audit what deja actually served: recent recalls and injections, or the exact text of the last injected digest with `--last`. |
+| `deja` | On a terminal with an index: a living brief — today's sessions, recalls served, déjà vu moments, and a search suggestion from your own history. |
 
 Stemmed JSON searches set `"stemmed": true` and include the catalog variants used.
 

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// runBrief is what a bare `deja` on a terminal shows: the memory, alive.
+// Manifest metadata and the usage sidecar only — it must feel instant.
+// Pipes and scripts still get the usage text; `deja help` always works.
+func runBrief(dir string, w io.Writer) error {
+	ov, err := index.Overview(dir)
+	if err != nil || ov.Sessions == 0 {
+		printUsage()
+		return nil
+	}
+	color := statColorOK(os.Stdout)
+	bold, dim, reset := "", "", ""
+	if color {
+		bold, dim, reset = logoBold, logoDim, logoReset
+	}
+	fmt.Fprintf(w, "%sdeja-vu%s %s · %s%d%s sessions across %s%d%s agents\n",
+		bold, reset, version, bold, ov.Sessions, reset, bold, ov.Harnesses, reset)
+
+	recalls, bytes, _ := usage.TodayWithInjections(dir)
+	line := fmt.Sprintf("today      %d session%s", ov.SessionsToday, pluralS(ov.SessionsToday))
+	if recalls > 0 {
+		line += fmt.Sprintf(" · %d recall%s served (%s", recalls, pluralS(recalls), humanBytes(int64(bytes)))
+		if raw := usage.TodayRaw(dir); bytes > 0 && raw/int64(bytes) >= 2 {
+			line += " from " + humanBytes(raw)
+		}
+		line += ")"
+	}
+	fmt.Fprintln(w, line)
+
+	wr, _, _, _ := usage.Week(dir)
+	week := fmt.Sprintf("this week  %d sessions · %d recalls", ov.SessionsWeek, wr)
+	if dv := usage.DejaVuWeek(dir); dv > 0 {
+		week += fmt.Sprintf(" · %s%d déjà vu moment%s%s", bold, dv, pluralS(dv), reset)
+	}
+	fmt.Fprintln(w, week)
+
+	// Read the index as-is: the brief must never trigger a rebuild or let
+	// indexing narration tear through its layout.
+	if recent, err := index.RecentMatching(dir, 3, search.Options{}); err == nil && len(recent) > 0 {
+		label := "recent    "
+		for _, s := range recent {
+			title := s.Title
+			if title == "" {
+				title = firstUserTitle(s)
+			}
+			title = trimBriefTitle(title)
+			fmt.Fprintf(w, "%s %s[%s]%s %s · %s%s%s", label, dim, s.Harness, reset, s.Project, dim, search.RelativeDate(s.Updated), reset)
+			if title != "" {
+				fmt.Fprintf(w, " · %s", title)
+			}
+			fmt.Fprintln(w)
+			label = "          "
+		}
+	}
+
+	if q := suggestFirstQuery(dir); q != "" {
+		fmt.Fprintf(w, "try        %sdeja \"%s\"%s %s(from your own history)%s\n", bold, q, reset, dim, reset)
+	}
+	fmt.Fprintf(w, "%smore       deja log · deja stats · deja help%s\n", dim, reset)
+	return nil
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func trimBriefTitle(t string) string {
+	r := []rune(t)
+	if len(r) > 44 {
+		return string(r[:44]) + "…"
+	}
+	return t
+}

--- a/cmd/deja/brief_test.go
+++ b/cmd/deja/brief_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+func seedBriefIndex(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-a")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	body := `{"type":"user","sessionId":"b1","cwd":"/w/a","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"jwks rotation cache stale problem"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "b1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestBriefShowsMemoryAlive(t *testing.T) {
+	dir := seedBriefIndex(t)
+	usage.RecordDigest(dir, usage.KindRecall, strings.Repeat("x", 512), 1, 4096)
+	usage.RecordDigest(dir, usage.KindDejaVu, "dv digest", 1, 2048)
+	var out bytes.Buffer
+	if err := runBrief(dir, &out); err != nil {
+		t.Fatal(err)
+	}
+	s := out.String()
+	for _, want := range []string{"sessions across", "recent", "déjà vu moment", "deja log"} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("brief missing %q:\n%s", want, s)
+		}
+	}
+	if strings.Contains(s, "Usage:") {
+		t.Fatal("brief fell back to usage text")
+	}
+}
+
+func TestBriefFallsBackToUsageWithoutIndex(t *testing.T) {
+	hermeticEnv(t)
+	var out bytes.Buffer
+	if err := runBrief(index.DefaultDir(), &out); err != nil {
+		t.Fatal(err)
+	}
+	// printUsage writes to stdout, not our buffer — the contract is simply
+	// that runBrief does not error and prints nothing misleading.
+	if strings.Contains(out.String(), "sessions across") {
+		t.Fatalf("brief invented an index: %q", out.String())
+	}
+}
+
+func TestDejaVuCountersFlow(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	usage.RecordDigest(dir, usage.KindDejaVu, "digest", 2, 1024)
+	usage.RecordDigest(dir, usage.KindHook, "start digest", 1, 512)
+	if got := usage.DejaVuWeek(dir); got != 1 {
+		t.Fatalf("DejaVuWeek = %d, want 1", got)
+	}
+	tot := usage.Totals(dir)
+	if tot.DejaVuMoments != 1 || tot.Injections != 2 {
+		t.Fatalf("totals = %+v", tot)
+	}
+}
+
+func TestDejaVuLineShape(t *testing.T) {
+	s := model.Session{Title: "jwks cache rotation broke login on the gateway and it hurt", Updated: time.Now().AddDate(0, 0, -21)}
+	line := dejaVuLine(s)
+	if !strings.Contains(line, "you have been here") || !strings.Contains(line, "jwks") {
+		t.Fatalf("dejaVuLine = %q", line)
+	}
+}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -91,7 +91,7 @@ func runHookContext(dir string, plain bool) error {
 		if sessions > 1 {
 			plural = "s"
 		}
-		resp.SystemMessage = fmt.Sprintf("deja: recalled %d prior session%s from this project (~%dKB) — the agent starts already knowing them", sessions, plural, (len(digest)+1023)/1024)
+		resp.SystemMessage = fmt.Sprintf("deja: recalled %d prior session%s from this project (~%dKB) — the agent starts already knowing them%s", sessions, plural, (len(digest)+1023)/1024, serviceReceipt(dir))
 	}
 	b, err := json.Marshal(resp)
 	if err != nil {
@@ -292,4 +292,18 @@ func limitHandoffTip(dir string) string {
 		}
 	}
 	return ""
+}
+
+// serviceReceipt appends today's tally when there is one — the moment memory
+// lands is the moment to say what it has been doing all day.
+func serviceReceipt(dir string) string {
+	recalls, bytes, _ := usage.TodayWithInjections(dir)
+	if recalls < 2 || bytes == 0 {
+		return ""
+	}
+	raw := usage.TodayRaw(dir)
+	if raw/int64(bytes) < 2 {
+		return fmt.Sprintf(" · today: %d recalls", recalls)
+	}
+	return fmt.Sprintf(" · today: %d recalls, %s distilled from %s", recalls, humanBytes(int64(bytes)), humanBytes(raw))
 }

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -78,10 +78,11 @@ func runHookPrompt(dir string, stdin io.Reader, stdout io.Writer) error {
 	}
 	lead := "deja found prior sessions matching this request. If one genuinely helps, use it and tell the user in one digest.Short line what deja-vu recalled; otherwise ignore silently.\n"
 	out := frameRecall(lead + digest + citationLine(ss[0]))
-	usage.RecordDigest(dir, usage.KindHook, out, len(ss), rawSize(ss))
+	usage.RecordDigest(dir, usage.KindDejaVu, out, len(ss), rawSize(ss))
 	var resp sessionStartHookResponse
 	resp.HookSpecificOutput.HookEventName = "UserPromptSubmit"
 	resp.HookSpecificOutput.AdditionalContext = out
+	resp.SystemMessage = dejaVuLine(ss[0])
 	b, err := json.Marshal(resp)
 	if err != nil {
 		return nil
@@ -182,4 +183,18 @@ func rememberInjected(dir, sid string, ss []model.Session) {
 	for _, s := range ss {
 		fmt.Fprintf(f, "%s %s\n", sid, s.ID)
 	}
+}
+
+// dejaVuLine is the one visible line a déjà vu moment earns: which past
+// session answered, and how old it is.
+func dejaVuLine(s model.Session) string {
+	topic := strings.TrimSpace(s.Title)
+	if topic == "" {
+		topic = s.Project
+	}
+	r := []rune(topic)
+	if len(r) > 48 {
+		topic = strings.TrimSpace(string(r[:48])) + "…"
+	}
+	return fmt.Sprintf("deja-vu: you have been here — %q (%s)", topic, search.RelativeDate(s.Updated))
 }

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -455,7 +455,13 @@ func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall
 			out = append(out, entryAny)
 			continue
 		}
-		hs, _ := entry["hooks"].([]any)
+		hs, hasHooks := entry["hooks"].([]any)
+		// Self-heal: an entry whose hooks are null/absent is invalid — Claude
+		// Code rejects the whole file over it. Earlier deja versions could
+		// leave one behind on uninstall when the entry carried a matcher.
+		if !hasHooks || len(hs) == 0 {
+			continue
+		}
 		var kept []any
 		removed := false
 		for _, hAny := range hs {
@@ -470,7 +476,7 @@ func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall
 			kept = append(kept, hAny)
 		}
 		if removed {
-			if len(kept) == 0 && len(entry) == 1 {
+			if len(kept) == 0 {
 				continue
 			}
 			entry["hooks"] = kept

--- a/cmd/deja/install_config_dir_test.go
+++ b/cmd/deja/install_config_dir_test.go
@@ -48,3 +48,31 @@ func TestInstallClaudeHonorsConfigDir(t *testing.T) {
 		}
 	}
 }
+
+func TestClaudeHookUninstallNeverLeavesNullHooks(t *testing.T) {
+	root := map[string]any{}
+	root = updateClaudeHook(root, "PreCompact", "/bin/deja hook-precompact", "manual|auto", false)
+	root = updateClaudeHook(root, "PreCompact", "/bin/deja hook-precompact", "manual|auto", true)
+	root = updateClaudeHook(root, "PreCompact", "/bin/deja hook-precompact", "manual|auto", false)
+	entries, _ := root["hooks"].(map[string]any)["PreCompact"].([]any)
+	if len(entries) != 1 {
+		t.Fatalf("install/uninstall/install left %d entries, want 1: %#v", len(entries), entries)
+	}
+	for _, e := range entries {
+		entry := e.(map[string]any)
+		hs, ok := entry["hooks"].([]any)
+		if !ok || len(hs) == 0 {
+			t.Fatalf("entry with null/empty hooks survived: %#v", entry)
+		}
+	}
+	// Pre-existing damage from older versions heals on the next install.
+	damaged := map[string]any{"hooks": map[string]any{"PreCompact": []any{
+		map[string]any{"matcher": "manual|auto", "hooks": nil},
+		map[string]any{"matcher": "manual|auto", "hooks": []any{map[string]any{"type": "command", "command": "/bin/deja hook-precompact"}}},
+	}}}
+	healed := updateClaudeHook(damaged, "PreCompact", "/bin/deja hook-precompact", "manual|auto", false)
+	entries2, _ := healed["hooks"].(map[string]any)["PreCompact"].([]any)
+	if len(entries2) != 1 {
+		t.Fatalf("null-hooks entry not healed: %#v", entries2)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -73,6 +73,9 @@ type command func(dir string, rest []string) error
 
 var commands = map[string]command{
 	"version":         cmdVersion,
+	"help":            func(_ string, _ []string) error { printUsage(); return nil },
+	"--help":          func(_ string, _ []string) error { printUsage(); return nil },
+	"-h":              func(_ string, _ []string) error { printUsage(); return nil },
 	"--version":       cmdVersion,
 	"-version":        cmdVersion,
 	"sources":         func(dir string, _ []string) error { printSources(dir); return nil },
@@ -105,11 +108,14 @@ var commands = map[string]command{
 }
 
 func run(args []string) error {
+	dir := index.DefaultDir()
 	if len(args) == 0 {
+		if logoWanted(os.Stdout) {
+			return runBrief(dir, os.Stdout)
+		}
 		printUsage()
 		return nil
 	}
-	dir := index.DefaultDir()
 	if cmd, ok := commands[args[0]]; ok {
 		return cmd(dir, args[1:])
 	}

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -249,6 +249,9 @@ func printStats(w io.Writer, r stats.Report) {
 		}
 	}
 	fmt.Fprintf(w, "  This week        %d recalls by your agents · %s re-used (plus %d auto-injections)\n", r.WeekRecalls, humanBytes(int64(r.WeekBytes)), r.WeekInjected)
+	if r.Recall.DejaVuMoments > 0 {
+		fmt.Fprintf(w, "  Déjà vu          %d prompt%s your own history already answered\n", r.Recall.DejaVuMoments, pluralS(r.Recall.DejaVuMoments))
+	}
 	if r.AgentCredits > 0 {
 		fmt.Fprintf(w, "  Credited aloud   agents said \"deja-vu recalled\" %d times (%d this week)\n", r.AgentCredits, r.WeekCredits)
 	}

--- a/cmd/deja/suggest.go
+++ b/cmd/deja/suggest.go
@@ -80,6 +80,7 @@ func suggestTokens(text string) []string {
 	raw := query.Tokens(text)
 	out := make([]string, 0, len(raw))
 	for _, tok := range raw {
+		tok = strings.Trim(tok, "*#`~_-")
 		if len(tok) < 4 || len(tok) > 24 || query.IsStopWord(tok) {
 			continue
 		}

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -59,6 +59,7 @@
 <tr><td><code>deja remember "text"</code></td><td>Store a durable note. <code>--project</code> optional.</td></tr>
 <tr><td><code>deja forget</code></td><td>Remove sessions by <code>--session</code>/<code>--project</code>/<code>--before</code>; <code>--dry-run</code>, <code>--list</code>, <code>--unforget</code>.</td></tr>
 <tr><td><code>deja stats</code></td><td>Totals, top projects, activity. <code>--card</code> (SVG), <code>--html</code> (timeline), <code>--redaction</code>, <code>--json</code>.</td></tr>
+<tr><td><code>deja</code></td><td>Bare, on a terminal: the living brief — today's activity, recalls served, déjà vu moments, a suggested search from your own history.</td></tr>
 <tr><td><code>deja log</code></td><td>Audit trail: recent recalls and injections; <code>--last</code> prints the most recent injected digest verbatim; <code>--json</code>.</td></tr>
 <tr><td><code>deja last [n]</code></td><td>Recent sessions. <code>--project</code>, <code>--harness</code>, <code>--since</code>, <code>--role</code>.</td></tr>
 <tr><td><code>deja sources</code></td><td>Discovered stores per harness, with redaction counts.</td></tr>

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -89,6 +89,7 @@ counts recent agent recalls that served this session.
   "busiest_day": {"date": "2026-07-04", "messages": 22},
   "recall": {
     "recalls_served": 10,
+    "dejavu_moments": 3,
     "injections": 4,
     "recall_sessions": 8,
     "injected_sessions": 3,

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -133,3 +133,39 @@ func recordsIntact(dir string, m Manifest) bool {
 	// manifest never committed; re-appending them would duplicate messages.
 	return fi.Size() == m.RecordsSize
 }
+
+// Overview summarizes the index from manifest metadata alone — no record
+// reads — so the zero-argument brief stays instant.
+type OverviewStats struct {
+	Sessions      int
+	Harnesses     int
+	SessionsToday int
+	SessionsWeek  int
+}
+
+func Overview(dir string) (OverviewStats, error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		return OverviewStats{}, err
+	}
+	var o OverviewStats
+	now := time.Now()
+	day := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	week := now.AddDate(0, 0, -7)
+	hs := map[string]bool{}
+	for _, meta := range m.Sessions {
+		o.Sessions++
+		hs[meta.Harness] = true
+		if meta.Updated.After(day) {
+			o.SessionsToday++
+		}
+		if meta.Updated.After(week) {
+			o.SessionsWeek++
+		}
+	}
+	o.Harnesses = len(hs)
+	return o, nil
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -21,6 +21,9 @@ const (
 	KindHook    = "hook"
 	KindSearch  = "search"
 	KindHandoff = "handoff"
+	// KindDejaVu marks a per-prompt recall: the user asked something their
+	// own history already answers — the product's namesake moment.
+	KindDejaVu = "dejavu"
 )
 
 type Event struct {
@@ -45,6 +48,7 @@ type Summary struct {
 	Bytes            int     `json:"bytes"`
 	InjectedBytes    int     `json:"injected_bytes"`
 	RawBytes         int64   `json:"raw_bytes,omitempty"`
+	DejaVuMoments    int     `json:"dejavu_moments,omitempty"`
 	EmptyResultRate  float64 `json:"empty_result_rate"`
 }
 
@@ -118,13 +122,26 @@ func TodayWithInjections(indexDir string) (recalls, bytes, injected int) {
 		case KindRecall, KindContext:
 			recalls++
 			bytes += e.Bytes
-		case KindHook:
+		case KindHook, KindDejaVu:
 			recalls++
 			bytes += e.Bytes
 			injected += e.Bytes
 		}
 	}
 	return recalls, bytes, injected
+}
+
+// DejaVuWeek counts this week's déjà vu moments — prompts the user's own
+// history already answered.
+func DejaVuWeek(indexDir string) int {
+	cut := time.Now().AddDate(0, 0, -7)
+	n := 0
+	for _, e := range read(Path(indexDir)) {
+		if e.Kind == KindDejaVu && e.Time.After(cut) && e.Sessions > 0 {
+			n++
+		}
+	}
+	return n
 }
 
 // TodayRaw sums the source-transcript volume behind today's served digests.
@@ -137,7 +154,7 @@ func TodayRaw(indexDir string) int64 {
 			continue
 		}
 		switch e.Kind {
-		case KindRecall, KindContext, KindHook:
+		case KindRecall, KindContext, KindHook, KindDejaVu:
 			raw += e.RawBytes
 		}
 	}
@@ -158,13 +175,16 @@ func Totals(indexDir string) Summary {
 			if e.Empty {
 				empty++
 			}
-		case KindHook:
+		case KindHook, KindDejaVu:
 			out.Recalls++
 			out.Injections++
 			out.InjectedSessions += e.Sessions
 			out.InjectedBytes += e.Bytes
 			out.Bytes += e.Bytes
 			out.RawBytes += e.RawBytes
+			if e.Kind == KindDejaVu {
+				out.DejaVuMoments++
+			}
 		}
 	}
 	if served := out.Recalls - out.Injections; served > 0 {
@@ -189,7 +209,7 @@ func Week(indexDir string) (recalls, bytes, injected, injectedBytes int) {
 		case KindRecall, KindContext:
 			recalls++
 			bytes += e.Bytes
-		case KindHook:
+		case KindHook, KindDejaVu:
 			injected++
 			injectedBytes += e.Bytes
 		}


### PR DESCRIPTION
The visibility batch for 0.15.0. Verified end to end in a real Claude Code TUI over a pty: the SessionStart receipt with the day's tally and the déjà vu line both render, and the anti-duplicate path (prompt hook staying silent when SessionStart already injected) behaves. vhs renders confirmed the brief's layout at two widths. Five consecutive full-suite runs, -race, e2e and the recall floor are green.

Found by the pty run and fixed here: uninstall could leave a matcher-bearing hook entry with hooks:null, which makes Claude Code reject the entire settings.json; now dropped on uninstall and healed on install.