### PR TITLE
fix(codex): adopt an existing hook entry instead of leaving it stale

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -37,10 +37,15 @@ func installCodexHooks(exe string, uninstall bool) (installResult, error) {
 	for _, entryAny := range entries {
 		entry, _ := entryAny.(map[string]any)
 		if entry != nil && entryHasCommand(entry, cmd) {
-			found = true
 			if uninstall {
 				continue
 			}
+			// Take the entry over rather than leaving it as it was: an install
+			// from a new binary path, or from a version that gained a field,
+			// has to update ours in place or the change never reaches anyone
+			// who already had it.
+			found = true
+			adoptCodexHookEntry(entry, cmd)
 		}
 		kept = append(kept, entryAny)
 	}
@@ -74,6 +79,22 @@ func installCodexHooks(exe string, uninstall bool) (installResult, error) {
 // entryHasCommand matches on the trailing subcommand rather than the whole
 // string, so an install from a new binary path replaces our old entry instead
 // of leaving it to fire alongside the new one.
+// adoptCodexHookEntry rewrites the command and status message of an entry deja
+// already owns.
+func adoptCodexHookEntry(entry map[string]any, cmd string) {
+	hs, _ := entry["hooks"].([]any)
+	for _, hAny := range hs {
+		h, _ := hAny.(map[string]any)
+		if h == nil || h["type"] != "command" || !isDejaHookCommand(h["command"], cmd) {
+			continue
+		}
+		h["command"] = cmd
+		if msg := hookStatusMessage("SessionStart"); msg != "" {
+			h["statusMessage"] = msg
+		}
+	}
+}
+
 func entryHasCommand(entry map[string]any, cmd string) bool {
 	hs, _ := entry["hooks"].([]any)
 	for _, hAny := range hs {
@@ -236,10 +257,15 @@ func installSettingsHook(path, event, matcher string, timeout int, exe string, u
 	for _, entryAny := range entries {
 		entry, _ := entryAny.(map[string]any)
 		if entry != nil && entryHasCommand(entry, cmd) {
-			found = true
 			if uninstall {
 				continue
 			}
+			// Take the entry over rather than leaving it as it was: an install
+			// from a new binary path, or from a version that gained a field,
+			// has to update ours in place or the change never reaches anyone
+			// who already had it.
+			found = true
+			adoptCodexHookEntry(entry, cmd)
 		}
 		kept = append(kept, entryAny)
 	}

--- a/cmd/deja/install_hooks_test.go
+++ b/cmd/deja/install_hooks_test.go
@@ -78,3 +78,58 @@ func TestKimiUninstallKeepsSomeoneElsesHooks(t *testing.T) {
 		t.Error("uninstall left our entry behind")
 	}
 }
+
+// An install from a newer deja has to update the entry it already owns —
+// otherwise anyone who installed once never sees a field added later, and a
+// moved binary leaves a second entry firing beside the new one.
+func TestCodexHookInstallAdoptsAnOlderEntry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// What an older version wrote: our command, no status message.
+	seed := `{"hooks":{"SessionStart":[{"matcher":"startup|resume","hooks":[{"type":"command","command":"/opt/old/deja hook-context","timeout":10}]}]}}`
+	if err := os.WriteFile(filepath.Join(dir, "hooks.json"), []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installCodexHooks("/usr/local/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "hooks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Command       string `json:"command"`
+				StatusMessage string `json:"statusMessage"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	groups := root.Hooks["SessionStart"]
+	var ours []string
+	for _, g := range groups {
+		for _, h := range g.Hooks {
+			if !strings.Contains(h.Command, "deja") {
+				continue
+			}
+			ours = append(ours, h.Command)
+			if h.StatusMessage == "" {
+				t.Error("adopted entry never gained the status message")
+			}
+		}
+	}
+	if len(ours) != 1 {
+		t.Fatalf("%d deja hooks, want 1: %v", len(ours), ours)
+	}
+	if !strings.HasPrefix(ours[0], "/usr/local/bin/deja") {
+		t.Fatalf("kept the stale path: %s", ours[0])
+	}
+}


### PR DESCRIPTION
#373 fixed this for Claude Code and missed the Codex installer, which has its own merge path. An entry deja already owns was left exactly as it was: a moved binary left the old command firing beside the new one, and `statusMessage` — added later — never reached anyone who had installed before it existed.

Codex now rewrites the command and the status message on the entry it owns, matching on the trailing subcommand the way Claude's installer does.

Found while re-checking Codex against the support checklist: the hook on this machine had been installed months ago and still had no status message after several reinstalls.
