### PR TITLE
fix(index): read paths no longer wait out a rebuild

### DIFF
--- a/internal/index/lock_nonblocking_test.go
+++ b/internal/index/lock_nonblocking_test.go
@@ -1,0 +1,36 @@
+package index
+
+import (
+	"testing"
+	"time"
+)
+
+// Read paths must never wait out a rebuild. The session-start hook goes
+// through these, and an index-format upgrade puts every user behind exactly
+// this rebuild on their first session — twelve seconds of an agent that looks
+// hung. A blocking lock here is a regression even though nothing fails.
+func TestReadsDoNotBlockWhileTheIndexIsLocked(t *testing.T) {
+	dir := t.TempDir() + "/index.db"
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Logf("build: %v", err) // an empty machine is fine: the lock is what matters
+	}
+	unlock, err := lockDir(dir)
+	if err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+	defer unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _, _ = FindByPrefix(dir, "nothing")
+		_, _, _ = ProjectRelevant(dir, []string{"p"}, []string{"term"}, 3)
+		_, _ = RecentProject(dir, "p", 3)
+		_, _, _ = FirstMatch(dir, []string{"term"}, 3)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("a read waited for the index lock: on a real corpus that is the length of a rebuild")
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -322,11 +322,16 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 	if dir == "" {
 		dir = DefaultDir()
 	}
-	unlock, err := lockDir(dir)
+	// Non-blocking, for the same reason searchDetailedOnce is: this runs on
+	// the session-start hook, and waiting here stalls the agent for the whole
+	// rebuild — which every user hits on an index-format upgrade.
+	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
 		return nil, nil, err
 	}
-	defer unlock()
+	if ok {
+		defer unlock()
+	}
 	m, err := readManifestCached(dir)
 	if err != nil {
 		return nil, nil, err
@@ -650,11 +655,13 @@ func FirstMatch(dir string, queries []string, limit int) ([]model.Session, strin
 	if dir == "" {
 		dir = DefaultDir()
 	}
-	unlock, err := lockDir(dir)
+	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
 		return nil, "", err
 	}
-	defer unlock()
+	if ok {
+		defer unlock()
+	}
 	m, err := readManifestCached(dir)
 	if err != nil {
 		return nil, "", fmt.Errorf("manifest: %w", err)
@@ -718,11 +725,13 @@ func RecentMatching(dir string, n int, o query.Options) ([]model.Session, error)
 	if dir == "" {
 		dir = DefaultDir()
 	}
-	unlock, err := lockDir(dir)
+	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
 		return nil, err
 	}
-	defer unlock()
+	if ok {
+		defer unlock()
+	}
 	m, err := readManifestCached(dir)
 	if err != nil {
 		return nil, err
@@ -753,11 +762,13 @@ func RecentProject(dir, project string, n int) ([]model.Session, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
-	unlock, err := lockDir(dir)
+	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
 		return nil, err
 	}
-	defer unlock()
+	if ok {
+		defer unlock()
+	}
 	m, err := readManifestCached(dir)
 	if err != nil {
 		return nil, err
@@ -812,11 +823,13 @@ func RecentProjects(dir string, projects []string, perName int) ([]model.Session
 	if dir == "" {
 		dir = DefaultDir()
 	}
-	unlock, err := lockDir(dir)
+	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
 		return nil, err
 	}
-	defer unlock()
+	if ok {
+		defer unlock()
+	}
 	m, err := readManifestCached(dir)
 	if err != nil {
 		return nil, err
@@ -851,11 +864,16 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
-	unlock, err := lockDir(dir)
+	// Non-blocking: the session-start hook reaches this through the handoff
+	// tip, and a blocking lock made the agent wait out the entire rebuild —
+	// twelve seconds on a real corpus, on the very upgrade that triggers one.
+	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
 		return model.Session{}, false, err
 	}
-	defer unlock()
+	if ok {
+		defer unlock()
+	}
 	m, err := readManifestCached(dir)
 	if err != nil {
 		return model.Session{}, false, err


### PR DESCRIPTION
A hook that runs while the index is rebuilding waited for the rebuild: 12.1 s on a real corpus against 0.15 s idle. 0.16.0 changes the index version, so every user would hit exactly this on their first session after updating.

`searchDetailedOnce` already documents the hazard and reads lock-free while a rebuild holds the lock. Five other read paths did not, and the session-start hook goes through one of them — `limitHandoffTip` → `FindByPrefix`. A goroutine dump during the hang named it outright.

All of them now use `tryLockDir` and fall back to the same lock-free snapshot read: the directory swap is atomic and a torn read fails `recordsIntact`, which the recovery path already retries.

After: 0.45–0.52 s during a rebuild, unchanged when idle.

The test locks the index and asserts the reads return anyway; without the fix it fails on the three-second timeout.

Closes #379.
