### PR TITLE
Hide the nightly tag from goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,12 @@ signs:
     args: ["sign-blob", "--yes", "--output-signature", "${signature}", "--output-certificate", "${certificate}", "${artifact}"]
     artifacts: checksum
 
+# The nightly publishes a rolling `nightly` tag. Left visible, it becomes the
+# most recent tag and every version template downstream fails on it.
+git:
+  ignore_tags:
+    - nightly
+
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 


### PR DESCRIPTION
The rolling `nightly` tag became the newest tag in the repo, so `git describe` fed it to goreleaser as the version and `{{ incpatch .Version }}` failed on it — `goreleaser check` is red on every open PR. `git.ignore_tags` excludes it, leaving version tags to drive templates as before.