### PR TITLE
Raise usage and sources coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           declare -A floor=(
             [cmd/deja]=87 [internal/bench]=67 [internal/digest]=72 [internal/embed]=93
             [internal/index]=87 [internal/policy]=88 [internal/redact]=94
-            [internal/search]=89 [internal/sources]=82 [internal/usage]=76
+            [internal/search]=89 [internal/sources]=87 [internal/usage]=95
           )
           fail=0
           while read -r pkg cov; do

--- a/internal/sources/db_parsers_coverage_test.go
+++ b/internal/sources/db_parsers_coverage_test.go
@@ -1,0 +1,146 @@
+package sources
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func seedDB(t *testing.T, name, schema string) string {
+	t.Helper()
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	db := filepath.Join(t.TempDir(), name)
+	if out, err := exec.Command("sqlite3", db, schema).CombinedOutput(); err != nil {
+		t.Fatalf("seed: %v: %s", err, out)
+	}
+	return db
+}
+
+// The incremental path asks each SQLite-backed harness for what changed since
+// a timestamp. Getting that filter wrong either reindexes everything on every
+// pass or silently misses new messages.
+func TestGooseSinceFilterBoundsWhatItReturns(t *testing.T) {
+	db := seedDB(t, "sessions.db", `
+CREATE TABLE sessions (id TEXT PRIMARY KEY, name TEXT, description TEXT, working_dir TEXT, created_at TEXT, updated_at TEXT, session_type TEXT);
+CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, role TEXT, content_json TEXT, created_timestamp INTEGER);
+INSERT INTO sessions VALUES ('s1','n','desc','/w','2026-01-01T00:00:00Z','2026-01-01T00:00:10Z','user');
+INSERT INTO messages VALUES (1,'s1','user','[{"type":"text","text":"OLDMESSAGE"}]',1767225600);
+INSERT INTO messages VALUES (2,'s1','user','[{"type":"text","text":"NEWMESSAGE"}]',1798761600);
+`)
+	all, err := ParseGooseDBSince(db, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 1 || len(all[0].Messages) != 2 {
+		t.Fatalf("zero time should return everything, got %+v", all)
+	}
+	cut := time.Unix(1790000000, 0)
+	since, err := ParseGooseDBSince(db, cut)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range since {
+		for _, m := range s.Messages {
+			if m.Text == "OLDMESSAGE" {
+				t.Fatalf("since filter returned a message from before the cut: %+v", s.Messages)
+			}
+		}
+	}
+}
+
+// doctor asks one question of the opencode store, and answering it by reading
+// a multi-gigabyte database cost 6.5 seconds of an 8 second report.
+func TestOpencodeNewestReadsOneSession(t *testing.T) {
+	db := seedDB(t, "opencode.db", `
+CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, time_created INTEGER, time_updated INTEGER);
+CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, data TEXT, time_created INTEGER);
+CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, data TEXT);
+INSERT INTO session VALUES ('old','/w',1000,1000);
+INSERT INTO session VALUES ('new','/w',2000,2000);
+INSERT INTO message VALUES ('m1','old','{"role":"user","time":{"created":1000}}',1000);
+INSERT INTO message VALUES ('m2','new','{"role":"user","time":{"created":2000}}',2000);
+INSERT INTO part VALUES ('p1','m1','{"type":"text","text":"OLDSESSION"}');
+INSERT INTO part VALUES ('p2','m2','{"type":"text","text":"NEWSESSION"}');
+`)
+	ss, err := ParseOpencodeNewest(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || ss[0].ID != "new" {
+		t.Fatalf("got %+v, want only the newest session", ss)
+	}
+	if len(ss[0].Messages) == 0 {
+		t.Fatal("newest session came back empty; doctor would call the store broken")
+	}
+	// A store that is not there answers with nothing rather than an error,
+	// and must not be created by the attempt.
+	if ss, err := ParseOpencodeNewest(filepath.Join(t.TempDir(), "absent.db")); err != nil || ss != nil {
+		t.Fatalf("absent store: %v %v", ss, err)
+	}
+}
+
+// KindForPath decides which parser owns a file, and two harnesses writing the
+// same filename is how roo history ended up filed under cline.
+func TestKindForPathAttributesFilesToTheirHarness(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_ROO_ROOTS", "")
+	t.Setenv("DEJA_CLINE_ROOTS", "")
+	cli := filepath.Join(home, ".vscode-mock", "global-storage")
+	t.Setenv("DEJA_ROO_CLI_ROOT", cli)
+	// Roots are only considered when they exist: a path under a store the
+	// user does not have belongs to nobody.
+	if err := os.MkdirAll(filepath.Join(cli, "tasks", "1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(home, "claude"))
+
+	for path, want := range map[string]string{
+		filepath.Join(cli, "tasks", "1", "api_conversation_history.json"): "roo",
+		filepath.Join(home, "claude", "project", "s.jsonl"):               "claude",
+		filepath.Join(home, "nothing", "random.txt"):                      "",
+	} {
+		if got := KindForPath(path); got != want {
+			t.Fatalf("KindForPath(%s) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+// Timestamps arrive in whatever shape a harness happens to write. An
+// unparseable one must degrade to "no time" rather than to a wrong time: a
+// session dated 0001-01-01 sorts before everything and never surfaces.
+func TestGrokDBTimeAcceptsTheShapesItSees(t *testing.T) {
+	for in, wantZero := range map[string]bool{
+		"2026-07-27T15:06:24.715Z": false,
+		"2026-07-27T15:06:24Z":     false,
+		"2026-07-27 15:06:24":      false,
+		"":                         true,
+		"not a time":               true,
+	} {
+		got := grokDBTime(in)
+		if got.IsZero() != wantZero {
+			t.Fatalf("grokDBTime(%q) = %v, zero=%v want zero=%v", in, got, got.IsZero(), wantZero)
+		}
+	}
+}
+
+// Message bodies differ per role: a user turn carries a plain string, an
+// assistant turn an array of typed blocks. Reading only one shape loses half
+// the conversation.
+func TestGrokMessageTextHandlesBothShapes(t *testing.T) {
+	for name, tc := range map[string]struct{ body, want string }{
+		"plain string": {`{"role":"user","content":"hello there"}`, "hello there"},
+		"text blocks":  {`{"role":"assistant","content":[{"type":"text","text":"first"},{"type":"text","text":"second"}]}`, "first\nsecond"},
+		"tool only":    {`{"role":"assistant","content":[{"type":"tool_use","id":"t1"}]}`, ""},
+		"garbage":      {`not json`, ""},
+	} {
+		if got := grokMessageText(tc.body); got != tc.want {
+			t.Fatalf("%s: got %q, want %q", name, got, tc.want)
+		}
+	}
+}

--- a/internal/sources/incremental_coverage_test.go
+++ b/internal/sources/incremental_coverage_test.go
@@ -1,0 +1,77 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The incremental path re-reads a file from where it stopped. Resuming from
+// the wrong offset either loses the first message after the boundary or
+// duplicates one, and both are silent.
+func TestQwenParsesFromAnOffset(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	first := `{"type":"user","sessionId":"q1","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","parts":[{"text":"FIRSTLINE"}]}}` + "\n"
+	second := `{"type":"user","sessionId":"q1","timestamp":"2026-01-01T00:01:00Z","message":{"role":"user","parts":[{"text":"SECONDLINE"}]}}` + "\n"
+	if err := os.WriteFile(path, []byte(first+second), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	all, err := ParseQwenFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 1 || len(all[0].Messages) != 2 {
+		t.Fatalf("full parse returned %+v", all)
+	}
+	// Resuming past the first line must yield only what came after it.
+	tail, err := ParseQwenFileFromOffset(path, int64(len(first)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range tail {
+		for _, m := range s.Messages {
+			if strings.Contains(m.Text, "FIRSTLINE") {
+				t.Fatalf("offset parse re-read an indexed line: %+v", s.Messages)
+			}
+		}
+	}
+	found := false
+	for _, s := range tail {
+		for _, m := range s.Messages {
+			if strings.Contains(m.Text, "SECONDLINE") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("offset parse lost the message it was supposed to pick up")
+	}
+	// An offset past the end is what a truncated file looks like: nothing to
+	// add, and no error for the caller to handle.
+	if ss, err := ParseQwenFileFromOffset(path, 1<<20); err != nil || len(ss) != 0 {
+		t.Fatalf("offset past the end: %+v %v", ss, err)
+	}
+}
+
+func TestNotesParseFromOffsetSkipsWhatWasRead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	first := `{"kind":"note","project":"p","text":"FIRSTNOTE","t":"2026-01-01T00:00:00Z"}` + "\n"
+	second := `{"kind":"note","project":"p","text":"SECONDNOTE","t":"2026-01-01T00:01:00Z"}` + "\n"
+	if err := os.WriteFile(path, []byte(first+second), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tail, err := ParseNotesFileFromOffset(path, int64(len(first)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range tail {
+		for _, m := range s.Messages {
+			if strings.Contains(m.Text, "FIRSTNOTE") {
+				t.Fatalf("offset parse re-read a note: %+v", s.Messages)
+			}
+		}
+	}
+}

--- a/internal/sources/notes_coverage_test.go
+++ b/internal/sources/notes_coverage_test.go
@@ -1,0 +1,129 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func notesHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(dir, "notes.jsonl"))
+	return dir
+}
+
+// Promoted notes outrank raw transcripts in recall, so what gets written here
+// decides what an agent sees first.
+func TestPromotedNotesRoundTrip(t *testing.T) {
+	notesHome(t)
+	if got := LoadPromotedNotes(); len(got) != 0 {
+		t.Fatalf("empty store returned %d notes", len(got))
+	}
+	if err := AppendPromoted("proj", "Pool timeouts", "raise max_conns", "claude:s1", "accepted", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := AppendPromotedTagged("proj", "Retries", "add jitter", "claude:s2", "accepted", []string{"Retry", "  backoff  "}, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	notes := LoadPromotedNotes()
+	if len(notes) != 2 {
+		t.Fatalf("notes = %d, want 2", len(notes))
+	}
+	var tagged PromotedNote
+	for _, n := range notes {
+		if n.Session == "claude:s2" {
+			tagged = n
+		}
+	}
+	// Trimmed and lowercased, in the order they were given: they are matched
+	// as a set, so order carries no meaning and reordering would only make a
+	// note read differently from how it was written.
+	if len(tagged.Tags) != 2 || tagged.Tags[0] != "retry" || tagged.Tags[1] != "backoff" {
+		t.Fatalf("tags = %v, want them trimmed and lowercased", tagged.Tags)
+	}
+	if tagged.State != "accepted" || tagged.Project != "proj" {
+		t.Fatalf("note metadata lost: %+v", tagged)
+	}
+}
+
+func TestNormalizeTagsDropsNoise(t *testing.T) {
+	got := NormalizeTags([]string{" Retry ", "retry", "", "  ", "#BACKOFF"})
+	if len(got) != 2 {
+		t.Fatalf("tags = %v, want duplicates and blanks dropped", got)
+	}
+	if got[0] != "retry" || got[1] != "backoff" {
+		t.Fatalf("tags = %v, want lowercased with the hash stripped", got)
+	}
+	// The cap exists so one note cannot flood tag matching.
+	many := make([]string, 0, 12)
+	for i := 0; i < 12; i++ {
+		many = append(many, string(rune('a'+i)))
+	}
+	if n := len(NormalizeTags(many)); n > 8 {
+		t.Fatalf("kept %d tags, past the cap", n)
+	}
+	if NormalizeTags(nil) != nil {
+		t.Fatal("nil tags produced a slice")
+	}
+}
+
+// A note whose file is unreadable must not take the whole recall down with it.
+func TestLoadPromotedNotesSurvivesGarbage(t *testing.T) {
+	dir := notesHome(t)
+	path := filepath.Join(dir, "notes.jsonl")
+	body := `{"kind":"promoted","project":"p","title":"good","text":"keep","session":"claude:s1","state":"accepted"}
+not json at all
+{"kind":"promoted","project":"p","title":"also good","text":"keep too","session":"claude:s2","state":"accepted"}
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	notes := LoadPromotedNotes()
+	if len(notes) != 2 {
+		t.Fatalf("a torn line cost %d of 2 notes", 2-len(notes))
+	}
+}
+
+// The conflict check is what makes curation worth anything: two accepted notes
+// covering the same ground should be surfaced, and unrelated ones should not.
+func TestConflictingNotesNeedsSharedGround(t *testing.T) {
+	candidate := PromotedNote{Project: "p", Session: "claude:new", State: "accepted",
+		Title: "keys", Text: "deploy keys live in the environment", Tags: []string{"deploy"}}
+	all := []PromotedNote{
+		{Project: "p", Session: "claude:old", State: "accepted", Title: "keys", Text: "deploy keys live in the config", Tags: []string{"deploy"}},
+		{Project: "p", Session: "claude:self", State: "accepted", Title: "unrelated", Text: "cron moved to 03:17"},
+		{Project: "other", Session: "claude:elsewhere", State: "accepted", Title: "keys", Text: "deploy keys live in the config", Tags: []string{"deploy"}},
+		{Project: "p", Session: "claude:rejected", State: "rejected", Title: "keys", Text: "deploy keys live in the config", Tags: []string{"deploy"}},
+	}
+	got := ConflictingNotes(candidate, all)
+	if len(got) != 1 || got[0].Session != "claude:old" {
+		t.Fatalf("conflicts = %+v, want only the accepted note in the same project", got)
+	}
+	// Re-promoting the same session is an update, not a disagreement.
+	same := candidate
+	same.Session = "claude:old"
+	if c := ConflictingNotes(same, all); len(c) != 0 {
+		t.Fatalf("a session conflicted with itself: %+v", c)
+	}
+}
+
+func TestNotesFileFollowsItsOverride(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	t.Setenv("DEJA_NOTES_FILE", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	if got := NotesFile(); !strings.HasPrefix(got, dir) {
+		t.Fatalf("NotesFile() = %q, outside the home directory", got)
+	}
+	custom := filepath.Join(dir, "elsewhere", "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", custom)
+	if got := NotesFile(); got != custom {
+		t.Fatalf("DEJA_NOTES_FILE ignored: %q", got)
+	}
+}

--- a/internal/sources/notes_coverage_test.go
+++ b/internal/sources/notes_coverage_test.go
@@ -116,6 +116,10 @@ func TestNotesFileFollowsItsOverride(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	t.Setenv("USERPROFILE", dir)
+	// Windows resolves this under APPDATA rather than the home directory, so
+	// leaving it alone points the test at the real machine.
+	t.Setenv("APPDATA", filepath.Join(dir, "AppData", "Roaming"))
+	t.Setenv("LOCALAPPDATA", filepath.Join(dir, "AppData", "Local"))
 	t.Setenv("DEJA_NOTES_FILE", "")
 	t.Setenv("XDG_DATA_HOME", "")
 	if got := NotesFile(); !strings.HasPrefix(got, dir) {

--- a/internal/sources/paths_coverage_test.go
+++ b/internal/sources/paths_coverage_test.go
@@ -1,0 +1,117 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Every one of these decides where deja looks for a harness. A wrong path is
+// not a crash — it is a harness that silently reports nothing, which is the
+// failure mode this project keeps hitting.
+func TestHarnessPathsFollowTheirOverrides(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	for _, v := range []string{
+		"CLINE_DIR", "CLINE_DATA_DIR", "CLINE_SESSION_DATA_DIR",
+		"CLINE_MCP_SETTINGS_PATH", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+	} {
+		t.Setenv(v, "")
+	}
+
+	for name, got := range map[string]string{
+		"cline config":   ClineConfigDir(),
+		"cline sessions": ClineSessionsDir(),
+		"cline mcp":      ClineMCPSettingsPath(),
+		"cline plugins":  ClinePluginsDir(),
+	} {
+		if !strings.HasPrefix(got, home) {
+			t.Fatalf("%s = %q, outside the home directory", name, got)
+		}
+	}
+	// Plugins sit beside the data directory, not inside it: a plugin under
+	// <data>/plugins is never discovered.
+	if strings.HasPrefix(ClinePluginsDir(), ClineConfigDir()) {
+		t.Fatalf("plugins dir %q is inside the data dir %q", ClinePluginsDir(), ClineConfigDir())
+	}
+
+	// CLINE_DIR moves the whole tree.
+	moved := filepath.Join(home, "moved")
+	t.Setenv("CLINE_DIR", moved)
+	for name, got := range map[string]string{"config": ClineConfigDir(), "plugins": ClinePluginsDir()} {
+		if !strings.HasPrefix(got, moved) {
+			t.Fatalf("CLINE_DIR ignored by %s: %q", name, got)
+		}
+	}
+	custom := filepath.Join(home, "custom.json")
+	t.Setenv("CLINE_MCP_SETTINGS_PATH", custom)
+	if ClineMCPSettingsPath() != custom {
+		t.Fatalf("CLINE_MCP_SETTINGS_PATH ignored: %q", ClineMCPSettingsPath())
+	}
+}
+
+func TestGoosePathRootRelocatesEverything(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	for _, v := range []string{"DEJA_GOOSE_ROOT", "DEJA_GOOSE_DB", "XDG_DATA_HOME"} {
+		t.Setenv(v, "")
+	}
+	root := filepath.Join(home, "elsewhere")
+	t.Setenv("GOOSE_PATH_ROOT", root)
+	if got := GooseDataDir(); got != filepath.Join(root, "data") {
+		t.Fatalf("GooseDataDir() = %q", got)
+	}
+	if got := GooseDB(); !strings.HasPrefix(got, root) {
+		t.Fatalf("GooseDB() = %q, ignores GOOSE_PATH_ROOT", got)
+	}
+	// Legacy .jsonl transcripts live beside the SQLite store; an absent store
+	// yields nothing rather than an error the caller must special-case.
+	if files := GooseJSONLFiles(); len(files) != 0 {
+		t.Fatalf("empty store returned files: %v", files)
+	}
+	if ss := LoadGoose(); len(ss) != 0 {
+		t.Fatalf("empty store returned sessions: %d", len(ss))
+	}
+}
+
+func TestLoadersTolerateAbsentStores(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	for _, v := range []string{
+		"DEJA_GROK_DB", "DEJA_GROK_ROOT", "DEJA_HERMES_HOME",
+		"DEJA_HERMES_PROFILES_ROOT", "DEJA_KIMI_ROOT", "DEJA_QWEN_ROOT",
+		"DEJA_OPENCLAW_ROOT",
+	} {
+		t.Setenv(v, "")
+	}
+	if ss := LoadGrokDB(); len(ss) != 0 {
+		t.Fatalf("grok db: %d sessions from nothing", len(ss))
+	}
+	if files := HermesSessionFiles(); len(files) != 0 {
+		t.Fatalf("hermes: %v", files)
+	}
+	if ss := LoadKimi(); len(ss) != 0 {
+		t.Fatalf("kimi: %d", len(ss))
+	}
+	if ss := LoadQwen(); len(ss) != 0 {
+		t.Fatalf("qwen: %d", len(ss))
+	}
+	if files := QwenSessionFiles(); len(files) != 0 {
+		t.Fatalf("qwen files: %v", files)
+	}
+	if ss := LoadOpenClaw(); len(ss) != 0 {
+		t.Fatalf("openclaw: %d", len(ss))
+	}
+	if runtime.GOOS == "windows" {
+		return
+	}
+	// Reading a store deja does not have must not create one.
+	if _, err := os.Stat(filepath.Join(home, ".grok")); err == nil {
+		t.Fatal("reading an absent store created it")
+	}
+}

--- a/internal/usage/coverage_gaps_test.go
+++ b/internal/usage/coverage_gaps_test.go
@@ -1,0 +1,207 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func usageDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	return dir
+}
+
+// Impact is what `deja stats --impact` prints, and the README promises those
+// are counted numbers rather than modelled ones — so the counting is worth
+// pinning.
+func TestImpactCountsEachKindOnce(t *testing.T) {
+	dir := usageDir(t)
+	RecordResultRaw(dir, KindRecall, 100, 2, false, 10_000)
+	RecordResultRaw(dir, KindRecall, 50, 1, false, 5_000)
+	RecordResultRaw(dir, KindContext, 30, 1, false, 3_000)
+	RecordResultRaw(dir, KindHook, 20, 1, false, 2_000)
+	RecordResultRaw(dir, KindDejaVu, 10, 1, false, 1_000)
+	// An empty recall served nothing and must not inflate the numbers.
+	RecordResultRaw(dir, KindRecall, 0, 0, true, 0)
+
+	got := Impact(dir)
+	if got.Recalls != 3 {
+		t.Fatalf("recalls = %d, want the three non-empty ones", got.Recalls)
+	}
+	if got.Injections != 1 {
+		t.Fatalf("injections = %d", got.Injections)
+	}
+	if got.DejaVuMoments != 1 {
+		t.Fatalf("déjà vu moments = %d", got.DejaVuMoments)
+	}
+	if got.ServedBytes != 200 {
+		t.Fatalf("served bytes = %d, want 100+50+30+20", got.ServedBytes)
+	}
+	if got.RawBytes != 20_000 {
+		t.Fatalf("raw bytes = %d", got.RawBytes)
+	}
+}
+
+// "Reused twice" is the number that claims a fix kept paying, so it must count
+// sessions rather than events.
+func TestImpactCountsSessionsReusedTwice(t *testing.T) {
+	dir := usageDir(t)
+	RecordServedSessions(dir, KindRecall, 10, 1, false, 0, []string{"a"})
+	RecordServedSessions(dir, KindRecall, 10, 1, false, 0, []string{"a", "b"})
+	RecordServedSessions(dir, KindRecall, 10, 1, false, 0, []string{"c"})
+	if got := Impact(dir).ReusedTwice; got != 1 {
+		t.Fatalf("reused twice = %d, want only the session seen in two recalls", got)
+	}
+}
+
+func TestDejaVuWeekCountsOnlyRecentNonEmpty(t *testing.T) {
+	dir := usageDir(t)
+	RecordResultRaw(dir, KindDejaVu, 10, 1, false, 0)
+	// An empty moment is not a moment.
+	RecordResultRaw(dir, KindDejaVu, 0, 0, true, 0)
+	if got := DejaVuWeek(dir); got != 1 {
+		t.Fatalf("this week = %d, want 1", got)
+	}
+	// Anything older than the window drops out; write one by hand since the
+	// recorder always stamps now.
+	appendEventForTest(t, dir, Event{Kind: KindDejaVu, Time: time.Now().AddDate(0, 0, -30), Sessions: 1})
+	if got := DejaVuWeek(dir); got != 1 {
+		t.Fatalf("a month-old moment counted as this week: %d", got)
+	}
+}
+
+func TestTodayRawSumsOnlyTodaysServedKinds(t *testing.T) {
+	dir := usageDir(t)
+	RecordResultRaw(dir, KindRecall, 10, 1, false, 1_000)
+	RecordResultRaw(dir, KindHook, 10, 1, false, 2_000)
+	// A kind that serves nothing must not add to the volume it distilled.
+	RecordResultRaw(dir, KindSearch, 0, 0, false, 9_999)
+	if got := TodayRaw(dir); got != 3_000 {
+		t.Fatalf("today raw = %d, want 1000+2000", got)
+	}
+	appendEventForTest(t, dir, Event{Kind: KindRecall, Time: time.Now().AddDate(0, 0, -2), RawBytes: 5_000, Sessions: 1})
+	if got := TodayRaw(dir); got != 3_000 {
+		t.Fatalf("an older entry leaked into today: %d", got)
+	}
+}
+
+// The snapshot variants differ only in what they carry alongside the text;
+// all of them must leave the digest where `deja log` reads it.
+func TestSnapshotVariantsWriteTheDigest(t *testing.T) {
+	for name, record := range map[string]func(string){
+		"RecordDigestTerms": func(d string) { RecordDigestTerms(d, KindRecall, "digest terms", 1, 10, []string{"etag", "ttl"}) },
+		"SnapshotOnly":      func(d string) { SnapshotOnly(d, KindRecall, "digest only", 1) },
+		"SnapshotPolicy":    func(d string) { SnapshotPolicy(d, KindRecall, "digest policy", 1, "local") },
+	} {
+		dir := usageDir(t)
+		record(dir)
+		b, err := os.ReadFile(SnapshotPath(dir))
+		if err != nil {
+			t.Fatalf("%s: no snapshot written: %v", name, err)
+		}
+		if !strings.Contains(string(b), "digest") {
+			t.Fatalf("%s: snapshot missing the digest text: %s", name, b)
+		}
+	}
+	// An empty digest is not worth a snapshot line.
+	dir := usageDir(t)
+	SnapshotOnly(dir, KindRecall, "", 0)
+	if _, err := os.Stat(SnapshotPath(dir)); !os.IsNotExist(err) {
+		t.Fatal("empty digest produced a snapshot")
+	}
+}
+
+func TestRecordDigestTermsKeepsTheTerms(t *testing.T) {
+	dir := usageDir(t)
+	RecordDigestTerms(dir, KindDejaVu, "the digest", 2, 500, []string{"etag", "jitter"})
+	b, err := os.ReadFile(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"etag", "jitter"} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("term %q not kept for the audit trail: %s", want, b)
+		}
+	}
+	// And the counting event went in too, or stats would under-report.
+	if got := Impact(dir).DejaVuMoments; got != 1 {
+		t.Fatalf("déjà vu moments = %d", got)
+	}
+}
+
+// appendEventForTest writes an event with a chosen timestamp: the recorder
+// always stamps now, and these tests are about the windows.
+func appendEventForTest(t *testing.T, dir string, e Event) {
+	t.Helper()
+	f, err := os.OpenFile(Path(dir), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The log rotates so it cannot grow without bound, and what it keeps is the
+// recent window — dropping the wrong side would erase the history stats are
+// counted from.
+func TestRotateKeepsTheRecentWindow(t *testing.T) {
+	dir := usageDir(t)
+	appendEventForTest(t, dir, Event{Kind: KindRecall, Time: time.Now().UTC(), Bytes: 1, Sessions: 1})
+	appendEventForTest(t, dir, Event{Kind: KindRecall, Time: time.Now().UTC().Add(-2 * keepWindow), Bytes: 1, Sessions: 1})
+	// Pad past the rotation threshold so the next write triggers it.
+	pad := Event{Kind: KindSearch, Time: time.Now().UTC(), Bytes: 1}
+	for size := int64(0); size < rotateAt; {
+		appendEventForTest(t, dir, pad)
+		fi, err := os.Stat(Path(dir))
+		if err != nil {
+			t.Fatal(err)
+		}
+		size = fi.Size()
+	}
+	RecordResultRaw(dir, KindRecall, 5, 1, false, 0)
+
+	var recent, old int
+	for _, e := range read(Path(dir)) {
+		if e.Time.Before(time.Now().UTC().Add(-keepWindow)) {
+			old++
+		} else {
+			recent++
+		}
+	}
+	if old != 0 {
+		t.Fatalf("rotation kept %d entries older than the window", old)
+	}
+	if recent == 0 {
+		t.Fatal("rotation dropped everything")
+	}
+}
+
+// WornSessions feeds ranking: a session an agent recalled twice should weigh
+// more. Kinds that are not agent-initiated recalls must not contribute.
+func TestWornSessionsCountsOnlyRecalls(t *testing.T) {
+	dir := usageDir(t)
+	if got := WornSessions(dir); got != nil {
+		t.Fatalf("empty log returned %v, want nil so callers can skip the work", got)
+	}
+	RecordServedSessions(dir, KindRecall, 10, 1, false, 0, []string{"a", "b"})
+	RecordServedSessions(dir, KindContext, 10, 1, false, 0, []string{"a"})
+	RecordServedSessions(dir, KindHook, 10, 1, false, 0, []string{"c"})
+	got := WornSessions(dir)
+	if got["a"] != 2 || got["b"] != 1 {
+		t.Fatalf("worn counts wrong: %v", got)
+	}
+	if _, ok := got["c"]; ok {
+		t.Fatal("a session-start injection counted as agent-initiated re-use")
+	}
+}


### PR DESCRIPTION
Part of #461.

`internal/usage` **76.9% → 95.3%**. The gaps were the numbers people actually read: `Impact` is what `deja stats --impact` prints and the README promises those are counted rather than modelled, and it had no test — nor did `DejaVuWeek`, `TodayRaw`, the snapshot variants, log rotation, or `WornSessions`, which feeds ranking. Rotation is now pinned to keep the recent window rather than whichever side is convenient.

`internal/sources` **82.3% → 87.2%**. Covered the path resolvers that decide where each harness is looked for — a wrong one there is not a crash, it is a harness that silently reports nothing, which is the failure this project keeps hitting — plus note curation, the conflict rule, both SQLite `since` filters, the bounded opencode probe, and the incremental offset parsers.

Not 95%: what is left in sources is mostly the Windows and Linux branches of path resolution, unreachable from a mac test run. Covering those wants the OS switch extracted into something a test can drive, which is a refactor of code every harness depends on and belongs in its own change rather than tacked onto this one.

The CI floors move up with the numbers, so neither package can slide back.