### PR TITLE
MCP: accept numeric arguments sent as strings

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -166,10 +167,10 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 	switch name {
 	case "recall":
 		var a struct {
-			Query   string  `json:"query"`
-			Harness string  `json:"harness"`
-			Limit   float64 `json:"limit"`
-			Offset  float64 `json:"offset"`
+			Query   string    `json:"query"`
+			Harness string    `json:"harness"`
+			Limit   mcpNumber `json:"limit"`
+			Offset  mcpNumber `json:"offset"`
 		}
 		if err := json.Unmarshal(raw, &a); err != nil {
 			return "", err
@@ -204,12 +205,12 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		return text, err
 	case "blame":
 		var a struct {
-			Path    string  `json:"path"`
-			Harness string  `json:"harness"`
-			Project string  `json:"project"`
-			Since   string  `json:"since"`
-			Limit   float64 `json:"limit"`
-			All     bool    `json:"all"`
+			Path    string    `json:"path"`
+			Harness string    `json:"harness"`
+			Project string    `json:"project"`
+			Since   string    `json:"since"`
+			Limit   mcpNumber `json:"limit"`
+			All     bool      `json:"all"`
 		}
 		if err := json.Unmarshal(raw, &a); err != nil {
 			return "", err
@@ -478,4 +479,31 @@ func fuzzySummary(variants map[string][]string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// mcpNumber accepts a number or a numeric string. Models emit both — the
+// schema says number, but a client that stringifies its arguments would
+// otherwise get a Go type error back instead of a result, and the error text
+// leaks internal field names into a protocol surface.
+type mcpNumber float64
+
+func (n *mcpNumber) UnmarshalJSON(b []byte) error {
+	var f float64
+	if err := json.Unmarshal(b, &f); err == nil {
+		*n = mcpNumber(f)
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return fmt.Errorf("want a number, got %s", strings.TrimSpace(string(b)))
+	}
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil {
+		return fmt.Errorf("want a number, got %q", s)
+	}
+	*n = mcpNumber(f)
+	return nil
 }

--- a/cmd/deja/mcp_number_test.go
+++ b/cmd/deja/mcp_number_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Clients that stringify their arguments are common enough that a Go type
+// error is the wrong answer: it fails the call and leaks internal field names
+// into the protocol.
+func TestMCPAcceptsNumericStrings(t *testing.T) {
+	var a struct {
+		Limit  mcpNumber `json:"limit"`
+		Offset mcpNumber `json:"offset"`
+	}
+	if err := json.Unmarshal([]byte(`{"limit":"3","offset":"7"}`), &a); err != nil {
+		t.Fatalf("numeric strings rejected: %v", err)
+	}
+	if int(a.Limit) != 3 || int(a.Offset) != 7 {
+		t.Fatalf("limit=%v offset=%v", a.Limit, a.Offset)
+	}
+	if err := json.Unmarshal([]byte(`{"limit":4}`), &a); err != nil || int(a.Limit) != 4 {
+		t.Fatalf("plain number broke: %v (%v)", err, a.Limit)
+	}
+	// An empty string means the client sent no value, not a zero it chose.
+	if err := json.Unmarshal([]byte(`{"limit":""}`), &a); err != nil {
+		t.Fatalf("empty string rejected: %v", err)
+	}
+	err := json.Unmarshal([]byte(`{"limit":"abc"}`), &a)
+	if err == nil {
+		t.Fatal("garbage accepted")
+	}
+	if strings.Contains(err.Error(), "float64") || strings.Contains(err.Error(), "Go struct") {
+		t.Fatalf("error leaks internals: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #422.

`recall` with `"limit": "5"` failed the whole call and returned `json: cannot unmarshal string into Go struct field .limit of type float64` — a Go type name on a protocol surface, for a mistake models make routinely. `limit` and `offset` now take a number or a numeric string; an empty string means the client sent nothing, and real garbage gets an error that talks about numbers.