### PR TITLE
fix(search): apply scope before truncation, keep session Ords unique

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -935,6 +935,22 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		return recErr
 	}
 	seenMsgs := msgSeen{}
+	// Ord is the posting's session id, so two sessions sharing one merges
+	// their postings. A replacement reclaims its Ord from the OLD manifest,
+	// which the new map has not seen yet — so a new session picked from
+	// max(new)+1 could collide with an Ord an existing session was about to
+	// take back. Reserve both sides before handing any out.
+	nextOrd := uint32(0)
+	for _, meta := range m.Sessions {
+		if meta.Ord > nextOrd {
+			nextOrd = meta.Ord
+		}
+	}
+	for _, meta := range old.Sessions {
+		if meta.Ord > nextOrd {
+			nextOrd = meta.Ord
+		}
+	}
 	for _, s := range replacements {
 		key := s.Harness + ":" + s.ID
 		ord := uint32(0)
@@ -944,7 +960,8 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 			ord = cur.Ord
 		}
 		if ord == 0 {
-			ord = nextSessionOrd(m.Sessions)
+			nextOrd++
+			ord = nextOrd
 		}
 		m.Sessions[key] = metaWithOrd(metaForSession(s), ord)
 		for _, msg := range s.Messages {

--- a/internal/index/ord_test.go
+++ b/internal/index/ord_test.go
@@ -1,0 +1,79 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	search "github.com/vshulcz/deja-vu/internal/query"
+)
+
+// Ord is the posting's session id. A new session takes max(Ord)+1 over the
+// manifest being built, but a re-parsed session takes its Ord from the OLD
+// manifest — which the new map has not seen yet. When every existing file
+// changes at once, the new session is handed an Ord an existing session is
+// about to reclaim, and the two sessions' postings merge: one of them stops
+// being findable by its own words.
+func TestOrdsStayUniqueWhenEveryFileChangesAtOnce(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(file, id, text string) {
+		line := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, file), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("s1.jsonl", "s1", "alpha original content")
+	write("s2.jsonl", "s2", "bravo original content")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Every existing file grows, and a new session appears whose file sorts
+	// ahead of them — so it is assigned an Ord before the old ones reclaim
+	// theirs.
+	write("s1.jsonl", "s1", "alpha original content plus quetzalcoatl marker")
+	write("s2.jsonl", "s2", "bravo original content plus xochipilli marker")
+	write("aaa.jsonl", "s3", "charlie brandnew tlaloc marker")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byOrd := map[uint32]string{}
+	for key, meta := range m.Sessions {
+		if other, dup := byOrd[meta.Ord]; dup {
+			t.Fatalf("sessions %q and %q share Ord %d — their postings are merged", other, key, meta.Ord)
+		}
+		byOrd[meta.Ord] = key
+	}
+	// And the behavior that Ord uniqueness protects: each session is findable
+	// by the marker only it contains.
+	for _, c := range []struct{ marker, id string }{
+		{"quetzalcoatl", "s1"},
+		{"xochipilli", "s2"},
+		{"tlaloc", "s3"},
+	} {
+		got, err := Search(dir, search.Options{Query: c.marker, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 || got[0].ID != c.id {
+			ids := []string{}
+			for _, s := range got {
+				ids = append(ids, s.ID)
+			}
+			t.Errorf("search %q returned %v, want exactly [%s]", c.marker, ids, c.id)
+		}
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -224,16 +224,15 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 	if len(terms) < 2 {
 		return SearchResult{}, nil
 	}
-	metas, _, anyMatched, termsKnown := relevantMetasCounts(dir, m, nil, terms, 50)
+	metas, _, anyMatched, termsKnown := relevantMetasCounts(dir, m, nil, terms, 50, func(meta SessionMeta) bool {
+		return sessionMetaMatches(meta, o)
+	})
 	if len(metas) == 0 {
 		return SearchResult{}, nil
 	}
 	keep := make([]SessionMeta, 0, len(metas))
 	var weak []SessionMeta
 	for i, meta := range metas {
-		if !sessionMetaMatches(meta, o) {
-			continue
-		}
 		if anyMatched[i] >= 2 {
 			keep = append(keep, meta)
 		} else {
@@ -314,7 +313,7 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 }
 
 func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n int) ([]SessionMeta, []int) {
-	metas, informative, _, _ := relevantMetasCounts(dir, m, projects, terms, n)
+	metas, informative, _, _ := relevantMetasCounts(dir, m, projects, terms, n, nil)
 	return metas, informative
 }
 
@@ -322,9 +321,16 @@ func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n in
 // each session matched — the noise gate for full-index relevance search,
 // where demanding two rare terms also rejects real answers that pair one
 // rare word with one ordinary one.
-func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int) ([]SessionMeta, []int, []int, int) {
+// keep, when non-nil, restricts the candidate pool before ranking. The
+// search tier used to rank the whole index, take the top n and only then
+// apply the scope, so a --harness or --project search came back empty
+// whenever the unfiltered head was full of other sessions.
+func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int, keep func(SessionMeta) bool) ([]SessionMeta, []int, []int, int) {
 	inProject := map[uint32]SessionMeta{}
 	for _, meta := range m.Sessions {
+		if keep != nil && !keep(meta) {
+			continue
+		}
 		if len(projects) == 0 { // empty scope = whole index
 			inProject[meta.Ord] = meta
 			continue

--- a/internal/index/scope_test.go
+++ b/internal/index/scope_test.go
@@ -1,0 +1,81 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	search "github.com/vshulcz/deja-vu/internal/query"
+)
+
+// The relevance tier took the global top 50 and only then applied the search
+// scope, so a filtered search returned nothing whenever the unfiltered head
+// was full of sessions from another harness or project — the deeper matches
+// the filter was asking for had already been cut.
+func TestRelevanceTierAppliesScopeBeforeTruncation(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	codexRoot := filepath.Join(tmp, "codex")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", codexRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// 60 Claude sessions matching three of the four query terms, so they all
+	// outrank the Codex one and fill the top 50 on their own.
+	for i := 0; i < 60; i++ {
+		line := fmt.Sprintf(`{"type":"user","sessionId":"c%d","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"kubernetes autoscaler telemetry notes %d"}}`, i, i) + "\n"
+		if err := os.WriteFile(filepath.Join(proj, fmt.Sprintf("c%d.jsonl", i)), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A session holding the fourth term and nothing else, so every query term
+	// resolves (the close tier drops terms it cannot resolve and ANDs the
+	// rest) while no session holds all four — which is what drops the ladder
+	// down to the relevance tier.
+	if err := os.WriteFile(filepath.Join(proj, "d1.jsonl"),
+		[]byte(`{"type":"user","sessionId":"d1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"dashboards"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// One Codex session matching two of the terms — a genuine answer for a
+	// harness-scoped search, and ranked below every Claude session.
+	sess := filepath.Join(codexRoot, "sessions", "2026", "01", "02")
+	if err := os.MkdirAll(sess, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	roll := `{"type":"session_meta","payload":{"id":"cx1","timestamp":"2026-01-02T03:04:05Z","cwd":"/tmp/app"}}` + "\n" +
+		`{"type":"event_msg","payload":{"type":"user_message","message":"kubernetes autoscaler runbook"},"timestamp":"2026-01-02T03:04:06Z"}` + "\n"
+	if err := os.WriteFile(filepath.Join(sess, "rollout-2026-01-02T03-04-05-cx1.jsonl"), []byte(roll), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// No session holds all four terms, so the ladder falls to the relevance
+	// tier — which is where the truncation happened.
+	const q = "kubernetes autoscaler telemetry dashboards"
+	all, err := SearchWithRecoveryDetailed(dir, search.Options{Query: q, All: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if all.Tier != search.TierRelevance {
+		t.Fatalf("fixture resolved through tier %q, want the relevance tier", all.Tier)
+	}
+	got, err := SearchWithRecoveryDetailed(dir, search.Options{Query: q, Harness: "codex", All: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Sessions) == 0 {
+		t.Fatal("harness-scoped relevance search returned nothing; the match was cut by truncation before the scope filter ran")
+	}
+	for _, s := range got.Sessions {
+		if s.Harness != "codex" {
+			t.Fatalf("scope leaked: got a %s session", s.Harness)
+		}
+	}
+}


### PR DESCRIPTION
Two independent bugs, each with a regression test that fails without its fix.

**Scope after truncation.** The relevance tier ranked the whole index, took the top 50, and only then applied the search scope. A `--harness codex` search came back empty whenever the unfiltered head was all Claude sessions, even with matching Codex sessions deeper down. The scope now restricts the candidate pool before ranking.

**Ord collision.** Ord is the posting's session id. On an incremental update a replaced session reclaims its Ord from the old manifest, but a new session took `max(Ord)+1` over the *new* map, which hasn't seen those yet. When every indexed file changes at once the new session gets an Ord an existing session then takes back, and the two sessions' postings merge — one stops being findable by its own words. Reproduced with three sessions where two grow and one appears (`replacements=3 mSessions=0 oldSessions=2`).

Full `-race` suite green, lint clean.