### PR TITLE
feat(opencode): toast the recall receipt, not just the build

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -120,8 +120,22 @@ export const DejaRecall = async ({ $, client }) => {
       try {
         const key = input.sessionID || "default"
         if (!cache.has(key)) {
-          const blob = await $%s%q %s%s.text()
-          cache.set(key, blob.trim())
+          const raw = await $%s%q %s%s.text()
+          let ctx = "", receipt = ""
+          try {
+            const parsed = JSON.parse(raw)
+            ctx = parsed?.hookSpecificOutput?.additionalContext || ""
+            receipt = parsed?.systemMessage || ""
+          } catch {
+            ctx = raw.trim()
+          }
+          cache.set(key, ctx)
+          // The receipt is the only sign the user gets that memory arrived.
+          // Once per session: repeating it every turn is wallpaper.
+          if (receipt && !told.has(key)) {
+            told.add(key)
+            await client.tui.showToast({ body: { message: receipt, variant: "info", duration: 6000 } })
+          }
         }
         const ctx = cache.get(key)
         if (ctx) {
@@ -142,7 +156,7 @@ export const DejaRecall = async ({ $, client }) => {
     },
   }
 }
-`, "`", exe, "hook-context --plain", "`", "`", exe, "warmup-status", "`")
+`, "`", exe, "hook-context", "`", "`", exe, "warmup-status", "`")
 }
 
 // Gemini CLI and Qwen Code both run a command before the agent loop, which is

--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -100,7 +100,7 @@ func TestInstallOpencodePlugin(t *testing.T) {
 		t.Fatal(err)
 	}
 	s := string(b)
-	for _, want := range []string{"experimental.chat.system.transform", "/opt/deja", "hook-context --plain", "cache"} {
+	for _, want := range []string{"experimental.chat.system.transform", "/opt/deja", "hook-context", "cache"} {
 		if !strings.Contains(s, want) {
 			t.Fatalf("plugin missing %q:\n%s", want, s)
 		}

--- a/cmd/deja/warmup_status_test.go
+++ b/cmd/deja/warmup_status_test.go
@@ -193,3 +193,25 @@ func TestWarmupProgressFragment(t *testing.T) {
 		t.Errorf("progress with unknown total = %q", got)
 	}
 }
+
+// opencode has no place to put a receipt in the prompt, so the toast is the
+// only sign the user gets that memory arrived. It fires once per session and
+// only when there is something to announce.
+func TestOpencodePluginToastsTheRecallReceipt(t *testing.T) {
+	src := opencodePluginJS("/bin/deja")
+	for _, want := range []string{
+		`hook-context`,         // JSON form: the receipt rides with the context
+		"hookSpecificOutput",   // context is read from the envelope
+		"systemMessage",        // receipt is read from the envelope
+		"told.add(key)",        // once per session
+		"client.tui.showToast", // opencode's own channel to the user
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("generated plugin missing %q:\n%s", want, src)
+		}
+	}
+	// --plain would drop the receipt on the floor.
+	if strings.Contains(src, "hook-context --plain") {
+		t.Fatal("plugin still asks for the plain digest, which carries no receipt")
+	}
+}


### PR DESCRIPTION
Claude Code and Codex both show the user a line when memory arrives; opencode showed nothing. Its plugin asked for `hook-context --plain`, which is the bare digest — the receipt travels in the JSON envelope and was being thrown away.

The plugin now reads the envelope: context from `hookSpecificOutput.additionalContext`, receipt from `systemMessage`, and the receipt goes to `client.tui.showToast` once per session. Verified on a rendered opencode TUI:

```
deja: recalled 3 prior sessions touching install_auto.go …
```

The build-in-progress toast that was already there is unchanged.
