### PR TITLE
feat(sources): OpenClaw harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <p align="center"><img src="assets/demo.gif" alt="deja demo"></p>
 
-Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Roo Code, pi and Copilot CLI write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
+Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Roo Code, OpenClaw, pi and Copilot CLI write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
 
 | Feature | What it does |
 | --- | --- |
@@ -206,7 +206,7 @@ the agent reach for memory on its own, add this to your `CLAUDE.md` /
 
 ```
 Before debugging or re-implementing something, run `deja "<query>"` (or the
- MCP recall tool) — past agent sessions across Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Copilot CLI and pi
+ MCP recall tool) — past agent sessions across Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, OpenClaw, Copilot CLI and pi
 are indexed locally. Cite what you reuse.
 ```
 
@@ -236,6 +236,7 @@ limits, trust assumptions, and release verification.
 | Harness | Store | MCP recall | Auto-recall | Resume | Handoff | Needs |
 | --- | --- | :-: | :-: | :-: | :-: | --- |
 | Claude Code | `${CLAUDE_CONFIG_DIR:-~/.claude}/projects/**/*.jsonl`<br>`${DEJA_CLAUDE_ROOT}/**/*.jsonl` | ✅ | ✅ | ✅ | ✅ | — |
+| Cline | `${CLINE_SESSION_DATA_DIR:-${CLINE_DATA_DIR:-${CLINE_DIR:-~/.cline}/data}/sessions}/*/*.messages.json`<br>`<vscode-globalStorage>/saoudrizwan.claude-dev/tasks/*/api_conversation_history.json`<br>`${DEJA_CLINE_ROOT}/*/*.messages.json`<br>`${DEJA_CLINE_ROOTS}/tasks/*/api_conversation_history.json` | ✅ | — | ✅ | paste | — |
 | Codex CLI | `${CODEX_HOME:-~/.codex}/sessions/**/rollout-*.jsonl`<br>`${CODEX_HOME:-~/.codex}/history.jsonl`<br>`${DEJA_CODEX_ROOT}/sessions/**/rollout-*.jsonl` | ✅ | ✅ | ✅ | ✅ | — |
 | opencode | `~/.local/share/opencode/opencode.db`<br>`${XDG_DATA_HOME}/opencode/opencode.db`<br>`${DEJA_OPENCODE_DB}` | ✅ | ✅ | ✅ | ✅ | sqlite3 |
 | aider | `~/.aider.chat.history.md`<br>`${AIDER_CHAT_HISTORY_FILE}`<br>`${DEJA_AIDER_ROOTS}/**/.aider.chat.history.md` | — | — | — | ✅ | — |
@@ -245,10 +246,10 @@ limits, trust assumptions, and release verification.
 | Grok Build | `${GROK_HOME:-~/.grok}/sessions/**/updates.jsonl`<br>`${DEJA_GROK_ROOT}/sessions/**/updates.jsonl` | ✅ | — | — | ✅ | — |
 | Qwen Code | `${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl` | ✅ | — | — | ✅ | — |
 | Kimi Code | `${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/main/wire.jsonl`<br>`${DEJA_KIMI_ROOT}/sessions/*/*/agents/main/wire.jsonl` | ✅ | — | ✅ | paste | — |
-| Cline | `${CLINE_DIR:-~/.cline}/data/sessions/*/*.messages.json`<br>VS Code globalStorage `saoudrizwan.claude-dev/tasks/*/api_conversation_history.json` | ✅ | — | ✅ | paste | — |
-| Roo Code | VS Code globalStorage `rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json` | — | — | — | paste | — |
 | pi | `${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl` | ✅ | — | ✅ | ✅ | — |
+| OpenClaw | `${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl`<br>`${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl` | — | — | — | paste | — |
 | Copilot CLI | `${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl` | ✅ | — | ✅ | ✅ | — |
+| Roo Code | `<vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json`<br>`${DEJA_ROO_ROOTS}/tasks/*/api_conversation_history.json` | — | — | — | paste | — |
 <!-- matrix:end -->
 
 Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_AIDER_ROOTS`, `DEJA_GEMINI_ROOT`, `DEJA_CURSOR_ROOT`, `DEJA_CURSOR_CLI_ROOT`, `DEJA_ANTIGRAVITY_ROOT`, `DEJA_GROK_ROOT`, `DEJA_QWEN_ROOT`, `DEJA_INDEX_DIR`. Each agent's own relocation variable is honored too: `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `GEMINI_CLI_HOME`, `CURSOR_CONFIG_DIR`, `GROK_HOME`, `AIDER_CHAT_HISTORY_FILE`, and `XDG_DATA_HOME` for opencode on Linux.
@@ -306,7 +307,7 @@ Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact cr
 **Does anything leave my machine?** Indexing and search are local. `deja update` downloads releases from GitHub, and user-invoked `deja sync ssh` transfers redacted batches through the system SSH client. Directory exports and shares go only to the destination you choose. See the [security model](docs/SECURITY-MODEL.md#data-flows) for the full data flow.
 
 **How is this different from cass?**
-[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, fourteen harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
+[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, fifteen harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
 
 [engram](https://github.com/Gentleman-Programming/engram) is the strongest of the record-forward memory tools: the agent calls `mem_save` and curated notes accumulate in SQLite. Curation buys it conflict detection — deja now surfaces conflicts too, between accepted notes at promote time — but it starts empty, only knows what an agent decided to save, and can't answer for the months of sessions that happened before it was installed. deja starts full: the transcripts are the memory, no cooperation required.
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Batches are plain JSONL, redacted on the way out. Import is idempotent, so keep 
 
 ## Teach your agent to remember
 
-`deja install --all` wires up MCP recall (Claude Code, Codex, opencode, Cursor, Gemini CLI, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Copilot CLI, pi — aider has no MCP client, pipe `deja ctx` instead); `deja install --auto` does the same and adds session-start auto-recall where the harness supports it (Claude Code hook, Codex hooks.json, an opencode plugin — Cursor, Gemini CLI, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Copilot CLI and pi have no hook that can inject context, so MCP is their full install). To make
+`deja install --all` wires up MCP recall (Claude Code, Codex, opencode, Cursor, Gemini CLI, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, OpenClaw, Copilot CLI, pi — aider has no MCP client, pipe `deja ctx` instead); `deja install --auto` does the same and adds session-start auto-recall where the harness supports it (Claude Code hook, Codex hooks.json, an opencode plugin — Cursor, Gemini CLI, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, OpenClaw, Copilot CLI and pi have no hook that can inject context, so MCP is their full install). To make
 the agent reach for memory on its own, add this to your `CLAUDE.md` /
 `AGENTS.md`:
 
@@ -247,7 +247,7 @@ limits, trust assumptions, and release verification.
 | Qwen Code | `${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl` | ✅ | — | — | ✅ | — |
 | Kimi Code | `${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/main/wire.jsonl`<br>`${DEJA_KIMI_ROOT}/sessions/*/*/agents/main/wire.jsonl` | ✅ | — | ✅ | paste | — |
 | pi | `${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl` | ✅ | — | ✅ | ✅ | — |
-| OpenClaw | `${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl`<br>`${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl` | — | — | — | paste | — |
+| OpenClaw | `${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl`<br>`${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl` | ✅ | — | — | paste | — |
 | Copilot CLI | `${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl` | ✅ | — | ✅ | ✅ | — |
 | Roo Code | `<vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json`<br>`${DEJA_ROO_ROOTS}/tasks/*/api_conversation_history.json` | — | — | — | paste | — |
 <!-- matrix:end -->

--- a/cmd/deja/capability_drift_test.go
+++ b/cmd/deja/capability_drift_test.go
@@ -98,7 +98,7 @@ func TestCapabilityRegistryMatchesCode(t *testing.T) {
 			t.Fatalf("%s: unknown handoff kind %q", h.ID, c.Handoff)
 		}
 	}
-	if seen != len(handoffTargets())+4 { // +4: antigravity, kimi, cline and roo are paste-only
+	if seen != len(handoffTargets())+5 { // +5: antigravity, kimi, cline, roo and openclaw are paste-only
 		t.Fatalf("registry covers %d harnesses, handoff targets %d", seen, len(handoffTargets()))
 	}
 

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -859,3 +859,26 @@ func TestSyncSSHAdditionalBranches(t *testing.T) {
 		t.Fatalf("push scp err=%v", err)
 	}
 }
+
+func TestInstallOpenClawMCP(t *testing.T) {
+	hermeticEnv(t)
+	t.Setenv("OPENCLAW_STATE_DIR", "")
+	r, err := installTarget("openclaw", "/bin/deja", false)
+	if err != nil || r.Action != "created" {
+		t.Fatalf("install openclaw: %#v %v", r, err)
+	}
+	b, _ := os.ReadFile(r.Path)
+	// OpenClaw nests servers under mcp.servers, not mcpServers.
+	if !strings.Contains(string(b), `"mcp"`) || !strings.Contains(string(b), `"servers"`) || !strings.Contains(string(b), "/bin/deja") {
+		t.Fatalf("bad openclaw.json: %s", b)
+	}
+	if r, err = installTarget("openclaw", "/bin/deja", true); err != nil || r.Action != "updated" {
+		t.Fatalf("uninstall openclaw: %#v %v", r, err)
+	}
+	if err := os.WriteFile(filepath.Join(homeDir(), ".openclaw", "openclaw.json"), []byte(`{"mcp":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installOpenClawMCP("/bin/deja", false); err == nil {
+		t.Fatal("expected malformed openclaw.json error")
+	}
+}

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -286,6 +286,8 @@ func doctorHarnesses(w io.Writer) {
 
 	piRoot := sources.PiRoot()
 	printRow("pi", piRoot, doctorExists(piRoot), doctorCount(len(sources.PiSessionFiles()), "file"))
+	openclawRoot := sources.OpenClawRoot()
+	printRow("openclaw", openclawRoot, doctorExists(openclawRoot), doctorCount(len(sources.OpenClawSessionFiles()), "file"))
 	copilotRoot := sources.CopilotRoot()
 	printRow("copilot", copilotRoot, doctorExists(copilotRoot), doctorCount(len(sources.CopilotSessionFiles()), "file"))
 	printRow("deja", sources.NotesFile(), doctorFilePresent(sources.NotesFile()), "notes")
@@ -386,7 +388,9 @@ func doctorMCPConfigs() []doctorMCPConfig {
 		{"grok", filepath.Join(sources.GrokHome(), "config.toml"), doctorTOMLWired},
 		{"qwen", filepath.Join(sources.QwenConfigDir(), "settings.json"), doctorJSONWired("mcpServers")},
 		{"kimi", filepath.Join(sources.KimiConfigDir(), "mcp.json"), doctorJSONWired("mcpServers")},
+		{"cline", sources.ClineMCPSettingsPath(), doctorJSONWired("mcpServers")},
 		{"pi", filepath.Join(sources.PiConfigDir(), "mcp.json"), doctorJSONWired("mcpServers")},
+		{"openclaw", filepath.Join(sources.OpenClawStateDir(), "openclaw.json"), doctorOpenClawWired},
 		{"copilot", guidancePath("copilot"), doctorFileWired},
 	}
 }
@@ -405,6 +409,22 @@ func doctorOpencodeConfigPath() string {
 		}
 	}
 	return path
+}
+
+// doctorOpenClawWired checks openclaw.json's nested mcp.servers map.
+func doctorOpenClawWired(path string) bool {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var root map[string]any
+	if json.Unmarshal(b, &root) != nil {
+		return strings.Contains(string(b), `"deja"`)
+	}
+	mcp, _ := root["mcp"].(map[string]any)
+	servers, _ := mcp["servers"].(map[string]any)
+	_, ok := servers["deja"]
+	return ok
 }
 
 func doctorJSONWired(key string) func(string) bool {

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -123,6 +123,7 @@ func doctorStoreChecks() []doctorStoreCheck {
 		{"qwen", []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.QwenSessionFiles(), sources.ParseQwenFile},
 		{"kimi", []string{filepath.Join(sources.KimiRoot(), "sessions")}, sources.KimiSessionFiles(), sources.ParseKimiFile},
 		{"pi", []string{sources.PiRoot()}, sources.PiSessionFiles(), sources.ParsePiFile},
+		{"openclaw", []string{sources.OpenClawRoot()}, sources.OpenClawSessionFiles(), sources.ParseOpenClawFile},
 		{"copilot", []string{sources.CopilotRoot()}, sources.CopilotSessionFiles(), sources.ParseCopilotFile},
 		{"deja", []string{sources.NotesFile()}, presentDoctorFile(sources.NotesFile()), sources.ParseNotesFile},
 	}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -255,6 +255,7 @@ func existingTargets() []string {
 		"kimi":        sources.KimiConfigDir(),
 		"cline":       sources.ClineConfigDir(),
 		"pi":          sources.PiConfigDir(),
+		"openclaw":    filepath.Join(sources.OpenClawStateDir(), "openclaw.json"),
 	}
 	var out []string
 	for name, p := range checks {
@@ -298,6 +299,8 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 		return installCopilotMCP(exe, uninstall)
 	case "pi":
 		return installMCPJSON(filepath.Join(sources.PiConfigDir(), "mcp.json"), exe, uninstall)
+	case "openclaw":
+		return installOpenClawMCP(exe, uninstall)
 	case "opencode":
 		return installOpencode(exe, uninstall)
 	case "opencode-auto":
@@ -651,6 +654,42 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 	} else {
 		command, args := mcpCommandArgs(exe)
 		m["deja"] = map[string]any{"type": "local", "command": command, "args": args, "tools": []string{"*"}}
+	}
+	next, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return installResult{}, err
+	}
+	next = append(next, '\n')
+	a, err := writeIfChanged(path, old, next)
+	return installResult{Path: path, Action: a}, err
+}
+
+// installOpenClawMCP wires deja into openclaw.json — OpenClaw keeps MCP
+// servers under mcp.servers, not the common mcpServers root.
+func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
+	path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
+	old, _ := os.ReadFile(path)
+	var root map[string]any
+	if len(bytes.TrimSpace(old)) == 0 {
+		root = map[string]any{}
+	} else if err := json.Unmarshal(old, &root); err != nil {
+		return installResult{}, err
+	}
+	mcp, _ := root["mcp"].(map[string]any)
+	if mcp == nil {
+		mcp = map[string]any{}
+		root["mcp"] = mcp
+	}
+	servers, _ := mcp["servers"].(map[string]any)
+	if servers == nil {
+		servers = map[string]any{}
+		mcp["servers"] = servers
+	}
+	if uninstall {
+		delete(servers, "deja")
+	} else {
+		command, args := mcpCommandArgs(exe)
+		servers["deja"] = map[string]any{"command": command, "args": args}
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -92,6 +92,14 @@
       "files": 0
     },
     {
+      "name": "openclaw",
+      "state": "missing",
+      "paths": [
+        "<tmp>/home/.openclaw/agents"
+      ],
+      "files": 0
+    },
+    {
       "name": "copilot",
       "state": "missing",
       "paths": [
@@ -159,9 +167,19 @@
       "path": "<tmp>/home/.kimi-code/mcp.json"
     },
     {
+      "name": "cline",
+      "state": "config-missing",
+      "path": "<tmp>/home/.cline/data/settings/cline_mcp_settings.json"
+    },
+    {
       "name": "pi",
       "state": "config-missing",
       "path": "<tmp>/home/.pi/agent/mcp.json"
+    },
+    {
+      "name": "openclaw",
+      "state": "config-missing",
+      "path": "<tmp>/home/.openclaw/openclaw.json"
     },
     {
       "name": "copilot",

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -70,7 +70,7 @@
 <tr><td>What is stored</td><td class="us">verbatim transcript, secrets redacted at ingest</td><td>LLM-extracted facts</td><td>self-edited memory blocks</td><td>distilled markdown</td><td>LLM-extracted rows (SQLite/Postgres)</td><td>LLM summaries (lossy)</td><td>captured events + embeddings</td></tr>
 <tr><td>Needs an LLM/embedding key to remember</td><td class="us">no</td><td>yes</td><td>yes</td><td>yes (embedding API)</td><td>yes (extraction)</td><td>yes (compression)</td><td>local model or API</td></tr>
 <tr><td>Background process</td><td class="us">none — search runs in-process, index updates inside the call</td><td>hosted platform or self-hosted server</td><td>server + Postgres</td><td>server (self-host) or cloud</td><td>in-process</td><td>worker process</td><td>daemon, several local ports</td></tr>
-<tr><td>Coding agents covered</td><td class="us">14 native transcript parsers (Claude Code, Codex, opencode, Cursor, Cline, Roo…)</td><td>via SDK/MCP integration</td><td>its own runtime</td><td>several via adapters</td><td>frameworks (LangChain, Agno…)</td><td>Claude Code</td><td>many via hooks</td></tr>
+<tr><td>Coding agents covered</td><td class="us">15 native transcript parsers (Claude Code, Codex, opencode, Cursor, Cline, OpenClaw…)</td><td>via SDK/MCP integration</td><td>its own runtime</td><td>several via adapters</td><td>frameworks (LangChain, Agno…)</td><td>Claude Code</td><td>many via hooks</td></tr>
 <tr><td>Cross-machine sync</td><td class="us">✅ SSH, watermarked, no cloud</td><td>cloud platform</td><td>server-side</td><td>cloud or self-host</td><td>your database</td><td>—</td><td>—</td></tr>
 <tr><td>Recall provenance</td><td class="us">✅ every injection logged (<code>deja log</code>), receipts show what/why</td><td>—</td><td>partial (agent-visible)</td><td>—</td><td>rows are queryable</td><td>viewer shows summaries</td><td>dashboard</td></tr>
 <tr><td>Retrieval</td><td class="us">tiered lexical (exact→fuzzy→co-occurrence→relevance), optional embedding endpoint</td><td>vector + graph</td><td>agent-driven + vector</td><td>embedding rank</td><td>SQL + vector optional</td><td>vector</td><td>hybrid RRF</td></tr>
@@ -87,7 +87,7 @@
 <p><b>Mem0 / Memori</b> — you are building an application and want to give <em>your users</em> memory through an API. deja has no SDK; it is not for app-embedded memory.</p>
 <p><b>Letta</b> — you want a full agent runtime with self-editing memory and you're happy living inside it. deja is the opposite bet: memory only, bring whatever agent you already use.</p>
 <p><b>memU</b> — you want curated, distilled knowledge files and don't mind the agent doing the distilling. deja keeps the verbatim record and searches it instead.</p>
-<p><b>claude-mem</b> — you only use Claude Code and prefer compressed summaries over raw history. deja covers 14 agents and keeps recall lossless.</p>
+<p><b>claude-mem</b> — you only use Claude Code and prefer compressed summaries over raw history. deja covers 15 agents and keeps recall lossless.</p>
 <p><b>A vector database + your own pipeline</b> — you need semantic paraphrase matching above all. deja's lexical ladder loses to embeddings on pure paraphrase (we say so in the <a href="benchmarks.html">benchmarks</a>); it wins on identifiers, error strings, and everything code-shaped, with no key and no daemon.</p>
 
 <h2>What only deja does</h2>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -5,11 +5,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Harnesses — deja-vu docs</title>
-<meta name="description" content="The fourteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta name="description" content="The fifteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Harnesses — deja-vu docs">
-<meta property="og:description" content="The fourteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta property="og:description" content="The fifteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -25,12 +25,12 @@
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
 <meta name="twitter:title" content="Harnesses — deja-vu docs">
-<meta name="twitter:description" content="The fourteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta name="twitter:description" content="The fifteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
 <link rel="apple-touch-icon" href="../assets/favicon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Harnesses","description":"The fourteen coding agents deja indexes today, where each stores its history, and how to add a new one.","url":"https://vshulcz.github.io/deja-vu/guide/harnesses.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Harnesses","description":"The fifteen coding agents deja indexes today, where each stores its history, and how to add a new one.","url":"https://vshulcz.github.io/deja-vu/guide/harnesses.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Harnesses","item":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"}]}</script>
 </head>
 <body>
@@ -53,11 +53,12 @@
 <article>
 
 <h1>Harnesses</h1>
-<p>deja indexes fourteen coding-agent histories into one retroactive index. A fix found in one agent is recalled inside another.</p>
+<p>deja indexes fifteen coding-agent histories into one retroactive index. A fix found in one agent is recalled inside another.</p>
 <!-- matrix:start -->
 <table>
 <tr><th>Harness</th><th>Store</th><th>MCP recall</th><th>Auto-recall</th><th>Resume</th><th>Handoff</th><th>Needs</th></tr>
 <tr><td>Claude Code</td><td><code>${CLAUDE_CONFIG_DIR:-~/.claude}/projects/**/*.jsonl</code><br><code>${DEJA_CLAUDE_ROOT}/**/*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
+<tr><td>Cline</td><td><code>${CLINE_SESSION_DATA_DIR:-${CLINE_DATA_DIR:-${CLINE_DIR:-~/.cline}/data}/sessions}/*/*.messages.json</code><br><code><vscode-globalStorage>/saoudrizwan.claude-dev/tasks/*/api_conversation_history.json</code><br><code>${DEJA_CLINE_ROOT}/*/*.messages.json</code><br><code>${DEJA_CLINE_ROOTS}/tasks/*/api_conversation_history.json</code></td><td>✅</td><td>—</td><td>✅</td><td>paste</td><td>—</td></tr>
 <tr><td>Codex CLI</td><td><code>${CODEX_HOME:-~/.codex}/sessions/**/rollout-*.jsonl</code><br><code>${CODEX_HOME:-~/.codex}/history.jsonl</code><br><code>${DEJA_CODEX_ROOT}/sessions/**/rollout-*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
 <tr><td>opencode</td><td><code>~/.local/share/opencode/opencode.db</code><br><code>${XDG_DATA_HOME}/opencode/opencode.db</code><br><code>${DEJA_OPENCODE_DB}</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>sqlite3</td></tr>
 <tr><td>aider</td><td><code>~/.aider.chat.history.md</code><br><code>${AIDER_CHAT_HISTORY_FILE}</code><br><code>${DEJA_AIDER_ROOTS}/**/.aider.chat.history.md</code></td><td>—</td><td>—</td><td>—</td><td>✅</td><td>—</td></tr>
@@ -67,10 +68,11 @@
 <tr><td>Grok Build</td><td><code>${GROK_HOME:-~/.grok}/sessions/**/updates.jsonl</code><br><code>${DEJA_GROK_ROOT}/sessions/**/updates.jsonl</code></td><td>✅</td><td>—</td><td>—</td><td>✅</td><td>—</td></tr>
 <tr><td>Qwen Code</td><td><code>${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl</code></td><td>✅</td><td>—</td><td>—</td><td>✅</td><td>—</td></tr>
 <tr><td>Kimi Code</td><td><code>${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/main/wire.jsonl</code><br><code>${DEJA_KIMI_ROOT}/sessions/*/*/agents/main/wire.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>paste</td><td>—</td></tr>
-<tr><td>Cline</td><td><code>${CLINE_DIR:-~/.cline}/data/sessions/*/*.messages.json</code><br>VS Code globalStorage <code>saoudrizwan.claude-dev/tasks/*/api_conversation_history.json</code></td><td>✅</td><td>—</td><td>✅</td><td>paste</td><td>—</td></tr>
-<tr><td>Roo Code</td><td>VS Code globalStorage <code>rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json</code></td><td>—</td><td>—</td><td>—</td><td>paste</td><td>—</td></tr>
 <tr><td>pi</td><td><code>${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>✅</td><td>—</td></tr>
+<tr><td>OpenClaw</td><td><code>${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl</code><br><code>${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl</code></td><td>—</td><td>—</td><td>—</td><td>paste</td><td>—</td></tr>
+<tr><td>OpenClaw</td><td><code>${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl</code><br><code>${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl</code></td><td>—</td><td>—</td><td>—</td><td>paste</td><td>—</td></tr>
 <tr><td>Copilot CLI</td><td><code>${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>✅</td><td>—</td></tr>
+<tr><td>Roo Code</td><td><code><vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json</code><br><code>${DEJA_ROO_ROOTS}/tasks/*/api_conversation_history.json</code></td><td>—</td><td>—</td><td>—</td><td>paste</td><td>—</td></tr>
 </table><!-- matrix:end -->
 <p>Each format is documented in the <a href="../registry/README.md">session format registry</a>, with synthetic fixtures and a conformance test that catches upstream drift.</p>
 <h2>Adding a harness</h2>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -69,8 +69,7 @@
 <tr><td>Qwen Code</td><td><code>${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl</code></td><td>✅</td><td>—</td><td>—</td><td>✅</td><td>—</td></tr>
 <tr><td>Kimi Code</td><td><code>${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/main/wire.jsonl</code><br><code>${DEJA_KIMI_ROOT}/sessions/*/*/agents/main/wire.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>paste</td><td>—</td></tr>
 <tr><td>pi</td><td><code>${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>✅</td><td>—</td></tr>
-<tr><td>OpenClaw</td><td><code>${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl</code><br><code>${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl</code></td><td>—</td><td>—</td><td>—</td><td>paste</td><td>—</td></tr>
-<tr><td>OpenClaw</td><td><code>${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl</code><br><code>${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl</code></td><td>—</td><td>—</td><td>—</td><td>paste</td><td>—</td></tr>
+<tr><td>OpenClaw</td><td><code>${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl</code><br><code>${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl</code></td><td>✅</td><td>—</td><td>—</td><td>paste</td><td>—</td></tr>
 <tr><td>Copilot CLI</td><td><code>${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl</code></td><td>✅</td><td>—</td><td>✅</td><td>✅</td><td>—</td></tr>
 <tr><td>Roo Code</td><td><code><vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json</code><br><code>${DEJA_ROO_ROOTS}/tasks/*/api_conversation_history.json</code></td><td>—</td><td>—</td><td>—</td><td>paste</td><td>—</td></tr>
 </table><!-- matrix:end -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>deja-vu — your agents already solved this. deja finds it.</title>
-<meta name="description" content="A memory layer for coding agents: search, MCP recall, auto-context, secret redaction, stats, share and sync over the session histories Claude Code, Codex, opencode, Cursor, Gemini CLI, aider, Antigravity, Grok Build, Qwen Code, Kimi Code, pi and Copilot CLI already write. One zero-dependency binary, fully local.">
+<meta name="description" content="A memory layer for coding agents: search, MCP recall, auto-context, secret redaction, stats, share and sync over the session histories Claude Code, Codex, opencode, Cursor, Gemini CLI, aider, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Roo Code, OpenClaw, pi and Copilot CLI already write. One zero-dependency binary, fully local.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="deja-vu — search every session your coding agents ever wrote">
-<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across fourteen coding agents, served back to them via MCP.">
+<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across fifteen coding agents, served back to them via MCP.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -365,7 +365,7 @@ footer .spacer{flex:1}
       <tr><td class="n">~12 ms</td><td class="c">typical warm search over gigabytes of history</td></tr>
       <tr><td class="n">~50 ms</td><td class="c">session-start hook on a 1000-session index — memory lands before you type</td></tr>
       <tr><td class="n">84.9%</td><td class="c">R@1 on LongMemEval-S session retrieval — no LLM, no embeddings, harness in-repo</td></tr>
-      <tr><td class="n">14</td><td class="c">coding agents indexed into one retroactive memory</td></tr>
+      <tr><td class="n">15</td><td class="c">coding agents indexed into one retroactive memory</td></tr>
     </table>
     <p class="foot"><a href="guide/benchmarks.html">how it's measured →</a></p>
   </div>
@@ -391,7 +391,7 @@ footer .spacer{flex:1}
 </section>
 
 <section class="reveal">
-  <p class="shead"><span class="p">$</span> <span class="cmd">deja doctor</span> <span class="out"># fourteen harnesses, one memory</span></p>
+  <p class="shead"><span class="p">$</span> <span class="cmd">deja doctor</span> <span class="out"># fifteen harnesses, one memory</span></p>
   <div class="sources">
     <table class="mx">
       <tr><th></th><th>mcp recall</th><th>auto-recall</th><th>resume</th><th>handoff</th><th>needs</th></tr>
@@ -406,6 +406,7 @@ footer .spacer{flex:1}
       <tr><td class="nm">kimi code</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="am">paste</td><td class="pa">—</td></tr>
       <tr><td class="nm">cline</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="am">paste</td><td class="pa">—</td></tr>
       <tr><td class="nm">roo code</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="am">paste</td><td class="pa">history still indexed</td></tr>
+      <tr><td class="nm">openclaw</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="am">paste</td><td class="pa">history still indexed</td></tr>
       <tr><td class="nm">pi</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="y">✓</td><td class="pa">—</td></tr>
       <tr><td class="nm">copilot cli</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="y">✓</td><td class="pa">—</td></tr>
       <tr><td class="nm">aider</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="y">✓</td><td class="pa">no MCP client — history still indexed</td></tr>
@@ -446,7 +447,7 @@ footer .spacer{flex:1}
     <a href="guide/agents.html">agents-and-mcp<span>recall, blame, remember, auto-recall</span></a>
     <a href="guide/search.html">search<span>phrases, fuzzy, semantic, tiers</span></a>
     <a href="guide/commands.html">cli-reference<span>every subcommand and flag</span></a>
-    <a href="guide/harnesses.html">harnesses<span>fourteen agents, and adding one</span></a>
+    <a href="guide/harnesses.html">harnesses<span>fifteen agents, and adding one</span></a>
     <a href="guide/privacy.html">privacy<span>redaction, forget, exclude</span></a>
     <a href="guide/benchmarks.html">benchmarks<span>the ~200× number, reproducible</span></a>
     <a href="guide/compare.html">compare<span>deja next to Mem0, Letta, memU…</span></a>
@@ -575,7 +576,7 @@ document.querySelectorAll('.reveal').forEach(function(el){io.observe(el)});
   }
   var COMMANDS={
     'help':'<p class="none">this input is a tiny deja: type words to search 16 demo sessions.\ncommands: <span class="t">sources</span> · <span class="t">stats</span> · <span class="t">version</span> · <span class="t">clear</span>\nthe real CLI does far more — see <a href="guide/commands.html">cli reference</a></p>',
-    'sources':'<p class="none">claude&nbsp;&nbsp;codex&nbsp;&nbsp;opencode&nbsp;&nbsp;cursor&nbsp;&nbsp;gemini&nbsp;&nbsp;aider&nbsp;&nbsp;antigravity&nbsp;&nbsp;grok&nbsp;&nbsp;qwen&nbsp;&nbsp;kimi&nbsp;&nbsp;cline&nbsp;&nbsp;roo&nbsp;&nbsp;pi&nbsp;&nbsp;copilot\n14 harnesses, one index — real paths in the <a href="#proof">matrix below</a></p>',
+    'sources':'<p class="none">claude&nbsp;&nbsp;codex&nbsp;&nbsp;opencode&nbsp;&nbsp;cursor&nbsp;&nbsp;gemini&nbsp;&nbsp;aider&nbsp;&nbsp;antigravity&nbsp;&nbsp;grok&nbsp;&nbsp;qwen&nbsp;&nbsp;kimi&nbsp;&nbsp;cline&nbsp;&nbsp;roo&nbsp;&nbsp;pi&nbsp;&nbsp;openclaw&nbsp;&nbsp;copilot\n15 harnesses, one index — real paths in the <a href="#proof">matrix below</a></p>',
     'stats':'<p class="none">sessions 16 · messages 412 · top project api-gateway\nlast 12 months&nbsp;&nbsp;▁▁▂▃▂▅▆▄▇█▆▇\n(demo numbers — <span class="t">deja stats</span> wraps your real year)</p>',
     'version':'<p class="none">deja 0.14.1</p>',
     'clear':''

--- a/docs/index.html
+++ b/docs/index.html
@@ -406,7 +406,7 @@ footer .spacer{flex:1}
       <tr><td class="nm">kimi code</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="am">paste</td><td class="pa">—</td></tr>
       <tr><td class="nm">cline</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="am">paste</td><td class="pa">—</td></tr>
       <tr><td class="nm">roo code</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="am">paste</td><td class="pa">history still indexed</td></tr>
-      <tr><td class="nm">openclaw</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="am">paste</td><td class="pa">history still indexed</td></tr>
+      <tr><td class="nm">openclaw</td><td class="y">✓</td><td class="n">—</td><td class="n">—</td><td class="am">paste</td><td class="pa">—</td></tr>
       <tr><td class="nm">pi</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="y">✓</td><td class="pa">—</td></tr>
       <tr><td class="nm">copilot cli</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="y">✓</td><td class="pa">—</td></tr>
       <tr><td class="nm">aider</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="y">✓</td><td class="pa">no MCP client — history still indexed</td></tr>

--- a/docs/registry/openclaw.md
+++ b/docs/registry/openclaw.md
@@ -1,0 +1,24 @@
+# OpenClaw
+
+- **ID**: `openclaw`
+- **Store**: `${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/<agentId>/sessions/<sessionId>.jsonl` — one append-only pi-format transcript per session, per agent
+- **Read override**: `DEJA_OPENCLAW_ROOT` (agents root), `OPENCLAW_STATE_DIR` (OpenClaw's own state override, also honored)
+- **Format**: JSONL, append-cheap incremental parse from offset
+
+OpenClaw's agent runtime is pi-lineage, so transcripts share pi's line shape:
+a `{"type":"session"}` header (id, timestamp, optional cwd) followed by
+`{"type":"message"}` entries whose `message.content` is a block array. The
+shared pi parser handles both; when the header carries a `cwd`, it becomes
+the project key, otherwise sessions attribute to `openclaw-<agentId>`.
+
+Skipped in the sessions directory: `sessions.json` (store metadata),
+compaction checkpoints (`<id>.checkpoint.<uuid>.jsonl`), and archived
+transcripts (`.deleted`/`.reset`/`.bak` suffixes). Newer OpenClaw builds can
+keep session *metadata* in SQLite; transcripts stay JSONL files, which is all
+deja reads. Format verified against openclaw source
+(`src/config/sessions/paths.ts`, `artifacts.ts`, `src/transcripts/store.ts`).
+
+- **MCP**: OpenClaw manages its own tool wiring; deja indexes its history and
+  serves it to other agents.
+- **Resume**: OpenClaw's own session continuity.
+- **Handoff**: paste.

--- a/docs/registry/openclaw.md
+++ b/docs/registry/openclaw.md
@@ -18,7 +18,9 @@ keep session *metadata* in SQLite; transcripts stay JSONL files, which is all
 deja reads. Format verified against openclaw source
 (`src/config/sessions/paths.ts`, `artifacts.ts`, `src/transcripts/store.ts`).
 
-- **MCP**: OpenClaw manages its own tool wiring; deja indexes its history and
-  serves it to other agents.
+- **MCP**: `deja install openclaw` wires deja into `openclaw.json` under
+  `mcp.servers` (OpenClaw's own layout, not the common `mcpServers` root).
+  Live-verified: `openclaw mcp probe deja` reports the tools and the agent
+  calls `recall` mid-turn.
 - **Resume**: OpenClaw's own session continuity.
 - **Handoff**: paste.

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -261,6 +261,27 @@
    }
   },
   {
+   "id": "openclaw",
+   "store_paths": [
+    "${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl",
+    "${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl"
+   ],
+   "format_kind": "jsonl",
+   "fixture_paths": [
+    "fixtures/registry/openclaw/agents/main/sessions/a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.jsonl"
+   ],
+   "parser_source": "internal/sources/openclaw.go",
+   "last_verified": "2026-07-23",
+   "display_name": "OpenClaw",
+   "capabilities": {
+    "mcp": false,
+    "auto": false,
+    "resume": false,
+    "handoff": "paste",
+    "prereq": ""
+   }
+  },
+  {
    "id": "copilot",
    "store_paths": [
     "${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl"

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -274,7 +274,7 @@
    "last_verified": "2026-07-23",
    "display_name": "OpenClaw",
    "capabilities": {
-    "mcp": false,
+    "mcp": true,
     "auto": false,
     "resume": false,
     "handoff": "paste",

--- a/fixtures/registry/openclaw/agents/main/sessions/a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.checkpoint.11111111-2222-4333-8444-555555555555.jsonl
+++ b/fixtures/registry/openclaw/agents/main/sessions/a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.checkpoint.11111111-2222-4333-8444-555555555555.jsonl
@@ -1,0 +1,2 @@
+{"type":"session","version":3,"id":"checkpoint-should-be-skipped","timestamp":"2026-07-20T09:00:00Z"}
+{"type":"message","id":"x1","timestamp":"2026-07-20T09:00:05Z","message":{"role":"user","content":[{"type":"text","text":"checkpoint content must not be indexed"}]}}

--- a/fixtures/registry/openclaw/agents/main/sessions/a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.jsonl
+++ b/fixtures/registry/openclaw/agents/main/sessions/a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.jsonl
@@ -1,0 +1,4 @@
+{"type":"session","version":3,"id":"a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d","timestamp":"2026-07-20T09:00:00Z","cwd":"/workspace/registry-demo"}
+{"type":"model_change","id":"mc1","parentId":null,"timestamp":"2026-07-20T09:00:01Z","provider":"anthropic","modelId":"claude-sonnet-4"}
+{"type":"message","id":"u1","parentId":"mc1","timestamp":"2026-07-20T09:00:05Z","message":{"role":"user","content":[{"type":"text","text":"openclaw registry conformance question"}],"timestamp":1784883605000}}
+{"type":"message","id":"a1","parentId":"u1","timestamp":"2026-07-20T09:00:10Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"reasoning"},{"type":"text","text":"openclaw registry conformance answer"}],"api":"anthropic","model":"claude-sonnet-4","usage":{"input":5,"output":10},"stopReason":"endTurn","timestamp":1784883610000}}

--- a/fixtures/registry/openclaw/agents/main/sessions/sessions.json
+++ b/fixtures/registry/openclaw/agents/main/sessions/sessions.json
@@ -1,0 +1,1 @@
+{"agent:main:main":{"sessionId":"a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d","updatedAt":1784883610000,"sessionFile":"a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.jsonl"}}

--- a/internal/sources/openclaw.go
+++ b/internal/sources/openclaw.go
@@ -1,0 +1,73 @@
+package sources
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// OpenClaw (github.com/openclaw/openclaw) runs pi-lineage agents; each agent
+// keeps pi-format JSONL transcripts under the state dir:
+//
+//	${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/<agentId>/sessions/<sessionId>.jsonl
+//
+// sessions.json in the same directory is store metadata, compaction
+// checkpoints (<id>.checkpoint.<uuid>.jsonl) are context snapshots, and
+// archived transcripts carry .deleted/.reset/.bak suffixes — all skipped.
+// Verified against openclaw src/config/sessions/{paths,artifacts}.ts.
+
+// OpenClawStateDir is the OpenClaw state root.
+func OpenClawStateDir() string {
+	return EnvPath("OPENCLAW_STATE_DIR", filepath.Join(Home(), ".openclaw"))
+}
+
+// OpenClawRoot returns the agents root, overridable via DEJA_OPENCLAW_ROOT.
+func OpenClawRoot() string {
+	return EnvPath("DEJA_OPENCLAW_ROOT", filepath.Join(OpenClawStateDir(), "agents"))
+}
+
+var openclawCheckpointRE = regexp.MustCompile(`(?i)\.checkpoint\.[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.jsonl$`)
+
+// openclawTranscript reports whether p is a live transcript directly inside
+// an agent's sessions dir (agents/<id>/sessions/<file>.jsonl).
+func openclawTranscript(root, p string) bool {
+	if !strings.HasSuffix(p, ".jsonl") || openclawCheckpointRE.MatchString(p) {
+		return false
+	}
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return false
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	return len(parts) == 3 && parts[1] == "sessions"
+}
+
+// OpenClawSessionFiles lists live transcript files for all agents.
+func OpenClawSessionFiles() []string {
+	root := OpenClawRoot()
+	return walkFiles(root, func(p string) bool { return openclawTranscript(root, p) })
+}
+
+// LoadOpenClaw loads all OpenClaw sessions.
+func LoadOpenClaw() []model.Session { return parseFiles(OpenClawSessionFiles(), ParseOpenClawFile) }
+
+// ParseOpenClawFile parses a single OpenClaw transcript.
+func ParseOpenClawFile(path string) ([]model.Session, error) {
+	return ParseOpenClawFileFromOffset(path, 0)
+}
+
+// ParseOpenClawFileFromOffset parses an OpenClaw transcript from a byte offset.
+func ParseOpenClawFileFromOffset(path string, offset int64) ([]model.Session, error) {
+	return parsePiShaped(path, offset, "openclaw", openclawProject(path), true)
+}
+
+// openclawProject attributes a session to its agent id; the header cwd, when
+// the session ran with one, overrides inside parsePiShaped.
+func openclawProject(path string) string {
+	if agent := filepath.Base(filepath.Dir(filepath.Dir(path))); agent != "" && agent != "." && agent != string(filepath.Separator) {
+		return "openclaw-" + agent
+	}
+	return "openclaw"
+}

--- a/internal/sources/openclaw_test.go
+++ b/internal/sources/openclaw_test.go
@@ -1,0 +1,56 @@
+package sources
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenClawSessionFiles(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", "..", "fixtures", "registry", "openclaw", "agents"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_OPENCLAW_ROOT", root)
+	files := OpenClawSessionFiles()
+	if len(files) != 1 {
+		t.Fatalf("files = %v, want exactly the live transcript (checkpoint and sessions.json skipped)", files)
+	}
+	if base := filepath.Base(files[0]); base != "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.jsonl" {
+		t.Fatalf("unexpected transcript %q", base)
+	}
+}
+
+func TestParseOpenClawFile(t *testing.T) {
+	path := filepath.Join("..", "..", "fixtures", "registry", "openclaw", "agents", "main", "sessions",
+		"a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.jsonl")
+	sessions, err := ParseOpenClawFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(sessions))
+	}
+	s := sessions[0]
+	if s.Harness != "openclaw" {
+		t.Fatalf("harness = %q", s.Harness)
+	}
+	if s.ID != "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d" {
+		t.Fatalf("id = %q", s.ID)
+	}
+	if len(s.Messages) != 2 {
+		t.Fatalf("messages = %d, want 2", len(s.Messages))
+	}
+	if s.Messages[0].Role != "user" || s.Messages[1].Role != "assistant" {
+		t.Fatalf("roles = %q,%q", s.Messages[0].Role, s.Messages[1].Role)
+	}
+	// Header cwd promotes to the project key.
+	if s.Project != claudeProjectName(pathToProjectKey("/workspace/registry-demo")) {
+		t.Fatalf("project = %q", s.Project)
+	}
+}
+
+func TestOpenClawProjectFallback(t *testing.T) {
+	if got := openclawProject("/x/agents/work/sessions/s.jsonl"); got != "openclaw-work" {
+		t.Fatalf("project = %q, want openclaw-work", got)
+	}
+}

--- a/internal/sources/pi.go
+++ b/internal/sources/pi.go
@@ -34,10 +34,17 @@ func ParsePiFileFromOffset(path string, offset int64) ([]model.Session, error) {
 }
 
 func parsePiFileFromOffset(path string, offset int64) ([]model.Session, error) {
+	return parsePiShaped(path, offset, "pi", piProjectName(path), false)
+}
+
+// parsePiShaped parses a pi-format transcript (shared by pi and OpenClaw,
+// whose agent runtime is the same lineage). useHeaderCwd promotes the session
+// header's cwd to the project key when present.
+func parsePiShaped(path string, offset int64, harness, project string, useHeaderCwd bool) ([]model.Session, error) {
 	s := model.Session{
-		Harness: "pi",
+		Harness: harness,
 		ID:      strings.TrimSuffix(filepath.Base(path), ".jsonl"),
-		Project: piProjectName(path),
+		Project: project,
 		Path:    path,
 	}
 	err := scanJSONLFromOffset(path, offset, func(m map[string]any) {
@@ -47,6 +54,11 @@ func parsePiFileFromOffset(path string, offset int64) ([]model.Session, error) {
 			// First line: session header with id and timestamp.
 			if id, _ := m["id"].(string); id != "" {
 				s.ID = id
+			}
+			if useHeaderCwd {
+				if cwd, _ := m["cwd"].(string); cwd != "" {
+					s.Project = claudeProjectName(pathToProjectKey(cwd))
+				}
 			}
 			t := parseTimeAny(m["timestamp"])
 			s.Touch(t)

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -242,6 +242,15 @@ func Registry() []Harness {
 			}},
 		},
 		{
+			Name: "openclaw", Load: LoadOpenClaw, Files: OpenClawSessionFiles,
+			Kinds: []FileKind{{
+				Name:      "openclaw",
+				Match:     func(p string) bool { return openclawTranscript(OpenClawRoot(), p) },
+				Parse:     fullParse(ParseOpenClawFile),
+				ParseFrom: offsetParse(ParseOpenClawFileFromOffset),
+			}},
+		},
+		{
 			Name: "copilot", Load: LoadCopilot, Files: CopilotSessionFiles,
 			Kinds: []FileKind{{
 				Name:      "copilot",

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -40,6 +40,7 @@ func TestFormatRegistryConformance(t *testing.T) {
 		"DEJA_PI_ROOT", "DEJA_QWEN_ROOT", "DEJA_KIMI_ROOT", "KIMI_CODE_HOME",
 		"DEJA_CLINE_ROOT", "DEJA_CLINE_ROOTS", "CLINE_DIR", "CLINE_DATA_DIR",
 		"CLINE_SESSION_DATA_DIR", "CLINE_MCP_SETTINGS_PATH", "DEJA_ROO_ROOTS",
+		"DEJA_OPENCLAW_ROOT", "OPENCLAW_STATE_DIR",
 		"DEJA_INCLUDE_SUBAGENTS", "DEJA_OPENCODE_DB", "GEMINI_CLI_HOME",
 		"GROK_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
 		"DEJA_NOTES_FILE",
@@ -168,6 +169,8 @@ func parseRegistryFixture(t *testing.T, id, path string) []model.Session {
 		sessions, err = ParseQwenFile(path)
 	case "pi":
 		sessions, err = ParsePiFile(path)
+	case "openclaw":
+		sessions, err = ParseOpenClawFile(path)
 	case "copilot":
 		sessions, err = ParseCopilotFile(path)
 	default:


### PR DESCRIPTION
Indexes OpenClaw session transcripts (pi-lineage JSONL under `~/.openclaw/agents/<id>/sessions`). Shares the pi parser; compaction checkpoints, archives and sessions.json are skipped, header cwd maps to the project. Registry entry + fixtures + conformance, all surfaces bumped to fifteen in the same PR.