### PR TITLE
fix(hooks): calibrate deja vu triggering

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,6 +20,10 @@ import (
 // promptHookBudget keeps per-prompt injections small: this fires on every
 // user message, so it must be a hint, not a payload.
 const promptHookBudget = 1024
+
+// dejaVuMaxMessages caps how large a session can be and still read as one
+// rememberable episode. Marathon catch-all sessions rank into everything.
+const dejaVuMaxMessages = 300
 
 type promptHookInput struct {
 	Prompt    string `json:"prompt"`
@@ -61,6 +66,11 @@ func runHookPrompt(dir string, stdin io.Reader, stdout io.Writer) error {
 		if matched[i] < 2 {
 			continue
 		}
+		// Marathon sessions that touched everything match everything; "you
+		// have been here" is about a focused episode, not a haystack.
+		if len(s.Messages) > dejaVuMaxMessages {
+			continue
+		}
 		// Never recall the session being written right now, or work fresh
 		// enough the user still remembers it — that is anti-magic.
 		if s.ID == input.SessionID || (!s.Updated.IsZero() && time.Since(s.Updated) < 15*time.Minute) {
@@ -78,6 +88,7 @@ func runHookPrompt(dir string, stdin io.Reader, stdout io.Writer) error {
 		return nil
 	}
 	rememberInjected(dir, input.SessionID, ss)
+	showLine := dejaVuLineDue(dir)
 	digest := search.AutoRecallDigest(ss, promptHookBudget-recallFrameOverhead)
 	if strings.TrimSpace(digest) == "" {
 		return nil
@@ -88,7 +99,9 @@ func runHookPrompt(dir string, stdin io.Reader, stdout io.Writer) error {
 	var resp sessionStartHookResponse
 	resp.HookSpecificOutput.HookEventName = "UserPromptSubmit"
 	resp.HookSpecificOutput.AdditionalContext = out
-	resp.SystemMessage = dejaVuLine(ss[0])
+	if showLine {
+		resp.SystemMessage = dejaVuLine(ss[0])
+	}
 	if resp.SystemMessage == "" {
 		// No presentable topic — inject the context silently rather than
 		// flashing harness plumbing at the user.
@@ -119,7 +132,7 @@ func promptSearchTerms(prompt string) []string {
 	var out []string
 	seen := map[string]bool{}
 	for _, f := range fields {
-		if len(f) < 3 || search.IsStopWord(f) || seen[f] {
+		if len(f) < 3 || search.IsStopWord(f) || seen[f] || !techTerm(f) {
 			continue
 		}
 		seen[f] = true
@@ -129,6 +142,24 @@ func promptSearchTerms(prompt string) []string {
 		}
 	}
 	return out
+}
+
+// techTerm keeps tokens that can actually identify past work: identifiers,
+// error codes, paths, or long plain-ASCII words. Ordinary prose — any
+// language — matches by theme, not by task, and theme matches are what made
+// déjà vu fire on every prompt.
+func techTerm(f string) bool {
+	long := 0
+	for _, r := range f {
+		if r == '_' || r == '.' || r == '/' || r == '-' || (r >= '0' && r <= '9') {
+			return true
+		}
+		if r > 127 {
+			return false
+		}
+		long++
+	}
+	return long >= 7
 }
 
 // citationLine pre-writes the narration so the agent copies structure instead
@@ -203,6 +234,20 @@ func rememberInjected(dir, sid string, ss []model.Session) {
 
 // dejaVuLine is the one visible line a déjà vu moment earns: which past
 // session answered, and how old it is.
+// dejaVuLineDue rate-limits the visible line: a déjà vu that fires every
+// prompt is wallpaper, and wallpaper trains the user to ignore the real
+// moments. Context still flows to the agent regardless.
+func dejaVuLineDue(dir string) bool {
+	p := dir + ".dejavu"
+	if b, err := os.ReadFile(p); err == nil {
+		if ts, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64); err == nil && time.Since(time.Unix(ts, 0)) < 20*time.Minute {
+			return false
+		}
+	}
+	_ = os.WriteFile(p, []byte(strconv.FormatInt(time.Now().Unix(), 10)), 0o600)
+	return true
+}
+
 func dejaVuLine(s model.Session) string {
 	topic := dejaVuTopic(s)
 	if topic == "" {

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -222,5 +223,49 @@ func TestDejaVuTopicSkipsHarnessPlumbing(t *testing.T) {
 		Messages: []model.Message{{Role: "user", Text: `{"type":"init"}`}}}
 	if got := dejaVuLine(junk); got != "" {
 		t.Fatalf("all-plumbing session must yield no visible line, got %q", got)
+	}
+}
+
+func TestHookPromptSkipsMarathonSessions(t *testing.T) {
+	hermeticEnv(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	var lines []string
+	for i := 0; i < dejaVuMaxMessages+10; i++ {
+		lines = append(lines, `{"type":"user","sessionId":"hay","timestamp":"`+old+`","message":{"role":"user","content":"quetzalcoatl stampede msg `+fmt.Sprint(i)+`"}}`)
+	}
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-hay", "hay.jsonl"), "hay", lines)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-hay", "focus.jsonl"), "focus", []string{
+		`{"type":"user","sessionId":"focus","timestamp":"` + old + `","message":{"role":"user","content":"the quetzalcoatl stampede fix: jittered ttl"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "hay")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	var out bytes.Buffer
+	in := strings.NewReader(`{"prompt":"quetzalcoatl stampede regression again","session_id":"s-new"}`)
+	if err := runHookPrompt(index.DefaultDir(), in, &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "you have been here") {
+		t.Fatalf("focused session must fire:\n%s", got)
+	}
+	if strings.Contains(got, "msg 5") {
+		t.Fatalf("marathon session leaked into injection:\n%s", got)
+	}
+}
+
+func TestDejaVuLineCooldown(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	if !dejaVuLineDue(dir) {
+		t.Fatal("first call must be due")
+	}
+	if dejaVuLineDue(dir) {
+		t.Fatal("second call within cooldown must be suppressed")
 	}
 }

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -19,6 +19,11 @@ import (
 
 func TestHookPromptInjectsOnRelevantHit(t *testing.T) {
 	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "hookfix.jsonl"), "hookfix", []string{
+		`{"type":"user","sessionId":"hookfix","timestamp":"` + old + `","message":{"role":"user","content":"gateway_timeout on the reconnect_loop keeps dropping heartbeats"}}`,
+	})
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +33,7 @@ func TestHookPromptInjectsOnRelevantHit(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(cwd)
-	in := strings.NewReader(`{"prompt":"long beta answer session"}`)
+	in := strings.NewReader(`{"prompt":"seeing gateway_timeout in the reconnect_loop again"}`)
 	if err := runHookPrompt(index.DefaultDir(), in, &out); err != nil {
 		t.Fatal(err)
 	}
@@ -77,11 +82,23 @@ func TestHookPromptSilentPaths(t *testing.T) {
 func TestPromptSearchTerms(t *testing.T) {
 	got := promptSearchTerms("Why is the connection pool exhausted again in the gateway???")
 	joined := strings.Join(got, " ")
-	if !strings.Contains(joined, "connection") || !strings.Contains(joined, "pool") || !strings.Contains(joined, "gateway") {
+	if !strings.Contains(joined, "connection") || !strings.Contains(joined, "gateway") {
 		t.Fatalf("terms = %v", got)
+	}
+	// Short prose words identify themes, not tasks — they must not survive.
+	if strings.Contains(joined, "pool") {
+		t.Fatalf("short prose term kept: %v", got)
 	}
 	if len(promptSearchTerms("a of to")) != 0 {
 		t.Fatal("stop words must not produce terms")
+	}
+	for term, want := range map[string]bool{
+		"auth.go": true, "e404": true, "npm_token": true, "singleflight": true,
+		"brew": false, "пост": false, "готовь": false,
+	} {
+		if techTerm(term) != want {
+			t.Fatalf("techTerm(%q) = %v, want %v", term, !want, want)
+		}
 	}
 }
 
@@ -129,6 +146,11 @@ func TestSSHSyncTipThresholdAndOnce(t *testing.T) {
 
 func TestHookPromptCitationAndDedupe(t *testing.T) {
 	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "citefix.jsonl"), "citefix", []string{
+		`{"type":"user","sessionId":"citefix","timestamp":"` + old + `","message":{"role":"user","content":"the exporter_batch job drops rows at utc_midnight"}}`,
+	})
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +159,7 @@ func TestHookPromptCitationAndDedupe(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(cwd)
-	in := `{"prompt":"long beta answer session","session_id":"agent-1"}`
+	in := `{"prompt":"exporter_batch dropping rows at utc_midnight again","session_id":"agent-1"}`
 	var out bytes.Buffer
 	if err := runHookPrompt(index.DefaultDir(), strings.NewReader(in), &out); err != nil {
 		t.Fatal(err)
@@ -155,7 +177,7 @@ func TestHookPromptCitationAndDedupe(t *testing.T) {
 	}
 	// A different agent session still gets it.
 	var out3 bytes.Buffer
-	if err := runHookPrompt(index.DefaultDir(), strings.NewReader(`{"prompt":"the long beta session broke again","session_id":"agent-2"}`), &out3); err != nil {
+	if err := runHookPrompt(index.DefaultDir(), strings.NewReader(`{"prompt":"exporter_batch utc_midnight rows again","session_id":"agent-2"}`), &out3); err != nil {
 		t.Fatal(err)
 	}
 	if out3.Len() == 0 {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -112,10 +112,17 @@ func SearchDetailed(dir string, o query.Options) (SearchResult, error) {
 // filler words. Each session scores the IDF-weighted sum of prompt terms it
 // contains (rare topical terms dominate; common filler barely moves it), from
 // bucket postings only. The best sessions are materialized with transcripts.
+// dejaVuIDFFloor is the informativeness bar for a term to count toward a
+// déjà vu match: ln(N/df) >= 2 keeps terms present in at most ~13% of
+// sessions. Conversational filler ("post", "text", "claude") is frequent in
+// any large corpus and clears nothing. Terms living in one or two sessions
+// are informative regardless — small corpora never reach the ratio bar.
+const dejaVuIDFFloor = 2.0
+
 // ProjectRelevant ranks the project's sessions by IDF-weighted overlap with
 // the prompt terms. matched reports, per returned session, how many distinct
-// terms hit — callers gate on it so one lucky rare word cannot manufacture a
-// confident "you have been here".
+// INFORMATIVE terms hit (idf >= dejaVuIDFFloor) — callers gate on it so
+// generic words cannot manufacture a confident "you have been here".
 func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Session, []int, error) {
 	if dir == "" {
 		dir = DefaultDir()
@@ -156,19 +163,31 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 		if err != nil || len(posts) == 0 {
 			continue
 		}
-		idf := math.Log(totalDocs / float64(len(posts)+1))
-		if idf <= 0 {
-			continue
-		}
+		// Document frequency in sessions, not postings: one marathon session
+		// repeating a term 300 times must not make the term look common.
+		df := map[uint32]bool{}
 		hit := map[uint32]bool{}
 		for _, pp := range posts {
+			df[pp.Sid] = true
 			if _, ok := inProject[pp.Sid]; ok {
 				hit[pp.Sid] = true
 			}
 		}
+		idf := math.Log(totalDocs / float64(len(df)+1))
+		if idf <= 0 {
+			// In a tiny corpus every ratio collapses to zero; a term living
+			// in only a couple of sessions still identifies them.
+			if len(df) > 2 {
+				continue
+			}
+			idf = 0.1
+		}
+		informative := idf >= dejaVuIDFFloor || len(df) <= 2
 		for ord := range hit {
 			score[ord] += idf
-			matchedTerms[ord]++
+			if informative {
+				matchedTerms[ord]++
+			}
 		}
 	}
 	type scored struct {


### PR DESCRIPTION
Follow-up to #292 after replaying a real session where 13 of 13 déjà vu moments were false. Four changes: prompt terms must be identifier-shaped (plain prose matches theme, not task — and in a mixed-language corpus every Russian word looked rare), document frequency now counts sessions instead of postings, marathon catch-all sessions (300+ messages) are never presented as "you have been here", and the visible line is rate-limited to one per 20 minutes. Replay: 8/8 conversational prompts now silent, focused technical repeats still fire (verified live in the Claude TUI both ways).