### PR TITLE
feat(doctor): --deep index verification

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -67,7 +67,7 @@ _deja_completion() {
             COMPREPLY=( $(compgen -W "bash zsh fish" -- "$cur") )
             ;;
         doctor)
-            COMPREPLY=( $(compgen -W "--json --offline" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--json --offline --deep" -- "$cur") )
             ;;
         forget)
             COMPREPLY=( $(compgen -W "--list --dry-run --session --project --before --unforget" -- "$cur") )
@@ -193,7 +193,7 @@ _deja() {
       _values 'shell' bash zsh fish
       ;;
     doctor)
-      _arguments '--json[print JSON]' '--offline[skip version check]'
+      _arguments '--json[print JSON]' '--offline[skip version check]' '--deep[verify index against sources]'
       ;;
     forget)
       _arguments '--list[list tombstones]' '--dry-run[show changes without applying]' '--session=[session ID prefix]:session:' '--project=[project substring]:project:' '--before=[duration or date]:time:' '--unforget=[tombstone ID]:ID:'
@@ -272,6 +272,7 @@ complete -c deja -n '__fish_seen_subcommand_from context' -l json
 complete -c deja -n '__fish_seen_subcommand_from context' -l seed -r
 complete -c deja -n '__fish_seen_subcommand_from doctor' -l json
 complete -c deja -n '__fish_seen_subcommand_from doctor' -l offline
+complete -c deja -n '__fish_seen_subcommand_from doctor' -l deep
 complete -c deja -n '__fish_seen_subcommand_from forget' -l list
 complete -c deja -n '__fish_seen_subcommand_from forget' -l dry-run
 complete -c deja -n '__fish_seen_subcommand_from forget' -l session -r

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -43,6 +43,7 @@ func defaultDoctorVersionLookup() doctorVersionLookup {
 // both human and JSON reports keep exit status 0.
 func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir string) error {
 	jsonOutput := false
+	deep := false
 	offline := os.Getenv("DEJA_OFFLINE") == "1"
 	for _, arg := range args {
 		switch arg {
@@ -50,6 +51,8 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir strin
 			jsonOutput = true
 		case "--offline":
 			offline = true
+		case "--deep":
+			deep = true
 		default:
 			return fmt.Errorf("doctor: unknown flag %q", arg)
 		}
@@ -58,10 +61,22 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir strin
 		lookup = nil
 	}
 	report := collectDoctorReport(lookup, dir)
+	var deepReport *index.DeepReport
+	if deep {
+		dr, err := index.DeepVerify(dir)
+		if err != nil {
+			return fmt.Errorf("doctor: deep verify: %w", err)
+		}
+		deepReport = &dr
+		report.Deep = deepReport
+	}
 	if jsonOutput {
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
-		return enc.Encode(report)
+		if err := enc.Encode(report); err != nil {
+			return err
+		}
+		return deepDriftErr(deepReport)
 	}
 	doctorHarnesses(w)
 	for _, store := range report.Stores {
@@ -89,7 +104,40 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir strin
 	} else {
 		doctorVersion(w, func() (string, bool) { return report.Version.Latest, report.Version.Latest != "" })
 	}
-	return nil
+	if deepReport != nil {
+		fmt.Fprintln(w)
+		doctorDeep(w, *deepReport)
+	}
+	return deepDriftErr(deepReport)
+}
+
+// doctorDeep prints the source-vs-index proof. Everything above it is deja
+// trusting its own bookkeeping; this section is the recount.
+func doctorDeep(w io.Writer, r index.DeepReport) {
+	fmt.Fprintln(w, "Deep verification:")
+	fmt.Fprintf(w, "  checked  %s, %s, %s re-parsed, %s resolved\n",
+		doctorCount(r.FilesChecked, "source file"),
+		doctorCount(r.SessionsIndexed, "indexed session"),
+		doctorCount(r.SampledFiles, "sampled file"),
+		doctorCount(r.SampledPostings, "posting"))
+	if len(r.Stale) > 0 {
+		fmt.Fprintf(w, "  stale    %s changed since last pass — `deja index` will absorb them\n", doctorCount(len(r.Stale), "source"))
+	}
+	if r.Clean() {
+		fmt.Fprintln(w, "  status   index matches sources — no memory lost")
+		return
+	}
+	for _, f := range r.Findings {
+		fmt.Fprintf(w, "  drift    [%s] %s\n", f.Kind, f.Detail)
+	}
+	fmt.Fprintf(w, "  status   %s — run `deja index --rebuild`\n", doctorCount(len(r.Findings), "finding"))
+}
+
+func deepDriftErr(r *index.DeepReport) error {
+	if r == nil || r.Clean() {
+		return nil
+	}
+	return fmt.Errorf("doctor: index drift detected (%s) — run `deja index --rebuild`", doctorCount(len(r.Findings), "finding"))
 }
 
 func doctorHooks(w io.Writer) {

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -43,6 +43,7 @@ type doctorReport struct {
 	Version       doctorVersionReport            `json:"version"`
 	Embed         *doctorEmbedReport             `json:"embed,omitempty"`
 	Ingest        map[string]index.HarnessIngest `json:"ingest_health,omitempty"`
+	Deep          *index.DeepReport              `json:"deep,omitempty"`
 }
 
 type doctorEmbedReport struct {

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -436,5 +437,62 @@ func writeFileMkdir(t *testing.T, path, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestDoctorDeepCleanAndDrift(t *testing.T) {
+	hermeticEnv(t)
+	src := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-tmp-proj", "sess.jsonl")
+	writeClaudeFixture(t, src, "sess", []string{
+		`{"type":"user","sessionId":"sess","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"deep verify me"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := runDoctor(&out, []string{"--deep", "--offline"}, nil, dir); err != nil {
+		t.Fatalf("clean deep doctor must exit 0: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "Deep verification:") || !strings.Contains(got, "index matches sources") {
+		t.Fatalf("missing clean deep section:\n%s", got)
+	}
+
+	if err := os.Remove(src); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	err := runDoctor(&out, []string{"--deep", "--offline"}, nil, dir)
+	if err == nil || !strings.Contains(err.Error(), "index drift") {
+		t.Fatalf("deleted source must fail deep doctor, err=%v", err)
+	}
+	if !strings.Contains(out.String(), "orphan-file") || !strings.Contains(out.String(), "deja index --rebuild") {
+		t.Fatalf("drift output missing finding or fix hint:\n%s", out.String())
+	}
+}
+
+func TestDoctorDeepJSON(t *testing.T) {
+	hermeticEnv(t)
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-tmp-proj", "s.jsonl"), "s", []string{
+		`{"type":"user","sessionId":"s","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"json deep"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := runDoctor(&out, []string{"--deep", "--json", "--offline"}, nil, dir); err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Deep *index.DeepReport `json:"deep"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Deep == nil || got.Deep.FilesChecked != 1 || !got.Deep.Clean() {
+		t.Fatalf("json deep report wrong: %#v", got.Deep)
 	}
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -807,7 +807,7 @@ Usage:
   deja completion <bash|zsh|fish>
   deja forget --session <id-prefix> [--project <substring>] [--before <duration|date>] [--dry-run]
   deja forget --list | --unforget <id>
-  deja doctor [--json]
+  deja doctor [--json] [--deep]
   deja warmup
   deja index [--rebuild]
   deja embed

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -66,7 +66,7 @@
 <tr><td><code>deja install &lt;target|--all|--auto&gt;</code></td><td>Wire MCP recall (and hooks) into your agents.</td></tr>
 <tr><td><code>deja embed</code></td><td>Build the semantic vector sidecar from a local endpoint.</td></tr>
 <tr><td><code>deja sync export/import/ssh</code></td><td>Move redacted memory between machines.</td></tr>
-<tr><td><code>deja doctor</code></td><td>Diagnose stores, wiring, index and version. <code>--json</code>, <code>--offline</code>.</td></tr>
+<tr><td><code>deja doctor</code></td><td>Diagnose stores, wiring, index and version. <code>--json</code>, <code>--offline</code>. <code>--deep</code> re-parses a sample of source files and resolves postings to prove the index against the sources; exits non-zero on drift.</td></tr>
 <tr><td><code>deja bench recall|context</code></td><td>Reproducible search-quality and context-readiness benchmarks.</td></tr>
 <tr><td><code>deja update</code></td><td>Update a standalone install (Homebrew/npm update via the package manager).</td></tr>
 </tbody></table>

--- a/internal/index/deepverify.go
+++ b/internal/index/deepverify.go
@@ -1,0 +1,190 @@
+package index
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// Deep verification proves the index against the sources instead of trusting
+// its own bookkeeping. The category's worst failure class is a green health
+// check over silently lost memory; this is the antidote: recount, re-parse a
+// deterministic sample, and resolve a sample of postings to live records.
+// It never mutates anything — it reports drift and the command that fixes it.
+
+type DeepFinding struct {
+	Kind   string `json:"kind"` // shrunk-file, orphan-file, parse-drift, dead-posting, torn-log
+	Detail string `json:"detail"`
+}
+
+type DeepReport struct {
+	FilesChecked    int `json:"files_checked"`
+	SessionsIndexed int `json:"sessions_indexed"`
+	SampledFiles    int `json:"sampled_files"`
+	SampledPostings int `json:"sampled_postings"`
+	// Stale lists sources that changed or appeared since the last index pass.
+	// That is ordinary life between passes — `deja index` absorbs it. Only
+	// Findings mean the index disagrees with what it already claimed to hold.
+	Stale    []string      `json:"stale,omitempty"`
+	Findings []DeepFinding `json:"findings,omitempty"`
+}
+
+func (r DeepReport) Clean() bool { return len(r.Findings) == 0 }
+
+const (
+	deepParseSample   = 5
+	deepPostingSample = 32
+)
+
+// DeepVerify compares the live index with the source stores. Sampling is
+// deterministic (path/token hashes), so repeated runs agree with each other.
+func DeepVerify(dir string) (DeepReport, error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	unlock, err := lockDir(dir)
+	if err != nil {
+		return DeepReport{}, err
+	}
+	defer unlock()
+	m, err := readManifest(dir)
+	if err != nil {
+		return DeepReport{}, fmt.Errorf("manifest: %w", err)
+	}
+	report := DeepReport{SessionsIndexed: len(m.Sessions)}
+
+	// 1. File inventory. New or grown files are ordinary staleness — sessions
+	// keep growing between passes. A file that shrank, or one the manifest
+	// knows but the disk lost, means the index claims memory it cannot back.
+	current := currentFiles("")
+	report.FilesChecked = len(current)
+	inSync := map[string]FileState{}
+	for p, st := range current {
+		old, ok := m.Files[p]
+		switch {
+		case !ok:
+			report.Stale = append(report.Stale, p)
+		case st.Size < old.Size:
+			report.Findings = append(report.Findings, DeepFinding{Kind: "shrunk-file", Detail: fmt.Sprintf("%s shrank from %d to %d bytes since indexing", p, old.Size, st.Size)})
+		case old.Size != st.Size || old.MTime != st.MTime:
+			report.Stale = append(report.Stale, p)
+		default:
+			inSync[p] = st
+		}
+	}
+	for p := range m.Files {
+		if _, ok := current[p]; !ok {
+			report.Findings = append(report.Findings, DeepFinding{Kind: "orphan-file", Detail: p + " is in the manifest but no longer on disk"})
+		}
+	}
+	sort.Strings(report.Stale)
+
+	// 2. Parse drift: deterministically sample in-sync source files (stale
+	// ones legitimately hold more than the index), full-parse them fresh, and
+	// compare per-session message counts with the index. A record log that
+	// cannot be walked is itself the worst finding, not an abort.
+	indexedCounts, cerr := indexedMessageCounts(dir)
+	if cerr != nil {
+		report.Findings = append(report.Findings, DeepFinding{Kind: "torn-log", Detail: "records.bin unreadable: " + cerr.Error()})
+	}
+	for _, p := range samplePaths(inSync, deepParseSample) {
+		if cerr != nil {
+			break
+		}
+		kind, ok := sources.KindForPathKind(p)
+		if !ok {
+			continue
+		}
+		ss, perr := kind.Parse(p, 0)
+		if perr != nil {
+			report.Findings = append(report.Findings, DeepFinding{Kind: "parse-drift", Detail: p + ": " + perr.Error()})
+			continue
+		}
+		report.SampledFiles++
+		seen := msgSeen{}
+		for _, s := range ss {
+			key := s.Harness + ":" + s.ID
+			if _, known := m.Sessions[key]; !known {
+				report.Findings = append(report.Findings, DeepFinding{Kind: "parse-drift", Detail: key + " parses from " + p + " but is absent from the index"})
+				continue
+			}
+			// Count with the same dedup ingestion applies, so duplicate
+			// messages in the source do not read as lost memory.
+			want := 0
+			for _, msg := range s.Messages {
+				if !seen.dup(key, msg.Role, msg.Time, msg.Text) {
+					want++
+				}
+			}
+			if got := indexedCounts[key]; got < want {
+				report.Findings = append(report.Findings, DeepFinding{Kind: "parse-drift", Detail: fmt.Sprintf("%s: source parses %d messages, index holds %d", key, want, got)})
+			}
+		}
+	}
+
+	// 3. Dead postings: a sample of tokens must resolve to readable records.
+	catalog, err := tokenCatalog(dir)
+	if err == nil {
+		f, ferr := os.Open(recordsPath(dir))
+		if ferr == nil {
+			defer func() { _ = f.Close() }()
+			for _, tok := range sampleTokens(catalog, deepPostingSample) {
+				posts, perr := postingsFor(dir, "t"+tok)
+				if perr != nil || len(posts) == 0 {
+					continue
+				}
+				report.SampledPostings++
+				if _, rerr := readRecordAt(f, posts[0].Off); rerr != nil {
+					report.Findings = append(report.Findings, DeepFinding{Kind: "dead-posting", Detail: fmt.Sprintf("token %q points at unreadable record offset %d", tok, posts[0].Off)})
+				}
+			}
+		}
+	}
+	return report, nil
+}
+
+func recordsPath(dir string) string { return filepath.Join(dir, "records.bin") }
+
+// indexedMessageCounts counts records per session key straight from the log.
+func indexedMessageCounts(dir string) (map[string]int, error) {
+	counts := map[string]int{}
+	err := eachRecord(recordsPath(dir), func(r Record) {
+		counts[r.Key]++
+	})
+	return counts, err
+}
+
+func hash64(s string) uint64 {
+	h := sha256.Sum256([]byte(s))
+	return binary.BigEndian.Uint64(h[:8])
+}
+
+func samplePaths(files map[string]FileState, n int) []string {
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Slice(paths, func(i, j int) bool { return hash64(paths[i]) < hash64(paths[j]) })
+	if len(paths) > n {
+		paths = paths[:n]
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func sampleTokens(catalog map[string]bool, n int) []string {
+	toks := make([]string, 0, len(catalog))
+	for t := range catalog {
+		toks = append(toks, t)
+	}
+	sort.Slice(toks, func(i, j int) bool { return hash64(toks[i]) < hash64(toks[j]) })
+	if len(toks) > n {
+		toks = toks[:n]
+	}
+	return toks
+}

--- a/internal/index/deepverify_test.go
+++ b/internal/index/deepverify_test.go
@@ -1,0 +1,175 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// deepFixture builds a real index over one claude session and returns the
+// index dir plus the source file path, fully isolated from the machine.
+func deepFixture(t *testing.T) (dir, src string) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir = filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-x")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src = filepath.Join(proj, "s1.jsonl")
+	data := `{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"fix the flaky auth token test"}}` + "\n" +
+		`{"type":"assistant","sessionId":"s1","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"text","text":"expiry check used < instead of <="}]}}` + "\n"
+	if err := os.WriteFile(src, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir, src
+}
+
+func findingKinds(r DeepReport) map[string]bool {
+	kinds := map[string]bool{}
+	for _, f := range r.Findings {
+		kinds[f.Kind] = true
+	}
+	return kinds
+}
+
+func TestDeepVerifyCleanIndex(t *testing.T) {
+	dir, _ := deepFixture(t)
+	r, err := DeepVerify(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Clean() {
+		t.Fatalf("fresh index must verify clean, got %#v", r.Findings)
+	}
+	if r.FilesChecked != 1 || r.SessionsIndexed != 1 || r.SampledFiles != 1 {
+		t.Fatalf("counts = files=%d sessions=%d sampled=%d, want 1/1/1", r.FilesChecked, r.SessionsIndexed, r.SampledFiles)
+	}
+	if r.SampledPostings == 0 {
+		t.Fatal("expected at least one posting resolved")
+	}
+}
+
+func TestDeepVerifyTreatsNewAndGrownFilesAsStale(t *testing.T) {
+	dir, src := deepFixture(t)
+	extra := filepath.Join(filepath.Dir(src), "s2.jsonl")
+	line := `{"type":"user","sessionId":"s2","timestamp":"2026-01-03T03:04:05Z","message":{"role":"user","content":"new session never indexed"}}` + "\n"
+	if err := os.WriteFile(extra, []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(src, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:05:05Z","message":{"role":"user","content":"appended after the index pass"}}` + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+	r, err := DeepVerify(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Stale) != 2 {
+		t.Fatalf("new + appended files are staleness, not drift: stale=%v findings=%#v", r.Stale, r.Findings)
+	}
+	if !r.Clean() {
+		t.Fatalf("staleness must not read as drift, got %#v", r.Findings)
+	}
+}
+
+func TestDeepVerifyFlagsShrunkSource(t *testing.T) {
+	dir, src := deepFixture(t)
+	fi, err := os.Stat(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Truncate(src, fi.Size()/2); err != nil {
+		t.Fatal(err)
+	}
+	r, err := DeepVerify(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !findingKinds(r)["shrunk-file"] {
+		t.Fatalf("want shrunk-file, got stale=%v findings=%#v", r.Stale, r.Findings)
+	}
+}
+
+func TestDeepVerifyFlagsDeletedSource(t *testing.T) {
+	dir, src := deepFixture(t)
+	if err := os.Remove(src); err != nil {
+		t.Fatal(err)
+	}
+	r, err := DeepVerify(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !findingKinds(r)["orphan-file"] {
+		t.Fatalf("want orphan-file for deleted source, got %#v", r.Findings)
+	}
+}
+
+func TestDeepVerifyFlagsSessionMissingFromIndex(t *testing.T) {
+	dir, _ := deepFixture(t)
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for k := range m.Sessions {
+		delete(m.Sessions, k)
+	}
+	if err := writeManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	r, err := DeepVerify(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hit bool
+	for _, f := range r.Findings {
+		if f.Kind == "parse-drift" && strings.Contains(f.Detail, "absent from the index") {
+			hit = true
+		}
+	}
+	if !hit {
+		t.Fatalf("want parse-drift for session missing from index, got %#v", r.Findings)
+	}
+}
+
+func TestDeepVerifyFlagsTruncatedRecords(t *testing.T) {
+	dir, _ := deepFixture(t)
+	if err := os.Truncate(recordsPath(dir), 3); err != nil {
+		t.Fatal(err)
+	}
+	r, err := DeepVerify(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kinds := findingKinds(r)
+	if !kinds["torn-log"] && !kinds["dead-posting"] {
+		t.Fatalf("truncated records.bin must surface torn-log or dead-posting, got %#v", r.Findings)
+	}
+}
+
+func TestDeepVerifyDeterministicSampling(t *testing.T) {
+	dir, _ := deepFixture(t)
+	a, err := DeepVerify(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := DeepVerify(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.SampledFiles != b.SampledFiles || a.SampledPostings != b.SampledPostings {
+		t.Fatalf("sampling must be deterministic: %d/%d vs %d/%d", a.SampledFiles, a.SampledPostings, b.SampledFiles, b.SampledPostings)
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -239,3 +239,16 @@ func KindForPath(p string) string {
 	}
 	return ""
 }
+
+// KindForPathKind returns the full FileKind whose Match accepts p, for
+// callers that need to parse, not just classify.
+func KindForPathKind(p string) (FileKind, bool) {
+	for _, h := range Registry() {
+		for _, k := range h.Kinds {
+			if k.Match(p) {
+				return k, true
+			}
+		}
+	}
+	return FileKind{}, false
+}


### PR DESCRIPTION
Adds `deja doctor --deep`: file inventory against the manifest, deterministic re-parse sample compared to indexed message counts, and a posting sample resolved to live records. Staleness is reported separately from drift; only drift exits non-zero. Closes #278.