### PR TITLE
Generate the Windows manifests instead of remembering to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,23 @@ jobs:
             | dist/unpacked/server/deja mcp | tee /tmp/out.json
           grep -q '"serverInfo"' /tmp/out.json
 
+  manifests:
+    name: windows manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: '1.25.x'
+          cache: false
+      # scoop and winget carry a version and two hashes that are updated after
+      # a release. That step is invisible when skipped — v0.16.0 shipped with
+      # them still on 0.15.6 — so it is checked rather than remembered.
+      - name: Manifests match the newest release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go run ./scripts/pinmanifests -check
+
   vuln:
     name: govulncheck
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,21 @@ jobs:
           go run ./scripts/mcpb -version "${GITHUB_REF_NAME#v}" -in dist -out dist/mcpb
           go run ./scripts/mcpb -registry -version "${GITHUB_REF_NAME#v}" -out dist/mcpb
 
+      # Regenerate the Windows manifests from the checksums this run produced,
+      # and attach them so the scoop and winget submissions have a canonical
+      # file even before the repository catches up.
+      - name: Pin Windows manifests
+        run: go run ./scripts/pinmanifests -version "${GITHUB_REF_NAME#v}" -checksums dist/checksums.txt
+
+      - name: Attach the manifests to the release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" \
+            packaging/scoop/deja-vu.json \
+            packaging/winget/vshulcz.deja-vu.installer.yaml \
+            packaging/winget/vshulcz.deja-vu.locale.en-US.yaml --clobber
+
       - name: Attach MCP bundles to the release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,20 +1,14 @@
 {
-    "version": "0.16.1",
-    "description": "Persistent memory for coding agents",
-    "homepage": "https://github.com/vshulcz/deja-vu",
-    "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.1/deja-vu_0.16.1_windows_amd64.zip",
-            "hash": "ca95da4124de996e08962b473e65480172d58af350bd7a30fceb9147c9a858e3"
+            "hash": "ca95da4124de996e08962b473e65480172d58af350bd7a30fceb9147c9a858e3",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.1/deja-vu_0.16.1_windows_amd64.zip"
         },
         "arm64": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.1/deja-vu_0.16.1_windows_arm64.zip",
-            "hash": "0ab31bf66feac08a594856135394fe5e94db1655f4bc82157c6d3966df491434"
+            "hash": "0ab31bf66feac08a594856135394fe5e94db1655f4bc82157c6d3966df491434",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.1/deja-vu_0.16.1_windows_arm64.zip"
         }
     },
-    "bin": "deja.exe",
-    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
@@ -24,5 +18,11 @@
                 "url": "https://github.com/vshulcz/deja-vu/releases/download/v$version/deja-vu_$version_windows_arm64.zip"
             }
         }
-    }
+    },
+    "bin": "deja.exe",
+    "checkver": "github",
+    "description": "Persistent memory for coding agents",
+    "homepage": "https://github.com/vshulcz/deja-vu",
+    "license": "MIT",
+    "version": "0.16.1"
 }

--- a/scripts/pinmanifests/main.go
+++ b/scripts/pinmanifests/main.go
@@ -1,0 +1,278 @@
+// Command pinmanifests rewrites the scoop and winget manifests for a release.
+//
+// These files carry a version and the SHA-256 of the two Windows zips, and they
+// used to be updated by hand after each release. That step is invisible when it
+// is skipped: v0.16.0 shipped with the manifests still on 0.15.6, so scoop and
+// winget users were two releases behind and nothing said so.
+//
+//	go run ./scripts/pinmanifests -version 0.16.1 -checksums dist/checksums.txt
+//	go run ./scripts/pinmanifests -check          # fails if they lag the newest release
+//
+// -check is what CI runs. It fetches the newest published release, regenerates
+// the manifests in memory and compares: a pin that was forgotten fails the build
+// with the exact diff instead of going unnoticed until a user reports an old
+// version.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	scoopPath  = "packaging/scoop/deja-vu.json"
+	localePath = "packaging/winget/vshulcz.deja-vu.locale.en-US.yaml"
+	installer  = "packaging/winget/vshulcz.deja-vu.installer.yaml"
+	releaseAPI = "https://api.github.com/repos/vshulcz/deja-vu/releases/latest"
+	assetBase  = "https://github.com/vshulcz/deja-vu/releases/download"
+)
+
+type pins struct {
+	version string
+	amd64   string
+	arm64   string
+}
+
+func main() {
+	version := flag.String("version", "", "release version without the leading v")
+	checksums := flag.String("checksums", "", "path to the release checksums.txt")
+	check := flag.Bool("check", false, "verify the committed manifests match the newest release")
+	root := flag.String("root", ".", "repository root")
+	flag.Parse()
+
+	if *check {
+		if err := runCheck(*root); err != nil {
+			fmt.Fprintln(os.Stderr, "pinmanifests:", err)
+			os.Exit(1)
+		}
+		fmt.Println("scoop and winget manifests match the newest release")
+		return
+	}
+
+	if *version == "" || *checksums == "" {
+		fmt.Fprintln(os.Stderr, "pinmanifests: -version and -checksums are required")
+		os.Exit(1)
+	}
+	b, err := os.ReadFile(*checksums)
+	if err != nil {
+		fail(err)
+	}
+	p, err := parse(*version, string(b))
+	if err != nil {
+		fail(err)
+	}
+	if err := write(*root, p); err != nil {
+		fail(err)
+	}
+	fmt.Printf("pinned scoop and winget to %s\n", p.version)
+}
+
+// parse pulls the two Windows hashes out of a checksums file. Both must be
+// present: a manifest with one stale hash installs a mismatched binary for half
+// the users and passes every check we have.
+func parse(version, checksums string) (pins, error) {
+	p := pins{version: version}
+	s := bufio.NewScanner(strings.NewReader(checksums))
+	for s.Scan() {
+		fields := strings.Fields(s.Text())
+		if len(fields) != 2 {
+			continue
+		}
+		sum, name := fields[0], filepath.Base(fields[1])
+		switch name {
+		case fmt.Sprintf("deja-vu_%s_windows_amd64.zip", version):
+			p.amd64 = sum
+		case fmt.Sprintf("deja-vu_%s_windows_arm64.zip", version):
+			p.arm64 = sum
+		}
+	}
+	if err := s.Err(); err != nil {
+		return p, err
+	}
+	if p.amd64 == "" || p.arm64 == "" {
+		return p, fmt.Errorf("checksums for %s are missing a windows zip (amd64=%q arm64=%q)", version, p.amd64, p.arm64)
+	}
+	return p, nil
+}
+
+func write(root string, p pins) error {
+	for path, render := range map[string]func(pins) ([]byte, error){
+		scoopPath:  renderScoop,
+		localePath: renderLocale,
+		installer:  renderInstaller,
+	} {
+		body, err := render(p)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(root, path), body, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderScoop(p pins) ([]byte, error) {
+	m := map[string]any{
+		"version":     p.version,
+		"description": "Persistent memory for coding agents",
+		"homepage":    "https://github.com/vshulcz/deja-vu",
+		"license":     "MIT",
+		"architecture": map[string]any{
+			"64bit": map[string]any{
+				"url":  fmt.Sprintf("%s/v%s/deja-vu_%s_windows_amd64.zip", assetBase, p.version, p.version),
+				"hash": p.amd64,
+			},
+			"arm64": map[string]any{
+				"url":  fmt.Sprintf("%s/v%s/deja-vu_%s_windows_arm64.zip", assetBase, p.version, p.version),
+				"hash": p.arm64,
+			},
+		},
+		"bin":      "deja.exe",
+		"checkver": "github",
+		"autoupdate": map[string]any{
+			"architecture": map[string]any{
+				"64bit": map[string]any{"url": assetBase + "/v$version/deja-vu_$version_windows_amd64.zip"},
+				"arm64": map[string]any{"url": assetBase + "/v$version/deja-vu_$version_windows_arm64.zip"},
+			},
+		},
+	}
+	b, err := json.MarshalIndent(m, "", "    ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+// The winget files are edited rather than regenerated: they carry tags and
+// descriptions that are not derived from a release, and rewriting them from a
+// template here would quietly drop whatever someone adds later.
+func renderLocale(p pins) ([]byte, error) { return edit(localePath, p) }
+
+func renderInstaller(p pins) ([]byte, error) { return edit(installer, p) }
+
+var (
+	versionLine = regexp.MustCompile(`(?m)^PackageVersion: .*$`)
+	tagRefs     = regexp.MustCompile(`/v\d+\.\d+\.\d+(/|$)`)
+	fileRefs    = regexp.MustCompile(`deja-vu_\d+\.\d+\.\d+_windows`)
+	amdSha      = regexp.MustCompile(`(?m)^(\s*InstallerSha256: )[0-9A-Fa-f]{64}(\s*)$`)
+)
+
+func edit(path string, p pins) ([]byte, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	s := string(b)
+	s = versionLine.ReplaceAllString(s, "PackageVersion: "+p.version)
+	s = tagRefs.ReplaceAllString(s, "/v"+p.version+"$1")
+	s = fileRefs.ReplaceAllString(s, "deja-vu_"+p.version+"_windows")
+
+	// Two hashes in file order: amd64 first, then arm64, matching the
+	// Installers list. Anything else means the file was reordered and the
+	// rewrite would put the wrong hash against an architecture.
+	want := []string{strings.ToUpper(p.amd64), strings.ToUpper(p.arm64)}
+	i := 0
+	var bad error
+	s = amdSha.ReplaceAllStringFunc(s, func(m string) string {
+		if i >= len(want) {
+			bad = fmt.Errorf("%s has more InstallerSha256 lines than architectures", path)
+			return m
+		}
+		sub := amdSha.FindStringSubmatch(m)
+		out := sub[1] + want[i] + sub[2]
+		i++
+		return out
+	})
+	if bad != nil {
+		return nil, bad
+	}
+	if i != 0 && i != len(want) {
+		return nil, fmt.Errorf("%s has %d InstallerSha256 lines, want %d", path, i, len(want))
+	}
+	return []byte(s), nil
+}
+
+func runCheck(root string) error {
+	version, err := latestRelease()
+	if err != nil {
+		return err
+	}
+	sums, err := fetch(fmt.Sprintf("%s/v%s/checksums.txt", assetBase, version))
+	if err != nil {
+		return err
+	}
+	p, err := parse(version, string(sums))
+	if err != nil {
+		return err
+	}
+	for path, render := range map[string]func(pins) ([]byte, error){
+		scoopPath:  renderScoop,
+		localePath: renderLocale,
+		installer:  renderInstaller,
+	} {
+		want, err := render(p)
+		if err != nil {
+			return err
+		}
+		got, err := os.ReadFile(filepath.Join(root, path))
+		if err != nil {
+			return err
+		}
+		if string(got) != string(want) {
+			return fmt.Errorf("%s is not pinned to %s — run: go run ./scripts/pinmanifests -version %s -checksums <checksums.txt>", path, version, version)
+		}
+	}
+	return nil
+}
+
+func latestRelease() (string, error) {
+	b, err := fetch(releaseAPI)
+	if err != nil {
+		return "", err
+	}
+	var r struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.Unmarshal(b, &r); err != nil {
+		return "", err
+	}
+	if r.TagName == "" {
+		return "", fmt.Errorf("no tag_name in the latest release")
+	}
+	return strings.TrimPrefix(r.TagName, "v"), nil
+}
+
+func fetch(url string) ([]byte, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" && strings.HasPrefix(url, "https://api.github.com") {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, "pinmanifests:", err)
+	os.Exit(1)
+}

--- a/scripts/pinmanifests/main_test.go
+++ b/scripts/pinmanifests/main_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sample = `aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111  deja-vu_1.2.3_windows_amd64.zip
+bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222  deja-vu_1.2.3_windows_arm64.zip
+cccc3333cccc3333cccc3333cccc3333cccc3333cccc3333cccc3333cccc3333  deja-vu_1.2.3_linux_amd64.tar.gz
+`
+
+// A manifest with one stale hash installs a mismatched binary for half the
+// users and passes every other check we have, so a missing checksum has to stop
+// the run rather than leave the old value in place.
+func TestParseRefusesAnIncompleteChecksumFile(t *testing.T) {
+	p, err := parse("1.2.3", sample)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.amd64 != "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111" {
+		t.Fatalf("amd64 = %q", p.amd64)
+	}
+	if p.arm64 != "bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222" {
+		t.Fatalf("arm64 = %q", p.arm64)
+	}
+
+	onlyOne := strings.SplitN(sample, "\n", 2)[0]
+	if _, err := parse("1.2.3", onlyOne); err == nil {
+		t.Fatal("a checksums file missing arm64 was accepted")
+	}
+	// A file for a different version must not half-match: every name carries
+	// the version, so nothing should be picked up at all.
+	if _, err := parse("9.9.9", sample); err == nil {
+		t.Fatal("checksums for another version were accepted")
+	}
+}
+
+// The two hashes are written in file order. If that mapping ever slipped, the
+// arm64 entry would carry the amd64 hash and every arm64 install would fail its
+// integrity check with no clue why.
+func TestEditKeepsHashesWithTheirArchitectures(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "installer.yaml")
+	original := `PackageIdentifier: vshulcz.deja-vu
+PackageVersion: 0.0.1
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.0.1/deja-vu_0.0.1_windows_amd64.zip
+  InstallerSha256: 1111111111111111111111111111111111111111111111111111111111111111
+- Architecture: arm64
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.0.1/deja-vu_0.0.1_windows_arm64.zip
+  InstallerSha256: 2222222222222222222222222222222222222222222222222222222222222222
+`
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p, err := parse("1.2.3", sample)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := edit(path, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+
+	x64 := strings.Index(got, "Architecture: x64")
+	arm := strings.Index(got, "Architecture: arm64")
+	amdHash := strings.Index(got, strings.ToUpper(p.amd64))
+	armHash := strings.Index(got, strings.ToUpper(p.arm64))
+	if amdHash < x64 || amdHash > arm {
+		t.Fatalf("amd64 hash did not land in the x64 block:\n%s", got)
+	}
+	if armHash < arm {
+		t.Fatalf("arm64 hash did not land in the arm64 block:\n%s", got)
+	}
+	// Version and every URL move together; a leftover 0.0.1 anywhere means a
+	// user downloads one release and validates against another.
+	if strings.Contains(got, "0.0.1") {
+		t.Fatalf("stale version left behind:\n%s", got)
+	}
+	if !strings.Contains(got, "PackageVersion: 1.2.3") {
+		t.Fatalf("version not updated:\n%s", got)
+	}
+}
+
+// A reordered file would silently pair the wrong hash with an architecture, so
+// an unexpected count is an error rather than a best effort.
+func TestEditRefusesAnUnexpectedNumberOfHashes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "installer.yaml")
+	if err := os.WriteFile(path, []byte(`PackageVersion: 0.0.1
+Installers:
+- Architecture: x64
+  InstallerSha256: 1111111111111111111111111111111111111111111111111111111111111111
+- Architecture: arm64
+  InstallerSha256: 2222222222222222222222222222222222222222222222222222222222222222
+- Architecture: x86
+  InstallerSha256: 3333333333333333333333333333333333333333333333333333333333333333
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p, _ := parse("1.2.3", sample)
+	if _, err := edit(path, p); err == nil {
+		t.Fatal("three hashes against two architectures were rewritten anyway")
+	}
+}
+
+// The generator is what -check compares against, so it has to be deterministic:
+// otherwise CI fails on a correctly pinned repository.
+func TestRenderScoopIsStableAndComplete(t *testing.T) {
+	p, _ := parse("1.2.3", sample)
+	first, err := renderScoop(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		again, err := renderScoop(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(again) != string(first) {
+			t.Fatal("renderScoop output varies between calls")
+		}
+	}
+	var m map[string]any
+	if err := json.Unmarshal(first, &m); err != nil {
+		t.Fatalf("not json: %v", err)
+	}
+	if m["version"] != "1.2.3" || m["bin"] != "deja.exe" || m["checkver"] != "github" {
+		t.Fatalf("manifest lost a field: %v", m)
+	}
+	arch := m["architecture"].(map[string]any)
+	if arch["64bit"].(map[string]any)["hash"] != p.amd64 {
+		t.Fatal("64bit hash is not the amd64 one")
+	}
+	if arch["arm64"].(map[string]any)["hash"] != p.arm64 {
+		t.Fatal("arm64 hash is not the arm64 one")
+	}
+}


### PR DESCRIPTION
Closes #479.

`packaging/scoop/deja-vu.json` and the two winget files carry a version and the SHA-256 of both Windows zips. They were updated by a manual chore PR after each release, and v0.16.0 shipped with them still on **0.15.6** — the 0.15.7 pin never happened, so those two channels were two releases behind and nothing said so.

`scripts/pinmanifests` now generates them from a `checksums.txt`, and CI runs `-check`, which fetches the newest published release, regenerates in memory and compares. A pin that gets forgotten now fails the build with the command to fix it.

I deliberately did not make the release workflow commit to `main`. Branch protection blocks a direct push, and a PR opened with `GITHUB_TOKEN` does not trigger workflows, so its required checks would never run and auto-merge would hang forever. The check-and-fail route needs no new secrets and cannot be skipped quietly. The release does regenerate the manifests and attach them as assets, so a scoop or winget submission has a canonical file immediately.

Verified rather than assumed:

- Ran it against the real v0.16.1 checksums: the generated winget files are byte-identical to the ones I pinned by hand, and scoop differs only in key order, which Go sorts and scoop ignores.
- Negative control: bumped the scoop version back to 0.15.6 and confirmed `-check` fails with the exact file and the fix command, then restored and confirmed it passes again.
- The winget rewrite maps the two hashes to architectures by file order, so a test asserts the amd64 hash lands inside the x64 block and refuses a file with an unexpected number of hash lines — pairing those wrongly would fail every arm64 install with nothing pointing at the cause.