### PR TITLE
fix(privacy): recall kill switch and policy bind every path

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -164,12 +164,17 @@ func receiptIsNews(dir, digest string) bool {
 const hookDigestTTL = 60 * time.Second
 
 type hookCacheEntry struct {
-	At          time.Time `json:"at"`
-	CWD         string    `json:"cwd"`
-	Digest      string    `json:"digest"`
-	Sessions    int       `json:"sessions"`
-	Raw         int64     `json:"raw"`
-	TaskMatched []string  `json:"task_matched,omitempty"`
+	At  time.Time `json:"at"`
+	CWD string    `json:"cwd"`
+	// Gate records the recall mode and the policy the digest was built
+	// under. A cache hit returns before either is consulted, so serving an
+	// entry built under different rules would let a cached digest outlive
+	// DEJA_RECALL=off or a policy that now forbids it.
+	Gate        string   `json:"gate,omitempty"`
+	Digest      string   `json:"digest"`
+	Sessions    int      `json:"sessions"`
+	Raw         int64    `json:"raw"`
+	TaskMatched []string `json:"task_matched,omitempty"`
 }
 
 func hookCachePath(dir, cwd string) string {
@@ -178,15 +183,27 @@ func hookCachePath(dir, cwd string) string {
 	return fmt.Sprintf("%s.hookcache-%08x", dir, h.Sum32())
 }
 
+// hookGate identifies the rules a digest was built under: the recall mode and
+// the auto-activation policy. Both are consulted only deep inside
+// hookDigestResult, which a cache hit never reaches.
+func hookGate() string {
+	mode := strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL")))
+	return mode + "|" + policy.Load().Describe(policy.ActivationAuto)
+}
+
 func cachedHookDigest(dir string) (string, int, int64, []string) {
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
 	if cwd == "" {
 		cwd, _ = os.Getwd()
 	}
+	if strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL"))) == search.RecallOff {
+		return "", 0, 0, nil
+	}
+	gate := hookGate()
 	p := hookCachePath(dir, cwd)
 	if b, err := os.ReadFile(p); err == nil {
 		var e hookCacheEntry
-		if json.Unmarshal(b, &e) == nil && e.Digest != "" && e.CWD == cwd {
+		if json.Unmarshal(b, &e) == nil && e.Digest != "" && e.CWD == cwd && e.Gate == gate {
 			if time.Since(e.At) >= hookDigestTTL {
 				// Serve stale instantly; a detached self-refresh rebuilds
 				// the cache off the startup path.
@@ -204,7 +221,7 @@ func writeHookCache(dir, cwd, digest string, sessions int, raw int64, taskMatche
 	if digest == "" {
 		return
 	}
-	if b, err := json.Marshal(hookCacheEntry{At: time.Now(), CWD: cwd, Digest: digest, Sessions: sessions, Raw: raw, TaskMatched: taskMatched}); err == nil {
+	if b, err := json.Marshal(hookCacheEntry{At: time.Now(), CWD: cwd, Gate: hookGate(), Digest: digest, Sessions: sessions, Raw: raw, TaskMatched: taskMatched}); err == nil {
 		_ = os.WriteFile(hookCachePath(dir, cwd), b, 0o600)
 	}
 }

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/search"
@@ -59,7 +60,14 @@ func runHookPrompt(dir string, stdin io.Reader, stdout io.Writer) error {
 	}
 	ss := make([]model.Session, 0, 2)
 	seen := alreadyInjected(dir, input.SessionID)
+	pol := policy.Load()
 	for i, s := range ranked {
+		// Every other injection path asks the policy first; this one is a
+		// per-prompt injection like any other, and imported projects reach
+		// it (a local project name is a substring of "imported:<name>").
+		if !pol.Allows(policy.ActivationAuto, s.Project) {
+			continue
+		}
 		// One lucky rare word is not a déjà vu. Demand real overlap before
 		// claiming "you have been here" — a false moment teaches the user to
 		// ignore the true ones.

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -569,7 +569,7 @@ func runBlame(dir string, args []string) error {
 	if err != nil {
 		return err
 	}
-	hits, err := findBlameHits(dir, target, o, os.Stderr)
+	hits, err := findBlameHits(dir, target, o, policy.ActivationSearch, os.Stderr)
 	if err != nil {
 		return fmt.Errorf("blame search: %w", err)
 	}
@@ -585,7 +585,7 @@ func runBlame(dir string, args []string) error {
 	return nil
 }
 
-func findBlameHits(dir string, target search.BlameTarget, o search.BlameOptions, progress io.Writer) ([]search.BlameHit, error) {
+func findBlameHits(dir string, target search.BlameTarget, o search.BlameOptions, activation string, progress io.Writer) ([]search.BlameHit, error) {
 	query := search.Options{Query: target.Stem, Harness: o.Harness, Project: o.Project, Since: o.Since, All: true}
 	if err := index.EnsureForSearch(dir, query, false, progress); err != nil {
 		return nil, err
@@ -594,7 +594,7 @@ func findBlameHits(dir string, target search.BlameTarget, o search.BlameOptions,
 	if err != nil {
 		return nil, err
 	}
-	return search.Blame(result.Sessions, target, o), nil
+	return policyFilterBlame(activation, search.Blame(result.Sessions, target, o)), nil
 }
 func parseDur(s string) (time.Duration, error) {
 	if strings.HasSuffix(s, "d") {

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -256,7 +256,7 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 	if err != nil {
 		return "", err
 	}
-	hits, err := findBlameHits(dir, target, o, mcpProgress())
+	hits, err := findBlameHits(dir, target, o, policy.ActivationMCP, mcpProgress())
 	if err != nil {
 		return "", err
 	}

--- a/cmd/deja/policy_leak_test.go
+++ b/cmd/deja/policy_leak_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	search "github.com/vshulcz/deja-vu/internal/search"
+)
+
+// policyLeakIndex builds an index holding one imported (peer) session and
+// points CLAUDE_PROJECT_DIR at a matching local project.
+func policyLeakIndex(t *testing.T) string {
+	t.Helper()
+	hermeticEnv(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	fresh := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-isoproj", "local.jsonl"), "local1", []string{
+		`{"type":"user","sessionId":"local1","timestamp":"` + fresh + `","message":{"role":"user","content":"local work on the parser"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// A peer session arriving over sync.
+	batch := t.TempDir()
+	line := `{"harness":"claude","session_id":"peer1","project":"isoproj","role":"user","text":"authentication middleware panicked in handler_test.go ZQSECRETMARKER","time":"` + fresh + `"}` + "\n"
+	if err := os.WriteFile(filepath.Join(batch, "b.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := index.Import(dir, batch); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "isoproj")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
+	return dir
+}
+
+// DEJA_RECALL=off is documented as the kill switch; a warm cache must not
+// keep injecting after it is set.
+func TestHookCacheHonorsRecallOff(t *testing.T) {
+	dir := policyLeakIndex(t)
+	if d, _, _, _ := cachedHookDigest(dir); d == "" {
+		t.Fatal("expected a digest before the kill switch")
+	}
+	t.Setenv("DEJA_RECALL", "off")
+	if d, _, _, _ := cachedHookDigest(dir); d != "" {
+		t.Fatalf("cache served a digest with DEJA_RECALL=off:\n%s", d)
+	}
+}
+
+// A digest cached under one policy must not be served under another: the
+// cache hit returns before the policy is ever consulted.
+func TestHookCacheRefusesEntryFromAnotherPolicy(t *testing.T) {
+	dir := policyLeakIndex(t)
+	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
+	// Warm the cache under the permissive policy.
+	warm, _, _, _ := cachedHookDigest(dir)
+	if warm == "" {
+		t.Fatal("expected a digest to cache")
+	}
+	// Plant a recognizable entry as if it had been built then.
+	planted := "PLANTED-UNDER-OLD-POLICY"
+	writeHookCache(dir, cwd, planted, 1, 10, nil)
+	if got, _, _, _ := cachedHookDigest(dir); got != planted {
+		t.Fatalf("cache did not serve its own entry back: %q", got)
+	}
+	t.Setenv("DEJA_AUTORECALL_LOCAL_ONLY", "1")
+	if got, _, _, _ := cachedHookDigest(dir); got == planted {
+		t.Fatal("cache served an entry built under a policy that no longer applies")
+	}
+}
+
+// The per-prompt déjà vu hook injects like any other path and must ask the
+// policy too.
+func TestPromptHookHonorsPolicy(t *testing.T) {
+	dir := policyLeakIndex(t)
+	t.Setenv("DEJA_AUTORECALL_LOCAL_ONLY", "1")
+	in := strings.NewReader(`{"session_id":"s","cwd":"` + os.Getenv("CLAUDE_PROJECT_DIR") + `","prompt":"why did authentication middleware panic in handler_test.go"}`)
+	var out strings.Builder
+	if err := runHookPrompt(dir, in, &out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "ZQSECRETMARKER") {
+		t.Fatalf("prompt hook injected policy-denied memory:\n%s", out.String())
+	}
+}
+
+// blame carries whole sessions, so it is the path that most needs the rule.
+func TestBlameHonorsPolicy(t *testing.T) {
+	dir := policyLeakIndex(t)
+	// Deny imported memory on every activation via a policy file.
+	pol := filepath.Join(t.TempDir(), "policy.json")
+	if err := os.WriteFile(pol, []byte(`{"activations":{"search":{"imported":false},"mcp":{"imported":false},"auto":{"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", pol)
+	got, err := blameTextResult(dir, search.BlameOptions{All: true}, "handler_test.go", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, "ZQSECRETMARKER") {
+		t.Fatalf("blame served policy-denied memory:\n%s", got)
+	}
+}

--- a/cmd/deja/policyfilter.go
+++ b/cmd/deja/policyfilter.go
@@ -12,3 +12,11 @@ func policyFilterHits(activation string, hits []search.Hit) []search.Hit {
 		return h.Session.Project
 	})
 }
+
+// policyFilterBlame is policyFilterHits for blame results, which carry whole
+// sessions rather than budgeted snippets — the path that most needs the rule.
+func policyFilterBlame(activation string, hits []search.BlameHit) []search.BlameHit {
+	return policy.Filter(policy.Load(), activation, hits, func(h search.BlameHit) string {
+		return h.Session.Project
+	})
+}

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -303,7 +303,15 @@ func TestBucketRecordGobAndRecoveryErrors(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if _, err := readRecordAt(os.NewFile(0, os.DevNull), 1); err == nil && runtime.GOOS != "windows" {
+	// os.NewFile(0, …) installs a finalizer that closes fd 0; once the GC
+	// runs it, an unrelated os.Create later in the suite gets the recycled
+	// descriptor and fails mid-write. Open the device instead.
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = devNull.Close() }()
+	if _, err := readRecordAt(devNull, 1); err == nil && runtime.GOOS != "windows" {
 		t.Fatal("readRecordAt bad seek returned nil")
 	}
 	if _, err := readRecord(&buf); !errors.Is(err, io.EOF) {


### PR DESCRIPTION
Found by an adversarial audit of the agent-facing surface. Each fix has a test proven to fail without it.

- **The session-start cache bypassed `DEJA_RECALL=off` and the policy.** Both gates live inside the digest builder, which a cache hit never reaches — and past the TTL the stale entry is served *and returned*, so a forbidden digest kept being injected at every session start. Cache entries now record the mode and policy they were built under.
- **The per-prompt déjà vu hook never consulted the policy.** Imported sessions reach it because a local project name is a substring of `imported:<name>`.
- **blame had no policy check** on either the CLI or the MCP path, and it marshals whole sessions rather than budgeted snippets.

Also: a test closed fd 0 via `os.NewFile`'s finalizer, which made an unrelated index test flake under repeated -race runs.

Full -race suite green, lint clean.