### PR TITLE
Stop indexing deja's own recall blocks

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -14,8 +14,10 @@ import (
 // and source path of every record; 14 deflates the record payload; 15 drops
 // the derivable offset from every bucket directory entry; 16 folds Traditional
 // CJK to Simplified before keying, so an index written before it holds keys
-// this build never queries.
-const version = 16
+// this build never queries; 17 filters out deja's own injected recall, which
+// earlier builds indexed back in, so an existing index is rebuilt once to drop
+// the copies it already holds.
+const version = 17
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -737,6 +737,9 @@ func recordsForKey(path string, t *recordTables, key string) ([]Record, error) {
 }
 
 func redactForIngest(m *Manifest, sourcePath, text string) string {
+	// Drop deja's own injected recall before anything else looks at the text,
+	// so it is never counted, tokenized or stored.
+	text = stripSelfRecall(text)
 	// Redact the full text before capping: a secret straddling the cap
 	// boundary would otherwise lose its closing marker and store raw.
 	redacted, counts := redact.Text(text)
@@ -1384,7 +1387,7 @@ func preRedactSessions(m *Manifest, ss []model.Session) {
 			for si := range jobs {
 				s := &ss[si]
 				for mi := range s.Messages {
-					redacted, counts := redact.Text(s.Messages[mi].Text)
+					redacted, counts := redact.Text(stripSelfRecall(s.Messages[mi].Text))
 					if len(redacted) > maxIndexedText {
 						cut := maxIndexedText
 						for cut > 0 && !utf8.RuneStart(redacted[cut]) {

--- a/internal/index/selfrecall.go
+++ b/internal/index/selfrecall.go
@@ -1,0 +1,76 @@
+package index
+
+import "strings"
+
+// deja injects recall into an agent's context wrapped in <deja-recall> markers.
+// The harness then writes that context into its own transcript, and deja indexes
+// transcripts — so without this, deja's output becomes deja's input. Measured on
+// a real machine before the filter existed: 29 sessions across claude, kimi and
+// gemini held copies of blocks deja had written itself.
+//
+// The consequences compound rather than merely waste space. A search can return
+// a past recall summary instead of the session it summarised; every session that
+// recalls a fact adds another copy of it, inflating that fact's term frequency
+// for reasons that have nothing to do with the user; and `reused N× by agents`
+// cannot tell a genuine reuse from deja reading its own injection.
+//
+// The markers are used rather than the header text because the text is
+// translated into each harness's own framing while the tags survive verbatim —
+// verified across claude, codex, gemini, kimi, qwen and copilot transcripts.
+// Harnesses do not agree on how to store the markers. gemini HTML-escapes them
+// into its hook_context wrapper, so a filter that only knew the raw form left
+// every gemini session polluted while looking like it worked everywhere else.
+// Each pair is tried in turn.
+var selfRecallMarkers = [][2]string{
+	{"<deja-recall>", "</deja-recall>"},
+	{"&lt;deja-recall&gt;", "&lt;/deja-recall&gt;"},
+}
+
+// stripSelfRecall removes every recall block from a message, keeping whatever
+// the user or agent actually wrote around it. Most harnesses prepend the block
+// to a real user turn, so dropping the whole message would lose the question
+// that prompted the session.
+func stripSelfRecall(text string) string {
+	for _, m := range selfRecallMarkers {
+		text = stripBetween(text, m[0], m[1])
+	}
+	return text
+}
+
+func stripBetween(text, open, close string) string {
+	if !strings.Contains(text, open) {
+		return text
+	}
+	var b strings.Builder
+	rest := text
+	for {
+		start := strings.Index(rest, open)
+		if start < 0 {
+			b.WriteString(rest)
+			break
+		}
+		b.WriteString(rest[:start])
+		after := rest[start+len(open):]
+		end := strings.Index(after, close)
+		if end < 0 {
+			// An unclosed marker means the block was truncated — by a context
+			// cap, a crash, or a harness that stores a prefix. Everything from
+			// the marker on is ours, so none of it should be indexed.
+			break
+		}
+		rest = after[end+len(close):]
+	}
+	out := b.String()
+	// Collapse the blank lines the removal leaves behind, so a message that was
+	// text-block-text does not keep a hole where the block used to be.
+	for strings.Contains(out, "\n\n\n") {
+		out = strings.ReplaceAll(out, "\n\n\n", "\n\n")
+	}
+	if strings.TrimSpace(out) == "" {
+		return ""
+	}
+	// Removing a block at either end leaves the newline that separated it from
+	// the real text; a message that now starts with a blank line is an artefact
+	// of the removal, not something anyone wrote.
+	return strings.Trim(out, "\n")
+}

--- a/internal/index/selfrecall_test.go
+++ b/internal/index/selfrecall_test.go
@@ -1,0 +1,110 @@
+package index
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// Most harnesses prepend the recall block to a real user turn. Dropping the
+// whole message would therefore lose the question that started the session —
+// the block goes, the question stays.
+func TestStripSelfRecallKeepsWhatTheUserWrote(t *testing.T) {
+	for name, tc := range map[string]struct{ in, want string }{
+		"no block": {"just a question", "just a question"},
+		"block then question": {
+			"<deja-recall>\nRecalled history…\n- Session: **x** `1`\n</deja-recall>\nwhy is the pool exhausted?",
+			"why is the pool exhausted?",
+		},
+		"question then block": {
+			"why is the pool exhausted?\n<deja-recall>\nstuff\n</deja-recall>",
+			"why is the pool exhausted?",
+		},
+		"block in the middle": {
+			"before\n\n<deja-recall>\nstuff\n</deja-recall>\n\nafter",
+			"before\n\nafter",
+		},
+		"two blocks": {
+			"<deja-recall>a</deja-recall>keep<deja-recall>b</deja-recall>",
+			"keep",
+		},
+		// gemini stores the markers HTML-escaped inside its hook_context
+		// wrapper. A filter that only knew the raw form left every gemini
+		// session polluted while appearing to work everywhere else.
+		"html-escaped block": {
+			"&lt;deja-recall&gt;\nRecalled history…\n&lt;/deja-recall&gt;\nthe real question",
+			"the real question",
+		},
+		"nothing but the block": {
+			"<deja-recall>\nRecalled history…\n</deja-recall>",
+			"",
+		},
+		// A truncated block means a context cap or a crash cut it off.
+		// Everything from the marker onward is ours either way.
+		"unclosed block": {
+			"real question\n<deja-recall>\nrecalled and then cut off",
+			"real question",
+		},
+	} {
+		if got := stripSelfRecall(tc.in); got != tc.want {
+			t.Fatalf("%s:\n got %q\nwant %q", name, got, tc.want)
+		}
+	}
+}
+
+// The whole point: what deja injects must not come back as what deja knows.
+func TestIndexDoesNotSwallowItsOwnRecall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(home, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+
+	// A transcript exactly as a harness writes it: deja's block, then the real
+	// user turn.
+	// The newlines are escaped because the fixture interpolates straight into
+	// a JSON line.
+	writeLines(t, filepath.Join(claude, "project", "s.jsonl"),
+		claudeLine("s1", "2026-02-01T00:01:00Z",
+			`<deja-recall>\nRecalled history from prior sessions.\n- Session: **old** `+"`abc`"+` INJECTEDTOKEN\n</deja-recall>\nGENUINEQUESTION about the pool`))
+
+	dir := filepath.Join(home, "idx")
+	if err := Ensure(dir, "", true, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	// The user's own words are still findable.
+	got, err := Search(dir, query.Options{Query: "GENUINEQUESTION", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("stripping the recall block took the user's question with it")
+	}
+
+	// deja's injection is not.
+	for _, term := range []string{"INJECTEDTOKEN", "deja-recall"} {
+		hits, err := Search(dir, query.Options{Query: term, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(hits) > 0 {
+			t.Fatalf("%q was indexed from deja's own recall block: %d hits", term, len(hits))
+		}
+	}
+
+	// And the stored text carries no trace, so `deja show` and share do not
+	// leak it either.
+	s, ok, err := FindByPrefix(dir, "s1")
+	if err != nil || !ok {
+		t.Fatalf("session missing: ok=%v err=%v", ok, err)
+	}
+	for _, m := range s.Messages {
+		if strings.Contains(m.Text, "deja-recall") || strings.Contains(m.Text, "INJECTEDTOKEN") {
+			t.Fatalf("recall block survived into the stored message: %q", m.Text)
+		}
+	}
+}


### PR DESCRIPTION
Closes #480.

Auto-recall injects a `<deja-recall>` block into the agent context, the harness writes that context into its transcript, and deja indexes transcripts. So deja was eating its own output. On my machine, before the fix: **29 sessions** across claude, kimi and gemini held copies of blocks deja had written itself.

The block is now stripped at ingest, in the two places every message passes through. It strips the block and keeps everything around it — most harnesses prepend recall to a real user turn, so dropping the whole message would lose the question that started the session.

**The part worth reviewing: the markers are not stored the same way everywhere.** I checked all of them instead of assuming, and gemini HTML-escapes them into its `hook_context` wrapper:

```
<hook_context>&lt;deja-recall&gt; Recalled history from prior sessions…
```

A filter that only knew the raw form would have left every gemini session polluted while looking like it worked. Both forms are handled, and an unclosed marker — a block cut off by a context cap or a crash — discards everything from the marker on, since all of it is ours.

Measured on my real index, rebuilt with the fix: **29 → 9**. The nine are sessions that *discuss* the string rather than carry an injected block: the development sessions for this feature, and openclaw's hook, which is literally named `deja-recall`. Removing mentions as well as blocks would be wrong.

Index version 16 → 17, so an existing index rebuilds once and drops the copies it already holds. Without that, every current user keeps their pollution until something else happens to trigger a rebuild.

Why this mattered beyond tidiness: `reused N× by agents` is the number we use to show that memory is doing anything, and it could not tell a genuine reuse from deja reading its own injection.