### PR TITLE
docs: 0.15.2 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 
 | Feature | What it does |
 | --- | --- |
-| **Search** | `deja "connection pool exhausted"` — ~12 ms over gigabytes, retroactive: months of logs from before you installed it |
+| **Search** | `deja "connection pool exhausted"` — ~12 ms over gigabytes, retroactive: months of logs from before you installed it; natural-language questions fall back to a relevance tier — 84.9% R@1 on LongMemEval-S session retrieval, harness in-repo |
 | **Agent recall** | MCP `recall` tool — the agent answers *"we fixed this three weeks ago"* instead of re-debugging, across harnesses: solve it in Codex, Claude remembers |
 | **Sync** | `deja sync ssh laptop` — your memory follows you between machines, append-only, idempotent, no cloud in the middle |
 | **Handoff** | `deja handoff --to codex` — stuck in one agent? package the live context and continue in another: `codex "$(deja handoff --to codex)"` |

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -61,6 +61,14 @@
 <p>The interesting number. Across seeded multi-session task chains, it compares four ways to assemble the context a task needs — deja recall, replaying full history, naive grep, and cold — reporting median tokens with spread and verbatim fact coverage. On the default corpus, deja reaches the same fact coverage as grepping the raw logs for roughly <b>200× fewer tokens</b> — and about 60× fewer than replaying the matched sessions in full — while injecting nothing on the negative-control chains where no prior fact is relevant.</p>
 <div class="note">The comparison is ablation-matched (same pipeline, memory on/off) with naive baselines, so the number isolates deja's contribution rather than "more context helps". Run it and read the distribution.</div>
 
+<h2>Public benchmarks</h2>
+<pre>go run ./scripts/longmemeval -skip-abs -data longmemeval_s.json
+go run ./scripts/locomo -data locomo10.json</pre>
+<p>Two published long-term-memory benchmarks run through the exact production path: haystack sessions are written as real transcript files, indexed by the normal pipeline (parsing, redaction, tokenization), and queried with the verbatim question text. No LLM, no embeddings, no question rewriting. Both harnesses ship in the repo and finish in minutes on the public datasets.</p>
+<p><b>LongMemEval-S</b> (session-level retrieval, 470 questions on the cleaned set): <b>R@1 84.9%</b>, R@5 94.0%, R@10 95.1%, R@20 96.8%, MRR 0.888, median search ~41&nbsp;ms. Weakest slice: preference questions (36.7% R@1 — pure paraphrase is where lexical retrieval loses to semantic indexes, by design; R@20 still reaches 100%). Full-set numbers (500 questions, abstention included): R@1 83.0%.</p>
+<p><b>LoCoMo</b> (session-level retrieval, 1,982 questions): R@1 63.7%, R@5 79.5%, MRR 0.708, median search ~7&nbsp;ms. Note: most published LoCoMo numbers are end-to-end QA accuracy with an answering LLM — a different metric; deja reports retrieval only.</p>
+<div class="note">Read these honestly: LongMemEval is lexically tractable — strong lexical retrievers cluster in the mid-90s at R@5, so R@5 does not differentiate systems there. deja's ranking is R@1-oriented and gates single-word noise, which caps deep R@k by design.</div>
+
 </article>
 </div>
 <footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -362,7 +362,8 @@ footer .spacer{flex:1}
     <table>
       <tr><td class="n">~200×</td><td class="c">fewer tokens to working context than grepping the raw logs, at equal fact coverage</td></tr>
       <tr><td class="n">~12 ms</td><td class="c">typical warm search over gigabytes of history</td></tr>
-      <tr><td class="n">~120 ms</td><td class="c">session-start hook on a 1000-session index — memory lands before you type</td></tr>
+      <tr><td class="n">~50 ms</td><td class="c">session-start hook on a 1000-session index — memory lands before you type</td></tr>
+      <tr><td class="n">84.9%</td><td class="c">R@1 on LongMemEval-S session retrieval — no LLM, no embeddings, harness in-repo</td></tr>
       <tr><td class="n">12</td><td class="c">coding agents indexed into one retroactive memory</td></tr>
     </table>
     <p class="foot"><a href="guide/benchmarks.html">how it's measured →</a></p>


### PR DESCRIPTION
Benchmarks guide gains the LongMemEval-S / LoCoMo sections with the honest caveats (lexical tractability, retrieval-vs-QA metric mismatch, preference weakness); landing bench table carries the 50ms warm hook and the R@1 headline; README search row updated.