### PR TITLE
fix(search): CJK questions reach the relevance tier

### DIFF
--- a/internal/index/cjk.go
+++ b/internal/index/cjk.go
@@ -52,25 +52,47 @@ func cjkBigrams(s string) []string {
 	return out
 }
 
-// expandCJKTokens maps each token to itself or, when the token is a pure CJK
-// run of 2+ runes, to its bigram set — the query-side mirror of the index
-// emitter, so multi-character queries AND their bigrams.
+// expandCJKTokens maps each token to itself plus, for every CJK run of 2+
+// runes inside it, that run's bigram set — the query-side mirror of the index
+// emitter. A phrase query ANDs its bigrams (they are contiguous in the text
+// that answers it); a sentence question's grammar bigrams cannot co-occur, so
+// its AND simply finds nothing and the ladder falls through to the relevance
+// tier, which is where a question belongs.
 func expandCJKTokens(toks []string) []string {
 	out := make([]string, 0, len(toks))
 	for _, t := range toks {
 		runes := []rune(t)
-		pure := len(runes) >= 2
+		hasCJK := false
+		allCJK := true
 		for _, r := range runes {
-			if !isCJK(r) {
-				pure = false
-				break
+			if isCJK(r) {
+				hasCJK = true
+			} else {
+				allCJK = false
 			}
 		}
-		if !pure {
+		if !hasCJK {
 			out = append(out, t)
 			continue
 		}
-		out = append(out, cjkBigrams(t)...)
+		if !allCJK {
+			// A glued CJK+latin token keeps its whole form as a key: that is
+			// exactly what the index emits for such text.
+			out = append(out, t)
+		}
+		i := 0
+		for i < len(runes) {
+			if !isCJK(runes[i]) {
+				i++
+				continue
+			}
+			j := i
+			for j < len(runes) && isCJK(runes[j]) {
+				j++
+			}
+			out = append(out, cjkBigrams(string(runes[i:j]))...)
+			i = j
+		}
 	}
 	return out
 }

--- a/internal/index/cjk_test.go
+++ b/internal/index/cjk_test.go
@@ -94,3 +94,112 @@ func TestCJKBigramsUnit(t *testing.T) {
 		t.Fatalf("ascii leaked = %v", got)
 	}
 }
+
+// cjkIndex builds a small index from the given id/text pairs.
+func cjkIndex(t *testing.T, docs map[string]string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for id, text := range docs {
+		line := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, id+".jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func cjkFirstID(t *testing.T, dir, q string) string {
+	t.Helper()
+	got, err := Search(dir, search.Options{Query: q, All: true})
+	if err != nil {
+		t.Fatalf("%q: %v", q, err)
+	}
+	if len(got) == 0 {
+		return ""
+	}
+	return got[0].ID
+}
+
+// A contiguous CJK phrase longer than a couple of characters must keep
+// matching through the AND — its bigrams really do co-occur in the text that
+// contains it.
+func TestCJKLongPhraseStillMatches(t *testing.T) {
+	dir := cjkIndex(t, map[string]string{
+		"s1": "我们讨论了刷新令牌怎么实现的问题",
+		"s2": "缓存重载和证书轮换的会议记录",
+	})
+	for _, q := range []string{"刷新令牌怎么实现", "令牌怎么实现", "我们讨论了刷新令牌", "刷新令牌"} {
+		if got := cjkFirstID(t, dir, q); got != "s1" {
+			t.Fatalf("phrase %q: got %q, want s1", q, got)
+		}
+	}
+}
+
+// A quoted CJK phrase keeps its exactness contract and must not be routed
+// into a path that cannot serve it.
+func TestCJKQuotedPhraseMatches(t *testing.T) {
+	dir := cjkIndex(t, map[string]string{
+		"s1": "我们讨论了刷新令牌怎么实现的问题",
+		"s2": "另一个会话讲的是缓存重载",
+	})
+	if got := cjkFirstID(t, dir, `"刷新令牌怎么实现"`); got != "s1" {
+		t.Fatalf(`quoted phrase: got %q, want s1`, got)
+	}
+}
+
+// A real question carries fullwidth punctuation and grammar; its bigrams
+// cannot all co-occur, so the ladder must fall through to relevance instead
+// of returning nothing.
+func TestCJKQuestionReachesRelevance(t *testing.T) {
+	dir := cjkIndex(t, map[string]string{
+		"s1": "刷新令牌在缓存没有重载之后开始失效，我们改了轮换逻辑",
+		"s2": "今天讨论了前端样式和构建速度的问题",
+	})
+	got, err := SearchDetailed(dir, search.Options{Query: "刷新令牌是什么时候开始失效的？", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Sessions) == 0 || got.Sessions[0].ID != "s1" {
+		t.Fatalf("question must reach the answer: %d sessions, tier %q", len(got.Sessions), got.Tier)
+	}
+}
+
+// Text that glues CJK and latin ("刷新token") is one token on both sides;
+// the query must still reach it.
+func TestCJKMixedTokenMatches(t *testing.T) {
+	dir := cjkIndex(t, map[string]string{
+		"s1": "我们用刷新token做了鉴权",
+		"s2": "别的会话说的是构建缓存",
+	})
+	for _, q := range []string{"刷新token", "刷新"} {
+		if got := cjkFirstID(t, dir, q); got != "s1" {
+			t.Fatalf("mixed %q: got %q, want s1", q, got)
+		}
+	}
+}
+
+// Latin-1, Greek and other scripts below U+0400 used to be shattered by the
+// relevance term splitter while the index kept them whole.
+func TestRelevanceTermsKeepNonASCIILetters(t *testing.T) {
+	got := RelevanceTerms("café naïve straße Ελλάδα")
+	want := []string{"café", "naïve", "straße", "ελλάδα"}
+	if len(got) != len(want) {
+		t.Fatalf("terms = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("terms = %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -183,10 +183,17 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 // lowercased, stopwords dropped. Exported so callers and the benchmark can
 // mirror exactly what the relevance tier scores against.
 func RelevanceTerms(q string) []string {
+	// Letters and digits are wordy in every script; everything else splits.
+	// The old "anything above U+0400 is wordy" rule swallowed CJK and
+	// fullwidth punctuation ("？", "，"), so a real Chinese question became
+	// one giant term that matched nothing and never reached bigram
+	// expansion.
 	fields := strings.FieldsFunc(strings.ToLower(q), func(r rune) bool {
-		wordy := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') ||
-			r == '-' || r == '_' || r == '.' || r == '/' || r >= 0x400
-		return !wordy
+		if r < 128 {
+			return (r < 'a' || r > 'z') && (r < '0' || r > '9') &&
+				r != '-' && r != '_' && r != '.' && r != '/'
+		}
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	})
 	fields = expandCJKTokens(fields)
 	seen := map[string]bool{}

--- a/scripts/miracl/main.go
+++ b/scripts/miracl/main.go
@@ -1,0 +1,387 @@
+// Command miracl measures deja's retrieval on MIRACL (Wikipedia passage
+// retrieval with human relevance judgments) in any of its languages, through
+// the exact production path: passages are written as real transcript files,
+// indexed by the normal pipeline, and queried with the verbatim question.
+//
+// MIRACL's official task retrieves over the full language corpus (millions of
+// passages) and scores nDCG@10. This harness builds a bounded pool instead —
+// every dev-set relevant passage plus random same-language passages up to
+// -pool — and reports hit@k and per-query recall@k over that pool. Numbers are
+// therefore comparable ACROSS LANGUAGES here, not against the MIRACL
+// leaderboard.
+package main
+
+import (
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/query"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+type passage struct {
+	DocID string `json:"docid"`
+	Title string `json:"title"`
+	Text  string `json:"text"`
+}
+
+func main() {
+	lang := flag.String("lang", "ru", "language code (matches the corpus/topics/qrels files)")
+	dir := flag.String("data", ".", "directory holding <lang>-*.jsonl.gz, topics-<lang>.tsv, qrels-<lang>.tsv")
+	pool := flag.Int("pool", 200000, "passage pool size: all relevant passages plus random fill")
+	limit := flag.Int("limit", 0, "run only the first N queries (0 = all)")
+	seed := flag.Int64("seed", 20260725, "sampling seed")
+	dumpMisses := flag.String("dump-misses", "", "write a JSONL miss report to this path")
+	flag.Parse()
+
+	topics, order, err := readTopics(filepath.Join(*dir, "topics-"+*lang+".tsv"))
+	if err != nil {
+		fatal(err)
+	}
+	qrels, err := readQrels(filepath.Join(*dir, "qrels-"+*lang+".tsv"))
+	if err != nil {
+		fatal(err)
+	}
+	gold := map[string]bool{}
+	for _, docs := range qrels {
+		for d := range docs {
+			gold[d] = true
+		}
+	}
+	fmt.Printf("MIRACL-%s · %d dev queries · %d relevant passages\n", *lang, len(order), len(gold))
+
+	tmp, err := os.MkdirTemp("", "miracl")
+	if err != nil {
+		fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-work-miracl")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		fatal(err)
+	}
+
+	t0 := time.Now()
+	written, haveGold, err := writePool(filepath.Join(*dir), *lang, proj, gold, *pool, *seed)
+	if err != nil {
+		fatal(err)
+	}
+	fmt.Printf("pool: %d passages written in %s · relevant passages present: %d/%d (%.1f%%)\n",
+		written, time.Since(t0).Round(time.Second), len(haveGold), len(gold),
+		100*float64(len(haveGold))/float64(len(gold)))
+
+	idx := filepath.Join(tmp, "index.db")
+	_ = os.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	_ = os.Setenv("DEJA_INDEX_DIR", idx)
+	t1 := time.Now()
+	if err := index.Ensure(idx, "claude", true, nil); err != nil {
+		fatal(err)
+	}
+	buildFor := time.Since(t1)
+	var indexBytes int64
+	_ = filepath.Walk(idx, func(_ string, fi os.FileInfo, err error) error {
+		if err == nil && !fi.IsDir() {
+			indexBytes += fi.Size()
+		}
+		return nil
+	})
+	fmt.Printf("index: built in %s, %.0f MB\n\n", buildFor.Round(time.Second), float64(indexBytes)/1e6)
+
+	var missFile *os.File
+	if *dumpMisses != "" {
+		if missFile, err = os.Create(*dumpMisses); err != nil {
+			fatal(err)
+		}
+		defer func() { _ = missFile.Close() }()
+	}
+
+	tiers := map[string]int{}
+	skipped := 0
+	var (
+		n, h1, h5, h10, h20 int
+		mrr                 float64
+		recall              = map[int]float64{}
+		times               []time.Duration
+	)
+	for qi, qid := range order {
+		if *limit > 0 && qi >= *limit {
+			break
+		}
+		want := map[string]bool{}
+		for d := range qrels[qid] {
+			if haveGold[d] {
+				want[d] = true
+			}
+		}
+		if len(want) == 0 {
+			skipped++
+			continue
+		}
+		rank, ranked, tier, elapsed, err := ask(idx, topics[qid], want)
+		if err != nil {
+			fatal(err)
+		}
+		tiers[tier]++
+		times = append(times, elapsed)
+		n++
+		if rank >= 1 {
+			mrr += 1 / float64(rank)
+		}
+		for _, k := range []int{1, 5, 10, 20} {
+			got := 0
+			for i, id := range ranked {
+				if i >= k {
+					break
+				}
+				if want[id] {
+					got++
+				}
+			}
+			recall[k] += float64(got) / float64(len(want))
+		}
+		switch {
+		case rank == 0:
+		case rank <= 1:
+			h1++
+			h5++
+			h10++
+			h20++
+		case rank <= 5:
+			h5++
+			h10++
+			h20++
+		case rank <= 10:
+			h10++
+			h20++
+		case rank <= 20:
+			h20++
+		}
+		if missFile != nil && rank != 1 {
+			top := ranked
+			if len(top) > 5 {
+				top = top[:5]
+			}
+			rec := map[string]any{"qid": qid, "query": topics[qid], "rank": rank, "gold": keys(want), "top5": top}
+			b, _ := json.Marshal(rec)
+			_, _ = missFile.Write(append(b, '\n'))
+		}
+	}
+	sort.Slice(times, func(i, j int) bool { return times[i] < times[j] })
+	fmt.Printf("%-12s %6s %8s %8s %8s %8s %8s\n", "lang", "n", "hit@1", "hit@5", "hit@10", "hit@20", "MRR")
+	fmt.Printf("%-12s %6d %7.1f%% %7.1f%% %7.1f%% %7.1f%%   %.3f\n", *lang, n,
+		pct(h1, n), pct(h5, n), pct(h10, n), pct(h20, n), mrr/float64(n))
+	fmt.Printf("%-12s %6s %7.1f%% %7.1f%% %7.1f%% %7.1f%%\n", "recall@k", "",
+		100*recall[1]/float64(n), 100*recall[5]/float64(n), 100*recall[10]/float64(n), 100*recall[20]/float64(n))
+	if len(times) > 0 {
+		fmt.Printf("median search: %s\n", times[len(times)/2].Round(time.Microsecond))
+	}
+	tierNames := make([]string, 0, len(tiers))
+	for t := range tiers {
+		tierNames = append(tierNames, t)
+	}
+	sort.Strings(tierNames)
+	parts := make([]string, 0, len(tierNames))
+	for _, t := range tierNames {
+		name := t
+		if name == "" {
+			name = "exact"
+		}
+		parts = append(parts, fmt.Sprintf("%s %d", name, tiers[t]))
+	}
+	fmt.Printf("tiers: %s\n", strings.Join(parts, " · "))
+	if skipped > 0 {
+		fmt.Printf("skipped %d queries whose relevant passages are outside the downloaded shards\n", skipped)
+	}
+}
+
+// ask runs one query through the production search path and returns the rank
+// of the first relevant passage (1-based, 0 if absent from the top 50) plus
+// the ranked docids.
+func ask(dir, q string, want map[string]bool) (int, []string, string, time.Duration, error) {
+	o := query.Options{Query: q, All: true}
+	t0 := time.Now()
+	result, err := index.SearchWithRecoveryDetailed(dir, o, nil)
+	if err != nil {
+		return 0, nil, "", 0, err
+	}
+	o.Tier = result.Tier
+	if result.Stemmed {
+		o.Stemmed = true
+		o.FuzzyVariants = result.Variants
+	} else if result.Fuzzy {
+		o.FuzzyVariants = result.Variants
+	}
+	var hits []search.Hit
+	if result.Tier == search.TierRelevance {
+		hits = search.RelevanceHits(result.Sessions, index.RelevanceTerms(q))
+	} else if hits, err = search.Run(result.Sessions, o); err != nil {
+		return 0, nil, "", 0, err
+	}
+	elapsed := time.Since(t0)
+	ranked := make([]string, 0, 50)
+	for i, h := range hits {
+		if i >= 50 {
+			break
+		}
+		ranked = append(ranked, unsanitize(h.Session.ID))
+	}
+	for i, id := range ranked {
+		if want[id] {
+			return i + 1, ranked, string(result.Tier), elapsed, nil
+		}
+	}
+	return 0, ranked, string(result.Tier), elapsed, nil
+}
+
+// writePool writes every relevant passage plus a random sample of the rest as
+// Claude-format transcripts, one file per passage.
+func writePool(dir, lang, proj string, gold map[string]bool, pool int, seed int64) (int, map[string]bool, error) {
+	have := map[string]bool{}
+	shards, err := filepath.Glob(filepath.Join(dir, lang+"-*.jsonl.gz"))
+	if err != nil {
+		return 0, have, err
+	}
+	if len(shards) == 0 {
+		return 0, have, fmt.Errorf("no %s-*.jsonl.gz shards in %s", lang, dir)
+	}
+	sort.Strings(shards)
+	rng := rand.New(rand.NewSource(seed))
+	// Reservoir-free two-pass-free approach: golds always kept, others kept
+	// with a probability that fills the remaining budget on a corpus of
+	// unknown size — a light bias toward early shards is acceptable for a
+	// distractor pool.
+	keepProb := 0.05
+	written := 0
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, shard := range shards {
+		f, err := os.Open(shard)
+		if err != nil {
+			return written, have, err
+		}
+		gz, err := gzip.NewReader(f)
+		if err != nil {
+			_ = f.Close()
+			return written, have, err
+		}
+		sc := bufio.NewScanner(gz)
+		sc.Buffer(make([]byte, 1<<20), 1<<22)
+		for sc.Scan() {
+			var p passage
+			if json.Unmarshal(sc.Bytes(), &p) != nil || p.DocID == "" {
+				continue
+			}
+			if !gold[p.DocID] {
+				if written >= pool || rng.Float64() > keepProb {
+					continue
+				}
+			}
+			text := strings.TrimSpace(p.Title + "\n" + p.Text)
+			if text == "" {
+				continue
+			}
+			id := sanitize(p.DocID)
+			line := map[string]any{
+				"type":      "user",
+				"sessionId": id,
+				"timestamp": base.Add(time.Duration(written) * time.Minute).Format(time.RFC3339),
+				"message":   map[string]any{"role": "user", "content": text},
+			}
+			b, err := json.Marshal(line)
+			if err != nil {
+				continue
+			}
+			if err := os.WriteFile(filepath.Join(proj, id+".jsonl"), append(b, '\n'), 0o644); err != nil {
+				_ = gz.Close()
+				_ = f.Close()
+				return written, have, err
+			}
+			if gold[p.DocID] {
+				have[p.DocID] = true
+			}
+			written++
+		}
+		_ = gz.Close()
+		if err := f.Close(); err != nil {
+			return written, have, err
+		}
+	}
+	return written, have, nil
+}
+
+// MIRACL docids look like "12345#7"; '#' is not a safe filename or session id.
+func sanitize(id string) string   { return strings.ReplaceAll(id, "#", "_") }
+func unsanitize(id string) string { return strings.ReplaceAll(id, "_", "#") }
+
+func readTopics(path string) (map[string]string, []string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = f.Close() }()
+	out := map[string]string{}
+	var order []string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1<<20), 1<<22)
+	for sc.Scan() {
+		parts := strings.SplitN(sc.Text(), "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		out[parts[0]] = parts[1]
+		order = append(order, parts[0])
+	}
+	return out, order, sc.Err()
+}
+
+func readQrels(path string) (map[string]map[string]bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	out := map[string]map[string]bool{}
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1<<20), 1<<22)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 4 || fields[3] == "0" {
+			continue
+		}
+		if out[fields[0]] == nil {
+			out[fields[0]] = map[string]bool{}
+		}
+		out[fields[0]][fields[2]] = true
+	}
+	return out, sc.Err()
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func pct(a, n int) float64 {
+	if n == 0 {
+		return 0
+	}
+	return 100 * float64(a) / float64(n)
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, "miracl:", err)
+	os.Exit(1)
+}


### PR DESCRIPTION
The relevance term splitter treated every rune above U+0400 as wordy, so CJK
and fullwidth punctuation glued a whole question into one term that matched
nothing — a real Chinese query like 二战是什么时候开始的？ returned zero.
Splitting on letters and digits instead also stops shattering Latin-1, Greek
and other scripts the index stores whole (café, straße, Ελλάδα).

Found by the new MIRACL harness, which measures retrieval in any language
through the production path.
