### PR TITLE
Add the cross-platform .mcpb bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,9 @@ jobs:
       # One bundle per platform: the .mcpb manifest has no architecture
       # selector, so a single universal file would be wrong for half of Linux.
       - name: Pack MCP bundles
-        run: go run ./scripts/mcpb -version "${GITHUB_REF_NAME#v}" -in dist -out dist/mcpb
+        run: |
+          go run ./scripts/mcpb -version "${GITHUB_REF_NAME#v}" -in dist -out dist/mcpb
+          go run ./scripts/mcpb -registry -version "${GITHUB_REF_NAME#v}" -out dist/mcpb
 
       - name: Attach MCP bundles to the release
         env:

--- a/scripts/mcpb/main.go
+++ b/scripts/mcpb/main.go
@@ -49,6 +49,7 @@ func main() {
 	in := flag.String("in", "dist", "directory holding the built binaries")
 	out := flag.String("out", "dist", "directory to write the bundles into")
 	manifestPath := flag.String("manifest", filepath.Join("packaging", "mcpb", "manifest.json"), "manifest template")
+	registry := flag.Bool("registry", false, "build the single cross-platform bundle registries take, instead of the per-platform ones")
 	flag.Parse()
 
 	if *version == "" {
@@ -60,6 +61,19 @@ func main() {
 	}
 	if err := os.MkdirAll(*out, 0o755); err != nil {
 		fail(err)
+	}
+
+	if *registry {
+		path := filepath.Join(*out, fmt.Sprintf("deja-vu_%s_registry.mcpb", *version))
+		if err := packRegistry(path, template, *version); err != nil {
+			fail(err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			fail(err)
+		}
+		fmt.Printf("%s  %d KB\n", filepath.Base(path), info.Size()/1024)
+		return
 	}
 
 	built := 0
@@ -149,6 +163,60 @@ func pack(path string, template []byte, binary string, t target, version string)
 	// The executable bit has to survive the zip, or the host installs a server
 	// it cannot start.
 	if err := add(z, "server/"+t.exe, body, 0o755); err != nil {
+		return err
+	}
+	if err := z.Close(); err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+// packRegistry builds the bundle for MCP registries, which accept one artifact
+// per server and have no way to offer a visitor the build for their machine.
+// A per-platform bundle would therefore be wrong for most people who found us
+// there, so this one launches the published npm package, which resolves the
+// right binary at run time. It is still a local stdio server — npx only does
+// the platform selection that the bundle format cannot express.
+//
+// It also carries no tools array. The MCPB format forbids inputSchema on tool
+// entries while the Smithery registry requires it, so a bundle that declares
+// its tools is rejected outright: https://github.com/smithery-ai/cli/issues/787
+func packRegistry(path string, template []byte, version string) error {
+	var m map[string]any
+	if err := json.Unmarshal(template, &m); err != nil {
+		return fmt.Errorf("manifest template: %w", err)
+	}
+	m["version"] = version
+	delete(m, "tools")
+	m["server"] = map[string]any{
+		"type":        "node",
+		"entry_point": "server/index.js",
+		"mcp_config": map[string]any{
+			"command": "npx",
+			"args":    []any{"-y", "@vshulcz/deja-vu@" + version, "mcp"},
+			"env":     map[string]any{},
+		},
+	}
+	m["compatibility"] = map[string]any{"platforms": []any{"darwin", "linux", "win32"}}
+
+	manifest, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	z := zip.NewWriter(f)
+	if err := add(z, "manifest.json", append(manifest, '\n'), 0o644); err != nil {
+		return err
+	}
+	// A one-line entry point so the bundle is self-describing if anyone opens
+	// it; the host starts the command above, not this file.
+	shim := "#!/usr/bin/env node\n// deja runs as `npx @vshulcz/deja-vu mcp`; see manifest.json.\n"
+	if err := add(z, "server/index.js", []byte(shim), 0o644); err != nil {
 		return err
 	}
 	if err := z.Close(); err != nil {

--- a/scripts/mcpb/main_test.go
+++ b/scripts/mcpb/main_test.go
@@ -145,3 +145,56 @@ func TestPackKeepsTheBinaryExecutable(t *testing.T) {
 		t.Fatalf("binary mode = %v, not executable", mode)
 	}
 }
+
+// The registry bundle is the one artifact MCP registries accept per server, so
+// it must work on every platform and must not declare tools — Smithery rejects
+// any bundle that does (smithery-ai/cli#787).
+func TestRegistryBundleIsCrossPlatformAndToolless(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "registry.mcpb")
+	if err := packRegistry(out, templateJSON(t), "1.2.3"); err != nil {
+		t.Fatal(err)
+	}
+	z, err := zip.OpenReader(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = z.Close() }()
+
+	var manifest map[string]any
+	found := false
+	for _, f := range z.File {
+		if f.Name != "manifest.json" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+			t.Fatal(err)
+		}
+		_ = rc.Close()
+		found = true
+	}
+	if !found {
+		t.Fatal("no manifest.json in the registry bundle")
+	}
+	if _, ok := manifest["tools"]; ok {
+		t.Fatal("registry bundle declares tools; Smithery rejects those outright")
+	}
+	platforms := manifest["compatibility"].(map[string]any)["platforms"].([]any)
+	if len(platforms) != 3 {
+		t.Fatalf("platforms = %v, want all three", platforms)
+	}
+	cfg := manifest["server"].(map[string]any)["mcp_config"].(map[string]any)
+	if cfg["command"] != "npx" {
+		t.Fatalf("command = %v, want npx so the platform is resolved at run time", cfg["command"])
+	}
+	// The version has to be pinned, or the listing silently drifts to whatever
+	// npm publishes next.
+	args := cfg["args"].([]any)
+	if len(args) < 2 || args[1] != "@vshulcz/deja-vu@1.2.3" {
+		t.Fatalf("args = %v, want the version pinned", args)
+	}
+}


### PR DESCRIPTION
Follow-up to #482. The native bundles are per-platform because the manifest has no architecture selector. That is right for a download page, where someone picks their own machine, and wrong for a registry, which accepts one artifact per server and cannot ask.

So this adds a second, 1 KB bundle whose command is `npx -y @vshulcz/deja-vu@<version> mcp`. It is still a local stdio server — npx only does the platform selection the bundle format cannot express — and the version is pinned so a listing cannot drift onto whatever npm publishes next. It validates against the published schema like the others, and ships alongside them.

**On Smithery specifically, which is why I went looking.** Publishing a bundle there does not currently work for any server that has tools, and I could not find a way around it:

- With a `tools` array, the registry rejects the bundle: the CLI forwards MCPB tools as MCP `Tool[]`, which require `inputSchema`, and the MCPB manifest format forbids that key. Reported upstream as [smithery-ai/cli#787](https://github.com/smithery-ai/cli/issues/787).
- I checked whether the two could be satisfied at once by adding `inputSchema` anyway. `mcpb validate` rejects it outright — `Unrecognized key(s) in object: inputSchema` on all four tools. The schemas are mutually exclusive, not merely inconvenient.
- Without a `tools` array, the CLI creates the server and then fails with `400 No values to set`, leaving an empty listing.

None of that is a reason to hold the artifact back; the constraint is theirs and the bundle is useful on its own.