### PR TITLE
perf(search): shard non-ASCII tokens across buckets

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -292,7 +292,10 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 	if mode == search.RecallOff {
 		return "", 0, 0, nil
 	}
-	if !index.HasManifest(dir) {
+	// A store from an older index version must be rebuilt before it is read:
+	// this path never calls Ensure, so otherwise the first prompts after an
+	// upgrade recall nothing and say nothing about why.
+	if !index.HasManifest(dir) || !index.IsCurrentVersion(dir) {
 		requestWarmup(dir)
 		return "", 0, 0, nil
 	}

--- a/internal/index/cyrillic_test.go
+++ b/internal/index/cyrillic_test.go
@@ -63,6 +63,14 @@ func TestRussianInflectionsFoldInRelevanceTier(t *testing.T) {
 		{"знаю", "знать"},
 		{"могу", "могли"},
 		{"говорит", "говорить"},
+		{"знать", "знаю"},
+		{"считаем", "считать"},
+		// Soft-masculine nouns take the hard endings, unlike the feminines.
+		{"автомобиль", "автомобиля"},
+		{"писатель", "писателем"},
+		// -ость nouns never folded before: "ть" matched ahead of "ь".
+		{"новость", "новостей"},
+		{"активность", "активности"},
 	} {
 		forms := stemMatchForms(c.query)
 		found := false
@@ -103,6 +111,9 @@ func TestRussianFoldDoesNotReachUnrelatedWords(t *testing.T) {
 		{"бить", "битой"},
 		{"верь", "вера"},
 		{"весь", "веса"},
+		{"цель", "целое"},
+		{"голубь", "голубой"},
+		{"столь", "стол"},
 	} {
 		for _, f := range stemMatchForms(c.query) {
 			if f == c.unrelated {

--- a/internal/index/cyrillic_test.go
+++ b/internal/index/cyrillic_test.go
@@ -49,6 +49,20 @@ func TestRussianInflectionsFoldInRelevanceTier(t *testing.T) {
 		{"репликация", "репликации"},
 		{"агентом", "агент"},
 		{"база", "базы"},
+		{"кластера", "кластеров"},
+		// Third-declension feminine nouns — 11% of the vocabulary, and the
+		// paradigm this fold was written for.
+		{"сеть", "сети"},
+		{"сеть", "сетью"},
+		{"жизнь", "жизни"},
+		{"ночь", "ночи"},
+		{"очередь", "очереди"},
+		// Short verb stems must still reach their own paradigm: a guard keyed
+		// on stem length alone cannot tell вес (noun) from зна (verb).
+		{"знать", "знал"},
+		{"знаю", "знать"},
+		{"могу", "могли"},
+		{"говорит", "говорить"},
 	} {
 		forms := stemMatchForms(c.query)
 		found := false
@@ -83,10 +97,12 @@ func TestRussianInflectionsFoldInRelevanceTier(t *testing.T) {
 func TestRussianFoldDoesNotReachUnrelatedWords(t *testing.T) {
 	for _, c := range []struct{ query, unrelated string }{
 		{"цель", "целая"},
+		{"цель", "целый"},
 		{"борись", "борис"},
 		{"весом", "весть"},
 		{"бить", "битой"},
 		{"верь", "вера"},
+		{"весь", "веса"},
 	} {
 		for _, f := range stemMatchForms(c.query) {
 			if f == c.unrelated {

--- a/internal/index/cyrillic_test.go
+++ b/internal/index/cyrillic_test.go
@@ -47,7 +47,8 @@ func TestRussianInflectionsFoldInRelevanceTier(t *testing.T) {
 		{"миграция", "миграциями"},
 		{"миграциями", "миграция"},
 		{"репликация", "репликации"},
-		{"сеть", "сети"},
+		{"агентом", "агент"},
+		{"база", "базы"},
 	} {
 		forms := stemMatchForms(c.query)
 		found := false
@@ -71,6 +72,27 @@ func TestRussianInflectionsFoldInRelevanceTier(t *testing.T) {
 	for _, w := range []string{"что", "как", "его"} {
 		if got := stemMatchForms(w); len(got) != 0 {
 			t.Errorf("stemMatchForms(%q) = %v, want none", w, got)
+		}
+	}
+}
+
+// The relevance tier has no catalog gate — whatever the fold invents is looked
+// up for real — so an over-eager ending reaches a word from another paradigm
+// and recalls a session that has nothing to do with the query. A wrong recall
+// costs more than a missed inflection.
+func TestRussianFoldDoesNotReachUnrelatedWords(t *testing.T) {
+	for _, c := range []struct{ query, unrelated string }{
+		{"цель", "целая"},
+		{"борись", "борис"},
+		{"весом", "весть"},
+		{"бить", "битой"},
+		{"верь", "вера"},
+	} {
+		for _, f := range stemMatchForms(c.query) {
+			if f == c.unrelated {
+				t.Errorf("stemMatchForms(%q) reaches the unrelated %q", c.query, c.unrelated)
+				break
+			}
 		}
 	}
 }

--- a/internal/index/cyrillic_test.go
+++ b/internal/index/cyrillic_test.go
@@ -71,6 +71,14 @@ func TestRussianInflectionsFoldInRelevanceTier(t *testing.T) {
 		// -ость nouns never folded before: "ть" matched ahead of "ь".
 		{"новость", "новостей"},
 		{"активность", "активности"},
+		// Real infinitives are vowel + ть and keep the verb branch.
+		{"делать", "делаю"},
+		{"работать", "работаю"},
+		{"видеть", "видел"},
+		// ...and ть-final nouns still fold within their own paradigm.
+		{"часть", "части"},
+		{"весть", "вести"},
+		{"власть", "власти"},
 	} {
 		forms := stemMatchForms(c.query)
 		found := false
@@ -114,6 +122,14 @@ func TestRussianFoldDoesNotReachUnrelatedWords(t *testing.T) {
 		{"цель", "целое"},
 		{"голубь", "голубой"},
 		{"столь", "стол"},
+		// A noun can end in "ть" too. Taking the verb branch sent часть to
+		// час and весть to вес — the latter being the surviving inverse of
+		// весом -> весть.
+		{"часть", "час"},
+		{"часть", "часа"},
+		{"весть", "вес"},
+		{"весть", "веса"},
+		{"лесть", "лес"},
 	} {
 		for _, f := range stemMatchForms(c.query) {
 			if f == c.unrelated {

--- a/internal/index/cyrillic_test.go
+++ b/internal/index/cyrillic_test.go
@@ -1,0 +1,116 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// bucket() sliced two bytes, so every non-ASCII token — all of Russian, all
+// of Chinese, all of Greek — collapsed into the single bucket "t_" and each
+// lookup scanned the entire non-ASCII vocabulary.
+func TestBucketsShardNonASCIITokens(t *testing.T) {
+	words := []string{"миграция", "репликация", "сеть", "база", "ключ", "ошибка", "запрос", "тест", "индекс", "поиск"}
+	seen := map[string]bool{}
+	for _, w := range words {
+		seen[bucket("t"+w)] = true
+	}
+	if len(seen) < 5 {
+		t.Fatalf("%d Russian words landed in %d buckets: %v", len(words), len(seen), seen)
+	}
+	cjk := []string{"数据库", "迁移", "网络", "错误", "请求", "测试"}
+	seen = map[string]bool{}
+	for _, w := range cjk {
+		seen[bucket("t"+w)] = true
+	}
+	if len(seen) < 4 {
+		t.Fatalf("%d Chinese words landed in %d buckets: %v", len(cjk), len(seen), seen)
+	}
+	// ASCII sharding must be byte-identical to the old scheme, or every
+	// English token silently moves house on upgrade.
+	for _, tok := range []string{"tmigration", "tdatabase", "t203", "tpkg/index", "tx"} {
+		if len(tok) >= 2 {
+			if got, want := bucket(tok), safe(tok[:2]); got != want {
+				t.Fatalf("bucket(%q) = %q, want %q — ASCII layout changed", tok, got, want)
+			}
+		}
+	}
+}
+
+// The relevance tier folds a term onto its inflections. Cyrillic terms used to
+// be handed to the ASCII stemmer, which appended English suffixes to Russian
+// words, so the fold never matched anything (#340 shipped as a no-op).
+func TestRussianInflectionsFoldInRelevanceTier(t *testing.T) {
+	for _, c := range []struct{ query, indexed string }{
+		{"миграция", "миграциями"},
+		{"миграциями", "миграция"},
+		{"репликация", "репликации"},
+		{"сеть", "сети"},
+	} {
+		forms := stemMatchForms(c.query)
+		found := false
+		for _, f := range forms {
+			if f == c.indexed {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("stemMatchForms(%q) does not reach %q: %v", c.query, c.indexed, forms)
+		}
+		for _, f := range forms {
+			if strings.ContainsAny(f, "abcdefghijklmnopqrstuvwxyz") {
+				t.Errorf("stemMatchForms(%q) produced a Latin-suffixed form %q", c.query, f)
+				break
+			}
+		}
+	}
+	// Three-letter function words must not fan out into the ending table.
+	for _, w := range []string{"что", "как", "его"} {
+		if got := stemMatchForms(w); len(got) != 0 {
+			t.Errorf("stemMatchForms(%q) = %v, want none", w, got)
+		}
+	}
+}
+
+// End to end through the relevance tier, which is what auto-recall uses: it
+// has no close/fuzzy ladder to fall back on, so a dead fold there means a
+// Russian prompt silently recalls nothing.
+func TestRussianRelevanceFoldsInflections(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mk := func(id, text string) {
+		line := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, id+".jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("s1", "обсуждали миграциями базы данных и чинили репликациями слейва")
+	// Filler so the target is not the only session in the corpus.
+	for i := 0; i < 12; i++ {
+		mk(fmt.Sprintf("f%d", i), "обычная рабочая сессия про сборку и деплой контейнеров")
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Nominative singular in the prompt, instrumental plural in the session.
+	got, matched, err := ProjectRelevant(dir, []string{"app"}, []string{"миграция", "репликация"}, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("relevance tier returned nothing for a Russian prompt")
+	}
+	if got[0].ID != "s1" || matched[0] == 0 {
+		t.Fatalf("top relevant session = %q (matched=%v), want s1 with a match", got[0].ID, matched)
+	}
+}

--- a/internal/index/cyrillic_test.go
+++ b/internal/index/cyrillic_test.go
@@ -124,6 +124,43 @@ func TestRussianFoldDoesNotReachUnrelatedWords(t *testing.T) {
 	}
 }
 
+// Both tiers must fold Russian the same way. The stem tier used to strip and
+// re-attach from one shared table, so пусть recalled a session that only said
+// пустой — the same defect the relevance tier was fixed for, one tier over.
+func TestStemTierFoldsLikeTheRelevanceTier(t *testing.T) {
+	for _, c := range []struct{ query, unrelated string }{
+		{"пусть", "пустой"},
+		{"пусть", "пустая"},
+		{"часть", "часто"},
+		{"цель", "целая"},
+	} {
+		for _, f := range cyrSuffixForms(c.query) {
+			if f == c.unrelated {
+				t.Errorf("stem tier folds %q onto the unrelated %q", c.query, c.unrelated)
+				break
+			}
+		}
+	}
+	for _, c := range []struct{ query, want string }{
+		{"жизнь", "жизни"},
+		{"дверь", "двери"},
+		{"приятель", "приятеля"},
+		{"часть", "части"},
+		{"миграция", "миграциями"},
+	} {
+		found := false
+		for _, f := range cyrSuffixForms(c.query) {
+			if f == c.want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("stem tier lost %q -> %q", c.query, c.want)
+		}
+	}
+}
+
 // End to end through the relevance tier, which is what auto-recall uses: it
 // has no close/fuzzy ladder to fall back on, so a dead fold there means a
 // Russian prompt silently recalls nothing.

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -10,7 +10,9 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
-const version = 11
+// version 12 reshards non-ASCII tokens across buckets; an index built by 11
+// keeps them all under "t_", where the new lookup would never find them.
+const version = 12
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -7,6 +7,19 @@ import (
 	"time"
 )
 
+// IsCurrentVersion reports whether the index on disk was written by this
+// build's format. Hook paths never call Ensure, so after an upgrade that
+// changes the layout they would read the old store directly — for version 12
+// that meant non-ASCII tokens hashing to buckets the old index never wrote,
+// i.e. silent zero recall for Russian and CJK while English kept working.
+func IsCurrentVersion(dir string) bool {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifest(dir)
+	return err == nil && m.Version == version
+}
+
 func HasManifest(dir string) bool {
 	if dir == "" {
 		dir = DefaultDir()

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1336,8 +1336,15 @@ var cyrEndings = []string{
 	// Soft-sign stems: сеть -> сети, сетью, сетям. Without "ью" and "ям"
 	// stripping the "ь" would strand the very forms the fold exists to reach.
 	"ью", "ям", "ем", "ом",
-	"ть", "л", "ла", "ло", "ли", "а", "я", "у", "ю", "ы", "и", "е", "о", "ь",
+	"ть", "л", "ла", "ло", "ли", "а", "я", "у", "ю", "ы", "и", "е", "о",
 }
+
+// Deliberately absent: a bare "ь". Stripping the soft sign off a four-rune
+// noun leaves a three-rune base that collides with unrelated words — цель
+// folds onto целая, верь onto вера, бить onto битой. It bought only
+// сеть->сети (новость->новости is taken by "ть" first), which is the same
+// shape as the false ones, so there is no rule that keeps one without the
+// others. A wrong recall costs more than a missed inflection.
 
 // cyrMatchForms folds a Russian term onto its inflection family for the
 // relevance tier: strip the longest known ending, then re-attach each, so
@@ -1360,13 +1367,24 @@ func cyrMatchForms(term string) []string {
 	if base != term {
 		forms = append(forms, base)
 	}
+	baseLen := len([]rune(base))
 	for _, end := range cyrEndings {
+		// Verb endings on a short base reach unrelated words: весом strips
+		// to вес, and вес+ть is весть. Nouns that short still fold through
+		// their vowel endings (баз -> базы, базе).
+		if baseLen < 4 && cyrVerbEndings[end] {
+			continue
+		}
 		if form := base + end; form != term {
 			forms = append(forms, form)
 		}
 	}
 	return forms
 }
+
+// cyrVerbEndings are the infinitive and past-tense endings; attaching one to
+// a noun stem is how a fold lands on a word from another paradigm.
+var cyrVerbEndings = map[string]bool{"ть": true, "л": true, "ла": true, "ло": true, "ли": true}
 
 // cyrSuffixForms bridges Russian inflection: strip the longest known ending,
 // then re-attach each — миграция matches миграции and миграцию. ASCII terms

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1342,12 +1342,14 @@ var cyrEndings = []string{
 // hard adjective endings there is what folded цель onto целая and верь onto
 // вера: сеть->сети needs "и", цель->целая needs "ая", so keeping the two
 // tables apart separates shapes that look identical by length alone.
-var cyrSoftEndings = []string{"и", "ью", "ям", "ях", "ями", "ей", "е"}
+var cyrSoftEndings = []string{"и", "ью", "ям", "ях", "ями", "ей", "е", "я", "ю", "ем"}
 
 // cyrVerbEndings are the infinitive and past-tense endings.
 var cyrVerbEndings = map[string]bool{"ть": true, "л": true, "ла": true, "ло": true, "ли": true}
 
-var cyrVerbEndingList = []string{"ть", "л", "ла", "ло", "ли"}
+// cyrVerbEndingList is what a ь-final infinitive's stem takes back: the past
+// tense plus the present-tense vowels, so знать reaches both знал and знаю.
+var cyrVerbEndingList = []string{"ть", "л", "ла", "ло", "ли", "ю", "у", "а", "я", "е", "и", "ем"}
 
 // cyrNominalEndings are unambiguously noun-case: a stem exposed by stripping
 // one of these came from a noun, so verb endings must not attach to it —
@@ -1357,7 +1359,7 @@ var cyrNominalEndings = map[string]bool{
 	"иями": true, "ями": true, "ами": true, "ией": true, "иях": true,
 	"ях": true, "ах": true, "ов": true, "ев": true, "ей": true, "ой": true,
 	"ий": true, "ия": true, "ию": true, "ии": true, "ие": true,
-	"ый": true, "ая": true, "ое": true, "ые": true, "ем": true, "ом": true,
+	"ый": true, "ая": true, "ое": true, "ые": true, "ом": true,
 }
 
 // cyrMatchForms folds a Russian term onto its inflection family for the

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1337,6 +1337,23 @@ var cyrEndings = []string{
 	"ть", "л", "ла", "ло", "ли", "а", "я", "у", "ю", "ы", "и", "е", "о", "ь",
 }
 
+// endsInfinitive reports whether a ть-final term is shaped like a verb: the
+// rune before "ть" is a vowel. Consonant-stem infinitives (лезть, сесть,
+// класть) are misread as nouns and lose the verb branch — 11 reachable pairs
+// across a 20k frequency list, against closing часть -> час and весть -> вес,
+// which are common words landing on a different lemma entirely.
+func endsInfinitive(term string) bool {
+	runes := []rune(term)
+	if len(runes) < 3 {
+		return false
+	}
+	switch runes[len(runes)-3] {
+	case 'а', 'е', 'ё', 'и', 'о', 'у', 'ы', 'э', 'ю', 'я':
+		return true
+	}
+	return false
+}
+
 // cyrSoftEndings is the third-declension feminine paradigm, and the only set
 // that may attach to a stem exposed by stripping a soft sign. Attaching the
 // hard adjective endings there is what folded цель onto целая and верь onto
@@ -1393,8 +1410,13 @@ func cyrMatchForms(term string) []string {
 				add(base + end)
 			}
 		}
-		// A ь-final infinitive is a verb, not a noun: знать -> знал.
-		if strings.HasSuffix(term, "ть") {
+		// A ь-final infinitive is a verb, not a noun: знать -> знал. But a
+		// noun can end in "ть" too, and часть taking the verb branch reaches
+		// час — a different lemma entirely. Infinitives are vowel + ть
+		// (де-лать, зна-ть, ви-деть); ть-final nouns are consonant + ть
+		// (час-ть, вес-ть, лес-ть, кос-ть). That also closes весть -> вес,
+		// which was the surviving inverse of весом -> весть.
+		if strings.HasSuffix(term, "ть") && endsInfinitive(term) {
 			if base := strings.TrimSuffix(term, "ть"); len([]rune(base)) >= 3 {
 				add(base)
 				for _, end := range cyrVerbEndingList {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1428,33 +1428,15 @@ func cyrMatchForms(term string) []string {
 // then re-attach each — миграция matches миграции and миграцию. ASCII terms
 // return nothing.
 func cyrSuffixForms(term string) []string {
-	runes := []rune(term)
-	if len(runes) < 5 {
+	if !isCyrToken(term) {
 		return nil
 	}
-	cyr := false
-	for _, r := range runes {
-		if r >= 'а' && r <= 'я' || r == 'ё' {
-			cyr = true
-			break
-		}
-	}
-	if !cyr {
-		return nil
-	}
-	base := term
-	for _, end := range cyrEndings {
-		if strings.HasSuffix(term, end) && len([]rune(term))-len([]rune(end)) >= 4 {
-			base = strings.TrimSuffix(term, end)
-			break
-		}
-	}
-	forms := make([]string, 0, len(cyrEndings)+1)
-	forms = append(forms, base)
-	for _, end := range cyrEndings {
-		forms = append(forms, base+end)
-	}
-	return forms
+	// Both tiers fold Russian the same way. This one used to strip and
+	// re-attach from one shared table, which is the цель->целая shape the
+	// relevance tier was fixed for — it survived here one tier over, letting
+	// пусть recall a session that only says пустой. The catalog gate and the
+	// 8-match cap made it milder, not correct.
+	return cyrMatchForms(term)
 }
 
 func suffixForms(word string) []string {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1333,58 +1333,94 @@ var devSynonyms = func() map[string][]string {
 var cyrEndings = []string{
 	"иями", "ями", "ами", "ией", "иях", "ях", "ах", "ов", "ев", "ей",
 	"ой", "ий", "ия", "ию", "ии", "ие", "ый", "ая", "ое", "ые",
-	// Soft-sign stems: сеть -> сети, сетью, сетям. Without "ью" and "ям"
-	// stripping the "ь" would strand the very forms the fold exists to reach.
 	"ью", "ям", "ем", "ом",
-	"ть", "л", "ла", "ло", "ли", "а", "я", "у", "ю", "ы", "и", "е", "о",
+	"ть", "л", "ла", "ло", "ли", "а", "я", "у", "ю", "ы", "и", "е", "о", "ь",
 }
 
-// Deliberately absent: a bare "ь". Stripping the soft sign off a four-rune
-// noun leaves a three-rune base that collides with unrelated words — цель
-// folds onto целая, верь onto вера, бить onto битой. It bought only
-// сеть->сети (новость->новости is taken by "ть" first), which is the same
-// shape as the false ones, so there is no rule that keeps one without the
-// others. A wrong recall costs more than a missed inflection.
+// cyrSoftEndings is the third-declension feminine paradigm, and the only set
+// that may attach to a stem exposed by stripping a soft sign. Attaching the
+// hard adjective endings there is what folded цель onto целая and верь onto
+// вера: сеть->сети needs "и", цель->целая needs "ая", so keeping the two
+// tables apart separates shapes that look identical by length alone.
+var cyrSoftEndings = []string{"и", "ью", "ям", "ях", "ями", "ей", "е"}
+
+// cyrVerbEndings are the infinitive and past-tense endings.
+var cyrVerbEndings = map[string]bool{"ть": true, "л": true, "ла": true, "ло": true, "ли": true}
+
+var cyrVerbEndingList = []string{"ть", "л", "ла", "ло", "ли"}
+
+// cyrNominalEndings are unambiguously noun-case: a stem exposed by stripping
+// one of these came from a noun, so verb endings must not attach to it —
+// весом strips to вес, and вес+ть is весть. Endings a verb can also carry
+// (ю, у, а, и ...) stay out of this set, so знаю -> зна -> знать survives.
+var cyrNominalEndings = map[string]bool{
+	"иями": true, "ями": true, "ами": true, "ией": true, "иях": true,
+	"ях": true, "ах": true, "ов": true, "ев": true, "ей": true, "ой": true,
+	"ий": true, "ия": true, "ию": true, "ии": true, "ие": true,
+	"ый": true, "ая": true, "ое": true, "ые": true, "ем": true, "ом": true,
+}
 
 // cyrMatchForms folds a Russian term onto its inflection family for the
-// relevance tier: strip the longest known ending, then re-attach each, so
-// "миграциями" reaches "миграция". Four runes is the floor — below it the
-// three-letter function words (что, как, его) would each fan out into the
-// whole ending table for nothing.
+// relevance tier: strip a known ending, then re-attach the endings that
+// belong to the same paradigm. Four runes is the floor — below it the
+// three-letter function words (что, как, его) would fan out for nothing.
+//
+// The tier has no catalog gate, so whatever this invents is looked up for
+// real and can surface a session. That is why stripping and re-attaching use
+// different tables: one shared table folded цель onto целая.
 func cyrMatchForms(term string) []string {
 	runes := []rune(term)
 	if len(runes) < 4 {
 		return nil
 	}
-	base := term
+	seen := map[string]bool{term: true}
+	forms := make([]string, 0, len(cyrEndings)+1)
+	add := func(f string) {
+		if !seen[f] {
+			seen[f] = true
+			forms = append(forms, f)
+		}
+	}
+	if strings.HasSuffix(term, "ь") {
+		// Soft stem — the third-declension nouns: сеть, жизнь, ночь, очередь.
+		if base := strings.TrimSuffix(term, "ь"); len([]rune(base)) >= 3 {
+			// The bare stem is deliberately not emitted: a third-declension
+			// noun's stem is not a word on its own (сеть -> сет), while for a
+			// ь-final imperative it is — борись would recall Борис.
+			for _, end := range cyrSoftEndings {
+				add(base + end)
+			}
+		}
+		// A ь-final infinitive is a verb, not a noun: знать -> знал.
+		if strings.HasSuffix(term, "ть") {
+			if base := strings.TrimSuffix(term, "ть"); len([]rune(base)) >= 3 {
+				add(base)
+				for _, end := range cyrVerbEndingList {
+					add(base + end)
+				}
+			}
+		}
+		return forms
+	}
+	base, stripped := term, ""
 	for _, end := range cyrEndings {
 		if strings.HasSuffix(term, end) && len(runes)-len([]rune(end)) >= 3 {
-			base = strings.TrimSuffix(term, end)
+			base, stripped = strings.TrimSuffix(term, end), end
 			break
 		}
 	}
-	forms := make([]string, 0, len(cyrEndings)+1)
 	if base != term {
-		forms = append(forms, base)
+		add(base)
 	}
-	baseLen := len([]rune(base))
+	nominal := cyrNominalEndings[stripped]
 	for _, end := range cyrEndings {
-		// Verb endings on a short base reach unrelated words: весом strips
-		// to вес, and вес+ть is весть. Nouns that short still fold through
-		// their vowel endings (баз -> базы, базе).
-		if baseLen < 4 && cyrVerbEndings[end] {
+		if nominal && cyrVerbEndings[end] {
 			continue
 		}
-		if form := base + end; form != term {
-			forms = append(forms, form)
-		}
+		add(base + end)
 	}
 	return forms
 }
-
-// cyrVerbEndings are the infinitive and past-tense endings; attaching one to
-// a noun stem is how a fold lands on a word from another paradigm.
-var cyrVerbEndings = map[string]bool{"ть": true, "л": true, "ла": true, "ло": true, "ли": true}
 
 // cyrSuffixForms bridges Russian inflection: strip the longest known ending,
 // then re-attach each — миграция matches миграции and миграцию. ASCII terms

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1333,7 +1333,39 @@ var devSynonyms = func() map[string][]string {
 var cyrEndings = []string{
 	"иями", "ями", "ами", "ией", "иях", "ях", "ах", "ов", "ев", "ей",
 	"ой", "ий", "ия", "ию", "ии", "ие", "ый", "ая", "ое", "ые",
-	"ть", "л", "ла", "ло", "ли", "а", "я", "у", "ю", "ы", "и", "е", "о",
+	// Soft-sign stems: сеть -> сети, сетью, сетям. Without "ью" and "ям"
+	// stripping the "ь" would strand the very forms the fold exists to reach.
+	"ью", "ям", "ем", "ом",
+	"ть", "л", "ла", "ло", "ли", "а", "я", "у", "ю", "ы", "и", "е", "о", "ь",
+}
+
+// cyrMatchForms folds a Russian term onto its inflection family for the
+// relevance tier: strip the longest known ending, then re-attach each, so
+// "миграциями" reaches "миграция". Four runes is the floor — below it the
+// three-letter function words (что, как, его) would each fan out into the
+// whole ending table for nothing.
+func cyrMatchForms(term string) []string {
+	runes := []rune(term)
+	if len(runes) < 4 {
+		return nil
+	}
+	base := term
+	for _, end := range cyrEndings {
+		if strings.HasSuffix(term, end) && len(runes)-len([]rune(end)) >= 3 {
+			base = strings.TrimSuffix(term, end)
+			break
+		}
+	}
+	forms := make([]string, 0, len(cyrEndings)+1)
+	if base != term {
+		forms = append(forms, base)
+	}
+	for _, end := range cyrEndings {
+		if form := base + end; form != term {
+			forms = append(forms, form)
+		}
+	}
+	return forms
 }
 
 // cyrSuffixForms bridges Russian inflection: strip the longest known ending,
@@ -1743,14 +1775,28 @@ func recordMatchesQueryVariants(r Record, o query.Options, variants map[string][
 	return query.MatchesParts(r.Text, terms, phrases, variants)
 }
 
+// bucket shards a token by its opening characters. It used to slice two
+// *bytes*, which for any non-ASCII token is a prefix plus half a UTF-8
+// sequence: safe() mapped the broken half to "_", so every Russian, Chinese
+// and Greek token in the corpus landed in the single bucket "t_". Each lookup
+// then had to scan the whole non-ASCII vocabulary. Sharding by runes keeps
+// ASCII bucket names exactly as they were and spreads the rest over 256.
 func bucket(tok string) string {
-	if len(tok) >= 2 {
-		return safe(tok[:2])
+	runes := []rune(tok)
+	if len(runes) >= 2 && isShardASCII(runes[0]) && isShardASCII(runes[1]) {
+		return safe(string(runes[:2]))
+	}
+	if len(runes) > 3 {
+		runes = runes[:3]
 	}
 	h := fnv.New32a()
-	_, _ = h.Write([]byte(tok))
+	_, _ = h.Write([]byte(string(runes)))
 	return fmt.Sprintf("x%02x", h.Sum32()%256)
 }
+
+// isShardASCII reports whether a rune is one byte wide, so slicing it cannot
+// split a multi-byte sequence.
+func isShardASCII(r rune) bool { return r < 128 }
 
 func safe(s string) string {
 	return strings.Map(func(r rune) rune {
@@ -1766,15 +1812,14 @@ func safe(s string) string {
 // empty buckets.
 func stemMatchForms(term string) []string {
 	runes := []rune(term)
+	// Cyrillic terms took the ASCII path, which appends English suffixes to
+	// Russian words — "миграции" became "миграцииed" and read nothing but
+	// empty buckets, so the relevance-tier fold was a no-op in both
+	// directions. Route them through the Russian ending table instead.
+	if isCyrToken(term) {
+		return cyrMatchForms(term)
+	}
 	if len(runes) < 5 {
-		if isCyrToken(term) && len(runes) >= 3 {
-			// Short Russian stems inflect too: сеть -> сетью, сети.
-			out := make([]string, 0, 12)
-			for _, end := range []string{"ю", "и", "е", "а", "у", "ы", "ой", "ей", "ью", "ям", "ях", "ами"} {
-				out = append(out, term+end)
-			}
-			return out
-		}
 		var out []string
 		for _, form := range []string{term + "s", term + "es", strings.TrimSuffix(term, "s")} {
 			if len(form) >= 3 && form != term {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1343,6 +1343,9 @@ var cyrEndings = []string{
 // across a 20k frequency list, against closing часть -> час and весть -> вес,
 // which are common words landing on a different lemma entirely.
 func endsInfinitive(term string) bool {
+	if !strings.HasSuffix(term, "ть") {
+		return false
+	}
 	runes := []rune(term)
 	if len(runes) < 3 {
 		return false

--- a/internal/index/version_upgrade_test.go
+++ b/internal/index/version_upgrade_test.go
@@ -1,0 +1,68 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	search "github.com/vshulcz/deja-vu/internal/query"
+)
+
+// Version 12 reshards non-ASCII tokens, so an index left at an older version
+// must be rebuilt before it is searched — and every script must survive that
+// rebuild. (This covers the upgrade path, not the shape of a genuine v11
+// store: several tiers enumerate bucket directories directly, so a v11 store
+// stays partly reachable rather than going dark.)
+func TestOlderIndexVersionIsRebuiltBeforeSearch(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"обсуждали миграцию базы и 数据库迁移 plus asciimarker"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Pretend this index was written by the previous version.
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.Version = 11
+	if err := writeManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	// The manifest cache keys on mtime+size, and a version field is the same
+	// size either way — move the mtime so the cache cannot serve the old copy.
+	tick := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(filepath.Join(dir, "manifest.gob"), tick, tick); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureForSearch(dir, search.Options{Query: "миграцию", All: true}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Version != version {
+		t.Fatalf("index still at version %d — a stale-version index was served, not rebuilt", got.Version)
+	}
+	for _, q := range []string{"миграцию", "数据库迁移", "asciimarker"} {
+		ss, err := Search(dir, search.Options{Query: q, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ss) == 0 {
+			t.Errorf("query %q found nothing after the version upgrade", q)
+		}
+	}
+}

--- a/internal/index/version_upgrade_test.go
+++ b/internal/index/version_upgrade_test.go
@@ -66,3 +66,44 @@ func TestOlderIndexVersionIsRebuiltBeforeSearch(t *testing.T) {
 		}
 	}
 }
+
+// Hook paths never call Ensure, so they must be able to tell an older store
+// apart and ask for a rebuild instead of reading it. Reading a v11 store with
+// v12 code returns nothing for Russian and CJK while English still works —
+// silent, and the user has no way to see why.
+func TestIsCurrentVersionDetectsOlderStore(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"обсуждали миграцию базы"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !IsCurrentVersion(dir) {
+		t.Fatal("a freshly built index must report as current")
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.Version = version - 1
+	if err := writeManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	if IsCurrentVersion(dir) {
+		t.Fatal("an older store reported as current — hook paths would read it and silently recall nothing")
+	}
+	// And a store that was never built is not "current" either.
+	if IsCurrentVersion(filepath.Join(tmp, "nope")) {
+		t.Fatal("a missing index reported as current")
+	}
+}


### PR DESCRIPTION
`bucket()` sharded a token by slicing its first two **bytes**. For any non-ASCII token that is a one-byte prefix plus half a UTF-8 sequence, and `safe()` mapped the broken half to `_` — so every Russian, Chinese and Greek token in the corpus landed in the single bucket `t_`, and every lookup scanned the entire non-ASCII vocabulary. English spread over ~250 buckets.

Sharding by runes instead. ASCII bucket names stay byte-identical (asserted in the test, so English layout cannot drift); everything else hashes its first three runes over 256 buckets. Index version 11 -> 12 so existing indexes rebuild rather than quietly failing to find their old `t_` tokens.

Measured on MIRACL (100k-passage pool, full dev query sets), median search:

| | before | after |
|---|---|---|
| zh | 4.02s | 1.45s |
| ru | 1.50s | 186ms |

Chinese accuracy is bit-identical before and after (40.4 / 64.1 / 70.4 / 78.4, MRR 0.507) on the same 379 queries — as it must be for a pure layout change.

Also in here: `stemMatchForms` handed Cyrillic terms to the ASCII stemmer, which appended English suffixes to Russian words (`миграции` -> `миграцииed`) and only ever read empty buckets, so the relevance-tier fold shipped in #340 was a no-op. Cyrillic now routes through the Russian ending table, and the table gained the soft-stem endings (`ью`, `ям`, `ем`, `ом`, `ь`) without which stripping `ь` would strand the very forms the fold exists to reach.

English guards unchanged: LongMemEval 83.8 / 93.6 / 95.6 / 97.0 MRR 0.883 and LoCoMo 69.7 / 85.6 / 0.767, both byte-identical to main. Full `-race` suite green, lint clean.

On the upgrade: `TestOlderIndexVersionIsRebuiltBeforeSearch` flips a manifest back to version 11 and asserts the rebuild happens and that Russian, Chinese and ASCII are all still findable afterwards. One honest limitation — I tried to build a stronger fixture by rewriting the store into a single legacy `t_.bin` and the Russian token stayed reachable anyway, because several tiers (the substring one in particular) enumerate bucket directories rather than hashing to one. So a real v11 store degrades rather than going dark, and the test is named for what it proves rather than what I first assumed.

**Correction to the paragraph above.** An independent review built the v11 fixture I failed to build, and a genuine v11 store does *not* merely degrade. `Search` degrades because its substring tier enumerates bucket directories, but `ProjectRelevant` — the auto-recall path behind the prompt hook — hashes and returns nothing: Russian recall goes to zero while English keeps working. No hook path calls Ensure, so that window stays open until the user's first CLI or MCP command. Fixed here: `index.IsCurrentVersion` plus a warmup request on version mismatch rather than only on a missing manifest.

Also narrowed the Russian fold after the same review measured its blast radius. The bare `ь` ending folded `цель` onto `целая`, `верь` onto `вера`, `борись` onto `борис`, and it never paid for itself — `новость`->`новости` is taken by `ть` first, so its only real delivery was `сеть`->`сети`, the same shape as the false ones. Dropped. Separately, verb endings (`ть`, `л`, `ла`, `ло`, `ли`) no longer attach to a base under four runes, which was how `весом` reached `весть`. The relevance tier has no catalog gate, so these were real recalls, not just candidate forms. Known cost: `очередь`->`очереди` no longer folds.

**Fold, final shape, measured on a 20k Russian frequency list.** One table doing both stripping and re-attaching is what folded `цель` onto `целая`. They are now separate: a stem exposed by stripping a soft sign takes the soft paradigm, verb endings attach only where the stripped ending wasn't unambiguously noun-case (so `весом`→`вес` can't reach `весть` while `знаю`→`зна` still reaches `знать`), and a ь-final term takes both a noun and a verb branch since `ть` sorts ahead of `ь`.

Reachable fold pairs over the frequent 20k, counting only forms that are themselves real words:

| | pairs | hits/term | ь-final terms folding to nothing |
|---|---|---|---|
| before this PR | 33 575 | 1.68 | 66.1% |
| first narrowing (too blunt) | 31 964 | 1.60 | 72.8% |
| shipped here | 33 572 | 1.68 | 63.4% |

Same coverage as before, better on soft stems. The 199 pairs it drops versus the old behaviour are spurious (`верь`→`вера`, `голубь`→`голубой`, `цель`→`цел`, `изабель`→`изабелла`); the 196 it gains are real and never worked — the `-ость` nouns (`новость`→`новостей`, `активность`→`активности`), which were blocked because `ть` matched ahead of `ь`.

Known residual, left in deliberately: ь-final imperatives are not nouns and can still reach a real noun form (`верь`→`вере`). Stem length cannot separate that case, and it is far narrower than what it replaced.

**Measured on the shipping commit**, MIRACL Russian, 1252 dev queries, 100k-passage pool:

| ru | hit@1 | hit@5 | hit@10 | MRR | median |
|---|---|---|---|---|---|
| main | 54.9% | 64.8% | 67.0% | 0.593 | 1.148 s |
| this PR | **57.4%** | **67.2%** | **69.6%** | **0.617** | **170 ms** |

+2.5 points hit@1 and 6.8x faster. The corrected fold matches what the buggy one scored (57.3 hit@1) while no longer recalling цель for целая — the accuracy came from sharding and from folding that actually fires, not from the over-eager endings.

Across languages on the same harness and pool: en 60.4 / 69.4 / 0.637 at 79 ms, ru 57.4 / 69.6 / 0.617 at 170 ms, zh 40.4 / 70.4 / 0.507 at 1.45 s. Russian is within 3 points of English at hit@1 and level at hit@10. Chinese matches English at hit@10 but trails at top-1; that is a bigram-ranking problem in `RelevanceTerms`, diagnosed but deliberately not fixed here.
