### PR TITLE
docs: comparison page and 14-harness site refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | **Déjà vu moments** | When a prompt matches work your history already answered, deja announces it — *you have been here* — with the session and its age, and counts the moment in `deja stats` |
 | **Redaction** | API keys, JWTs, private keys are stripped at index time — the cache is safe to keep |
 | **Stats** | `deja stats` — your agent work, wrapped; `--impact` reports only counted numbers: recalls served, session starts that began with memory, served-vs-raw ratio |
-| **Promote** | `deja promote <id>` — distill a session into a curated note with provenance and a lifecycle state (accepted / rejected / superseded / stale); notes outrank raw transcripts |
+| **Promote** | `deja promote <id>` — distill a session into a curated note with provenance, `--tag` keywords and a lifecycle state (accepted / rejected / superseded / stale); notes outrank raw transcripts, and promoting over an existing accepted note surfaces the conflict |
 | **Trust scopes** | `policy.json` decides what memory activates where: search / MCP / auto × local / imported / per-peer; receipts and `deja log` name the rule |
 | **Deep verify** | `deja doctor --deep` proves the index against the sources — re-parses a sample, resolves postings, separates staleness from drift |
 | **Share** | `deja share <id>` — hand a colleague a sanitized digest of a session, secrets already scrubbed |
@@ -306,9 +306,9 @@ Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact cr
 **Does anything leave my machine?** Indexing and search are local. `deja update` downloads releases from GitHub, and user-invoked `deja sync ssh` transfers redacted batches through the system SSH client. Directory exports and shares go only to the destination you choose. See the [security model](docs/SECURITY-MODEL.md#data-flows) for the full data flow.
 
 **How is this different from cass?**
-[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, twelve harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
+[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, fourteen harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
 
-[engram](https://github.com/Gentleman-Programming/engram) is the strongest of the record-forward memory tools: the agent calls `mem_save` and curated notes accumulate in SQLite. Curation buys it conflict detection deja doesn't attempt — but it starts empty, only knows what an agent decided to save, and can't answer for the months of sessions that happened before it was installed. deja starts full: the transcripts are the memory, no cooperation required.
+[engram](https://github.com/Gentleman-Programming/engram) is the strongest of the record-forward memory tools: the agent calls `mem_save` and curated notes accumulate in SQLite. Curation buys it conflict detection — deja now surfaces conflicts too, between accepted notes at promote time — but it starts empty, only knows what an agent decided to save, and can't answer for the months of sessions that happened before it was installed. deja starts full: the transcripts are the memory, no cooperation required.
 
 **And from MemPalace / Mem0 / Letta?**
 Those are memory *platforms*: a Python runtime, embedding models, a vector store, and capture hooks that only remember what happens after you adopt them. deja has no capture step and no stack — one binary over the logs your agents already wrote, so it knows your history from day one, including everything from before you installed it.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 <p align="center"><strong>Your agents already solved this. deja finds it.</strong><br>Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk &mdash; months of history from before you installed it &mdash; searches 3.3&nbsp;GB in ~12&nbsp;ms, serves it back to any agent over MCP, and moves with you between machines over SSH. One zero-dependency binary, fully local.</p>
 
-<p align="center"><a href="https://vshulcz.github.io/deja-vu/">vshulcz.github.io/deja-vu</a></p>
+<p align="center"><strong>84.9% R@1</strong> on LongMemEval-S retrieval &mdash; no LLM, no embeddings, no API key. <a href="https://vshulcz.github.io/deja-vu/guide/benchmarks.html">Harness in-repo, run it yourself.</a></p>
+
+<p align="center"><a href="https://vshulcz.github.io/deja-vu/">vshulcz.github.io/deja-vu</a> &middot; <a href="https://vshulcz.github.io/deja-vu/guide/compare.html">how deja compares</a></p>
 
 <p align="center">
   <a href="https://github.com/vshulcz/deja-vu/actions/workflows/ci.yml"><img src="https://github.com/vshulcz/deja-vu/actions/workflows/ci.yml/badge.svg" alt="CI"></a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -45,6 +45,7 @@
 <a href="harnesses.html">Harnesses</a>
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -45,6 +45,7 @@
 <a href="harnesses.html">Harnesses</a>
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html" aria-current="page">Benchmarks</a>
+<a href="compare.html">Compare</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -45,6 +45,7 @@
 <a href="harnesses.html">Harnesses</a>
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -57,7 +57,7 @@
 <tr><td><code>deja "query"</code></td><td>Search indexed history. Filters: <code>--harness --project --since --role --re --json</code>.</td></tr>
 <tr><td><code>deja ctx "query"</code></td><td>Print a context digest to stdout (for piping into an agent).</td></tr>
 <tr><td><code>deja blame &lt;path&gt;</code></td><td>Sessions that discussed a file, most specific first.</td></tr>
-<tr><td><code>deja remember "text"</code></td><td>Store a durable note. <code>--project</code> optional.</td></tr>
+<tr><td><code>deja remember "text"</code></td><td>Store a durable note. <code>--project</code> optional; <code>--tag</code> (repeatable) attaches keywords that boost matching queries.</td></tr>
 <tr><td><code>deja forget</code></td><td>Remove sessions by <code>--session</code>/<code>--project</code>/<code>--before</code>; <code>--dry-run</code>, <code>--list</code>, <code>--unforget</code>.</td></tr>
 <tr><td><code>deja stats</code></td><td>Totals, top projects, activity. <code>--card</code> (SVG), <code>--html</code> (timeline), <code>--redaction</code>, <code>--json</code>. <code>--impact</code> prints the measured impact report (recalls, reuse, distillation ratio) with the arithmetic labeled.</td></tr>
 <tr><td><code>deja</code></td><td>Bare, on a terminal: the living brief — today's activity, recalls served, déjà vu moments, a suggested search from your own history.</td></tr>
@@ -67,7 +67,7 @@
 <tr><td><code>deja install &lt;target|--all|--auto&gt;</code></td><td>Wire MCP recall (and hooks) into your agents.</td></tr>
 <tr><td><code>deja embed</code></td><td>Build the semantic vector sidecar from a local endpoint.</td></tr>
 <tr><td><code>deja sync export/import/ssh</code></td><td>Move redacted memory between machines.</td></tr>
-<tr><td><code>deja promote &lt;id&gt;</code></td><td>Distill a session into a curated note: quoted evidence with provenance and a lifecycle state (<code>--state accepted|rejected|superseded|stale</code>). Corrections append; the note outranks the raw transcript in recall. <code>--to path</code> also appends a Markdown block for repo-visible notes.</td></tr>
+<tr><td><code>deja promote &lt;id&gt;</code></td><td>Distill a session into a curated note: quoted evidence with provenance and a lifecycle state (<code>--state accepted|rejected|superseded|stale</code>). Corrections append; the note outranks the raw transcript in recall. <code>--to path</code> also appends a Markdown block for repo-visible notes. <code>--tag</code> adds keywords; promoting into ground another accepted note already covers prints a conflict warning naming the older note.</td></tr>
 <tr><td><code>deja doctor</code></td><td>Diagnose stores, wiring, index and version. <code>--json</code>, <code>--offline</code>. <code>--deep</code> re-parses a sample of source files and resolves postings to prove the index against the sources; exits non-zero on drift.</td></tr>
 <tr><td><code>deja bench recall|context</code></td><td>Reproducible search-quality and context-readiness benchmarks.</td></tr>
 <tr><td><code>deja update</code></td><td>Update a standalone install (Homebrew/npm update via the package manager).</td></tr>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>How deja compares — Mem0, Letta, memU, Memori, claude-mem &amp; others</title>
+<meta name="description" content="An honest feature-by-feature comparison of deja-vu with Mem0, Letta, memU, Memori, claude-mem and agentmemory: capture model, storage fidelity, infrastructure, retrieval, benchmarks.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/compare.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="How deja compares — coding-agent memory systems">
+<meta property="og:description" content="Capture model, storage fidelity, infrastructure, retrieval and benchmarks — deja-vu next to Mem0, Letta, memU, Memori, claude-mem and agentmemory.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/compare.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="How deja compares — coding-agent memory systems">
+<meta name="twitter:description" content="Capture model, storage fidelity, infrastructure, retrieval and benchmarks — deja-vu next to Mem0, Letta, memU, Memori, claude-mem and agentmemory.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/favicon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"How deja compares","description":"An honest feature-by-feature comparison of deja-vu with Mem0, Letta, memU, Memori, claude-mem and agentmemory.","url":"https://vshulcz.github.io/deja-vu/guide/compare.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/compare.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Compare","item":"https://vshulcz.github.io/deja-vu/guide/compare.html"}]}</script>
+<style>
+.cmpwrap{overflow-x:auto;margin:0 0 16px}
+.cmpwrap table{min-width:900px;font-size:.8rem}
+.cmpwrap td:first-child,.cmpwrap th:first-child{position:sticky;left:0;background:var(--bg,#0d0b16);white-space:nowrap}
+.cmpwrap .us{color:#7ee2a0}
+</style>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/favicon.svg" alt="">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="agents.html">Agents & MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html" aria-current="page">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.md">Format registry</a></aside>
+<article>
+
+<h1>How deja compares</h1>
+<p>There are a lot of AI memory systems. Most solve a different problem than deja: they give <em>applications</em> a memory API you call from code, or wrap an agent runtime around their own store. deja is narrower — it makes the transcripts your coding agents <em>already write to disk</em> searchable, and serves them back to those agents. That one difference (retroactive indexing vs forward capture) drives most of the table below.</p>
+
+<div class="cmpwrap">
+<table>
+<tr><th></th><th class="us">deja-vu</th><th>Mem0</th><th>Letta</th><th>memU</th><th>Memori</th><th>claude-mem</th><th>agentmemory</th></tr>
+<tr><td>What it is</td><td class="us">retroactive index over coding-agent transcripts</td><td>memory API/SDK for apps</td><td>stateful agent runtime (MemGPT)</td><td>memory filesystem for agents</td><td>SQL-native memory SDK</td><td>Claude Code plugin, compressed session memory</td><td>capture daemon for coding agents</td></tr>
+<tr><td>Starts with your history</td><td class="us">✅ months of existing sessions indexed on install</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td><td>— (records forward from install)</td></tr>
+<tr><td>Capture step</td><td class="us">none — agents already write the files</td><td>API calls in your code</td><td>runs inside its runtime</td><td>agent distills sessions to files</td><td>SDK wraps your LLM calls</td><td>hooks + LLM compression</td><td>hooks into each agent</td></tr>
+<tr><td>What is stored</td><td class="us">verbatim transcript, secrets redacted at ingest</td><td>LLM-extracted facts</td><td>self-edited memory blocks</td><td>distilled markdown</td><td>LLM-extracted rows (SQLite/Postgres)</td><td>LLM summaries (lossy)</td><td>captured events + embeddings</td></tr>
+<tr><td>Needs an LLM/embedding key to remember</td><td class="us">no</td><td>yes</td><td>yes</td><td>yes (embedding API)</td><td>yes (extraction)</td><td>yes (compression)</td><td>local model or API</td></tr>
+<tr><td>Background process</td><td class="us">none — search runs in-process, index updates inside the call</td><td>hosted platform or self-hosted server</td><td>server + Postgres</td><td>server (self-host) or cloud</td><td>in-process</td><td>worker process</td><td>daemon, several local ports</td></tr>
+<tr><td>Coding agents covered</td><td class="us">14 native transcript parsers (Claude Code, Codex, opencode, Cursor, Cline, Roo…)</td><td>via SDK/MCP integration</td><td>its own runtime</td><td>several via adapters</td><td>frameworks (LangChain, Agno…)</td><td>Claude Code</td><td>many via hooks</td></tr>
+<tr><td>Cross-machine sync</td><td class="us">✅ SSH, watermarked, no cloud</td><td>cloud platform</td><td>server-side</td><td>cloud or self-host</td><td>your database</td><td>—</td><td>—</td></tr>
+<tr><td>Recall provenance</td><td class="us">✅ every injection logged (<code>deja log</code>), receipts show what/why</td><td>—</td><td>partial (agent-visible)</td><td>—</td><td>rows are queryable</td><td>viewer shows summaries</td><td>dashboard</td></tr>
+<tr><td>Retrieval</td><td class="us">tiered lexical (exact→fuzzy→co-occurrence→relevance), optional embedding endpoint</td><td>vector + graph</td><td>agent-driven + vector</td><td>embedding rank</td><td>SQL + vector optional</td><td>vector</td><td>hybrid RRF</td></tr>
+<tr><td>Published retrieval numbers, harness in repo</td><td class="us">LongMemEval-S R@1 84.9% · LoCoMo R@1 63.7% — reproducible, <a href="benchmarks.html">how measured</a></td><td>self-reported LoCoMo (QA metric)</td><td>research lineage (MemGPT)</td><td>self-reported LoCoMo 92.09 (QA)</td><td>self-reported LoCoMo 81.95 (QA)</td><td>—</td><td>—</td></tr>
+<tr><td>Install</td><td class="us">one static binary, zero runtime deps</td><td>pip + keys</td><td>docker/server</td><td>pip/server</td><td>pip</td><td>npm + Claude</td><td>installer + binary deps</td></tr>
+<tr><td>License</td><td class="us">MIT</td><td>Apache-2.0 (+ hosted)</td><td>Apache-2.0</td><td>Apache-2.0</td><td>Apache-2.0</td><td>MIT</td><td>MIT</td></tr>
+</table>
+</div>
+
+<div class="note">Benchmark rows are not directly comparable across systems: most projects publish end-to-end QA accuracy (an answering LLM on top of retrieval), deja publishes retrieval-only numbers with the harness in-repo so you can rerun them. Competitor cells reflect their public READMEs as of July 2026 — corrections welcome, <a href="https://github.com/vshulcz/deja-vu/issues">open an issue</a>.</div>
+
+<h2>When to pick something else</h2>
+<p>Honest routing, because the categories genuinely differ:</p>
+<p><b>Mem0 / Memori</b> — you are building an application and want to give <em>your users</em> memory through an API. deja has no SDK; it is not for app-embedded memory.</p>
+<p><b>Letta</b> — you want a full agent runtime with self-editing memory and you're happy living inside it. deja is the opposite bet: memory only, bring whatever agent you already use.</p>
+<p><b>memU</b> — you want curated, distilled knowledge files and don't mind the agent doing the distilling. deja keeps the verbatim record and searches it instead.</p>
+<p><b>claude-mem</b> — you only use Claude Code and prefer compressed summaries over raw history. deja covers 14 agents and keeps recall lossless.</p>
+<p><b>A vector database + your own pipeline</b> — you need semantic paraphrase matching above all. deja's lexical ladder loses to embeddings on pure paraphrase (we say so in the <a href="benchmarks.html">benchmarks</a>); it wins on identifiers, error strings, and everything code-shaped, with no key and no daemon.</p>
+
+<h2>What only deja does</h2>
+<p>Across the systems we've studied, these have no equivalent elsewhere: indexing history from <em>before</em> the tool was installed; déjà&nbsp;vu recurrence detection ("you have been here" when a prompt matches solved work); origin-trust scopes on imported memory; <code>deja blame</code> — which sessions touched a file and what was decided; sanitized <code>deja share</code> digests; and the whole thing in one binary you can <code>scp</code>.</p>
+
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -45,6 +45,7 @@
 <a href="harnesses.html">Harnesses</a>
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -5,11 +5,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Harnesses — deja-vu docs</title>
-<meta name="description" content="The twelve coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta name="description" content="The fourteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Harnesses — deja-vu docs">
-<meta property="og:description" content="The twelve coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta property="og:description" content="The fourteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -25,12 +25,12 @@
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
 <meta name="twitter:title" content="Harnesses — deja-vu docs">
-<meta name="twitter:description" content="The twelve coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta name="twitter:description" content="The fourteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
 <link rel="apple-touch-icon" href="../assets/favicon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Harnesses","description":"The twelve coding agents deja indexes today, where each stores its history, and how to add a new one.","url":"https://vshulcz.github.io/deja-vu/guide/harnesses.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Harnesses","description":"The fourteen coding agents deja indexes today, where each stores its history, and how to add a new one.","url":"https://vshulcz.github.io/deja-vu/guide/harnesses.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Harnesses","item":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"}]}</script>
 </head>
 <body>
@@ -45,6 +45,7 @@
 <a href="harnesses.html" aria-current="page">Harnesses</a>
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
@@ -52,7 +53,7 @@
 <article>
 
 <h1>Harnesses</h1>
-<p>deja indexes twelve coding-agent histories into one retroactive index. A fix found in one agent is recalled inside another.</p>
+<p>deja indexes fourteen coding-agent histories into one retroactive index. A fix found in one agent is recalled inside another.</p>
 <!-- matrix:start -->
 <table>
 <tr><th>Harness</th><th>Store</th><th>MCP recall</th><th>Auto-recall</th><th>Resume</th><th>Handoff</th><th>Needs</th></tr>
@@ -66,6 +67,8 @@
 <tr><td>Grok Build</td><td><code>${GROK_HOME:-~/.grok}/sessions/**/updates.jsonl</code><br><code>${DEJA_GROK_ROOT}/sessions/**/updates.jsonl</code></td><td>✅</td><td>—</td><td>—</td><td>✅</td><td>—</td></tr>
 <tr><td>Qwen Code</td><td><code>${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl</code></td><td>✅</td><td>—</td><td>—</td><td>✅</td><td>—</td></tr>
 <tr><td>Kimi Code</td><td><code>${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/main/wire.jsonl</code><br><code>${DEJA_KIMI_ROOT}/sessions/*/*/agents/main/wire.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>paste</td><td>—</td></tr>
+<tr><td>Cline</td><td><code>${CLINE_DIR:-~/.cline}/data/sessions/*/*.messages.json</code><br>VS Code globalStorage <code>saoudrizwan.claude-dev/tasks/*/api_conversation_history.json</code></td><td>✅</td><td>—</td><td>✅</td><td>paste</td><td>—</td></tr>
+<tr><td>Roo Code</td><td>VS Code globalStorage <code>rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json</code></td><td>—</td><td>—</td><td>—</td><td>paste</td><td>—</td></tr>
 <tr><td>pi</td><td><code>${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>✅</td><td>—</td></tr>
 <tr><td>Copilot CLI</td><td><code>${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>✅</td><td>—</td></tr>
 </table><!-- matrix:end -->

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -45,6 +45,7 @@
 <a href="harnesses.html">Harnesses</a>
 <a href="privacy.html" aria-current="page">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -45,6 +45,7 @@
 <a href="harnesses.html">Harnesses</a>
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="deja-vu — search every session your coding agents ever wrote">
-<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across twelve coding agents, served back to them via MCP.">
+<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across fourteen coding agents, served back to them via MCP.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -314,6 +314,7 @@ footer .spacer{flex:1}
 ██████╔╝███████╗╚█████╔╝██║  ██║       ╚████╔╝ ╚██████╔╝
 ╚═════╝ ╚══════╝ ╚════╝ ╚═╝  ╚═╝        ╚═══╝   ╚═════╝</pre>
     <h1 class="tagline">your agents already solved this. <span class="f2">deja finds it.</span></h1>
+    <p class="tagline" style="margin-top:8px;font-size:clamp(.85rem,2vw,1.05rem)"><span class="f2">84.9% R@1</span> on LongMemEval-S retrieval — no LLM, no embeddings, no API key. <a href="guide/benchmarks.html" style="color:inherit">measured, in-repo →</a></p>
     <p class="sub">Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk, searches gigabytes in ~12&nbsp;ms, serves memory back over MCP, and moves with you between machines over SSH. One zero-dependency binary, fully local.</p>
     <div class="heroline">
       <span class="p">$</span>
@@ -364,7 +365,7 @@ footer .spacer{flex:1}
       <tr><td class="n">~12 ms</td><td class="c">typical warm search over gigabytes of history</td></tr>
       <tr><td class="n">~50 ms</td><td class="c">session-start hook on a 1000-session index — memory lands before you type</td></tr>
       <tr><td class="n">84.9%</td><td class="c">R@1 on LongMemEval-S session retrieval — no LLM, no embeddings, harness in-repo</td></tr>
-      <tr><td class="n">12</td><td class="c">coding agents indexed into one retroactive memory</td></tr>
+      <tr><td class="n">14</td><td class="c">coding agents indexed into one retroactive memory</td></tr>
     </table>
     <p class="foot"><a href="guide/benchmarks.html">how it's measured →</a></p>
   </div>
@@ -390,7 +391,7 @@ footer .spacer{flex:1}
 </section>
 
 <section class="reveal">
-  <p class="shead"><span class="p">$</span> <span class="cmd">deja doctor</span> <span class="out"># twelve harnesses, one memory</span></p>
+  <p class="shead"><span class="p">$</span> <span class="cmd">deja doctor</span> <span class="out"># fourteen harnesses, one memory</span></p>
   <div class="sources">
     <table class="mx">
       <tr><th></th><th>mcp recall</th><th>auto-recall</th><th>resume</th><th>handoff</th><th>needs</th></tr>
@@ -403,6 +404,8 @@ footer .spacer{flex:1}
       <tr><td class="nm">grok build</td><td class="y">✓</td><td class="n">—</td><td class="n">—</td><td class="y">✓</td><td class="pa">—</td></tr>
       <tr><td class="nm">qwen code</td><td class="y">✓</td><td class="n">—</td><td class="n">—</td><td class="y">✓</td><td class="pa">—</td></tr>
       <tr><td class="nm">kimi code</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="am">paste</td><td class="pa">—</td></tr>
+      <tr><td class="nm">cline</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="am">paste</td><td class="pa">—</td></tr>
+      <tr><td class="nm">roo code</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="am">paste</td><td class="pa">history still indexed</td></tr>
       <tr><td class="nm">pi</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="y">✓</td><td class="pa">—</td></tr>
       <tr><td class="nm">copilot cli</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="y">✓</td><td class="pa">—</td></tr>
       <tr><td class="nm">aider</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="y">✓</td><td class="pa">no MCP client — history still indexed</td></tr>
@@ -443,9 +446,10 @@ footer .spacer{flex:1}
     <a href="guide/agents.html">agents-and-mcp<span>recall, blame, remember, auto-recall</span></a>
     <a href="guide/search.html">search<span>phrases, fuzzy, semantic, tiers</span></a>
     <a href="guide/commands.html">cli-reference<span>every subcommand and flag</span></a>
-    <a href="guide/harnesses.html">harnesses<span>twelve agents, and adding one</span></a>
+    <a href="guide/harnesses.html">harnesses<span>fourteen agents, and adding one</span></a>
     <a href="guide/privacy.html">privacy<span>redaction, forget, exclude</span></a>
     <a href="guide/benchmarks.html">benchmarks<span>the ~200× number, reproducible</span></a>
+    <a href="guide/compare.html">compare<span>deja next to Mem0, Letta, memU…</span></a>
     <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">architecture<span>index format, internals</span></a>
   </div>
 </section>
@@ -461,7 +465,7 @@ footer .spacer{flex:1}
       <tr><td class="nm">cross-machine sync</td><td class="am">git / cloud</td><td class="n">—</td><td class="y">✓ ssh, local</td></tr>
       <tr><td class="nm">setup</td><td class="am">wire MCP + teach agents to save</td><td class="am">Rust toolchain / TUI</td><td class="y">one binary, works on the past</td></tr>
     </table>
-    <p class="mx-foot"><a href="https://github.com/Gentleman-Programming/engram">engram</a> curates what an agent chooses to save — good conflict detection, empty past. <a href="https://github.com/Dicklesworthstone/coding_agent_session_search">cass</a> is the kitchen-sink search take. deja's bet: the transcripts are the memory — retroactive, redacted, synced over your own ssh.</p>
+    <p class="mx-foot"><a href="https://github.com/Gentleman-Programming/engram">engram</a> curates what an agent chooses to save — good conflict detection, empty past. <a href="https://github.com/Dicklesworthstone/coding_agent_session_search">cass</a> is the kitchen-sink search take. deja's bet: the transcripts are the memory — retroactive, redacted, synced over your own ssh. Full table against Mem0, Letta, memU, Memori, claude-mem: <a href="guide/compare.html">guide/compare</a>.</p>
   </div>
 </section>
 
@@ -571,7 +575,7 @@ document.querySelectorAll('.reveal').forEach(function(el){io.observe(el)});
   }
   var COMMANDS={
     'help':'<p class="none">this input is a tiny deja: type words to search 16 demo sessions.\ncommands: <span class="t">sources</span> · <span class="t">stats</span> · <span class="t">version</span> · <span class="t">clear</span>\nthe real CLI does far more — see <a href="guide/commands.html">cli reference</a></p>',
-    'sources':'<p class="none">claude&nbsp;&nbsp;codex&nbsp;&nbsp;opencode&nbsp;&nbsp;cursor&nbsp;&nbsp;gemini&nbsp;&nbsp;aider&nbsp;&nbsp;antigravity&nbsp;&nbsp;grok&nbsp;&nbsp;qwen&nbsp;&nbsp;kimi&nbsp;&nbsp;pi&nbsp;&nbsp;copilot\n12 harnesses, one index — real paths in the <a href="#proof">matrix below</a></p>',
+    'sources':'<p class="none">claude&nbsp;&nbsp;codex&nbsp;&nbsp;opencode&nbsp;&nbsp;cursor&nbsp;&nbsp;gemini&nbsp;&nbsp;aider&nbsp;&nbsp;antigravity&nbsp;&nbsp;grok&nbsp;&nbsp;qwen&nbsp;&nbsp;kimi&nbsp;&nbsp;cline&nbsp;&nbsp;roo&nbsp;&nbsp;pi&nbsp;&nbsp;copilot\n14 harnesses, one index — real paths in the <a href="#proof">matrix below</a></p>',
     'stats':'<p class="none">sessions 16 · messages 412 · top project api-gateway\nlast 12 months&nbsp;&nbsp;▁▁▂▃▂▅▆▄▇█▆▇\n(demo numbers — <span class="t">deja stats</span> wraps your real year)</p>',
     'version':'<p class="none">deja 0.14.1</p>',
     'clear':''

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -7,5 +7,6 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/commands.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/harnesses.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/privacy.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/benchmarks.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/benchmarks.html</loc><lastmod>2026-07-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/compare.html</loc><lastmod>2026-07-23</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
 </urlset>


### PR DESCRIPTION
Adds guide/compare.html (deja next to Mem0/Letta/memU/Memori/claude-mem/agentmemory, honest routing included), updates the site matrix to 14 harnesses (Cline/Roo were missing), and puts the 84.9% R@1 number at the top of README and the homepage. Prompted by #310.