### PR TITLE
feat: deja promote — curated note layer

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -35,7 +35,7 @@ _deja_completion() {
     command="${COMP_WORDS[1]}"
     action="${COMP_WORDS[2]}"
 
-    local commands="blame bench completion ctx doctor embed forget handoff index install last log mcp remember resume share show sources stats statusline sync uninstall update version warmup"
+    local commands="blame bench completion ctx doctor embed forget handoff index install last log mcp promote remember resume share show sources stats statusline sync uninstall update version warmup"
     local harnesses="claude codex opencode aider gemini cursor antigravity grok qwen pi copilot deja"
     local install_targets="claude-code codex opencode cursor gemini antigravity grok qwen kimi copilot pi statusline --all --auto"
 
@@ -147,6 +147,7 @@ _deja() {
     'completion:generate shell completion'
     'ctx:print a compact context digest'
     'doctor:diagnose local stores and wiring'
+    'promote:distill a session into a curated note'
     'embed:build the semantic sidecar'
     'forget:remove indexed sessions'
     'handoff:continue a session in another agent'
@@ -248,7 +249,7 @@ const fishCompletion = `function __deja_needs_command
     test (count (commandline -opc)) -eq 1
 end
 
-complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed forget handoff index install last log mcp remember resume share show sources stats statusline sync uninstall update version warmup'
+complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed forget handoff index install last log mcp promote remember resume share show sources stats statusline sync uninstall update version warmup'
 complete -c deja -n '__deja_needs_command' -l json -d 'Print JSON'
 complete -c deja -n '__deja_needs_command' -l re -d 'Interpret query as a regular expression'
 complete -c deja -n '__deja_needs_command' -l all -d 'Include all results'

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -75,7 +76,8 @@ func runHookContext(dir string, plain bool) error {
 		digest += "\n" + tip
 	}
 	digest = frameRecall(digest)
-	usage.RecordDigest(dir, usage.KindHook, digest, sessions, raw)
+	polName := policy.Load().Describe(policy.ActivationAuto)
+	usage.RecordDigestPolicy(dir, usage.KindHook, digest, sessions, raw, polName)
 	if plain {
 		fmt.Fprintln(os.Stdout, digest)
 		return nil
@@ -97,7 +99,13 @@ func runHookContext(dir string, plain bool) error {
 		if len(taskMatched) > 0 {
 			why = "touching " + strings.Join(taskMatched, ", ")
 		}
-		resp.SystemMessage = fmt.Sprintf("deja: recalled %d prior session%s %s (~%dKB) — the agent starts already knowing them%s", sessions, plural, why, (len(digest)+1023)/1024, serviceReceipt(dir))
+		// A non-default policy is part of the receipt: the user should see
+		// that a rule, not chance, decided what memory crossed over.
+		polNote := ""
+		if polName != "local+imported" {
+			polNote = " · policy: " + polName
+		}
+		resp.SystemMessage = fmt.Sprintf("deja: recalled %d prior session%s %s (~%dKB) — the agent starts already knowing them%s%s", sessions, plural, why, (len(digest)+1023)/1024, serviceReceipt(dir), polNote)
 	}
 	b, err := json.Marshal(resp)
 	if err != nil {
@@ -158,7 +166,7 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 			names = append(names, base)
 		}
 	}
-	localOnly := os.Getenv("DEJA_AUTORECALL_LOCAL_ONLY") == "1"
+	pol := policy.Load()
 	var ss []model.Session
 	seen := map[string]bool{}
 	lookupNames := names
@@ -185,7 +193,7 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 			continue
 		}
 		for _, s := range got {
-			if localOnly && strings.HasPrefix(s.Project, "imported:") {
+			if !pol.Allows(policy.ActivationAuto, s.Project) {
 				continue
 			}
 			k := s.Harness + ":" + s.ID

--- a/cmd/deja/hook_local_only_test.go
+++ b/cmd/deja/hook_local_only_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -9,7 +10,10 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
 // DEJA_AUTORECALL_LOCAL_ONLY=1 keeps synced sessions out of the startup
@@ -64,5 +68,41 @@ func TestAutoRecallLocalOnly(t *testing.T) {
 	}
 	if !strings.Contains(digest, "isoproj") {
 		t.Fatalf("local-only digest lost local session: %q", digest)
+	}
+}
+
+func TestPolicyFileBlocksImportedInSearchHits(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+	if err := os.WriteFile(path, []byte(`{"activations":{"mcp":{"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hits := []search.Hit{
+		{Session: model.Session{ID: "a", Project: "deja-vu"}},
+		{Session: model.Session{ID: "b", Project: "imported:mini/deja-vu"}},
+	}
+	got := policyFilterHits(policy.ActivationMCP, hits)
+	if len(got) != 1 || got[0].Session.ID != "a" {
+		t.Fatalf("mcp filter wrong: %#v", got)
+	}
+	// The search path has no rule in this file, so nothing is dropped.
+	hits2 := []search.Hit{
+		{Session: model.Session{ID: "a", Project: "deja-vu"}},
+		{Session: model.Session{ID: "b", Project: "imported:mini/deja-vu"}},
+	}
+	if got := policyFilterHits(policy.ActivationSearch, hits2); len(got) != 2 {
+		t.Fatalf("search filter must pass all: %#v", got)
+	}
+}
+
+func TestLogLastNamesPolicy(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	usage.RecordDigestPolicy(dir, usage.KindHook, "digest body", 2, 100, "local-only")
+	var out bytes.Buffer
+	if err := runLogTo(&out, dir, []string{"--last"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "policy: local-only") {
+		t.Fatalf("log --last must name the policy:\n%s", out.String())
 	}
 }

--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -46,7 +46,11 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 			enc.SetIndent("", "  ")
 			return enc.Encode(s)
 		}
-		fmt.Fprintf(w, "# %s · %s · %d sessions · %s\n\n", s.Kind, s.Time.Local().Format("2006-01-02 15:04"), s.Sessions, humanBytes(int64(s.Bytes)))
+		pol := ""
+		if s.Policy != "" {
+			pol = " · policy: " + s.Policy
+		}
+		fmt.Fprintf(w, "# %s · %s · %d sessions · %s%s\n\n", s.Kind, s.Time.Local().Format("2006-01-02 15:04"), s.Sessions, humanBytes(int64(s.Bytes)), pol)
 		fmt.Fprintln(w, s.Digest)
 		return nil
 	}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -89,6 +89,7 @@ var commands = map[string]command{
 	"statusline":      func(dir string, _ []string) error { return runStatusline(dir, os.Stdin, os.Stdout) },
 	"stats":           runStats,
 	"remember":        runRemember,
+	"promote":         func(dir string, rest []string) error { return runPromote(dir, rest, os.Stdout) },
 	"forget":          runForget,
 	"mcp":             func(dir string, _ []string) error { return serveMCP(dir, os.Stdin, os.Stdout) },
 	"hook-prompt":     func(dir string, _ []string) error { return runHookPrompt(dir, os.Stdin, os.Stdout) },
@@ -818,6 +819,7 @@ Usage:
   deja statusline
   deja stats [--json] [--card [path]] [--html [path]]
 	deja remember "text" [--project name]
+  deja promote <id-prefix> [--state accepted|rejected|superseded|stale] [--note "text"] [--to path]
   deja mcp
   deja version
   deja update

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -274,6 +275,7 @@ func runSearch(dir string, args []string) error {
 	if err != nil {
 		return fmt.Errorf("run: %w", err)
 	}
+	hits = policyFilterHits(policy.ActivationSearch, hits)
 	if !o.NoEmbed && os.Getenv("DEJA_EMBED") != "off" {
 		hits = maybeRerank(dir, hits, o, os.Stderr)
 	}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -168,7 +169,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if err == nil {
 			text = frameRecall(text)
 			usage.RecordServedSessions(dir, usage.KindRecall, len(text), sessions, sessions == 0, raw, ids)
-			usage.SnapshotOnly(dir, usage.KindRecall, text, sessions)
+			usage.SnapshotPolicy(dir, usage.KindRecall, text, sessions, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
 	case "recall_context":
@@ -186,7 +187,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if err == nil {
 			text = frameRecall(text)
 			usage.RecordServedSessions(dir, usage.KindContext, len(text), sessions, sessions == 0, raw, ids)
-			usage.SnapshotOnly(dir, usage.KindContext, text, sessions)
+			usage.SnapshotPolicy(dir, usage.KindContext, text, sessions, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
 	case "blame":
@@ -290,6 +291,7 @@ func recallTextResult(dir, q, harness string, limit, budget int) (string, int, i
 	if err != nil {
 		return "", 0, 0, nil, err
 	}
+	hits = policyFilterHits(policy.ActivationMCP, hits)
 	if os.Getenv("DEJA_EMBED") != "off" {
 		hits = maybeRerank(dir, hits, o, os.Stderr)
 	}
@@ -390,6 +392,7 @@ func recallContextResult(dir, q, harness string) (string, int, int64, []string, 
 	if err != nil {
 		return "", 0, 0, nil, err
 	}
+	hits = policyFilterHits(policy.ActivationMCP, hits)
 	var semantic bool
 	hits, semantic = maybeSemantic(dir, hits, o, os.Stderr)
 	if semantic {

--- a/cmd/deja/policyfilter.go
+++ b/cmd/deja/policyfilter.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// policyFilterHits drops search hits the trust policy blocks on this
+// activation path. The default policy blocks nothing.
+func policyFilterHits(activation string, hits []search.Hit) []search.Hit {
+	return policy.Filter(policy.Load(), activation, hits, func(h search.Hit) string {
+		return h.Session.Project
+	})
+}

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// runPromote distills a session into a curated note: quoted evidence with
+// provenance and a lifecycle state, stored in the notes source so it indexes
+// like everything else but outranks the raw transcript it came from.
+func runPromote(dir string, args []string, stdout io.Writer) error {
+	prefix := ""
+	state := "accepted"
+	noteText := ""
+	exportPath := ""
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--state":
+			if i+1 >= len(args) {
+				return fmt.Errorf("promote: --state needs a value")
+			}
+			i++
+			state = strings.ToLower(args[i])
+		case "--note":
+			if i+1 >= len(args) {
+				return fmt.Errorf("promote: --note needs text")
+			}
+			i++
+			noteText = args[i]
+		case "--to":
+			if i+1 >= len(args) {
+				return fmt.Errorf("promote: --to needs a path")
+			}
+			i++
+			exportPath = args[i]
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("promote: unknown flag %q", args[i])
+			}
+			prefix = args[i]
+		}
+	}
+	if prefix == "" {
+		return fmt.Errorf("promote needs a session id prefix (see `deja last`)")
+	}
+	if !sources.NoteStates[state] {
+		return fmt.Errorf("promote: state must be accepted, rejected, superseded or stale")
+	}
+	s, ok, err := findByPrefix(dir, prefix)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("no session matches %q", prefix)
+	}
+	if s.Harness == "deja" {
+		return fmt.Errorf("%q is already a note — promote the source session instead", prefix)
+	}
+	text := strings.TrimSpace(noteText)
+	if text == "" {
+		text = distillSession(s)
+	}
+	src := s.Harness + ":" + s.ID
+	title := strings.TrimSpace(s.Title)
+	if title == "" {
+		title = firstLine(text)
+	}
+	if err := sources.AppendPromoted(s.Project, title, text, src, state, time.Now()); err != nil {
+		return err
+	}
+	if exportPath != "" {
+		if err := exportPromoted(exportPath, title, text, src, state, s.Updated); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintf(stdout, "promoted %s as %s: %s\n", src, state, title)
+	if exportPath != "" {
+		fmt.Fprintf(stdout, "exported to %s\n", exportPath)
+	}
+	fmt.Fprintln(stdout, "the note now outranks the raw transcript in recall; corrections append with `deja promote", prefix, "--state <state>`")
+	return nil
+}
+
+// distillSession quotes the session instead of summarizing it: the first user
+// ask and the last assistant word, each trimmed — receipts, not generation.
+func distillSession(s model.Session) string {
+	var ask, answer string
+	for _, m := range s.Messages {
+		t := strings.TrimSpace(m.Text)
+		if t == "" {
+			continue
+		}
+		if ask == "" && m.Role == "user" {
+			ask = t
+		}
+		if m.Role == "assistant" {
+			answer = t
+		}
+	}
+	parts := make([]string, 0, 2)
+	if ask != "" {
+		parts = append(parts, "asked: "+trimRunes(ask, 300))
+	}
+	if answer != "" {
+		parts = append(parts, "outcome: "+trimRunes(answer, 300))
+	}
+	if len(parts) == 0 {
+		return "promoted session (no text messages)"
+	}
+	return strings.Join(parts, " · ")
+}
+
+func trimRunes(s string, n int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i > 0 {
+		s = s[:i]
+	}
+	return trimRunes(s, 80)
+}
+
+// exportPromoted appends a Markdown block to a repo-visible notes file.
+// Append-only like the store: a correction adds a new block below the old.
+func exportPromoted(path, title, text, src, state string, updated time.Time) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	day := updated.UTC().Format("2006-01-02")
+	if updated.IsZero() {
+		day = time.Now().UTC().Format("2006-01-02")
+	}
+	_, err = fmt.Fprintf(f, "\n## %s\n\n- state: %s\n- source: %s (%s)\n\n%s\n", title, state, src, day, text)
+	return err
+}

--- a/cmd/deja/promote_test.go
+++ b/cmd/deja/promote_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"io"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+func promoteFixture(t *testing.T) string {
+	t.Helper()
+	hermeticEnv(t)
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-tmp-proj", "sess.jsonl"), "sess1234", []string{
+		`{"type":"user","sessionId":"sess1234","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"how do we rotate the signing key without downtime"}}`,
+		`{"type":"assistant","sessionId":"sess1234","timestamp":"2026-01-02T03:05:05Z","message":{"role":"assistant","content":[{"type":"text","text":"double-publish the JWKS for one TTL, then swap the active kid"}]}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestPromoteWritesNoteWithProvenanceAndState(t *testing.T) {
+	dir := promoteFixture(t)
+	var out bytes.Buffer
+	if err := runPromote(dir, []string{"sess1234"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "promoted claude:sess1234 as accepted") {
+		t.Fatalf("receipt wrong:\n%s", out.String())
+	}
+	b, err := os.ReadFile(sources.NotesFile())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	for _, want := range []string{`"kind":"promoted"`, `"session":"claude:sess1234"`, `"state":"accepted"`, "signing key", "double-publish"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("note missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestPromoteCorrectionAppends(t *testing.T) {
+	dir := promoteFixture(t)
+	if err := runPromote(dir, []string{"sess1234"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := runPromote(dir, []string{"sess1234", "--state", "superseded", "--note", "replaced by the KMS flow"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(sources.NotesFile())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(b), `"session":"claude:sess1234"`) != 2 {
+		t.Fatalf("correction must append, not rewrite:\n%s", b)
+	}
+	ss, err := sources.ParseNotesFile(sources.NotesFile())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("both entries must fold into one note session, got %d", len(ss))
+	}
+	if !strings.HasSuffix(ss[0].Title, "[superseded]") {
+		t.Fatalf("title must carry the latest state, got %q", ss[0].Title)
+	}
+	if len(ss[0].Messages) != 2 || !strings.Contains(ss[0].Messages[1].Text, "[superseded]") {
+		t.Fatalf("messages must keep the full history: %#v", ss[0].Messages)
+	}
+}
+
+func TestPromoteRejectsBadStateAndNotes(t *testing.T) {
+	dir := promoteFixture(t)
+	if err := runPromote(dir, []string{"sess1234", "--state", "maybe"}, &bytes.Buffer{}); err == nil {
+		t.Fatal("bad state must fail")
+	}
+	if err := runPromote(dir, []string{"missing"}, &bytes.Buffer{}); err == nil {
+		t.Fatal("unknown prefix must fail")
+	}
+}
+
+func TestPromoteExportsMarkdown(t *testing.T) {
+	dir := promoteFixture(t)
+	md := filepath.Join(t.TempDir(), "NOTES.md")
+	if err := runPromote(dir, []string{"sess1234", "--to", md}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(md)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	for _, want := range []string{"- state: accepted", "- source: claude:sess1234", "double-publish"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestPromotedNoteOutranksTranscriptInSearch(t *testing.T) {
+	dir := promoteFixture(t)
+	if err := runPromote(dir, []string{"sess1234", "--note", "signing key rotation: double-publish JWKS for one TTL then swap kid"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	hits := searchHits(t, dir, "signing key")
+	if len(hits) < 2 {
+		t.Fatalf("want note + transcript, got %d hits", len(hits))
+	}
+	if hits[0].Session.Harness != "deja" {
+		t.Fatalf("promoted note must rank first, got %s:%s", hits[0].Session.Harness, hits[0].Session.ID)
+	}
+	if !strings.Contains(hits[0].Session.Title, "[accepted]") {
+		t.Fatalf("state must show in the result title, got %q", hits[0].Session.Title)
+	}
+}
+
+func searchHits(t *testing.T, dir, q string) []search.Hit {
+	t.Helper()
+	o := search.Options{Query: q, All: true}
+	result, err := index.SearchWithRecoveryDetailed(dir, o, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Tier = result.Tier
+	hits, err := search.Run(result.Sessions, o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hits
+}

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -66,6 +66,7 @@
 <tr><td><code>deja install &lt;target|--all|--auto&gt;</code></td><td>Wire MCP recall (and hooks) into your agents.</td></tr>
 <tr><td><code>deja embed</code></td><td>Build the semantic vector sidecar from a local endpoint.</td></tr>
 <tr><td><code>deja sync export/import/ssh</code></td><td>Move redacted memory between machines.</td></tr>
+<tr><td><code>deja promote &lt;id&gt;</code></td><td>Distill a session into a curated note: quoted evidence with provenance and a lifecycle state (<code>--state accepted|rejected|superseded|stale</code>). Corrections append; the note outranks the raw transcript in recall. <code>--to path</code> also appends a Markdown block for repo-visible notes.</td></tr>
 <tr><td><code>deja doctor</code></td><td>Diagnose stores, wiring, index and version. <code>--json</code>, <code>--offline</code>. <code>--deep</code> re-parses a sample of source files and resolves postings to prove the index against the sources; exits non-zero on drift.</td></tr>
 <tr><td><code>deja bench recall|context</code></td><td>Reproducible search-quality and context-readiness benchmarks.</td></tr>
 <tr><td><code>deja update</code></td><td>Update a standalone install (Homebrew/npm update via the package manager).</td></tr>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -63,6 +63,7 @@
 <li><b>Forget</b> — <code>deja forget</code> removes sessions and records a tombstone so they don't come back on the next index; <code>--dry-run</code> to preview, <code>--unforget</code> to reverse.</li>
 <li><b>Redaction report</b> — <code>deja stats --redaction</code> shows what was masked, per rule and harness.</li>
 <li><b>Audit what agents received</b> — <code>deja log</code> lists recent recalls and injections; <code>deja log --last</code> prints the exact digest most recently served.</li>
+<li><b>Trust scopes</b> — <code>~/.config/deja/policy.json</code> controls what memory activates where. Per activation path (<code>search</code>, <code>mcp</code>, <code>auto</code>) you allow or deny origins: <code>local</code>, <code>imported</code> (anything synced from another machine), or a single peer like <code>imported:mini</code>. Example — synced sessions stay searchable but never auto-inject: <code>{"activations":{"auto":{"imported":false}}}</code>. <code>DEJA_AUTORECALL_LOCAL_ONLY=1</code> remains an alias for exactly that rule. Receipts and <code>deja log --last</code> name the policy that allowed each injection.</li>
 </ul>
 <p>Full details in the <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">security model</a>.</p>
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,0 +1,130 @@
+// Package policy decides what memory activates where. Recall crossing a
+// machine boundary was the launch thread's top concern; instead of one env
+// var, a small explicit table: per activation (search, mcp, auto), which
+// origins (local, imported, imported:<peer>) may inject. Defaults allow
+// everything, matching prior behavior; DEJA_AUTORECALL_LOCAL_ONLY=1 stays as
+// an alias for denying imported memory on the auto path.
+package policy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+const (
+	ActivationSearch = "search"
+	ActivationMCP    = "mcp"
+	ActivationAuto   = "auto"
+)
+
+// Policy maps activation → origin rules. A missing activation allows every
+// origin. Origin keys: "local", "imported" (any peer), "imported:<peer>"
+// (most specific wins).
+type Policy struct {
+	Activations map[string]map[string]bool `json:"activations,omitempty"`
+}
+
+func Path() string {
+	if p := os.Getenv("DEJA_POLICY_FILE"); p != "" {
+		return p
+	}
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		base = filepath.Join(sources.Home(), ".config")
+	}
+	return filepath.Join(base, "deja", "policy.json")
+}
+
+// Load reads the policy file and folds in the env alias. Any read or parse
+// failure means the default policy — recall must not break because a config
+// file is malformed; doctor is the place to complain.
+func Load() Policy {
+	var p Policy
+	if b, err := os.ReadFile(Path()); err == nil {
+		_ = json.Unmarshal(b, &p)
+	}
+	if os.Getenv("DEJA_AUTORECALL_LOCAL_ONLY") == "1" {
+		if p.Activations == nil {
+			p.Activations = map[string]map[string]bool{}
+		}
+		if p.Activations[ActivationAuto] == nil {
+			p.Activations[ActivationAuto] = map[string]bool{"local": true}
+		}
+		p.Activations[ActivationAuto]["imported"] = false
+	}
+	return p
+}
+
+// Origin classifies a session's project name.
+func Origin(project string) string {
+	if peer, ok := strings.CutPrefix(project, "imported:"); ok {
+		if i := strings.IndexByte(peer, '/'); i > 0 {
+			return "imported:" + peer[:i]
+		}
+		return "imported"
+	}
+	return "local"
+}
+
+// Allows reports whether memory from the session's origin may activate on
+// this path. Most specific rule wins: imported:<peer> over imported over the
+// activation default (allow).
+func (p Policy) Allows(activation, project string) bool {
+	rules := p.Activations[activation]
+	if rules == nil {
+		return true
+	}
+	origin := Origin(project)
+	if v, ok := rules[origin]; ok {
+		return v
+	}
+	if strings.HasPrefix(origin, "imported:") {
+		if v, ok := rules["imported"]; ok {
+			return v
+		}
+	}
+	if v, ok := rules["*"]; ok {
+		return v
+	}
+	return true
+}
+
+// Describe names the active rule set for receipts and `deja log`, so the
+// audit trail explains itself. The default policy reads "local+imported".
+func (p Policy) Describe(activation string) string {
+	rules := p.Activations[activation]
+	if rules == nil {
+		return "local+imported"
+	}
+	if v, ok := rules["imported"]; ok && !v {
+		return "local-only"
+	}
+	denied := make([]string, 0, len(rules))
+	for origin, allowed := range rules {
+		if !allowed {
+			denied = append(denied, origin)
+		}
+	}
+	if len(denied) == 0 {
+		return "local+imported"
+	}
+	sort.Strings(denied)
+	return "deny " + strings.Join(denied, ",")
+}
+
+// Filter drops the items whose project the policy blocks on this path.
+// projectOf maps an element to its session project name.
+func Filter[T any](p Policy, activation string, items []T, projectOf func(T) string) []T {
+	out := items[:0]
+	for _, it := range items {
+		if p.Allows(activation, projectOf(it)) {
+			out = append(out, it)
+		}
+	}
+	return out
+}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -1,0 +1,111 @@
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultsAllowEverything(t *testing.T) {
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing.json"))
+	p := Load()
+	for _, act := range []string{ActivationSearch, ActivationMCP, ActivationAuto} {
+		for _, proj := range []string{"deja-vu", "imported:mini/deja-vu"} {
+			if !p.Allows(act, proj) {
+				t.Fatalf("default policy must allow %s/%s", act, proj)
+			}
+		}
+		if got := p.Describe(act); got != "local+imported" {
+			t.Fatalf("Describe(%s) = %q", act, got)
+		}
+	}
+}
+
+func TestOriginClassification(t *testing.T) {
+	cases := map[string]string{
+		"deja-vu":                "local",
+		"imported:mini/deja-vu":  "imported:mini",
+		"imported:mini":          "imported",
+		"imported:work/api/auth": "imported:work",
+	}
+	for proj, want := range cases {
+		if got := Origin(proj); got != want {
+			t.Fatalf("Origin(%q) = %q, want %q", proj, got, want)
+		}
+	}
+}
+
+func TestFileDeniesImportedOnAuto(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+	if err := os.WriteFile(path, []byte(`{"activations":{"auto":{"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := Load()
+	if p.Allows(ActivationAuto, "imported:mini/deja-vu") {
+		t.Fatal("auto must deny imported")
+	}
+	if !p.Allows(ActivationAuto, "deja-vu") || !p.Allows(ActivationMCP, "imported:mini/deja-vu") {
+		t.Fatal("local auto and imported mcp must stay allowed")
+	}
+	if got := p.Describe(ActivationAuto); got != "local-only" {
+		t.Fatalf("Describe(auto) = %q, want local-only", got)
+	}
+}
+
+func TestPeerSpecificRuleWins(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+	if err := os.WriteFile(path, []byte(`{"activations":{"mcp":{"imported":true,"imported:untrusted":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := Load()
+	if p.Allows(ActivationMCP, "imported:untrusted/box") {
+		t.Fatal("peer rule must deny untrusted")
+	}
+	if !p.Allows(ActivationMCP, "imported:mini/deja-vu") {
+		t.Fatal("other peers stay allowed")
+	}
+	if got := p.Describe(ActivationMCP); got != "deny imported:untrusted" {
+		t.Fatalf("Describe = %q", got)
+	}
+}
+
+func TestEnvAliasStillWorks(t *testing.T) {
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing.json"))
+	t.Setenv("DEJA_AUTORECALL_LOCAL_ONLY", "1")
+	p := Load()
+	if p.Allows(ActivationAuto, "imported:mini/deja-vu") {
+		t.Fatal("env alias must deny imported on auto")
+	}
+	if !p.Allows(ActivationAuto, "deja-vu") || !p.Allows(ActivationSearch, "imported:mini/deja-vu") {
+		t.Fatal("alias must only touch the auto path")
+	}
+	if got := p.Describe(ActivationAuto); got != "local-only" {
+		t.Fatalf("Describe = %q", got)
+	}
+}
+
+func TestMalformedFileFallsBackToDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+	if err := os.WriteFile(path, []byte(`{broken`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !Load().Allows(ActivationAuto, "imported:mini/x") {
+		t.Fatal("malformed policy must not lock recall out")
+	}
+}
+
+func TestFilterDropsBlocked(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+	if err := os.WriteFile(path, []byte(`{"activations":{"search":{"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	items := []string{"deja-vu", "imported:mini/deja-vu", "other"}
+	got := Filter(Load(), ActivationSearch, items, func(s string) string { return s })
+	if len(got) != 2 || got[0] != "deja-vu" || got[1] != "other" {
+		t.Fatalf("Filter = %v", got)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -298,6 +298,11 @@ func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLengt
 			doc.hit.Reused = n
 			score *= wornBoost(n)
 		}
+		// Curated notes are distilled truth with provenance; they outrank the
+		// raw transcripts they were promoted from.
+		if doc.hit.Session.Harness == "deja" {
+			score *= promotedNoteBoost
+		}
 		score *= freshnessDecay(doc.hit.Session.Updated, now)
 		doc.hit.Score = score
 		hits = append(hits, doc.hit)
@@ -359,6 +364,10 @@ func proximityBoost(window, queryTokenCount int) float64 {
 	boost := 1 + 0.35*(200/(200+span))
 	return boost
 }
+
+// promotedNoteBoost lifts curated deja notes over raw transcripts on equal
+// relevance. Kept modest: a note about X must not bury a transcript about Y.
+const promotedNoteBoost = 1.25
 
 // wornBoost rewards sessions agents keep recalling — capped hard at +20% so
 // popularity can never outrank relevance, only break near-ties.

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -17,6 +17,13 @@ type note struct {
 	TS      string `json:"ts"`
 	Project string `json:"project"`
 	Text    string `json:"text"`
+	// Promoted-note fields. Session carries provenance (harness:id of the
+	// source transcript), State its lifecycle: accepted, rejected,
+	// superseded, stale. Corrections append a new entry; nothing rewrites.
+	Kind    string `json:"kind,omitempty"`
+	Session string `json:"session,omitempty"`
+	State   string `json:"state,omitempty"`
+	Title   string `json:"title,omitempty"`
 }
 
 func NotesFile() string {
@@ -86,6 +93,29 @@ func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error
 			return
 		}
 		project = strings.TrimSpace(project)
+		if kind, _ := m["kind"].(string); kind == "promoted" {
+			// One session per promoted source session; corrections append as
+			// further messages and the title tracks the latest state.
+			src, _ := m["session"].(string)
+			state, _ := m["state"].(string)
+			title, _ := m["title"].(string)
+			if src == "" || !NoteStates[state] {
+				return
+			}
+			key := "promoted\x00" + src
+			s := byDay[key]
+			if s == nil {
+				s = &model.Session{ID: "deja-note-" + strings.ReplaceAll(src, ":", "-"), Harness: "deja", Project: project, Path: path}
+				byDay[key] = s
+			}
+			if title == "" {
+				title = "promoted from " + src
+			}
+			s.Title = title + " [" + state + "]"
+			s.Touch(t)
+			s.Messages = append(s.Messages, model.Message{Role: "user", Text: "[" + state + "] " + text + " (from " + src + ", " + t.UTC().Format("2006-01-02") + ")", Time: t})
+			return
+		}
 		day := t.UTC().Format("2006-01-02")
 		key := project + "\x00" + day
 		s := byDay[key]
@@ -110,4 +140,44 @@ func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error
 		return out[i].Project < out[j].Project
 	})
 	return out, nil
+}
+
+// NoteStates are the lifecycle states a promoted note may carry.
+var NoteStates = map[string]bool{"accepted": true, "rejected": true, "superseded": true, "stale": true}
+
+// AppendPromoted appends a curated note distilled from a session. Appending
+// the same session again records a correction; history is never rewritten.
+func AppendPromoted(project, title, text, session, state string, now time.Time) error {
+	if strings.TrimSpace(session) == "" {
+		return fmt.Errorf("session required")
+	}
+	if !NoteStates[state] {
+		return fmt.Errorf("state must be accepted, rejected, superseded or stale")
+	}
+	project = strings.TrimSpace(project)
+	if project == "" || strings.TrimSpace(text) == "" {
+		return fmt.Errorf("project and text required")
+	}
+	path := NotesFile()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("notes file is a symlink")
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	if err := f.Chmod(0o600); err != nil && runtime.GOOS != "windows" {
+		return err
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	return json.NewEncoder(f).Encode(note{
+		TS: now.UTC().Format(time.RFC3339Nano), Project: project, Text: text,
+		Kind: "promoted", Session: session, State: state, Title: title,
+	})
 }

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -17,7 +17,10 @@ type Snapshot struct {
 	Kind     string    `json:"kind"`
 	Sessions int       `json:"sessions,omitempty"`
 	Bytes    int       `json:"bytes"`
-	Digest   string    `json:"digest"`
+	// Policy names the rule set that allowed this injection, so the audit
+	// trail explains itself ("local+imported", "local-only").
+	Policy string `json:"policy,omitempty"`
+	Digest string `json:"digest"`
 }
 
 const (
@@ -35,13 +38,28 @@ func SnapshotPath(indexDir string) string {
 // the text. raw is the size of the source transcripts the digest distilled.
 // Best-effort like all usage recording.
 func RecordDigest(indexDir, kind, digest string, sessions int, raw int64) {
+	RecordDigestPolicy(indexDir, kind, digest, sessions, raw, "")
+}
+
+// RecordDigestPolicy is RecordDigest plus the name of the policy that allowed
+// the injection, kept with the snapshot for `deja log`.
+func RecordDigestPolicy(indexDir, kind, digest string, sessions int, raw int64, policyName string) {
 	RecordResultRaw(indexDir, kind, len(digest), sessions, sessions == 0, raw)
-	SnapshotOnly(indexDir, kind, digest, sessions)
+	snapshotWrite(indexDir, kind, digest, sessions, policyName)
 }
 
 // SnapshotOnly stores the digest text without writing a counting event, for
 // callers that already recorded one with extra fields.
 func SnapshotOnly(indexDir, kind, digest string, sessions int) {
+	snapshotWrite(indexDir, kind, digest, sessions, "")
+}
+
+// SnapshotPolicy is SnapshotOnly plus the policy name for the audit trail.
+func SnapshotPolicy(indexDir, kind, digest string, sessions int, policyName string) {
+	snapshotWrite(indexDir, kind, digest, sessions, policyName)
+}
+
+func snapshotWrite(indexDir, kind, digest string, sessions int, policyName string) {
 	if digest == "" {
 		return
 	}
@@ -55,7 +73,7 @@ func SnapshotOnly(indexDir, kind, digest string, sessions int) {
 		return
 	}
 	defer func() { _ = f.Close() }()
-	b, err := json.Marshal(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions, Bytes: len(digest), Digest: digest})
+	b, err := json.Marshal(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions, Bytes: len(digest), Policy: policyName, Digest: digest})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
`deja promote <id>` turns a session into a note built on the notes source: quoted evidence plus provenance (harness:id, date) and a lifecycle state. Re-promoting appends a correction, never rewrites. Notes get a modest ranking boost over raw transcripts and the state shows in result titles. `--to path` appends a repo-visible Markdown block. Closes #279.