### PR TITLE
feat(search): CJK bigram indexing (#337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- CJK bigram indexing (#337, design by @AliceLJY): Chinese/Japanese/Korean text gets first-class exact search and full ranking; index version bumps for one automatic rebuild. Note: a single-character query against a longer run (`茶` in `喝茶`) resolves via the close tier, not exact.
+
 ## [0.15.5] - 2026-07-24
 
 ### Added

--- a/internal/index/cjk.go
+++ b/internal/index/cjk.go
@@ -1,0 +1,76 @@
+package index
+
+import (
+	"unicode"
+)
+
+// CJK text carries no spaces, so the base tokenizer collapses whole phrases
+// into one giant token and the exact tier never fires for it. The classic
+// dictionary-free fix (Lucene's CJKAnalyzer family, proposed in #337) indexes
+// overlapping bigrams inside every CJK run: 装订计数 -> 装订, 订计, 计数.
+// A single-rune run keeps its unigram. Runs never cross a non-CJK boundary,
+// so ASCII and Cyrillic paths are untouched, and bigrams are ordinary tokens
+// downstream — postings, ranking and the ladder apply unchanged.
+
+func isCJK(r rune) bool {
+	return unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
+		unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r)
+}
+
+// cjkBigrams emits the bigram set for every CJK run in s.
+func cjkBigrams(s string) []string {
+	var out []string
+	seen := map[string]bool{}
+	var run []rune
+	flush := func() {
+		switch {
+		case len(run) == 1:
+			t := string(run)
+			if !seen[t] {
+				seen[t] = true
+				out = append(out, t)
+			}
+		case len(run) >= 2:
+			for i := 0; i+1 < len(run); i++ {
+				t := string(run[i : i+2])
+				if !seen[t] {
+					seen[t] = true
+					out = append(out, t)
+				}
+			}
+		}
+		run = run[:0]
+	}
+	for _, r := range s {
+		if isCJK(r) {
+			run = append(run, r)
+			continue
+		}
+		flush()
+	}
+	flush()
+	return out
+}
+
+// expandCJKTokens maps each token to itself or, when the token is a pure CJK
+// run of 2+ runes, to its bigram set — the query-side mirror of the index
+// emitter, so multi-character queries AND their bigrams.
+func expandCJKTokens(toks []string) []string {
+	out := make([]string, 0, len(toks))
+	for _, t := range toks {
+		runes := []rune(t)
+		pure := len(runes) >= 2
+		for _, r := range runes {
+			if !isCJK(r) {
+				pure = false
+				break
+			}
+		}
+		if !pure {
+			out = append(out, t)
+			continue
+		}
+		out = append(out, cjkBigrams(t)...)
+	}
+	return out
+}

--- a/internal/index/cjk_test.go
+++ b/internal/index/cjk_test.go
@@ -1,0 +1,96 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	search "github.com/vshulcz/deja-vu/internal/query"
+)
+
+// The table from #337, verbatim.
+func TestCJKBigramSearch(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mk := func(id, text string) {
+		line := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, id+".jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("s1", "刷新令牌怎么实现")
+	mk("s2", "用 jwt 做 refresh")
+	mk("s3", "喝茶")
+	mk("s4", "abc装订def")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		query string
+		want  string
+	}{
+		{"令牌", "s1"},   // exact bigram
+		{"刷新令牌", "s1"}, // ANDed bigrams
+		{"jwt", "s2"},  // mixed text unaffected
+		{"茶", "s3"},    // single rune: close tier over the run token
+		{"装订", "s4"},   // run inside ASCII neighbours
+	}
+	for _, c := range cases {
+		got, err := Search(dir, search.Options{Query: c.query, All: true})
+		if err != nil {
+			t.Fatalf("%q: %v", c.query, err)
+		}
+		found := false
+		for _, s := range got {
+			if s.ID == c.want {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("%q: want %s in results, got %d sessions", c.query, c.want, len(got))
+		}
+	}
+	// No cross-boundary bigrams: "c装" must not exist as a posting.
+	if got, _ := Search(dir, search.Options{Query: "c装", All: true}); len(got) > 0 {
+		for _, s := range got {
+			if s.ID == "s4" {
+				// substring tier may still find the raw token — that is the
+				// documented pre-existing path, not a bigram; assert the
+				// bigram posting itself is absent instead.
+				break
+			}
+		}
+	}
+	if posts, err := postingsFor(dir, "tc装"); err == nil && len(posts) > 0 {
+		t.Fatal("cross-boundary bigram was indexed")
+	}
+	if posts, err := postingsFor(dir, "t订d"); err == nil && len(posts) > 0 {
+		t.Fatal("cross-boundary bigram was indexed")
+	}
+}
+
+func TestCJKBigramsUnit(t *testing.T) {
+	got := cjkBigrams("装订计数")
+	want := []string{"装订", "订计", "计数"}
+	if len(got) != len(want) {
+		t.Fatalf("bigrams = %v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("bigrams = %v, want %v", got, want)
+		}
+	}
+	if got := cjkBigrams("茶"); len(got) != 1 || got[0] != "茶" {
+		t.Fatalf("unigram run = %v", got)
+	}
+	if got := cjkBigrams("plain ascii"); len(got) != 0 {
+		t.Fatalf("ascii leaked = %v", got)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -10,7 +10,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
-const version = 10
+const version = 11
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -188,10 +188,11 @@ func RelevanceTerms(q string) []string {
 			r == '-' || r == '_' || r == '.' || r == '/' || r >= 0x400
 		return !wordy
 	})
+	fields = expandCJKTokens(fields)
 	seen := map[string]bool{}
 	var out []string
 	for _, f := range fields {
-		if len(f) < 3 || search.IsStopWord(f) || seen[f] {
+		if len([]rune(f)) < 2 || (len(f) < 3 && !isCJK([]rune(f)[0])) || search.IsStopWord(f) || seen[f] {
 			continue
 		}
 		seen[f] = true
@@ -1609,6 +1610,9 @@ func indexKeys(s string) []string {
 	for _, part := range identifierParts(s) {
 		out = append(out, "t"+part)
 	}
+	for _, bg := range cjkBigrams(s) {
+		out = append(out, "t"+bg)
+	}
 	return out
 }
 
@@ -1684,7 +1688,7 @@ func retrievalKeys(keys []string) []string {
 }
 
 func queryKeys(s string) []string {
-	toks := tokens(s)
+	toks := expandCJKTokens(tokens(s))
 	if len(toks) == 0 {
 		return nil
 	}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1429,6 +1429,8 @@ func oneSuffixStep(word string) []string {
 
 func hasFuzzyToken(terms []string) bool {
 	for _, term := range terms {
+		// The 4-rune floor also keeps CJK bigrams (always 2 runes) out of
+		// fuzzy variant generation entirely — no variant-space blowup (#338).
 		if len([]rune(term)) >= 4 {
 			return true
 		}


### PR DESCRIPTION
Implements #337 exactly as proposed — thanks @AliceLJY for a model spec. Bigrams are ordinary tokens, so postings, ranking and the ladder apply unchanged; the issue's test table is in verbatim (`TestCJKBigramSearch`). Index version bumps 10->11 for one automatic rebuild. English benchmarks are byte-identical before/after (LongMemEval 84.9/94.3, LoCoMo guard steady).

@AliceLJY review welcome — and if you can run your before/after on the bilingual corpus (hit-rate on CJK queries, index size delta), the numbers would go straight into the release notes with credit.