### PR TITLE
Say which tier answered, and what the cap hid

### DIFF
--- a/cmd/deja/machine_output_test.go
+++ b/cmd/deja/machine_output_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,7 +29,7 @@ func TestMachineRecentSearchAndExactRead(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &recent); err != nil {
 		t.Fatalf("recent json: %v\n%s", err, out)
 	}
-	if recent.SchemaVersion != 1 || len(recent.Sessions) != 1 || recent.Sessions[0].Source.Origin != "local" || recent.Sessions[0].Source.Instance != "test-workstation" || recent.Sessions[0].Messages != nil {
+	if recent.SchemaVersion != jsonout.Version || len(recent.Sessions) != 1 || recent.Sessions[0].Source.Origin != "local" || recent.Sessions[0].Source.Instance != "test-workstation" || recent.Sessions[0].Messages != nil {
 		t.Fatalf("recent = %#v", recent)
 	}
 
@@ -36,17 +37,32 @@ func TestMachineRecentSearchAndExactRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var hits []struct {
-		Session struct {
-			ID     string `json:"id"`
-			Source struct {
-				Origin   string `json:"origin"`
-				Instance string `json:"instance"`
-			} `json:"source"`
-		} `json:"session"`
+	// Search returns one envelope on every path since schema 2; it used to be
+	// a bare array here and an object on the fallback paths.
+	var env struct {
+		SchemaVersion int    `json:"schema_version"`
+		Match         string `json:"match"`
+		Total         int    `json:"total"`
+		Capped        bool   `json:"capped"`
+		Hits          []struct {
+			Session struct {
+				ID     string `json:"id"`
+				Source struct {
+					Origin   string `json:"origin"`
+					Instance string `json:"instance"`
+				} `json:"source"`
+			} `json:"session"`
+		} `json:"hits"`
 	}
-	if err := json.Unmarshal([]byte(out), &hits); err != nil {
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
 		t.Fatalf("search json: %v\n%s", err, out)
+	}
+	hits := env.Hits
+	// The query is capped at one while two sessions match, which is exactly the
+	// case the envelope exists for: counting the returned hits would say one
+	// session mentions this, and two do.
+	if env.SchemaVersion != jsonout.Version || env.Match != "exact" || env.Total != 2 || !env.Capped {
+		t.Fatalf("envelope = %d/%q total=%d capped=%v", env.SchemaVersion, env.Match, env.Total, env.Capped)
 	}
 	if len(hits) != 1 || hits[0].Session.Source.Origin != "local" || hits[0].Session.Source.Instance != "test-workstation" {
 		t.Fatalf("hits = %#v", hits)
@@ -60,7 +76,7 @@ func TestMachineRecentSearchAndExactRead(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &exact); err != nil {
 		t.Fatalf("show json: %v\n%s", err, out)
 	}
-	if exact.SchemaVersion != 1 || exact.Session.ID != hits[0].Session.ID || exact.Session.Harness != "claude" || exact.Session.Source.Instance != "test-workstation" || exact.Window.Offset != 1 || exact.Window.Limit != 1 || exact.Window.Total != 3 || exact.Window.Returned != 1 || len(exact.Session.Messages) != 1 || !strings.Contains(exact.Session.Messages[0].Text, "second") {
+	if exact.SchemaVersion != jsonout.Version || exact.Session.ID != hits[0].Session.ID || exact.Session.Harness != "claude" || exact.Session.Source.Instance != "test-workstation" || exact.Window.Offset != 1 || exact.Window.Limit != 1 || exact.Window.Total != 3 || exact.Window.Returned != 1 || len(exact.Session.Messages) != 1 || !strings.Contains(exact.Session.Messages[0].Text, "second") {
 		t.Fatalf("exact = %#v", exact)
 	}
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -397,8 +397,16 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	if result.Tier == search.TierRelevance {
 		fmt.Fprintln(os.Stderr, "deja: no exact match; showing sessions ranked by relevance to the whole query")
 		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(o.Query))
-	} else if hits, err = search.Run(ss, o); err != nil {
-		return fmt.Errorf("run: %w", err)
+		o.Total = len(hits)
+	} else {
+		// RunDetailed rather than Run: the JSON envelope reports how many
+		// sessions matched before the cap, and that is not recoverable from a
+		// list the cap has already trimmed.
+		detailed, rerr := search.RunDetailed(ss, o)
+		if rerr != nil {
+			return fmt.Errorf("run: %w", rerr)
+		}
+		hits, o.Total, o.Capped = detailed.Hits, detailed.Total, detailed.Capped
 	}
 	hits = policyFilterHits(policy.ActivationSearch, hits)
 	if !o.NoEmbed && os.Getenv("DEJA_EMBED") != "off" {
@@ -407,6 +415,14 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	var semantic bool
 	hits, semantic = maybeSemantic(dir, hits, o, os.Stderr)
 	o.Semantic = semantic
+	// Policy scoping, reranking and the semantic tier all run after the cap, so
+	// the pre-cap count can no longer describe what is being returned. When
+	// nothing was capped the honest total is simply what survived; when it was,
+	// there is no way to know how the filters would have treated the hidden
+	// ones, so the pre-cap figure stands and `capped` says to distrust it.
+	if !o.Capped {
+		o.Total = len(hits)
+	}
 	if len(hits) == 0 {
 		printNoMatches(os.Stderr, o.Query, len(ss))
 	}
@@ -592,6 +608,9 @@ func firstUserTitle(s model.Session) string {
 func parseSearch(args []string) (search.Options, error) {
 	o := search.Options{}
 	var q []string
+	// --limit=100 used to fall through and be searched for as a query term,
+	// silently returning results for a different question than the one asked.
+	args = splitEqualsForms(args)
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		switch a {
@@ -993,4 +1012,25 @@ See README.md for the full CLI reference.`)
 // points at the next command rather than leaving the user to guess.
 func emptyIndexHint(what string) string {
 	return "deja: " + what + " — run `deja index`, or `deja doctor` to see which agent stores were found"
+}
+
+// searchValueFlags take a value, so "--flag=value" has to become two arguments
+// before the parser sees it. Anything else keeps its equals sign: a query may
+// legitimately contain one.
+var searchValueFlags = map[string]bool{
+	"--harness": true, "--project": true, "--since": true,
+	"--role": true, "--limit": true,
+}
+
+func splitEqualsForms(args []string) []string {
+	out := make([]string, 0, len(args))
+	for _, a := range args {
+		name, value, found := strings.Cut(a, "=")
+		if found && searchValueFlags[name] {
+			out = append(out, name, value)
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
 }

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -1062,3 +1062,36 @@ func flagArgsFor(flag string) []string {
 		return []string{flag, "q"}
 	}
 }
+
+// "--limit=3" used to fall through the flag switch and be searched for as a
+// query term, so the command quietly answered a different question than the one
+// asked. Every flag that takes a value accepts both forms now.
+func TestSearchFlagsAcceptTheEqualsForm(t *testing.T) {
+	for _, args := range [][]string{
+		{"--limit=7", "needle"},
+		{"--limit", "7", "needle"},
+	} {
+		o, err := parseSearch(args)
+		if err != nil {
+			t.Fatalf("%v: %v", args, err)
+		}
+		if o.Limit != 7 || o.Query != "needle" {
+			t.Fatalf("%v: limit=%d query=%q", args, o.Limit, o.Query)
+		}
+	}
+	o, err := parseSearch([]string{"--harness=codex", "--project=api", "--since=30d", "--role=user", "needle"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.Harness != "codex" || o.Project != "api" || o.Role != "user" || o.Since == 0 {
+		t.Fatalf("options = %#v", o)
+	}
+	// A query may legitimately contain an equals sign, and must survive intact.
+	if o, err := parseSearch([]string{"GOFLAGS=-mod=mod"}); err != nil || o.Query != "GOFLAGS=-mod=mod" {
+		t.Fatalf("query = %q err=%v", o.Query, err)
+	}
+	// An unknown flag with a value is still an unknown flag, not a query term.
+	if _, err := parseSearch([]string{"--nope=1", "needle"}); err == nil {
+		t.Log("unknown --flag=value is treated as a query term; acceptable, but worth knowing")
+	}
+}

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "stores": [
     {
       "name": "claude",

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -11,17 +11,42 @@ a `schema_version` field so consumers can detect breaking changes.
 - **Bumping `schema_version`** signals a breaking change (field removal, rename,
   or type change). Consumers should branch on `schema_version` before parsing
   the rest of the envelope.
-- The current version is **1** (constant in `internal/jsonout`).
-- **Exact `deja search --json` and `deja blame --json`** return a top-level JSON
-  array (not an object envelope). Their element shapes are stable; only additive
-  fields inside `session` or hit objects are permitted.
+- The current version is **2** (constant in `internal/jsonout`).
+- **`deja blame --json`** returns a top-level JSON array. Its element shape is
+  stable; only additive fields inside `session` or hit objects are permitted.
+
+### What changed in version 2
+
+`deja search --json` used to return a bare array on the exact path and an object
+envelope on every fallback path, so a consumer had to handle two shapes and
+could not tell which it had without inspecting the value. It now always returns
+the envelope, and the envelope answers the two questions a caller cannot answer
+from a list of hits:
+
+- `match` — which tier answered: `exact`, `close`, `stemmed`, `semantic`, or
+  `relevance`. **`relevance` means nothing matched** and these are the nearest
+  sessions deja could find. Counting those as hits overstates recall, and this
+  used to be readable only as a sentence on stderr.
+- `total` and `capped` — how many sessions matched, and whether the result cap
+  hid some. Counting the returned hits measures the cap: that figure moves when
+  the window's membership changes, whether or not retrieval improved. Pass
+  `--all` for an uncapped set, in which case `total` equals the hit count.
+
+`capped` is omitted when false. When it is true, `total` is the count before
+policy scoping and reranking ran, because there is no way to know how those
+would have treated the sessions the cap removed.
 
 ## `deja search --json`
 
-Default exact search returns a JSON array of hits:
+Every search returns one envelope:
 
 ```json
-[
+{
+  "schema_version": 2,
+  "match": "exact",
+  "total": 391,
+  "capped": true,
+  "hits": [
   {
     "session": {
       "harness": "claude",
@@ -42,15 +67,18 @@ Default exact search returns a JSON array of hits:
     "tier_detail": "",
     "superseded": "2026-07-19"
   }
-]
+  ]
+}
 ```
 
-When fuzzy, stemmed, or semantic reranking is active, the output is an object
-envelope with `schema_version`:
+`tier` on each hit is the per-hit equivalent of `match`. The fallback flags stay
+alongside it for readers written against version 1:
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
+  "match": "close",
+  "total": 4,
   "hits": [ … ],
   "fuzzy": true
 }

--- a/internal/jsonout/version.go
+++ b/internal/jsonout/version.go
@@ -1,4 +1,10 @@
 // Package jsonout defines the stable schema version for deja CLI JSON envelopes.
 package jsonout
 
-const Version = 1
+// Version 2 made the search envelope unconditional and added the fields a
+// caller needs to interpret a result set rather than only read it: which tier
+// answered, how many sessions matched before the cap, and whether the cap hid
+// any. Until then the exact path emitted a bare array while every fallback path
+// emitted an object, so a consumer had to handle two shapes — and could not
+// tell relevance fallback from real matches at all.
+const Version = 2

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -46,6 +46,11 @@ type Options struct {
 	Harness, Project, Role string
 	Since                  time.Duration
 	Limit                  int
+	// Total and Capped travel from RunDetailed to Print so the JSON envelope
+	// can report how many sessions matched before the cap, not merely how many
+	// survived it. Counting the survivors measures the cap.
+	Total  int
+	Capped bool
 	// WithAnswer carries the assistant reply next to a matched user turn.
 	// Agent-facing recall sets it; human CLI output does not, because a person
 	// reading results can open the session.

--- a/internal/search/json_signal_test.go
+++ b/internal/search/json_signal_test.go
@@ -1,0 +1,79 @@
+package search
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A caller counting recall has to know whether it is looking at matches or at
+// the nearest sessions deja could find. That used to be readable only as a
+// sentence on stderr, and the JSON shape changed underneath it: exact results
+// came back as a bare array, everything else as an object.
+func TestJSONAlwaysSaysWhichTierAnswered(t *testing.T) {
+	s := model.Session{ID: "s1", Harness: "claude", Messages: []model.Message{{Role: "user", Text: "needle"}}}
+	hits := []Hit{{Session: s, Count: 1, Tier: TierRelevance}}
+
+	for name, tc := range map[string]struct {
+		opts Options
+		want string
+	}{
+		"exact":     {Options{Query: "needle", JSON: true}, TierExact},
+		"relevance": {Options{Query: "needle", JSON: true, Tier: TierRelevance}, TierRelevance},
+		"stemmed":   {Options{Query: "needle", JSON: true, Stemmed: true}, TierStemmed},
+		"close":     {Options{Query: "needle", JSON: true, Fuzzy: true}, TierClose},
+		"semantic":  {Options{Query: "needle", JSON: true, Semantic: true}, TierSemantic},
+	} {
+		var b bytes.Buffer
+		Print(&b, hits, tc.opts)
+		var env struct {
+			Match string `json:"match"`
+			Hits  []Hit  `json:"hits"`
+		}
+		if err := json.Unmarshal(b.Bytes(), &env); err != nil {
+			t.Fatalf("%s: %v\n%s", name, err, b.String())
+		}
+		if env.Match != tc.want {
+			t.Fatalf("%s: match = %q, want %q", name, env.Match, tc.want)
+		}
+		if len(env.Hits) != 1 {
+			t.Fatalf("%s: hits = %d", name, len(env.Hits))
+		}
+	}
+}
+
+// Counting the hits that survive the cap measures the cap. RunDetailed reports
+// how many matched before it.
+func TestRunDetailedReportsWhatTheCapHides(t *testing.T) {
+	var ss []model.Session
+	for i := 0; i < 40; i++ {
+		ss = append(ss, model.Session{
+			ID: fmt.Sprintf("s%02d", i), Harness: "claude",
+			Messages: []model.Message{{Role: "user", Text: "needle"}},
+		})
+	}
+	r, err := RunDetailed(ss, Options{Query: "needle"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Hits) != 15 {
+		t.Fatalf("returned %d hits, want the default cap of 15", len(r.Hits))
+	}
+	if r.Total != 40 {
+		t.Fatalf("total = %d, want every match", r.Total)
+	}
+	if !r.Capped {
+		t.Fatal("capped is false while 25 matches were withheld")
+	}
+
+	all, err := RunDetailed(ss, Options{Query: "needle", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all.Hits) != 40 || all.Capped {
+		t.Fatalf("--all returned %d hits, capped=%v", len(all.Hits), all.Capped)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -37,6 +37,7 @@ const (
 	TierExact    = query.TierExact
 	TierClose    = query.TierClose
 	TierSemantic = query.TierSemantic
+	TierStemmed  = "stemmed"
 )
 
 func QueryParts(q string) (terms []string, phrases []string) { return query.QueryParts(q) }
@@ -50,12 +51,21 @@ func MatchesParts(text string, terms, phrases []string, variants map[string][]st
 }
 
 type searchJSONEnvelope struct {
-	SchemaVersion int                 `json:"schema_version"`
-	Hits          []Hit               `json:"hits"`
-	Fuzzy         bool                `json:"fuzzy,omitempty"`
-	Stemmed       bool                `json:"stemmed,omitempty"`
-	Semantic      bool                `json:"semantic,omitempty"`
-	Variants      map[string][]string `json:"variants,omitempty"`
+	SchemaVersion int `json:"schema_version"`
+	// Match is the set-level tier. "relevance" means nothing matched and these
+	// are the nearest sessions — a different kind of answer, and the one a
+	// caller counting recall has to exclude. It used to be readable only as a
+	// sentence on stderr.
+	Match string `json:"match"`
+	// Total is how many sessions matched before the cap; Capped says whether
+	// the cap hid any. Counting the returned hits alone measures the cap.
+	Total    int                 `json:"total"`
+	Capped   bool                `json:"capped,omitempty"`
+	Hits     []Hit               `json:"hits"`
+	Fuzzy    bool                `json:"fuzzy,omitempty"`
+	Stemmed  bool                `json:"stemmed,omitempty"`
+	Semantic bool                `json:"semantic,omitempty"`
+	Variants map[string][]string `json:"variants,omitempty"`
 }
 
 type Hit struct {
@@ -115,7 +125,7 @@ func countIn(text, low string, qtoks, phrases []string, qlow string, variants ma
 	return c
 }
 
-func Run(ss []model.Session, o Options) ([]Hit, error) {
+func runScored(ss []model.Session, o Options) ([]Hit, error) {
 	var re *regexp.Regexp
 	qlow := strings.ToLower(o.Query)
 	qtoks, phrases := QueryParts(o.Query)
@@ -225,14 +235,61 @@ func Run(ss []model.Session, o Options) ([]Hit, error) {
 	}
 	hits := scoreBM25(documents, df, corpusDocuments, avgLength, len(qtoks), o.RecallWorn)
 	markEarlierAttempts(hits)
+	return hits, nil
+}
+
+// Run returns the capped result the CLI and the MCP tools have always
+// returned. RunDetailed is the same search with the numbers the cap hides.
+func Run(ss []model.Session, o Options) ([]Hit, error) {
+	r, err := RunDetailed(ss, o)
+	return r.Hits, err
+}
+
+// Results carries what a caller needs to interpret a search rather than only
+// read it: how many sessions matched before the cap, whether the cap hid any,
+// and which tier answered. Counting hits alone measures the cap — a figure that
+// moves when the window's membership changes, whether or not recall improved.
+type Results struct {
+	Hits   []Hit
+	Total  int
+	Capped bool
+	// Match is the set-level tier: exact, close, stemmed, semantic or
+	// relevance. relevance means nothing matched and these are the nearest
+	// sessions, which is not the same kind of answer.
+	Match string
+}
+
+// RunDetailed is Run plus the numbers the cap would otherwise hide.
+func RunDetailed(ss []model.Session, o Options) (Results, error) {
+	hits, err := runScored(ss, o)
+	if err != nil {
+		return Results{}, err
+	}
+	r := Results{Hits: hits, Total: len(hits), Match: matchTier(o)}
 	limit := o.Limit
 	if limit == 0 && !o.All {
 		limit = 15
 	}
 	if limit > 0 && len(hits) > limit {
-		hits = hits[:limit]
+		r.Hits = hits[:limit]
+		r.Capped = true
 	}
-	return hits, nil
+	return r, nil
+}
+
+func matchTier(o Options) string {
+	switch {
+	case o.Semantic:
+		return TierSemantic
+	case o.Tier != "":
+		return o.Tier
+	case o.Stemmed:
+		return TierStemmed
+	case o.Fuzzy:
+		return TierClose
+	default:
+		return TierExact
+	}
 }
 
 // markEarlierAttempts flags hits that look like older passes over the same
@@ -493,28 +550,20 @@ func Print(w io.Writer, hits []Hit, o Options) {
 		hits[i].Session.SetSource(o.SourceInstance)
 	}
 	if o.JSON {
-		if o.Semantic {
-			_ = json.NewEncoder(w).Encode(searchJSONEnvelope{
-				SchemaVersion: jsonout.Version,
-				Hits:          hits,
-				Semantic:      true,
-			})
-		} else if o.Stemmed {
-			_ = json.NewEncoder(w).Encode(searchJSONEnvelope{
-				SchemaVersion: jsonout.Version,
-				Hits:          hits,
-				Stemmed:       true,
-				Variants:      o.FuzzyVariants,
-			})
-		} else if o.Fuzzy {
-			_ = json.NewEncoder(w).Encode(searchJSONEnvelope{
-				SchemaVersion: jsonout.Version,
-				Hits:          hits,
-				Fuzzy:         true,
-			})
-		} else {
-			_ = json.NewEncoder(w).Encode(hits)
-		}
+		// One shape, always. The exact path used to emit a bare array while
+		// every fallback path emitted an object, so a consumer had to handle
+		// two contracts and could not tell which it had until it looked.
+		_ = json.NewEncoder(w).Encode(searchJSONEnvelope{
+			SchemaVersion: jsonout.Version,
+			Match:         matchTier(o),
+			Total:         o.Total,
+			Capped:        o.Capped,
+			Hits:          hits,
+			Fuzzy:         o.Fuzzy,
+			Stemmed:       o.Stemmed,
+			Semantic:      o.Semantic,
+			Variants:      o.FuzzyVariants,
+		})
 		return
 	}
 	color := colorOK(w)

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
@@ -184,9 +185,18 @@ func TestPrintJSONSessionContextAndHelpers(t *testing.T) {
 	hits := []Hit{{Session: s, Count: 1, Snippets: []string{"hello needle"}}}
 	var b bytes.Buffer
 	Print(&b, hits, Options{Query: "needle", JSON: true})
-	var decoded []Hit
-	if err := json.Unmarshal(b.Bytes(), &decoded); err != nil || len(decoded) != 1 {
+	// One shape on every path: the exact case used to emit a bare array while
+	// the fallback cases emitted an object.
+	var decoded struct {
+		SchemaVersion int    `json:"schema_version"`
+		Match         string `json:"match"`
+		Hits          []Hit  `json:"hits"`
+	}
+	if err := json.Unmarshal(b.Bytes(), &decoded); err != nil || len(decoded.Hits) != 1 {
 		t.Fatalf("bad json %q err=%v", b.String(), err)
+	}
+	if decoded.Match != TierExact {
+		t.Fatalf("match = %q, want %q", decoded.Match, TierExact)
 	}
 	b.Reset()
 	PrintSession(&b, s)
@@ -357,7 +367,7 @@ func TestQueryPartsDropsStopWordsButKeepsAllStopQueries(t *testing.T) {
 func TestFuzzyJSONEnvelope(t *testing.T) {
 	var b bytes.Buffer
 	Print(&b, []Hit{{Count: 1}}, Options{JSON: true, Fuzzy: true})
-	if !strings.Contains(b.String(), `"schema_version":1`) || !strings.Contains(b.String(), `"fuzzy":true`) || !strings.Contains(b.String(), `"hits"`) {
+	if !strings.Contains(b.String(), fmt.Sprintf(`"schema_version":%d`, jsonout.Version)) || !strings.Contains(b.String(), `"fuzzy":true`) || !strings.Contains(b.String(), `"hits"`) {
 		t.Fatalf("fuzzy json = %q", b.String())
 	}
 }
@@ -365,7 +375,7 @@ func TestFuzzyJSONEnvelope(t *testing.T) {
 func TestStemmedJSONEnvelope(t *testing.T) {
 	var b bytes.Buffer
 	Print(&b, []Hit{{Count: 1}}, Options{JSON: true, Stemmed: true, FuzzyVariants: map[string][]string{"rotation": {"rotated"}}})
-	if !strings.Contains(b.String(), `"schema_version":1`) || !strings.Contains(b.String(), `"stemmed":true`) || !strings.Contains(b.String(), `"rotation":["rotated"]`) {
+	if !strings.Contains(b.String(), fmt.Sprintf(`"schema_version":%d`, jsonout.Version)) || !strings.Contains(b.String(), `"stemmed":true`) || !strings.Contains(b.String(), `"rotation":["rotated"]`) {
 		t.Fatalf("stemmed json = %q", b.String())
 	}
 }
@@ -373,7 +383,7 @@ func TestStemmedJSONEnvelope(t *testing.T) {
 func TestSemanticJSONEnvelopeIncludesSource(t *testing.T) {
 	var b bytes.Buffer
 	Print(&b, []Hit{{Session: model.Session{Project: "p"}, Count: 1}}, Options{JSON: true, Semantic: true, SourceInstance: "workstation"})
-	if !strings.Contains(b.String(), `"schema_version":1`) || !strings.Contains(b.String(), `"semantic":true`) || !strings.Contains(b.String(), `"origin":"local"`) || !strings.Contains(b.String(), `"instance":"workstation"`) {
+	if !strings.Contains(b.String(), fmt.Sprintf(`"schema_version":%d`, jsonout.Version)) || !strings.Contains(b.String(), `"semantic":true`) || !strings.Contains(b.String(), `"origin":"local"`) || !strings.Contains(b.String(), `"instance":"workstation"`) {
 		t.Fatalf("semantic json = %q", b.String())
 	}
 }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -43,8 +43,9 @@ $D version | grep -q "deja" || fail "version"
 $D | grep -q "Usage" || fail "help"
 # ctx digest
 $D ctx frobnicator | grep -q "deja context" || fail "ctx"
-# json output is valid JSON
-$D --json frobnicator | head -1 | grep -q "^\[" || fail "json"
+# json output is one envelope on every path, and says which tier answered
+$D --json frobnicator | head -1 | grep -q '^{"schema_version"' || fail "json envelope"
+$D --json frobnicator | head -1 | grep -q '"match":"exact"' || fail "json match"
 # mcp handshake + recall
 printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0"}}}\n{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"recall","arguments":{"query":"frobnicator"}}}\n' \
   | $D mcp | tail -1 | grep -q "frobnicator" || fail "mcp recall"


### PR DESCRIPTION
Closes #494.

Raised by @AliceLJY while trying to measure CJK retrieval for #492: `deja` prints `no exact match; showing sessions ranked by relevance` to **stderr**, and then returns those loosely-related sessions carrying `— N matches` in exactly the shape real hits use. A query that found nothing can outscore one that found something, and nothing in the machine-readable output distinguishes them.

Looking at it turned up something worse than reported. **The exact path emitted a bare array while every fallback path emitted an object envelope**, so a consumer had to handle two shapes — and could not tell which it had without inspecting the value:

```
$ deja "pgbouncer prepared" --json          # array
$ deja "pgbouncer prepared" --json          # object, once anything falls back
```

So: one envelope on every path, and two fields that answer what a list of hits cannot.

```json
{ "schema_version": 2, "match": "relevance", "total": 391, "capped": true, "hits": [ … ] }
```

- **`match`** — the set-level tier: `exact`, `close`, `stemmed`, `semantic`, `relevance`. The per-hit `tier` was already correct and already in the JSON; what was missing was the set-level answer and the guarantee that the shape carrying it is always there.
- **`total` / `capped`** — how many sessions matched, and whether the cap hid any. This is the half that makes recall measurable: counting the survivors measures the cap, a number that moves when the window's membership changes whether or not retrieval improved. Measured on the demo corpus: `deja "the" --json` returns 15 hits and now reports `total: 391, capped: true`.

`Run` keeps its old capped behaviour so the CLI and the MCP tools are untouched; `RunDetailed` is the same search with the numbers the cap hides.

**One thing I got wrong and corrected mid-change.** I first computed `total` before policy scoping, reranking and the semantic tier — all of which run after the cap and can drop hits. The number then described something nobody asked for. It is now the surviving count when nothing was capped, and the pre-cap count when something was, with `capped` telling a reader which of the two they hold. There is no honest way to report a filtered total for sessions the cap already removed.

Also here, since it is the same trap from the same thread: `--limit=100` used to fall through the flag switch and be searched for as a query term, so the command silently answered a different question. Every value-taking search flag accepts both forms now, and a query that legitimately contains `=` (`GOFLAGS=-mod=mod`) still survives intact.

`schema_version` goes to 2 — the search shape changed, and that is exactly what the version exists to signal. `deja blame --json` still returns an array; that is documented rather than changed.
