### PR TITLE
chore(packaging): pin scoop/winget manifests to 0.16.2

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,12 +1,12 @@
 {
     "architecture": {
         "64bit": {
-            "hash": "ca95da4124de996e08962b473e65480172d58af350bd7a30fceb9147c9a858e3",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.1/deja-vu_0.16.1_windows_amd64.zip"
+            "hash": "affa6e6883d07ad9675efd2e27923de25f65a26437e4a2c6a9a40cee29a4f7c0",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.2/deja-vu_0.16.2_windows_amd64.zip"
         },
         "arm64": {
-            "hash": "0ab31bf66feac08a594856135394fe5e94db1655f4bc82157c6d3966df491434",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.1/deja-vu_0.16.1_windows_arm64.zip"
+            "hash": "62a091c3e0916f9fcf22a37d583e70bc24dd2aab14671a6b7cf942668e10a930",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.2/deja-vu_0.16.2_windows_arm64.zip"
         }
     },
     "autoupdate": {
@@ -24,5 +24,5 @@
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
-    "version": "0.16.1"
+    "version": "0.16.2"
 }

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.1
+PackageVersion: 0.16.2
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.1/deja-vu_0.16.1_windows_amd64.zip
-  InstallerSha256: CA95DA4124DE996E08962B473E65480172D58AF350BD7A30FCEB9147C9A858E3
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.2/deja-vu_0.16.2_windows_amd64.zip
+  InstallerSha256: AFFA6E6883D07AD9675EFD2E27923DE25F65A26437E4A2C6A9A40CEE29A4F7C0
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.1/deja-vu_0.16.1_windows_arm64.zip
-  InstallerSha256: 0AB31BF66FEAC08A594856135394FE5E94DB1655F4BC82157C6D3966DF491434
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.2/deja-vu_0.16.2_windows_arm64.zip
+  InstallerSha256: 62A091C3E0916F9FCF22A37D583E70BC24DD2AAB14671A6B7CF942668E10A930
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.1
+PackageVersion: 0.16.2
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.1/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.2/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider


### PR DESCRIPTION
Post-release pin, checksums from the v0.16.2 release.