### PR TITLE
Repair wiring written by an older deja

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Install also writes user-level guidance for the harnesses it detects: Claude Cod
 
 Install reports whether it found local history and builds the first index immediately when history is present.
 
+Install records what it wired. When a later version changes how a hook or plugin is generated, the next session start rewrites those same targets — only the ones deja installed — so a fix reaches people who installed months ago without them re-running anything.
+
 That's it. Next session, ask your agent:
 
 > have we dealt with jwt refresh rotation before? check your memory

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -74,6 +74,12 @@ func runHookPrecompact(dir string) {
 // Code / Codex hook JSON envelope; plain=true prints the bare digest for
 // hosts that inject raw text (the opencode plugin).
 func runHookContext(dir string, plain bool) error {
+	// A session start is the one moment deja is guaranteed to run on every
+	// harness, which makes it the only reliable place to repair wiring left
+	// behind by an older binary. It costs one small file read when nothing
+	// changed, and it says nothing: the user asked for memory, not for
+	// maintenance notes.
+	refreshWiringAfterUpgrade()
 	// SessionStart fires for startup, resume, clear and compact; the payload
 	// says which. After a compaction the model just lost its working context,
 	// so the lead line changes to say the memory below survived it.

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -93,6 +93,9 @@ func runInstall(dir string, args []string, uninstall bool) error {
 		return err
 	}
 	exe, _ = filepath.Abs(exe)
+	// Remembered so a later upgrade can refresh exactly these and nothing
+	// else: the generators change, the files on disk do not.
+	defer recordWiring(targets, uninstall)
 	banner := !uninstall && (targetArgs[0] == "--auto" || targetArgs[0] == "--all") && logoWanted(os.Stdout)
 	type lineItem struct{ target, action, path string }
 	var done []lineItem

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -245,9 +245,13 @@ func installGeminiAuto(exe string, uninstall bool) (installResult, error) {
 // hookEventName in the reply matches the event — so the SessionStart-shaped
 // output of `hook-context` was dropped without a word.
 func installQwenAuto(exe string, uninstall bool) (installResult, error) {
-	return installSettingsHookCmd(
+	// Older deja wrote SessionStart here, which qwen never consumed. Naming
+	// it as retired means an upgrade removes the dead entry instead of
+	// leaving qwen to run a hook that answers into the void.
+	return installSettingsHookRetiring(
 		filepath.Join(sources.QwenConfigDir(), "settings.json"),
-		"UserPromptSubmit", "", 60000, exe+" hook-prompt", uninstall)
+		"UserPromptSubmit", "", 60000, exe+" hook-prompt", uninstall,
+		map[string]bool{"SessionStart": true})
 }
 
 // installSettingsHook merges one hook entry into a settings.json that the
@@ -257,6 +261,13 @@ func installSettingsHook(path, event, matcher string, timeout int, exe string, u
 }
 
 func installSettingsHookCmd(path, event, matcher string, timeout int, cmd string, uninstall bool) (installResult, error) {
+	return installSettingsHookRetiring(path, event, matcher, timeout, cmd, uninstall, nil)
+}
+
+// installSettingsHookRetiring also drops deja hooks under events this harness
+// no longer uses. Without it a generator fix ships and the old, dead entry
+// keeps firing next to the new one for everyone who installed before.
+func installSettingsHookRetiring(path, event, matcher string, timeout int, cmd string, uninstall bool, retire map[string]bool) (installResult, error) {
 	old, _ := os.ReadFile(path)
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {
@@ -268,6 +279,25 @@ func installSettingsHookCmd(path, event, matcher string, timeout int, cmd string
 	if hooks == nil {
 		hooks = map[string]any{}
 		root["hooks"] = hooks
+	}
+	for name := range retire {
+		if name == event {
+			continue
+		}
+		old, _ := hooks[name].([]any)
+		var survivors []any
+		for _, entryAny := range old {
+			entry, _ := entryAny.(map[string]any)
+			if entry != nil && dejaHookEntry(entry) {
+				continue
+			}
+			survivors = append(survivors, entryAny)
+		}
+		if len(survivors) == 0 {
+			delete(hooks, name)
+		} else {
+			hooks[name] = survivors
+		}
 	}
 	entries, _ := hooks[event].([]any)
 	var kept []any
@@ -364,4 +394,22 @@ func removeKimiHookBlock(s string) string {
 		i-- // the loop's own i++ steps onto the next table header
 	}
 	return strings.TrimRight(strings.Join(out, "\n"), "\n") + "\n"
+}
+
+// dejaHookEntry reports whether a settings.json hook entry runs deja. Used to
+// retire wiring written by an older version under an event we abandoned.
+func dejaHookEntry(entry map[string]any) bool {
+	inner, _ := entry["hooks"].([]any)
+	for _, h := range inner {
+		m, _ := h.(map[string]any)
+		cmd, _ := m["command"].(string)
+		// Any deja subcommand counts: the point is to find wiring we wrote,
+		// whatever the old binary called.
+		for _, sub := range []string{"hook-context", "hook-prompt", "hook-precompact", "hook-goose", "hook-antigravity"} {
+			if isDejaHookCommand(cmd, "deja "+sub) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// A hook or plugin deja wrote is a copy of what this binary generates, frozen
+// at install time. Upgrade the binary and those copies stay as they were:
+// when a generator changes — a wrong event name, a timeout in the wrong unit —
+// the fix ships and never reaches anyone, because nobody re-runs an installer
+// that already succeeded. That is how qwen and kimi sat with dead wiring here
+// for weeks.
+//
+// So deja records what it wired and with which version, and refreshes those
+// same targets after an upgrade. Only targets it installed itself, never a
+// new one: this repairs, it does not spread.
+type wiringState struct {
+	Version string   `json:"version"`
+	Targets []string `json:"targets"`
+}
+
+func wiringStatePath() string {
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		base = filepath.Join(homeDir(), ".config")
+	}
+	return filepath.Join(base, "deja", "wiring.json")
+}
+
+func readWiringState() wiringState {
+	var st wiringState
+	b, err := os.ReadFile(wiringStatePath())
+	if err != nil {
+		return st
+	}
+	_ = json.Unmarshal(b, &st)
+	return st
+}
+
+// recordWiring remembers the targets an install wrote. Uninstalled ones drop
+// out, so a user who removes a harness is not re-wired behind their back.
+func recordWiring(targets []string, uninstall bool) {
+	st := readWiringState()
+	have := map[string]bool{}
+	for _, t := range st.Targets {
+		have[t] = true
+	}
+	for _, t := range targets {
+		if t == "statusline" {
+			continue
+		}
+		have[t] = !uninstall
+	}
+	var kept []string
+	for t, on := range have {
+		if on {
+			kept = append(kept, t)
+		}
+	}
+	sort.Strings(kept)
+	st = wiringState{Version: version, Targets: kept}
+	b, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return
+	}
+	path := wiringStatePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(path, append(b, '\n'), 0o644)
+}
+
+// refreshWiringAfterUpgrade rewrites the recorded targets when the binary that
+// wrote them is not the one running now. It returns the targets it changed, so
+// a caller with somewhere to print can say so; the hook paths call it and stay
+// quiet, because a session start is not the place for maintenance chatter.
+func refreshWiringAfterUpgrade() []string {
+	st := readWiringState()
+	if len(st.Targets) == 0 || st.Version == version || version == "" {
+		return nil
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return nil
+	}
+	exe, _ = filepath.Abs(exe)
+	var changed []string
+	for _, target := range st.Targets {
+		res, err := installTarget(target, exe, false)
+		if err != nil {
+			// A harness the user has since removed is not an error worth
+			// surfacing: the next install run will drop it from the record.
+			continue
+		}
+		if res.Action != "" && res.Action != "unchanged" {
+			changed = append(changed, target)
+		}
+	}
+	recordWiring(st.Targets, false)
+	return changed
+}

--- a/cmd/deja/wiring_state_test.go
+++ b/cmd/deja/wiring_state_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The scenario this exists for: a user installed months ago, the generator
+// has been fixed since, and their config still holds the broken version.
+// Nobody re-runs an installer that already succeeded, so the repair has to
+// happen without being asked.
+func TestWiringRefreshesAfterUpgrade(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
+	t.Setenv("DEJA_QWEN_ROOT", "")
+	if err := os.MkdirAll(filepath.Join(home, ".qwen"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installQwenAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	recordWiring([]string{"qwen-auto"}, false)
+
+	// Rewind: the wiring an older deja wrote, under an event qwen never
+	// consumes, with a timeout it reads as ten milliseconds.
+	settings := filepath.Join(home, ".qwen", "settings.json")
+	stale := map[string]any{"hooks": map[string]any{
+		"SessionStart": []any{map[string]any{"hooks": []any{map[string]any{
+			"type": "command", "command": "/old/deja hook-context", "timeout": 10,
+		}}}},
+	}}
+	b, _ := json.MarshalIndent(stale, "", "  ")
+	if err := os.WriteFile(settings, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	statePath := wiringStatePath()
+	if err := os.WriteFile(statePath, []byte(`{"version":"0.14.0","targets":["qwen-auto"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed := refreshWiringAfterUpgrade()
+	if len(changed) == 0 {
+		t.Fatal("upgrade left the stale wiring in place")
+	}
+	var got map[string]any
+	raw, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	hooks, _ := got["hooks"].(map[string]any)
+	if _, dead := hooks["SessionStart"]; dead {
+		t.Fatalf("the abandoned event survived: %s", raw)
+	}
+	if _, live := hooks["UserPromptSubmit"]; !live {
+		t.Fatalf("the working hook was not restored: %s", raw)
+	}
+	// And the record now says this binary owns it, so the repair does not
+	// repeat on every session start.
+	st := readWiringState()
+	if st.Version != version {
+		t.Fatalf("state still says %q", st.Version)
+	}
+	if second := refreshWiringAfterUpgrade(); second != nil {
+		t.Fatalf("repair ran twice: %v", second)
+	}
+}
+
+// Repair, not spread: a harness the user never wired must stay untouched.
+func TestWiringRefreshTouchesOnlyRecordedTargets(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
+	if err := os.MkdirAll(filepath.Join(home, ".qwen"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(wiringStatePath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wiringStatePath(), []byte(`{"version":"0.1.0","targets":["qwen-auto"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	refreshWiringAfterUpgrade()
+	if _, err := os.Stat(filepath.Join(home, ".kimi-code", "config.toml")); !os.IsNotExist(err) {
+		t.Fatal("refresh wired a harness the user never asked for")
+	}
+}


### PR DESCRIPTION
Closes #416.

A hook or plugin deja writes is a copy of what that binary generated, frozen at install time. Upgrade the binary and the copy stays as it was — so when a generator gets fixed, the fix ships and reaches nobody, because nobody re-runs an installer that already succeeded. That is exactly how `~/.qwen/settings.json` and `~/.kimi-code/config.toml` sat here for weeks with the wrong event and a timeout Qwen reads as 10ms.

Install now records which targets it wired and with which version. On the next session start — the one moment deja is guaranteed to run on every harness — a version mismatch rewrites those same targets and updates the record. It costs one small file read when nothing changed, and says nothing: the user asked for memory, not for maintenance notes.

Repair, not spread: only targets deja itself installed, never a new one, with a test for that.

The qwen case also needed retiring the abandoned event — the old `SessionStart` entry pointing at a binary that may no longer exist would otherwise keep firing next to the new one. Installers can now name events they have stopped using.