### PR TITLE
fix(search): report the pool the relevance window was taken from

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -400,7 +400,18 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	if result.Tier == search.TierRelevance {
 		fmt.Fprintln(os.Stderr, "deja: no exact match; showing sessions ranked by relevance to the whole query")
 		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(o.Query))
-		o.Total = len(hits)
+		// This tier ranks and truncates inside retrieval, so counting the
+		// sessions it handed back measures its window, not the match: every
+		// query deeper than the window reported the window's own size and
+		// capped: false, which told a consumer to stop checking exactly when
+		// there was something to check. Take the tier's figures when it has
+		// them; the paths that report none (a quoted query retried without
+		// its quotes, served here under the relevance label) never truncated,
+		// so what arrived is the whole of it.
+		o.Total, o.Capped = result.Total, result.Capped
+		if o.Total < len(hits) {
+			o.Total = len(hits)
+		}
 	} else {
 		// RunDetailed rather than Run: the JSON envelope reports how many
 		// sessions matched before the cap, and that is not recoverable from a

--- a/cmd/deja/relevance_envelope_test.go
+++ b/cmd/deja/relevance_envelope_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/jsonout"
+)
+
+type searchEnvelope struct {
+	SchemaVersion int    `json:"schema_version"`
+	Tier          string `json:"tier"`
+	Total         int    `json:"total"`
+	Capped        bool   `json:"capped"`
+	Hits          []struct {
+		Session struct {
+			ID string `json:"id"`
+		} `json:"session"`
+	} `json:"hits"`
+}
+
+func decodeEnvelope(t *testing.T, out string) searchEnvelope {
+	t.Helper()
+	var env searchEnvelope
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("search json: %v\n%s", err, out)
+	}
+	if env.SchemaVersion != jsonout.Version {
+		t.Fatalf("schema_version = %d, want %d\n%s", env.SchemaVersion, jsonout.Version, out)
+	}
+	return env
+}
+
+// total and capped are the two questions a caller cannot answer from a list of
+// hits, and on the relevance tier both used to answer about the ranking window
+// instead of the match: 50 sessions returned, "total": 50, "capped": false,
+// whatever the pool behind it was. A consumer reading that stops checking at
+// the exact moment there is something to check.
+func TestRelevanceEnvelopeReportsThePreCapTotal(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	// 60 sessions carry three of the four query terms and one carries only the
+	// fourth: every term resolves in the corpus, no session holds them all —
+	// which is what drops the ladder to the relevance tier — and the scored
+	// pool is 61, deeper than the window it is served through.
+	for i := 0; i < 60; i++ {
+		id := fmt.Sprintf("rel%02d", i)
+		writeClaudeFixture(t, filepath.Join(root, "relevance", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"kubernetes autoscaler telemetry notes ` + id + `"}}`,
+		})
+	}
+	writeClaudeFixture(t, filepath.Join(root, "relevance", "dash.jsonl"), "dash", []string{
+		`{"type":"user","sessionId":"dash","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"dashboards"}}`,
+	})
+
+	const q = "kubernetes autoscaler telemetry dashboards"
+	out, err := captureRun(t, "--json", "--no-embed", q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := decodeEnvelope(t, out)
+	if env.Tier != "relevance" {
+		t.Fatalf("tier = %q, want relevance — the fixture stopped exercising the path\n%s", env.Tier, out)
+	}
+	if len(env.Hits) != 50 {
+		t.Fatalf("hits = %d, want the relevance window of 50", len(env.Hits))
+	}
+	if env.Total != 61 || !env.Capped {
+		t.Fatalf("total = %d capped = %v, want 61 and true: 11 scored sessions were withheld", env.Total, env.Capped)
+	}
+
+	// --all lifts the result cap, not a window that lives in retrieval. The
+	// point of saying so here is that a consumer passing --all to escape the
+	// cap must still read capped rather than assume it escaped one.
+	out, err = captureRun(t, "--json", "--no-embed", "--all", q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env = decodeEnvelope(t, out); env.Total != 61 || !env.Capped || len(env.Hits) != 50 {
+		t.Fatalf("--all: total = %d capped = %v hits = %d, want 61/true/50", env.Total, env.Capped, len(env.Hits))
+	}
+
+	// The exact tier keeps its own window and its own numbers: one session
+	// holds this word, and the cap never came near it.
+	out, err = captureRun(t, "--json", "--no-embed", "dashboards")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env = decodeEnvelope(t, out); env.Tier != "exact" || env.Total != 1 || env.Capped || len(env.Hits) != 1 {
+		t.Fatalf("exact: tier = %q total = %d capped = %v hits = %d", env.Tier, env.Total, env.Capped, len(env.Hits))
+	}
+
+	// Nothing matched is still an answer with a shape: the envelope, a total of
+	// zero and no capped, rather than the bare array this used to fall back to.
+	out, err = captureRun(t, "--json", "--no-embed", "zzqqxx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env = decodeEnvelope(t, out); env.Total != 0 || env.Capped || len(env.Hits) != 0 {
+		t.Fatalf("empty: total = %d capped = %v hits = %d\n%s", env.Total, env.Capped, len(env.Hits), out)
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -27,14 +27,36 @@ from a list of hits:
   `relevance`. **`relevance` means nothing matched** and these are the nearest
   sessions deja could find. Counting those as hits overstates recall, and this
   used to be readable only as a sentence on stderr.
-- `total` and `capped` — how many sessions matched, and whether the result cap
-  hid some. Counting the returned hits measures the cap: that figure moves when
-  the window's membership changes, whether or not retrieval improved. Pass
-  `--all` for an uncapped set, in which case `total` equals the hit count.
+- `total` and `capped` — how many sessions matched, and whether a cap hid some.
+  Counting the returned hits measures the cap: that figure moves when the
+  window's membership changes, whether or not retrieval improved.
+  **`capped: false` means the response holds everything that matched, on every
+  tier**; when it is `true`, `total` is the figure to read and the hit count is
+  not.
 
 `capped` is omitted when false. When it is true, `total` is the count before
 policy scoping and reranking ran, because there is no way to know how those
 would have treated the sessions the cap removed.
+
+### `hits` is not a fixed window across tiers
+
+The number of hits a tier returns is that tier's own decision, so the same
+invocation can return 15 on one tier and 50 on another. Read `total` and
+`capped` for coverage; the length of `hits` answers a different question.
+
+- `exact`, `close`, `stemmed` and `semantic` serve the ranked result cap:
+  `--limit N` (1–100), 15 by default, and `--all` for no cap. With `--all`,
+  `total` equals the hit count.
+- `relevance` ranks the candidate pool and serves the top 50. That bound belongs
+  to the ranking rather than to output: it is applied during retrieval, and
+  `--limit` and `--all` act on the result set downstream of it, so neither moves
+  it. A relevance response can therefore come back `capped: true` with `--all`
+  passed, and `total` can exceed the 50 hits it returned.
+
+Reporting `total` as the length of that window instead of the pool behind it was
+[#497](https://github.com/vshulcz/deja-vu/issues/497): deeper queries all came
+back `"total": 50, "capped": false`, which reads as "50 matched, none withheld"
+in the one case where a consumer most needs to keep looking.
 
 ## `deja search --json`
 
@@ -90,8 +112,10 @@ Stemmed search may also include `variants`; semantic search sets `semantic`.
 matches overlap this hit — an earlier-attempt signal. `reused` (optional)
 counts recent agent recalls that served this session.
 
-`--limit N` bounds the ranked result set to 1–100 hits. Every machine session
-has `source.origin`, either `local` or `imported`. When
+`--limit N` bounds the ranked result set to 1–100 hits, on the tiers that serve
+that cap (see [`hits` is not a fixed
+window](#hits-is-not-a-fixed-window-across-tiers)). Every machine session has
+`source.origin`, either `local` or `imported`. When
 `DEJA_SOURCE_INSTANCE` is configured, local sessions also carry that stable
 operator-chosen `source.instance`; imported sessions omit it because current
 sync batches do not carry trustworthy peer identity.

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -171,6 +171,14 @@ type SearchResult struct {
 	Stemmed  bool
 	Variants map[string][]string
 	Tier     string
+	// Total is how many sessions the tier matched before its own window
+	// trimmed them, and Capped whether that trimming withheld any. The
+	// relevance tier is the one that needs them: it ranks and truncates
+	// inside retrieval, so a caller counting Sessions is measuring the
+	// window rather than the match. Zero Total means the tier reports no
+	// figure of its own and the caller's count stands.
+	Total  int
+	Capped bool
 }
 
 func DefaultDir() string {

--- a/internal/index/relevance_test.go
+++ b/internal/index/relevance_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,4 +56,87 @@ func TestLadderFallsBackToRelevance(t *testing.T) {
 	if len(r2.Sessions) != 0 {
 		t.Fatalf("nonsense query must stay empty, got %d sessions", len(r2.Sessions))
 	}
+}
+
+// The relevance tier ranks the whole candidate pool and serves the top
+// relevanceWindow of it, so the sessions it returns are the window rather than
+// the match. Counting them and calling that the total reported the window's own
+// size on every query deeper than it, with capped: false alongside — a missing
+// signal sends a consumer to check, a wrong one tells it to stop.
+func TestRelevanceReportsThePoolItsWindowTrimmed(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		candidates int
+		wantTotal  int
+		wantServed int
+		wantCapped bool
+	}{
+		// One session per candidate plus the one holding the fourth term,
+		// which the ranking scores too: it is the pool, not the answer set.
+		{"pool deeper than the window", 60, 61, relevanceWindow, true},
+		{"pool inside the window", 10, 11, 11, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := relevancePoolFixture(t, tc.candidates)
+			const q = "kubernetes autoscaler telemetry dashboards"
+			r, err := SearchWithRecoveryDetailed(dir, query.Options{Query: q, All: true}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Guard the fixture, not the fix: if the ladder stops falling
+			// through to relevance the numbers below mean nothing.
+			if r.Tier != query.TierRelevance {
+				t.Fatalf("fixture resolved through tier %q, want the relevance tier", r.Tier)
+			}
+			if len(r.Sessions) != tc.wantServed {
+				t.Fatalf("served %d sessions, want %d", len(r.Sessions), tc.wantServed)
+			}
+			if r.Total != tc.wantTotal {
+				t.Fatalf("total = %d, want %d — every session the ranking scored, before the window", r.Total, tc.wantTotal)
+			}
+			if r.Capped != tc.wantCapped {
+				t.Fatalf("capped = %v with %d of %d sessions served", r.Capped, len(r.Sessions), r.Total)
+			}
+			// The invariant the reporting exists for: capped false has to mean
+			// the caller is holding everything that matched.
+			if !r.Capped && r.Total != len(r.Sessions) {
+				t.Fatalf("capped is false while %d of %d matches were withheld", r.Total-len(r.Sessions), r.Total)
+			}
+		})
+	}
+}
+
+// relevancePoolFixture indexes n sessions carrying three of the four query
+// terms and one carrying only the fourth, so every term resolves in the corpus
+// while no session holds them all — which is what drops the ladder to the
+// relevance tier — and the scored pool is n+1.
+func relevancePoolFixture(t *testing.T, n int) string {
+	t.Helper()
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, sid, text string) {
+		line := `{"type":"user","sessionId":"` + sid + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, name), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("c%d", i)
+		write(id+".jsonl", id, fmt.Sprintf("kubernetes autoscaler telemetry notes %d", i))
+	}
+	write("d1.jsonl", "d1", "dashboards")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
 }

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -130,7 +130,14 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 									merged = append(merged, c)
 								}
 							}
-							return SearchResult{Sessions: merged, Tier: query.TierRelevance}, nil
+							// The tail carries sessions the relevance pool did
+							// not hold, so they are matches too and count
+							// toward the total. Adding them on both sides
+							// leaves `capped` reading the relevance window,
+							// which is still the only thing that withheld
+							// anything here.
+							tail := len(merged) - len(rel.Sessions)
+							return relevanceResult(merged, rel.Total+tail), nil
 						}
 					}
 				}
@@ -238,6 +245,13 @@ func RelevanceMatchTerms(q string) []string {
 	return out
 }
 
+// relevanceWindow bounds how many ranked sessions the relevance tier serves.
+// It belongs to the ranking rather than to output: --limit and --all act on the
+// result set, which is downstream of this. That is also why this tier has to
+// report Total and Capped — the pool the window was taken from does not survive
+// the return, so a caller counting sessions is counting the window.
+const relevanceWindow = 50
+
 // relevanceSearch is the ladder's last resort: no AND survived, so rank every
 // session by IDF-weighted overlap with the query's informative words. Order
 // carries the ranking; callers must not re-sort by exact-match BM25 (the whole
@@ -254,7 +268,7 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 	if len(terms) < 2 {
 		return SearchResult{}, nil
 	}
-	metas, _, anyMatched, termsKnown := relevantMetasCounts(dir, m, nil, terms, 50, func(meta SessionMeta) bool {
+	metas, _, anyMatched, termsKnown, matched := relevantMetasCounts(dir, m, nil, terms, relevanceWindow, func(meta SessionMeta) bool {
 		return sessionMetaMatches(meta, o)
 	})
 	if len(metas) == 0 {
@@ -280,26 +294,40 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 		if len(weak) == 0 || len(terms) < 3 || termsKnown < 2 {
 			return SearchResult{}, nil
 		}
-		if len(weak) > 50 {
-			weak = weak[:50]
+		if len(weak) > relevanceWindow {
+			weak = weak[:relevanceWindow]
 		}
 		ss, err := sessionsForMetas(dir, weak)
 		if err != nil {
 			return SearchResult{}, err
 		}
-		return SearchResult{Sessions: ss, Tier: query.TierRelevance}, nil
+		return relevanceResult(ss, matched), nil
 	}
 	// Single-term sessions ride BEHIND every strong candidate: they widen
 	// deep recall without letting a lucky word outrank a real match.
-	if len(keep)+len(weak) > 50 {
-		weak = weak[:50-len(keep)]
+	if len(keep)+len(weak) > relevanceWindow {
+		weak = weak[:relevanceWindow-len(keep)]
 	}
 	keep = append(keep, weak...)
 	ss, err := sessionsForMetas(dir, keep)
 	if err != nil {
 		return SearchResult{}, err
 	}
-	return SearchResult{Sessions: ss, Tier: query.TierRelevance}, nil
+	return relevanceResult(ss, matched), nil
+}
+
+// relevanceResult labels a relevance answer with the pool it was drawn from:
+// matched is every session the ranking scored, counted before the window
+// trimmed it, so capped can say plainly whether the caller is holding all of
+// them. Reporting len(ss) as the total was the bug in #497 — the window is
+// exactly the thing the number was supposed to see past.
+func relevanceResult(ss []model.Session, matched int) SearchResult {
+	return SearchResult{
+		Sessions: ss,
+		Tier:     query.TierRelevance,
+		Total:    matched,
+		Capped:   matched > len(ss),
+	}
 }
 
 // ProjectRelevant ranks the current project's sessions by how well they match
@@ -348,7 +376,7 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 }
 
 func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n int) ([]SessionMeta, []int) {
-	metas, informative, _, _ := relevantMetasCounts(dir, m, projects, terms, n, nil)
+	metas, informative, _, _, _ := relevantMetasCounts(dir, m, projects, terms, n, nil)
 	return metas, informative
 }
 
@@ -360,7 +388,14 @@ func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n in
 // search tier used to rank the whole index, take the top n and only then
 // apply the scope, so a --harness or --project search came back empty
 // whenever the unfiltered head was full of other sessions.
-func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int, keep func(SessionMeta) bool) ([]SessionMeta, []int, []int, int) {
+// The last return value is how many sessions the ranking scored in total,
+// counted before n truncated the slice. Everything above it is already
+// computed and sorted by then, so the count is free — and it is the only
+// place it exists: after the return, the pool the top n came out of is gone.
+// Returns, in order: the ranked metas, their informative-term counts, their
+// any-frequency term counts, how many query terms the corpus knows at all,
+// and that pre-truncation total.
+func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int, keep func(SessionMeta) bool) ([]SessionMeta, []int, []int, int, int) {
 	inProject := map[uint32]SessionMeta{}
 	for _, meta := range m.Sessions {
 		if keep != nil && !keep(meta) {
@@ -380,7 +415,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		}
 	}
 	if len(inProject) == 0 {
-		return nil, nil, nil, 0
+		return nil, nil, nil, 0, 0
 	}
 	br := newBucketReader(dir)
 	defer br.close()
@@ -605,7 +640,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		ranked = append(ranked, scored{inProject[ord], sc, matchedTerms[ord], anyTerms[ord]})
 	}
 	if len(ranked) == 0 {
-		return nil, nil, nil, termsKnown
+		return nil, nil, nil, termsKnown, 0
 	}
 	sort.Slice(ranked, func(i, j int) bool {
 		if ranked[i].score != ranked[j].score {
@@ -618,6 +653,9 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		// what the user sees first.
 		return ranked[i].meta.ID < ranked[j].meta.ID
 	})
+	// Counted here, one line above the truncation, because this is the last
+	// moment the pool exists.
+	matchedTotal := len(ranked)
 	if n > 0 && len(ranked) > n {
 		ranked = ranked[:n]
 	}
@@ -629,7 +667,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		matched = append(matched, r.matched)
 		anyMatched = append(anyMatched, r.any)
 	}
-	return metas, matched, anyMatched, termsKnown
+	return metas, matched, anyMatched, termsKnown, matchedTotal
 }
 
 // loadSessionRecords materializes one session's transcript from the index.


### PR DESCRIPTION
## What was wrong

`relevantMetasCounts` collects every candidate, sorts the whole slice, and truncates on its last line. `relevanceSearch` asks it for the top 50, and `runSearch` then took `total` from the sessions it had been handed:

```go
hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(o.Query))
o.Total = len(hits)          // ss was already cut to 50, inside retrieval
```

`o.Capped` was never set on that branch at all. So the two fields whose whole job is to describe a cap were describing the cap itself: `"total": 50, "capped": false`, however deep the pool behind it went.

## The fix

Option one, and it is free exactly as you measured: the pre-cap count is `len(ranked)` one line above `ranked = ranked[:n]`. No extra scan, no second pass, no `schema_version` bump, and the exact path keeps both its numbers and its shape.

- `relevantMetasCounts` returns the pre-truncation count as a fifth value. That is the only place it exists — after the return, the pool the top 50 came out of is gone.
- `relevanceResult()` labels every relevance exit with `Total: matched, Capped: matched > len(ss)`. That includes the merged close-tier tail path, where the tail sessions are added on both sides so `capped` still reads the relevance window — the only thing that withheld anything there.
- `runSearch` takes the tier's figures, with `len(hits)` as a floor for the paths that report none. The quoted-phrase retry is one: a query re-run without its quotes is served under the relevance label but never truncated, so what arrived is the whole of it, which is also what it reported before this change.
- The literal `50` became `relevanceWindow` in the three places `relevanceSearch` used it. Same number, same behaviour; it now has somewhere to write down that `--limit` and `--all` act downstream of it.

## Reproduction, before → after

Sealed against the demo corpus — no real history, and `~/.cache/deja` untouched (fingerprinted before and after, byte-identical):

```sh
DEMO=$(mktemp -d); go run ./scripts/demo -out "$DEMO"        # 392 sessions
export HOME=$DEMO USERPROFILE=$DEMO
export DEJA_CLAUDE_ROOT=$DEMO/.claude/projects DEJA_CODEX_ROOT=$DEMO/.codex DEJA_CURSOR_ROOT=$DEMO/.cursor
export DEJA_INDEX_DIR=$(mktemp -d)/index.db DEJA_EMBED=off
deja --json --no-embed "keepalive column" | jq '{tier, total, capped, hits: (.hits|length)}'
```

| query | before | after | counted independently |
|---|---|---|---|
| `keepalive column` | total 50, capped false, 50 hits | **total 53, capped true**, 50 hits | 53 |
| `middleware keepalive` | total 50, capped false, 50 hits | **total 79, capped true**, 50 hits | 79 |
| `keepalive retry column` | total 50, capped false, 50 hits | **total 96, capped true**, 50 hits | 96 |

The last column is the exact path counting the same term sets on its own — `--all --re 'keepalive|column'` → 53, `'middleware|keepalive'` → 79, `'keepalive|retry|column'` → 96. Two unrelated code paths, the same three numbers.

The issue reported 82 / 117 / 143 against a different corpus; these are the same shape measured somewhere anyone can re-measure.

## Docs

`docs/json-output.md` carries the invariant — `capped: false` means the response holds everything that matched, on every tier — and gains a section saying the length of `hits` is not a fixed window across tiers: exact serves 15 and relevance serves 50 from the same invocation, and neither `--limit` nor `--all` reaches the relevance window because it is applied during retrieval, upstream of both.

That last part is behaviour I documented rather than changed: `--limit 5` on a relevance query returns 50 hits today, and `--all` leaves `capped: true`. Both follow from where the window lives. If you would rather `--limit` were plumbed through to it, that is a behaviour change and I would send it separately.

## Tests

- `internal/index` — `TestRelevanceReportsThePoolItsWindowTrimmed`: table-driven over a pool deeper than the window (61 scored, 50 served, capped) and one inside it (11 scored, 11 served, not capped), on a `t.TempDir()` fixture with `HOME`, `USERPROFILE` and `DEJA_*` pinned. It asserts the tier the fixture resolved through, so it fails loudly rather than silently if the ladder stops falling to relevance, and it asserts the invariant directly: not capped ⇒ `total == len(sessions)`.
- `cmd/deja` — `TestRelevanceEnvelopeReportsThePreCapTotal`: the envelope a consumer actually parses. Relevance total/capped/hits, `--all` not lifting the window, the exact tier unchanged, and a query matching nothing still answering with the envelope rather than the bare array it used to fall back to.
- Both fail against the old semantics with the bug's own signature, `total = 50 capped = false`. I checked that before keeping them.

## Verification

```
go test ./... -race -count=1      every package ok
go vet ./...                      clean
gofmt -s -l cmd internal          no output
sh scripts/e2e.sh                 e2e OK
deja bench recall --json          lexical.recall_at_5 = 1.0   (CI floor 0.85)
```

Per-package coverage, measured the way CONTRIBUTING asks:

| package | floor | measured |
|---|---|---|
| `cmd/deja` | 88 | 88.4 |
| `internal/index` | 90 | 90.6 |

Aggregate over shipped packages: 87.9% against the 87.5% floor.

## Not in this change

- `CHANGELOG.md` — you write those in their own passes; glad to add an Unreleased entry here if you would rather it travelled with the fix.
- The MCP `recall` tool's `matches N-M of T` line counts the hits it is paginating, which is a different contract from the envelope's `total`. Left alone.
- The 50 itself, and anything near #492.

Closes #497.
