### PR TITLE
fix(gemini): hook SessionStart so the receipt is visible

### DIFF
--- a/cmd/deja/install_gemini.go
+++ b/cmd/deja/install_gemini.go
@@ -52,9 +52,10 @@ func installGeminiExtension(exe string, uninstall bool) (installResult, error) {
 	}
 	hooks, err := json.MarshalIndent(map[string]any{
 		"hooks": map[string]any{
-			// BeforeAgent runs once before the agent loop, which is where the
-			// session digest belongs.
-			"BeforeAgent": []any{map[string]any{
+			// SessionStart, not BeforeAgent: it injects additionalContext into
+			// the session history and prints systemMessage, while BeforeAgent
+			// surfaces the message only when the hook blocks execution.
+			"SessionStart": []any{map[string]any{
 				"hooks": []any{map[string]any{
 					"type": "command", "command": exe + " hook-context",
 					// Gemini reads timeout in milliseconds; a Claude-style 10

--- a/cmd/deja/install_gemini_test.go
+++ b/cmd/deja/install_gemini_test.go
@@ -35,9 +35,9 @@ func TestInstallGeminiWritesAnExtension(t *testing.T) {
 		t.Fatalf("install: %v", err)
 	}
 	hooks := geminiExtensionHooks(t, home)
-	group := hooks["BeforeAgent"]
+	group := hooks["SessionStart"]
 	if len(group) == 0 {
-		t.Fatalf("no BeforeAgent group: %v", hooks)
+		t.Fatalf("no SessionStart group: %v", hooks)
 	}
 	inner, _ := group[0]["hooks"].([]any)
 	if len(inner) != 1 {


### PR DESCRIPTION
Gemini's `BeforeAgent` surfaces `systemMessage` only when the hook blocks execution, so the recall receipt and the cold-build line were invisible there. `SessionStart` does both jobs: it injects `additionalContext` into the session history and prints `systemMessage` — to stderr headless, as a UI info item interactively.

Verified on 0.52.0 with the real extension:

```
deja: indexing your history (reading sessions 50%) — recall comes online in a few seconds
deja: recalled 3 prior sessions touching install_auto.go …
```
