### PR TITLE
docs: 0.15.0 surface updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | **Sync** | `deja sync ssh laptop` — your memory follows you between machines, append-only, idempotent, no cloud in the middle |
 | **Handoff** | `deja handoff --to codex` — stuck in one agent? package the live context and continue in another: `codex "$(deja handoff --to codex)"` |
 | **Auto-recall** | `install --auto` adds a SessionStart hook: relevant memory lands in context before you ask; Claude Code also captures the current transcript before compaction |
+| **Déjà vu moments** | When a prompt matches work your history already answered, deja announces it — *you have been here* — with the session and its age, and counts the moment in `deja stats` |
 | **Redaction** | API keys, JWTs, private keys are stripped at index time — the cache is safe to keep |
 | **Stats** | `deja stats` — your agent work, wrapped: harnesses, top projects, activity sparkline |
 | **Share** | `deja share <id>` — hand a colleague a sanitized digest of a session, secrets already scrubbed |

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -65,6 +65,8 @@
 <h2>Windows</h2>
 <div class="note">On Windows, stdio MCP clients spawn through <code>cmd /c deja mcp</code>. <code>deja install</code> writes that form automatically.</div>
 
+<h2>Seeing it work</h2>
+<p>Memory that lands silently builds no habit, so the hooks talk — once, when it matters. The session-start receipt names how many sessions were recalled and the day's tally; a per-prompt match on already-solved work announces <code>deja-vu: you have been here — "&lt;that session&gt;" (3w ago)</code>; and <code>deja log --last</code> replays the exact digest an agent received.</p>
 </article>
 </div>
 <footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -347,7 +347,7 @@ footer .spacer{flex:1}
 
 <section class="reveal">
   <p class="shead"><span class="p">$</span> <span class="cmd">deja mcp</span> <span class="out"># what your agent does with it</span></p>
-  <p class="slead">After <span class="cmd">deja install --all</span>, every agent with an MCP client gets a <span class="cmd">recall</span> tool (aider's CLI has none — its history is still indexed). Add <span class="cmd">--auto</span> for session-start auto-recall where the agent supports it.</p>
+  <p class="slead">After <span class="cmd">deja install --all</span>, every agent with an MCP client gets a <span class="cmd">recall</span> tool (aider's CLI has none — its history is still indexed). Add <span class="cmd">--auto</span> for session-start auto-recall where the agent supports it — and when a prompt matches work your history already answered, deja says so out loud: <span class="q">deja-vu: you have been here</span>.</p>
   <div class="replay">
     <p class="u"><span class="who">you ›</span> have we dealt with jwt refresh rotation before? check your memory</p>
     <p class="tool">→ recall("jwt refresh rotation") · 1 match · 3.2 KB</p>
@@ -381,6 +381,7 @@ footer .spacer{flex:1}
       <dt>deja share &lt;id&gt;</dt><dd>hand a colleague a sanitized digest — problem, key conclusions, secrets already scrubbed.</dd>
       <dt>deja stats</dt><dd>sessions, top projects, activity sparkline. <span class="dim">Your agent year, one screenshot.</span></dd>
       <dt>deja log</dt><dd>audit trail: what was recalled or injected, when, into which agent — <span class="dim">--last prints the exact digest an agent received.</span></dd>
+      <dt>deja</dt><dd>bare, on a terminal: the living brief — today's sessions, recalls served, déjà vu moments, a suggested search from your own history.</dd>
     </dl>
   </div>
   <p class="slead" style="margin-top:16px">Secrets never reach the index: API keys, JWTs, private-key blocks and bare high-entropy values in secret-shaped spots are stripped at ingest — the cache is safe to keep, shares and exports are safe to send.</p>


### PR DESCRIPTION
Déjà vu moments and the living brief reach the README feature table, the site help section, and the agents guide; repo description refreshed.