### PR TITLE
doctor: report every auto-recall integration

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 // runCompletion writes a shell-specific script so the binary stays dependency-free.
@@ -14,6 +15,9 @@ func runCompletion(args []string) error {
 	if !ok {
 		return fmt.Errorf("unknown shell %q; want bash, zsh, or fish", args[0])
 	}
+	// The target list is substituted rather than duplicated per shell: three
+	// hand-maintained copies is how this one fell seven harnesses behind.
+	script = strings.ReplaceAll(script, "%INSTALL_TARGETS%", strings.Join(installTargetNames(), " "))
 	_, err := fmt.Fprint(os.Stdout, script)
 	return err
 }
@@ -37,7 +41,7 @@ _deja_completion() {
 
     local commands="blame bench completion ctx doctor embed forget handoff index install last log mcp promote remember resume share show sources stats statusline sync uninstall update version warmup"
     local harnesses="claude codex opencode aider gemini cursor antigravity grok qwen pi copilot deja"
-    local install_targets="claude-code codex opencode cursor gemini antigravity grok qwen kimi copilot pi statusline --all --auto"
+    local install_targets="%INSTALL_TARGETS% --all --auto"
 
     if (( COMP_CWORD == 1 )); then
         COMPREPLY=( $(compgen -W "$commands --version -version --json --re --all --no-embed --harness --project --since --role --rebuild" -- "$cur") )
@@ -170,7 +174,7 @@ _deja() {
     'warmup:build or refresh the index'
   )
   harnesses=(claude codex opencode aider gemini cursor antigravity grok qwen pi copilot deja)
-  install_targets=(claude-code codex opencode cursor gemini antigravity grok qwen kimi copilot pi statusline --all --auto)
+  install_targets=(%INSTALL_TARGETS% --all --auto)
 
   if (( CURRENT == 2 )); then
     _describe -t commands 'deja command' commands
@@ -284,7 +288,7 @@ complete -c deja -n '__fish_seen_subcommand_from handoff' -l to -r -a 'claude co
 complete -c deja -n '__fish_seen_subcommand_from handoff' -l exec
 complete -c deja -n '__fish_seen_subcommand_from hook-context' -l plain
 complete -c deja -n '__fish_seen_subcommand_from index' -l rebuild
-complete -c deja -n '__fish_seen_subcommand_from install uninstall' -a 'claude-code codex opencode cursor gemini antigravity grok qwen copilot pi statusline --all --auto'
+complete -c deja -n '__fish_seen_subcommand_from install uninstall' -a '%INSTALL_TARGETS% --all --auto'
 complete -c deja -n '__fish_seen_subcommand_from install uninstall' -l no-guidance
 complete -c deja -n '__fish_seen_subcommand_from last' -l harness -r -a 'claude codex opencode aider gemini cursor antigravity grok qwen pi copilot deja'
 complete -c deja -n '__fish_seen_subcommand_from last' -l project -r

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -27,6 +27,11 @@ func hermeticEnv(t *testing.T) string {
 	home := filepath.Join(tmp, "home")
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	// Windows resolvers read APPDATA rather than the home directory — goose's
+	// config is one — so leaving it alone lets one test's install show up in
+	// another's report.
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+	t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	// Goose resolves through %APPDATA% on Windows; pin it so the doctor

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -163,6 +163,7 @@ func doctorHooks(w io.Writer) {
 	}
 	fmt.Fprintf(w, "  %-12s %-11s %s\n", "precompact", status, path)
 	doctorCodexHook(w)
+	doctorAutoRecall(w)
 }
 
 // doctorCodexHook reports the codex session-start hook state. Codex gates
@@ -410,6 +411,8 @@ func doctorMCPConfigs() []doctorMCPConfig {
 		{"pi", filepath.Join(sources.PiConfigDir(), "mcp.json"), doctorJSONWired("mcpServers")},
 		{"openclaw", filepath.Join(sources.OpenClawStateDir(), "openclaw.json"), doctorOpenClawWired},
 		{"copilot", guidancePath("copilot"), doctorFileWired},
+		{"hermes", filepath.Join(sources.HermesHome(), "config.yaml"), doctorHermesWired},
+		{"goose", filepath.Join(gooseConfigDir(), "config.yaml"), doctorGooseWired},
 	}
 }
 

--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// autoWiring is one harness's session-start recall: the file deja writes and
+// the marker that proves the file is still ours rather than a leftover the
+// user or the harness rewrote.
+type autoWiring struct {
+	name   string
+	path   func() string
+	marker string
+}
+
+// autoWirings is the single list doctor and the coverage test both read.
+// Every harness deja can wire for auto-recall belongs here; a harness with an
+// -auto install target and no entry is a hole in the only report a user has
+// when memory goes quiet.
+func autoWirings() []autoWiring {
+	return []autoWiring{
+		{"opencode", func() string {
+			return filepath.Join(opencodeConfigHome(), "opencode", "plugins", "deja.js")
+		}, "hook-context"},
+		{"cursor", func() string { return filepath.Join(sources.CursorCLIHome(), "hooks.json") }, "hook-context"},
+		{"gemini", func() string {
+			return filepath.Join(sources.GeminiHome(), "extensions", "deja", "hooks", "hooks.json")
+		}, "hook-context"},
+		{"qwen", func() string { return filepath.Join(sources.QwenConfigDir(), "settings.json") }, "hook-prompt"},
+		{"kimi", func() string { return filepath.Join(sources.KimiConfigDir(), "config.toml") }, "hook-prompt"},
+		{"antigravity", func() string {
+			return filepath.Join(antigravityConfigHome(), "plugins", "deja", "hooks.json")
+		}, "hook-antigravity"},
+		{"pi", func() string { return filepath.Join(sources.PiConfigDir(), "extensions", "deja.ts") }, "hook-context"},
+		{"hermes", func() string {
+			return filepath.Join(sources.HermesHome(), "plugins", "deja", "__init__.py")
+		}, "hook-context"},
+		{"openclaw", func() string {
+			return filepath.Join(sources.OpenClawStateDir(), "hooks", openclawHookName, "handler.js")
+		}, "hook-context"},
+		{"cline", func() string { return filepath.Join(sources.ClinePluginsDir(), "deja", "index.js") }, "hook-context"},
+		{"goose", func() string { return gooseHookPath() }, "hook-goose"},
+		{"aider", func() string { return aiderContextPath() }, ""},
+		{"roo", func() string { return rooRulesPath() }, ""},
+	}
+}
+
+// doctorAutoRecall prints one line per harness. "stale" is the interesting
+// state: the file is there, so an install looks done, but nothing in it calls
+// deja any more — which is exactly how a silently dead integration looks.
+func doctorAutoRecall(w io.Writer) {
+	for _, a := range autoWirings() {
+		path := a.path()
+		b, err := os.ReadFile(path)
+		switch {
+		case err != nil:
+			fmt.Fprintf(w, "  %-12s %-11s %s\n", a.name, "missing", path)
+		case a.marker != "" && !strings.Contains(string(b), a.marker):
+			fmt.Fprintf(w, "  %-12s %-11s %s  (no %s call — reinstall)\n", a.name, "stale", path, a.marker)
+		default:
+			fmt.Fprintf(w, "  %-12s %-11s %s\n", a.name, "wired", path)
+		}
+	}
+}
+
+// Goose and Hermes keep MCP servers in YAML rather than JSON or TOML, and
+// both nest ours under a key: a plain "deja appears in the file" check would
+// pass on a disabled entry.
+func doctorGooseWired(path string) bool {
+	b, err := os.ReadFile(path)
+	return err == nil && strings.Contains(string(b), "\n  deja:\n")
+}
+
+func doctorHermesWired(path string) bool {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	s := string(b)
+	return strings.Contains(s, "\nmcp_servers:\n") && strings.Contains(s, "\n  deja:\n")
+}

--- a/cmd/deja/doctor_auto_test.go
+++ b/cmd/deja/doctor_auto_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// doctor is where someone looks when recall goes quiet. A harness deja can
+// wire for auto-recall but doctor does not report is a hole exactly there —
+// this pins the two lists together so a new harness cannot open one.
+func TestDoctorCoversEveryAutoTarget(t *testing.T) {
+	covered := map[string]bool{
+		// The two that predate the table and print their own lines.
+		"claude": true, "codex": true,
+	}
+	for _, a := range autoWirings() {
+		covered[a.name] = true
+	}
+	for _, target := range installTargetNames() {
+		name, ok := strings.CutSuffix(target, "-auto")
+		if !ok {
+			continue
+		}
+		if !covered[name] {
+			t.Fatalf("install target %q has no doctor row: add it to autoWirings()", target)
+		}
+	}
+}
+
+// A file that exists but no longer calls deja is the shape of every dead
+// integration: the install looks done and nothing ever fires.
+func TestDoctorReportsStaleWiring(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
+	path := filepath.Join(home, ".pi", "agent", "extensions", "deja.ts")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("// an old extension that calls nothing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	doctorAutoRecall(&buf)
+	out := buf.String()
+	line := ""
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(l, " pi ") {
+			line = l
+		}
+	}
+	if !strings.Contains(line, "stale") {
+		t.Fatalf("an extension with no deja call is not reported stale:\n%s", out)
+	}
+	// Missing and stale must not read the same: one is "never installed",
+	// the other "installed and broken", and they need different fixes.
+	if !strings.Contains(out, "missing") {
+		t.Fatalf("nothing reported missing in an otherwise empty home:\n%s", out)
+	}
+}
+
+func TestDoctorReportsWiredWhenTheMarkerIsThere(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
+	if _, err := installPiAuto("/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	var buf bytes.Buffer
+	doctorAutoRecall(&buf)
+	for _, l := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(l, " pi ") && !strings.Contains(l, "wired") {
+			t.Fatalf("a fresh install is not reported wired: %q", l)
+		}
+	}
+}
+
+// Every target the installer accepts must be reachable from the shell too:
+// the fish script had fallen seven harnesses behind before this was shared.
+func TestCompletionListsEveryInstallTarget(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish"} {
+		out := captureStdout(t, func() {
+			if err := runCompletion([]string{shell}); err != nil {
+				t.Fatalf("%s: %v", shell, err)
+			}
+		})
+		if strings.Contains(out, "%INSTALL_TARGETS%") {
+			t.Fatalf("%s script still has the placeholder", shell)
+		}
+		for _, target := range []string{"cline-auto", "goose-auto", "hermes-auto", "roo", "aider", "openclaw-auto"} {
+			if !strings.Contains(out, target) {
+				t.Fatalf("%s completion never offers %q", shell, target)
+			}
+		}
+	}
+}

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -174,6 +174,10 @@ func TestDoctorJSONGolden(t *testing.T) {
 	got := strings.ReplaceAll(out.String(), `\\`, `/`)
 	got = filepath.ToSlash(got)
 	got = strings.ReplaceAll(got, filepath.ToSlash(tmp), "<tmp>")
+	// Goose is the one harness whose config lives under a vendor directory on
+	// Windows rather than ~/.config, so the golden keeps the posix path and
+	// the platform difference is normalised here.
+	got = strings.ReplaceAll(got, "<tmp>/home/AppData/Roaming/Block/goose/config", "<tmp>/home/.config/goose")
 	wantRaw, err := os.ReadFile(filepath.Join("testdata", "doctor.json"))
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1009,3 +1009,27 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) []byte {
 	out = append(out, lines[insert:]...)
 	return []byte(strings.Join(out, "\n") + "\n")
 }
+
+// installTargetNames is the one list of what `deja install` accepts. Shell
+// completion and doctor's coverage test both read it, so a harness added to
+// installTarget without appearing here is caught rather than quietly missing
+// from both.
+func installTargetNames() []string {
+	return []string{
+		"claude-code", "claude-auto",
+		"codex", "codex-auto",
+		"opencode", "opencode-auto",
+		"cursor", "cursor-auto",
+		"gemini", "gemini-auto",
+		"antigravity", "antigravity-auto",
+		"qwen", "qwen-auto",
+		"kimi", "kimi-auto",
+		"hermes", "hermes-auto",
+		"pi", "pi-auto",
+		"openclaw", "openclaw-auto",
+		"cline", "cline-auto",
+		"goose", "goose-auto",
+		"grok", "copilot", "roo", "aider",
+		"statusline",
+	}
+}

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -193,6 +193,16 @@
       "name": "copilot",
       "state": "config-missing",
       "path": "<tmp>/home/.copilot/skills/deja-history/SKILL.md"
+    },
+    {
+      "name": "hermes",
+      "state": "config-missing",
+      "path": "<tmp>/home/.hermes/config.yaml"
+    },
+    {
+      "name": "goose",
+      "state": "config-missing",
+      "path": "<tmp>/home/.config/goose/config.yaml"
     }
   ],
   "sqlite3": {


### PR DESCRIPTION
Closes #415.

`deja doctor` listed two of the thirteen things deja wires for session-start recall — Claude's PreCompact and the Codex hook. The opencode plugin, cursor hooks, the gemini extension, qwen and kimi prompt hooks, the pi extension, the hermes plugin, the openclaw hook pack, the antigravity plugin, the cline plugin, the goose hook and aider's read file were all invisible: delete any of them and doctor still reported a clean bill of health. hermes and goose had no MCP row either.

One table now drives it, with a third state that matters more than the other two: **stale** — the file is there, so the install looks done, but nothing in it calls deja any more. Running this on my own machine immediately turned up `~/.qwen/settings.json` and `~/.kimi-code/config.toml` still carrying the pre-fix wiring (wrong event, and a timeout Qwen reads as 10ms), dead since those bugs were fixed and never reported by anything. That upgrade path is filed separately as #416.

Shell completion had drifted the same way — three hand-maintained copies of the target list, the newest seven harnesses missing from all of them. It now substitutes one list, and tests pin both doctor's coverage and completion's against it.