### PR TITLE
Do not append onto a rewritten prefix

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -72,6 +72,12 @@ type FileState struct {
 	// A session file caught mid-write ends in a torn line; parsing skips it,
 	// and the next append must resume from here or that message is lost.
 	SafeSize int64 `json:"safe_size,omitempty"`
+	// PrefixHash fingerprints the bytes up to SafeSize. Growth alone does not
+	// prove the earlier bytes are untouched: agents rewind a session by
+	// truncating and rewriting it, and once it grows past its old length that
+	// looks exactly like an append. Without this the rewritten prefix keeps
+	// its old text in the index and the new text is never read.
+	PrefixHash uint64 `json:"prefix_hash,omitempty"`
 }
 
 type SessionMeta struct {

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1037,6 +1037,13 @@ func canAppendIncremental(changed map[string]FileState, old map[string]FileState
 		if of.SafeSize == 0 && of.Size > 0 {
 			return false
 		}
+		// Growth is not proof that the earlier bytes are untouched: a rewind
+		// that truncates and regrows past the old length looks exactly like
+		// an append, and appending onto it leaves the rewritten prefix in the
+		// index with its old text. Compare the prefix before trusting it.
+		if of.PrefixHash != 0 && filePrefixHash(p, of.SafeSize) != of.PrefixHash {
+			return false
+		}
 		switch harnessForPath(p) {
 		case "claude", "codex", "codex-history", "opencode", "cursor-db", "goose-db", "deja", "pi", "copilot":
 		default:
@@ -1248,6 +1255,7 @@ func currentFiles(h string) map[string]FileState {
 			fs := FileState{Path: p, Size: fi.Size(), MTime: fi.ModTime().UnixNano()}
 			if strings.HasSuffix(p, ".jsonl") {
 				fs.SafeSize = lastCompleteLineOffset(p, fi.Size())
+				fs.PrefixHash = filePrefixHash(p, fs.SafeSize)
 			}
 			if harnessForPath(p) == "grok" {
 				if summary, err := os.Lstat(filepath.Join(filepath.Dir(p), "summary.json")); err == nil && summary.Mode()&os.ModeSymlink == 0 && !summary.IsDir() {
@@ -1365,4 +1373,23 @@ func preRedactSessions(m *Manifest, ss []model.Session) {
 	}
 	close(jobs)
 	wg.Wait()
+}
+
+// filePrefixHash fingerprints the first n bytes of a file. Only used to decide
+// whether an append is safe, so a fast non-cryptographic hash is the right
+// tool: a collision costs one unnecessary full reparse, never a wrong index.
+func filePrefixHash(path string, n int64) uint64 {
+	if n <= 0 {
+		return 0
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = f.Close() }()
+	h := fnv.New64a()
+	if _, err := io.Copy(h, io.LimitReader(f, n)); err != nil {
+		return 0
+	}
+	return h.Sum64()
 }

--- a/internal/index/rewind_test.go
+++ b/internal/index/rewind_test.go
@@ -1,0 +1,63 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeLines(t *testing.T, path string, lines ...string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Agents rewind a session by truncating the transcript and writing it again.
+// Once it grows past its old length that is indistinguishable from an append
+// by size alone, and appending onto it leaves the rewritten prefix in the
+// index with its old text while the new text is never read.
+func TestRewrittenPrefixIsNotTreatedAsAppend(t *testing.T) {
+	dir := t.TempDir()
+	// The append fast path only applies to recognised harness files, so the
+	// fixture has to live where the claude parser looks.
+	t.Setenv("DEJA_CLAUDE_ROOT", dir)
+	path := filepath.Join(dir, "project", "session.jsonl")
+	writeLines(t, path, claudeLine("s1", "2026-01-01T00:01:00Z", "ORIGINAL text"), claudeLine("s1", "2026-01-01T00:02:00Z", "second"))
+	before := currentFileStateFor(t, path)
+
+	// The rewind: shorter, then longer again with a different first line.
+	writeLines(t, path, claudeLine("s1", "2026-01-01T00:01:00Z", "REWRITTEN text"), claudeLine("s1", "2026-01-01T00:02:00Z", "second"), claudeLine("s1", "2026-01-01T00:03:00Z", "third"))
+	after := currentFileStateFor(t, path)
+
+	if after.Size <= before.Size {
+		t.Fatalf("test does not exercise the case: sizes %d -> %d", before.Size, after.Size)
+	}
+	if canAppendIncremental(map[string]FileState{path: after}, map[string]FileState{path: before}) {
+		t.Fatal("a rewritten prefix was accepted as an append; the old text would stay indexed")
+	}
+
+	// A genuine append must still take the fast path, or every session write
+	// becomes a full reparse.
+	writeLines(t, path, claudeLine("s1", "2026-01-01T00:01:00Z", "REWRITTEN text"), claudeLine("s1", "2026-01-01T00:02:00Z", "second"), claudeLine("s1", "2026-01-01T00:03:00Z", "third"), claudeLine("s1", "2026-01-01T00:04:00Z", "fourth"))
+	grown := currentFileStateFor(t, path)
+	if !canAppendIncremental(map[string]FileState{path: grown}, map[string]FileState{path: after}) {
+		t.Fatal("a plain append no longer takes the append path")
+	}
+}
+
+func currentFileStateFor(t *testing.T, path string) FileState {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := FileState{Path: path, Size: fi.Size(), MTime: fi.ModTime().UnixNano()}
+	fs.SafeSize = lastCompleteLineOffset(path, fi.Size())
+	fs.PrefixHash = filePrefixHash(path, fs.SafeSize)
+	return fs
+}


### PR DESCRIPTION
Closes #453.

Agents rewind a session by truncating the transcript and writing it again. Once it grows past its old length that is indistinguishable from an append by size alone, and `canAppendIncremental` gated on size alone — so the rewritten prefix kept its old text in the index and the new text was never read. One further `deja index` converges, which is what makes it easy to miss.

Reproduced before fixing: after a truncate-then-regrow, `deja search` found the old line and not the new one, and `deja last` printed the old text as the session title.

`FileState` now carries a hash of the bytes up to the previous safe offset, and the append path checks it. A collision costs one unnecessary full reparse and never a wrong index, so fnv is the right tool here. A plain append still takes the fast path — there is a test for that, since turning every session write into a full reparse would be a worse bug than the one being fixed.

Timings on my index after the change: unchanged at the millisecond level.