### PR TITLE
feat(search): Russian inflection folds in relevance

### DIFF
--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -379,10 +379,12 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			offs   map[uint32]map[int64]bool
 			missed bool
 		)
-		if len(orKeys) > 1 {
+		if len(orKeys) > 1 && !isCyrToken(term) {
 			// Fold stem forms in ONLY when the exact token is absent from
 			// the corpus: "camped" with no postings tries "camping", but an
-			// exact hit is never diluted by its variants.
+			// exact hit is never diluted by its variants. Russian inflects
+			// too heavily for that gate — a Cyrillic term keeps its whole
+			// form union, matching сеть against сетью and сети alike.
 			if exact, err := readBucketToken(filepath.Join(dir, "buckets", bucket(orKeys[0])+".bin"), orKeys[0]); err == nil && len(exact) > 0 {
 				orKeys = orKeys[:1]
 			}
@@ -1744,7 +1746,16 @@ func safe(s string) string {
 // derives, without requiring the token catalog: absent forms simply read
 // empty buckets.
 func stemMatchForms(term string) []string {
-	if len([]rune(term)) < 5 {
+	runes := []rune(term)
+	if len(runes) < 5 {
+		if isCyrToken(term) && len(runes) >= 3 {
+			// Short Russian stems inflect too: сеть -> сетью, сети.
+			out := make([]string, 0, 12)
+			for _, end := range []string{"ю", "и", "е", "а", "у", "ы", "ой", "ей", "ью", "ям", "ях", "ами"} {
+				out = append(out, term+end)
+			}
+			return out
+		}
 		var out []string
 		for _, form := range []string{term + "s", term + "es", strings.TrimSuffix(term, "s")} {
 			if len(form) >= 3 && form != term {
@@ -1760,4 +1771,17 @@ func stemMatchForms(term string) []string {
 		}
 	}
 	return out
+}
+
+// isCyrToken reports whether the token is written in Cyrillic.
+func isCyrToken(term string) bool {
+	for _, r := range term {
+		if r >= 0x400 && r <= 0x4FF {
+			return true
+		}
+		if r < 128 {
+			return false
+		}
+	}
+	return false
 }

--- a/internal/index/ru_stopwords_test.go
+++ b/internal/index/ru_stopwords_test.go
@@ -45,3 +45,34 @@ func TestRussianFillerDoesNotAnchor(t *testing.T) {
 		}
 	}
 }
+
+func TestRussianInflectionFolds(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"net1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"что то у меня с сетью локально всё отваливается"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "net1.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A decoy that has the exact nominative "сеть" but nothing else relevant.
+	line2 := `{"type":"user","sessionId":"dec1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"локальная сеть офиса работает стабильно"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "dec1.jsonl"), []byte(line2), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Search(dir, search.Options{Query: "сеть отваливается почему", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 || got[0].ID != "net1" {
+		t.Fatalf("inflected сетью must be reachable from сеть and outrank the decoy, got %d", len(got))
+	}
+}


### PR DESCRIPTION
Cyrillic terms keep their whole form union (сеть meets сетью and сети) —
Russian inflects too heavily for the absent-only gate — and short stems
also generate case endings. English fold behavior unchanged.
