### PR TITLE
doctor: find the MCP server whatever it was named

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -469,9 +470,60 @@ func doctorJSONWired(key string) func(string) bool {
 			return strings.Contains(string(b), `"deja"`)
 		}
 		m, _ := root[key].(map[string]any)
-		_, ok := m["deja"]
-		return ok
+		if _, ok := m["deja"]; ok {
+			return true
+		}
+		// Someone who wired the server by hand may have called it anything —
+		// "deja-vu" is the obvious other choice. What identifies it is the
+		// command it runs, not the key it was filed under, and telling a
+		// working setup it is not wired sends the debugging the wrong way.
+		for _, v := range m {
+			if mcpEntryRunsDeja(v) {
+				return true
+			}
+		}
+		return false
 	}
+}
+
+// mcpEntryRunsDeja reports whether an MCP server entry launches deja, in any
+// of the shapes clients accept: a bare command, a command plus args, or a
+// nested transport object.
+func mcpEntryRunsDeja(v any) bool {
+	m, _ := v.(map[string]any)
+	if m == nil {
+		return false
+	}
+	if t, ok := m["transport"].(map[string]any); ok {
+		if mcpEntryRunsDeja(t) {
+			return true
+		}
+	}
+	cmd, _ := m["command"].(string)
+	if commandIsDeja(cmd) {
+		return true
+	}
+	// Windows and npx-style wiring puts the binary in args instead.
+	args, _ := m["args"].([]any)
+	for _, a := range args {
+		if s, ok := a.(string); ok && commandIsDeja(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func commandIsDeja(cmd string) bool {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return false
+	}
+	// A windows path read on a unix build and vice versa: filepath.Base only
+	// knows the separator it was compiled for, and these configs travel.
+	cmd = strings.ReplaceAll(cmd, `\`, "/")
+	base := strings.ToLower(path.Base(cmd))
+	base = strings.TrimSuffix(base, ".exe")
+	return base == "deja"
 }
 
 func doctorTOMLWired(path string) bool {
@@ -479,7 +531,22 @@ func doctorTOMLWired(path string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.Contains(string(b), "[mcp_servers.deja]")
+	if strings.Contains(string(b), "[mcp_servers.deja]") {
+		return true
+	}
+	// Same reasoning as the JSON probe: a hand-wired server under another
+	// name still runs deja. The TOML here is small and flat enough that
+	// finding a command line naming the binary is enough.
+	for _, line := range strings.Split(string(b), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "command" {
+			continue
+		}
+		if commandIsDeja(strings.Trim(strings.TrimSpace(value), `"`)) {
+			return true
+		}
+	}
+	return false
 }
 
 func doctorIndex(w io.Writer, idx doctorComponent, dir string) {

--- a/cmd/deja/doctor_mcp_name_test.go
+++ b/cmd/deja/doctor_mcp_name_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Reported from a real setup: the server registered by hand as "deja-vu" for
+// three releases, answering calls daily, and doctor called it not wired. The
+// first thing someone runs when memory goes quiet must not send them looking
+// in the wrong place.
+func TestDoctorFindsTheServerUnderAnyName(t *testing.T) {
+	dir := t.TempDir()
+	probe := doctorJSONWired("mcpServers")
+	cases := map[string]string{
+		"named deja-vu":    `{"mcpServers":{"deja-vu":{"command":"/usr/local/bin/deja","args":["mcp"]}}}`,
+		"named memory":     `{"mcpServers":{"memory":{"command":"deja","args":["mcp"]}}}`,
+		"windows cmd shim": `{"mcpServers":{"deja-vu":{"command":"cmd","args":["/c","deja","mcp"]}}}`,
+		"windows exe":      `{"mcpServers":{"dj":{"command":"C:\\tools\\deja.exe","args":["mcp"]}}}`,
+		"nested transport": `{"mcpServers":{"whatever":{"transport":{"type":"stdio","command":"/opt/deja","args":["mcp"]}}}}`,
+		"canonical name":   `{"mcpServers":{"deja":{"command":"/usr/local/bin/deja","args":["mcp"]}}}`,
+	}
+	for name, body := range cases {
+		p := filepath.Join(dir, name+".json")
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if !probe(p) {
+			t.Fatalf("%s: reported not wired", name)
+		}
+	}
+	// A config with someone else's server must still read as not wired, or
+	// the check tells everyone they are fine.
+	other := filepath.Join(dir, "other.json")
+	if err := os.WriteFile(other, []byte(`{"mcpServers":{"memory":{"command":"npx","args":["-y","@modelcontextprotocol/server-memory"]}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if probe(other) {
+		t.Fatal("an unrelated MCP server was reported as deja")
+	}
+}
+
+func TestDoctorTOMLFindsTheServerUnderAnyName(t *testing.T) {
+	dir := t.TempDir()
+	renamed := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(renamed, []byte("[mcp_servers.deja-vu]\ncommand = \"/usr/local/bin/deja\"\nargs = [\"mcp\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !doctorTOMLWired(renamed) {
+		t.Fatal("renamed toml server reported not wired")
+	}
+	foreign := filepath.Join(dir, "foreign.toml")
+	if err := os.WriteFile(foreign, []byte("[mcp_servers.memory]\ncommand = \"npx\"\nargs = [\"-y\",\"server-memory\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if doctorTOMLWired(foreign) {
+		t.Fatal("an unrelated toml server was reported as deja")
+	}
+}


### PR DESCRIPTION
Closes #363.

Reported from a real setup: the server registered by hand as `deja-vu`, answering recall calls daily since 0.12.x, and `deja doctor` calling it `not wired`. doctor is the first thing someone runs when memory goes quiet, so a false negative there sends the debugging in the wrong direction.

What identifies the server is the command it runs, not the key it was filed under. The JSON and TOML probes now accept any entry whose command is a deja binary, in the shapes clients actually use: bare command, command plus args, a nested `transport` object, and the Windows `cmd /c deja mcp` shim. Paths are compared with the separator normalised, since these configs are read on the platform they were not written on.

An unrelated server still reads as not wired — there is a test for that too, or the check would tell everyone they are fine.