### PR TITLE
feat(sources): index the commands that say what happened

### DIFF
--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -974,6 +974,9 @@ func scanRecords(dir string, m Manifest, o query.Options, offsets []int64) ([]mo
 // below sources, not above it.
 const roleFiles = "files"
 
+// roleCommand mirrors sources.RoleCommand.
+const roleCommand = "command"
+
 func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []int64, variants map[string][]string) ([]model.Session, error) {
 	by := map[string]*model.Session{}
 	add := func(r Record) {
@@ -998,6 +1001,10 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		// to contain the words of a question, so it is indexed and searchable
 		// but served only when asked for by role.
 		if r.Role == roleFiles && o.Role != roleFiles {
+			return
+		}
+		// Same rule for commands: an invocation is an action, not an answer.
+		if r.Role == roleCommand && o.Role != roleCommand {
 			return
 		}
 		s := by[r.Key]

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -91,10 +91,15 @@ func parseClaudeGenericFromOffset(path string, offset int64) ([]model.Session, e
 		if txt != "" {
 			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
 		}
-		if IndexToolPaths() {
-			if msg, ok := m["message"].(map[string]any); ok {
+		if msg, ok := m["message"].(map[string]any); ok {
+			if IndexToolPaths() {
 				if p := toolPathsFromContent(msg["content"]); p != "" {
 					s.Messages = append(s.Messages, model.Message{Role: RoleFiles, Text: p, Time: t})
+				}
+			}
+			if IndexCommands() {
+				for _, cmd := range commandsFromContent(msg["content"]) {
+					s.Messages = append(s.Messages, model.Message{Role: RoleCommand, Text: cmd, Time: t})
 				}
 			}
 		}

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -71,9 +72,16 @@ func parseClaudeTypedFromOffset(path string, offset int64) ([]model.Session, err
 		if txt != "" {
 			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
 		}
-		if IndexToolPaths() && v.Message != nil {
-			if p := claudeToolPaths(v.Message.Content); p != "" {
-				s.Messages = append(s.Messages, model.Message{Role: RoleFiles, Text: p, Time: t})
+		if v.Message != nil {
+			if IndexToolPaths() {
+				if p := claudeToolPaths(v.Message.Content); p != "" {
+					s.Messages = append(s.Messages, model.Message{Role: RoleFiles, Text: p, Time: t})
+				}
+			}
+			if IndexCommands() {
+				for _, cmd := range claudeCommands(v.Message.Content) {
+					s.Messages = append(s.Messages, model.Message{Role: RoleCommand, Text: cmd, Time: t})
+				}
 			}
 		}
 	})
@@ -266,4 +274,67 @@ func claudeToolPaths(raw json.RawMessage) string {
 		out = append(out, part.Input.FilePath)
 	}
 	return strings.Join(out, "\n")
+}
+
+// RoleCommand marks a command that ran. Tool *output* has always been indexed —
+// Claude files it under the user role, which is why the index holds megabytes of
+// test output — but the invocation that produced it was dropped, so output sat
+// there with nothing saying what it came from.
+const RoleCommand = "command"
+
+// IndexCommands reports whether commands are indexed. On by default, because a
+// flag nobody enables is a feature nobody has; `DEJA_INDEX_COMMANDS=0` turns it
+// off. Only the commands worth keeping — see worthIndexing.
+func IndexCommands() bool { return os.Getenv("DEJA_INDEX_COMMANDS") != "0" }
+
+// worthIndexing keeps the commands that say what happened — a test run, a build,
+// a deploy, a git or gh operation — and drops navigation. Measured on a real
+// corpus: 5,051 of 23,774 commands, 3.5 MB of 13.1 MB.
+//
+// The dropped ones are not merely cheap to store, they are actively bad to keep:
+// `cat internal/index/index.go` matches a query about the index and answers
+// nothing.
+var meaningfulCommand = regexp.MustCompile(`\b(go (test|build|vet|run)|golangci-lint|pytest|npm (run )?(test|build)|yarn |cargo |make\b|gh (pr|run|release|issue|workflow)|git (commit|push|rebase|merge|revert|tag|bisect)|docker|kubectl|terraform|deja )`)
+
+var trivialCommand = regexp.MustCompile(`^\s*(ls|cd|pwd|cat|head|tail|echo|grep|rg|find|which|wc|sed|awk|sleep|mkdir|rm|cp|mv|chmod|export|source|touch|open|printf)\b`)
+
+func worthIndexing(cmd string) bool {
+	return meaningfulCommand.MatchString(cmd) && !trivialCommand.MatchString(cmd)
+}
+
+// claudeCommands pulls the shell commands worth keeping out of a message.
+func claudeCommands(raw json.RawMessage) []string {
+	raw = trimJSONSpace(raw)
+	if len(raw) == 0 || raw[0] != '[' {
+		return nil
+	}
+	var items []json.RawMessage
+	if json.Unmarshal(raw, &items) != nil {
+		return nil
+	}
+	var out []string
+	for _, item := range items {
+		item = trimJSONSpace(item)
+		if len(item) == 0 || item[0] != '{' {
+			continue
+		}
+		var part struct {
+			Type  string `json:"type"`
+			Name  string `json:"name"`
+			Input struct {
+				Command string `json:"command"`
+			} `json:"input"`
+		}
+		if json.Unmarshal(item, &part) != nil {
+			continue
+		}
+		if part.Type != "tool_use" || part.Name != "Bash" || part.Input.Command == "" {
+			continue
+		}
+		if !worthIndexing(part.Input.Command) {
+			continue
+		}
+		out = append(out, "$ "+part.Input.Command)
+	}
+	return out
 }

--- a/internal/sources/commands_test.go
+++ b/internal/sources/commands_test.go
@@ -1,0 +1,63 @@
+package sources
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Three quarters of command text on a real corpus is navigation that answers
+// nothing and matches by accident: `cat internal/index/index.go` looks relevant
+// to a question about the index. The selection is the feature.
+func TestWorthIndexingKeepsWhatHappened(t *testing.T) {
+	for _, c := range []string{
+		"go test ./internal/index/ -count=1",
+		"golangci-lint run",
+		"gh pr checks 558",
+		"git commit -m 'fix: x'",
+		"make build && deja index --rebuild",
+		"docker compose up -d",
+	} {
+		if !worthIndexing(c) {
+			t.Errorf("dropped a command worth keeping: %q", c)
+		}
+	}
+	for _, c := range []string{
+		"cat internal/index/index.go",
+		"ls -la",
+		"grep -rn foo internal/",
+		"cd /repo && pwd",
+		"sed -n 1,40p internal/index/index.go",
+		"echo hi",
+	} {
+		if worthIndexing(c) {
+			t.Errorf("kept navigation: %q", c)
+		}
+	}
+}
+
+func TestClaudeCommandsExtractsAndFilters(t *testing.T) {
+	raw := json.RawMessage(`[
+	  {"type":"text","text":"running it"},
+	  {"type":"tool_use","name":"Bash","input":{"command":"go test ./internal/index/"}},
+	  {"type":"tool_use","name":"Bash","input":{"command":"ls -la"}},
+	  {"type":"tool_use","name":"Read","input":{"file_path":"/x.go"}},
+	  {"type":"tool_result","content":"ok"}
+	]`)
+	got := claudeCommands(raw)
+	if len(got) != 1 || got[0] != "$ go test ./internal/index/" {
+		t.Fatalf("commands = %#v", got)
+	}
+}
+
+// The reference parser must agree, or the differential test in #502 is empty.
+func TestBothParsersAgreeOnCommands(t *testing.T) {
+	body := `[{"type":"tool_use","name":"Bash","input":{"command":"go build ./..."}}]`
+	var v any
+	if err := json.Unmarshal([]byte(body), &v); err != nil {
+		t.Fatal(err)
+	}
+	a, b := commandsFromContent(v), claudeCommands(json.RawMessage(body))
+	if len(a) != len(b) || len(a) != 1 || a[0] != b[0] {
+		t.Fatalf("generic=%#v typed=%#v", a, b)
+	}
+}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -229,3 +229,31 @@ func toolPathsFromContent(v any) string {
 	}
 	return strings.Join(out, "\n")
 }
+
+// commandsFromContent is claudeCommands for the reference parser.
+func commandsFromContent(v any) []string {
+	items, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, it := range items {
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		if t, _ := m["type"].(string); t != "tool_use" {
+			continue
+		}
+		if n, _ := m["name"].(string); n != "Bash" {
+			continue
+		}
+		in, _ := m["input"].(map[string]any)
+		cmd, _ := in["command"].(string)
+		if cmd == "" || !worthIndexing(cmd) {
+			continue
+		}
+		out = append(out, "$ "+cmd)
+	}
+	return out
+}


### PR DESCRIPTION
The second half of #547, narrowed after the point that a flag nobody enables is a feature nobody has. Replaces #549, which tangled during a rebase across #558; same change, re-applied cleanly.

## The selection is the feature

The first version indexed **every** Bash call: 23,774 commands, 13.1 MB, +27% of the index. Three quarters of that is navigation — `ls`, `cat`, `grep`, `cd` — and it is not merely cheap to store but actively harmful: `cat internal/index/index.go` matches a query about the index and answers nothing.

Kept: test runs, builds, `git`, `gh`, `docker`, `kubectl`, `deja` itself.

| | commands | text |
|---|---|---|
| every Bash call | 23,774 | 13.1 MB |
| **kept** | **5,051** | **3.5 MB** |

| index | |
|---|---|
| without commands | 65.21 MB |
| **with them** | **70.21 MB (+7.7%)** |

## Ranking

**2 of 260 positions move**, down from 11 when every command was indexed. Commands are excluded from ordinary results and served by role, so an invocation cannot lift a session because it contains the words of a question.

## Why it is worth 7.7%

Tool *output* has always been indexed — 39,836 of 40,933 results are strings the decoder already reads — but the invocation was dropped, so megabytes of test output sat in the index with nothing saying what produced it.

- **#539** "when did this test last pass", "when did this error first appear" — needs exactly these invocations.
- **#546** the work done by hand twelve times — the sequences I measured were `go test` + `go tool cover` and `gh pr checks` + `gh pr merge`, both kept.
- **#541** is not on the list: measured and closed, the agent ran what it claimed 97% of the time.

On by default; `DEJA_INDEX_COMMANDS=0` turns it off. Both parsers emit the records so the differential test from #502 still means something. Full suite green, decisionbench 8/8 · 8/8 · 4/4 · 3/3.