### PR TITLE
doctor: stop warning about unused sessions

### DIFF
--- a/cmd/deja/doctor_parsed_zero_test.go
+++ b/cmd/deja/doctor_parsed_zero_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Opening a harness and closing it without typing leaves a file of setup
+// records and no conversation. Reporting that as a parse failure sends people
+// looking for a bug in deja — it happened on my own machine after taking a
+// screenshot of a TUI.
+func TestParsedZeroIgnoresSessionsWithNoConversation(t *testing.T) {
+	dir := t.TempDir()
+	setupOnly := filepath.Join(dir, "wire.jsonl")
+	body := `{"type":"metadata","protocol_version":"1.4"}
+{"type":"config.update","profileName":"agent","systemPrompt":"You are a coding agent"}
+{"type":"tools.set_active_tools","tools":["read","write"]}
+`
+	if err := os.WriteFile(setupOnly, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if fileHasConversation(setupOnly) {
+		t.Fatal("a file of setup records was read as a conversation")
+	}
+
+	// A file that does hold turns must still be flagged when it parses to
+	// nothing: that is the case the warning exists for.
+	withTurns := filepath.Join(dir, "real.jsonl")
+	if err := os.WriteFile(withTurns, []byte(body+`{"type":"user","message":{"role":"user","content":"hello"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !fileHasConversation(withTurns) {
+		t.Fatal("a file with a user turn was read as empty")
+	}
+
+	// aider's markdown store marks turns with #### rather than JSON roles.
+	md := filepath.Join(dir, "history.md")
+	if err := os.WriteFile(md, []byte("# aider chat started at 2026-01-01\n\n#### fix the parser\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !fileHasConversation(md) {
+		t.Fatal("aider's turn marker was not recognised")
+	}
+	// An unreadable file is a real problem and must not be silenced.
+	if !fileHasConversation(filepath.Join(dir, "absent.jsonl")) {
+		t.Fatal("a missing file was treated as merely empty")
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -205,6 +207,13 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 	_ = f.Close()
 	sessions, _ := check.parse(newest)
 	store.State = "ok"
+	// A session someone opened and closed without typing parses to nothing,
+	// correctly. Calling that a parse failure sends people looking for a bug
+	// in deja when the file simply holds no conversation — so only a file
+	// with something to parse counts.
+	if len(sessions) == 0 && !fileHasConversation(newest) {
+		return store, mod
+	}
 	if len(sessions) == 0 {
 		store.State = "parsed-zero"
 	}
@@ -300,4 +309,32 @@ func doctorParsedZeroWarning() string {
 		return ""
 	}
 	return "warning: " + strings.Join(names, ", ") + " files found but newest parsed to zero"
+}
+
+// fileHasConversation reports whether a store file holds anything that should
+// have produced a message. Harness files begin with setup records — protocol
+// metadata, model config, tool lists — and a session that was opened and never
+// used contains only those.
+func fileHasConversation(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return true // unreadable is a real problem; let the caller flag it
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(io.LimitReader(f, 1<<20))
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() {
+		line := sc.Bytes()
+		for _, marker := range [][]byte{
+			[]byte(`"role":"user"`), []byte(`"role": "user"`),
+			[]byte(`"role":"assistant"`), []byte(`"role": "assistant"`),
+			[]byte(`"type":"user"`), []byte(`"type":"assistant"`),
+			[]byte("#### "),
+		} {
+			if bytes.Contains(line, marker) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -105,7 +105,9 @@ func TestDoctorStoreStates(t *testing.T) {
 	}
 
 	file := filepath.Join(tmp, "session.jsonl")
-	if err := os.WriteFile(file, []byte("fixture"), 0o600); err != nil {
+	// The file has to look like a transcript: a store whose newest file holds
+	// no conversation at all is an unused session, not a parse failure.
+	if err := os.WriteFile(file, []byte(`{"type":"user","message":{"role":"user","content":"hi"}}`+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	for _, tc := range []struct {

--- a/cmd/deja/onboarding_test.go
+++ b/cmd/deja/onboarding_test.go
@@ -150,8 +150,11 @@ func TestHookContextMissingManifestStaysSilent(t *testing.T) {
 
 func TestFirstIndexGreetingIncludesParsedZeroWarning(t *testing.T) {
 	hermeticEnv(t)
+	// A transcript with a turn in it that the parser cannot read — which is
+	// the case worth warning about. A file holding only setup records is an
+	// unused session and stays quiet.
 	bad := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "project", "bad.jsonl")
-	writeFileMkdir(t, bad, "not json\n")
+	writeFileMkdir(t, bad, `{"type":"user","message":{"role":"user","content":"hi"` + "\n")
 	oldLogoWanted := logoWanted
 	logoWanted = func(*os.File) bool { return true }
 	defer func() { logoWanted = oldLogoWanted }()

--- a/cmd/deja/onboarding_test.go
+++ b/cmd/deja/onboarding_test.go
@@ -154,7 +154,7 @@ func TestFirstIndexGreetingIncludesParsedZeroWarning(t *testing.T) {
 	// the case worth warning about. A file holding only setup records is an
 	// unused session and stays quiet.
 	bad := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "project", "bad.jsonl")
-	writeFileMkdir(t, bad, `{"type":"user","message":{"role":"user","content":"hi"` + "\n")
+	writeFileMkdir(t, bad, `{"type":"user","message":{"role":"user","content":"hi"`+"\n")
 	oldLogoWanted := logoWanted
 	logoWanted = func(*os.File) bool { return true }
 	defer func() { logoWanted = oldLogoWanted }()


### PR DESCRIPTION
Closes #439.

`warning: kimi files found but newest parsed to zero` on my own machine, and the parse was right: I opened the Kimi TUI for a screenshot and closed it without typing, leaving a `wire.jsonl` with a protocol version, two config records and a tool list. Every harness writes those the moment it starts, so anyone who opens an agent and closes it again gets told their store looks broken.

The warning now requires the file to hold something that should have produced a message — a user or assistant turn in JSON, or aider's `####` marker. A transcript with turns that deja cannot read still warns, which is the case it exists for, and an unreadable file is still treated as a real problem rather than an empty one.

Two existing tests asserted the old behaviour on a file whose entire contents were the word `fixture`; they now use a transcript-shaped fixture, so they exercise the case they were written for.