### PR TITLE
fix(hooks): codex session-start hang + trust visibility

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -146,11 +146,13 @@ func doctorHooks(w io.Writer) {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		fmt.Fprintf(w, "  %-12s missing      %s\n", "claude-code", path)
+		doctorCodexHook(w)
 		return
 	}
 	var root map[string]any
 	if json.Unmarshal(b, &root) != nil {
 		fmt.Fprintf(w, "  %-12s unreadable   %s\n", "claude-code", path)
+		doctorCodexHook(w)
 		return
 	}
 	hooks, _ := root["hooks"].(map[string]any)
@@ -160,6 +162,34 @@ func doctorHooks(w io.Writer) {
 		status = "wired"
 	}
 	fmt.Fprintf(w, "  %-12s %-11s %s\n", "precompact", status, path)
+	doctorCodexHook(w)
+}
+
+// doctorCodexHook reports the codex session-start hook state. Codex gates
+// hooks behind its own trust store: hooks.json can be perfectly wired while
+// codex keeps the hook disabled — memory then silently never arrives.
+func doctorCodexHook(w io.Writer) {
+	hooksPath := filepath.Join(sources.CodexHome(), "hooks.json")
+	if _, err := os.Stat(hooksPath); err != nil {
+		fmt.Fprintf(w, "  %-12s missing      %s\n", "codex-hook", hooksPath)
+		return
+	}
+	cfg, err := os.ReadFile(filepath.Join(sources.CodexHome(), "config.toml"))
+	status := "wired"
+	if err == nil {
+		if i := strings.Index(string(cfg), "hooks.json:session_start"); i >= 0 {
+			rest := string(cfg[i:])
+			off, on := strings.Index(rest, "enabled = false"), strings.Index(rest, "enabled = true")
+			if off >= 0 && (on == -1 || on > off) {
+				status = "disabled"
+			}
+		}
+	}
+	line := fmt.Sprintf("  %-12s %-11s %s", "codex-hook", status, hooksPath)
+	if status == "disabled" {
+		line += "  (codex trusts but disabled it — re-enable in codex settings or hooks.state)"
+	}
+	fmt.Fprintln(w, line)
 }
 
 func hookEventWired(hooks map[string]any, event, command string) bool {

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -513,3 +513,50 @@ func TestDoctorHooksMatchAbsolutePathCommands(t *testing.T) {
 		t.Fatalf("absolute-path hook must count as wired:\n%s", out.String())
 	}
 }
+
+func TestDoctorCodexHookStates(t *testing.T) {
+	tmp := hermeticEnv(t)
+	codexHome := filepath.Join(tmp, "home", ".codex")
+	t.Setenv("CODEX_HOME", codexHome)
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	doctorHooks(&out)
+	if !strings.Contains(out.String(), "codex-hook   missing") {
+		t.Fatalf("missing state wrong:\n%s", out.String())
+	}
+	if err := os.WriteFile(filepath.Join(codexHome, "hooks.json"), []byte(`{"hooks":{"SessionStart":[]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte("[hooks.state.\"/x/hooks.json:session_start:0:0\"]\ntrusted_hash = \"sha256:aa\"\nenabled = false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	doctorHooks(&out)
+	if !strings.Contains(out.String(), "codex-hook   disabled") || !strings.Contains(out.String(), "re-enable") {
+		t.Fatalf("disabled state wrong:\n%s", out.String())
+	}
+}
+
+func TestHookContextDoesNotBlockOnSilentStdin(t *testing.T) {
+	hermeticEnv(t)
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close(); _ = r.Close() }()
+	old := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = old }()
+	done := make(chan error, 1)
+	go func() { done <- runHookContext(index.DefaultDir(), false) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("hook-context must not hang when the host never closes stdin (codex does this)")
+	}
+}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -48,9 +48,10 @@ type precompactHookInput struct {
 // stdin hangs the whole session start — the harness then disables the hook
 // and the user just sees memory quietly stop working.
 func readHookStdin() []byte {
+	in := os.Stdin // capture before the goroutine: tests swap the global
 	ch := make(chan []byte, 1)
 	go func() {
-		b, _ := io.ReadAll(io.LimitReader(os.Stdin, 1<<20))
+		b, _ := io.ReadAll(io.LimitReader(in, 1<<20))
 		ch <- b
 	}()
 	select {
@@ -160,6 +161,15 @@ func hookDigest(dir string) string {
 
 func hookDigestResult(dir string) (string, int, int64, []string) {
 	defer func() { _ = recover() }()
+	trace := os.Getenv("DEJA_TRACE") == "1"
+	t0 := time.Now()
+	mark := func(stage string) {
+		if trace {
+			fmt.Fprintf(os.Stderr, "trace %-16s %6.1fms\n", stage, float64(time.Since(t0).Microseconds())/1000)
+			t0 = time.Now()
+		}
+	}
+	_ = mark
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL")))
 	if mode == search.RecallOff {
 		return "", 0, 0, nil
@@ -177,7 +187,9 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 		}
 	}
 	names := digest.ProjectNameCandidates(cwd)
+	mark("names+worktrees")
 	pol := policy.Load()
+	mark("policy")
 	var ss []model.Session
 	seen := map[string]bool{}
 	lookupNames := names
@@ -194,15 +206,12 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 	// files to match against, older sessions are worth considering; without
 	// it, recency alone decides and a small pool is enough.
 	taskFiles := changedTaskFiles(cwd)
+	mark("git-taskfiles")
 	perName := 3
 	if len(taskFiles) > 0 {
 		perName = 12
 	}
-	for _, name := range lookupNames {
-		got, err := index.RecentProject(dir, name, perName)
-		if err != nil {
-			continue
-		}
+	if got, err := index.RecentProjects(dir, lookupNames, perName); err == nil {
 		for _, s := range got {
 			if !pol.Allows(policy.ActivationAuto, s.Project) {
 				continue
@@ -215,6 +224,7 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 			ss = append(ss, s)
 		}
 	}
+	mark("load-sessions")
 	if len(ss) == 0 {
 		return "", 0, 0, nil
 	}
@@ -228,7 +238,16 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 	if len(ss) > 12 {
 		ss = ss[:12]
 	}
+	// Digest and scoring only ever use the recent tail; hauling a marathon
+	// session's megabytes through word sets is pure waste.
+	for i := range ss {
+		if len(ss[i].Messages) > 150 {
+			ss[i].Messages = ss[i].Messages[len(ss[i].Messages)-150:]
+		}
+	}
+	mark("task-scores")
 	result := search.BuildAutoRecall(ss, search.AutoRecallOptions{Mode: mode, ProjectNames: names, TaskScores: scores})
+	mark("build-digest")
 	if result.Sessions == 0 {
 		matched = nil
 	}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -42,11 +43,29 @@ type precompactHookInput struct {
 	Trigger        string `json:"trigger"`
 }
 
+// readHookStdin reads the hook payload without trusting the host to close
+// stdin. Codex keeps the pipe open and silent, and a hook that blocks on
+// stdin hangs the whole session start — the harness then disables the hook
+// and the user just sees memory quietly stop working.
+func readHookStdin() []byte {
+	ch := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(io.LimitReader(os.Stdin, 1<<20))
+		ch <- b
+	}()
+	select {
+	case b := <-ch:
+		return b
+	case <-time.After(300 * time.Millisecond):
+		return nil
+	}
+}
+
 // runHookPrecompact is deliberately best effort: Claude must be able to
 // compact even when the input is incomplete or the index cannot start.
 func runHookPrecompact(dir string) {
 	var input precompactHookInput
-	_ = json.NewDecoder(os.Stdin).Decode(&input)
+	_ = json.Unmarshal(readHookStdin(), &input)
 	requestWarmup(dir)
 }
 
@@ -60,7 +79,7 @@ func runHookContext(dir string, plain bool) error {
 	var input struct {
 		Source string `json:"source"`
 	}
-	_ = json.NewDecoder(os.Stdin).Decode(&input)
+	_ = json.Unmarshal(readHookStdin(), &input)
 	digest, sessions, raw, taskMatched := hookDigestResult(dir)
 	if digest == "" {
 		return nil

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -213,15 +213,15 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 	if n > 0 && len(ranked) > n {
 		ranked = ranked[:n]
 	}
-	out := make([]model.Session, 0, len(ranked))
+	metas := make([]SessionMeta, 0, len(ranked))
 	matched := make([]int, 0, len(ranked))
 	for _, r := range ranked {
-		full, err := loadSessionRecords(dir, m, r.meta)
-		if err != nil || len(full.Messages) == 0 {
-			full = sessionFromMeta(r.meta)
-		}
-		out = append(out, full)
+		metas = append(metas, r.meta)
 		matched = append(matched, r.matched)
+	}
+	out, err := sessionsForMetas(dir, metas)
+	if err != nil {
+		return nil, nil, err
 	}
 	return out, matched, nil
 }
@@ -373,19 +373,69 @@ func RecentProject(dir, project string, n int) ([]model.Session, error) {
 	if n > 0 && len(metas) > n {
 		metas = metas[:n]
 	}
-	out := make([]model.Session, 0, len(metas))
-	for _, meta := range metas {
-		s := sessionFromMeta(meta)
-		recs, err := recordsForKey(filepath.Join(dir, "records.bin"), meta.Harness+":"+meta.ID)
-		if err != nil {
-			return nil, err
+	return sessionsForMetas(dir, metas)
+}
+
+// sessionsForMetas loads full sessions for the given metas in ONE pass over
+// records.bin. The per-session variant re-scanned the whole log for every
+// session, which turned a session-start hook into hundreds of milliseconds.
+func sessionsForMetas(dir string, metas []SessionMeta) ([]model.Session, error) {
+	want := make(map[string]int, len(metas))
+	out := make([]model.Session, len(metas))
+	for i, meta := range metas {
+		want[meta.Harness+":"+meta.ID] = i
+		out[i] = sessionFromMeta(meta)
+	}
+	err := eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
+		if i, ok := want[r.Key]; ok {
+			out[i].Messages = append(out[i].Messages, model.Message{Role: r.Role, Text: r.Text, Time: r.Time})
 		}
-		for _, r := range recs {
-			s.Messages = append(s.Messages, model.Message{Role: r.Role, Text: r.Text, Time: r.Time})
-		}
-		out = append(out, s)
+	})
+	if err != nil {
+		return nil, err
 	}
 	return out, nil
+}
+
+// RecentProjects is RecentProject for several project names at once: one
+// manifest read and one records pass instead of names × sessions scans.
+func RecentProjects(dir string, projects []string, perName int) ([]model.Session, error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	unlock, err := lockDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+	m, err := readManifest(dir)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	var metas []SessionMeta
+	for _, project := range projects {
+		project = strings.ToLower(project)
+		var mine []SessionMeta
+		for _, meta := range m.Sessions {
+			p := strings.ToLower(meta.Project)
+			if p == project || (project != "" && strings.Contains(p, project)) {
+				mine = append(mine, meta)
+			}
+		}
+		sort.Slice(mine, func(i, j int) bool { return mine[i].Updated.After(mine[j].Updated) })
+		if perName > 0 && len(mine) > perName {
+			mine = mine[:perName]
+		}
+		for _, meta := range mine {
+			k := meta.Harness + ":" + meta.ID
+			if !seen[k] {
+				seen[k] = true
+				metas = append(metas, meta)
+			}
+		}
+	}
+	return sessionsForMetas(dir, metas)
 }
 
 func FindByPrefix(dir, p string) (model.Session, bool, error) {


### PR DESCRIPTION
Found while verifying every harness before 0.15.1: codex launches the session-start hook with an open, silent stdin. `deja hook-context` blocked on it forever, codex hung, and its trust store ended up with the hook disabled — memory silently never arrived. Stdin now reads with a 300ms deadline (regression test with a never-closed pipe), and `doctor` prints the codex hook state including the disabled-by-trust case. Verified live: `codex exec` now logs a hook injection.