### PR TITLE
feat(identity): unify project identity across git worktrees

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
-	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
@@ -157,15 +157,7 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 			return "", 0, 0, nil
 		}
 	}
-	names := []string{sources.ClaudeProjectName(cwd)}
-	if base := filepath.Base(cwd); base != "" {
-		if two := filepath.Join(filepath.Base(filepath.Dir(cwd)), base); two != names[0] {
-			names = append(names, two)
-		}
-		if base != names[0] {
-			names = append(names, base)
-		}
-	}
+	names := digest.ProjectNameCandidates(cwd)
 	pol := policy.Load()
 	var ss []model.Session
 	seen := map[string]bool{}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -3,7 +3,9 @@
 package digest
 
 import (
+	"context"
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -211,15 +213,53 @@ func UTF8SafeCut(s string, n int) string {
 
 func ProjectNameCandidates(cwd string) []string {
 	names := []string{sources.ClaudeProjectName(cwd)}
-	if base := filepath.Base(cwd); base != "" {
-		if two := filepath.Join(filepath.Base(filepath.Dir(cwd)), base); two != names[0] {
-			names = append(names, two)
+	add := func(name string) {
+		for _, n := range names {
+			if n == name {
+				return
+			}
 		}
-		if base != names[0] {
-			names = append(names, base)
+		names = append(names, name)
+	}
+	if base := filepath.Base(cwd); base != "" {
+		add(filepath.Join(filepath.Base(filepath.Dir(cwd)), base))
+		add(base)
+	}
+	// The same repo appears under every worktree's path; sessions recorded in
+	// one worktree belong to the project, not to that checkout. Each worktree
+	// root contributes its name forms so recall sees one project. Two
+	// different repos that merely share a basename stay separate everywhere
+	// the full encoded path matches first.
+	for _, root := range gitWorktreeRoots(cwd) {
+		add(sources.ClaudeProjectName(root))
+		if base := filepath.Base(root); base != "" {
+			add(filepath.Join(filepath.Base(filepath.Dir(root)), base))
+			add(base)
 		}
 	}
 	return names
+}
+
+// gitWorktreeRoots lists the repo's worktree roots (including the main one)
+// when cwd is inside a git repository. Best effort with a hard timeout: no
+// git, no repo, or a slow disk simply yields nothing.
+func gitWorktreeRoots(cwd string) []string {
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "git", "-C", cwd, "worktree", "list", "--porcelain").Output()
+	if err != nil {
+		return nil
+	}
+	var roots []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if p, ok := strings.CutPrefix(line, "worktree "); ok && strings.TrimSpace(p) != "" {
+			roots = append(roots, strings.TrimSpace(p))
+		}
+	}
+	if len(roots) < 2 {
+		return nil // a single worktree adds nothing beyond cwd's own names
+	}
+	return roots
 }
 
 // agentArtifactMarkers flag transcript entries that are tool output or

--- a/internal/digest/project_identity_test.go
+++ b/internal/digest/project_identity_test.go
@@ -1,0 +1,58 @@
+package digest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestProjectNameCandidatesIncludesWorktreeSiblings(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	tmp := t.TempDir()
+	main := filepath.Join(tmp, "deja-vu")
+	wt := filepath.Join(tmp, "deja-vu-fix")
+	if err := os.MkdirAll(main, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", main}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	if err := os.WriteFile(filepath.Join(main, "a.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-q", "-m", "seed")
+	run("worktree", "add", "-q", wt, "-b", "fix")
+
+	names := ProjectNameCandidates(wt)
+	var hasMainBase bool
+	for _, n := range names {
+		if n == "deja-vu" {
+			hasMainBase = true
+		}
+	}
+	if !hasMainBase {
+		t.Fatalf("worktree lookup must include the main checkout's name, got %v", names)
+	}
+}
+
+func TestProjectNameCandidatesPlainDirUnchanged(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "utils")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	names := ProjectNameCandidates(dir)
+	if len(names) == 0 || names[0] != "utils" {
+		t.Fatalf("plain dir must keep the classic forms, got %v", names)
+	}
+}


### PR DESCRIPTION
Recall lookups now include the name forms of every worktree root of the current repo (`git worktree list`, 400ms budget, best-effort), so sessions recorded in one checkout surface in the others. Exact encoded-path names still match first, so two unrelated repos sharing a basename stay separate. Closes #44.