### PR TITLE
Ship the MCP server in the plugin bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ claude plugin marketplace add vshulcz/deja-vu
 claude plugin install deja-vu@deja-vu
 ```
 
-The plugin wires the same three hooks and the `/deja` command. It stands down on its own if `deja install` already wired them, so having both does not recall twice.
+The plugin wires the same three hooks, the `/deja` command and the MCP server. It stands down on its own if `deja install` already wired them, so having both does not recall twice.
 
 Codex, Cursor and Qwen read the same bundle from their own registries:
 
@@ -96,13 +96,14 @@ cursor-agent plugin marketplace add https://github.com/vshulcz/deja-vu
 qwen extensions install https://github.com/vshulcz/deja-vu
 ```
 
-OpenClaw takes it too:
+Copilot CLI takes it too, and OpenClaw installs plugins from a path rather than a URL:
 
 ```sh
-openclaw plugins install https://github.com/vshulcz/deja-vu
+copilot plugin marketplace add vshulcz/deja-vu && copilot plugin install deja-vu@deja-vu
+openclaw plugins install ./deja-vu/claude-plugin
 ```
 
-Cursor, Qwen and OpenClaw all read the Claude plugin format, so **one bundle installs into five harnesses**. Their hook support differs — OpenClaw runs its own hook packs, which `deja install openclaw-auto` writes — but the MCP server, skill and `/deja` command come from the same directory in this repository.
+Cursor, Qwen, OpenClaw and Copilot all read the Claude plugin format, so **one bundle installs into six harnesses**. Their hook support differs — OpenClaw runs its own hook packs, which `deja install openclaw-auto` writes, and Copilot runs the hooks but drops their context, so recall there is MCP plus the skill — while the MCP server, skill and `/deja` command come from the same directory in this repository.
 
 On Windows, register the MCP server through the shell wrapper most stdio servers need there: `cmd /c deja mcp` (deja install writes this form automatically; use it if you wire configs by hand).
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -13,7 +13,7 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/deja.sh hook-context",
             "timeout": 10,
-            "statusMessage": "Recalling past sessions…"
+            "statusMessage": "Recalling past sessions\u2026"
           }
         ]
       }
@@ -25,7 +25,7 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/deja.sh hook-prompt",
             "timeout": 10,
-            "statusMessage": "Searching past sessions…"
+            "statusMessage": "Searching past sessions\u2026"
           }
         ]
       }
@@ -38,10 +38,16 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/deja.sh hook-precompact",
             "timeout": 10,
-            "statusMessage": "Saving this session to memory…"
+            "statusMessage": "Saving this session to memory\u2026"
           }
         ]
       }
     ]
+  },
+  "mcpServers": {
+    "deja": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/mcp/deja-mcp.sh",
+      "args": []
+    }
   }
 }

--- a/claude-plugin/mcp/deja-mcp.sh
+++ b/claude-plugin/mcp/deja-mcp.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Starts the deja MCP server for harnesses that take MCP servers from a plugin.
+#
+# Unlike the hook bridge this does not stand down when deja is also installed
+# locally: clients key MCP servers by name, so the plugin entry and a local one
+# collapse into a single "deja" rather than running twice.
+set -u
+
+for candidate in \
+	"$HOME/.local/bin/deja" \
+	"/opt/homebrew/bin/deja" \
+	"/usr/local/bin/deja" \
+	"$HOME/go/bin/deja"; do
+	if [ -x "$candidate" ]; then
+		exec "$candidate" mcp
+	fi
+done
+
+if command -v deja >/dev/null 2>&1; then
+	exec deja mcp
+fi
+
+# No binary: fail loudly here rather than silently registering a server that
+# answers nothing. The client reports it as one server that would not start.
+echo "deja binary not found — install it with: brew install vshulcz/tap/deja" >&2
+exit 1

--- a/cmd/deja/plugin_manifest_test.go
+++ b/cmd/deja/plugin_manifest_test.go
@@ -69,6 +69,41 @@ func TestClaudePluginManifestsAreWellFormed(t *testing.T) {
 	}
 }
 
+// Five registries install this one bundle, and in four of them it is the only
+// thing the user runs — so the recall tools have to come with it rather than
+// waiting for a separate `deja install`.
+func TestPluginBundleShipsTheMCPServer(t *testing.T) {
+	var plugin struct {
+		MCPServers map[string]struct {
+			Command string `json:"command"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(repoFile(t, "claude-plugin/.claude-plugin/plugin.json"), &plugin); err != nil {
+		t.Fatalf("plugin.json: %v", err)
+	}
+	server, ok := plugin.MCPServers["deja"]
+	if !ok {
+		t.Fatalf("bundle declares no MCP server: %+v", plugin.MCPServers)
+	}
+	// An absolute path from the author's machine, or a bare `deja` that is not
+	// on the client's PATH, both register a server that never starts.
+	if !strings.HasPrefix(server.Command, "${CLAUDE_PLUGIN_ROOT}/") {
+		t.Fatalf("MCP command is not plugin-relative: %q", server.Command)
+	}
+	launcher := string(repoFile(t, "claude-plugin/mcp/deja-mcp.sh"))
+	if !strings.Contains(launcher, "mcp") {
+		t.Fatalf("launcher does not start the MCP server:\n%s", launcher)
+	}
+	// The hook bridge stands down when deja is installed locally; the MCP
+	// launcher must not copy that, or the server exits at handshake.
+	if strings.Contains(launcher, "settings.json") {
+		t.Fatal("MCP launcher stands down like the hook bridge; clients dedupe by name instead")
+	}
+	if strings.Contains(launcher, "exit 0") {
+		t.Fatal("launcher exits clean without a binary; the client would report a server that answers nothing")
+	}
+}
+
 // The plugin ships its own copy of the slash command; it must not drift from
 // the one `deja install` writes.
 func TestPluginCommandMatchesInstaller(t *testing.T) {

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -74,8 +74,9 @@ deja install --auto     # same, plus session-start auto-recall where supported</
 codex  plugin marketplace add vshulcz/deja-vu &amp;&amp; codex plugin add deja-vu@deja-vu
 cursor-agent plugin marketplace add https://github.com/vshulcz/deja-vu
 qwen   extensions install https://github.com/vshulcz/deja-vu
-openclaw plugins install https://github.com/vshulcz/deja-vu</pre>
-<div class="note">Cursor, Qwen and OpenClaw read the Claude plugin format directly, so all five install from the one bundle in this repository. OpenClaw runs hooks only from its own packs — <code>deja install openclaw-auto</code> writes one. The plugin stands down if <code>deja install</code> already wired the same hooks, so having both does not recall twice.</div>
+openclaw plugins install ./deja-vu/claude-plugin
+copilot plugin marketplace add vshulcz/deja-vu &amp;&amp; copilot plugin install deja-vu@deja-vu</pre>
+<div class="note">Cursor, Qwen, OpenClaw and Copilot read the Claude plugin format directly, so all six install from the one bundle in this repository, which carries the hooks, the <code>/deja</code> command and the MCP server. OpenClaw runs hooks only from its own packs — <code>deja install openclaw-auto</code> writes one — and Copilot runs the plugin hooks but drops their context, so recall there is MCP plus the skill. The plugin stands down if <code>deja install</code> already wired the same hooks, so having both does not recall twice.</div>
 <p>After that, an agent can call <code>recall</code> the moment you reference past work — see <a href="agents.html">Agents &amp; MCP</a>. Confirm the wiring any time with <code>deja doctor</code>.</p>
 <h2>Optional: semantic recall</h2>
 <p>If you run a local embedding endpoint (Ollama, LM Studio), <code>deja embed</code> adds a vector sidecar so rephrased queries still match. Without one, deja works exactly as before. See <a href="search.html">Search</a>.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -440,13 +440,14 @@ footer .spacer{flex:1}
     <div class="inst"><span class="k">Go</span><div class="row"><pre id="i3">go install github.com/vshulcz/deja-vu/cmd/deja@latest</pre><button class="copy" data-copy="i3">copy</button></div></div>
     <div class="inst"><span class="k">npm</span><div class="row"><pre id="i4">npx @vshulcz/deja-vu "your query"</pre><button class="copy" data-copy="i4">copy</button></div></div>
   </div>
-  <p class="shead"><span class="p">$</span> <span class="cmd">or from your agent's own registry</span> <span class="out"># one bundle, five harnesses</span></p>
+  <p class="shead"><span class="p">$</span> <span class="cmd">or from your agent's own registry</span> <span class="out"># one bundle, six harnesses</span></p>
   <div class="installs">
     <div class="inst"><span class="k">Claude Code</span><div class="row"><pre id="i5">claude plugin marketplace add vshulcz/deja-vu</pre><button class="copy" data-copy="i5">copy</button></div></div>
     <div class="inst"><span class="k">Codex</span><div class="row"><pre id="i6">codex plugin marketplace add vshulcz/deja-vu</pre><button class="copy" data-copy="i6">copy</button></div></div>
     <div class="inst"><span class="k">Cursor</span><div class="row"><pre id="i7">cursor-agent plugin marketplace add https://github.com/vshulcz/deja-vu</pre><button class="copy" data-copy="i7">copy</button></div></div>
     <div class="inst"><span class="k">Qwen Code</span><div class="row"><pre id="i8">qwen extensions install https://github.com/vshulcz/deja-vu</pre><button class="copy" data-copy="i8">copy</button></div></div>
-    <div class="inst"><span class="k">OpenClaw</span><div class="row"><pre id="i9">openclaw plugins install https://github.com/vshulcz/deja-vu</pre><button class="copy" data-copy="i9">copy</button></div></div>
+    <div class="inst"><span class="k">OpenClaw</span><div class="row"><pre id="i9">openclaw plugins install ./deja-vu/claude-plugin</pre><button class="copy" data-copy="i9">copy</button></div></div>
+    <div class="inst"><span class="k">Copilot CLI</span><div class="row"><pre id="i10">copilot plugin marketplace add vshulcz/deja-vu</pre><button class="copy" data-copy="i10">copy</button></div></div>
   </div>
 </section>
 


### PR DESCRIPTION
Closes #393.

The bundle installs into six harnesses now — Copilot CLI and OpenClaw both read the Claude plugin format, same as Cursor and Qwen — but it carried only hooks and the slash command, so a marketplace install still needed a separate `deja install` to get the recall tools.

Adds an `mcpServers` entry pointing at a small launcher in the bundle. It resolves the binary the way the hook bridge does but does not stand down when deja is installed locally: clients key MCP servers by name, so the two collapse into one.

Verified live: `✔ Connected` in Claude, a recall call answering in Copilot, and OpenClaw listing the server as coming from the bundle. Also worth recording — Copilot does run plugin hooks, but their `additionalContext` never reaches the model, so recall there is MCP plus the skill.