### PR TITLE
Ignore harness artefacts so testing cannot commit them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,17 @@ fixtures/synthetic/opencode.db
 .deja-bench/
 /longmemeval
 /locomo
+
+# Harness artefacts: running an agent inside this checkout to test an
+# integration leaves its own history and config here. None of it belongs in
+# the repository — three of these were committed by a careless `git add -A`.
+.aider.chat.history.md
+.aider.input.history
+.aider.tags.cache.v*/
+.grok/
+.roo/
+.cline/
+.goose/
+.opencode/
+.qwen/
+.kimi-code/


### PR DESCRIPTION
The three files themselves are gone — purged from history and force-pushed, so `.aider.chat.history.md`, `.aider.input.history` and `.grok/settings.json` no longer appear in any commit.

What is left, and what matters going forward: running an agent inside this checkout to verify an integration makes it write its own history and config here, and `git add -A` takes them. The ignore list covers every harness that does that — aider, grok, roo, cline, goose, opencode, qwen, kimi — so the same mistake cannot land twice.