### PR TITLE
fix(hooks): stop the file-ranking test from depending on a 400 ms git budget

### DIFF
--- a/cmd/deja/hook_task.go
+++ b/cmd/deja/hook_task.go
@@ -23,12 +23,22 @@ var taskNoiseFiles = map[string]bool{
 	"gemfile.lock": true, "poetry.lock": true, "uv.lock": true,
 }
 
+// taskGitBudget is how long the two git calls together may take before recall
+// gives up on file ranking. It is deliberately short: this runs on the hook
+// path, in front of an agent that is waiting.
+//
+// A variable rather than a constant because a slow machine — a cold Windows
+// runner was the first one seen — blows through it and both calls return
+// nothing, which is indistinguishable from "no repo" and made the test for
+// this function flaky (#516).
+var taskGitBudget = 400 * time.Millisecond
+
 // changedTaskFiles returns basenames of files the repo is actively touching:
 // uncommitted changes first, then files from the last few commits. Best
 // effort — outside a repo, or with git missing or slow, it returns nil and
 // recall falls back to recency.
 func changedTaskFiles(cwd string) []string {
-	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), taskGitBudget)
 	defer cancel()
 	var out []string
 	seen := map[string]bool{}

--- a/cmd/deja/hook_task_test.go
+++ b/cmd/deja/hook_task_test.go
@@ -45,6 +45,14 @@ func TestChangedTaskFilesReadsGitState(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not installed")
 	}
+	// Spawning git twice inside 400 ms is a budget a loaded CI runner does not
+	// always meet, and when it misses, both calls return nothing and the
+	// failure reads as a parsing bug. This test is about what the output
+	// parses into, not about the budget — the budget has its own test below.
+	old := taskGitBudget
+	taskGitBudget = 20 * time.Second
+	t.Cleanup(func() { taskGitBudget = old })
+
 	repo := t.TempDir()
 	run := func(args ...string) {
 		t.Helper()
@@ -143,5 +151,26 @@ func TestHookContextReceiptNamesTaskFiles(t *testing.T) {
 	}
 	if heroPos != -1 && heroPos < authPos {
 		t.Fatalf("task-matched session must outrank fresher unrelated one:\n%s", digest)
+	}
+}
+
+// TestChangedTaskFilesRespectsItsBudget is the other half: this runs in front
+// of a waiting agent, so exceeding the budget must mean empty results rather
+// than a stalled hook.
+func TestChangedTaskFilesRespectsItsBudget(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	old := taskGitBudget
+	taskGitBudget = time.Nanosecond
+	t.Cleanup(func() { taskGitBudget = old })
+
+	started := time.Now()
+	got := changedTaskFiles(t.TempDir())
+	if len(got) != 0 {
+		t.Fatalf("expired budget returned %v", got)
+	}
+	if d := time.Since(started); d > 5*time.Second {
+		t.Fatalf("took %v — the budget did not bound the call", d)
 	}
 }


### PR DESCRIPTION
Closes #516.

The Windows failure was `got []` from `changedTaskFiles` in a repo the test had just seeded — which reads as a parsing or path bug, and is not one. The function gives **both** git calls 400 ms together, deliberately, because it runs on the hook path in front of a waiting agent. A loaded Windows runner does not always spawn git twice inside that, both calls return nothing, and empty is indistinguishable from "not a repo".

So the budget is a variable now. The test that cares about parsing gets a real one; a second test pins the behaviour the budget exists for — an expired budget returns empty promptly rather than stalling the hook.

Worth noting what this does not fix: on a genuinely slow machine a real user loses file-based ranking silently and falls back to recency. That is the intended degradation, but it has never been measured on Windows, where git is slowest. Left as it stands rather than raising the budget on a guess.