### PR TITLE
feat(notes): tags + conflict surfacing

### DIFF
--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -19,6 +19,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	state := "accepted"
 	noteText := ""
 	exportPath := ""
+	var tags []string
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--state":
@@ -39,6 +40,12 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 			}
 			i++
 			exportPath = args[i]
+		case "--tag":
+			if i+1 >= len(args) {
+				return fmt.Errorf("promote: --tag needs a value")
+			}
+			i++
+			tags = append(tags, args[i])
 		default:
 			if strings.HasPrefix(args[i], "-") {
 				return fmt.Errorf("promote: unknown flag %q", args[i])
@@ -71,7 +78,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	if title == "" {
 		title = firstLine(text)
 	}
-	if err := sources.AppendPromoted(s.Project, title, text, src, state, time.Now()); err != nil {
+	if err := sources.AppendPromotedTagged(s.Project, title, text, src, state, tags, time.Now()); err != nil {
 		return err
 	}
 	if exportPath != "" {
@@ -80,6 +87,14 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 		}
 	}
 	fmt.Fprintf(stdout, "promoted %s as %s: %s\n", src, state, title)
+	if state == "accepted" {
+		all := sources.LoadPromotedNotes()
+		me := sources.PromotedNote{Project: s.Project, Session: src, State: state, Title: title, Text: text, Tags: sources.NormalizeTags(tags)}
+		for _, c := range sources.ConflictingNotes(me, all) {
+			fmt.Fprintf(stdout, "conflict: another accepted note covers this ground — %q (from %s, %s). If one replaced the other: deja promote <id> --state superseded\n",
+				firstLine(c.Title+" "+c.Text), c.Session, c.At.Format("2006-01-02"))
+		}
+	}
 	if exportPath != "" {
 		fmt.Fprintf(stdout, "exported to %s\n", exportPath)
 	}

--- a/cmd/deja/promote_test.go
+++ b/cmd/deja/promote_test.go
@@ -141,3 +141,38 @@ func searchHits(t *testing.T, dir, q string) []search.Hit {
 	}
 	return hits
 }
+
+func TestPromoteSurfacesConflicts(t *testing.T) {
+	dir := promoteFixture(t)
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-tmp-proj", "sess2.jsonl"), "sess9999", []string{
+		`{"type":"user","sessionId":"sess9999","timestamp":"2026-01-05T03:04:05Z","message":{"role":"user","content":"the signing key rotation keeps breaking downstream verification"}}`,
+		`{"type":"assistant","sessionId":"sess9999","timestamp":"2026-01-05T03:05:05Z","message":{"role":"assistant","content":[{"type":"text","text":"rotate the signing key monthly and pin the previous kid for one overlap window"}]}}`,
+	})
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := runPromote(dir, []string{"sess1234", "--tag", "signing"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := runPromote(dir, []string{"sess9999", "--tag", "signing"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "conflict: another accepted note") {
+		t.Fatalf("conflict must surface at promote time:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "--state superseded") {
+		t.Fatalf("resolution hint missing:\n%s", out.String())
+	}
+	// Superseding the older note dissolves the conflict for the next promote.
+	if err := runPromote(dir, []string{"sess1234", "--state", "superseded"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	if err := runPromote(dir, []string{"sess9999", "--tag", "signing"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "conflict:") {
+		t.Fatalf("superseded note must not conflict:\n%s", out.String())
+	}
+}

--- a/cmd/deja/remember.go
+++ b/cmd/deja/remember.go
@@ -13,12 +13,21 @@ import (
 
 func runRemember(dir string, args []string) error {
 	var text, project string
+	var tags []string
 	for i := 0; i < len(args); i++ {
 		if args[i] == "--project" {
 			if i+1 >= len(args) {
 				return fmt.Errorf("remember: --project needs value")
 			}
 			project = args[i+1]
+			i++
+			continue
+		}
+		if args[i] == "--tag" {
+			if i+1 >= len(args) {
+				return fmt.Errorf("remember: --tag needs value")
+			}
+			tags = append(tags, args[i+1])
 			i++
 			continue
 		}
@@ -40,12 +49,16 @@ func runRemember(dir string, args []string) error {
 		}
 		project = sources.ClaudeProjectName(cwd)
 	}
-	if err := sources.AppendNote(project, text, time.Now()); err != nil {
+	if err := sources.AppendNoteTagged(project, text, tags, time.Now()); err != nil {
 		return err
 	}
 	if err := index.EnsureForSearch(dir, search.Options{All: true}, false, os.Stderr); err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stdout, "deja: remembered under %s\n", strings.TrimSpace(project))
+	suffix := ""
+	if norm := sources.NormalizeTags(tags); len(norm) > 0 {
+		suffix = " #" + strings.Join(norm, " #")
+	}
+	fmt.Fprintf(os.Stdout, "deja: remembered under %s%s\n", strings.TrimSpace(project), suffix)
 	return nil
 }

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -20,10 +20,11 @@ type note struct {
 	// Promoted-note fields. Session carries provenance (harness:id of the
 	// source transcript), State its lifecycle: accepted, rejected,
 	// superseded, stale. Corrections append a new entry; nothing rewrites.
-	Kind    string `json:"kind,omitempty"`
-	Session string `json:"session,omitempty"`
-	State   string `json:"state,omitempty"`
-	Title   string `json:"title,omitempty"`
+	Kind    string   `json:"kind,omitempty"`
+	Session string   `json:"session,omitempty"`
+	State   string   `json:"state,omitempty"`
+	Title   string   `json:"title,omitempty"`
+	Tags    []string `json:"tags,omitempty"`
 }
 
 func NotesFile() string {
@@ -44,7 +45,27 @@ func NotesFile() string {
 	return filepath.Join(Home(), ".local", "share", "deja", "notes.jsonl")
 }
 
+// NormalizeTags lowercases, trims a leading '#', drops empties/dupes and
+// caps the count — tags are navigation handles, not prose.
+func NormalizeTags(tags []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, t := range tags {
+		t = strings.ToLower(strings.TrimPrefix(strings.TrimSpace(t), "#"))
+		if t == "" || seen[t] || len(out) >= 8 {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	return out
+}
+
 func AppendNote(project, text string, now time.Time) error {
+	return AppendNoteTagged(project, text, nil, now)
+}
+
+func AppendNoteTagged(project, text string, tags []string, now time.Time) error {
 	project = strings.TrimSpace(project)
 	if project == "" {
 		return fmt.Errorf("project required")
@@ -70,7 +91,7 @@ func AppendNote(project, text string, now time.Time) error {
 	if now.IsZero() {
 		now = time.Now()
 	}
-	return json.NewEncoder(f).Encode(note{TS: now.UTC().Format(time.RFC3339Nano), Project: project, Text: text})
+	return json.NewEncoder(f).Encode(note{TS: now.UTC().Format(time.RFC3339Nano), Project: project, Text: text, Tags: NormalizeTags(tags)})
 }
 
 func LoadNotes() []model.Session {
@@ -113,7 +134,11 @@ func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error
 			}
 			s.Title = title + " [" + state + "]"
 			s.Touch(t)
-			s.Messages = append(s.Messages, model.Message{Role: "user", Text: "[" + state + "] " + text + " (from " + src + ", " + t.UTC().Format("2006-01-02") + ")", Time: t})
+			body := "[" + state + "] " + text + " (from " + src + ", " + t.UTC().Format("2006-01-02") + ")"
+			if tagLine := renderNoteTags(m); tagLine != "" {
+				body += " " + tagLine
+			}
+			s.Messages = append(s.Messages, model.Message{Role: "user", Text: body, Time: t})
 			return
 		}
 		day := t.UTC().Format("2006-01-02")
@@ -124,6 +149,9 @@ func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error
 			byDay[key] = s
 		}
 		s.Touch(t)
+		if tagLine := renderNoteTags(m); tagLine != "" {
+			text += " " + tagLine
+		}
 		s.Messages = append(s.Messages, model.Message{Role: "user", Text: text, Time: t})
 	})
 	if err != nil {
@@ -148,6 +176,10 @@ var NoteStates = map[string]bool{"accepted": true, "rejected": true, "superseded
 // AppendPromoted appends a curated note distilled from a session. Appending
 // the same session again records a correction; history is never rewritten.
 func AppendPromoted(project, title, text, session, state string, now time.Time) error {
+	return AppendPromotedTagged(project, title, text, session, state, nil, now)
+}
+
+func AppendPromotedTagged(project, title, text, session, state string, tags []string, now time.Time) error {
 	if strings.TrimSpace(session) == "" {
 		return fmt.Errorf("session required")
 	}
@@ -179,5 +211,120 @@ func AppendPromoted(project, title, text, session, state string, now time.Time) 
 	return json.NewEncoder(f).Encode(note{
 		TS: now.UTC().Format(time.RFC3339Nano), Project: project, Text: text,
 		Kind: "promoted", Session: session, State: state, Title: title,
+		Tags: NormalizeTags(tags),
 	})
+}
+
+// renderNoteTags folds the tags array into "#tag" tokens appended to the
+// indexed text: search, snippets and recall then handle tags with zero extra
+// machinery, and `deja "#api"` works lexically.
+func renderNoteTags(m map[string]any) string {
+	raw, _ := m["tags"].([]any)
+	var parts []string
+	for _, tAny := range raw {
+		if t, ok := tAny.(string); ok && t != "" {
+			parts = append(parts, "#"+t)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// PromotedNote is one curated note with its lifecycle state, for conflict
+// surfacing.
+type PromotedNote struct {
+	Project string
+	Session string
+	State   string
+	Title   string
+	Text    string
+	Tags    []string
+	At      time.Time
+}
+
+// LoadPromotedNotes returns the latest state per promoted source session.
+func LoadPromotedNotes() []PromotedNote {
+	latest := map[string]*PromotedNote{}
+	var order []string
+	_ = scanJSONLFromOffset(NotesFile(), 0, func(m map[string]any) {
+		kind, _ := m["kind"].(string)
+		if kind != "promoted" {
+			return
+		}
+		src, _ := m["session"].(string)
+		state, _ := m["state"].(string)
+		if src == "" || !NoteStates[state] {
+			return
+		}
+		ts, _ := m["ts"].(string)
+		t, _ := time.Parse(time.RFC3339Nano, ts)
+		title, _ := m["title"].(string)
+		text, _ := m["text"].(string)
+		project, _ := m["project"].(string)
+		var tags []string
+		if raw, ok := m["tags"].([]any); ok {
+			for _, x := range raw {
+				if v, ok := x.(string); ok {
+					tags = append(tags, v)
+				}
+			}
+		}
+		n, ok := latest[src]
+		if !ok {
+			n = &PromotedNote{Session: src}
+			latest[src] = n
+			order = append(order, src)
+		}
+		n.Project, n.State, n.Title, n.Text, n.Tags, n.At = project, state, title, text, tags, t
+	})
+	out := make([]PromotedNote, 0, len(order))
+	for _, src := range order {
+		out = append(out, *latest[src])
+	}
+	return out
+}
+
+// ConflictingNotes returns other ACCEPTED notes in the same project that
+// overlap this note's topic — shared tags, or 3+ shared informative words.
+// deja never auto-resolves; it puts the disagreement in front of the user
+// with dates so the human can promote one and supersede the other.
+func ConflictingNotes(candidate PromotedNote, all []PromotedNote) []PromotedNote {
+	ctags := map[string]bool{}
+	for _, t := range candidate.Tags {
+		ctags[t] = true
+	}
+	cwords := noteWordSet(candidate.Title + " " + candidate.Text)
+	var out []PromotedNote
+	for _, n := range all {
+		if n.Session == candidate.Session || n.State != "accepted" || n.Project != candidate.Project {
+			continue
+		}
+		shareTag := false
+		for _, t := range n.Tags {
+			if ctags[t] {
+				shareTag = true
+				break
+			}
+		}
+		shared := 0
+		for w := range noteWordSet(n.Title + " " + n.Text) {
+			if cwords[w] {
+				shared++
+			}
+		}
+		if shareTag || shared >= 3 {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func noteWordSet(s string) map[string]bool {
+	out := map[string]bool{}
+	for _, w := range strings.Fields(strings.ToLower(s)) {
+		w = strings.Trim(w, ".,!?:;()[]\"'`")
+		if len(w) >= 5 {
+			out[w] = true
+		}
+	}
+	return out
 }

--- a/internal/sources/notes_test.go
+++ b/internal/sources/notes_test.go
@@ -94,3 +94,27 @@ func appendMustRead(t *testing.T, path, suffix string) []byte {
 	}
 	return append(b, suffix...)
 }
+
+func TestConflictingNotes(t *testing.T) {
+	a := PromotedNote{Project: "app", Session: "claude:a", State: "accepted", Title: "retry policy", Text: "use exponential backoff with jitter for outbound retries", Tags: []string{"retries"}}
+	b := PromotedNote{Project: "app", Session: "claude:b", State: "accepted", Title: "retry policy v2", Text: "fixed-interval retries are simpler and sufficient here", Tags: []string{"retries"}}
+	c := PromotedNote{Project: "app", Session: "claude:c", State: "superseded", Title: "old retries", Text: "exponential backoff jitter outbound retries", Tags: []string{"retries"}}
+	d := PromotedNote{Project: "other", Session: "claude:d", State: "accepted", Title: "retry policy", Text: "exponential backoff with jitter for outbound retries", Tags: []string{"retries"}}
+	all := []PromotedNote{a, b, c, d}
+	got := ConflictingNotes(a, all)
+	if len(got) != 1 || got[0].Session != "claude:b" {
+		t.Fatalf("conflicts = %+v", got)
+	}
+	// No tags: 3+ shared informative words still connect them ("retry",
+	// "policy", "retries" — a genuine topical clash).
+	a2, b2 := a, b
+	a2.Tags, b2.Tags = nil, nil
+	if got := ConflictingNotes(a2, []PromotedNote{a2, b2}); len(got) != 1 {
+		t.Fatalf("topical word overlap must conflict, got %+v", got)
+	}
+	// A note sharing fewer than 3 informative words stays unrelated.
+	far := PromotedNote{Project: "app", Session: "claude:e", State: "accepted", Title: "logging", Text: "ship structured logs with retries counter"}
+	if got := ConflictingNotes(a2, []PromotedNote{a2, far}); len(got) != 0 {
+		t.Fatalf("weak overlap conflicted: %+v", got)
+	}
+}


### PR DESCRIPTION
remember/promote gain --tag (normalized, capped, stored structurally); tags render as #tokens in the indexed text so search, snippets and recall handle them with zero new machinery — deja "#queue" works lexically. Promoting an accepted note now names other accepted notes covering the same ground (shared tag, or 3+ shared informative words) with dates and a supersede hint. Surfaced, never auto-resolved. Both from the market-research feedback list.