### PR TITLE
Measure the reuse ceiling, and let a déjà vu moment count

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -166,7 +166,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	}
 	lead := "deja found prior sessions matching this request. If one genuinely helps, use it and tell the user in one digest.Short line what deja-vu recalled; otherwise ignore silently.\n"
 	out := frameRecall(lead + digest + citationLine(ss[0]))
-	usage.RecordDigestTerms(dir, usage.KindDejaVu, out, len(ss), rawSize(ss), terms)
+	usage.RecordDigestTerms(dir, usage.KindDejaVu, out, len(ss), rawSize(ss), terms, sessionIDs(ss)...)
 	if plain {
 		fmt.Fprintln(stdout, out)
 		return nil
@@ -571,6 +571,18 @@ func densestMessages(msgs []model.Message, terms []string, cap int) []model.Mess
 	for i, m := range msgs {
 		if keep[i] {
 			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// sessionIDs is what the usage log needs to attribute a déjà vu moment to the
+// sessions it was about.
+func sessionIDs(ss []model.Session) []string {
+	out := make([]string, 0, len(ss))
+	for _, s := range ss {
+		if s.ID != "" {
+			out = append(out, s.ID)
 		}
 	}
 	return out

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -44,9 +44,15 @@ func RecordDigest(indexDir, kind, digest string, sessions int, raw int64) {
 	RecordDigestPolicy(indexDir, kind, digest, sessions, raw, "")
 }
 
-// RecordDigestTerms is RecordDigest plus the query terms, for déjà vu audits.
-func RecordDigestTerms(indexDir, kind, digest string, sessions int, raw int64, terms []string) {
-	RecordResultRaw(indexDir, kind, len(digest), sessions, sessions == 0, raw)
+// RecordDigestTerms is RecordDigest plus the query terms, for déjà vu audits,
+// and the ids of the sessions the moment surfaced.
+//
+// The ids were missing, which meant a déjà vu moment — the user returning to
+// ground they had covered before — left no trace on the session it was about.
+// It is the only signal deja has that the *user* came back, as opposed to an
+// agent pulling something, and it could not reach ranking at all.
+func RecordDigestTerms(indexDir, kind, digest string, sessions int, raw int64, terms []string, ids ...string) {
+	RecordServedSessions(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids)
 	snapshotWriteTerms(indexDir, kind, digest, sessions, "", terms)
 }
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -278,7 +278,13 @@ func rotate(p string) {
 func WornSessions(indexDir string) map[string]int {
 	out := map[string]int{}
 	for _, e := range read(Path(indexDir)) {
-		if e.Kind != KindRecall && e.Kind != KindContext {
+		// Agent recalls and the user's own déjà vu moments both count. They
+		// mean different things — one is an agent pulling a session, the other
+		// is the user returning to the same ground — and both say the session
+		// keeps mattering. The bounded boost is what keeps this from becoming
+		// a feedback loop: a session that ranks higher gets surfaced more,
+		// which would compound without the ceiling in wornBoost.
+		if e.Kind != KindRecall && e.Kind != KindContext && e.Kind != KindDejaVu {
 			continue
 		}
 		for _, id := range e.SessionIDs {

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -171,3 +171,29 @@ func TestRecordSilentOnMkdirFailure(t *testing.T) {
 		t.Fatalf("unexpected events recorded: %d/%d", r, b)
 	}
 }
+
+// A déjà vu moment — the user asking something their own history already
+// answered — is the only signal deja has that the *user* came back, rather than
+// an agent pulling a session. It was recorded without session ids, so it could
+// not reach ranking at all.
+func TestDejaVuMomentsCountTowardsWornSessions(t *testing.T) {
+	dir := t.TempDir()
+	RecordDigestTerms(dir, KindDejaVu, "digest", 2, 100, []string{"pgbouncer"}, "s1", "s2")
+	RecordServedSessions(dir, KindRecall, 10, 1, false, 50, []string{"s1"})
+	// Kinds that say nothing about a session mattering must not count.
+	RecordServedSessions(dir, KindSearch, 10, 1, false, 50, []string{"s3"})
+	RecordServedSessions(dir, KindHandoff, 10, 1, false, 50, []string{"s4"})
+
+	worn := WornSessions(dir)
+	if worn["s1"] != 2 {
+		t.Fatalf("s1 = %d, want the déjà vu moment and the recall", worn["s1"])
+	}
+	if worn["s2"] != 1 {
+		t.Fatalf("s2 = %d, want the déjà vu moment", worn["s2"])
+	}
+	for _, id := range []string{"s3", "s4"} {
+		if worn[id] != 0 {
+			t.Fatalf("%s = %d, want nothing: a search or a handoff is not evidence the session mattered", id, worn[id])
+		}
+	}
+}

--- a/scripts/decisionbench/main.go
+++ b/scripts/decisionbench/main.go
@@ -26,6 +26,87 @@ import (
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
+// reportUsage asks what the reuse signal is worth. Two sessions answer the
+// question equally well on the text; one of them is the one agents keep pulling
+// back. That is the only signal deja has about what actually helped someone,
+// as opposed to what reads like an answer — and until now nothing measured
+// whether the 1.2× ceiling on it does anything at all.
+func reportUsage(sessions []model.Session, verbose bool) {
+	// Two equally-worded sessions per topic, one of them worn.
+	var corpus []model.Session
+	var probes []probe
+	worn := map[string]int{}
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	for i, t := range []string{"retry budget", "cache stampede", "leader election", "schema drift"} {
+		day := base.AddDate(0, 0, -i)
+		a := "used-" + fmt.Sprint(i)
+		b := "unused-" + fmt.Sprint(i)
+		text := t + " is the thing we keep hitting; here is what happens and why"
+		corpus = append(corpus, session(a, day, []string{text, "and a second turn about " + t}))
+		corpus = append(corpus, session(b, day, []string{text, "and a second turn about " + t}))
+		worn[a] = 6
+		probes = append(probes, probe{query: t, decision: a})
+	}
+	corpus = append(corpus, sessions...)
+
+	for _, boost := range []struct {
+		name string
+		worn map[string]int
+	}{{"off", nil}, {"on", worn}} {
+		first := 0
+		for _, p := range probes {
+			hits, err := search.Run(corpus, search.Options{Query: p.query, All: true, RecallWorn: boost.worn})
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			if len(hits) > 0 && hits[0].Session.ID == p.decision {
+				first++
+			} else if verbose && boost.name == "on" {
+				top := "—"
+				if len(hits) > 0 {
+					top = hits[0].Session.ID
+				}
+				fmt.Printf("  miss  %-38q want=%s top=%s\n", p.query, p.decision, top)
+			}
+		}
+		fmt.Printf("reuse %-4s %d · ranked first %d (%.0f%%)\n", boost.name, len(probes), first, 100*float64(first)/float64(len(probes)))
+	}
+
+	// The ceiling question is not "is it enough for a tie" but "can it win one
+	// it should lose". A heavily-used session that barely matches must not
+	// outrank one that answers the question squarely.
+	var risk []model.Session
+	riskWorn := map[string]int{}
+	kept := 0
+	for i, t := range []string{"connection pool", "index rebuild", "token refresh"} {
+		day := base.AddDate(0, 0, -i)
+		strong := "strong-" + fmt.Sprint(i)
+		wornWeak := "worn-weak-" + fmt.Sprint(i)
+		risk = append(risk, session(strong, day, []string{
+			t + " " + t + " keeps failing, and here is the whole story of " + t,
+			"more about " + t,
+		}))
+		risk = append(risk, session(wornWeak, day, []string{
+			"mostly about something else entirely, though " + t + " came up once",
+			"the rest is unrelated",
+		}))
+		riskWorn[wornWeak] = 40 // far past anything the cap allows
+		risk = append(risk, session("filler-"+fmt.Sprint(i), day, []string{"unrelated chatter"}))
+		hits, _ := search.Run(risk, search.Options{Query: t, All: true, RecallWorn: riskWorn})
+		if len(hits) > 0 && hits[0].Session.ID == strong {
+			kept++
+		} else if verbose {
+			top := "—"
+			if len(hits) > 0 {
+				top = hits[0].Session.ID
+			}
+			fmt.Printf("  miss  %-38q want=%s top=%s\n", t, strong, top)
+		}
+	}
+	fmt.Printf("reuse cap  %d · relevance still wins %d (%.0f%%)\n", 3, kept, 100*float64(kept)/3)
+}
+
 // report is the same measurement for a second set of questions.
 func report(label string, sessions []model.Session, probes []probe, verbose bool) {
 	first := 0
@@ -92,6 +173,7 @@ func main() {
 	fmt.Printf("decisions  %d · ranked first %d (%.0f%%) · in top 3 %d (%.0f%%)\n",
 		len(probes), hit1, 100*float64(hit1)/float64(len(probes)), hit3, 100*float64(hit3)/float64(len(probes)))
 	report("noise     ", sessions, noise, *verbose)
+	reportUsage(sessions, *verbose)
 }
 
 // corpus builds, for each question, one deciding session and several louder


### PR DESCRIPTION
Last of the ranking work in #507, and the part I said had to be measured before it could be touched.

## The reuse ceiling, answered with evidence instead of opinion

`wornBoost` caps at 1.2×, and nothing measured whether that number does anything or does too much. Neither existing benchmark carries usage data — LongMemEval has none by construction, `decisionbench` had none — so `scripts/decisionbench` now builds both halves of the question:

```
reuse off  4 · ranked first 0 (0%)     two textually identical sessions, tie broken arbitrarily
reuse on   4 · ranked first 4 (100%)   the one agents keep pulling wins
reuse cap  3 · relevance still wins 3 (100%)
```

The last line is the one that matters: a session with **40 recorded recalls** that barely mentions the query still loses to one that answers it squarely. So 1.2× is enough to decide a tie and cannot win one it should lose. The constant was right; now it is checked, and a future change to it will show up as a failing number rather than a judgement call.

## Déjà vu moments were recorded without the session they were about

`RecordDigestTerms` wrote the kind, the digest size and the query terms, and dropped the ids. So the one signal deja has that **the user came back to the same ground** — as opposed to an agent pulling a session — left no trace on the session it concerned, and could not reach ranking at all.

The ids are recorded now, and `WornSessions` counts `KindDejaVu` alongside recalls. A search and a handoff still count for nothing: neither is evidence that a session mattered.

**On the feedback loop**, because this is the same class of problem as #480, where deja indexed its own output: a session that ranks higher gets surfaced more, which records more, which ranks it higher. What bounds it is the ceiling that was already there — `1 + 0.05·log₂(1+n)`, capped at 1.2×. Forty recalls and four recalls land in the same place, so the loop converges instead of compounding. That is why this went into the existing bounded signal rather than becoming a new one.

## Not regressed

| | |
|---|---|
| LongMemEval-S | 84.9% hit@1 · 94.3% hit@5 · MRR 0.891 — unchanged |
| decisionbench decisions / noise | 8/8 · 8/8 |
| full suite | green |
