### PR TITLE
doctor: catch the codex hook held for review

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -183,10 +183,19 @@ func doctorCodexHook(w io.Writer) {
 			off, on := strings.Index(rest, "enabled = false"), strings.Index(rest, "enabled = true")
 			if off >= 0 && (on == -1 || on > off) {
 				status = "disabled"
+			} else if !codexHookTrusted(hooksPath, rest) {
+				// Codex pins the hook file's hash when the user trusts it.
+				// Any reinstall that rewrites hooks.json invalidates that,
+				// and the hook stops running while enabled stays true — so
+				// this is the state that looks healthiest and works least.
+				status = "untrusted"
 			}
 		}
 	}
 	line := fmt.Sprintf("  %-12s %-11s %s", "codex-hook", status, hooksPath)
+	if status == "untrusted" {
+		line += "  (codex will not run it until you review it — press t in codex, or run /hooks)"
+	}
 	if status == "disabled" {
 		line += "  (codex trusts but disabled it — re-enable in codex settings or hooks.state)"
 	}

--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -84,4 +86,26 @@ func doctorHermesWired(path string) bool {
 	}
 	s := string(b)
 	return strings.Contains(s, "\nmcp_servers:\n") && strings.Contains(s, "\n  deja:\n")
+}
+
+// codexHookTrusted compares the hook file against the hash codex recorded
+// when the user last trusted it. A mismatch means codex is holding the hook
+// for review, however enabled it looks in the config.
+func codexHookTrusted(hooksPath, stateSection string) bool {
+	i := strings.Index(stateSection, "trusted_hash = \"sha256:")
+	if i < 0 {
+		return true // no pin recorded: nothing to contradict
+	}
+	rest := stateSection[i+len("trusted_hash = \"sha256:"):]
+	end := strings.IndexByte(rest, '"')
+	if end < 0 {
+		return true
+	}
+	want := rest[:end]
+	b, err := os.ReadFile(hooksPath)
+	if err != nil {
+		return true
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]) == want
 }

--- a/cmd/deja/doctor_auto_test.go
+++ b/cmd/deja/doctor_auto_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,5 +99,31 @@ func TestCompletionListsEveryInstallTarget(t *testing.T) {
 				t.Fatalf("%s completion never offers %q", shell, target)
 			}
 		}
+	}
+}
+
+// Codex pins the hook file's hash when the user trusts it, and any reinstall
+// that rewrites hooks.json invalidates the pin. The hook then stops running
+// while `enabled = true` stays in the config — the state that looks healthiest
+// and works least, and the one doctor used to call "wired".
+func TestCodexHookTrustDetectsARewrittenFile(t *testing.T) {
+	dir := t.TempDir()
+	hooks := filepath.Join(dir, "hooks.json")
+	if err := os.WriteFile(hooks, []byte(`{"hooks":{"session_start":[]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256([]byte(`{"hooks":{"session_start":[]}}`))
+	matching := "\ntrusted_hash = \"sha256:" + hex.EncodeToString(sum[:]) + "\"\nenabled = true\n"
+	if !codexHookTrusted(hooks, matching) {
+		t.Fatal("an untouched hook file is reported untrusted")
+	}
+	stale := "\ntrusted_hash = \"sha256:0000000000000000000000000000000000000000000000000000000000000000\"\nenabled = true\n"
+	if codexHookTrusted(hooks, stale) {
+		t.Fatal("a rewritten hook file is reported trusted")
+	}
+	// A config with no pin at all is a codex that never asked; saying
+	// "untrusted" there would be a false alarm on every fresh install.
+	if !codexHookTrusted(hooks, "\nenabled = true\n") {
+		t.Fatal("absence of a pin reported as untrusted")
 	}
 }


### PR DESCRIPTION
Closes #427.

A TUI snapshot on this machine showed Codex holding our hook: `SessionStart  Installed 1  Active 0  Review 1`, with `⚠ 1 hook needs review before it can run`. `deja doctor` for the same state said `codex-hook wired`.

Codex pins the hook file's hash when the user trusts it. Any reinstall that rewrites `hooks.json` — new binary path, changed command — invalidates the pin, and the hook stops firing while `enabled = true` stays in the config, which is what doctor keyed on. So the healthiest-looking state was the broken one.

doctor now compares the file against the recorded hash and says `untrusted`, with the fix on the same line. No pin recorded means codex never asked, which stays `wired` rather than raising a false alarm on a fresh install.