### PR TITLE
Recall returns the decision, not just the question

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -272,6 +272,45 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 	return string(b), err
 }
 
+// attachAnswers puts the decision next to the question.
+//
+// A recall query describes a symptom, so the user turn wins on term overlap and
+// its snippet restates what the caller already knows. Search cannot fix this on
+// its own: it returns only the messages that matched, so the reply that resolved
+// the session is not in memory at that point. Here the index is at hand, so the
+// session is read back and the reply carried along.
+func attachAnswers(dir string, hits []search.Hit) {
+	for i := range hits {
+		h := &hits[i]
+		if len(h.Snippets) == 0 || len(h.Snippets) >= 3 {
+			continue
+		}
+		var matchedUser string
+		for _, m := range h.Session.Messages {
+			if m.Role == "user" {
+				matchedUser = m.Text
+				break
+			}
+		}
+		if matchedUser == "" {
+			continue
+		}
+		full, ok, err := index.FindByIdentity(dir, h.Session.Harness, h.Session.ID)
+		if err != nil || !ok {
+			continue
+		}
+		for mi, m := range full.Messages {
+			if m.Role != "user" || m.Text != matchedUser {
+				continue
+			}
+			if a := search.AnswerAfter(full.Messages, mi); a != "" {
+				h.Snippets = append(h.Snippets, "→ "+a)
+			}
+			break
+		}
+	}
+}
+
 func recallText(dir, q, harness string, limit, budget int) (string, error) {
 	text, _, _, _, err := recallTextResult(dir, q, harness, limit, 0, budget)
 	return text, err
@@ -335,6 +374,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		remaining = len(hits) - limit
 		hits = hits[:limit]
 	}
+	attachAnswers(dir, hits)
 	var b strings.Builder
 	served := 0
 	if stale {

--- a/cmd/deja/mcp_contract_test.go
+++ b/cmd/deja/mcp_contract_test.go
@@ -287,3 +287,28 @@ func pageSessionID(page string) string {
 	}
 	return ""
 }
+
+// What an agent needs back is what was decided, not a restatement of the
+// symptom it just described. Recording a real agent session against a synthetic
+// corpus, the model said the quiet part out loud: "the recall only preserved
+// the incident title, not the exact fix."
+func TestRecallReturnsTheDecisionNotOnlyTheQuestion(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "payments", "s1.jsonl"), "s1", []string{
+		`{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"prepared statements keep failing behind pgbouncer after the driver upgrade"}}`,
+		`{"type":"assistant","sessionId":"s1","timestamp":"2026-01-02T03:05:05Z","message":{"role":"assistant","content":"pgbouncer in transaction mode cannot hold those across connections. We pinned pgx to 5.4.3 and left a note to revisit later."}}`,
+	})
+
+	got, err := recallText(index.DefaultDir(), "prepared statements pgbouncer", "", 5, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "pinned pgx to 5.4.3") {
+		t.Fatalf("recall returned the question without the decision:\n%s", got)
+	}
+	// The question stays too — the pair is the unit of memory.
+	if !strings.Contains(got, "prepared statements keep failing") {
+		t.Fatalf("recall dropped the question:\n%s", got)
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -41,11 +41,15 @@ var stopWords = map[string]bool{
 // QueryParts separates ordinary terms from quoted phrases without changing
 // the query syntax used by callers.
 type Options struct {
-	Query                     string
-	Regex                     bool
-	Harness, Project, Role    string
-	Since                     time.Duration
-	Limit                     int
+	Query                  string
+	Regex                  bool
+	Harness, Project, Role string
+	Since                  time.Duration
+	Limit                  int
+	// WithAnswer carries the assistant reply next to a matched user turn.
+	// Agent-facing recall sets it; human CLI output does not, because a person
+	// reading results can open the session.
+	WithAnswer                bool
 	All, JSON, Fuzzy, Stemmed bool
 	NoEmbed                   bool
 	Semantic                  bool                `json:"-"`

--- a/internal/search/answer.go
+++ b/internal/search/answer.go
@@ -1,0 +1,115 @@
+package search
+
+import (
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// answerAfter returns the assistant reply that followed a matched user turn,
+// trimmed to the part worth carrying.
+//
+// A recall query describes a symptom, so the user turn always scores highest on
+// term overlap and its snippet hands back a restatement of the question. Asked
+// about a real incident, an agent said so out loud: "the recall only preserved
+// the incident title, not the exact fix". The fix was in the very next message.
+// AnswerAfter is called from the recall path rather than from scoring: search
+// returns only the messages that matched, so the reply does not exist in memory
+// at scoring time and has to be read back from the index.
+func AnswerAfter(messages []model.Message, i int) string {
+	for j := i + 1; j < len(messages) && j <= i+3; j++ {
+		m := messages[j]
+		if m.Role == "user" {
+			// The user spoke again before any answer; there is no reply to
+			// attach, and reaching further would attach someone else's.
+			return ""
+		}
+		if m.Role != "assistant" {
+			continue
+		}
+		if text := DecisionText(m.Text); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+// decisionPhrases mark the sentence a reader actually wants. They are the
+// shapes engineers use when recording an outcome, in transcripts across every
+// harness deja indexes.
+var decisionPhrases = []string{
+	"we pinned", "we moved", "we dropped", "we switched", "we chose",
+	"decision:", "fixed by", "fixed it by", "the fix", "root cause",
+	"turned out", "traced it to", "instead of", "the cause was",
+	"resolved by", "worked around", "we set", "we added",
+}
+
+// decisionText picks the sentence that records the outcome, falling back to the
+// opening of the reply. A reply is usually diagnosis-first, so the opening is a
+// reasonable second choice — but a decision sentence anywhere in it beats it.
+func DecisionText(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	sentences := splitSentences(text)
+	low := make([]string, len(sentences))
+	for i, s := range sentences {
+		low[i] = strings.ToLower(s)
+	}
+	for i, s := range low {
+		for _, phrase := range decisionPhrases {
+			if strings.Contains(s, phrase) {
+				out := sentences[i]
+				// A decision often needs the sentence after it to make sense
+				// ("We pinned pgx to 5.4.3. Revisit when 1.24 ships.").
+				if i+1 < len(sentences) && len(out)+len(sentences[i+1]) < answerCap {
+					out += " " + sentences[i+1]
+				}
+				return clip(out)
+			}
+		}
+	}
+	return clip(text)
+}
+
+const answerCap = 260
+
+func clip(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) <= answerCap {
+		return s
+	}
+	cut := answerCap
+	for cut > 0 && !isBoundary(s[cut]) {
+		cut--
+	}
+	if cut == 0 {
+		cut = answerCap
+	}
+	return strings.TrimSpace(s[:cut]) + "…"
+}
+
+func isBoundary(b byte) bool { return b == ' ' || b == '\n' || b == '\t' }
+
+func splitSentences(text string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(text); i++ {
+		if text[i] != '.' && text[i] != '!' && text[i] != '?' && text[i] != '\n' {
+			continue
+		}
+		// A period inside a version or a path is not a sentence end.
+		if text[i] == '.' && i+1 < len(text) && !isBoundary(text[i+1]) {
+			continue
+		}
+		if s := strings.TrimSpace(text[start : i+1]); s != "" {
+			out = append(out, s)
+		}
+		start = i + 1
+	}
+	if s := strings.TrimSpace(text[start:]); s != "" {
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/search/answer_test.go
+++ b/internal/search/answer_test.go
@@ -1,0 +1,56 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The reply is attached by the recall path rather than by scoring, because
+// search returns only the messages that matched — see attachAnswers in
+// cmd/deja. These cover the pieces it builds on.
+
+func TestAnswerAfterOnlyTakesTheReplyToThisTurn(t *testing.T) {
+	msgs := []model.Message{
+		{Role: "user", Text: "first question"},
+		{Role: "user", Text: "second question before any answer"},
+		{Role: "assistant", Text: "We pinned the driver."},
+	}
+	// The user spoke twice; the reply belongs to the second turn, not the first.
+	if got := AnswerAfter(msgs, 0); got != "" {
+		t.Fatalf("attached a reply across an intervening user turn: %q", got)
+	}
+	if got := AnswerAfter(msgs, 1); !strings.Contains(got, "pinned") {
+		t.Fatalf("missed the reply that follows: %q", got)
+	}
+	// Nothing follows the last message.
+	if got := AnswerAfter(msgs, 2); got != "" {
+		t.Fatalf("invented a reply after the last message: %q", got)
+	}
+}
+
+func TestDecisionTextPrefersTheOutcomeSentence(t *testing.T) {
+	long := "The stack trace points at the pool. Metrics show it saturating at 40 connections. " +
+		"Root cause was a pool sized from the wrong config key. We set it from the pod limit instead."
+	got := DecisionText(long)
+	if !strings.Contains(got, "Root cause") {
+		t.Fatalf("did not pick the outcome sentence: %q", got)
+	}
+	// A version number is not a sentence boundary.
+	if got := DecisionText("We pinned pgx to 5.4.3 and moved on."); !strings.Contains(got, "5.4.3 and moved on") {
+		t.Fatalf("split on a version number: %q", got)
+	}
+	// With no decision language, the opening of the reply is a fair fallback.
+	if got := DecisionText("Looks like the proxy closes idle connections earlier than the client expects."); !strings.HasPrefix(got, "Looks like") {
+		t.Fatalf("fallback lost the opening: %q", got)
+	}
+	if DecisionText("   ") != "" {
+		t.Fatal("whitespace produced an answer")
+	}
+	// Long replies are clipped on a word boundary rather than mid-token.
+	got = DecisionText(strings.Repeat("word ", 200))
+	if len(got) > answerCap+3 || strings.HasSuffix(got, "wo…") {
+		t.Fatalf("clip landed badly: %d chars, %q", len(got), got[max(0, len(got)-20):])
+	}
+}


### PR DESCRIPTION
Closes #490.

Found by recording a real Codex session against a synthetic corpus. The model answered, and then said the quiet part out loud:

> deja-vu recalled: we did hit this before in `payments` on `2025-11-29` … **The recall only preserved the incident title, not the exact fix.**

It was right. A recall query describes a symptom, so the user turn wins on term overlap and the snippet hands back the question the caller already has. The fix was in the very next message.

**Why it could not be fixed in scoring.** I tried there first and it does nothing, because search never sees the reply: retrieval returns only the messages that matched. Confirmed directly —

```
$ deja "prepared statements pgbouncer" --json
сообщений в найденной сессии: 1
 - user : prepared statements keep failing behind pgbouncer after the…
```

So the reply is read back from the index in the recall path, where the index is at hand, and carried next to the question. Before and after, same query:

```
- prepared statements keep failing behind pgbouncer after the driver upgrade

- prepared statements keep failing behind pgbouncer after the driver upgrade
- → We pinned pgx to 5.4.3 and left a note to revisit once pgbouncer 1.24 ships prepared-statement support.
```

The reply is trimmed to the sentence that records the outcome — "we pinned", "root cause", "fixed by", "traced it to" — falling back to its opening, since replies are diagnosis-first. A version number is not treated as a sentence end, and a reply is only attached to the turn it actually answers: if the user spoke twice before any response, nothing is attached rather than attaching someone else's answer.

Agent-facing recall only. Human CLI output is unchanged, because a person reading results can open the session; an agent cannot afford the second call.