### PR TITLE
feat(sources): index the file paths tool calls name

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -17,7 +17,9 @@ import (
 // this build never queries; 17 filters out deja's own injected recall, which
 // earlier builds indexed back in, so an existing index is rebuilt once to drop
 // the copies it already holds.
-const version = 17
+// 18: file paths from tool calls are indexed (#558). An index built before this
+// has none of them, so it is rebuilt rather than reused.
+const version = 18
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/plumbing_test.go
+++ b/internal/index/plumbing_test.go
@@ -1,6 +1,14 @@
 package index
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
 
 // TestStripsHarnessPlumbing pins what comes out of a transcript that a harness
 // wrote to itself. Measured on a real index before this existed: 304 records
@@ -36,5 +44,54 @@ func TestKeepsWhatIsNotPlumbing(t *testing.T) {
 		if got := stripSelfRecall(in); got != in {
 			t.Errorf("stripped a mention rather than plumbing:\n in:  %q\n out: %q", in, got)
 		}
+	}
+}
+
+// TestFileRecordsStayOutOfOrdinaryRanking is the same rule tool records follow:
+// a list of files a turn touched answers "which files", never "what did we
+// decide", and left in the ordinary ranking a path would lift a session because
+// it contained the words of a question.
+func TestFileRecordsStayOutOfOrdinaryRanking(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "idx")
+	ss := []model.Session{{
+		ID: "s1", Harness: "claude", Project: "app",
+		Started: time.Unix(1700000000, 0), Updated: time.Unix(1700000000, 0),
+		Messages: []model.Message{
+			{Role: "user", Text: "why is the pool slow", Time: time.Unix(1700000000, 0)},
+			{Role: roleFiles, Text: "/repo/internal/db/pool_slow_path.go", Time: time.Unix(1700000001, 0)},
+		},
+	}}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, ss, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	hits, err := Search(dir, search.Options{Query: "pool slow", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range hits {
+		for _, m := range s.Messages {
+			if m.Role == roleFiles {
+				t.Fatalf("file record served to an ordinary query: %q", m.Text)
+			}
+		}
+	}
+	byRole, err := Search(dir, search.Options{Query: "pool slow", Role: roleFiles, All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, s := range byRole {
+		for _, m := range s.Messages {
+			if m.Role == roleFiles {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("asking by role returned no file records")
 	}
 }

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -970,6 +970,10 @@ func scanRecords(dir string, m Manifest, o query.Options, offsets []int64) ([]mo
 	return scanRecordsWithVariants(dir, m, o, offsets, nil)
 }
 
+// roleFiles mirrors sources.RoleFiles without importing it: this package sits
+// below sources, not above it.
+const roleFiles = "files"
+
 func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []int64, variants map[string][]string) ([]model.Session, error) {
 	by := map[string]*model.Session{}
 	add := func(r Record) {
@@ -987,6 +991,13 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 			return
 		}
 		if o.Role != "" && r.Role != o.Role {
+			return
+		}
+		// A file list is a record of what a turn touched, not something said.
+		// Left in ordinary ranking it lifts a session because a path happened
+		// to contain the words of a question, so it is indexed and searchable
+		// but served only when asked for by role.
+		if r.Role == roleFiles && o.Role != roleFiles {
 			return
 		}
 		s := by[r.Key]

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -91,6 +91,13 @@ func parseClaudeGenericFromOffset(path string, offset int64) ([]model.Session, e
 		if txt != "" {
 			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
 		}
+		if IndexToolPaths() {
+			if msg, ok := m["message"].(map[string]any); ok {
+				if p := toolPathsFromContent(msg["content"]); p != "" {
+					s.Messages = append(s.Messages, model.Message{Role: RoleFiles, Text: p, Time: t})
+				}
+			}
+		}
 	})
 	if len(s.Messages) == 0 {
 		return nil, err

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -213,11 +213,15 @@ func scanJSONLBytes(path string, offset int64, fn func([]byte)) error {
 // has no material at all.
 const RoleFiles = "files"
 
-// IndexToolPaths reports whether file paths from tool calls are indexed. Off by
-// default while the cost is measured. This is the cheapest slice of #547 — 0.6 MB
-// of path text across a 644 MB corpus, against 13.6 MB for commands and 80 MB
-// for the bodies of files that were read.
-func IndexToolPaths() bool { return os.Getenv("DEJA_INDEX_PATHS") == "1" }
+// IndexToolPaths reports whether file paths from tool calls are indexed. On by
+// default: a feature behind a flag does not exist for the people who would
+// benefit from it, and this one costs 2% of the index. `DEJA_INDEX_PATHS=0`
+// turns it off for anyone who wants the smaller index back.
+//
+// This is the cheapest slice of #547 — 0.6 MB of path text across a 644 MB
+// corpus, against 13.6 MB for commands and 80 MB for the bodies of files that
+// were read — and three features rest on it: #542, #531 and #534.
+func IndexToolPaths() bool { return os.Getenv("DEJA_INDEX_PATHS") != "0" }
 
 // pathTools are the calls whose input names a file. Bash is deliberately absent:
 // a path inside a shell command is guesswork, and guessing is what made the

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -71,6 +71,11 @@ func parseClaudeTypedFromOffset(path string, offset int64) ([]model.Session, err
 		if txt != "" {
 			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
 		}
+		if IndexToolPaths() && v.Message != nil {
+			if p := claudeToolPaths(v.Message.Content); p != "" {
+				s.Messages = append(s.Messages, model.Message{Role: RoleFiles, Text: p, Time: t})
+			}
+		}
 	})
 	if len(s.Messages) == 0 {
 		return nil, err
@@ -198,4 +203,63 @@ func scanJSONLBytes(path string, offset int64, fn func([]byte)) error {
 			return err
 		}
 	}
+}
+
+// RoleFiles marks a record that lists the files a turn touched, rather than
+// anything said. It exists because the reliable answer to "which file is this
+// session about" is what the agent opened and edited, and that lives in
+// tool_use inputs — measured three times over: #542 works with these paths and
+// not with prose mentions, #531 fails its kill condition without them, and #537
+// has no material at all.
+const RoleFiles = "files"
+
+// IndexToolPaths reports whether file paths from tool calls are indexed. Off by
+// default while the cost is measured. This is the cheapest slice of #547 — 0.6 MB
+// of path text across a 644 MB corpus, against 13.6 MB for commands and 80 MB
+// for the bodies of files that were read.
+func IndexToolPaths() bool { return os.Getenv("DEJA_INDEX_PATHS") == "1" }
+
+// pathTools are the calls whose input names a file. Bash is deliberately absent:
+// a path inside a shell command is guesswork, and guessing is what made the
+// prose-mention approach unusable.
+var pathTools = map[string]bool{"Read": true, "Edit": true, "Write": true, "MultiEdit": true, "NotebookEdit": true}
+
+// claudeToolPaths returns the distinct file paths a message's tool calls name,
+// one per line, or "" when it names none.
+func claudeToolPaths(raw json.RawMessage) string {
+	raw = trimJSONSpace(raw)
+	if len(raw) == 0 || raw[0] != '[' {
+		return ""
+	}
+	var items []json.RawMessage
+	if json.Unmarshal(raw, &items) != nil {
+		return ""
+	}
+	var out []string
+	seen := map[string]bool{}
+	for _, item := range items {
+		item = trimJSONSpace(item)
+		if len(item) == 0 || item[0] != '{' {
+			continue
+		}
+		var part struct {
+			Type  string `json:"type"`
+			Name  string `json:"name"`
+			Input struct {
+				FilePath string `json:"file_path"`
+			} `json:"input"`
+		}
+		if json.Unmarshal(item, &part) != nil {
+			continue
+		}
+		if part.Type != "tool_use" || !pathTools[part.Name] || part.Input.FilePath == "" {
+			continue
+		}
+		if seen[part.Input.FilePath] {
+			continue
+		}
+		seen[part.Input.FilePath] = true
+		out = append(out, part.Input.FilePath)
+	}
+	return strings.Join(out, "\n")
 }

--- a/internal/sources/claude_paths_test.go
+++ b/internal/sources/claude_paths_test.go
@@ -1,0 +1,37 @@
+package sources
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestClaudeToolPathsTakesOnlyNamedFiles(t *testing.T) {
+	raw := json.RawMessage(`[
+	  {"type":"text","text":"editing the reader"},
+	  {"type":"tool_use","name":"Read","input":{"file_path":"/repo/internal/index/store_io.go"}},
+	  {"type":"tool_use","name":"Edit","input":{"file_path":"/repo/internal/index/store_io.go"}},
+	  {"type":"tool_use","name":"Write","input":{"file_path":"/repo/docs/notes.md"}},
+	  {"type":"tool_use","name":"Bash","input":{"command":"go test ./internal/index/store_io_test.go"}},
+	  {"type":"tool_result","content":"ok"}
+	]`)
+	got := claudeToolPaths(raw)
+	want := "/repo/internal/index/store_io.go\n/repo/docs/notes.md"
+	if got != want {
+		t.Fatalf("paths =\n%q\nwant\n%q", got, want)
+	}
+}
+
+// Bash is excluded on purpose: a path inside a shell command is guesswork, and
+// guessing at paths is what made the prose-mention approach unusable (#531).
+func TestClaudeToolPathsIgnoresEverythingElse(t *testing.T) {
+	for _, raw := range []string{
+		`[{"type":"tool_use","name":"Bash","input":{"command":"cat internal/index/index.go"}}]`,
+		`[{"type":"text","text":"internal/index/index.go is the file"}]`,
+		`[{"type":"tool_use","name":"Read","input":{}}]`,
+		`"plain string"`, `null`, `[]`, `[1,2]`,
+	} {
+		if got := claudeToolPaths(json.RawMessage(raw)); got != "" {
+			t.Fatalf("%s yielded %q", raw, got)
+		}
+	}
+}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -196,3 +196,36 @@ func parseFiles(files []string, parse func(string) ([]model.Session, error)) []m
 	}
 	return all
 }
+
+// toolPathsFromContent is claudeToolPaths for the reference parser, which walks
+// decoded maps rather than raw JSON. The two must agree or the differential
+// test in #502 stops meaning anything.
+func toolPathsFromContent(v any) string {
+	items, ok := v.([]any)
+	if !ok {
+		return ""
+	}
+	var out []string
+	seen := map[string]bool{}
+	for _, it := range items {
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		if t, _ := m["type"].(string); t != "tool_use" {
+			continue
+		}
+		name, _ := m["name"].(string)
+		if !pathTools[name] {
+			continue
+		}
+		in, _ := m["input"].(map[string]any)
+		p, _ := in["file_path"].(string)
+		if p == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	return strings.Join(out, "\n")
+}


### PR DESCRIPTION
Closes part of #547 — the cheapest slice, and the one three separate measurements point at.

**On by default.** A flag would have made this free for me and useless for everyone else: nobody enables an option they have not heard of, so the three features resting on this slice would never reach a user. `DEJA_INDEX_PATHS=0` turns it off for anyone who wants the smaller index back.

## Cost

| | off | **default** |
|---|---|---|
| index | 63.86 MB | **64.90 MB (+1.6%)** |
| `rankdiff` on a real store | — | **0 of 260 positions move** |

Against +27% for Bash commands (#549) and 80 MB for the bodies of files that were read. An order of magnitude cheaper than either, and it is the slice with measured features behind it.

## Why paths and not prose

| issue | with prose mentions | with tool-call paths |
|---|---|---|
| #542 which files matter for a topic | the same five files for every topic | 4 of 5 topics correct |
| #531 is this decision stale | a session about the relevance tier linked to `client.go` | exact linkage |
| #534 which prompt produced this commit | 0 of 40 commits attributed | **21 of 40, zero ties** |

Prose mentions resolve for 43% of hits and are wrong more often than right, because two-segment path matching collides across a corpus spanning several projects.

## Details

File records are kept out of ordinary results and served by role, so a path cannot lift a session because it contains the words of a question — hence 0 of 260. `Bash` is deliberately not a source: a path inside a shell command is guesswork, and guessing at paths is what makes the prose approach unusable.

Both parsers emit the records, so the differential test from #502 still means something. Index version 17 → 18, so an existing index rebuilds once on upgrade.

Full suite green, decisionbench 8/8 · 8/8 · 4/4 · 3/3.