### PR TITLE
Nightly: install syft, serialise runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,11 @@ on:
 
 permissions: {}
 
+# Two runs publishing the same rolling release would race over the tag.
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Snapshot build
@@ -39,6 +44,11 @@ jobs:
         with:
           go-version: '1.25.x'
           cache: false
+
+      # goreleaser catalogs an SBOM per archive and shells out to syft to do
+      # it; without this the build gets all the way to archiving and dies.
+      - if: steps.changed.outputs.run == 'true'
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
       # The nightly is only worth shipping if it passes what a release passes.
       - if: steps.changed.outputs.run == 'true'


### PR DESCRIPTION
The nightly built all six targets and then died on `exec: "syft": executable file not found` — goreleaser catalogs an SBOM per archive and the release workflow installs syft where the nightly did not. Adds the same step, plus a concurrency group so two dispatches cannot race over the rolling tag.