### PR TITLE
fix(index): report build phases on the path that builds the first index

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -439,6 +439,16 @@ func rebuildForSearch(dir string, o query.Options, scope string, files map[strin
 	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o700); err != nil {
 		return err
 	}
+	// The same phase reporting rebuild() has. Without it the first run of a
+	// search — which is how almost everyone builds their index the first time,
+	// rather than by typing `deja index` — showed a spinner reading "starting"
+	// and a bar frozen at one notch for the whole build.
+	total := 0
+	progressWeights = filesPerHarness(files)
+	for _, n := range progressWeights {
+		total += n
+	}
+	reportPhase("reading sessions", total)
 	ss := sources.FilterSessions(filterTombstoned(loadProgress("", progress)))
 	imported := importedSessions(dir)
 	ss = append(ss, imported.sessions...)
@@ -468,8 +478,10 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 		return err
 	}
 	seenMsgs := msgSeen{}
+	reportPhase("indexing messages", len(ss))
 	buckets, err := indexTextParallel(func(push func(tokenJob)) error {
 		for _, s := range ss {
+			reportAdvance(1)
 			key := s.Harness + ":" + s.ID
 			ord := uint32(0)
 			if old, ok := m.Sessions[key]; ok {
@@ -514,6 +526,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 		return err
 	}
 	buildCooccur(tmp, ss)
+	reportPhase("writing index", len(buckets))
 	if err := writeBucketsConcurrent(filepath.Join(tmp, "buckets"), buckets); err != nil {
 		return err
 	}
@@ -637,6 +650,7 @@ func writeBucketsConcurrent(dir string, buckets bucketPostings) error {
 		go func() {
 			defer wg.Done()
 			for job := range jobs {
+				reportAdvance(1)
 				if err := writeBucket(filepath.Join(dir, job.name+".bin"), job.data); err != nil {
 					select {
 					case errCh <- err:

--- a/internal/index/progress_phases_test.go
+++ b/internal/index/progress_phases_test.go
@@ -1,0 +1,103 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+type recordingProgress struct {
+	mu       sync.Mutex
+	phases   []string
+	advances map[string]int
+}
+
+func (r *recordingProgress) Phase(name string, _ int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.phases = append(r.phases, name)
+}
+
+func (r *recordingProgress) Advance(units int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.phases) == 0 {
+		return
+	}
+	if r.advances == nil {
+		r.advances = map[string]int{}
+	}
+	r.advances[r.phases[len(r.phases)-1]] += units
+}
+
+func (r *recordingProgress) Harness(string, int, int) {}
+
+// seedClaudeCorpus writes enough of a transcript for a build to have something
+// to report on.
+func seedClaudeCorpus(t *testing.T, root string) {
+	t.Helper()
+	proj := filepath.Join(root, "projects", "app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		var b []byte
+		when := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC).Add(time.Duration(i) * time.Hour)
+		for j := 0; j < 4; j++ {
+			line, err := json.Marshal(map[string]any{
+				"type":      "user",
+				"sessionId": "s" + string(rune('a'+i)),
+				"timestamp": when.Add(time.Duration(j) * time.Minute).Format(time.RFC3339),
+				"message":   map[string]any{"role": "user", "content": "connection pool exhausted again"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			b = append(append(b, line...), '\n')
+		}
+		if err := os.WriteFile(filepath.Join(proj, "s"+string(rune('a'+i))+".jsonl"), b, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestFirstSearchBuildReportsPhases guards the path almost every user takes to
+// their first index: they run a search, not `deja index`. That path built
+// through rebuildForSearch, which reported no phases at all, so the first-run
+// display sat on "starting" with an unmoving bar for the whole build while
+// `deja index` — which few people run first — animated correctly.
+func TestFirstSearchBuildReportsPhases(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	seedClaudeCorpus(t, filepath.Join(tmp, "claude"))
+
+	rec := &recordingProgress{}
+	SetProgress(rec)
+	defer SetProgress(nil)
+
+	dir := filepath.Join(tmp, "idx")
+	if err := EnsureForSearch(dir, query.Options{Query: "connection pool"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	seen := map[string]bool{}
+	for _, p := range rec.phases {
+		seen[p] = true
+	}
+	for _, want := range []string{"reading sessions", "indexing messages", "writing index"} {
+		if !seen[want] {
+			t.Fatalf("phase %q never reported; got %v", want, rec.phases)
+		}
+	}
+	// A phase that announces a total and never advances is a bar that does not
+	// move, which is the defect this test exists for.
+	for _, want := range []string{"indexing messages", "writing index"} {
+		if rec.advances[want] == 0 {
+			t.Fatalf("phase %q reported no progress; advances=%v", want, rec.advances)
+		}
+	}
+}


### PR DESCRIPTION
Part of #505 — the "report better rather than finish faster" half, which turned out to be a plain bug rather than a design question.

## The first run showed nothing, and only the first run

deja has a build display: a spinner, a phase name, a progress bar, stores appearing as they finish. Running `deja index --rebuild` on a terminal animates all of it correctly.

Almost nobody builds their first index that way. They install deja and type a search — and that path goes through `rebuildForSearch`, which reported **no phases at all**. Captured from a real first run on a pty, the whole ten seconds:

```
phases:  starting
bar:     [1]          ← one notch of twenty-two, never moved
```

So the moment the issue is about — the ten seconds where a new user decides whether this tool is worth keeping — was a spinner spinning next to a frozen bar. The polished display existed the entire time and the common path never fed it.

After:

```
phases:  starting → reading sessions → indexing messages → writing index
bar:     1→20, 1→15, 2→20     ← sweeps once per phase
```

## Also: a phase that announced a total and never advanced

`writeBucketsConcurrent` had no `reportAdvance`, so even on the path that did report phases, the last stage set the bar to zero and left it there. It is ~5 s of the build on a large store — the silent tail after the per-store lines land. It moves now.

## Not a speed change

Build time is unchanged: 12.12 / 11.14 s before, 11.65 / 11.20 s after, interleaved. Nothing here is meant to make the build faster, and #505 stays open for the two options that would — being useful before the build finishes, and reading less of the opencode store.

The regression test asserts both halves: that the search path reports all three phases, and that phases which announce a total actually advance. Reverting the fix fails it with `phase "reading sessions" never reported; got []`, which is exactly what a user was looking at.
