### PR TITLE
docs(site): wide tables scroll in place; compare page drops the broken nav strip

### DIFF
--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -68,7 +68,7 @@ footer a:hover{color:var(--ph)}
 .doc article li::marker{color:var(--faint)}
 .doc article pre{background:var(--panel);border:1px solid var(--line);padding:14px 16px;overflow-x:auto;margin:0 0 16px;font-family:var(--mono);font-size:.85rem;line-height:1.6;color:var(--ph);box-shadow:inset 0 0 30px rgba(74,240,139,.03)}
 .doc article :not(pre)>code{color:var(--ph);background:var(--panel);border:1px solid var(--line);padding:1px 6px}
-.doc article table{width:100%;border-collapse:collapse;margin:0 0 16px;font-size:.85rem}
+.doc article table{width:100%;border-collapse:collapse;margin:0 0 16px;font-size:.85rem;display:block;overflow-x:auto}
 .doc article th,.doc article td{border:1px solid var(--line);padding:7px 11px;text-align:left}
 .doc article th{background:var(--panel);color:var(--faint);font-weight:400;text-transform:uppercase;font-size:.72rem;letter-spacing:.1em}
 .doc article img{max-width:100%;border:1px solid var(--line)}

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -35,8 +35,7 @@
 <style>
 /* Full-width page: the matrix needs every pixel, so the sidebar folds into a top strip. */
 .doc{display:block}
-.doc aside{position:static;display:flex;flex-wrap:wrap;gap:4px 14px;margin-bottom:22px;border-bottom:1px solid var(--line);padding-bottom:12px}
-.doc aside .grp{display:none}
+.doc aside{display:none}
 .cmpwrap{overflow-x:auto;margin:0 0 16px;border:1px solid var(--line)}
 .cmpwrap table{table-layout:fixed;border-collapse:collapse;margin:0;font-size:.8rem;min-width:820px;width:100%}
 .cmpwrap th,.cmpwrap td{padding:7px 9px;vertical-align:top;overflow-wrap:break-word;border:1px solid var(--line)}


### PR DESCRIPTION
Mobile pages no longer overflow the body sideways (harnesses was 1090px wide
on a 390px viewport), compare loses the two-row link debris and mid-word
label breaks.
