### PR TITLE
fix(packaging): pin the winget version manifest too

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,12 +1,12 @@
 {
     "architecture": {
         "64bit": {
-            "hash": "ca95da4124de996e08962b473e65480172d58af350bd7a30fceb9147c9a858e3",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.1/deja-vu_0.16.1_windows_amd64.zip"
+            "hash": "affa6e6883d07ad9675efd2e27923de25f65a26437e4a2c6a9a40cee29a4f7c0",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.2/deja-vu_0.16.2_windows_amd64.zip"
         },
         "arm64": {
-            "hash": "0ab31bf66feac08a594856135394fe5e94db1655f4bc82157c6d3966df491434",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.1/deja-vu_0.16.1_windows_arm64.zip"
+            "hash": "62a091c3e0916f9fcf22a37d583e70bc24dd2aab14671a6b7cf942668e10a930",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.2/deja-vu_0.16.2_windows_arm64.zip"
         }
     },
     "autoupdate": {
@@ -24,5 +24,5 @@
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
-    "version": "0.16.1"
+    "version": "0.16.2"
 }

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.1
+PackageVersion: 0.16.2
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.1/deja-vu_0.16.1_windows_amd64.zip
-  InstallerSha256: CA95DA4124DE996E08962B473E65480172D58AF350BD7A30FCEB9147C9A858E3
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.2/deja-vu_0.16.2_windows_amd64.zip
+  InstallerSha256: AFFA6E6883D07AD9675EFD2E27923DE25F65A26437E4A2C6A9A40CEE29A4F7C0
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.1/deja-vu_0.16.1_windows_arm64.zip
-  InstallerSha256: 0AB31BF66FEAC08A594856135394FE5E94DB1655F4BC82157C6D3966DF491434
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.2/deja-vu_0.16.2_windows_arm64.zip
+  InstallerSha256: 62A091C3E0916F9FCF22A37D583E70BC24DD2AAB14671A6B7CF942668E10A930
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.1
+PackageVersion: 0.16.2
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.1/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.2/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.1
+PackageVersion: 0.16.2
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0

--- a/scripts/pinmanifests/main.go
+++ b/scripts/pinmanifests/main.go
@@ -29,11 +29,12 @@ import (
 )
 
 const (
-	scoopPath  = "packaging/scoop/deja-vu.json"
-	localePath = "packaging/winget/vshulcz.deja-vu.locale.en-US.yaml"
-	installer  = "packaging/winget/vshulcz.deja-vu.installer.yaml"
-	releaseAPI = "https://api.github.com/repos/vshulcz/deja-vu/releases/latest"
-	assetBase  = "https://github.com/vshulcz/deja-vu/releases/download"
+	scoopPath   = "packaging/scoop/deja-vu.json"
+	versionPath = "packaging/winget/vshulcz.deja-vu.yaml"
+	localePath  = "packaging/winget/vshulcz.deja-vu.locale.en-US.yaml"
+	installer   = "packaging/winget/vshulcz.deja-vu.installer.yaml"
+	releaseAPI  = "https://api.github.com/repos/vshulcz/deja-vu/releases/latest"
+	assetBase   = "https://github.com/vshulcz/deja-vu/releases/download"
 )
 
 type pins struct {
@@ -106,9 +107,10 @@ func parse(version, checksums string) (pins, error) {
 
 func write(root string, p pins) error {
 	for path, render := range map[string]func(pins) ([]byte, error){
-		scoopPath:  renderScoop,
-		localePath: renderLocale,
-		installer:  renderInstaller,
+		scoopPath:   renderScoop,
+		versionPath: renderVersion,
+		localePath:  renderLocale,
+		installer:   renderInstaller,
 	} {
 		body, err := render(p)
 		if err != nil {
@@ -156,6 +158,12 @@ func renderScoop(p pins) ([]byte, error) {
 // The winget files are edited rather than regenerated: they carry tags and
 // descriptions that are not derived from a release, and rewriting them from a
 // template here would quietly drop whatever someone adds later.
+// renderVersion covers the winget version manifest, which carries its own
+// PackageVersion. Leaving it out pinned two of the three winget files and the
+// set failed its own consistency test — caught after 0.16.2 shipped, having
+// been fixed by hand before that.
+func renderVersion(p pins) ([]byte, error) { return edit(versionPath, p) }
+
 func renderLocale(p pins) ([]byte, error) { return edit(localePath, p) }
 
 func renderInstaller(p pins) ([]byte, error) { return edit(installer, p) }
@@ -216,9 +224,10 @@ func runCheck(root string) error {
 		return err
 	}
 	for path, render := range map[string]func(pins) ([]byte, error){
-		scoopPath:  renderScoop,
-		localePath: renderLocale,
-		installer:  renderInstaller,
+		scoopPath:   renderScoop,
+		versionPath: renderVersion,
+		localePath:  renderLocale,
+		installer:   renderInstaller,
 	} {
 		want, err := render(p)
 		if err != nil {


### PR DESCRIPTION
Replaces #522, which failed CI for a good reason.

`pinmanifests` knew about the scoop manifest and two of the three winget files. It did not know about `vshulcz.deja-vu.yaml`, which carries its own `PackageVersion`, so a post-release pin left the winget set internally inconsistent and `TestWinGetManifestSet` failed on all three platforms:

```
vshulcz.deja-vu.locale.en-US.yaml version = "0.16.2", want "0.16.1"
installer is missing x64 release URL
```

That has been true for every release; it was being fixed by hand. Now the tool covers all four files, in both the write and the `-check` path CI runs, and the 0.16.2 pin is in this PR.