### PR TITLE
docs: sixteen harnesses; changelog for 0.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.6] - 2026-07-24
+
 ### Added
 - CJK bigram indexing (#337, design by @AliceLJY): Chinese/Japanese/Korean text gets first-class exact search and full ranking; index version bumps for one automatic rebuild. Note: a single-character query against a longer run (`茶` in `喝茶`) resolves via the close tier, not exact.
-- Goose harness: legacy JSONL sessions and SQLite `sessions.db` (>= 1.10.0), resume via `goose session --resume --session-id`. ([#255](https://github.com/vshulcz/deja-vu/issues/255))
+- Goose harness by @syf2211: legacy JSONL sessions and SQLite `sessions.db` (>= 1.10.0), resume via `goose session --resume --session-id` — sixteen agents indexed. ([#255](https://github.com/vshulcz/deja-vu/issues/255))
+- Russian: conversational stop words and inflection folding in relevance ranking — сеть meets сетью and сети; instruction glue no longer anchors search or déjà vu.
 
 ## [0.15.5] - 2026-07-24
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact cr
 **Does anything leave my machine?** Indexing and search are local. `deja update` downloads releases from GitHub, and user-invoked `deja sync ssh` transfers redacted batches through the system SSH client. Directory exports and shares go only to the destination you choose. See the [security model](docs/SECURITY-MODEL.md#data-flows) for the full data flow.
 
 **How is this different from cass?**
-[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, fifteen harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
+[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, sixteen harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
 
 [engram](https://github.com/Gentleman-Programming/engram) is the strongest of the record-forward memory tools: the agent calls `mem_save` and curated notes accumulate in SQLite. Curation buys it conflict detection — deja now surfaces conflicts too, between accepted notes at promote time — but it starts empty, only knows what an agent decided to save, and can't answer for the months of sessions that happened before it was installed. deja starts full: the transcripts are the memory, no cooperation required.
 

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -77,7 +77,7 @@
 <tr><td>Stored as</td><td class="us">verbatim, redacted</td><td>LLM facts</td><td>memory blocks</td><td>markdown</td><td>SQL rows</td><td>LLM summaries</td><td>events + vectors</td></tr>
 <tr><td>Needs LLM/embedding key</td><td class="us y">no</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>model or API</td></tr>
 <tr><td>Background process</td><td class="us y">none</td><td>server / cloud</td><td>server + Postgres</td><td>server / cloud</td><td class="y">none</td><td>worker</td><td>daemon, ports</td></tr>
-<tr><td>Coding agents</td><td class="us">15 native parsers</td><td>via SDK/MCP</td><td>own runtime</td><td>adapters</td><td>frameworks</td><td>Claude Code</td><td>via hooks</td></tr>
+<tr><td>Coding agents</td><td class="us">16 native parsers</td><td>via SDK/MCP</td><td>own runtime</td><td>adapters</td><td>frameworks</td><td>Claude Code</td><td>via hooks</td></tr>
 <tr><td>Cross-machine sync</td><td class="us y">✓ SSH, no cloud</td><td>cloud</td><td>server-side</td><td>cloud / self-host</td><td>your DB</td><td class="n">—</td><td class="n">—</td></tr>
 <tr><td>Recall provenance</td><td class="us y">✓ log + receipts</td><td class="n">—</td><td>partial</td><td class="n">—</td><td>queryable rows</td><td>viewer</td><td>dashboard</td></tr>
 <tr><td>Retrieval</td><td class="us">tiered lexical, optional embeddings</td><td>vector + graph</td><td>agent + vector</td><td>embeddings</td><td>SQL + vector</td><td>vector</td><td>hybrid RRF</td></tr>
@@ -94,7 +94,7 @@
 <p><b>Mem0 / Memori</b> — you are building an application and want to give <em>your users</em> memory through an API. deja has no SDK; it is not for app-embedded memory.</p>
 <p><b>Letta</b> — you want a full agent runtime with self-editing memory and you're happy living inside it. deja is the opposite bet: memory only, bring whatever agent you already use.</p>
 <p><b>memU</b> — you want curated, distilled knowledge files and don't mind the agent doing the distilling. deja keeps the verbatim record and searches it instead.</p>
-<p><b>claude-mem</b> — you only use Claude Code and prefer compressed summaries over raw history. deja covers 15 agents and keeps recall lossless.</p>
+<p><b>claude-mem</b> — you only use Claude Code and prefer compressed summaries over raw history. deja covers 16 agents and keeps recall lossless.</p>
 <p><b>A vector database + your own pipeline</b> — you need semantic paraphrase matching above all. deja's lexical ladder loses to embeddings on pure paraphrase (we say so in the <a href="benchmarks.html">benchmarks</a>); it wins on identifiers, error strings, and everything code-shaped, with no key and no daemon.</p>
 
 <h2>What only deja does</h2>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -5,11 +5,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Harnesses — deja-vu docs</title>
-<meta name="description" content="The fifteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta name="description" content="The sixteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Harnesses — deja-vu docs">
-<meta property="og:description" content="The fifteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta property="og:description" content="The sixteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -25,12 +25,12 @@
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
 <meta name="twitter:title" content="Harnesses — deja-vu docs">
-<meta name="twitter:description" content="The fifteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta name="twitter:description" content="The sixteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
 <link rel="apple-touch-icon" href="../assets/favicon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Harnesses","description":"The fifteen coding agents deja indexes today, where each stores its history, and how to add a new one.","url":"https://vshulcz.github.io/deja-vu/guide/harnesses.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Harnesses","description":"The sixteen coding agents deja indexes today, where each stores its history, and how to add a new one.","url":"https://vshulcz.github.io/deja-vu/guide/harnesses.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Harnesses","item":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"}]}</script>
 </head>
 <body>
@@ -53,7 +53,7 @@
 <article>
 
 <h1>Harnesses</h1>
-<p>deja indexes fifteen coding-agent histories into one retroactive index. A fix found in one agent is recalled inside another.</p>
+<p>deja indexes sixteen coding-agent histories into one retroactive index. A fix found in one agent is recalled inside another.</p>
 <!-- matrix:start -->
 <table>
 <tr><th>Harness</th><th>Store</th><th>MCP recall</th><th>Auto-recall</th><th>Resume</th><th>Handoff</th><th>Needs</th></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="deja-vu — search every session your coding agents ever wrote">
-<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across fifteen coding agents, served back to them via MCP.">
+<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across sixteen coding agents, served back to them via MCP.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -365,7 +365,7 @@ footer .spacer{flex:1}
       <tr><td class="n">~12 ms</td><td class="c">typical warm search over gigabytes of history</td></tr>
       <tr><td class="n">~50 ms</td><td class="c">session-start hook on a 1000-session index — memory lands before you type</td></tr>
       <tr><td class="n">84.9%</td><td class="c">hit@1 on LongMemEval-S session retrieval (94.3% hit@5) — no LLM, no embeddings, harness in-repo</td></tr>
-      <tr><td class="n">15</td><td class="c">coding agents indexed into one retroactive memory</td></tr>
+      <tr><td class="n">16</td><td class="c">coding agents indexed into one retroactive memory</td></tr>
     </table>
     <p class="foot"><a href="guide/benchmarks.html">how it's measured →</a></p>
   </div>
@@ -392,7 +392,7 @@ footer .spacer{flex:1}
 </section>
 
 <section class="reveal">
-  <p class="shead"><span class="p">$</span> <span class="cmd">deja doctor</span> <span class="out"># fifteen harnesses, one memory</span></p>
+  <p class="shead"><span class="p">$</span> <span class="cmd">deja doctor</span> <span class="out"># sixteen harnesses, one memory</span></p>
   <div class="sources">
     <table class="mx">
       <tr><th></th><th>mcp recall</th><th>auto-recall</th><th>resume</th><th>handoff</th><th>needs</th></tr>
@@ -408,6 +408,7 @@ footer .spacer{flex:1}
       <tr><td class="nm">cline</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="am">paste</td><td class="pa">—</td></tr>
       <tr><td class="nm">roo code</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="am">paste</td><td class="pa">history still indexed</td></tr>
       <tr><td class="nm">openclaw</td><td class="y">✓</td><td class="n">—</td><td class="n">—</td><td class="am">paste</td><td class="pa">—</td></tr>
+      <tr><td class="nm">goose</td><td class="n">—</td><td class="n">—</td><td class="y">✓</td><td class="am">paste</td><td class="pa">sqlite3 (new store)</td></tr>
       <tr><td class="nm">pi</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="y">✓</td><td class="pa">—</td></tr>
       <tr><td class="nm">copilot cli</td><td class="y">✓</td><td class="n">—</td><td class="y">✓</td><td class="y">✓</td><td class="pa">—</td></tr>
       <tr><td class="nm">aider</td><td class="n">—</td><td class="n">—</td><td class="n">—</td><td class="y">✓</td><td class="pa">no MCP client — history still indexed</td></tr>
@@ -448,7 +449,7 @@ footer .spacer{flex:1}
     <a href="guide/agents.html">agents-and-mcp<span>recall, blame, remember, auto-recall</span></a>
     <a href="guide/search.html">search<span>phrases, fuzzy, semantic, tiers</span></a>
     <a href="guide/commands.html">cli-reference<span>every subcommand and flag</span></a>
-    <a href="guide/harnesses.html">harnesses<span>fifteen agents, and adding one</span></a>
+    <a href="guide/harnesses.html">harnesses<span>sixteen agents, and adding one</span></a>
     <a href="guide/privacy.html">privacy<span>redaction, forget, exclude</span></a>
     <a href="guide/benchmarks.html">benchmarks<span>the ~200× number, reproducible</span></a>
     <a href="guide/compare.html">compare<span>deja next to Mem0, Letta, memU…</span></a>
@@ -577,7 +578,7 @@ document.querySelectorAll('.reveal').forEach(function(el){io.observe(el)});
   }
   var COMMANDS={
     'help':'<p class="none">this input is a tiny deja: type words to search 16 demo sessions.\ncommands: <span class="t">sources</span> · <span class="t">stats</span> · <span class="t">version</span> · <span class="t">clear</span>\nthe real CLI does far more — see <a href="guide/commands.html">cli reference</a></p>',
-    'sources':'<p class="none">claude&nbsp;&nbsp;codex&nbsp;&nbsp;opencode&nbsp;&nbsp;cursor&nbsp;&nbsp;gemini&nbsp;&nbsp;aider&nbsp;&nbsp;antigravity&nbsp;&nbsp;grok&nbsp;&nbsp;qwen&nbsp;&nbsp;kimi&nbsp;&nbsp;cline&nbsp;&nbsp;roo&nbsp;&nbsp;pi&nbsp;&nbsp;openclaw&nbsp;&nbsp;copilot\n15 harnesses, one index — real paths in the <a href="#proof">matrix below</a></p>',
+    'sources':'<p class="none">claude&nbsp;&nbsp;codex&nbsp;&nbsp;opencode&nbsp;&nbsp;cursor&nbsp;&nbsp;gemini&nbsp;&nbsp;aider&nbsp;&nbsp;antigravity&nbsp;&nbsp;grok&nbsp;&nbsp;qwen&nbsp;&nbsp;kimi&nbsp;&nbsp;cline&nbsp;&nbsp;roo&nbsp;&nbsp;pi&nbsp;&nbsp;openclaw&nbsp;&nbsp;goose&nbsp;&nbsp;copilot\n16 harnesses, one index — real paths in the <a href="#proof">matrix below</a></p>',
     'stats':'<p class="none">sessions 16 · messages 412 · top project api-gateway\nlast 12 months&nbsp;&nbsp;▁▁▂▃▂▅▆▄▇█▆▇\n(demo numbers — <span class="t">deja stats</span> wraps your real year)</p>',
     'version':'<p class="none">deja 0.14.1</p>',
     'clear':''


### PR DESCRIPTION
Surface pass for the language + Goose release: sixteen everywhere, compare table, changelog with contributor credits.