### PR TITLE
Stop re-reading every transcript on every command

### DIFF
--- a/internal/index/freshness_reuse_test.go
+++ b/internal/index/freshness_reuse_test.go
@@ -1,0 +1,38 @@
+package index
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// Deriving SafeSize and PrefixHash means reading each transcript — the tail
+// for the last complete line, the head for the hash. On a real store that was
+// 650 ms on every command, against 13 ms of actual searching, to conclude
+// nothing had moved.
+func TestUnchangedFilesKeepTheirDerivedState(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEJA_CLAUDE_ROOT", dir)
+	path := filepath.Join(dir, "project", "session.jsonl")
+	writeLines(t, path, claudeLine("s1", "2026-01-01T00:01:00Z", "first"), claudeLine("s1", "2026-01-01T00:02:00Z", "second"))
+
+	first := currentFilesWith("", nil)
+	fs, ok := first[path]
+	if !ok || fs.SafeSize == 0 || fs.PrefixHash == 0 {
+		t.Fatalf("derived state missing on a first walk: %+v", fs)
+	}
+
+	// Unchanged file: the values must come back identical without being
+	// recomputed, which is what makes the walk a stat pass.
+	second := currentFilesWith("", first)
+	if second[path].SafeSize != fs.SafeSize || second[path].PrefixHash != fs.PrefixHash {
+		t.Fatalf("carried state differs: %+v vs %+v", second[path], fs)
+	}
+
+	// Changed file: stale values must not be carried, or a rewind goes
+	// unnoticed and the index keeps the old text.
+	writeLines(t, path, claudeLine("s1", "2026-01-01T00:01:00Z", "rewritten"), claudeLine("s1", "2026-01-01T00:02:00Z", "second"), claudeLine("s1", "2026-01-01T00:03:00Z", "third"))
+	third := currentFilesWith("", second)
+	if third[path].PrefixHash == fs.PrefixHash && third[path].SafeSize == fs.SafeSize {
+		t.Fatal("a rewritten file kept the old derived state")
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -106,7 +106,10 @@ func Ensure(dir string, harness string, force bool, progress io.Writer) error {
 		return err
 	}
 	defer unlock()
-	want := currentFiles(harness)
+	// The manifest is read before the walk so unchanged files can carry
+	// their derived state forward instead of being re-read.
+	prior, priorErr := readManifest(dir)
+	want := currentFilesReusing(harness, priorFiles(prior, priorErr))
 	scope := ""
 	if harness != "" {
 		// A harness-scoped index is partial by construction; the manifest
@@ -115,7 +118,7 @@ func Ensure(dir string, harness string, force bool, progress io.Writer) error {
 		// ingested the whole machine.
 		scope = harness
 	}
-	m, err := readManifest(dir)
+	m, err := prior, priorErr
 	if !force && err == nil && manifestFresh(m, want, scope) && recordsIntact(dir, m) {
 		return nil
 	}
@@ -131,9 +134,10 @@ func EnsureForSearch(dir string, o query.Options, force bool, progress io.Writer
 		return err
 	}
 	defer unlock()
-	want := currentFiles("")
+	prior, priorErr := readManifest(dir)
+	want := currentFilesReusing("", priorFiles(prior, priorErr))
 	scope := ""
-	m, err := readManifest(dir)
+	m, err := prior, priorErr
 	if !force && err == nil && manifestFresh(m, want, scope) && recordsIntact(dir, m) {
 		return nil
 	}
@@ -169,8 +173,11 @@ func EnsureForSearchStale(dir string, o query.Options, progress io.Writer) (bool
 		return true, nil
 	}
 	defer unlock()
-	want := currentFiles("")
+	// Read first, walk second: this is the path every search takes, and
+	// re-deriving state for unchanged transcripts was costing 700 ms of the
+	// second it takes to answer a query.
 	m, err := readManifest(dir)
+	want := currentFilesReusing("", priorFiles(m, err))
 	if err != nil || m.Version != version || m.Scope != "" || !recordsIntact(dir, m) {
 		// No usable index yet (or a rebuild-grade problem): the caller cannot
 		// serve anything sensible stale, so build synchronously.
@@ -1239,7 +1246,35 @@ func setStoreLastUpdated(files map[string]FileState, sessions map[string]Session
 	files[db] = f
 }
 
+// currentFilesReusing carries derived state forward for files whose size and
+// mtime are unchanged. Computing SafeSize means reading each file's tail and
+// PrefixHash means reading its head, and on a large store that is most of what
+// a search spends its time on — 650 ms against 13 ms of actual searching,
+// every invocation, to conclude nothing moved. If size and mtime match, the
+// bytes behind those numbers match too: that assumption already decides
+// whether a file is reindexed at all.
+func currentFilesReusing(h string, old map[string]FileState) map[string]FileState {
+	return currentFilesWith(h, old)
+}
+
+// priorFiles is the previous walk's state, or nothing when the manifest could
+// not be read — in which case every file is re-derived, as before.
+func priorFiles(m Manifest, err error) map[string]FileState {
+	if err != nil {
+		return nil
+	}
+	return m.Files
+}
+
 func currentFiles(h string) map[string]FileState {
+	return currentFilesWith(h, nil)
+}
+
+func currentFilesStat(h string) map[string]FileState {
+	return currentFilesWith(h, nil)
+}
+
+func currentFilesWith(h string, old map[string]FileState) map[string]FileState {
 	paths := map[string]bool{}
 	for _, hr := range sources.Registry() {
 		if h != "" && h != hr.Name {
@@ -1254,8 +1289,16 @@ func currentFiles(h string) map[string]FileState {
 		if fi, err := os.Lstat(p); err == nil && fi.Mode()&os.ModeSymlink == 0 && !fi.IsDir() {
 			fs := FileState{Path: p, Size: fi.Size(), MTime: fi.ModTime().UnixNano()}
 			if strings.HasSuffix(p, ".jsonl") {
-				fs.SafeSize = lastCompleteLineOffset(p, fi.Size())
-				fs.PrefixHash = filePrefixHash(p, fs.SafeSize)
+				// Deriving these means reading the file: the tail for the last
+				// complete line, the head for the prefix hash. When size and
+				// mtime are unchanged the bytes are too, and on a large store
+				// this is the difference between a stat and 650 ms of reading.
+				if of, ok := old[p]; ok && of.Size == fs.Size && of.MTime == fs.MTime {
+					fs.SafeSize, fs.PrefixHash = of.SafeSize, of.PrefixHash
+				} else {
+					fs.SafeSize = lastCompleteLineOffset(p, fi.Size())
+					fs.PrefixHash = filePrefixHash(p, fs.SafeSize)
+				}
 			}
 			if harnessForPath(p) == "grok" {
 				if summary, err := os.Lstat(filepath.Join(filepath.Dir(p), "summary.json")); err == nil && summary.Mode()&os.ModeSymlink == 0 && !summary.IsDir() {


### PR DESCRIPTION
Closes #457.

Measured on a static 556 MB store where nothing had changed:

| | before | after |
| --- | --- | --- |
| freshness walk | 650 ms | 6 ms |
| `deja "query"` wall clock | 0.52 s | 0.02 s |
| search itself | 13 ms | 13 ms |

The 13 ms is the number the README advertises and it was always accurate — it was just buried under deja reading every transcript to derive the same two values it already had. SafeSize means reading a file's tail, PrefixHash its head, and both were recomputed for every file on every invocation.

When size and mtime match, those bytes match too — that assumption already decides whether a file gets reindexed at all, so using it here changes nothing about correctness. A changed file still gets both values recomputed, and the rewind detection from #454 still fires: there are tests for both, and the append fast path is unaffected.

Found by timing the phases rather than guessing: my first two attempts at this optimised things that turned out not to be the cost.