### PR TITLE
feat(sources): Cline harness + non-blocking MCP under rebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center"><img src="assets/demo.gif" alt="deja demo"></p>
 
-Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, pi and Copilot CLI write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
+Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, pi and Copilot CLI write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
 
 | Feature | What it does |
 | --- | --- |
@@ -198,13 +198,13 @@ Batches are plain JSONL, redacted on the way out. Import is idempotent, so keep 
 
 ## Teach your agent to remember
 
-`deja install --all` wires up MCP recall (Claude Code, Codex, opencode, Cursor, Gemini CLI, Antigravity, Grok Build, Qwen Code, Kimi Code, Copilot CLI, pi — aider has no MCP client, pipe `deja ctx` instead); `deja install --auto` does the same and adds session-start auto-recall where the harness supports it (Claude Code hook, Codex hooks.json, an opencode plugin — Cursor, Gemini CLI, Antigravity, Grok Build, Qwen Code, Kimi Code, Copilot CLI and pi have no hook that can inject context, so MCP is their full install). To make
+`deja install --all` wires up MCP recall (Claude Code, Codex, opencode, Cursor, Gemini CLI, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Copilot CLI, pi — aider has no MCP client, pipe `deja ctx` instead); `deja install --auto` does the same and adds session-start auto-recall where the harness supports it (Claude Code hook, Codex hooks.json, an opencode plugin — Cursor, Gemini CLI, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Copilot CLI and pi have no hook that can inject context, so MCP is their full install). To make
 the agent reach for memory on its own, add this to your `CLAUDE.md` /
 `AGENTS.md`:
 
 ```
 Before debugging or re-implementing something, run `deja "<query>"` (or the
- MCP recall tool) — past agent sessions across Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, Copilot CLI and pi
+ MCP recall tool) — past agent sessions across Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Copilot CLI and pi
 are indexed locally. Cite what you reuse.
 ```
 
@@ -243,6 +243,7 @@ limits, trust assumptions, and release verification.
 | Grok Build | `${GROK_HOME:-~/.grok}/sessions/**/updates.jsonl`<br>`${DEJA_GROK_ROOT}/sessions/**/updates.jsonl` | ✅ | — | — | ✅ | — |
 | Qwen Code | `${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl` | ✅ | — | — | ✅ | — |
 | Kimi Code | `${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/main/wire.jsonl`<br>`${DEJA_KIMI_ROOT}/sessions/*/*/agents/main/wire.jsonl` | ✅ | — | ✅ | paste | — |
+| Cline | `${CLINE_DIR:-~/.cline}/data/sessions/*/*.messages.json`<br>VS Code globalStorage `saoudrizwan.claude-dev/tasks/*/api_conversation_history.json` | ✅ | — | ✅ | paste | — |
 | pi | `${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl` | ✅ | — | ✅ | ✅ | — |
 | Copilot CLI | `${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl` | ✅ | — | ✅ | ✅ | — |
 <!-- matrix:end -->

--- a/cmd/deja/capability_drift_test.go
+++ b/cmd/deja/capability_drift_test.go
@@ -98,7 +98,7 @@ func TestCapabilityRegistryMatchesCode(t *testing.T) {
 			t.Fatalf("%s: unknown handoff kind %q", h.ID, c.Handoff)
 		}
 	}
-	if seen != len(handoffTargets())+2 { // +2: antigravity and kimi are paste-only
+	if seen != len(handoffTargets())+3 { // +3: antigravity, kimi and cline are paste-only
 		t.Fatalf("registry covers %d harnesses, handoff targets %d", seen, len(handoffTargets()))
 	}
 

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -269,6 +269,14 @@ func doctorHarnesses(w io.Writer) {
 	kimiRoot := filepath.Join(sources.KimiRoot(), "sessions")
 	printRow("kimi", kimiRoot, doctorExists(kimiRoot), doctorCount(len(sources.KimiSessionFiles()), "file"))
 
+	clineModern := sources.ClineSessionsDir()
+	clineFiles := len(sources.ClineSessionFiles())
+	clineLoc := clineModern
+	if legacy := sources.ClineLegacyRoots(); len(legacy) > 0 {
+		clineLoc += ", " + strings.Join(legacy, string(os.PathListSeparator))
+	}
+	printRow("cline", clineLoc, clineFiles > 0 || doctorExists(clineModern), doctorCount(clineFiles, "file"))
+
 	piRoot := sources.PiRoot()
 	printRow("pi", piRoot, doctorExists(piRoot), doctorCount(len(sources.PiSessionFiles()), "file"))
 	copilotRoot := sources.CopilotRoot()

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -253,6 +253,7 @@ func existingTargets() []string {
 		"grok":        sources.GrokRoot(),
 		"qwen":        sources.QwenConfigDir(),
 		"kimi":        sources.KimiConfigDir(),
+		"cline":       sources.ClineConfigDir(),
 		"pi":          sources.PiConfigDir(),
 	}
 	var out []string
@@ -291,6 +292,8 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 		return installMCPJSON(filepath.Join(sources.QwenConfigDir(), "settings.json"), exe, uninstall)
 	case "kimi":
 		return installMCPJSON(filepath.Join(sources.KimiConfigDir(), "mcp.json"), exe, uninstall)
+	case "cline":
+		return installMCPJSON(sources.ClineMCPSettingsPath(), exe, uninstall)
 	case "copilot":
 		return installCopilotMCP(exe, uninstall)
 	case "pi":

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -826,7 +826,7 @@ Usage:
   deja mcp
   deja version
   deja update
-  deja install <claude-code|codex|opencode|cursor|gemini|antigravity|grok|qwen|kimi|statusline|--all|--auto>
+  deja install <claude-code|codex|opencode|cursor|gemini|antigravity|grok|qwen|kimi|cline|statusline|--all|--auto>
   deja uninstall <claude-code|codex|opencode|cursor|gemini|antigravity|grok|qwen|kimi|statusline|--all|--auto>
 
 Examples:

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -280,8 +280,15 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		limit = 5
 	}
 	o := search.Options{Query: q, Harness: harness, All: true, RecallWorn: usage.WornSessions(dir)}
-	if err := index.EnsureForSearch(dir, o, false, mcpProgress()); err != nil {
+	stale, err := index.EnsureForSearchStale(dir, o, mcpProgress())
+	if err != nil {
 		return "", 0, 0, nil, err
+	}
+	if stale {
+		// A store rewrote itself (cline, cursor); rebuilding inline would
+		// blow the client's tool timeout, so refresh detached and serve the
+		// current index with an honest note.
+		requestWarmup(dir)
 	}
 	result, err := index.SearchWithRecoveryDetailed(dir, o, mcpProgress())
 	if err != nil {
@@ -328,6 +335,9 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	}
 	var b strings.Builder
 	served := 0
+	if stale {
+		fmt.Fprintln(&b, "(index refresh running in the background — the very newest sessions may not appear yet)")
+	}
 	if result.Stemmed {
 		fmt.Fprintf(&b, "No exact match; using word forms: %s\n", strings.Join(fuzzySummary(result.Variants), ", "))
 	} else if result.Fuzzy {
@@ -401,8 +411,10 @@ func recallContext(dir, q string) (string, error) {
 
 func recallContextResult(dir, q, harness string) (string, int, int64, []string, error) {
 	o := search.Options{Query: q, Harness: harness, All: true, RecallWorn: usage.WornSessions(dir)}
-	if err := index.EnsureForSearch(dir, o, false, mcpProgress()); err != nil {
+	if stale, err := index.EnsureForSearchStale(dir, o, mcpProgress()); err != nil {
 		return "", 0, 0, nil, err
+	} else if stale {
+		requestWarmup(dir)
 	}
 	result, err := index.SearchWithRecoveryDetailed(dir, o, mcpProgress())
 	if err != nil {

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -112,6 +112,11 @@ func resumeCommand(s model.Session) (string, string, error) {
 		return "", "", fmt.Errorf("cursor IDE chats reopen from the Cursor UI, not the terminal")
 	case "grok":
 		return "", "", fmt.Errorf("grok has no session resume — start grok in %s to continue", sources.GrokCWDForSession(s.Path))
+	case "cline":
+		if strings.HasPrefix(s.ID, "cline-task-") {
+			return "", "", fmt.Errorf("legacy Cline VS Code tasks reopen from the extension's history UI, not the terminal")
+		}
+		return "", "cline --id " + s.ID, nil
 	case "kimi":
 		return "", "kimi --session " + s.ID, nil
 	case "pi":

--- a/docs/registry/cline.md
+++ b/docs/registry/cline.md
@@ -1,0 +1,25 @@
+# Cline
+
+- **ID**: `cline`
+- **Stores** (two generations, one harness):
+  - modern CLI/SDK: `${CLINE_SESSION_DATA_DIR:-${CLINE_DATA_DIR:-${CLINE_DIR:-~/.cline}/data}/sessions}/<sessionId>/<sessionId>.messages.json` with a `<sessionId>.json` manifest beside it
+  - legacy VS Code extension (`saoudrizwan.claude-dev`): `<host globalStorage>/tasks/<taskId>/api_conversation_history.json` with `state/taskHistory.json` supplying title, cwd and timestamp; Code, Code Insiders, VSCodium, Cursor and Windsurf host roots are probed
+- **Read overrides**: `DEJA_CLINE_ROOT` (modern sessions dir), `DEJA_CLINE_ROOTS` (path list of legacy extension roots)
+- **Format**: whole-file JSON rewritten on change (not append-only) — full re-parse after atomic replacement, no incremental offsets
+
+Only `user`/`assistant` turns with string content or `type:"text"` blocks are
+indexed. Tool payloads, thinking, files, images, compaction artifacts and
+non-lead agents are skipped by design. The legacy `<task>...</task>` user
+envelope is unwrapped so the tags are not indexed.
+
+- **MCP**: `deja install cline` writes `mcpServers.deja` into
+  `${CLINE_MCP_SETTINGS_PATH:-$CLINE_DATA_DIR/settings/cline_mcp_settings.json}`
+  (flattened command/args shape, accepted by current Cline; existing entries
+  preserved).
+- **Resume**: `cline --id <sessionId>` for modern sessions only; legacy VS
+  Code tasks reopen from the extension UI.
+- **Handoff**: paste.
+
+Specified by the community in
+[#253](https://github.com/vshulcz/deja-vu/issues/253) with synthetic samples
+and upstream source references.

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -1,260 +1,284 @@
 {
-  "schema_version": 1,
-  "harnesses": [
-    {
-      "id": "claude",
-      "store_paths": [
-        "${CLAUDE_CONFIG_DIR:-~/.claude}/projects/**/*.jsonl",
-        "${DEJA_CLAUDE_ROOT}/**/*.jsonl"
-      ],
-      "format_kind": "jsonl",
-      "fixture_paths": [
-        "fixtures/registry/claude-code/session.jsonl"
-      ],
-      "parser_source": "internal/sources/claude.go",
-      "last_verified": "2026-07-17",
-      "display_name": "Claude Code",
-      "capabilities": {
-        "mcp": true,
-        "auto": true,
-        "resume": true,
-        "handoff": "exec",
-        "prereq": ""
-      }
-    },
-    {
-      "id": "codex",
-      "store_paths": [
-        "${CODEX_HOME:-~/.codex}/sessions/**/rollout-*.jsonl",
-        "${CODEX_HOME:-~/.codex}/history.jsonl",
-        "${DEJA_CODEX_ROOT}/sessions/**/rollout-*.jsonl"
-      ],
-      "format_kind": "jsonl-rollout-and-history",
-      "fixture_paths": [
-        "fixtures/registry/codex/rollout-2026-07-17T09-00-00-registry-codex.jsonl"
-      ],
-      "parser_source": "internal/sources/codex.go",
-      "last_verified": "2026-07-17",
-      "display_name": "Codex CLI",
-      "capabilities": {
-        "mcp": true,
-        "auto": true,
-        "resume": true,
-        "handoff": "exec",
-        "prereq": ""
-      }
-    },
-    {
-      "id": "opencode",
-      "store_paths": [
-        "~/.local/share/opencode/opencode.db",
-        "${XDG_DATA_HOME}/opencode/opencode.db",
-        "${DEJA_OPENCODE_DB}"
-      ],
-      "format_kind": "sqlite",
-      "fixture_paths": [
-        "fixtures/registry/opencode/opencode.sql"
-      ],
-      "parser_source": "internal/sources/opencode.go",
-      "last_verified": "2026-07-17",
-      "display_name": "opencode",
-      "capabilities": {
-        "mcp": true,
-        "auto": true,
-        "resume": true,
-        "handoff": "exec",
-        "prereq": "sqlite3"
-      }
-    },
-    {
-      "id": "aider",
-      "store_paths": [
-        "~/.aider.chat.history.md",
-        "${AIDER_CHAT_HISTORY_FILE}",
-        "${DEJA_AIDER_ROOTS}/**/.aider.chat.history.md"
-      ],
-      "format_kind": "markdown-log",
-      "fixture_paths": [
-        "fixtures/registry/aider/.aider.chat.history.md"
-      ],
-      "parser_source": "internal/sources/aider.go",
-      "last_verified": "2026-07-17",
-      "display_name": "aider",
-      "capabilities": {
-        "mcp": false,
-        "auto": false,
-        "resume": false,
-        "handoff": "exec",
-        "prereq": ""
-      }
-    },
-    {
-      "id": "gemini",
-      "store_paths": [
-        "${GEMINI_CLI_HOME:-~}/.gemini/tmp/*/chats/**/*.{json,jsonl}",
-        "${DEJA_GEMINI_ROOT}/tmp/*/chats/**/*.{json,jsonl}"
-      ],
-      "format_kind": "json-or-jsonl",
-      "fixture_paths": [
-        "fixtures/registry/gemini/session.jsonl"
-      ],
-      "parser_source": "internal/sources/gemini.go",
-      "last_verified": "2026-07-17",
-      "display_name": "Gemini CLI",
-      "capabilities": {
-        "mcp": true,
-        "auto": false,
-        "resume": false,
-        "handoff": "exec",
-        "prereq": ""
-      }
-    },
-    {
-      "id": "cursor",
-      "store_paths": [
-        "~/Library/Application Support/Cursor/User/{globalStorage,workspaceStorage/*}/state.vscdb",
-        "~/.config/Cursor/User/{globalStorage,workspaceStorage/*}/state.vscdb",
-        "${CURSOR_CONFIG_DIR:-~/.cursor}/projects/**/agent-transcripts/**/*.jsonl",
-        "${DEJA_CURSOR_ROOT}",
-        "${DEJA_CURSOR_CLI_ROOT}"
-      ],
-      "format_kind": "sqlite-kv-or-jsonl",
-      "fixture_paths": [
-        "fixtures/registry/cursor/projects/registry-demo/agent-transcripts/registry-cursor.jsonl"
-      ],
-      "parser_source": "internal/sources/cursor.go",
-      "last_verified": "2026-07-17",
-      "display_name": "Cursor",
-      "capabilities": {
-        "mcp": true,
-        "auto": false,
-        "resume": false,
-        "handoff": "exec",
-        "prereq": "sqlite3 (IDE chats)"
-      }
-    },
-    {
-      "id": "antigravity",
-      "store_paths": [
-        "~/.gemini/antigravity*/brain/*/.system_generated/logs/transcript.jsonl",
-        "${DEJA_ANTIGRAVITY_ROOT}/brain/*/.system_generated/logs/transcript.jsonl"
-      ],
-      "format_kind": "jsonl",
-      "fixture_paths": [
-        "fixtures/registry/antigravity/brain/registry-antigravity/.system_generated/logs/transcript.jsonl"
-      ],
-      "parser_source": "internal/sources/antigravity.go",
-      "last_verified": "2026-07-17",
-      "display_name": "Antigravity",
-      "capabilities": {
-        "mcp": true,
-        "auto": false,
-        "resume": true,
-        "handoff": "paste",
-        "prereq": ""
-      }
-    },
-    {
-      "id": "grok",
-      "store_paths": [
-        "${GROK_HOME:-~/.grok}/sessions/**/updates.jsonl",
-        "${DEJA_GROK_ROOT}/sessions/**/updates.jsonl"
-      ],
-      "format_kind": "acp-jsonl-with-json-metadata",
-      "fixture_paths": [
-        "fixtures/registry/grok/sessions/workspace%2Fregistry-demo/registry-grok/updates.jsonl"
-      ],
-      "parser_source": "internal/sources/grok.go",
-      "last_verified": "2026-07-17",
-      "display_name": "Grok Build",
-      "capabilities": {
-        "mcp": true,
-        "auto": false,
-        "resume": false,
-        "handoff": "exec",
-        "prereq": ""
-      }
-    },
-    {
-      "id": "qwen",
-      "store_paths": [
-        "${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl"
-      ],
-      "format_kind": "jsonl",
-      "fixture_paths": [
-        "fixtures/registry/qwen/projects/-workspace-registry-demo/chats/registry-qwen.jsonl"
-      ],
-      "parser_source": "internal/sources/qwen.go",
-      "last_verified": "2026-07-17",
-      "display_name": "Qwen Code",
-      "capabilities": {
-        "mcp": true,
-        "auto": false,
-        "resume": false,
-        "handoff": "exec",
-        "prereq": ""
-      }
-    },
-    {
-      "id": "kimi",
-      "store_paths": [
-        "${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/main/wire.jsonl",
-        "${DEJA_KIMI_ROOT}/sessions/*/*/agents/main/wire.jsonl"
-      ],
-      "format_kind": "jsonl",
-      "fixture_paths": [
-        "fixtures/registry/kimi/sessions/wd_demo_0123456789ab/session_fixture01/agents/main/wire.jsonl"
-      ],
-      "parser_source": "internal/sources/kimi.go",
-      "last_verified": "2026-07-21",
-      "display_name": "Kimi Code",
-      "capabilities": {
-        "mcp": true,
-        "auto": false,
-        "resume": true,
-        "handoff": "paste",
-        "prereq": ""
-      }
-    },
-    {
-      "id": "pi",
-      "store_paths": [
-        "${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl"
-      ],
-      "format_kind": "jsonl",
-      "fixture_paths": [
-        "fixtures/registry/pi/session.jsonl"
-      ],
-      "parser_source": "internal/sources/pi.go",
-      "last_verified": "2026-07-19",
-      "display_name": "pi",
-      "capabilities": {
-        "mcp": true,
-        "auto": false,
-        "resume": true,
-        "handoff": "exec",
-        "prereq": ""
-      }
-    },
-    {
-      "id": "copilot",
-      "store_paths": [
-        "${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl"
-      ],
-      "format_kind": "jsonl",
-      "fixture_paths": [
-        "fixtures/registry/copilot/7cf44517-55ca-435c-893a-3fde1973a44e/events.jsonl"
-      ],
-      "parser_source": "internal/sources/copilot.go",
-      "last_verified": "2026-07-20",
-      "display_name": "Copilot CLI",
-      "capabilities": {
-        "mcp": true,
-        "auto": false,
-        "resume": true,
-        "handoff": "exec",
-        "prereq": ""
-      }
-    }
-  ]
+ "schema_version": 1,
+ "harnesses": [
+  {
+   "id": "claude",
+   "store_paths": [
+    "${CLAUDE_CONFIG_DIR:-~/.claude}/projects/**/*.jsonl",
+    "${DEJA_CLAUDE_ROOT}/**/*.jsonl"
+   ],
+   "format_kind": "jsonl",
+   "fixture_paths": [
+    "fixtures/registry/claude-code/session.jsonl"
+   ],
+   "parser_source": "internal/sources/claude.go",
+   "last_verified": "2026-07-17",
+   "display_name": "Claude Code",
+   "capabilities": {
+    "mcp": true,
+    "auto": true,
+    "resume": true,
+    "handoff": "exec",
+    "prereq": ""
+   }
+  },
+  {
+   "id": "cline",
+   "store_paths": [
+    "${CLINE_SESSION_DATA_DIR:-${CLINE_DATA_DIR:-${CLINE_DIR:-~/.cline}/data}/sessions}/*/*.messages.json",
+    "<vscode-globalStorage>/saoudrizwan.claude-dev/tasks/*/api_conversation_history.json",
+    "${DEJA_CLINE_ROOT}/*/*.messages.json",
+    "${DEJA_CLINE_ROOTS}/tasks/*/api_conversation_history.json"
+   ],
+   "format_kind": "json",
+   "fixture_paths": [
+    "fixtures/registry/cline/modern/sessions/session_synthetic_01/session_synthetic_01.messages.json",
+    "fixtures/registry/cline/legacy/tasks/1767225600000/api_conversation_history.json"
+   ],
+   "parser_source": "internal/sources/cline.go",
+   "last_verified": "2026-07-23",
+   "display_name": "Cline",
+   "capabilities": {
+    "mcp": true,
+    "auto": false,
+    "resume": true,
+    "handoff": "paste",
+    "prereq": ""
+   }
+  },
+  {
+   "id": "codex",
+   "store_paths": [
+    "${CODEX_HOME:-~/.codex}/sessions/**/rollout-*.jsonl",
+    "${CODEX_HOME:-~/.codex}/history.jsonl",
+    "${DEJA_CODEX_ROOT}/sessions/**/rollout-*.jsonl"
+   ],
+   "format_kind": "jsonl-rollout-and-history",
+   "fixture_paths": [
+    "fixtures/registry/codex/rollout-2026-07-17T09-00-00-registry-codex.jsonl"
+   ],
+   "parser_source": "internal/sources/codex.go",
+   "last_verified": "2026-07-17",
+   "display_name": "Codex CLI",
+   "capabilities": {
+    "mcp": true,
+    "auto": true,
+    "resume": true,
+    "handoff": "exec",
+    "prereq": ""
+   }
+  },
+  {
+   "id": "opencode",
+   "store_paths": [
+    "~/.local/share/opencode/opencode.db",
+    "${XDG_DATA_HOME}/opencode/opencode.db",
+    "${DEJA_OPENCODE_DB}"
+   ],
+   "format_kind": "sqlite",
+   "fixture_paths": [
+    "fixtures/registry/opencode/opencode.sql"
+   ],
+   "parser_source": "internal/sources/opencode.go",
+   "last_verified": "2026-07-17",
+   "display_name": "opencode",
+   "capabilities": {
+    "mcp": true,
+    "auto": true,
+    "resume": true,
+    "handoff": "exec",
+    "prereq": "sqlite3"
+   }
+  },
+  {
+   "id": "aider",
+   "store_paths": [
+    "~/.aider.chat.history.md",
+    "${AIDER_CHAT_HISTORY_FILE}",
+    "${DEJA_AIDER_ROOTS}/**/.aider.chat.history.md"
+   ],
+   "format_kind": "markdown-log",
+   "fixture_paths": [
+    "fixtures/registry/aider/.aider.chat.history.md"
+   ],
+   "parser_source": "internal/sources/aider.go",
+   "last_verified": "2026-07-17",
+   "display_name": "aider",
+   "capabilities": {
+    "mcp": false,
+    "auto": false,
+    "resume": false,
+    "handoff": "exec",
+    "prereq": ""
+   }
+  },
+  {
+   "id": "gemini",
+   "store_paths": [
+    "${GEMINI_CLI_HOME:-~}/.gemini/tmp/*/chats/**/*.{json,jsonl}",
+    "${DEJA_GEMINI_ROOT}/tmp/*/chats/**/*.{json,jsonl}"
+   ],
+   "format_kind": "json-or-jsonl",
+   "fixture_paths": [
+    "fixtures/registry/gemini/session.jsonl"
+   ],
+   "parser_source": "internal/sources/gemini.go",
+   "last_verified": "2026-07-17",
+   "display_name": "Gemini CLI",
+   "capabilities": {
+    "mcp": true,
+    "auto": false,
+    "resume": false,
+    "handoff": "exec",
+    "prereq": ""
+   }
+  },
+  {
+   "id": "cursor",
+   "store_paths": [
+    "~/Library/Application Support/Cursor/User/{globalStorage,workspaceStorage/*}/state.vscdb",
+    "~/.config/Cursor/User/{globalStorage,workspaceStorage/*}/state.vscdb",
+    "${CURSOR_CONFIG_DIR:-~/.cursor}/projects/**/agent-transcripts/**/*.jsonl",
+    "${DEJA_CURSOR_ROOT}",
+    "${DEJA_CURSOR_CLI_ROOT}"
+   ],
+   "format_kind": "sqlite-kv-or-jsonl",
+   "fixture_paths": [
+    "fixtures/registry/cursor/projects/registry-demo/agent-transcripts/registry-cursor.jsonl"
+   ],
+   "parser_source": "internal/sources/cursor.go",
+   "last_verified": "2026-07-17",
+   "display_name": "Cursor",
+   "capabilities": {
+    "mcp": true,
+    "auto": false,
+    "resume": false,
+    "handoff": "exec",
+    "prereq": "sqlite3 (IDE chats)"
+   }
+  },
+  {
+   "id": "antigravity",
+   "store_paths": [
+    "~/.gemini/antigravity*/brain/*/.system_generated/logs/transcript.jsonl",
+    "${DEJA_ANTIGRAVITY_ROOT}/brain/*/.system_generated/logs/transcript.jsonl"
+   ],
+   "format_kind": "jsonl",
+   "fixture_paths": [
+    "fixtures/registry/antigravity/brain/registry-antigravity/.system_generated/logs/transcript.jsonl"
+   ],
+   "parser_source": "internal/sources/antigravity.go",
+   "last_verified": "2026-07-17",
+   "display_name": "Antigravity",
+   "capabilities": {
+    "mcp": true,
+    "auto": false,
+    "resume": true,
+    "handoff": "paste",
+    "prereq": ""
+   }
+  },
+  {
+   "id": "grok",
+   "store_paths": [
+    "${GROK_HOME:-~/.grok}/sessions/**/updates.jsonl",
+    "${DEJA_GROK_ROOT}/sessions/**/updates.jsonl"
+   ],
+   "format_kind": "acp-jsonl-with-json-metadata",
+   "fixture_paths": [
+    "fixtures/registry/grok/sessions/workspace%2Fregistry-demo/registry-grok/updates.jsonl"
+   ],
+   "parser_source": "internal/sources/grok.go",
+   "last_verified": "2026-07-17",
+   "display_name": "Grok Build",
+   "capabilities": {
+    "mcp": true,
+    "auto": false,
+    "resume": false,
+    "handoff": "exec",
+    "prereq": ""
+   }
+  },
+  {
+   "id": "qwen",
+   "store_paths": [
+    "${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl"
+   ],
+   "format_kind": "jsonl",
+   "fixture_paths": [
+    "fixtures/registry/qwen/projects/-workspace-registry-demo/chats/registry-qwen.jsonl"
+   ],
+   "parser_source": "internal/sources/qwen.go",
+   "last_verified": "2026-07-17",
+   "display_name": "Qwen Code",
+   "capabilities": {
+    "mcp": true,
+    "auto": false,
+    "resume": false,
+    "handoff": "exec",
+    "prereq": ""
+   }
+  },
+  {
+   "id": "kimi",
+   "store_paths": [
+    "${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/main/wire.jsonl",
+    "${DEJA_KIMI_ROOT}/sessions/*/*/agents/main/wire.jsonl"
+   ],
+   "format_kind": "jsonl",
+   "fixture_paths": [
+    "fixtures/registry/kimi/sessions/wd_demo_0123456789ab/session_fixture01/agents/main/wire.jsonl"
+   ],
+   "parser_source": "internal/sources/kimi.go",
+   "last_verified": "2026-07-21",
+   "display_name": "Kimi Code",
+   "capabilities": {
+    "mcp": true,
+    "auto": false,
+    "resume": true,
+    "handoff": "paste",
+    "prereq": ""
+   }
+  },
+  {
+   "id": "pi",
+   "store_paths": [
+    "${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl"
+   ],
+   "format_kind": "jsonl",
+   "fixture_paths": [
+    "fixtures/registry/pi/session.jsonl"
+   ],
+   "parser_source": "internal/sources/pi.go",
+   "last_verified": "2026-07-19",
+   "display_name": "pi",
+   "capabilities": {
+    "mcp": true,
+    "auto": false,
+    "resume": true,
+    "handoff": "exec",
+    "prereq": ""
+   }
+  },
+  {
+   "id": "copilot",
+   "store_paths": [
+    "${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl"
+   ],
+   "format_kind": "jsonl",
+   "fixture_paths": [
+    "fixtures/registry/copilot/7cf44517-55ca-435c-893a-3fde1973a44e/events.jsonl"
+   ],
+   "parser_source": "internal/sources/copilot.go",
+   "last_verified": "2026-07-20",
+   "display_name": "Copilot CLI",
+   "capabilities": {
+    "mcp": true,
+    "auto": false,
+    "resume": true,
+    "handoff": "exec",
+    "prereq": ""
+   }
+  }
+ ]
 }

--- a/fixtures/registry/cline/legacy/state/taskHistory.json
+++ b/fixtures/registry/cline/legacy/state/taskHistory.json
@@ -1,0 +1,3 @@
+[
+  {"id": "1767225600000", "ts": 1767225600000, "task": "Say hello", "tokensIn": 10, "tokensOut": 2, "totalCost": 0, "cwdOnTaskInitialization": "/home/example/work/demo", "modelId": "synthetic-model"}
+]

--- a/fixtures/registry/cline/legacy/tasks/1767225600000/api_conversation_history.json
+++ b/fixtures/registry/cline/legacy/tasks/1767225600000/api_conversation_history.json
@@ -1,0 +1,4 @@
+[
+  {"role": "user", "content": [{"type": "text", "text": "<task>\nSay hello\n</task>"}]},
+  {"role": "assistant", "content": [{"type": "text", "text": "Hello!"}]}
+]

--- a/fixtures/registry/cline/modern/sessions/session_synthetic_01/session_synthetic_01.json
+++ b/fixtures/registry/cline/modern/sessions/session_synthetic_01/session_synthetic_01.json
@@ -1,0 +1,13 @@
+{
+  "session_id": "session_synthetic_01",
+  "created_at": "2026-01-01T00:00:00.000Z",
+  "updated_at": "2026-01-01T00:00:03.000Z",
+  "interactive": true,
+  "provider": "anthropic",
+  "model": "synthetic-model",
+  "cwd": "/home/example/work/demo",
+  "workspace_root": "/home/example/work/demo",
+  "prompt": "Say hello",
+  "metadata": {"title": "Synthetic parser example"},
+  "messages_path": "/home/example/.cline/data/sessions/session_synthetic_01/session_synthetic_01.messages.json"
+}

--- a/fixtures/registry/cline/modern/sessions/session_synthetic_01/session_synthetic_01.messages.json
+++ b/fixtures/registry/cline/modern/sessions/session_synthetic_01/session_synthetic_01.messages.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "updated_at": "2026-01-01T00:00:03.000Z",
+  "agent": "lead",
+  "sessionId": "session_synthetic_01",
+  "messages": [
+    {"id": "msg_user_01", "role": "user", "content": [{"type": "text", "text": "Say hello"}], "ts": 1767225600000},
+    {"id": "msg_assistant_01", "role": "assistant", "content": [{"type": "text", "text": "Hello!"}, {"type": "thinking", "text": "hidden"}], "ts": 1767225603000}
+  ]
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -141,6 +141,56 @@ func EnsureForSearch(dir string, o query.Options, force bool, progress io.Writer
 	return nil
 }
 
+// EnsureForSearchStale is EnsureForSearch for latency-bound callers (the MCP
+// server): cheap append-only increments run synchronously, but anything that
+// would rewrite the index (full rebuild or a whole-file store change) is
+// kicked to a detached warmup instead. The return value says whether the
+// caller is serving a stale view so it can say so honestly.
+func EnsureForSearchStale(dir string, o query.Options, progress io.Writer) (bool, error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	unlock, ok, err := tryLockDir(dir)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		// A rebuild is already running; serve the current snapshot.
+		return true, nil
+	}
+	defer unlock()
+	want := currentFiles("")
+	m, err := readManifest(dir)
+	if err != nil || m.Version != version || m.Scope != "" || !recordsIntact(dir, m) {
+		// No usable index yet (or a rebuild-grade problem): the caller cannot
+		// serve anything sensible stale, so build synchronously.
+		return false, updateIndex(dir, o.Harness, "", want, false, progress)
+	}
+	if manifestFresh(m, want, "") {
+		return false, nil
+	}
+	changed := map[string]FileState{}
+	removedAny := false
+	for p, f := range want {
+		if of, ok := m.Files[p]; !ok || !sameFile(of, f) {
+			changed[p] = f
+		}
+	}
+	for p := range m.Files {
+		if p == syncImportPath {
+			continue
+		}
+		if _, ok := want[p]; !ok {
+			removedAny = true
+		}
+	}
+	if !removedAny && canAppendIncremental(changed, m.Files) {
+		return false, updateIndex(dir, o.Harness, "", want, false, progress)
+	}
+	// Caller detaches the rebuild (it owns the executable path).
+	return true, nil
+}
+
 func rebuild(dir string, harness string, scope string, files map[string]FileState, progress io.Writer) error {
 	return rebuildWithTombstones(dir, harness, scope, files, progress, readTombstones())
 }
@@ -810,7 +860,10 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		if !ok {
 			return nil
 		}
-		r.Text = redactForIngest(&m, r.SourcePath, r.Text)
+		// Carried records were redacted when first written; re-running the
+		// regex battery over the whole corpus made every incremental update
+		// cost O(index), which is what a live cline/cursor store hits on
+		// each change.
 		off, err := rw.write(r)
 		if err != nil {
 			return err

--- a/internal/index/lock_unix.go
+++ b/internal/index/lock_unix.go
@@ -32,3 +32,29 @@ func lockDir(dir string) (func(), error) {
 		_ = f.Close()
 	}, nil
 }
+
+// tryLockDir is lockDir without blocking: ok=false means another process
+// (typically a detached rebuild) holds the lock. Read paths fall back to
+// lock-free snapshot reads — the atomic directory swap plus the corrupt-index
+// recovery retry make that safe, while waiting here would stall an MCP tool
+// call for the length of a rebuild.
+func tryLockDir(dir string) (func(), bool, error) {
+	lockPath := dir + ".lock"
+	_ = os.Chmod(dir, 0o700)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return nil, false, err
+	}
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		f.Close()
+		return nil, false, nil
+	}
+	recoverIndexDir(dir)
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, true, nil
+}

--- a/internal/index/lock_windows.go
+++ b/internal/index/lock_windows.go
@@ -10,7 +10,10 @@ import (
 	"unsafe"
 )
 
-const lockfileExclusiveLock = 0x2
+const (
+	lockfileExclusiveLock   = 0x2
+	lockfileFailImmediately = 0x1
+)
 
 var (
 	kernel32         = syscall.NewLazyDLL("kernel32.dll")
@@ -64,4 +67,30 @@ func unlockFileEx(h syscall.Handle, reserved, low, high uint32, ol *syscall.Over
 		return syscall.EINVAL
 	}
 	return nil
+}
+
+// tryLockDir mirrors the unix non-blocking variant using
+// LOCKFILE_FAIL_IMMEDIATELY.
+func tryLockDir(dir string) (func(), bool, error) {
+	lockPath := dir + ".lock"
+	_ = os.Chmod(dir, 0o700)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return nil, false, err
+	}
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, false, err
+	}
+	h := syscall.Handle(f.Fd())
+	var ol syscall.Overlapped
+	if err := lockFileEx(h, lockfileExclusiveLock|lockfileFailImmediately, 0, 1, 0, &ol); err != nil {
+		f.Close()
+		return nil, false, nil
+	}
+	recoverIndexDir(dir)
+	return func() {
+		var ol2 syscall.Overlapped
+		_ = unlockFileEx(h, 0, 1, 0, &ol2)
+		_ = f.Close()
+	}, true, nil
 }

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -27,11 +27,16 @@ func SearchDetailed(dir string, o query.Options) (SearchResult, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
-	unlock, err := lockDir(dir)
+	// Non-blocking: while a detached rebuild holds the lock, read the
+	// current snapshot lock-free — the directory swap is atomic and a torn
+	// read fails recordsIntact, which SearchWithRecoveryDetailed retries.
+	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
 		return SearchResult{}, err
 	}
-	defer unlock()
+	if ok {
+		defer unlock()
+	}
 	m, err := readManifestCached(dir)
 	if err != nil {
 		return SearchResult{}, fmt.Errorf("manifest: %w", err)

--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -1,0 +1,361 @@
+package sources
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Cline (github.com/cline/cline) has two session-store generations, both
+// covered by one harness with two file kinds (issue #253):
+//
+//  1. The current CLI/SDK shared store:
+//     ${CLINE_SESSION_DATA_DIR:-${CLINE_DATA_DIR:-${CLINE_DIR:-~/.cline}/data}/sessions}/
+//     <sessionId>/<sessionId>.json          (manifest: cwd, timestamps, title)
+//     <sessionId>/<sessionId>.messages.json (transcript)
+//
+//  2. The released VS Code extension's legacy store under the host's
+//     globalStorage (saoudrizwan.claude-dev):
+//     state/taskHistory.json                (task metadata list)
+//     tasks/<taskId>/api_conversation_history.json (transcript)
+//
+// Both transcript formats are whole-file JSON rewritten on change, not
+// append-only logs, so there is no incremental ParseFrom. Only user and
+// assistant text blocks are indexed; tool payloads, thinking, files, images,
+// subagents and compaction artifacts are skipped by design. Modern messages
+// files are indexed only for the lead agent.
+
+// ClineConfigDir is the native modern data root (~/.cline/data by default),
+// following Cline's own precedence chain.
+func ClineConfigDir() string {
+	if p := os.Getenv("CLINE_DATA_DIR"); p != "" {
+		return p
+	}
+	if p := os.Getenv("CLINE_DIR"); p != "" {
+		return filepath.Join(p, "data")
+	}
+	return filepath.Join(Home(), ".cline", "data")
+}
+
+// ClineSessionsDir is the modern shared session store. DEJA_CLINE_ROOT
+// relocates reads only, mirroring every other harness.
+func ClineSessionsDir() string {
+	if p := os.Getenv("DEJA_CLINE_ROOT"); p != "" {
+		return p
+	}
+	if p := os.Getenv("CLINE_SESSION_DATA_DIR"); p != "" {
+		return p
+	}
+	return filepath.Join(ClineConfigDir(), "sessions")
+}
+
+// ClineMCPSettingsPath is where `deja install cline` writes the MCP entry.
+func ClineMCPSettingsPath() string {
+	if p := os.Getenv("CLINE_MCP_SETTINGS_PATH"); p != "" {
+		return p
+	}
+	return filepath.Join(ClineConfigDir(), "settings", "cline_mcp_settings.json")
+}
+
+// ClineLegacyRoots enumerates the VS Code-compatible hosts' extension
+// global-storage directories. The extension has no native relocation
+// variable, so DEJA_CLINE_ROOTS (a path list) is the read override.
+func ClineLegacyRoots() []string {
+	if list := os.Getenv("DEJA_CLINE_ROOTS"); list != "" {
+		var out []string
+		for _, p := range filepath.SplitList(list) {
+			if p != "" {
+				out = append(out, p)
+			}
+		}
+		return out
+	}
+	const ext = "saoudrizwan.claude-dev"
+	var bases []string
+	switch runtime.GOOS {
+	case "darwin":
+		app := filepath.Join(Home(), "Library", "Application Support")
+		for _, host := range []string{"Code", "Code - Insiders", "VSCodium", "Cursor", "Windsurf"} {
+			bases = append(bases, filepath.Join(app, host, "User", "globalStorage", ext))
+		}
+	case "windows":
+		app := os.Getenv("APPDATA")
+		if app == "" {
+			app = filepath.Join(Home(), "AppData", "Roaming")
+		}
+		for _, host := range []string{"Code", "Code - Insiders", "VSCodium", "Cursor", "Windsurf"} {
+			bases = append(bases, filepath.Join(app, host, "User", "globalStorage", ext))
+		}
+	default:
+		cfg := os.Getenv("XDG_CONFIG_HOME")
+		if cfg == "" {
+			cfg = filepath.Join(Home(), ".config")
+		}
+		for _, host := range []string{"Code", "Code - Insiders", "VSCodium", "Cursor", "Windsurf"} {
+			bases = append(bases, filepath.Join(cfg, host, "User", "globalStorage", ext))
+		}
+	}
+	var out []string
+	for _, b := range bases {
+		if fi, err := os.Stat(b); err == nil && fi.IsDir() {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// ClineSessionFiles lists both generations' transcript files.
+func ClineSessionFiles() []string {
+	files := walkFiles(ClineSessionsDir(), func(p string) bool {
+		return strings.HasSuffix(p, ".messages.json")
+	})
+	for _, root := range ClineLegacyRoots() {
+		files = append(files, walkFiles(filepath.Join(root, "tasks"), func(p string) bool {
+			return filepath.Base(p) == "api_conversation_history.json"
+		})...)
+	}
+	return files
+}
+
+func LoadCline() []model.Session {
+	return parseFiles(ClineSessionFiles(), ParseClineFile)
+}
+
+// ParseClineFile dispatches on the file kind.
+func ParseClineFile(path string) ([]model.Session, error) {
+	if filepath.Base(path) == "api_conversation_history.json" {
+		return parseClineLegacyTask(path)
+	}
+	return parseClineModernSession(path)
+}
+
+// --- modern CLI/SDK store ---
+
+type clineManifest struct {
+	SessionID     string `json:"session_id"`
+	CreatedAt     string `json:"created_at"`
+	UpdatedAt     string `json:"updated_at"`
+	StartedAt     string `json:"started_at"`
+	EndedAt       string `json:"ended_at"`
+	CWD           string `json:"cwd"`
+	WorkspaceRoot string `json:"workspace_root"`
+	Prompt        string `json:"prompt"`
+	Metadata      struct {
+		Title string `json:"title"`
+	} `json:"metadata"`
+}
+
+type clineMessages struct {
+	Agent    string `json:"agent"`
+	Messages []struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+		TS      int64           `json:"ts"`
+	} `json:"messages"`
+}
+
+func parseClineModernSession(path string) ([]model.Session, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var msgs clineMessages
+	if err := json.Unmarshal(b, &msgs); err != nil {
+		diagMalformedLine(path)
+		return nil, nil
+	}
+	// Only the lead agent's transcript is a user-facing session; subagent
+	// and teammate message files share the format but not the meaning.
+	if msgs.Agent != "" && msgs.Agent != "lead" {
+		return nil, nil
+	}
+	sessionDir := filepath.Dir(path)
+	id := filepath.Base(sessionDir)
+	s := model.Session{Harness: "cline", ID: id, Path: path, Project: "cline"}
+	var man clineManifest
+	if mb, err := os.ReadFile(filepath.Join(sessionDir, id+".json")); err == nil {
+		if json.Unmarshal(mb, &man) == nil {
+			cwd := man.CWD
+			if cwd == "" {
+				cwd = man.WorkspaceRoot
+			}
+			if cwd != "" {
+				s.Project = claudeProjectName(strings.ReplaceAll(cwd, "/", "-"))
+			}
+			s.Title = strings.TrimSpace(man.Metadata.Title)
+			if s.Title == "" {
+				s.Title = firstLineTrim(man.Prompt)
+			}
+			// The spec'd manifest uses created_at/updated_at; the shipped
+			// CLI (3.0.46, observed live) writes started_at/ended_at.
+			if t := parseTimeAny(firstNonEmpty(man.CreatedAt, man.StartedAt)); !t.IsZero() {
+				s.Started = t
+			}
+			if t := parseTimeAny(firstNonEmpty(man.UpdatedAt, man.EndedAt)); !t.IsZero() {
+				s.Updated = t
+			}
+		}
+	}
+	for _, m := range msgs.Messages {
+		if m.Role != "user" && m.Role != "assistant" {
+			continue
+		}
+		text := clineContentText(m.Content)
+		if m.Role == "user" {
+			text = unwrapClineTask(text)
+		}
+		if text == "" {
+			continue
+		}
+		ts := s.Started
+		if m.TS > 0 {
+			ts = time.UnixMilli(m.TS)
+		}
+		s.Touch(ts)
+		s.Messages = append(s.Messages, model.Message{Role: m.Role, Text: text, Time: ts})
+	}
+	if len(s.Messages) == 0 {
+		return nil, nil
+	}
+	return []model.Session{s}, nil
+}
+
+// --- legacy VS Code extension store ---
+
+type clineTaskMeta struct {
+	ID   string `json:"id"`
+	TS   int64  `json:"ts"`
+	Task string `json:"task"`
+	CWD  string `json:"cwdOnTaskInitialization"`
+}
+
+func parseClineLegacyTask(path string) ([]model.Session, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var turns []struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(b, &turns); err != nil {
+		diagMalformedLine(path)
+		return nil, nil
+	}
+	taskDir := filepath.Dir(path)
+	taskID := filepath.Base(taskDir)
+	root := filepath.Dir(filepath.Dir(taskDir))
+	s := model.Session{Harness: "cline", ID: "cline-task-" + taskID, Path: path, Project: "cline"}
+	base := time.Time{}
+	if hb, err := os.ReadFile(filepath.Join(root, "state", "taskHistory.json")); err == nil {
+		var metas []clineTaskMeta
+		if json.Unmarshal(hb, &metas) == nil {
+			for _, m := range metas {
+				if m.ID == taskID {
+					s.Title = firstLineTrim(m.Task)
+					if m.CWD != "" {
+						s.Project = claudeProjectName(strings.ReplaceAll(m.CWD, "/", "-"))
+					}
+					if m.TS > 0 {
+						base = time.UnixMilli(m.TS)
+					}
+					break
+				}
+			}
+		}
+	}
+	if base.IsZero() {
+		if fi, err := os.Stat(path); err == nil {
+			base = fi.ModTime()
+		}
+	}
+	for ti, m := range turns {
+		if m.Role != "user" && m.Role != "assistant" {
+			continue
+		}
+		text := clineContentText(m.Content)
+		if m.Role == "user" {
+			text = unwrapClineTask(text)
+		}
+		if text == "" {
+			continue
+		}
+		ts := base.Add(time.Duration(ti) * time.Second)
+		s.Touch(ts)
+		s.Messages = append(s.Messages, model.Message{Role: m.Role, Text: text, Time: ts})
+	}
+	if len(s.Messages) == 0 {
+		return nil, nil
+	}
+	return []model.Session{s}, nil
+}
+
+// clineContentText extracts plain text from either a string content or a
+// typed block list, keeping only type:"text" blocks.
+func clineContentText(raw json.RawMessage) string {
+	var asString string
+	if json.Unmarshal(raw, &asString) == nil {
+		return strings.TrimSpace(asString)
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &blocks) != nil {
+		return ""
+	}
+	var parts []string
+	for _, blk := range blocks {
+		if blk.Type == "text" && strings.TrimSpace(blk.Text) != "" {
+			parts = append(parts, strings.TrimSpace(blk.Text))
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// unwrapClineTask strips the legacy <task>...</task> envelope (and its modern
+// user-input equivalent) so the tags themselves are not indexed.
+func unwrapClineTask(text string) string {
+	t := strings.TrimSpace(text)
+	for _, tag := range []string{"task", "user_message", "user_input"} {
+		open := "<" + tag
+		if !strings.HasPrefix(t, open) {
+			continue
+		}
+		rest := t[len(open):]
+		// The live CLI writes attributes: <user_input mode="act">.
+		gt := strings.IndexByte(rest, '>')
+		if gt < 0 {
+			return t
+		}
+		rest = rest[gt+1:]
+		if i := strings.Index(rest, "</"+tag+">"); i >= 0 {
+			rest = rest[:i] + rest[i+len("</"+tag+">"):]
+		}
+		return strings.TrimSpace(rest)
+	}
+	return t
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+func firstLineTrim(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i > 0 {
+		s = s[:i]
+	}
+	if len(s) > 120 {
+		s = s[:120]
+	}
+	return s
+}

--- a/internal/sources/cline_test.go
+++ b/internal/sources/cline_test.go
@@ -1,0 +1,94 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseClineModernSession(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	path := filepath.Join(root, "fixtures", "registry", "cline", "modern", "sessions", "session_synthetic_01", "session_synthetic_01.messages.json")
+	ss, err := ParseClineFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d", len(ss))
+	}
+	s := ss[0]
+	if s.ID != "session_synthetic_01" || s.Harness != "cline" {
+		t.Fatalf("identity wrong: %+v", s)
+	}
+	if s.Title != "Synthetic parser example" {
+		t.Fatalf("title = %q", s.Title)
+	}
+	if s.Project == "cline" || s.Project == "" {
+		t.Fatalf("project must derive from cwd, got %q", s.Project)
+	}
+	if len(s.Messages) != 2 {
+		t.Fatalf("messages = %d", len(s.Messages))
+	}
+	if s.Messages[1].Text != "Hello!" {
+		t.Fatalf("thinking block must not leak: %q", s.Messages[1].Text)
+	}
+}
+
+func TestParseClineModernSkipsNonLeadAgents(t *testing.T) {
+	dir := t.TempDir()
+	sess := filepath.Join(dir, "session_x")
+	if err := os.MkdirAll(sess, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(sess, "session_x.messages.json")
+	data := `{"version":1,"agent":"subagent-3","sessionId":"session_x","messages":[{"role":"user","content":[{"type":"text","text":"internal"}],"ts":1767225600000}]}`
+	if err := os.WriteFile(p, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseClineFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 0 {
+		t.Fatalf("non-lead agent transcript must be skipped, got %d sessions", len(ss))
+	}
+}
+
+func TestParseClineLegacyTask(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	path := filepath.Join(root, "fixtures", "registry", "cline", "legacy", "tasks", "1767225600000", "api_conversation_history.json")
+	ss, err := ParseClineFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d", len(ss))
+	}
+	s := ss[0]
+	if s.ID != "cline-task-1767225600000" {
+		t.Fatalf("id = %q", s.ID)
+	}
+	if s.Title != "Say hello" {
+		t.Fatalf("title from taskHistory wrong: %q", s.Title)
+	}
+	if s.Messages[0].Text != "Say hello" {
+		t.Fatalf("task envelope must be unwrapped: %q", s.Messages[0].Text)
+	}
+	if s.Started.Year() != 2025 && s.Started.Year() != 2026 {
+		t.Fatalf("timestamp not from taskHistory: %v", s.Started)
+	}
+}
+
+func TestClineSessionFilesHonorsOverrides(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	t.Setenv("DEJA_CLINE_ROOT", filepath.Join(root, "fixtures", "registry", "cline", "modern", "sessions"))
+	t.Setenv("DEJA_CLINE_ROOTS", filepath.Join(root, "fixtures", "registry", "cline", "legacy"))
+	files := ClineSessionFiles()
+	if len(files) != 2 {
+		t.Fatalf("files = %v", files)
+	}
+	ss := LoadCline()
+	if len(ss) != 2 {
+		t.Fatalf("sessions = %d", len(ss))
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -199,6 +199,22 @@ func Registry() []Harness {
 			}},
 		},
 		{
+			Name: "cline", Load: LoadCline, Files: ClineSessionFiles,
+			Kinds: []FileKind{{
+				Name: "cline-sdk",
+				Match: func(p string) bool {
+					return strings.HasSuffix(p, ".messages.json") && strings.HasPrefix(p, ClineSessionsDir())
+				},
+				Parse: fullParse(ParseClineFile),
+			}, {
+				Name: "cline-vscode",
+				Match: func(p string) bool {
+					return hasBase(p, "api_conversation_history.json")
+				},
+				Parse: fullParse(ParseClineFile),
+			}},
+		},
+		{
 			Name: "pi", Load: LoadPi, Files: PiSessionFiles,
 			Kinds: []FileKind{{
 				Name:      "pi",

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -38,6 +38,8 @@ func TestFormatRegistryConformance(t *testing.T) {
 		"DEJA_CLAUDE_ROOT", "DEJA_CODEX_ROOT", "DEJA_CURSOR_CLI_ROOT",
 		"DEJA_CURSOR_ROOT", "DEJA_GEMINI_ROOT", "DEJA_GROK_ROOT",
 		"DEJA_PI_ROOT", "DEJA_QWEN_ROOT", "DEJA_KIMI_ROOT", "KIMI_CODE_HOME",
+		"DEJA_CLINE_ROOT", "DEJA_CLINE_ROOTS", "CLINE_DIR", "CLINE_DATA_DIR",
+		"CLINE_SESSION_DATA_DIR", "CLINE_MCP_SETTINGS_PATH",
 		"DEJA_INCLUDE_SUBAGENTS", "DEJA_OPENCODE_DB", "GEMINI_CLI_HOME",
 		"GROK_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
 		"DEJA_NOTES_FILE",
@@ -135,6 +137,8 @@ func parseRegistryFixture(t *testing.T, id, path string) []model.Session {
 		sessions, err = ParseCodexRollout(path)
 	case "kimi":
 		sessions, err = ParseKimiFile(path)
+	case "cline":
+		sessions, err = ParseClineFile(path)
 	case "opencode":
 		if !SQLite3Available() {
 			t.Skip("sqlite3 not installed")


### PR DESCRIPTION
Implements #253 with both store generations and the community's synthetic fixtures; live-validated against cline 3.0.46 via OpenRouter (two spec divergences found and handled: started_at/ended_at manifest fields, attributed <user_input> envelopes). The live loop also exposed that whole-file stores made every incremental update rewrite and re-redact the entire index inside the MCP call — carried records now skip re-redaction, and recall serves the current snapshot lock-free (tryLock + atomic-swap recovery) while the rebuild runs detached with an honest staleness note. Dirty-store recall: 5.8s → 0.05–0.5s; cline's own MCP loop verified end-to-end with no timeouts. Closes #253.