### PR TITLE
Understand month names, and say what a time hint does

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 
 | Feature | What it does |
 | --- | --- |
-| **Search** | `deja "connection pool exhausted"` — ~12 ms over gigabytes, retroactive: months of logs from before you installed it; natural-language questions fall back to a relevance tier — 84.9% hit@1 on LongMemEval-S session retrieval, harness in-repo; time works too: `deja "what did we do in may"`, "a week ago" |
+| **Search** | `deja "connection pool exhausted"` — ~12 ms over gigabytes, retroactive: months of logs from before you installed it; natural-language questions fall back to a relevance tier — 84.9% hit@1 on LongMemEval-S session retrieval, harness in-repo; time is a hint, not a filter: `deja "what did we do in may"` and "a week ago" push that month's sessions up the ranking, they do not exclude the rest — use `--since 30d` when you mean a window |
 | **Agent recall** | MCP `recall` tool — the agent answers *"we fixed this three weeks ago"* instead of re-debugging, across harnesses: solve it in Codex, Claude remembers |
 | **Sync** | `deja sync ssh laptop` — your memory follows you between machines, append-only, idempotent, no cloud in the middle |
 | **Handoff** | `deja handoff --to codex` — stuck in one agent? package the live context and continue in another: `codex "$(deja handoff --to codex)"`; thirteen harnesses can be started directly, the rest print the prompt to paste |

--- a/internal/index/reltime.go
+++ b/internal/index/reltime.go
@@ -17,6 +17,43 @@ var relTimeRE = regexp.MustCompile(`(?i)\b(?:(a|an|one|two|three|four|five|six|s
 
 var relTimeNums = map[string]int{"a": 1, "an": 1, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10}
 
+// monthNames maps what people type to a month. Russian is here because the
+// tool is used in both languages in the same session, and someone asking "что
+// делали в мае" means the same thing as "what did we do in may".
+var monthNames = map[string]time.Month{
+	"january": time.January, "february": time.February, "march": time.March,
+	"april": time.April, "may": time.May, "june": time.June, "july": time.July,
+	"august": time.August, "september": time.September, "october": time.October,
+	"november": time.November, "december": time.December,
+	"jan": time.January, "feb": time.February, "mar": time.March, "apr": time.April,
+	"jun": time.June, "jul": time.July, "aug": time.August, "sep": time.September,
+	"sept": time.September, "oct": time.October, "nov": time.November, "dec": time.December,
+	"январь": time.January, "января": time.January, "январе": time.January,
+	"февраль": time.February, "февраля": time.February, "феврале": time.February,
+	"март": time.March, "марта": time.March, "марте": time.March,
+	"апрель": time.April, "апреля": time.April, "апреле": time.April,
+	"май": time.May, "мая": time.May, "мае": time.May,
+	"июнь": time.June, "июня": time.June, "июне": time.June,
+	"июль": time.July, "июля": time.July, "июле": time.July,
+	"август": time.August, "августа": time.August, "августе": time.August,
+	"сентябрь": time.September, "сентября": time.September, "сентябре": time.September,
+	"октябрь": time.October, "октября": time.October, "октябре": time.October,
+	"ноябрь": time.November, "ноября": time.November, "ноябре": time.November,
+	"декабрь": time.December, "декабря": time.December, "декабре": time.December,
+}
+
+var wordRE = regexp.MustCompile(`[\p{L}]+`)
+
+// monthOccurrence resolves a bare month name to its most recent occurrence:
+// asking about may in july means this may, not next year's.
+func monthOccurrence(m time.Month, now time.Time) time.Time {
+	year := now.Year()
+	if m > now.Month() {
+		year--
+	}
+	return time.Date(year, m, 1, 0, 0, 0, 0, now.Location())
+}
+
 func relativeTimeTerms(q string, now time.Time) []string {
 	if now.IsZero() {
 		now = time.Now()
@@ -29,6 +66,11 @@ func relativeTimeTerms(q string, now time.Time) []string {
 				seen[tok] = true
 				out = append(out, tok)
 			}
+		}
+	}
+	for _, w := range wordRE.FindAllString(strings.ToLower(q), -1) {
+		if month, ok := monthNames[w]; ok {
+			add(monthOccurrence(month, now))
 		}
 	}
 	for _, m := range relTimeRE.FindAllStringSubmatch(q, -1) {

--- a/internal/index/reltime_month_test.go
+++ b/internal/index/reltime_month_test.go
@@ -1,0 +1,43 @@
+package index
+
+import (
+	"testing"
+	"time"
+)
+
+// The README offers `deja "what did we do in may"` as a feature, and the
+// parser knew only relative phrases — "may" was searched as an ordinary word.
+func TestMonthNamesResolveToTheMostRecentOccurrence(t *testing.T) {
+	now := time.Date(2026, time.July, 28, 12, 0, 0, 0, time.UTC)
+	for query, want := range map[string]string{
+		"what did we do in may": "2026-05",
+		"что делали в мае":      "2026-05",
+		"in june":               "2026-06",
+		"back in january":       "2026-01",
+		// Asking about a month later than the current one means last year's:
+		// nobody is asking what they did next December.
+		"in december": "2025-12",
+	} {
+		got := relativeTimeTerms(query, now)
+		found := false
+		for _, tok := range got {
+			if tok == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("%q -> %v, want %s among them", query, got, want)
+		}
+	}
+	// A query with no time in it must stay empty, or every search picks up
+	// month hints it never asked for.
+	if got := relativeTimeTerms("fix the parser", now); len(got) != 0 {
+		t.Fatalf("time hints invented for a plain query: %v", got)
+	}
+	// "March" as a verb, and "may" as a modal, are the cost of this: both
+	// produce a hint. The tier only ever OR-scores them, so a wrong hint
+	// costs ranking weight and never filters anything out.
+	if got := relativeTimeTerms("we may need to fix this", now); len(got) == 0 {
+		t.Log("modal 'may' produced no hint; fine either way")
+	}
+}


### PR DESCRIPTION
Closes #455.

The README offered `deja "what did we do in may"` as a feature. The parser knew `N days ago`, `yesterday` and `last week|month|year` — month names were not in it at all, so "may" was searched as an ordinary word.

Month names now resolve, in English and Russian, to the most recent occurrence: asking about may in july means this may, and asking about december means last year's, since nobody is asking what they did next December.

The rest of the change is the README, because the parser fix alone does not deliver what the sentence promised. These terms are OR-scored hints for the relevance tier, not a filter — measured on my index, "what did we do in may" still ranks today's session first even with 12 May sessions present, because the words match it strongly. So the line now says what a time hint actually does and points at `--since` for a real window.

Whether ranking should weight a time hint more heavily is a retrieval question and wants `bench prompt` rather than an opinion; left in the issue.