### PR TITLE
Cover the stale-serving path, project recall and the cooccur tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           declare -A floor=(
             [cmd/deja]=88 [internal/bench]=100 [internal/digest]=90 [internal/embed]=93
-            [internal/index]=87 [internal/policy]=88 [internal/redact]=94
+            [internal/index]=90 [internal/policy]=88 [internal/redact]=94
             [internal/search]=89 [internal/sources]=87 [internal/usage]=95
           )
           fail=0

--- a/internal/index/cooccur_tier_test.go
+++ b/internal/index/cooccur_tier_test.go
@@ -1,0 +1,63 @@
+package index
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// The co-occurrence tier is the last thing tried before falling back to
+// relevance: when a query's exact words find nothing, it substitutes a term
+// for one that kept company with it in this corpus. It is the tier that
+// answers "the thing next to the thing you remember".
+func TestCooccurTierSubstitutesANeighbouringTerm(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(home, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	dir := filepath.Join(home, "idx")
+	// "postgres" and "connection" keep company across the corpus; "psql"
+	// never appears with "connection" at all.
+	for i, text := range []string{
+		"the postgres connection pool ran dry again",
+		"postgres connection limits raised to 200",
+		"restarted postgres and the connection settled",
+		"psql prints the schema",
+	} {
+		writeLines(t, filepath.Join(claude, "project", "s"+string(rune('1'+i))+".jsonl"),
+			claudeLine("s"+string(rune('1'+i)), "2026-01-0"+string(rune('1'+i))+"T00:01:00Z", text))
+	}
+	if err := Ensure(dir, "", true, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A query needs at least two terms: one lucky word is not a co-occurrence.
+	if got, err := cooccurSearch(dir, m, query.Options{Query: "postgres", All: true}); err != nil || len(got.Sessions) != 0 {
+		t.Fatalf("single term produced %d sessions (%v)", len(got.Sessions), err)
+	}
+
+	// Both words present is the exact tier's job, not this one's — but asking
+	// here must not error, and must not invent sessions that lack the terms.
+	got, err := cooccurSearch(dir, m, query.Options{Query: "postgres connection", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range got.Sessions {
+		var b strings.Builder
+		for _, msg := range s.Messages {
+			b.WriteString(strings.ToLower(msg.Text))
+			b.WriteString(" ")
+		}
+		if !strings.Contains(b.String(), "postgres") && !strings.Contains(b.String(), "connection") {
+			t.Fatalf("session %s has neither term: %q", s.ID, b.String())
+		}
+	}
+}

--- a/internal/index/stale_path_test.go
+++ b/internal/index/stale_path_test.go
@@ -1,0 +1,151 @@
+package index
+
+import (
+	"github.com/vshulcz/deja-vu/internal/model"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// EnsureForSearchStale decides whether a hook can answer from the index it has
+// while a rebuild happens behind it. Getting it wrong either blocks a session
+// start on a full rebuild or serves an index that is missing the answer.
+func TestEnsureForSearchStaleDecidesWhatToServe(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(home, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	dir := filepath.Join(home, "idx")
+	path := filepath.Join(claude, "project", "s.jsonl")
+	writeLines(t, path, claudeLine("s1", "2026-01-01T00:01:00Z", "first"))
+
+	// No index yet: nothing sensible to serve stale, so it must build.
+	stale, err := EnsureForSearchStale(dir, query.Options{All: true}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stale {
+		t.Fatal("an absent index was reported as servable")
+	}
+	if !HasManifest(dir) {
+		t.Fatal("no index was built")
+	}
+
+	// Nothing changed: no work, nothing stale.
+	if stale, err := EnsureForSearchStale(dir, query.Options{All: true}, io.Discard); err != nil || stale {
+		t.Fatalf("unchanged store: stale=%v err=%v", stale, err)
+	}
+
+	// A plain append is cheap enough to absorb synchronously.
+	writeLines(t, path, claudeLine("s1", "2026-01-01T00:01:00Z", "first"), claudeLine("s1", "2026-01-01T00:02:00Z", "second"))
+	if stale, err := EnsureForSearchStale(dir, query.Options{All: true}, io.Discard); err != nil || stale {
+		t.Fatalf("append should be absorbed in place: stale=%v err=%v", stale, err)
+	}
+
+	// A removed file cannot be absorbed by appending: the caller has to
+	// rebuild, and until it does the current snapshot is what gets served.
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	stale, err = EnsureForSearchStale(dir, query.Options{All: true}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stale {
+		t.Fatal("a removed transcript did not ask for a rebuild")
+	}
+}
+
+// A rewound file must not take the append path here either, or the hook
+// serves an index holding text the transcript no longer has.
+func TestEnsureForSearchStaleRefusesToAppendOntoARewind(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(home, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	dir := filepath.Join(home, "idx")
+	path := filepath.Join(claude, "project", "s.jsonl")
+	writeLines(t, path, claudeLine("s1", "2026-01-01T00:01:00Z", "ORIGINAL"), claudeLine("s1", "2026-01-01T00:02:00Z", "second"))
+	if _, err := EnsureForSearchStale(dir, query.Options{All: true}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	writeLines(t, path,
+		claudeLine("s1", "2026-01-01T00:01:00Z", "REWRITTEN"),
+		claudeLine("s1", "2026-01-01T00:02:00Z", "second"),
+		claudeLine("s1", "2026-01-01T00:03:00Z", "third"))
+	stale, err := EnsureForSearchStale(dir, query.Options{All: true}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stale {
+		t.Fatal("a rewritten prefix was absorbed as an append; the old text would stay indexed")
+	}
+}
+
+// RecentProjects is how the session-start digest picks what to show: the most
+// recent sessions of the projects the working tree points at. Matching is by
+// substring because project names arrive in different shapes per harness, and
+// a session must never be listed twice when two names both match it.
+func TestRecentProjectsRanksAndDeduplicates(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(home, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	dir := filepath.Join(home, "idx")
+	for _, tc := range []struct{ project, id, ts, text string }{
+		{"alpha", "a1", "2026-01-01T00:01:00Z", "oldest alpha"},
+		{"alpha", "a2", "2026-03-01T00:01:00Z", "newest alpha"},
+		{"beta", "b1", "2026-02-01T00:01:00Z", "only beta"},
+	} {
+		writeLines(t, filepath.Join(claude, tc.project, tc.id+".jsonl"), claudeLine(tc.id, tc.ts, tc.text))
+	}
+	if err := Ensure(dir, "", true, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	// Newest first, and the per-name cap applies to each name separately.
+	got, err := RecentProjects(dir, []string{"alpha"}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "a2" {
+		t.Fatalf("got %+v, want only the newest alpha session", ids(got))
+	}
+
+	// Two names that both match the same session must not list it twice —
+	// the digest would spend its budget saying the same thing.
+	both, err := RecentProjects(dir, []string{"alpha", "alph"}, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	for _, s := range both {
+		if seen[s.ID] {
+			t.Fatalf("session %s listed twice: %v", s.ID, ids(both))
+		}
+		seen[s.ID] = true
+	}
+	if len(both) != 2 {
+		t.Fatalf("got %v, want both alpha sessions once each", ids(both))
+	}
+
+	// An unknown project yields nothing rather than everything, or a fresh
+	// checkout would recall the whole machine.
+	if got, err := RecentProjects(dir, []string{"gamma"}, 5); err != nil || len(got) != 0 {
+		t.Fatalf("unknown project returned %v (%v)", ids(got), err)
+	}
+}
+
+func ids(ss []model.Session) []string {
+	out := make([]string, 0, len(ss))
+	for _, s := range ss {
+		out = append(out, s.ID)
+	}
+	return out
+}


### PR DESCRIPTION
Part of #461. `internal/index` 87.9% → 90.4%.

Three pieces of machinery that decide what an agent sees, none of them tested:

**`EnsureForSearchStale`** picks whether a hook answers from the index it has while a rebuild runs behind it. Wrong either way is bad — blocking a session start on a full rebuild, or serving an index that is missing the answer. Now pinned across four states: no index, unchanged, a plain append, and a removed transcript. The rewind case from #453 is pinned here too, since this path has its own copy of that decision.

**`RecentProjects`** is how the session-start digest chooses what to show. Matching is by substring because project names arrive differently per harness, which means two names can match the same session — and listing it twice spends the digest budget saying one thing. Also pinned: an unknown project recalls nothing rather than everything.

**The co-occurrence tier** is the last thing tried before relevance: when the exact words find nothing, it substitutes a term for one that kept company with it. Pinned that it needs two terms to work at all, and that it never returns a session containing neither.

Floor raised to 90.