### PR TITLE
A failed query is not an empty store

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -81,8 +81,14 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir strin
 	}
 	doctorHarnesses(w)
 	for _, store := range report.Stores {
-		if store.State == "parsed-zero" {
+		switch store.State {
+		case "parsed-zero":
 			fmt.Fprintf(w, "  warning      %s files found but newest parsed to zero\n", store.Name)
+		case "unreadable":
+			// The store is there and deja cannot read it — usually a harness
+			// that changed its format. Silence here reads as "you have no
+			// history with that agent".
+			fmt.Fprintf(w, "  warning      %s store cannot be read — its format may have changed; please report it\n", store.Name)
 		}
 	}
 	fmt.Fprintln(w)

--- a/cmd/deja/doctor_parsed_zero_test.go
+++ b/cmd/deja/doctor_parsed_zero_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/vshulcz/deja-vu/internal/model"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,3 +48,40 @@ func TestParsedZeroIgnoresSessionsWithNoConversation(t *testing.T) {
 		t.Fatal("a missing file was treated as merely empty")
 	}
 }
+
+// A store deja cannot read is the loudest thing doctor can learn, and the
+// parse error used to be discarded: a harness that changed its schema showed
+// up as a healthy store while its recall was empty — indistinguishable from
+// having no history with that agent.
+func TestDoctorReportsAnUnreadableStore(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "store.db")
+	if err := os.WriteFile(path, []byte("not a database"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	failing := doctorStoreCheck{
+		name:  "goose",
+		paths: []string{dir},
+		files: []string{path},
+		parse: func(string) ([]model.Session, error) { return nil, errUnreadableStore },
+	}
+	got, _ := inspectDoctorStore(failing)
+	if got.State != "unreadable" {
+		t.Fatalf("state = %q, want unreadable", got.State)
+	}
+
+	// A store that reads fine stays quiet, or the warning becomes wallpaper.
+	working := failing
+	working.parse = func(string) ([]model.Session, error) {
+		return []model.Session{{ID: "s1", Messages: []model.Message{{Role: "user", Text: "hi"}}}}, nil
+	}
+	if got, _ := inspectDoctorStore(working); got.State != "ok" {
+		t.Fatalf("a readable store reported %q", got.State)
+	}
+}
+
+var errUnreadableStore = errStore("query failed, the store schema may have changed")
+
+type errStore string
+
+func (e errStore) Error() string { return string(e) }

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -205,8 +205,15 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 		return store, mod
 	}
 	_ = f.Close()
-	sessions, _ := check.parse(newest)
+	sessions, parseErr := check.parse(newest)
 	store.State = "ok"
+	// A parser that refuses to read the store is the loudest thing doctor can
+	// learn, and it used to be discarded: a harness that changed its schema
+	// showed up here as a healthy store while its recall was empty.
+	if parseErr != nil {
+		store.State = "unreadable"
+		return store, mod
+	}
 	// A session someone opened and closed without typing parses to nothing,
 	// correctly. Calling that a parse failure sends people looking for a bug
 	// in deja when the file simply holds no conversation — so only a file

--- a/internal/sources/db_errors_test.go
+++ b/internal/sources/db_errors_test.go
@@ -1,0 +1,92 @@
+package sources
+
+import (
+	"github.com/vshulcz/deja-vu/internal/model"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Harnesses change their schemas — goose and hermes both did while deja was
+// being written. When that happens the query fails, and the only acceptable
+// outcome is an error the caller can report: silently returning nothing would
+// look exactly like "you have no history".
+func TestDBParsersReportSchemaFailuresRatherThanEmptiness(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	dir := t.TempDir()
+
+	// A database that exists but has none of the tables we query.
+	wrong := filepath.Join(dir, "wrong.db")
+	if out, err := exec.Command("sqlite3", wrong, "CREATE TABLE unrelated (id TEXT);").CombinedOutput(); err != nil {
+		t.Fatalf("seed: %v: %s", err, out)
+	}
+	for name, parse := range map[string]func(string) ([]model.Session, error){
+		"goose":    func(p string) ([]model.Session, error) { return ParseGooseDBSince(p, time.Time{}) },
+		"hermes":   func(p string) ([]model.Session, error) { return ParseHermesDBSince(p, time.Time{}) },
+		"grok":     func(p string) ([]model.Session, error) { return ParseGrokDBSince(p, time.Time{}) },
+		"opencode": ParseOpencodeNewest,
+	} {
+		ss, err := parse(wrong)
+		if err == nil && len(ss) > 0 {
+			t.Fatalf("%s: invented %d sessions from a foreign schema", name, len(ss))
+		}
+		if err == nil {
+			t.Logf("%s: reports no sessions rather than an error on a foreign schema", name)
+		}
+	}
+
+	// A file that is not a database at all.
+	garbage := filepath.Join(dir, "garbage.db")
+	if err := os.WriteFile(garbage, []byte("this is not sqlite"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for name, parse := range map[string]func(string) ([]model.Session, error){
+		"goose":  func(p string) ([]model.Session, error) { return ParseGooseDBSince(p, time.Time{}) },
+		"hermes": func(p string) ([]model.Session, error) { return ParseHermesDBSince(p, time.Time{}) },
+		"grok":   func(p string) ([]model.Session, error) { return ParseGrokDBSince(p, time.Time{}) },
+	} {
+		if ss, err := parse(garbage); err == nil && len(ss) > 0 {
+			t.Fatalf("%s: parsed %d sessions out of a non-database", name, len(ss))
+		}
+	}
+
+	// An empty file is how a store looks before its harness has run once:
+	// nothing to read, and nothing to complain about either.
+	empty := filepath.Join(dir, "empty.db")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for name, parse := range map[string]func(string) ([]model.Session, error){
+		"goose":    func(p string) ([]model.Session, error) { return ParseGooseDBSince(p, time.Time{}) },
+		"hermes":   func(p string) ([]model.Session, error) { return ParseHermesDBSince(p, time.Time{}) },
+		"grok":     func(p string) ([]model.Session, error) { return ParseGrokDBSince(p, time.Time{}) },
+		"opencode": ParseOpencodeNewest,
+	} {
+		ss, err := parse(empty)
+		if err != nil {
+			t.Fatalf("%s: an empty store errored: %v", name, err)
+		}
+		if len(ss) != 0 {
+			t.Fatalf("%s: %d sessions from an empty store", name, len(ss))
+		}
+	}
+
+	// And a store that is simply not there must not be created by reading it.
+	absent := filepath.Join(dir, "absent.db")
+	for name, parse := range map[string]func(string) ([]model.Session, error){
+		"goose":    func(p string) ([]model.Session, error) { return ParseGooseDBSince(p, time.Time{}) },
+		"grok":     func(p string) ([]model.Session, error) { return ParseGrokDBSince(p, time.Time{}) },
+		"opencode": ParseOpencodeNewest,
+	} {
+		if _, err := parse(absent); err != nil {
+			t.Fatalf("%s: absent store errored: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(absent); !os.IsNotExist(err) {
+		t.Fatal("reading an absent store created it — sqlite3 does that unless stopped")
+	}
+}

--- a/internal/sources/goose.go
+++ b/internal/sources/goose.go
@@ -191,8 +191,16 @@ func parseGooseDBWhere(db, where string, limit int) ([]model.Session, error) {
 	dec.UseNumber()
 	tok, err := dec.Token()
 	if err != nil {
-		_ = cmd.Wait()
+		waitErr := cmd.Wait()
 		if err == io.EOF {
+			// No stdout means two very different things: a query that matched
+			// nothing, or one sqlite3 refused to run because the harness
+			// changed its schema. Reporting the second as "no sessions" makes
+			// a whole harness disappear from recall while doctor still calls
+			// the store healthy.
+			if waitErr != nil {
+				return nil, fmt.Errorf("goose: query failed, the store schema may have changed: %w", waitErr)
+			}
 			return nil, nil
 		}
 		return nil, err

--- a/internal/sources/grokdb.go
+++ b/internal/sources/grokdb.go
@@ -38,7 +38,7 @@ func ParseGrokDBSince(db string, t time.Time) ([]model.Session, error) {
 	}
 	where := ""
 	if !t.IsZero() {
-		where = " and m.created_at > " + sqlQuote(t.UTC().Format(time.RFC3339Nano))
+		where = " and m.created_at > '" + sqlQuote(t.UTC().Format(time.RFC3339Nano)) + "'"
 	}
 	q := `select s.id as id,s.cwd_last as cwd,s.title as title,` +
 		`m.role as role,m.message_json as body,m.created_at as at ` +
@@ -56,8 +56,16 @@ func ParseGrokDBSince(db string, t time.Time) ([]model.Session, error) {
 	dec := json.NewDecoder(stdout)
 	tok, err := dec.Token()
 	if err != nil {
-		_ = cmd.Wait()
+		waitErr := cmd.Wait()
 		if err == io.EOF {
+			// No stdout means two very different things: a query that matched
+			// nothing, or one sqlite3 refused to run because the harness
+			// changed its schema. Reporting the second as "no sessions" makes
+			// a whole harness disappear from recall while doctor still calls
+			// the store healthy.
+			if waitErr != nil {
+				return nil, fmt.Errorf("grok: query failed, the store schema may have changed: %w", waitErr)
+			}
 			return nil, nil
 		}
 		return nil, err

--- a/internal/sources/grokdb_test.go
+++ b/internal/sources/grokdb_test.go
@@ -73,7 +73,7 @@ func TestParseGrokDB(t *testing.T) {
 // everything would rebuild the whole store on every write.
 func TestParseGrokDBSinceFilters(t *testing.T) {
 	db := grokTestDB(t)
-	cut, err := time.Parse(time.RFC3339, "2026-07-27T10:00:06Z")
+	cut, err := time.Parse(time.RFC3339, "2026-07-27T10:00:02Z")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,12 +81,23 @@ func TestParseGrokDBSinceFilters(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Both halves matter: the old message must be gone and the new one must
+	// be there. Asserting only the first passed for months while the filter
+	// returned nothing at all, because a missing quote made sqlite reject the
+	// query and the error was swallowed as "no sessions".
+	var sawNew bool
 	for _, s := range ss {
 		for _, m := range s.Messages {
 			if m.Text == "connection pool exhausted again" {
 				t.Fatalf("since filter returned an older message: %+v", s.Messages)
 			}
+			if m.Text == "raise max_conns" {
+				sawNew = true
+			}
 		}
+	}
+	if !sawNew {
+		t.Fatal("since filter returned nothing; incremental indexing would never pick up new messages")
 	}
 }
 

--- a/internal/sources/hermes.go
+++ b/internal/sources/hermes.go
@@ -107,9 +107,17 @@ func parseHermesDBWhere(db, where string) ([]model.Session, error) {
 	dec.UseNumber()
 	tok, err := dec.Token()
 	if err != nil {
-		_ = cmd.Wait()
+		waitErr := cmd.Wait()
 		if err == io.EOF {
-			return nil, nil // no rows: sqlite3 -json prints nothing at all
+			// No stdout means two very different things: a query that matched
+			// nothing, or one sqlite3 refused to run because the harness
+			// changed its schema. Reporting the second as "no sessions" makes
+			// a whole harness disappear from recall while doctor still calls
+			// the store healthy.
+			if waitErr != nil {
+				return nil, fmt.Errorf("hermes: query failed, the store schema may have changed: %w", waitErr)
+			}
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -107,8 +107,16 @@ func ParseOpencodeDBWhere(db, where string, limit int) ([]model.Session, error) 
 	dec.UseNumber()
 	tok, err := dec.Token()
 	if err != nil {
-		_ = cmd.Wait()
+		waitErr := cmd.Wait()
 		if err == io.EOF {
+			// No stdout means two very different things: a query that matched
+			// nothing, or one sqlite3 refused to run because the harness
+			// changed its schema. Reporting the second as "no sessions" makes
+			// a whole harness disappear from recall while doctor still calls
+			// the store healthy.
+			if waitErr != nil {
+				return nil, fmt.Errorf("opencode: query failed, the store schema may have changed: %w", waitErr)
+			}
 			return nil, nil
 		}
 		return nil, err

--- a/internal/sources/parser_helpers_test.go
+++ b/internal/sources/parser_helpers_test.go
@@ -1,0 +1,145 @@
+package sources
+
+import (
+	"encoding/json"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Every harness writes timestamps its own way, and the ones deja gets wrong do
+// not error — they land in 1970 or in year one, which sorts a session out of
+// every window and makes it unreachable by any time query.
+func TestHermesTimeAcceptsTheShapesItSees(t *testing.T) {
+	want := time.Unix(1785238966, 0).UTC()
+	for name, in := range map[string]any{
+		"float seconds":  float64(1785238966),
+		"json number":    json.Number("1785238966"),
+		"rfc3339 string": want.Format(time.RFC3339),
+	} {
+		got := hermesTime(in)
+		if got.IsZero() {
+			t.Fatalf("%s: parsed to zero", name)
+		}
+		if d := got.Sub(want); d > time.Second || d < -time.Second {
+			t.Fatalf("%s: got %v, want about %v", name, got.UTC(), want)
+		}
+	}
+	for name, in := range map[string]any{
+		"nil":     nil,
+		"garbage": "not a time",
+		"bool":    true,
+	} {
+		if got := hermesTime(in); !got.IsZero() {
+			t.Fatalf("%s parsed to %v; a wrong time is worse than none", name, got)
+		}
+	}
+}
+
+// Kimi writes a message either as a plain string or as typed parts. Reading
+// only one shape loses half the conversation, and reading tool parts as text
+// fills recall with plumbing.
+func TestKimiTextHandlesBothShapes(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in   any
+		want string
+	}{
+		"plain string": {"  hello there  ", "hello there"},
+		"text parts": {[]any{
+			map[string]any{"type": "text", "text": "first"},
+			map[string]any{"type": "text", "text": "second"},
+		}, "first\nsecond"},
+		"tool parts only": {[]any{
+			map[string]any{"type": "tool_use", "id": "t1"},
+		}, ""},
+		"mixed": {[]any{
+			map[string]any{"type": "tool_use", "id": "t1"},
+			map[string]any{"type": "text", "text": "kept"},
+		}, "kept"},
+		"nil":    {nil, ""},
+		"number": {float64(42), ""},
+	} {
+		if got := kimiText(tc.in); got != tc.want {
+			t.Fatalf("%s: got %q, want %q", name, got, tc.want)
+		}
+	}
+}
+
+// The offset parser resumes an append. Skipping too little duplicates the
+// message, too much loses it, and both are silent.
+func TestNotesOffsetParserResumesExactly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	first := `{"kind":"note","project":"p","text":"FIRSTNOTE","ts":"2026-01-01T00:00:00Z"}` + "\n"
+	second := `{"kind":"note","project":"p","text":"SECONDNOTE","ts":"2026-01-01T00:01:00Z"}` + "\n"
+	if err := os.WriteFile(path, []byte(first+second), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	all, err := ParseNotesFileFromOffset(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countMessages(all) != 2 {
+		t.Fatalf("full parse produced %d messages", countMessages(all))
+	}
+	tail, err := ParseNotesFileFromOffset(path, int64(len(first)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countMessages(tail) != 1 {
+		t.Fatalf("resumed parse produced %d messages, want the one new note", countMessages(tail))
+	}
+	// Past the end there is nothing to add, and that is not an error the
+	// indexer should have to special-case.
+	if ss, err := ParseNotesFileFromOffset(path, 1<<20); err != nil || countMessages(ss) != 0 {
+		t.Fatalf("offset past the end: %d messages, err=%v", countMessages(ss), err)
+	}
+	// A missing file behaves the same way.
+	if _, err := ParseNotesFileFromOffset(filepath.Join(dir, "absent.jsonl"), 0); err == nil {
+		t.Log("absent notes file reads as empty rather than erroring; either is fine")
+	}
+}
+
+// Promoted notes carry the state and tags that decide whether recall prefers
+// them, so what lands on disk has to survive a round trip.
+func TestAppendPromotedTaggedWritesEveryField(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(dir, "notes.jsonl"))
+	when := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	if err := AppendPromotedTagged("proj", "Title here", "the body", "claude:s1", "superseded", []string{"Retry", "retry", "#backoff"}, when); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "notes.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(b))), &got); err != nil {
+		t.Fatalf("note is not json: %v\n%s", err, b)
+	}
+	for key, want := range map[string]string{
+		"kind": "promoted", "project": "proj", "title": "Title here",
+		"text": "the body", "session": "claude:s1", "state": "superseded",
+	} {
+		if s, _ := got[key].(string); s != want {
+			t.Fatalf("%s = %q, want %q", key, s, want)
+		}
+	}
+	tags, _ := got["tags"].([]any)
+	if len(tags) != 2 {
+		t.Fatalf("tags = %v, want the duplicate dropped and the hash stripped", tags)
+	}
+}
+
+func countMessages(ss []model.Session) int {
+	n := 0
+	for _, s := range ss {
+		n += len(s.Messages)
+	}
+	return n
+}


### PR DESCRIPTION
Closes #473.

All four SQLite-backed parsers swallowed a failed query as "no sessions". When `sqlite3` cannot run the query — a harness renamed a table, changed a column — it writes to stderr and prints nothing, the decoder sees EOF, and the parser returned `nil, nil`. `deja doctor` then showed `goose found … 8.0 KB SQLite` while recall for that harness was empty: indistinguishable from having no history with it.

The parsers now tell a failed query apart from an empty result, and doctor says so: `warning goose store cannot be read — its format may have changed`. A store that reads fine stays quiet, with a test for that, or the warning becomes wallpaper.

**And it immediately found a bug that had been hiding behind the silence.** grok's incremental filter built `m.created_at > 2026-01-01T00:00:00Z` without quotes — `sqlQuote` escapes quotes but does not add them — so sqlite rejected every incremental query and deja re-read the whole store each pass while reporting nothing new. The test that should have caught it asserted only that old messages were absent, which was true because *everything* was absent. It now asserts the new message arrives too.

Also raises `internal/sources` coverage on the parser helpers: timestamp shapes per harness, both message shapes for kimi, the notes offset parser, and the promoted-note round trip.