### PR TITLE
A query that names a subcommand no longer runs it

### DIFF
--- a/.aider.chat.history.md
+++ b/.aider.chat.history.md
@@ -208,3 +208,7 @@
 > Retrying in 32.0 seconds...  
 > litellm.InternalServerError: InternalServerError: OpenAIException - Empty or invalid response from LLM endpoint. Received: 'data: {"id":"1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":null}]}\n\ndata: {"id":"1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n'. Check the reverse proxy or model server configuration.  
 > The API provider's servers are down or overloaded.  
+
+# aider chat started at 2026-07-27 22:36:47
+
+> Can't initialize prompt toolkit: [Errno 32] Broken pipe  

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ openclaw plugins install ./deja-vu/claude-plugin
 
 Cursor, Qwen, OpenClaw and Copilot all read the Claude plugin format, so **one bundle installs into six harnesses**. Their hook support differs — OpenClaw runs its own hook packs, which `deja install openclaw-auto` writes, and Copilot runs the hooks but drops their context, so recall there is MCP plus the skill — while the MCP server, skill and `/deja` command come from the same directory in this repository.
 
-aider has no MCP client and no hooks, but read-only files are re-read from disk on every message. `deja install aider` adds a context file to `read:` in `~/.aider.conf.yml`, and `deja aider [args…]` refreshes it and starts aider — the digest is in context from the first message, and one line says how many sessions it recalled. Everything after `deja aider` goes to aider unchanged.
+aider has no MCP client and no hooks, but read-only files are re-read from disk on every message. `deja install aider` adds a context file to `read:` in `~/.aider.conf.yml`, and `deja aider <args…>` refreshes it and starts aider (bare `deja aider` searches for the word instead of launching anything) — the digest is in context from the first message, and one line says how many sessions it recalled. Everything after `deja aider` goes to aider unchanged.
 
 On Windows, register the MCP server through the shell wrapper most stdio servers need there: `cmd /c deja mcp` (deja install writes this form automatically; use it if you wire configs by hand).
 

--- a/cmd/deja/install_aider.go
+++ b/cmd/deja/install_aider.go
@@ -135,6 +135,12 @@ const aiderLead = "The sessions below are from this project's recent history. " 
 // cmdAider refreshes the context file and then becomes aider. Everything after
 // the subcommand belongs to aider, including flags deja also has.
 func cmdAider(dir string, rest []string) error {
+	// `deja aider` with nothing after it is ambiguous, and the harmless
+	// reading is the right default: search for the word rather than start
+	// an editor the user did not ask for.
+	if len(rest) == 0 {
+		return cmdSearch(dir, []string{"aider"})
+	}
 	if err := refreshAiderContext(dir); err != nil {
 		// A failed recall is not a reason to keep the user out of their editor.
 		fmt.Fprintf(os.Stderr, "deja: could not refresh recall: %v\n", err)

--- a/cmd/deja/install_cline.go
+++ b/cmd/deja/install_cline.go
@@ -78,7 +78,7 @@ export default {
         if (!query) return "Usage: /deja <what you are looking for>";
         // A command the user just typed can wait: the first search may have
         // to build the index, which a hook never gets to do.
-        const found = run([query], "", 120000);
+        const found = run(["search", query], "", 120000);
         return found || `+"`No past session matches ${query}.`"+`;
       },
     });

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -211,7 +211,10 @@ const gooseLead = "The sessions below are from this project's recent history. " 
 // cmdGoose turns MOIM on for the session it starts: recall is then re-read
 // every turn rather than pinned to whatever the session began with, and it
 // survives compaction.
-func cmdGoose(_ string, rest []string) error {
+func cmdGoose(dir string, rest []string) error {
+	if len(rest) == 0 {
+		return cmdSearch(dir, []string{"goose"})
+	}
 	moim := filepath.Join(gooseConfigDir(), "deja-recall.md")
 	if os.Getenv("GOOSE_MOIM_MESSAGE_FILE") == "" {
 		if err := os.Setenv("GOOSE_MOIM_MESSAGE_FILE", moim); err != nil {

--- a/cmd/deja/install_hermes.go
+++ b/cmd/deja/install_hermes.go
@@ -106,7 +106,7 @@ def search(raw_args):
         return "Usage: /deja <what you are looking for>"
     # A hook must not stall a turn, but a command the user just typed can
     # wait: a first search may rebuild the index, which took 18s here.
-    found = _deja([query], timeout=120)
+    found = _deja(["search", query], timeout=120)
     return found or f"Nothing in your history matches {query!r}."
 
 

--- a/cmd/deja/install_pi.go
+++ b/cmd/deja/install_pi.go
@@ -94,7 +94,7 @@ export default function (pi: any) {
       }
       // The user is waiting on this one, so it may outlive the hook budget:
       // a first search can rebuild the index.
-      const found = run([query], "", 120000);
+      const found = run(["search", query], "", 120000);
       ctx.ui.notify(found || "Nothing in your history matches " + query, "info");
     },
   });

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -124,12 +124,12 @@ var commands = map[string]command{
 	// likely someone searching for the word than someone asking to launch
 	// an editor, and launching one from a search is not a mistake worth
 	// making. See cmdAider/cmdGoose.
-	"aider":           cmdAider,
-	"goose":           cmdGoose,
-	"hook-goose":      cmdGooseHook,
-	"search":          cmdSearch,
-	"blame":           runBlame,
-	"last":            cmdLast,
+	"aider":      cmdAider,
+	"goose":      cmdGoose,
+	"hook-goose": cmdGooseHook,
+	"search":     cmdSearch,
+	"blame":      runBlame,
+	"last":       cmdLast,
 }
 
 func run(args []string) error {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -120,9 +120,14 @@ var commands = map[string]command{
 	"log":             runLog,
 	"sync":            runSync,
 	"ctx":             cmdCtx,
+	// Wrappers, but only with arguments: bare `deja aider` is far more
+	// likely someone searching for the word than someone asking to launch
+	// an editor, and launching one from a search is not a mistake worth
+	// making. See cmdAider/cmdGoose.
 	"aider":           cmdAider,
 	"goose":           cmdGoose,
 	"hook-goose":      cmdGooseHook,
+	"search":          cmdSearch,
 	"blame":           runBlame,
 	"last":            cmdLast,
 }
@@ -253,6 +258,17 @@ func cmdLast(dir string, rest []string) error {
 		fmt.Println()
 	}
 	return nil
+}
+
+// cmdSearch is the explicit form. Bare `deja <words>` also searches, but a
+// single word that happens to name a subcommand runs that instead, which is
+// how `/deja uninstall` inside a plugin came back with "nothing matches".
+// Anything shelling out to deja with user text should use this.
+func cmdSearch(dir string, rest []string) error {
+	if len(rest) == 0 {
+		return fmt.Errorf("search needs a query")
+	}
+	return runSearch(dir, rest)
 }
 
 func runSearch(dir string, args []string) error {

--- a/cmd/deja/search_command_test.go
+++ b/cmd/deja/search_command_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A one-word query that names a subcommand used to run it. Two of those
+// commands start an editor, so a search could launch a whole agent.
+func TestBareWrapperNamesSearchInsteadOfLaunching(t *testing.T) {
+	for _, name := range []string{"aider", "goose"} {
+		cmd, ok := commands[name]
+		if !ok {
+			t.Fatalf("%s is not a command any more; this guard needs updating", name)
+		}
+		// With no arguments the wrapper must not reach exec.LookPath at all.
+		// Searching an empty index is quiet and harmless, which is the point.
+		if err := cmd(t.TempDir(), nil); err != nil && strings.Contains(err.Error(), "not on PATH") {
+			t.Fatalf("bare `deja %s` tried to launch the harness: %v", name, err)
+		}
+	}
+}
+
+// The plugins shell out with whatever the user typed, so they need a form
+// that can never be mistaken for a command.
+func TestPluginsUseTheExplicitSearchForm(t *testing.T) {
+	for name, js := range map[string]string{
+		"pi":     piExtensionTS("/bin/deja"),
+		"cline":  clinePluginJS("/bin/deja"),
+		"hermes": hermesPluginPy("/bin/deja"),
+	} {
+		if !strings.Contains(js, `"search"`) {
+			t.Fatalf("%s plugin passes the query as the first argument: a query of \"index\" would rebuild the index", name)
+		}
+	}
+}
+
+func TestSearchCommandNeedsAQuery(t *testing.T) {
+	if err := cmdSearch(t.TempDir(), nil); err == nil {
+		t.Fatal("empty search accepted")
+	}
+}


### PR DESCRIPTION
Closes #429.

`deja "uninstall"` ran the uninstaller instead of searching, and the wrappers I added made the collision dangerous rather than annoying: `deja goose` and `deja aider` started an agent from a one-word search. `deja index` rebuilt the index.

Found while taking a pi TUI snapshot — `/deja uninstall` answered "nothing in your history matches uninstall", which the index flatly contradicts. The pi, cline and hermes plugins all shell out with the user's text as the first argument, so `/deja goose` in any of them would have launched goose inside the plugin process.

Adds `deja search <words>`, which can never be read as a command, and points all three plugins at it. A bare wrapper name with no arguments now searches instead of launching; with arguments it still starts the harness, since `deja aider --model …` is unambiguous.