### PR TITLE
fix(search): treat Traditional and Cantonese function words as grammar

### DIFF
--- a/internal/index/cjk.go
+++ b/internal/index/cjk.go
@@ -108,7 +108,13 @@ func expandCJKTokens(toks []string) []string {
 // bigram that merely contains one would delete real words. This filter runs
 // at query time only — the index keeps every bigram, so nothing about
 // ingestion changes.
+//
+// The list covers three scripts of the same closed class. Simplified Mandarin
+// alone is not enough: a Traditional writer's 哪個 and a Cantonese writer's
+// 我點 / 唔用 / 嘅索 are the same grammar, and without them a question ranks on
+// its own wording instead of on the entity it asks about.
 var cjkFunctionRunes = map[rune]bool{
+	// Simplified Mandarin
 	'的': true, '了': true, '是': true, '在': true, '和': true, '与': true,
 	'或': true, '而': true, '但': true, '就': true, '都': true, '也': true,
 	'还': true, '又': true, '再': true, '只': true, '才': true, '很': true,
@@ -119,6 +125,18 @@ var cjkFunctionRunes = map[rune]bool{
 	'给': true, '向': true, '于': true, '以': true, '从': true, '到': true,
 	'由': true, '对': true, '因': true, '如': true, '若': true, '则': true,
 	'并': true, '且': true, '为': true, '个': true, '有': true, '会': true,
+
+	// Traditional forms of the entries above, for zh-TW / zh-HK writing
+	'與': true, '還': true, '們': true, '這': true, '麼': true, '嗎': true,
+	'讓': true, '給': true, '於': true, '從': true, '對': true, '則': true,
+	'並': true, '為': true, '個': true, '會': true,
+
+	// Cantonese closed class: 嘅=的 係=是 喺=在 唔=不 咩/乜=什麼 點=怎
+	// 哋=們 嗰=那 啲=些 樣=樣(如「咁樣」) 冇=沒 嚟=來, plus the
+	// sentence-final particles 咪 囉 喎 啦.
+	'嘅': true, '係': true, '喺': true, '唔': true, '咩': true, '乜': true,
+	'點': true, '哋': true, '嗰': true, '啲': true, '樣': true, '冇': true,
+	'嚟': true, '咪': true, '囉': true, '喎': true, '啦': true, '咁': true,
 }
 
 // cjkFunctionBigram reports whether every rune of a CJK token is a function

--- a/internal/index/cjk_traditional_test.go
+++ b/internal/index/cjk_traditional_test.go
@@ -1,0 +1,113 @@
+package index
+
+import "testing"
+
+func hasTerm(terms []string, want string) bool {
+	for _, term := range terms {
+		if term == want {
+			return true
+		}
+	}
+	return false
+}
+
+// cjkFunctionRunes listed only Simplified Mandarin forms, so the same closed
+// class written in Traditional characters arrived as content: a Traditional
+// writer asking 復旦大學在哪個城市 got 在哪 and 哪個 weighted like the entity
+// they were asking about, which is exactly what
+// TestCJKFunctionBigramsAreNotQueryTerms prevents for Simplified input.
+func TestCJKFunctionBigramsTraditional(t *testing.T) {
+	terms := RelevanceTerms("復旦大學在哪個城市？")
+	for _, junk := range []string{"在哪", "哪個"} {
+		if hasTerm(terms, junk) {
+			t.Errorf("Traditional function bigram %q survived as a query term: %v", junk, terms)
+		}
+	}
+	for _, want := range []string{"復旦", "大學", "城市"} {
+		if !hasTerm(terms, want) {
+			t.Errorf("content bigram %q was dropped: %v", want, terms)
+		}
+	}
+	// The "every rune" rule must keep real words whose characters are function
+	// runes on their own, exactly as it does for Simplified.
+	if got := RelevanceTerms("中國有多少個人"); !hasTerm(got, "中國") || !hasTerm(got, "個人") {
+		t.Errorf("real words dropped from 中國有多少個人: %v", got)
+	}
+	if got := RelevanceTerms("目的是什麼"); !hasTerm(got, "目的") {
+		t.Errorf("real word 目的 dropped: %v", got)
+	}
+	for _, pair := range []struct{ query, want string }{
+		{"這個關係好緊要", "關係"},
+		{"樣本數量", "樣本"},
+		{"重點係邊個", "重點"},
+	} {
+		if got := RelevanceTerms(pair.query); !hasTerm(got, pair.want) {
+			t.Errorf("real word %q dropped from %q: %v", pair.want, pair.query, got)
+		}
+	}
+}
+
+// Cantonese writes its own closed class — 嘅 for 的, 係 for 是, 喺 for 在,
+// 唔 for 不, 咩/乜 for 什麼, 點 for 怎, 哋 for 們, 嗰 for 那, 啲 for 些 — none
+// of which were listed, so a Cantonese question contributed its whole grammar
+// to the relevance tier.
+func TestCJKFunctionBigramsCantonese(t *testing.T) {
+	terms := RelevanceTerms("我點解唔用 postgres 嘅索引")
+	if hasTerm(terms, "我點") {
+		t.Errorf("Cantonese grammar bigram 我點 survived as a query term: %v", terms)
+	}
+	if !hasTerm(terms, "postgres") {
+		t.Errorf("the entity being asked about was dropped: %v", terms)
+	}
+	if !hasTerm(terms, "索引") {
+		t.Errorf("content bigram 索引 was dropped: %v", terms)
+	}
+
+	// Bigrams that are grammar end to end.
+	for _, junk := range []string{"係咁", "咁樣", "喺呢", "嗰啲", "我哋", "呢啲"} {
+		if got := RelevanceTerms(junk + "做"); hasTerm(got, junk) {
+			t.Errorf("Cantonese grammar bigram %q survived: %v", junk, got)
+		}
+	}
+
+	// Content words built from characters that are function runes on their own
+	// must survive, the same guarantee the Simplified list already gives.
+	for _, pair := range []struct{ query, want string }{
+		{"睇下個人資料", "個人"},
+		{"關係好緊要", "關係"},
+		{"重點係邊個", "重點"},
+		{"冇錢用", "冇錢"},
+	} {
+		if got := RelevanceTerms(pair.query); !hasTerm(got, pair.want) {
+			t.Errorf("real word %q dropped from %q: %v", pair.want, pair.query, got)
+		}
+	}
+}
+
+// The point of the patch is parity: a question asked in Traditional or in
+// Cantonese should reduce to the same shape of terms as its Simplified
+// counterpart. Boundary bigrams that pair a particle with a content character
+// (的索 in Simplified, 嘅索 in Cantonese) survive in both — that is inherent to
+// bigram tokenization, not a script-specific defect.
+func TestCJKFunctionBigramParityAcrossScripts(t *testing.T) {
+	countGrammar := func(q string, grammar []string) int {
+		terms := RelevanceTerms(q)
+		n := 0
+		for _, g := range grammar {
+			if hasTerm(terms, g) {
+				n++
+			}
+		}
+		return n
+	}
+	// Pure-grammar bigrams of the question form "why don't I use X".
+	if simp := countGrammar("我为什么不用 postgres 的索引", []string{"我为", "为什", "什么"}); simp != 0 {
+		t.Fatalf("baseline changed: Simplified grammar bigrams leaked: %d", simp)
+	}
+	if yue := countGrammar("我點解唔用 postgres 嘅索引", []string{"我點"}); yue != 0 {
+		t.Errorf("Cantonese grammar bigrams leaked where Simplified's did not: %d", yue)
+	}
+	if trad := countGrammar("復旦大學在哪個城市？", []string{"在哪", "哪個"}); trad != 0 {
+		t.Errorf("Traditional grammar bigrams leaked where Simplified's did not: %d", trad)
+	}
+}


### PR DESCRIPTION
`cjkFunctionRunes` lists Simplified Mandarin forms only, so the same closed class written in Traditional or Cantonese reaches the relevance tier as content. The guarantee `TestCJKFunctionBigramsAreNotQueryTerms` gives Simplified input does not hold for the other two ways of writing the same language.

Reproduced on `main` — both new tests fail before the change and pass after:

```
RelevanceTerms("復旦大學在哪個城市？")
  before → [復旦 旦大 大學 學在 哪個 個城 城市]      # 哪個 is grammar
  after  → [復旦 旦大 大學 學在 個城 城市]

RelevanceTerms("我點解唔用 postgres 嘅索引")
  before → [我點 點解 解唔 唔用 postgres 嘅索 索引]  # 5 of 7 terms are grammar
  after  → [點解 解唔 唔用 postgres 嘅索 索引]
```

The Cantonese case matters because 點解 ("why") and 我哋 ("we") appear in nearly every session written by a Cantonese speaker, so the tier ranks on the question's wording rather than on the entity being asked about.

### What the patch adds

- Traditional forms of entries already in the map: 與 還 們 這 麼 嗎 讓 給 於 從 對 則 並 為 個 會
- The Cantonese closed class: 嘅(的) 係(是) 喺(在) 唔(不) 咩/乜(什麼) 點(怎) 哋(們) 嗰(那) 啲(些) 樣 冇(沒) 嚟(來), plus the sentence-final particles 咪 囉 喎 啦 咁

The both-runes rule is untouched, so words whose characters are function runes individually still survive — covered by tests: 關係, 重點, 個人, 樣本, 冇錢, 中國, 目的, 這個關係. Query-time only, so the index is unchanged and no reindex is needed.

### Scope, deliberately narrow

The tests assert **parity with the Simplified baseline**, not a stricter standard. Boundary bigrams pairing a particle with a content character survive in both scripts (`的索` in Simplified, `嘅索` in Cantonese) — inherent to bigram tokenization. Two things I did not do:

- `解` is not added, even though 點解 is the Cantonese "why": adding it would filter 了解, a real Simplified word, under the both-runes rule.
- Japanese and Korean function words are still unlisted. `isCJK` accepts Hiragana/Katakana/Hangul but the map is Chinese-only — out of scope here.

### Verification

- `go test ./internal/index/ -run CJK` — 10/10 pass including the two new tests
- `go test ./...` — full suite green
- `gofmt -l` and `go vet` clean
- Built and run against a real 3,300-session / 106k-message mixed-script corpus: grammar noise drops (a Cantonese question's match count 549 → 532, 202 → 132) and on-topic sessions stay on top. To be straight about it: this is a noise reduction, not a dramatic ranking change.

I have a second, independent change for Simplified↔Traditional folding — separate PR, since it needs a reindex and this one does not.
