### PR TITLE
feat(search): Russian conversational stopwords

### DIFF
--- a/internal/index/ru_stopwords_test.go
+++ b/internal/index/ru_stopwords_test.go
@@ -1,0 +1,47 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	search "github.com/vshulcz/deja-vu/internal/query"
+)
+
+func TestRussianFillerDoesNotAnchor(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mk := func(id, text string) {
+		line := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, id+".jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("a", "починил ретраи очереди доставки для отчетов")
+	mk("b", "давай сделай все красиво и покажи мне это")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The filler-only session must not outrank content on a question full of
+	// Russian glue: every meaningful word points at session a.
+	got, err := Search(dir, search.Options{Query: "давай посмотри как мы делали ретраи доставки", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 || got[0].ID != "a" {
+		t.Fatalf("content session must rank first, got %d sessions", len(got))
+	}
+	terms := RelevanceTerms("давай сделай все по шагам и говори мне")
+	for _, term := range terms {
+		if term == "давай" || term == "сделай" || term == "говори" {
+			t.Fatalf("filler survived RelevanceTerms: %v", terms)
+		}
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -17,6 +17,25 @@ var stopWords = map[string]bool{
 	"of": true, "on": true, "or": true, "that": true, "the": true,
 	"this": true, "to": true, "was": true, "we": true, "what": true,
 	"when": true, "where": true, "which": true, "who": true, "with": true,
+	// Russian conversational filler — the words that made déjà vu fire on
+	// "делай все по шагам" (#313 history). Same bar as the English list:
+	// words that identify no task, only грамматика and instruction glue.
+	"и": true, "в": true, "во": true, "не": true, "на": true, "но": true,
+	"я": true, "ты": true, "он": true, "она": true, "оно": true, "мы": true,
+	"вы": true, "они": true, "что": true, "чтобы": true, "как": true,
+	"так": true, "это": true, "этот": true, "эта": true, "эти": true,
+	"тот": true, "все": true, "всё": true, "всех": true, "был": true,
+	"была": true, "было": true, "были": true, "есть": true, "быть": true,
+	"будет": true, "для": true, "от": true, "до": true, "по": true,
+	"из": true, "у": true, "за": true, "с": true, "со": true, "к": true,
+	"ко": true, "о": true, "об": true, "обо": true, "же": true, "ну": true,
+	"вот": true, "или": true, "если": true, "когда": true, "где": true,
+	"куда": true, "там": true, "тут": true, "здесь": true, "его": true,
+	"её": true, "их": true, "мне": true, "меня": true, "тебе": true,
+	"тебя": true, "нам": true, "вам": true, "надо": true, "нужно": true,
+	"можно": true, "может": true, "давай": true, "сделай": true,
+	"делай": true, "делать": true, "сделать": true, "скажи": true,
+	"говори": true, "покажи": true, "посмотри": true, "пожалуйста": true,
 }
 
 // QueryParts separates ordinary terms from quoted phrases without changing


### PR DESCRIPTION
The words that let déjà vu fire on instruction glue now carry the same
stop-word status as their English counterparts; content words rank, filler
does not anchor.
