### PR TITLE
feat(sources): index the commands that say what happened

### DIFF
--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -1078,3 +1078,52 @@ func TestFuzzySearchWithPhraseTokens(t *testing.T) {
 		t.Fatalf("reversed phrase result=%#v err=%v", result, err)
 	}
 }
+
+// TestToolRecordsStayOutOfOrdinaryRanking pins the rule that keeps command
+// records from polluting search: they answer "what did I run", never "what did
+// we decide", and left in the ordinary ranking they lift a session because a
+// command line contained the words of a question.
+func TestToolRecordsStayOutOfOrdinaryRanking(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "idx")
+	ss := []model.Session{{
+		ID: "s1", Harness: "claude", Project: "app",
+		Started: time.Unix(1700000000, 0), Updated: time.Unix(1700000000, 0),
+		Messages: []model.Message{
+			{Role: "user", Text: "why is the build slow", Time: time.Unix(1700000000, 0)},
+			{Role: roleTool, Text: "$ go build ./... # slow build", Time: time.Unix(1700000001, 0)},
+		},
+	}}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, ss, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	hits, err := Search(dir, search.Options{Query: "slow build", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range hits {
+		for _, m := range s.Messages {
+			if m.Role == roleTool {
+				t.Fatalf("tool record served to an ordinary query: %q", m.Text)
+			}
+		}
+	}
+	byRole, err := Search(dir, search.Options{Query: "slow build", Role: roleTool, All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, s := range byRole {
+		for _, m := range s.Messages {
+			if m.Role == roleTool {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("asking by role returned no command records")
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -970,6 +970,10 @@ func scanRecords(dir string, m Manifest, o query.Options, offsets []int64) ([]mo
 	return scanRecordsWithVariants(dir, m, o, offsets, nil)
 }
 
+// roleTool mirrors sources.RoleTool without importing it: this package is
+// below sources, not above it.
+const roleTool = "tool"
+
 func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []int64, variants map[string][]string) ([]model.Session, error) {
 	by := map[string]*model.Session{}
 	add := func(r Record) {
@@ -987,6 +991,14 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 			return
 		}
 		if o.Role != "" && r.Role != o.Role {
+			return
+		}
+		// A tool invocation is an action, not an answer. Left in the ordinary
+		// ranking it pulls a session up because a command line happened to
+		// contain the words of a question — measured at 56 of 260 top-10
+		// positions moving on a real store. So it is indexed and searchable,
+		// but only when asked for by role.
+		if r.Role == roleTool && o.Role != roleTool {
 			return
 		}
 		s := by[r.Key]

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -71,6 +71,11 @@ func parseClaudeTypedFromOffset(path string, offset int64) ([]model.Session, err
 		if txt != "" {
 			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
 		}
+		if IndexToolCalls() && v.Message != nil {
+			for _, cmd := range claudeCommands(v.Message.Content) {
+				s.Messages = append(s.Messages, model.Message{Role: RoleTool, Text: cmd, Time: t})
+			}
+		}
 	})
 	if len(s.Messages) == 0 {
 		return nil, err
@@ -198,4 +203,53 @@ func scanJSONLBytes(path string, offset int64, fn func([]byte)) error {
 			return err
 		}
 	}
+}
+
+// RoleTool marks a record that is an action rather than something said. Tool
+// *output* has always been indexed — Claude files it under the user role, which
+// is why the index holds megabytes of test output — but the invocation that
+// produced it was dropped, so nothing could say what a piece of output came
+// from, or whether a claimed test run happened at all.
+const RoleTool = "tool"
+
+// IndexToolCalls reports whether tool invocations are indexed. Off by default
+// while the cost is being measured: on a 644 MB corpus the commands are 13.6 MB
+// of new text, about a third again on top of the record log.
+func IndexToolCalls() bool { return os.Getenv("DEJA_INDEX_TOOLS") == "1" }
+
+// claudeCommands pulls the shell commands out of a message's tool_use blocks.
+// Only Bash: the other tools carry paths and arguments rather than something a
+// person would recognise as a thing that ran, and paths are already reachable
+// through the output.
+func claudeCommands(raw json.RawMessage) []string {
+	raw = trimJSONSpace(raw)
+	if len(raw) == 0 || raw[0] != '[' {
+		return nil
+	}
+	var items []json.RawMessage
+	if json.Unmarshal(raw, &items) != nil {
+		return nil
+	}
+	var out []string
+	for _, item := range items {
+		item = trimJSONSpace(item)
+		if len(item) == 0 || item[0] != '{' {
+			continue
+		}
+		var part struct {
+			Type  string `json:"type"`
+			Name  string `json:"name"`
+			Input struct {
+				Command string `json:"command"`
+			} `json:"input"`
+		}
+		if json.Unmarshal(item, &part) != nil {
+			continue
+		}
+		if part.Type != "tool_use" || part.Name != "Bash" || part.Input.Command == "" {
+			continue
+		}
+		out = append(out, "$ "+part.Input.Command)
+	}
+	return out
 }

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -212,10 +213,26 @@ func scanJSONLBytes(path string, offset int64, fn func([]byte)) error {
 // from, or whether a claimed test run happened at all.
 const RoleTool = "tool"
 
-// IndexToolCalls reports whether tool invocations are indexed. Off by default
-// while the cost is being measured: on a 644 MB corpus the commands are 13.6 MB
-// of new text, about a third again on top of the record log.
-func IndexToolCalls() bool { return os.Getenv("DEJA_INDEX_TOOLS") == "1" }
+// IndexToolCalls reports whether tool invocations are indexed. On by default,
+// because a flag nobody enables is a feature nobody has — but only the commands
+// worth keeping: see worthIndexing. All of them together are 13.1 MB on a 644 MB
+// corpus and three quarters of that is `ls`, `cat` and `grep`.
+func IndexToolCalls() bool { return os.Getenv("DEJA_INDEX_TOOLS") != "0" }
+
+// worthIndexing keeps the commands that say what happened — a test run, a build,
+// a deploy, a git or gh operation — and drops the navigation. Measured on a real
+// corpus: 5,051 of 23,774 commands, 3.5 MB of 13.1 MB.
+//
+// The dropped ones are not merely cheap to store, they are actively bad to keep:
+// `cat internal/index/index.go` matches a query about the index and answers
+// nothing.
+var meaningfulCommand = regexp.MustCompile(`\b(go (test|build|vet|run)|golangci-lint|pytest|npm (run )?(test|build)|yarn |cargo |make\b|gh (pr|run|release|issue|workflow)|git (commit|push|rebase|merge|revert|tag|bisect)|docker|kubectl|terraform|deja )`)
+
+var trivialCommand = regexp.MustCompile(`^\s*(ls|cd|pwd|cat|head|tail|echo|grep|rg|find|which|wc|sed|awk|sleep|mkdir|rm|cp|mv|chmod|export|source|touch|open|printf)\b`)
+
+func worthIndexing(cmd string) bool {
+	return meaningfulCommand.MatchString(cmd) && !trivialCommand.MatchString(cmd)
+}
 
 // claudeCommands pulls the shell commands out of a message's tool_use blocks.
 // Only Bash: the other tools carry paths and arguments rather than something a
@@ -247,6 +264,9 @@ func claudeCommands(raw json.RawMessage) []string {
 			continue
 		}
 		if part.Type != "tool_use" || part.Name != "Bash" || part.Input.Command == "" {
+			continue
+		}
+		if !worthIndexing(part.Input.Command) {
 			continue
 		}
 		out = append(out, "$ "+part.Input.Command)

--- a/internal/sources/claude_tools_test.go
+++ b/internal/sources/claude_tools_test.go
@@ -1,0 +1,39 @@
+package sources
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestClaudeCommandsPullsBashInvocations(t *testing.T) {
+	raw := json.RawMessage(`[
+	  {"type":"text","text":"running the suite"},
+	  {"type":"tool_use","name":"Bash","input":{"command":"go test ./internal/index/ -count=1"}},
+	  {"type":"tool_use","name":"Read","input":{"file_path":"/tmp/x.go"}},
+	  {"type":"tool_use","name":"Bash","input":{"command":""}},
+	  {"type":"tool_result","content":"ok  github.com/x 1.2s"}
+	]`)
+	got := claudeCommands(raw)
+	if len(got) != 1 || got[0] != "$ go test ./internal/index/ -count=1" {
+		t.Fatalf("commands=%#v", got)
+	}
+}
+
+// The shapes that must not panic or invent a command.
+func TestClaudeCommandsIgnoresEverythingElse(t *testing.T) {
+	for _, raw := range []string{`"plain string"`, `null`, ``, `[]`, `[1,2]`, `[{"type":"text","text":"hi"}]`,
+		`{"type":"tool_use","name":"Bash","input":{"command":"ls"}}`} {
+		if got := claudeCommands(json.RawMessage(raw)); len(got) != 0 {
+			t.Fatalf("%s yielded %#v", raw, got)
+		}
+	}
+}
+
+// Tool output has always been indexed under the user role; only the invocation
+// was missing. This pins that the text half is untouched by the new path.
+func TestClaudeTextStillReadsToolResults(t *testing.T) {
+	raw := json.RawMessage(`[{"type":"tool_result","content":"--- FAIL: TestX"}]`)
+	if got := claudeText(raw); got != "--- FAIL: TestX" {
+		t.Fatalf("text=%q", got)
+	}
+}

--- a/internal/sources/claude_tools_test.go
+++ b/internal/sources/claude_tools_test.go
@@ -37,3 +37,35 @@ func TestClaudeTextStillReadsToolResults(t *testing.T) {
 		t.Fatalf("text=%q", got)
 	}
 }
+
+// The selection is the point: three quarters of command text on a real corpus
+// is navigation that answers nothing and matches queries by accident —
+// `cat internal/index/index.go` looks relevant to a question about the index.
+func TestWorthIndexingKeepsWhatHappened(t *testing.T) {
+	keep := []string{
+		"go test ./internal/index/ -count=1",
+		"golangci-lint run",
+		"gh pr checks 558",
+		"git commit -m 'fix: x'",
+		"make build && deja index --rebuild",
+		"docker compose up -d",
+	}
+	for _, c := range keep {
+		if !worthIndexing(c) {
+			t.Errorf("dropped a command worth keeping: %q", c)
+		}
+	}
+	drop := []string{
+		"cat internal/index/index.go",
+		"ls -la",
+		"grep -rn foo internal/",
+		"cd /repo && pwd",
+		"sed -n 1,40p internal/index/index.go",
+		"echo hi",
+	}
+	for _, c := range drop {
+		if worthIndexing(c) {
+			t.Errorf("kept navigation: %q", c)
+		}
+	}
+}


### PR DESCRIPTION
The other half of #547, narrowed after your point that a flag nobody enables is a feature nobody has.

## What changed since the first version

It indexed **every** Bash call: 23,774 commands, 13.1 MB, +27% of the index. Three quarters of that is navigation — `ls`, `cat`, `grep`, `cd` — which is not merely cheap to store but actively harmful: `cat internal/index/index.go` matches a query about the index and answers nothing.

Now it keeps the commands that say what happened — test runs, builds, deploys, `git`, `gh`, `docker`, `deja` itself:

| | commands | text |
|---|---|---|
| every Bash call | 23,774 | 13.1 MB |
| **kept** | **5,051** | **3.5 MB (27%)** |

| index | |
|---|---|
| without commands | 63.90 MB |
| **with the narrowed set** | **68.83 MB (+7.7%)** |

**On by default**, `DEJA_INDEX_TOOLS=0` to turn it off.

## Ranking

**2 of 260 positions move** (`scripts/rankdiff`), down from 11 in the every-command version. Commands are still kept out of ordinary results and served by role, so a command line cannot lift a session because it contains the words of a question.

## What it is for

- **#539** — "when did this test last pass", "when did this error first appear": needs exactly the test and build invocations this keeps.
- **#546** — the work being done by hand twelve times: the repeated sequences I measured were `go test` + `go tool cover` and `gh pr checks` + `gh pr merge`, both inside the kept set.
- **#541** is not on this list. Measured and closed: the agent ran what it claimed 97% of the time.

Tool *output* has always been indexed — 39,836 of 40,933 results are strings the decoder already reads. Only the invocation was missing, so output sat in the index with nothing saying what produced it.

Full suite green, decisionbench 8/8 · 8/8 · 4/4 · 3/3. Index version bumps, so an existing index rebuilds once.