### PR TITLE
feat(search): natural queries fall through junk substring hits to relevance

### DIFF
--- a/internal/index/nl_fallback_test.go
+++ b/internal/index/nl_fallback_test.go
@@ -102,3 +102,31 @@ func TestStemFallbackNeedsTwoAnchors(t *testing.T) {
 		t.Fatalf("single anchor produced results: %+v", result.Sessions)
 	}
 }
+
+func TestCloseTierDisagreeFallsThroughToRelevance(t *testing.T) {
+	// Session a answers the question but lacks "birthday" in any form, so the
+	// substring intersection lands only on b — an incidental session whose
+	// long words contain every query token. The ladder used to stop at b.
+	dir := nlIndex(t,
+		"picked a scarf as the gift for my sister celebration",
+		"gifted birthdays sisterhood newsletter volume nine",
+	)
+	result, err := SearchDetailed(dir, search.Options{Query: "sister birthday gift", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Sessions) < 2 || result.Sessions[0].ID != "a" {
+		t.Fatalf("relevance must lead when substring hits disagree: %+v", idsOf(result.Sessions))
+	}
+	if result.Sessions[1].ID != "b" {
+		t.Fatalf("substring hit must survive as the tail: %+v", idsOf(result.Sessions))
+	}
+}
+
+func idsOf(ss []model.Session) []string {
+	out := make([]string, 0, len(ss))
+	for _, s := range ss {
+		out = append(out, s.ID)
+	}
+	return out
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -67,6 +67,42 @@ func SearchDetailed(dir string, o query.Options) (SearchResult, error) {
 				if len(posts) > 0 {
 					fallbackVariants = variants
 					fallbackTier = query.TierClose
+					// A natural-language query that degraded to substring
+					// intersection often lands on one incidental session and
+					// the ladder used to stop there. When the query carries
+					// enough informative words to rank by relevance, prefer
+					// that ranking and keep the substring hits as the tail.
+					if rel, rerr := relevanceSearch(dir, m, o); rerr == nil && len(rel.Sessions) > 0 {
+						closeSS, serr := scanRecords(dir, m, o, postingOffsets(cutPostingsBySession(posts, m, o)))
+						agree := false
+						if serr == nil {
+							top := rel.Sessions[0].Harness + ":" + rel.Sessions[0].ID
+							for _, c := range closeSS {
+								if c.Harness+":"+c.ID == top {
+									agree = true
+									break
+								}
+							}
+						}
+						// Substring hits that contain relevance's own best
+						// candidate are trustworthy — keep the close tier
+						// (and its variant annotations). When they disagree,
+						// the intersection landed on an incidental session;
+						// serve the relevance ranking with close as a tail.
+						if serr == nil && len(closeSS) > 0 && !agree {
+							seen := map[string]bool{}
+							for _, r := range rel.Sessions {
+								seen[r.Harness+":"+r.ID] = true
+							}
+							merged := rel.Sessions
+							for _, c := range closeSS {
+								if !seen[c.Harness+":"+c.ID] {
+									merged = append(merged, c)
+								}
+							}
+							return SearchResult{Sessions: merged, Tier: query.TierRelevance}, nil
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The substring tier could land on one incidental session and stop the ladder;
28 of 30 answer-absent misses on LongMemEval were this. Relevance takes over
only when the substring set is non-empty and disagrees with its top pick.
