### PR TITLE
chore(packaging): pin scoop/winget to 0.15.1

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.15.0",
+    "version": "0.15.1",
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.15.0/deja-vu_0.15.0_windows_amd64.zip",
-            "hash": "a4b96c9f62fc8e78537c74dd9e428ff6b9194e76d019af33a5c98c3569fc4653"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.15.1/deja-vu_0.15.1_windows_amd64.zip",
+            "hash": "5887500d346cbdbe15bf16a029b73ee6470e108a7551c577895d0b98dc27610e"
         },
         "arm64": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.15.0/deja-vu_0.15.0_windows_arm64.zip",
-            "hash": "b8f19dace29c94c98c97d1a1ffe646cc358e5c8945fe4ba1a62ec81809512d9c"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.15.1/deja-vu_0.15.1_windows_arm64.zip",
+            "hash": "ca7e2aca45ab28f38ac6054dc443d15a9fc9aca0e73bfee2f8e658cf7393c497"
         }
     },
     "bin": "deja.exe",

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.15.0
+PackageVersion: 0.15.1
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.15.0/deja-vu_0.15.0_windows_amd64.zip
-  InstallerSha256: A4B96C9F62FC8E78537C74DD9E428FF6B9194E76D019AF33A5C98C3569FC4653
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.15.1/deja-vu_0.15.1_windows_amd64.zip
+  InstallerSha256: 5887500D346CBDBE15BF16A029B73EE6470E108A7551C577895D0B98DC27610E
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.15.0/deja-vu_0.15.0_windows_arm64.zip
-  InstallerSha256: B8F19DACE29C94C98C97D1A1FFE646CC358E5C8945FE4BA1A62EC81809512D9C
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.15.1/deja-vu_0.15.1_windows_arm64.zip
+  InstallerSha256: CA7E2ACA45AB28F38AC6054DC443D15A9FC9ACA0E73BFEE2F8E658CF7393C497
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.15.0
+PackageVersion: 0.15.1
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.15.0/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.15.1/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider
@@ -17,6 +17,6 @@ Tags:
 - cursor
 - mcp
 - memory
-ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.15.0
+ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.15.1
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.15.0
+PackageVersion: 0.15.1
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Same as #275 for the new release; hashes verified against the published archives.