### PR TITLE
fix(search): deterministic relevance tie-break (main is red)

### DIFF
--- a/internal/index/relevance_test.go
+++ b/internal/index/relevance_test.go
@@ -34,7 +34,7 @@ func TestLadderFallsBackToRelevance(t *testing.T) {
 	}
 	// A natural question: no session contains every word, so exact/stem/fuzzy
 	// all miss — the relevance tier must surface the graduation session.
-	r, err := SearchWithRecoveryDetailed(dir, query.Options{Query: "quetzal figment bartleby marzipan wombat cufflink", All: true}, nil)
+	r, err := SearchWithRecoveryDetailed(dir, query.Options{Query: "quetzal figment bartleby snorkel marzipan wombat cufflink", All: true}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -335,10 +335,15 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		return nil, nil, nil
 	}
 	sort.Slice(ranked, func(i, j int) bool {
-		if ranked[i].score == ranked[j].score {
+		if ranked[i].score != ranked[j].score {
+			return ranked[i].score > ranked[j].score
+		}
+		if !ranked[i].meta.Updated.Equal(ranked[j].meta.Updated) {
 			return ranked[i].meta.Updated.After(ranked[j].meta.Updated)
 		}
-		return ranked[i].score > ranked[j].score
+		// Total order even on full ties: map iteration must never decide
+		// what the user sees first.
+		return ranked[i].meta.ID < ranked[j].meta.ID
 	})
 	if n > 0 && len(ranked) > n {
 		ranked = ranked[:n]


### PR DESCRIPTION
TestLadderFallsBackToRelevance seeded two sessions with equal scores and identical timestamps; ordering fell to map iteration, passing on the PR and failing on main on all three OSes. The comparator now ends in an ID tie-break (map order must never decide user-visible ranking) and the fixture has distinct scores. 20 consecutive -race runs green.