### PR TITLE
docs: show the four registry installs, count Hermes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,15 @@ claude plugin install deja-vu@deja-vu
 
 The plugin wires the same three hooks and the `/deja` command. It stands down on its own if `deja install` already wired them, so having both does not recall twice.
 
-Codex has its own marketplace:
+Codex, Cursor and Qwen read the same bundle from their own registries:
 
 ```sh
-codex plugin marketplace add vshulcz/deja-vu
-codex plugin add deja-vu@deja-vu
+codex plugin marketplace add vshulcz/deja-vu && codex plugin add deja-vu@deja-vu
+cursor-agent plugin marketplace add https://github.com/vshulcz/deja-vu
+qwen extensions install https://github.com/vshulcz/deja-vu
 ```
+
+Cursor and Qwen accept the Claude plugin format directly, so one bundle covers four harnesses.
 
 On Windows, register the MCP server through the shell wrapper most stdio servers need there: `cmd /c deja mcp` (deja install writes this form automatically; use it if you wire configs by hand).
 
@@ -326,7 +329,7 @@ Local inverted index in `~/.cache/deja`: parse JSONL/SQLite stores → redact cr
 **Does anything leave my machine?** Indexing and search are local. `deja update` downloads releases from GitHub, and user-invoked `deja sync ssh` transfers redacted batches through the system SSH client. Directory exports and shares go only to the destination you choose. See the [security model](docs/SECURITY-MODEL.md#data-flows) for the full data flow.
 
 **How is this different from cass?**
-[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, sixteen harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
+[cass](https://github.com/Dicklesworthstone/coding_agent_session_search) is the kitchen-sink take on session search: 22 providers, Rust, optional semantic embeddings, a TUI. deja is the opposite bet — one small Go binary, pure lexical, seventeen harnesses, zero setup — plus the memory-layer pieces around it: auto-recall, redaction, share, sync.
 
 [engram](https://github.com/Gentleman-Programming/engram) is the strongest of the record-forward memory tools: the agent calls `mem_save` and curated notes accumulate in SQLite. Curation buys it conflict detection — deja now surfaces conflicts too, between accepted notes at promote time — but it starts empty, only knows what an agent decided to save, and can't answer for the months of sessions that happened before it was installed. deja starts full: the transcripts are the memory, no cooperation required.
 

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -69,6 +69,12 @@ deja "have we dealt with jwt refresh rotation before"</pre>
 <h2>Wire it into your agents</h2>
 <pre>deja install --all      # MCP recall for every agent found on this machine
 deja install --auto     # same, plus session-start auto-recall where supported</pre>
+<p>Four harnesses can pull deja straight from their own plugin registry instead — same wiring, no local step:</p>
+<pre>claude plugin marketplace add vshulcz/deja-vu &amp;&amp; claude plugin install deja-vu@deja-vu
+codex  plugin marketplace add vshulcz/deja-vu &amp;&amp; codex plugin add deja-vu@deja-vu
+cursor-agent plugin marketplace add https://github.com/vshulcz/deja-vu
+qwen   extensions install https://github.com/vshulcz/deja-vu</pre>
+<div class="note">Cursor and Qwen read the Claude plugin format directly, so all four install from the one bundle in this repository. The plugin stands down if <code>deja install</code> already wired the same hooks, so having both does not recall twice.</div>
 <p>After that, an agent can call <code>recall</code> the moment you reference past work — see <a href="agents.html">Agents &amp; MCP</a>. Confirm the wiring any time with <code>deja doctor</code>.</p>
 <h2>Optional: semantic recall</h2>
 <p>If you run a local embedding endpoint (Ollama, LM Studio), <code>deja embed</code> adds a vector sidecar so rephrased queries still match. Without one, deja works exactly as before. See <a href="search.html">Search</a>.</p>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -5,11 +5,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Harnesses — deja-vu docs</title>
-<meta name="description" content="The sixteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta name="description" content="The seventeen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Harnesses — deja-vu docs">
-<meta property="og:description" content="The sixteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta property="og:description" content="The seventeen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -25,12 +25,12 @@
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
 <meta name="twitter:title" content="Harnesses — deja-vu docs">
-<meta name="twitter:description" content="The sixteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta name="twitter:description" content="The seventeen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
 <link rel="apple-touch-icon" href="../assets/favicon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Harnesses","description":"The sixteen coding agents deja indexes today, where each stores its history, and how to add a new one.","url":"https://vshulcz.github.io/deja-vu/guide/harnesses.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Harnesses","description":"The seventeen coding agents deja indexes today, where each stores its history, and how to add a new one.","url":"https://vshulcz.github.io/deja-vu/guide/harnesses.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Harnesses","item":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"}]}</script>
 </head>
 <body>
@@ -53,7 +53,7 @@
 <article>
 
 <h1>Harnesses</h1>
-<p>deja indexes sixteen coding-agent histories into one retroactive index. A fix found in one agent is recalled inside another.</p>
+<p>deja indexes seventeen coding-agent histories into one retroactive index. A fix found in one agent is recalled inside another.</p>
 <!-- matrix:start -->
 <table>
 <tr><th>Harness</th><th>Store</th><th>MCP recall</th><th>Auto-recall</th><th>Resume</th><th>Handoff</th><th>Needs</th></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="deja-vu — search every session your coding agents ever wrote">
-<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across sixteen coding agents, served back to them via MCP.">
+<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across seventeen coding agents, served back to them via MCP.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -392,7 +392,7 @@ footer .spacer{flex:1}
 </section>
 
 <section class="reveal">
-  <p class="shead"><span class="p">$</span> <span class="cmd">deja doctor</span> <span class="out"># sixteen harnesses, one memory</span></p>
+  <p class="shead"><span class="p">$</span> <span class="cmd">deja doctor</span> <span class="out"># seventeen harnesses, one memory</span></p>
   <div class="sources">
     <table class="mx">
       <tr><th></th><th>mcp recall</th><th>auto-recall</th><th>resume</th><th>handoff</th><th>needs</th></tr>
@@ -440,6 +440,13 @@ footer .spacer{flex:1}
     <div class="inst"><span class="k">Go</span><div class="row"><pre id="i3">go install github.com/vshulcz/deja-vu/cmd/deja@latest</pre><button class="copy" data-copy="i3">copy</button></div></div>
     <div class="inst"><span class="k">npm</span><div class="row"><pre id="i4">npx @vshulcz/deja-vu "your query"</pre><button class="copy" data-copy="i4">copy</button></div></div>
   </div>
+  <p class="shead"><span class="p">$</span> <span class="cmd">or from your agent's own registry</span> <span class="out"># one bundle, four harnesses</span></p>
+  <div class="installs">
+    <div class="inst"><span class="k">Claude Code</span><div class="row"><pre id="i5">claude plugin marketplace add vshulcz/deja-vu</pre><button class="copy" data-copy="i5">copy</button></div></div>
+    <div class="inst"><span class="k">Codex</span><div class="row"><pre id="i6">codex plugin marketplace add vshulcz/deja-vu</pre><button class="copy" data-copy="i6">copy</button></div></div>
+    <div class="inst"><span class="k">Cursor</span><div class="row"><pre id="i7">cursor-agent plugin marketplace add https://github.com/vshulcz/deja-vu</pre><button class="copy" data-copy="i7">copy</button></div></div>
+    <div class="inst"><span class="k">Qwen Code</span><div class="row"><pre id="i8">qwen extensions install https://github.com/vshulcz/deja-vu</pre><button class="copy" data-copy="i8">copy</button></div></div>
+  </div>
 </section>
 
 <section id="docs" class="reveal">
@@ -449,7 +456,7 @@ footer .spacer{flex:1}
     <a href="guide/agents.html">agents-and-mcp<span>recall, blame, remember, auto-recall</span></a>
     <a href="guide/search.html">search<span>phrases, fuzzy, semantic, tiers</span></a>
     <a href="guide/commands.html">cli-reference<span>every subcommand and flag</span></a>
-    <a href="guide/harnesses.html">harnesses<span>sixteen agents, and adding one</span></a>
+    <a href="guide/harnesses.html">harnesses<span>seventeen agents, and adding one</span></a>
     <a href="guide/privacy.html">privacy<span>redaction, forget, exclude</span></a>
     <a href="guide/benchmarks.html">benchmarks<span>the ~200× number, reproducible</span></a>
     <a href="guide/compare.html">compare<span>deja next to Mem0, Letta, memU…</span></a>


### PR DESCRIPTION
Four harnesses can install deja from their own registry, and none of it was written down. Cursor and Qwen read the Claude plugin format directly, so the one bundle in this repository covers all four:

```sh
claude plugin marketplace add vshulcz/deja-vu && claude plugin install deja-vu@deja-vu
codex  plugin marketplace add vshulcz/deja-vu && codex plugin add deja-vu@deja-vu
cursor-agent plugin marketplace add https://github.com/vshulcz/deja-vu
qwen   extensions install https://github.com/vshulcz/deja-vu
```

Each was run against the real client — Qwen prints "installing an extension from Claude" and picks up the `/deja` command.

Landing page, getting-started and the README now carry them, and the harness count follows Hermes to seventeen (the matrix already listed it).
