### PR TITLE
fix(sources): label tool output as tool output, not as the user

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -512,9 +512,15 @@ const decisionBoost = 2.0
 // conversation about one. It looks only at non-user turns: a user writing "we
 // should just pin it" is a proposal, and the same words from the side that did
 // the work are a record of what happened.
+// roleToolOutput mirrors sources.RoleToolOutput; this package sits below it.
+const roleToolOutput = "tool-output"
+
 func decidesSomething(s model.Session) bool {
 	for _, m := range s.Messages {
-		if m.Role == "user" || m.Role == "" {
+		// Tool output is not the assistant concluding something. Before #559 it
+		// arrived labelled `user` and was skipped here by accident; now it is
+		// labelled honestly and has to be skipped on purpose.
+		if m.Role == "user" || m.Role == "" || m.Role == roleToolOutput {
 			continue
 		}
 		low := strings.ToLower(m.Text)

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -86,7 +86,11 @@ func parseClaudeGenericFromOffset(path string, offset int64) ([]model.Session, e
 			if r, _ := msg["role"].(string); r != "" {
 				role = r
 			}
-			txt = textFromContent(msg["content"])
+			var toolOut bool
+			txt, toolOut = textFromContentKind(msg["content"])
+			if toolOut {
+				role = RoleToolOutput
+			}
 		}
 		if txt != "" {
 			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -67,7 +67,11 @@ func parseClaudeTypedFromOffset(path string, offset int64) ([]model.Session, err
 			if v.Message.Role != "" {
 				role = v.Message.Role
 			}
-			txt = claudeText(v.Message.Content)
+			var toolOut bool
+			txt, toolOut = claudeTextKind(v.Message.Content)
+			if toolOut {
+				role = RoleToolOutput
+			}
 		}
 		if txt != "" {
 			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
@@ -125,23 +129,39 @@ func claudeTime(raw json.RawMessage) time.Time {
 // objects with neither key, are skipped rather than failing the line — a
 // transcript mixing shapes must not cost the whole message.
 func claudeText(raw json.RawMessage) string {
+	txt, _ := claudeTextKind(raw)
+	return txt
+}
+
+// RoleToolOutput marks text a tool produced. Claude Code files tool results
+// inside `user` messages, so without this the index labels 89% of its user-role
+// content as if a person had typed it — 33,027 of 37,077 messages, 77.8 MB
+// (#559). The text is worth keeping and searching; only the attribution was
+// wrong.
+const RoleToolOutput = "tool-output"
+
+// claudeTextKind joins a message's text and reports whether what it joined came
+// from tool results rather than from speech. A message mixing both counts as
+// speech: the person said something, and the tool output rode along with it.
+func claudeTextKind(raw json.RawMessage) (string, bool) {
+	var sawToolResult, sawSpeech bool
 	raw = trimJSONSpace(raw)
 	if len(raw) == 0 {
-		return ""
+		return "", false
 	}
 	if raw[0] == '"' {
 		var s string
 		if json.Unmarshal(raw, &s) != nil {
-			return ""
+			return "", false
 		}
-		return s
+		return s, false
 	}
 	if raw[0] != '[' {
-		return ""
+		return "", false
 	}
 	var items []json.RawMessage
 	if json.Unmarshal(raw, &items) != nil {
-		return ""
+		return "", false
 	}
 	var b strings.Builder
 	for _, item := range items {
@@ -150,6 +170,7 @@ func claudeText(raw json.RawMessage) string {
 			continue
 		}
 		var part struct {
+			Type    string `json:"type"`
 			Text    string `json:"text"`
 			Content string `json:"content"`
 		}
@@ -160,6 +181,11 @@ func claudeText(raw json.RawMessage) string {
 		if chunk == "" {
 			chunk = part.Content
 		}
+		if part.Type == "tool_result" {
+			sawToolResult = true
+		} else if chunk != "" {
+			sawSpeech = true
+		}
 		if chunk == "" {
 			continue
 		}
@@ -168,7 +194,7 @@ func claudeText(raw json.RawMessage) string {
 		}
 		b.WriteString(chunk)
 	}
-	return b.String()
+	return b.String(), sawToolResult && !sawSpeech
 }
 
 func trimJSONSpace(b []byte) []byte {

--- a/internal/sources/tool_output_role_test.go
+++ b/internal/sources/tool_output_role_test.go
@@ -1,0 +1,54 @@
+package sources
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// A message that carries only tool results is not the user speaking, however
+// the harness files it. Measured before this existed: 32,239 of 40,313 records
+// under the user role — 80% — were tool output (#559).
+func TestToolResultOnlyMessageIsLabelled(t *testing.T) {
+	raw := json.RawMessage(`[{"type":"tool_result","content":"ok  github.com/x  1.2s"}]`)
+	txt, isTool := claudeTextKind(raw)
+	if txt != "ok  github.com/x  1.2s" {
+		t.Fatalf("text = %q", txt)
+	}
+	if !isTool {
+		t.Fatal("a tool_result-only message must be labelled as tool output")
+	}
+}
+
+// Speech wins a mixed message: the person said something and the output rode
+// along with it, so attributing the whole turn to a tool would lose the words.
+func TestMixedMessageStaysSpeech(t *testing.T) {
+	raw := json.RawMessage(`[
+	  {"type":"text","text":"here is what I ran"},
+	  {"type":"tool_result","content":"exit status 1"}
+	]`)
+	if _, isTool := claudeTextKind(raw); isTool {
+		t.Fatal("a message containing speech must not be labelled tool output")
+	}
+}
+
+func TestPlainAndEmptyShapesAreSpeech(t *testing.T) {
+	for _, raw := range []string{`"just a sentence"`, `[]`, `null`, `[{"type":"text","text":"hi"}]`} {
+		if _, isTool := claudeTextKind(json.RawMessage(raw)); isTool {
+			t.Fatalf("%s was labelled tool output", raw)
+		}
+	}
+}
+
+// The reference parser must agree with the typed one, or the differential test
+// in #502 stops meaning anything.
+func TestBothParsersAgreeOnTheLabel(t *testing.T) {
+	var v any
+	if err := json.Unmarshal([]byte(`[{"type":"tool_result","content":"boom"}]`), &v); err != nil {
+		t.Fatal(err)
+	}
+	_, generic := textFromContentKind(v)
+	_, typed := claudeTextKind(json.RawMessage(`[{"type":"tool_result","content":"boom"}]`))
+	if generic != typed || !generic {
+		t.Fatalf("generic=%v typed=%v, want both true", generic, typed)
+	}
+}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -52,6 +52,32 @@ func unixGuess(n int64) time.Time {
 	return time.Time{}
 }
 
+// textFromContentKind is textFromContent plus the attribution question: did
+// everything it joined come from tool results? Claude files those inside `user`
+// messages, and labelling them as speech was wrong for 89% of that role (#559).
+func textFromContentKind(v any) (string, bool) {
+	c, ok := v.([]any)
+	if !ok {
+		return textFromContent(v), false
+	}
+	var sawTool, sawSpeech bool
+	for _, it := range c {
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		typ, _ := m["type"].(string)
+		txt, _ := m["text"].(string)
+		str, _ := m["content"].(string)
+		if typ == "tool_result" {
+			sawTool = true
+		} else if txt != "" || str != "" {
+			sawSpeech = true
+		}
+	}
+	return textFromContent(v), sawTool && !sawSpeech
+}
+
 func textFromContent(v any) string {
 	switch c := v.(type) {
 	case string:


### PR DESCRIPTION
Closes #559. **Costs nothing on disk — the text was already stored, only the attribution was wrong.**

## What changed on a real index

| role | before | after |
|---|---|---|
| `user` | 40,313 records · 29.1 MB | **8,071 · 7.3 MB** |
| `tool-output` | — | **32,239 · 21.8 MB** |
| `assistant` | 31,775 · 20.8 MB | unchanged |

**80% of what was filed under `user` was not the user.** Claude Code puts tool results inside `user` messages and the parser read `part.Content` without looking at `part.Type`.

A message that mixes speech and tool results stays speech: the person said something and the output rode along, so attributing the whole turn to a tool would lose the words.

## What it fixes

- **`userCount` in scoring now means what its name says.** It fed `countDocumentWords` while being inflated fivefold.
- **`decidesSomething` keeps excluding tool output** — it did so before by accident, because the output was labelled `user`; now it does so on purpose, and the exclusion is written down where the next person will read it.
- Anything counting "messages" as conversation was counting command output. That includes my own rework measurement in #529, which came out **ten times too low** before I noticed the denominator was mostly `git status`.
- It is the precondition for `deja uncompact` (#543), where the top results were git output no matter how the ranking was tuned — no heuristic separates a one-line git status from prose, but a label does.

## Gates

| | |
|---|---|
| LongMemEval-S | **84.2% hit@1 · 93.8% hit@5 · MRR 0.886 — identical** |
| decisionbench | 8/8 · 8/8 · 4/4 · 3/3 |
| `bench recall` | R@5 1.00 |
| full suite | green |
| `rankdiff` on a real store | **25 of 260 positions move, top-1 unchanged on all 26 queries** |

Those 25 are traceable to `userCount` becoming accurate, which is the point of the change rather than a side effect — but they are real movement on a real corpus, so they belong in the description rather than in a footnote.

Both parsers apply the same rule, so the differential test from #502 keeps meaning something; there is a test asserting they agree.