### PR TITLE
Pin scoop/winget manifests to 0.16.0

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.15.6",
+    "version": "0.16.0",
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.15.6/deja-vu_0.15.6_windows_amd64.zip",
-            "hash": "853ad5e8cbecaf6809917c9bf156f4aaddd173ae3908094884fb4b42c01770c4"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.0/deja-vu_0.16.0_windows_amd64.zip",
+            "hash": "09a3a905517196fedd3858896ef4f03b1eead2f74642b3707607fc7e54dd77ff"
         },
         "arm64": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.15.6/deja-vu_0.15.6_windows_arm64.zip",
-            "hash": "25f5818e4c7baa20a6378cb276b8c582fbb9e078f16a1840227d3c6fc1edda43"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.0/deja-vu_0.16.0_windows_arm64.zip",
+            "hash": "95b74a0c8979a7cc26ae6b892b0be37d80238b907705e4d94ef7f172dd9db286"
         }
     },
     "bin": "deja.exe",

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.15.6
+PackageVersion: 0.16.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.15.6/deja-vu_0.15.6_windows_amd64.zip
-  InstallerSha256: 853AD5E8CBECAF6809917C9BF156F4AADDD173AE3908094884FB4B42C01770C4
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.0/deja-vu_0.16.0_windows_amd64.zip
+  InstallerSha256: 09A3A905517196FEDD3858896EF4F03B1EEAD2F74642B3707607FC7E54DD77FF
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.15.6/deja-vu_0.15.6_windows_arm64.zip
-  InstallerSha256: 25F5818E4C7BAA20A6378CB276B8C582FBB9E078F16A1840227D3C6FC1EDDA43
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.0/deja-vu_0.16.0_windows_arm64.zip
+  InstallerSha256: 95B74A0C8979A7CC26AE6B892B0BE37D80238B907705E4D94EF7F172DD9DB286
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.15.6
+PackageVersion: 0.16.0
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.15.6/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.0/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider
@@ -17,6 +17,6 @@ Tags:
 - cursor
 - mcp
 - memory
-ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.15.6
+ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.16.0
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.15.6
+PackageVersion: 0.16.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Hashes taken from the signed `checksums.txt` of the v0.16.0 release and confirmed by downloading both zips. Note these were on 0.15.6, not 0.15.7 — the pin was skipped last release, so scoop and winget users have been two versions behind. Automating that is #479.