### PR TITLE
Ship .mcpb bundles for one-click desktop install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,33 @@ jobs:
             done
           done
 
+  mcpb:
+    name: mcpb bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: '1.25.x'
+          cache: false
+      - name: Pack a bundle
+        run: |
+          mkdir -p dist/deja_linux_amd64
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o dist/deja_linux_amd64/deja ./cmd/deja
+          go run ./scripts/mcpb -version 0.0.0-ci -in dist -out dist/mcpb
+      # The manifest is validated against the published schema rather than our
+      # reading of it: a bundle that fails here would fail on a user's machine
+      # with nothing to explain why.
+      - name: Validate against the official schema
+        run: |
+          npx -y @anthropic-ai/mcpb@latest unpack dist/mcpb/deja-vu_0.0.0-ci_linux_amd64.mcpb dist/unpacked
+          npx -y @anthropic-ai/mcpb@latest validate dist/unpacked/manifest.json
+      - name: Start the server straight out of the bundle
+        run: |
+          printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"ci","version":"1"}}}' \
+            | dist/unpacked/server/deja mcp | tee /tmp/out.json
+          grep -q '"serverInfo"' /tmp/out.json
+
   vuln:
     name: govulncheck
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,16 @@ jobs:
         with:
           subject-checksums: dist/checksums.txt
 
+      # One bundle per platform: the .mcpb manifest has no architecture
+      # selector, so a single universal file would be wrong for half of Linux.
+      - name: Pack MCP bundles
+        run: go run ./scripts/mcpb -version "${GITHUB_REF_NAME#v}" -in dist -out dist/mcpb
+
+      - name: Attach MCP bundles to the release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" dist/mcpb/*.mcpb --clobber
+
   npm:
     name: npm packages
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ fixtures/synthetic/opencode.db
 .opencode/
 .qwen/
 .kimi-code/
+
+# compiled helpers from `go build ./scripts/...`
+/mcpb
+/dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,14 @@ builds:
     ldflags:
       - -s -w -X main.version={{ .Version }}
 
+# macOS gets one bundle instead of two: the .mcpb manifest cannot select an
+# architecture, so the two Mach-O binaries are joined before packing.
+universal_binaries:
+  - id: deja-universal
+    ids: [deja]
+    replace: false
+    name_template: deja
+
 archives:
   - id: default
     builds:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ npx @vshulcz/deja-vu "query"                            # npm, no install
 brew install vshulcz/tap/deja-vu                        # Homebrew
 ```
 
+For desktop apps that install MCP servers as bundles, every release ships an
+`.mcpb` per platform — download it from the
+[latest release](https://github.com/vshulcz/deja-vu/releases/latest) and open it.
+The bundle carries the binary, so there is nothing else to install. Terminal
+agents use `deja install` below instead.
+
 ### Shell completion
 
 ```sh

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -61,6 +61,7 @@
 brew install vshulcz/tap/deja-vu
 npm  install -g @vshulcz/deja-vu
 go   install github.com/vshulcz/deja-vu/cmd/deja@latest</pre>
+<p>Desktop apps that install MCP servers as bundles take the <code>.mcpb</code> file published with every release — one per platform, carrying the binary, so nothing else is needed. Open it and the app installs the server. Terminal agents use <code>deja install</code>, described under <a href="harnesses.html">harnesses</a>.</p>
 <h2>Search your history</h2>
 <p>The first search builds the index automatically from every agent history it finds — retroactively, including sessions from before you installed deja.</p>
 <pre>deja "connection pool exhausted"

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -1,0 +1,64 @@
+{
+  "manifest_version": "0.3",
+  "name": "deja-vu",
+  "display_name": "deja-vu",
+  "version": "0.0.0",
+  "description": "Local searchable memory over your coding-agent session histories, served back over MCP.",
+  "long_description": "deja indexes the session transcripts your coding agents already write to disk — Claude Code, Codex, Cursor, opencode, aider, cline, roo, goose and others — and serves them back over MCP. It starts full rather than empty: history from before you installed it is searchable immediately. Retrieval is lexical, with no LLM, no embedding model and no API key. Secrets are redacted before anything is indexed. Nothing leaves the machine.",
+  "author": {
+    "name": "vshulcz",
+    "url": "https://github.com/vshulcz"
+  },
+  "homepage": "https://vshulcz.github.io/deja-vu/",
+  "documentation": "https://vshulcz.github.io/deja-vu/guide/",
+  "support": "https://github.com/vshulcz/deja-vu/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vshulcz/deja-vu"
+  },
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "search",
+    "session-history",
+    "coding-agents",
+    "local-first",
+    "offline"
+  ],
+  "server": {
+    "type": "binary",
+    "entry_point": "server/deja",
+    "mcp_config": {
+      "command": "${__dirname}/server/deja",
+      "args": [
+        "mcp"
+      ],
+      "env": {}
+    }
+  },
+  "tools": [
+    {
+      "name": "recall",
+      "description": "Search the user's own past coding sessions across every AI tool they have used and return the best matches as dense text."
+    },
+    {
+      "name": "recall_context",
+      "description": "Return a full markdown digest of the single best-matching prior session — problem, decisions, outcome."
+    },
+    {
+      "name": "blame",
+      "description": "Before editing or deleting a file, find the prior sessions that discussed it and why it is shaped the way it is."
+    },
+    {
+      "name": "remember",
+      "description": "Store one durable decision or conclusion so a future session can recall it."
+    }
+  ],
+  "compatibility": {
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ]
+  }
+}

--- a/scripts/mcpb/main.go
+++ b/scripts/mcpb/main.go
@@ -1,0 +1,205 @@
+// Command mcpb packs deja into MCP Bundles — the .mcpb format desktop apps
+// install by double-clicking.
+//
+// The manifest format has no architecture selector: platform_overrides
+// distinguishes darwin, linux and win32 and nothing finer. A single universal
+// bundle would therefore have to guess an architecture and be wrong for half of
+// Linux, so this builds one bundle per platform-architecture pair instead. macOS
+// is the exception: goreleaser joins the two Mach-O binaries into one universal
+// file, so a Mac user still has a single bundle to choose.
+//
+// Usage:
+//
+//	go run ./scripts/mcpb -version 0.16.0 -in dist -out dist
+//
+// -in holds the built binaries laid out the way goreleaser leaves them. Targets
+// are located by the binary inside each directory, not by the directory name,
+// which goreleaser does not treat as a public contract.
+package main
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type target struct {
+	os       string // GOOS, as it appears in goreleaser's directory names
+	arch     string // GOARCH, or "universal" for the joined macOS binary
+	platform string // manifest platform id: darwin, linux or win32
+	suffix   string // artifact name suffix
+	exe      string
+}
+
+var targets = []target{
+	{os: "darwin", arch: "universal", platform: "darwin", suffix: "darwin", exe: "deja"},
+	{os: "linux", arch: "amd64", platform: "linux", suffix: "linux_amd64", exe: "deja"},
+	{os: "linux", arch: "arm64", platform: "linux", suffix: "linux_arm64", exe: "deja"},
+	{os: "windows", arch: "amd64", platform: "win32", suffix: "windows_amd64", exe: "deja.exe"},
+	{os: "windows", arch: "arm64", platform: "win32", suffix: "windows_arm64", exe: "deja.exe"},
+}
+
+func main() {
+	version := flag.String("version", "", "release version, without the leading v")
+	in := flag.String("in", "dist", "directory holding the built binaries")
+	out := flag.String("out", "dist", "directory to write the bundles into")
+	manifestPath := flag.String("manifest", filepath.Join("packaging", "mcpb", "manifest.json"), "manifest template")
+	flag.Parse()
+
+	if *version == "" {
+		fail(fmt.Errorf("-version is required"))
+	}
+	template, err := os.ReadFile(*manifestPath)
+	if err != nil {
+		fail(err)
+	}
+	if err := os.MkdirAll(*out, 0o755); err != nil {
+		fail(err)
+	}
+
+	built := 0
+	for _, t := range targets {
+		binary, err := findBinary(*in, t)
+		if err != nil {
+			// A missing target is not fatal: a local run may have built one
+			// platform. Say so, rather than packing a bundle whose manifest
+			// promises a binary it does not carry.
+			fmt.Fprintf(os.Stderr, "skipping %s: %v\n", t.suffix, err)
+			continue
+		}
+		path := filepath.Join(*out, fmt.Sprintf("deja-vu_%s_%s.mcpb", *version, t.suffix))
+		if err := pack(path, template, binary, t, *version); err != nil {
+			fail(fmt.Errorf("%s: %w", t.suffix, err))
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			fail(err)
+		}
+		fmt.Printf("%s  %d KB\n", filepath.Base(path), info.Size()/1024)
+		built++
+	}
+	if built == 0 {
+		fail(fmt.Errorf("no binaries found under %s — nothing to pack", *in))
+	}
+}
+
+func findBinary(root string, t target) (string, error) {
+	var found []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && d.Name() == t.exe && matches(filepath.Dir(path), t) {
+			found = append(found, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	switch len(found) {
+	case 0:
+		return "", fmt.Errorf("no %s/%s binary under %s", t.os, t.arch, root)
+	case 1:
+		return found[0], nil
+	default:
+		return "", fmt.Errorf("%d candidates for %s/%s: %s", len(found), t.os, t.arch, strings.Join(found, ", "))
+	}
+}
+
+func matches(dir string, t target) bool {
+	name := strings.ToLower(filepath.Base(dir))
+	if !strings.Contains(name, t.os) {
+		return false
+	}
+	if t.arch == "universal" {
+		// goreleaser names the joined build "…_darwin_all".
+		return strings.Contains(name, "universal") || strings.Contains(name, "all")
+	}
+	// "amd64" must not match a directory built for arm64, and vice versa.
+	return strings.Contains(name, t.arch)
+}
+
+// pack writes the bundle: a zip with manifest.json at the root and the binary
+// under server/, which is the layout the format expects.
+func pack(path string, template []byte, binary string, t target, version string) error {
+	manifest, err := render(template, t, version)
+	if err != nil {
+		return err
+	}
+	body, err := os.ReadFile(binary)
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	z := zip.NewWriter(f)
+	if err := add(z, "manifest.json", manifest, 0o644); err != nil {
+		return err
+	}
+	// The executable bit has to survive the zip, or the host installs a server
+	// it cannot start.
+	if err := add(z, "server/"+t.exe, body, 0o755); err != nil {
+		return err
+	}
+	if err := z.Close(); err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func add(z *zip.Writer, name string, body []byte, mode fs.FileMode) error {
+	h := &zip.FileHeader{Name: name, Method: zip.Deflate}
+	h.SetMode(mode)
+	w, err := z.CreateHeader(h)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(body)
+	return err
+}
+
+// render fills the template in for one target. Each bundle carries exactly one
+// binary, so it declares exactly one platform: a manifest listing three while
+// shipping one would install cleanly and then fail to start.
+func render(template []byte, t target, version string) ([]byte, error) {
+	var m map[string]any
+	if err := json.Unmarshal(template, &m); err != nil {
+		return nil, fmt.Errorf("manifest template: %w", err)
+	}
+	server, ok := m["server"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("manifest template has no server object")
+	}
+
+	entry := "server/" + t.exe
+	m["version"] = version
+	server["type"] = "binary"
+	server["entry_point"] = entry
+	server["mcp_config"] = map[string]any{
+		"command": "${__dirname}/" + entry,
+		"args":    []any{"mcp"},
+		"env":     map[string]any{},
+	}
+	m["compatibility"] = map[string]any{"platforms": []any{t.platform}}
+
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(out, '\n'), nil
+}
+
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, "mcpb:", err)
+	os.Exit(1)
+}

--- a/scripts/mcpb/main_test.go
+++ b/scripts/mcpb/main_test.go
@@ -127,7 +127,7 @@ func TestPackKeepsTheBinaryExecutable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer z.Close()
+	defer func() { _ = z.Close() }()
 	seen := map[string]os.FileMode{}
 	for _, f := range z.File {
 		seen[f.Name] = f.Mode()

--- a/scripts/mcpb/main_test.go
+++ b/scripts/mcpb/main_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func templateJSON(t *testing.T) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("..", "..", "packaging", "mcpb", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// A bundle carries one binary. If its manifest claimed every platform, the host
+// would install it happily on Linux and then fail to start a Mach-O binary.
+func TestRenderDeclaresOnlyTheePlatformItShips(t *testing.T) {
+	tmpl := templateJSON(t)
+	for _, tc := range targets {
+		out, err := render(tmpl, tc, "1.2.3")
+		if err != nil {
+			t.Fatalf("%s: %v", tc.suffix, err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(out, &m); err != nil {
+			t.Fatalf("%s: rendered manifest is not json: %v", tc.suffix, err)
+		}
+		if m["version"] != "1.2.3" {
+			t.Fatalf("%s: version = %v", tc.suffix, m["version"])
+		}
+		platforms := m["compatibility"].(map[string]any)["platforms"].([]any)
+		if len(platforms) != 1 || platforms[0] != tc.platform {
+			t.Fatalf("%s: platforms = %v, want exactly [%s]", tc.suffix, platforms, tc.platform)
+		}
+		server := m["server"].(map[string]any)
+		wantEntry := "server/" + tc.exe
+		if server["entry_point"] != wantEntry {
+			t.Fatalf("%s: entry_point = %v, want %s", tc.suffix, server["entry_point"], wantEntry)
+		}
+		cfg := server["mcp_config"].(map[string]any)
+		if cfg["command"] != "${__dirname}/"+wantEntry {
+			t.Fatalf("%s: command = %v", tc.suffix, cfg["command"])
+		}
+		// Windows entries must carry the extension: the format only appends
+		// .exe automatically for some hosts, and a missing binary is silent.
+		if tc.platform == "win32" && filepath.Ext(wantEntry) != ".exe" {
+			t.Fatalf("%s: windows entry point has no .exe", tc.suffix)
+		}
+	}
+}
+
+// The whole reason for per-target bundles is that amd64 and arm64 are not
+// interchangeable. A substring match that confused them would produce a bundle
+// that installs and then crashes on launch.
+func TestMatchesDoesNotConfuseArchitectures(t *testing.T) {
+	amd := target{os: "linux", arch: "amd64"}
+	arm := target{os: "linux", arch: "arm64"}
+	for dir, want := range map[string]bool{
+		"deja_linux_amd64": true,
+		"deja_linux_arm64": false,
+		"deja_darwin_all":  false,
+	} {
+		if got := matches(dir, amd); got != want {
+			t.Fatalf("matches(%q, linux/amd64) = %v, want %v", dir, got, want)
+		}
+	}
+	if !matches("deja_linux_arm64", arm) {
+		t.Fatal("linux/arm64 did not match its own directory")
+	}
+	if matches("deja_windows_amd64", amd) {
+		t.Fatal("a windows directory matched a linux target")
+	}
+
+	universal := target{os: "darwin", arch: "universal"}
+	for dir, want := range map[string]bool{
+		"deja_darwin_all":       true,
+		"deja_darwin_universal": true,
+		"deja_darwin_arm64":     false,
+	} {
+		if got := matches(dir, universal); got != want {
+			t.Fatalf("matches(%q, darwin/universal) = %v, want %v", dir, got, want)
+		}
+	}
+}
+
+// Two candidate binaries mean the layout changed under us. Picking one at
+// random would ship the wrong architecture to everybody who downloads it.
+func TestFindBinaryRefusesToGuess(t *testing.T) {
+	root := t.TempDir()
+	for _, dir := range []string{"deja_linux_amd64", "other_linux_amd64"} {
+		p := filepath.Join(root, dir)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(p, "deja"), []byte("binary"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := findBinary(root, targets[1]); err == nil {
+		t.Fatal("two candidates were resolved silently")
+	}
+	if _, err := findBinary(t.TempDir(), targets[1]); err == nil {
+		t.Fatal("a missing binary was not reported")
+	}
+}
+
+// The executable bit has to survive the zip. Without it the host installs a
+// server it cannot start, and the failure appears as a connection error with
+// nothing pointing at permissions.
+func TestPackKeepsTheBinaryExecutable(t *testing.T) {
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "deja")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "bundle.mcpb")
+	if err := pack(out, templateJSON(t), binary, targets[1], "9.9.9"); err != nil {
+		t.Fatal(err)
+	}
+
+	z, err := zip.OpenReader(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer z.Close()
+	seen := map[string]os.FileMode{}
+	for _, f := range z.File {
+		seen[f.Name] = f.Mode()
+	}
+	// manifest.json must sit at the root, or the host will not recognise the
+	// file as a bundle at all.
+	if _, ok := seen["manifest.json"]; !ok {
+		t.Fatalf("no manifest.json at the bundle root: %v", seen)
+	}
+	mode, ok := seen["server/deja"]
+	if !ok {
+		t.Fatalf("binary missing from the bundle: %v", seen)
+	}
+	if mode&0o111 == 0 {
+		t.Fatalf("binary mode = %v, not executable", mode)
+	}
+}


### PR DESCRIPTION
Closes #481.

Desktop apps install MCP servers as [MCPB bundles](https://github.com/modelcontextprotocol/mcpb): a zip with a manifest, stdio transport, first-class support for standalone binaries. That is what deja already is, so the bundle carries the real binary and runs locally — no hosted endpoint, no runtime, no package manager.

**One bundle per platform, not one universal file.** The manifest format distinguishes `darwin`, `linux` and `win32` and has no architecture selector at all, so a single bundle would have to guess between amd64 and arm64 and be wrong for half of Linux. macOS is the exception: goreleaser now joins the two Mach-O binaries, so Mac users still have one file. Each manifest declares exactly the one platform it ships — a bundle claiming three while carrying one would install cleanly and then fail to start.

Verified end to end rather than by reading the spec:

- `mcpb validate` passes against the published schema.
- Unpacked the bundle, ran `server/deja mcp` straight out of it: initialize answers and all four tools list.
- The executable bit survives the zip, which is the failure that would otherwise surface as an unexplained connection error.

CI does the same three checks on every PR, so a manifest that would break on a user's machine breaks on ours first.

Not in scope: a hosted HTTP transport. deja reads the session files on your own disk; a remote endpoint would be a different product.

While looking into this I checked Codex desktop, since it was the other target asked for — its app bundles the codex binary and reads the same `~/.codex/config.toml` (709 references to it in the bundle, zero to `.mcpb`). So `deja install codex` already wires the desktop app, and no bundle work is needed there.