### PR TITLE
Benchmark per-prompt recall, and fix the term floor

### DIFF
--- a/cmd/deja/bench.go
+++ b/cmd/deja/bench.go
@@ -34,11 +34,14 @@ type benchReport struct {
 }
 
 func runBench(args []string) error {
+	if len(args) > 0 && args[0] == "prompt" {
+		return runBenchPrompt(args[1:])
+	}
 	if len(args) > 0 && args[0] == "context" {
 		return runBenchContext(args[1:])
 	}
 	if len(args) < 1 || args[0] != "recall" || len(args) > 2 || (len(args) == 2 && args[1] != "--json") {
-		return fmt.Errorf("bench: usage: bench recall [--json]")
+		return fmt.Errorf("bench: usage: bench recall|context|prompt [--json]")
 	}
 	return runBenchRecall(len(args) == 2)
 }

--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/bench"
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// The per-prompt hook had no benchmark, so changes to its term extraction
+// were unmeasurable: `bench recall` scores search and `bench context` scores
+// the session-start digest, and neither runs promptSearchTerms.
+//
+// The questions here are phrased the way people ask them — short identifiers,
+// filler words, sometimes another language — because that is exactly what the
+// extractor has to survive. Negative controls ask about work the corpus does
+// not contain: a run that fires on those is trading noise for coverage.
+// negativeQuestions ask about work no chain contains. A run that fires on
+// these is buying coverage with noise.
+func negativeQuestions() []string {
+	return []string{
+		"how do I bake sourdough bread at home",
+		"what is the capital of Portugal",
+		"explain quicksort to me",
+		// The dangerous shape: short words that live in every session's
+		// working noise. A floor low enough to keep "ttl" must not start
+		// recalling on "the output".
+		"can you run the tests again",
+		"paste the output of that command",
+		"walk me through the trace",
+		"adjust the patch and try again",
+		"add a log line here",
+		"open the file and read it",
+		"write the code for this",
+	}
+}
+
+type promptArmReport struct {
+	Cases      int     `json:"cases"`
+	Fired      int     `json:"fired"`
+	FireRate   float64 `json:"fire_rate"`
+	Correct    int     `json:"correct"`
+	Precision  float64 `json:"precision"`
+	FalseFires int     `json:"false_fires"`
+	MedianTerm float64 `json:"median_terms"`
+}
+
+type promptReport struct {
+	CorpusHash string          `json:"corpus_hash"`
+	Seed       int64           `json:"seed"`
+	Real       promptArmReport `json:"real_questions"`
+	Negative   promptArmReport `json:"negative_controls"`
+}
+
+func runBenchPrompt(args []string) error {
+	jsonOut := false
+	for _, a := range args {
+		if a == "--json" {
+			jsonOut = true
+		}
+	}
+	report, err := measurePrompt(bench.Seed)
+	if err != nil {
+		return err
+	}
+	if jsonOut {
+		return json.NewEncoder(os.Stdout).Encode(report)
+	}
+	fmt.Println("deja bench prompt")
+	fmt.Printf("corpus: %d chains, seed %d\n", bench.ContextChainCount, report.Seed)
+	fmt.Println("arm                fired  correct  precision")
+	fmt.Printf("real questions     %2d/%-2d  %2d       %.2f\n",
+		report.Real.Fired, report.Real.Cases, report.Real.Correct, report.Real.Precision)
+	fmt.Printf("negative controls  %2d/%-2d  —        false fires: %d\n",
+		report.Negative.Fired, report.Negative.Cases, report.Negative.FalseFires)
+	return nil
+}
+
+func measurePrompt(seed int64) (promptReport, error) {
+	corpus := bench.GeneratePrompt(seed)
+	root, err := benchmarkTempDir()
+	if err != nil {
+		return promptReport{}, err
+	}
+	defer func() { _ = os.RemoveAll(root) }()
+	claudeRoot := filepath.Join(root, "claude")
+	indexDir := filepath.Join(root, "index.db")
+	var sessions []model.Session
+	for _, chain := range corpus.Chains {
+		sessions = append(sessions, chain.Sessions...)
+	}
+	if err := writeBenchCorpus(claudeRoot, sessions); err != nil {
+		return promptReport{}, err
+	}
+	restore := isolateBenchEnv(root, claudeRoot, indexDir)
+	defer restore()
+	if err := index.EnsureForSearch(indexDir, search.Options{Query: "", All: true}, true, io.Discard); err != nil {
+		return promptReport{}, fmt.Errorf("build prompt benchmark index: %w", err)
+	}
+	report := promptReport{CorpusHash: corpus.Hash, Seed: seed}
+	var realTerms, negTerms []int
+	for _, chain := range corpus.Chains {
+		if chain.Negative {
+			continue
+		}
+		terms := promptSearchTerms(chain.Question)
+		realTerms = append(realTerms, len(terms))
+		fired, correct := promptBenchProbe(indexDir, chain.Project, chain.ID, terms)
+		report.Real.Cases++
+		if fired {
+			report.Real.Fired++
+		}
+		if correct {
+			report.Real.Correct++
+		}
+	}
+	// Negative questions are asked against every project in turn: firing
+	// anywhere is a false fire.
+	for _, q := range negativeQuestions() {
+		terms := promptSearchTerms(q)
+		negTerms = append(negTerms, len(terms))
+		report.Negative.Cases++
+		for _, chain := range corpus.Chains {
+			if fired, _ := promptBenchProbe(indexDir, chain.Project, chain.ID, terms); fired {
+				report.Negative.Fired++
+				report.Negative.FalseFires++
+				break
+			}
+		}
+	}
+	finishPromptArm(&report.Real, realTerms)
+	finishPromptArm(&report.Negative, negTerms)
+	return report, nil
+}
+
+// promptBenchProbe runs the same two steps the hook runs: extract terms, then
+// ask the index for this project's sessions ranked by them. Anything the hook
+// would discard downstream is discarded here too, so the number reported is
+// what a user would actually see.
+func promptBenchProbe(dir, project, chainID string, terms []string) (fired, correct bool) {
+	if len(terms) < 2 {
+		return false, false
+	}
+	ranked, matched, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	if err != nil {
+		return false, false
+	}
+	for i, s := range ranked {
+		if matched[i] < 2 || len(s.Messages) > dejaVuMaxMessages {
+			continue
+		}
+		fired = true
+		if strings.HasPrefix(s.ID, chainID) {
+			correct = true
+		}
+		break
+	}
+	return fired, correct
+}
+
+func finishPromptArm(arm *promptArmReport, terms []int) {
+	if arm.Cases > 0 {
+		arm.FireRate = float64(arm.Fired) / float64(arm.Cases)
+	}
+	if arm.Fired > 0 {
+		arm.Precision = float64(arm.Correct) / float64(arm.Fired)
+	}
+	if len(terms) > 0 {
+		arm.MedianTerm = percentileInt(terms, 50)
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -285,7 +285,14 @@ func techTerm(f string) bool {
 		}
 		long++
 	}
-	return long >= 7
+	// Seven was a proxy for "looks like an identifier" and the wrong one:
+	// etag, ttl, mutex, gzip, oauth and most of what people actually type is
+	// shorter. Measured on `deja bench prompt`, dropping to four takes real
+	// questions answered from 2/12 to 7/12 with precision unchanged at 1.00
+	// and no false fire on any negative control; three scores higher still
+	// but starts keeping words like "log" and "run", so four is where the
+	// evidence stops being comfortable.
+	return long >= 4
 }
 
 // citationLine pre-writes the narration so the agent copies structure instead

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -85,16 +85,23 @@ func TestPromptSearchTerms(t *testing.T) {
 	if !strings.Contains(joined, "connection") || !strings.Contains(joined, "gateway") {
 		t.Fatalf("terms = %v", got)
 	}
-	// Short prose words identify themes, not tasks — they must not survive.
-	if strings.Contains(joined, "pool") {
-		t.Fatalf("short prose term kept: %v", got)
+	// Short words used to be dropped on the theory that they identify themes
+	// rather than tasks. `deja bench prompt` says otherwise: keeping them
+	// takes answered questions from 2/12 to 7/12 with precision unchanged and
+	// no false fire, because "pool" is exactly what names the session someone
+	// is asking about. Noise is held back by the two-term overlap gate, not
+	// by a length floor.
+	if !strings.Contains(joined, "pool") {
+		t.Fatalf("short identifier dropped: %v", got)
 	}
 	if len(promptSearchTerms("a of to")) != 0 {
 		t.Fatal("stop words must not produce terms")
 	}
 	for term, want := range map[string]bool{
 		"auth.go": true, "e404": true, "npm_token": true, "singleflight": true,
-		"brew": false, "пост": false, "готовь": false,
+		// Four characters is the floor `deja bench prompt` settled on: "brew"
+		// is a real command name, and words this short are what people type.
+		"brew": true, "ttl": false, "пост": false, "готовь": false,
 	} {
 		if techTerm(term) != want {
 			t.Fatalf("techTerm(%q) = %v, want %v", term, !want, want)

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -1,0 +1,111 @@
+package bench
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The context corpus gives every chain the same vocabulary, which makes it
+// useless for scoring per-prompt recall: a term that appears in all thirty
+// chains identifies none of them, so the relevance pass counts zero matches
+// no matter how the extractor behaves.
+//
+// This corpus gives each chain its own topic, and deliberately uses the kind
+// of short identifiers people type — etag, ttl, mutex — because the question
+// under test is what the extractor keeps.
+type PromptChain struct {
+	ID       string
+	Project  string
+	Topic    string
+	Question string
+	Sessions []model.Session
+	Negative bool
+}
+
+type PromptCorpus struct {
+	Chains []PromptChain
+	Hash   string
+}
+
+type promptTopic struct {
+	word     string
+	fact     string
+	question string
+}
+
+// Each topic is one short word plus the sentence a session would record and
+// the question someone would ask about it months later.
+func promptTopics() []promptTopic {
+	return []promptTopic{
+		{"etag", "the stale etag reuse was replaced with generation checks", "why did we replace the stale etag reuse?"},
+		{"ttl", "the ttl for cached tokens was settled at 14 minutes", "what ttl did we settle on?"},
+		{"jitter", "retry backoff got jitter so retries stop arriving together", "did we add jitter to the backoff?"},
+		{"mutex", "the mutex around the writer was replaced with a channel", "what did we do about the writer mutex?"},
+		{"quota", "the upload quota check moved before the multipart parse", "where does the quota check happen now?"},
+		{"gzip", "gzip was disabled for streaming responses because it buffered", "why is gzip off for streaming?"},
+		{"utf8", "invalid utf8 in filenames is now replaced rather than rejected", "how do we handle invalid utf8 in names?"},
+		{"cron", "the nightly cron moved to 03:17 to miss the backup window", "when does the nightly cron run?"},
+		{"oauth", "oauth refresh tokens are rotated on every use", "are oauth refresh tokens rotated?"},
+		{"dns", "dns lookups are cached for 30 seconds inside the pool", "how long do we cache dns lookups?"},
+		{"panic", "a panic in the parser is recovered and logged as a corrupt file", "what happens when the parser panics?"},
+		{"wal", "wal mode is enabled so readers stop blocking the writer", "why did we turn on wal mode?"},
+	}
+}
+
+const PromptNegativeCount = 3
+
+// GeneratePrompt builds one chain per topic: three prior sessions carrying the
+// fact under working noise, and no task session — the question comes from the
+// caller, the way a prompt does.
+func GeneratePrompt(seed int64) PromptCorpus {
+	rng := rand.New(rand.NewSource(seed))
+	topics := promptTopics()
+	base := time.Date(2099, time.February, 1, 0, 0, 0, 0, time.UTC)
+	chains := make([]PromptChain, 0, len(topics)+PromptNegativeCount)
+	for i, topic := range topics {
+		chain := PromptChain{
+			ID:       fmt.Sprintf("prompt-chain-%02d", i),
+			Project:  fmt.Sprintf("promptbench%02d", i),
+			Topic:    topic.word,
+			Question: topic.question,
+		}
+		for j := 0; j < ContextPriorCount; j++ {
+			t := base.Add(time.Duration(i*10+j) * time.Minute)
+			msgs := []model.Message{{Role: "user", Text: fmt.Sprintf("we decided %s", topic.fact), Time: t}}
+			for k := 0; k < 4+rng.Intn(6); k++ {
+				msgs = append(msgs,
+					model.Message{Role: "user", Text: fillerText(rng, "ran it again and pasted the output"), Time: t.Add(time.Duration(2*k+2) * time.Minute)},
+					model.Message{Role: "assistant", Text: fillerText(rng, "walked the trace and adjusted the patch"), Time: t.Add(time.Duration(2*k+3) * time.Minute)},
+				)
+			}
+			chain.Sessions = append(chain.Sessions, model.Session{
+				ID: fmt.Sprintf("%s-session-%d", chain.ID, j), Harness: "claude",
+				Project: chain.Project, Started: t, Updated: t, Messages: msgs,
+			})
+		}
+		chains = append(chains, chain)
+	}
+	// Negative controls share the corpus but hold none of its topics, so a
+	// question about them must not recall anything.
+	for i := 0; i < PromptNegativeCount; i++ {
+		id := fmt.Sprintf("prompt-negative-%02d", i)
+		t := base.Add(time.Duration(500+i*10) * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: fmt.Sprintf("promptbenchneg%02d", i), Negative: true,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: fmt.Sprintf("promptbenchneg%02d", i),
+				Started: t, Updated: t,
+				Messages: []model.Message{{Role: "user", Text: "unrelated maintenance with no durable decision", Time: t}},
+			}},
+		})
+	}
+	b, _ := json.Marshal(chains)
+	h := sha256.Sum256(b)
+	return PromptCorpus{Chains: chains, Hash: hex.EncodeToString(h[:])}
+}


### PR DESCRIPTION
Closes #418. Closes #419.

Per-prompt recall had no benchmark: `bench recall` scores search and `bench context` scores the session-start digest, and neither runs the term extractor. So the 2/12 figure below was previously unmeasurable, and any change to it unjustifiable.

`deja bench prompt` builds a corpus with **one topic per chain** — the context corpus gives all thirty chains the same vocabulary, which makes every term uninformative and scores zero no matter what the extractor does. Twelve chains carry a short identifier each (etag, ttl, jitter, mutex, gzip, oauth…), and ten negative questions include the dangerous shape: short words that live in every session's working noise, like "paste the output" and "add a log line here".

| ASCII floor | answered | precision | false fires |
| --- | --- | --- | --- |
| 7 (before) | 2/12 | 1.00 | 0/10 |
| 5 | 5/12 | 1.00 | 0/10 |
| **4 (now)** | **7/12** | **1.00** | **0/10** |
| 3 | 10/12 | 1.00 | 0/10 |

Three scores higher still, but it starts keeping "log" and "run", and ten negatives is not enough evidence to spend on that. Four is where the measurement is comfortable.

`bench context` is unchanged at 278 tokens and full coverage, so the session-start path is unaffected.

One existing test asserted the opposite belief — that short prose words must not survive — and is now inverted with the numbers in the comment, since "pool" in "connection pool exhausted" is precisely what names the session being asked about. Noise is held back by the two-term overlap gate, not by a length floor.