### PR TITLE
feat(opencode): recall on every prompt, not just at session start

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -154,9 +154,32 @@ export const DejaRecall = async ({ $, client }) => {
         // memory is optional: never break the session over it
       }
     },
+    // Per-prompt recall, the same relevance pass Claude Code gets on
+    // UserPromptSubmit: the session digest is ranked by the project, this is
+    // ranked by what the user just asked. Silent when nothing matches.
+    "experimental.chat.messages.transform": async (_input, output) => {
+      try {
+        const msgs = output.messages || []
+        let last
+        for (let i = msgs.length - 1; i >= 0; i--) {
+          if (msgs[i]?.info?.role === "user") { last = msgs[i]; break }
+        }
+        if (!last) return
+        const parts = (last.parts || []).filter((p) => p?.type === "text" && p.text)
+        const prompt = parts.map((p) => p.text).join("\n").trim()
+        if (!prompt) return
+        const raw = await $%secho ${JSON.stringify({ prompt })} | %s%q hook-prompt%s.text()
+        if (!raw.trim()) return
+        const extra = JSON.parse(raw)?.hookSpecificOutput?.additionalContext
+        if (!extra) return
+        parts[parts.length - 1].text += "\n\n" + extra
+      } catch {
+        // memory is optional: never break the session over it
+      }
+    },
   }
 }
-`, "`", exe, "hook-context", "`", "`", exe, "warmup-status", "`")
+`, "`", exe, "hook-context", "`", "`", exe, "warmup-status", "`", "`", "", exe, "`")
 }
 
 // Gemini CLI and Qwen Code both run a command before the agent loop, which is

--- a/cmd/deja/warmup_status_test.go
+++ b/cmd/deja/warmup_status_test.go
@@ -215,3 +215,24 @@ func TestOpencodePluginToastsTheRecallReceipt(t *testing.T) {
 		t.Fatal("plugin still asks for the plain digest, which carries no receipt")
 	}
 }
+
+// Claude Code gets a relevance pass on every prompt; opencode has the same
+// opening in messages.transform, and without it recall there is only ever as
+// good as the session digest.
+func TestOpencodePluginRecallsPerPrompt(t *testing.T) {
+	src := opencodePluginJS("/bin/deja")
+	for _, want := range []string{
+		"experimental.chat.messages.transform",
+		`info?.role === "user"`, // the last user turn, not the last message
+		"hook-prompt",
+		"additionalContext",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("generated plugin missing %q:\n%s", want, src)
+		}
+	}
+	// It appends to the prompt rather than replacing it.
+	if !strings.Contains(src, `parts[parts.length - 1].text += `) {
+		t.Fatalf("recall does not append to the user's own text:\n%s", src)
+	}
+}


### PR DESCRIPTION
Claude Code gets a relevance pass on every prompt through `UserPromptSubmit`; opencode only had the session digest, which is ranked by project rather than by what the user just asked.

`experimental.chat.messages.transform` gives the plugin the message list, so the last user turn goes to `deja hook-prompt` and the result is appended to that turn's text. Silent when nothing matches, which is most turns.

Verified end to end: a prompt in another project appended

```
deja found prior sessions matching this request …
```

to the user message before it reached the model.

The message shape was read off a live session rather than assumed — `{info: {role}, parts: [{type: "text", text}]}`.
