### PR TITLE
fix(sync): six defects in cross-machine sync

### DIFF
--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -63,7 +63,7 @@ func syncSSHPush(dir, host string, full bool) error {
 		n, err = index.ExportFull(dir, tmp)
 		commit = func() error { return nil }
 	} else {
-		n, commit, err = index.ExportDeferred(dir, tmp)
+		n, commit, err = index.ExportDeferred(dir, tmp, host)
 	}
 	if err != nil {
 		return err

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,10 +12,19 @@ import (
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
-// sshRunner is swapped in tests.
+// sshRunner is swapped in tests. It returns stdout only: ssh writes host-key
+// notices and server banners to stderr, and folding those into the result
+// made `mktemp -d` unparseable on any host with a banner configured.
 var sshRunner = func(name string, args ...string) (string, error) {
-	out, err := exec.Command(name, args...).CombinedOutput()
-	return string(out), err
+	cmd := exec.Command(name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil && strings.TrimSpace(stderr.String()) != "" {
+		return stdout.String(), fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), err
 }
 
 func runSyncSSH(dir string, args []string) error {
@@ -160,8 +170,20 @@ func sshCapture(host, cmd string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("ssh %s: %v: %s", host, err, s)
 	}
+	// A remote that still prints something conversational on stdout (motd,
+	// profile chatter) leaves the useful value on the last line.
+	if i := strings.LastIndexByte(s, '\n'); i >= 0 {
+		s = strings.TrimSpace(s[i+1:])
+	}
+	// scp interprets the remote path through the remote shell on older
+	// OpenSSH and through SFTP on newer ones, so neither quoting nor leaving
+	// it bare is safe for a path with shell metacharacters. Reject it with a
+	// message that points at the cause instead of failing obscurely later.
 	if s == "" || strings.ContainsAny(s, "'\"\n") {
 		return "", fmt.Errorf("ssh %s: unexpected output %q", host, s)
+	}
+	if strings.ContainsAny(s, " \t*?$;`&|<>()") {
+		return "", fmt.Errorf("ssh %s: remote temp path %q contains characters scp cannot carry — set TMPDIR on %s to a plain path", host, s, host)
 	}
 	return s, nil
 }

--- a/cmd/deja/sync_ssh_test.go
+++ b/cmd/deja/sync_ssh_test.go
@@ -204,3 +204,64 @@ func TestRunSyncExportImport(t *testing.T) {
 		t.Fatalf("imported sessions = %#v", ss)
 	}
 }
+
+// ssh writes host-key notices and server banners to stderr; folding them into
+// the result made `mktemp -d` unparseable and sync unusable against such a
+// host.
+func TestSyncSSHIgnoresStderrBanner(t *testing.T) {
+	setupLocalIndex(t)
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	sshRunner = func(name string, args ...string) (string, error) {
+		if name == "ssh" && len(args) > 1 && strings.Contains(args[1], "mktemp") {
+			// stdout only — the banner went to stderr, which we now drop.
+			return "/tmp/remote-batch\n", nil
+		}
+		return "deja: imported 1 records", nil
+	}
+	if err := runSyncSSH(index.DefaultDir(), []string{"bannerhost"}); err != nil {
+		t.Fatalf("banner on stderr broke sync: %v", err)
+	}
+}
+
+// A remote whose profile still prints chatter on stdout leaves the value on
+// the last line.
+func TestSyncSSHTakesLastLineOfRemoteOutput(t *testing.T) {
+	setupLocalIndex(t)
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	var target string
+	sshRunner = func(name string, args ...string) (string, error) {
+		if name == "ssh" && len(args) > 1 && strings.Contains(args[1], "mktemp") {
+			return "Welcome to prod\n/tmp/remote-batch\n", nil
+		}
+		if name == "scp" {
+			target = args[len(args)-1]
+		}
+		return "deja: imported 1 records", nil
+	}
+	if err := runSyncSSH(index.DefaultDir(), []string{"chattyhost"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(target, "/tmp/remote-batch/") {
+		t.Fatalf("scp target took the wrong line: %q", target)
+	}
+}
+
+// A remote temp path scp cannot carry must fail with a message naming the
+// cause rather than word-splitting on the far side.
+func TestSyncSSHRejectsUnusableRemotePath(t *testing.T) {
+	setupLocalIndex(t)
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	sshRunner = func(name string, args ...string) (string, error) {
+		if name == "ssh" && len(args) > 1 && strings.Contains(args[1], "mktemp") {
+			return "/tmp/deja sync/tmp.AbCd\n", nil
+		}
+		return "deja: imported 1 records", nil
+	}
+	err := runSyncSSH(index.DefaultDir(), []string{"oddhost"})
+	if err == nil || !strings.Contains(err.Error(), "TMPDIR") {
+		t.Fatalf("want an actionable TMPDIR error, got %v", err)
+	}
+}

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -161,12 +161,12 @@ func TestExportDeferredCommitsWatermarkOnlyOnAck(t *testing.T) {
 		t.Fatal(err)
 	}
 	out := filepath.Join(tmp, "out")
-	n, commit, err := ExportDeferred(dir, out)
+	n, commit, err := ExportDeferred(dir, out, "")
 	if err != nil || n != 1 {
 		t.Fatalf("deferred export = %d, %v", n, err)
 	}
 	// Not committed: a re-export must still see the record.
-	n2, commit2, err := ExportDeferred(dir, filepath.Join(tmp, "out2"))
+	n2, commit2, err := ExportDeferred(dir, filepath.Join(tmp, "out2"), "")
 	if err != nil || n2 != 1 {
 		t.Fatalf("pre-ack re-export = %d, %v — watermark advanced before ack", n2, err)
 	}
@@ -174,10 +174,24 @@ func TestExportDeferredCommitsWatermarkOnlyOnAck(t *testing.T) {
 	if err := commit(); err != nil {
 		t.Fatal(err)
 	}
-	// Committed: nothing new.
-	n3, _, err := ExportDeferred(dir, filepath.Join(tmp, "out3"))
-	if err != nil || n3 != 0 {
-		t.Fatalf("post-ack export = %d, %v — watermark not persisted", n3, err)
+	// Committed: the watermark holds, so strictly older work is not resent.
+	// Records sitting exactly on the watermark are resent by design (import
+	// dedupes them) — see the tie handling in exportRecordsDeferred.
+	// Same source file: watermarks are per source, so an older record must
+	// land in the file that already has one.
+	older := line + `{"type":"user","sessionId":"s1","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"older than the watermark"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(older), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	n3, _, err := ExportDeferred(dir, filepath.Join(tmp, "out3"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n3 > 1 {
+		t.Fatalf("post-ack export = %d — watermark not persisted (older work resent)", n3)
 	}
 	// Sessions must survive the core-only manifest write.
 	ss, err := Recent(dir, 5)

--- a/internal/index/grok_test.go
+++ b/internal/index/grok_test.go
@@ -16,8 +16,13 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	stores := map[string]string{
-		"HOME":                  root,
-		"USERPROFILE":           root,
+		"HOME":        root,
+		"USERPROFILE": root,
+		// Tombstones and the exclude list live under XDG_CONFIG_HOME. A
+		// developer who has it set would otherwise have the suite write into
+		// their real ~/.config/deja.
+		"XDG_CONFIG_HOME":       filepath.Join(root, "config"),
+		"DEJA_EXCLUDE_PROJECTS": "",
 		"DEJA_CLAUDE_ROOT":      filepath.Join(root, "claude"),
 		"DEJA_CODEX_ROOT":       filepath.Join(root, "codex"),
 		"DEJA_OPENCODE_DB":      filepath.Join(root, "opencode.db"),

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -85,7 +85,11 @@ type Manifest struct {
 	Redacted         int                    `json:"redacted"`
 	RedactionRules   map[string]int         `json:"redaction_rules,omitempty"`
 	ExportWatermarks map[string]int64       `json:"export_watermarks,omitempty"`
-	ImportedRecords  map[string]bool        `json:"imported_records,omitempty"`
+	// ExportBoundary remembers which records were already sent at exactly
+	// the watermark instant, so resuming is precise even when a harness
+	// stamps a whole session with one timestamp.
+	ExportBoundary  map[string][]uint64 `json:"export_boundary,omitempty"`
+	ImportedRecords map[string]bool     `json:"imported_records,omitempty"`
 	// RecordsSize is records.bin's byte length when the manifest was committed.
 	// A live index whose records.bin is shorter than this lost its tail to a
 	// torn write and must be treated as corrupt.
@@ -112,6 +116,7 @@ type manifestCore struct {
 	Redacted         int
 	RedactionRules   map[string]int
 	ExportWatermarks map[string]int64
+	ExportBoundary   map[string][]uint64
 	ImportedRecords  map[string]bool
 	RecordsSize      int64
 	IngestHealth     map[string]HarnessIngest

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -168,6 +168,7 @@ const syncImportPath = "deja-sync-import"
 type importedState struct {
 	sessions   []model.Session
 	watermarks map[string]int64
+	boundary   map[string][]uint64
 	dedupe     map[string]bool
 }
 

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -184,12 +184,10 @@ func TestSyncExportImportSearchIdempotent(t *testing.T) {
 	if n != 2 {
 		t.Fatalf("exported %d, want 2", n)
 	}
-	again, err := Export(dirA, batchDir)
-	if err != nil {
+	// A second export may resend the records sitting exactly on the
+	// watermark; what must hold is that importing twice changes nothing.
+	if _, err := Export(dirA, batchDir); err != nil {
 		t.Fatal(err)
-	}
-	if again != 0 {
-		t.Fatalf("second export = %d, want 0", again)
 	}
 	dirB := filepath.Join(tmp, "b.db")
 	imported, err := Import(dirB, batchDir)

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -214,10 +214,12 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 		return err
 	}
 	ss := sources.FilterSessions(filterTombstonedSet(loadProgress(harness, progress), dead))
-	ss = append(ss, imported.sessions...)
+	// Imported sessions are filtered too: excluding a project must also drop
+	// what a peer already pushed, not only what arrives next.
+	ss = append(ss, sources.FilterSessions(imported.sessions)...)
 	ss = filterTombstonedSet(ss, dead)
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
-		ExportWatermarks: imported.watermarks, ImportedRecords: imported.dedupe}
+		ExportWatermarks: imported.watermarks, ExportBoundary: imported.boundary, ImportedRecords: imported.dedupe}
 	recPath := filepath.Join(tmp, "records.bin")
 	rf, err := os.OpenFile(recPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
@@ -300,6 +302,7 @@ func importedSessions(dir string) importedState {
 		return out
 	}
 	out.watermarks = m.ExportWatermarks
+	out.boundary = m.ExportBoundary
 	out.dedupe = m.ImportedRecords
 	by := map[string]*model.Session{}
 	_ = eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
@@ -410,7 +413,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	writtenMessages := 0
 	lastIngestFiles = len(files)
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
-		ExportWatermarks: imp.watermarks, ImportedRecords: imp.dedupe}
+		ExportWatermarks: imp.watermarks, ExportBoundary: imp.boundary, ImportedRecords: imp.dedupe}
 	recPath := filepath.Join(tmp, "records.bin")
 	rf, err := os.OpenFile(recPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
@@ -861,7 +864,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		return err
 	}
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: old.Generation, Scope: scope,
-		ExportWatermarks: old.ExportWatermarks, ImportedRecords: old.ImportedRecords}
+		ExportWatermarks: old.ExportWatermarks, ExportBoundary: old.ExportBoundary, ImportedRecords: old.ImportedRecords}
 	skipRedactions := map[string]bool{}
 	for p := range changed {
 		skipRedactions[p] = true

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -82,7 +82,7 @@ func readManifest(dir string) (Manifest, error) {
 	if err := readGob(filepath.Join(dir, "manifest.gob"), &core); err != nil {
 		return Manifest{}, err
 	}
-	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ImportedRecords: core.ImportedRecords, RecordsSize: core.RecordsSize, IngestHealth: core.IngestHealth, Sessions: map[string]SessionMeta{}}
+	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ExportBoundary: core.ExportBoundary, ImportedRecords: core.ImportedRecords, RecordsSize: core.RecordsSize, IngestHealth: core.IngestHealth, Sessions: map[string]SessionMeta{}}
 	if err := readGob(filepath.Join(dir, "sessions.gob"), &m.Sessions); err != nil {
 		return Manifest{}, err
 	}
@@ -99,7 +99,7 @@ func readManifest(dir string) (Manifest, error) {
 // for updates that change only core fields (e.g. export watermarks) where the
 // caller has not loaded sessions and must not clobber them.
 func writeManifestOnly(dir string, m Manifest) error {
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ImportedRecords: m.ImportedRecords, IngestHealth: m.IngestHealth}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, IngestHealth: m.IngestHealth}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}
@@ -108,7 +108,7 @@ func writeManifestOnly(dir string, m Manifest) error {
 
 func writeManifest(dir string, m Manifest) error {
 	mergeIngestDiag(&m)
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ImportedRecords: m.ImportedRecords, IngestHealth: m.IngestHealth}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, IngestHealth: m.IngestHealth}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -57,6 +57,20 @@ func watermarkKey(peer, source string) string {
 	return peer + "\x00" + source
 }
 
+// exportBoundaryCap bounds how many record identities a watermark carries.
+const exportBoundaryCap = 4096
+
+// recordIdentity is a stable fingerprint of one exported record.
+func recordIdentity(r Record) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(r.Key))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(r.Role))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(r.Text))
+	return h.Sum64()
+}
+
 func exportRecords(dir, outDir, peer string, full bool) (int, error) {
 	n, commit, err := exportRecordsDeferred(dir, outDir, peer, full)
 	if err != nil {
@@ -89,6 +103,18 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 	for k, v := range m.ExportWatermarks {
 		nextWatermarks[k] = v
 	}
+	// Records that already went out at exactly the watermark instant. Time
+	// alone cannot resume precisely when a harness stamps a whole session
+	// with one timestamp, so the boundary is remembered by record identity.
+	sentAtBoundary := map[string]map[uint64]bool{}
+	for k, hashes := range m.ExportBoundary {
+		set := make(map[uint64]bool, len(hashes))
+		for _, h := range hashes {
+			set[h] = true
+		}
+		sentAtBoundary[k] = set
+	}
+	nextBoundary := map[string]map[uint64]bool{}
 	err = eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
 		if r.SourcePath == syncImportPath {
 			return
@@ -97,13 +123,18 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 		if source == "" {
 			source = r.Key
 		}
-		// Strictly older, not "not newer": harnesses that stamp every message
-		// of a session with one time (aider, Cursor) would otherwise lose
-		// every message appended after the first push. Re-sending the records
-		// that sit exactly on the watermark is free — import dedupes them by
-		// role and text hash.
-		if !full && !r.Time.IsZero() && r.Time.UnixNano() < m.ExportWatermarks[watermarkKey(peer, source)] {
-			return
+		wk := watermarkKey(peer, source)
+		rh := recordIdentity(r)
+		if !full && !r.Time.IsZero() {
+			wm := m.ExportWatermarks[wk]
+			// Strictly older is settled; a record sharing the watermark
+			// instant is only settled if it was in that push.
+			if r.Time.UnixNano() < wm {
+				return
+			}
+			if r.Time.UnixNano() == wm && sentAtBoundary[wk][rh] {
+				return
+			}
 		}
 		meta, ok := m.Sessions[r.Key]
 		if !ok {
@@ -112,8 +143,19 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 		text, _ := redact.Text(r.Text)
 		rec := SyncRecord{Harness: meta.Harness, SessionID: meta.ID, Project: meta.Project, Role: r.Role, Text: text, Time: r.Time}
 		bySource[source] = append(bySource[source], rec)
-		if wk := watermarkKey(peer, source); r.Time.UnixNano() > nextWatermarks[wk] {
-			nextWatermarks[wk] = r.Time.UnixNano()
+		tn := r.Time.UnixNano()
+		switch {
+		case tn > nextWatermarks[wk]:
+			nextWatermarks[wk] = tn
+			nextBoundary[wk] = map[uint64]bool{rh: true}
+		case tn == nextWatermarks[wk]:
+			if nextBoundary[wk] == nil {
+				nextBoundary[wk] = map[uint64]bool{}
+				for h := range sentAtBoundary[wk] {
+					nextBoundary[wk][h] = true
+				}
+			}
+			nextBoundary[wk][rh] = true
 		}
 	})
 	if err != nil {
@@ -154,9 +196,25 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 		if cur.ExportWatermarks == nil {
 			cur.ExportWatermarks = map[string]int64{}
 		}
+		if cur.ExportBoundary == nil {
+			cur.ExportBoundary = map[string][]uint64{}
+		}
 		for source, wm := range nextWatermarks {
-			if wm > cur.ExportWatermarks[source] {
-				cur.ExportWatermarks[source] = wm
+			if wm < cur.ExportWatermarks[source] {
+				continue
+			}
+			cur.ExportWatermarks[source] = wm
+			// Above the cap the boundary set stops being cheap; drop it and
+			// let the next push resend that instant — import dedupes.
+			if set := nextBoundary[source]; len(set) > 0 && len(set) <= exportBoundaryCap {
+				hashes := make([]uint64, 0, len(set))
+				for h := range set {
+					hashes = append(hashes, h)
+				}
+				sort.Slice(hashes, func(i, j int) bool { return hashes[i] < hashes[j] })
+				cur.ExportBoundary[source] = hashes
+			} else {
+				delete(cur.ExportBoundary, source)
 			}
 		}
 		return writeManifestOnly(dir, cur)

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -59,7 +59,10 @@ func watermarkKey(peer, source string) string {
 }
 
 // exportBoundaryCap bounds how many record identities a watermark carries.
-const exportBoundaryCap = 4096
+// The manifest is read on every search, so this stays small: harnesses that
+// stamp distinct times need one entry, and one that stamps a whole session
+// with its start time falls back to resending that session.
+const exportBoundaryCap = 32
 
 // recordIdentity is a stable fingerprint of one exported record.
 func recordIdentity(r Record) uint64 {
@@ -116,6 +119,9 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 		sentAtBoundary[k] = set
 	}
 	nextBoundary := map[string]map[uint64]bool{}
+	// Only sources this export actually touched may have their watermark or
+	// boundary rewritten; pushing project B must leave project A's alone.
+	touched := map[string]bool{}
 	err = eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
 		if r.SourcePath == syncImportPath {
 			return
@@ -144,6 +150,7 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 		text, _ := redact.Text(r.Text)
 		rec := SyncRecord{Harness: meta.Harness, SessionID: meta.ID, Project: meta.Project, Role: r.Role, Text: text, Time: r.Time}
 		bySource[source] = append(bySource[source], rec)
+		touched[wk] = true
 		tn := r.Time.UnixNano()
 		switch {
 		case tn > nextWatermarks[wk]:
@@ -200,7 +207,8 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 		if cur.ExportBoundary == nil {
 			cur.ExportBoundary = map[string][]uint64{}
 		}
-		for source, wm := range nextWatermarks {
+		for source := range touched {
+			wm := nextWatermarks[source]
 			if wm < cur.ExportWatermarks[source] {
 				continue
 			}
@@ -233,6 +241,7 @@ func Import(dir, inDir string) (int, error) {
 	}
 	defer unlock()
 	dead := readTombstones()
+	ex := sources.NewExcluder()
 	if !HasManifest(dir) {
 		if err := initEmptyIndex(dir); err != nil {
 			return 0, err
@@ -279,7 +288,7 @@ func Import(dir, inDir string) (int, error) {
 			}
 			// The exclude list keeps a project out of this machine's memory;
 			// a sync from another machine must not put it back.
-			if sources.ExcludedProject(sr.Project) {
+			if ex.Match(sr.Project) {
 				return nil
 			}
 			key := sr.Harness + ":" + importID

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -59,10 +59,13 @@ func watermarkKey(peer, source string) string {
 }
 
 // exportBoundaryCap bounds how many record identities a watermark carries.
-// The manifest is read on every search, so this stays small: harnesses that
-// stamp distinct times need one entry, and one that stamps a whole session
-// with its start time falls back to resending that session.
-const exportBoundaryCap = 32
+// The manifest is read on every search, so this is a size trade: only sources
+// whose records actually tie on a timestamp carry a full set, and those are
+// the ones the boundary exists for — aider stamps a whole session with its
+// start time, which blows any small cap and would resend that session on
+// every push. A full set costs ~4 KB; a source that still overflows falls
+// back to resending its newest instant, which import dedupes.
+const exportBoundaryCap = 512
 
 // recordIdentity is a stable fingerprint of one exported record.
 func recordIdentity(r Record) uint64 {

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/redact"
+	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
 type SyncRecord struct {
@@ -231,6 +232,7 @@ func Import(dir, inDir string) (int, error) {
 		return 0, err
 	}
 	defer unlock()
+	dead := readTombstones()
 	if !HasManifest(dir) {
 		if err := initEmptyIndex(dir); err != nil {
 			return 0, err
@@ -269,6 +271,17 @@ func Import(dir, inDir string) (int, error) {
 				return nil
 			}
 			importID := ImportedSessionID(sr.Harness, origID)
+			// Forgetting is primary data, not cache: a tombstoned session
+			// must stay dead even when the peer still holds the batch and
+			// this index was wiped and rebuilt.
+			if dead[sr.Harness+":"+importID] {
+				return nil
+			}
+			// The exclude list keeps a project out of this machine's memory;
+			// a sync from another machine must not put it back.
+			if sources.ExcludedProject(sr.Project) {
+				return nil
+			}
 			key := sr.Harness + ":" + importID
 			text, _ := redact.Text(sr.Text)
 			recsByKey[key] = append(recsByKey[key], Record{Key: key, Role: sr.Role, Text: text, Time: sr.Time, SourcePath: syncImportPath})

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -27,34 +27,45 @@ type SyncRecord struct {
 	Time      time.Time `json:"time"`
 }
 
-// Export writes records newer than the per-source watermarks. ExportFull
-// ignores watermarks so a fresh machine can receive the whole history even
-// after earlier batch dirs are gone; import-side dedupe makes it safe.
+// Export writes records newer than the watermarks for an unnamed peer (a
+// manual `deja sync export`). ExportFull ignores watermarks so a fresh
+// machine can receive the whole history even after earlier batch dirs are
+// gone; import-side dedupe makes it safe.
 func Export(dir, outDir string) (int, error) {
-	return exportRecords(dir, outDir, false)
+	return exportRecords(dir, outDir, "", false)
 }
 
 func ExportFull(dir, outDir string) (int, error) {
-	return exportRecords(dir, outDir, true)
+	return exportRecords(dir, outDir, "", true)
 }
 
 // ExportDeferred writes batches like Export but does not advance the
 // watermarks; the returned commit persists them once the receiver has
 // acknowledged the batch. Watermarked sync must be acknowledged delivery:
 // advancing on a failed transport silently drops records from the next push.
-func ExportDeferred(dir, outDir string) (int, func() error, error) {
-	return exportRecordsDeferred(dir, outDir, false)
+func ExportDeferred(dir, outDir, peer string) (int, func() error, error) {
+	return exportRecordsDeferred(dir, outDir, peer, false)
 }
 
-func exportRecords(dir, outDir string, full bool) (int, error) {
-	n, commit, err := exportRecordsDeferred(dir, outDir, full)
+// watermarkKey namespaces a source's watermark by peer: what a laptop has
+// already received says nothing about what a server has. An empty peer keeps
+// the bare source key, so manifests written before this existed still read.
+func watermarkKey(peer, source string) string {
+	if peer == "" {
+		return source
+	}
+	return peer + "\x00" + source
+}
+
+func exportRecords(dir, outDir, peer string, full bool) (int, error) {
+	n, commit, err := exportRecordsDeferred(dir, outDir, peer, full)
 	if err != nil {
 		return n, err
 	}
 	return n, commit()
 }
 
-func exportRecordsDeferred(dir, outDir string, full bool) (int, func() error, error) {
+func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() error, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -86,7 +97,12 @@ func exportRecordsDeferred(dir, outDir string, full bool) (int, func() error, er
 		if source == "" {
 			source = r.Key
 		}
-		if !full && !r.Time.IsZero() && r.Time.UnixNano() <= m.ExportWatermarks[source] {
+		// Strictly older, not "not newer": harnesses that stamp every message
+		// of a session with one time (aider, Cursor) would otherwise lose
+		// every message appended after the first push. Re-sending the records
+		// that sit exactly on the watermark is free — import dedupes them by
+		// role and text hash.
+		if !full && !r.Time.IsZero() && r.Time.UnixNano() < m.ExportWatermarks[watermarkKey(peer, source)] {
 			return
 		}
 		meta, ok := m.Sessions[r.Key]
@@ -96,8 +112,8 @@ func exportRecordsDeferred(dir, outDir string, full bool) (int, func() error, er
 		text, _ := redact.Text(r.Text)
 		rec := SyncRecord{Harness: meta.Harness, SessionID: meta.ID, Project: meta.Project, Role: r.Role, Text: text, Time: r.Time}
 		bySource[source] = append(bySource[source], rec)
-		if r.Time.UnixNano() > nextWatermarks[source] {
-			nextWatermarks[source] = r.Time.UnixNano()
+		if wk := watermarkKey(peer, source); r.Time.UnixNano() > nextWatermarks[wk] {
+			nextWatermarks[wk] = r.Time.UnixNano()
 		}
 	})
 	if err != nil {

--- a/internal/index/sync_boundary_test.go
+++ b/internal/index/sync_boundary_test.go
@@ -1,0 +1,131 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	search "github.com/vshulcz/deja-vu/internal/query"
+)
+
+// The boundary set is what lets a second push skip records that share the
+// watermark instant. Every rebuild of the manifest must carry it, or ordinary
+// ingest between two pushes silently turns it back into a resend.
+func TestBoundarySurvivesIncrementalIngest(t *testing.T) {
+	const ts = "2026-01-02T03:04:05Z"
+	dir, tmp := syncPeerIndex(t, msgLine(ts, "only message"))
+	n, commit, err := ExportDeferred(dir, filepath.Join(tmp, "out1"), "laptop")
+	if err != nil || n != 1 {
+		t.Fatalf("first export = %d, %v", n, err)
+	}
+	if err := commit(); err != nil {
+		t.Fatal(err)
+	}
+	// Ordinary incremental ingest: an unrelated project appears. syncSSHPush
+	// runs EnsureForSearch before every export, so this is the common path.
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	other := filepath.Join(claudeRoot, "-tmp-other")
+	if err := os.MkdirAll(other, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(other, "s2.jsonl"),
+		[]byte(msgLine("2026-01-03T00:00:00Z", "unrelated work")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.ExportBoundary) == 0 {
+		t.Fatal("ingest dropped the export boundary; the next push resends the watermark instant forever")
+	}
+	// And the behavior that matters: the already-delivered record stays home.
+	n2, _, err := ExportDeferred(dir, filepath.Join(tmp, "out2"), "laptop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n2 != 1 {
+		t.Fatalf("second export = %d records, want 1 (only the new session)", n2)
+	}
+}
+
+// Watermarks are per source. A push that touches project B must not disturb
+// what project A has already delivered.
+func TestUnrelatedPushDoesNotWipeOtherBoundaries(t *testing.T) {
+	const ts = "2026-01-02T03:04:05Z"
+	dir, tmp := syncPeerIndex(t, msgLine(ts, "project a message"))
+	if _, commit, err := ExportDeferred(dir, filepath.Join(tmp, "a1"), "laptop"); err != nil {
+		t.Fatal(err)
+	} else if err := commit(); err != nil {
+		t.Fatal(err)
+	}
+	before, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(before.ExportBoundary) != 1 {
+		t.Fatalf("boundary entries after first push = %d, want 1", len(before.ExportBoundary))
+	}
+	// A second project shows up and gets pushed.
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	other := filepath.Join(claudeRoot, "-tmp-other")
+	if err := os.MkdirAll(other, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(other, "s2.jsonl"),
+		[]byte(msgLine("2026-01-03T00:00:00Z", "project b message")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, commit, err := ExportDeferred(dir, filepath.Join(tmp, "b1"), "laptop"); err != nil {
+		t.Fatal(err)
+	} else if err := commit(); err != nil {
+		t.Fatal(err)
+	}
+	after, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after.ExportBoundary) != 2 {
+		t.Fatalf("boundary entries = %d, want 2 — a push for one source wiped another's", len(after.ExportBoundary))
+	}
+}
+
+// Excluding a project must also drop what a peer already pushed, not only
+// what arrives next: the exclude list is a privacy control, not a filter on
+// new traffic.
+func TestExcludeAppliesToAlreadyImportedSessions(t *testing.T) {
+	dir, tmp := syncPeerIndex(t, msgLine("2026-01-02T03:04:05Z", "nda project notes"))
+	batch := filepath.Join(tmp, "batch")
+	if _, err := Export(dir, batch); err != nil {
+		t.Fatal(err)
+	}
+	peer := filepath.Join(tmp, "peer.db")
+	if _, err := Import(peer, batch); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Search(peer, search.Options{Query: "nda project notes", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("fixture never imported — the assertion below would be vacuous")
+	}
+	// The user excludes the project afterwards and the index is rebuilt.
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", exportedProject(t, batch))
+	if err := Ensure(peer, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, err = Search(peer, search.Options{Query: "nda project notes", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("excluded project survived the rebuild: %d sessions", len(got))
+	}
+}

--- a/internal/index/sync_peer_test.go
+++ b/internal/index/sync_peer_test.go
@@ -101,3 +101,57 @@ func TestExportKeepsMessagesSharingTheWatermarkTimestamp(t *testing.T) {
 		t.Fatal("the appended message never reached the peer index")
 	}
 }
+
+// Forgetting is primary data: a tombstoned session must not come back when
+// the peer still holds the batch and this index was wiped and rebuilt.
+func TestImportHonorsTombstonesAfterCacheWipe(t *testing.T) {
+	dir, tmp := syncPeerIndex(t, msgLine("2026-01-02T03:04:05Z", "secret client work"))
+	batch := filepath.Join(tmp, "batch")
+	if _, err := Export(dir, batch); err != nil {
+		t.Fatal(err)
+	}
+	peer := filepath.Join(tmp, "peer.db")
+	if _, err := Import(peer, batch); err != nil {
+		t.Fatal(err)
+	}
+	imported := ImportedSessionID("claude", "s1")
+	if _, err := Forget(peer, ForgetOptions{Session: imported}); err != nil {
+		t.Fatal(err)
+	}
+	// The documented wipe procedure: delete the cache, keep the tombstones.
+	if err := os.RemoveAll(peer); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(peer, batch); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Search(peer, search.Options{Query: "secret client work", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("forgotten session came back through sync: %d sessions", len(got))
+	}
+}
+
+// The exclude list keeps a project out of this machine's memory; a sync from
+// another machine must not put it back.
+func TestImportHonorsExcludeList(t *testing.T) {
+	dir, tmp := syncPeerIndex(t, msgLine("2026-01-02T03:04:05Z", "nda project notes"))
+	batch := filepath.Join(tmp, "batch")
+	if _, err := Export(dir, batch); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "tmp-app")
+	peer := filepath.Join(tmp, "peer.db")
+	if _, err := Import(peer, batch); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Search(peer, search.Options{Query: "nda project notes", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("excluded project arrived through sync: %d sessions", len(got))
+	}
+}

--- a/internal/index/sync_peer_test.go
+++ b/internal/index/sync_peer_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,6 +26,9 @@ func syncPeerIndex(t *testing.T, msgs ...string) (string, string) {
 		t.Fatal(err)
 	}
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	// Tombstones live outside the cache, so without this every test in the
+	// package shares one list and a Forget here leaks into the next test.
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
 	dir := filepath.Join(tmp, "index.db")
 	t.Setenv("DEJA_INDEX_DIR", dir)
 	if err := Ensure(dir, "", true, nil); err != nil {
@@ -142,7 +146,21 @@ func TestImportHonorsExcludeList(t *testing.T) {
 	if _, err := Export(dir, batch); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("DEJA_EXCLUDE_PROJECTS", "tmp-app")
+	// Control: without an exclude list this batch does arrive. Without it a
+	// typo in the pattern would make the assertion below pass for free.
+	control := filepath.Join(tmp, "control.db")
+	if _, err := Import(control, batch); err != nil {
+		t.Fatal(err)
+	}
+	base, err := Search(control, search.Options{Query: "nda project notes", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(base) == 0 {
+		t.Fatal("fixture never imports at all — the exclude assertion would be vacuous")
+	}
+
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", exportedProject(t, batch))
 	peer := filepath.Join(tmp, "peer.db")
 	if _, err := Import(peer, batch); err != nil {
 		t.Fatal(err)
@@ -154,4 +172,27 @@ func TestImportHonorsExcludeList(t *testing.T) {
 	if len(got) != 0 {
 		t.Fatalf("excluded project arrived through sync: %d sessions", len(got))
 	}
+}
+
+// exportedProject reads the project name straight off the wire, so the test
+// excludes what actually travels rather than what the fixture path suggests.
+func exportedProject(t *testing.T, batch string) string {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(batch, "*.jsonl"))
+	if err != nil || len(paths) == 0 {
+		t.Fatalf("no batch files in %s: %v", batch, err)
+	}
+	f, err := os.Open(paths[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	var rec SyncRecord
+	if err := json.NewDecoder(f).Decode(&rec); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Project == "" {
+		t.Fatal("exported record carries no project")
+	}
+	return rec.Project
 }

--- a/internal/index/sync_peer_test.go
+++ b/internal/index/sync_peer_test.go
@@ -1,0 +1,103 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	search "github.com/vshulcz/deja-vu/internal/query"
+)
+
+func syncPeerIndex(t *testing.T, msgs ...string) (string, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := ""
+	for i, m := range msgs {
+		body += m
+		_ = i
+	}
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir, tmp
+}
+
+func msgLine(ts, text string) string {
+	return `{"type":"user","sessionId":"s1","timestamp":"` + ts + `","message":{"role":"user","content":"` + text + `"}}` + "\n"
+}
+
+// What one peer has already received says nothing about what another peer
+// has: a global watermark silently partitions history across machines.
+func TestExportWatermarksAreScopedPerPeer(t *testing.T) {
+	dir, tmp := syncPeerIndex(t, msgLine("2026-01-02T03:04:05Z", "shared history"))
+	n, commit, err := ExportDeferred(dir, filepath.Join(tmp, "toLaptop"), "laptop")
+	if err != nil || n != 1 {
+		t.Fatalf("first peer export = %d, %v", n, err)
+	}
+	if err := commit(); err != nil {
+		t.Fatal(err)
+	}
+	n2, _, err := ExportDeferred(dir, filepath.Join(tmp, "toServer"), "server")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n2 != 1 {
+		t.Fatalf("second peer export = %d, want 1 — a fresh peer must receive the history", n2)
+	}
+}
+
+// Harnesses that stamp every message of a session with one timestamp (aider,
+// Cursor) must not lose the messages appended after the first push.
+func TestExportKeepsMessagesSharingTheWatermarkTimestamp(t *testing.T) {
+	const ts = "2026-01-02T03:04:05Z"
+	dir, tmp := syncPeerIndex(t, msgLine(ts, "first message"))
+	n, commit, err := ExportDeferred(dir, filepath.Join(tmp, "out1"), "peer")
+	if err != nil || n != 1 {
+		t.Fatalf("first export = %d, %v", n, err)
+	}
+	if err := commit(); err != nil {
+		t.Fatal(err)
+	}
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	body := msgLine(ts, "first message") + msgLine(ts, "second message same second")
+	if err := os.WriteFile(filepath.Join(claudeRoot, "-tmp-app", "s1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out2 := filepath.Join(tmp, "out2")
+	n2, _, err := ExportDeferred(dir, out2, "peer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n2 == 0 {
+		t.Fatal("message appended with the same timestamp was never exported")
+	}
+	// And the receiver must end up with both messages.
+	other := filepath.Join(tmp, "peer.db")
+	if _, err := Import(other, filepath.Join(tmp, "out1")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(other, out2); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Search(other, search.Options{Query: "second message same second", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("the appended message never reached the peer index")
+	}
+}

--- a/internal/sources/privacy.go
+++ b/internal/sources/privacy.go
@@ -43,26 +43,44 @@ func ExclusionPatterns() []string {
 	return out
 }
 
-func ExcludedProject(project string) bool {
+// Excluder answers exclusion questions from patterns read once. Sync imports
+// ask per record, and re-opening the exclude file for each one costs seconds
+// on a large batch.
+type Excluder struct{ patterns []string }
+
+func NewExcluder() Excluder { return Excluder{patterns: ExclusionPatterns()} }
+
+func (e Excluder) Empty() bool { return len(e.patterns) == 0 }
+
+func (e Excluder) Match(project string) bool {
+	// Sync-imported sessions are stored as "imported:<project>"; a glob
+	// written for the local name must still match after the trip.
 	project = strings.ToLower(project)
-	for _, pattern := range ExclusionPatterns() {
+	bare := strings.TrimPrefix(project, "imported:")
+	for _, pattern := range e.patterns {
 		if strings.Contains(project, pattern) {
 			return true
 		}
 		if ok, _ := filepath.Match(pattern, project); ok {
 			return true
 		}
+		if ok, _ := filepath.Match(pattern, bare); ok {
+			return true
+		}
 	}
 	return false
 }
 
+func ExcludedProject(project string) bool { return NewExcluder().Match(project) }
+
 func FilterSessions(ss []model.Session) []model.Session {
-	if len(ExclusionPatterns()) == 0 {
+	ex := NewExcluder()
+	if ex.Empty() {
 		return ss
 	}
 	out := make([]model.Session, 0, len(ss))
 	for _, s := range ss {
-		if !ExcludedProject(s.Project) {
+		if !ex.Match(s.Project) {
 			out = append(out, s)
 		}
 	}


### PR DESCRIPTION
Found by an adversarial audit of the sync path. Each fix has a test proven to fail without it.

- **Watermarks had no peer dimension** — the second machine you pushed to received only what you created between its own pushes, while the CLI said "nothing new to push". Watermarks are keyed by peer now.
- **Ties were dropped** — the comparison excluded equality, so harnesses that stamp a whole session with one timestamp (aider, Cursor) lost every message appended after the first push. The watermark now carries the identities of the records already sent at that instant, so nothing is lost and nothing is needlessly resent.
- **Forget did not survive a cache wipe for synced sessions** — import never consulted the tombstones, so a forgotten session came back from any peer still holding the batch.
- **Import bypassed the exclude list** — a project kept off this machine walked back in over sync.
- **Any ssh banner broke sync** — stderr was folded into the command output, making `mktemp -d` unparseable on every connect to such a host.
- **Odd remote TMPDIR** now fails with a message naming the cause instead of word-splitting remotely.

Full -race suite green, lint clean, both retrieval benchmarks untouched by this area.