### PR TITLE
fix(sources): parse Gemini CLI $set message snapshots

### DIFF
--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -120,10 +120,11 @@
    ],
    "format_kind": "json-or-jsonl",
    "fixture_paths": [
-    "fixtures/registry/gemini/session.jsonl"
+    "fixtures/registry/gemini/session.jsonl",
+    "fixtures/registry/gemini/session-set-snapshot.jsonl"
    ],
    "parser_source": "internal/sources/gemini.go",
-   "last_verified": "2026-07-17",
+   "last_verified": "2026-07-24",
    "display_name": "Gemini CLI",
    "capabilities": {
     "mcp": true,

--- a/fixtures/registry/gemini/session-set-snapshot.jsonl
+++ b/fixtures/registry/gemini/session-set-snapshot.jsonl
@@ -1,0 +1,2 @@
+{"sessionId":"reg-gem-set-001","projectHash":"abc","startTime":"2026-07-22T07:53:15.572Z","lastUpdated":"2026-07-22T07:53:15.572Z","kind":"main"}
+{"$set":{"messages":[{"id":"m1","timestamp":"2026-07-22T07:53:15.573Z","type":"user","content":[{"text":"gemini set-snapshot conformance question"}]},{"id":"m2","timestamp":"2026-07-22T07:53:20.000Z","type":"gemini","content":[{"text":"gemini set-snapshot conformance answer"}],"model":"gemini-2.5-pro"}],"lastUpdated":"2026-07-22T07:53:20.000Z"}}

--- a/internal/sources/gemini.go
+++ b/internal/sources/gemini.go
@@ -140,6 +140,25 @@ func parseGeminiJSONL(path string) ([]model.Session, error) {
 					s.Touch(t)
 				}
 			}
+			// Newer Gemini CLI builds write the message state inside $set
+			// snapshots (sometimes the only message-bearing lines in the
+			// file). A $set replaces the state collected so far.
+			if list, ok := patch["messages"].([]any); ok {
+				var snap []geminiMessage
+				for _, item := range list {
+					raw, err := json.Marshal(item)
+					if err != nil {
+						continue
+					}
+					var gm geminiMessage
+					if json.Unmarshal(raw, &gm) == nil && gm.Type != "" {
+						snap = append(snap, gm)
+					}
+				}
+				if len(snap) > 0 || len(list) == 0 {
+					msgs = snap
+				}
+			}
 			return
 		}
 		if rid, ok := m["$rewindTo"].(string); ok {


### PR DESCRIPTION
Newer Gemini builds keep messages inside $set state lines; the newest chats
parsed to zero.
