### PR TITLE
test: pin the cold-build status file the UI reads

### DIFF
--- a/cmd/deja/warmup_path_test.go
+++ b/cmd/deja/warmup_path_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Everything the user sees about a cold build — the status bar line, the
+// hook's systemMessage, the opencode toast, the MCP instructions note — reads
+// one status file. If the detached build stops writing it, all of them go
+// quiet at once and nothing else fails, so this pins the whole path rather
+// than fileProgress in isolation.
+func TestWarmupPublishesStatusDuringBuild(t *testing.T) {
+	withTempStores(t)
+	dir := os.Getenv("DEJA_INDEX_DIR")
+	if dir == "" {
+		t.Fatal("DEJA_INDEX_DIR not set by withTempStores")
+	}
+	t.Setenv("DEJA_WARMUP_SENTINEL", dir+"/warmup.sentinel")
+	seen := false
+	err := withWarmupStatus(dir, func() error {
+		if err := index.Ensure(dir, "", true, os.Stderr); err != nil {
+			return err
+		}
+		_, statErr := os.Stat(warmupStatusPath(dir))
+		seen = statErr == nil
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !seen {
+		t.Fatal("no status file during the build: the status bar and hooks have nothing to report")
+	}
+	// And it must not outlive the build, or the agent claims forever that
+	// memory is on its way.
+	if _, err := os.Stat(warmupStatusPath(dir)); !os.IsNotExist(err) {
+		t.Fatalf("status file survived the build: %v", err)
+	}
+}


### PR DESCRIPTION
Everything the user sees about a cold build — the status bar line, the hook's `systemMessage`, the opencode toast, the MCP `instructions` note — reads one status file beside the index. Nothing tested that file being written by the build that is supposed to write it; the existing tests cover `fileProgress` on its own, which would keep passing if the detached warmup stopped calling it.

This adds the missing test: run the build under the environment the detached warmup runs with, assert the file exists while it builds and is gone after.

Filed as #374 after a shell poll failed to catch the file. That was the harness racing the build, not a bug — a warm page cache finishes it in two seconds. The upgrade path was measured too, since 0.16.0 changes the index version: a hook against an index one version behind returns in 0.05 s and leaves the rebuild detached.

Closes #374.
