### PR TITLE
A reverted decision comes back marked, not as current truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,19 @@
 <sub>Both harnesses ship in this repo and run on the public datasets in minutes — <a href="https://vshulcz.github.io/deja-vu/guide/benchmarks.html">check the numbers yourself</a>.</sub>
 </p>
 
+<p align="center">
+<code>curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</code><br>
+<sub>or <code>brew install vshulcz/tap/deja-vu</code> &middot; <code>npm i -g @vshulcz/deja-vu</code> &middot; <code>scoop install deja-vu</code> &middot; <a href="https://github.com/vshulcz/deja-vu/releases/latest">.mcpb for desktop apps</a><br>
+then <code>deja install --auto</code> to wire it into every agent you have.</sub>
+</p>
+
 Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Roo Code, OpenClaw, Goose, pi and Copilot CLI write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
 
 | Feature | What it does |
 | --- | --- |
 | **Search** | `deja "connection pool exhausted"` — ~12 ms over gigabytes, retroactive: months of logs from before you installed it; natural-language questions fall back to a relevance tier — 84.9% hit@1 on LongMemEval-S session retrieval, harness in-repo; time is a hint, not a filter: `deja "what did we do in may"` and "a week ago" push that month's sessions up the ranking, they do not exclude the rest — use `--since 30d` when you mean a window |
 | **Agent recall** | MCP `recall` tool — the agent answers *"we fixed this three weeks ago"* instead of re-debugging, across harnesses: solve it in Codex, Claude remembers |
+| **Knows what held** | `deja promote <id> --state rejected --note "why"` — a decision you reverted comes back marked *tried and rejected*, with the reason and the date, on every hit for that session. Nothing is deleted: the agent sees what was decided **and** that it changed |
 | **Sync** | `deja sync ssh laptop` — your memory follows you between machines, append-only, idempotent, no cloud in the middle |
 | **Handoff** | `deja handoff --to codex` — stuck in one agent? package the live context and continue in another: `codex "$(deja handoff --to codex)"`; thirteen harnesses can be started directly, the rest print the prompt to paste |
 | **Auto-recall** | `install --auto` adds a SessionStart hook: relevant memory lands in context before you ask — ranked by the files your repo is touching, ~120 ms on a 1000-session index; Claude Code also captures the current transcript before compaction |

--- a/cmd/deja/lifecycle.go
+++ b/cmd/deja/lifecycle.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// attachLifecycles marks hits whose decision was later rejected, superseded or
+// left to go stale.
+//
+// deja recorded this already: `deja promote <id> --state rejected` writes the
+// state and the correction, and prints that the note "now outranks the raw
+// transcript in recall". Measured, it did not — the correction only surfaced
+// when its own wording matched the query, so asking about a reverted decision
+// returned the transcript that made it, reading like current truth. The state
+// belongs to the session; ranking was never going to carry it.
+func attachLifecycles(hits []search.Hit) {
+	if len(hits) == 0 {
+		return
+	}
+	states := sources.PromotedLifecycles()
+	if len(states) == 0 {
+		return
+	}
+	for i := range hits {
+		h := &hits[i]
+		key := h.Session.Harness + ":" + h.Session.ID
+		lc, ok := states[key]
+		if !ok || lc.State == "" || lc.State == "accepted" {
+			continue
+		}
+		h.Lifecycle = lc.State
+		h.LifecycleNote = lc.Note
+		if !lc.At.IsZero() {
+			h.LifecycleAt = lc.At.Format("2006-01-02")
+		}
+	}
+}
+
+// lifecycleLine is what a reader — human or model — is told about a hit whose
+// decision did not hold. The wording says what happened rather than naming the
+// state, because "superseded" means nothing to someone who has not read our
+// docs, and the model has to act on it without asking.
+func lifecycleLine(h search.Hit) string {
+	if h.Lifecycle == "" {
+		return ""
+	}
+	var b strings.Builder
+	switch h.Lifecycle {
+	case "rejected":
+		b.WriteString("[this was tried and rejected")
+	case "superseded":
+		b.WriteString("[a later decision replaced this")
+	case "stale":
+		b.WriteString("[marked stale — may no longer hold")
+	default:
+		b.WriteString("[" + h.Lifecycle)
+	}
+	if h.LifecycleAt != "" {
+		fmt.Fprintf(&b, ", %s", h.LifecycleAt)
+	}
+	b.WriteString("]")
+	if h.LifecycleNote != "" {
+		b.WriteString(" " + h.LifecycleNote)
+	}
+	return b.String()
+}

--- a/cmd/deja/lifecycle_test.go
+++ b/cmd/deja/lifecycle_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// The objection this answers, in the words it was raised in: "how do you know
+// what was true, what was rejected, and what's obsolete?" deja recorded all
+// three and then answered as though everything still stood — a session promoted
+// as rejected came back through recall with its original conclusion and no
+// trace of the reversal, because the correction only surfaced when its own
+// wording happened to match the query.
+func TestRecallSaysWhenADecisionWasReverted(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "payments", "s1.jsonl"), "s1", []string{
+		`{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"prepared statements fail behind pgbouncer"}}`,
+		`{"type":"assistant","sessionId":"s1","timestamp":"2026-01-02T03:05:05Z","message":{"role":"assistant","content":"We pinned pgx to 5.4.3 and left a note to revisit."}}`,
+	})
+	dir := index.DefaultDir()
+
+	// Before anything is recorded, the transcript speaks for itself.
+	before, err := recallText(dir, "prepared statements pgbouncer", "", 5, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(before, "rejected") {
+		t.Fatalf("nothing was promoted yet:\n%s", before)
+	}
+
+	if err := runPromote(dir, []string{"s1", "--state", "rejected", "--note", "the pin was reverted; pgbouncer 1.24 handles it natively"}, os.Stdout); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := recallText(dir, "prepared statements pgbouncer", "", 5, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The state has to arrive with the hit on the transcript, not only as a
+	// separate note that may or may not match the query.
+	if !strings.Contains(got, "tried and rejected") {
+		t.Fatalf("recall did not say the decision was rejected:\n%s", got)
+	}
+	if !strings.Contains(got, "pgbouncer 1.24 handles it natively") {
+		t.Fatalf("recall dropped the correction:\n%s", got)
+	}
+	// And the original is still there: deja keeps history rather than deleting
+	// it, so the reader can see what was decided as well as that it changed.
+	if !strings.Contains(got, "pinned pgx to 5.4.3") {
+		t.Fatalf("recall lost the original decision:\n%s", got)
+	}
+}
+
+// A session promoted as accepted is not annotated: the marker means "this did
+// not hold", so putting it on everything would make it noise.
+func TestAcceptedSessionsAreNotAnnotated(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "infra", "s2.jsonl"), "s2", []string{
+		`{"type":"user","sessionId":"s2","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"queue keeps losing messages"}}`,
+		`{"type":"assistant","sessionId":"s2","timestamp":"2026-01-02T03:05:05Z","message":{"role":"assistant","content":"Moved the job queue to Postgres advisory locks."}}`,
+	})
+	dir := index.DefaultDir()
+	if err := runPromote(dir, []string{"s2", "--state", "accepted"}, os.Stdout); err != nil {
+		t.Fatal(err)
+	}
+	got, err := recallText(dir, "queue losing messages", "", 5, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unwanted := range []string{"tried and rejected", "replaced by a later decision", "marked stale"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("an accepted session was annotated with %q:\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestLifecycleWordingSaysWhatHappened(t *testing.T) {
+	for state, want := range map[string]string{
+		"rejected":   "tried and rejected",
+		"superseded": "a later decision replaced this",
+		"stale":      "may no longer hold",
+	} {
+		got := lifecycleLine(hitWithLifecycle(state, "2026-07-29", "because reasons"))
+		if !strings.Contains(got, want) {
+			t.Fatalf("%s rendered as %q, want it to contain %q", state, got, want)
+		}
+		if !strings.Contains(got, "2026-07-29") || !strings.Contains(got, "because reasons") {
+			t.Fatalf("%s lost its date or note: %q", state, got)
+		}
+	}
+	if lifecycleLine(hitWithLifecycle("", "", "")) != "" {
+		t.Fatal("a hit with no recorded state produced a line")
+	}
+}
+
+func hitWithLifecycle(state, at, note string) search.Hit {
+	return search.Hit{Lifecycle: state, LifecycleAt: at, LifecycleNote: note}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -423,6 +423,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	// nothing was capped the honest total is simply what survived; when it was,
 	// there is no way to know how the filters would have treated the hidden
 	// ones, so the pre-cap figure stands and `capped` says to distrust it.
+	attachLifecycles(hits)
 	if !o.Capped {
 		o.Total = len(hits)
 	}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -104,7 +104,7 @@ func handleMCP(dir string, req rpcRequest) (any, int, string) {
 		return map[string]any{"tools": []map[string]any{
 			{
 				"name":        "recall",
-				"description": "Search the user's own past coding sessions across every AI tool they've used (Claude Code, Codex, Cursor, opencode, aider, gemini, and others) and return the best matches as dense text under ~4KB. Call this the moment the user implies work already happened — 'didn't we fix this before?', 'what was that error again', 'we already set this up', 'how did we solve X last time', 'what did we decide about Y' — and always before debugging an error or re-implementing something that might already exist. Query with the most specific token available: an exact error string, function name, file path, or flag (multiple words are ANDed). Do NOT use this for general knowledge or library/API docs — only this user's prior sessions. Follow up with recall_context when one session looks right and you need its full story. Optionally filter by harness. When a result genuinely helps the task at hand — you reuse a fix, skip re-debugging, or confirm a prior decision — tell the user in one digest.Short line what deja-vu recalled and how you used it (e.g. \"deja-vu recalled: we hit this JWT skew in March — reusing that fix\"). Even a partial hint counts if it changed your approach. Say nothing about recalls that did not help.",
+				"description": "Search the user's own past coding sessions across every AI tool they've used (Claude Code, Codex, Cursor, opencode, aider, gemini, and others) and return the best matches as dense text under ~4KB. Call this the moment the user implies work already happened — 'didn't we fix this before?', 'what was that error again', 'we already set this up', 'how did we solve X last time', 'what did we decide about Y' — and always before debugging an error or re-implementing something that might already exist. Query with the most specific token available: an exact error string, function name, file path, or flag (multiple words are ANDed). Do NOT use this for general knowledge or library/API docs — only this user's prior sessions. A result may carry a bracketed marker before its snippets — [this was tried and rejected], [a later decision replaced this], [marked stale — may no longer hold] — with the reason and the date. That is the user's own later judgement on that session: do not repeat a rejected approach, prefer the replacement over what it replaced, and treat stale results as needing confirmation before you act on them. An unmarked result carries no such judgement either way. Follow up with recall_context when one session looks right and you need its full story. Optionally filter by harness. When a result genuinely helps the task at hand — you reuse a fix, skip re-debugging, or confirm a prior decision — tell the user in one digest.Short line what deja-vu recalled and how you used it (e.g. \"deja-vu recalled: we hit this JWT skew in March — reusing that fix\"). Even a partial hint counts if it changed your approach. Say nothing about recalls that did not help.",
 				"annotations": map[string]any{"title": "Search past sessions", "readOnlyHint": true, "openWorldHint": false},
 				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "Search terms; specific tokens (error strings, function names, flags) match best. Multiple words are ANDed."}, "harness": map[string]any{"type": "string", "description": "Optional filter: claude, codex, opencode, aider, gemini, cursor, antigravity, grok or qwen."}, "limit": map[string]any{"type": "number", "description": "Max sessions to return (default 5)."}, "offset": map[string]any{"type": "number", "description": "Skip this many ranked matches — page through results without re-ranking."}}, "required": []string{"query"}},
 			},
@@ -375,6 +375,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		hits = hits[:limit]
 	}
 	attachAnswers(dir, hits)
+	attachLifecycles(hits)
 	var b strings.Builder
 	served := 0
 	if stale {
@@ -401,6 +402,9 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 			fmt.Fprintf(&b, " · reused %d×", h.Reused)
 		}
 		fmt.Fprintln(&b)
+		if line := lifecycleLine(h); line != "" {
+			fmt.Fprintf(&b, "%s\n", line)
+		}
 		if h.Superseded != "" {
 			fmt.Fprintf(&b, "[earlier attempt — a newer session in this project covers the same ground, updated %s]\n", h.Superseded)
 		}

--- a/internal/search/json_signal_test.go
+++ b/internal/search/json_signal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -75,5 +76,44 @@ func TestRunDetailedReportsWhatTheCapHides(t *testing.T) {
 	}
 	if len(all.Hits) != 40 || all.Capped {
 		t.Fatalf("--all returned %d hits, capped=%v", len(all.Hits), all.Capped)
+	}
+}
+
+// A hit whose decision did not hold says so above its snippets, in words a
+// reader can act on without knowing our vocabulary for them.
+func TestLifecycleIsPrintedBeforeTheSnippets(t *testing.T) {
+	base := model.Session{ID: "s1", Harness: "claude", Project: "payments",
+		Messages: []model.Message{{Role: "user", Text: "needle"}}}
+	for state, want := range map[string]string{
+		"rejected":   "tried and rejected",
+		"superseded": "replaced by a later decision",
+		"stale":      "may no longer hold",
+		"invented":   "invented",
+	} {
+		hit := Hit{Session: base, Count: 1, Snippets: []string{"needle"},
+			Lifecycle: state, LifecycleAt: "2026-07-29", LifecycleNote: "the pin was reverted"}
+		var b bytes.Buffer
+		Print(&b, []Hit{hit}, Options{Query: "needle"})
+		out := b.String()
+		if !strings.Contains(out, want) {
+			t.Fatalf("%s: %q missing from\n%s", state, want, out)
+		}
+		if !strings.Contains(out, "2026-07-29") || !strings.Contains(out, "the pin was reverted") {
+			t.Fatalf("%s dropped the date or the reason:\n%s", state, out)
+		}
+		// The marker has to come before the snippet: a reader who stops after
+		// one line must not stop on a conclusion that was reverted.
+		if strings.Index(out, want) > strings.Index(out, "needle\n") && strings.Contains(out, "needle\n") {
+			t.Fatalf("%s printed after the snippet:\n%s", state, out)
+		}
+	}
+
+	// Nothing recorded, nothing said.
+	var b bytes.Buffer
+	Print(&b, []Hit{{Session: base, Count: 1, Snippets: []string{"needle"}}}, Options{Query: "needle"})
+	for _, unwanted := range []string{"rejected", "replaced", "stale"} {
+		if strings.Contains(b.String(), unwanted) {
+			t.Fatalf("an unmarked hit mentioned %q:\n%s", unwanted, b.String())
+		}
 	}
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -80,6 +80,13 @@ type Hit struct {
 	Superseded string `json:"superseded,omitempty"`
 	// Reused counts recent agent recalls that served this session.
 	Reused int `json:"reused,omitempty"`
+	// Lifecycle carries what was later recorded about this session: that its
+	// decision was rejected, superseded or has gone stale. A hit on a raw
+	// transcript used to arrive with no trace of that, so a decision someone
+	// had explicitly reverted came back reading like current truth.
+	Lifecycle     string `json:"lifecycle,omitempty"`
+	LifecycleNote string `json:"lifecycle_note,omitempty"`
+	LifecycleAt   string `json:"lifecycle_at,omitempty"`
 }
 
 const (
@@ -453,6 +460,30 @@ func proximityBoost(window, queryTokenCount int) float64 {
 
 // promotedNoteBoost lifts curated deja notes over raw transcripts on equal
 // relevance. Kept modest: a note about X must not bury a transcript about Y.
+// lifecycleSummary words a hit's recorded state for a person. It says what
+// happened rather than naming the state: "superseded" is our vocabulary, not
+// the reader's.
+func lifecycleSummary(h Hit) string {
+	var head string
+	switch h.Lifecycle {
+	case "rejected":
+		head = "tried and rejected"
+	case "superseded":
+		head = "replaced by a later decision"
+	case "stale":
+		head = "marked stale — may no longer hold"
+	default:
+		head = h.Lifecycle
+	}
+	if h.LifecycleAt != "" {
+		head += " (" + h.LifecycleAt + ")"
+	}
+	if h.LifecycleNote != "" {
+		head += ": " + h.LifecycleNote
+	}
+	return head
+}
+
 const promotedNoteBoost = 1.25
 
 // wornBoost rewards sessions agents keep recalling — capped hard at +20% so
@@ -581,6 +612,16 @@ func Print(w io.Writer, hits []Hit, o Options) {
 			note := fmt.Sprintf("  reused %d× by agents recently", h.Reused)
 			if color {
 				note = cDim + note + cReset
+			}
+			fmt.Fprintln(w, note)
+		}
+		// What was later recorded about this decision comes before anything
+		// else about the hit: a reader who stops after one line must not stop
+		// on a conclusion that was reverted.
+		if h.Lifecycle != "" {
+			note := "  " + lifecycleSummary(h)
+			if color {
+				note = cOrange + note + cReset
 			}
 			fmt.Fprintln(w, note)
 		}

--- a/internal/sources/lifecycle.go
+++ b/internal/sources/lifecycle.go
@@ -1,0 +1,100 @@
+package sources
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Lifecycle is what a session's own history says about whether it still holds:
+// a decision that was accepted, one that was tried and rejected, one a later
+// session replaced, or one nobody has revisited in long enough to trust.
+type Lifecycle struct {
+	State string    // accepted, rejected, superseded, stale
+	Note  string    // why, in the words of whoever recorded it
+	At    time.Time // when the state was last set
+}
+
+// PromotedLifecycles maps a session key ("claude:a1f2c93b") to its latest
+// recorded state.
+//
+// deja already stores this — `deja promote` writes it and the note is indexed —
+// but a search that hit the raw transcript never learned about it. Promoting a
+// session as rejected and then asking about it returned the transcript, with
+// its original conclusion, and nothing else: the correction only surfaced if
+// its own wording happened to match the query. So the tool knew a decision had
+// been reverted and answered as though it still stood.
+//
+// Binding the state to the session rather than hoping the correction wins the
+// ranking is the difference between recording a lifecycle and using one.
+func PromotedLifecycles() map[string]Lifecycle {
+	return promotedLifecyclesFrom(NotesFile())
+}
+
+func promotedLifecyclesFrom(path string) map[string]Lifecycle {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+
+	type entry struct {
+		Lifecycle
+		seq int
+	}
+	byKey := map[string]entry{}
+	s := bufio.NewScanner(f)
+	s.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	seq := 0
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" {
+			continue
+		}
+		var n struct {
+			Kind    string `json:"kind"`
+			Session string `json:"session"`
+			State   string `json:"state"`
+			Text    string `json:"text"`
+			TS      string `json:"ts"`
+		}
+		if json.Unmarshal([]byte(line), &n) != nil {
+			continue
+		}
+		seq++
+		if n.Kind != "promoted" || n.Session == "" || !NoteStates[n.State] {
+			continue
+		}
+		at, _ := time.Parse(time.RFC3339Nano, n.TS)
+		prev, seen := byKey[n.Session]
+		// Later wins. Ties on timestamp fall back to file order, because a
+		// correction written in the same second as the note it corrects is
+		// still the correction.
+		if seen && !at.After(prev.At) && seq < prev.seq {
+			continue
+		}
+		byKey[n.Session] = entry{Lifecycle{State: n.State, Note: strings.TrimSpace(n.Text), At: at}, seq}
+	}
+	if len(byKey) == 0 {
+		return nil
+	}
+	out := make(map[string]Lifecycle, len(byKey))
+	for k, e := range byKey {
+		out[k] = e.Lifecycle
+	}
+	return out
+}
+
+// LifecycleKeys returns the keys in a stable order, for tests and for anything
+// that reports what is recorded.
+func LifecycleKeys(m map[string]Lifecycle) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/sources/lifecycle_test.go
+++ b/internal/sources/lifecycle_test.go
@@ -1,0 +1,102 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeNotes(t *testing.T, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "notes.jsonl")
+	body := ""
+	for _, l := range lines {
+		body += l + "\n"
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// A session's state is whatever was recorded last. Getting this backwards means
+// a correction is ignored and the thing it corrected is served as current — the
+// exact failure this map exists to prevent.
+func TestLatestRecordedStateWins(t *testing.T) {
+	path := writeNotes(t,
+		`{"kind":"promoted","session":"claude:s1","state":"accepted","text":"looked right","ts":"2026-01-01T00:00:00Z"}`,
+		`{"kind":"promoted","session":"claude:s1","state":"rejected","text":"reverted a week later","ts":"2026-01-08T00:00:00Z"}`,
+		`{"kind":"promoted","session":"claude:s2","state":"accepted","text":"still holds","ts":"2026-01-02T00:00:00Z"}`,
+	)
+	got := promotedLifecyclesFrom(path)
+	if len(got) != 2 {
+		t.Fatalf("sessions = %v", LifecycleKeys(got))
+	}
+	if got["claude:s1"].State != "rejected" || got["claude:s1"].Note != "reverted a week later" {
+		t.Fatalf("s1 = %+v, want the later rejection", got["claude:s1"])
+	}
+	if got["claude:s2"].State != "accepted" {
+		t.Fatalf("s2 = %+v", got["claude:s2"])
+	}
+}
+
+// Two entries stamped in the same second still have an order: the file's. A
+// correction written moments after the note it corrects is still the correction.
+func TestSameTimestampFallsBackToFileOrder(t *testing.T) {
+	path := writeNotes(t,
+		`{"kind":"promoted","session":"claude:s1","state":"accepted","text":"first","ts":"2026-01-01T00:00:00Z"}`,
+		`{"kind":"promoted","session":"claude:s1","state":"superseded","text":"second","ts":"2026-01-01T00:00:00Z"}`,
+	)
+	if got := promotedLifecyclesFrom(path)["claude:s1"]; got.State != "superseded" || got.Note != "second" {
+		t.Fatalf("got %+v, want the later line", got)
+	}
+}
+
+// Everything that is not a promotion with a known state is ignored rather than
+// guessed at: a plain note, an unknown state, a line with no session, and text
+// that is not JSON at all.
+func TestOnlyPromotionsWithKnownStatesCount(t *testing.T) {
+	path := writeNotes(t,
+		`{"kind":"note","project":"p","text":"a plain note","ts":"2026-01-01T00:00:00Z"}`,
+		`{"kind":"promoted","session":"claude:s1","state":"invented","text":"nope","ts":"2026-01-01T00:00:00Z"}`,
+		`{"kind":"promoted","session":"","state":"rejected","text":"no session","ts":"2026-01-01T00:00:00Z"}`,
+		`not json at all`,
+		``,
+		`{"kind":"promoted","session":"codex:s9","state":"stale","text":"kept","ts":"2026-01-01T00:00:00Z"}`,
+	)
+	got := promotedLifecyclesFrom(path)
+	if len(got) != 1 || got["codex:s9"].State != "stale" {
+		t.Fatalf("got %v", LifecycleKeys(got))
+	}
+}
+
+func TestMissingNotesFileIsNotAnError(t *testing.T) {
+	if got := promotedLifecyclesFrom(filepath.Join(t.TempDir(), "absent.jsonl")); got != nil {
+		t.Fatalf("got %v, want nothing", LifecycleKeys(got))
+	}
+	if got := promotedLifecyclesFrom(writeNotes(t)); got != nil {
+		t.Fatalf("an empty file produced %v", LifecycleKeys(got))
+	}
+}
+
+// A note with no timestamp still records a state; it just cannot claim to be
+// newer than one that has a date.
+func TestUndatedEntriesStillCount(t *testing.T) {
+	path := writeNotes(t,
+		`{"kind":"promoted","session":"claude:s1","state":"rejected","text":"undated"}`,
+	)
+	got := promotedLifecyclesFrom(path)["claude:s1"]
+	if got.State != "rejected" || !got.At.IsZero() {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestPromotedLifecyclesReadsTheConfiguredFile(t *testing.T) {
+	path := writeNotes(t,
+		`{"kind":"promoted","session":"claude:s1","state":"rejected","text":"why","ts":"2026-01-01T00:00:00Z"}`,
+	)
+	t.Setenv("DEJA_NOTES_FILE", path)
+	if got := PromotedLifecycles()["claude:s1"]; got.State != "rejected" {
+		t.Fatalf("got %+v", got)
+	}
+}


### PR DESCRIPTION
The objection people actually raise about memory built from raw transcripts, in the words it was raised in on HN: *"How do you know what was true, what was rejected, and what's obsolete?"*

deja records all three. `deja promote <id> --state rejected --note "why"` has existed for months, writes the state and the correction, and prints:

> the note now outranks the raw transcript in recall

**That was not true, and I measured it rather than reading it.** Promoting a session as rejected and then asking about it:

```
2. [claude] payments · a1f2c93b · updated 2025-11-29
- prepared statements keep failing behind pgbouncer after the driver upgrade
- → We pinned pgx to 5.4.3 and left a note to revisit once pgbouncer 1.24 ships support.
```

The reversal is nowhere. The agent gets a decision the user explicitly reverted, reading like current truth, and will confidently re-apply it. The correction *was* indexed — it only surfaced when its own wording happened to match the query, and "the pin was reverted; pgbouncer 1.24 handles it natively" shares no terms with "prepared statements pgbouncer".

Ranking was never going to carry this. A 1.25× boost cannot help a note that does not match the query at all. **The state belongs to the session**, so it is now attached to the session and travels with every hit on it:

```
2. [claude] payments · a1f2c93b · updated 2025-11-29
[this was tried and rejected, 2026-07-29] the pin was reverted; pgbouncer 1.24 handles it natively
- prepared statements keep failing behind pgbouncer after the driver upgrade
- → We pinned pgx to 5.4.3 and left a note to revisit once pgbouncer 1.24 ships support.
```

and in the CLI, in amber above the snippets:

```
[claude] payments · Nov 29 2025 · a1f2c93b — 6 matches
  tried and rejected (2026-07-29): the pin was reverted; pgbouncer 1.24 handles it natively
```

Three things I was deliberate about:

**The original is not hidden.** deja's whole position is that history is the record, not a cache to be cleaned. The reader sees what was decided *and* that it changed — which is more useful than either alone, and is the difference between a memory and a wiki.

**The wording says what happened, not what we call it.** "superseded" is our vocabulary; "a later decision replaced this" is a sentence a model can act on without reading our docs. The `recall` tool description now says what to do with each: do not repeat a rejected approach, prefer the replacement over what it replaced, treat stale as needing confirmation, and an unmarked result carries no judgement either way.

**Accepted sessions are not annotated.** The marker means "this did not hold". On everything, it would be noise, and there is a test asserting it stays off.

Also here, since it is the same first-screen problem: the install commands move directly under the demo, where someone who just watched the thing work looks next.
