### PR TITLE
Fix the demo corpus path in its own doc comment

### DIFF
--- a/scripts/demo/corpus.go
+++ b/scripts/demo/corpus.go
@@ -11,7 +11,7 @@
 // eight months so the "history from before you installed deja" claim is visible
 // rather than asserted.
 //
-//	go run ./scripts/demo/corpus -out /tmp/demo-home
+//	go run ./scripts/demo -out /tmp/demo-home
 package main
 
 import (


### PR DESCRIPTION
The comment said `go run ./scripts/demo/corpus`, which is not a package path that exists. Spotted by @AliceLJY while reproducing #497.