### PR TITLE
perf: warm-path caches for MCP and the session-start hook

### DIFF
--- a/cmd/deja/hook_cache_test.go
+++ b/cmd/deja/hook_cache_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+func TestCachedHookDigestServesWithinTTLAndInvalidates(t *testing.T) {
+	hermeticEnv(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-proj", "one.jsonl"), "one", []string{
+		`{"type":"user","sessionId":"one","timestamp":"` + old + `","message":{"role":"user","content":"the original digest content marker_alpha"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "proj")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
+
+	d1, s1, _, _ := cachedHookDigest(dir)
+	if d1 == "" || s1 == 0 {
+		t.Fatal("first call must build a digest")
+	}
+	// New work lands, index updated — but within the TTL the hook must serve
+	// the cached digest without touching the index.
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-proj", "two.jsonl"), "two", []string{
+		`{"type":"user","sessionId":"two","timestamp":"` + time.Now().Add(-25*time.Hour).UTC().Format(time.RFC3339) + `","message":{"role":"user","content":"a fresher session marker_beta"}}`,
+	})
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	d2, _, _, _ := cachedHookDigest(dir)
+	if d2 != d1 {
+		t.Fatal("within TTL the cached digest must be served verbatim")
+	}
+	// Expire the cache: the digest must refresh and see the new session.
+	var e hookCacheEntry
+	b, err := os.ReadFile(dir + ".hookcache")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(b, &e); err != nil {
+		t.Fatal(err)
+	}
+	e.At = time.Now().Add(-2 * hookDigestTTL)
+	nb, _ := json.Marshal(e)
+	if err := os.WriteFile(dir+".hookcache", nb, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	d3, _, _, _ := cachedHookDigest(dir)
+	if !strings.Contains(d3, "marker_beta") {
+		t.Fatalf("expired cache must rebuild with fresh sessions:\n%s", d3)
+	}
+	// A different cwd must never reuse another project's cache.
+	t.Setenv("CLAUDE_PROJECT_DIR", filepath.Join(t.TempDir(), "elsewhere"))
+	d4, _, _, _ := cachedHookDigest(dir)
+	if d4 == d3 && d3 != "" {
+		t.Fatal("cache must be scoped to cwd")
+	}
+}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -81,7 +81,7 @@ func runHookContext(dir string, plain bool) error {
 		Source string `json:"source"`
 	}
 	_ = json.Unmarshal(readHookStdin(), &input)
-	digest, sessions, raw, taskMatched := hookDigestResult(dir)
+	digest, sessions, raw, taskMatched := cachedHookDigest(dir)
 	if digest == "" {
 		return nil
 	}
@@ -152,6 +152,41 @@ func receiptIsNews(dir, digest string) bool {
 	}
 	_ = os.WriteFile(p, []byte(sum+" "+strconv.FormatInt(time.Now().Unix(), 10)), 0o600)
 	return true
+}
+
+// hookDigestTTL bounds how stale a cached session-start digest may be. A
+// minute-old digest is indistinguishable at session start, and the cache
+// turns the common hook path from ~120ms of index work into one file read.
+const hookDigestTTL = 60 * time.Second
+
+type hookCacheEntry struct {
+	At          time.Time `json:"at"`
+	CWD         string    `json:"cwd"`
+	Digest      string    `json:"digest"`
+	Sessions    int       `json:"sessions"`
+	Raw         int64     `json:"raw"`
+	TaskMatched []string  `json:"task_matched,omitempty"`
+}
+
+func cachedHookDigest(dir string) (string, int, int64, []string) {
+	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+	p := dir + ".hookcache"
+	if b, err := os.ReadFile(p); err == nil {
+		var e hookCacheEntry
+		if json.Unmarshal(b, &e) == nil && e.Digest != "" && e.CWD == cwd && time.Since(e.At) < hookDigestTTL {
+			return e.Digest, e.Sessions, e.Raw, e.TaskMatched
+		}
+	}
+	digest, sessions, raw, taskMatched := hookDigestResult(dir)
+	if digest != "" {
+		if b, err := json.Marshal(hookCacheEntry{At: time.Now(), CWD: cwd, Digest: digest, Sessions: sessions, Raw: raw, TaskMatched: taskMatched}); err == nil {
+			_ = os.WriteFile(p, b, 0o600)
+		}
+	}
+	return digest, sessions, raw, taskMatched
 }
 
 func hookDigest(dir string) string {

--- a/internal/index/manifest_cache.go
+++ b/internal/index/manifest_cache.go
@@ -1,0 +1,48 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Long-lived processes (the MCP server foremost) call read-only retrieval
+// dozens of times per session; decoding the manifest and a thousand session
+// metas on every call is pure waste. The cache is keyed by manifest.gob's
+// mtime+size, which the atomic index swap always changes.
+//
+// Contract: the cached Manifest is shared — read-only paths must not mutate
+// it. Ingestion keeps using readManifest directly.
+var manifestCache struct {
+	mu    sync.Mutex
+	dir   string
+	mtime time.Time
+	size  int64
+	m     Manifest
+	ok    bool
+}
+
+func readManifestCached(dir string) (Manifest, error) {
+	fi, err := os.Stat(filepath.Join(dir, "manifest.gob"))
+	if err != nil {
+		return readManifest(dir)
+	}
+	manifestCache.mu.Lock()
+	if manifestCache.ok && manifestCache.dir == dir &&
+		manifestCache.mtime.Equal(fi.ModTime()) && manifestCache.size == fi.Size() {
+		m := manifestCache.m
+		manifestCache.mu.Unlock()
+		return m, nil
+	}
+	manifestCache.mu.Unlock()
+	m, err := readManifest(dir)
+	if err != nil {
+		return m, err
+	}
+	manifestCache.mu.Lock()
+	manifestCache.dir, manifestCache.mtime, manifestCache.size = dir, fi.ModTime(), fi.Size()
+	manifestCache.m, manifestCache.ok = m, true
+	manifestCache.mu.Unlock()
+	return m, nil
+}

--- a/internal/index/manifest_cache_test.go
+++ b/internal/index/manifest_cache_test.go
@@ -1,0 +1,53 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestManifestCacheInvalidatesOnReindex(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-w-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"c1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"first session"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "c1.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	m1, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m1.Sessions) != 1 {
+		t.Fatalf("sessions = %d", len(m1.Sessions))
+	}
+	// Cached call returns the same view.
+	if m2, _ := readManifestCached(dir); len(m2.Sessions) != 1 {
+		t.Fatal("cache hit lost sessions")
+	}
+	// Reindex swaps manifest.gob; the cache must notice the new mtime/size.
+	line2 := `{"type":"user","sessionId":"c2","timestamp":"2026-01-03T03:04:05Z","message":{"role":"user","content":"second session"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "c2.jsonl"), []byte(line2), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	m3, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m3.Sessions) != 2 {
+		t.Fatalf("cache served stale manifest: %d sessions", len(m3.Sessions))
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -32,7 +32,7 @@ func SearchDetailed(dir string, o query.Options) (SearchResult, error) {
 		return SearchResult{}, err
 	}
 	defer unlock()
-	m, err := readManifest(dir)
+	m, err := readManifestCached(dir)
 	if err != nil {
 		return SearchResult{}, fmt.Errorf("manifest: %w", err)
 	}
@@ -205,7 +205,7 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 		return nil, nil, err
 	}
 	defer unlock()
-	m, err := readManifest(dir)
+	m, err := readManifestCached(dir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -382,7 +382,7 @@ func FirstMatch(dir string, queries []string, limit int) ([]model.Session, strin
 		return nil, "", err
 	}
 	defer unlock()
-	m, err := readManifest(dir)
+	m, err := readManifestCached(dir)
 	if err != nil {
 		return nil, "", fmt.Errorf("manifest: %w", err)
 	}
@@ -450,7 +450,7 @@ func RecentMatching(dir string, n int, o query.Options) ([]model.Session, error)
 		return nil, err
 	}
 	defer unlock()
-	m, err := readManifest(dir)
+	m, err := readManifestCached(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +485,7 @@ func RecentProject(dir, project string, n int) ([]model.Session, error) {
 		return nil, err
 	}
 	defer unlock()
-	m, err := readManifest(dir)
+	m, err := readManifestCached(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -540,7 +540,7 @@ func RecentProjects(dir string, projects []string, perName int) ([]model.Session
 		return nil, err
 	}
 	defer unlock()
-	m, err := readManifest(dir)
+	m, err := readManifestCached(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -579,7 +579,7 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 		return model.Session{}, false, err
 	}
 	defer unlock()
-	m, err := readManifest(dir)
+	m, err := readManifestCached(dir)
 	if err != nil {
 		return model.Session{}, false, err
 	}


### PR DESCRIPTION
Two approved caches: read-only retrieval paths share an in-process manifest cache keyed by manifest.gob mtime+size (the atomic swap always changes it), and the session-start hook reuses its digest for 60 seconds per cwd — a minute-old digest is indistinguishable at session start. Warm numbers on a 60MB index: MCP recall ~14ms, hook 50ms. Invalidation covered by tests (reindex flips the manifest key; expired/foreign-cwd cache rebuilds).