### PR TITLE
Stop parsing what cannot match: 12% off a full rebuild

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -21,10 +21,13 @@ import (
 var version = "dev"
 
 func main() {
+	stopProfiling := startProfiling()
 	if err := run(os.Args[1:]); err != nil {
+		stopProfiling()
 		fmt.Fprintln(os.Stderr, "deja:", err)
 		os.Exit(1)
 	}
+	stopProfiling()
 }
 
 func loadAll(h string) []model.Session {

--- a/cmd/deja/profile.go
+++ b/cmd/deja/profile.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/pprof"
+)
+
+// Profiling is reachable from the real binary rather than only from `go test`,
+// because the interesting corpus is the one on someone's disk and a test cannot
+// see it. Indexing questions — which phase owns the time, what holds the memory
+// — are answered by running the command that is actually slow.
+//
+//	DEJA_CPUPROFILE=/tmp/cpu.out deja index --rebuild
+//	DEJA_MEMPROFILE=/tmp/mem.out deja index --rebuild
+//	go tool pprof -top /tmp/cpu.out
+//
+// Both are off unless the variable is set, so this costs a nil check per run.
+func startProfiling() func() {
+	var stops []func()
+
+	if path := os.Getenv("DEJA_CPUPROFILE"); path != "" {
+		f, err := os.Create(path)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "deja: cpu profile:", err)
+		} else if err := pprof.StartCPUProfile(f); err != nil {
+			fmt.Fprintln(os.Stderr, "deja: cpu profile:", err)
+			_ = f.Close()
+		} else {
+			stops = append(stops, func() {
+				pprof.StopCPUProfile()
+				_ = f.Close()
+				fmt.Fprintln(os.Stderr, "deja: cpu profile written to", path)
+			})
+		}
+	}
+
+	if path := os.Getenv("DEJA_MEMPROFILE"); path != "" {
+		stops = append(stops, func() {
+			f, err := os.Create(path)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "deja: mem profile:", err)
+				return
+			}
+			defer func() { _ = f.Close() }()
+			// The heap profile is a snapshot, so it is taken at the end and
+			// after a GC: without one it reports garbage the run had already
+			// finished with.
+			runtime.GC()
+			if err := pprof.WriteHeapProfile(f); err != nil {
+				fmt.Fprintln(os.Stderr, "deja: mem profile:", err)
+				return
+			}
+			fmt.Fprintln(os.Stderr, "deja: heap profile written to", path)
+		})
+	}
+
+	return func() {
+		for _, stop := range stops {
+			stop()
+		}
+	}
+}

--- a/cmd/deja/profile_test.go
+++ b/cmd/deja/profile_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Profiling is off unless asked for, and asking for it must not be able to
+// break the command: a bad path is a reason to say so on stderr and carry on
+// indexing, not a reason to fail the run someone is trying to profile.
+func TestProfilingWritesWhenAskedAndStaysOutOfTheWayOtherwise(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Setenv("DEJA_CPUPROFILE", "")
+	t.Setenv("DEJA_MEMPROFILE", "")
+	stop := startProfiling()
+	stop()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("profiling wrote %d files without being asked", len(entries))
+	}
+
+	cpu := filepath.Join(dir, "cpu.out")
+	mem := filepath.Join(dir, "mem.out")
+	t.Setenv("DEJA_CPUPROFILE", cpu)
+	t.Setenv("DEJA_MEMPROFILE", mem)
+	stop = startProfiling()
+	// Something for the CPU profile to sample; an empty profile is still a
+	// valid file, so the assertion below is only that both were written.
+	sum := 0
+	for i := 0; i < 200000; i++ {
+		sum += i % 7
+	}
+	_ = sum
+	stop()
+	for _, path := range []string{cpu, mem} {
+		fi, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("%s: %v", filepath.Base(path), err)
+		}
+		if fi.Size() == 0 {
+			t.Fatalf("%s is empty", filepath.Base(path))
+		}
+	}
+
+	// A directory that does not exist is a typo, not a crash.
+	t.Setenv("DEJA_CPUPROFILE", filepath.Join(dir, "no", "such", "cpu.out"))
+	t.Setenv("DEJA_MEMPROFILE", filepath.Join(dir, "no", "such", "mem.out"))
+	stop = startProfiling()
+	stop()
+}

--- a/internal/redact/bench_test.go
+++ b/internal/redact/bench_test.go
@@ -1,0 +1,60 @@
+package redact
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Redaction runs over every message on every index build, and profiling a real
+// rebuild put it at 23.5% of total CPU. These benchmarks are the baseline that
+// any change to the matchers has to beat — and the corpus below is deliberately
+// ordinary developer chatter, because that is what the cost is actually paid
+// on. Text containing an actual secret is rare; text containing the *words*
+// "token" or "secret" is not, and that is what makes the gates pass.
+var (
+	plain = strings.Repeat(
+		"the handler returns 500 when the body is empty, and the retry loop "+
+			"swallows the error. moved the check above the decode call.\n", 12)
+
+	// No secrets, but every gate word a developer uses in passing.
+	chatty = strings.Repeat(
+		"the auth token expires after 15m, so the refresh secret has to be read "+
+			"from the environment; see the Authorization header and the api_key "+
+			"we pass to the client. base64 payload aGVsbG8gd29ybGQgb2YgZGVqYQ==\n", 8)
+
+	// Long identifier-ish runs: hashes, paths, base64 — what the entropy pass
+	// exists for and what it spends its time on when nothing is a secret.
+	hashy = strings.Repeat(
+		"commit 4f3d2b1a9c8e7f6d5b4a3928170695847362514e touched "+
+			"internal/index/ingest.go and vendor/github.com/some/long-package-name/file.go\n", 8)
+
+	withSecret = chatty + "\napi_key = \"sk-abcdefghijklmnopqrstuvwxyz012345\"\n"
+)
+
+func BenchmarkTextPlain(b *testing.B)  { benchText(b, plain) }
+func BenchmarkTextChatty(b *testing.B) { benchText(b, chatty) }
+func BenchmarkTextHashy(b *testing.B)  { benchText(b, hashy) }
+func BenchmarkTextSecret(b *testing.B) { benchText(b, withSecret) }
+
+func benchText(b *testing.B, s string) {
+	b.SetBytes(int64(len(s)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, c := Text(s); c.Total() < 0 {
+			b.Fatal("impossible")
+		}
+	}
+}
+
+// A sanity print, so a reader of the benchmark output knows which inputs
+// actually redact anything.
+func TestBenchCorpusShape(t *testing.T) {
+	for name, s := range map[string]string{
+		"plain": plain, "chatty": chatty, "hashy": hashy, "secret": withSecret,
+	} {
+		_, c := Text(s)
+		t.Log(fmt.Sprintf("%-7s %6d bytes  %d redactions", name, len(s), c.Total()))
+	}
+}

--- a/internal/redact/bench_test.go
+++ b/internal/redact/bench_test.go
@@ -1,7 +1,6 @@
 package redact
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 )
@@ -55,6 +54,6 @@ func TestBenchCorpusShape(t *testing.T) {
 		"plain": plain, "chatty": chatty, "hashy": hashy, "secret": withSecret,
 	} {
 		_, c := Text(s)
-		t.Log(fmt.Sprintf("%-7s %6d bytes  %d redactions", name, len(s), c.Total()))
+		t.Logf("%-7s %6d bytes  %d redactions", name, len(s), c.Total())
 	}
 }

--- a/internal/redact/entropy_scan_test.go
+++ b/internal/redact/entropy_scan_test.go
@@ -1,0 +1,84 @@
+package redact
+
+import (
+	"math/rand"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// entropySpans replaced a regexp. A rewrite of a matcher that decides what gets
+// redacted is exactly the change that must be proved rather than reviewed, so
+// this checks it against the pattern it replaced on inputs designed to hit the
+// boundaries, and then on a lot of random ones.
+var referenceRE = regexp.MustCompile(`[A-Za-z0-9+/_-]{20,}={0,2}`)
+
+func reference(s string) [][2]int {
+	var out [][2]int
+	for _, m := range referenceRE.FindAllStringIndex(s, -1) {
+		out = append(out, [2]int{m[0], m[1]})
+	}
+	return out
+}
+
+func TestEntropySpansMatchesThePatternItReplaced(t *testing.T) {
+	cases := []string{
+		"",
+		"short",
+		strings.Repeat("a", 19),         // one below the threshold
+		strings.Repeat("a", 20),         // exactly the threshold
+		strings.Repeat("a", 20) + "=",   // one pad
+		strings.Repeat("a", 20) + "==",  // two pads
+		strings.Repeat("a", 20) + "===", // a third is not part of it
+		strings.Repeat("a", 20) + "=" + strings.Repeat("b", 25),
+		"prefix " + strings.Repeat("x", 30) + " suffix",
+		strings.Repeat("a", 19) + " " + strings.Repeat("b", 21),
+		"a+b/c_d-e" + strings.Repeat("Z", 25),
+		"кириллица " + strings.Repeat("q", 22) + " ещё",
+		strings.Repeat("=", 5),
+		strings.Repeat("a", 25) + "==" + strings.Repeat("b", 25) + "=",
+	}
+	for _, s := range cases {
+		if got, want := entropySpans(s), reference(s); !reflect.DeepEqual(got, want) {
+			t.Fatalf("input %q:\n got %v\nwant %v", s, got, want)
+		}
+	}
+}
+
+func TestEntropySpansMatchesOnRandomInput(t *testing.T) {
+	// A fixed seed: a matcher test that fails only sometimes is worse than no
+	// test, because nobody can reproduce the failure.
+	rng := rand.New(rand.NewSource(20260729))
+	alphabet := []byte("abcXYZ019+/_-= \n\t.:\"'{}")
+	for i := 0; i < 4000; i++ {
+		n := rng.Intn(120)
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = alphabet[rng.Intn(len(alphabet))]
+		}
+		s := string(b)
+		if got, want := entropySpans(s), reference(s); !reflect.DeepEqual(got, want) {
+			t.Fatalf("input %q:\n got %v\nwant %v", s, got, want)
+		}
+	}
+}
+
+// The scan is only worth having if it is faster than what it replaced.
+func BenchmarkEntropySpans(b *testing.B) {
+	s := hashy
+	b.SetBytes(int64(len(s)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = entropySpans(s)
+	}
+}
+
+func BenchmarkEntropySpansRegexp(b *testing.B) {
+	s := hashy
+	b.SetBytes(int64(len(s)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = referenceRE.FindAllStringIndex(s, -1)
+	}
+}

--- a/internal/redact/kvgate_test.go
+++ b/internal/redact/kvgate_test.go
@@ -1,0 +1,75 @@
+package redact
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// The key-value gate is an optimisation that decides whether a secret matcher
+// runs at all. If it is ever wrong in the direction of skipping, a credential
+// stays in the index — so this proves the gate is a necessary condition rather
+// than a heuristic: whenever the regex matches, the gate must have passed.
+func TestKVGateNeverHidesAMatch(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260729))
+	// Fragments chosen to land near the boundary: hint words, assignment
+	// punctuation, quoting, and values just under and just over the length the
+	// pattern requires.
+	parts := []string{
+		"api_key", "api-key", "apikey", "secret", "token", "passwd", "password",
+		"Authorization", "AUTHORIZATION", "my.api_key", "x-secret-token",
+		"=", ":", " = ", " : ", "\"", "'", " ", "\t", "\n",
+		"abcdefghijklmnop", "abcdefghijklmnopqrstuvwxyz012345", "short",
+		"the", "handler", "returns", "500", "sk-", "Bearer",
+	}
+	for i := 0; i < 20000; i++ {
+		var b strings.Builder
+		for n := rng.Intn(8); n >= 0; n-- {
+			b.WriteString(parts[rng.Intn(len(parts))])
+		}
+		s := b.String()
+		matched := genericKVRE.FindStringIndex(s) != nil
+		if matched && !kvAssignmentNearby(strings.ToLower(s)) {
+			t.Fatalf("gate skipped a real match: %q", s)
+		}
+	}
+}
+
+// And the gate has to actually skip the case it exists for, or it is only
+// overhead: ordinary chatter containing every hint word and no assignment.
+func TestKVGateSkipsOrdinaryChatter(t *testing.T) {
+	for _, s := range []string{
+		"the auth token expires after 15m",
+		"read the refresh secret from the environment",
+		"we pass an api_key to the client",
+		"check the Authorization header",
+		"the key insight was that the pool was too small",
+	} {
+		if kvAssignmentNearby(strings.ToLower(s)) {
+			t.Fatalf("gate passed on text with no assignment: %q", s)
+		}
+		if genericKVRE.FindStringIndex(s) != nil {
+			t.Fatalf("the regex itself matched, so the gate is not the issue: %q", s)
+		}
+	}
+}
+
+// The shapes that must still be caught, end to end through Text.
+func TestKVGatePassesRealCredentials(t *testing.T) {
+	for _, s := range []string{
+		`api_key = "sk-abcdefghijklmnopqrstuvwxyz012345"`,
+		`API_KEY: abcdefghijklmnopqrstuvwx`,
+		"my.api_key='abcdefghijklmnopqrstuvwx'",
+		`{"secret":"abcdefghijklmnopqrstuvwx"}`,
+		"password\t=\tabcdefghijklmnopqrstuvwx",
+		"x-secret-token: abcdefghijklmnopqrstuvwx",
+	} {
+		out, counts := Text(s)
+		if counts.Total() == 0 {
+			t.Fatalf("nothing redacted in %q", s)
+		}
+		if strings.Contains(out, "abcdefghijklmnopqrstuvwx") && !strings.Contains(out, "[redacted") {
+			t.Fatalf("secret survived: %q -> %q", s, out)
+		}
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -50,6 +50,57 @@ var (
 
 func Disabled() bool { return os.Getenv("DEJA_NO_REDACT") == "1" }
 
+// kvAssignmentNearby reports whether any key-ish word in the text is followed
+// by an assignment. genericKVRE cannot match unless one is, so this is a
+// necessary condition and skipping on a negative cannot change what is
+// redacted — TestKVGateNeverHidesAMatch proves it on random input.
+//
+// The word gate alone was not enough. "token", "secret" and "key" are ordinary
+// words in a developer's session, so the gate passed constantly and the regex
+// ran over the whole message to find nothing: on a 1.6 KB message of ordinary
+// chatter it cost 289µs, which was the single largest item in index-time
+// redaction.
+func kvAssignmentNearby(lower string) bool {
+	for _, hint := range kvHints {
+		for at := 0; ; {
+			i := strings.Index(lower[at:], hint)
+			if i < 0 {
+				break
+			}
+			pos := at + i + len(hint)
+			if assignmentFollows(lower, pos) {
+				return true
+			}
+			at += i + 1
+		}
+	}
+	return false
+}
+
+// assignmentFollows skips what genericKVRE allows between the name and the
+// value — the rest of a longer name, spaces and an optional quote — and looks
+// for the ':' or '=' the pattern requires.
+func assignmentFollows(s string, i int) bool {
+	for i < len(s) && (isWordByte(s[i]) || s[i] == '.' || s[i] == '-') {
+		i++
+	}
+	// The pattern uses \s, which is more than a space: a fuzz case of
+	// "passwd\n:" slipped past an earlier version of this that only skipped
+	// spaces and tabs.
+	for i < len(s) && (isSpaceByte(s[i]) || s[i] == '\'' || s[i] == '"') {
+		i++
+	}
+	return i < len(s) && (s[i] == ':' || s[i] == '=')
+}
+
+func isSpaceByte(c byte) bool {
+	switch c {
+	case ' ', '\t', '\n', '\r', '\f', '\v':
+		return true
+	}
+	return false
+}
+
 // kvHints are the substrings genericKVRE can anchor on; providerHints the
 // literal prefixes of providerRE. Checking them first keeps the regexes off
 // the vast majority of messages, which contain no credentials at all.
@@ -97,7 +148,7 @@ func Text(s string) (string, Counts) {
 	if strings.Contains(s, "eyJ") {
 		s = replaceWhole(s, jwtRE, "jwt", counts)
 	}
-	if containsAnyFold(lower, kvHints) {
+	if kvAssignmentNearby(lower) {
 		s = replaceSubmatch(s, genericKVRE, "credential", counts, func(m []string) string {
 			return m[1] + m[2] + m[3] + "[redacted:credential]" + closingQuote(m[3], m[5])
 		})
@@ -313,11 +364,54 @@ func standaloneLine(s string, start, end int) bool {
 	return true
 }
 
+// entropySpans finds the runs entropyTokenRE describes — twenty or more
+// characters from [A-Za-z0-9+/_-], plus up to two trailing '=' — without the
+// regexp engine.
+//
+// This pass is the only one with no cheap gate in front of it: every message
+// pays it, matching or not. Profiling a real rebuild put redaction at 23.5% of
+// index CPU and this scan at a third of that, spent almost entirely on text
+// that turns out to hold nothing. A byte loop does the same job; the filtering
+// that follows is unchanged, so what gets redacted does not move.
+func entropySpans(s string) [][2]int {
+	var out [][2]int
+	for i := 0; i < len(s); {
+		if !isEntropyByte(s[i]) {
+			i++
+			continue
+		}
+		run := i
+		for i < len(s) && isEntropyByte(s[i]) {
+			i++
+		}
+		if i-run < entropyMinAssign {
+			continue
+		}
+		end := i
+		for pad := 0; pad < 2 && end < len(s) && s[end] == '='; pad++ {
+			end++
+		}
+		out = append(out, [2]int{run, end})
+		i = end
+	}
+	return out
+}
+
+func isEntropyByte(c byte) bool {
+	switch {
+	case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		return true
+	case c == '+', c == '/', c == '_', c == '-':
+		return true
+	}
+	return false
+}
+
 func redactEntropy(s string, counts Counts) string {
 	if len(s) < entropyMinAssign {
 		return s
 	}
-	spans := entropyTokenRE.FindAllStringIndex(s, -1)
+	spans := entropySpans(s)
 	if spans == nil {
 		return s
 	}

--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -94,7 +94,16 @@ func ParseOpencodeDBWhere(db, where string, limit int) ([]model.Session, error) 
 		`json_extract(p.data,'$.time.start') as pt,` +
 		`json_extract(m.data,'$.time.created') as mt ` +
 		`from session s join message m on m.session_id=s.id join part p on p.message_id=m.id ` +
-		`where json_extract(p.data,'$.type')='text'` + where + ` order by s.id,m.time_created,p.id` + lim
+		// The type test is written twice on purpose. json_extract on its own
+		// parses every blob in the table — parts average ~12 KB and are mostly
+		// tool output — while the substring test reads only the head of the
+		// row, which for a large blob means SQLite never follows the overflow
+		// pages. `"type"` sits within the first 80 bytes of every part opencode
+		// writes. The exact test still decides: the cheap one only avoids
+		// parsing rows that cannot match. Measured on a 2.8 GB store: 6.9s to
+		// 5.6s, byte-identical output.
+		`where instr(substr(p.data,1,120),'"type":"text"')>0 ` +
+		`and json_extract(p.data,'$.type')='text'` + where + ` order by s.id,m.time_created,p.id` + lim
 	cmd := exec.Command("sqlite3", "-json", db, q)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
Two changes to index build cost, both found by profiling rather than by reading the code, and measured by interleaved runs because this machine's timings are not comparable across runs.

## Redaction: 23.5% of index CPU, mostly spent on text with no secrets

Profiling a full rebuild of a real store put `redact.Text` at 23.5% of total CPU. It runs on every message, and the profile showed where it went: `replaceSubmatch` 43%, `redactEntropy` 31%, `replaceProvider` 15%.

**The entropy pass had no gate at all** — every message paid a `[A-Za-z0-9+/_-]{20,}={0,2}` scan. It is now a byte loop, 22× faster (36 MB/s → 840 MB/s), and proved equivalent to the pattern it replaced on boundary cases and 4,000 random inputs.

**The key-value matcher had a word gate that stopped nothing.** It ran whenever the text contained "key", "secret", "token", "passw" or "authorization" — which in a developer's session is most of the time — and then scanned the whole message with an expensive case-insensitive pattern to find nothing. The gate now also requires an assignment to follow the word, which is a necessary condition for the pattern to match at all.

That gate decides whether a secret matcher runs, so it is fuzz-tested in the direction that matters: 20,000 generated inputs assert that **whenever the regex matches, the gate passed**. It caught a real hole while I was writing it — `passwd\n:` — because the pattern's `\s` includes newlines and my first scan skipped only spaces and tabs. That is exactly the bug that would have quietly left a credential in an index.

Per message, on 1.6 KB of text:

| input | before | after |
|---|---|---|
| ordinary prose | 71 µs | 13 µs (−82%) |
| prose with hashes and paths | 39 µs | 11 µs (−71%) |
| prose using the words token/secret/api_key | 368 µs | 21 µs (−94%) |
| an actual credential | 377 µs | 299 µs (−21%) |

**On its own this changed wall-clock by nothing**, which is worth saying plainly: at that point the build is not CPU-bound. It is still worth having — it is a quarter of the CPU a rebuild burns, it matters on a loaded machine, and it makes the next profile readable.

## opencode: 57% of a rebuild was one SQL query

Splitting the build by source: with the opencode store, a full rebuild took 13.2s; without it, 5.7s. Timing the query alone: **7.1s, for 17.7 MB of output.** The cost was not the pipe or our parsing — it was inside SQLite.

The `part` table holds 226,677 rows averaging ~12 KB, mostly tool output, and the filter was `json_extract(p.data,'$.type')='text'` — which parses every blob in the table to read a key that sits in its first 80 bytes. Adding a cheap substring test on the head of the row lets SQLite skip parsing, and for a large blob it never follows the overflow pages:

```sql
where instr(substr(p.data,1,120),'"type":"text"')>0
  and json_extract(p.data,'$.type')='text'
```

The exact test still decides — the cheap one only avoids work on rows that cannot match — and the output is byte-identical.

## Result

Full rebuild of the same store, three interleaved runs of each build:

| | before | after |
|---|---|---|
| wall clock | 16.32 / 16.55 / 16.93 s | 14.33 / 14.58 / 14.61 s |
| index size | 60.3 MB | 60.3 MB |

**−12%**, and the sessions and messages indexed are identical (983 / 17,940).

## Also here

`DEJA_CPUPROFILE` and `DEJA_MEMPROFILE` on the real binary. A test cannot see the corpus that is actually slow — someone's own store — so profiling has to be reachable from the command that is slow. Both are off unless set. This is also what #492 needs to find where the CJK path spends its time.

Size did not move, and I have not looked at it yet. The profile now points at allocation churn — `memclrNoHeapPointers` is 17.5% of what is left — which is the next thing worth pulling on.
