### PR TITLE
Say what deja update verifies

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,25 @@ You can expect an initial response within 72 hours. Please include a minimal
 reproduction and, if the issue involves a session file format, a redacted
 sample.
 
+## What `deja update` checks
+
+It downloads `checksums.txt` and the release archive for your platform from the
+same GitHub release and compares sha256 before replacing the binary. That
+catches a corrupt or truncated download; it does not catch a tampered release,
+since whoever could replace the archive could replace the checksums beside it.
+
+Releases are signed with cosign and carry build provenance, and the client does
+not verify either. If you need that guarantee, verify before installing:
+
+```sh
+cosign verify-blob --certificate checksums.txt.pem --signature checksums.txt.sig \
+  --certificate-identity-regexp 'https://github.com/vshulcz/deja-vu/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com checksums.txt
+```
+
+Nightly builds are prereleases and are not signed. `deja update` follows
+`releases/latest`, which excludes them.
+
 ## Scope notes
 
 deja-vu reads coding-agent session logs from the local disk and builds a local


### PR DESCRIPTION
Part of #445.

SECURITY.md said `deja update` fetches releases from GitHub and stopped there. What it actually does is compare sha256 against `checksums.txt` from the same release — enough for a corrupt download, not enough for a tampered one, since both files come from the same place.

The releases are cosign-signed and the client ignores the signature. That is a defensible choice for a binary that advertises no dependencies, but it is not something a reader can infer, so it is now written down along with the `cosign verify-blob` invocation for anyone who needs the stronger guarantee.

Also noted: nightlies are unsigned prereleases, and `deja update` follows `releases/latest`, which excludes them — checked rather than assumed.

Whether to verify the signature in the client is left to #445.