### PR TITLE
feat(opencode): index the transcript before compaction

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -176,6 +176,16 @@ export const DejaRecall = async ({ $, client }) => {
         // memory is optional: never break the session over it
       }
     },
+    // Compaction is about to throw away the working transcript. Claude Code
+    // gets the same treatment through PreCompact: index what exists now, so
+    // the session survives in memory even after the window is collapsed.
+    "experimental.session.compacting": async () => {
+      try {
+        await $%s%q hook-precompact%s.quiet()
+      } catch {
+        // memory is optional: never break a compaction over it
+      }
+    },
     // Per-prompt recall, the same relevance pass Claude Code gets on
     // UserPromptSubmit: the session digest is ranked by the project, this is
     // ranked by what the user just asked. Silent when nothing matches.
@@ -201,7 +211,7 @@ export const DejaRecall = async ({ $, client }) => {
     },
   }
 }
-`, "`", exe, "hook-context", "`", "`", exe, "warmup-status", "`", "`", "", exe, "`")
+`, "`", exe, "hook-context", "`", "`", exe, "warmup-status", "`", "`", exe, "`", "`", "", exe, "`")
 }
 
 // Gemini CLI and Qwen Code both run a command before the agent loop, which is

--- a/cmd/deja/warmup_status_test.go
+++ b/cmd/deja/warmup_status_test.go
@@ -236,3 +236,16 @@ func TestOpencodePluginRecallsPerPrompt(t *testing.T) {
 		t.Fatalf("recall does not append to the user's own text:\n%s", src)
 	}
 }
+
+// Compaction throws away the working transcript. Claude Code gets it indexed
+// first through PreCompact; opencode fires experimental.session.compacting at
+// the same moment and was going unused.
+func TestOpencodePluginIndexesBeforeCompaction(t *testing.T) {
+	src := opencodePluginJS("/bin/deja")
+	if !strings.Contains(src, "experimental.session.compacting") {
+		t.Fatalf("compaction passes without indexing:\n%s", src)
+	}
+	if !strings.Contains(src, "hook-precompact") {
+		t.Fatalf("compaction hook does not index:\n%s", src)
+	}
+}


### PR DESCRIPTION
Claude Code has indexed the working transcript before a compaction discards it since PreCompact was wired. opencode fires `experimental.session.compacting` at exactly that moment and we were not listening, so an opencode session that compacted lost whatever had not been indexed yet.

The plugin now runs `deja hook-precompact` there, the same call Claude Code's hook makes.

Verified by driving `/compact` in a rendered opencode TUI with a probe plugin on the same event.

This closes the last gap the broad plugin survey turned up for opencode: its only in-TUI channel is the toast we already use — status-bar widgets are still just a feature request (anomalyco/opencode#23539), and the neighbouring plugins reach for desktop notifications or a tmux pane, neither of which suits a recall line.
