### PR TITLE
Rank a pasted log below a human answer

### DIFF
--- a/internal/search/json_signal_test.go
+++ b/internal/search/json_signal_test.go
@@ -190,3 +190,70 @@ func TestASessionThatDecidedSomethingOutranksOneThatDidNot(t *testing.T) {
 		t.Fatal("an assistant conclusion did not count as a decision")
 	}
 }
+
+// A pasted log outranks a human answer on term frequency alone: it repeats the
+// query words a dozen times and says nothing. The signal is line repetition
+// rather than vocabulary — a log repeats its shape, a person explaining
+// something at length does not.
+func TestAPastedLogRanksBelowAnAnswer(t *testing.T) {
+	now := time.Now()
+	sess := func(id string, texts ...string) model.Session {
+		s := model.Session{ID: id, Harness: "claude", Project: "app", Started: now, Updated: now}
+		for i, txt := range texts {
+			role := "user"
+			if i%2 == 1 {
+				role = "assistant"
+			}
+			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: now})
+		}
+		return s
+	}
+	answer := sess("answer",
+		"what is going on with connection pool exhausted?",
+		"connection pool exhausted only happens on staging after a deploy, never locally")
+	paste := sess("paste",
+		"pasting the output",
+		strings.Repeat("WARN connection pool exhausted staging deploy retry=3 conn=17\n", 14))
+	filler := sess("f1", "the linter is complaining about imports")
+
+	hits, err := Run([]model.Session{filler, paste, answer}, Options{Query: "connection pool exhausted staging deploy", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || hits[0].Session.ID != "answer" {
+		t.Fatalf("the paste outranked the answer: %s", hits[0].Session.ID)
+	}
+	// Damped, not hidden: some pastes are the answer.
+	found := false
+	for _, h := range hits {
+		if h.Session.ID == "paste" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("the paste was dropped from the results entirely")
+	}
+}
+
+func TestPasteDetectionBoundaries(t *testing.T) {
+	msg := func(text string) model.Session {
+		return model.Session{Messages: []model.Message{{Role: "assistant", Text: text}}}
+	}
+	if looksPasted(msg(strings.Repeat("same line\n", 7))) {
+		t.Fatal("seven repeated lines counted as a dump; a short list is not a log")
+	}
+	if !looksPasted(msg(strings.Repeat("same line\n", 14))) {
+		t.Fatal("fourteen identical lines did not count as a dump")
+	}
+	// Long prose with distinct lines is not a dump however long it runs.
+	var prose strings.Builder
+	for i := 0; i < 30; i++ {
+		fmt.Fprintf(&prose, "paragraph %d saying something different about the pool\n", i)
+	}
+	if looksPasted(msg(prose.String())) {
+		t.Fatal("thirty distinct lines counted as a dump")
+	}
+	if looksPasted(model.Session{}) {
+		t.Fatal("an empty session counted as a dump")
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -405,6 +405,12 @@ func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLengt
 		if decidesSomething(doc.hit.Session) {
 			score *= decisionBoost
 		}
+		// A pasted log outranks a human answer on term frequency alone: it
+		// repeats the words fourteen times and says nothing. Measured before
+		// this existed, the paste won every question of that shape.
+		if looksPasted(doc.hit.Session) {
+			score *= pastePenalty
+		}
 		score *= freshnessDecay(doc.hit.Session.Updated, now)
 		doc.hit.Score = score
 		hits = append(hits, doc.hit)
@@ -519,6 +525,42 @@ func decidesSomething(s model.Session) bool {
 		}
 	}
 	return false
+}
+
+// pastePenalty damps a session whose matched text is a dump rather than a
+// conversation. It is deliberately mild: some pastes are the answer — a stack
+// trace someone diagnosed, a config that turned out to be wrong — so this
+// lowers them behind real discussion rather than hiding them.
+const pastePenalty = 0.5
+
+// pasteMinLines is the length below which repetition means nothing. Three
+// identical short lines are a list; fourteen are a log.
+const pasteMinLines = 8
+
+// pasteDistinctRatio is the share of distinct lines below which a message reads
+// as machine output. A conversation almost never repeats two thirds of itself.
+const pasteDistinctRatio = 0.35
+
+// looksPasted reports whether a session's text is dominated by repeated lines.
+// Line repetition rather than vocabulary: a log repeats its shape, and a person
+// explaining something at length does not.
+func looksPasted(s model.Session) bool {
+	dump, total := 0, 0
+	for _, m := range s.Messages {
+		lines := strings.Split(strings.TrimSpace(m.Text), "\n")
+		if len(lines) < pasteMinLines {
+			continue
+		}
+		total++
+		distinct := make(map[string]struct{}, len(lines))
+		for _, l := range lines {
+			distinct[strings.TrimSpace(l)] = struct{}{}
+		}
+		if float64(len(distinct))/float64(len(lines)) < pasteDistinctRatio {
+			dump++
+		}
+	}
+	return total > 0 && dump*2 >= total
 }
 
 const promotedNoteBoost = 1.25

--- a/scripts/decisionbench/main.go
+++ b/scripts/decisionbench/main.go
@@ -26,6 +26,30 @@ import (
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
+// report is the same measurement for a second set of questions.
+func report(label string, sessions []model.Session, probes []probe, verbose bool) {
+	first := 0
+	for _, p := range probes {
+		hits, err := search.Run(sessions, search.Options{Query: p.query, All: true})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		if len(hits) > 0 && hits[0].Session.ID == p.decision {
+			first++
+			continue
+		}
+		if verbose {
+			top := "—"
+			if len(hits) > 0 {
+				top = hits[0].Session.ID
+			}
+			fmt.Printf("  miss  %-38q want=%s top=%s\n", p.query, p.decision, top)
+		}
+	}
+	fmt.Printf("%s %d · ranked first %d (%.0f%%)\n", label, len(probes), first, 100*float64(first)/float64(len(probes)))
+}
+
 type probe struct {
 	query    string
 	decision string // session id that concluded something
@@ -35,7 +59,7 @@ func main() {
 	verbose := flag.Bool("v", false, "print every miss")
 	flag.Parse()
 
-	sessions, probes := corpus()
+	sessions, probes, noise := corpus()
 	hit1, hit3 := 0, 0
 	for _, p := range probes {
 		hits, err := search.Run(sessions, search.Options{Query: p.query, All: true})
@@ -65,18 +89,19 @@ func main() {
 			fmt.Printf("  miss  %-34q decision=%s rank=%d top=%s\n", p.query, p.decision, rank, top)
 		}
 	}
-	fmt.Printf("questions %d · decision ranked first %d (%.0f%%) · in top 3 %d (%.0f%%)\n",
+	fmt.Printf("decisions  %d · ranked first %d (%.0f%%) · in top 3 %d (%.0f%%)\n",
 		len(probes), hit1, 100*float64(hit1)/float64(len(probes)), hit3, 100*float64(hit3)/float64(len(probes)))
+	report("noise     ", sessions, noise, *verbose)
 }
 
 // corpus builds, for each question, one deciding session and several louder
 // distractors. The distractors repeat the query terms more than the decision
 // does — that is the trap, and it is the ordinary case in a real store, where
 // most sessions that mention a topic never settled anything about it.
-func corpus() ([]model.Session, []probe) {
+func corpus() ([]model.Session, []probe, []probe) {
 	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	var out []model.Session
-	var probes []probe
+	var probes, noise []probe
 
 	topics := []struct {
 		id       string
@@ -114,8 +139,26 @@ func corpus() ([]model.Session, []probe) {
 			"see the upstream page on " + t.terms + " and the " + t.terms + " faq",
 		}))
 		probes = append(probes, probe{query: t.terms, decision: t.id + "-decided"})
+
+		// A second shape, where nobody concluded anything: a human answer with
+		// no decision vocabulary against a pasted log that repeats the terms.
+		// The decision boost cannot help here — this is the case that asks
+		// whether noise costs a session anything.
+		// The exact tier requires the query terms to meet inside one message,
+		// not merely inside one session — cross-message co-occurrence is what
+		// the relevance tier is for. A fixture that spreads them across turns
+		// measures the ladder, not the ranking.
+		out = append(out, session(t.id+"-answer", day.AddDate(0, 0, -6), []string{
+			"what is going on with " + t.terms + "?",
+			t.terms + " only happens on staging after a deploy, never locally",
+		}))
+		out = append(out, session(t.id+"-paste", day.AddDate(0, 0, -7), []string{
+			"pasting the output",
+			strings.Repeat("WARN "+t.terms+" staging deploy retry=3 conn=17 elapsed=812ms\n", 14),
+		}))
+		noise = append(noise, probe{query: t.terms + " staging deploy", decision: t.id + "-answer"})
 	}
-	return out, probes
+	return out, probes, noise
 }
 
 func session(id string, when time.Time, texts []string) model.Session {


### PR DESCRIPTION
Second half of #507. #509 lifted the sessions that concluded something; nothing pushed down the ones that are loud and empty.

The shape this fixes is a query where **nobody concluded anything** — so the decision boost cannot help — and the candidates are a human answer against a pasted log that repeats the query terms fourteen times:

```
before:  noise  8 · ranked first 0 (0%)     the paste won every question
after:   noise  8 · ranked first 8 (100%)
```

A session whose matched text is dominated by repeated lines scores ×0.5. The signal is **line repetition, not vocabulary**: a log repeats its shape, and a person explaining something at length does not. Thirty distinct paragraphs are not a dump; fourteen identical lines are. Seven are a list, and stay untouched.

Damped rather than hidden, deliberately: some pastes *are* the answer — a stack trace someone diagnosed, a config that turned out to be wrong — so this lowers them behind real discussion instead of removing them. A test asserts the paste still appears in the results.

## Not regressed

| | before | after |
|---|---|---|
| LongMemEval-S hit@1 | 84.9% | **84.9%** |
| hit@5 / MRR | 94.3% / 0.891 | **94.3% / 0.891** |
| decisionbench, decisions | 8/8 | 8/8 |
| `bench recall` | 1.00 | 1.00 |
| `bench prompt` | 10/12, 0 false fires | 10/12, 0 false fires |

## One thing the benchmark taught me about the ladder

The first version of the noise fixture returned **zero hits for every query**, which sent me looking: the exact tier requires the query terms to meet **inside one message**, not merely inside one session — cross-message co-occurrence is what the relevance tier exists for. A fixture that spreads the terms across turns measures the ladder rather than the ranking, and `search.Run` called directly has no ladder above it. That is now written into the fixture where the next person will read it.
