### PR TITLE
feat(pi): add /deja and keep recall stats in the footer

### DIFF
--- a/cmd/deja/install_pi.go
+++ b/cmd/deja/install_pi.go
@@ -43,12 +43,12 @@ import { execFileSync } from "node:child_process";
 
 const DEJA = %q;
 
-function run(args: string[], input: string): string {
+function run(args: string[], input: string, timeout = 10000): string {
   try {
     return execFileSync(DEJA, args, {
       input,
       encoding: "utf8",
-      timeout: 10000,
+      timeout,
       maxBuffer: 4 * 1024 * 1024,
       stdio: ["pipe", "pipe", "ignore"],
     }).trim();
@@ -82,6 +82,23 @@ export default function (pi: any) {
     }
   });
 
+  // pi surfaces registered commands in the prompt box, which is how someone
+  // who never read the docs finds this at all.
+  pi.registerCommand("deja", {
+    description: "Search your own past coding sessions",
+    handler: async (args: string, ctx: any) => {
+      const query = (args || "").trim();
+      if (!query) {
+        ctx.ui.notify("Usage: /deja <what you are looking for>", "info");
+        return;
+      }
+      // The user is waiting on this one, so it may outlive the hook budget:
+      // a first search can rebuild the index.
+      const found = run([query], "", 120000);
+      ctx.ui.notify(found || "Nothing in your history matches " + query, "info");
+    },
+  });
+
   pi.on("before_agent_start", async (event: any, ctx: any) => {
     try {
       if (!injected) {
@@ -101,6 +118,10 @@ export default function (pi: any) {
           // The receipt is what tells the user memory arrived; without it the
           // recall is invisible and reads as the model guessing.
           if (receipt) ctx.ui.notify(receipt, "info");
+          // pi keeps the footer until it is cleared, so the session carries a
+          // quiet reminder that memory is on rather than a one-off toast.
+          const stats = run(["statusline"], "");
+          if (stats) ctx.ui.setStatus("deja", stats);
           return { message: { customType: "deja-recall", content: digest, display: false } };
         }
         // Nothing to recall: either there is no history yet, or the first

--- a/cmd/deja/install_pi_test.go
+++ b/cmd/deja/install_pi_test.go
@@ -63,3 +63,15 @@ func TestPiExtensionQuotesExecutablePath(t *testing.T) {
 		t.Fatalf("executable path not escaped:\n%s", src)
 	}
 }
+
+// A search the user typed may rebuild the index; a hook may not. One shared
+// timeout made /deja answer "nothing matches" for a query with real hits.
+func TestPiCommandOutlivesTheHookTimeout(t *testing.T) {
+	src := piExtensionTS("/bin/deja")
+	if !strings.Contains(src, "120000") {
+		t.Fatalf("the slash command runs on the hook budget:\n%s", src)
+	}
+	if !strings.Contains(src, "timeout = 10000") {
+		t.Fatalf("the hook budget is no longer the default:\n%s", src)
+	}
+}


### PR DESCRIPTION
pi's extension ecosystem is mostly footers — powerline-footer, zentui, statusbar, pulse all live there — and pi gives extensions the same surface through `ctx.ui.setStatus`. deja was using it only to report the first index build and then clearing it.

Now the footer carries the same line Claude Code's status bar shows once recall has happened:

```
deja · 1 recall · 1.3 KB ctx today · 1.3 KB injected · ~38× less than replaying
```

And `/deja <query>` is registered as a command, which is how pi is browsed — the prompt box lists what is available. Verified on a rendered pi TUI: the command returns real matches from history.

Its timeout is 120 s against the hook's 10 s, for the same reason as the Hermes plugin: a search the user typed may rebuild the index, and with one shared budget the command answers "nothing matches" for a query that has hits.
