### PR TITLE
share: count the secrets that were already redacted

### DIFF
--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -35,7 +35,12 @@ func printSanitized(w io.Writer, text string) {
 	}
 	// The boundary line goes to stderr so piped output stays clean. Precise
 	// non-claims: pattern redaction is a floor, not a guarantee.
-	masked := 0
+	// Secrets are redacted at index time, so by the time a share is built
+	// most of them are already markers in the text and this pass finds
+	// nothing new. Counting only what this pass replaced reported "0 secrets
+	// masked" on a document visibly full of them — the opposite of what the
+	// line is for.
+	masked := strings.Count(redacted, redact.Marker)
 	for _, n := range counts {
 		masked += n
 	}

--- a/cmd/deja/share_count_test.go
+++ b/cmd/deja/share_count_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The line under a share tells the user how much was scrubbed, and it read
+// "0 secrets masked" on a document visibly full of markers: secrets are
+// redacted at index time, so the pass share runs over already-clean text
+// replaces nothing.
+func TestShareCountsSecretsRedactedEarlier(t *testing.T) {
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	var out bytes.Buffer
+	printSanitized(&out, "key [redacted:openai-key] and password [redacted:credential]\n")
+	_ = w.Close()
+	os.Stderr = old
+	var msg bytes.Buffer
+	if _, err := msg.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(msg.String(), "2 secrets masked") {
+		t.Fatalf("count is wrong: %q", msg.String())
+	}
+}
+
+func TestShareCountsZeroWhenNothingWasRedacted(t *testing.T) {
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	var out bytes.Buffer
+	printSanitized(&out, "nothing sensitive here at all\n")
+	_ = w.Close()
+	os.Stderr = old
+	var msg bytes.Buffer
+	if _, err := msg.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(msg.String(), "0 secrets masked") {
+		t.Fatalf("clean document reported as masked: %q", msg.String())
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -179,6 +179,11 @@ func closingQuote(open, close string) string {
 
 var entropyTokenRE = regexp.MustCompile(`[A-Za-z0-9+/_-]{20,}={0,2}`)
 
+// Marker is the prefix every replacement shares. Callers count it to report
+// how much of a document was already scrubbed at index time, since a later
+// pass over redacted text finds nothing left to replace.
+const Marker = "[redacted:"
+
 const (
 	entropyMinBits       = 4.5
 	entropyMinAssign     = 20


### PR DESCRIPTION
Closes #443.

The line under a share said `0 secrets masked` on a document with two `[redacted:...]` markers in it. Secrets are redacted at index time, so the pass share runs over the digest replaces nothing and was reporting its own tally rather than the document's.

It now counts the markers present as well. That line is what someone reads before sending a session to a colleague, and understating it is the wrong direction to be wrong in.

A document with nothing to hide still reports zero — there is a test for that, or the number stops meaning anything.