### PR TITLE
feat: show the first build as a moving bar, and in pi's footer

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -612,6 +612,12 @@ func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall
 	return root
 }
 
+// combinedStatusline builds a command that runs the existing statusline and
+// deja's, separated by a middle dot.
+func combinedStatusline(existing, exe string) string {
+	return fmt.Sprintf(`sh -c 'json=$(cat); printf "%%s" "$json" | %s; printf " · "; printf "%%s" "$json" | %s statusline'`, existing, exe)
+}
+
 // installStatusline wires `deja statusline` as the Claude Code status bar.
 // It refuses to replace a statusline the user already configured (many run
 // ccstatusline or their own script) — printing how to combine instead.
@@ -633,7 +639,12 @@ func installStatusline(exe string, uninstall bool) (installResult, error) {
 		delete(root, "statusLine")
 	} else {
 		if existing != nil && existing["command"] != cmd {
-			return installResult{}, fmt.Errorf("a statusline is already configured (%v) — append `deja statusline` output to it instead of replacing it", existing["command"])
+			// Most people already run something here. Replacing it silently
+			// would be rude, and "append our output" is not actionable — so
+			// hand over the line that runs both. Claude pipes session JSON to
+			// the command, so it is captured once and fed to each in turn.
+			prev, _ := existing["command"].(string)
+			return installResult{}, fmt.Errorf("a statusline is already configured — to keep both, set statusLine.command to:\n\n  %s", combinedStatusline(prev, exe))
 		}
 		// refreshInterval makes Claude Code re-run the command on a timer
 		// instead of only after a turn, so the first index build shows a

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -635,7 +635,11 @@ func installStatusline(exe string, uninstall bool) (installResult, error) {
 		if existing != nil && existing["command"] != cmd {
 			return installResult{}, fmt.Errorf("a statusline is already configured (%v) — append `deja statusline` output to it instead of replacing it", existing["command"])
 		}
-		root["statusLine"] = map[string]any{"type": "command", "command": cmd}
+		// refreshInterval makes Claude Code re-run the command on a timer
+		// instead of only after a turn, so the first index build shows a
+		// moving bar rather than a number frozen at whatever it was when the
+		// user last typed.
+		root["statusLine"] = map[string]any{"type": "command", "command": cmd, "refreshInterval": 1000}
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {

--- a/cmd/deja/install_pi.go
+++ b/cmd/deja/install_pi.go
@@ -61,22 +61,53 @@ export default function (pi: any) {
   let injected = false;
   let toldBuilding = false;
 
+  // pi keeps a footer status line: while the first index builds, that is
+  // where the user can see it happening instead of wondering why recall is
+  // quiet. Cleared as soon as the build finishes.
+  const showBuild = (ctx: any) => {
+    const status = run(["warmup-status"], "");
+    if (status) {
+      ctx.ui.setStatus("deja", status);
+      return true;
+    }
+    ctx.ui.setStatus("deja", "");
+    return false;
+  };
+
+  pi.on("session_start", async (_event: any, ctx: any) => {
+    try {
+      showBuild(ctx);
+    } catch {
+      // memory is optional: never break the session over it
+    }
+  });
+
   pi.on("before_agent_start", async (event: any, ctx: any) => {
     try {
       if (!injected) {
-        const digest = run(["hook-context", "--plain"], "");
+        const raw = run(["hook-context"], "");
+        let digest = "";
+        let receipt = "";
+        try {
+          const parsed = JSON.parse(raw);
+          digest = parsed?.hookSpecificOutput?.additionalContext || "";
+          receipt = parsed?.systemMessage || "";
+        } catch {
+          digest = raw;
+        }
         if (digest) {
           injected = true;
+          ctx.ui.setStatus("deja", "");
+          // The receipt is what tells the user memory arrived; without it the
+          // recall is invisible and reads as the model guessing.
+          if (receipt) ctx.ui.notify(receipt, "info");
           return { message: { customType: "deja-recall", content: digest, display: false } };
         }
         // Nothing to recall: either there is no history yet, or the first
         // index is still building. Only the second is worth saying, once.
-        if (!toldBuilding) {
-          const status = run(["warmup-status"], "");
-          if (status) {
-            toldBuilding = true;
-            ctx.ui.notify(status, "info");
-          }
+        if (!toldBuilding && showBuild(ctx)) {
+          toldBuilding = true;
+          ctx.ui.notify(run(["warmup-status"], ""), "info");
         }
         return;
       }

--- a/cmd/deja/install_pi_test.go
+++ b/cmd/deja/install_pi_test.go
@@ -26,6 +26,8 @@ func TestInstallPiExtensionWritesDiscoverableFile(t *testing.T) {
 		"hook-context",
 		"hook-prompt",
 		"ctx.ui.notify",
+		"ctx.ui.setStatus", // pi keeps a footer line; the build belongs there
+		"session_start",    // status has to appear before the first prompt
 		`"/bin/deja"`,
 	} {
 		if !strings.Contains(src, want) {

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
@@ -17,7 +18,7 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 	// one surface the user is already looking at, so the build reports there
 	// instead of leaving them to wonder why recall is quiet.
 	if st := readWarmupStatus(dir); st != nil {
-		fmt.Fprintf(stdout, "deja · building memory · %s", st.progress())
+		fmt.Fprintf(stdout, "deja %s %s", warmupBar(st), st.progress())
 		return nil
 	}
 	recalls, bytes, injected := usage.TodayWithInjections(dir)
@@ -39,6 +40,21 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 	}
 	fmt.Fprint(stdout, line)
 	return nil
+}
+
+// warmupBar draws the build as a bar rather than a bare percentage: a status
+// line is read at a glance, and a moving bar reads as progress where a number
+// reads as noise. Width is fixed so the line does not jitter between frames.
+func warmupBar(st *warmupStatus) string {
+	const width = 10
+	filled := 0
+	if st.Total > 0 {
+		filled = width * st.Done / st.Total
+		if filled > width {
+			filled = width
+		}
+	}
+	return "▕" + strings.Repeat("█", filled) + strings.Repeat("░", width-filled) + "▏"
 }
 
 // Claude Code pipes session JSON to statusline commands. We don't need it,

--- a/cmd/deja/statusline_test.go
+++ b/cmd/deja/statusline_test.go
@@ -119,3 +119,33 @@ func TestStatuslineReportsColdBuild(t *testing.T) {
 		t.Fatalf("statusline still claims a build: %q", out.String())
 	}
 }
+
+// Most people already run something in the status bar, so the conflict path is
+// the common one. It has to hand over a line that works, not advice.
+func TestStatuslineConflictOffersAWorkingCommand(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	dir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := `{"statusLine":{"type":"command","command":"bash /opt/theirs.sh"}}`
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := installStatusline("/bin/deja", false)
+	if err == nil {
+		t.Fatal("replaced someone else's statusline")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"bash /opt/theirs.sh", // theirs still runs
+		"/bin/deja statusline",
+		"json=$(cat)", // Claude pipes session JSON: capture once, feed both
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("conflict message is not a usable command, missing %q:\n%s", want, msg)
+		}
+	}
+}

--- a/cmd/deja/statusline_test.go
+++ b/cmd/deja/statusline_test.go
@@ -106,8 +106,8 @@ func TestStatuslineReportsColdBuild(t *testing.T) {
 	if err := runStatusline(dir, strings.NewReader(""), &out); err != nil {
 		t.Fatal(err)
 	}
-	if got := out.String(); !strings.Contains(got, "building memory") || !strings.Contains(got, "75%") {
-		t.Fatalf("statusline = %q, want the build and its progress", got)
+	if got := out.String(); !strings.Contains(got, "███") || !strings.Contains(got, "75%") {
+		t.Fatalf("statusline = %q, want a filled bar and the percentage", got)
 	}
 	// Once the build is done the line goes back to reporting recalls.
 	_ = os.Remove(warmupStatusPath(dir))
@@ -115,7 +115,7 @@ func TestStatuslineReportsColdBuild(t *testing.T) {
 	if err := runStatusline(dir, strings.NewReader(""), &out); err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(out.String(), "building memory") {
+	if strings.Contains(out.String(), "███") {
 		t.Fatalf("statusline still claims a build: %q", out.String())
 	}
 }


### PR DESCRIPTION
Two ideas taken from the plugins people actually keep installed, rather than from the memory ones.

**A bar that moves.** `claude-hud` sets `refreshInterval` on its statusline entry, so Claude Code re-runs the command on a timer instead of only after a turn. Without it our build percentage sat frozen at whatever it was when the user last typed. The line is now a fixed-width bar:

```
deja ▕██░░░░░░░░▏ indexing messages 25%
```

**pi has a footer.** `ctx.ui.setStatus` puts a line at the bottom of pi's TUI for as long as you want it there, which is exactly where a build belongs — visible without being in the way, cleared the moment recall comes online. The extension also stopped throwing the receipt away: it reads the JSON envelope now, so pi shows "deja: recalled 3 prior sessions …" the way Claude Code and Codex do.

Both verified on rendered TUIs.
