### PR TITLE
Roo: install target and CLI storage root

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,12 @@ signs:
     args: ["sign-blob", "--yes", "--output-signature", "${signature}", "--output-certificate", "${certificate}", "${artifact}"]
     artifacts: checksum
 
+# The nightly publishes a rolling `nightly` tag. Left visible, it becomes the
+# most recent tag and every version template downstream fails on it.
+git:
+  ignore_tags:
+    - nightly
+
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -47,6 +47,10 @@ func guidancePath(harness string) string {
 		return filepath.Join(sources.GrokHome(), "GROK.md")
 	case "opencode":
 		return filepath.Join(opencodeConfigHome(), "opencode", "AGENTS.md")
+	case "roo":
+		// Global rules are read for every mode and every task, which is the
+		// only always-on channel Roo has.
+		return rooRulesPath()
 	default:
 		return ""
 	}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -285,6 +285,7 @@ func existingTargets() []string {
 		// latter itself, which would make every machine look like a Goose
 		// machine after one install.
 		"goose": sources.GooseRoot(),
+		"roo":   rooFirstRoot(),
 	}
 	var out []string
 	for name, p := range checks {
@@ -334,6 +335,8 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 		return installKimiAuto(exe, uninstall)
 	case "cline":
 		return installMCPJSON(sources.ClineMCPSettingsPath(), exe, uninstall)
+	case "roo":
+		return installRoo(exe, uninstall)
 	case "cline-auto":
 		return installClineAuto(exe, uninstall)
 	case "copilot":

--- a/cmd/deja/install_roo.go
+++ b/cmd/deja/install_roo.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// Roo has no lifecycle hooks — the only "hooks" in its bundle are React ones.
+// What it has is an MCP settings file per VS Code host, and a global rules
+// directory read into every task regardless of mode.
+//
+// Rules are the closest thing to session-start injection Roo offers. They are
+// static, and nothing in Roo can refresh them mid-session, so what goes there
+// is the guidance block rather than a digest that would rot.
+func rooMCPSettingsPaths() []string {
+	var out []string
+	for _, root := range sources.RooRoots() {
+		out = append(out, filepath.Join(root, "settings", "mcp_settings.json"))
+	}
+	return out
+}
+
+// installRoo writes the MCP server into every host that has Roo installed:
+// the same person often runs it in both VS Code and Cursor, and wiring one
+// leaves the other silently without recall.
+func installRoo(exe string, uninstall bool) (installResult, error) {
+	paths := rooMCPSettingsPaths()
+	var last installResult
+	wrote := false
+	for _, p := range paths {
+		// Only hosts Roo has actually run in: creating the directory would
+		// leave settings behind for an editor that is not installed.
+		if _, err := os.Stat(filepath.Dir(filepath.Dir(p))); err != nil {
+			continue
+		}
+		res, err := installMCPJSON(p, exe, uninstall)
+		if err != nil {
+			return installResult{}, err
+		}
+		last = res
+		if res.Action != "unchanged" {
+			wrote = true
+		}
+	}
+	if !wrote && last.Path == "" {
+		return installResult{Path: "roo", Action: "unchanged"}, nil
+	}
+	return last, nil
+}
+
+// rooRulesPath is the global rules directory: <home>/.roo/rules, read for
+// every mode. Mode-specific directories (rules-code, rules-ask, …) sit beside
+// it and would each need their own copy.
+func rooRulesPath() string {
+	return filepath.Join(homeDir(), ".roo", "rules", "deja.md")
+}
+
+// rooFirstRoot is a path that exists only when Roo has run in one of the
+// hosts, so detection does not fire on a machine that merely has VS Code.
+func rooFirstRoot() string {
+	for _, root := range sources.RooRoots() {
+		if _, err := os.Stat(root); err == nil {
+			return root
+		}
+	}
+	return filepath.Join(os.DevNull, "roo")
+}

--- a/cmd/deja/install_roo_test.go
+++ b/cmd/deja/install_roo_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func rooStorage(t *testing.T, home, host string) string {
+	t.Helper()
+	p := filepath.Join(home, "Library", "Application Support", host, "User", "globalStorage", "rooveterinaryinc.roo-cline")
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// Roo keeps MCP settings per editor host. Someone running it in both VS Code
+// and Cursor would otherwise get recall in one and silence in the other.
+func TestInstallRooWritesEveryHostItRunsIn(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_ROO_ROOTS", strings.Join([]string{
+		rooStorage(t, home, "Code"),
+		rooStorage(t, home, "Cursor"),
+	}, string(os.PathListSeparator)))
+	if _, err := installRoo("/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	for _, host := range []string{"Code", "Cursor"} {
+		p := filepath.Join(home, "Library", "Application Support", host, "User", "globalStorage",
+			"rooveterinaryinc.roo-cline", "settings", "mcp_settings.json")
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("%s: settings not written: %v", host, err)
+		}
+		var root struct {
+			Servers map[string]any `json:"mcpServers"`
+		}
+		if err := json.Unmarshal(b, &root); err != nil {
+			t.Fatalf("%s: %v", host, err)
+		}
+		if _, ok := root.Servers["deja"]; !ok {
+			t.Fatalf("%s: no deja server: %s", host, b)
+		}
+	}
+	if _, err := installRoo("/bin/deja", true); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	b, _ := os.ReadFile(filepath.Join(home, "Library", "Application Support", "Code", "User", "globalStorage",
+		"rooveterinaryinc.roo-cline", "settings", "mcp_settings.json"))
+	if strings.Contains(string(b), "deja") {
+		t.Fatalf("uninstall left the server behind: %s", b)
+	}
+}
+
+// A host Roo has never run in has no storage directory. Creating one there
+// leaves settings for an editor that will never read them.
+func TestInstallRooSkipsHostsWithoutStorage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	absent := filepath.Join(home, "Library", "Application Support", "VSCodium", "User", "globalStorage", "rooveterinaryinc.roo-cline")
+	t.Setenv("DEJA_ROO_ROOTS", absent)
+	if _, err := installRoo("/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := os.Stat(absent); !os.IsNotExist(err) {
+		t.Fatalf("install created storage for a host that does not have Roo: %v", err)
+	}
+}
+
+// Roo has no hook that could refresh a digest, so what goes into the global
+// rules is guidance — text that stays true — not recalled sessions.
+func TestRooGuidanceGoesToGlobalRules(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if _, err := installGuidance("roo", false); err != nil {
+		t.Fatalf("guidance: %v", err)
+	}
+	p := filepath.Join(home, ".roo", "rules", "deja.md")
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("rules file missing: %v", err)
+	}
+	if !strings.Contains(string(b), guidanceStart) {
+		t.Fatalf("no deja block:\n%s", b)
+	}
+	// Mode-specific directories sit beside this one; writing into one of them
+	// would make recall advice appear in Code mode and vanish in Ask mode.
+	if strings.Contains(p, "rules-") {
+		t.Fatalf("guidance landed in a mode-specific directory: %s", p)
+	}
+	if _, err := installGuidance("roo", true); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	b, _ = os.ReadFile(p)
+	if strings.Contains(string(b), guidanceStart) {
+		t.Fatalf("uninstall left the block:\n%s", b)
+	}
+}


### PR DESCRIPTION
Closes #413.

Verified against Roo 3.54.0 in VS Code and `@roo-code/cli` 0.1.17 run headless in a scratch prefix.

**Install.** Roo has no hooks — every `hook` in the bundle is a React one. Its channels are MCP settings per editor host and the global rules directory, read verbatim into the system prompt for every mode. `deja install roo` writes the MCP server into each host Roo has actually run in, skipping editors it hasn't, and the guidance goes to `~/.roo/rules/deja.md` rather than a mode-specific directory where it would appear in Code mode and vanish in Ask.

**CLI history.** `roo` runs the extension against a VS Code shim, so its tasks live in `~/.vscode-mock/global-storage/tasks/` — deja never looked there.

**And the reason none of it showed up:** Roo and Cline write the same filename in the same layout, and Cline's file kind matched *any* `api_conversation_history.json` regardless of root. Registered first, it claimed every Roo task, so Roo history has been filed under cline all along. Scoping that matcher to Cline's own roots fixes it — in my index the probe session moved from cline to roo, and cline's message count dropped by exactly that session's 5703.

`deja "roows2"` now returns `[roo] scratchpad/roows2`. Regression test pins the kind for a CLI task path.