### PR TITLE
feat(policy): trust scopes

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -75,7 +76,8 @@ func runHookContext(dir string, plain bool) error {
 		digest += "\n" + tip
 	}
 	digest = frameRecall(digest)
-	usage.RecordDigest(dir, usage.KindHook, digest, sessions, raw)
+	polName := policy.Load().Describe(policy.ActivationAuto)
+	usage.RecordDigestPolicy(dir, usage.KindHook, digest, sessions, raw, polName)
 	if plain {
 		fmt.Fprintln(os.Stdout, digest)
 		return nil
@@ -97,7 +99,13 @@ func runHookContext(dir string, plain bool) error {
 		if len(taskMatched) > 0 {
 			why = "touching " + strings.Join(taskMatched, ", ")
 		}
-		resp.SystemMessage = fmt.Sprintf("deja: recalled %d prior session%s %s (~%dKB) — the agent starts already knowing them%s", sessions, plural, why, (len(digest)+1023)/1024, serviceReceipt(dir))
+		// A non-default policy is part of the receipt: the user should see
+		// that a rule, not chance, decided what memory crossed over.
+		polNote := ""
+		if polName != "local+imported" {
+			polNote = " · policy: " + polName
+		}
+		resp.SystemMessage = fmt.Sprintf("deja: recalled %d prior session%s %s (~%dKB) — the agent starts already knowing them%s%s", sessions, plural, why, (len(digest)+1023)/1024, serviceReceipt(dir), polNote)
 	}
 	b, err := json.Marshal(resp)
 	if err != nil {
@@ -158,7 +166,7 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 			names = append(names, base)
 		}
 	}
-	localOnly := os.Getenv("DEJA_AUTORECALL_LOCAL_ONLY") == "1"
+	pol := policy.Load()
 	var ss []model.Session
 	seen := map[string]bool{}
 	lookupNames := names
@@ -185,7 +193,7 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 			continue
 		}
 		for _, s := range got {
-			if localOnly && strings.HasPrefix(s.Project, "imported:") {
+			if !pol.Allows(policy.ActivationAuto, s.Project) {
 				continue
 			}
 			k := s.Harness + ":" + s.ID

--- a/cmd/deja/hook_local_only_test.go
+++ b/cmd/deja/hook_local_only_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -9,7 +10,10 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
 // DEJA_AUTORECALL_LOCAL_ONLY=1 keeps synced sessions out of the startup
@@ -64,5 +68,41 @@ func TestAutoRecallLocalOnly(t *testing.T) {
 	}
 	if !strings.Contains(digest, "isoproj") {
 		t.Fatalf("local-only digest lost local session: %q", digest)
+	}
+}
+
+func TestPolicyFileBlocksImportedInSearchHits(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+	if err := os.WriteFile(path, []byte(`{"activations":{"mcp":{"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hits := []search.Hit{
+		{Session: model.Session{ID: "a", Project: "deja-vu"}},
+		{Session: model.Session{ID: "b", Project: "imported:mini/deja-vu"}},
+	}
+	got := policyFilterHits(policy.ActivationMCP, hits)
+	if len(got) != 1 || got[0].Session.ID != "a" {
+		t.Fatalf("mcp filter wrong: %#v", got)
+	}
+	// The search path has no rule in this file, so nothing is dropped.
+	hits2 := []search.Hit{
+		{Session: model.Session{ID: "a", Project: "deja-vu"}},
+		{Session: model.Session{ID: "b", Project: "imported:mini/deja-vu"}},
+	}
+	if got := policyFilterHits(policy.ActivationSearch, hits2); len(got) != 2 {
+		t.Fatalf("search filter must pass all: %#v", got)
+	}
+}
+
+func TestLogLastNamesPolicy(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	usage.RecordDigestPolicy(dir, usage.KindHook, "digest body", 2, 100, "local-only")
+	var out bytes.Buffer
+	if err := runLogTo(&out, dir, []string{"--last"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "policy: local-only") {
+		t.Fatalf("log --last must name the policy:\n%s", out.String())
 	}
 }

--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -46,7 +46,11 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 			enc.SetIndent("", "  ")
 			return enc.Encode(s)
 		}
-		fmt.Fprintf(w, "# %s · %s · %d sessions · %s\n\n", s.Kind, s.Time.Local().Format("2006-01-02 15:04"), s.Sessions, humanBytes(int64(s.Bytes)))
+		pol := ""
+		if s.Policy != "" {
+			pol = " · policy: " + s.Policy
+		}
+		fmt.Fprintf(w, "# %s · %s · %d sessions · %s%s\n\n", s.Kind, s.Time.Local().Format("2006-01-02 15:04"), s.Sessions, humanBytes(int64(s.Bytes)), pol)
 		fmt.Fprintln(w, s.Digest)
 		return nil
 	}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -274,6 +275,7 @@ func runSearch(dir string, args []string) error {
 	if err != nil {
 		return fmt.Errorf("run: %w", err)
 	}
+	hits = policyFilterHits(policy.ActivationSearch, hits)
 	if !o.NoEmbed && os.Getenv("DEJA_EMBED") != "off" {
 		hits = maybeRerank(dir, hits, o, os.Stderr)
 	}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -168,7 +169,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if err == nil {
 			text = frameRecall(text)
 			usage.RecordServedSessions(dir, usage.KindRecall, len(text), sessions, sessions == 0, raw, ids)
-			usage.SnapshotOnly(dir, usage.KindRecall, text, sessions)
+			usage.SnapshotPolicy(dir, usage.KindRecall, text, sessions, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
 	case "recall_context":
@@ -186,7 +187,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if err == nil {
 			text = frameRecall(text)
 			usage.RecordServedSessions(dir, usage.KindContext, len(text), sessions, sessions == 0, raw, ids)
-			usage.SnapshotOnly(dir, usage.KindContext, text, sessions)
+			usage.SnapshotPolicy(dir, usage.KindContext, text, sessions, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
 	case "blame":
@@ -290,6 +291,7 @@ func recallTextResult(dir, q, harness string, limit, budget int) (string, int, i
 	if err != nil {
 		return "", 0, 0, nil, err
 	}
+	hits = policyFilterHits(policy.ActivationMCP, hits)
 	if os.Getenv("DEJA_EMBED") != "off" {
 		hits = maybeRerank(dir, hits, o, os.Stderr)
 	}
@@ -390,6 +392,7 @@ func recallContextResult(dir, q, harness string) (string, int, int64, []string, 
 	if err != nil {
 		return "", 0, 0, nil, err
 	}
+	hits = policyFilterHits(policy.ActivationMCP, hits)
 	var semantic bool
 	hits, semantic = maybeSemantic(dir, hits, o, os.Stderr)
 	if semantic {

--- a/cmd/deja/policyfilter.go
+++ b/cmd/deja/policyfilter.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// policyFilterHits drops search hits the trust policy blocks on this
+// activation path. The default policy blocks nothing.
+func policyFilterHits(activation string, hits []search.Hit) []search.Hit {
+	return policy.Filter(policy.Load(), activation, hits, func(h search.Hit) string {
+		return h.Session.Project
+	})
+}

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -63,6 +63,7 @@
 <li><b>Forget</b> — <code>deja forget</code> removes sessions and records a tombstone so they don't come back on the next index; <code>--dry-run</code> to preview, <code>--unforget</code> to reverse.</li>
 <li><b>Redaction report</b> — <code>deja stats --redaction</code> shows what was masked, per rule and harness.</li>
 <li><b>Audit what agents received</b> — <code>deja log</code> lists recent recalls and injections; <code>deja log --last</code> prints the exact digest most recently served.</li>
+<li><b>Trust scopes</b> — <code>~/.config/deja/policy.json</code> controls what memory activates where. Per activation path (<code>search</code>, <code>mcp</code>, <code>auto</code>) you allow or deny origins: <code>local</code>, <code>imported</code> (anything synced from another machine), or a single peer like <code>imported:mini</code>. Example — synced sessions stay searchable but never auto-inject: <code>{"activations":{"auto":{"imported":false}}}</code>. <code>DEJA_AUTORECALL_LOCAL_ONLY=1</code> remains an alias for exactly that rule. Receipts and <code>deja log --last</code> name the policy that allowed each injection.</li>
 </ul>
 <p>Full details in the <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">security model</a>.</p>
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,0 +1,130 @@
+// Package policy decides what memory activates where. Recall crossing a
+// machine boundary was the launch thread's top concern; instead of one env
+// var, a small explicit table: per activation (search, mcp, auto), which
+// origins (local, imported, imported:<peer>) may inject. Defaults allow
+// everything, matching prior behavior; DEJA_AUTORECALL_LOCAL_ONLY=1 stays as
+// an alias for denying imported memory on the auto path.
+package policy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+const (
+	ActivationSearch = "search"
+	ActivationMCP    = "mcp"
+	ActivationAuto   = "auto"
+)
+
+// Policy maps activation → origin rules. A missing activation allows every
+// origin. Origin keys: "local", "imported" (any peer), "imported:<peer>"
+// (most specific wins).
+type Policy struct {
+	Activations map[string]map[string]bool `json:"activations,omitempty"`
+}
+
+func Path() string {
+	if p := os.Getenv("DEJA_POLICY_FILE"); p != "" {
+		return p
+	}
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		base = filepath.Join(sources.Home(), ".config")
+	}
+	return filepath.Join(base, "deja", "policy.json")
+}
+
+// Load reads the policy file and folds in the env alias. Any read or parse
+// failure means the default policy — recall must not break because a config
+// file is malformed; doctor is the place to complain.
+func Load() Policy {
+	var p Policy
+	if b, err := os.ReadFile(Path()); err == nil {
+		_ = json.Unmarshal(b, &p)
+	}
+	if os.Getenv("DEJA_AUTORECALL_LOCAL_ONLY") == "1" {
+		if p.Activations == nil {
+			p.Activations = map[string]map[string]bool{}
+		}
+		if p.Activations[ActivationAuto] == nil {
+			p.Activations[ActivationAuto] = map[string]bool{"local": true}
+		}
+		p.Activations[ActivationAuto]["imported"] = false
+	}
+	return p
+}
+
+// Origin classifies a session's project name.
+func Origin(project string) string {
+	if peer, ok := strings.CutPrefix(project, "imported:"); ok {
+		if i := strings.IndexByte(peer, '/'); i > 0 {
+			return "imported:" + peer[:i]
+		}
+		return "imported"
+	}
+	return "local"
+}
+
+// Allows reports whether memory from the session's origin may activate on
+// this path. Most specific rule wins: imported:<peer> over imported over the
+// activation default (allow).
+func (p Policy) Allows(activation, project string) bool {
+	rules := p.Activations[activation]
+	if rules == nil {
+		return true
+	}
+	origin := Origin(project)
+	if v, ok := rules[origin]; ok {
+		return v
+	}
+	if strings.HasPrefix(origin, "imported:") {
+		if v, ok := rules["imported"]; ok {
+			return v
+		}
+	}
+	if v, ok := rules["*"]; ok {
+		return v
+	}
+	return true
+}
+
+// Describe names the active rule set for receipts and `deja log`, so the
+// audit trail explains itself. The default policy reads "local+imported".
+func (p Policy) Describe(activation string) string {
+	rules := p.Activations[activation]
+	if rules == nil {
+		return "local+imported"
+	}
+	if v, ok := rules["imported"]; ok && !v {
+		return "local-only"
+	}
+	denied := make([]string, 0, len(rules))
+	for origin, allowed := range rules {
+		if !allowed {
+			denied = append(denied, origin)
+		}
+	}
+	if len(denied) == 0 {
+		return "local+imported"
+	}
+	sort.Strings(denied)
+	return "deny " + strings.Join(denied, ",")
+}
+
+// Filter drops the items whose project the policy blocks on this path.
+// projectOf maps an element to its session project name.
+func Filter[T any](p Policy, activation string, items []T, projectOf func(T) string) []T {
+	out := items[:0]
+	for _, it := range items {
+		if p.Allows(activation, projectOf(it)) {
+			out = append(out, it)
+		}
+	}
+	return out
+}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -1,0 +1,111 @@
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultsAllowEverything(t *testing.T) {
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing.json"))
+	p := Load()
+	for _, act := range []string{ActivationSearch, ActivationMCP, ActivationAuto} {
+		for _, proj := range []string{"deja-vu", "imported:mini/deja-vu"} {
+			if !p.Allows(act, proj) {
+				t.Fatalf("default policy must allow %s/%s", act, proj)
+			}
+		}
+		if got := p.Describe(act); got != "local+imported" {
+			t.Fatalf("Describe(%s) = %q", act, got)
+		}
+	}
+}
+
+func TestOriginClassification(t *testing.T) {
+	cases := map[string]string{
+		"deja-vu":                "local",
+		"imported:mini/deja-vu":  "imported:mini",
+		"imported:mini":          "imported",
+		"imported:work/api/auth": "imported:work",
+	}
+	for proj, want := range cases {
+		if got := Origin(proj); got != want {
+			t.Fatalf("Origin(%q) = %q, want %q", proj, got, want)
+		}
+	}
+}
+
+func TestFileDeniesImportedOnAuto(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+	if err := os.WriteFile(path, []byte(`{"activations":{"auto":{"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := Load()
+	if p.Allows(ActivationAuto, "imported:mini/deja-vu") {
+		t.Fatal("auto must deny imported")
+	}
+	if !p.Allows(ActivationAuto, "deja-vu") || !p.Allows(ActivationMCP, "imported:mini/deja-vu") {
+		t.Fatal("local auto and imported mcp must stay allowed")
+	}
+	if got := p.Describe(ActivationAuto); got != "local-only" {
+		t.Fatalf("Describe(auto) = %q, want local-only", got)
+	}
+}
+
+func TestPeerSpecificRuleWins(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+	if err := os.WriteFile(path, []byte(`{"activations":{"mcp":{"imported":true,"imported:untrusted":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := Load()
+	if p.Allows(ActivationMCP, "imported:untrusted/box") {
+		t.Fatal("peer rule must deny untrusted")
+	}
+	if !p.Allows(ActivationMCP, "imported:mini/deja-vu") {
+		t.Fatal("other peers stay allowed")
+	}
+	if got := p.Describe(ActivationMCP); got != "deny imported:untrusted" {
+		t.Fatalf("Describe = %q", got)
+	}
+}
+
+func TestEnvAliasStillWorks(t *testing.T) {
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing.json"))
+	t.Setenv("DEJA_AUTORECALL_LOCAL_ONLY", "1")
+	p := Load()
+	if p.Allows(ActivationAuto, "imported:mini/deja-vu") {
+		t.Fatal("env alias must deny imported on auto")
+	}
+	if !p.Allows(ActivationAuto, "deja-vu") || !p.Allows(ActivationSearch, "imported:mini/deja-vu") {
+		t.Fatal("alias must only touch the auto path")
+	}
+	if got := p.Describe(ActivationAuto); got != "local-only" {
+		t.Fatalf("Describe = %q", got)
+	}
+}
+
+func TestMalformedFileFallsBackToDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+	if err := os.WriteFile(path, []byte(`{broken`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !Load().Allows(ActivationAuto, "imported:mini/x") {
+		t.Fatal("malformed policy must not lock recall out")
+	}
+}
+
+func TestFilterDropsBlocked(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+	if err := os.WriteFile(path, []byte(`{"activations":{"search":{"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	items := []string{"deja-vu", "imported:mini/deja-vu", "other"}
+	got := Filter(Load(), ActivationSearch, items, func(s string) string { return s })
+	if len(got) != 2 || got[0] != "deja-vu" || got[1] != "other" {
+		t.Fatalf("Filter = %v", got)
+	}
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -17,7 +17,10 @@ type Snapshot struct {
 	Kind     string    `json:"kind"`
 	Sessions int       `json:"sessions,omitempty"`
 	Bytes    int       `json:"bytes"`
-	Digest   string    `json:"digest"`
+	// Policy names the rule set that allowed this injection, so the audit
+	// trail explains itself ("local+imported", "local-only").
+	Policy string `json:"policy,omitempty"`
+	Digest string `json:"digest"`
 }
 
 const (
@@ -35,13 +38,28 @@ func SnapshotPath(indexDir string) string {
 // the text. raw is the size of the source transcripts the digest distilled.
 // Best-effort like all usage recording.
 func RecordDigest(indexDir, kind, digest string, sessions int, raw int64) {
+	RecordDigestPolicy(indexDir, kind, digest, sessions, raw, "")
+}
+
+// RecordDigestPolicy is RecordDigest plus the name of the policy that allowed
+// the injection, kept with the snapshot for `deja log`.
+func RecordDigestPolicy(indexDir, kind, digest string, sessions int, raw int64, policyName string) {
 	RecordResultRaw(indexDir, kind, len(digest), sessions, sessions == 0, raw)
-	SnapshotOnly(indexDir, kind, digest, sessions)
+	snapshotWrite(indexDir, kind, digest, sessions, policyName)
 }
 
 // SnapshotOnly stores the digest text without writing a counting event, for
 // callers that already recorded one with extra fields.
 func SnapshotOnly(indexDir, kind, digest string, sessions int) {
+	snapshotWrite(indexDir, kind, digest, sessions, "")
+}
+
+// SnapshotPolicy is SnapshotOnly plus the policy name for the audit trail.
+func SnapshotPolicy(indexDir, kind, digest string, sessions int, policyName string) {
+	snapshotWrite(indexDir, kind, digest, sessions, policyName)
+}
+
+func snapshotWrite(indexDir, kind, digest string, sessions int, policyName string) {
 	if digest == "" {
 		return
 	}
@@ -55,7 +73,7 @@ func SnapshotOnly(indexDir, kind, digest string, sessions int) {
 		return
 	}
 	defer func() { _ = f.Close() }()
-	b, err := json.Marshal(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions, Bytes: len(digest), Digest: digest})
+	b, err := json.Marshal(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions, Bytes: len(digest), Policy: policyName, Digest: digest})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Replaces the one env var with a small policy table: per activation path (search, mcp, auto), which origins may inject (local, imported, imported:<peer>). Defaults keep today's behavior, DEJA_AUTORECALL_LOCAL_ONLY stays as an alias, and receipts plus `deja log --last` name the policy that allowed each injection. Closes #276.