### PR TITLE
Serve a read-only index instead of refusing

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1,9 +1,11 @@
 package index
 
 import (
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -131,6 +133,13 @@ func EnsureForSearch(dir string, o query.Options, force bool, progress io.Writer
 	}
 	unlock, err := lockDir(dir)
 	if err != nil {
+		// A read-only index — a container mount, a locked-down machine — can
+		// still answer every question asked of it. Failing here made deja
+		// unusable on those, while the hook path in the same situation simply
+		// stays quiet. Serve what is on disk and skip the freshness check.
+		if errors.Is(err, fs.ErrPermission) && HasManifest(dir) {
+			return nil
+		}
 		return err
 	}
 	defer unlock()

--- a/internal/index/lock_unix.go
+++ b/internal/index/lock_unix.go
@@ -3,7 +3,9 @@
 package index
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -42,10 +44,21 @@ func tryLockDir(dir string) (func(), bool, error) {
 	lockPath := dir + ".lock"
 	_ = os.Chmod(dir, 0o700)
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
+		// A read-only index is not an error for a reader: a container mount
+		// or a locked-down machine can still answer every question asked of
+		// it. Treat it the way a lock already held is treated — carry on
+		// without one. The directory swap is atomic, so the snapshot read
+		// stays safe.
+		if errors.Is(err, fs.ErrPermission) {
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {

--- a/internal/index/lock_windows.go
+++ b/internal/index/lock_windows.go
@@ -3,7 +3,9 @@
 package index
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -75,10 +77,21 @@ func tryLockDir(dir string) (func(), bool, error) {
 	lockPath := dir + ".lock"
 	_ = os.Chmod(dir, 0o700)
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
+		// A read-only index is not an error for a reader: a container mount
+		// or a locked-down machine can still answer every question asked of
+		// it. Treat it the way a lock already held is treated — carry on
+		// without one. The directory swap is atomic, so the snapshot read
+		// stays safe.
+		if errors.Is(err, fs.ErrPermission) {
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 	h := syscall.Handle(f.Fd())

--- a/internal/index/readonly_test.go
+++ b/internal/index/readonly_test.go
@@ -1,0 +1,87 @@
+package index
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// A container with a read-only mount, or a locked-down work machine, can still
+// answer every question its index already holds. deja used to stop instead:
+// `deja "query"` died on `open …/idx.lock: permission denied` while the index
+// beside it was complete and readable.
+func TestReadOnlyIndexStillAnswers(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits behave differently on windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permission bits this test relies on")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(home, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	writeLines(t, filepath.Join(claude, "project", "s.jsonl"),
+		claudeLine("s1", "2026-02-01T00:01:00Z", "READONLY probe"))
+
+	// Build the index somewhere writable, then take away the ability to
+	// create the lock file beside it.
+	locked := filepath.Join(home, "locked")
+	dir := filepath.Join(locked, "idx")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	// The build left a lock file behind; remove it so the assertion below
+	// is about what the read path does, not what the build did.
+	_ = os.Remove(dir + ".lock")
+	if err := os.Chmod(locked, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	// The freshness check cannot run, and that is not a reason to refuse.
+	if err := EnsureForSearch(dir, query.Options{Query: "readonly", All: true}, false, io.Discard); err != nil {
+		t.Fatalf("EnsureForSearch on a read-only index: %v", err)
+	}
+	got, err := Search(dir, query.Options{Query: "readonly", All: true})
+	if err != nil {
+		t.Fatalf("search on a read-only index: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("read-only index answered with nothing")
+	}
+
+	// The lock file must not have been created, or the fallback is really a
+	// write that happened to succeed.
+	if _, err := os.Stat(dir + ".lock"); err == nil {
+		t.Fatal("a lock file appeared in a read-only directory")
+	}
+}
+
+// The fallback is for permission alone. Every other failure to take the lock
+// still has to surface, or a broken index reads as an empty one.
+func TestLockFailuresOtherThanPermissionStillSurface(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// A path whose parent is a file, not a directory: MkdirAll fails with
+	// something that is not a permission problem.
+	blocker := filepath.Join(home, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, ok, err := tryLockDir(filepath.Join(blocker, "idx"))
+	if err == nil {
+		t.Fatal("a structurally impossible lock path reported no error")
+	}
+	if ok {
+		t.Fatal("reported holding a lock it could not take")
+	}
+}


### PR DESCRIPTION
Closes #471.

On a machine where the index directory's parent cannot be written — a container with a read-only mount, a locked-down laptop — `deja "query"` stopped with `open …/idx.lock: permission denied`, while the index beside it was complete and readable. The only thing that had failed was taking a lock for a freshness check that would have found nothing changed.

Everywhere else deja treats memory as optional and never breaks the caller; the session-start hook in that same state simply stays quiet. Reads now do the same: a permission error taking the lock is treated exactly like a lock someone else already holds — carry on without one. The directory swap is atomic, so the snapshot read stays safe, and this is the fallback the non-blocking path was already built around.

Every other failure to take the lock still surfaces, with a test for that: a broken index must not read as an empty one.

Verified on the real thing — search answers, doctor reports the index, and no lock file appears in the read-only directory.