### PR TITLE
perf(index): drop the derivable offset from bucket directories

### DIFF
--- a/internal/index/compress_test.go
+++ b/internal/index/compress_test.go
@@ -96,3 +96,45 @@ func TestCompressedDumpsStaySearchable(t *testing.T) {
 		t.Fatalf("compressed dump came back truncated: %d bytes, want >= %d", len(full), len(dump))
 	}
 }
+
+// A bucket directory no longer stores each token's offset; it is the running
+// sum of the block lengths. Every token must still land on its own postings.
+func TestBucketOffsetsAreDerivedCorrectly(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "ab.bin")
+	want := map[string][]posting{
+		"talpha": {{Off: 1, Sid: 1}, {Off: 900, Sid: 2}},
+		"tbeta":  {{Off: 5, Sid: 3}},
+		"tgamma": {},
+		"tdelta": {{Off: 7, Sid: 4}, {Off: 8, Sid: 5}, {Off: 9000000, Sid: 6}},
+	}
+	if err := writeBucket(p, want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readBucket(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for tok, w := range want {
+		g := got[tok]
+		if len(g) != len(w) {
+			t.Errorf("token %q: %d postings, want %d", tok, len(g), len(w))
+			continue
+		}
+		for i := range w {
+			if g[i] != w[i] {
+				t.Errorf("token %q posting %d = %+v, want %+v", tok, i, g[i], w[i])
+			}
+		}
+	}
+	// And reading one token directly must land on the same block.
+	for tok, w := range want {
+		g, err := readBucketToken(p, tok)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(g) != len(w) {
+			t.Errorf("readBucketToken(%q) = %d postings, want %d", tok, len(g), len(w))
+		}
+	}
+}

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -469,18 +470,34 @@ func TestDefaultDirQueriesFiltersAndCorruptBucketBranches(t *testing.T) {
 	if _, _, err := openBucketDir(shortTok); err == nil || !IsCorrupt(err) {
 		t.Fatalf("short token err=%v", err)
 	}
+	// A directory entry that ends before its posting-block length.
 	b.Reset()
 	b.Write(bucketMagic)
 	b.WriteByte(1)
 	b.WriteByte(1)
 	b.WriteByte('a')
-	b.Write([]byte{1, 2})
 	shortFixed := filepath.Join(tmp, "short-fixed.bin")
 	if err := os.WriteFile(shortFixed, b.Bytes(), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := openBucketDir(shortFixed); err == nil || !IsCorrupt(err) {
 		t.Fatalf("short fixed err=%v", err)
+	}
+	// A block length no file could hold must be rejected rather than
+	// truncated into a uint32.
+	b.Reset()
+	b.Write(bucketMagic)
+	b.WriteByte(1)
+	b.WriteByte(1)
+	b.WriteByte('a')
+	var huge [binary.MaxVarintLen64]byte
+	b.Write(huge[:binary.PutUvarint(huge[:], uint64(math.MaxUint32)+9)])
+	hugeBlock := filepath.Join(tmp, "huge-block.bin")
+	if err := os.WriteFile(hugeBlock, b.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := openBucketDir(hugeBlock); err == nil || !IsCorrupt(err) {
+		t.Fatalf("huge block err=%v", err)
 	}
 }
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -11,8 +11,9 @@ import (
 )
 
 // version 12 resharded non-ASCII tokens across buckets; 13 interned the key
-// and source path of every record; 14 deflates the record payload.
-const version = 14
+// and source path of every record; 14 deflates the record payload; 15 drops
+// the derivable offset from every bucket directory entry.
+const version = 15
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -8,6 +8,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -447,11 +448,16 @@ func writeBucket(p string, data map[string][]posting) error {
 		toks = append(toks, tok)
 	}
 	sort.Strings(toks)
+	// Posting blocks are written back to back in directory order, so an
+	// entry's offset is the running sum of the lengths before it. Storing it
+	// cost 8 bytes per token — 180k tokens on a real corpus — to record a
+	// number the reader can add up itself.
 	encoded := make(map[string][]byte, len(toks))
 	dirLen := len(bucketMagic) + uvarintLen(uint64(len(toks)))
 	for _, tok := range toks {
-		dirLen += uvarintLen(uint64(len(tok))) + len(tok) + 8 + 4
-		encoded[tok] = encodePostings(data[tok])
+		b := encodePostings(data[tok])
+		encoded[tok] = b
+		dirLen += uvarintLen(uint64(len(tok))) + len(tok) + uvarintLen(uint64(len(b)))
 	}
 	entries := make([]bucketEntry, 0, len(toks))
 	pos := uint64(dirLen)
@@ -483,10 +489,8 @@ func writeBucket(p string, data map[string][]posting) error {
 		if _, err := w.Write([]byte(e.tok)); err != nil {
 			return err
 		}
-		var fixed [12]byte
-		binary.LittleEndian.PutUint64(fixed[:8], e.off)
-		binary.LittleEndian.PutUint32(fixed[8:], e.n)
-		if _, err := w.Write(fixed[:]); err != nil {
+		n = binary.PutUvarint(scratch[:], uint64(e.n))
+		if _, err := w.Write(scratch[:n]); err != nil {
 			return err
 		}
 	}
@@ -572,6 +576,9 @@ func openBucketDir(p string) ([]bucketEntry, *os.File, error) {
 		return nil, nil, fmt.Errorf("%w: %v", errCorruptIndex, err)
 	}
 	entries := make([]bucketEntry, 0, count)
+	// Offsets are not stored; they are the running sum of the lengths, taken
+	// from where the directory ends.
+	dirLen := uint64(len(bucketMagic)) + uint64(uvarintLen(count))
 	for i := uint64(0); i < count; i++ {
 		ln, err := binary.ReadUvarint(r)
 		if err != nil {
@@ -583,12 +590,22 @@ func openBucketDir(p string) ([]bucketEntry, *os.File, error) {
 			f.Close()
 			return nil, nil, fmt.Errorf("%w: %v", errCorruptIndex, err)
 		}
-		var fixed [12]byte
-		if _, err := io.ReadFull(r, fixed[:]); err != nil {
+		size, err := binary.ReadUvarint(r)
+		if err != nil {
 			f.Close()
 			return nil, nil, fmt.Errorf("%w: %v", errCorruptIndex, err)
 		}
-		entries = append(entries, bucketEntry{tok: string(tb), off: binary.LittleEndian.Uint64(fixed[:8]), n: binary.LittleEndian.Uint32(fixed[8:])})
+		if size > math.MaxUint32 {
+			f.Close()
+			return nil, nil, fmt.Errorf("%w: posting block length %d", errCorruptIndex, size)
+		}
+		dirLen += uint64(uvarintLen(ln)) + ln + uint64(uvarintLen(size))
+		entries = append(entries, bucketEntry{tok: string(tb), n: uint32(size)})
+	}
+	pos := dirLen
+	for i := range entries {
+		entries[i].off = pos
+		pos += uint64(entries[i].n)
 	}
 	return entries, f, nil
 }


### PR DESCRIPTION
A bucket directory stored, per token, an 8-byte absolute offset and a 4-byte length. Posting blocks are written back to back in directory order, so the offset is just the running sum of the lengths before it — 8 bytes per token to record a number the reader can add up itself. The length is now a uvarint too.

On a 216 010-token corpus (a real store has ~180k):

| | before | after |
|---|---|---|
| buckets | 7.27 MB | **4.89 MB** |
| query falling through the ladder | 118 ms | 113 ms |
| query at the exact tier | 85 ms | 84 ms |

Latency moves slightly the right way — there is less directory to read on every catalog build.

The saving is per token, so it is invisible on a corpus with a small vocabulary and largest exactly where it matters: a real store with many identifiers, paths and hashes.

Two test updates this forced, both real rather than cosmetic: the old "truncated fixed block" fixture is valid under the new layout, so it now truncates before the block length; and a length that would overflow uint32 is rejected as corruption instead of being silently wrapped. `TestBucketOffsetsAreDerivedCorrectly` covers multi-token round trip including an empty block, and fails if the running sum is not accumulated.

Index version 14 to 15. Full `-race` suite green, lint clean. Stacked on #357.
