### PR TITLE
feat(mcp): browsable sessions resource + recall offset

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -107,7 +107,7 @@ _deja_completion() {
             if [[ "$prev" == "--harness" ]]; then
                 COMPREPLY=( $(compgen -W "$harnesses" -- "$cur") )
             else
-                COMPREPLY=( $(compgen -W "--json --html --redaction --card --harness --project --since --role" -- "$cur") )
+                COMPREPLY=( $(compgen -W "--json --impact --html --redaction --card --harness --project --since --role" -- "$cur") )
             fi
             ;;
         sync)
@@ -221,7 +221,7 @@ _deja() {
       _arguments '--exec[launch the native harness]' '1:session ID prefix:'
       ;;
     stats)
-      _arguments '--json[print JSON]' '--html=[write HTML timeline]:path:_files' '--redaction[include redaction facts]' '--card=[write SVG card]:path:_files' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(user assistant tool)'
+      _arguments '--json[print JSON]' '--impact[measured impact report]' '--html=[write HTML timeline]:path:_files' '--redaction[include redaction facts]' '--card=[write SVG card]:path:_files' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(user assistant tool)'
       ;;
     sync)
       if (( CURRENT == 3 )); then
@@ -293,6 +293,7 @@ complete -c deja -n '__fish_seen_subcommand_from last' -l role -r -a 'user assis
 complete -c deja -n '__fish_seen_subcommand_from remember' -l project -r
 complete -c deja -n '__fish_seen_subcommand_from resume' -l exec
 complete -c deja -n '__fish_seen_subcommand_from stats' -l json
+complete -c deja -n '__fish_seen_subcommand_from stats' -l impact
 complete -c deja -n '__fish_seen_subcommand_from stats' -l html -r
 complete -c deja -n '__fish_seen_subcommand_from stats' -l redaction
 complete -c deja -n '__fish_seen_subcommand_from stats' -l card -r

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -382,6 +382,9 @@ func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 	}
 	fmt.Fprintf(w, "  location %s\n", loc)
 	fmt.Fprintf(w, "  exclusions %d active patterns\n", len(sources.ExclusionPatterns()))
+	// A precise non-claim: users deciding what to trust deserve to read the
+	// boundary in the tool itself, not only in the security docs.
+	fmt.Fprintln(w, "  security plaintext on disk — protected by file permissions only, no encryption or access control")
 	if idx.State == "missing" {
 		fmt.Fprintln(w, "  status   not built (run `deja warmup`)")
 		return

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
-	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
@@ -157,15 +157,7 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 			return "", 0, 0, nil
 		}
 	}
-	names := []string{sources.ClaudeProjectName(cwd)}
-	if base := filepath.Base(cwd); base != "" {
-		if two := filepath.Join(filepath.Base(filepath.Dir(cwd)), base); two != names[0] {
-			names = append(names, two)
-		}
-		if base != names[0] {
-			names = append(names, base)
-		}
-	}
+	names := digest.ProjectNameCandidates(cwd)
 	pol := policy.Load()
 	var ss []model.Session
 	seen := map[string]bool{}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -817,7 +817,7 @@ Usage:
   deja bench recall [--json]
   deja log [n] [--last] [--json]
   deja statusline
-  deja stats [--json] [--card [path]] [--html [path]]
+  deja stats [--json] [--impact] [--card [path]] [--html [path]]
 	deja remember "text" [--project name]
   deja promote <id-prefix> [--state accepted|rejected|superseded|stale] [--note "text"] [--to path]
   deja mcp

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -95,7 +95,7 @@ func handleMCP(dir string, req rpcRequest) (any, int, string) {
 	case "initialize":
 		return map[string]any{
 			"protocolVersion": mcpProtocolVersion,
-			"capabilities":    map[string]any{"tools": map[string]any{}},
+			"capabilities":    map[string]any{"tools": map[string]any{}, "resources": map[string]any{}},
 			"serverInfo":      map[string]any{"name": "deja", "version": version},
 		}, 0, ""
 	case "tools/list":
@@ -104,7 +104,7 @@ func handleMCP(dir string, req rpcRequest) (any, int, string) {
 				"name":        "recall",
 				"description": "Search the user's own past coding sessions across every AI tool they've used (Claude Code, Codex, Cursor, opencode, aider, gemini, and others) and return the best matches as dense text under ~4KB. Call this the moment the user implies work already happened — 'didn't we fix this before?', 'what was that error again', 'we already set this up', 'how did we solve X last time', 'what did we decide about Y' — and always before debugging an error or re-implementing something that might already exist. Query with the most specific token available: an exact error string, function name, file path, or flag (multiple words are ANDed). Do NOT use this for general knowledge or library/API docs — only this user's prior sessions. Follow up with recall_context when one session looks right and you need its full story. Optionally filter by harness. When a result genuinely helps the task at hand — you reuse a fix, skip re-debugging, or confirm a prior decision — tell the user in one digest.Short line what deja-vu recalled and how you used it (e.g. \"deja-vu recalled: we hit this JWT skew in March — reusing that fix\"). Even a partial hint counts if it changed your approach. Say nothing about recalls that did not help.",
 				"annotations": map[string]any{"title": "Search past sessions", "readOnlyHint": true, "openWorldHint": false},
-				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "Search terms; specific tokens (error strings, function names, flags) match best. Multiple words are ANDed."}, "harness": map[string]any{"type": "string", "description": "Optional filter: claude, codex, opencode, aider, gemini, cursor, antigravity, grok or qwen."}, "limit": map[string]any{"type": "number", "description": "Max sessions to return (default 5)."}}, "required": []string{"query"}},
+				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "Search terms; specific tokens (error strings, function names, flags) match best. Multiple words are ANDed."}, "harness": map[string]any{"type": "string", "description": "Optional filter: claude, codex, opencode, aider, gemini, cursor, antigravity, grok or qwen."}, "limit": map[string]any{"type": "number", "description": "Max sessions to return (default 5)."}, "offset": map[string]any{"type": "number", "description": "Skip this many ranked matches — page through results without re-ranking."}}, "required": []string{"query"}},
 			},
 			{
 				"name":        "recall_context",
@@ -125,6 +125,16 @@ func handleMCP(dir string, req rpcRequest) (any, int, string) {
 				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"text": map[string]any{"type": "string", "description": "A durable fact, decision, or conclusion to remember."}, "project": map[string]any{"type": "string", "description": "Optional project name; defaults to notes."}}, "required": []string{"text"}},
 			},
 		}}, 0, ""
+	case "resources/list":
+		return mcpResourcesList(dir)
+	case "resources/read":
+		var p struct {
+			URI string `json:"uri"`
+		}
+		if err := json.Unmarshal(req.Params, &p); err != nil {
+			return nil, -32602, "invalid params"
+		}
+		return mcpResourceRead(dir, p.URI)
 	case "tools/call":
 		var p struct {
 			Name      string          `json:"name"`
@@ -158,6 +168,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			Query   string  `json:"query"`
 			Harness string  `json:"harness"`
 			Limit   float64 `json:"limit"`
+			Offset  float64 `json:"offset"`
 		}
 		if err := json.Unmarshal(raw, &a); err != nil {
 			return "", err
@@ -165,7 +176,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Query) == "" {
 			return "", fmt.Errorf("query required")
 		}
-		text, sessions, raw, ids, err := recallTextResult(dir, a.Query, a.Harness, int(a.Limit), 4096-recallFrameOverhead)
+		text, sessions, raw, ids, err := recallTextResult(dir, a.Query, a.Harness, int(a.Limit), int(a.Offset), 4096-recallFrameOverhead)
 		if err == nil {
 			text = frameRecall(text)
 			usage.RecordServedSessions(dir, usage.KindRecall, len(text), sessions, sessions == 0, raw, ids)
@@ -260,11 +271,11 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 }
 
 func recallText(dir, q, harness string, limit, budget int) (string, error) {
-	text, _, _, _, err := recallTextResult(dir, q, harness, limit, budget)
+	text, _, _, _, err := recallTextResult(dir, q, harness, limit, 0, budget)
 	return text, err
 }
 
-func recallTextResult(dir, q, harness string, limit, budget int) (string, int, int64, []string, error) {
+func recallTextResult(dir, q, harness string, limit, offset, budget int) (string, int, int64, []string, error) {
 	if limit <= 0 {
 		limit = 5
 	}
@@ -301,7 +312,16 @@ func recallTextResult(dir, q, harness string, limit, budget int) (string, int, i
 	if len(hits) == 0 {
 		return fmt.Sprintf("No prior deja sessions matched %q.", q), 0, 0, nil, nil
 	}
+	total := len(hits)
+	if offset > 0 {
+		if offset >= total {
+			return fmt.Sprintf("No more matches for %q: %d total, offset %d.", q, total, offset), 0, 0, nil, nil
+		}
+		hits = hits[offset:]
+	}
+	remaining := 0
 	if len(hits) > limit {
+		remaining = len(hits) - limit
 		hits = hits[:limit]
 	}
 	var b strings.Builder
@@ -311,7 +331,11 @@ func recallTextResult(dir, q, harness string, limit, budget int) (string, int, i
 	} else if result.Fuzzy {
 		fmt.Fprintf(&b, "No exact match; using close spellings: %s\n", strings.Join(fuzzySummary(result.Variants), ", "))
 	}
-	fmt.Fprintf(&b, "deja recall for %q (%d match(es))\n", q, len(hits))
+	if offset > 0 {
+		fmt.Fprintf(&b, "deja recall for %q (matches %d-%d of %d)\n", q, offset+1, offset+len(hits), total)
+	} else {
+		fmt.Fprintf(&b, "deja recall for %q (%d match(es))\n", q, len(hits))
+	}
 	for i, h := range hits {
 		fmt.Fprintf(&b, "\n%d. [%s] %s · %s · %d matches", i+1, h.Session.Harness, h.Session.Project, h.Session.ID, h.Count)
 		if !h.Session.Updated.IsZero() {
@@ -334,6 +358,9 @@ func recallTextResult(dir, q, harness string, limit, budget int) (string, int, i
 		if b.Len() >= budget {
 			break
 		}
+	}
+	if remaining > 0 {
+		fmt.Fprintf(&b, "\n%d more match(es) — call recall again with offset=%d.\n", remaining, offset+served)
 	}
 	out := b.String()
 	if len(out) > budget {

--- a/cmd/deja/mcp_contract_test.go
+++ b/cmd/deja/mcp_contract_test.go
@@ -221,3 +221,69 @@ func TestMCPToolContract(t *testing.T) {
 		}
 	})
 }
+
+func TestMCPResourcesAndPagination(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	seedClaude(t, claude, "app", "sess-alpha", "the frobnicator crash in parser.go", "fixed the frobnicator")
+	seedClaude(t, claude, "app", "sess-beta", "another frobnicator regression today", "frobnicator again")
+
+	t.Run("resources list and read", func(t *testing.T) {
+		resp := driveMCP(t,
+			`{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}`)
+		resources := resp[0]["result"].(map[string]any)["resources"].([]any)
+		if len(resources) != 2 {
+			t.Fatalf("want 2 resources, got %d: %#v", len(resources), resources)
+		}
+		first := resources[0].(map[string]any)
+		uri, _ := first["uri"].(string)
+		if !strings.HasPrefix(uri, "deja://session/claude:") {
+			t.Fatalf("uri = %q", uri)
+		}
+		read := driveMCP(t, `{"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"`+uri+`"}}`)
+		contents := read[0]["result"].(map[string]any)["contents"].([]any)
+		text := contents[0].(map[string]any)["text"].(string)
+		if !strings.Contains(text, "frobnicator") {
+			t.Fatalf("resource text wrong:\n%s", text)
+		}
+	})
+
+	t.Run("recall offset pages", func(t *testing.T) {
+		resp := driveMCP(t,
+			`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"recall","arguments":{"query":"frobnicator","limit":1}}}`,
+			`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"recall","arguments":{"query":"frobnicator","limit":1,"offset":1}}}`,
+			`{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"recall","arguments":{"query":"frobnicator","limit":1,"offset":9}}}`)
+		page1 := mcpToolText(t, resp[0])
+		page2 := mcpToolText(t, resp[1])
+		past := mcpToolText(t, resp[2])
+		if !strings.Contains(page1, "offset=1") {
+			t.Fatalf("page1 must advertise the next offset:\n%s", page1)
+		}
+		if !strings.Contains(page2, "matches 2-2 of 2") {
+			t.Fatalf("page2 header wrong:\n%s", page2)
+		}
+		id1, id2 := pageSessionID(page1), pageSessionID(page2)
+		if id1 == "" || id2 == "" || id1 == id2 {
+			t.Fatalf("pages must serve different sessions: %q vs %q", id1, id2)
+		}
+		if !strings.Contains(past, "No more matches") {
+			t.Fatalf("past-the-end page wrong:\n%s", past)
+		}
+	})
+}
+
+func mcpToolText(t *testing.T, resp map[string]any) string {
+	t.Helper()
+	content := resp["result"].(map[string]any)["content"].([]any)
+	return content[0].(map[string]any)["text"].(string)
+}
+
+func pageSessionID(page string) string {
+	for _, id := range []string{"sess-alpha", "sess-beta"} {
+		if strings.Contains(page, id) {
+			return id
+		}
+	}
+	return ""
+}

--- a/cmd/deja/mcp_resources.go
+++ b/cmd/deja/mcp_resources.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+const mcpResourceLimit = 20
+
+// mcpResourcesList exposes recent sessions as browsable MCP resources, so an
+// agent can look around without guessing search terms first.
+func mcpResourcesList(dir string) (any, int, string) {
+	if err := index.Ensure(dir, "", false, mcpProgress()); err != nil {
+		return nil, -32603, err.Error()
+	}
+	ss, err := index.Recent(dir, mcpResourceLimit*2)
+	if err != nil {
+		return nil, -32603, err.Error()
+	}
+	pol := policy.Load()
+	resources := make([]map[string]any, 0, mcpResourceLimit)
+	for _, s := range ss {
+		if !pol.Allows(policy.ActivationMCP, s.Project) {
+			continue
+		}
+		name := strings.TrimSpace(s.Title)
+		if name == "" {
+			name = s.ID
+		}
+		desc := s.Project
+		if !s.Updated.IsZero() {
+			desc += " · " + s.Updated.Format("2006-01-02")
+		}
+		resources = append(resources, map[string]any{
+			"uri":         "deja://session/" + s.Harness + ":" + s.ID,
+			"name":        name,
+			"description": desc,
+			"mimeType":    "text/markdown",
+		})
+		if len(resources) >= mcpResourceLimit {
+			break
+		}
+	}
+	return map[string]any{"resources": resources}, 0, ""
+}
+
+// mcpResourceRead serves one session's digest by its deja://session/ URI.
+func mcpResourceRead(dir, uri string) (any, int, string) {
+	ref, ok := strings.CutPrefix(uri, "deja://session/")
+	if !ok {
+		return nil, -32602, "unknown resource uri"
+	}
+	id := ref
+	if i := strings.IndexByte(ref, ':'); i >= 0 {
+		id = ref[i+1:]
+	}
+	s, found, err := findByPrefix(dir, id)
+	if err != nil {
+		return nil, -32603, err.Error()
+	}
+	if !found {
+		return nil, -32602, fmt.Sprintf("no session matches %q", id)
+	}
+	if !policy.Load().Allows(policy.ActivationMCP, s.Project) {
+		return nil, -32602, "blocked by trust policy"
+	}
+	var b bytes.Buffer
+	search.PrintContext(&b, s, "")
+	return map[string]any{"contents": []map[string]any{{
+		"uri":      uri,
+		"mimeType": "text/markdown",
+		"text":     b.String(),
+	}}}, 0, ""
+}

--- a/cmd/deja/security_ux_test.go
+++ b/cmd/deja/security_ux_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+func TestShareEndsWithBoundaryLine(t *testing.T) {
+	hermeticEnv(t)
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-tmp-proj", "s.jsonl"), "s1", []string{
+		`{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"the api broke with token sk-test1234567890abcdefghijklmnop in the header"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	stderr := captureStderr(t, func() {
+		var out bytes.Buffer
+		if err := runShare(dir, []string{"s1"}, &out); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(out.String(), "review before sending") {
+			t.Fatal("boundary line must go to stderr, not into the shared text")
+		}
+	})
+	if !strings.Contains(stderr, "pattern redaction is a floor") || !strings.Contains(stderr, "rotate anything that leaked") {
+		t.Fatalf("share must end with the boundary line, got:\n%s", stderr)
+	}
+}
+
+func TestSyncExportPrintsBoundaryLine(t *testing.T) {
+	hermeticEnv(t)
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-tmp-proj", "s.jsonl"), "s1", []string{
+		`{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"export me"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	stderr := captureStderr(t, func() {
+		if err := runSync(dir, []string{"export", filepath.Join(t.TempDir(), "out")}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(stderr, "pattern redaction is a floor") {
+		t.Fatalf("sync export must print the boundary line, got:\n%s", stderr)
+	}
+}
+
+func TestDoctorStatesSecurityBoundary(t *testing.T) {
+	hermeticEnv(t)
+	var out bytes.Buffer
+	if err := runDoctor(&out, []string{"--offline"}, nil, index.DefaultDir()); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "plaintext on disk") || !strings.Contains(out.String(), "no encryption") {
+		t.Fatalf("doctor must state the security boundary:\n%s", out.String())
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var b bytes.Buffer
+		_, _ = b.ReadFrom(r)
+		done <- b.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stderr = old
+	return <-done
+}

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/digest"
@@ -27,9 +28,16 @@ func runShare(dir string, args []string, w io.Writer) error {
 func printSanitized(w io.Writer, text string) {
 	// Redact the whole document at once: multiline secrets (PEM private key
 	// blocks) never match when scanned line-by-line.
-	redacted, _ := redact.Text(text)
+	redacted, counts := redact.Text(text)
 	fmt.Fprint(w, redacted)
 	if !strings.HasSuffix(redacted, "\n") {
 		fmt.Fprintln(w)
 	}
+	// The boundary line goes to stderr so piped output stays clean. Precise
+	// non-claims: pattern redaction is a floor, not a guarantee.
+	masked := 0
+	for _, n := range counts {
+		masked += n
+	}
+	fmt.Fprintf(os.Stderr, "deja: %d secrets masked in this share. pattern redaction is a floor — review before sending; rotate anything that leaked.\n", masked)
 }

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -35,6 +35,7 @@ type redactionReport struct {
 
 func runStats(dir string, args []string) error {
 	jsonOut := false
+	impact := false
 	cardPath := ""
 	card := false
 	htmlPath := ""
@@ -57,6 +58,8 @@ func runStats(dir string, args []string) error {
 			}
 		case "--redaction":
 			redaction = true
+		case "--impact":
+			impact = true
 		case "--card":
 			if card {
 				return fmt.Errorf("stats: --card specified twice")
@@ -93,6 +96,9 @@ func runStats(dir string, args []string) error {
 	}
 	if (jsonOut && card) || (jsonOut && html) || (card && html) {
 		return fmt.Errorf("stats: choose one output")
+	}
+	if impact {
+		return runStatsImpact(os.Stdout, dir, jsonOut)
 	}
 	if redaction && card {
 		return fmt.Errorf("stats: --redaction cannot combine with --card")

--- a/cmd/deja/stats_impact.go
+++ b/cmd/deja/stats_impact.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// runStatsImpact prints the measured proof that recall changes outcomes.
+// Every line is counted from this machine's usage log; the closing note says
+// exactly what was counted so nobody has to take the numbers on faith.
+func runStatsImpact(w io.Writer, dir string, jsonOut bool) error {
+	r := usage.Impact(dir)
+	if jsonOut {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(r)
+	}
+	if r.Recalls == 0 && r.Injections == 0 {
+		fmt.Fprintln(w, "deja: no recall activity recorded yet — impact numbers appear once agents start recalling")
+		return nil
+	}
+	fmt.Fprintln(w, "deja impact — measured on this machine, nothing modeled")
+	fmt.Fprintf(w, "  recalls served     %d agent-initiated recalls returned matches\n", r.Recalls)
+	fmt.Fprintf(w, "  memory at start    %d session starts began with project memory\n", r.Injections)
+	if r.RawBytes > 0 && r.ServedBytes > 0 {
+		ratio := float64(r.RawBytes) / float64(r.ServedBytes)
+		fmt.Fprintf(w, "  context distilled  %s served instead of %s of raw transcripts (%.0f× less)\n",
+			humanBytes(int64(r.ServedBytes)), humanBytes(r.RawBytes), ratio)
+	}
+	if r.ReusedTwice > 0 {
+		fmt.Fprintf(w, "  knowledge re-used  %d sessions recalled 2+ times — fixes that keep paying\n", r.ReusedTwice)
+	}
+	if r.DejaVuMoments > 0 {
+		fmt.Fprintf(w, "  déjà vu moments    %d prompts matched work you had already done\n", r.DejaVuMoments)
+	}
+	fmt.Fprintln(w, "\ncounted: served bytes = digests actually returned to agents; raw bytes =")
+	fmt.Fprintln(w, "the source transcripts those digests distilled. `deja log` shows every entry.")
+	fmt.Fprintln(w, "for retrieval timing on your own corpus, run `deja bench recall`.")
+	return nil
+}

--- a/cmd/deja/stats_impact_test.go
+++ b/cmd/deja/stats_impact_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+func TestStatsImpactCountsAndArithmetic(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	usage.RecordServedSessions(dir, usage.KindRecall, 1000, 2, false, 50000, []string{"s1", "s2"})
+	usage.RecordServedSessions(dir, usage.KindRecall, 500, 1, false, 25000, []string{"s1"})
+	usage.RecordResultRaw(dir, usage.KindRecall, 0, 0, true, 0) // empty result must not count
+	usage.RecordResultRaw(dir, usage.KindHook, 2000, 3, false, 100000)
+	usage.RecordResult(dir, usage.KindDejaVu, 100, 1, false)
+
+	var out bytes.Buffer
+	if err := runStatsImpact(&out, dir, false); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"2 agent-initiated recalls",
+		"1 session starts began with project memory",
+		"1 sessions recalled 2+ times",
+		"1 prompts matched work",
+		"50× less",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("impact output missing %q:\n%s", want, got)
+		}
+	}
+
+	out.Reset()
+	if err := runStatsImpact(&out, dir, true); err != nil {
+		t.Fatal(err)
+	}
+	var r usage.ImpactReport
+	if err := json.Unmarshal(out.Bytes(), &r); err != nil {
+		t.Fatal(err)
+	}
+	if r.Recalls != 2 || r.Injections != 1 || r.ReusedTwice != 1 || r.DejaVuMoments != 1 || r.ServedBytes != 3500 || r.RawBytes != 175000 {
+		t.Fatalf("json report wrong: %+v", r)
+	}
+}
+
+func TestStatsImpactEmpty(t *testing.T) {
+	var out bytes.Buffer
+	if err := runStatsImpact(&out, filepath.Join(t.TempDir(), "index.db"), false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "no recall activity recorded yet") {
+		t.Fatalf("empty state wrong:\n%s", out.String())
+	}
+}

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -43,6 +43,11 @@ func runSync(dir string, args []string) error {
 			return err
 		}
 		fmt.Fprintf(os.Stdout, "deja: exported %d records\n", n)
+		masked := 0
+		if rs, rerr := index.Redactions(dir); rerr == nil {
+			masked = rs.Total
+		}
+		fmt.Fprintf(os.Stderr, "deja: records were redacted at index time (%d masked). pattern redaction is a floor — review the export before moving it; rotate anything that leaked.\n", masked)
 		return nil
 	case "import":
 		n, err := index.Import(dir, args[1])

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -58,7 +58,7 @@
 <tr><td><code>deja blame &lt;path&gt;</code></td><td>Sessions that discussed a file, most specific first.</td></tr>
 <tr><td><code>deja remember "text"</code></td><td>Store a durable note. <code>--project</code> optional.</td></tr>
 <tr><td><code>deja forget</code></td><td>Remove sessions by <code>--session</code>/<code>--project</code>/<code>--before</code>; <code>--dry-run</code>, <code>--list</code>, <code>--unforget</code>.</td></tr>
-<tr><td><code>deja stats</code></td><td>Totals, top projects, activity. <code>--card</code> (SVG), <code>--html</code> (timeline), <code>--redaction</code>, <code>--json</code>.</td></tr>
+<tr><td><code>deja stats</code></td><td>Totals, top projects, activity. <code>--card</code> (SVG), <code>--html</code> (timeline), <code>--redaction</code>, <code>--json</code>. <code>--impact</code> prints the measured impact report (recalls, reuse, distillation ratio) with the arithmetic labeled.</td></tr>
 <tr><td><code>deja</code></td><td>Bare, on a terminal: the living brief — today's activity, recalls served, déjà vu moments, a suggested search from your own history.</td></tr>
 <tr><td><code>deja log</code></td><td>Audit trail: recent recalls and injections; <code>--last</code> prints the most recent injected digest verbatim; <code>--json</code>.</td></tr>
 <tr><td><code>deja last [n]</code></td><td>Recent sessions. <code>--project</code>, <code>--harness</code>, <code>--since</code>, <code>--role</code>.</td></tr>

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -3,7 +3,9 @@
 package digest
 
 import (
+	"context"
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -211,15 +213,53 @@ func UTF8SafeCut(s string, n int) string {
 
 func ProjectNameCandidates(cwd string) []string {
 	names := []string{sources.ClaudeProjectName(cwd)}
-	if base := filepath.Base(cwd); base != "" {
-		if two := filepath.Join(filepath.Base(filepath.Dir(cwd)), base); two != names[0] {
-			names = append(names, two)
+	add := func(name string) {
+		for _, n := range names {
+			if n == name {
+				return
+			}
 		}
-		if base != names[0] {
-			names = append(names, base)
+		names = append(names, name)
+	}
+	if base := filepath.Base(cwd); base != "" {
+		add(filepath.Join(filepath.Base(filepath.Dir(cwd)), base))
+		add(base)
+	}
+	// The same repo appears under every worktree's path; sessions recorded in
+	// one worktree belong to the project, not to that checkout. Each worktree
+	// root contributes its name forms so recall sees one project. Two
+	// different repos that merely share a basename stay separate everywhere
+	// the full encoded path matches first.
+	for _, root := range gitWorktreeRoots(cwd) {
+		add(sources.ClaudeProjectName(root))
+		if base := filepath.Base(root); base != "" {
+			add(filepath.Join(filepath.Base(filepath.Dir(root)), base))
+			add(base)
 		}
 	}
 	return names
+}
+
+// gitWorktreeRoots lists the repo's worktree roots (including the main one)
+// when cwd is inside a git repository. Best effort with a hard timeout: no
+// git, no repo, or a slow disk simply yields nothing.
+func gitWorktreeRoots(cwd string) []string {
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "git", "-C", cwd, "worktree", "list", "--porcelain").Output()
+	if err != nil {
+		return nil
+	}
+	var roots []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if p, ok := strings.CutPrefix(line, "worktree "); ok && strings.TrimSpace(p) != "" {
+			roots = append(roots, strings.TrimSpace(p))
+		}
+	}
+	if len(roots) < 2 {
+		return nil // a single worktree adds nothing beyond cwd's own names
+	}
+	return roots
 }
 
 // agentArtifactMarkers flag transcript entries that are tool output or

--- a/internal/digest/project_identity_test.go
+++ b/internal/digest/project_identity_test.go
@@ -1,0 +1,58 @@
+package digest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestProjectNameCandidatesIncludesWorktreeSiblings(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	tmp := t.TempDir()
+	main := filepath.Join(tmp, "deja-vu")
+	wt := filepath.Join(tmp, "deja-vu-fix")
+	if err := os.MkdirAll(main, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", main}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	if err := os.WriteFile(filepath.Join(main, "a.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-q", "-m", "seed")
+	run("worktree", "add", "-q", wt, "-b", "fix")
+
+	names := ProjectNameCandidates(wt)
+	var hasMainBase bool
+	for _, n := range names {
+		if n == "deja-vu" {
+			hasMainBase = true
+		}
+	}
+	if !hasMainBase {
+		t.Fatalf("worktree lookup must include the main checkout's name, got %v", names)
+	}
+}
+
+func TestProjectNameCandidatesPlainDirUnchanged(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "utils")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	names := ProjectNameCandidates(dir)
+	if len(names) == 0 || names[0] != "utils" {
+		t.Fatalf("plain dir must keep the classic forms, got %v", names)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -290,3 +290,47 @@ func WornSessions(indexDir string) map[string]int {
 	}
 	return out
 }
+
+// ImpactReport assembles the measured proof that recall changes outcomes.
+// Every number is counted from recorded events on this machine — nothing is
+// modeled, sampled, or estimated.
+type ImpactReport struct {
+	Recalls       int   `json:"recalls"`        // agent-initiated, non-empty
+	Injections    int   `json:"injections"`     // session starts that began with memory
+	ServedBytes   int   `json:"served_bytes"`   // digest bytes actually returned
+	RawBytes      int64 `json:"raw_bytes"`      // source transcripts those digests distilled
+	ReusedTwice   int   `json:"reused_twice"`   // sessions agents recalled 2+ times
+	DejaVuMoments int   `json:"dejavu_moments"` // prompts matched to prior work, all time
+}
+
+// Impact counts across the whole usage log.
+func Impact(indexDir string) ImpactReport {
+	var r ImpactReport
+	worn := map[string]int{}
+	for _, e := range read(Path(indexDir)) {
+		switch e.Kind {
+		case KindRecall, KindContext:
+			if e.Empty {
+				continue
+			}
+			r.Recalls++
+			r.ServedBytes += e.Bytes
+			r.RawBytes += e.RawBytes
+			for _, id := range e.SessionIDs {
+				worn[id]++
+			}
+		case KindHook:
+			r.Injections++
+			r.ServedBytes += e.Bytes
+			r.RawBytes += e.RawBytes
+		case KindDejaVu:
+			r.DejaVuMoments++
+		}
+	}
+	for _, n := range worn {
+		if n >= 2 {
+			r.ReusedTwice++
+		}
+	}
+	return r
+}


### PR DESCRIPTION
Agents can now browse instead of guessing search terms: `resources/list` returns recent sessions as `deja://session/<harness>:<id>` resources, `resources/read` serves the digest, both behind the trust policy. `recall` gains `offset` and tells the agent the exact next call when more matches remain. Closes #12.