### PR TITLE
fix(cli): openclaw install detection and resume guidance

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -255,7 +255,7 @@ func existingTargets() []string {
 		"kimi":        sources.KimiConfigDir(),
 		"cline":       sources.ClineConfigDir(),
 		"pi":          sources.PiConfigDir(),
-		"openclaw":    filepath.Join(sources.OpenClawStateDir(), "openclaw.json"),
+		"openclaw":    sources.OpenClawStateDir(),
 	}
 	var out []string
 	for name, p := range checks {

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -119,6 +119,10 @@ func resumeCommand(s model.Session) (string, string, error) {
 		return "", "cline --id " + s.ID, nil
 	case "roo":
 		return "", "", fmt.Errorf("roo tasks reopen from the extension's history UI, not the terminal")
+	case "qwen":
+		return "", "", fmt.Errorf("qwen sessions reopen from inside the CLI: run qwen, then /chat resume")
+	case "openclaw":
+		return "", "", fmt.Errorf("openclaw keeps its own session continuity — message the same agent and it continues; see openclaw sessions")
 	case "kimi":
 		return "", "kimi --session " + s.ID, nil
 	case "pi":


### PR DESCRIPTION
install --all detected openclaw only after openclaw.json existed; a fresh
install was skipped. qwen and openclaw resume errors now say what to do
instead of the generic fallback.
