### PR TITLE
Nightly: skip signing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,7 +59,9 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --snapshot --clean
+          # Signing and attestation belong to tagged releases: keyless cosign
+          # needs an OIDC identity this job deliberately does not carry.
+          args: release --snapshot --clean --skip=sign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Second failure on the same class of missing tool: goreleaser signs checksums with cosign, which the release workflow installs. A nightly does not need a signature — it is not a release artifact and keyless cosign would need an OIDC identity this job deliberately does not carry — so it skips the sign step instead. Checksums are still published.