### PR TITLE
fix(sync): unstamped messages could never reach a peer

### DIFF
--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -189,6 +189,10 @@ func eachRecordForKeys(path string, want map[string]bool, fn func(Record)) error
 	}
 }
 
+// zeroTimeUnixNano is what the zero time serializes to; records.bin has
+// always stored it, so it stays the on-disk marker for "never stamped".
+var zeroTimeUnixNano = time.Time{}.UnixNano()
+
 func encodeRecord(r Record) []byte {
 	b := make([]byte, 0, len(r.Key)+len(r.SourcePath)+len(r.Role)+len(r.Text)+32)
 	b = appendField(b, r.Key)
@@ -219,7 +223,15 @@ func decodeRecord(b []byte) (Record, error) {
 	if len(b) < 8 {
 		return rec, io.ErrUnexpectedEOF
 	}
-	rec.Time = time.Unix(0, int64(binary.LittleEndian.Uint64(b[:8])))
+	// time.Time{}.UnixNano() is a large negative number that time.Unix turns
+	// into the year 1754, so an unstamped message never satisfied IsZero()
+	// again. Sync then read it as older than any watermark and skipped it on
+	// every push — the message could never reach another machine, silently.
+	if n := int64(binary.LittleEndian.Uint64(b[:8])); n == zeroTimeUnixNano {
+		rec.Time = time.Time{}
+	} else {
+		rec.Time = time.Unix(0, n)
+	}
 	b = b[8:]
 	if rec.Text, _, ok = consumeField(b); !ok {
 		return rec, io.ErrUnexpectedEOF

--- a/internal/index/unstamped_test.go
+++ b/internal/index/unstamped_test.go
@@ -1,0 +1,91 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A record whose message carried no timestamp round-trips through records.bin
+// as time.Time{}.UnixNano(), which decodes to the year 1754 — never IsZero().
+// Export then compares it as "very old" against a watermark of 0 and skips it
+// on the first push and every push after, so those messages never reach
+// another machine and nothing reports the loss.
+func TestZeroTimeRoundTripsAsZero(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "records.bin")
+	f, err := os.OpenFile(p, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rw, err := newRecordWriter(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rw.write(Record{Key: "claude:s1", SourcePath: "/tmp/s1.jsonl", Role: "user", Text: "unstamped message"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var got Record
+	if err := eachRecord(p, func(r Record) { got = r }); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Time.IsZero() {
+		t.Fatalf("unstamped record decoded as %v, want the zero time — export treats it as ancient and never sends it", got.Time)
+	}
+	// A real timestamp must still survive untouched.
+	when := time.Date(2026, 1, 2, 3, 4, 5, 6, time.UTC)
+	f2, err := os.OpenFile(filepath.Join(dir, "r2.bin"), os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rw2, err := newRecordWriter(f2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rw2.write(Record{Key: "claude:s1", SourcePath: "/tmp/s1.jsonl", Role: "user", Text: "stamped", Time: when}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rw2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var got2 Record
+	if err := eachRecord(filepath.Join(dir, "r2.bin"), func(r Record) { got2 = r }); err != nil {
+		t.Fatal(err)
+	}
+	if !got2.Time.Equal(when) {
+		t.Fatalf("stamped record decoded as %v, want %v", got2.Time, when)
+	}
+}
+
+// End to end: an unstamped message must reach a peer.
+func TestUnstampedMessagesReachThePeer(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// No "timestamp" field at all — the harness never stamped this message.
+	line := `{"type":"user","sessionId":"s1","message":{"role":"user","content":"unstamped but real work"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	n, _, err := ExportDeferred(dir, filepath.Join(tmp, "out"), "laptop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n == 0 {
+		t.Fatal("unstamped message was never exported — it can never reach another machine")
+	}
+}


### PR DESCRIPTION
A message whose harness never stamped it round-trips through `records.bin` as `time.Time{}.UnixNano()`, which `time.Unix` turns back into 1754-08-31 — so `r.Time.IsZero()` is never true again. Export then compares it against the watermark as "very old" and skips it on the first push and every push after. Only `--full` ever moved those records, and nothing reported the loss.

Decoding restores the zero time from the marker records.bin has always written, which makes the existing `!r.Time.IsZero()` guard in the export path live again — unstamped records are always sent, and import dedupes them.

Two tests: the decode round-trip in isolation, and end-to-end that a session with no `timestamp` field is actually exported. Both fail without the fix. Full `-race` suite green, lint clean.