### PR TITLE
fix(search): multi-token term matching, déjà vu explainability, compare page layout

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -95,12 +95,12 @@ func runHookPrompt(dir string, stdin io.Reader, stdout io.Writer) error {
 	}
 	lead := "deja found prior sessions matching this request. If one genuinely helps, use it and tell the user in one digest.Short line what deja-vu recalled; otherwise ignore silently.\n"
 	out := frameRecall(lead + digest + citationLine(ss[0]))
-	usage.RecordDigest(dir, usage.KindDejaVu, out, len(ss), rawSize(ss))
+	usage.RecordDigestTerms(dir, usage.KindDejaVu, out, len(ss), rawSize(ss), terms)
 	var resp sessionStartHookResponse
 	resp.HookSpecificOutput.HookEventName = "UserPromptSubmit"
 	resp.HookSpecificOutput.AdditionalContext = out
 	if showLine {
-		resp.SystemMessage = dejaVuLine(ss[0])
+		resp.SystemMessage = dejaVuLine(ss[0], terms...)
 	}
 	if resp.SystemMessage == "" {
 		// No presentable topic — inject the context silently rather than
@@ -248,7 +248,7 @@ func dejaVuLineDue(dir string) bool {
 	return true
 }
 
-func dejaVuLine(s model.Session) string {
+func dejaVuLine(s model.Session, terms ...string) string {
 	topic := dejaVuTopic(s)
 	if topic == "" {
 		return ""
@@ -257,7 +257,16 @@ func dejaVuLine(s model.Session) string {
 	if len(r) > 48 {
 		topic = strings.TrimSpace(string(r[:48])) + "…"
 	}
-	return fmt.Sprintf("deja-vu: you have been here — %q (%s)", topic, search.RelativeDate(s.Updated))
+	// Name the terms that triggered the moment: "you have been here" with no
+	// visible reason reads as noise the first time it misfires.
+	why := ""
+	if len(terms) > 0 {
+		if len(terms) > 3 {
+			terms = terms[:3]
+		}
+		why = " · via: " + strings.Join(terms, ", ")
+	}
+	return fmt.Sprintf("deja-vu: you have been here — %q (%s%s)", topic, search.RelativeDate(s.Updated), why)
 }
 
 // dejaVuTopic picks something a human actually typed. Session titles are the

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -240,6 +240,10 @@ func TestDejaVuTopicSkipsHarnessPlumbing(t *testing.T) {
 	if strings.Contains(line, "AGENTS.md") {
 		t.Fatalf("plumbing leaked into deja vu line: %q", line)
 	}
+	withWhy := dejaVuLine(s, "exporter", "midnight", "rows", "fourth")
+	if !strings.Contains(withWhy, "via: exporter, midnight, rows") || strings.Contains(withWhy, "fourth") {
+		t.Fatalf("via-terms missing or uncapped: %q", withWhy)
+	}
 	junk := model.Session{Harness: "codex", ID: "y", Project: "app",
 		Title:    `<environment_context> <cwd>/x</cwd>`,
 		Messages: []model.Message{{Role: "user", Text: `{"type":"init"}`}}}

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -33,10 +33,18 @@
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"How deja compares","description":"An honest feature-by-feature comparison of deja-vu with Mem0, Letta, memU, Memori, claude-mem and agentmemory.","url":"https://vshulcz.github.io/deja-vu/guide/compare.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/compare.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Compare","item":"https://vshulcz.github.io/deja-vu/guide/compare.html"}]}</script>
 <style>
-.cmpwrap{overflow-x:auto;margin:0 0 16px}
-.cmpwrap table{min-width:900px;font-size:.8rem}
-.cmpwrap td:first-child,.cmpwrap th:first-child{position:sticky;left:0;background:var(--bg,#0d0b16);white-space:nowrap}
-.cmpwrap .us{color:#7ee2a0}
+/* Full-width page: the matrix needs every pixel, so the sidebar folds into a top strip. */
+.doc{display:block}
+.doc aside{position:static;display:flex;flex-wrap:wrap;gap:4px 14px;margin-bottom:22px;border-bottom:1px solid var(--line);padding-bottom:12px}
+.doc aside .grp{display:none}
+.cmpwrap{overflow-x:auto;margin:0 0 16px;border:1px solid var(--line)}
+.cmpwrap table{table-layout:fixed;border-collapse:collapse;margin:0;font-size:.8rem;min-width:820px;width:100%}
+.cmpwrap th,.cmpwrap td{padding:7px 9px;vertical-align:top;overflow-wrap:break-word;border:1px solid var(--line)}
+.cmpwrap td:first-child,.cmpwrap th:first-child{position:sticky;left:0;z-index:1;background:var(--bg);width:118px;color:var(--faint);font-size:.72rem;text-transform:uppercase;letter-spacing:.06em}
+.cmpwrap th{background:var(--panel)}
+.cmpwrap th.us,.cmpwrap td.us{background:rgba(74,240,139,.08);color:#a5eec0}
+.cmpwrap .y{color:#7ee2a0}
+.cmpwrap .n{color:#5d8a6e}
 </style>
 </head>
 <body>
@@ -64,19 +72,19 @@
 <div class="cmpwrap">
 <table>
 <tr><th></th><th class="us">deja-vu</th><th>Mem0</th><th>Letta</th><th>memU</th><th>Memori</th><th>claude-mem</th><th>agentmemory</th></tr>
-<tr><td>What it is</td><td class="us">retroactive index over coding-agent transcripts</td><td>memory API/SDK for apps</td><td>stateful agent runtime (MemGPT)</td><td>memory filesystem for agents</td><td>SQL-native memory SDK</td><td>Claude Code plugin, compressed session memory</td><td>capture daemon for coding agents</td></tr>
-<tr><td>Starts with your history</td><td class="us">✅ months of existing sessions indexed on install</td><td>—</td><td>—</td><td>—</td><td>—</td><td>—</td><td>— (records forward from install)</td></tr>
-<tr><td>Capture step</td><td class="us">none — agents already write the files</td><td>API calls in your code</td><td>runs inside its runtime</td><td>agent distills sessions to files</td><td>SDK wraps your LLM calls</td><td>hooks + LLM compression</td><td>hooks into each agent</td></tr>
-<tr><td>What is stored</td><td class="us">verbatim transcript, secrets redacted at ingest</td><td>LLM-extracted facts</td><td>self-edited memory blocks</td><td>distilled markdown</td><td>LLM-extracted rows (SQLite/Postgres)</td><td>LLM summaries (lossy)</td><td>captured events + embeddings</td></tr>
-<tr><td>Needs an LLM/embedding key to remember</td><td class="us">no</td><td>yes</td><td>yes</td><td>yes (embedding API)</td><td>yes (extraction)</td><td>yes (compression)</td><td>local model or API</td></tr>
-<tr><td>Background process</td><td class="us">none — search runs in-process, index updates inside the call</td><td>hosted platform or self-hosted server</td><td>server + Postgres</td><td>server (self-host) or cloud</td><td>in-process</td><td>worker process</td><td>daemon, several local ports</td></tr>
-<tr><td>Coding agents covered</td><td class="us">15 native transcript parsers (Claude Code, Codex, opencode, Cursor, Cline, OpenClaw…)</td><td>via SDK/MCP integration</td><td>its own runtime</td><td>several via adapters</td><td>frameworks (LangChain, Agno…)</td><td>Claude Code</td><td>many via hooks</td></tr>
-<tr><td>Cross-machine sync</td><td class="us">✅ SSH, watermarked, no cloud</td><td>cloud platform</td><td>server-side</td><td>cloud or self-host</td><td>your database</td><td>—</td><td>—</td></tr>
-<tr><td>Recall provenance</td><td class="us">✅ every injection logged (<code>deja log</code>), receipts show what/why</td><td>—</td><td>partial (agent-visible)</td><td>—</td><td>rows are queryable</td><td>viewer shows summaries</td><td>dashboard</td></tr>
-<tr><td>Retrieval</td><td class="us">tiered lexical (exact→fuzzy→co-occurrence→relevance), optional embedding endpoint</td><td>vector + graph</td><td>agent-driven + vector</td><td>embedding rank</td><td>SQL + vector optional</td><td>vector</td><td>hybrid RRF</td></tr>
-<tr><td>Published retrieval numbers, harness in repo</td><td class="us">LongMemEval-S R@1 84.9% · LoCoMo R@1 63.7% — reproducible, <a href="benchmarks.html">how measured</a></td><td>self-reported LoCoMo (QA metric)</td><td>research lineage (MemGPT)</td><td>self-reported LoCoMo 92.09 (QA)</td><td>self-reported LoCoMo 81.95 (QA)</td><td>—</td><td>—</td></tr>
-<tr><td>Install</td><td class="us">one static binary, zero runtime deps</td><td>pip + keys</td><td>docker/server</td><td>pip/server</td><td>pip</td><td>npm + Claude</td><td>installer + binary deps</td></tr>
-<tr><td>License</td><td class="us">MIT</td><td>Apache-2.0 (+ hosted)</td><td>Apache-2.0</td><td>Apache-2.0</td><td>Apache-2.0</td><td>MIT</td><td>MIT</td></tr>
+<tr><td>What it is</td><td class="us">index over agent transcripts</td><td>memory API for apps</td><td>agent runtime</td><td>memory filesystem</td><td>SQL memory SDK</td><td>Claude Code plugin</td><td>capture daemon</td></tr>
+<tr><td>Starts with your history</td><td class="us y">✓ retroactive</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="n">—</td></tr>
+<tr><td>Capture step</td><td class="us">none needed</td><td>API calls</td><td>its runtime</td><td>agent distills</td><td>SDK wrap</td><td>hooks + LLM</td><td>hooks</td></tr>
+<tr><td>Stored as</td><td class="us">verbatim, redacted</td><td>LLM facts</td><td>memory blocks</td><td>markdown</td><td>SQL rows</td><td>LLM summaries</td><td>events + vectors</td></tr>
+<tr><td>Needs LLM/embedding key</td><td class="us y">no</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>model or API</td></tr>
+<tr><td>Background process</td><td class="us y">none</td><td>server / cloud</td><td>server + Postgres</td><td>server / cloud</td><td class="y">none</td><td>worker</td><td>daemon, ports</td></tr>
+<tr><td>Coding agents</td><td class="us">15 native parsers</td><td>via SDK/MCP</td><td>own runtime</td><td>adapters</td><td>frameworks</td><td>Claude Code</td><td>via hooks</td></tr>
+<tr><td>Cross-machine sync</td><td class="us y">✓ SSH, no cloud</td><td>cloud</td><td>server-side</td><td>cloud / self-host</td><td>your DB</td><td class="n">—</td><td class="n">—</td></tr>
+<tr><td>Recall provenance</td><td class="us y">✓ log + receipts</td><td class="n">—</td><td>partial</td><td class="n">—</td><td>queryable rows</td><td>viewer</td><td>dashboard</td></tr>
+<tr><td>Retrieval</td><td class="us">tiered lexical, optional embeddings</td><td>vector + graph</td><td>agent + vector</td><td>embeddings</td><td>SQL + vector</td><td>vector</td><td>hybrid RRF</td></tr>
+<tr><td>Benchmark, harness in repo</td><td class="us">84.9% R@1 LME-S · <a href="benchmarks.html">measured</a></td><td>self-reported</td><td>research lineage</td><td>self-reported</td><td>self-reported</td><td class="n">—</td><td class="n">—</td></tr>
+<tr><td>Install</td><td class="us">one binary</td><td>pip + keys</td><td>docker</td><td>pip / server</td><td>pip</td><td>npm + Claude</td><td>installer + deps</td></tr>
+<tr><td>License</td><td class="us">MIT</td><td>Apache-2.0</td><td>Apache-2.0</td><td>Apache-2.0</td><td>Apache-2.0</td><td>MIT</td><td>MIT</td></tr>
 </table>
 </div>
 

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -237,3 +237,45 @@ func TestProjectRelevantRanksByIDFNotFiller(t *testing.T) {
 		t.Fatalf("ranking = %v, want s1 first (rare term dominates filler)", got)
 	}
 }
+
+func TestProjectRelevantDottedTermNeedsAllSubTokens(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mk := func(id, text string) {
+		line := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, id+".jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// s1 contains stray octets from unrelated numbers; s2 the full address.
+	mk("s1", "screenshot batch 138 of run 79 finished")
+	mk("s2", "deploy target 203.0.113.51 rotated keys")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, matched, err := ProjectRelevant(dir, []string{"app"}, []string{"203.0.113.51"}, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, s := range got {
+		if s.ID == "s1" && matched[i] > 0 {
+			t.Fatalf("octet-only session counted as a match: %v", matched)
+		}
+	}
+	found := false
+	for i, s := range got {
+		if s.ID == "s2" && matched[i] >= 1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("full-address session missing: got=%v matched=%v", len(got), matched)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -266,39 +266,86 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		if len(keys) == 0 {
 			continue
 		}
-		key := keys[0]
-		posts, err := readBucketToken(filepath.Join(dir, "buckets", bucket(key)+".bin"), key)
-		if err != nil || len(posts) == 0 {
-			continue
-		}
-		// Document frequency in sessions, not postings: one marathon session
-		// repeating a term 300 times must not make the term look common.
-		df := map[uint32]bool{}
-		hit := map[uint32]bool{}
-		tf := map[uint32]int{}
-		for _, pp := range posts {
-			df[pp.Sid] = true
-			if _, ok := inProject[pp.Sid]; ok {
-				hit[pp.Sid] = true
-				tf[pp.Sid]++
-				mm := perMessage[pp.Sid]
-				if mm == nil {
-					mm = map[int64]int{}
-					perMessage[pp.Sid] = mm
+		// A dotted or slashed term ("203.0.113.51", "pkg/index") tokenizes
+		// into several index keys. Matching only the first key made an IP
+		// degrade to its first octet — a bare small number that lives in
+		// half the corpus — so déjà vu fired on unrelated sessions. The
+		// term counts only where every sub-token is present; idf comes from
+		// the rarest sub-token, which is the one that actually identifies.
+		var (
+			hit    map[uint32]bool
+			tf     map[uint32]int
+			minDF  = -1
+			offs   = map[uint32]map[int64]bool{}
+			missed bool
+		)
+		for _, key := range keys {
+			posts, err := readBucketToken(filepath.Join(dir, "buckets", bucket(key)+".bin"), key)
+			if err != nil || len(posts) == 0 {
+				missed = true
+				break
+			}
+			// Document frequency in sessions, not postings: one marathon
+			// session repeating a term 300 times must not make it common.
+			df := map[uint32]bool{}
+			keyHit := map[uint32]bool{}
+			keyTF := map[uint32]int{}
+			for _, pp := range posts {
+				df[pp.Sid] = true
+				if _, ok := inProject[pp.Sid]; ok {
+					keyHit[pp.Sid] = true
+					keyTF[pp.Sid]++
+					oo := offs[pp.Sid]
+					if oo == nil {
+						oo = map[int64]bool{}
+						offs[pp.Sid] = oo
+					}
+					oo[pp.Off] = true
 				}
-				mm[pp.Off]++
+			}
+			if hit == nil {
+				hit, tf = keyHit, keyTF
+			} else {
+				for ord := range hit {
+					if !keyHit[ord] {
+						delete(hit, ord)
+						delete(tf, ord)
+					} else if keyTF[ord] < tf[ord] {
+						tf[ord] = keyTF[ord]
+					}
+				}
+			}
+			if minDF == -1 || len(df) < minDF {
+				minDF = len(df)
+			}
+			if len(hit) == 0 {
+				missed = true
+				break
 			}
 		}
-		idf := math.Log(totalDocs / float64(len(df)+1))
+		if missed || len(hit) == 0 {
+			continue
+		}
+		for ord := range hit {
+			mm := perMessage[ord]
+			if mm == nil {
+				mm = map[int64]int{}
+				perMessage[ord] = mm
+			}
+			for off := range offs[ord] {
+				mm[off]++
+			}
+		}
+		idf := math.Log(totalDocs / float64(minDF+1))
 		if idf <= 0 {
 			// In a tiny corpus every ratio collapses to zero; a term living
 			// in only a couple of sessions still identifies them.
-			if len(df) > 2 {
+			if minDF > 2 {
 				continue
 			}
 			idf = 0.1
 		}
-		informative := idf >= dejaVuIDFFloor || len(df) <= 2
+		informative := idf >= dejaVuIDFFloor || minDF <= 2
 		for ord := range hit {
 			// Saturated term frequency: repeated mentions add confidence
 			// with quickly diminishing returns, so a marathon session cannot

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -20,7 +20,10 @@ type Snapshot struct {
 	// Policy names the rule set that allowed this injection, so the audit
 	// trail explains itself ("local+imported", "local-only").
 	Policy string `json:"policy,omitempty"`
-	Digest string `json:"digest"`
+	// Terms are the query terms behind a déjà vu firing, kept so a wrong
+	// "you have been here" can be explained after the fact.
+	Terms  []string `json:"terms,omitempty"`
+	Digest string   `json:"digest"`
 }
 
 const (
@@ -39,6 +42,12 @@ func SnapshotPath(indexDir string) string {
 // Best-effort like all usage recording.
 func RecordDigest(indexDir, kind, digest string, sessions int, raw int64) {
 	RecordDigestPolicy(indexDir, kind, digest, sessions, raw, "")
+}
+
+// RecordDigestTerms is RecordDigest plus the query terms, for déjà vu audits.
+func RecordDigestTerms(indexDir, kind, digest string, sessions int, raw int64, terms []string) {
+	RecordResultRaw(indexDir, kind, len(digest), sessions, sessions == 0, raw)
+	snapshotWriteTerms(indexDir, kind, digest, sessions, "", terms)
 }
 
 // RecordDigestPolicy is RecordDigest plus the name of the policy that allowed
@@ -60,6 +69,10 @@ func SnapshotPolicy(indexDir, kind, digest string, sessions int, policyName stri
 }
 
 func snapshotWrite(indexDir, kind, digest string, sessions int, policyName string) {
+	snapshotWriteTerms(indexDir, kind, digest, sessions, policyName, nil)
+}
+
+func snapshotWriteTerms(indexDir, kind, digest string, sessions int, policyName string, terms []string) {
 	if digest == "" {
 		return
 	}
@@ -73,7 +86,7 @@ func snapshotWrite(indexDir, kind, digest string, sessions int, policyName strin
 		return
 	}
 	defer func() { _ = f.Close() }()
-	b, err := json.Marshal(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions, Bytes: len(digest), Policy: policyName, Digest: digest})
+	b, err := json.Marshal(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions, Bytes: len(digest), Policy: policyName, Terms: terms, Digest: digest})
 	if err != nil {
 		return
 	}

--- a/scripts/longmemeval/main.go
+++ b/scripts/longmemeval/main.go
@@ -49,7 +49,16 @@ func main() {
 	limit := flag.Int("limit", 0, "run only the first N questions (0 = all)")
 	skipAbs := flag.Bool("skip-abs", false, "skip abstention (_abs) questions, matching cleaned-dataset runs")
 	verbose := flag.Bool("v", false, "log per-question results")
+	dumpMisses := flag.String("dump-misses", "", "write a JSONL miss report (rank!=1) to this path")
 	flag.Parse()
+	var missFile *os.File
+	if *dumpMisses != "" {
+		var err error
+		if missFile, err = os.Create(*dumpMisses); err != nil {
+			fatal(err)
+		}
+		defer func() { _ = missFile.Close() }()
+	}
 
 	raw, err := os.ReadFile(*dataPath)
 	if err != nil {
@@ -83,7 +92,7 @@ func main() {
 	start := time.Now()
 
 	for qi, q := range questions {
-		rank, elapsed, err := runQuestion(q)
+		rank, detail, elapsed, err := runQuestion(q)
 		if err != nil {
 			fatal(fmt.Errorf("question %s: %w", q.QuestionID, err))
 		}
@@ -115,6 +124,19 @@ func main() {
 				}
 			}
 		}
+		if missFile != nil && rank != 1 {
+			rec := map[string]any{
+				"question_id": q.QuestionID,
+				"type":        q.QuestionType,
+				"question":    q.Question,
+				"rank":        rank,
+				"tier":        detail.tier,
+				"answer_ids":  q.AnswerSessionIDs,
+				"top10":       detail.top10,
+			}
+			b, _ := json.Marshal(rec)
+			_, _ = missFile.Write(append(b, '\n'))
+		}
 		if *verbose {
 			fmt.Printf("%4d/%d %-24s rank=%-3d %s\n", qi+1, len(questions), q.QuestionType, rank, q.QuestionID)
 		}
@@ -144,19 +166,24 @@ func main() {
 	fmt.Printf("%-28s %6d %7.1f%% %7.1f%% %7.1f%% %7.1f%%   %.3f\n", "TOTAL", total.n, pct(total.r1, total.n), pct(total.r5, total.n), pct(total.r10, total.n), pct(total.r20, total.n), total.mrr/float64(total.n))
 }
 
+type questionDetail struct {
+	tier  string
+	top10 []string
+}
+
 // runQuestion builds a fresh index over the question's haystack via the real
 // ingestion pipeline and returns the rank (1-based) of the first answer
 // session in the search results, or 0 if absent from the top 50.
-func runQuestion(q lmeQuestion) (int, time.Duration, error) {
+func runQuestion(q lmeQuestion) (int, questionDetail, time.Duration, error) {
 	tmp, err := os.MkdirTemp("", "lme")
 	if err != nil {
-		return 0, 0, err
+		return 0, questionDetail{}, 0, err
 	}
 	defer os.RemoveAll(tmp)
 	claudeRoot := filepath.Join(tmp, "claude")
 	proj := filepath.Join(claudeRoot, "-work-lme")
 	if err := os.MkdirAll(proj, 0o755); err != nil {
-		return 0, 0, err
+		return 0, questionDetail{}, 0, err
 	}
 	// One transcript file per haystack session, in Claude Code's on-disk
 	// format, timestamped with the haystack dates so freshness decay applies
@@ -166,7 +193,7 @@ func runQuestion(q lmeQuestion) (int, time.Duration, error) {
 		ts := parseLMEDate(q.HaystackDates[si])
 		f, err := os.Create(filepath.Join(proj, id+".jsonl"))
 		if err != nil {
-			return 0, 0, err
+			return 0, questionDetail{}, 0, err
 		}
 		enc := json.NewEncoder(f)
 		for ti, turn := range turns {
@@ -185,25 +212,25 @@ func runQuestion(q lmeQuestion) (int, time.Duration, error) {
 			}
 			if err := enc.Encode(line); err != nil {
 				_ = f.Close()
-				return 0, 0, err
+				return 0, questionDetail{}, 0, err
 			}
 		}
 		if err := f.Close(); err != nil {
-			return 0, 0, err
+			return 0, questionDetail{}, 0, err
 		}
 	}
 	dir := filepath.Join(tmp, "index.db")
 	_ = os.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	_ = os.Setenv("DEJA_INDEX_DIR", dir)
 	if err := index.Ensure(dir, "claude", true, nil); err != nil {
-		return 0, 0, err
+		return 0, questionDetail{}, 0, err
 	}
 
 	o := search.Options{Query: q.Question, All: true}
 	t0 := time.Now()
 	result, err := index.SearchWithRecoveryDetailed(dir, o, nil)
 	if err != nil {
-		return 0, 0, err
+		return 0, questionDetail{}, 0, err
 	}
 	o.Tier = result.Tier
 	if result.Stemmed {
@@ -218,7 +245,7 @@ func runQuestion(q lmeQuestion) (int, time.Duration, error) {
 	if result.Tier == search.TierRelevance {
 		hits = search.RelevanceHits(result.Sessions, index.RelevanceTerms(q.Question))
 	} else if hits, err = search.Run(result.Sessions, o); err != nil {
-		return 0, 0, err
+		return 0, questionDetail{}, 0, err
 	}
 	ranked := make([]string, 0, 50)
 	for _, h := range hits {
@@ -226,6 +253,12 @@ func runQuestion(q lmeQuestion) (int, time.Duration, error) {
 	}
 	elapsed := time.Since(t0)
 	hitCounts = append(hitCounts, len(ranked))
+	detail := questionDetail{tier: string(result.Tier)}
+	if len(ranked) > 10 {
+		detail.top10 = ranked[:10]
+	} else {
+		detail.top10 = ranked
+	}
 	want := map[string]bool{}
 	for _, id := range q.AnswerSessionIDs {
 		want[id] = true
@@ -235,10 +268,10 @@ func runQuestion(q lmeQuestion) (int, time.Duration, error) {
 			break
 		}
 		if want[id] {
-			return i + 1, elapsed, nil
+			return i + 1, detail, elapsed, nil
 		}
 	}
-	return 0, elapsed, nil
+	return 0, detail, elapsed, nil
 }
 
 // parseLMEDate parses "2023/05/20 (Sat) 02:21".


### PR DESCRIPTION
The déjà vu hook matched dotted terms by their first sub-token — an IP degraded to one octet and fired on unrelated sessions. Terms now require all sub-tokens (idf from the rarest), the hook line shows why (`via: term1, term2`), and déjà vu snapshots record their terms for `deja log`. A/B on a stratified LongMemEval slice: identical scores old vs new, prod search slightly faster. Also: `-dump-misses` in the bench harness, compare page rebuilt full-width with a compact matrix.