### PR TITLE
Rename sqlQuote to sqlEscape

### DIFF
--- a/internal/sources/db_errors_test.go
+++ b/internal/sources/db_errors_test.go
@@ -90,3 +90,24 @@ func TestDBParsersReportSchemaFailuresRatherThanEmptiness(t *testing.T) {
 		t.Fatal("reading an absent store created it — sqlite3 does that unless stopped")
 	}
 }
+
+// The escape helper is the one that cost two bugs in a day, both times by
+// being read as "quote". It escapes; the caller quotes.
+func TestSQLEscapeDoublesQuotesWithoutAddingThem(t *testing.T) {
+	for in, want := range map[string]string{
+		"plain":            "plain",
+		"o'brien":          "o''brien",
+		"''":               "''''",
+		"2026-01-01T00:00": "2026-01-01T00:00",
+		"":                 "",
+	} {
+		if got := sqlEscape(in); got != want {
+			t.Fatalf("sqlEscape(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// The point of the name: no quotes are added, so a caller that forgets
+	// them builds a broken query rather than a working one.
+	if got := sqlEscape("value"); got == "'value'" {
+		t.Fatal("sqlEscape now quotes; the call sites double-quote and every query breaks")
+	}
+}

--- a/internal/sources/goose.go
+++ b/internal/sources/goose.go
@@ -161,7 +161,7 @@ func ParseGooseDBSince(db string, t time.Time) ([]model.Session, error) {
 		return parseGooseDBWhere(db, "", 0)
 	}
 	sec := t.Unix()
-	rfc := sqlQuote(t.UTC().Format(time.RFC3339Nano))
+	rfc := sqlEscape(t.UTC().Format(time.RFC3339Nano))
 	where := fmt.Sprintf(" and (m.created_timestamp > %d or s.updated_at > '%s')", sec, rfc)
 	return parseGooseDBWhere(db, where, 0)
 }

--- a/internal/sources/grokdb.go
+++ b/internal/sources/grokdb.go
@@ -38,7 +38,7 @@ func ParseGrokDBSince(db string, t time.Time) ([]model.Session, error) {
 	}
 	where := ""
 	if !t.IsZero() {
-		where = " and m.created_at > '" + sqlQuote(t.UTC().Format(time.RFC3339Nano)) + "'"
+		where = " and m.created_at > '" + sqlEscape(t.UTC().Format(time.RFC3339Nano)) + "'"
 	}
 	q := `select s.id as id,s.cwd_last as cwd,s.title as title,` +
 		`m.role as role,m.message_json as body,m.created_at as at ` +

--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -41,7 +41,7 @@ func LoadOpencode() []model.Session {
 }
 
 func LoadOpencodeMatching(q string) []model.Session {
-	where := fmt.Sprintf(" and lower(p.data) like '%%%s%%'", sqlQuote(strings.ToLower(q)))
+	where := fmt.Sprintf(" and lower(p.data) like '%%%s%%'", sqlEscape(strings.ToLower(q)))
 	ss, _ := ParseOpencodeDBWhere(OpencodeDB(), where, 5000)
 	return ss
 }
@@ -57,7 +57,7 @@ func LoadOpencodeSince(t time.Time) []model.Session {
 }
 
 func LoadOpencodePrefix(p string) []model.Session {
-	where := fmt.Sprintf(" and s.id like '%s%%'", sqlQuote(p))
+	where := fmt.Sprintf(" and s.id like '%s%%'", sqlEscape(p))
 	ss, _ := ParseOpencodeDBWhere(OpencodeDB(), where, 0)
 	return ss
 }
@@ -70,7 +70,7 @@ func ParseOpencodeDBSince(db string, t time.Time) ([]model.Session, error) {
 	if t.IsZero() {
 		return ParseOpencodeDBWhere(db, "", 0)
 	}
-	rfc := sqlQuote(t.UTC().Format(time.RFC3339Nano))
+	rfc := sqlEscape(t.UTC().Format(time.RFC3339Nano))
 	ms := t.UnixMilli()
 	where := fmt.Sprintf(" and (m.time_created > %d or m.time_created > '%s' or json_extract(p.data,'$.time.start') > %d or json_extract(p.data,'$.time.start') > '%s')", ms, rfc, ms, rfc)
 	return ParseOpencodeDBWhere(db, where, 0)
@@ -188,7 +188,12 @@ func OpencodeCounts() (sessions, messages int, err error) {
 	return
 }
 
-func sqlQuote(s string) string { return strings.ReplaceAll(s, "'", "''") }
+// sqlEscape doubles single quotes for embedding in a SQL literal. It does not
+// add the surrounding quotes — the caller does, because half the call sites
+// build a LIKE pattern around the value. It was called sqlQuote, and that name
+// cost two bugs in one day: both times the quotes were left off and sqlite
+// rejected the query, which the parsers then reported as an empty store.
+func sqlEscape(s string) string { return strings.ReplaceAll(s, "'", "''") }
 
 func str(v any) string { s, _ := v.(string); return s }
 func parseNestedTime(m map[string]any, k, sub string) time.Time {
@@ -213,5 +218,5 @@ func ParseOpencodeNewest(db string) ([]model.Session, error) {
 	if id == "" {
 		return nil, nil
 	}
-	return ParseOpencodeDBWhere(db, " and s.id='"+sqlQuote(id)+"'", 0)
+	return ParseOpencodeDBWhere(db, " and s.id='"+sqlEscape(id)+"'", 0)
 }

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -250,7 +250,7 @@ func TestScanJSONLSkipsMalformedLines(t *testing.T) {
 
 func TestSQLQuoteDoublesSingleQuotes(t *testing.T) {
 	in := `x' or 1=1 --`
-	if got := sqlQuote(in); got != `x'' or 1=1 --` {
-		t.Fatalf("sqlQuote(%q) = %q", in, got)
+	if got := sqlEscape(in); got != `x'' or 1=1 --` {
+		t.Fatalf("sqlEscape(%q) = %q", in, got)
 	}
 }


### PR DESCRIPTION
The helper doubles single quotes and does not add the surrounding ones — the caller does, because half the call sites build a LIKE pattern around the value. It was called `sqlQuote`.

That name cost two bugs in one day, both mine, both the same mistake: `s.id=` + escaped value with no quotes in the opencode doctor probe (#459), and `m.created_at > ` + escaped timestamp in grok's incremental filter (#473). Both produced a query sqlite rejected, which the parsers reported as an empty store — so neither failed loudly.

Renaming is the whole change, plus a comment saying which half of the job it does and a test asserting it does not quote. Two occurrences of a mistake in one day is a property of the name, not of the day.