### PR TITLE
feat(sources): Roo Code harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center"><img src="assets/demo.gif" alt="deja demo"></p>
 
-Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, pi and Copilot CLI write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
+Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Roo Code, pi and Copilot CLI write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
 
 | Feature | What it does |
 | --- | --- |
@@ -244,6 +244,7 @@ limits, trust assumptions, and release verification.
 | Qwen Code | `${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl` | ✅ | — | — | ✅ | — |
 | Kimi Code | `${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/main/wire.jsonl`<br>`${DEJA_KIMI_ROOT}/sessions/*/*/agents/main/wire.jsonl` | ✅ | — | ✅ | paste | — |
 | Cline | `${CLINE_DIR:-~/.cline}/data/sessions/*/*.messages.json`<br>VS Code globalStorage `saoudrizwan.claude-dev/tasks/*/api_conversation_history.json` | ✅ | — | ✅ | paste | — |
+| Roo Code | VS Code globalStorage `rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json` | — | — | — | paste | — |
 | pi | `${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl` | ✅ | — | ✅ | ✅ | — |
 | Copilot CLI | `${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl` | ✅ | — | ✅ | ✅ | — |
 <!-- matrix:end -->

--- a/cmd/deja/capability_drift_test.go
+++ b/cmd/deja/capability_drift_test.go
@@ -98,7 +98,7 @@ func TestCapabilityRegistryMatchesCode(t *testing.T) {
 			t.Fatalf("%s: unknown handoff kind %q", h.ID, c.Handoff)
 		}
 	}
-	if seen != len(handoffTargets())+3 { // +3: antigravity, kimi and cline are paste-only
+	if seen != len(handoffTargets())+4 { // +4: antigravity, kimi, cline and roo are paste-only
 		t.Fatalf("registry covers %d harnesses, handoff targets %d", seen, len(handoffTargets()))
 	}
 

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -277,6 +277,13 @@ func doctorHarnesses(w io.Writer) {
 	}
 	printRow("cline", clineLoc, clineFiles > 0 || doctorExists(clineModern), doctorCount(clineFiles, "file"))
 
+	rooFiles := len(sources.RooTaskFiles())
+	rooLoc := "VS Code globalStorage rooveterinaryinc.roo-cline"
+	if roots := sources.RooRoots(); len(roots) > 0 {
+		rooLoc = strings.Join(roots, string(os.PathListSeparator))
+	}
+	printRow("roo", rooLoc, rooFiles > 0, doctorCount(rooFiles, "file"))
+
 	piRoot := sources.PiRoot()
 	printRow("pi", piRoot, doctorExists(piRoot), doctorCount(len(sources.PiSessionFiles()), "file"))
 	copilotRoot := sources.CopilotRoot()

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -117,6 +117,8 @@ func resumeCommand(s model.Session) (string, string, error) {
 			return "", "", fmt.Errorf("legacy Cline VS Code tasks reopen from the extension's history UI, not the terminal")
 		}
 		return "", "cline --id " + s.ID, nil
+	case "roo":
+		return "", "", fmt.Errorf("Roo Code tasks reopen from the extension's history UI, not the terminal")
 	case "kimi":
 		return "", "kimi --session " + s.ID, nil
 	case "pi":

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -118,7 +118,7 @@ func resumeCommand(s model.Session) (string, string, error) {
 		}
 		return "", "cline --id " + s.ID, nil
 	case "roo":
-		return "", "", fmt.Errorf("Roo Code tasks reopen from the extension's history UI, not the terminal")
+		return "", "", fmt.Errorf("roo tasks reopen from the extension's history UI, not the terminal")
 	case "kimi":
 		return "", "kimi --session " + s.ID, nil
 	case "pi":

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -279,6 +279,27 @@
     "handoff": "exec",
     "prereq": ""
    }
+  },
+  {
+   "id": "roo",
+   "store_paths": [
+    "<vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json",
+    "${DEJA_ROO_ROOTS}/tasks/*/api_conversation_history.json"
+   ],
+   "format_kind": "json",
+   "fixture_paths": [
+    "fixtures/registry/roo/tasks/1767225700000/api_conversation_history.json"
+   ],
+   "parser_source": "internal/sources/roo.go",
+   "last_verified": "2026-07-23",
+   "display_name": "Roo Code",
+   "capabilities": {
+    "mcp": false,
+    "auto": false,
+    "resume": false,
+    "handoff": "paste",
+    "prereq": ""
+   }
   }
  ]
 }

--- a/docs/registry/roo.md
+++ b/docs/registry/roo.md
@@ -1,0 +1,18 @@
+# Roo Code
+
+- **ID**: `roo`
+- **Store**: VS Code-host globalStorage `rooveterinaryinc.roo-cline/tasks/<taskId>/api_conversation_history.json`; per-task metadata in `history_item.json` (id, ts, task, workspace). Code, Code Insiders, VSCodium, Cursor and Windsurf host roots are probed.
+- **Read override**: `DEJA_ROO_ROOTS` (path list)
+- **Format**: whole-file JSON rewritten on change; full re-parse per pass
+
+The transcript shape matches Cline's legacy store (Roo is a Cline fork), so
+the same text-block extraction and `<task>` envelope unwrapping apply.
+Format verified against Roo-Code source (`src/shared/globalFileNames.ts`,
+`src/core/task-persistence`); a live-loop validation with the running
+extension is still welcome — Roo is GUI-only, so deja reads its history and
+serves it to other agents rather than injecting into Roo itself.
+
+- **MCP**: Roo manages its own MCP servers from the extension UI
+  (`mcp_settings.json`); point it at `deja mcp` manually if desired.
+- **Resume**: extension UI only.
+- **Handoff**: paste.

--- a/fixtures/registry/roo/tasks/1767225700000/api_conversation_history.json
+++ b/fixtures/registry/roo/tasks/1767225700000/api_conversation_history.json
@@ -1,0 +1,4 @@
+[
+  {"role": "user", "content": [{"type": "text", "text": "<task>\nFix the flaky test\n</task>"}]},
+  {"role": "assistant", "content": [{"type": "text", "text": "The retry loop reused a stale timeout; pinned it per attempt."}]}
+]

--- a/fixtures/registry/roo/tasks/1767225700000/history_item.json
+++ b/fixtures/registry/roo/tasks/1767225700000/history_item.json
@@ -1,0 +1,1 @@
+{"id": "1767225700000", "number": 1, "ts": 1767225700000, "task": "Fix the flaky test", "tokensIn": 12, "tokensOut": 4, "totalCost": 0, "workspace": "/home/example/work/demo"}

--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -185,7 +185,7 @@ func parseClineModernSession(path string) ([]model.Session, error) {
 				cwd = man.WorkspaceRoot
 			}
 			if cwd != "" {
-				s.Project = claudeProjectName(strings.ReplaceAll(cwd, "/", "-"))
+				s.Project = claudeProjectName(pathToProjectKey(cwd))
 			}
 			s.Title = strings.TrimSpace(man.Metadata.Title)
 			if s.Title == "" {
@@ -259,7 +259,7 @@ func parseClineLegacyTask(path string) ([]model.Session, error) {
 				if m.ID == taskID {
 					s.Title = firstLineTrim(m.Task)
 					if m.CWD != "" {
-						s.Project = claudeProjectName(strings.ReplaceAll(m.CWD, "/", "-"))
+						s.Project = claudeProjectName(pathToProjectKey(m.CWD))
 					}
 					if m.TS > 0 {
 						base = time.UnixMilli(m.TS)
@@ -347,6 +347,13 @@ func firstNonEmpty(a, b string) string {
 		return a
 	}
 	return b
+}
+
+// pathToProjectKey converts an absolute workspace path to the dash-encoded
+// key claudeProjectName expects, so cline/roo sessions land in the same
+// project namespace as every other harness.
+func pathToProjectKey(p string) string {
+	return strings.ReplaceAll(p, "/", "-")
 }
 
 func firstLineTrim(s string) string {

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -215,6 +215,24 @@ func Registry() []Harness {
 			}},
 		},
 		{
+			Name: "roo", Load: LoadRoo, Files: RooTaskFiles,
+			Kinds: []FileKind{{
+				Name: "roo",
+				Match: func(p string) bool {
+					if !hasBase(p, "api_conversation_history.json") {
+						return false
+					}
+					for _, root := range RooRoots() {
+						if strings.HasPrefix(p, root) {
+							return true
+						}
+					}
+					return false
+				},
+				Parse: fullParse(ParseRooTask),
+			}},
+		},
+		{
 			Name: "pi", Load: LoadPi, Files: PiSessionFiles,
 			Kinds: []FileKind{{
 				Name:      "pi",

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -39,7 +39,7 @@ func TestFormatRegistryConformance(t *testing.T) {
 		"DEJA_CURSOR_ROOT", "DEJA_GEMINI_ROOT", "DEJA_GROK_ROOT",
 		"DEJA_PI_ROOT", "DEJA_QWEN_ROOT", "DEJA_KIMI_ROOT", "KIMI_CODE_HOME",
 		"DEJA_CLINE_ROOT", "DEJA_CLINE_ROOTS", "CLINE_DIR", "CLINE_DATA_DIR",
-		"CLINE_SESSION_DATA_DIR", "CLINE_MCP_SETTINGS_PATH",
+		"CLINE_SESSION_DATA_DIR", "CLINE_MCP_SETTINGS_PATH", "DEJA_ROO_ROOTS",
 		"DEJA_INCLUDE_SUBAGENTS", "DEJA_OPENCODE_DB", "GEMINI_CLI_HOME",
 		"GROK_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
 		"DEJA_NOTES_FILE",
@@ -139,6 +139,8 @@ func parseRegistryFixture(t *testing.T, id, path string) []model.Session {
 		sessions, err = ParseKimiFile(path)
 	case "cline":
 		sessions, err = ParseClineFile(path)
+	case "roo":
+		sessions, err = ParseRooTask(path)
 	case "opencode":
 		if !SQLite3Available() {
 			t.Skip("sqlite3 not installed")

--- a/internal/sources/roo.go
+++ b/internal/sources/roo.go
@@ -1,0 +1,141 @@
+package sources
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Roo Code (github.com/RooCodeInc/Roo-Code) is a Cline fork whose VS Code
+// extension (rooveterinaryinc.roo-cline) keeps tasks under the host's
+// globalStorage:
+//
+//	tasks/<taskId>/api_conversation_history.json  (transcript, Cline shape)
+//	tasks/<taskId>/history_item.json              (id, ts, task, workspace)
+//	tasks/_index.json                             (index; not needed here)
+//
+// Verified against Roo-Code source (src/shared/globalFileNames.ts,
+// src/core/task-persistence) — the transcript format matches Cline's legacy
+// store, but metadata is per-task history_item.json instead of a global
+// taskHistory.json. Text-only turns are indexed; the same envelope
+// unwrapping applies.
+
+func RooRoots() []string {
+	if list := os.Getenv("DEJA_ROO_ROOTS"); list != "" {
+		var out []string
+		for _, p := range filepath.SplitList(list) {
+			if p != "" {
+				out = append(out, p)
+			}
+		}
+		return out
+	}
+	const ext = "rooveterinaryinc.roo-cline"
+	var bases []string
+	switch runtime.GOOS {
+	case "darwin":
+		app := filepath.Join(Home(), "Library", "Application Support")
+		for _, host := range []string{"Code", "Code - Insiders", "VSCodium", "Cursor", "Windsurf"} {
+			bases = append(bases, filepath.Join(app, host, "User", "globalStorage", ext))
+		}
+	case "windows":
+		app := os.Getenv("APPDATA")
+		if app == "" {
+			app = filepath.Join(Home(), "AppData", "Roaming")
+		}
+		for _, host := range []string{"Code", "Code - Insiders", "VSCodium", "Cursor", "Windsurf"} {
+			bases = append(bases, filepath.Join(app, host, "User", "globalStorage", ext))
+		}
+	default:
+		cfg := os.Getenv("XDG_CONFIG_HOME")
+		if cfg == "" {
+			cfg = filepath.Join(Home(), ".config")
+		}
+		for _, host := range []string{"Code", "Code - Insiders", "VSCodium", "Cursor", "Windsurf"} {
+			bases = append(bases, filepath.Join(cfg, host, "User", "globalStorage", ext))
+		}
+	}
+	var out []string
+	for _, b := range bases {
+		if fi, err := os.Stat(b); err == nil && fi.IsDir() {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+func RooTaskFiles() []string {
+	var files []string
+	for _, root := range RooRoots() {
+		files = append(files, walkFiles(filepath.Join(root, "tasks"), func(p string) bool {
+			return filepath.Base(p) == "api_conversation_history.json"
+		})...)
+	}
+	return files
+}
+
+func LoadRoo() []model.Session { return parseFiles(RooTaskFiles(), ParseRooTask) }
+
+type rooHistoryItem struct {
+	ID        string `json:"id"`
+	TS        int64  `json:"ts"`
+	Task      string `json:"task"`
+	Workspace string `json:"workspace"`
+}
+
+func ParseRooTask(path string) ([]model.Session, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var turns []struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(b, &turns); err != nil {
+		diagMalformedLine(path)
+		return nil, nil
+	}
+	taskDir := filepath.Dir(path)
+	taskID := filepath.Base(taskDir)
+	s := model.Session{Harness: "roo", ID: "roo-task-" + taskID, Path: path, Project: "roo"}
+	base := time.Time{}
+	var item rooHistoryItem
+	if hb, err := os.ReadFile(filepath.Join(taskDir, "history_item.json")); err == nil && json.Unmarshal(hb, &item) == nil {
+		s.Title = firstLineTrim(item.Task)
+		if item.Workspace != "" {
+			s.Project = claudeProjectName(pathToProjectKey(item.Workspace))
+		}
+		if item.TS > 0 {
+			base = time.UnixMilli(item.TS)
+		}
+	}
+	if base.IsZero() {
+		if fi, err := os.Stat(path); err == nil {
+			base = fi.ModTime()
+		}
+	}
+	for ti, m := range turns {
+		if m.Role != "user" && m.Role != "assistant" {
+			continue
+		}
+		text := clineContentText(m.Content)
+		if m.Role == "user" {
+			text = unwrapClineTask(text)
+		}
+		if text == "" {
+			continue
+		}
+		ts := base.Add(time.Duration(ti) * time.Second)
+		s.Touch(ts)
+		s.Messages = append(s.Messages, model.Message{Role: m.Role, Text: text, Time: ts})
+	}
+	if len(s.Messages) == 0 {
+		return nil, nil
+	}
+	return []model.Session{s}, nil
+}

--- a/internal/sources/roo_test.go
+++ b/internal/sources/roo_test.go
@@ -1,0 +1,42 @@
+package sources
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestParseRooTask(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	path := filepath.Join(root, "fixtures", "registry", "roo", "tasks", "1767225700000", "api_conversation_history.json")
+	ss, err := ParseRooTask(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d", len(ss))
+	}
+	s := ss[0]
+	if s.ID != "roo-task-1767225700000" || s.Harness != "roo" {
+		t.Fatalf("identity: %+v", s)
+	}
+	if s.Title != "Fix the flaky test" {
+		t.Fatalf("title = %q", s.Title)
+	}
+	if s.Project == "roo" {
+		t.Fatalf("project must come from history_item workspace, got %q", s.Project)
+	}
+	if s.Messages[0].Text != "Fix the flaky test" {
+		t.Fatalf("envelope not unwrapped: %q", s.Messages[0].Text)
+	}
+}
+
+func TestRooRootsOverride(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", ".."))
+	t.Setenv("DEJA_ROO_ROOTS", filepath.Join(root, "fixtures", "registry", "roo"))
+	if files := RooTaskFiles(); len(files) != 1 {
+		t.Fatalf("files = %v", files)
+	}
+	if ss := LoadRoo(); len(ss) != 1 {
+		t.Fatalf("sessions = %d", len(ss))
+	}
+}


### PR DESCRIPTION
Cline-fork store under rooveterinaryinc.roo-cline globalStorage: tasks/<id>/api_conversation_history.json with per-task history_item.json metadata (id/ts/task/workspace) — verified against Roo-Code src (globalFileNames, task-persistence). DEJA_ROO_ROOTS read override, fixtures + registry + conformance, doctor row. Roo is GUI-only, so deja reads its history for other agents; live-loop note in docs/registry/roo.md.