### PR TITLE
feat(hooks): task-aware session-start recall

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -60,7 +60,7 @@ func runHookContext(dir string, plain bool) error {
 		Source string `json:"source"`
 	}
 	_ = json.NewDecoder(os.Stdin).Decode(&input)
-	digest, sessions, raw := hookDigestResult(dir)
+	digest, sessions, raw, taskMatched := hookDigestResult(dir)
 	if digest == "" {
 		return nil
 	}
@@ -91,7 +91,13 @@ func runHookContext(dir string, plain bool) error {
 		if sessions > 1 {
 			plural = "s"
 		}
-		resp.SystemMessage = fmt.Sprintf("deja: recalled %d prior session%s from this project (~%dKB) — the agent starts already knowing them%s", sessions, plural, (len(digest)+1023)/1024, serviceReceipt(dir))
+		// The receipt says why these sessions and not just "recent": when the
+		// working tree pointed at them, name the files that did it.
+		why := "from this project"
+		if len(taskMatched) > 0 {
+			why = "touching " + strings.Join(taskMatched, ", ")
+		}
+		resp.SystemMessage = fmt.Sprintf("deja: recalled %d prior session%s %s (~%dKB) — the agent starts already knowing them%s", sessions, plural, why, (len(digest)+1023)/1024, serviceReceipt(dir))
 	}
 	b, err := json.Marshal(resp)
 	if err != nil {
@@ -121,26 +127,26 @@ func receiptIsNews(dir, digest string) bool {
 }
 
 func hookDigest(dir string) string {
-	digest, _, _ := hookDigestResult(dir)
+	digest, _, _, _ := hookDigestResult(dir)
 	return digest
 }
 
-func hookDigestResult(dir string) (string, int, int64) {
+func hookDigestResult(dir string) (string, int, int64, []string) {
 	defer func() { _ = recover() }()
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL")))
 	if mode == search.RecallOff {
-		return "", 0, 0
+		return "", 0, 0, nil
 	}
 	if !index.HasManifest(dir) {
 		requestWarmup(dir)
-		return "", 0, 0
+		return "", 0, 0, nil
 	}
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
 	if cwd == "" {
 		var err error
 		cwd, err = os.Getwd()
 		if err != nil {
-			return "", 0, 0
+			return "", 0, 0, nil
 		}
 	}
 	names := []string{sources.ClaudeProjectName(cwd)}
@@ -165,8 +171,16 @@ func hookDigestResult(dir string) (string, int, int64) {
 			}
 		}
 	}
+	// The task signal decides how wide the candidate pool is: with changed
+	// files to match against, older sessions are worth considering; without
+	// it, recency alone decides and a small pool is enough.
+	taskFiles := changedTaskFiles(cwd)
+	perName := 3
+	if len(taskFiles) > 0 {
+		perName = 12
+	}
 	for _, name := range lookupNames {
-		got, err := index.RecentProject(dir, name, 3)
+		got, err := index.RecentProject(dir, name, perName)
 		if err != nil {
 			continue
 		}
@@ -183,14 +197,23 @@ func hookDigestResult(dir string) (string, int, int64) {
 		}
 	}
 	if len(ss) == 0 {
-		return "", 0, 0
+		return "", 0, 0, nil
 	}
-	sort.Slice(ss, func(i, j int) bool { return ss[i].Updated.After(ss[j].Updated) })
+	scores, matched := taskScores(ss, taskFiles)
+	sort.Slice(ss, func(i, j int) bool {
+		if scores[ss[i].Harness+":"+ss[i].ID] != scores[ss[j].Harness+":"+ss[j].ID] {
+			return scores[ss[i].Harness+":"+ss[i].ID] > scores[ss[j].Harness+":"+ss[j].ID]
+		}
+		return ss[i].Updated.After(ss[j].Updated)
+	})
 	if len(ss) > 12 {
 		ss = ss[:12]
 	}
-	result := search.BuildAutoRecall(ss, search.AutoRecallOptions{Mode: mode, ProjectNames: names})
-	return result.Text, result.Sessions, rawSize(ss)
+	result := search.BuildAutoRecall(ss, search.AutoRecallOptions{Mode: mode, ProjectNames: names, TaskScores: scores})
+	if result.Sessions == 0 {
+		matched = nil
+	}
+	return result.Text, result.Sessions, rawSize(ss), matched
 }
 
 func requestWarmup(dir string) {

--- a/cmd/deja/hook_task.go
+++ b/cmd/deja/hook_task.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Task-aware session-start recall: there is no prompt at session start, but
+// the repository says what the work is about. Sessions that mention the files
+// the working tree is touching outrank plain recency.
+
+const taskFileCap = 8
+
+var taskNoiseFiles = map[string]bool{
+	"go.sum": true, "go.mod": true, "package-lock.json": true,
+	"yarn.lock": true, "pnpm-lock.yaml": true, "cargo.lock": true,
+	"gemfile.lock": true, "poetry.lock": true, "uv.lock": true,
+}
+
+// changedTaskFiles returns basenames of files the repo is actively touching:
+// uncommitted changes first, then files from the last few commits. Best
+// effort — outside a repo, or with git missing or slow, it returns nil and
+// recall falls back to recency.
+func changedTaskFiles(cwd string) []string {
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	var out []string
+	seen := map[string]bool{}
+	add := func(path string) {
+		base := strings.ToLower(filepath.Base(strings.TrimSpace(path)))
+		if base == "" || base == "." || taskNoiseFiles[base] || strings.HasSuffix(base, ".lock") {
+			return
+		}
+		if !strings.Contains(base, ".") {
+			return // directories and extensionless noise carry little signal
+		}
+		if !seen[base] && len(out) < taskFileCap {
+			seen[base] = true
+			out = append(out, base)
+		}
+	}
+	if b, err := exec.CommandContext(ctx, "git", "-C", cwd, "status", "--porcelain").Output(); err == nil {
+		for _, line := range strings.Split(string(b), "\n") {
+			if len(line) < 4 {
+				continue
+			}
+			path := line[3:]
+			if i := strings.Index(path, " -> "); i >= 0 {
+				path = path[i+4:]
+			}
+			add(path)
+		}
+	}
+	if b, err := exec.CommandContext(ctx, "git", "-C", cwd, "log", "--name-only", "-3", "--pretty=format:").Output(); err == nil {
+		for _, line := range strings.Split(string(b), "\n") {
+			add(line)
+		}
+	}
+	return out
+}
+
+// taskScores counts, per session, how many of the changed files it mentions.
+// The returned matched list holds the files that drove the ranking, most
+// mentioned first, for the receipt line.
+func taskScores(ss []model.Session, files []string) (map[string]int, []string) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+	scores := map[string]int{}
+	fileHits := map[string]int{}
+	for _, s := range ss {
+		var text strings.Builder
+		text.WriteString(strings.ToLower(s.Title))
+		for _, m := range s.Messages {
+			text.WriteString(" ")
+			text.WriteString(strings.ToLower(m.Text))
+		}
+		low := text.String()
+		n := 0
+		for _, f := range files {
+			if strings.Contains(low, f) {
+				n++
+				fileHits[f]++
+			}
+		}
+		if n > 0 {
+			scores[s.Harness+":"+s.ID] = n
+		}
+	}
+	if len(scores) == 0 {
+		return nil, nil
+	}
+	matched := make([]string, 0, len(fileHits))
+	for f := range fileHits {
+		matched = append(matched, f)
+	}
+	sort.Slice(matched, func(i, j int) bool {
+		if fileHits[matched[i]] != fileHits[matched[j]] {
+			return fileHits[matched[i]] > fileHits[matched[j]]
+		}
+		return matched[i] < matched[j]
+	})
+	if len(matched) > 3 {
+		matched = matched[:3]
+	}
+	return scores, matched
+}

--- a/cmd/deja/hook_task_test.go
+++ b/cmd/deja/hook_task_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+func TestTaskScoresRanksByFileOverlap(t *testing.T) {
+	ss := []model.Session{
+		{Harness: "claude", ID: "old", Title: "jwt refresh", Messages: []model.Message{
+			{Role: "user", Text: "the expiry bug lives in auth.go and jwks.go"},
+		}},
+		{Harness: "claude", ID: "new", Title: "css tweaks", Messages: []model.Message{
+			{Role: "user", Text: "make the landing hero wider"},
+		}},
+	}
+	scores, matched := taskScores(ss, []string{"auth.go", "jwks.go"})
+	if scores["claude:old"] != 2 || scores["claude:new"] != 0 {
+		t.Fatalf("scores = %#v, want old=2 new=0", scores)
+	}
+	if strings.Join(matched, ",") != "auth.go,jwks.go" {
+		t.Fatalf("matched = %v", matched)
+	}
+}
+
+func TestTaskScoresEmptyWithoutSignal(t *testing.T) {
+	ss := []model.Session{{Harness: "claude", ID: "s", Title: "anything"}}
+	if scores, matched := taskScores(ss, nil); scores != nil || matched != nil {
+		t.Fatalf("no files must mean no scores, got %#v %v", scores, matched)
+	}
+	if scores, matched := taskScores(ss, []string{"auth.go"}); scores != nil || matched != nil {
+		t.Fatalf("zero overlap must return nil, got %#v %v", scores, matched)
+	}
+}
+
+func TestChangedTaskFilesReadsGitState(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	repo := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	if err := os.WriteFile(filepath.Join(repo, "auth.go"), []byte("package a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "go.sum"), []byte("noise"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-q", "-m", "seed")
+	if err := os.WriteFile(filepath.Join(repo, "jwks.go"), []byte("package a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := changedTaskFiles(repo)
+	set := map[string]bool{}
+	for _, f := range got {
+		set[f] = true
+	}
+	if !set["jwks.go"] || !set["auth.go"] {
+		t.Fatalf("want uncommitted jwks.go and committed auth.go, got %v", got)
+	}
+	if set["go.sum"] {
+		t.Fatalf("lockfile noise must be filtered, got %v", got)
+	}
+}
+
+func TestChangedTaskFilesOutsideRepo(t *testing.T) {
+	if got := changedTaskFiles(t.TempDir()); got != nil {
+		t.Fatalf("outside a repo must return nil, got %v", got)
+	}
+}
+
+func TestHookContextReceiptNamesTaskFiles(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	hermeticEnv(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+
+	repo := filepath.Join(t.TempDir(), "proj")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	if err := os.WriteFile(filepath.Join(repo, "auth.go"), []byte("package a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	proj := sources.ClaudeProjectName(repo)
+	old := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
+	fresh := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, proj, "task.jsonl"), "task", []string{
+		`{"type":"user","sessionId":"task","timestamp":"` + old + `","message":{"role":"user","content":"token expiry check in auth.go uses < instead of <= and drops the last second"}}`,
+		`{"type":"assistant","sessionId":"task","timestamp":"` + old + `","message":{"role":"assistant","content":[{"type":"text","text":"fixed the comparison in auth.go and added a regression test for expiry"}]}}`,
+	})
+	writeClaudeFixture(t, filepath.Join(claudeRoot, proj, "other.jsonl"), "other", []string{
+		`{"type":"user","sessionId":"other","timestamp":"` + fresh + `","message":{"role":"user","content":"reword the landing hero copy and center the pricing table"}}`,
+		`{"type":"assistant","sessionId":"other","timestamp":"` + fresh + `","message":{"role":"assistant","content":[{"type":"text","text":"updated the hero copy and pricing layout styles"}]}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", repo)
+
+	digest, sessions, _, matched := hookDigestResult(dir)
+	if sessions == 0 || digest == "" {
+		t.Fatal("expected recall output")
+	}
+	if len(matched) == 0 || matched[0] != "auth.go" {
+		t.Fatalf("matched = %v, want auth.go first", matched)
+	}
+	authPos := strings.Index(digest, "expiry")
+	heroPos := strings.Index(digest, "hero")
+	if authPos == -1 {
+		t.Fatalf("task-matched session missing from digest:\n%s", digest)
+	}
+	if heroPos != -1 && heroPos < authPos {
+		t.Fatalf("task-matched session must outrank fresher unrelated one:\n%s", digest)
+	}
+}

--- a/cmd/deja/onboarding_test.go
+++ b/cmd/deja/onboarding_test.go
@@ -129,7 +129,7 @@ func TestHookMissingManifestRequestsWarmup(t *testing.T) {
 	oldSpawn := spawnWarmup
 	spawnWarmup = func(_, _ string) error { called = true; return nil }
 	defer func() { spawnWarmup = oldSpawn }()
-	if digest, sessions, _ := hookDigestResult(index.DefaultDir()); digest != "" || sessions != 0 {
+	if digest, sessions, _, _ := hookDigestResult(index.DefaultDir()); digest != "" || sessions != 0 {
 		t.Fatalf("missing-manifest digest = %q, sessions=%d", digest, sessions)
 	}
 	if !called {

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -21,6 +21,10 @@ type AutoRecallOptions struct {
 	Mode         string
 	ProjectNames []string
 	Now          time.Time
+	// TaskScores ranks sessions by overlap with what the repo is touching
+	// right now (harness:ID → matched-file count). Sessions the task points
+	// at outrank plain recency; zero or a nil map falls back to recency.
+	TaskScores map[string]int
 }
 
 type AutoRecallResult struct {
@@ -68,6 +72,11 @@ func BuildAutoRecall(ss []model.Session, o AutoRecallOptions) AutoRecallResult {
 	}
 	candidates := append([]model.Session(nil), ss...)
 	sort.SliceStable(candidates, func(i, j int) bool {
+		ti := o.TaskScores[candidates[i].Harness+":"+candidates[i].ID]
+		tj := o.TaskScores[candidates[j].Harness+":"+candidates[j].ID]
+		if ti != tj {
+			return ti > tj
+		}
 		iRecent := !candidates[i].Updated.Before(o.Now.AddDate(0, 0, -90))
 		jRecent := !candidates[j].Updated.Before(o.Now.AddDate(0, 0, -90))
 		if iRecent != jRecent {


### PR DESCRIPTION
Session start has no prompt, but the repo says what the work is about: changed-file basenames from `git status` and the last commits re-rank candidate sessions, and the receipt says why (`recalled 2 sessions touching auth.go, jwks.go`). Recency stays the fallback. Closes #277.