### PR TITLE
Coverage: bar at 90%, bench and digest raised, corpus hash fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           go tool cover -func=coverage.out | tail -1
           total=$(go tool cover -func=coverage.out | tail -1 | grep -oE '[0-9]+\.[0-9]+')
-          floor=80.0
+          floor=82.0
           echo "total coverage ${total}%, floor ${floor}%"
           awk -v t="$total" -v f="$floor" 'BEGIN { if (t+0 < f+0) { printf "coverage %.1f%% is below the %.1f%% floor\n", t, f; exit 1 } }'
       # A floor per package, set at where each stands today. Raise them as
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         run: |
           declare -A floor=(
-            [cmd/deja]=87 [internal/bench]=67 [internal/digest]=72 [internal/embed]=93
+            [cmd/deja]=88 [internal/bench]=100 [internal/digest]=90 [internal/embed]=93
             [internal/index]=87 [internal/policy]=88 [internal/redact]=94
             [internal/search]=89 [internal/sources]=87 [internal/usage]=95
           )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ go build ./cmd/deja
 ```
 
 Run `gofmt -s` on changed Go files. Every package touched by a change must keep
-at least 95% statement coverage for new packages, and never less than the
+at least 90% statement coverage for new packages, and never less than the
 floor CI enforces for the package you touched (`.github/workflows/ci.yml`,
 "Per-package coverage floor"). Those floors are where each package stands
 today, not where it should be: raise one when you improve it, and treat

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -67,6 +67,32 @@ const PromptNegativeCount = 3
 // GeneratePrompt builds one chain per topic: three prior sessions carrying the
 // fact under working noise, and no task session — the question comes from the
 // caller, the way a prompt does.
+// promptCorpusHash fingerprints what the corpus asks, not when it was built.
+// The fresh chain is dated relative to now by design, so hashing the sessions
+// wholesale gave a different hash on every run — and a hash that changes
+// without the inputs changing cannot be used to compare two runs, which is
+// the only reason it is reported.
+func promptCorpusHash(chains []PromptChain) string {
+	type stable struct {
+		ID, Project, Topic, Question, Kind string
+		Negative                           bool
+		Texts                              []string
+	}
+	out := make([]stable, 0, len(chains))
+	for _, c := range chains {
+		s := stable{ID: c.ID, Project: c.Project, Topic: c.Topic, Question: c.Question, Kind: c.Kind, Negative: c.Negative}
+		for _, sess := range c.Sessions {
+			for _, m := range sess.Messages {
+				s.Texts = append(s.Texts, m.Role+":"+m.Text)
+			}
+		}
+		out = append(out, s)
+	}
+	b, _ := json.Marshal(out)
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
 // promptShapeChain builds one chain with a given session length and start
 // time, so a gate can be measured instead of argued about.
 func promptShapeChain(rng *rand.Rand, i int, kind string, topic promptTopic, start time.Time, turns int) PromptChain {
@@ -149,7 +175,5 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
-	b, _ := json.Marshal(chains)
-	h := sha256.Sum256(b)
-	return PromptCorpus{Chains: chains, Hash: hex.EncodeToString(h[:])}
+	return PromptCorpus{Chains: chains, Hash: promptCorpusHash(chains)}
 }

--- a/internal/bench/prompt_test.go
+++ b/internal/bench/prompt_test.go
@@ -1,0 +1,115 @@
+package bench
+
+import (
+	"testing"
+	"time"
+)
+
+// This corpus is what makes changes to per-prompt recall arguable instead of
+// opinionated, so its shape is the thing to pin. Every property below was
+// wrong at some point while it was being written, and each mistake made the
+// benchmark score zero or lie.
+func TestGeneratePromptShape(t *testing.T) {
+	corpus := GeneratePrompt(Seed)
+	if corpus.Hash == "" {
+		t.Fatal("no hash: two runs cannot be compared")
+	}
+	topics := map[string]bool{}
+	projects := map[string]bool{}
+	var real, negative, marathon, fresh int
+	for _, c := range corpus.Chains {
+		if projects[c.Project] {
+			t.Fatalf("project %q shared by two chains; a query would match both", c.Project)
+		}
+		projects[c.Project] = true
+		if c.Negative {
+			negative++
+			if len(c.Sessions) == 0 {
+				t.Fatalf("negative chain %s has no sessions to rule out", c.ID)
+			}
+			continue
+		}
+		real++
+		// One topic per chain: the context corpus gives them all the same
+		// vocabulary, and a term in every chain identifies none of them.
+		if topics[c.Topic] {
+			t.Fatalf("topic %q appears twice", c.Topic)
+		}
+		topics[c.Topic] = true
+		if c.Question == "" {
+			t.Fatalf("chain %s has no question", c.ID)
+		}
+		switch c.Kind {
+		case "marathon":
+			marathon++
+		case "fresh":
+			fresh++
+		}
+		for _, s := range c.Sessions {
+			if len(s.Messages) == 0 {
+				t.Fatalf("chain %s has an empty session", c.ID)
+			}
+			// A corpus dated in the future reads as newer than now, and the
+			// freshness gate withholds all of it.
+			if s.Updated.After(time.Now()) {
+				t.Fatalf("chain %s is dated in the future: %v", c.ID, s.Updated)
+			}
+			if s.Project != c.Project {
+				t.Fatalf("chain %s has a session filed under %q", c.ID, s.Project)
+			}
+		}
+	}
+	if real < 12 || negative != PromptNegativeCount {
+		t.Fatalf("chains: %d real, %d negative", real, negative)
+	}
+	if marathon != 1 || fresh != 1 {
+		t.Fatalf("gated shapes: %d marathon, %d fresh — both are needed to measure the gates", marathon, fresh)
+	}
+}
+
+// The gated shapes have to actually be gated, or the arms measure nothing.
+func TestGeneratePromptGatedShapesAreExtreme(t *testing.T) {
+	corpus := GeneratePrompt(Seed)
+	for _, c := range corpus.Chains {
+		switch c.Kind {
+		case "marathon":
+			if n := len(c.Sessions[0].Messages); n <= 300 {
+				t.Fatalf("marathon chain has %d messages, under the cap it exists to cross", n)
+			}
+		case "fresh":
+			if age := time.Since(c.Sessions[0].Updated); age > 15*time.Minute {
+				t.Fatalf("fresh chain is %v old, past the window it exists to test", age)
+			}
+		}
+	}
+}
+
+// Same seed, same corpus: a benchmark whose inputs drift cannot be compared
+// across runs, which is the whole point of reporting a hash.
+func TestGeneratePromptIsDeterministic(t *testing.T) {
+	a := GeneratePrompt(Seed)
+	b := GeneratePrompt(Seed)
+	if a.Hash != b.Hash {
+		t.Fatalf("hashes differ across runs: %s vs %s", a.Hash, b.Hash)
+	}
+	if len(a.Chains) != len(b.Chains) {
+		t.Fatalf("chain counts differ: %d vs %d", len(a.Chains), len(b.Chains))
+	}
+	// A different seed must produce a different corpus, or the seed is decoration.
+	if c := GeneratePrompt(Seed + 1); c.Hash == a.Hash {
+		t.Fatal("the seed changes nothing")
+	}
+}
+
+func TestPromptTopicsAreUsableTerms(t *testing.T) {
+	for _, topic := range promptTopics() {
+		if topic.word == "" || topic.fact == "" || topic.question == "" {
+			t.Fatalf("incomplete topic: %+v", topic)
+		}
+		// The corpus exists to test what the extractor keeps, so the topics
+		// have to be the short identifiers people actually type.
+		if len(topic.word) > 12 {
+			t.Fatalf("topic %q is not the short kind this corpus is for", topic.word)
+		}
+	}
+}

--- a/internal/digest/coverage_gaps_test.go
+++ b/internal/digest/coverage_gaps_test.go
@@ -1,0 +1,119 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Digests are cut to a byte budget. Cutting mid-rune puts a replacement
+// character into whatever the agent reads next, so the cut has to land on a
+// boundary — every harness downstream trusts this.
+func TestUTF8SafeCutLandsOnRuneBoundaries(t *testing.T) {
+	s := "привет мир"
+	for n := 0; n <= len(s)+2; n++ {
+		got := UTF8SafeCut(s, n)
+		if !utf8.ValidString(got) {
+			t.Fatalf("cut at %d produced invalid utf8: %q", n, got)
+		}
+		if len(got) > n && n <= len(s) {
+			t.Fatalf("cut at %d returned %d bytes", n, len(got))
+		}
+	}
+	if UTF8SafeCut(s, 0) != "" {
+		t.Fatal("zero budget returned text")
+	}
+	if UTF8SafeCut(s, -5) != "" {
+		t.Fatal("negative budget returned text")
+	}
+	if UTF8SafeCut(s, len(s)+10) != s {
+		t.Fatal("a budget past the end truncated")
+	}
+	// ASCII is unaffected, or every English digest pays for this.
+	if got := UTF8SafeCut("hello world", 5); got != "hello" {
+		t.Fatalf("ascii cut = %q", got)
+	}
+}
+
+func TestShortTrimsIdentifiers(t *testing.T) {
+	if got := Short("2fc1d1ef-59f0-4044-b986-ba349e11c53c"); got != "2fc1d1ef-59f" {
+		t.Fatalf("Short() = %q", got)
+	}
+	if got := Short("abc"); got != "abc" {
+		t.Fatalf("a short id was trimmed: %q", got)
+	}
+	if got := Short(""); got != "" {
+		t.Fatalf("empty id became %q", got)
+	}
+}
+
+// Handoff packages a session for another agent to continue. It is read by a
+// model with no other context, so the framing has to say where the work came
+// from and that it should not be re-derived.
+func TestHandoffFramesThePackagedContext(t *testing.T) {
+	s := model.Session{
+		ID: "s1", Harness: "claude", Project: "api", Updated: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		Messages: []model.Message{
+			{Role: "user", Text: "the connection pool keeps running out"},
+			{Role: "assistant", Text: "raised max_conns and added jitter to the retries"},
+		},
+	}
+	got := Handoff(s, 4096)
+	for _, want := range []string{"handed off", "claude", "api", "2026-05-01"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("handoff missing %q:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, "connection pool") {
+		t.Fatalf("handoff dropped the problem statement:\n%s", got)
+	}
+	if len(got) > 4096 {
+		t.Fatalf("handoff is %d bytes, over budget", len(got))
+	}
+	// A session with no timestamp still hands off; saying "unknown" beats
+	// printing a zero date that reads as 1 January year one.
+	s.Updated = time.Time{}
+	if got := Handoff(s, 4096); !strings.Contains(got, "unknown") {
+		t.Fatalf("undated session lost its date framing:\n%s", got)
+	}
+}
+
+// Transcripts are full of plumbing recorded under a user role. Indexing it
+// makes recall answer with tool echoes instead of what the user said.
+func TestIsAgentArtifactSpotsPlumbing(t *testing.T) {
+	for text, want := range map[string]bool{
+		"<environment_context>cwd: /tmp</environment_context>": true,
+		"total 24\ndrwxr-xr-x  3 user staff":                   true,
+		"File created successfully at: /tmp/x.go":              true,
+		"diff --git a/main.go b/main.go":                       true,
+		"$ go test ./...":                                      true,
+		"the connection pool keeps running out":                false,
+		"why did we replace the etag reuse?":                   false,
+		"":                                                     false,
+	} {
+		if got := IsAgentArtifact(text); got != want {
+			t.Fatalf("IsAgentArtifact(%.40q) = %v, want %v", text, got, want)
+		}
+	}
+}
+
+// Terminal output lands in transcripts with escape codes in it. Left in, they
+// are indexed as tokens and shown back to the user as garbage.
+func TestStripANSIRemovesEscapesOnly(t *testing.T) {
+	in := "\x1b[31mred\x1b[0m and \x1b[1;32mgreen\x1b[0m"
+	got := stripANSI(in)
+	if strings.Contains(got, "\x1b") {
+		t.Fatalf("escape survived: %q", got)
+	}
+	if !strings.Contains(got, "red") || !strings.Contains(got, "green") {
+		t.Fatalf("stripping took the text with it: %q", got)
+	}
+	// Text with no escapes must come back untouched, byte for byte.
+	plain := "plain text with [brackets] and 0m digits"
+	if stripANSI(plain) != plain {
+		t.Fatalf("plain text was altered: %q", stripANSI(plain))
+	}
+}


### PR DESCRIPTION
Closes #465. Part of #461.

The bar in CONTRIBUTING is now 90% rather than 95% — 95 was aspirational enough that nobody measured against it, which is how the number quietly reached 80.

| package | before | after |
| --- | --- | --- |
| internal/bench | 67.7% | **100%** |
| internal/digest | 73.1% | **90.4%** |

**A bug the new tests found.** `bench prompt --json` prints a `corpus_hash` so two runs can be compared, and it changed on every run: the fresh chain is dated relative to now by design, and the hash covered the timestamps. The one field claiming "these runs measured the same thing" said the opposite every time. It now hashes what the corpus asks — ids, topics, questions, message text — not when it was built.

The digest tests cover machinery every harness reads through: cutting to a budget without splitting a rune, the handoff framing another agent gets with no other context, the filter that keeps tool echoes and `<environment_context>` plumbing out of recall, and ANSI stripping that must not eat the text along with the escapes.

CI floors move up to the new numbers; the total floor is 82%, which is what the weighted total actually is.