### PR TITLE
Roo: follow the customStoragePath setting

### DIFF
--- a/.grok/settings.json
+++ b/.grok/settings.json
@@ -1,0 +1,3 @@
+{
+  "model": "grok-code-fast-1"
+}

--- a/internal/sources/roo.go
+++ b/internal/sources/roo.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -63,6 +64,7 @@ func RooRoots() []string {
 	// tasks land under a mock storage root rather than any editor's. Same
 	// layout, so the parser needs nothing new — only the path.
 	bases = append(bases, RooCLIRoot())
+	bases = append(bases, rooCustomStorageRoots()...)
 	var out []string
 	for _, b := range bases {
 		if fi, err := os.Stat(b); err == nil && fi.IsDir() {
@@ -70,6 +72,152 @@ func RooRoots() []string {
 		}
 	}
 	return out
+}
+
+// rooCustomStorageRoots reads the `roo-cline.customStoragePath` setting each
+// VS Code host may carry. Roo writes it with ConfigurationTarget.Global, so it
+// lives in the host's User/settings.json, and when it is set the tasks are
+// there and nowhere else — deja would otherwise index none of that history.
+func rooCustomStorageRoots() []string {
+	var out []string
+	for _, settings := range vsCodeUserSettingsPaths() {
+		b, err := os.ReadFile(settings)
+		if err != nil {
+			continue
+		}
+		// The file is JSONC in practice: comments and trailing commas are
+		// normal, so a strict decode would silently skip real users.
+		var cfg map[string]any
+		if json.Unmarshal(stripJSONCComments(b), &cfg) != nil {
+			continue
+		}
+		if p, _ := cfg["roo-cline.customStoragePath"].(string); strings.TrimSpace(p) != "" {
+			out = append(out, expandTilde(strings.TrimSpace(p)))
+		}
+	}
+	return out
+}
+
+// vsCodeUserSettingsPaths is the settings file for each host Roo runs in, in
+// the same order as the storage roots above.
+func vsCodeUserSettingsPaths() []string {
+	hosts := []string{"Code", "Code - Insiders", "VSCodium", "Cursor", "Windsurf"}
+	var out []string
+	switch runtime.GOOS {
+	case "darwin":
+		app := filepath.Join(Home(), "Library", "Application Support")
+		for _, host := range hosts {
+			out = append(out, filepath.Join(app, host, "User", "settings.json"))
+		}
+	case "windows":
+		app := os.Getenv("APPDATA")
+		if app == "" {
+			app = filepath.Join(Home(), "AppData", "Roaming")
+		}
+		for _, host := range hosts {
+			out = append(out, filepath.Join(app, host, "User", "settings.json"))
+		}
+	default:
+		cfg := os.Getenv("XDG_CONFIG_HOME")
+		if cfg == "" {
+			cfg = filepath.Join(Home(), ".config")
+		}
+		for _, host := range hosts {
+			out = append(out, filepath.Join(cfg, host, "User", "settings.json"))
+		}
+	}
+	return out
+}
+
+// stripJSONCComments removes // and /* */ comments outside strings. VS Code
+// settings files carry them by default, and a strict decode would treat every
+// commented settings file as absent.
+func stripJSONCComments(b []byte) []byte {
+	out := make([]byte, 0, len(b))
+	inString, escaped := false, false
+	for i := 0; i < len(b); i++ {
+		c := b[i]
+		if inString {
+			out = append(out, c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+		switch {
+		case c == '"':
+			inString = true
+			out = append(out, c)
+		case c == '/' && i+1 < len(b) && b[i+1] == '/':
+			for i < len(b) && b[i] != '\n' {
+				i++
+			}
+			out = append(out, '\n')
+		case c == '/' && i+1 < len(b) && b[i+1] == '*':
+			i += 2
+			for i+1 < len(b) && !(b[i] == '*' && b[i+1] == '/') {
+				i++
+			}
+			i++
+		default:
+			out = append(out, c)
+		}
+	}
+	return dropTrailingCommas(out)
+}
+
+// dropTrailingCommas removes the comma VS Code tolerates before a closing
+// brace or bracket. Settings files written by hand have them, and without
+// this the whole file decodes as invalid and the setting is missed.
+func dropTrailingCommas(b []byte) []byte {
+	out := make([]byte, 0, len(b))
+	inString, escaped := false, false
+	for i := 0; i < len(b); i++ {
+		c := b[i]
+		if inString {
+			out = append(out, c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+		if c == '"' {
+			inString = true
+			out = append(out, c)
+			continue
+		}
+		if c == ',' {
+			j := i + 1
+			for j < len(b) && (b[j] == ' ' || b[j] == '\t' || b[j] == '\n' || b[j] == '\r') {
+				j++
+			}
+			if j < len(b) && (b[j] == '}' || b[j] == ']') {
+				continue
+			}
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+func expandTilde(p string) string {
+	if p == "~" {
+		return Home()
+	}
+	if strings.HasPrefix(p, "~/") || strings.HasPrefix(p, `~\`) {
+		return filepath.Join(Home(), p[2:])
+	}
+	return p
 }
 
 // RooCLIRoot is where @roo-code/cli keeps tasks and settings: it runs the

--- a/internal/sources/roo.go
+++ b/internal/sources/roo.go
@@ -160,7 +160,7 @@ func stripJSONCComments(b []byte) []byte {
 			out = append(out, '\n')
 		case c == '/' && i+1 < len(b) && b[i+1] == '*':
 			i += 2
-			for i+1 < len(b) && !(b[i] == '*' && b[i+1] == '/') {
+			for i+1 < len(b) && (b[i] != '*' || b[i+1] != '/') {
 				i++
 			}
 			i++

--- a/internal/sources/roo_test.go
+++ b/internal/sources/roo_test.go
@@ -77,8 +77,11 @@ func TestRooRootsFollowsCustomStoragePath(t *testing.T) {
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("DEJA_ROO_ROOTS", "")
 	t.Setenv("DEJA_ROO_CLI_ROOT", filepath.Join(home, "absent"))
-	dir := filepath.Join(home, "Library", "Application Support", "Code", "User")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	// The settings file lives somewhere different on each platform; ask the
+	// resolver rather than hardcoding the mac path, which is how this test
+	// passed locally and failed on linux.
+	settingsPath := vsCodeUserSettingsPaths()[0]
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	store := filepath.Join(home, "relocated")
@@ -89,7 +92,7 @@ func TestRooRootsFollowsCustomStoragePath(t *testing.T) {
 	// strict decode treats this as invalid and silently finds nothing.
 	settings := "{\n  // moved to an external disk\n  \"roo-cline.customStoragePath\": " +
 		strconv.Quote(store) + ",\n}\n"
-	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(settings), 0o644); err != nil {
+	if err := os.WriteFile(settingsPath, []byte(settings), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	roots := RooRoots()

--- a/internal/sources/roo_test.go
+++ b/internal/sources/roo_test.go
@@ -1,8 +1,10 @@
 package sources
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
@@ -63,5 +65,53 @@ func TestRooTasksAreNotClaimedByCline(t *testing.T) {
 	}
 	if got := KindForPath(task); got != "roo" {
 		t.Fatalf("KindForPath(%s) = %q, want roo", task, got)
+	}
+}
+
+// Roo lets a user move its whole store with the roo-cline.customStoragePath
+// setting. deja read only the default location, so for those users it indexed
+// nothing at all and said the harness was missing.
+func TestRooRootsFollowsCustomStoragePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_ROO_ROOTS", "")
+	t.Setenv("DEJA_ROO_CLI_ROOT", filepath.Join(home, "absent"))
+	dir := filepath.Join(home, "Library", "Application Support", "Code", "User")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store := filepath.Join(home, "relocated")
+	if err := os.MkdirAll(filepath.Join(store, "tasks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Written the way VS Code writes it: comments and a trailing comma. A
+	// strict decode treats this as invalid and silently finds nothing.
+	settings := "{\n  // moved to an external disk\n  \"roo-cline.customStoragePath\": " +
+		strconv.Quote(store) + ",\n}\n"
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(settings), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	roots := RooRoots()
+	found := false
+	for _, r := range roots {
+		if r == store {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("relocated store not in roots: %v", roots)
+	}
+}
+
+func TestStripJSONCHandlesCommentsAndCommas(t *testing.T) {
+	in := []byte("{\n  \"a\": \"http://x/y\", // trailing note\n  /* block */ \"b\": [1,2,],\n}")
+	var got map[string]any
+	if err := json.Unmarshal(dropTrailingCommas(stripJSONCComments(in)), &got); err != nil {
+		t.Fatalf("jsonc not accepted: %v", err)
+	}
+	// A // inside a string is part of the value, not a comment.
+	if got["a"] != "http://x/y" {
+		t.Fatalf("a = %v", got["a"])
 	}
 }


### PR DESCRIPTION
Closes #425.

Roo can relocate its entire store through `roo-cline.customStoragePath`, written to each VS Code host's `User/settings.json`. deja looked only in the default globalStorage directory, so those users got `roo missing` in doctor and no history at all.

Reading that file needs two things the strict decoder does not do: VS Code writes comments and tolerates a trailing comma, and the path may be `~`-relative. Both are handled, with a test that pins a settings file written the way VS Code actually writes one — a `//` inside a URL stays part of the value.

Verified end to end: with the setting pointed at a scratch directory, `deja --harness roo` indexes and finds the task there.