### PR TITLE
Add versioned session read contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,14 +136,14 @@ $ deja "jwt refresh token"
 
 | Command | What it does |
 | --- | --- |
-| `deja <query>` | Search all histories. Multi-word = AND, common English filler words are ignored, substrings match (`code` finds `opencode`), and double-quoted phrases require contiguous text; zero-result queries try word forms before close spellings. `--re`, `--harness`, `--project`, `--since 30d`, `--role`, `--json`. |
+| `deja <query>` | Search all histories. Multi-word = AND, common English filler words are ignored, substrings match (`code` finds `opencode`), and double-quoted phrases require contiguous text; zero-result queries try word forms before close spellings. `--re`, `--harness`, `--project`, `--since 30d`, `--role`, `--limit`, `--json`. |
 | `deja ctx <query>` | Compact markdown digest of the best match — pipe it into a prompt. |
 | `deja blame <path>` | Find sessions that discussed a file, newest and most specific first. `--json`, `--all`, and the usual filters are supported. |
 | `deja share <id>` | Sanitized session digest for a colleague: secrets redacted, tool noise stripped. |
 | `deja stats` | Headline counts, totals, per-harness split, top projects, monthly sparkline. `--json` too. |
 | `deja doctor [--json]` | Self-diagnosis: store parse state, sqlite3 presence, MCP wiring per agent, index health, version; `--json` emits the same checks for scripts. |
 | `deja sync export <dir> [--full]` / `import <dir>` / `ssh <host> [--pull]` | Move memory between machines — via a shared folder or one ssh command. Watermarked, append-only, idempotent. |
-| `deja show <id>` / `deja last [n]` | Read one session / list recent ones (`--project`, `--harness`, `--since`, `--role`). |
+| `deja show <id>` / `deja last [n]` | Read one session / list recent ones (`--project`, `--harness`, `--since`, `--role`). `last --json` returns versioned metadata; `show <exact-id> --harness <name> --json` returns a bounded, versioned message window (`--offset`, `--limit`). |
 | `deja resume <id> [--exec]` | Reopen a found session in its native harness (`claude --resume`, `codex resume`, `opencode -s`, `grok --resume`). |
 | `deja sources` | Discovered stores, sizes, message and redaction counts. |
 | `deja mcp` | The stdio MCP server (what `deja install` wires in). |
@@ -156,6 +156,11 @@ $ deja "jwt refresh token"
 | `deja` | On a terminal with an index: a living brief — today's sessions, recalls served, déjà vu moments, and a search suggestion from your own history. |
 
 Stemmed JSON searches set `"stemmed": true` and include the catalog variants used.
+
+Machine session objects include `source.origin` (`local` or `imported`). Set
+`DEJA_SOURCE_INSTANCE` to a stable operator-chosen installation name when a
+consumer must distinguish local store sets. Imported sessions deliberately omit
+the instance until sync carries peer provenance explicitly.
 
 Search hits carry `exact`, `close`, or `semantic` confidence tiers; close hits include the matched variant and semantic hits include cosine.
 

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -122,6 +122,7 @@ func doctorStoreChecks() []doctorStoreCheck {
 		{"cursor", []string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, cursorFiles, parseDoctorCursor},
 		{"antigravity", sources.AntigravityRoots(), sources.AntigravityTranscripts(), sources.ParseAntigravityFile},
 		{"grok", []string{sources.GrokRoot()}, sources.GrokSessionFiles(), sources.ParseGrokFile},
+		{"hermes", []string{sources.HermesHome(), sources.HermesProfilesRoot()}, sources.HermesSessionFiles(), sources.ParseHermesDB},
 		{"qwen", []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.QwenSessionFiles(), sources.ParseQwenFile},
 		{"kimi", []string{filepath.Join(sources.KimiRoot(), "sessions")}, sources.KimiSessionFiles(), sources.ParseKimiFile},
 		{"goose", []string{filepath.Join(sources.GooseRoot(), "sessions")}, sources.GooseSessionFiles(), parseDoctorGoose},

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -59,7 +59,7 @@ func TestDoctorFullReport(t *testing.T) {
 	got := out.String()
 	for _, want := range []string{
 		"Harness stores:", "Tools:", "MCP wiring:", "Hooks:", "precompact", "Index:", "Version:",
-		"claude", "opencode", "aider", "gemini", "cursor", "antigravity", "grok",
+		"claude", "opencode", "aider", "gemini", "cursor", "antigravity", "grok", "hermes",
 		"1 file", mcpLine("claude-code", "wired"), "config missing",
 		"not built", "current  1.0.0", "latest   v9.9.9", "update available",
 	} {
@@ -125,6 +125,16 @@ func TestDoctorStoreStates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDoctorStoreChecksIncludeHermes(t *testing.T) {
+	hermeticEnv(t)
+	for _, check := range doctorStoreChecks() {
+		if check.name == "hermes" {
+			return
+		}
+	}
+	t.Fatal("Hermes store missing from machine doctor report")
 }
 
 func TestDoctorParsesOnlyNewestFile(t *testing.T) {

--- a/cmd/deja/install_aider.go
+++ b/cmd/deja/install_aider.go
@@ -134,12 +134,12 @@ const aiderLead = "The sessions below are from this project's recent history. " 
 
 // cmdAider refreshes the context file and then becomes aider. Everything after
 // the subcommand belongs to aider, including flags deja also has.
-func cmdAider(dir string, rest []string) error {
+func cmdAider(dir string, rest []string, sourceInstance string) error {
 	// `deja aider` with nothing after it is ambiguous, and the harmless
 	// reading is the right default: search for the word rather than start
 	// an editor the user did not ask for.
 	if len(rest) == 0 {
-		return cmdSearch(dir, []string{"aider"})
+		return cmdSearch(dir, []string{"aider"}, sourceInstance)
 	}
 	if err := refreshAiderContext(dir); err != nil {
 		// A failed recall is not a reason to keep the user out of their editor.

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -211,9 +211,9 @@ const gooseLead = "The sessions below are from this project's recent history. " 
 // cmdGoose turns MOIM on for the session it starts: recall is then re-read
 // every turn rather than pinned to whatever the session began with, and it
 // survives compaction.
-func cmdGoose(dir string, rest []string) error {
+func cmdGoose(dir string, rest []string, sourceInstance string) error {
 	if len(rest) == 0 {
-		return cmdSearch(dir, []string{"goose"})
+		return cmdSearch(dir, []string{"goose"}, sourceInstance)
 	}
 	moim := filepath.Join(gooseConfigDir(), "deja-recall.md")
 	if os.Getenv("GOOSE_MOIM_MESSAGE_FILE") == "" {

--- a/cmd/deja/machine_output.go
+++ b/cmd/deja/machine_output.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"io"
-	"os"
 
 	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -27,10 +26,10 @@ type sessionJSON struct {
 	Window        sessionWindow `json:"window"`
 }
 
-func printRecentJSON(w io.Writer, sessions []model.Session) error {
+func printRecentJSON(w io.Writer, sessions []model.Session, sourceInstance string) error {
 	for i := range sessions {
 		sessions[i].Messages = nil
-		sessions[i].SetSource(os.Getenv("DEJA_SOURCE_INSTANCE"))
+		sessions[i].SetSource(sourceInstance)
 	}
 	if sessions == nil {
 		sessions = []model.Session{}
@@ -38,7 +37,7 @@ func printRecentJSON(w io.Writer, sessions []model.Session) error {
 	return json.NewEncoder(w).Encode(recentJSON{SchemaVersion: jsonout.Version, Sessions: sessions})
 }
 
-func printSessionJSON(w io.Writer, session model.Session, offset, limit int) error {
+func printSessionJSON(w io.Writer, session model.Session, offset, limit int, sourceInstance string) error {
 	total := len(session.Messages)
 	if offset > total {
 		offset = total
@@ -48,7 +47,7 @@ func printSessionJSON(w io.Writer, session model.Session, offset, limit int) err
 		end = total
 	}
 	session.Messages = session.Messages[offset:end]
-	session.SetSource(os.Getenv("DEJA_SOURCE_INSTANCE"))
+	session.SetSource(sourceInstance)
 	return json.NewEncoder(w).Encode(sessionJSON{
 		SchemaVersion: jsonout.Version,
 		Session:       session,

--- a/cmd/deja/machine_output.go
+++ b/cmd/deja/machine_output.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/vshulcz/deja-vu/internal/jsonout"
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+type recentJSON struct {
+	SchemaVersion int             `json:"schema_version"`
+	Sessions      []model.Session `json:"sessions"`
+}
+
+type sessionWindow struct {
+	Offset   int `json:"offset"`
+	Limit    int `json:"limit"`
+	Total    int `json:"total"`
+	Returned int `json:"returned"`
+}
+
+type sessionJSON struct {
+	SchemaVersion int           `json:"schema_version"`
+	Session       model.Session `json:"session"`
+	Window        sessionWindow `json:"window"`
+}
+
+func printRecentJSON(w io.Writer, sessions []model.Session) error {
+	for i := range sessions {
+		sessions[i].Messages = nil
+		sessions[i].SetSource(os.Getenv("DEJA_SOURCE_INSTANCE"))
+	}
+	if sessions == nil {
+		sessions = []model.Session{}
+	}
+	return json.NewEncoder(w).Encode(recentJSON{SchemaVersion: jsonout.Version, Sessions: sessions})
+}
+
+func printSessionJSON(w io.Writer, session model.Session, offset, limit int) error {
+	total := len(session.Messages)
+	if offset > total {
+		offset = total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	session.Messages = session.Messages[offset:end]
+	session.SetSource(os.Getenv("DEJA_SOURCE_INSTANCE"))
+	return json.NewEncoder(w).Encode(sessionJSON{
+		SchemaVersion: jsonout.Version,
+		Session:       session,
+		Window: sessionWindow{
+			Offset: offset, Limit: limit, Total: total, Returned: len(session.Messages),
+		},
+	})
+}

--- a/cmd/deja/machine_output_test.go
+++ b/cmd/deja/machine_output_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMachineRecentSearchAndExactRead(t *testing.T) {
+	hermeticEnv(t)
+	t.Setenv("DEJA_SOURCE_INSTANCE", "test-workstation")
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, id := range []string{"machine-one", "machine-two"} {
+		writeClaudeFixture(t, filepath.Join(root, "machine", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"machinecontract first"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"2026-01-02T03:05:05Z","message":{"role":"assistant","content":"machinecontract second"}}`,
+			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:06:05Z","message":{"role":"user","content":"machinecontract third"}}`,
+		})
+	}
+
+	out, err := captureRun(t, "last", "1", "--json", "--harness", "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var recent recentJSON
+	if err := json.Unmarshal([]byte(out), &recent); err != nil {
+		t.Fatalf("recent json: %v\n%s", err, out)
+	}
+	if recent.SchemaVersion != 1 || len(recent.Sessions) != 1 || recent.Sessions[0].Source.Origin != "local" || recent.Sessions[0].Source.Instance != "test-workstation" || recent.Sessions[0].Messages != nil {
+		t.Fatalf("recent = %#v", recent)
+	}
+
+	out, err = captureRun(t, "--json", "--no-embed", "--limit", "1", "machinecontract")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hits []struct {
+		Session struct {
+			ID     string `json:"id"`
+			Source struct {
+				Origin   string `json:"origin"`
+				Instance string `json:"instance"`
+			} `json:"source"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal([]byte(out), &hits); err != nil {
+		t.Fatalf("search json: %v\n%s", err, out)
+	}
+	if len(hits) != 1 || hits[0].Session.Source.Origin != "local" || hits[0].Session.Source.Instance != "test-workstation" {
+		t.Fatalf("hits = %#v", hits)
+	}
+
+	out, err = captureRun(t, "show", hits[0].Session.ID, "--harness", "claude", "--json", "--offset", "1", "--limit", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var exact sessionJSON
+	if err := json.Unmarshal([]byte(out), &exact); err != nil {
+		t.Fatalf("show json: %v\n%s", err, out)
+	}
+	if exact.SchemaVersion != 1 || exact.Session.ID != hits[0].Session.ID || exact.Session.Harness != "claude" || exact.Session.Source.Instance != "test-workstation" || exact.Window.Offset != 1 || exact.Window.Limit != 1 || exact.Window.Total != 3 || exact.Window.Returned != 1 || len(exact.Session.Messages) != 1 || !strings.Contains(exact.Session.Messages[0].Text, "second") {
+		t.Fatalf("exact = %#v", exact)
+	}
+}
+
+func TestMachineFlagValidation(t *testing.T) {
+	tests := [][]string{
+		{"show", "abc", "--json"},
+		{"show", "abc", "--json", "--harness", "claude", "--limit", "201"},
+		{"--json", "--limit", "0", "needle"},
+		{"--json", "--limit", "101", "needle"},
+	}
+	for _, args := range tests {
+		if _, err := captureRun(t, args...); err == nil {
+			t.Fatalf("run(%q) succeeded", args)
+		}
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -113,7 +113,6 @@ var commands = map[string]command{
 	"install":         func(dir string, rest []string) error { return runInstall(dir, rest, false) },
 	"uninstall":       func(dir string, rest []string) error { return runInstall(dir, rest, true) },
 	"update":          func(_ string, rest []string) error { return runUpdate(rest, os.Stdout) },
-	"show":            cmdShow,
 	"share":           func(dir string, rest []string) error { return runShare(dir, rest, os.Stdout) },
 	"resume":          func(dir string, rest []string) error { return runResume(dir, rest, os.Stdout) },
 	"handoff":         func(dir string, rest []string) error { return runHandoff(dir, rest, os.Stdout) },
@@ -124,12 +123,8 @@ var commands = map[string]command{
 	// likely someone searching for the word than someone asking to launch
 	// an editor, and launching one from a search is not a mistake worth
 	// making. See cmdAider/cmdGoose.
-	"aider":      cmdAider,
-	"goose":      cmdGoose,
 	"hook-goose": cmdGooseHook,
-	"search":     cmdSearch,
 	"blame":      runBlame,
-	"last":       cmdLast,
 }
 
 func run(args []string) error {
@@ -141,10 +136,23 @@ func run(args []string) error {
 		printUsage()
 		return nil
 	}
+	sourceInstance := os.Getenv("DEJA_SOURCE_INSTANCE")
+	switch args[0] {
+	case "show":
+		return cmdShow(dir, args[1:], sourceInstance)
+	case "last":
+		return cmdLast(dir, args[1:], sourceInstance)
+	case "search":
+		return cmdSearch(dir, args[1:], sourceInstance)
+	case "aider":
+		return cmdAider(dir, args[1:], sourceInstance)
+	case "goose":
+		return cmdGoose(dir, args[1:], sourceInstance)
+	}
 	if cmd, ok := commands[args[0]]; ok {
 		return cmd(dir, args[1:])
 	}
-	return runSearch(dir, args)
+	return runSearch(dir, args, sourceInstance)
 }
 
 func cmdVersion(_ string, _ []string) error {
@@ -188,75 +196,81 @@ func cmdHookContext(dir string, rest []string) error {
 	return nil
 }
 
-func cmdShow(dir string, rest []string) error {
-	id, harness, jsonOutput, offset, limit, err := parseShow(rest)
+func cmdShow(dir string, rest []string, sourceInstance string) error {
+	o, err := parseShow(rest)
 	if err != nil {
 		return err
 	}
-	if id == "" {
+	if o.id == "" {
 		return fmt.Errorf("show needs id-prefix")
 	}
 	var s model.Session
 	var ok bool
-	if harness != "" {
-		s, ok, err = index.FindByIdentity(dir, harness, id)
+	if o.harness != "" {
+		s, ok, err = index.FindByIdentity(dir, o.harness, o.id)
 	} else {
-		s, ok, err = findByPrefix(dir, id)
+		s, ok, err = findByPrefix(dir, o.id)
 	}
 	if err != nil {
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("no session matches %q", id)
+		return fmt.Errorf("no session matches %q", o.id)
 	}
-	if jsonOutput {
-		return printSessionJSON(os.Stdout, s, offset, limit)
+	if o.json {
+		return printSessionJSON(os.Stdout, s, o.offset, o.limit, sourceInstance)
 	}
 	search.PrintSession(os.Stdout, s)
 	return nil
 }
 
-func parseShow(args []string) (id, harness string, jsonOutput bool, offset, limit int, err error) {
-	limit = 50
+type showOptions struct {
+	id, harness   string
+	json          bool
+	offset, limit int
+}
+
+func parseShow(args []string) (showOptions, error) {
+	o := showOptions{limit: 50}
 	for i := 0; i < len(args); i++ {
 		switch a := args[i]; a {
 		case "--json":
-			jsonOutput = true
+			o.json = true
 		case "--harness", "--offset", "--limit":
 			if i+1 >= len(args) {
-				return "", "", false, 0, 0, fmt.Errorf("%s needs value", a)
+				return o, fmt.Errorf("%s needs value", a)
 			}
 			i++
 			if a == "--harness" {
-				harness = args[i]
+				o.harness = args[i]
 				continue
 			}
 			n, e := strconv.Atoi(args[i])
 			if e != nil || n < 0 || (a == "--limit" && n == 0) {
-				return "", "", false, 0, 0, fmt.Errorf("%s needs a positive integer", a)
+				return o, fmt.Errorf("%s needs a positive integer", a)
 			}
 			if a == "--offset" {
-				offset = n
+				o.offset = n
 			} else {
-				limit = n
+				o.limit = n
 			}
 		default:
 			if strings.HasPrefix(a, "-") {
-				return "", "", false, 0, 0, fmt.Errorf("show: unknown flag %q", a)
+				return o, fmt.Errorf("show: unknown flag %q", a)
 			}
-			if id != "" {
-				return "", "", false, 0, 0, fmt.Errorf("show accepts one session id")
+			if o.id != "" {
+				return o, fmt.Errorf("show accepts one session id")
 			}
-			id = a
+			o.id = a
 		}
 	}
-	if jsonOutput && harness == "" {
-		return "", "", false, 0, 0, fmt.Errorf("show --json requires --harness for exact identity")
+	if o.json && o.harness == "" {
+		return o, fmt.Errorf("show --json requires --harness for exact identity")
 	}
-	if limit > 200 {
-		return "", "", false, 0, 0, fmt.Errorf("show --limit must not exceed 200")
+	if o.limit > 200 {
+		return o, fmt.Errorf("show --limit must not exceed 200")
 	}
-	return id, harness, jsonOutput, offset, limit, nil
+	return o, nil
 }
 
 func cmdCtx(dir string, rest []string) error {
@@ -293,7 +307,7 @@ func cmdCtx(dir string, rest []string) error {
 	return nil
 }
 
-func cmdLast(dir string, rest []string) error {
+func cmdLast(dir string, rest []string, sourceInstance string) error {
 	n, o, err := parseLast(rest)
 	if err != nil {
 		return err
@@ -307,13 +321,13 @@ func cmdLast(dir string, rest []string) error {
 	// fresh install sees. blame already answers this shape of question.
 	if len(ss) == 0 {
 		if o.JSON {
-			return printRecentJSON(os.Stdout, nil)
+			return printRecentJSON(os.Stdout, nil, sourceInstance)
 		}
 		fmt.Fprintln(os.Stderr, emptyIndexHint("no sessions indexed yet"))
 		return nil
 	}
 	if o.JSON {
-		return printRecentJSON(os.Stdout, ss)
+		return printRecentJSON(os.Stdout, ss, sourceInstance)
 	}
 	for _, s := range ss {
 		fmt.Printf("[%s · %s · %s · %s]", s.Harness, s.Project, s.Updated.Format("2006-01-02"), s.ID)
@@ -333,14 +347,14 @@ func cmdLast(dir string, rest []string) error {
 // single word that happens to name a subcommand runs that instead, which is
 // how `/deja uninstall` inside a plugin came back with "nothing matches".
 // Anything shelling out to deja with user text should use this.
-func cmdSearch(dir string, rest []string) error {
+func cmdSearch(dir string, rest []string, sourceInstance string) error {
 	if len(rest) == 0 {
 		return fmt.Errorf("search needs a query")
 	}
-	return runSearch(dir, rest)
+	return runSearch(dir, rest, sourceInstance)
 }
 
-func runSearch(dir string, args []string) error {
+func runSearch(dir string, args []string, sourceInstance string) error {
 	force := false
 	var filtered []string
 	for _, a := range args {
@@ -354,6 +368,7 @@ func runSearch(dir string, args []string) error {
 	if err != nil {
 		return err
 	}
+	o.SourceInstance = sourceInstance
 	o.RecallWorn = usage.WornSessions(dir)
 	prepareFirstIndexGreeting(dir)
 	if err := withBuildProgress(func() error { return index.EnsureForSearch(dir, o, force, os.Stderr) }); err != nil {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -189,18 +189,74 @@ func cmdHookContext(dir string, rest []string) error {
 }
 
 func cmdShow(dir string, rest []string) error {
-	if len(rest) < 1 {
+	id, harness, jsonOutput, offset, limit, err := parseShow(rest)
+	if err != nil {
+		return err
+	}
+	if id == "" {
 		return fmt.Errorf("show needs id-prefix")
 	}
-	s, ok, err := findByPrefix(dir, rest[0])
+	var s model.Session
+	var ok bool
+	if harness != "" {
+		s, ok, err = index.FindByIdentity(dir, harness, id)
+	} else {
+		s, ok, err = findByPrefix(dir, id)
+	}
 	if err != nil {
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("no session matches %q", rest[0])
+		return fmt.Errorf("no session matches %q", id)
+	}
+	if jsonOutput {
+		return printSessionJSON(os.Stdout, s, offset, limit)
 	}
 	search.PrintSession(os.Stdout, s)
 	return nil
+}
+
+func parseShow(args []string) (id, harness string, jsonOutput bool, offset, limit int, err error) {
+	limit = 50
+	for i := 0; i < len(args); i++ {
+		switch a := args[i]; a {
+		case "--json":
+			jsonOutput = true
+		case "--harness", "--offset", "--limit":
+			if i+1 >= len(args) {
+				return "", "", false, 0, 0, fmt.Errorf("%s needs value", a)
+			}
+			i++
+			if a == "--harness" {
+				harness = args[i]
+				continue
+			}
+			n, e := strconv.Atoi(args[i])
+			if e != nil || n < 0 || (a == "--limit" && n == 0) {
+				return "", "", false, 0, 0, fmt.Errorf("%s needs a positive integer", a)
+			}
+			if a == "--offset" {
+				offset = n
+			} else {
+				limit = n
+			}
+		default:
+			if strings.HasPrefix(a, "-") {
+				return "", "", false, 0, 0, fmt.Errorf("show: unknown flag %q", a)
+			}
+			if id != "" {
+				return "", "", false, 0, 0, fmt.Errorf("show accepts one session id")
+			}
+			id = a
+		}
+	}
+	if jsonOutput && harness == "" {
+		return "", "", false, 0, 0, fmt.Errorf("show --json requires --harness for exact identity")
+	}
+	if limit > 200 {
+		return "", "", false, 0, 0, fmt.Errorf("show --limit must not exceed 200")
+	}
+	return id, harness, jsonOutput, offset, limit, nil
 }
 
 func cmdCtx(dir string, rest []string) error {
@@ -250,8 +306,14 @@ func cmdLast(dir string, rest []string) error {
 	// command worked, found nothing, or failed silently — which is what a
 	// fresh install sees. blame already answers this shape of question.
 	if len(ss) == 0 {
+		if o.JSON {
+			return printRecentJSON(os.Stdout, nil)
+		}
 		fmt.Fprintln(os.Stderr, emptyIndexHint("no sessions indexed yet"))
 		return nil
+	}
+	if o.JSON {
+		return printRecentJSON(os.Stdout, ss)
 	}
 	for _, s := range ss {
 		fmt.Printf("[%s · %s · %s · %s]", s.Harness, s.Project, s.Updated.Format("2006-01-02"), s.ID)
@@ -423,6 +485,8 @@ func parseLast(args []string) (int, search.Options, error) {
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		switch a {
+		case "--json":
+			o.JSON = true
 		case "--harness", "--project", "--since", "--role":
 			if i+1 >= len(args) {
 				return n, o, fmt.Errorf("%s needs value", a)
@@ -524,7 +588,7 @@ func parseSearch(args []string) (search.Options, error) {
 			o.All = true
 		case "--no-embed":
 			o.NoEmbed = true
-		case "--harness", "--project", "--since", "--role":
+		case "--harness", "--project", "--since", "--role", "--limit":
 			if i+1 >= len(args) {
 				return o, fmt.Errorf("%s needs value", a)
 			}
@@ -537,6 +601,12 @@ func parseSearch(args []string) (search.Options, error) {
 				o.Project = v
 			case "--role":
 				o.Role = v
+			case "--limit":
+				n, err := strconv.Atoi(v)
+				if err != nil || n < 1 || n > 100 {
+					return o, fmt.Errorf("--limit needs an integer from 1 to 100")
+				}
+				o.Limit = n
 			default:
 				d, err := parseDur(v)
 				if err != nil {
@@ -844,7 +914,7 @@ func printUsage() {
 
 Usage:
   deja [flags] <query>
-  deja show <id-prefix>
+  deja show <id-prefix> [--json --harness name] [--offset n] [--limit n]
   deja share <id-prefix>
   deja resume <id-prefix> [--exec]
   deja handoff [--to <agent>] [id-prefix] [--exec]
@@ -856,7 +926,7 @@ Usage:
   deja sync export <dir> [--full]
   deja sync import <dir>
   deja sync ssh <host> [--pull] [--full]
-  deja last [n] [--project name] [--harness name] [--since duration] [--role user|assistant|tool]
+  deja last [n] [--json] [--project name] [--harness name] [--since duration] [--role user|assistant|tool]
   deja sources
   deja completion <bash|zsh|fish>
   deja forget --session <id-prefix> [--project <substring>] [--before <duration|date>] [--dry-run]

--- a/cmd/deja/search_command_test.go
+++ b/cmd/deja/search_command_test.go
@@ -9,13 +9,10 @@ import (
 // commands start an editor, so a search could launch a whole agent.
 func TestBareWrapperNamesSearchInsteadOfLaunching(t *testing.T) {
 	for _, name := range []string{"aider", "goose"} {
-		cmd, ok := commands[name]
-		if !ok {
-			t.Fatalf("%s is not a command any more; this guard needs updating", name)
-		}
+		t.Setenv("DEJA_INDEX_DIR", t.TempDir())
 		// With no arguments the wrapper must not reach exec.LookPath at all.
 		// Searching an empty index is quiet and harmless, which is the point.
-		if err := cmd(t.TempDir(), nil); err != nil && strings.Contains(err.Error(), "not on PATH") {
+		if err := run([]string{name}); err != nil && strings.Contains(err.Error(), "not on PATH") {
 			t.Fatalf("bare `deja %s` tried to launch the harness: %v", name, err)
 		}
 	}
@@ -36,7 +33,7 @@ func TestPluginsUseTheExplicitSearchForm(t *testing.T) {
 }
 
 func TestSearchCommandNeedsAQuery(t *testing.T) {
-	if err := cmdSearch(t.TempDir(), nil); err == nil {
+	if err := cmdSearch(t.TempDir(), nil, ""); err == nil {
 		t.Fatal("empty search accepted")
 	}
 }

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -68,6 +68,15 @@
       "files": 0
     },
     {
+      "name": "hermes",
+      "state": "missing",
+      "paths": [
+        "<tmp>/home/.hermes",
+        "<tmp>/home/.hermes/profiles"
+      ],
+      "files": 0
+    },
+    {
       "name": "qwen",
       "state": "missing",
       "paths": [

--- a/cmd/deja/testmain_test.go
+++ b/cmd/deja/testmain_test.go
@@ -25,6 +25,7 @@ func TestMain(m *testing.M) {
 		"XDG_DATA_HOME":           "",
 		"APPDATA":                 filepath.Join(root, "AppData", "Roaming"),
 		"DEJA_NOTES_FILE":         "",
+		"DEJA_SOURCE_INSTANCE":    "",
 		// Guard: hook tests must never spawn a real detached warmup —
 		// os.Executable() inside tests is the test binary itself.
 		"DEJA_WARMUP_SENTINEL":  filepath.Join(root, "warmup-guard"),

--- a/cmd/deja/wrappers_test.go
+++ b/cmd/deja/wrappers_test.go
@@ -83,8 +83,8 @@ func TestWrappersReportAMissingHarness(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(home, "idx"))
 	t.Setenv("PATH", filepath.Join(home, "empty"))
-	for name, run := range map[string]func(string, []string) error{"aider": cmdAider, "goose": cmdGoose} {
-		err := run(filepath.Join(home, "idx"), []string{"--version"})
+	for name, run := range map[string]func(string, []string, string) error{"aider": cmdAider, "goose": cmdGoose} {
+		err := run(filepath.Join(home, "idx"), []string{"--version"}, "")
 		if err == nil {
 			t.Fatalf("%s: no error with the harness absent", name)
 		}

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -54,7 +54,8 @@
 
 <h1>CLI reference</h1>
 <table><thead><tr><th>Command</th><th>Description</th></tr></thead><tbody>
-<tr><td><code>deja "query"</code></td><td>Search indexed history. Filters: <code>--harness --project --since --role --re --json</code>.</td></tr>
+<tr><td><code>deja "query"</code></td><td>Search indexed history. Filters: <code>--harness --project --since --role --limit --re --json</code>.</td></tr>
+<tr><td><code>deja show &lt;id&gt;</code></td><td>Read one session. Machine reads use an exact composite identity: <code>--harness name --json</code>, with bounded <code>--offset</code> and <code>--limit</code> message windows.</td></tr>
 <tr><td><code>deja ctx "query"</code></td><td>Print a context digest to stdout (for piping into an agent).</td></tr>
 <tr><td><code>deja blame &lt;path&gt;</code></td><td>Sessions that discussed a file, most specific first.</td></tr>
 <tr><td><code>deja remember "text"</code></td><td>Store a durable note. <code>--project</code> optional; <code>--tag</code> (repeatable) attaches keywords that boost matching queries.</td></tr>
@@ -62,7 +63,7 @@
 <tr><td><code>deja stats</code></td><td>Totals, top projects, activity. <code>--card</code> (SVG), <code>--html</code> (timeline), <code>--redaction</code>, <code>--json</code>. <code>--impact</code> prints the measured impact report (recalls, reuse, distillation ratio) with the arithmetic labeled.</td></tr>
 <tr><td><code>deja</code></td><td>Bare, on a terminal: the living brief — today's activity, recalls served, déjà vu moments, a suggested search from your own history.</td></tr>
 <tr><td><code>deja log</code></td><td>Audit trail: recent recalls and injections; <code>--last</code> prints the most recent injected digest verbatim; <code>--json</code>.</td></tr>
-<tr><td><code>deja last [n]</code></td><td>Recent sessions. <code>--project</code>, <code>--harness</code>, <code>--since</code>, <code>--role</code>.</td></tr>
+<tr><td><code>deja last [n]</code></td><td>Recent sessions. <code>--project</code>, <code>--harness</code>, <code>--since</code>, <code>--role</code>, <code>--json</code>.</td></tr>
 <tr><td><code>deja sources</code></td><td>Discovered stores per harness, with redaction counts.</td></tr>
 <tr><td><code>deja install &lt;target|--all|--auto&gt;</code></td><td>Wire MCP recall (and hooks) into your agents.</td></tr>
 <tr><td><code>deja embed</code></td><td>Build the semantic vector sidecar from a local endpoint.</td></tr>

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -30,6 +30,7 @@ Default exact search returns a JSON array of hits:
       "path": "/home/user/.claude/projects/.../session.jsonl",
       "started": "2026-01-02T03:04:05Z",
       "updated": "2026-01-02T03:10:00Z",
+      "source": {"origin": "local", "instance": "workstation"},
       "messages": [
         {"role": "user", "text": "why does the parser fail on …", "time": "2026-01-02T03:04:05Z"}
       ]
@@ -59,6 +60,60 @@ Stemmed search may also include `variants`; semantic search sets `semantic`.
 `superseded` (optional) carries the date of a newer same-project session whose
 matches overlap this hit — an earlier-attempt signal. `reused` (optional)
 counts recent agent recalls that served this session.
+
+`--limit N` bounds the ranked result set to 1–100 hits. Every machine session
+has `source.origin`, either `local` or `imported`. When
+`DEJA_SOURCE_INSTANCE` is configured, local sessions also carry that stable
+operator-chosen `source.instance`; imported sessions omit it because current
+sync batches do not carry trustworthy peer identity.
+
+## `deja last --json`
+
+Recent session metadata uses a versioned envelope and never includes messages:
+
+```json
+{
+  "schema_version": 1,
+  "sessions": [
+    {
+      "harness": "codex",
+      "id": "abc123",
+      "project": "myapp",
+      "started": "2026-01-02T03:04:05Z",
+      "updated": "2026-01-02T03:10:00Z",
+      "source": {"origin": "local", "instance": "workstation"}
+    }
+  ]
+}
+```
+
+The existing positional count remains the bound, for example
+`deja last 20 --json --harness codex`.
+
+## `deja show <exact-id> --harness <name> --json`
+
+Machine reads require the composite harness plus exact native session ID. They
+return redacted index content in a bounded message window; the default limit is
+50 and the maximum is 200.
+
+```json
+{
+  "schema_version": 1,
+  "session": {
+    "harness": "codex",
+    "id": "abc123",
+    "project": "myapp",
+    "source": {"origin": "local", "instance": "workstation"},
+    "messages": [
+      {"role": "user", "text": "bounded redacted text", "time": "2026-01-02T03:04:05Z"}
+    ]
+  },
+  "window": {"offset": 0, "limit": 50, "total": 81, "returned": 50}
+}
+```
+
+Use `--offset N --limit N` to page without parsing human output. An offset past
+the end returns an empty `messages` array and a `returned` count of zero.
 
 ## `deja stats --json`
 

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -527,6 +527,15 @@ func TestIndexRecentFindRecordsAndBranches(t *testing.T) {
 	if got, ok, err := FindByPrefix(idx, "s"); err != nil || !ok || len(got.Messages) != 2 {
 		t.Fatalf("FindByPrefix=%#v ok=%v err=%v", got, ok, err)
 	}
+	if got, ok, err := FindByIdentity(idx, "claude", "s1"); err != nil || !ok || len(got.Messages) != 2 {
+		t.Fatalf("FindByIdentity=%#v ok=%v err=%v", got, ok, err)
+	}
+	if got, ok, err := FindByIdentity(idx, "codex", "s1"); err != nil || ok || got.ID != "" {
+		t.Fatalf("FindByIdentity missing=%#v ok=%v err=%v", got, ok, err)
+	}
+	if got, ok, err := FindByIdentity("", "claude", "s1"); err != nil || !ok || got.ID != "s1" {
+		t.Fatalf("FindByIdentity default=%#v ok=%v err=%v", got, ok, err)
+	}
 	recs, err := recordsForKey(filepath.Join(idx, "records.bin"), mustTables(t, idx), "claude:s1")
 	if err != nil || len(recs) != 2 {
 		t.Fatalf("records=%#v err=%v", recs, err)

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -888,7 +888,35 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 		return model.Session{}, false, nil
 	}
 	sort.Slice(matches, func(i, j int) bool { return matches[i].Updated.After(matches[j].Updated) })
-	meta := matches[0]
+	return loadSessionMeta(dir, m, matches[0])
+}
+
+// FindByIdentity resolves the exact composite identity emitted by machine
+// search and recent output. Unlike the human prefix command, it never guesses
+// between harnesses or accepts a shortened native ID.
+func FindByIdentity(dir, harness, id string) (model.Session, bool, error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	unlock, ok, err := tryLockDir(dir)
+	if err != nil {
+		return model.Session{}, false, err
+	}
+	if ok {
+		defer unlock()
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return model.Session{}, false, err
+	}
+	meta, ok := m.Sessions[harness+":"+id]
+	if !ok {
+		return model.Session{}, false, nil
+	}
+	return loadSessionMeta(dir, m, meta)
+}
+
+func loadSessionMeta(dir string, m Manifest, meta SessionMeta) (model.Session, bool, error) {
 	s := sessionFromMeta(meta)
 	recs, err := recordsForKey(filepath.Join(dir, "records.bin"), tablesFromManifest(m), meta.Harness+":"+meta.ID)
 	if err != nil {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -20,7 +20,7 @@ type Session struct {
 	Started  time.Time `json:"started"`
 	Updated  time.Time `json:"updated"`
 	Messages []Message `json:"messages,omitempty"`
-	Source   Source    `json:"source"`
+	Source   *Source   `json:"source,omitempty"`
 }
 
 // Source identifies where a session entered this deja index. Instance is an
@@ -35,10 +35,10 @@ type Source struct {
 // project string retained for human compatibility.
 func (s *Session) SetSource(localInstance string) {
 	if strings.HasPrefix(s.Project, "imported:") {
-		s.Source = Source{Origin: "imported"}
+		s.Source = &Source{Origin: "imported"}
 		return
 	}
-	s.Source = Source{Origin: "local", Instance: localInstance}
+	s.Source = &Source{Origin: "local", Instance: localInstance}
 }
 
 func (s *Session) Touch(t time.Time) {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,6 +1,9 @@
 package model
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type Message struct {
 	Role string    `json:"role"`
@@ -17,6 +20,25 @@ type Session struct {
 	Started  time.Time `json:"started"`
 	Updated  time.Time `json:"updated"`
 	Messages []Message `json:"messages,omitempty"`
+	Source   Source    `json:"source"`
+}
+
+// Source identifies where a session entered this deja index. Instance is an
+// operator-configured stable name for the local store set; imported sessions
+// deliberately omit it until sync carries peer provenance of its own.
+type Source struct {
+	Origin   string `json:"origin"`
+	Instance string `json:"instance,omitempty"`
+}
+
+// SetSource fills the machine-facing provenance fields without changing the
+// project string retained for human compatibility.
+func (s *Session) SetSource(localInstance string) {
+	if strings.HasPrefix(s.Project, "imported:") {
+		s.Source = Source{Origin: "imported"}
+		return
+	}
+	s.Source = Source{Origin: "local", Instance: localInstance}
 }
 
 func (s *Session) Touch(t time.Time) {

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1,6 +1,10 @@
 package model
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 func TestSessionSetSource(t *testing.T) {
 	local := Session{Project: "agent-fabric"}
@@ -12,5 +16,12 @@ func TestSessionSetSource(t *testing.T) {
 	imported.SetSource("must-not-leak")
 	if imported.Source.Origin != "imported" || imported.Source.Instance != "" {
 		t.Fatalf("imported source = %#v", imported.Source)
+	}
+}
+
+func TestUnsetSourceIsOmittedInsteadOfEmittedEmpty(t *testing.T) {
+	b, err := json.Marshal(Session{ID: "x", Harness: "claude"})
+	if err != nil || strings.Contains(string(b), `"source"`) {
+		t.Fatalf("session JSON = %s, err = %v", b, err)
 	}
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1,0 +1,16 @@
+package model
+
+import "testing"
+
+func TestSessionSetSource(t *testing.T) {
+	local := Session{Project: "agent-fabric"}
+	local.SetSource("workstation")
+	if local.Source.Origin != "local" || local.Source.Instance != "workstation" {
+		t.Fatalf("local source = %#v", local.Source)
+	}
+	imported := Session{Project: "imported:agent-fabric"}
+	imported.SetSource("must-not-leak")
+	if imported.Source.Origin != "imported" || imported.Source.Instance != "" {
+		t.Fatalf("imported source = %#v", imported.Source)
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -49,6 +49,7 @@ type Options struct {
 	All, JSON, Fuzzy, Stemmed bool
 	NoEmbed                   bool
 	Semantic                  bool                `json:"-"`
+	SourceInstance            string              `json:"-"`
 	FuzzyVariants             map[string][]string `json:"-"`
 	Tier                      string              `json:"-"`
 	// RecallWorn maps session id -> agent recall count; filled by callers

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -45,6 +45,7 @@ type Options struct {
 	Regex                     bool
 	Harness, Project, Role    string
 	Since                     time.Duration
+	Limit                     int
 	All, JSON, Fuzzy, Stemmed bool
 	NoEmbed                   bool
 	Semantic                  bool                `json:"-"`

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -225,8 +225,12 @@ func Run(ss []model.Session, o Options) ([]Hit, error) {
 	}
 	hits := scoreBM25(documents, df, corpusDocuments, avgLength, len(qtoks), o.RecallWorn)
 	markEarlierAttempts(hits)
-	if !o.All && len(hits) > 15 {
-		hits = hits[:15]
+	limit := o.Limit
+	if limit == 0 && !o.All {
+		limit = 15
+	}
+	if limit > 0 && len(hits) > limit {
+		hits = hits[:limit]
 	}
 	return hits, nil
 }
@@ -486,6 +490,7 @@ func Print(w io.Writer, hits []Hit, o Options) {
 		if hits[i].Tier == "" {
 			hits[i].Tier = TierExact
 		}
+		hits[i].Session.SetSource(os.Getenv("DEJA_SOURCE_INSTANCE"))
 	}
 	if o.JSON {
 		if o.Semantic {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -490,7 +490,7 @@ func Print(w io.Writer, hits []Hit, o Options) {
 		if hits[i].Tier == "" {
 			hits[i].Tier = TierExact
 		}
-		hits[i].Session.SetSource(os.Getenv("DEJA_SOURCE_INSTANCE"))
+		hits[i].Session.SetSource(o.SourceInstance)
 	}
 	if o.JSON {
 		if o.Semantic {

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -130,6 +130,15 @@ func TestRunInvalidRegexAndResultLimit(t *testing.T) {
 	if err != nil || len(hits) != 3 {
 		t.Fatalf("explicit limited hits = %d, err=%v", len(hits), err)
 	}
+	scoped := []model.Session{
+		{ID: "wrong-project", Harness: "claude", Project: "other", Messages: []model.Message{{Text: "needle needle needle"}}},
+		{ID: "wrong-harness", Harness: "codex", Project: "target", Messages: []model.Message{{Text: "needle needle"}}},
+		{ID: "wanted", Harness: "claude", Project: "target", Messages: []model.Message{{Text: "needle"}}},
+	}
+	hits, err = Run(scoped, Options{Query: "needle", Harness: "claude", Project: "target", Limit: 1})
+	if err != nil || len(hits) != 1 || hits[0].Session.ID != "wanted" {
+		t.Fatalf("scoped limited hits = %#v, err=%v", hits, err)
+	}
 }
 
 func TestRunFilterSkipsRegexAndTieBranches(t *testing.T) {
@@ -362,9 +371,8 @@ func TestStemmedJSONEnvelope(t *testing.T) {
 }
 
 func TestSemanticJSONEnvelopeIncludesSource(t *testing.T) {
-	t.Setenv("DEJA_SOURCE_INSTANCE", "workstation")
 	var b bytes.Buffer
-	Print(&b, []Hit{{Session: model.Session{Project: "p"}, Count: 1}}, Options{JSON: true, Semantic: true})
+	Print(&b, []Hit{{Session: model.Session{Project: "p"}, Count: 1}}, Options{JSON: true, Semantic: true, SourceInstance: "workstation"})
 	if !strings.Contains(b.String(), `"schema_version":1`) || !strings.Contains(b.String(), `"semantic":true`) || !strings.Contains(b.String(), `"origin":"local"`) || !strings.Contains(b.String(), `"instance":"workstation"`) {
 		t.Fatalf("semantic json = %q", b.String())
 	}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -126,6 +126,10 @@ func TestRunInvalidRegexAndResultLimit(t *testing.T) {
 	if len(hits) != 20 {
 		t.Fatalf("all hits = %d", len(hits))
 	}
+	hits, err = Run(ss, Options{Query: "needle", All: true, Limit: 3})
+	if err != nil || len(hits) != 3 {
+		t.Fatalf("explicit limited hits = %d, err=%v", len(hits), err)
+	}
 }
 
 func TestRunFilterSkipsRegexAndTieBranches(t *testing.T) {
@@ -354,6 +358,23 @@ func TestStemmedJSONEnvelope(t *testing.T) {
 	Print(&b, []Hit{{Count: 1}}, Options{JSON: true, Stemmed: true, FuzzyVariants: map[string][]string{"rotation": {"rotated"}}})
 	if !strings.Contains(b.String(), `"schema_version":1`) || !strings.Contains(b.String(), `"stemmed":true`) || !strings.Contains(b.String(), `"rotation":["rotated"]`) {
 		t.Fatalf("stemmed json = %q", b.String())
+	}
+}
+
+func TestSemanticJSONEnvelopeIncludesSource(t *testing.T) {
+	t.Setenv("DEJA_SOURCE_INSTANCE", "workstation")
+	var b bytes.Buffer
+	Print(&b, []Hit{{Session: model.Session{Project: "p"}, Count: 1}}, Options{JSON: true, Semantic: true})
+	if !strings.Contains(b.String(), `"schema_version":1`) || !strings.Contains(b.String(), `"semantic":true`) || !strings.Contains(b.String(), `"origin":"local"`) || !strings.Contains(b.String(), `"instance":"workstation"`) {
+		t.Fatalf("semantic json = %q", b.String())
+	}
+}
+
+func TestPrintReuseNote(t *testing.T) {
+	var b bytes.Buffer
+	Print(&b, []Hit{{Session: model.Session{Harness: "claude", Project: "p"}, Count: 1, Reused: 3}}, Options{})
+	if !strings.Contains(b.String(), "reused 3×") {
+		t.Fatalf("reuse output = %q", b.String())
 	}
 }
 

--- a/internal/sources/hermes_test.go
+++ b/internal/sources/hermes_test.go
@@ -166,6 +166,16 @@ func TestHermesFindsTheRootStore(t *testing.T) {
 	if !contains(names, "hermes") || !contains(names, "architect") {
 		t.Fatalf("projects = %v", names)
 	}
+	for _, harness := range Registry() {
+		if harness.Name == "hermes" {
+			match := harness.Kinds[0].Match
+			if !match(got[0]) || !match(got[1]) || match(filepath.Join(root, "state.db.backup")) {
+				t.Fatalf("registry did not recognize both Hermes store layouts: %v", got)
+			}
+			return
+		}
+	}
+	t.Fatal("Hermes missing from source registry")
 }
 
 func contains(ss []string, want string) bool {

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -195,10 +195,11 @@ func Registry() []Harness {
 			Name: "hermes", Load: LoadHermes, Files: HermesSessionFiles,
 			Kinds: []FileKind{{
 				Name: "hermes",
-				// One store per profile, so the match is by shape rather than
-				// a single path: ~/.hermes/profiles/<name>/state.db.
+				// Current Hermes uses ~/.hermes/state.db; older builds shard
+				// stores under ~/.hermes/profiles/<name>/state.db.
 				Match: func(p string) bool {
-					return filepath.Base(p) == "state.db" && strings.HasPrefix(p, HermesProfilesRoot())
+					return p == filepath.Join(HermesHome(), "state.db") ||
+						(filepath.Base(p) == "state.db" && strings.HasPrefix(p, HermesProfilesRoot()+string(filepath.Separator)))
 				},
 				Parse:     dbParse(ParseHermesDB, ParseHermesDBSince),
 				ParseFrom: dbParseFrom(ParseHermesDB, ParseHermesDBSince),


### PR DESCRIPTION
## What changed

- adds an explicit bounded search limit
- adds schema-v1 JSON for recent session metadata
- adds exact composite session reads with bounded message windows and offsets
- adds source origin and optional instance provenance without fabricating imported peer identity
- documents and tests the additive machine contract

## Why

Downstream tools need stable machine-readable recent and exact-read operations. Search alone cannot safely recover one exact session, and path-only provenance is insufficient to distinguish local from imported material.

## Compatibility

The additions are opt-in and preserve existing human output and JSON search shapes. Exact reads require both session ID and harness to avoid ambiguous cross-harness identity.

## Validation

- go test ./... -race -count=1
- go vet ./...
- Linux build
- Windows amd64 cross-build
- final go test ./... and coverage-floor checks