### PR TITLE
chore(packaging): pin scoop/winget manifests to 0.16.3

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,12 +1,12 @@
 {
     "architecture": {
         "64bit": {
-            "hash": "affa6e6883d07ad9675efd2e27923de25f65a26437e4a2c6a9a40cee29a4f7c0",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.2/deja-vu_0.16.2_windows_amd64.zip"
+            "hash": "ba7d97644a01a4d770d4c212dfa812c749c3784217bbc9a047abf3d838fdf905",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.3/deja-vu_0.16.3_windows_amd64.zip"
         },
         "arm64": {
-            "hash": "62a091c3e0916f9fcf22a37d583e70bc24dd2aab14671a6b7cf942668e10a930",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.2/deja-vu_0.16.2_windows_arm64.zip"
+            "hash": "0a2e3b02bebccc76f30d70ec02318fd862ae90a26323296f76ccd170f2f85946",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.3/deja-vu_0.16.3_windows_arm64.zip"
         }
     },
     "autoupdate": {
@@ -24,5 +24,5 @@
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
-    "version": "0.16.2"
+    "version": "0.16.3"
 }

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.2
+PackageVersion: 0.16.3
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.2/deja-vu_0.16.2_windows_amd64.zip
-  InstallerSha256: AFFA6E6883D07AD9675EFD2E27923DE25F65A26437E4A2C6A9A40CEE29A4F7C0
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.3/deja-vu_0.16.3_windows_amd64.zip
+  InstallerSha256: BA7D97644A01A4D770D4C212DFA812C749C3784217BBC9A047ABF3D838FDF905
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.2/deja-vu_0.16.2_windows_arm64.zip
-  InstallerSha256: 62A091C3E0916F9FCF22A37D583E70BC24DD2AAB14671A6B7CF942668E10A930
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.3/deja-vu_0.16.3_windows_arm64.zip
+  InstallerSha256: 0A2E3B02BEBCCC76F30D70EC02318FD862AE90A26323296F76CCD170F2F85946
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.2
+PackageVersion: 0.16.3
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.2/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.3/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.2
+PackageVersion: 0.16.3
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Post-release pin, checksums from v0.16.3. All four manifests — the version manifest joined the tool in #523, so this is the first release where it does not need a hand fix.