### PR TITLE
Answer on an empty index instead of printing nothing

### DIFF
--- a/cmd/deja/empty_state_test.go
+++ b/cmd/deja/empty_state_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"github.com/vshulcz/deja-vu/internal/stats"
+	"strings"
+	"testing"
+)
+
+// A fresh install has nothing indexed, and the two commands people try first
+// answered with silence and with section headings over nothing. Both read as
+// broken rather than empty.
+func TestStatsSaysWhatIsMissingWhenNothingIsIndexed(t *testing.T) {
+	var out bytes.Buffer
+	printStats(&out, stats.Report{})
+	got := out.String()
+	if !strings.Contains(got, "nothing indexed yet") {
+		t.Fatalf("no explanation on an empty index:\n%s", got)
+	}
+	// The headings are the part that made it look like a broken report.
+	for _, heading := range []string{"By harness", "Top projects", "Last 12 months"} {
+		if strings.Contains(got, heading) {
+			t.Fatalf("empty section %q printed over an empty index:\n%s", heading, got)
+		}
+	}
+	if !strings.Contains(got, "deja index") {
+		t.Fatalf("no next step offered:\n%s", got)
+	}
+}
+
+// A report with data must still print everything, or this guard has cost the
+// feature rather than fixed it.
+func TestStatsStillPrintsSectionsWithData(t *testing.T) {
+	var out bytes.Buffer
+	printStats(&out, stats.Report{TotalSessions: 3, TotalMessages: 40})
+	got := out.String()
+	for _, heading := range []string{"By harness", "Top projects"} {
+		if !strings.Contains(got, heading) {
+			t.Fatalf("section %q went missing with data present:\n%s", heading, got)
+		}
+	}
+}
+
+func TestEmptyIndexHintNamesTheNextCommand(t *testing.T) {
+	got := emptyIndexHint("no sessions indexed yet")
+	for _, want := range []string{"no sessions indexed yet", "deja index", "deja doctor"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("hint missing %q: %q", want, got)
+		}
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -246,6 +246,13 @@ func cmdLast(dir string, rest []string) error {
 	if err != nil {
 		return err
 	}
+	// Printing nothing at all and exiting 0 leaves no way to tell whether the
+	// command worked, found nothing, or failed silently — which is what a
+	// fresh install sees. blame already answers this shape of question.
+	if len(ss) == 0 {
+		fmt.Fprintln(os.Stderr, emptyIndexHint("no sessions indexed yet"))
+		return nil
+	}
 	for _, s := range ss {
 		fmt.Printf("[%s · %s · %s · %s]", s.Harness, s.Project, s.Updated.Format("2006-01-02"), s.ID)
 		title := s.Title
@@ -883,4 +890,10 @@ Examples:
   deja install --all
 
 See README.md for the full CLI reference.`)
+}
+
+// emptyIndexHint phrases the nothing-here answer the same way everywhere, and
+// points at the next command rather than leaving the user to guess.
+func emptyIndexHint(what string) string {
+	return "deja: " + what + " — run `deja index`, or `deja doctor` to see which agent stores were found"
 }

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -205,6 +205,12 @@ func printStats(w io.Writer, r stats.Report) {
 	}
 	fmt.Fprintf(w, "%sdeja stats%s\n", bold, reset)
 	fmt.Fprintf(w, "%sindexed agent work, wrapped for sharing%s\n\n", faint, reset)
+	// Section headings over an empty index read as a broken report rather
+	// than an empty one. Say what is missing and stop.
+	if r.TotalSessions == 0 {
+		fmt.Fprintln(w, emptyIndexHint("nothing indexed yet"))
+		return
+	}
 	if headline := statsHeadline(r); headline != "" {
 		fmt.Fprintf(w, "%s%s%s\n\n", bold, headline, reset)
 	}


### PR DESCRIPTION
Closes #447.

On a fresh install `deja last` printed nothing at all and exited 0 — no way to tell whether it worked, found nothing, or failed quietly — and `deja stats` printed `By harness`, `Top projects` and `Last 12 months` with nothing under them, which reads as a broken report rather than an empty one.

`blame` already answers this shape of question well, so both now say the same kind of thing and name the next command. With data present stats prints every section as before; there is a test for that, since a guard like this can quietly cost the feature it was meant to protect.