### PR TITLE
Rank the session that concluded something above the one that discussed it

### DIFF
--- a/internal/search/json_signal_test.go
+++ b/internal/search/json_signal_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/model"
 )
@@ -115,5 +116,77 @@ func TestLifecycleIsPrintedBeforeTheSnippets(t *testing.T) {
 		if strings.Contains(b.String(), unwanted) {
 			t.Fatalf("an unmarked hit mentioned %q:\n%s", unwanted, b.String())
 		}
+	}
+}
+
+// Term frequency ranks these backwards: the session where someone kept asking
+// repeats the words most, and the one that answered says them once and then
+// explains. Measured on a corpus built for that shape, the deciding session was
+// last of four in every case before this existed.
+//
+// The corpus carries unrelated sessions on purpose. With only the candidates in
+// it, every document contains every query term, IDF collapses to zero, BM25
+// scores everything 0.0000 and the order is not decided by ranking at all — a
+// smaller fixture would have tested nothing.
+func TestASessionThatDecidedSomethingOutranksOneThatDidNot(t *testing.T) {
+	// Sessions need timestamps: freshnessDecay multiplies an undated session
+	// into the floor, and a fixture without dates measures the decay rather
+	// than the ranking.
+	now := time.Now()
+	filler := func(id, text string) model.Session {
+		return model.Session{ID: id, Harness: "claude", Project: "app", Started: now, Updated: now,
+			Messages: []model.Message{{Role: "user", Text: text, Time: now}}}
+	}
+	corpus := []model.Session{
+		filler("f1", "the deploy pipeline is red again"),
+		filler("f2", "renaming the config keys"),
+		filler("f3", "who owns the staging database"),
+		filler("f4", "we should write down the release checklist"),
+		filler("f5", "the linter is complaining about imports"),
+	}
+	asking := model.Session{ID: "asking", Harness: "claude", Project: "app", Started: now, Updated: now, Messages: []model.Message{
+		{Role: "user", Text: "anyone seen prepared statements pgbouncer? prepared statements pgbouncer again today"},
+		{Role: "assistant", Text: "still looking at prepared statements pgbouncer, no idea yet"},
+	}}
+	decided := model.Session{ID: "decided", Harness: "claude", Project: "app", Started: now, Updated: now, Messages: []model.Message{
+		{Role: "user", Text: "prepared statements pgbouncer keeps failing"},
+		{Role: "assistant", Text: "Root cause was transaction pooling. We pinned pgx to 5.4.3."},
+	}}
+	hits, err := Run(append(corpus, asking, decided), Options{Query: "prepared statements pgbouncer", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) < 2 || hits[0].Session.ID != "decided" {
+		t.Fatalf("the session that concluded something did not rank first: %s", hits[0].Session.ID)
+	}
+
+	// It is a tie-breaker, not an override: a conclusion about something else
+	// must not outrank a session that squarely matches the question.
+	elsewhere := model.Session{ID: "elsewhere", Harness: "claude", Project: "app", Started: now, Updated: now, Messages: []model.Message{
+		{Role: "user", Text: "the icon barrel file"},
+		{Role: "assistant", Text: "Root cause was tree shaking. We dropped the barrel file."},
+	}}
+	onTopic := model.Session{ID: "on-topic", Harness: "claude", Project: "app", Started: now, Updated: now, Messages: []model.Message{
+		{Role: "user", Text: "prepared statements pgbouncer prepared statements pgbouncer"},
+		{Role: "user", Text: "prepared statements pgbouncer once more"},
+	}}
+	hits, err = Run(append(corpus, elsewhere, onTopic), Options{Query: "prepared statements pgbouncer", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || hits[0].Session.ID != "on-topic" {
+		t.Fatalf("a conclusion about another topic outranked the matching session: %s", hits[0].Session.ID)
+	}
+
+	// A user proposing something is not a decision; the record is what the
+	// side that did the work wrote.
+	proposal := model.Session{ID: "proposal", Harness: "claude", Project: "app", Started: now, Updated: now, Messages: []model.Message{
+		{Role: "user", Text: "we should just pin pgx, root cause is obvious"},
+	}}
+	if decidesSomething(proposal) {
+		t.Fatal("a user proposal counted as a decision")
+	}
+	if !decidesSomething(decided) {
+		t.Fatal("an assistant conclusion did not count as a decision")
 	}
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -396,6 +396,15 @@ func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLengt
 		if doc.hit.Session.Harness == "deja" {
 			score *= promotedNoteBoost
 		}
+		// A session that reached a conclusion outranks one that only discussed
+		// the topic. Term frequency alone ranks these backwards: the session
+		// where someone kept asking repeats the words most, and the one that
+		// answered says them once and then explains. Measured on a corpus built
+		// for exactly that shape, the deciding session was ranked last of four
+		// in every case before this.
+		if decidesSomething(doc.hit.Session) {
+			score *= decisionBoost
+		}
 		score *= freshnessDecay(doc.hit.Session.Updated, now)
 		doc.hit.Score = score
 		hits = append(hits, doc.hit)
@@ -482,6 +491,34 @@ func lifecycleSummary(h Hit) string {
 		head += ": " + h.LifecycleNote
 	}
 	return head
+}
+
+// decisionBoost is sized to the effect it has to overcome, not tuned until a
+// test passed: a session that repeats the query terms about three times more
+// than another scores roughly twice as high once BM25 saturation is accounted
+// for, and that is the ordinary shape of "someone kept asking" against "someone
+// answered". It stays a tie-breaker rather than an override — a conclusion
+// about a different topic must not outrank a session that squarely matches the
+// question, and there is a test for exactly that.
+const decisionBoost = 2.0
+
+// decidesSomething reports whether a session contains an answer rather than a
+// conversation about one. It looks only at non-user turns: a user writing "we
+// should just pin it" is a proposal, and the same words from the side that did
+// the work are a record of what happened.
+func decidesSomething(s model.Session) bool {
+	for _, m := range s.Messages {
+		if m.Role == "user" || m.Role == "" {
+			continue
+		}
+		low := strings.ToLower(m.Text)
+		for _, phrase := range decisionPhrases {
+			if strings.Contains(low, phrase) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 const promotedNoteBoost = 1.25

--- a/scripts/decisionbench/main.go
+++ b/scripts/decisionbench/main.go
@@ -1,0 +1,131 @@
+// Command decisionbench asks whether the session that *decided* something wins
+// over sessions that merely talk about it.
+//
+// That is the claim behind #507 — "how do you filter signal from noise?" — and
+// it is not answerable by the benchmarks already in the repo: bench recall
+// returns 1.00 and bench prompt fires 10/12 with no false positives, so both
+// are saturated and would show any change as a flat line.
+//
+// The shape is deliberately adversarial. For each question there is exactly one
+// session that reached a conclusion, and several that mention the same terms
+// *more often* while deciding nothing: someone asking, someone quoting a log,
+// someone linking a doc. A lexical ranker should get these wrong, and if it does
+// not, the feature this measures is not needed.
+//
+//	go run ./scripts/decisionbench [-v]
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+type probe struct {
+	query    string
+	decision string // session id that concluded something
+}
+
+func main() {
+	verbose := flag.Bool("v", false, "print every miss")
+	flag.Parse()
+
+	sessions, probes := corpus()
+	hit1, hit3 := 0, 0
+	for _, p := range probes {
+		hits, err := search.Run(sessions, search.Options{Query: p.query, All: true})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		rank := -1
+		for i, h := range hits {
+			if h.Session.ID == p.decision {
+				rank = i + 1
+				break
+			}
+		}
+		switch {
+		case rank == 1:
+			hit1++
+			hit3++
+		case rank >= 2 && rank <= 3:
+			hit3++
+		}
+		if *verbose && rank != 1 {
+			top := "—"
+			if len(hits) > 0 {
+				top = hits[0].Session.ID
+			}
+			fmt.Printf("  miss  %-34q decision=%s rank=%d top=%s\n", p.query, p.decision, rank, top)
+		}
+	}
+	fmt.Printf("questions %d · decision ranked first %d (%.0f%%) · in top 3 %d (%.0f%%)\n",
+		len(probes), hit1, 100*float64(hit1)/float64(len(probes)), hit3, 100*float64(hit3)/float64(len(probes)))
+}
+
+// corpus builds, for each question, one deciding session and several louder
+// distractors. The distractors repeat the query terms more than the decision
+// does — that is the trap, and it is the ordinary case in a real store, where
+// most sessions that mention a topic never settled anything about it.
+func corpus() ([]model.Session, []probe) {
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	var out []model.Session
+	var probes []probe
+
+	topics := []struct {
+		id       string
+		terms    string
+		decision string
+	}{
+		{"pgbouncer", "prepared statements pgbouncer", "We pinned pgx to 5.4.3. Root cause was that pgbouncer in transaction mode cannot hold prepared statements across connections."},
+		{"queue", "job queue redis", "Decision: we moved the job queue to Postgres advisory locks, because redis eviction does not respect list keys."},
+		{"hydration", "hydration mismatch dates", "Fixed by formatting dates on the client after mount; the server rendered them in UTC and the browser in the local zone."},
+		{"bundle", "bundle size icons", "We dropped the barrel file. Root cause: re-exporting every icon defeated tree shaking."},
+		{"jwt", "jwt refresh clock skew", "Traced it to clock skew between the auth pods; we set a 60s leeway and moved to 15m tokens."},
+		{"trigram", "trigram index size", "We dropped the trigram index instead of tuning it — it was 40% of the database and helped 2% of queries."},
+		{"oom", "reindex job memory", "Fixed by streaming the postings writes per bucket; the job had been loading the whole map first."},
+		{"backup", "backup restore flaky", "The fix was waiting on the archive marker rather than a fixed sleep."},
+	}
+
+	for i, t := range topics {
+		day := base.AddDate(0, 0, -i*3)
+		// The session that concluded something. It says the terms once.
+		out = append(out, session(t.id+"-decided", day, []string{
+			t.terms + " keeps failing",
+			t.decision,
+		}))
+		// Louder sessions that decide nothing.
+		out = append(out, session(t.id+"-asking", day.AddDate(0, 0, -1), []string{
+			"anyone seen " + t.terms + "? " + t.terms + " again today",
+			"still looking at " + t.terms + ", no idea yet",
+		}))
+		out = append(out, session(t.id+"-log", day.AddDate(0, 0, -2), []string{
+			"dumping the log for " + t.terms,
+			strings.Repeat(t.terms+" warn ", 6),
+		}))
+		out = append(out, session(t.id+"-link", day.AddDate(0, 0, -4), []string{
+			"docs about " + t.terms,
+			"see the upstream page on " + t.terms + " and the " + t.terms + " faq",
+		}))
+		probes = append(probes, probe{query: t.terms, decision: t.id + "-decided"})
+	}
+	return out, probes
+}
+
+func session(id string, when time.Time, texts []string) model.Session {
+	s := model.Session{ID: id, Harness: "claude", Project: "app", Started: when, Updated: when}
+	for i, t := range texts {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		s.Messages = append(s.Messages, model.Message{Role: role, Text: t, Time: when.Add(time.Duration(i) * time.Minute)})
+	}
+	return s
+}


### PR DESCRIPTION
First half of #507 — *"how do you filter out signal from noise?"*

Term frequency ranks these backwards, and the reason is structural rather than a tuning miss: **the session where someone kept asking repeats the query terms most, and the session that answered says them once and then explains.** So a lexical ranker puts the noise on top by construction.

## Measured before writing anything

Neither benchmark in the repo could see this. `bench recall` returns 1.00 and `bench prompt` fires 10/12 with no false positives — both saturated, both would have shown any change as a flat line. So `scripts/decisionbench` builds the adversarial shape on purpose: for each question one session concluded something, and three louder ones mention the same terms more while deciding nothing — someone asking, someone pasting a log, someone linking docs.

```
before:  questions 8 · decision ranked first 0 (0%)  · in top 3 0 (0%)
after:   questions 8 · decision ranked first 8 (100%) · in top 3 8 (100%)
```

Before, the deciding session was ranked **last of four in every single case**, and the session where someone was still asking came first every time.

## The change

A session whose non-user turns contain decision language — the vocabulary #491 already identified for picking which sentence to return: `we pinned`, `root cause`, `fixed by`, `traced it to`, `decision:` — scores ×2.0.

Only non-user turns count. A user writing *"we should just pin it, root cause is obvious"* is a proposal; the same words from the side that did the work are a record of what happened. There is a test for that distinction.

The constant is sized to the effect it has to overcome rather than tuned until something passed: a session repeating the terms ~3× more scores roughly twice as high once BM25 saturation is accounted for, which is the ordinary shape of "kept asking" against "answered". It stays a tie-breaker — a conclusion about a *different* topic must not outrank a session that squarely matches the question, and that is asserted separately.

## Two things the measurement taught me about the ranker

Both cost me a wrong test before I understood them, and both are now written down where the next person will hit them:

- **With a small candidate set the ranking is not exercised at all.** If every session in the corpus contains every query term, IDF collapses to zero, BM25 scores everything `0.0000`, and the order falls out of tie-breakers. My first fixture had two sessions and proved nothing — no value of the boost changed it, which is what sent me looking.
- **A fixture without timestamps measures `freshnessDecay`, not relevance.** An undated session is multiplied into the floor. The second fixture failed for that reason alone.

## Not regressed

`bench recall` 1.00/1.00 unchanged, `bench prompt` 10/12 with 0 false fires unchanged, full suite green.

I could not run LongMemEval-S — the dataset is not on this machine — so the 84.9% hit@1 figure on the front page is **not** re-verified here. Worth running before the next release rather than assuming; the harness is in-repo and takes minutes.

The other half of #507 — the reused counter and repeat-visit signal as inputs to ranking — is untouched, and self-correction stays out of scope for the reason written in the issue: deja cannot know a decision was wrong, and claiming otherwise is what would cost trust.
