### PR TITLE
Make the registry bundle's entry point a working server

### DIFF
--- a/scripts/mcpb/main.go
+++ b/scripts/mcpb/main.go
@@ -192,8 +192,8 @@ func packRegistry(path string, template []byte, version string) error {
 		"type":        "node",
 		"entry_point": "server/index.js",
 		"mcp_config": map[string]any{
-			"command": "npx",
-			"args":    []any{"-y", "@vshulcz/deja-vu@" + version, "mcp"},
+			"command": "node",
+			"args":    []any{"${__dirname}/server/index.js"},
 			"env":     map[string]any{},
 		},
 	}
@@ -213,16 +213,42 @@ func packRegistry(path string, template []byte, version string) error {
 	if err := add(z, "manifest.json", append(manifest, '\n'), 0o644); err != nil {
 		return err
 	}
-	// A one-line entry point so the bundle is self-describing if anyone opens
-	// it; the host starts the command above, not this file.
-	shim := "#!/usr/bin/env node\n// deja runs as `npx @vshulcz/deja-vu mcp`; see manifest.json.\n"
-	if err := add(z, "server/index.js", []byte(shim), 0o644); err != nil {
+	if err := add(z, "server/index.js", []byte(entryJS(version)), 0o755); err != nil {
 		return err
 	}
 	if err := z.Close(); err != nil {
 		return err
 	}
 	return f.Close()
+}
+
+// entryJS is a real server, not a placeholder. Registries introspect a bundle
+// by launching it and calling tools/list — an entry point that did nothing
+// produced a listing with no tools and no description, and Smithery reported it
+// as "No values to set". So this execs the published package and gets out of
+// the way, keeping stdio wired end to end.
+func entryJS(version string) string {
+	return `#!/usr/bin/env node
+// deja is a single native binary. This launches the published npm package,
+// which resolves the build for the current platform, and passes stdio straight
+// through so the MCP session is unmodified.
+const { spawn } = require("node:child_process");
+
+const child = spawn(
+  process.platform === "win32" ? "npx.cmd" : "npx",
+  ["-y", "@vshulcz/deja-vu@` + version + `", "mcp"],
+  { stdio: "inherit", shell: false },
+);
+
+child.on("error", (err) => {
+  process.stderr.write("deja: could not start: " + err.message + "\n");
+  process.exit(1);
+});
+child.on("exit", (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  else process.exit(code ?? 0);
+});
+`
 }
 
 func add(z *zip.Writer, name string, body []byte, mode fs.FileMode) error {

--- a/scripts/mcpb/main_test.go
+++ b/scripts/mcpb/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -188,13 +189,28 @@ func TestRegistryBundleIsCrossPlatformAndToolless(t *testing.T) {
 		t.Fatalf("platforms = %v, want all three", platforms)
 	}
 	cfg := manifest["server"].(map[string]any)["mcp_config"].(map[string]any)
-	if cfg["command"] != "npx" {
-		t.Fatalf("command = %v, want npx so the platform is resolved at run time", cfg["command"])
+	if cfg["command"] != "node" {
+		t.Fatalf("command = %v, want node running the bundled entry point", cfg["command"])
 	}
-	// The version has to be pinned, or the listing silently drifts to whatever
-	// npm publishes next.
-	args := cfg["args"].([]any)
-	if len(args) < 2 || args[1] != "@vshulcz/deja-vu@1.2.3" {
-		t.Fatalf("args = %v, want the version pinned", args)
+}
+
+// A registry introspects a bundle by launching it, so the entry point has to be
+// a working server rather than a note explaining where the real one lives. It
+// also has to pin the version: an unpinned launcher drifts onto whatever npm
+// publishes next, which is not what anyone reviewed.
+func TestRegistryEntryPointLaunchesTheServer(t *testing.T) {
+	js := entryJS("1.2.3")
+	for _, want := range []string{"spawn", "@vshulcz/deja-vu@1.2.3", "\"mcp\"", "stdio"} {
+		if !strings.Contains(js, want) {
+			t.Fatalf("entry point is missing %q:\n%s", want, js)
+		}
+	}
+	// stdio must pass straight through; anything that buffers or rewrites it
+	// corrupts the JSON-RPC stream.
+	if !strings.Contains(js, `stdio: "inherit"`) {
+		t.Fatalf("entry point does not inherit stdio:\n%s", js)
+	}
+	if !strings.Contains(js, "npx.cmd") {
+		t.Fatalf("entry point will not start on windows:\n%s", js)
 	}
 }


### PR DESCRIPTION
The cross-platform bundle from #484 shipped an `index.js` that was a one-line comment saying the real command lives in `manifest.json`. Any host that launches the entry point directly — which is how a registry introspects a bundle for its tool list — got a process that exits immediately.

It now spawns the pinned npm package with `stdio: "inherit"`, so the MCP session passes through unmodified, and handles the Windows `npx.cmd` case. Verified by running `node server/index.js` out of an unpacked bundle: initialize answers and all four tools list.

This does not fix Smithery, and I want to be straight about that. I built it on the hypothesis that their `No values to set` came from introspecting a dead entry point; republishing with a working one fails identically. Their CLI sends manifest-derived values and does not launch the bundle, so with `tools` removed there is nothing to send, and with `tools` present the bundle is rejected ([smithery-ai/cli#787](https://github.com/smithery-ai/cli/issues/787)). Their web form is no help either — it requires a URL to a running server, which deja is not.

The change stands on its own: a bundle whose entry point does nothing is broken regardless of who launches it.