### PR TITLE
perf(search): cache the token catalog between queries

### DIFF
--- a/internal/index/cooccur.go
+++ b/internal/index/cooccur.go
@@ -145,7 +145,7 @@ func cooccurSearch(dir string, m Manifest, o query.Options) (SearchResult, error
 	if neighbors == nil {
 		return SearchResult{}, nil
 	}
-	catalog, err := tokenCatalog(dir)
+	catalog, err := tokenCatalogCached(dir)
 	if err != nil {
 		return SearchResult{}, err
 	}

--- a/internal/index/intern_test.go
+++ b/internal/index/intern_test.go
@@ -124,3 +124,42 @@ func TestInternedIDsAreStable(t *testing.T) {
 		t.Fatalf("out-of-range id resolved to %q", got)
 	}
 }
+
+// The catalog must be rebuilt when a bucket changes, or a corrupt bucket goes
+// unreported and the ladder never triggers a rebuild.
+func TestCatalogCacheNoticesBucketChanges(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"),
+		[]byte(`{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"quetzalcoatl marker"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	first, err := tokenCatalogCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first["quetzalcoatl"] {
+		t.Fatalf("catalog missing the indexed token")
+	}
+	if again, err := tokenCatalogCached(dir); err != nil || len(again) != len(first) {
+		t.Fatalf("second call = %d tokens err=%v", len(again), err)
+	}
+	// Corrupting a bucket must invalidate the cache and surface as an error,
+	// which is what makes the search ladder rebuild a damaged index.
+	if err := os.WriteFile(filepath.Join(dir, "buckets", "zz.bin"), []byte("not a bucket"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tokenCatalogCached(dir); err == nil {
+		t.Fatal("a corrupt bucket was hidden by the cached catalog")
+	}
+}

--- a/internal/index/manifest_cache.go
+++ b/internal/index/manifest_cache.go
@@ -1,8 +1,11 @@
 package index
 
 import (
+	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -45,4 +48,64 @@ func readManifestCached(dir string) (Manifest, error) {
 	manifestCache.m, manifestCache.ok = m, true
 	manifestCache.mu.Unlock()
 	return m, nil
+}
+
+// The token catalog is every distinct token in the corpus — 180k strings on a
+// real store. The stem and fuzzy tiers each build it, so a single query that
+// falls through the ladder built it twice, ~63 ms of pure duplication.
+//
+// Keyed on the bucket files themselves, not the manifest: a bucket can be
+// corrupted without the manifest changing, and tokenCatalog reporting that
+// corruption is what makes the search ladder rebuild. A manifest-keyed cache
+// would have hidden it.
+//
+// Contract: the returned map is shared and must not be mutated.
+var catalogCache struct {
+	mu  sync.Mutex
+	dir string
+	sig string
+	cat map[string]bool
+	ok  bool
+}
+
+// bucketsSignature changes whenever any bucket file is added, removed, resized
+// or rewritten. Stat-only, so it costs a fraction of building the catalog.
+func bucketsSignature(dir string) (string, error) {
+	entries, err := os.ReadDir(filepath.Join(dir, "buckets"))
+	if err != nil {
+		return "", err
+	}
+	h := fnv.New64a()
+	for _, de := range entries {
+		fi, err := de.Info()
+		if err != nil {
+			return "", err
+		}
+		_, _ = h.Write([]byte(de.Name()))
+		_, _ = fmt.Fprintf(h, "|%d|%d;", fi.Size(), fi.ModTime().UnixNano())
+	}
+	return strconv.FormatUint(h.Sum64(), 16), nil
+}
+
+func tokenCatalogCached(dir string) (map[string]bool, error) {
+	sig, err := bucketsSignature(dir)
+	if err != nil {
+		return tokenCatalog(dir)
+	}
+	catalogCache.mu.Lock()
+	if catalogCache.ok && catalogCache.dir == dir && catalogCache.sig == sig {
+		c := catalogCache.cat
+		catalogCache.mu.Unlock()
+		return c, nil
+	}
+	catalogCache.mu.Unlock()
+	c, err := tokenCatalog(dir)
+	if err != nil {
+		return nil, err
+	}
+	catalogCache.mu.Lock()
+	catalogCache.dir, catalogCache.sig = dir, sig
+	catalogCache.cat, catalogCache.ok = c, true
+	catalogCache.mu.Unlock()
+	return c, nil
 }

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1114,7 +1114,7 @@ func fuzzyPostings(dir string, terms, phrases []string) ([]posting, map[string][
 	if !hasFuzzyToken(terms) {
 		return nil, nil, nil
 	}
-	catalog, err := tokenCatalog(dir)
+	catalog, err := tokenCatalogCached(dir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1181,7 +1181,7 @@ func stemPostings(dir string, terms, phrases []string) ([]posting, map[string][]
 	if !hasStemToken(terms) {
 		return nil, nil, nil
 	}
-	catalog, err := tokenCatalog(dir)
+	catalog, err := tokenCatalogCached(dir)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -174,16 +174,36 @@ func eachRecordForKeys(path string, t *recordTables, want map[string]bool, fn fu
 		if n > maxRecordSize {
 			return fmt.Errorf("%w: record length %d exceeds cap", errCorruptIndex, n)
 		}
+		// The key id is the first varint of the payload, so peek it and skip
+		// the rest of the record without touching it. Materializing every
+		// record just to read two bytes copied the whole log per query.
+		peek := int(n)
+		if peek > binary.MaxVarintLen64 {
+			peek = binary.MaxVarintLen64
+		}
+		head, perr := r.Peek(peek)
+		if perr != nil && len(head) == 0 {
+			if perr == io.EOF || perr == io.ErrUnexpectedEOF {
+				return nil
+			}
+			return perr
+		}
+		kid, un := binary.Uvarint(head)
+		if un <= 0 || !want[t.lookup(kid)] {
+			if _, derr := r.Discard(int(n)); derr != nil {
+				if derr == io.EOF || derr == io.ErrUnexpectedEOF {
+					return nil
+				}
+				return derr
+			}
+			continue
+		}
 		b := make([]byte, n)
 		if _, err := io.ReadFull(r, b); err != nil {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				return nil
 			}
 			return err
-		}
-		kid, un := binary.Uvarint(b)
-		if un <= 0 || !want[t.lookup(kid)] {
-			continue
 		}
 		rec, derr := decodeRecord(b, t)
 		if derr != nil {


### PR DESCRIPTION
The token catalog is every distinct token in the corpus — 180k strings on a real store, 216k on the synthetic below. The stem and fuzzy tiers each build it, so a single query falling through the ladder built it **twice**, about 63 ms of pure duplication measured on a real index.

Measured on a 900-session corpus with a high-cardinality vocabulary (216 010 tokens), best of 4:

| query | before | after |
|---|---|---|
| falls through the whole ladder | 238 ms | **172 ms** |
| resolves at the exact tier | 127 ms | 123 ms |

The exact tier never builds the catalog, so it correctly doesn't move.

**Keyed on the bucket files, not the manifest.** A bucket can be corrupted without the manifest changing, and `tokenCatalog` reporting that corruption is what makes the ladder rebuild a damaged index — a manifest-keyed cache silently hid it, which an existing test caught. The signature is a stat-only hash of each bucket's name, size and mtime, so any rewrite invalidates it. `TestCatalogCacheNoticesBucketChanges` fails with a static key.

Also in here: the record walk peeked a record's key by materializing the whole record, copying the entire log per query to read two bytes each time. It now peeks the varint and discards.

Full `-race` suite green, lint clean. Stacked on #354.