### PR TITLE
perf: index size and search latency

### DIFF
--- a/internal/index/cjk.go
+++ b/internal/index/cjk.go
@@ -96,3 +96,42 @@ func expandCJKTokens(toks []string) []string {
 	}
 	return out
 }
+
+// cjkFunctionRunes are Chinese particles, pronouns and question words: the
+// closed class that carries no topic. A bigram made of two of them ("在哪",
+// "什么", "怎么") is grammar, not content — it is the CJK counterpart of a
+// stop word, and nothing else filters it because IsStopWord only knows
+// Latin and Cyrillic.
+//
+// The test is deliberately "both runes", not "either": 中 and 个 are function
+// runes on their own but carry meaning in 中国 and 个人, and dropping every
+// bigram that merely contains one would delete real words. This filter runs
+// at query time only — the index keeps every bigram, so nothing about
+// ingestion changes.
+var cjkFunctionRunes = map[rune]bool{
+	'的': true, '了': true, '是': true, '在': true, '和': true, '与': true,
+	'或': true, '而': true, '但': true, '就': true, '都': true, '也': true,
+	'还': true, '又': true, '再': true, '只': true, '才': true, '很': true,
+	'我': true, '你': true, '他': true, '她': true, '它': true, '们': true,
+	'这': true, '那': true, '些': true, '什': true, '么': true, '哪': true,
+	'怎': true, '呢': true, '吗': true, '吧': true, '啊': true, '之': true,
+	'其': true, '此': true, '所': true, '被': true, '把': true, '让': true,
+	'给': true, '向': true, '于': true, '以': true, '从': true, '到': true,
+	'由': true, '对': true, '因': true, '如': true, '若': true, '则': true,
+	'并': true, '且': true, '为': true, '个': true, '有': true, '会': true,
+}
+
+// cjkFunctionBigram reports whether every rune of a CJK token is a function
+// rune, i.e. the token is pure grammar.
+func cjkFunctionBigram(tok string) bool {
+	runes := []rune(tok)
+	if len(runes) < 2 {
+		return false
+	}
+	for _, r := range runes {
+		if !isCJK(r) || !cjkFunctionRunes[r] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/index/cjk_test.go
+++ b/internal/index/cjk_test.go
@@ -203,3 +203,41 @@ func TestRelevanceTermsKeepNonASCIILetters(t *testing.T) {
 		}
 	}
 }
+
+// A Chinese question expands into one bigram per adjacent character pair, so
+// the grammar of the question ("在哪", "什么") arrives as terms carrying the
+// same weight as the entity being asked about. Nothing else filters them:
+// IsStopWord only knows Latin and Cyrillic.
+func TestCJKFunctionBigramsAreNotQueryTerms(t *testing.T) {
+	has := func(terms []string, want string) bool {
+		for _, term := range terms {
+			if term == want {
+				return true
+			}
+		}
+		return false
+	}
+	terms := RelevanceTerms("复旦大学在哪个城市？")
+	for _, junk := range []string{"在哪", "哪个"} {
+		if has(terms, junk) {
+			t.Errorf("function bigram %q survived as a query term: %v", junk, terms)
+		}
+	}
+	for _, want := range []string{"复旦", "大学", "城市"} {
+		if !has(terms, want) {
+			t.Errorf("content bigram %q was dropped: %v", want, terms)
+		}
+	}
+	// The rule is "every rune is a function rune", not "any": these are real
+	// words built from characters that are function runes on their own.
+	if got := RelevanceTerms("中国有多少个人"); !has(got, "中国") || !has(got, "个人") {
+		t.Errorf("real words dropped from %q: %v", "中国有多少个人", got)
+	}
+	if got := RelevanceTerms("目的是什么"); !has(got, "目的") {
+		t.Errorf("real word 目的 dropped: %v", got)
+	}
+	// Latin is untouched — the filter requires CJK runes.
+	if got := RelevanceTerms("what is the database migration"); !has(got, "database") {
+		t.Errorf("ASCII query lost content terms: %v", got)
+	}
+}

--- a/internal/index/compress_test.go
+++ b/internal/index/compress_test.go
@@ -96,3 +96,45 @@ func TestCompressedDumpsStaySearchable(t *testing.T) {
 		t.Fatalf("compressed dump came back truncated: %d bytes, want >= %d", len(full), len(dump))
 	}
 }
+
+// A bucket directory no longer stores each token's offset; it is the running
+// sum of the block lengths. Every token must still land on its own postings.
+func TestBucketOffsetsAreDerivedCorrectly(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "ab.bin")
+	want := map[string][]posting{
+		"talpha": {{Off: 1, Sid: 1}, {Off: 900, Sid: 2}},
+		"tbeta":  {{Off: 5, Sid: 3}},
+		"tgamma": {},
+		"tdelta": {{Off: 7, Sid: 4}, {Off: 8, Sid: 5}, {Off: 9000000, Sid: 6}},
+	}
+	if err := writeBucket(p, want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readBucket(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for tok, w := range want {
+		g := got[tok]
+		if len(g) != len(w) {
+			t.Errorf("token %q: %d postings, want %d", tok, len(g), len(w))
+			continue
+		}
+		for i := range w {
+			if g[i] != w[i] {
+				t.Errorf("token %q posting %d = %+v, want %+v", tok, i, g[i], w[i])
+			}
+		}
+	}
+	// And reading one token directly must land on the same block.
+	for tok, w := range want {
+		g, err := readBucketToken(p, tok)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(g) != len(w) {
+			t.Errorf("readBucketToken(%q) = %d postings, want %d", tok, len(g), len(w))
+		}
+	}
+}

--- a/internal/index/compress_test.go
+++ b/internal/index/compress_test.go
@@ -1,0 +1,98 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	search "github.com/vshulcz/deja-vu/internal/query"
+)
+
+// Large payloads are deflated; everything else is stored as it is. Whatever
+// the encoding, the text must come back byte-identical and stay findable.
+func TestCompressedRecordsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "records.bin")
+	f, err := os.OpenFile(p, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tbl := newRecordTables()
+	rw, err := newRecordWriter(f, tbl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	big := strings.Repeat("func encodeRecord(r Record) []byte { return nil } // padding line\n", 400)
+	random := make([]byte, compressFloor*2)
+	for i := range random {
+		random[i] = byte(i*7 + i/251) // poorly compressible
+	}
+	want := []Record{
+		{Key: "claude:s1", SourcePath: "/tmp/s1.jsonl", Role: "user", Text: "short one", Time: time.Unix(10, 20)},
+		{Key: "claude:s1", SourcePath: "/tmp/s1.jsonl", Role: "assistant", Text: big, Time: time.Unix(30, 40)},
+		{Key: "claude:s2", SourcePath: "/tmp/s2.jsonl", Role: "user", Text: string(random), Time: time.Unix(50, 60)},
+		{Key: "claude:s2", SourcePath: "/tmp/s2.jsonl", Role: "user", Text: "", Time: time.Unix(70, 80)},
+	}
+	for _, r := range want {
+		if _, err := rw.write(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := rw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var got []Record
+	if err := eachRecord(p, tbl, func(r Record) { got = append(got, r) }); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("read %d records, wrote %d", len(got), len(want))
+	}
+	for i, w := range want {
+		g := got[i]
+		if g.Text != w.Text || g.Key != w.Key || g.SourcePath != w.SourcePath || g.Role != w.Role || !g.Time.Equal(w.Time) {
+			t.Errorf("record %d round-tripped wrong: key=%q role=%q len(text)=%d want len=%d", i, g.Key, g.Role, len(g.Text), len(w.Text))
+		}
+	}
+}
+
+// A big tool dump is exactly what gets compressed, so it must still be
+// searchable and still come back in full.
+func TestCompressedDumpsStaySearchable(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dump := strings.Repeat("internal/index/store_io.go:63 encodeRecord ok padding padding ", 300) + " quetzalcoatlmarker tail"
+	line := `{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + dump + `"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(dump) < compressFloor {
+		t.Fatalf("fixture is %d bytes, below the %d floor — it would never be compressed", len(dump), compressFloor)
+	}
+	ss, err := Search(dir, search.Options{Query: "quetzalcoatlmarker", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("compressed dump not found: %d sessions", len(ss))
+	}
+	var full string
+	for _, m := range ss[0].Messages {
+		full += m.Text
+	}
+	if !strings.Contains(full, "quetzalcoatlmarker") || len(full) < len(dump) {
+		t.Fatalf("compressed dump came back truncated: %d bytes, want >= %d", len(full), len(dump))
+	}
+}

--- a/internal/index/cooccur.go
+++ b/internal/index/cooccur.go
@@ -145,7 +145,7 @@ func cooccurSearch(dir string, m Manifest, o query.Options) (SearchResult, error
 	if neighbors == nil {
 		return SearchResult{}, nil
 	}
-	catalog, err := tokenCatalog(dir)
+	catalog, err := tokenCatalogCached(dir)
 	if err != nil {
 		return SearchResult{}, err
 	}

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -77,7 +77,7 @@ func BenchmarkFuzzyTokenEnumeration(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = closeTokens("synthetic-token-12345", catalog)
+		_ = closeTokens("synthetic-token-12345", newTokenIndex(catalog))
 	}
 }
 
@@ -162,7 +162,7 @@ func containsString(values []string, want string) bool {
 
 func TestFuzzyHelperCapsAndDistanceRules(t *testing.T) {
 	catalog := map[string]bool{"abcdefgh": true, "abcdefgi": true, "abcdxfgh": true, "abcdefghij": true}
-	got := closeTokens("abcdefgh", catalog)
+	got := closeTokens("abcdefgh", newTokenIndex(catalog))
 	if len(got) > 8 || len(got) == 0 || got[0] != "abcdefgh" {
 		t.Fatalf("close tokens=%v", got)
 	}

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -311,13 +311,13 @@ func TestBucketRecordGobAndRecoveryErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = devNull.Close() }()
-	if _, err := readRecordAt(devNull, 1); err == nil && runtime.GOOS != "windows" {
+	if _, err := readRecordAt(devNull, 1, newRecordTables()); err == nil && runtime.GOOS != "windows" {
 		t.Fatal("readRecordAt bad seek returned nil")
 	}
-	if _, err := readRecord(&buf); !errors.Is(err, io.EOF) {
+	if _, err := readRecord(&buf, newRecordTables()); !errors.Is(err, io.EOF) {
 		t.Fatalf("empty readRecord err=%v", err)
 	}
-	if _, err := decodeRecord([]byte{1, 'k'}); !errors.Is(err, io.ErrUnexpectedEOF) {
+	if _, err := decodeRecord([]byte{1, 'k'}, newRecordTables()); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("short decode err=%v", err)
 	}
 	gobPath := filepath.Join(tmp, "bad.gob")
@@ -523,17 +523,20 @@ func TestCurrentFilesAllHarnessesAndRecordEdgeCases(t *testing.T) {
 	if lastCompleteLineOffset(noNL, 3) != 0 {
 		t.Fatal("unterminated short file did not return 0")
 	}
-	buf := appendField(nil, "k")
-	if _, err := decodeRecord(buf); !errors.Is(err, io.ErrUnexpectedEOF) {
+	// A record is [keyID][pathID][role][time][text]; truncating at each
+	// boundary must fail cleanly rather than return a half-built record.
+	rtbl := testTables(Record{Key: "k", SourcePath: "src"})
+	buf := binary.AppendUvarint(nil, rtbl.intern("k"))
+	if _, err := decodeRecord(buf, rtbl); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("decode missing source err=%v", err)
 	}
-	buf = appendField(buf, "src")
+	buf = binary.AppendUvarint(buf, rtbl.intern("src"))
 	buf = appendField(buf, "role")
-	if rec, err := decodeRecord(buf); !errors.Is(err, io.ErrUnexpectedEOF) || rec.Key != "k" {
+	if rec, err := decodeRecord(buf, rtbl); !errors.Is(err, io.ErrUnexpectedEOF) || rec.Key != "k" || rec.SourcePath != "src" {
 		t.Fatalf("decode missing time rec=%#v err=%v", rec, err)
 	}
 	buf = binary.LittleEndian.AppendUint64(buf, uint64(time.Now().UnixNano()))
-	if _, err := decodeRecord(buf); !errors.Is(err, io.ErrUnexpectedEOF) {
+	if _, err := decodeRecord(buf, rtbl); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("decode missing text err=%v", err)
 	}
 	if _, err := scanRecords(filepath.Join(tmp, "missing-index"), Manifest{}, search.Options{}, nil); err == nil {
@@ -813,7 +816,7 @@ func TestRequestedCodecLineAndSubstringBranches(t *testing.T) {
 		appendField(nil, "key"),
 		[]byte("garbage"),
 	} {
-		if _, err := decodeRecord(data); !errors.Is(err, io.ErrUnexpectedEOF) {
+		if _, err := decodeRecord(data, newRecordTables()); !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Fatalf("decodeRecord(%v) err=%v", data, err)
 		}
 	}
@@ -826,7 +829,7 @@ func TestRequestedCodecLineAndSubstringBranches(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	if _, err := readRecordAt(f, 99); !errors.Is(err, io.EOF) {
+	if _, err := readRecordAt(f, 99, newRecordTables()); !errors.Is(err, io.EOF) {
 		t.Fatalf("readRecordAt bad offset err=%v", err)
 	}
 

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -531,6 +531,10 @@ func TestCurrentFilesAllHarnessesAndRecordEdgeCases(t *testing.T) {
 		t.Fatalf("decode missing source err=%v", err)
 	}
 	buf = binary.AppendUvarint(buf, rtbl.intern("src"))
+	if _, err := decodeRecord(buf, rtbl); !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("decode missing encoding flag err=%v", err)
+	}
+	buf = append(buf, recordRaw)
 	buf = appendField(buf, "role")
 	if rec, err := decodeRecord(buf, rtbl); !errors.Is(err, io.ErrUnexpectedEOF) || rec.Key != "k" || rec.SourcePath != "src" {
 		t.Fatalf("decode missing time rec=%#v err=%v", rec, err)
@@ -813,12 +817,16 @@ func TestRequestedCodecLineAndSubstringBranches(t *testing.T) {
 
 	for _, data := range [][]byte{
 		{0x80},
-		appendField(nil, "key"),
-		[]byte("garbage"),
+		{1, 1},
+		{1, 1, recordRaw},
 	} {
 		if _, err := decodeRecord(data, newRecordTables()); !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Fatalf("decodeRecord(%v) err=%v", data, err)
 		}
+	}
+	// An encoding byte the reader does not know is corruption, not EOF.
+	if _, err := decodeRecord([]byte{1, 1, 9}, newRecordTables()); !IsCorrupt(err) {
+		t.Fatalf("unknown encoding flag err=%v, want a corruption error", err)
 	}
 	recPath := filepath.Join(tmp, "records.bin")
 	if err := os.WriteFile(recPath, []byte{0, 0, 0}, 0o644); err != nil {

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -469,18 +470,34 @@ func TestDefaultDirQueriesFiltersAndCorruptBucketBranches(t *testing.T) {
 	if _, _, err := openBucketDir(shortTok); err == nil || !IsCorrupt(err) {
 		t.Fatalf("short token err=%v", err)
 	}
+	// A directory entry that ends before its posting-block length.
 	b.Reset()
 	b.Write(bucketMagic)
 	b.WriteByte(1)
 	b.WriteByte(1)
 	b.WriteByte('a')
-	b.Write([]byte{1, 2})
 	shortFixed := filepath.Join(tmp, "short-fixed.bin")
 	if err := os.WriteFile(shortFixed, b.Bytes(), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := openBucketDir(shortFixed); err == nil || !IsCorrupt(err) {
 		t.Fatalf("short fixed err=%v", err)
+	}
+	// A block length no file could hold must be rejected rather than
+	// truncated into a uint32.
+	b.Reset()
+	b.Write(bucketMagic)
+	b.WriteByte(1)
+	b.WriteByte(1)
+	b.WriteByte('a')
+	var huge [binary.MaxVarintLen64]byte
+	b.Write(huge[:binary.PutUvarint(huge[:], uint64(math.MaxUint32)+9)])
+	hugeBlock := filepath.Join(tmp, "huge-block.bin")
+	if err := os.WriteFile(hugeBlock, b.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := openBucketDir(hugeBlock); err == nil || !IsCorrupt(err) {
+		t.Fatalf("huge block err=%v", err)
 	}
 }
 

--- a/internal/index/coverage_recover2_test.go
+++ b/internal/index/coverage_recover2_test.go
@@ -27,7 +27,7 @@ func TestRecordIOErrorsViaClosedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := newRecordWriter(f); err == nil {
+	if _, err := newRecordWriter(f, newRecordTables()); err == nil {
 		t.Fatal("newRecordWriter on closed file returned nil error")
 	}
 
@@ -42,7 +42,7 @@ func TestRecordIOErrorsViaClosedFile(t *testing.T) {
 	if err := f2.Close(); err != nil {
 		t.Fatal(err)
 	}
-	rw := &recordWriter{f: f2, w: bufio.NewWriterSize(f2, 1)}
+	rw := &recordWriter{f: f2, w: bufio.NewWriterSize(f2, 1), tables: newRecordTables()}
 	if _, err := rw.write(rec); err == nil {
 		t.Fatal("write on closed file returned nil error")
 	}
@@ -59,7 +59,7 @@ func TestRecordIOErrorsViaClosedFile(t *testing.T) {
 	if err := f2b.Close(); err != nil {
 		t.Fatal(err)
 	}
-	rwBig := &recordWriter{f: f2b, w: bufio.NewWriterSize(f2b, 8)}
+	rwBig := &recordWriter{f: f2b, w: bufio.NewWriterSize(f2b, 8), tables: newRecordTables()}
 	if _, err := rwBig.write(rec); err == nil {
 		t.Fatal("write (body) on closed file returned nil error")
 	}
@@ -74,7 +74,7 @@ func TestRecordIOErrorsViaClosedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f3.Close()
-	if _, err := writeRecord(f3, rec); err == nil {
+	if _, err := writeRecord(f3, rec, newRecordTables()); err == nil {
 		t.Fatal("writeRecord on a read-only file returned nil error")
 	}
 
@@ -85,7 +85,7 @@ func TestRecordIOErrorsViaClosedFile(t *testing.T) {
 	if err := f4.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := readRecordAt(f4, 0); err == nil {
+	if _, err := readRecordAt(f4, 0, newRecordTables()); err == nil {
 		t.Fatal("readRecordAt on closed file returned nil error")
 	}
 }
@@ -226,7 +226,10 @@ func TestExportDefaultDirSourceFallbackAndOrphanSkip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rw, err := newRecordWriter(rf)
+	// Appending continues the index's own string table; a fresh one would
+	// hand id 0 to a new string and repoint records that already use it.
+	atbl := mustTables(t, dir)
+	rw, err := newRecordWriter(rf, atbl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,6 +240,14 @@ func TestExportDefaultDirSourceFallbackAndOrphanSkip(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := rw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	am, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	am.RecordStrings = atbl.strs
+	if err := writeManifest(dir, am); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/index/coverage_recover3_test.go
+++ b/internal/index/coverage_recover3_test.go
@@ -40,7 +40,7 @@ func TestLastCompleteLineOffsetReadAtError(t *testing.T) {
 func TestDecodeRecordMissingRole(t *testing.T) {
 	buf := appendField(nil, "key")
 	buf = appendField(buf, "src")
-	if _, err := decodeRecord(buf); err == nil {
+	if _, err := decodeRecord(buf, newRecordTables()); err == nil {
 		t.Fatal("decodeRecord missing role field returned nil error")
 	}
 }
@@ -54,7 +54,7 @@ func TestEachRecordNonEOFReadError(t *testing.T) {
 	if err := os.MkdirAll(dirAsFile, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := eachRecord(dirAsFile, func(Record) {}); err == nil {
+	if err := eachRecord(dirAsFile, newRecordTables(), func(Record) {}); err == nil {
 		t.Fatal("eachRecord over a directory returned nil error")
 	}
 }
@@ -101,7 +101,7 @@ func TestImportedSessionsOrphanRecordSkipped(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rw, err := newRecordWriter(rf)
+	rw, err := newRecordWriter(rf, newRecordTables())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestScanRecordsMetaMissingAndOpenError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rw, err := newRecordWriter(rf)
+	rw, err := newRecordWriter(rf, newRecordTables())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func TestUpdateIndexReplacePathOrphanRecordsDropped(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rw, err := newRecordWriter(rf)
+	rw, err := newRecordWriter(rf, newRecordTables())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/deepverify.go
+++ b/internal/index/deepverify.go
@@ -129,7 +129,8 @@ func DeepVerify(dir string) (DeepReport, error) {
 
 	// 3. Dead postings: a sample of tokens must resolve to readable records.
 	catalog, err := tokenCatalog(dir)
-	if err == nil {
+	dvTables, dvErr := loadRecordTables(dir)
+	if err == nil && dvErr == nil {
 		f, ferr := os.Open(recordsPath(dir))
 		if ferr == nil {
 			defer func() { _ = f.Close() }()
@@ -139,7 +140,7 @@ func DeepVerify(dir string) (DeepReport, error) {
 					continue
 				}
 				report.SampledPostings++
-				if _, rerr := readRecordAt(f, posts[0].Off); rerr != nil {
+				if _, rerr := readRecordAt(f, posts[0].Off, dvTables); rerr != nil {
 					report.Findings = append(report.Findings, DeepFinding{Kind: "dead-posting", Detail: fmt.Sprintf("token %q points at unreadable record offset %d", tok, posts[0].Off)})
 				}
 			}
@@ -153,7 +154,11 @@ func recordsPath(dir string) string { return filepath.Join(dir, "records.bin") }
 // indexedMessageCounts counts records per session key straight from the log.
 func indexedMessageCounts(dir string) (map[string]int, error) {
 	counts := map[string]int{}
-	err := eachRecord(recordsPath(dir), func(r Record) {
+	tbl, terr := loadRecordTables(dir)
+	if terr != nil {
+		return nil, terr
+	}
+	err := eachRecord(recordsPath(dir), tbl, func(r Record) {
 		counts[r.Key]++
 	})
 	return counts, err

--- a/internal/index/fuzzy_index_test.go
+++ b/internal/index/fuzzy_index_test.go
@@ -1,0 +1,108 @@
+package index
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// bruteCloseTokens is the definition closeTokens must not drift from: every
+// token in the corpus, compared directly.
+func bruteCloseTokens(query string, catalog map[string]bool) []string {
+	type match struct {
+		token string
+		d     int
+	}
+	limit := 1
+	if len([]rune(query)) >= 8 {
+		limit = 2
+	}
+	var ms []match
+	for token := range catalog {
+		if d := damerauDistance(query, token, limit); d <= limit {
+			ms = append(ms, match{token, d})
+		}
+	}
+	sort.Slice(ms, func(i, j int) bool {
+		if ms[i].d == ms[j].d {
+			return ms[i].token < ms[j].token
+		}
+		return ms[i].d < ms[j].d
+	})
+	if len(ms) > 8 {
+		ms = ms[:8]
+	}
+	out := make([]string, len(ms))
+	for i, m := range ms {
+		out[i] = m.token
+	}
+	return out
+}
+
+// Bucketing by length must not lose a match. Only tokens within the edit
+// limit of the query's length can match, but the bookkeeping — rune vs byte
+// length, the overflow bucket for very long tokens — is where it would go
+// wrong quietly.
+func TestFuzzyLengthBucketsMatchBruteForce(t *testing.T) {
+	rng := rand.New(rand.NewSource(3))
+	al := []rune("abcdefghijklmnopqrstuvwxyz")
+	cyr := []rune("абвгдеёжзийклмнопрстуфхцчшщыэюя")
+	catalog := map[string]bool{}
+	word := func(alpha []rune, n int) string {
+		b := make([]rune, n)
+		for i := range b {
+			b[i] = alpha[rng.Intn(len(alpha))]
+		}
+		return string(b)
+	}
+	for i := 0; i < 4000; i++ {
+		catalog[word(al, 1+rng.Intn(30))] = true
+		catalog[word(cyr, 1+rng.Intn(20))] = true
+	}
+	// Tokens past the bucket cap must still be reachable.
+	long := word(al, maxIndexedTokenLen+8)
+	catalog[long] = true
+	catalog[long[:len(long)-1]] = true
+	catalog[word(cyr, maxIndexedTokenLen+3)] = true
+
+	idx := newTokenIndex(catalog)
+	queries := []string{"a", "ab", "abcdefgh", "мосты", "конфигурация", long, long[:20], strings.Repeat("z", 40)}
+	for i := 0; i < 40; i++ {
+		queries = append(queries, word(al, 1+rng.Intn(20)), word(cyr, 1+rng.Intn(16)))
+	}
+	for _, q := range queries {
+		want := bruteCloseTokens(q, catalog)
+		got := closeTokens(q, idx)
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Fatalf("query %q (%d runes): bucketed=%v brute=%v", q, utf8.RuneCountInString(q), got, want)
+		}
+	}
+}
+
+// Every token must land in exactly one bucket, and the bucket must agree with
+// the token's rune length.
+func TestTokenIndexBucketsByRuneLength(t *testing.T) {
+	catalog := map[string]bool{"ab": true, "abc": true, "мир": true, "конфигурация": true, strings.Repeat("x", maxIndexedTokenLen+5): true}
+	idx := newTokenIndex(catalog)
+	seen := map[string]int{}
+	for n, bucket := range idx.byLen {
+		for _, tok := range bucket {
+			seen[tok]++
+			want := utf8.RuneCountInString(tok)
+			if want > maxIndexedTokenLen {
+				want = maxIndexedTokenLen + 1
+			}
+			if n != want {
+				t.Errorf("token %q sits in bucket %d, want %d", tok, n, want)
+			}
+		}
+	}
+	for tok := range catalog {
+		if seen[tok] != 1 {
+			t.Errorf("token %q appears in %d buckets", tok, seen[tok])
+		}
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -10,9 +10,9 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
-// version 12 reshards non-ASCII tokens across buckets; an index built by 11
-// keeps them all under "t_", where the new lookup would never find them.
-const version = 12
+// version 12 resharded non-ASCII tokens across buckets; 13 interns the key
+// and source path of every record, which an older log spells out in full.
+const version = 13
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message
@@ -92,6 +92,10 @@ type Manifest struct {
 	// stamps a whole session with one timestamp.
 	ExportBoundary  map[string][]uint64 `json:"export_boundary,omitempty"`
 	ImportedRecords map[string]bool     `json:"imported_records,omitempty"`
+	// RecordStrings interns the keys and source paths of records.bin; a
+	// record stores an index into this table instead of repeating the
+	// strings. Append-only, so an appended log keeps resolving.
+	RecordStrings []string `json:"record_strings,omitempty"`
 	// RecordsSize is records.bin's byte length when the manifest was committed.
 	// A live index whose records.bin is shorter than this lost its tail to a
 	// torn write and must be treated as corrupt.
@@ -120,6 +124,7 @@ type manifestCore struct {
 	ExportWatermarks map[string]int64
 	ExportBoundary   map[string][]uint64
 	ImportedRecords  map[string]bool
+	RecordStrings    []string
 	RecordsSize      int64
 	IngestHealth     map[string]HarnessIngest
 }
@@ -193,9 +198,10 @@ type msgSeen map[string]bool
 // the file offset in memory: the hot rebuild path used to pay a Seek syscall
 // per record, which dominated cold-rebuild profiles.
 type recordWriter struct {
-	f   *os.File
-	w   *bufio.Writer
-	off int64
+	f      *os.File
+	w      *bufio.Writer
+	off    int64
+	tables *recordTables
 }
 
 type bucketEntry struct {

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -10,9 +10,9 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
-// version 12 resharded non-ASCII tokens across buckets; 13 interns the key
-// and source path of every record, which an older log spells out in full.
-const version = 13
+// version 12 resharded non-ASCII tokens across buckets; 13 interned the key
+// and source path of every record; 14 deflates the record payload.
+const version = 14
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -11,8 +11,9 @@ import (
 )
 
 // version 12 resharded non-ASCII tokens across buckets; 13 interned the key
-// and source path of every record; 14 deflates the record payload.
-const version = 14
+// and source path of every record; 14 deflates the record payload; 15 drops
+// the derivable offset from every bucket directory entry.
+const version = 15
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -93,7 +93,8 @@ func TestReadRecordsAndGeneration(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := Record{Key: "claude:s", SourcePath: "session.jsonl", Role: "user", Text: "semantic text", Time: time.Unix(10, 20)}
-	off, err := writeRecord(f, want)
+	wtbl := newRecordTables()
+	off, err := writeRecord(f, want, wtbl)
 	if err != nil {
 		_ = f.Close()
 		t.Fatal(err)
@@ -101,9 +102,15 @@ func TestReadRecordsAndGeneration(t *testing.T) {
 	if off != 0 || f.Close() != nil {
 		t.Fatal("record write did not start at zero")
 	}
+	if err := writeManifest(dir, Manifest{Version: version, Sessions: map[string]SessionMeta{}, RecordStrings: wtbl.strs}); err != nil {
+		t.Fatal(err)
+	}
 	got, err := ReadRecords(dir)
 	if err != nil || len(got) != 1 || got[0].Offset != 0 || got[0].Record.Text != want.Text || got[0].Record.Time != want.Time {
 		t.Fatalf("records=%#v err=%v", got, err)
+	}
+	if got[0].Record.Key != want.Key || got[0].Record.SourcePath != want.SourcePath {
+		t.Fatalf("interned fields lost: key=%q path=%q", got[0].Record.Key, got[0].Record.SourcePath)
 	}
 	if err := writeManifest(dir, Manifest{Version: version, BuiltAt: time.Unix(20, 0), Generation: "gen-1", Sessions: map[string]SessionMeta{}}); err != nil {
 		t.Fatal(err)
@@ -318,7 +325,9 @@ func TestMultiWordSearchUsesAllPostingsAndDoesNotFullScan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = writeRecord(rec, Record{Key: "claude:unposted", Role: "user", Text: "jwt only refresh would appear during a full scan", Time: time.Now()})
+	utbl := mustTables(t, dir)
+	_, err = writeRecord(rec, Record{Key: "claude:unposted", Role: "user", Text: "jwt only refresh would appear during a full scan", Time: time.Now()}, utbl)
+	m.RecordStrings = utbl.strs
 	if closeErr := rec.Close(); err != nil {
 		t.Fatal(err)
 	} else if closeErr != nil {
@@ -518,7 +527,7 @@ func TestIndexRecentFindRecordsAndBranches(t *testing.T) {
 	if got, ok, err := FindByPrefix(idx, "s"); err != nil || !ok || len(got.Messages) != 2 {
 		t.Fatalf("FindByPrefix=%#v ok=%v err=%v", got, ok, err)
 	}
-	recs, err := recordsForKey(filepath.Join(idx, "records.bin"), "claude:s1")
+	recs, err := recordsForKey(filepath.Join(idx, "records.bin"), mustTables(t, idx), "claude:s1")
 	if err != nil || len(recs) != 2 {
 		t.Fatalf("records=%#v err=%v", recs, err)
 	}
@@ -742,7 +751,8 @@ func TestEachRecordIgnoresTruncatedTail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := writeRecord(f, Record{Key: "claude:s1", SourcePath: "s1.jsonl", Role: "user", Text: "complete"}); err != nil {
+	ttbl := newRecordTables()
+	if _, err := writeRecord(f, Record{Key: "claude:s1", SourcePath: "s1.jsonl", Role: "user", Text: "complete"}, ttbl); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := f.Write([]byte{99, 0, 0, 0, '{'}); err != nil {
@@ -752,7 +762,7 @@ func TestEachRecordIgnoresTruncatedTail(t *testing.T) {
 		t.Fatal(err)
 	}
 	var got []Record
-	if err := eachRecord(p, func(r Record) { got = append(got, r) }); err != nil {
+	if err := eachRecord(p, ttbl, func(r Record) { got = append(got, r) }); err != nil {
 		t.Fatal(err)
 	}
 	if len(got) != 1 || got[0].Text != "complete" {

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -225,7 +225,8 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	if err != nil {
 		return err
 	}
-	rw, err := newRecordWriter(rf)
+	tbl := newRecordTables()
+	rw, err := newRecordWriter(rf, tbl)
 	if err != nil {
 		_ = rf.Close()
 		return err
@@ -283,6 +284,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 		return err
 	}
 	setOpencodeLastUpdated(m.Files, m.Sessions)
+	m.RecordStrings = tbl.strs
 	if err := writeManifest(tmp, m); err != nil {
 		return err
 	}
@@ -305,7 +307,7 @@ func importedSessions(dir string) importedState {
 	out.boundary = m.ExportBoundary
 	out.dedupe = m.ImportedRecords
 	by := map[string]*model.Session{}
-	_ = eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
+	_ = eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
 		if r.SourcePath != syncImportPath {
 			return
 		}
@@ -419,7 +421,8 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	if err != nil {
 		return err
 	}
-	rw, err := newRecordWriter(rf)
+	tbl := newRecordTables()
+	rw, err := newRecordWriter(rf, tbl)
 	if err != nil {
 		_ = rf.Close()
 		return err
@@ -475,6 +478,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 		return err
 	}
 	setOpencodeLastUpdated(m.Files, m.Sessions)
+	m.RecordStrings = tbl.strs
 	if err := writeManifest(tmp, m); err != nil {
 		return err
 	}
@@ -682,9 +686,9 @@ func truncateTitle(s string, n int) string {
 	return strings.TrimSpace(string(r[:n])) + "…"
 }
 
-func recordsForKey(path, key string) ([]Record, error) {
+func recordsForKey(path string, t *recordTables, key string) ([]Record, error) {
 	var out []Record
-	err := eachRecord(path, func(r Record) {
+	err := eachRecord(path, t, func(r Record) {
 		if r.Key == key {
 			out = append(out, r)
 		}
@@ -858,7 +862,8 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	if err != nil {
 		return err
 	}
-	rw, err := newRecordWriter(rf)
+	tbl := newRecordTables()
+	rw, err := newRecordWriter(rf, tbl)
 	if err != nil {
 		_ = rf.Close()
 		return err
@@ -912,7 +917,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		return nil
 	}
 	var recErr error
-	if err := eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
+	if err := eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(old), func(r Record) {
 		if recErr != nil {
 			return
 		}
@@ -982,6 +987,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		return err
 	}
 	setOpencodeLastUpdated(m.Files, m.Sessions)
+	m.RecordStrings = tbl.strs
 	if err := writeManifest(tmp, m); err != nil {
 		return err
 	}
@@ -1020,7 +1026,11 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	if err != nil {
 		return 0, 0, err
 	}
-	rw, err := newRecordWriter(rf)
+	// The log is being APPENDED to, so ids must continue where the existing
+	// records left off. Starting a fresh table would hand id 0 to a new
+	// string and silently repoint every record that already uses it.
+	tbl := tablesFromManifest(old)
+	rw, err := newRecordWriter(rf, tbl)
 	if err != nil {
 		_ = rf.Close()
 		return 0, 0, err
@@ -1117,6 +1127,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 		return filesTouched, messages, err
 	}
 	setOpencodeLastUpdated(m.Files, m.Sessions)
+	m.RecordStrings = tbl.strs
 	if err := writeManifest(dir, m); err != nil {
 		return filesTouched, messages, err
 	}

--- a/internal/index/integration_test.go
+++ b/internal/index/integration_test.go
@@ -158,7 +158,7 @@ func TestRebuildDeterminism(t *testing.T) {
 			t.Fatal(err)
 		}
 		msgs := 0
-		_ = eachRecord(filepath.Join(dir, "records.bin"), func(r Record) { msgs++ })
+		_ = eachRecord(filepath.Join(dir, "records.bin"), mustTables(t, dir), func(r Record) { msgs++ })
 		return len(m.Sessions), msgs
 	}
 	s1, m1 := count()

--- a/internal/index/intern_test.go
+++ b/internal/index/intern_test.go
@@ -1,0 +1,126 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	search "github.com/vshulcz/deja-vu/internal/query"
+)
+
+// Records intern their key and source path into a table stored in the
+// manifest. The table is append-only, so a log that grows must keep the ids
+// it already handed out: restarting the table would give id 0 to a new string
+// and silently repoint every record already using it — a message would come
+// back attributed to a different session.
+func TestInternedIDsSurviveIncrementalAppend(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(id, ts, text string) string {
+		return `{"type":"user","sessionId":"` + id + `","timestamp":"` + ts + `","message":{"role":"user","content":"` + text + `"}}` + "\n"
+	}
+	// Two sessions up front, so the table already holds s1's strings at the
+	// low ids.
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"),
+		[]byte(line("s1", "2026-01-02T03:04:05Z", "alpha first message")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(proj, "s2.jsonl"),
+		[]byte(line("s2", "2026-01-02T04:04:05Z", "bravo first message")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Grow ONLY the second session. A restarted table would intern s2's key
+	// as id 0 — the id s1 already owns — and s1's existing records would come
+	// back attributed to s2. Adding a file instead would force a full rebuild
+	// and never exercise the append path.
+	if err := os.WriteFile(filepath.Join(proj, "s2.jsonl"),
+		[]byte(line("s2", "2026-01-02T04:04:05Z", "bravo first message")+
+			line("s2", "2026-01-02T04:05:05Z", "bravo second message")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Every record must still name the session it belongs to.
+	tbl, err := loadRecordTables(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byText := map[string]string{}
+	if err := eachRecord(filepath.Join(dir, "records.bin"), tbl, func(r Record) {
+		byText[r.Text] = r.Key
+		if _, ok := m.Sessions[r.Key]; !ok {
+			t.Errorf("record %q resolved to key %q, which is not a session", r.Text, r.Key)
+		}
+		if r.SourcePath == "" {
+			t.Errorf("record %q lost its source path", r.Text)
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for text, want := range map[string]string{
+		"alpha first message":  "claude:s1",
+		"bravo first message":  "claude:s2",
+		"bravo second message": "claude:s2",
+	} {
+		if got := byText[text]; got != want {
+			t.Errorf("record %q attributed to %q, want %q", text, got, want)
+		}
+	}
+	// And the whole thing is still searchable per session.
+	for _, c := range []struct{ q, id string }{{"alpha first message", "s1"}, {"bravo second message", "s2"}} {
+		ss, err := Search(dir, search.Options{Query: c.q, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ss) != 1 || ss[0].ID != c.id {
+			t.Errorf("search %q returned %d sessions, want just %s", c.q, len(ss), c.id)
+		}
+	}
+}
+
+// The table only ever grows, so ids already in use keep their meaning.
+func TestInternedIDsAreStable(t *testing.T) {
+	tbl := newRecordTables()
+	a := tbl.intern("claude:one")
+	b := tbl.intern("/path/one.jsonl")
+	if a == b {
+		t.Fatal("distinct strings shared an id")
+	}
+	if again := tbl.intern("claude:one"); again != a {
+		t.Fatalf("id changed on re-intern: %d then %d", a, again)
+	}
+	// A reader rebuilt from the persisted slice resolves the same way.
+	rt := tablesFromStrings(tbl.strs)
+	if rt.lookup(a) != "claude:one" || rt.lookup(b) != "/path/one.jsonl" {
+		t.Fatalf("round trip lost ids: %q %q", rt.lookup(a), rt.lookup(b))
+	}
+	// Continuing a persisted table must not reuse an id.
+	grown := tablesFromStrings(tbl.strs)
+	c := grown.intern("claude:two")
+	if c == a || c == b {
+		t.Fatalf("new string reused id %d", c)
+	}
+	if grown.lookup(a) != "claude:one" {
+		t.Fatal("growing the table repointed an existing id")
+	}
+	// An unknown id resolves to empty rather than panicking or aliasing.
+	if got := rt.lookup(uint64(len(tbl.strs)) + 5); got != "" {
+		t.Fatalf("out-of-range id resolved to %q", got)
+	}
+}

--- a/internal/index/intern_test.go
+++ b/internal/index/intern_test.go
@@ -124,3 +124,42 @@ func TestInternedIDsAreStable(t *testing.T) {
 		t.Fatalf("out-of-range id resolved to %q", got)
 	}
 }
+
+// The catalog must be rebuilt when a bucket changes, or a corrupt bucket goes
+// unreported and the ladder never triggers a rebuild.
+func TestCatalogCacheNoticesBucketChanges(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"),
+		[]byte(`{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"quetzalcoatl marker"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	first, err := tokenCatalogCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first["quetzalcoatl"] {
+		t.Fatalf("catalog missing the indexed token")
+	}
+	if again, err := tokenCatalogCached(dir); err != nil || len(again) != len(first) {
+		t.Fatalf("second call = %d tokens err=%v", len(again), err)
+	}
+	// Corrupting a bucket must invalidate the cache and surface as an error,
+	// which is what makes the search ladder rebuild a damaged index.
+	if err := os.WriteFile(filepath.Join(dir, "buckets", "zz.bin"), []byte("not a bucket"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tokenCatalogCached(dir); err == nil {
+		t.Fatal("a corrupt bucket was hidden by the cached catalog")
+	}
+}

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -95,7 +95,7 @@ func readManifest(dir string) (Manifest, error) {
 	if err := readGob(filepath.Join(dir, "manifest.gob"), &core); err != nil {
 		return Manifest{}, err
 	}
-	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ExportBoundary: core.ExportBoundary, ImportedRecords: core.ImportedRecords, RecordsSize: core.RecordsSize, IngestHealth: core.IngestHealth, Sessions: map[string]SessionMeta{}}
+	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ExportBoundary: core.ExportBoundary, ImportedRecords: core.ImportedRecords, RecordStrings: core.RecordStrings, RecordsSize: core.RecordsSize, IngestHealth: core.IngestHealth, Sessions: map[string]SessionMeta{}}
 	if err := readGob(filepath.Join(dir, "sessions.gob"), &m.Sessions); err != nil {
 		return Manifest{}, err
 	}
@@ -112,7 +112,7 @@ func readManifest(dir string) (Manifest, error) {
 // for updates that change only core fields (e.g. export watermarks) where the
 // caller has not loaded sessions and must not clobber them.
 func writeManifestOnly(dir string, m Manifest) error {
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, IngestHealth: m.IngestHealth}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}
@@ -121,7 +121,7 @@ func writeManifestOnly(dir string, m Manifest) error {
 
 func writeManifest(dir string, m Manifest) error {
 	mergeIngestDiag(&m)
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, IngestHealth: m.IngestHealth}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}

--- a/internal/index/manifest_cache.go
+++ b/internal/index/manifest_cache.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"sync"
 	"time"
+	"unicode/utf8"
 )
 
 // Long-lived processes (the MCP server foremost) call read-only retrieval
@@ -64,8 +65,54 @@ var catalogCache struct {
 	mu  sync.Mutex
 	dir string
 	sig string
-	cat map[string]bool
+	idx *tokenIndex
 	ok  bool
+}
+
+// tokenIndex is the catalog plus the same tokens bucketed by rune length.
+// Fuzzy matching only ever considers tokens within its edit limit of the
+// query's length, so bucketing turns a scan of every token in the corpus into
+// a walk of a few short slices.
+type tokenIndex struct {
+	set   map[string]bool
+	byLen [][]string
+}
+
+const maxIndexedTokenLen = 64
+
+func newTokenIndex(set map[string]bool) *tokenIndex {
+	idx := &tokenIndex{set: set, byLen: make([][]string, maxIndexedTokenLen+2)}
+	for tok := range set {
+		n := len(tok)
+		if !isASCIIString(tok) {
+			n = utf8.RuneCountInString(tok)
+		}
+		if n > maxIndexedTokenLen {
+			n = maxIndexedTokenLen + 1 // one overflow bucket, always scanned
+		}
+		idx.byLen[n] = append(idx.byLen[n], tok)
+	}
+	return idx
+}
+
+// candidates visits the tokens whose rune length is within limit of n, plus
+// the overflow bucket, which holds tokens too long to bucket exactly.
+func (t *tokenIndex) candidates(n, limit int, fn func(string)) {
+	lo, hi := n-limit, n+limit
+	if lo < 0 {
+		lo = 0
+	}
+	if hi > maxIndexedTokenLen {
+		hi = maxIndexedTokenLen
+	}
+	for l := lo; l <= hi && l < len(t.byLen); l++ {
+		for _, tok := range t.byLen[l] {
+			fn(tok)
+		}
+	}
+	for _, tok := range t.byLen[maxIndexedTokenLen+1] {
+		fn(tok)
+	}
 }
 
 // bucketsSignature changes whenever any bucket file is added, removed, resized
@@ -88,24 +135,37 @@ func bucketsSignature(dir string) (string, error) {
 }
 
 func tokenCatalogCached(dir string) (map[string]bool, error) {
+	idx, err := tokenIndexCached(dir)
+	if err != nil {
+		return nil, err
+	}
+	return idx.set, nil
+}
+
+func tokenIndexCached(dir string) (*tokenIndex, error) {
 	sig, err := bucketsSignature(dir)
 	if err != nil {
-		return tokenCatalog(dir)
+		c, cerr := tokenCatalog(dir)
+		if cerr != nil {
+			return nil, cerr
+		}
+		return newTokenIndex(c), nil
 	}
 	catalogCache.mu.Lock()
 	if catalogCache.ok && catalogCache.dir == dir && catalogCache.sig == sig {
-		c := catalogCache.cat
+		i := catalogCache.idx
 		catalogCache.mu.Unlock()
-		return c, nil
+		return i, nil
 	}
 	catalogCache.mu.Unlock()
 	c, err := tokenCatalog(dir)
 	if err != nil {
 		return nil, err
 	}
+	i := newTokenIndex(c)
 	catalogCache.mu.Lock()
 	catalogCache.dir, catalogCache.sig = dir, sig
-	catalogCache.cat, catalogCache.ok = c, true
+	catalogCache.idx, catalogCache.ok = i, true
 	catalogCache.mu.Unlock()
-	return c, nil
+	return i, nil
 }

--- a/internal/index/manifest_cache.go
+++ b/internal/index/manifest_cache.go
@@ -1,8 +1,11 @@
 package index
 
 import (
+	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -45,4 +48,64 @@ func readManifestCached(dir string) (Manifest, error) {
 	manifestCache.m, manifestCache.ok = m, true
 	manifestCache.mu.Unlock()
 	return m, nil
+}
+
+// The token catalog is every distinct token in the corpus — 180k strings on a
+// real store. The stem and fuzzy tiers each build it, so a single query that
+// falls through the ladder built it twice, ~63 ms of pure duplication.
+//
+// Keyed on the bucket files themselves, not the manifest: a bucket can be
+// corrupted without the manifest changing, and tokenCatalog reporting that
+// corruption is what makes the search ladder rebuild. A manifest-keyed cache
+// would have hidden it.
+//
+// Contract: the returned map is shared and must not be mutated.
+var catalogCache struct {
+	mu  sync.Mutex
+	dir string
+	sig string
+	cat map[string]bool
+	ok  bool
+}
+
+// bucketsSignature changes whenever any bucket file is added, removed, resized
+// or rewritten. Stat-only, so it costs a fraction of building the catalog.
+func bucketsSignature(dir string) (string, error) {
+	entries, err := os.ReadDir(filepath.Join(dir, "buckets"))
+	if err != nil {
+		return "", err
+	}
+	h := fnv.New64a()
+	for _, de := range entries {
+		fi, err := de.Info()
+		if err != nil {
+			return "", err
+		}
+		_, _ = h.Write([]byte(de.Name()))
+		_, _ = fmt.Fprintf(h, "|%d|%d;", fi.Size(), fi.ModTime().UnixNano())
+	}
+	return strconv.FormatUint(h.Sum64(), 16), nil
+}
+
+func tokenCatalogCached(dir string) (map[string]bool, error) {
+	sig, err := bucketsSignature(dir)
+	if err != nil {
+		return tokenCatalog(dir)
+	}
+	catalogCache.mu.Lock()
+	if catalogCache.ok && catalogCache.dir == dir && catalogCache.sig == sig {
+		c := catalogCache.cat
+		catalogCache.mu.Unlock()
+		return c, nil
+	}
+	catalogCache.mu.Unlock()
+	c, err := tokenCatalog(dir)
+	if err != nil {
+		return nil, err
+	}
+	catalogCache.mu.Lock()
+	catalogCache.dir, catalogCache.sig = dir, sig
+	catalogCache.cat, catalogCache.ok = c, true
+	catalogCache.mu.Unlock()
+	return c, nil
 }

--- a/internal/index/privacy_test.go
+++ b/internal/index/privacy_test.go
@@ -25,16 +25,17 @@ func TestForgetTombstoneLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := writeRecord(f, Record{Key: "claude:abc123", Role: "user", Text: "one", Time: time.Now()}); err != nil {
+	ptbl := newRecordTables()
+	if _, err := writeRecord(f, Record{Key: "claude:abc123", Role: "user", Text: "one", Time: time.Now()}, ptbl); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := writeRecord(f, Record{Key: "claude:keep", Role: "user", Text: "two", Time: time.Now()}); err != nil {
+	if _, err := writeRecord(f, Record{Key: "claude:keep", Role: "user", Text: "two", Time: time.Now()}, ptbl); err != nil {
 		t.Fatal(err)
 	}
 	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeManifest(dir, Manifest{Version: version, Files: map[string]FileState{}, Sessions: map[string]SessionMeta{
+	if err := writeManifest(dir, Manifest{Version: version, Files: map[string]FileState{}, RecordStrings: ptbl.strs, Sessions: map[string]SessionMeta{
 		"claude:abc123": {ID: "abc123", Harness: "claude", Project: "secret", Updated: time.Now()},
 		"claude:keep":   {ID: "keep", Harness: "claude", Project: "public", Updated: time.Now()},
 	}}); err != nil {

--- a/internal/index/record_alloc_test.go
+++ b/internal/index/record_alloc_test.go
@@ -14,7 +14,7 @@ func TestReadRecordRejectsHugeLengthPrefix(t *testing.T) {
 	if err := os.WriteFile(p, append(hdr[:], 'x'), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	err := eachRecord(p, func(Record) { t.Fatal("should not decode a corrupt record") })
+	err := eachRecord(p, newRecordTables(), func(Record) { t.Fatal("should not decode a corrupt record") })
 	if err == nil || !IsCorrupt(err) {
 		t.Fatalf("expected corrupt-index error, got %v", err)
 	}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -202,6 +202,9 @@ func RelevanceTerms(q string) []string {
 		if len([]rune(f)) < 2 || (len(f) < 3 && !isCJK([]rune(f)[0])) || search.IsStopWord(f) || seen[f] {
 			continue
 		}
+		if cjkFunctionBigram(f) {
+			continue
+		}
 		seen[f] = true
 		out = append(out, f)
 	}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1142,14 +1142,14 @@ func fuzzyPostings(dir string, terms, phrases []string) ([]posting, map[string][
 	if !hasFuzzyToken(terms) {
 		return nil, nil, nil
 	}
-	catalog, err := tokenCatalogCached(dir)
+	idx, err := tokenIndexCached(dir)
 	if err != nil {
 		return nil, nil, err
 	}
 	perToken := make([]map[int64]posting, len(terms))
 	variants := map[string][]string{}
 	for i, term := range terms {
-		matches := closeTokens(term, catalog)
+		matches := closeTokens(term, idx)
 		if len(matches) == 0 {
 			return nil, nil, nil
 		}
@@ -1608,22 +1608,26 @@ func tokenCatalog(dir string) (map[string]bool, error) {
 	return catalog, nil
 }
 
-func closeTokens(query string, catalog map[string]bool) []string {
+func closeTokens(query string, idx *tokenIndex) []string {
 	type match struct {
 		token    string
 		distance int
 	}
 	var matches []match
+	qr := len([]rune(query))
 	limit := 1
-	if len([]rune(query)) >= 8 {
+	if qr >= 8 {
 		limit = 2
 	}
-	for token := range catalog {
-		d := damerauDistance(query, token, limit)
-		if d <= limit {
+	// An edit changes the length by at most one and a transposition not at
+	// all, so only tokens within the limit of the query's length can match.
+	// Walking those buckets replaces a Damerau-Levenshtein run against every
+	// token in the corpus — ~200k of them — with a few short slices.
+	idx.candidates(qr, limit, func(token string) {
+		if d := damerauDistance(query, token, limit); d <= limit {
 			matches = append(matches, match{token: token, distance: d})
 		}
-	}
+	})
 	sort.Slice(matches, func(i, j int) bool {
 		if matches[i].distance == matches[j].distance {
 			return matches[i].token < matches[j].token
@@ -1638,6 +1642,17 @@ func closeTokens(query string, catalog map[string]bool) []string {
 		out[i] = m.token
 	}
 	return out
+}
+
+// isASCIIString reports whether every byte is one rune, so the byte length is
+// the rune count.
+func isASCIIString(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
 }
 
 func damerauDistance(a, b string, max int) int {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1142,7 +1142,7 @@ func fuzzyPostings(dir string, terms, phrases []string) ([]posting, map[string][
 	if !hasFuzzyToken(terms) {
 		return nil, nil, nil
 	}
-	catalog, err := tokenCatalog(dir)
+	catalog, err := tokenCatalogCached(dir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1209,7 +1209,7 @@ func stemPostings(dir string, terms, phrases []string) ([]posting, map[string][]
 	if !hasStemToken(terms) {
 		return nil, nil, nil
 	}
-	catalog, err := tokenCatalog(dir)
+	catalog, err := tokenCatalogCached(dir)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -780,6 +780,10 @@ func RecentProject(dir, project string, n int) ([]model.Session, error) {
 // records.bin. The per-session variant re-scanned the whole log for every
 // session, which turned a session-start hook into hundreds of milliseconds.
 func sessionsForMetas(dir string, metas []SessionMeta) ([]model.Session, error) {
+	tbl, terr := loadRecordTables(dir)
+	if terr != nil {
+		return nil, terr
+	}
 	want := make(map[string]int, len(metas))
 	out := make([]model.Session, len(metas))
 	for i, meta := range metas {
@@ -790,7 +794,7 @@ func sessionsForMetas(dir string, metas []SessionMeta) ([]model.Session, error) 
 	for k := range want {
 		keys[k] = true
 	}
-	err := eachRecordForKeys(filepath.Join(dir, "records.bin"), keys, func(r Record) {
+	err := eachRecordForKeys(filepath.Join(dir, "records.bin"), tbl, keys, func(r Record) {
 		if i, ok := want[r.Key]; ok {
 			out[i].Messages = append(out[i].Messages, model.Message{Role: r.Role, Text: r.Text, Time: r.Time})
 		}
@@ -867,7 +871,7 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 	sort.Slice(matches, func(i, j int) bool { return matches[i].Updated.After(matches[j].Updated) })
 	meta := matches[0]
 	s := sessionFromMeta(meta)
-	recs, err := recordsForKey(filepath.Join(dir, "records.bin"), meta.Harness+":"+meta.ID)
+	recs, err := recordsForKey(filepath.Join(dir, "records.bin"), tablesFromManifest(m), meta.Harness+":"+meta.ID)
 	if err != nil {
 		return model.Session{}, false, err
 	}
@@ -916,12 +920,12 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		defer func() { _ = f.Close() }()
 		offsets = sortedUniqueOffsets(offsets)
 		for _, off := range offsets {
-			if r, err := readRecordAt(f, off); err == nil && recordMatchesQueryVariants(r, o, variants) {
+			if r, err := readRecordAt(f, off, tablesFromManifest(m)); err == nil && recordMatchesQueryVariants(r, o, variants) {
 				add(r)
 			}
 		}
 	} else {
-		if err := eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
+		if err := eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
 			if recordMatchesQueryVariants(r, o, variants) {
 				add(r)
 			}

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -13,6 +13,10 @@ import (
 )
 
 func ReadRecords(dir string) ([]OffsetRecord, error) {
+	t, err := loadRecordTables(dir)
+	if err != nil {
+		return nil, err
+	}
 	var out []OffsetRecord
 	f, err := os.Open(filepath.Join(dir, "records.bin"))
 	if err != nil {
@@ -24,7 +28,7 @@ func ReadRecords(dir string) ([]OffsetRecord, error) {
 		if err != nil {
 			return nil, err
 		}
-		r, err := readRecord(f)
+		r, err := readRecord(f, t)
 		if err == io.EOF {
 			break
 		}
@@ -47,16 +51,16 @@ func Generation(dir string) (string, error) {
 	return m.BuiltAt.UTC().Format(time.RFC3339Nano), nil
 }
 
-func newRecordWriter(f *os.File) (*recordWriter, error) {
+func newRecordWriter(f *os.File, t *recordTables) (*recordWriter, error) {
 	off, err := f.Seek(0, io.SeekEnd)
 	if err != nil {
 		return nil, err
 	}
-	return &recordWriter{f: f, w: bufio.NewWriterSize(f, 1<<20), off: off}, nil
+	return &recordWriter{f: f, w: bufio.NewWriterSize(f, 1<<20), off: off, tables: t}, nil
 }
 
 func (rw *recordWriter) write(r Record) (int64, error) {
-	b := encodeRecord(r)
+	b := encodeRecord(r, rw.tables)
 	if len(b) > 1<<31 {
 		return 0, fmt.Errorf("record too large")
 	}
@@ -88,12 +92,12 @@ func (rw *recordWriter) Close() error {
 	return cerr
 }
 
-func writeRecord(f *os.File, r Record) (int64, error) {
+func writeRecord(f *os.File, r Record, t *recordTables) (int64, error) {
 	off, err := f.Seek(0, io.SeekCurrent)
 	if err != nil {
 		return 0, err
 	}
-	b := encodeRecord(r)
+	b := encodeRecord(r, t)
 	if len(b) > 1<<31 {
 		return 0, fmt.Errorf("record too large")
 	}
@@ -106,14 +110,14 @@ func writeRecord(f *os.File, r Record) (int64, error) {
 	return off, err
 }
 
-func readRecordAt(f *os.File, off int64) (Record, error) {
+func readRecordAt(f *os.File, off int64, t *recordTables) (Record, error) {
 	if _, err := f.Seek(off, io.SeekStart); err != nil {
 		return Record{}, err
 	}
-	return readRecord(f)
+	return readRecord(f, t)
 }
 
-func eachRecord(path string, fn func(Record)) error {
+func eachRecord(path string, t *recordTables, fn func(Record)) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
@@ -121,7 +125,7 @@ func eachRecord(path string, fn func(Record)) error {
 	defer func() { _ = f.Close() }()
 	r := bufio.NewReaderSize(f, 1024*1024)
 	for {
-		rec, err := readRecord(r)
+		rec, err := readRecord(r, t)
 		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			return nil
 		}
@@ -132,7 +136,7 @@ func eachRecord(path string, fn func(Record)) error {
 	}
 }
 
-func readRecord(r io.Reader) (Record, error) {
+func readRecord(r io.Reader, t *recordTables) (Record, error) {
 	var hdr [4]byte
 	if _, err := io.ReadFull(r, hdr[:]); err != nil {
 		return Record{}, err
@@ -145,13 +149,13 @@ func readRecord(r io.Reader) (Record, error) {
 	if _, err := io.ReadFull(r, b); err != nil {
 		return Record{}, err
 	}
-	return decodeRecord(b)
+	return decodeRecord(b, t)
 }
 
 // eachRecordForKeys walks the log decoding only records whose Key is in
 // want; other bodies are skipped after peeking the key field. On a large log
 // this trades a full decode of every record for a few length reads.
-func eachRecordForKeys(path string, want map[string]bool, fn func(Record)) error {
+func eachRecordForKeys(path string, t *recordTables, want map[string]bool, fn func(Record)) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
@@ -177,11 +181,11 @@ func eachRecordForKeys(path string, want map[string]bool, fn func(Record)) error
 			}
 			return err
 		}
-		key, _, ok := consumeField(b)
-		if !ok || !want[key] {
+		kid, un := binary.Uvarint(b)
+		if un <= 0 || !want[t.lookup(kid)] {
 			continue
 		}
-		rec, derr := decodeRecord(b)
+		rec, derr := decodeRecord(b, t)
 		if derr != nil {
 			continue
 		}
@@ -193,10 +197,78 @@ func eachRecordForKeys(path string, want map[string]bool, fn func(Record)) error
 // always stored it, so it stays the on-disk marker for "never stamped".
 var zeroTimeUnixNano = time.Time{}.UnixNano()
 
-func encodeRecord(r Record) []byte {
-	b := make([]byte, 0, len(r.Key)+len(r.SourcePath)+len(r.Role)+len(r.Text)+32)
-	b = appendField(b, r.Key)
-	b = appendField(b, r.SourcePath)
+// recordTables interns the two fields every record used to repeat verbatim.
+// A corpus of 57k messages held only 90 distinct source paths and 1073
+// distinct keys, so writing them per record cost 7.3 MB — 15% of the record
+// log — to store 1163 strings.
+//
+// The table is its own thing, deliberately not the session Ord: reusing Ord
+// would make a record's identity depend on the manifest's Ord bookkeeping
+// being right, turning an Ord bug from "postings merged" into "this message
+// belongs to a different session". The table is written by the same pass that
+// writes the records and swapped with them.
+type recordTables struct {
+	strs []string
+	id   map[string]uint64
+}
+
+func newRecordTables() *recordTables {
+	return &recordTables{id: map[string]uint64{}}
+}
+
+// tablesFromStrings is the read path: resolving an id is a slice index, so
+// the string->id map is left nil and built lazily only if something interns.
+// Building it eagerly here cost a map of every string in the corpus on every
+// search.
+func tablesFromStrings(strs []string) *recordTables {
+	return &recordTables{strs: strs}
+}
+
+func tablesFromManifest(m Manifest) *recordTables { return tablesFromStrings(m.RecordStrings) }
+
+func loadRecordTables(dir string) (*recordTables, error) {
+	// Cached: this sits on the search path, and re-decoding the whole
+	// manifest per query is what the interning was meant to avoid paying for.
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return nil, err
+	}
+	return tablesFromManifest(m), nil
+}
+
+// intern returns the id for s, appending it on first sight. Ids are stable:
+// the table only ever grows, so an appended record log keeps resolving.
+func (t *recordTables) intern(s string) uint64 {
+	if t.id == nil {
+		// A zero-value table is usable; callers that build a writer by hand
+		// should not have to know about the map.
+		t.id = make(map[string]uint64, len(t.strs)+8)
+		for i, v := range t.strs {
+			if _, ok := t.id[v]; !ok {
+				t.id[v] = uint64(i)
+			}
+		}
+	}
+	if id, ok := t.id[s]; ok {
+		return id
+	}
+	id := uint64(len(t.strs))
+	t.strs = append(t.strs, s)
+	t.id[s] = id
+	return id
+}
+
+func (t *recordTables) lookup(id uint64) string {
+	if id < uint64(len(t.strs)) {
+		return t.strs[id]
+	}
+	return ""
+}
+
+func encodeRecord(r Record, t *recordTables) []byte {
+	b := make([]byte, 0, len(r.Role)+len(r.Text)+32)
+	b = binary.AppendUvarint(b, t.intern(r.Key))
+	b = binary.AppendUvarint(b, t.intern(r.SourcePath))
 	b = appendField(b, r.Role)
 	b = binary.LittleEndian.AppendUint64(b, uint64(r.Time.UnixNano()))
 	b = appendField(b, r.Text)
@@ -208,15 +280,21 @@ func appendField(b []byte, s string) []byte {
 	return append(b, s...)
 }
 
-func decodeRecord(b []byte) (Record, error) {
+func decodeRecord(b []byte, t *recordTables) (Record, error) {
 	var rec Record
 	var ok bool
-	if rec.Key, b, ok = consumeField(b); !ok {
+	kid, n := binary.Uvarint(b)
+	if n <= 0 {
 		return rec, io.ErrUnexpectedEOF
 	}
-	if rec.SourcePath, b, ok = consumeField(b); !ok {
+	b = b[n:]
+	pid, n := binary.Uvarint(b)
+	if n <= 0 {
 		return rec, io.ErrUnexpectedEOF
 	}
+	b = b[n:]
+	rec.Key = t.lookup(kid)
+	rec.SourcePath = t.lookup(pid)
 	if rec.Role, b, ok = consumeField(b); !ok {
 		return rec, io.ErrUnexpectedEOF
 	}

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -8,6 +8,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -447,11 +448,16 @@ func writeBucket(p string, data map[string][]posting) error {
 		toks = append(toks, tok)
 	}
 	sort.Strings(toks)
+	// Posting blocks are written back to back in directory order, so an
+	// entry's offset is the running sum of the lengths before it. Storing it
+	// cost 8 bytes per token — 180k tokens on a real corpus — to record a
+	// number the reader can add up itself.
 	encoded := make(map[string][]byte, len(toks))
 	dirLen := len(bucketMagic) + uvarintLen(uint64(len(toks)))
 	for _, tok := range toks {
-		dirLen += uvarintLen(uint64(len(tok))) + len(tok) + 8 + 4
-		encoded[tok] = encodePostings(data[tok])
+		b := encodePostings(data[tok])
+		encoded[tok] = b
+		dirLen += uvarintLen(uint64(len(tok))) + len(tok) + uvarintLen(uint64(len(b)))
 	}
 	entries := make([]bucketEntry, 0, len(toks))
 	pos := uint64(dirLen)
@@ -483,10 +489,8 @@ func writeBucket(p string, data map[string][]posting) error {
 		if _, err := w.Write([]byte(e.tok)); err != nil {
 			return err
 		}
-		var fixed [12]byte
-		binary.LittleEndian.PutUint64(fixed[:8], e.off)
-		binary.LittleEndian.PutUint32(fixed[8:], e.n)
-		if _, err := w.Write(fixed[:]); err != nil {
+		n = binary.PutUvarint(scratch[:], uint64(e.n))
+		if _, err := w.Write(scratch[:n]); err != nil {
 			return err
 		}
 	}
@@ -572,6 +576,9 @@ func openBucketDir(p string) ([]bucketEntry, *os.File, error) {
 		return nil, nil, fmt.Errorf("%w: %v", errCorruptIndex, err)
 	}
 	entries := make([]bucketEntry, 0, count)
+	// Offsets are not stored; they are the running sum of the lengths, taken
+	// from where the directory ends.
+	dirLen := uint64(len(bucketMagic)) + uint64(uvarintLen(count))
 	for i := uint64(0); i < count; i++ {
 		ln, err := binary.ReadUvarint(r)
 		if err != nil {
@@ -583,12 +590,22 @@ func openBucketDir(p string) ([]bucketEntry, *os.File, error) {
 			f.Close()
 			return nil, nil, fmt.Errorf("%w: %v", errCorruptIndex, err)
 		}
-		var fixed [12]byte
-		if _, err := io.ReadFull(r, fixed[:]); err != nil {
+		size, err := binary.ReadUvarint(r)
+		if err != nil {
 			f.Close()
 			return nil, nil, fmt.Errorf("%w: %v", errCorruptIndex, err)
 		}
-		entries = append(entries, bucketEntry{tok: string(tb), off: binary.LittleEndian.Uint64(fixed[:8]), n: binary.LittleEndian.Uint32(fixed[8:])})
+		if size > math.MaxUint32 {
+			f.Close()
+			return nil, nil, fmt.Errorf("%w: posting block length %d", errCorruptIndex, size)
+		}
+		dirLen += uint64(uvarintLen(ln)) + ln + uint64(uvarintLen(size))
+		entries = append(entries, bucketEntry{tok: string(tb), n: uint32(size)})
+	}
+	pos := dirLen
+	for i := range entries {
+		entries[i].off = pos
+		pos += uint64(entries[i].n)
 	}
 	return entries, f, nil
 }

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -2,6 +2,8 @@ package index
 
 import (
 	"bufio"
+	"bytes"
+	"compress/flate"
 	"encoding/binary"
 	"encoding/gob"
 	"fmt"
@@ -9,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -285,14 +288,52 @@ func (t *recordTables) lookup(id uint64) string {
 	return ""
 }
 
+// compressFloor is deliberately high. Compressing every message halved the
+// record log but doubled index build time and tripled the latency of a query
+// that materializes many records — the payload is touched once per message on
+// write and once per message shown. The mass is in the tail instead: on a real
+// corpus 1.1% of messages (tool output, file dumps) hold 22.6% of the text, so
+// only those are worth the CPU.
+const compressFloor = 8192
+
+const (
+	recordRaw      = 0
+	recordDeflated = 1
+)
+
+var deflateWriters = sync.Pool{New: func() any { w, _ := flate.NewWriter(nil, flate.DefaultCompression); return w }}
+var inflateReaders = sync.Pool{New: func() any { return flate.NewReader(nil) }}
+
+// A record is [keyID][pathID][flag][payload]. The ids stay outside the
+// payload so a walk can peek the key and skip the record without inflating
+// anything — that path never touches a compressed byte.
 func encodeRecord(r Record, t *recordTables) []byte {
-	b := make([]byte, 0, len(r.Role)+len(r.Text)+32)
+	body := make([]byte, 0, len(r.Role)+len(r.Text)+24)
+	body = appendField(body, r.Role)
+	body = binary.LittleEndian.AppendUint64(body, uint64(r.Time.UnixNano()))
+	body = appendField(body, r.Text)
+
+	b := make([]byte, 0, len(body)+16)
 	b = binary.AppendUvarint(b, t.intern(r.Key))
 	b = binary.AppendUvarint(b, t.intern(r.SourcePath))
-	b = appendField(b, r.Role)
-	b = binary.LittleEndian.AppendUint64(b, uint64(r.Time.UnixNano()))
-	b = appendField(b, r.Text)
-	return b
+	if len(body) < compressFloor {
+		return append(append(b, recordRaw), body...)
+	}
+	var buf bytes.Buffer
+	w := deflateWriters.Get().(*flate.Writer)
+	w.Reset(&buf)
+	if _, err := w.Write(body); err != nil {
+		deflateWriters.Put(w)
+		return append(append(b, recordRaw), body...)
+	}
+	err := w.Close()
+	deflateWriters.Put(w)
+	// Incompressible payloads (already-compressed blobs, random ids) are
+	// stored as they are rather than grown.
+	if err != nil || buf.Len() >= len(body) {
+		return append(append(b, recordRaw), body...)
+	}
+	return append(append(b, recordDeflated), buf.Bytes()...)
 }
 
 func appendField(b []byte, s string) []byte {
@@ -315,6 +356,26 @@ func decodeRecord(b []byte, t *recordTables) (Record, error) {
 	b = b[n:]
 	rec.Key = t.lookup(kid)
 	rec.SourcePath = t.lookup(pid)
+	if len(b) < 1 {
+		return rec, io.ErrUnexpectedEOF
+	}
+	flag := b[0]
+	b = b[1:]
+	if flag == recordDeflated {
+		zr := inflateReaders.Get().(io.ReadCloser)
+		if err := zr.(flate.Resetter).Reset(bytes.NewReader(b), nil); err != nil {
+			inflateReaders.Put(zr)
+			return rec, err
+		}
+		body, err := io.ReadAll(zr)
+		inflateReaders.Put(zr)
+		if err != nil {
+			return rec, err
+		}
+		b = body
+	} else if flag != recordRaw {
+		return rec, fmt.Errorf("%w: unknown record encoding %d", errCorruptIndex, flag)
+	}
 	if rec.Role, b, ok = consumeField(b); !ok {
 		return rec, io.ErrUnexpectedEOF
 	}

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -174,16 +174,36 @@ func eachRecordForKeys(path string, t *recordTables, want map[string]bool, fn fu
 		if n > maxRecordSize {
 			return fmt.Errorf("%w: record length %d exceeds cap", errCorruptIndex, n)
 		}
+		// The key id is the first varint of the payload, so peek it and skip
+		// the rest of the record without touching it. Materializing every
+		// record just to read two bytes copied the whole log per query.
+		peek := int(n)
+		if peek > binary.MaxVarintLen64 {
+			peek = binary.MaxVarintLen64
+		}
+		head, perr := r.Peek(peek)
+		if perr != nil && len(head) == 0 {
+			if perr == io.EOF || perr == io.ErrUnexpectedEOF {
+				return nil
+			}
+			return perr
+		}
+		kid, un := binary.Uvarint(head)
+		if un <= 0 || !want[t.lookup(kid)] {
+			if _, derr := r.Discard(int(n)); derr != nil {
+				if derr == io.EOF || derr == io.ErrUnexpectedEOF {
+					return nil
+				}
+				return derr
+			}
+			continue
+		}
 		b := make([]byte, n)
 		if _, err := io.ReadFull(r, b); err != nil {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				return nil
 			}
 			return err
-		}
-		kid, un := binary.Uvarint(b)
-		if un <= 0 || !want[t.lookup(kid)] {
-			continue
 		}
 		rec, derr := decodeRecord(b, t)
 		if derr != nil {

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -125,7 +125,7 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 	// Only sources this export actually touched may have their watermark or
 	// boundary rewritten; pushing project B must leave project A's alone.
 	touched := map[string]bool{}
-	err = eachRecord(filepath.Join(dir, "records.bin"), func(r Record) {
+	err = eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
 		if r.SourcePath == syncImportPath {
 			return
 		}
@@ -367,7 +367,8 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 	if err != nil {
 		return err
 	}
-	rw, err := newRecordWriter(rf)
+	tbl := tablesFromManifest(*m)
+	rw, err := newRecordWriter(rf, tbl)
 	if err != nil {
 		_ = rf.Close()
 		return err
@@ -428,6 +429,7 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 	if err := rw.Close(); err != nil {
 		return err
 	}
+	m.RecordStrings = tbl.strs
 	if err := writeBucketsConcurrent(filepath.Join(dir, "buckets"), buckets); err != nil {
 		return err
 	}

--- a/internal/index/testtables_test.go
+++ b/internal/index/testtables_test.go
@@ -1,0 +1,21 @@
+package index
+
+// testTables builds a record table covering records assembled by hand, so a
+// test can round-trip through the log without standing up a manifest.
+func testTables(recs ...Record) *recordTables {
+	t := newRecordTables()
+	for _, r := range recs {
+		t.intern(r.Key)
+		t.intern(r.SourcePath)
+	}
+	return t
+}
+
+// mustTables loads the table an index on disk was written with.
+func mustTables(t interface{ Fatal(...any) }, dir string) *recordTables {
+	tbl, err := loadRecordTables(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tbl
+}

--- a/internal/index/unstamped_test.go
+++ b/internal/index/unstamped_test.go
@@ -19,7 +19,7 @@ func TestZeroTimeRoundTripsAsZero(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rw, err := newRecordWriter(f)
+	rw, err := newRecordWriter(f, newRecordTables())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +30,7 @@ func TestZeroTimeRoundTripsAsZero(t *testing.T) {
 		t.Fatal(err)
 	}
 	var got Record
-	if err := eachRecord(p, func(r Record) { got = r }); err != nil {
+	if err := eachRecord(p, newRecordTables(), func(r Record) { got = r }); err != nil {
 		t.Fatal(err)
 	}
 	if !got.Time.IsZero() {
@@ -42,7 +42,7 @@ func TestZeroTimeRoundTripsAsZero(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rw2, err := newRecordWriter(f2)
+	rw2, err := newRecordWriter(f2, newRecordTables())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestZeroTimeRoundTripsAsZero(t *testing.T) {
 		t.Fatal(err)
 	}
 	var got2 Record
-	if err := eachRecord(filepath.Join(dir, "r2.bin"), func(r Record) { got2 = r }); err != nil {
+	if err := eachRecord(filepath.Join(dir, "r2.bin"), newRecordTables(), func(r Record) { got2 = r }); err != nil {
 		t.Fatal(err)
 	}
 	if !got2.Time.Equal(when) {


### PR DESCRIPTION
Carries the six changes that were stranded when I merged the stack in the wrong order — a stacked PR merges into its own base, not into main, so #353, #354 and #356 landed in intermediate branches that were then deleted. Nothing was lost; these are the same commits rebased onto main. #357, #358 and #359 are superseded by this and are closed.

Contents, each measured and each with tests that fail without its fix:

- **CJK function-word bigrams dropped from query terms** (was #353). A Chinese question expands into one bigram per character pair, so its grammar weighed as much as the entity asked about. MIRACL Chinese hit@1 40.4 → 42.5, MRR 0.507 → 0.525, English guards byte-identical.
- **Record keys and source paths interned** (was #354). 90 distinct paths and 1073 keys were spelled out in all 57k records — 8.3 MB, 17% of the record log.
- **Records skipped without copying** (was #356). The walk materialized every record to read the two bytes of its key.
- **Token catalog cached between queries** (was #356). The stem and fuzzy tiers each rebuilt the 180k-token catalog. Keyed on the bucket files, not the manifest, so a corrupt bucket is still reported.
- **Large record payloads deflated** (was #357). Tool output and dumps are ~1% of messages but 22.6% of the text. Index 44.6 MB → 22.3 MB on a corpus with a realistic tail, with index build and search latency unchanged. Compressing *every* message instead doubled build time and tripled latency — the floor is high on purpose.
- **Derivable offsets dropped from bucket directories** (was #358). Buckets 7.27 MB → 4.89 MB on a 216k-token corpus.
- **Token catalog bucketed by length for fuzzy** (was #359). Damerau-Levenshtein ran against all 267k tokens per query term: `closeTokens` 168 ms → 36 ms.

Index version 11 → 15, so every existing index is rebuilt once on upgrade.

Full `-race` suite green, lint clean.
