### PR TITLE
stats --card: keep the filename honest

### DIFF
--- a/cmd/deja/log_view_test.go
+++ b/cmd/deja/log_view_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// `deja log` is the audit trail: what was injected, when, and under which
+// policy. It is how someone checks that memory is actually being served, and
+// what was in it.
+func TestLogRendersTheAuditTrail(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+
+	var empty bytes.Buffer
+	if err := runLogTo(&empty, dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	// An empty log has to explain itself rather than print nothing — the
+	// same rule the other commands follow.
+	if strings.TrimSpace(empty.String()) == "" {
+		t.Fatal("empty log printed nothing at all")
+	}
+
+	usage.RecordDigestPolicy(dir, usage.KindHook, "<deja-recall>\n  - Session: **a** `1`\n", 1, 4096, "local+imported")
+	usage.RecordDigestPolicy(dir, usage.KindRecall, "<deja-recall>\n  - Session: **b** `2`\n", 2, 8192, "local-only")
+
+	var out bytes.Buffer
+	if err := runLogTo(&out, dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{"hook", "recall"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("log missing %q:\n%s", want, got)
+		}
+	}
+
+	// --last shows the digest itself, which is the point: seeing what the
+	// agent was actually given.
+	var last bytes.Buffer
+	if err := runLogTo(&last, dir, []string{"--last"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(last.String(), "Session") {
+		t.Fatalf("--last did not print the digest:\n%s", last.String())
+	}
+
+	// --json is consumed by scripts, so it has to parse.
+	var jsonOut bytes.Buffer
+	if err := runLogTo(&jsonOut, dir, []string{"--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var parsed any
+	if err := json.Unmarshal(jsonOut.Bytes(), &parsed); err != nil {
+		t.Fatalf("--json is not json: %v\n%s", err, jsonOut.String())
+	}
+
+	// A count limits the output; garbage is refused rather than ignored.
+	var limited bytes.Buffer
+	if err := runLogTo(&limited, dir, []string{"1"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, bad := range []string{"--nope", "0", "-3", "abc"} {
+		if err := runLogTo(&bytes.Buffer{}, dir, []string{bad}); err == nil {
+			t.Fatalf("log accepted %q", bad)
+		}
+	}
+}
+
+// `deja view` writes the whole memory as one local HTML file. It is the
+// privacy-sensitive surface people share screenshots of, so what it will and
+// will not do with its arguments is worth pinning.
+func TestViewWritesLocalHTML(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	out := filepath.Join(t.TempDir(), "memory.html")
+	if err := runView(dir, []string{"--out", out, "--no-open"}); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("view wrote no file: %v", err)
+	}
+	body := string(b)
+	if !strings.Contains(strings.ToLower(body), "<html") {
+		t.Fatalf("output is not a page:\n%.200s", body)
+	}
+	// Everything has to be inline: a page that fetches from the network is
+	// no longer "nothing leaves your machine".
+	for _, forbidden := range []string{"http://", "https://cdn", "<script src="} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("page reaches outside for %q", forbidden)
+		}
+	}
+	if err := runView(dir, []string{"--out"}); err == nil {
+		t.Fatal("--out without a path was accepted")
+	}
+	if err := runView(dir, []string{"--nope"}); err == nil {
+		t.Fatal("an unknown flag was accepted")
+	}
+}

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -67,7 +67,7 @@ func runStats(dir string, args []string) error {
 			card = true
 			cardPath = "deja-stats.svg"
 			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-				cardPath = args[i+1]
+				cardPath = cardFileName(args[i+1])
 				i++
 			}
 		case "--harness", "--project", "--since", "--role":
@@ -311,4 +311,15 @@ func statHarnessTag(h string, color bool) string {
 		return "\x1b[94m" + tag + statReset + statBold
 	}
 	return tag
+}
+
+// cardFileName keeps the card's name honest. The card is an SVG document, and
+// writing it into card.png produced a file GitHub serves as a PNG and every
+// browser refuses — while the command cheerfully printed the markdown to embed
+// it. A name that already says svg is left alone.
+func cardFileName(path string) string {
+	if strings.EqualFold(filepath.Ext(path), ".svg") {
+		return path
+	}
+	return path + ".svg"
 }

--- a/cmd/deja/stats_test.go
+++ b/cmd/deja/stats_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+)
+
+// The card is an SVG document. Writing it into card.png produced a file
+// GitHub serves as a PNG and browsers refuse, while the command printed the
+// markdown to embed it — a broken image for anyone who followed the hint.
+
+func TestCardFileNameKeepsTheFormatHonest(t *testing.T) {
+	for in, want := range map[string]string{
+		"deja-stats.svg": "deja-stats.svg",
+		"CARD.SVG":       "CARD.SVG",
+		"card.png":       "card.png.svg",
+		"card.txt":       "card.txt.svg",
+		"card":           "card.svg",
+		"dir/card":       "dir/card.svg",
+	} {
+		if got := cardFileName(in); got != want {
+			t.Fatalf("cardFileName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/deja-stats.svg
+++ b/deja-stats.svg
@@ -1,0 +1,428 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="420" viewBox="0 0 800 420">
+<defs>
+<linearGradient id="dg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#7c6cf0"/><stop offset="1" stop-color="#4ecdc4"/></linearGradient>
+<pattern id="scan" width="4" height="3" patternUnits="userSpaceOnUse"><rect width="4" height="1" y="2" fill="#000000" fill-opacity="0.16"/></pattern>
+</defs>
+<rect width="800" height="420" fill="#050807"/>
+<rect x="0.5" y="0.5" width="799" height="419" fill="none" stroke="#12291c"/>
+<g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" fill="#d7f5e2">
+<g transform="translate(36,26) scale(0.185)"><path d="M64 16 A48 48 0 1 0 112 64" fill="none" stroke="url(#dg)" stroke-width="14" stroke-linecap="round"/><path d="M112 64 l-20 -14 M112 64 l-24 6" fill="none" stroke="url(#dg)" stroke-width="14" stroke-linecap="round"/><circle cx="64" cy="64" r="8" fill="url(#dg)"/></g>
+<text x="70" y="48" font-size="15" font-weight="700" fill="#4af08b" letter-spacing="0.5">deja-vu</text>
+<text x="145" y="48" font-size="13" font-weight="400" fill="#5d8a6e">· agent history</text>
+<text x="760" y="48" font-size="13" font-weight="400" fill="#5d8a6e" text-anchor="end">2026-04-18 – 2026-07-28</text>
+<text x="40" y="90" font-size="22" font-weight="800" fill="#eafff2">deja handed your agents memory 155 times this week.</text>
+<text x="44" y="122" font-size="10" font-weight="400" fill="#5d8a6e">Jul</text>
+<text x="70" y="122" font-size="10" font-weight="400" fill="#5d8a6e">Aug</text>
+<text x="135" y="122" font-size="10" font-weight="400" fill="#5d8a6e">Sep</text>
+<text x="187" y="122" font-size="10" font-weight="400" fill="#5d8a6e">Oct</text>
+<text x="239" y="122" font-size="10" font-weight="400" fill="#5d8a6e">Nov</text>
+<text x="304" y="122" font-size="10" font-weight="400" fill="#5d8a6e">Dec</text>
+<text x="356" y="122" font-size="10" font-weight="400" fill="#5d8a6e">Jan</text>
+<text x="408" y="122" font-size="10" font-weight="400" fill="#5d8a6e">Feb</text>
+<text x="460" y="122" font-size="10" font-weight="400" fill="#5d8a6e">Mar</text>
+<text x="525" y="122" font-size="10" font-weight="400" fill="#5d8a6e">Apr</text>
+<text x="577" y="122" font-size="10" font-weight="400" fill="#5d8a6e">May</text>
+<text x="642" y="122" font-size="10" font-weight="400" fill="#5d8a6e">Jun</text>
+<text x="694" y="122" font-size="10" font-weight="400" fill="#5d8a6e">Jul</text>
+<rect x="44" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="44" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="44" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="44" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="44" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="44" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="44" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="57" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="57" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="57" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="57" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="57" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="57" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="57" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="70" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="70" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="70" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="70" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="70" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="70" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="70" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="83" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="83" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="83" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="83" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="83" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="83" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="83" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="96" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="96" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="96" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="96" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="96" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="96" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="96" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="109" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="109" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="109" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="109" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="109" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="109" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="109" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="122" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="122" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="122" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="122" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="122" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="122" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="122" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="135" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="135" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="135" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="135" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="135" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="135" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="135" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="148" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="148" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="148" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="148" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="148" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="148" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="148" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="161" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="161" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="161" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="161" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="161" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="161" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="161" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="174" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="174" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="174" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="174" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="174" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="174" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="174" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="187" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="187" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="187" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="187" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="187" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="187" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="187" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="200" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="200" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="200" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="200" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="200" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="200" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="200" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="213" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="213" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="213" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="213" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="213" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="213" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="213" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="226" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="226" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="226" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="226" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="226" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="226" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="226" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="239" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="239" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="239" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="239" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="239" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="239" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="239" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="252" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="252" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="252" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="252" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="252" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="252" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="252" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="265" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="265" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="265" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="265" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="265" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="265" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="265" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="278" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="278" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="278" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="278" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="278" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="278" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="278" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="291" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="291" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="291" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="291" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="291" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="291" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="291" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="304" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="304" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="304" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="304" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="304" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="304" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="304" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="317" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="317" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="317" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="317" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="317" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="317" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="317" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="330" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="330" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="330" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="330" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="330" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="330" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="330" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="343" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="343" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="343" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="343" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="343" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="343" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="343" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="356" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="356" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="356" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="356" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="356" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="356" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="356" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="369" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="369" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="369" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="369" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="369" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="369" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="369" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="382" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="382" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="382" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="382" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="382" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="382" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="382" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="395" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="395" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="395" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="395" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="395" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="395" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="395" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="408" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="408" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="408" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="408" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="408" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="408" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="408" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="421" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="421" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="421" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="421" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="421" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="421" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="421" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="434" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="434" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="434" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="434" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="434" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="434" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="434" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="447" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="447" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="447" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="447" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="447" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="447" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="447" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="460" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="460" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="460" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="460" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="460" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="460" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="460" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="473" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="473" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="473" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="473" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="473" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="473" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="473" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="486" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="486" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="486" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="486" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="486" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="486" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="486" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="499" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="499" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="499" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="499" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="499" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="499" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="499" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="512" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="512" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="512" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="512" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="512" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="512" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="512" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="525" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="525" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="525" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="525" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="525" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="525" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="525" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="538" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="538" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="538" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="538" y="167" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="538" y="180" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="538" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="538" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="551" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="551" y="141" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="551" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="551" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="551" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="551" y="193" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="551" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="564" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="564" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="564" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="564" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="564" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="564" y="193" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="564" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="577" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="577" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="577" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="577" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="577" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="577" y="193" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="577" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="590" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="590" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="590" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="590" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="590" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="590" y="193" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="590" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="603" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="603" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="603" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="603" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="603" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="603" y="193" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="603" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="616" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="616" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="616" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="616" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="616" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="616" y="193" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="616" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="629" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="629" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="629" y="154" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="629" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="629" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="629" y="193" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="629" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="642" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="642" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="642" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="642" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="642" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="642" y="193" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="642" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="655" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="655" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="655" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="655" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="655" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="655" y="193" width="11" height="11" rx="2" fill="#4af08b" opacity="0.72"/>
+<rect x="655" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="668" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="668" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="668" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="668" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="668" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="668" y="193" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="668" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="681" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="681" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="681" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="681" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="681" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="681" y="193" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="681" y="206" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="694" y="128" width="11" height="11" rx="2" fill="#0b1410" opacity="1.00"/>
+<rect x="694" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="694" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="694" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="694" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="694" y="193" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="694" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="707" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="707" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="707" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="707" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="707" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="707" y="193" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="707" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="720" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="720" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="720" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="720" y="167" width="11" height="11" rx="2" fill="#4af08b" opacity="0.28"/>
+<rect x="720" y="180" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="720" y="193" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="720" y="206" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="733" y="128" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<rect x="733" y="141" width="11" height="11" rx="2" fill="#4af08b" opacity="1.00"/>
+<rect x="733" y="154" width="11" height="11" rx="2" fill="#4af08b" opacity="0.50"/>
+<text x="44" y="300" font-size="30" font-weight="800" fill="#4af08b">1,127</text>
+<text x="44" y="320" font-size="12" font-weight="400" fill="#5d8a6e">sessions</text>
+<text x="196" y="300" font-size="30" font-weight="700" fill="#d7f5e2">65,727</text>
+<text x="196" y="320" font-size="12" font-weight="400" fill="#5d8a6e">messages</text>
+<text x="348" y="300" font-size="30" font-weight="700" fill="#d7f5e2">14</text>
+<text x="348" y="320" font-size="12" font-weight="400" fill="#5d8a6e">agents</text>
+<text x="470" y="276" font-size="11" font-weight="700" fill="#5d8a6e" letter-spacing="1.5">TOP AGENTS</text>
+<text x="470" y="299" font-size="10" font-weight="400" fill="#a9cbb6">opencode</text>
+<rect x="570" y="291" width="90" height="8" rx="4" fill="#4af08b"/>
+<text x="672" y="299" font-size="10" font-weight="700" fill="#a9cbb6">977</text>
+<text x="470" y="312" font-size="10" font-weight="400" fill="#a9cbb6">claude</text>
+<rect x="570" y="304" width="3" height="8" rx="4" fill="#4af08b"/>
+<text x="672" y="312" font-size="10" font-weight="700" fill="#a9cbb6">40</text>
+<text x="470" y="325" font-size="10" font-weight="400" fill="#a9cbb6">codex</text>
+<rect x="570" y="317" width="2" height="8" rx="4" fill="#4af08b"/>
+<text x="672" y="325" font-size="10" font-weight="700" fill="#a9cbb6">24</text>
+<text x="470" y="338" font-size="10" font-weight="400" fill="#a9cbb6">cline</text>
+<rect x="570" y="330" width="1" height="8" rx="4" fill="#4af08b"/>
+<text x="672" y="338" font-size="10" font-weight="700" fill="#a9cbb6">15</text>
+<text x="470" y="351" font-size="10" font-weight="400" fill="#a9cbb6">other</text>
+<rect x="570" y="343" width="6" height="8" rx="4" fill="#4af08b"/>
+<text x="672" y="351" font-size="10" font-weight="700" fill="#a9cbb6">71</text>
+<text x="40" y="402" font-size="11" font-weight="400" fill="#5d8a6e">$ deja stats --card · vdev</text>
+<text x="760" y="402" font-size="12" font-weight="700" fill="#4af08b" text-anchor="end">vshulcz.github.io/deja-vu</text>
+</g>
+<rect width="800" height="420" fill="url(#scan)"/>
+</svg>


### PR DESCRIPTION
Closes #469.

`deja stats --card card.png` wrote an SVG document into `card.png` and then printed `![deja](card.png)` to paste into a README — where GitHub serves it as a PNG and every browser refuses it. The same for `.txt`, which is what people type when they are not thinking about formats. The default is `deja-stats.svg`, so the intent was never in doubt; the command just never looked at what it was handed.

A name that already ends in `.svg` is left alone, whatever its case.

Also covers `deja log` and `deja view`, which had none. Both matter beyond the percentage: log is the audit trail people check when they want to know what was injected and under which policy, and view writes the whole memory into one local HTML file — the test pins that the page reaches nowhere outside itself, since "nothing leaves your machine" is the claim it has to keep.

While I was there I checked what the shareable card actually contains: harness names and counts, no project names and no paths. Nothing to redact.