### PR TITLE
docs: one bundle installs into five harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,13 @@ cursor-agent plugin marketplace add https://github.com/vshulcz/deja-vu
 qwen extensions install https://github.com/vshulcz/deja-vu
 ```
 
-Cursor and Qwen accept the Claude plugin format directly, so one bundle covers four harnesses.
+OpenClaw takes it too:
+
+```sh
+openclaw plugins install https://github.com/vshulcz/deja-vu
+```
+
+Cursor, Qwen and OpenClaw all read the Claude plugin format, so **one bundle installs into five harnesses**. Their hook support differs — OpenClaw runs its own hook packs, which `deja install openclaw-auto` writes — but the MCP server, skill and `/deja` command come from the same directory in this repository.
 
 On Windows, register the MCP server through the shell wrapper most stdio servers need there: `cmd /c deja mcp` (deja install writes this form automatically; use it if you wire configs by hand).
 

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -73,8 +73,9 @@ deja install --auto     # same, plus session-start auto-recall where supported</
 <pre>claude plugin marketplace add vshulcz/deja-vu &amp;&amp; claude plugin install deja-vu@deja-vu
 codex  plugin marketplace add vshulcz/deja-vu &amp;&amp; codex plugin add deja-vu@deja-vu
 cursor-agent plugin marketplace add https://github.com/vshulcz/deja-vu
-qwen   extensions install https://github.com/vshulcz/deja-vu</pre>
-<div class="note">Cursor and Qwen read the Claude plugin format directly, so all four install from the one bundle in this repository. The plugin stands down if <code>deja install</code> already wired the same hooks, so having both does not recall twice.</div>
+qwen   extensions install https://github.com/vshulcz/deja-vu
+openclaw plugins install https://github.com/vshulcz/deja-vu</pre>
+<div class="note">Cursor, Qwen and OpenClaw read the Claude plugin format directly, so all five install from the one bundle in this repository. OpenClaw runs hooks only from its own packs — <code>deja install openclaw-auto</code> writes one. The plugin stands down if <code>deja install</code> already wired the same hooks, so having both does not recall twice.</div>
 <p>After that, an agent can call <code>recall</code> the moment you reference past work — see <a href="agents.html">Agents &amp; MCP</a>. Confirm the wiring any time with <code>deja doctor</code>.</p>
 <h2>Optional: semantic recall</h2>
 <p>If you run a local embedding endpoint (Ollama, LM Studio), <code>deja embed</code> adds a vector sidecar so rephrased queries still match. Without one, deja works exactly as before. See <a href="search.html">Search</a>.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -440,12 +440,13 @@ footer .spacer{flex:1}
     <div class="inst"><span class="k">Go</span><div class="row"><pre id="i3">go install github.com/vshulcz/deja-vu/cmd/deja@latest</pre><button class="copy" data-copy="i3">copy</button></div></div>
     <div class="inst"><span class="k">npm</span><div class="row"><pre id="i4">npx @vshulcz/deja-vu "your query"</pre><button class="copy" data-copy="i4">copy</button></div></div>
   </div>
-  <p class="shead"><span class="p">$</span> <span class="cmd">or from your agent's own registry</span> <span class="out"># one bundle, four harnesses</span></p>
+  <p class="shead"><span class="p">$</span> <span class="cmd">or from your agent's own registry</span> <span class="out"># one bundle, five harnesses</span></p>
   <div class="installs">
     <div class="inst"><span class="k">Claude Code</span><div class="row"><pre id="i5">claude plugin marketplace add vshulcz/deja-vu</pre><button class="copy" data-copy="i5">copy</button></div></div>
     <div class="inst"><span class="k">Codex</span><div class="row"><pre id="i6">codex plugin marketplace add vshulcz/deja-vu</pre><button class="copy" data-copy="i6">copy</button></div></div>
     <div class="inst"><span class="k">Cursor</span><div class="row"><pre id="i7">cursor-agent plugin marketplace add https://github.com/vshulcz/deja-vu</pre><button class="copy" data-copy="i7">copy</button></div></div>
     <div class="inst"><span class="k">Qwen Code</span><div class="row"><pre id="i8">qwen extensions install https://github.com/vshulcz/deja-vu</pre><button class="copy" data-copy="i8">copy</button></div></div>
+    <div class="inst"><span class="k">OpenClaw</span><div class="row"><pre id="i9">openclaw plugins install https://github.com/vshulcz/deja-vu</pre><button class="copy" data-copy="i9">copy</button></div></div>
   </div>
 </section>
 


### PR DESCRIPTION
OpenClaw reads the Claude plugin format too, so the bundle in this repository now installs into Claude Code, Codex, Cursor, Qwen Code and OpenClaw from their own registries.

Hook support differs — OpenClaw only runs its own hook packs, which `deja install openclaw-auto` writes — so the note says as much rather than implying parity.