### PR TITLE
fix(install): adopt an existing deja hook instead of adding a second

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -520,6 +520,22 @@ func hookStatusMessage(event string) string {
 	return ""
 }
 
+// isDejaHookCommand reports whether an existing hook entry is one of ours for
+// the same subcommand. Matching on the trailing subcommand rather than the
+// whole string means moving the binary replaces the old entry instead of
+// leaving a duplicate that fires alongside the new one.
+func isDejaHookCommand(existing any, cmd string) bool {
+	s, ok := existing.(string)
+	if !ok {
+		return false
+	}
+	if s == cmd {
+		return true
+	}
+	sub := cmd[strings.LastIndex(cmd, " ")+1:]
+	return strings.HasSuffix(s, " "+sub) && strings.Contains(s, "deja")
+}
+
 func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall bool) map[string]any {
 	hooks, _ := root["hooks"].(map[string]any)
 	if hooks == nil {
@@ -546,14 +562,24 @@ func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall
 		removed := false
 		for _, hAny := range hs {
 			h, _ := hAny.(map[string]any)
-			if h != nil && h["type"] == "command" && h["command"] == cmd {
-				found = true
+			if h != nil && h["type"] == "command" && isDejaHookCommand(h["command"], cmd) {
 				if uninstall {
 					removed = true
 					continue
 				}
+				// An entry of ours for this event already exists. Take it over
+				// rather than adding a second one: installing from a new path
+				// used to leave the old entry behind, and both would fire.
+				found = true
+				h["command"] = cmd
+				if msg := hookStatusMessage(event); msg != "" {
+					h["statusMessage"] = msg
+				}
 			}
 			kept = append(kept, hAny)
+		}
+		if len(kept) != len(hs) || found {
+			entry["hooks"] = kept
 		}
 		if removed {
 			if len(kept) == 0 {

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -505,9 +505,10 @@ func updateClaudeSessionStartHook(root map[string]any, exe string, uninstall boo
 	return root
 }
 
-// hookStatusMessage is what Claude Code shows while the hook runs. Without it
-// the pause before the first prompt is unexplained; with it, the one moment
-// deja costs the user is the moment it announces itself.
+// hookStatusMessage labels the hook while it runs. Codex carries it through
+// to its hook run summary; Claude Code 2.1.220 parses the field but shows
+// nothing for it — there the receipt in systemMessage is what the user sees,
+// which was checked by rendering the actual TUI rather than by reading docs.
 func hookStatusMessage(event string) string {
 	switch event {
 	case "SessionStart":

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -50,8 +50,7 @@ func installCodexHooks(exe string, uninstall bool) (installResult, error) {
 			"matcher": "startup|resume",
 			"hooks": []any{map[string]any{
 				"type": "command", "command": cmd, "timeout": 10,
-				// Codex renders statusMessage while the hook runs, same as
-				// Claude Code — the one pause deja costs says what it is for.
+				// Codex surfaces statusMessage in its hook run summary.
 				"statusMessage": hookStatusMessage("SessionStart"),
 			}},
 		})

--- a/cmd/deja/install_config_dir_test.go
+++ b/cmd/deja/install_config_dir_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -74,5 +75,56 @@ func TestClaudeHookUninstallNeverLeavesNullHooks(t *testing.T) {
 	entries2, _ := healed["hooks"].(map[string]any)["PreCompact"].([]any)
 	if len(entries2) != 1 {
 		t.Fatalf("null-hooks entry not healed: %#v", entries2)
+	}
+}
+
+// Installing from a new path used to leave the old entry behind, so both
+// fired: the digest was injected twice and hook-prompt ran twice per prompt.
+func TestClaudeHookInstallTakesOverAnOlderPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if _, err := installClaudeHook("/opt/old/deja", false); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if _, err := installClaudeHook("/usr/local/bin/deja", false); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Command       string `json:"command"`
+				StatusMessage string `json:"statusMessage"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	for event, groups := range root.Hooks {
+		var ours []string
+		for _, g := range groups {
+			for _, h := range g.Hooks {
+				if !strings.Contains(h.Command, "deja") {
+					continue
+				}
+				ours = append(ours, h.Command)
+				// An entry we own carries the status message whether it was
+				// created now or adopted from an older install.
+				if hookStatusMessage(event) != "" && h.StatusMessage == "" {
+					t.Errorf("%s: adopted entry has no statusMessage", event)
+				}
+			}
+		}
+		if len(ours) != 1 {
+			t.Errorf("%s: %d deja hooks, want 1: %v", event, len(ours), ours)
+		}
+		if len(ours) == 1 && !strings.HasPrefix(ours[0], "/usr/local/bin/deja") {
+			t.Errorf("%s: kept the stale path: %s", event, ours[0])
+		}
 	}
 }


### PR DESCRIPTION
Found on a machine that had deja installed twice from different paths: every hook existed twice, so the session-start digest was injected twice and `hook-prompt` ran twice per prompt.

`updateClaudeHook` matched an existing entry by the whole command string, so a new path looked like a new hook. It now matches on the trailing subcommand — `hook-context`, `hook-prompt`, `hook-precompact` — and takes the entry over: the path is rewritten and `statusMessage` is set on it. That also fixes the second half, where anyone who installed before `statusMessage` existed kept an entry that never gained it, because re-running install reported "unchanged".

While verifying this against a real TUI I also corrected a claim I had made in comments: Claude Code 2.1.220 does not render `statusMessage` for hooks — every occurrence of the name in its binary belongs to Bun's HTTP layer. What the user actually sees there is the `systemMessage` receipt, confirmed on a rendered screen:

```
⎿ SessionStart:startup says: deja: recalled 3 prior sessions from this project (~2KB)
  — the agent starts already knowing them · today: 38 recalls, 60.5 KB distilled from 6.8 MB
```

Codex does carry `statusMessage` through to its hook run summary, so the field stays.

Closes #372.
