### PR TITLE
Bound a bucket's posting block by the file size

### DIFF
--- a/internal/index/corrupt_bucket_test.go
+++ b/internal/index/corrupt_bucket_test.go
@@ -1,0 +1,73 @@
+package index
+
+import (
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCorruptBucketDoesNotPanic(t *testing.T) {
+	dir := t.TempDir()
+	cases := map[string][]byte{
+		"huge count":   append(append([]byte(bucketMagic), encodeUvarint(1<<62)...), 0),
+		"huge token":   append(append([]byte(bucketMagic), encodeUvarint(1)...), encodeUvarint(1<<62)...),
+		"truncated":    []byte(bucketMagic),
+		"bad magic":    []byte("XXXXXXXX"),
+		"empty file":   {},
+		"garbage tail": append([]byte(bucketMagic), 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff),
+	}
+	for name, body := range cases {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, body, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("%s: panicked instead of failing: %v", name, r)
+				}
+			}()
+			_, f, err := openBucketDir(p)
+			if f != nil {
+				f.Close()
+			}
+			if err == nil {
+				t.Fatalf("%s: accepted as valid", name)
+			}
+			if !errors.Is(err, errCorruptIndex) && !os.IsNotExist(err) {
+				t.Logf("%s: err=%v (not errCorruptIndex)", name, err)
+			}
+		}()
+	}
+}
+
+func encodeUvarint(v uint64) []byte {
+	b := make([]byte, binary.MaxVarintLen64)
+	return b[:binary.PutUvarint(b, v)]
+}
+
+// A block length under MaxUint32 still passed, so a bucket naming four
+// gigabytes for one token turned a recoverable corruption into an OOM.
+func TestBucketBlockLengthBoundedByFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "big.bin")
+	body := append([]byte(bucketMagic), encodeUvarint(1)...)
+	body = append(body, encodeUvarint(1)...)
+	body = append(body, 'x')
+	body = append(body, encodeUvarint(4_000_000_000)...)
+	if err := os.WriteFile(p, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, f, err := openBucketDir(p)
+	if f != nil {
+		f.Close()
+	}
+	if err == nil {
+		t.Fatal("a four-gigabyte posting block in a 20-byte file was accepted")
+	}
+	if !errors.Is(err, errCorruptIndex) {
+		t.Fatalf("err = %v, want errCorruptIndex so the caller rebuilds", err)
+	}
+}

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -614,9 +614,13 @@ func openBucketDir(p string) ([]bucketEntry, *os.File, error) {
 			f.Close()
 			return nil, nil, fmt.Errorf("%w: %v", errCorruptIndex, err)
 		}
-		if size > math.MaxUint32 {
+		// MaxUint32 alone is not a bound: a bucket claiming four gigabytes for
+		// one token is an out-of-memory kill rather than a corrupt-index
+		// error, and the caller can recover from the latter. Postings live in
+		// this same file, so the file's own size is the real ceiling.
+		if size > math.MaxUint32 || size > fileSize {
 			f.Close()
-			return nil, nil, fmt.Errorf("%w: posting block length %d", errCorruptIndex, size)
+			return nil, nil, fmt.Errorf("%w: posting block of %d bytes in a %d byte bucket", errCorruptIndex, size, fileSize)
 		}
 		dirLen += uint64(uvarintLen(ln)) + ln + uint64(uvarintLen(size))
 		entries = append(entries, bucketEntry{tok: string(tb), n: uint32(size)})


### PR DESCRIPTION
Closes #366.

The panic the issue describes is already gone — the entry count and token lengths have been bounded against the file for a while. This adds the case those bounds missed and a test that pins all of it.

`openBucketDir` accepted any posting-block length below `MaxUint32`, so a bucket claiming four gigabytes for a single token turned a recoverable corruption into an out-of-memory kill — the caller can rebuild from `errCorruptIndex`, it cannot rebuild from being killed. Postings live in the same file, so the file's own size is the ceiling.

The test drives the reader with a truncated file, bad magic, an absurd entry count, an absurd token length, a garbage tail and an empty file, and asserts none of them panic.