### PR TITLE
fix(search): drop CJK function-word bigrams from query terms

### DIFF
--- a/internal/index/cjk.go
+++ b/internal/index/cjk.go
@@ -96,3 +96,42 @@ func expandCJKTokens(toks []string) []string {
 	}
 	return out
 }
+
+// cjkFunctionRunes are Chinese particles, pronouns and question words: the
+// closed class that carries no topic. A bigram made of two of them ("在哪",
+// "什么", "怎么") is grammar, not content — it is the CJK counterpart of a
+// stop word, and nothing else filters it because IsStopWord only knows
+// Latin and Cyrillic.
+//
+// The test is deliberately "both runes", not "either": 中 and 个 are function
+// runes on their own but carry meaning in 中国 and 个人, and dropping every
+// bigram that merely contains one would delete real words. This filter runs
+// at query time only — the index keeps every bigram, so nothing about
+// ingestion changes.
+var cjkFunctionRunes = map[rune]bool{
+	'的': true, '了': true, '是': true, '在': true, '和': true, '与': true,
+	'或': true, '而': true, '但': true, '就': true, '都': true, '也': true,
+	'还': true, '又': true, '再': true, '只': true, '才': true, '很': true,
+	'我': true, '你': true, '他': true, '她': true, '它': true, '们': true,
+	'这': true, '那': true, '些': true, '什': true, '么': true, '哪': true,
+	'怎': true, '呢': true, '吗': true, '吧': true, '啊': true, '之': true,
+	'其': true, '此': true, '所': true, '被': true, '把': true, '让': true,
+	'给': true, '向': true, '于': true, '以': true, '从': true, '到': true,
+	'由': true, '对': true, '因': true, '如': true, '若': true, '则': true,
+	'并': true, '且': true, '为': true, '个': true, '有': true, '会': true,
+}
+
+// cjkFunctionBigram reports whether every rune of a CJK token is a function
+// rune, i.e. the token is pure grammar.
+func cjkFunctionBigram(tok string) bool {
+	runes := []rune(tok)
+	if len(runes) < 2 {
+		return false
+	}
+	for _, r := range runes {
+		if !isCJK(r) || !cjkFunctionRunes[r] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/index/cjk_test.go
+++ b/internal/index/cjk_test.go
@@ -203,3 +203,41 @@ func TestRelevanceTermsKeepNonASCIILetters(t *testing.T) {
 		}
 	}
 }
+
+// A Chinese question expands into one bigram per adjacent character pair, so
+// the grammar of the question ("在哪", "什么") arrives as terms carrying the
+// same weight as the entity being asked about. Nothing else filters them:
+// IsStopWord only knows Latin and Cyrillic.
+func TestCJKFunctionBigramsAreNotQueryTerms(t *testing.T) {
+	has := func(terms []string, want string) bool {
+		for _, term := range terms {
+			if term == want {
+				return true
+			}
+		}
+		return false
+	}
+	terms := RelevanceTerms("复旦大学在哪个城市？")
+	for _, junk := range []string{"在哪", "哪个"} {
+		if has(terms, junk) {
+			t.Errorf("function bigram %q survived as a query term: %v", junk, terms)
+		}
+	}
+	for _, want := range []string{"复旦", "大学", "城市"} {
+		if !has(terms, want) {
+			t.Errorf("content bigram %q was dropped: %v", want, terms)
+		}
+	}
+	// The rule is "every rune is a function rune", not "any": these are real
+	// words built from characters that are function runes on their own.
+	if got := RelevanceTerms("中国有多少个人"); !has(got, "中国") || !has(got, "个人") {
+		t.Errorf("real words dropped from %q: %v", "中国有多少个人", got)
+	}
+	if got := RelevanceTerms("目的是什么"); !has(got, "目的") {
+		t.Errorf("real word 目的 dropped: %v", got)
+	}
+	// Latin is untouched — the filter requires CJK runes.
+	if got := RelevanceTerms("what is the database migration"); !has(got, "database") {
+		t.Errorf("ASCII query lost content terms: %v", got)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -202,6 +202,9 @@ func RelevanceTerms(q string) []string {
 		if len([]rune(f)) < 2 || (len(f) < 3 && !isCJK([]rune(f)[0])) || search.IsStopWord(f) || seen[f] {
 			continue
 		}
+		if cjkFunctionBigram(f) {
+			continue
+		}
 		seen[f] = true
 		out = append(out, f)
 	}


### PR DESCRIPTION
A Chinese question expands into one bigram per adjacent character pair, so `复旦大学在哪个城市？` becomes eight terms — including `在哪` and `哪个`, which are grammar, not content. Nothing filtered them: `IsStopWord` only knows Latin and Cyrillic. They weighed the same as `复旦`.

The rule is *every* rune is a function rune, not *any* — `中国`, `个人` and `目的` are real words built from characters that are function runes on their own, and dropping every bigram merely containing one would delete them. Query-side only: the index still stores every bigram, so ingestion is byte-for-byte unchanged and no version bump is involved.

| MIRACL zh (379 queries) | hit@1 | hit@5 | hit@10 | hit@20 | MRR |
|---|---|---|---|---|---|
| before | 40.4% | 64.1% | 70.4% | 78.4% | 0.507 |
| after | **42.5%** | **64.9%** | **71.0%** | **78.9%** | **0.525** |

Every metric moved up, no trade-off. Median search 1.350s -> 1.374s (+1.8%, noise on a run-to-run basis). Index build untouched — `cjkFunctionBigram` has exactly one caller, `RelevanceTerms`, which no ingest path reaches.

English guards byte-identical: LongMemEval 83.8 / 93.6 / 95.6 / 97.0 MRR 0.883, LoCoMo 69.7 / 85.6 / 0.766. Structurally they must be — the filter requires CJK runes — but measured rather than assumed.

**What I tried and dropped.** The change I expected to carry this was making the same-message co-occurrence multiplier count only *informative* terms, on the theory that junk bigrams were inflating it. Measured on its own it did nothing at all on Chinese — byte-identical to baseline — and on English it was a wash at best (LongMemEval hit@5 +0.4, LoCoMo hit@1 −0.2, MRR −0.002). It is not in this PR.

Stacked on #351; the remaining gap to English is a bigram-ranking problem that filters cannot close.