### PR TITLE
fix(hooks): no false deja vu moments

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -48,13 +48,19 @@ func runHookPrompt(dir string, stdin io.Reader, stdout io.Writer) error {
 	// (IDF-weighted), rather than reconstructing an AND query — natural
 	// prompts are full of filler that poisons an AND. n=8 to leave room after
 	// excluding the current/too-fresh sessions.
-	ranked, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, 8)
+	ranked, matched, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, 8)
 	if err != nil || len(ranked) == 0 {
 		return nil
 	}
 	ss := make([]model.Session, 0, 2)
 	seen := alreadyInjected(dir, input.SessionID)
-	for _, s := range ranked {
+	for i, s := range ranked {
+		// One lucky rare word is not a déjà vu. Demand real overlap before
+		// claiming "you have been here" — a false moment teaches the user to
+		// ignore the true ones.
+		if matched[i] < 2 {
+			continue
+		}
 		// Never recall the session being written right now, or work fresh
 		// enough the user still remembers it — that is anti-magic.
 		if s.ID == input.SessionID || (!s.Updated.IsZero() && time.Since(s.Updated) < 15*time.Minute) {
@@ -83,6 +89,16 @@ func runHookPrompt(dir string, stdin io.Reader, stdout io.Writer) error {
 	resp.HookSpecificOutput.HookEventName = "UserPromptSubmit"
 	resp.HookSpecificOutput.AdditionalContext = out
 	resp.SystemMessage = dejaVuLine(ss[0])
+	if resp.SystemMessage == "" {
+		// No presentable topic — inject the context silently rather than
+		// flashing harness plumbing at the user.
+		b, err := json.Marshal(resp)
+		if err != nil {
+			return nil
+		}
+		fmt.Fprintln(stdout, string(b))
+		return nil
+	}
 	b, err := json.Marshal(resp)
 	if err != nil {
 		return nil
@@ -188,13 +204,44 @@ func rememberInjected(dir, sid string, ss []model.Session) {
 // dejaVuLine is the one visible line a déjà vu moment earns: which past
 // session answered, and how old it is.
 func dejaVuLine(s model.Session) string {
-	topic := strings.TrimSpace(s.Title)
+	topic := dejaVuTopic(s)
 	if topic == "" {
-		topic = s.Project
+		return ""
 	}
 	r := []rune(topic)
 	if len(r) > 48 {
 		topic = strings.TrimSpace(string(r[:48])) + "…"
 	}
 	return fmt.Sprintf("deja-vu: you have been here — %q (%s)", topic, search.RelativeDate(s.Updated))
+}
+
+// dejaVuTopic picks something a human actually typed. Session titles are the
+// first user message, which for some harnesses is injected plumbing
+// ("# AGENTS.md instructions <INSTRUCTIONS>...") — showing that as "you have
+// been here" reads as a glitch, not a memory.
+func dejaVuTopic(s model.Session) string {
+	if t := strings.TrimSpace(s.Title); t != "" && presentableTopic(t) {
+		return t
+	}
+	for _, m := range s.Messages {
+		if m.Role != "user" || digest.IsAgentArtifact(m.Text) {
+			continue
+		}
+		t := strings.TrimSpace(digest.MessageText(m.Text))
+		if t != "" && presentableTopic(t) {
+			return t
+		}
+	}
+	return ""
+}
+
+func presentableTopic(t string) bool {
+	if digest.IsAgentArtifact(t) {
+		return false
+	}
+	r := []rune(t)[0]
+	if r == '#' || r == '<' || r == '{' || r == '[' {
+		return false
+	}
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r >= 0x400
 }

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -174,3 +174,53 @@ func TestAgentCreditsCountedFromIndex(t *testing.T) {
 		t.Fatalf("credits = %d/%d, want 2/1", r.AgentCredits, r.WeekCredits)
 	}
 }
+
+func TestHookPromptRequiresRealOverlap(t *testing.T) {
+	hermeticEnv(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	// A session sharing exactly ONE informative term with the prompt.
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-gamma", "one.jsonl"), "one", []string{
+		`{"type":"user","sessionId":"one","timestamp":"` + old + `","message":{"role":"user","content":"tune the quetzalcoatl dashboard colors"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "gamma")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	var out bytes.Buffer
+	in := strings.NewReader(`{"prompt":"quetzalcoatl deploy pipeline retries failing"}`)
+	if err := runHookPrompt(index.DefaultDir(), in, &out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "you have been here") {
+		t.Fatalf("single-term overlap must not claim deja vu:\n%s", out.String())
+	}
+}
+
+func TestDejaVuTopicSkipsHarnessPlumbing(t *testing.T) {
+	s := model.Session{
+		Harness: "codex", ID: "x", Project: "app",
+		Title: `# AGENTS.md instructions <INSTRUCTIONS> <!-- deja guidance:start -->`,
+		Messages: []model.Message{
+			{Role: "user", Text: `# AGENTS.md instructions <INSTRUCTIONS> <!-- deja guidance:start -->`},
+			{Role: "user", Text: "why does the exporter drop rows at midnight"},
+		},
+	}
+	if got := dejaVuTopic(s); got != "why does the exporter drop rows at midnight" {
+		t.Fatalf("topic = %q", got)
+	}
+	line := dejaVuLine(s)
+	if strings.Contains(line, "AGENTS.md") {
+		t.Fatalf("plumbing leaked into deja vu line: %q", line)
+	}
+	junk := model.Session{Harness: "codex", ID: "y", Project: "app",
+		Title:    `<environment_context> <cwd>/x</cwd>`,
+		Messages: []model.Message{{Role: "user", Text: `{"type":"init"}`}}}
+	if got := dejaVuLine(junk); got != "" {
+		t.Fatalf("all-plumbing session must yield no visible line, got %q", got)
+	}
+}

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -229,7 +229,7 @@ func TestProjectRelevantRanksByIDFNotFiller(t *testing.T) {
 		t.Fatal(err)
 	}
 	// A prompt full of filler plus the one rare term must rank s1 first.
-	got, err := ProjectRelevant(dir, []string{"app"}, []string{"need", "the", "quetzalcoatl"}, 2)
+	got, _, err := ProjectRelevant(dir, []string{"app"}, []string{"need", "the", "quetzalcoatl"}, 2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -112,18 +112,22 @@ func SearchDetailed(dir string, o query.Options) (SearchResult, error) {
 // filler words. Each session scores the IDF-weighted sum of prompt terms it
 // contains (rare topical terms dominate; common filler barely moves it), from
 // bucket postings only. The best sessions are materialized with transcripts.
-func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Session, error) {
+// ProjectRelevant ranks the project's sessions by IDF-weighted overlap with
+// the prompt terms. matched reports, per returned session, how many distinct
+// terms hit — callers gate on it so one lucky rare word cannot manufacture a
+// confident "you have been here".
+func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Session, []int, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
 	unlock, err := lockDir(dir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer unlock()
 	m, err := readManifest(dir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	inProject := map[uint32]SessionMeta{}
 	for _, meta := range m.Sessions {
@@ -137,10 +141,11 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 		}
 	}
 	if len(inProject) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	totalDocs := float64(len(m.Sessions)) + 1
 	score := map[uint32]float64{}
+	matchedTerms := map[uint32]int{}
 	for _, term := range terms {
 		keys := queryKeys(term)
 		if len(keys) == 0 {
@@ -163,20 +168,22 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 		}
 		for ord := range hit {
 			score[ord] += idf
+			matchedTerms[ord]++
 		}
 	}
 	type scored struct {
-		meta  SessionMeta
-		score float64
+		meta    SessionMeta
+		score   float64
+		matched int
 	}
 	ranked := make([]scored, 0, len(score))
 	for ord, sc := range score {
 		if sc > 0 {
-			ranked = append(ranked, scored{inProject[ord], sc})
+			ranked = append(ranked, scored{inProject[ord], sc, matchedTerms[ord]})
 		}
 	}
 	if len(ranked) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	sort.Slice(ranked, func(i, j int) bool {
 		if ranked[i].score == ranked[j].score {
@@ -188,14 +195,16 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 		ranked = ranked[:n]
 	}
 	out := make([]model.Session, 0, len(ranked))
+	matched := make([]int, 0, len(ranked))
 	for _, r := range ranked {
 		full, err := loadSessionRecords(dir, m, r.meta)
 		if err != nil || len(full.Messages) == 0 {
 			full = sessionFromMeta(r.meta)
 		}
 		out = append(out, full)
+		matched = append(matched, r.matched)
 	}
-	return out, nil
+	return out, matched, nil
 }
 
 // loadSessionRecords materializes one session's transcript from the index.


### PR DESCRIPTION
Two quality holes found in the wild: a single lucky rare word could rank a session into a confident "you have been here", and codex sessions whose first message is injected AGENTS.md plumbing showed that preamble as the topic. Now the moment needs 2+ matched terms, topics come from text a human actually typed, and an all-plumbing session injects silently instead of flashing a glitchy line. Closes nothing — found during dogfood.