### PR TITLE
Pin relevance ranking and policy precedence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,8 @@ jobs:
         run: |
           declare -A floor=(
             [cmd/deja]=88 [internal/bench]=100 [internal/digest]=90 [internal/embed]=93
-            [internal/index]=90 [internal/policy]=88 [internal/redact]=94
-            [internal/search]=89 [internal/sources]=87 [internal/usage]=95
+            [internal/index]=90 [internal/policy]=100 [internal/redact]=94
+            [internal/search]=93 [internal/sources]=87 [internal/usage]=95
           )
           fail=0
           while read -r pkg cov; do

--- a/internal/policy/precedence_test.go
+++ b/internal/policy/precedence_test.go
@@ -1,0 +1,130 @@
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The policy decides which memory may activate where. Getting precedence wrong
+// is the kind of failure nobody reports: a peer someone deliberately blocked
+// keeps being injected, and the receipt still says the rule was applied.
+func TestAllowsMostSpecificRuleWins(t *testing.T) {
+	p := Policy{Activations: map[string]map[string]bool{
+		ActivationAuto: {
+			"imported:laptop": true,
+			"imported":        false,
+			"*":               true,
+		},
+	}}
+	for project, want := range map[string]bool{
+		"imported:laptop/api": true,  // named peer beats the imported default
+		"imported:mini/api":   false, // any other peer takes the imported rule
+		// The marker is the "imported:" prefix — a local project happening to
+		// be called "imported" is still local.
+		"imported:":     false,
+		"imported":      true,
+		"local-project": true, // "*" covers what no rule names
+	} {
+		if got := p.Allows(ActivationAuto, project); got != want {
+			t.Fatalf("Allows(%q) = %v, want %v", project, got, want)
+		}
+	}
+	// An activation with no rules allows everything: a policy file that
+	// mentions one path must not silently gate the others.
+	if !p.Allows(ActivationMCP, "imported:mini/api") {
+		t.Fatal("an unmentioned activation blocked memory")
+	}
+}
+
+func TestOriginClassifiesPeers(t *testing.T) {
+	for project, want := range map[string]string{
+		"api":                 "local",
+		"":                    "local",
+		"imported:laptop/api": "imported:laptop",
+		"imported:laptop":     "imported",
+		"imported:":           "imported",
+		"imported:mini/a/b":   "imported:mini",
+		"not-imported:laptop": "local",
+	} {
+		if got := Origin(project); got != want {
+			t.Fatalf("Origin(%q) = %q, want %q", project, got, want)
+		}
+	}
+}
+
+// Describe names the rule in receipts and `deja log`, so the audit trail
+// explains itself. A wrong name there is worse than none: it claims a policy
+// was applied that was not.
+func TestDescribeNamesTheRuleSet(t *testing.T) {
+	for name, tc := range map[string]struct {
+		p    Policy
+		want string
+	}{
+		"no rules":      {Policy{}, "local+imported"},
+		"local only":    {Policy{Activations: map[string]map[string]bool{ActivationAuto: {"imported": false}}}, "local-only"},
+		"allows all":    {Policy{Activations: map[string]map[string]bool{ActivationAuto: {"*": true}}}, "local+imported"},
+		"denies a peer": {Policy{Activations: map[string]map[string]bool{ActivationAuto: {"imported:mini": false}}}, "deny imported:mini"},
+	} {
+		if got := tc.p.Describe(ActivationAuto); got != tc.want {
+			t.Fatalf("%s: Describe = %q, want %q", name, got, tc.want)
+		}
+	}
+	// Several denials are listed in a stable order, or the same policy reads
+	// differently from one receipt to the next.
+	p := Policy{Activations: map[string]map[string]bool{ActivationAuto: {"imported:mini": false, "imported:laptop": false}}}
+	first := p.Describe(ActivationAuto)
+	for i := 0; i < 20; i++ {
+		if got := p.Describe(ActivationAuto); got != first {
+			t.Fatalf("description varies between calls: %q then %q", first, got)
+		}
+	}
+	if !strings.Contains(first, "imported:laptop") || !strings.Contains(first, "imported:mini") {
+		t.Fatalf("both denials should be named: %q", first)
+	}
+}
+
+func TestPathFollowsItsOverrides(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_POLICY_FILE", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	if got := Path(); !strings.HasPrefix(got, home) {
+		t.Fatalf("Path() = %q, outside the home directory", got)
+	}
+	xdg := filepath.Join(home, "xdg")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	if got := Path(); !strings.HasPrefix(got, xdg) {
+		t.Fatalf("XDG_CONFIG_HOME ignored: %q", got)
+	}
+	explicit := filepath.Join(home, "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", explicit)
+	if got := Path(); got != explicit {
+		t.Fatalf("DEJA_POLICY_FILE ignored: %q", got)
+	}
+}
+
+// A policy file that cannot be read must not silently block everything, and
+// must not silently allow everything either — the safe default is the
+// documented one: allow, since deja is local-first and the file is optional.
+func TestLoadFallsBackToTheDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	broken := filepath.Join(home, "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", broken)
+	if err := os.WriteFile(broken, []byte("{ not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p := Load()
+	if !p.Allows(ActivationAuto, "anything") {
+		t.Fatal("an unreadable policy file blocked recall")
+	}
+	// And an absent file behaves the same way.
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(home, "absent.json"))
+	if !Load().Allows(ActivationMCP, "imported:mini/api") {
+		t.Fatal("a missing policy file blocked recall")
+	}
+}

--- a/internal/search/relevance_hits_test.go
+++ b/internal/search/relevance_hits_test.go
@@ -1,0 +1,128 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func msg(text string) model.Message { return model.Message{Role: "user", Text: text} }
+
+// The relevance tier is what answers a natural-language question when no exact
+// match exists. The sessions arrive already ranked by the index — IDF-weighted
+// against the whole query — so this must preserve that order rather than
+// re-score by match count, which would throw away the ranking that made the
+// tier worth having.
+func TestRelevanceHitsKeepsTheIndexOrder(t *testing.T) {
+	ss := []model.Session{
+		{ID: "best", Messages: []model.Message{msg("etag reuse was replaced")}},
+		{ID: "second", Messages: []model.Message{msg("etag etag etag etag everywhere")}},
+		{ID: "third", Messages: []model.Message{msg("nothing to do with it")}},
+	}
+	hits := RelevanceHits(ss, []string{"etag"})
+	if len(hits) != 3 {
+		t.Fatalf("hits = %d", len(hits))
+	}
+	if hits[0].Session.ID != "best" || hits[1].Session.ID != "second" {
+		t.Fatalf("order changed: %s, %s", hits[0].Session.ID, hits[1].Session.ID)
+	}
+	// The second session mentions the term far more often and must still rank
+	// below the first: term frequency is not this tier's ranking signal.
+	if hits[0].Score <= hits[1].Score {
+		t.Fatalf("scores %v, %v do not follow the incoming order", hits[0].Score, hits[1].Score)
+	}
+	// Count is for display — how much of the session mentions the terms.
+	if hits[0].Count != 1 || hits[2].Count != 0 {
+		t.Fatalf("counts = %d, %d", hits[0].Count, hits[2].Count)
+	}
+	if hits[2].Tier != TierRelevance {
+		t.Fatalf("tier = %v", hits[2].Tier)
+	}
+}
+
+// Snippets are what the user reads; two per session is the budget, and a
+// session that mentions a term in every message must not spend the whole
+// screen on one result.
+func TestRelevanceHitsCapsSnippets(t *testing.T) {
+	var msgs []model.Message
+	for i := 0; i < 10; i++ {
+		msgs = append(msgs, msg("the etag check failed again"))
+	}
+	hits := RelevanceHits([]model.Session{{ID: "s", Messages: msgs}}, []string{"etag"})
+	if len(hits[0].Snippets) > 2 {
+		t.Fatalf("kept %d snippets", len(hits[0].Snippets))
+	}
+	if hits[0].Count != 10 {
+		t.Fatalf("count = %d, should still see every mention", hits[0].Count)
+	}
+}
+
+// A Simplified term should find Traditional text and the other way round: the
+// same person writes both, and the index folds them together.
+func TestRelevanceHitsFoldsAcrossScripts(t *testing.T) {
+	hits := RelevanceHits([]model.Session{
+		{ID: "trad", Messages: []model.Message{msg("修復連接池洩漏")}},
+	}, []string{"修复"})
+	if hits[0].Count == 0 {
+		t.Fatal("a Simplified term did not match Traditional text")
+	}
+	if len(hits[0].Snippets) == 0 {
+		t.Fatal("matched without producing a snippet to show for it")
+	}
+}
+
+func TestRelativeDateReadsAsAHuman(t *testing.T) {
+	now := time.Now()
+	for name, tc := range map[string]struct {
+		when time.Time
+		want string
+	}{
+		"today":     {now, "today"},
+		"yesterday": {now.AddDate(0, 0, -1), "1d ago"},
+		"days":      {now.AddDate(0, 0, -3), "3d ago"},
+	} {
+		if got := RelativeDate(tc.when); got != tc.want {
+			t.Fatalf("%s: RelativeDate = %q, want %q", name, got, tc.want)
+		}
+	}
+	// Past a week it becomes a date rather than a growing day count, and past
+	// a year it carries the year — "Jan 2" alone would be ambiguous.
+	if got := RelativeDate(now.AddDate(0, 0, -20)); strings.HasSuffix(got, "d ago") {
+		t.Fatalf("a three-week-old session reads as %q", got)
+	}
+	if got := RelativeDate(now.AddDate(-2, 0, 0)); !strings.Contains(got, now.AddDate(-2, 0, 0).Format("2006")) {
+		t.Fatalf("a two-year-old session reads as %q, without its year", got)
+	}
+}
+
+// Stop words are what keeps a query of filler from matching everything.
+func TestIsStopWordCoversFillerNotIdentifiers(t *testing.T) {
+	for word, want := range map[string]bool{
+		"the": true, "and": true, "with": true,
+		"etag": false, "deja": false, "connection": false,
+	} {
+		if got := IsStopWord(word); got != want {
+			t.Fatalf("IsStopWord(%q) = %v, want %v", word, got, want)
+		}
+	}
+}
+
+// Snippet is the line the user reads under a result: it has to contain the
+// term that matched, and stay short enough to scan.
+func TestSnippetCentresOnTheMatch(t *testing.T) {
+	long := strings.Repeat("padding text ", 40) + "the etag check failed " + strings.Repeat("more padding ", 40)
+	got := Snippet(long, "etag")
+	if !strings.Contains(got, "etag") {
+		t.Fatalf("snippet lost the term: %q", got)
+	}
+	if len(got) >= len(long) {
+		t.Fatalf("snippet is the whole message: %d bytes", len(got))
+	}
+	// A term that is not there gives the head of the message rather than
+	// nothing, so a result never renders as a blank line.
+	if got := Snippet("short message", "absent"); got == "" {
+		t.Fatal("snippet for an absent term is empty")
+	}
+}


### PR DESCRIPTION
Part of #461. `internal/search` 89.7% → 93.1%, `internal/policy` 88.2% → **100%**.

**Ranking.** `RelevanceHits` scores purely by the order it receives, ignoring how often a session mentions the terms — which looks like a bug until you see that the index already ranked those sessions IDF-weighted against the whole query. Re-scoring by match count here would throw that away, so the intent is now a test: a session mentioning the term five times still ranks below one the index put first.

Also pinned: two snippets per session so one result cannot take the screen, cross-script folding so a Simplified term finds Traditional text, and the date rendering people read on every line — day counts inside a week, a date past it, a year past twelve months.

**Policy.** This decides which memory activates where, and getting precedence wrong fails silently: a peer someone deliberately blocked keeps being injected while the receipt still claims the rule applied. Now pinned across the ladder — named peer beats `imported`, `imported` beats `*`, an activation with no rules allows everything — plus that an unreadable or absent policy file falls back to allowing rather than to blocking, since the file is optional and deja is local-first.

One expectation of mine was wrong and the code was right: a project literally named `imported` is local, because the marker is the `imported:` prefix. Corrected the test, not the behaviour.