### PR TITLE
fix(search): relevance results no longer render "0 matches"

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -280,7 +280,7 @@ func runSearch(dir string, args []string) error {
 	var hits []search.Hit
 	if result.Tier == search.TierRelevance {
 		fmt.Fprintln(os.Stderr, "deja: no exact match; showing sessions ranked by relevance to the whole query")
-		hits = search.RelevanceHits(ss, index.RelevanceTerms(o.Query))
+		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(o.Query))
 	} else if hits, err = search.Run(ss, o); err != nil {
 		return fmt.Errorf("run: %w", err)
 	}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -307,7 +307,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	}
 	var hits []search.Hit
 	if result.Tier == search.TierRelevance {
-		hits = search.RelevanceHits(ss, index.RelevanceTerms(q))
+		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(q))
 	} else if hits, err = search.Run(ss, o); err != nil {
 		return "", 0, 0, nil, err
 	}
@@ -433,7 +433,7 @@ func recallContextResult(dir, q, harness string) (string, int, int64, []string, 
 	}
 	var hits []search.Hit
 	if result.Tier == search.TierRelevance {
-		hits = search.RelevanceHits(ss, index.RelevanceTerms(q))
+		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(q))
 	} else if hits, err = search.Run(ss, o); err != nil {
 		return "", 0, 0, nil, err
 	}

--- a/internal/index/matchterms_test.go
+++ b/internal/index/matchterms_test.go
@@ -1,0 +1,35 @@
+package index
+
+import "testing"
+
+// A session can surface through the relevance tier's fold — "camped" ranking a
+// session that only ever says "camping". Callers count matches and cut
+// snippets by looking for the query's words in the text, so with the raw terms
+// alone such a result rendered as "0 matches" with no snippet.
+func TestRelevanceMatchTermsCarryFoldForms(t *testing.T) {
+	got := RelevanceMatchTerms("camped beside the lake")
+	first := map[string]int{}
+	for i, term := range got {
+		if _, seen := first[term]; !seen {
+			first[term] = i
+		}
+	}
+	if _, ok := first["camped"]; !ok {
+		t.Fatalf("raw query term missing: %v", got)
+	}
+	if _, ok := first["camping"]; !ok {
+		t.Fatalf("fold form %q missing, so a session saying it renders 0 matches: %v", "camping", got)
+	}
+	// Raw terms come first: callers that truncate keep the words the user typed.
+	if first["camping"] < first["camped"] {
+		t.Fatalf("fold forms must follow the raw terms: %v", got)
+	}
+	// No duplicates — the count is user-visible.
+	seen := map[string]bool{}
+	for _, term := range got {
+		if seen[term] {
+			t.Fatalf("duplicate term %q in %v", term, got)
+		}
+		seen[term] = true
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -208,6 +208,32 @@ func RelevanceTerms(q string) []string {
 	return out
 }
 
+// RelevanceMatchTerms returns the query's relevance terms plus the surface
+// forms the relevance tier actually matches on. Callers count and snippet
+// with these: a session surfaced through the fold ("camped" ranking a session
+// that says "camping") otherwise rendered as "0 matches" with no snippet,
+// because the raw term appears nowhere in its text.
+func RelevanceMatchTerms(q string) []string {
+	terms := RelevanceTerms(q)
+	out := make([]string, 0, len(terms))
+	seen := map[string]bool{}
+	for _, t := range terms {
+		if !seen[t] {
+			seen[t] = true
+			out = append(out, t)
+		}
+	}
+	for _, t := range terms {
+		for _, f := range stemMatchForms(t) {
+			if !seen[f] {
+				seen[f] = true
+				out = append(out, f)
+			}
+		}
+	}
+	return out
+}
+
 // relevanceSearch is the ladder's last resort: no AND survived, so rank every
 // session by IDF-weighted overlap with the query's informative words. Order
 // carries the ranking; callers must not re-sort by exact-match BM25 (the whole


### PR DESCRIPTION
The relevance tier ranks a session through folded forms — "camped" can rank a session that only ever says "camping" — but callers counted matches and cut snippets by looking for the *raw* query words, which appear nowhere in that text. The result rendered as "0 matches" with no snippet while still being displayed.

New `index.RelevanceMatchTerms` returns the query terms followed by the forms the tier actually matched on; the CLI and both MCP paths use it. Raw terms stay first so anything that truncates keeps the user's own words.

Test fails without the fix. Full `-race` suite green, lint clean.