### PR TITLE
feat(cli): deja view — browse memory in one local HTML

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -96,6 +96,7 @@ var commands = map[string]command{
 	"hook-context":    cmdHookContext,
 	"hook-precompact": func(dir string, _ []string) error { runHookPrecompact(dir); return nil },
 	"hook-refresh":    func(dir string, _ []string) error { runHookRefresh(dir); return nil },
+	"view":            runView,
 	"install":         func(dir string, rest []string) error { return runInstall(dir, rest, false) },
 	"uninstall":       func(dir string, rest []string) error { return runInstall(dir, rest, true) },
 	"update":          func(_ string, rest []string) error { return runUpdate(rest, os.Stdout) },
@@ -804,6 +805,7 @@ Usage:
   deja resume <id-prefix> [--exec]
   deja handoff [--to <agent>] [id-prefix] [--exec]
   deja hook-prompt   (UserPromptSubmit hook: relevance recall per prompt)
+  deja view          (browse your memory: sessions, recalls, notes — one local HTML)
   deja ctx <query|id-prefix>
   deja blame <path> [--all] [--json] [--project name] [--harness name] [--since 30d]
   deja sync export <dir> [--full]

--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/digest"
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+	"github.com/vshulcz/deja-vu/internal/sources"
+	"github.com/vshulcz/deja-vu/internal/stats"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// viewTranscripts caps how many recent sessions embed message previews; the
+// rest stay browsable by metadata. viewPreviewBytes caps each preview so the
+// page stays a single fast file even over a multi-gigabyte store.
+const (
+	viewTranscripts  = 200
+	viewPreviewBytes = 6 << 10
+	viewRecalls      = 100
+)
+
+type viewSession struct {
+	ID      string `json:"id"`
+	Harness string `json:"harness"`
+	Project string `json:"project"`
+	Title   string `json:"title"`
+	Updated string `json:"updated"`
+	Preview string `json:"preview,omitempty"`
+}
+
+type viewRecall struct {
+	Time     string   `json:"time"`
+	Kind     string   `json:"kind"`
+	Sessions int      `json:"sessions"`
+	Bytes    int      `json:"bytes"`
+	Policy   string   `json:"policy,omitempty"`
+	Terms    []string `json:"terms,omitempty"`
+	Digest   string   `json:"digest"`
+}
+
+type viewNote struct {
+	Project string   `json:"project"`
+	State   string   `json:"state"`
+	Title   string   `json:"title"`
+	Text    string   `json:"text"`
+	Tags    []string `json:"tags,omitempty"`
+	At      string   `json:"at"`
+}
+
+type viewPage struct {
+	GeneratedAt   string
+	TotalSessions int
+	Harnesses     int
+	DateStart     string
+	DateEnd       string
+	SessionsJSON  template.JS
+	RecallsJSON   template.JS
+	NotesJSON     template.JS
+	PreviewCount  int
+}
+
+func runView(dir string, args []string) error {
+	out := ""
+	openBrowser := true
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--out":
+			if i+1 >= len(args) {
+				return fmt.Errorf("view: --out needs a path")
+			}
+			i++
+			out = args[i]
+		case "--no-open":
+			openBrowser = false
+		default:
+			return fmt.Errorf("view: unknown flag %q", args[i])
+		}
+	}
+	if err := index.EnsureForSearch(dir, query.Options{All: true}, false, os.Stderr); err != nil {
+		return err
+	}
+	if dir == "" {
+		dir = index.DefaultDir()
+	}
+	if out == "" {
+		out = dir + ".view.html"
+	}
+	path, err := writeViewHTML(dir, out)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "deja: view written to %s\n", path)
+	if openBrowser {
+		openInBrowser(path)
+	}
+	return nil
+}
+
+func writeViewHTML(dir, out string) (string, error) {
+	abs, err := filepath.Abs(out)
+	if err != nil {
+		return "", err
+	}
+	metas, err := index.Recent(dir, 0)
+	if err != nil {
+		return "", err
+	}
+	report := stats.Build(metas, time.Now())
+	page := viewPage{
+		GeneratedAt:   time.Now().Format("2006-01-02 15:04"),
+		TotalSessions: report.TotalSessions,
+		Harnesses:     len(report.Harnesses),
+	}
+	if len(metas) > 0 {
+		page.DateEnd = metas[0].Updated.Format("2006-01-02")
+		page.DateStart = metas[len(metas)-1].Updated.Format("2006-01-02")
+	}
+	sessions := make([]viewSession, 0, len(metas))
+	for i, s := range metas {
+		v := viewSession{
+			ID: s.ID, Harness: s.Harness, Project: s.Project,
+			Title:   strings.TrimSpace(s.Title),
+			Updated: s.Updated.Format("2006-01-02 15:04"),
+		}
+		if i < viewTranscripts {
+			if full, ok, err := index.FindByPrefix(dir, s.ID); err == nil && ok {
+				v.Preview = sessionPreview(full.Messages)
+				page.PreviewCount++
+			}
+		}
+		sessions = append(sessions, v)
+	}
+	recalls := make([]viewRecall, 0, viewRecalls)
+	for _, sn := range usage.Snapshots(dir, viewRecalls) {
+		recalls = append(recalls, viewRecall{
+			Time: sn.Time.Local().Format("2006-01-02 15:04"), Kind: sn.Kind,
+			Sessions: sn.Sessions, Bytes: sn.Bytes, Policy: sn.Policy,
+			Terms: sn.Terms, Digest: sn.Digest,
+		})
+	}
+	notes := make([]viewNote, 0, 16)
+	for _, n := range sources.LoadPromotedNotes() {
+		notes = append(notes, viewNote{
+			Project: n.Project, State: n.State, Title: n.Title, Text: n.Text,
+			Tags: n.Tags, At: n.At.Format("2006-01-02"),
+		})
+	}
+	sj, err := json.Marshal(sessions)
+	if err != nil {
+		return "", err
+	}
+	rj, err := json.Marshal(recalls)
+	if err != nil {
+		return "", err
+	}
+	nj, err := json.Marshal(notes)
+	if err != nil {
+		return "", err
+	}
+	page.SessionsJSON = jsonForScript(sj)
+	page.RecallsJSON = jsonForScript(rj)
+	page.NotesJSON = jsonForScript(nj)
+	var b strings.Builder
+	if err := viewTemplate.Execute(&b, page); err != nil {
+		return "", fmt.Errorf("render view: %w", err)
+	}
+	if err := os.WriteFile(abs, []byte(b.String()), 0o644); err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+// jsonForScript makes embedded JSON safe inside a <script> block.
+func jsonForScript(b []byte) template.JS {
+	s := string(b)
+	s = strings.ReplaceAll(s, "</", "<\\/")
+	return template.JS(s) // #nosec G203 -- JSON-marshalled, script-closer escaped
+}
+
+// sessionPreview flattens the first messages of a transcript into a capped
+// plain-text preview. Text comes from the index, so it is already redacted.
+func sessionPreview(msgs []model.Message) string {
+	var b strings.Builder
+	for _, m := range msgs {
+		t := strings.TrimSpace(m.Text)
+		if t == "" || digest.IsAgentArtifact(t) || strings.HasPrefix(t, "<local-command") ||
+			strings.HasPrefix(t, "<command-") || strings.HasPrefix(t, "Caveat:") {
+			continue
+		}
+		b.WriteString(m.Role)
+		b.WriteString(": ")
+		b.WriteString(t)
+		b.WriteString("\n")
+		if b.Len() >= viewPreviewBytes {
+			break
+		}
+	}
+	out := b.String()
+	if len(out) > viewPreviewBytes {
+		out = out[:viewPreviewBytes] + "…"
+	}
+	return out
+}
+
+func openInBrowser(path string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", path)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", "", path)
+	default:
+		cmd = exec.Command("xdg-open", path)
+	}
+	_ = cmd.Start()
+}

--- a/cmd/deja/view_template.go
+++ b/cmd/deja/view_template.go
@@ -1,0 +1,80 @@
+package main
+
+import "html/template"
+
+// viewTemplate is the whole viewer: one self-contained dark-terminal page,
+// no external assets, all data embedded as JSON and filtered client-side.
+var viewTemplate = template.Must(template.New("view").Parse(`<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>deja view</title>
+<style>
+:root{--bg:#050807;--ph:#4af08b;--hi:#8affc0;--amber:#ffb454;--body:#a9cbb6;--faint:#5d8a6e;--line:#12291c;--panel:#070d0a}
+*{margin:0;padding:0;box-sizing:border-box}
+body{background:var(--bg);color:var(--body);font:14px/1.6 "SF Mono","JetBrains Mono",Menlo,Consolas,monospace;padding:0 0 60px}
+a{color:var(--ph);text-decoration:none}
+header{position:sticky;top:0;background:rgba(5,8,7,.95);border-bottom:1px solid var(--line);padding:12px 22px;display:flex;gap:18px;align-items:baseline;flex-wrap:wrap;z-index:5}
+header b{color:var(--ph)}
+header .meta{color:var(--faint);font-size:.8rem}
+.wrap{max-width:1100px;margin:0 auto;padding:0 22px}
+.stats{display:flex;gap:26px;flex-wrap:wrap;margin:20px 0}
+.stat b{display:block;color:var(--hi);font-size:1.25rem}
+.stat span{color:var(--faint);font-size:.78rem}
+.tabs{display:flex;gap:2px;margin:8px 0 14px;border-bottom:1px solid var(--line)}
+.tabs button{background:none;border:none;color:var(--faint);font:inherit;padding:8px 14px;cursor:pointer;border-bottom:2px solid transparent}
+.tabs button.on{color:var(--ph);border-bottom-color:var(--ph)}
+input[type=search]{width:100%;background:var(--panel);border:1px solid var(--line);color:var(--body);font:inherit;padding:9px 12px;margin:0 0 12px}
+input[type=search]:focus{outline:none;border-color:var(--ph)}
+.row{border:1px solid var(--line);border-top:none;padding:9px 12px;cursor:pointer}
+.row:first-of-type{border-top:1px solid var(--line)}
+.row:hover{background:var(--panel)}
+.row .t{color:#d7f5e2}
+.row .m{color:var(--faint);font-size:.78rem}
+.row .h{color:var(--amber)}
+.row pre{display:none;white-space:pre-wrap;color:var(--body);border-top:1px dashed var(--line);margin-top:8px;padding-top:8px;font-size:.82rem;max-height:420px;overflow:auto}
+.row.open pre{display:block}
+.badge{border:1px solid var(--line);padding:0 6px;font-size:.72rem;color:var(--faint)}
+.badge.accepted{color:var(--ph)}.badge.rejected{color:#e2604a}.badge.superseded,.badge.stale{color:var(--amber)}
+.note{color:var(--faint);font-size:.78rem;margin:10px 0 30px}
+.empty{color:var(--faint);padding:24px 0}
+</style></head><body>
+<header><b>deja view</b><span class="meta">generated {{.GeneratedAt}} · local file, nothing leaves this machine</span></header>
+<div class="wrap">
+<div class="stats">
+<div class="stat"><b>{{.TotalSessions}}</b><span>sessions</span></div>
+<div class="stat"><b>{{.Harnesses}}</b><span>agents</span></div>
+<div class="stat"><b>{{.DateStart}} → {{.DateEnd}}</b><span>covered</span></div>
+</div>
+<div class="tabs">
+<button class="on" data-tab="sessions">Sessions</button>
+<button data-tab="recalls">Recalls</button>
+<button data-tab="notes">Notes</button>
+</div>
+<div id="tab-sessions">
+<input type="search" id="q" placeholder="filter sessions — title, project, harness, preview text">
+<div id="list"></div>
+<p class="note">previews embedded for the {{.PreviewCount}} most recent sessions and capped — full-text search lives in <b>deja "query"</b> and the agents' recall tool.</p>
+</div>
+<div id="tab-recalls" style="display:none"><div id="rlist"></div>
+<p class="note">every injection an agent received, verbatim — the audit trail behind <b>deja log</b>.</p></div>
+<div id="tab-notes" style="display:none"><div id="nlist"></div>
+<p class="note">curated notes from <b>deja promote</b> / <b>deja remember</b>; lifecycle states shown as badges.</p></div>
+</div>
+<script>
+const S={{.SessionsJSON}},R={{.RecallsJSON}},N={{.NotesJSON}};
+const esc=s=>(s||'').replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+function rowS(s){return '<div class="row" onclick="this.classList.toggle(\'open\')"><span class="h">['+esc(s.harness)+']</span> <span class="t">'+esc(s.title||s.id)+'</span> <span class="m">'+esc(s.project)+' · '+esc(s.updated)+'</span>'+(s.preview?'<pre>'+esc(s.preview)+'</pre>':'')+'</div>'}
+function rowR(r){return '<div class="row" onclick="this.classList.toggle(\'open\')"><span class="h">['+esc(r.kind)+']</span> <span class="t">'+r.sessions+' sessions · '+r.bytes+' B</span> <span class="m">'+esc(r.time)+(r.policy?' · '+esc(r.policy):'')+(r.terms&&r.terms.length?' · via: '+esc(r.terms.join(', ')):'')+'</span><pre>'+esc(r.digest)+'</pre></div>'}
+function rowN(n){return '<div class="row"><span class="badge '+esc(n.state)+'">'+esc(n.state)+'</span> <span class="t">'+esc(n.title)+'</span> <span class="m">'+esc(n.project)+' · '+esc(n.at)+(n.tags&&n.tags.length?' · #'+esc(n.tags.join(' #')):'')+'</span><pre style="display:block">'+esc(n.text)+'</pre></div>'}
+function draw(){const q=(document.getElementById('q').value||'').toLowerCase();
+const hit=S.filter(s=>!q||[s.title,s.project,s.harness,s.preview,s.id].join(' ').toLowerCase().includes(q));
+document.getElementById('list').innerHTML=hit.length?hit.map(rowS).join(''):'<div class="empty">nothing matches — try deja "'+esc(q)+'" for full-text search</div>'}
+document.getElementById('q').addEventListener('input',draw);
+document.getElementById('rlist').innerHTML=R.length?R.map(rowR).join(''):'<div class="empty">no recalls recorded yet</div>';
+document.getElementById('nlist').innerHTML=N.length?N.map(rowN).join(''):'<div class="empty">no curated notes yet — deja promote &lt;id&gt;</div>';
+document.querySelectorAll('.tabs button').forEach(b=>b.addEventListener('click',()=>{
+document.querySelectorAll('.tabs button').forEach(x=>x.classList.remove('on'));b.classList.add('on');
+['sessions','recalls','notes'].forEach(t=>document.getElementById('tab-'+t).style.display=t===b.dataset.tab?'':'none')}));
+draw();
+</script></body></html>
+`))

--- a/cmd/deja/view_test.go
+++ b/cmd/deja/view_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func viewFixtureIndex(t *testing.T) string {
+	t.Helper()
+	hermeticEnv(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	ts := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-app", "one.jsonl"), "one", []string{
+		`{"type":"user","sessionId":"one","timestamp":"` + ts + `","message":{"role":"user","content":"<local-command-caveat>plumbing</local-command-caveat>"}}`,
+		`{"type":"user","sessionId":"one","timestamp":"` + ts + `","message":{"role":"user","content":"real question about </script> escaping"}}`,
+		`{"type":"user","sessionId":"one","timestamp":"` + ts + `","message":{"role":"assistant","content":[{"type":"text","text":"real answer"}]}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestViewGeneratesSelfContainedHTML(t *testing.T) {
+	dir := viewFixtureIndex(t)
+	out := filepath.Join(t.TempDir(), "view.html")
+	path, err := writeViewHTML(dir, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, want := range []string{"deja view", "Sessions", "Recalls", "Notes", "real question about"} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("view missing %q", want)
+		}
+	}
+	// Self-contained: no external fetches of any kind.
+	if regexp.MustCompile(`(src|href)="https?://`).MatchString(s) {
+		t.Fatal("view references external assets")
+	}
+	// Script-closer inside indexed text must not break out of the data block.
+	if strings.Contains(s, "about </script>") {
+		t.Fatal("unescaped script closer leaked into the page")
+	}
+	// Plumbing wrappers stay out of previews.
+	if strings.Contains(s, "local-command-caveat") {
+		t.Fatal("plumbing leaked into preview")
+	}
+}
+
+func TestViewPreviewCap(t *testing.T) {
+	long := strings.Repeat("word ", viewPreviewBytes)
+	got := sessionPreview([]model.Message{{Role: "user", Text: long}})
+	if len(got) > viewPreviewBytes+8 {
+		t.Fatalf("preview exceeds cap: %d", len(got))
+	}
+}


### PR DESCRIPTION
Sessions with capped previews, the recall audit trail, and curated notes in
a single self-contained file; no server, no external assets, opens in the
browser. Previews skip plumbing wrappers; embedded JSON escapes script
closers.
