### PR TITLE
Name the set-level field tier

### DIFF
--- a/cmd/deja/machine_output_test.go
+++ b/cmd/deja/machine_output_test.go
@@ -41,7 +41,7 @@ func TestMachineRecentSearchAndExactRead(t *testing.T) {
 	// a bare array here and an object on the fallback paths.
 	var env struct {
 		SchemaVersion int    `json:"schema_version"`
-		Match         string `json:"match"`
+		Tier          string `json:"tier"`
 		Total         int    `json:"total"`
 		Capped        bool   `json:"capped"`
 		Hits          []struct {
@@ -61,8 +61,8 @@ func TestMachineRecentSearchAndExactRead(t *testing.T) {
 	// The query is capped at one while two sessions match, which is exactly the
 	// case the envelope exists for: counting the returned hits would say one
 	// session mentions this, and two do.
-	if env.SchemaVersion != jsonout.Version || env.Match != "exact" || env.Total != 2 || !env.Capped {
-		t.Fatalf("envelope = %d/%q total=%d capped=%v", env.SchemaVersion, env.Match, env.Total, env.Capped)
+	if env.SchemaVersion != jsonout.Version || env.Tier != "exact" || env.Total != 2 || !env.Capped {
+		t.Fatalf("envelope = %d/%q total=%d capped=%v", env.SchemaVersion, env.Tier, env.Total, env.Capped)
 	}
 	if len(hits) != 1 || hits[0].Session.Source.Origin != "local" || hits[0].Session.Source.Instance != "test-workstation" {
 		t.Fatalf("hits = %#v", hits)

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -23,7 +23,7 @@ could not tell which it had without inspecting the value. It now always returns
 the envelope, and the envelope answers the two questions a caller cannot answer
 from a list of hits:
 
-- `match` — which tier answered: `exact`, `close`, `stemmed`, `semantic`, or
+- `tier` — which tier answered: `exact`, `close`, `stemmed`, `semantic`, or
   `relevance`. **`relevance` means nothing matched** and these are the nearest
   sessions deja could find. Counting those as hits overstates recall, and this
   used to be readable only as a sentence on stderr.
@@ -43,7 +43,7 @@ Every search returns one envelope:
 ```json
 {
   "schema_version": 2,
-  "match": "exact",
+  "tier": "exact",
   "total": 391,
   "capped": true,
   "hits": [
@@ -71,13 +71,14 @@ Every search returns one envelope:
 }
 ```
 
-`tier` on each hit is the per-hit equivalent of `match`. The fallback flags stay
-alongside it for readers written against version 1:
+The envelope's `tier` and each hit's `tier` are the same idea at two scopes,
+which is why they share a name. The fallback flags stay alongside for readers
+written against version 1:
 
 ```json
 {
   "schema_version": 2,
-  "match": "close",
+  "tier": "close",
   "total": 4,
   "hits": [ … ],
   "fuzzy": true

--- a/internal/search/json_signal_test.go
+++ b/internal/search/json_signal_test.go
@@ -30,14 +30,14 @@ func TestJSONAlwaysSaysWhichTierAnswered(t *testing.T) {
 		var b bytes.Buffer
 		Print(&b, hits, tc.opts)
 		var env struct {
-			Match string `json:"match"`
-			Hits  []Hit  `json:"hits"`
+			Tier string `json:"tier"`
+			Hits []Hit  `json:"hits"`
 		}
 		if err := json.Unmarshal(b.Bytes(), &env); err != nil {
 			t.Fatalf("%s: %v\n%s", name, err, b.String())
 		}
-		if env.Match != tc.want {
-			t.Fatalf("%s: match = %q, want %q", name, env.Match, tc.want)
+		if env.Tier != tc.want {
+			t.Fatalf("%s: match = %q, want %q", name, env.Tier, tc.want)
 		}
 		if len(env.Hits) != 1 {
 			t.Fatalf("%s: hits = %d", name, len(env.Hits))

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -56,7 +56,7 @@ type searchJSONEnvelope struct {
 	// are the nearest sessions — a different kind of answer, and the one a
 	// caller counting recall has to exclude. It used to be readable only as a
 	// sentence on stderr.
-	Match string `json:"match"`
+	Tier string `json:"tier"`
 	// Total is how many sessions matched before the cap; Capped says whether
 	// the cap hid any. Counting the returned hits alone measures the cap.
 	Total    int                 `json:"total"`
@@ -253,10 +253,10 @@ type Results struct {
 	Hits   []Hit
 	Total  int
 	Capped bool
-	// Match is the set-level tier: exact, close, stemmed, semantic or
+	// Tier is the set-level answer: exact, close, stemmed, semantic or
 	// relevance. relevance means nothing matched and these are the nearest
 	// sessions, which is not the same kind of answer.
-	Match string
+	Tier string
 }
 
 // RunDetailed is Run plus the numbers the cap would otherwise hide.
@@ -265,7 +265,7 @@ func RunDetailed(ss []model.Session, o Options) (Results, error) {
 	if err != nil {
 		return Results{}, err
 	}
-	r := Results{Hits: hits, Total: len(hits), Match: matchTier(o)}
+	r := Results{Hits: hits, Total: len(hits), Tier: setTier(o)}
 	limit := o.Limit
 	if limit == 0 && !o.All {
 		limit = 15
@@ -277,7 +277,7 @@ func RunDetailed(ss []model.Session, o Options) (Results, error) {
 	return r, nil
 }
 
-func matchTier(o Options) string {
+func setTier(o Options) string {
 	switch {
 	case o.Semantic:
 		return TierSemantic
@@ -555,7 +555,7 @@ func Print(w io.Writer, hits []Hit, o Options) {
 		// two contracts and could not tell which it had until it looked.
 		_ = json.NewEncoder(w).Encode(searchJSONEnvelope{
 			SchemaVersion: jsonout.Version,
-			Match:         matchTier(o),
+			Tier:          setTier(o),
 			Total:         o.Total,
 			Capped:        o.Capped,
 			Hits:          hits,

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -189,7 +189,7 @@ func TestPrintJSONSessionContextAndHelpers(t *testing.T) {
 	// the fallback cases emitted an object.
 	var decoded struct {
 		SchemaVersion int    `json:"schema_version"`
-		Match         string `json:"match"`
+		Match         string `json:"tier"`
 		Hits          []Hit  `json:"hits"`
 	}
 	if err := json.Unmarshal(b.Bytes(), &decoded); err != nil || len(decoded.Hits) != 1 {

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -45,7 +45,7 @@ $D | grep -q "Usage" || fail "help"
 $D ctx frobnicator | grep -q "deja context" || fail "ctx"
 # json output is one envelope on every path, and says which tier answered
 $D --json frobnicator | head -1 | grep -q '^{"schema_version"' || fail "json envelope"
-$D --json frobnicator | head -1 | grep -q '"match":"exact"' || fail "json match"
+$D --json frobnicator | head -1 | grep -q '"tier":"exact"' || fail "json match"
 # mcp handshake + recall
 printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0"}}}\n{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"recall","arguments":{"query":"frobnicator"}}}\n' \
   | $D mcp | tail -1 | grep -q "frobnicator" || fail "mcp recall"


### PR DESCRIPTION
Follow-up to #495, adopting @AliceLJY's naming from [her analysis on #494](https://github.com/vshulcz/deja-vu/issues/494#issuecomment-5116063095).

I shipped the field as `match`. She proposed `tier`, symmetric with the per-hit `Hit.Tier` that has carried the same values since long before any of this. She is right: two words for one idea is a thing every consumer has to learn and nothing gains from.

```json
{ "schema_version": 2, "tier": "relevance", "total": 391, "capped": true, "hits": [ { …, "tier": "relevance" } ] }
```

Free to do now — schema 2 exists only on main and has never been released, so no consumer has seen `match`.

Her reading of the cause was also more precise than the issue I wrote: it was never that the set-level state was uncomputed. `main.go` already set `Options.Tier` before `Print`, and `Print` read only the three bools and never that field; the one branch carrying relevance was the one branch that never built an envelope. The fix in #495 matches that reading.