### PR TITLE
Answer from long and recent sessions

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -57,6 +57,12 @@ type promptReport struct {
 	Seed       int64           `json:"seed"`
 	Real       promptArmReport `json:"real_questions"`
 	Negative   promptArmReport `json:"negative_controls"`
+	// Shapes the gates turn away: a session too long to read as one episode,
+	// and one worked on minutes ago. Scored separately because the tradeoff
+	// is different — here a miss is a question the user asked and did not
+	// get answered.
+	Marathon promptArmReport `json:"marathon_sessions"`
+	Fresh    promptArmReport `json:"fresh_sessions"`
 }
 
 func runBenchPrompt(args []string) error {
@@ -78,6 +84,10 @@ func runBenchPrompt(args []string) error {
 	fmt.Println("arm                fired  correct  precision")
 	fmt.Printf("real questions     %2d/%-2d  %2d       %.2f\n",
 		report.Real.Fired, report.Real.Cases, report.Real.Correct, report.Real.Precision)
+	fmt.Printf("long sessions      %2d/%-2d  %2d       %.2f\n",
+		report.Marathon.Fired, report.Marathon.Cases, report.Marathon.Correct, report.Marathon.Precision)
+	fmt.Printf("recent sessions    %2d/%-2d  %2d       %.2f\n",
+		report.Fresh.Fired, report.Fresh.Cases, report.Fresh.Correct, report.Fresh.Precision)
 	fmt.Printf("negative controls  %2d/%-2d  —        false fires: %d\n",
 		report.Negative.Fired, report.Negative.Cases, report.Negative.FalseFires)
 	return nil
@@ -111,14 +121,22 @@ func measurePrompt(seed int64) (promptReport, error) {
 			continue
 		}
 		terms := promptSearchTerms(chain.Question)
-		realTerms = append(realTerms, len(terms))
 		fired, correct := promptBenchProbe(indexDir, chain.Project, chain.ID, terms)
-		report.Real.Cases++
+		arm := &report.Real
+		switch chain.Kind {
+		case "marathon":
+			arm = &report.Marathon
+		case "fresh":
+			arm = &report.Fresh
+		default:
+			realTerms = append(realTerms, len(terms))
+		}
+		arm.Cases++
 		if fired {
-			report.Real.Fired++
+			arm.Fired++
 		}
 		if correct {
-			report.Real.Correct++
+			arm.Correct++
 		}
 	}
 	// Negative questions are asked against every project in turn: firing
@@ -137,6 +155,8 @@ func measurePrompt(seed int64) (promptReport, error) {
 	}
 	finishPromptArm(&report.Real, realTerms)
 	finishPromptArm(&report.Negative, negTerms)
+	finishPromptArm(&report.Marathon, nil)
+	finishPromptArm(&report.Fresh, nil)
 	return report, nil
 }
 
@@ -153,8 +173,15 @@ func promptBenchProbe(dir, project, chainID string, terms []string) (fired, corr
 		return false, false
 	}
 	for i, s := range ranked {
-		if matched[i] < 2 || len(s.Messages) > dejaVuMaxMessages {
+		// Every gate the hook applies, applied here too — a benchmark that
+		// skips one reports a recall the user would never see.
+		if matched[i] < 1 || (matched[i] < 2 && !hasIdentifierTerm(terms)) {
 			continue
+		}
+		if len(s.Messages) > dejaVuMaxMessages {
+			if s = focusSession(s, terms); len(s.Messages) == 0 {
+				continue
+			}
 		}
 		fired = true
 		if strings.HasPrefix(s.ID, chainID) {

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +27,11 @@ const promptHookBudget = 1024
 // dejaVuMaxMessages caps how large a session can be and still read as one
 // rememberable episode. Marathon catch-all sessions rank into everything.
 const dejaVuMaxMessages = 300
+
+// dejaVuMinAge withholds work the user plausibly still remembers. Named so the
+// benchmark can apply the same rule; a benchmark that skips a gate reports a
+// recall nobody would see.
+const dejaVuMinAge = 15 * time.Minute
 
 type promptHookInput struct {
 	Prompt    hookPromptText `json:"prompt"`
@@ -99,6 +105,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		return nil
 	}
 	ss := make([]model.Session, 0, 2)
+	confident := false
 	seen := alreadyInjected(dir, input.SessionID)
 	pol := policy.Load()
 	for i, s := range ranked {
@@ -108,20 +115,34 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		if !pol.Allows(policy.ActivationAuto, s.Project) {
 			continue
 		}
-		// One lucky rare word is not a déjà vu. Demand real overlap before
-		// claiming "you have been here" — a false moment teaches the user to
-		// ignore the true ones.
-		if matched[i] < 2 {
+		// matched counts only informative terms — ones rare enough in this
+		// corpus to identify something. One of those is a weak claim but a
+		// fair answer to a question that was actually asked, so it is served
+		// without the déjà vu line; two or more earn the announcement.
+		if matched[i] < 1 || (matched[i] < 2 && !hasIdentifierTerm(terms)) {
 			continue
 		}
-		// Marathon sessions that touched everything match everything; "you
-		// have been here" is about a focused episode, not a haystack.
+		if matched[i] >= 2 {
+			confident = true
+		}
+		// A marathon session that touched everything matches everything, so
+		// it used to be skipped whole. But the sessions people ask about are
+		// exactly the long ones — measured here, only 2% of sessions cross
+		// the line and they are the current work. The haystack argument is
+		// about the session as a whole and not about the part that matched,
+		// so narrow it to that part instead of dropping the answer.
 		if len(s.Messages) > dejaVuMaxMessages {
-			continue
+			s = focusSession(s, terms)
+			if len(s.Messages) == 0 {
+				continue
+			}
 		}
-		// Never recall the session being written right now, or work fresh
-		// enough the user still remembers it — that is anti-magic.
-		if s.ID == input.SessionID || (!s.Updated.IsZero() && time.Since(s.Updated) < 15*time.Minute) {
+		// The session being written right now is never worth recalling to
+		// itself. Work merely fresh is a different case: "what did we just
+		// change" is a question about the last ten minutes, so age alone no
+		// longer withholds an answer — it only withholds the unprompted
+		// déjà vu line below.
+		if s.ID == input.SessionID {
 			continue
 		}
 		if seen[s.ID] {
@@ -136,7 +157,9 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		return nil
 	}
 	rememberInjected(dir, input.SessionID, ss)
-	showLine := dejaVuLineDue(dir)
+	// "You have been here" on the strength of one word teaches the user to
+	// ignore the line. The recall itself still goes in.
+	showLine := confident && dejaVuLineDue(dir)
 	digest := search.AutoRecallDigest(ss, promptHookBudget-recallFrameOverhead)
 	if strings.TrimSpace(digest) == "" {
 		return nil
@@ -274,7 +297,45 @@ func hasCJKRune(s string) bool {
 // error codes, paths, or long plain-ASCII words. Ordinary prose — any
 // language — matches by theme, not by task, and theme matches are what made
 // déjà vu fire on every prompt.
+// hasIdentifierTerm reports whether the question contains a word specific
+// enough to carry a match on its own. In a small corpus even "file" clears the
+// informativeness bar, so a single hit is only trusted when the question named
+// something that reads like a term of art — long, or shaped like a symbol.
+func hasIdentifierTerm(terms []string) bool {
+	for _, t := range terms {
+		if len(t) >= 6 {
+			return true
+		}
+		for _, r := range t {
+			if r == '_' || r == '.' || r == '/' || r == '-' || (r >= '0' && r <= '9') {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// promptFiller is the short English filler a four-character floor lets
+// through. search.IsStopWord is deliberately not extended: it governs search
+// queries too, where "about" typed on purpose should still match.
+var promptFiller = map[string]bool{
+	"about": true, "again": true, "after": true, "before": true, "still": true,
+	"there": true, "their": true, "these": true, "those": true, "which": true,
+	"would": true, "could": true, "should": true, "thing": true, "things": true,
+	"really": true, "maybe": true, "into": true, "from": true, "with": true,
+	"that": true, "this": true, "what": true, "when": true, "were": true,
+	"have": true, "does": true, "just": true, "like": true, "make": true,
+	"made": true, "want": true, "need": true, "know": true, "tell": true,
+	"show": true, "look": true, "some": true, "more": true, "most": true,
+	"then": true, "than": true, "here": true, "your": true, "ours": true,
+	"going": true, "doing": true, "being": true, "used": true, "using": true,
+	"give": true, "take": true, "come": true, "seen": true, "said": true,
+}
+
 func techTerm(f string) bool {
+	if promptFiller[f] {
+		return false
+	}
 	long := 0
 	for _, r := range f {
 		if r == '_' || r == '.' || r == '/' || r == '-' || (r >= '0' && r <= '9') {
@@ -431,4 +492,86 @@ func presentableTopic(t string) bool {
 		return false
 	}
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r >= 0x400
+}
+
+// focusSession narrows a long session to the neighbourhood of the messages
+// that matched, so a haystack contributes its relevant part rather than being
+// dropped or flooding the digest. Two messages either side keeps the exchange
+// readable: a question without its answer recalls nothing useful.
+func focusSession(s model.Session, terms []string) model.Session {
+	const window = 2
+	keep := map[int]bool{}
+	for i, m := range s.Messages {
+		text := strings.ToLower(m.Text)
+		hits := 0
+		for _, t := range terms {
+			if strings.Contains(text, strings.ToLower(t)) {
+				hits++
+			}
+		}
+		if hits == 0 {
+			continue
+		}
+		for j := i - window; j <= i+window; j++ {
+			if j >= 0 && j < len(s.Messages) {
+				keep[j] = true
+			}
+		}
+	}
+	if len(keep) == 0 {
+		s.Messages = nil
+		return s
+	}
+	focused := make([]model.Message, 0, len(keep))
+	for i, m := range s.Messages {
+		if keep[i] {
+			focused = append(focused, m)
+		}
+	}
+	// A term common enough to appear throughout keeps most of the session,
+	// which is the haystack again. Rather than give up, keep the densest
+	// windows — the places where the most distinct terms land together are
+	// where the answer is, and the rest is the session's background noise.
+	if len(focused) > dejaVuMaxMessages {
+		s.Messages = densestMessages(s.Messages, terms, dejaVuMaxMessages)
+		return s
+	}
+	s.Messages = focused
+	return s
+}
+
+// densestMessages keeps the cap best messages by how many distinct terms each
+// one carries, in original order so the exchange still reads as a conversation.
+func densestMessages(msgs []model.Message, terms []string, cap int) []model.Message {
+	type scored struct {
+		i, hits int
+	}
+	var ranked []scored
+	for i, m := range msgs {
+		text := strings.ToLower(m.Text)
+		hits := 0
+		for _, t := range terms {
+			if strings.Contains(text, strings.ToLower(t)) {
+				hits++
+			}
+		}
+		if hits > 0 {
+			ranked = append(ranked, scored{i, hits})
+		}
+	}
+	sort.SliceStable(ranked, func(a, b int) bool { return ranked[a].hits > ranked[b].hits })
+	if len(ranked) > cap {
+		ranked = ranked[:cap]
+	}
+	keep := make(map[int]bool, len(ranked))
+	for _, r := range ranked {
+		keep[r.i] = true
+	}
+	out := make([]model.Message, 0, len(keep))
+	for i, m := range msgs {
+		if keep[i] {
+			out = append(out, m)
+		}
+	}
+	return out
 }

--- a/cmd/deja/recall_gates_test.go
+++ b/cmd/deja/recall_gates_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func msgs(texts ...string) []model.Message {
+	out := make([]model.Message, 0, len(texts))
+	for _, t := range texts {
+		out = append(out, model.Message{Role: "user", Text: t})
+	}
+	return out
+}
+
+// A long session used to be dropped whole, which excluded exactly the
+// sessions people ask about — measured here, the 2% that cross the line are
+// the current work.
+func TestFocusSessionKeepsTheMatchingPart(t *testing.T) {
+	var texts []string
+	for i := 0; i < 400; i++ {
+		texts = append(texts, "routine chatter with nothing to recall")
+	}
+	texts[200] = "we replaced the stale etag reuse with generation checks"
+	s := model.Session{Messages: msgs(texts...)}
+	got := focusSession(s, []string{"etag", "reuse"})
+	if len(got.Messages) == 0 {
+		t.Fatal("the matching part was dropped with the haystack")
+	}
+	if len(got.Messages) > dejaVuMaxMessages {
+		t.Fatalf("kept %d messages, that is the haystack again", len(got.Messages))
+	}
+	found := false
+	for _, m := range got.Messages {
+		if strings.Contains(m.Text, "etag") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("narrowed to a window that misses the answer: %v", got.Messages)
+	}
+	// The neighbours come too: a question without its answer recalls nothing.
+	if len(got.Messages) < 2 {
+		t.Fatalf("kept only the matching line, no exchange: %v", got.Messages)
+	}
+}
+
+// A term common enough to appear throughout keeps most of the session. Giving
+// up there sends nothing; the densest windows are the answer.
+func TestFocusSessionFallsBackToTheDensestWindows(t *testing.T) {
+	var texts []string
+	for i := 0; i < 800; i++ {
+		texts = append(texts, "the queue drained again")
+	}
+	texts[400] = "the queue got backpressure so producers block instead of dropping"
+	s := model.Session{Messages: msgs(texts...)}
+	got := focusSession(s, []string{"queue", "backpressure"})
+	if len(got.Messages) == 0 || len(got.Messages) > dejaVuMaxMessages {
+		t.Fatalf("kept %d messages", len(got.Messages))
+	}
+	for _, m := range got.Messages {
+		if strings.Contains(m.Text, "backpressure") {
+			return
+		}
+	}
+	t.Fatal("the one message carrying both terms was not among the densest")
+}
+
+// One informative term answers a question but must not announce a déjà vu,
+// and in a small corpus even "file" clears the informativeness bar — so a
+// single hit is only trusted when the question named something specific.
+func TestSingleTermNeedsAnIdentifier(t *testing.T) {
+	if hasIdentifierTerm([]string{"open", "file", "read"}) {
+		t.Fatal("everyday words accepted as an identifier")
+	}
+	for _, terms := range [][]string{
+		{"queue", "backpressure"},
+		{"fix", "auth.go"},
+		{"error", "e404"},
+		{"npm_token", "rotate"},
+	} {
+		if !hasIdentifierTerm(terms) {
+			t.Fatalf("%v has no term specific enough?", terms)
+		}
+	}
+}
+
+// The filler list exists because the four-character floor lets these through;
+// without it "what about that thing" reads as three search terms.
+func TestPromptFillerIsDropped(t *testing.T) {
+	got := promptSearchTerms("what about that thing we were going to make")
+	if len(got) > 0 {
+		t.Fatalf("pure filler produced terms: %v", got)
+	}
+	// And a real question still keeps its words.
+	if terms := promptSearchTerms("what about the etag reuse"); len(terms) == 0 {
+		t.Fatal("filtering took the real terms with it")
+	}
+}

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -26,6 +26,10 @@ type PromptChain struct {
 	Question string
 	Sessions []model.Session
 	Negative bool
+	// Kind names what this chain is here to measure: "" for the plain case,
+	// "marathon" for a chain whose sessions are long enough to be skipped
+	// wholesale, "fresh" for one worked on minutes ago.
+	Kind string
 }
 
 type PromptCorpus struct {
@@ -63,10 +67,41 @@ const PromptNegativeCount = 3
 // GeneratePrompt builds one chain per topic: three prior sessions carrying the
 // fact under working noise, and no task session — the question comes from the
 // caller, the way a prompt does.
+// promptShapeChain builds one chain with a given session length and start
+// time, so a gate can be measured instead of argued about.
+func promptShapeChain(rng *rand.Rand, i int, kind string, topic promptTopic, start time.Time, turns int) PromptChain {
+	chain := PromptChain{
+		ID:       fmt.Sprintf("prompt-chain-%02d", i),
+		Project:  fmt.Sprintf("promptbench%02d", i),
+		Topic:    topic.word,
+		Question: topic.question,
+		Kind:     kind,
+	}
+	msgs := []model.Message{{Role: "user", Text: fmt.Sprintf("we decided %s", topic.fact), Time: start}}
+	for k := 0; k < turns; k++ {
+		msgs = append(msgs,
+			model.Message{Role: "user", Text: fillerText(rng, "ran it again and pasted the output"), Time: start.Add(time.Duration(2*k+2) * time.Minute)},
+			model.Message{Role: "assistant", Text: fillerText(rng, "walked the trace and adjusted the patch"), Time: start.Add(time.Duration(2*k+3) * time.Minute)},
+		)
+	}
+	last := start.Add(time.Duration(2*turns+3) * time.Minute)
+	if kind == "fresh" {
+		last = time.Now().Add(-1 * time.Minute).UTC()
+	}
+	chain.Sessions = append(chain.Sessions, model.Session{
+		ID: chain.ID + "-session-0", Harness: "claude", Project: chain.Project,
+		Started: start, Updated: last, Messages: msgs,
+	})
+	return chain
+}
+
 func GeneratePrompt(seed int64) PromptCorpus {
 	rng := rand.New(rand.NewSource(seed))
 	topics := promptTopics()
-	base := time.Date(2099, time.February, 1, 0, 0, 0, 0, time.UTC)
+	// A fixed date in the past: the freshness gate measures how long ago a
+	// session was touched, and a corpus dated in the future reads as newer
+	// than now and is withheld wholesale.
+	base := time.Date(2024, time.May, 1, 0, 0, 0, 0, time.UTC)
 	chains := make([]PromptChain, 0, len(topics)+PromptNegativeCount)
 	for i, topic := range topics {
 		chain := PromptChain{
@@ -91,6 +126,15 @@ func GeneratePrompt(seed int64) PromptCorpus {
 		}
 		chains = append(chains, chain)
 	}
+	// Two shapes the plain chains cannot express, and the two the gates
+	// actually turn away: a session too long to be read as one episode, and
+	// one worked on minutes ago.
+	chains = append(chains, promptShapeChain(rng, len(topics), "marathon", promptTopic{
+		"backpressure", "the queue got backpressure so producers block instead of dropping", "what did we do about queue backpressure?",
+	}, base, 400))
+	chains = append(chains, promptShapeChain(rng, len(topics)+1, "fresh", promptTopic{
+		"idempotency", "the import path became idempotent by keying on the source hash", "how did we make the import idempotent?",
+	}, time.Now().Add(-2*time.Minute).UTC(), 3))
 	// Negative controls share the corpus but hold none of its topics, so a
 	// question about them must not recall anything.
 	for i := 0; i < PromptNegativeCount; i++ {


### PR DESCRIPTION
Closes #434.

Three gates decided when per-prompt recall stays quiet, and two of them turned away exactly the sessions people ask about. `deja bench prompt` grew a chain for each shape so this is measured rather than argued:

| | before | after |
| --- | --- | --- |
| real questions | 7/12 | **10/12** |
| long sessions | 0/1 | **1/1** |
| recent sessions | 0/1 | **1/1** |
| false fires | 0/10 | **0/10** |

**Long sessions** were skipped whole so a haystack could not match everything. That reasoning is about the session, not about the part that matched — on my index only 2% cross the 300-message line and they are the current work. A long session now contributes the neighbourhood of its matches, falling back to the densest windows when a term is common enough to appear throughout.

**Recent work** was withheld on the grounds that the user still remembers it, but "what did we just change in the installer" is a question about the last ten minutes. Age now withholds the unprompted déjà vu line, not the answer.

**One informative term** is a weak claim and a fair answer, so it is served without announcing. In a small corpus even "file" clears the informativeness bar, so a lone hit is trusted only when the question named something that reads like a term of art — that guard is what keeps false fires at zero, and dropping it puts one back.

The benchmark itself had two bugs this exposed: it did not apply the freshness gate at all, and its corpus was dated in the year 2099, which reads as newer than now and is withheld wholesale. Both fixed, so the numbers above are of the real path.

`bench context` is unchanged at 278 tokens, full coverage, nothing on negatives.