### PR TITLE
perf(hook): serve stale digest instantly, refresh detached

### DIFF
--- a/cmd/deja/hook_cache_test.go
+++ b/cmd/deja/hook_cache_test.go
@@ -44,9 +44,11 @@ func TestCachedHookDigestServesWithinTTLAndInvalidates(t *testing.T) {
 	if d2 != d1 {
 		t.Fatal("within TTL the cached digest must be served verbatim")
 	}
-	// Expire the cache: the digest must refresh and see the new session.
+	// Expire the cache: startup must still serve the stale digest instantly
+	// (stale-while-revalidate) — freshness arrives via the detached refresh.
+	cachePath := hookCachePath(dir, cwd)
 	var e hookCacheEntry
-	b, err := os.ReadFile(dir + ".hookcache")
+	b, err := os.ReadFile(cachePath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,13 +57,20 @@ func TestCachedHookDigestServesWithinTTLAndInvalidates(t *testing.T) {
 	}
 	e.At = time.Now().Add(-2 * hookDigestTTL)
 	nb, _ := json.Marshal(e)
-	if err := os.WriteFile(dir+".hookcache", nb, 0o600); err != nil {
+	if err := os.WriteFile(cachePath, nb, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	d3, _, _, _ := cachedHookDigest(dir)
-	if !strings.Contains(d3, "marker_beta") {
-		t.Fatalf("expired cache must rebuild with fresh sessions:\n%s", d3)
+	if d3 != d1 {
+		t.Fatalf("expired cache must serve stale instantly, got:\n%s", d3)
 	}
+	// The refresh itself must produce the fresh view.
+	runHookRefresh(dir)
+	d3b, _, _, _ := cachedHookDigest(dir)
+	if !strings.Contains(d3b, "marker_beta") {
+		t.Fatalf("refresh must rebuild with fresh sessions:\n%s", d3b)
+	}
+	d3 = d3b
 	// A different cwd must never reuse another project's cache.
 	t.Setenv("CLAUDE_PROJECT_DIR", filepath.Join(t.TempDir(), "elsewhere"))
 	d4, _, _, _ := cachedHookDigest(dir)

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -226,6 +226,11 @@ func requestHookRefresh(dir, cwd string) {
 	if err != nil {
 		return
 	}
+	// Under `go test` the executable is the test binary; spawning it as a
+	// refresher would rerun the suite (and hung the Windows runner).
+	if strings.HasSuffix(strings.TrimSuffix(exe, ".exe"), ".test") {
+		return
+	}
 	cmd := exec.Command(exe, "hook-refresh")
 	cmd.Env = append(os.Environ(), "DEJA_HOOK_REFRESH=1", "CLAUDE_PROJECT_DIR="+cwd)
 	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -154,7 +154,11 @@ func receiptIsNews(dir, digest string) bool {
 	return true
 }
 
-// hookDigestTTL bounds how stale a cached session-start digest may be. A
+// hookDigestTTL bounds how long a cached session-start digest is considered
+// fresh. Older entries are still served instantly — startup must never wait
+// on digest work — but a detached refresh is kicked so the next session gets
+// a current one (stale-while-revalidate).
+// A
 // minute-old digest is indistinguishable at session start, and the cache
 // turns the common hook path from ~120ms of index work into one file read.
 const hookDigestTTL = 60 * time.Second
@@ -168,25 +172,82 @@ type hookCacheEntry struct {
 	TaskMatched []string  `json:"task_matched,omitempty"`
 }
 
+func hookCachePath(dir, cwd string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(cwd))
+	return fmt.Sprintf("%s.hookcache-%08x", dir, h.Sum32())
+}
+
 func cachedHookDigest(dir string) (string, int, int64, []string) {
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
 	if cwd == "" {
 		cwd, _ = os.Getwd()
 	}
-	p := dir + ".hookcache"
+	p := hookCachePath(dir, cwd)
 	if b, err := os.ReadFile(p); err == nil {
 		var e hookCacheEntry
-		if json.Unmarshal(b, &e) == nil && e.Digest != "" && e.CWD == cwd && time.Since(e.At) < hookDigestTTL {
+		if json.Unmarshal(b, &e) == nil && e.Digest != "" && e.CWD == cwd {
+			if time.Since(e.At) >= hookDigestTTL {
+				// Serve stale instantly; a detached self-refresh rebuilds
+				// the cache off the startup path.
+				requestHookRefresh(dir, cwd)
+			}
 			return e.Digest, e.Sessions, e.Raw, e.TaskMatched
 		}
 	}
 	digest, sessions, raw, taskMatched := hookDigestResult(dir)
-	if digest != "" {
-		if b, err := json.Marshal(hookCacheEntry{At: time.Now(), CWD: cwd, Digest: digest, Sessions: sessions, Raw: raw, TaskMatched: taskMatched}); err == nil {
-			_ = os.WriteFile(p, b, 0o600)
-		}
-	}
+	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched)
 	return digest, sessions, raw, taskMatched
+}
+
+func writeHookCache(dir, cwd, digest string, sessions int, raw int64, taskMatched []string) {
+	if digest == "" {
+		return
+	}
+	if b, err := json.Marshal(hookCacheEntry{At: time.Now(), CWD: cwd, Digest: digest, Sessions: sessions, Raw: raw, TaskMatched: taskMatched}); err == nil {
+		_ = os.WriteFile(hookCachePath(dir, cwd), b, 0o600)
+	}
+}
+
+// requestHookRefresh spawns a detached `deja hook-refresh` for cwd; a
+// same-named sentinel prevents stampedes. Best effort by design.
+func requestHookRefresh(dir, cwd string) {
+	if os.Getenv("DEJA_HOOK_REFRESH") != "" {
+		return
+	}
+	sentinel := hookCachePath(dir, cwd) + ".refreshing"
+	if fi, err := os.Stat(sentinel); err == nil && time.Since(fi.ModTime()) < 2*time.Minute {
+		return
+	}
+	if err := os.WriteFile(sentinel, []byte("1"), 0o600); err != nil {
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(exe, "hook-refresh")
+	cmd.Env = append(os.Environ(), "DEJA_HOOK_REFRESH=1", "CLAUDE_PROJECT_DIR="+cwd)
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		return
+	}
+	defer func() { _ = devNull.Close() }()
+	cmd.Stdout = devNull
+	cmd.Stderr = cmd.Stdout
+	_ = startDetached(cmd)
+}
+
+// runHookRefresh recomputes the session-start digest for the cwd in the
+// environment and rewrites its cache entry.
+func runHookRefresh(dir string) {
+	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+	digest, sessions, raw, taskMatched := hookDigestResult(dir)
+	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched)
+	_ = os.Remove(hookCachePath(dir, cwd) + ".refreshing")
 }
 
 func hookDigest(dir string) string {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -95,6 +95,7 @@ var commands = map[string]command{
 	"hook-prompt":     func(dir string, _ []string) error { return runHookPrompt(dir, os.Stdin, os.Stdout) },
 	"hook-context":    cmdHookContext,
 	"hook-precompact": func(dir string, _ []string) error { runHookPrecompact(dir); return nil },
+	"hook-refresh":    func(dir string, _ []string) error { runHookRefresh(dir); return nil },
 	"install":         func(dir string, rest []string) error { return runInstall(dir, rest, false) },
 	"uninstall":       func(dir string, rest []string) error { return runInstall(dir, rest, true) },
 	"update":          func(_ string, rest []string) error { return runUpdate(rest, os.Stdout) },


### PR DESCRIPTION
Session-start reads whatever cache exists (per-cwd now) and never waits on
digest work; an expired entry kicks a detached self-refresh. opencode
startup overhead drops from ~1.8s to ~0.8s on a dirty store.
