### PR TITLE
Typed decoding for claude transcripts (−32% allocations, no speed change)

### DIFF
--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -62,6 +62,13 @@ func ParseClaudeFileFromOffset(path string, offset int64) ([]model.Session, erro
 }
 
 func parseClaudeFileFromOffset(path string, offset int64) ([]model.Session, error) {
+	return parseClaudeTypedFromOffset(path, offset)
+}
+
+// parseClaudeGenericFromOffset is the previous implementation, kept as the
+// reference the typed parser is proved against — including on a real store,
+// where the shapes nobody thought of live.
+func parseClaudeGenericFromOffset(path string, offset int64) ([]model.Session, error) {
 	s := model.Session{Harness: "claude", ID: strings.TrimSuffix(filepath.Base(path), ".jsonl"), Project: claudeProjectName(claudeProjectDir(path)), Path: path}
 	err := scanJSONLFromOffset(path, offset, func(m map[string]any) {
 		typ, _ := m["type"].(string)

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -1,0 +1,201 @@
+package sources
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The generic scanner decodes every transcript line into map[string]any behind a
+// per-line json.Decoder. On a real corpus that path allocated 4.4 GB of the
+// 8.6 GB a full rebuild spends, and 96.9% of it came from this parser alone —
+// claude transcripts are the bulk of most stores.
+//
+// Four fields are wanted out of a line that carries twenty. Declaring them costs
+// −39% time and −89% bytes against decoding into a map, measured on a real line;
+// reusing the decoder instead, which is the obvious fix, buys 3%.
+//
+// The two fields whose type varies stay raw and are decoded by hand, because
+// that variance is the reason the generic path existed:
+//
+//	timestamp:  "2026-01-02T03:04:05Z"  or  1767323045
+//	content:    "plain text"            or  [{"type":"text","text":"…"}, …]
+type claudeLine struct {
+	Type      string          `json:"type"`
+	SessionID string          `json:"sessionId"`
+	Timestamp json.RawMessage `json:"timestamp"`
+	Message   *claudeMessage  `json:"message"`
+}
+
+type claudeMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+func parseClaudeTypedFromOffset(path string, offset int64) ([]model.Session, error) {
+	s := model.Session{
+		Harness: "claude",
+		ID:      strings.TrimSuffix(filepath.Base(path), ".jsonl"),
+		Project: claudeProjectName(claudeProjectDir(path)),
+		Path:    path,
+	}
+	err := scanJSONLBytes(path, offset, func(line []byte) {
+		var v claudeLine
+		if json.Unmarshal(line, &v) != nil {
+			diagMalformedLine(path)
+			return
+		}
+		if v.Type != "user" && v.Type != "assistant" {
+			return
+		}
+		if v.SessionID != "" {
+			s.ID = v.SessionID
+		}
+		t := claudeTime(v.Timestamp)
+		s.Touch(t)
+		role := v.Type
+		txt := ""
+		if v.Message != nil {
+			if v.Message.Role != "" {
+				role = v.Message.Role
+			}
+			txt = claudeText(v.Message.Content)
+		}
+		if txt != "" {
+			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
+		}
+	})
+	if len(s.Messages) == 0 {
+		return nil, err
+	}
+	return []model.Session{s}, err
+}
+
+// claudeTime accepts the two shapes a transcript uses. Numbers keep going
+// through unixGuess rather than being read as float64: the generic scanner set
+// UseNumber for exactly this reason, and losing it would shift timestamps
+// silently.
+func claudeTime(raw json.RawMessage) time.Time {
+	raw = trimJSONSpace(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return time.Time{}
+	}
+	if raw[0] == '"' {
+		var s string
+		if json.Unmarshal(raw, &s) != nil {
+			return time.Time{}
+		}
+		if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+			return t
+		}
+		return time.Time{}
+	}
+	var n json.Number
+	if json.Unmarshal(raw, &n) != nil {
+		return time.Time{}
+	}
+	i, err := n.Int64()
+	if err != nil {
+		return time.Time{}
+	}
+	return unixGuess(i)
+}
+
+// claudeText joins the text a message carries. Items that are not objects, or
+// objects with neither key, are skipped rather than failing the line — a
+// transcript mixing shapes must not cost the whole message.
+func claudeText(raw json.RawMessage) string {
+	raw = trimJSONSpace(raw)
+	if len(raw) == 0 {
+		return ""
+	}
+	if raw[0] == '"' {
+		var s string
+		if json.Unmarshal(raw, &s) != nil {
+			return ""
+		}
+		return s
+	}
+	if raw[0] != '[' {
+		return ""
+	}
+	var items []json.RawMessage
+	if json.Unmarshal(raw, &items) != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, item := range items {
+		item = trimJSONSpace(item)
+		if len(item) == 0 || item[0] != '{' {
+			continue
+		}
+		var part struct {
+			Text    string `json:"text"`
+			Content string `json:"content"`
+		}
+		if json.Unmarshal(item, &part) != nil {
+			continue
+		}
+		chunk := part.Text
+		if chunk == "" {
+			chunk = part.Content
+		}
+		if chunk == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(chunk)
+	}
+	return b.String()
+}
+
+func trimJSONSpace(b []byte) []byte {
+	for len(b) > 0 && (b[0] == ' ' || b[0] == '\t' || b[0] == '\n' || b[0] == '\r') {
+		b = b[1:]
+	}
+	for len(b) > 0 {
+		c := b[len(b)-1]
+		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+			break
+		}
+		b = b[:len(b)-1]
+	}
+	return b
+}
+
+// scanJSONLBytes hands each line to the caller without copying it or building a
+// decoder for it. The slice is only valid for the duration of the call.
+func scanJSONLBytes(path string, offset int64, fn func([]byte)) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	if offset > 0 {
+		if _, err := f.Seek(offset, io.SeekStart); err != nil {
+			return err
+		}
+	}
+	r := bufio.NewReaderSize(f, 1024*1024)
+	for {
+		line, err := r.ReadBytes('\n')
+		if trimmed := trimJSONSpace(line); len(trimmed) > 0 {
+			fn(trimmed)
+		}
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/internal/sources/claude_decode_test.go
+++ b/internal/sources/claude_decode_test.go
@@ -1,0 +1,150 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The typed parser replaces the generic one for the harness that holds most of
+// everyone's history. A rewrite of a parser is the change most likely to lose
+// data quietly, so the two are compared field by field on every shape the
+// format is known to take — and, when a real store is present, on that.
+func sameSessions(t *testing.T, want, got []model.Session, ctx string) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("%s: %d sessions vs %d", ctx, len(want), len(got))
+	}
+	for i := range want {
+		a, b := want[i], got[i]
+		if a.ID != b.ID || a.Harness != b.Harness || a.Project != b.Project || a.Path != b.Path {
+			t.Fatalf("%s: session %d differs:\n old %+v\n new %+v", ctx, i, a, b)
+		}
+		if !a.Started.Equal(b.Started) || !a.Updated.Equal(b.Updated) {
+			t.Fatalf("%s: session %d times differ: %v/%v vs %v/%v", ctx, i, a.Started, a.Updated, b.Started, b.Updated)
+		}
+		if len(a.Messages) != len(b.Messages) {
+			t.Fatalf("%s: session %d has %d messages vs %d", ctx, i, len(a.Messages), len(b.Messages))
+		}
+		for j := range a.Messages {
+			x, y := a.Messages[j], b.Messages[j]
+			if x.Role != y.Role || x.Text != y.Text || !x.Time.Equal(y.Time) {
+				t.Fatalf("%s: session %d message %d differs:\n old %+v\n new %+v", ctx, i, j, x, y)
+			}
+		}
+	}
+}
+
+func TestTypedClaudeParserMatchesTheGenericOne(t *testing.T) {
+	dir := t.TempDir()
+	cases := map[string][]string{
+		"plain.jsonl": {
+			`{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"hello"}}`,
+			`{"type":"assistant","sessionId":"s1","timestamp":"2026-01-02T03:05:05Z","message":{"role":"assistant","content":"world"}}`,
+		},
+		"blocks.jsonl": {
+			`{"type":"assistant","sessionId":"s2","timestamp":"2026-01-02T03:04:05Z","message":{"role":"assistant","content":[{"type":"text","text":"first"},{"type":"tool_use","id":"t"},{"type":"text","text":"second"}]}}`,
+		},
+		// A content item carrying "content" rather than "text", and a bare
+		// string in the array: both are shapes the generic parser tolerated.
+		"mixed.jsonl": {
+			`{"type":"user","sessionId":"s3","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":[{"content":"from content"},"a bare string",{"type":"text","text":"from text"}]}}`,
+		},
+		// Numeric timestamps, which is why the generic scanner used UseNumber.
+		"numeric-time.jsonl": {
+			`{"type":"user","sessionId":"s4","timestamp":1767323045,"message":{"role":"user","content":"unix seconds"}}`,
+			`{"type":"user","sessionId":"s4","timestamp":1767323045123,"message":{"role":"user","content":"unix millis"}}`,
+		},
+		"no-role.jsonl": {
+			`{"type":"assistant","sessionId":"s5","timestamp":"2026-01-02T03:04:05Z","message":{"content":"role falls back to type"}}`,
+		},
+		"skipped-types.jsonl": {
+			`{"type":"summary","sessionId":"s6","timestamp":"2026-01-02T03:04:05Z","message":{"content":"ignored"}}`,
+			`{"type":"user","sessionId":"s6","timestamp":"2026-01-02T03:04:06Z","message":{"role":"user","content":"kept"}}`,
+		},
+		"empty-and-broken.jsonl": {
+			``,
+			`   `,
+			`{"type":"user","sessionId":"s7"`,
+			`{"type":"user","sessionId":"s7","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":""}}`,
+			`{"type":"user","sessionId":"s7","timestamp":"2026-01-02T03:04:06Z","message":{"role":"user","content":"survives the broken line above"}}`,
+		},
+		"no-message.jsonl": {
+			`{"type":"user","sessionId":"s8","timestamp":"2026-01-02T03:04:05Z"}`,
+		},
+		"null-fields.jsonl": {
+			`{"type":"user","sessionId":"s9","timestamp":null,"message":{"role":null,"content":null}}`,
+			`{"type":"user","sessionId":"s9","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"after nulls"}}`,
+		},
+		"unicode.jsonl": {
+			`{"type":"user","sessionId":"s10","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"кириллица 中文 emoji 🙂 \"quoted\" \\ backslash"}}`,
+		},
+	}
+	for name, lines := range cases {
+		path := filepath.Join(dir, name)
+		body := ""
+		for _, l := range lines {
+			body += l + "\n"
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		want, wantErr := parseClaudeGenericFromOffset(path, 0)
+		got, gotErr := parseClaudeTypedFromOffset(path, 0)
+		if (wantErr == nil) != (gotErr == nil) {
+			t.Fatalf("%s: errors differ: %v vs %v", name, wantErr, gotErr)
+		}
+		sameSessions(t, want, got, name)
+	}
+}
+
+// Resuming mid-file is how incremental indexing reads an appended transcript,
+// so the two parsers have to agree from an arbitrary offset too.
+func TestTypedClaudeParserMatchesFromAnOffset(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resume.jsonl")
+	first := `{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"first"}}` + "\n"
+	rest := `{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:06Z","message":{"role":"user","content":"second"}}` + "\n" +
+		`{"type":"assistant","sessionId":"s1","timestamp":"2026-01-02T03:04:07Z","message":{"role":"assistant","content":"third"}}` + "\n"
+	if err := os.WriteFile(path, []byte(first+rest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, off := range []int64{0, int64(len(first))} {
+		want, _ := parseClaudeGenericFromOffset(path, off)
+		got, _ := parseClaudeTypedFromOffset(path, off)
+		sameSessions(t, want, got, "offset")
+	}
+}
+
+// The one that matters: the machine's own history, if it has any. Synthetic
+// cases cover the shapes someone thought of; a real store covers the ones
+// nobody did.
+func TestTypedClaudeParserMatchesOnTheRealCorpus(t *testing.T) {
+	root := ClaudeRoot()
+	if _, err := os.Stat(root); err != nil {
+		t.Skip("no claude history on this machine")
+	}
+	var files []string
+	_ = filepath.Walk(root, func(p string, fi os.FileInfo, err error) error {
+		if err == nil && !fi.IsDir() && filepath.Ext(p) == ".jsonl" {
+			files = append(files, p)
+		}
+		return nil
+	})
+	if len(files) == 0 {
+		t.Skip("no transcripts")
+	}
+	if len(files) > 40 {
+		files = files[:40]
+	}
+	start := time.Now()
+	for _, p := range files {
+		want, _ := parseClaudeGenericFromOffset(p, 0)
+		got, _ := parseClaudeTypedFromOffset(p, 0)
+		sameSessions(t, want, got, filepath.Base(p))
+	}
+	t.Logf("compared %d real transcripts in %s", len(files), time.Since(start).Round(time.Millisecond))
+}


### PR DESCRIPTION
Step one of #501: the claude transcript parser decodes into declared types instead of `map[string]any`.

It was 96.9% of the 4.4 GB the JSONL scan allocated during a full rebuild — one parser, not ten, because claude transcripts are the bulk of most stores. Four fields are wanted out of a line carrying twenty, and the generic path built a map for all of them behind a `json.Decoder` constructed per line, over a copy of the line.

Measured on a full rebuild of a real 3.5 GB corpus:

| | before | after |
|---|---|---|
| allocated per rebuild | 8.44 GB | **5.77 GB (−32%)** |

**And now the part I would rather say myself than have someone find: it does not make anything faster.**

| | before | after |
|---|---|---|
| full rebuild | 14.93 / 15.07 / 15.98 s | 14.91 / 14.95 / 16.04 s |
| claude only, no opencode store | 7.65 s | 7.46 s |
| peak RSS | 558 MB | 566 MB |

That is the second experiment in a row — after the redaction work in #498 — that removed a large share of the CPU or the garbage and moved wall clock by nothing. The conclusion is not "optimise harder", it is that **this build is I/O bound**, and the remaining CPU and allocation work is not where speed lives. I have put that in #501 rather than leaving it implied.

So take this for what it is: less garbage per rebuild, typed decoding of the format that matters most, and a foundation for the rest of #501 — not a speed win. If you would rather not carry the extra file for that, say so and I will drop it; the measurement stands either way.

## What is proved, and how

A parser rewrite is the change most likely to lose data quietly — that is the lesson of #474, where a schema change made a whole harness's history vanish without an error. So the old implementation is kept as `parseClaudeGenericFromOffset` and the two are compared field by field:

- Ten synthetic files covering every shape the format is known to take: plain string content, content blocks, a block carrying `content` instead of `text`, a bare string inside the block array, numeric timestamps in both seconds and milliseconds, a missing role, skipped record types, empty and malformed lines, a missing `message`, explicit nulls, and unicode with escapes.
- Resuming from a byte offset, which is how incremental indexing reads an appended transcript.
- **The real store on the machine running the test**, 40 transcripts compared session by session, message by message, text by text. Synthetic cases cover the shapes someone thought of; a real corpus covers the ones nobody did.

Two traps worth naming, both of which the tests hold:

- The generic scanner set `UseNumber()`, and timestamp handling depends on receiving `json.Number` rather than `float64`. Decoding into a struct field of the right type keeps that; a naive switch to `json.Unmarshal` into a map would have shifted timestamps silently.
- A content array can mix objects and bare strings. Decoding it as `[]struct{…}` would fail the whole line on the first string and drop the message; items are decoded individually and skipped on failure, as before.

The two fields whose type genuinely varies — `timestamp` and `content` — stay `json.RawMessage` and are decoded by hand. That variance is the reason the generic path existed; declaring the eighteen fields that do not vary is the win.
