### PR TITLE
perf(index): intern record keys and source paths

### DIFF
--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -311,13 +311,13 @@ func TestBucketRecordGobAndRecoveryErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = devNull.Close() }()
-	if _, err := readRecordAt(devNull, 1); err == nil && runtime.GOOS != "windows" {
+	if _, err := readRecordAt(devNull, 1, newRecordTables()); err == nil && runtime.GOOS != "windows" {
 		t.Fatal("readRecordAt bad seek returned nil")
 	}
-	if _, err := readRecord(&buf); !errors.Is(err, io.EOF) {
+	if _, err := readRecord(&buf, newRecordTables()); !errors.Is(err, io.EOF) {
 		t.Fatalf("empty readRecord err=%v", err)
 	}
-	if _, err := decodeRecord([]byte{1, 'k'}); !errors.Is(err, io.ErrUnexpectedEOF) {
+	if _, err := decodeRecord([]byte{1, 'k'}, newRecordTables()); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("short decode err=%v", err)
 	}
 	gobPath := filepath.Join(tmp, "bad.gob")
@@ -523,17 +523,20 @@ func TestCurrentFilesAllHarnessesAndRecordEdgeCases(t *testing.T) {
 	if lastCompleteLineOffset(noNL, 3) != 0 {
 		t.Fatal("unterminated short file did not return 0")
 	}
-	buf := appendField(nil, "k")
-	if _, err := decodeRecord(buf); !errors.Is(err, io.ErrUnexpectedEOF) {
+	// A record is [keyID][pathID][role][time][text]; truncating at each
+	// boundary must fail cleanly rather than return a half-built record.
+	rtbl := testTables(Record{Key: "k", SourcePath: "src"})
+	buf := binary.AppendUvarint(nil, rtbl.intern("k"))
+	if _, err := decodeRecord(buf, rtbl); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("decode missing source err=%v", err)
 	}
-	buf = appendField(buf, "src")
+	buf = binary.AppendUvarint(buf, rtbl.intern("src"))
 	buf = appendField(buf, "role")
-	if rec, err := decodeRecord(buf); !errors.Is(err, io.ErrUnexpectedEOF) || rec.Key != "k" {
+	if rec, err := decodeRecord(buf, rtbl); !errors.Is(err, io.ErrUnexpectedEOF) || rec.Key != "k" || rec.SourcePath != "src" {
 		t.Fatalf("decode missing time rec=%#v err=%v", rec, err)
 	}
 	buf = binary.LittleEndian.AppendUint64(buf, uint64(time.Now().UnixNano()))
-	if _, err := decodeRecord(buf); !errors.Is(err, io.ErrUnexpectedEOF) {
+	if _, err := decodeRecord(buf, rtbl); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("decode missing text err=%v", err)
 	}
 	if _, err := scanRecords(filepath.Join(tmp, "missing-index"), Manifest{}, search.Options{}, nil); err == nil {
@@ -813,7 +816,7 @@ func TestRequestedCodecLineAndSubstringBranches(t *testing.T) {
 		appendField(nil, "key"),
 		[]byte("garbage"),
 	} {
-		if _, err := decodeRecord(data); !errors.Is(err, io.ErrUnexpectedEOF) {
+		if _, err := decodeRecord(data, newRecordTables()); !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Fatalf("decodeRecord(%v) err=%v", data, err)
 		}
 	}
@@ -826,7 +829,7 @@ func TestRequestedCodecLineAndSubstringBranches(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	if _, err := readRecordAt(f, 99); !errors.Is(err, io.EOF) {
+	if _, err := readRecordAt(f, 99, newRecordTables()); !errors.Is(err, io.EOF) {
 		t.Fatalf("readRecordAt bad offset err=%v", err)
 	}
 

--- a/internal/index/coverage_recover2_test.go
+++ b/internal/index/coverage_recover2_test.go
@@ -27,7 +27,7 @@ func TestRecordIOErrorsViaClosedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := newRecordWriter(f); err == nil {
+	if _, err := newRecordWriter(f, newRecordTables()); err == nil {
 		t.Fatal("newRecordWriter on closed file returned nil error")
 	}
 
@@ -42,7 +42,7 @@ func TestRecordIOErrorsViaClosedFile(t *testing.T) {
 	if err := f2.Close(); err != nil {
 		t.Fatal(err)
 	}
-	rw := &recordWriter{f: f2, w: bufio.NewWriterSize(f2, 1)}
+	rw := &recordWriter{f: f2, w: bufio.NewWriterSize(f2, 1), tables: newRecordTables()}
 	if _, err := rw.write(rec); err == nil {
 		t.Fatal("write on closed file returned nil error")
 	}
@@ -59,7 +59,7 @@ func TestRecordIOErrorsViaClosedFile(t *testing.T) {
 	if err := f2b.Close(); err != nil {
 		t.Fatal(err)
 	}
-	rwBig := &recordWriter{f: f2b, w: bufio.NewWriterSize(f2b, 8)}
+	rwBig := &recordWriter{f: f2b, w: bufio.NewWriterSize(f2b, 8), tables: newRecordTables()}
 	if _, err := rwBig.write(rec); err == nil {
 		t.Fatal("write (body) on closed file returned nil error")
 	}
@@ -74,7 +74,7 @@ func TestRecordIOErrorsViaClosedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f3.Close()
-	if _, err := writeRecord(f3, rec); err == nil {
+	if _, err := writeRecord(f3, rec, newRecordTables()); err == nil {
 		t.Fatal("writeRecord on a read-only file returned nil error")
 	}
 
@@ -85,7 +85,7 @@ func TestRecordIOErrorsViaClosedFile(t *testing.T) {
 	if err := f4.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := readRecordAt(f4, 0); err == nil {
+	if _, err := readRecordAt(f4, 0, newRecordTables()); err == nil {
 		t.Fatal("readRecordAt on closed file returned nil error")
 	}
 }
@@ -226,7 +226,10 @@ func TestExportDefaultDirSourceFallbackAndOrphanSkip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rw, err := newRecordWriter(rf)
+	// Appending continues the index's own string table; a fresh one would
+	// hand id 0 to a new string and repoint records that already use it.
+	atbl := mustTables(t, dir)
+	rw, err := newRecordWriter(rf, atbl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,6 +240,14 @@ func TestExportDefaultDirSourceFallbackAndOrphanSkip(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := rw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	am, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	am.RecordStrings = atbl.strs
+	if err := writeManifest(dir, am); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/index/coverage_recover3_test.go
+++ b/internal/index/coverage_recover3_test.go
@@ -40,7 +40,7 @@ func TestLastCompleteLineOffsetReadAtError(t *testing.T) {
 func TestDecodeRecordMissingRole(t *testing.T) {
 	buf := appendField(nil, "key")
 	buf = appendField(buf, "src")
-	if _, err := decodeRecord(buf); err == nil {
+	if _, err := decodeRecord(buf, newRecordTables()); err == nil {
 		t.Fatal("decodeRecord missing role field returned nil error")
 	}
 }
@@ -54,7 +54,7 @@ func TestEachRecordNonEOFReadError(t *testing.T) {
 	if err := os.MkdirAll(dirAsFile, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := eachRecord(dirAsFile, func(Record) {}); err == nil {
+	if err := eachRecord(dirAsFile, newRecordTables(), func(Record) {}); err == nil {
 		t.Fatal("eachRecord over a directory returned nil error")
 	}
 }
@@ -101,7 +101,7 @@ func TestImportedSessionsOrphanRecordSkipped(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rw, err := newRecordWriter(rf)
+	rw, err := newRecordWriter(rf, newRecordTables())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestScanRecordsMetaMissingAndOpenError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rw, err := newRecordWriter(rf)
+	rw, err := newRecordWriter(rf, newRecordTables())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func TestUpdateIndexReplacePathOrphanRecordsDropped(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rw, err := newRecordWriter(rf)
+	rw, err := newRecordWriter(rf, newRecordTables())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/deepverify.go
+++ b/internal/index/deepverify.go
@@ -129,7 +129,8 @@ func DeepVerify(dir string) (DeepReport, error) {
 
 	// 3. Dead postings: a sample of tokens must resolve to readable records.
 	catalog, err := tokenCatalog(dir)
-	if err == nil {
+	dvTables, dvErr := loadRecordTables(dir)
+	if err == nil && dvErr == nil {
 		f, ferr := os.Open(recordsPath(dir))
 		if ferr == nil {
 			defer func() { _ = f.Close() }()
@@ -139,7 +140,7 @@ func DeepVerify(dir string) (DeepReport, error) {
 					continue
 				}
 				report.SampledPostings++
-				if _, rerr := readRecordAt(f, posts[0].Off); rerr != nil {
+				if _, rerr := readRecordAt(f, posts[0].Off, dvTables); rerr != nil {
 					report.Findings = append(report.Findings, DeepFinding{Kind: "dead-posting", Detail: fmt.Sprintf("token %q points at unreadable record offset %d", tok, posts[0].Off)})
 				}
 			}
@@ -153,7 +154,11 @@ func recordsPath(dir string) string { return filepath.Join(dir, "records.bin") }
 // indexedMessageCounts counts records per session key straight from the log.
 func indexedMessageCounts(dir string) (map[string]int, error) {
 	counts := map[string]int{}
-	err := eachRecord(recordsPath(dir), func(r Record) {
+	tbl, terr := loadRecordTables(dir)
+	if terr != nil {
+		return nil, terr
+	}
+	err := eachRecord(recordsPath(dir), tbl, func(r Record) {
 		counts[r.Key]++
 	})
 	return counts, err

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -10,9 +10,9 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
-// version 12 reshards non-ASCII tokens across buckets; an index built by 11
-// keeps them all under "t_", where the new lookup would never find them.
-const version = 12
+// version 12 resharded non-ASCII tokens across buckets; 13 interns the key
+// and source path of every record, which an older log spells out in full.
+const version = 13
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message
@@ -92,6 +92,10 @@ type Manifest struct {
 	// stamps a whole session with one timestamp.
 	ExportBoundary  map[string][]uint64 `json:"export_boundary,omitempty"`
 	ImportedRecords map[string]bool     `json:"imported_records,omitempty"`
+	// RecordStrings interns the keys and source paths of records.bin; a
+	// record stores an index into this table instead of repeating the
+	// strings. Append-only, so an appended log keeps resolving.
+	RecordStrings []string `json:"record_strings,omitempty"`
 	// RecordsSize is records.bin's byte length when the manifest was committed.
 	// A live index whose records.bin is shorter than this lost its tail to a
 	// torn write and must be treated as corrupt.
@@ -120,6 +124,7 @@ type manifestCore struct {
 	ExportWatermarks map[string]int64
 	ExportBoundary   map[string][]uint64
 	ImportedRecords  map[string]bool
+	RecordStrings    []string
 	RecordsSize      int64
 	IngestHealth     map[string]HarnessIngest
 }
@@ -193,9 +198,10 @@ type msgSeen map[string]bool
 // the file offset in memory: the hot rebuild path used to pay a Seek syscall
 // per record, which dominated cold-rebuild profiles.
 type recordWriter struct {
-	f   *os.File
-	w   *bufio.Writer
-	off int64
+	f      *os.File
+	w      *bufio.Writer
+	off    int64
+	tables *recordTables
 }
 
 type bucketEntry struct {

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -93,7 +93,8 @@ func TestReadRecordsAndGeneration(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := Record{Key: "claude:s", SourcePath: "session.jsonl", Role: "user", Text: "semantic text", Time: time.Unix(10, 20)}
-	off, err := writeRecord(f, want)
+	wtbl := newRecordTables()
+	off, err := writeRecord(f, want, wtbl)
 	if err != nil {
 		_ = f.Close()
 		t.Fatal(err)
@@ -101,9 +102,15 @@ func TestReadRecordsAndGeneration(t *testing.T) {
 	if off != 0 || f.Close() != nil {
 		t.Fatal("record write did not start at zero")
 	}
+	if err := writeManifest(dir, Manifest{Version: version, Sessions: map[string]SessionMeta{}, RecordStrings: wtbl.strs}); err != nil {
+		t.Fatal(err)
+	}
 	got, err := ReadRecords(dir)
 	if err != nil || len(got) != 1 || got[0].Offset != 0 || got[0].Record.Text != want.Text || got[0].Record.Time != want.Time {
 		t.Fatalf("records=%#v err=%v", got, err)
+	}
+	if got[0].Record.Key != want.Key || got[0].Record.SourcePath != want.SourcePath {
+		t.Fatalf("interned fields lost: key=%q path=%q", got[0].Record.Key, got[0].Record.SourcePath)
 	}
 	if err := writeManifest(dir, Manifest{Version: version, BuiltAt: time.Unix(20, 0), Generation: "gen-1", Sessions: map[string]SessionMeta{}}); err != nil {
 		t.Fatal(err)
@@ -318,7 +325,9 @@ func TestMultiWordSearchUsesAllPostingsAndDoesNotFullScan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = writeRecord(rec, Record{Key: "claude:unposted", Role: "user", Text: "jwt only refresh would appear during a full scan", Time: time.Now()})
+	utbl := mustTables(t, dir)
+	_, err = writeRecord(rec, Record{Key: "claude:unposted", Role: "user", Text: "jwt only refresh would appear during a full scan", Time: time.Now()}, utbl)
+	m.RecordStrings = utbl.strs
 	if closeErr := rec.Close(); err != nil {
 		t.Fatal(err)
 	} else if closeErr != nil {
@@ -518,7 +527,7 @@ func TestIndexRecentFindRecordsAndBranches(t *testing.T) {
 	if got, ok, err := FindByPrefix(idx, "s"); err != nil || !ok || len(got.Messages) != 2 {
 		t.Fatalf("FindByPrefix=%#v ok=%v err=%v", got, ok, err)
 	}
-	recs, err := recordsForKey(filepath.Join(idx, "records.bin"), "claude:s1")
+	recs, err := recordsForKey(filepath.Join(idx, "records.bin"), mustTables(t, idx), "claude:s1")
 	if err != nil || len(recs) != 2 {
 		t.Fatalf("records=%#v err=%v", recs, err)
 	}
@@ -742,7 +751,8 @@ func TestEachRecordIgnoresTruncatedTail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := writeRecord(f, Record{Key: "claude:s1", SourcePath: "s1.jsonl", Role: "user", Text: "complete"}); err != nil {
+	ttbl := newRecordTables()
+	if _, err := writeRecord(f, Record{Key: "claude:s1", SourcePath: "s1.jsonl", Role: "user", Text: "complete"}, ttbl); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := f.Write([]byte{99, 0, 0, 0, '{'}); err != nil {
@@ -752,7 +762,7 @@ func TestEachRecordIgnoresTruncatedTail(t *testing.T) {
 		t.Fatal(err)
 	}
 	var got []Record
-	if err := eachRecord(p, func(r Record) { got = append(got, r) }); err != nil {
+	if err := eachRecord(p, ttbl, func(r Record) { got = append(got, r) }); err != nil {
 		t.Fatal(err)
 	}
 	if len(got) != 1 || got[0].Text != "complete" {

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -225,7 +225,8 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	if err != nil {
 		return err
 	}
-	rw, err := newRecordWriter(rf)
+	tbl := newRecordTables()
+	rw, err := newRecordWriter(rf, tbl)
 	if err != nil {
 		_ = rf.Close()
 		return err
@@ -283,6 +284,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 		return err
 	}
 	setOpencodeLastUpdated(m.Files, m.Sessions)
+	m.RecordStrings = tbl.strs
 	if err := writeManifest(tmp, m); err != nil {
 		return err
 	}
@@ -305,7 +307,7 @@ func importedSessions(dir string) importedState {
 	out.boundary = m.ExportBoundary
 	out.dedupe = m.ImportedRecords
 	by := map[string]*model.Session{}
-	_ = eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
+	_ = eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
 		if r.SourcePath != syncImportPath {
 			return
 		}
@@ -419,7 +421,8 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	if err != nil {
 		return err
 	}
-	rw, err := newRecordWriter(rf)
+	tbl := newRecordTables()
+	rw, err := newRecordWriter(rf, tbl)
 	if err != nil {
 		_ = rf.Close()
 		return err
@@ -475,6 +478,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 		return err
 	}
 	setOpencodeLastUpdated(m.Files, m.Sessions)
+	m.RecordStrings = tbl.strs
 	if err := writeManifest(tmp, m); err != nil {
 		return err
 	}
@@ -682,9 +686,9 @@ func truncateTitle(s string, n int) string {
 	return strings.TrimSpace(string(r[:n])) + "…"
 }
 
-func recordsForKey(path, key string) ([]Record, error) {
+func recordsForKey(path string, t *recordTables, key string) ([]Record, error) {
 	var out []Record
-	err := eachRecord(path, func(r Record) {
+	err := eachRecord(path, t, func(r Record) {
 		if r.Key == key {
 			out = append(out, r)
 		}
@@ -858,7 +862,8 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	if err != nil {
 		return err
 	}
-	rw, err := newRecordWriter(rf)
+	tbl := newRecordTables()
+	rw, err := newRecordWriter(rf, tbl)
 	if err != nil {
 		_ = rf.Close()
 		return err
@@ -912,7 +917,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		return nil
 	}
 	var recErr error
-	if err := eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
+	if err := eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(old), func(r Record) {
 		if recErr != nil {
 			return
 		}
@@ -982,6 +987,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		return err
 	}
 	setOpencodeLastUpdated(m.Files, m.Sessions)
+	m.RecordStrings = tbl.strs
 	if err := writeManifest(tmp, m); err != nil {
 		return err
 	}
@@ -1020,7 +1026,11 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	if err != nil {
 		return 0, 0, err
 	}
-	rw, err := newRecordWriter(rf)
+	// The log is being APPENDED to, so ids must continue where the existing
+	// records left off. Starting a fresh table would hand id 0 to a new
+	// string and silently repoint every record that already uses it.
+	tbl := tablesFromManifest(old)
+	rw, err := newRecordWriter(rf, tbl)
 	if err != nil {
 		_ = rf.Close()
 		return 0, 0, err
@@ -1117,6 +1127,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 		return filesTouched, messages, err
 	}
 	setOpencodeLastUpdated(m.Files, m.Sessions)
+	m.RecordStrings = tbl.strs
 	if err := writeManifest(dir, m); err != nil {
 		return filesTouched, messages, err
 	}

--- a/internal/index/integration_test.go
+++ b/internal/index/integration_test.go
@@ -158,7 +158,7 @@ func TestRebuildDeterminism(t *testing.T) {
 			t.Fatal(err)
 		}
 		msgs := 0
-		_ = eachRecord(filepath.Join(dir, "records.bin"), func(r Record) { msgs++ })
+		_ = eachRecord(filepath.Join(dir, "records.bin"), mustTables(t, dir), func(r Record) { msgs++ })
 		return len(m.Sessions), msgs
 	}
 	s1, m1 := count()

--- a/internal/index/intern_test.go
+++ b/internal/index/intern_test.go
@@ -1,0 +1,126 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	search "github.com/vshulcz/deja-vu/internal/query"
+)
+
+// Records intern their key and source path into a table stored in the
+// manifest. The table is append-only, so a log that grows must keep the ids
+// it already handed out: restarting the table would give id 0 to a new string
+// and silently repoint every record already using it — a message would come
+// back attributed to a different session.
+func TestInternedIDsSurviveIncrementalAppend(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(id, ts, text string) string {
+		return `{"type":"user","sessionId":"` + id + `","timestamp":"` + ts + `","message":{"role":"user","content":"` + text + `"}}` + "\n"
+	}
+	// Two sessions up front, so the table already holds s1's strings at the
+	// low ids.
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"),
+		[]byte(line("s1", "2026-01-02T03:04:05Z", "alpha first message")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(proj, "s2.jsonl"),
+		[]byte(line("s2", "2026-01-02T04:04:05Z", "bravo first message")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Grow ONLY the second session. A restarted table would intern s2's key
+	// as id 0 — the id s1 already owns — and s1's existing records would come
+	// back attributed to s2. Adding a file instead would force a full rebuild
+	// and never exercise the append path.
+	if err := os.WriteFile(filepath.Join(proj, "s2.jsonl"),
+		[]byte(line("s2", "2026-01-02T04:04:05Z", "bravo first message")+
+			line("s2", "2026-01-02T04:05:05Z", "bravo second message")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Every record must still name the session it belongs to.
+	tbl, err := loadRecordTables(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byText := map[string]string{}
+	if err := eachRecord(filepath.Join(dir, "records.bin"), tbl, func(r Record) {
+		byText[r.Text] = r.Key
+		if _, ok := m.Sessions[r.Key]; !ok {
+			t.Errorf("record %q resolved to key %q, which is not a session", r.Text, r.Key)
+		}
+		if r.SourcePath == "" {
+			t.Errorf("record %q lost its source path", r.Text)
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for text, want := range map[string]string{
+		"alpha first message":  "claude:s1",
+		"bravo first message":  "claude:s2",
+		"bravo second message": "claude:s2",
+	} {
+		if got := byText[text]; got != want {
+			t.Errorf("record %q attributed to %q, want %q", text, got, want)
+		}
+	}
+	// And the whole thing is still searchable per session.
+	for _, c := range []struct{ q, id string }{{"alpha first message", "s1"}, {"bravo second message", "s2"}} {
+		ss, err := Search(dir, search.Options{Query: c.q, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ss) != 1 || ss[0].ID != c.id {
+			t.Errorf("search %q returned %d sessions, want just %s", c.q, len(ss), c.id)
+		}
+	}
+}
+
+// The table only ever grows, so ids already in use keep their meaning.
+func TestInternedIDsAreStable(t *testing.T) {
+	tbl := newRecordTables()
+	a := tbl.intern("claude:one")
+	b := tbl.intern("/path/one.jsonl")
+	if a == b {
+		t.Fatal("distinct strings shared an id")
+	}
+	if again := tbl.intern("claude:one"); again != a {
+		t.Fatalf("id changed on re-intern: %d then %d", a, again)
+	}
+	// A reader rebuilt from the persisted slice resolves the same way.
+	rt := tablesFromStrings(tbl.strs)
+	if rt.lookup(a) != "claude:one" || rt.lookup(b) != "/path/one.jsonl" {
+		t.Fatalf("round trip lost ids: %q %q", rt.lookup(a), rt.lookup(b))
+	}
+	// Continuing a persisted table must not reuse an id.
+	grown := tablesFromStrings(tbl.strs)
+	c := grown.intern("claude:two")
+	if c == a || c == b {
+		t.Fatalf("new string reused id %d", c)
+	}
+	if grown.lookup(a) != "claude:one" {
+		t.Fatal("growing the table repointed an existing id")
+	}
+	// An unknown id resolves to empty rather than panicking or aliasing.
+	if got := rt.lookup(uint64(len(tbl.strs)) + 5); got != "" {
+		t.Fatalf("out-of-range id resolved to %q", got)
+	}
+}

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -95,7 +95,7 @@ func readManifest(dir string) (Manifest, error) {
 	if err := readGob(filepath.Join(dir, "manifest.gob"), &core); err != nil {
 		return Manifest{}, err
 	}
-	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ExportBoundary: core.ExportBoundary, ImportedRecords: core.ImportedRecords, RecordsSize: core.RecordsSize, IngestHealth: core.IngestHealth, Sessions: map[string]SessionMeta{}}
+	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ExportBoundary: core.ExportBoundary, ImportedRecords: core.ImportedRecords, RecordStrings: core.RecordStrings, RecordsSize: core.RecordsSize, IngestHealth: core.IngestHealth, Sessions: map[string]SessionMeta{}}
 	if err := readGob(filepath.Join(dir, "sessions.gob"), &m.Sessions); err != nil {
 		return Manifest{}, err
 	}
@@ -112,7 +112,7 @@ func readManifest(dir string) (Manifest, error) {
 // for updates that change only core fields (e.g. export watermarks) where the
 // caller has not loaded sessions and must not clobber them.
 func writeManifestOnly(dir string, m Manifest) error {
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, IngestHealth: m.IngestHealth}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}
@@ -121,7 +121,7 @@ func writeManifestOnly(dir string, m Manifest) error {
 
 func writeManifest(dir string, m Manifest) error {
 	mergeIngestDiag(&m)
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, IngestHealth: m.IngestHealth}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}

--- a/internal/index/privacy_test.go
+++ b/internal/index/privacy_test.go
@@ -25,16 +25,17 @@ func TestForgetTombstoneLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := writeRecord(f, Record{Key: "claude:abc123", Role: "user", Text: "one", Time: time.Now()}); err != nil {
+	ptbl := newRecordTables()
+	if _, err := writeRecord(f, Record{Key: "claude:abc123", Role: "user", Text: "one", Time: time.Now()}, ptbl); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := writeRecord(f, Record{Key: "claude:keep", Role: "user", Text: "two", Time: time.Now()}); err != nil {
+	if _, err := writeRecord(f, Record{Key: "claude:keep", Role: "user", Text: "two", Time: time.Now()}, ptbl); err != nil {
 		t.Fatal(err)
 	}
 	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeManifest(dir, Manifest{Version: version, Files: map[string]FileState{}, Sessions: map[string]SessionMeta{
+	if err := writeManifest(dir, Manifest{Version: version, Files: map[string]FileState{}, RecordStrings: ptbl.strs, Sessions: map[string]SessionMeta{
 		"claude:abc123": {ID: "abc123", Harness: "claude", Project: "secret", Updated: time.Now()},
 		"claude:keep":   {ID: "keep", Harness: "claude", Project: "public", Updated: time.Now()},
 	}}); err != nil {

--- a/internal/index/record_alloc_test.go
+++ b/internal/index/record_alloc_test.go
@@ -14,7 +14,7 @@ func TestReadRecordRejectsHugeLengthPrefix(t *testing.T) {
 	if err := os.WriteFile(p, append(hdr[:], 'x'), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	err := eachRecord(p, func(Record) { t.Fatal("should not decode a corrupt record") })
+	err := eachRecord(p, newRecordTables(), func(Record) { t.Fatal("should not decode a corrupt record") })
 	if err == nil || !IsCorrupt(err) {
 		t.Fatalf("expected corrupt-index error, got %v", err)
 	}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -752,6 +752,10 @@ func RecentProject(dir, project string, n int) ([]model.Session, error) {
 // records.bin. The per-session variant re-scanned the whole log for every
 // session, which turned a session-start hook into hundreds of milliseconds.
 func sessionsForMetas(dir string, metas []SessionMeta) ([]model.Session, error) {
+	tbl, terr := loadRecordTables(dir)
+	if terr != nil {
+		return nil, terr
+	}
 	want := make(map[string]int, len(metas))
 	out := make([]model.Session, len(metas))
 	for i, meta := range metas {
@@ -762,7 +766,7 @@ func sessionsForMetas(dir string, metas []SessionMeta) ([]model.Session, error) 
 	for k := range want {
 		keys[k] = true
 	}
-	err := eachRecordForKeys(filepath.Join(dir, "records.bin"), keys, func(r Record) {
+	err := eachRecordForKeys(filepath.Join(dir, "records.bin"), tbl, keys, func(r Record) {
 		if i, ok := want[r.Key]; ok {
 			out[i].Messages = append(out[i].Messages, model.Message{Role: r.Role, Text: r.Text, Time: r.Time})
 		}
@@ -839,7 +843,7 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 	sort.Slice(matches, func(i, j int) bool { return matches[i].Updated.After(matches[j].Updated) })
 	meta := matches[0]
 	s := sessionFromMeta(meta)
-	recs, err := recordsForKey(filepath.Join(dir, "records.bin"), meta.Harness+":"+meta.ID)
+	recs, err := recordsForKey(filepath.Join(dir, "records.bin"), tablesFromManifest(m), meta.Harness+":"+meta.ID)
 	if err != nil {
 		return model.Session{}, false, err
 	}
@@ -888,12 +892,12 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		defer func() { _ = f.Close() }()
 		offsets = sortedUniqueOffsets(offsets)
 		for _, off := range offsets {
-			if r, err := readRecordAt(f, off); err == nil && recordMatchesQueryVariants(r, o, variants) {
+			if r, err := readRecordAt(f, off, tablesFromManifest(m)); err == nil && recordMatchesQueryVariants(r, o, variants) {
 				add(r)
 			}
 		}
 	} else {
-		if err := eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
+		if err := eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
 			if recordMatchesQueryVariants(r, o, variants) {
 				add(r)
 			}

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -13,6 +13,10 @@ import (
 )
 
 func ReadRecords(dir string) ([]OffsetRecord, error) {
+	t, err := loadRecordTables(dir)
+	if err != nil {
+		return nil, err
+	}
 	var out []OffsetRecord
 	f, err := os.Open(filepath.Join(dir, "records.bin"))
 	if err != nil {
@@ -24,7 +28,7 @@ func ReadRecords(dir string) ([]OffsetRecord, error) {
 		if err != nil {
 			return nil, err
 		}
-		r, err := readRecord(f)
+		r, err := readRecord(f, t)
 		if err == io.EOF {
 			break
 		}
@@ -47,16 +51,16 @@ func Generation(dir string) (string, error) {
 	return m.BuiltAt.UTC().Format(time.RFC3339Nano), nil
 }
 
-func newRecordWriter(f *os.File) (*recordWriter, error) {
+func newRecordWriter(f *os.File, t *recordTables) (*recordWriter, error) {
 	off, err := f.Seek(0, io.SeekEnd)
 	if err != nil {
 		return nil, err
 	}
-	return &recordWriter{f: f, w: bufio.NewWriterSize(f, 1<<20), off: off}, nil
+	return &recordWriter{f: f, w: bufio.NewWriterSize(f, 1<<20), off: off, tables: t}, nil
 }
 
 func (rw *recordWriter) write(r Record) (int64, error) {
-	b := encodeRecord(r)
+	b := encodeRecord(r, rw.tables)
 	if len(b) > 1<<31 {
 		return 0, fmt.Errorf("record too large")
 	}
@@ -88,12 +92,12 @@ func (rw *recordWriter) Close() error {
 	return cerr
 }
 
-func writeRecord(f *os.File, r Record) (int64, error) {
+func writeRecord(f *os.File, r Record, t *recordTables) (int64, error) {
 	off, err := f.Seek(0, io.SeekCurrent)
 	if err != nil {
 		return 0, err
 	}
-	b := encodeRecord(r)
+	b := encodeRecord(r, t)
 	if len(b) > 1<<31 {
 		return 0, fmt.Errorf("record too large")
 	}
@@ -106,14 +110,14 @@ func writeRecord(f *os.File, r Record) (int64, error) {
 	return off, err
 }
 
-func readRecordAt(f *os.File, off int64) (Record, error) {
+func readRecordAt(f *os.File, off int64, t *recordTables) (Record, error) {
 	if _, err := f.Seek(off, io.SeekStart); err != nil {
 		return Record{}, err
 	}
-	return readRecord(f)
+	return readRecord(f, t)
 }
 
-func eachRecord(path string, fn func(Record)) error {
+func eachRecord(path string, t *recordTables, fn func(Record)) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
@@ -121,7 +125,7 @@ func eachRecord(path string, fn func(Record)) error {
 	defer func() { _ = f.Close() }()
 	r := bufio.NewReaderSize(f, 1024*1024)
 	for {
-		rec, err := readRecord(r)
+		rec, err := readRecord(r, t)
 		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			return nil
 		}
@@ -132,7 +136,7 @@ func eachRecord(path string, fn func(Record)) error {
 	}
 }
 
-func readRecord(r io.Reader) (Record, error) {
+func readRecord(r io.Reader, t *recordTables) (Record, error) {
 	var hdr [4]byte
 	if _, err := io.ReadFull(r, hdr[:]); err != nil {
 		return Record{}, err
@@ -145,13 +149,13 @@ func readRecord(r io.Reader) (Record, error) {
 	if _, err := io.ReadFull(r, b); err != nil {
 		return Record{}, err
 	}
-	return decodeRecord(b)
+	return decodeRecord(b, t)
 }
 
 // eachRecordForKeys walks the log decoding only records whose Key is in
 // want; other bodies are skipped after peeking the key field. On a large log
 // this trades a full decode of every record for a few length reads.
-func eachRecordForKeys(path string, want map[string]bool, fn func(Record)) error {
+func eachRecordForKeys(path string, t *recordTables, want map[string]bool, fn func(Record)) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
@@ -177,11 +181,11 @@ func eachRecordForKeys(path string, want map[string]bool, fn func(Record)) error
 			}
 			return err
 		}
-		key, _, ok := consumeField(b)
-		if !ok || !want[key] {
+		kid, un := binary.Uvarint(b)
+		if un <= 0 || !want[t.lookup(kid)] {
 			continue
 		}
-		rec, derr := decodeRecord(b)
+		rec, derr := decodeRecord(b, t)
 		if derr != nil {
 			continue
 		}
@@ -193,10 +197,78 @@ func eachRecordForKeys(path string, want map[string]bool, fn func(Record)) error
 // always stored it, so it stays the on-disk marker for "never stamped".
 var zeroTimeUnixNano = time.Time{}.UnixNano()
 
-func encodeRecord(r Record) []byte {
-	b := make([]byte, 0, len(r.Key)+len(r.SourcePath)+len(r.Role)+len(r.Text)+32)
-	b = appendField(b, r.Key)
-	b = appendField(b, r.SourcePath)
+// recordTables interns the two fields every record used to repeat verbatim.
+// A corpus of 57k messages held only 90 distinct source paths and 1073
+// distinct keys, so writing them per record cost 7.3 MB — 15% of the record
+// log — to store 1163 strings.
+//
+// The table is its own thing, deliberately not the session Ord: reusing Ord
+// would make a record's identity depend on the manifest's Ord bookkeeping
+// being right, turning an Ord bug from "postings merged" into "this message
+// belongs to a different session". The table is written by the same pass that
+// writes the records and swapped with them.
+type recordTables struct {
+	strs []string
+	id   map[string]uint64
+}
+
+func newRecordTables() *recordTables {
+	return &recordTables{id: map[string]uint64{}}
+}
+
+// tablesFromStrings is the read path: resolving an id is a slice index, so
+// the string->id map is left nil and built lazily only if something interns.
+// Building it eagerly here cost a map of every string in the corpus on every
+// search.
+func tablesFromStrings(strs []string) *recordTables {
+	return &recordTables{strs: strs}
+}
+
+func tablesFromManifest(m Manifest) *recordTables { return tablesFromStrings(m.RecordStrings) }
+
+func loadRecordTables(dir string) (*recordTables, error) {
+	// Cached: this sits on the search path, and re-decoding the whole
+	// manifest per query is what the interning was meant to avoid paying for.
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return nil, err
+	}
+	return tablesFromManifest(m), nil
+}
+
+// intern returns the id for s, appending it on first sight. Ids are stable:
+// the table only ever grows, so an appended record log keeps resolving.
+func (t *recordTables) intern(s string) uint64 {
+	if t.id == nil {
+		// A zero-value table is usable; callers that build a writer by hand
+		// should not have to know about the map.
+		t.id = make(map[string]uint64, len(t.strs)+8)
+		for i, v := range t.strs {
+			if _, ok := t.id[v]; !ok {
+				t.id[v] = uint64(i)
+			}
+		}
+	}
+	if id, ok := t.id[s]; ok {
+		return id
+	}
+	id := uint64(len(t.strs))
+	t.strs = append(t.strs, s)
+	t.id[s] = id
+	return id
+}
+
+func (t *recordTables) lookup(id uint64) string {
+	if id < uint64(len(t.strs)) {
+		return t.strs[id]
+	}
+	return ""
+}
+
+func encodeRecord(r Record, t *recordTables) []byte {
+	b := make([]byte, 0, len(r.Role)+len(r.Text)+32)
+	b = binary.AppendUvarint(b, t.intern(r.Key))
+	b = binary.AppendUvarint(b, t.intern(r.SourcePath))
 	b = appendField(b, r.Role)
 	b = binary.LittleEndian.AppendUint64(b, uint64(r.Time.UnixNano()))
 	b = appendField(b, r.Text)
@@ -208,15 +280,21 @@ func appendField(b []byte, s string) []byte {
 	return append(b, s...)
 }
 
-func decodeRecord(b []byte) (Record, error) {
+func decodeRecord(b []byte, t *recordTables) (Record, error) {
 	var rec Record
 	var ok bool
-	if rec.Key, b, ok = consumeField(b); !ok {
+	kid, n := binary.Uvarint(b)
+	if n <= 0 {
 		return rec, io.ErrUnexpectedEOF
 	}
-	if rec.SourcePath, b, ok = consumeField(b); !ok {
+	b = b[n:]
+	pid, n := binary.Uvarint(b)
+	if n <= 0 {
 		return rec, io.ErrUnexpectedEOF
 	}
+	b = b[n:]
+	rec.Key = t.lookup(kid)
+	rec.SourcePath = t.lookup(pid)
 	if rec.Role, b, ok = consumeField(b); !ok {
 		return rec, io.ErrUnexpectedEOF
 	}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -125,7 +125,7 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 	// Only sources this export actually touched may have their watermark or
 	// boundary rewritten; pushing project B must leave project A's alone.
 	touched := map[string]bool{}
-	err = eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
+	err = eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
 		if r.SourcePath == syncImportPath {
 			return
 		}
@@ -367,7 +367,8 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 	if err != nil {
 		return err
 	}
-	rw, err := newRecordWriter(rf)
+	tbl := tablesFromManifest(*m)
+	rw, err := newRecordWriter(rf, tbl)
 	if err != nil {
 		_ = rf.Close()
 		return err
@@ -428,6 +429,7 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 	if err := rw.Close(); err != nil {
 		return err
 	}
+	m.RecordStrings = tbl.strs
 	if err := writeBucketsConcurrent(filepath.Join(dir, "buckets"), buckets); err != nil {
 		return err
 	}

--- a/internal/index/testtables_test.go
+++ b/internal/index/testtables_test.go
@@ -1,0 +1,21 @@
+package index
+
+// testTables builds a record table covering records assembled by hand, so a
+// test can round-trip through the log without standing up a manifest.
+func testTables(recs ...Record) *recordTables {
+	t := newRecordTables()
+	for _, r := range recs {
+		t.intern(r.Key)
+		t.intern(r.SourcePath)
+	}
+	return t
+}
+
+// mustTables loads the table an index on disk was written with.
+func mustTables(t interface{ Fatal(...any) }, dir string) *recordTables {
+	tbl, err := loadRecordTables(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tbl
+}

--- a/internal/index/unstamped_test.go
+++ b/internal/index/unstamped_test.go
@@ -19,7 +19,7 @@ func TestZeroTimeRoundTripsAsZero(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rw, err := newRecordWriter(f)
+	rw, err := newRecordWriter(f, newRecordTables())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +30,7 @@ func TestZeroTimeRoundTripsAsZero(t *testing.T) {
 		t.Fatal(err)
 	}
 	var got Record
-	if err := eachRecord(p, func(r Record) { got = r }); err != nil {
+	if err := eachRecord(p, newRecordTables(), func(r Record) { got = r }); err != nil {
 		t.Fatal(err)
 	}
 	if !got.Time.IsZero() {
@@ -42,7 +42,7 @@ func TestZeroTimeRoundTripsAsZero(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rw2, err := newRecordWriter(f2)
+	rw2, err := newRecordWriter(f2, newRecordTables())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestZeroTimeRoundTripsAsZero(t *testing.T) {
 		t.Fatal(err)
 	}
 	var got2 Record
-	if err := eachRecord(filepath.Join(dir, "r2.bin"), func(r Record) { got2 = r }); err != nil {
+	if err := eachRecord(filepath.Join(dir, "r2.bin"), newRecordTables(), func(r Record) { got2 = r }); err != nil {
 		t.Fatal(err)
 	}
 	if !got2.Time.Equal(when) {


### PR DESCRIPTION
Every record in `records.bin` spelled out its session key and source path. On a 57k-message corpus that is **8.3 MB — 17% of the record log — to store 1163 distinct strings** (90 paths, 1073 keys). Records now store ids into a table kept in the manifest.

Measured on that corpus by field: text 41.6 MB, sourcePath 4.9 MB, key 2.4 MB, role/time/header 1.1 MB. The interned form replaces the 7.3 MB of key+path with two varints per record (~0.2 MB) plus ~0.1 MB of table, so the record log goes 49.9 → ~42 MB and the whole index 65 → ~57 MB, about **12%**.

**No search regression.** The table is deliberately not the session `Ord`: reusing it would make a record's identity depend on Ord bookkeeping, turning an Ord bug from "postings merged" into "this message belongs to another session". It is its own append-only table, written by the pass that writes the records.

Two things this needed, both caught by measurement rather than review:
- The append path must **continue** the existing table. A fresh one hands id 0 to a new string and silently repoints every record already using it. `TestInternedIDsSurviveIncrementalAppend` grows only the second of two sessions so the id order diverges; with a restarted table it fails with `"alpha first message" attributed to "claude:s2"`.
- The read path must not rebuild anything. My first version built a string→id map per query and re-decoded the manifest uncached, which took a full-walk search from 44 ms to **316 ms**. Resolving an id is a slice index, so the map is now built lazily only when something interns, and the manifest comes from the cache. Same query: 43 ms.

Index version 12 → 13; an older log spells the strings out and is rebuilt.

Full `-race` suite green, lint clean. Stacked on #353.