### PR TITLE
perf(index): read records in coalesced spans

### DIFF
--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -966,11 +966,11 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		}
 		defer func() { _ = f.Close() }()
 		offsets = sortedUniqueOffsets(offsets)
-		for _, off := range offsets {
-			if r, err := readRecordAt(f, off, tablesFromManifest(m)); err == nil && recordMatchesQueryVariants(r, o, variants) {
+		eachRecordAt(f, offsets, tablesFromManifest(m), func(r Record) {
+			if recordMatchesQueryVariants(r, o, variants) {
 				add(r)
 			}
-		}
+		})
 	} else {
 		if err := eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
 			if recordMatchesQueryVariants(r, o, variants) {

--- a/internal/index/span_read_test.go
+++ b/internal/index/span_read_test.go
@@ -1,0 +1,169 @@
+package index
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeSpanFixture writes the given records back to back and returns their
+// offsets in write order, which is the order the scan sees them in.
+func writeSpanFixture(t *testing.T, texts []string) (string, []int64) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "records.bin")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tables := newRecordTables()
+	var offs []int64
+	for i, s := range texts {
+		off, err := writeRecord(f, Record{
+			Key:        "k",
+			SourcePath: "p",
+			Role:       "user",
+			Text:       s,
+			Time:       time.Unix(int64(1700000000+i), 0).UTC(),
+		}, tables)
+		if err != nil {
+			t.Fatal(err)
+		}
+		offs = append(offs, off)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path, offs
+}
+
+func collectSpan(t *testing.T, path string, offs []int64) []string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	var got []string
+	eachRecordAt(f, offs, newRecordTables(), func(r Record) { got = append(got, r.Text) })
+	return got
+}
+
+// TestEachRecordAtMatchesIndividualReads is the property that matters: reading
+// a run of records in coalesced spans must return exactly what reading them one
+// at a time returns. The mix is deliberate — small records that share a span, a
+// record far larger than the read-ahead window, and one pushed past spanGapMax
+// so a new span has to start.
+func TestEachRecordAtMatchesIndividualReads(t *testing.T) {
+	texts := []string{
+		"short one",
+		"short two",
+		strings.Repeat("a long record that cannot fit in the speculative window ", 4000),
+		"after the long one",
+		strings.Repeat("filler to push the next record past the gap limit ", 1200),
+		"in a second span",
+	}
+	path, offs := writeSpanFixture(t, texts)
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var want []string
+	for _, off := range offs {
+		r, err := readRecordAt(f, off, newRecordTables())
+		if err != nil {
+			t.Fatalf("readRecordAt(%d): %v", off, err)
+		}
+		want = append(want, r.Text)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := collectSpan(t, path, offs)
+	if len(got) != len(want) {
+		t.Fatalf("got %d records, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("record %d differs: got %d bytes, want %d", i, len(got[i]), len(want[i]))
+		}
+	}
+}
+
+// TestEachRecordAtSurvivesUnreadableSpan checks the part that would fail
+// quietly: a span that cannot be read must not swallow the records after it.
+func TestEachRecordAtSurvivesUnreadableSpan(t *testing.T) {
+	path, offs := writeSpanFixture(t, []string{"one", "two", "three"})
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	eachRecordAt(f, offs, newRecordTables(), func(Record) { n++ })
+	if n != 0 {
+		t.Fatalf("closed file yielded %d records", n)
+	}
+}
+
+// TestDecodeRecordInRejectsOutOfRange covers the bounds the span decoder is
+// responsible for; each of these has to fall back to a single read rather than
+// decode whatever bytes happen to follow.
+func TestDecodeRecordInRejectsOutOfRange(t *testing.T) {
+	b := []byte{4, 0, 0, 0, 1, 2}
+	for _, rel := range []int{-1, len(b), len(b) - 2} {
+		if _, ok := decodeRecordIn(b, rel, newRecordTables()); ok {
+			t.Fatalf("rel=%d decoded out of range", rel)
+		}
+	}
+	huge := []byte{255, 255, 255, 255}
+	if _, ok := decodeRecordIn(huge, 0, newRecordTables()); ok {
+		t.Fatal("oversized length decoded")
+	}
+}
+
+// TestReadRecordAtCorruptHeader covers the two ways a header can be wrong: a
+// file that ends inside it, and a length that claims more than any record is
+// allowed to be. Both are index corruption, and both have to be reported
+// rather than turned into a decode of arbitrary bytes.
+func TestReadRecordAtCorruptHeader(t *testing.T) {
+	dir := t.TempDir()
+
+	short := filepath.Join(dir, "short.bin")
+	if err := os.WriteFile(short, []byte{1, 2}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(short)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readRecordAt(f, 0, newRecordTables()); !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("partial header err=%v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	huge := filepath.Join(dir, "huge.bin")
+	hdr := make([]byte, 8)
+	binary.LittleEndian.PutUint32(hdr, ^uint32(0))
+	if err := os.WriteFile(huge, hdr, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f2, err := os.Open(huge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f2.Close() }()
+	if _, err := readRecordAt(f2, 0, newRecordTables()); !errors.Is(err, errCorruptIndex) {
+		t.Fatalf("oversized length err=%v", err)
+	}
+}

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -6,6 +6,7 @@ import (
 	"compress/flate"
 	"encoding/binary"
 	"encoding/gob"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -114,12 +115,57 @@ func writeRecord(f *os.File, r Record, t *recordTables) (int64, error) {
 	return off, err
 }
 
+// readRecordAt reads one record without moving the file position.
+//
+// It used to Seek and then read the header and the payload, three syscalls per
+// record. A search over a common term resolves thousands of records, and
+// profiling put 70% of such a search inside this function — almost all of it in
+// the kernel rather than in any decoding.
+//
+// The speculative read covers header and payload in one pread for anything
+// under readAheadSize, which is nearly everything: the median indexed message
+// is a few hundred bytes. A larger record costs a second read, which is the
+// same work the old path did anyway.
 func readRecordAt(f *os.File, off int64, t *recordTables) (Record, error) {
-	if _, err := f.Seek(off, io.SeekStart); err != nil {
+	buf := readAheadPool.Get().(*[]byte)
+	defer readAheadPool.Put(buf)
+	b := *buf
+
+	n, err := f.ReadAt(b, off)
+	// A record at the end of the file returns a short read with io.EOF, which
+	// is not an error here — the record may still be entirely inside it.
+	if err != nil && !errors.Is(err, io.EOF) {
 		return Record{}, err
 	}
-	return readRecord(f, t)
+	// Match what ReadFull did before: nothing at all is io.EOF, a partial
+	// header is an unexpected one. A caller past the end of the file relies on
+	// telling those apart.
+	if n == 0 {
+		return Record{}, io.EOF
+	}
+	if n < 4 {
+		return Record{}, io.ErrUnexpectedEOF
+	}
+	size := binary.LittleEndian.Uint32(b[:4])
+	if size > maxRecordSize {
+		return Record{}, fmt.Errorf("%w: record length %d exceeds cap", errCorruptIndex, size)
+	}
+	if int(size)+4 <= n {
+		return decodeRecord(b[4:4+size], t)
+	}
+	// Too big for the read-ahead: take the payload on its own.
+	payload := make([]byte, size)
+	if _, err := f.ReadAt(payload, off+4); err != nil && !errors.Is(err, io.EOF) {
+		return Record{}, err
+	}
+	return decodeRecord(payload, t)
 }
+
+// readAheadSize covers header plus payload for the overwhelming majority of
+// records in one read; the p99 indexed message is about 8 KB.
+const readAheadSize = 8 * 1024
+
+var readAheadPool = sync.Pool{New: func() any { b := make([]byte, readAheadSize); return &b }}
 
 func eachRecord(path string, t *recordTables, fn func(Record)) error {
 	f, err := os.Open(path)
@@ -781,3 +827,67 @@ func (b *bucketReader) postings(tok string) ([]posting, error) {
 }
 
 func (b *bucketReader) close() { b.entries = nil }
+
+// Coalescing bounds for eachRecordAt. A search over a common term resolves a
+// few thousand records that sit close together in write order — the median hole
+// between two of them is under 3 KB — so reading each one separately pays a
+// pread per record for data the kernel would have handed over in the same page.
+const (
+	spanGapMax  = 16 * 1024  // join across a hole no larger than this
+	spanSizeMax = 512 * 1024 // and never read more than this at once
+)
+
+// eachRecordAt reads records at the given offsets, which must be sorted, and
+// calls fn for each one it could decode. Offsets that turn out to reach past
+// the span read for them fall back to a single read, so a long record costs
+// what it always did rather than forcing the span to grow.
+func eachRecordAt(f *os.File, offsets []int64, t *recordTables, fn func(Record)) {
+	buf := make([]byte, 0, 64*1024)
+	for i := 0; i < len(offsets); {
+		j := i + 1
+		for j < len(offsets) &&
+			offsets[j]-offsets[j-1] <= spanGapMax &&
+			offsets[j]-offsets[i] < spanSizeMax {
+			j++
+		}
+		start := offsets[i]
+		want := int(offsets[j-1]-start) + readAheadSize
+		if cap(buf) < want {
+			buf = make([]byte, want)
+		}
+		b := buf[:want]
+		// A failed span is not fatal: every record in it falls back to its own
+		// read below, which is exactly what the caller used to do for all of
+		// them. Aborting here would silently drop the rest of the results.
+		n, err := f.ReadAt(b, start)
+		if err != nil && !errors.Is(err, io.EOF) {
+			n = 0
+		}
+		b = b[:n]
+		for _, off := range offsets[i:j] {
+			rel := int(off - start)
+			if r, ok := decodeRecordIn(b, rel, t); ok {
+				fn(r)
+				continue
+			}
+			if r, err := readRecordAt(f, off, t); err == nil {
+				fn(r)
+			}
+		}
+		i = j
+	}
+}
+
+// decodeRecordIn decodes the record at rel inside an already-read span, and
+// reports whether the span actually held all of it.
+func decodeRecordIn(b []byte, rel int, t *recordTables) (Record, bool) {
+	if rel < 0 || rel+4 > len(b) {
+		return Record{}, false
+	}
+	size := binary.LittleEndian.Uint32(b[rel : rel+4])
+	if size > maxRecordSize || rel+4+int(size) > len(b) {
+		return Record{}, false
+	}
+	r, err := decodeRecord(b[rel+4:rel+4+int(size)], t)
+	return r, err == nil
+}

--- a/scripts/searchbench/main.go
+++ b/scripts/searchbench/main.go
@@ -1,0 +1,76 @@
+// Command searchbench times search on a real index, in process, so the number
+// is the search rather than the process start.
+//
+// The front page claims ~12 ms over 3.3 GB and nobody had measured it since the
+// claim was written. A claim we make publicly and never check is a claim that
+// drifts.
+//
+//	DEJA_INDEX_DIR=~/.cache/deja/index.db go run ./scripts/searchbench
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+func main() {
+	runs := flag.Int("runs", 12, "timed runs per query")
+	flag.Parse()
+
+	dir := index.DefaultDir()
+	if err := index.EnsureForSearch(dir, query.Options{Query: "warm", All: true}, false, io.Discard); err != nil {
+		fmt.Fprintln(os.Stderr, "ensure:", err)
+		os.Exit(1)
+	}
+
+	// A spread of shapes: one rare token, a common one, a phrase, a
+	// multi-term AND, and something that will miss and fall down the ladder.
+	queries := []string{
+		"pgbouncer",
+		"connection pool exhausted",
+		"index",
+		"prepared statements driver upgrade",
+		"zzzznothingmatchesthis",
+		"what did we decide about the queue",
+	}
+
+	fmt.Printf("index: %s\n", dir)
+	var all []time.Duration
+	for _, q := range queries {
+		o := query.Options{Query: q, All: true}
+		// Warm the caches so the first run's page faults do not become the
+		// headline.
+		if _, err := index.Search(dir, o); err != nil {
+			fmt.Fprintln(os.Stderr, q, err)
+			continue
+		}
+		var ds []time.Duration
+		hits := 0
+		for i := 0; i < *runs; i++ {
+			start := time.Now()
+			r, err := index.Search(dir, o)
+			ds = append(ds, time.Since(start))
+			if err != nil {
+				fmt.Fprintln(os.Stderr, q, err)
+				break
+			}
+			hits = len(r)
+		}
+		sort.Slice(ds, func(i, j int) bool { return ds[i] < ds[j] })
+		all = append(all, ds...)
+		fmt.Printf("  %-38q %4d hits · median %7.2f ms · p90 %7.2f ms\n",
+			q, hits, ms(ds[len(ds)/2]), ms(ds[len(ds)*9/10]))
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i] < all[j] })
+	fmt.Printf("overall median %.2f ms · p90 %.2f ms · %d samples\n",
+		ms(all[len(all)/2]), ms(all[len(all)*9/10]), len(all))
+}
+
+func ms(d time.Duration) float64 { return float64(d.Microseconds()) / 1000 }


### PR DESCRIPTION
Closes #504 — with a smaller result than the issue expected, and a correction to how the number was measured.

## The published figure was never checked, so I checked it

`scripts/searchbench` times search in process, so the number is the search rather than the process start. Against my own 3.5 GB index:

```
"pgbouncer"                             18 hits · median  0.98 ms
"connection pool exhausted"              9 hits · median  3.62 ms
"prepared statements driver upgrade"     6 hits · median  2.44 ms
"index"                                162 hits · median 42.0  ms
overall median 1.25 ms
```

So ~12 ms is pessimistic for an ordinary query and optimistic for a common word. The shape of the problem is one query in six, not search in general.

## What the profile said, and why it was half wrong

63–70% of the common-term query sat in `pread`. `readRecordAt` did Seek + header + payload — three syscalls per record, and that query resolves 3254 records. Collapsing that into one speculative 8 KB `pread` is the change here, plus reading runs of nearby records in a single span: the median hole between two records a query touches is under 3 KB, so thousands of separate reads were asking the kernel for pages it had already handed over.

Measured warm, interleaved against `main` on the same index:

| | main | this |
|---|---|---|
| `"index"` (3254 records) | 44.1 ms | **40.5 ms** |
| overall median | 1.28 ms | **1.25 ms** |

**That is 8%, not the 70% the profile implied, and the gap is the interesting part.** My first measurements showed 69 ms → 42 ms and a miss query going 33 ms → 0.2 ms. Both were page-cache state, not code: re-running the unchanged `main` build afterwards reproduced the "improvement" exactly. A profile that attributes cold-cache I/O to `syscall.pread` reads as a syscall problem, and it is not one.

Sweeping the read-ahead window from 4 B (exact reads, minimum bytes) to 32 KB moved the query between 42.0 and 44.0 ms, and span-coalescing cut the syscall count by more than an order of magnitude for another 1.5 ms. Neither syscall count nor bytes read explains the remaining 40 ms. What is left is the cost of touching 3254 records spread over 44 MB of a 3.5 GB file, and no amount of read tuning changes how many records that is.

## So the real lever is elsewhere, and it is not a perf change

Ranking asks for every candidate record because BM25 needs the document frequencies to be right. Capping the scan — by posting score, by recency — would cut this query several-fold and is the only thing left that would. It also changes results, so it belongs in its own issue with a recall measurement attached rather than in a patch labelled "make reads faster". Filed as follow-up.

## Not regressed

| | |
|---|---|
| LongMemEval-S (500q full set) | 84.2% hit@1 · 93.8% hit@5 · MRR 0.886 — identical to `main` on every category |
| decisionbench | decisions 8/8 · noise 8/8 · reuse 4/4 · cap 3/3 |
| full suite | green, `internal/index` 90.2% |

Span reads are covered by a differential test — the same offsets read one at a time and in coalesced spans must return identical records, over a fixture that deliberately mixes small records, one far larger than the read-ahead window, and one past the gap limit so a second span has to start. A span that fails to read falls back per record instead of dropping the rest of the results, which is the bug that would otherwise have been silent.
