### PR TITLE
doctor: stop reading the whole opencode database

### DIFF
--- a/cmd/deja/doctor_probe_test.go
+++ b/cmd/deja/doctor_probe_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// doctor asks one question of a store — does it parse into sessions — and for
+// opencode it was answering by reading the whole database: 6.5 seconds of an
+// 8 second report on a 2.8 GB store.
+func TestOpencodeProbeReadsOnlyTheNewestSession(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	db := filepath.Join(t.TempDir(), "opencode.db")
+	sql := `
+CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, time_created INTEGER, time_updated INTEGER);
+CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, data TEXT, time_created INTEGER);
+CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, data TEXT);
+INSERT INTO session VALUES ('old','/w',1000,1000);
+INSERT INTO session VALUES ('new','/w',2000,2000);
+INSERT INTO message VALUES ('m1','old','{"role":"user","time":{"created":1000}}',1000);
+INSERT INTO message VALUES ('m2','new','{"role":"user","time":{"created":2000}}',2000);
+INSERT INTO part VALUES ('p1','m1','{"type":"text","text":"OLDSESSION"}');
+INSERT INTO part VALUES ('p2','m2','{"type":"text","text":"NEWSESSION"}');
+`
+	if out, err := exec.Command("sqlite3", db, sql).CombinedOutput(); err != nil {
+		t.Fatalf("seed: %v: %s", err, out)
+	}
+	ss, err := doctorProbeOpencode(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || ss[0].ID != "new" {
+		t.Fatalf("probe returned %d sessions, want just the newest: %+v", len(ss), ss)
+	}
+	// The point of the check survives: a store that parses reports sessions.
+	if len(ss[0].Messages) == 0 {
+		t.Fatal("probe returned a session with no messages, doctor would call the store broken")
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -116,7 +116,7 @@ func doctorStoreChecks() []doctorStoreCheck {
 	return []doctorStoreCheck{
 		{"claude", []string{sources.ClaudeRoot()}, sources.ClaudeFiles(), sources.ParseClaudeFile},
 		{"codex", []string{sources.CodexRoot()}, sources.CodexFiles(), parseDoctorCodex},
-		{"opencode", []string{sources.OpencodeDB()}, presentDoctorFile(sources.OpencodeDB()), sources.ParseOpencodeDB},
+		{"opencode", []string{sources.OpencodeDB()}, presentDoctorFile(sources.OpencodeDB()), doctorProbeOpencode},
 		{"aider", aiderPaths, sources.AiderFiles(), sources.ParseAiderFile},
 		{"gemini", []string{sources.GeminiRoot()}, sources.GeminiChatFiles(), sources.ParseGeminiFile},
 		{"cursor", []string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, cursorFiles, parseDoctorCursor},
@@ -337,4 +337,15 @@ func fileHasConversation(path string) bool {
 		}
 	}
 	return false
+}
+
+// doctorProbeOpencode answers the only question the store check asks — does
+// this store parse into sessions — without reading all of it. Parsing the
+// whole database took 6.5 seconds of doctor's 8 on a 2.8 GB store, and every
+// row after the first few adds nothing to the answer.
+func doctorProbeOpencode(db string) ([]model.Session, error) {
+	// A plain limit does not help: the query orders by session and message
+	// time, so sqlite sorts the whole join before it can take the first row.
+	// Narrowing to the newest session first is what makes this cheap.
+	return sources.ParseOpencodeNewest(db)
 }

--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -189,3 +189,21 @@ func parseNestedTime(m map[string]any, k, sub string) time.Time {
 	}
 	return time.Time{}
 }
+
+// ParseOpencodeNewest reads only the most recent session. deja doctor asks
+// one question of a store — does it parse into sessions — and answering it by
+// reading a multi-gigabyte database took 6.5 seconds of an 8 second report.
+func ParseOpencodeNewest(db string) ([]model.Session, error) {
+	if fi, err := os.Stat(db); err != nil || fi.Size() == 0 {
+		return nil, nil
+	}
+	out, err := exec.Command("sqlite3", db, "select id from session order by time_created desc limit 1").Output()
+	if err != nil {
+		return nil, err
+	}
+	id := strings.TrimSpace(string(out))
+	if id == "" {
+		return nil, nil
+	}
+	return ParseOpencodeDBWhere(db, " and s.id='"+sqlQuote(id)+"'", 0)
+}


### PR DESCRIPTION
Closes #459.

`deja doctor` took 8 seconds here, 6.5 of them in one store check: opencode's, which parsed every session in a 2.8 GB database to answer whether the store parses at all.

A plain `limit` does not fix it — the query orders by session and message time, so sqlite sorts the whole join before it can take a row. Asking for the newest session id first and parsing only that session does: **8.08s → 1.42s**, and `--offline` is now 0.5s.

The check still answers the same question, and the test pins that: a store with two sessions returns the newer one, with its messages, so a genuinely broken store is still reported broken.

Worth recording since it cost me two attempts: `sqlQuote` escapes quotes but does not add them, so the first version built `s.id=new` and quietly matched nothing — doctor got fast by asking for a session that did not exist.