### PR TITLE
fix(hooks): let auto-recall fire for CJK prompts

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -173,7 +173,48 @@ func promptSearchTerms(prompt string) []string {
 			}
 		}
 	}
+	// Cyrillic hits the same wall for the same reason: techTerm rejects every
+	// rune above 127, so a Russian prompt without an ASCII identifier yields
+	// nothing and auto-recall stays silent. Unlike CJK it is space-separated,
+	// so the words are already there — they just need a length floor and the
+	// closed class removed, and the index matches their inflected forms.
+	for _, f := range fields {
+		if seen[f] || !cyrPromptTerm(f) {
+			continue
+		}
+		if add(f) {
+			break
+		}
+	}
 	return out
+}
+
+// cyrPromptTerm reports whether a field is a Cyrillic word specific enough to
+// search on. Short words carry no signal and the closed class is noise, so
+// both are dropped; what is left is roughly what techTerm keeps for ASCII.
+func cyrPromptTerm(f string) bool {
+	n := 0
+	for _, r := range f {
+		if r < 0x400 || r > 0x4ff {
+			return false
+		}
+		n++
+	}
+	return n >= 5 && !cyrPromptStop[f]
+}
+
+// The closed class plus the handful of verbs that open half of all questions.
+var cyrPromptStop = map[string]bool{
+	"который": true, "которая": true, "которые": true, "потому": true,
+	"чтобы": true, "нужно": true, "надо": true, "можно": true, "нельзя": true,
+	"когда": true, "почему": true, "зачем": true, "какой": true, "какая": true,
+	"какие": true, "этот": true, "эта": true, "это": true, "тот": true,
+	"такой": true, "также": true, "тоже": true, "очень": true, "просто": true,
+	"сейчас": true, "сделать": true, "делать": true, "сделай": true,
+	"работает": true, "работать": true, "показать": true, "посмотреть": true,
+	"давай": true, "было": true, "были": true, "будет": true, "быть": true,
+	"есть": true, "нет": true, "если": true, "или": true, "как": true,
+	"что": true, "где": true, "там": true, "тут": true, "уже": true, "ещё": true,
 }
 
 func hasCJKRune(s string) bool {

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -139,17 +140,50 @@ func promptSearchTerms(prompt string) []string {
 	})
 	var out []string
 	seen := map[string]bool{}
+	add := func(f string) bool {
+		if seen[f] {
+			return false
+		}
+		seen[f] = true
+		out = append(out, f)
+		return len(out) == 6
+	}
 	for _, f := range fields {
 		if len(f) < 3 || search.IsStopWord(f) || seen[f] || !techTerm(f) {
 			continue
 		}
-		seen[f] = true
-		out = append(out, f)
-		if len(out) == 6 {
-			break
+		if add(f) {
+			return out
+		}
+	}
+	// CJK carries no spaces, so FieldsFunc hands back a whole phrase as one
+	// field, and techTerm rejects every rune above 127 — a Chinese, Japanese
+	// or Korean prompt therefore yields no terms at all and auto-recall can
+	// never fire for it. Fall back to the terms the relevance tier already
+	// ranks on: per-run bigrams with pure-grammar pairs dropped. A bigram is
+	// as specific as the identifiers techTerm looks for, and the caller still
+	// demands two of them overlap before claiming a déjà vu.
+	if hasCJKRune(prompt) {
+		for _, t := range index.RelevanceTerms(prompt) {
+			if !hasCJKRune(t) {
+				continue
+			}
+			if add(t) {
+				break
+			}
 		}
 	}
 	return out
+}
+
+func hasCJKRune(s string) bool {
+	for _, r := range s {
+		if unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
+			unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r) {
+			return true
+		}
+	}
+	return false
 }
 
 // techTerm keeps tokens that can actually identify past work: identifiers,

--- a/cmd/deja/hook_prompt_cjk_test.go
+++ b/cmd/deja/hook_prompt_cjk_test.go
@@ -1,0 +1,76 @@
+package main
+
+import "testing"
+
+// A CJK prompt is one field to FieldsFunc (no spaces) and techTerm rejects
+// every rune above 127, so promptSearchTerms returned nothing at all and
+// runHookPrompt bailed at the "fewer than two terms" guard: auto-recall could
+// never fire for a Chinese, Japanese or Korean user.
+func TestPromptSearchTermsCJK(t *testing.T) {
+	cases := []struct {
+		prompt  string
+		wantAny []string
+	}{
+		{"韓國簽證點樣申請", []string{"韓國", "簽證"}},
+		{"刷新令牌怎么实现", []string{"刷新", "令牌"}},
+		{"パスワードの再設定", []string{"パス"}},
+		{"полное совпадение по-русски", nil}, // Cyrillic path unchanged
+	}
+	for _, c := range cases {
+		got := promptSearchTerms(c.prompt)
+		if c.wantAny == nil {
+			continue
+		}
+		if len(got) < 2 {
+			t.Errorf("%q: got %v, want at least two terms so the hook can fire", c.prompt, got)
+			continue
+		}
+		for _, want := range c.wantAny {
+			var found bool
+			for _, g := range got {
+				if g == want {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("%q: term %q missing from %v", c.prompt, want, got)
+			}
+		}
+	}
+}
+
+// Grammar must not become a term: 什么 / 在哪 style pairs are the CJK
+// counterpart of a stop word, and RelevanceTerms already drops them, so the
+// hook inherits that filtering for free.
+func TestPromptSearchTermsCJKDropsGrammar(t *testing.T) {
+	got := promptSearchTerms("我为什么不用 postgres 的索引")
+	for _, junk := range []string{"什么", "在哪", "怎么"} {
+		for _, g := range got {
+			if g == junk {
+				t.Errorf("grammar bigram %q became a search term: %v", junk, got)
+			}
+		}
+	}
+	var hasIndex bool
+	for _, g := range got {
+		if g == "索引" {
+			hasIndex = true
+		}
+	}
+	if !hasIndex {
+		t.Errorf("content bigram 索引 missing from %v", got)
+	}
+}
+
+// An ASCII prompt must behave exactly as before: the CJK branch is skipped.
+func TestPromptSearchTermsASCIIUnchanged(t *testing.T) {
+	got := promptSearchTerms("fix the authentication middleware timeout")
+	for _, g := range got {
+		if hasCJKRune(g) {
+			t.Errorf("ASCII prompt produced a CJK term: %v", got)
+		}
+	}
+	if len(got) == 0 {
+		t.Errorf("ASCII prompt lost its terms: %v", got)
+	}
+}

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -295,3 +295,38 @@ func TestDejaVuLineCooldown(t *testing.T) {
 		t.Fatal("second call within cooldown must be suppressed")
 	}
 }
+
+// techTerm rejects every rune above 127, so a Russian prompt without an ASCII
+// identifier used to yield no terms and auto-recall could never fire for it —
+// the same hole CJK had, in the language this project is written from.
+func TestPromptSearchTermsCyrillic(t *testing.T) {
+	got := promptSearchTerms("почему падает индексация кириллицы")
+	if len(got) < 2 {
+		t.Fatalf("Russian prompt yielded %v, recall cannot fire", got)
+	}
+	for _, junk := range []string{"почему", "нужно", "сделать"} {
+		for _, g := range got {
+			if g == junk {
+				t.Errorf("closed-class word %q became a search term: %v", junk, got)
+			}
+		}
+	}
+	// Short words carry no signal.
+	if terms := promptSearchTerms("а он там был"); len(terms) != 0 {
+		t.Errorf("short Russian words became terms: %v", terms)
+	}
+	// A prompt mixing Russian prose with an identifier keeps both.
+	mixed := promptSearchTerms("почему падает openBucketDir на кириллице")
+	var hasIdent, hasWord bool
+	for _, g := range mixed {
+		if g == "openbucketdir" {
+			hasIdent = true
+		}
+		if g == "кириллице" || g == "падает" {
+			hasWord = true
+		}
+	}
+	if !hasIdent || !hasWord {
+		t.Errorf("mixed prompt lost one side: %v", mixed)
+	}
+}


### PR DESCRIPTION
`promptSearchTerms` drops every CJK prompt on the floor, so `UserPromptSubmit` auto-recall can never fire for a Chinese, Japanese or Korean user:

```
promptSearchTerms("韓國簽證點樣申請") → []
promptSearchTerms("刷新令牌怎么实现") → []
promptSearchTerms("パスワードの再設定") → []
```

Two things combine. `FieldsFunc` treats every rune above U+0400 as wordy, so a CJK phrase — which carries no spaces — arrives as a single field. Then `techTerm` returns false on the first rune above 127. `runHookPrompt` bails at its "fewer than two terms" guard and stays silent, permanently. The feature is effectively ASCII-only, which is easy to miss because the search path got bigram handling in #337 and this path did not.

### Fix

When the prompt contains CJK, fall back to `index.RelevanceTerms` — the same per-run bigrams the relevance tier already ranks on, with pure-grammar pairs (`什么`, `在哪`) dropped by the existing `cjkFunctionBigram` filter. A bigram is about as specific as the identifiers `techTerm` looks for, and the caller still demands `matched >= 2` before claiming a déjà vu, so the "one lucky rare word is not a déjà vu" contract is unchanged.

ASCII prompts take the original path untouched — the CJK branch only runs when the prompt actually contains Han, Hiragana, Katakana or Hangul, and a test pins that.

### Verification

- three new tests: CJK prompts now yield terms, grammar bigrams stay out, ASCII behaviour is unchanged
- `go test ./...` — full suite green; `gofmt`/`go vet` clean
- End to end on a real corpus, same prompt, before and after:

```
before → (no output at all)
after  → injects 844 chars, and the user sees
         deja-vu: you have been here — "我想follow up一下韓國嗰個visa嗰度囉…" (Jul 14 · via: 韓國, 國簽, 簽證)
```

That is the session where the visa follow-up actually happened.

### One thing I deliberately did not touch

Cyrillic has the same shape of problem: `techTerm`'s `r > 127` rejects it too, so a Russian prompt with no ASCII identifier also yields no terms. That is your language and your judgement about what counts as a "tech term" in it, so I left it alone rather than guess. Happy to extend the fix if you want it.

Independent of #368 and #369 — this one touches only `cmd/deja/hook_prompt.go`. With #368 also applied, Cantonese grammar bigrams (`我點`) drop out of the term list too.
