### PR TITLE
Keep forgotten sessions forgotten when the config is lost

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 `deja forget` removes matching sessions from a rebuilt index and records exact
 session tombstones so a later `deja index` cannot restore them from source
 history. Tombstones are stored at `~/.config/deja/tombstones` (or
-`$XDG_CONFIG_HOME/deja/tombstones`); use `--dry-run`, `--list`, or `--unforget`.
+`$XDG_CONFIG_HOME/deja/tombstones`) and mirrored beside the index, so losing
+either one does not resurrect what you forgot; use `--dry-run`, `--list`, or
+`--unforget`.
 Ingest exclusions are one case-insensitive project pattern per line in
 `~/.config/deja/exclude` (XDG-aware), or comma-separated in
 `DEJA_EXCLUDE_PROJECTS`. `deja stats --redaction` reports redactions by

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -36,9 +36,31 @@ func privacyDir() string {
 
 func tombstonePath() string { return filepath.Join(privacyDir(), "tombstones") }
 
+// tombstoneMirrorPath is the second copy, kept beside the index the record
+// protects. One file in ~/.config is a single point of failure for the one
+// operation people use on things they specifically do not want kept: a wiped
+// config directory, a machine migration or a changed XDG_CONFIG_HOME and the
+// next rebuild resurrects them from source history that is still on disk.
+func tombstoneMirrorPath(dir string) string {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	return filepath.Join(dir, "tombstones")
+}
+
+// readTombstones merges both copies: whichever survived is authoritative,
+// because a tombstone can only ever be removed deliberately through unforget.
 func readTombstones() map[string]bool {
+	out := readTombstoneFile(tombstonePath())
+	for key := range readTombstoneFile(tombstoneMirrorPath("")) {
+		out[key] = true
+	}
+	return out
+}
+
+func readTombstoneFile(path string) map[string]bool {
 	out := map[string]bool{}
-	f, err := os.Open(tombstonePath())
+	f, err := os.Open(path)
 	if err != nil {
 		return out
 	}
@@ -82,7 +104,44 @@ func writeTombstones(set map[string]bool) error {
 	if err := f.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmp, tombstonePath())
+	if err := os.Rename(tmp, tombstonePath()); err != nil {
+		return err
+	}
+	// The mirror is best effort: an index directory that cannot be written
+	// is a problem the caller already has, and failing here would leave the
+	// forget half-done after the authoritative copy is already on disk.
+	_ = writeTombstoneMirror(keys)
+	return nil
+}
+
+func writeTombstoneMirror(keys []string) error {
+	return writeTombstoneMirrorAt("", keys)
+}
+
+func writeTombstoneMirrorAt(dir string, keys []string) error {
+	path := tombstoneMirrorPath(dir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	for _, key := range keys {
+		if _, err := fmt.Fprintln(f, key); err != nil {
+			_ = f.Close()
+			return err
+		}
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }
 
 func filterTombstoned(ss []model.Session) []model.Session {
@@ -157,7 +216,19 @@ func Forget(dir string, o ForgetOptions) (ForgetResult, error) {
 	if err := writeTombstones(dead); err != nil {
 		return result, err
 	}
-	return result, rebuildWithTombstones(dir, "", "", currentFiles(""), nil, dead)
+	if err := rebuildWithTombstones(dir, "", "", currentFiles(""), nil, dead); err != nil {
+		return result, err
+	}
+	// After the rebuild, not before: rebuilding recreates the index directory
+	// and takes the mirror with it, which is how the second copy silently
+	// failed to exist the first time this was written.
+	keys := make([]string, 0, len(dead))
+	for key := range dead {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	_ = writeTombstoneMirrorAt(dir, keys)
+	return result, nil
 }
 
 func readRecordsForForget(dir string) []OffsetRecord {

--- a/internal/index/tombstone_durability_test.go
+++ b/internal/index/tombstone_durability_test.go
@@ -1,0 +1,78 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Forgetting is what people use on things they specifically do not want kept,
+// and the record of it lived in exactly one file. Lose ~/.config — a wiped
+// directory, a migration, a changed XDG_CONFIG_HOME — and the next rebuild
+// brings those sessions back from source history that is still on disk.
+func TestTombstonesSurviveLosingTheConfigDirectory(t *testing.T) {
+	home := t.TempDir()
+	cfg := filepath.Join(home, "cfg")
+	idx := filepath.Join(home, "idx")
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	t.Setenv("DEJA_INDEX_DIR", idx)
+	if err := os.MkdirAll(idx, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTombstones(map[string]bool{"claude:sensitive-1": true}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := os.Stat(tombstoneMirrorPath("")); err != nil {
+		t.Fatalf("no copy beside the index: %v", err)
+	}
+	if !readTombstones()["claude:sensitive-1"] {
+		t.Fatal("tombstone not readable at all")
+	}
+
+	// The config directory is gone. What was forgotten must stay forgotten.
+	if err := os.RemoveAll(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if !readTombstones()["claude:sensitive-1"] {
+		t.Fatal("losing the config directory resurrected a forgotten session")
+	}
+
+	// And the other way round: the index can be rebuilt from scratch at any
+	// time, so the config copy has to carry it alone too.
+	if err := os.MkdirAll(cfg, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTombstones(map[string]bool{"claude:sensitive-1": true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(idx); err != nil {
+		t.Fatal(err)
+	}
+	if !readTombstones()["claude:sensitive-1"] {
+		t.Fatal("losing the index directory resurrected a forgotten session")
+	}
+}
+
+// Unforget is the deliberate reversal and must clear both copies, or the
+// session comes back on one rebuild and vanishes on the next.
+func TestUnforgetClearsBothCopies(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(home, "idx"))
+	if err := os.MkdirAll(filepath.Join(home, "idx"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTombstones(map[string]bool{"a": true, "b": true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTombstones(map[string]bool{"b": true}); err != nil {
+		t.Fatal(err)
+	}
+	got := readTombstones()
+	if got["a"] {
+		t.Fatal("a removed tombstone survived in the mirror")
+	}
+	if !got["b"] {
+		t.Fatal("the remaining tombstone was lost")
+	}
+}


### PR DESCRIPTION
Closes #441.

`deja forget` records a tombstone so a later index cannot restore a session from source history that is still on disk. That record lived in exactly one file, `$XDG_CONFIG_HOME/deja/tombstones`. Delete it — wiped config directory, machine migration, a changed XDG path, someone tidying up — and the next rebuild brings the session back. I reproduced it before fixing it.

Tombstones are now mirrored beside the index and the two are merged on read, so whichever copy survives keeps the promise; unforget clears both. Losing both at once is a much narrower accident, and the index is exactly what the record protects.

One detail worth writing down, because it cost me the first attempt: the mirror has to be written **after** the rebuild that forget triggers. Rebuilding recreates the index directory and takes the copy with it, so a mirror written beforehand silently does not exist.