### PR TITLE
feat(sources): name a session after the repository it worked in

### DIFF
--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -111,6 +111,9 @@ func parseClaudeGenericFromOffset(path string, offset int64) ([]model.Session, e
 	if len(s.Messages) == 0 {
 		return nil, err
 	}
+	if p := projectFromPaths(s.Messages); p != "" {
+		s.Project = p
+	}
 	return []model.Session{s}, err
 }
 

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -92,6 +92,11 @@ func parseClaudeTypedFromOffset(path string, offset int64) ([]model.Session, err
 	if len(s.Messages) == 0 {
 		return nil, err
 	}
+	// The directory a session was started from is a weak guess at what it was
+	// about; the files it touched are a strong one.
+	if p := projectFromPaths(s.Messages); p != "" {
+		s.Project = p
+	}
 	return []model.Session{s}, err
 }
 

--- a/internal/sources/project_paths.go
+++ b/internal/sources/project_paths.go
@@ -1,0 +1,109 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A Claude session takes its project from the directory the transcript lives in,
+// which is the directory the agent was started from. Start it from a home
+// directory — as anyone running one agent across several repositories does — and
+// every session on the machine lands in a single bucket named after that home.
+//
+// Measured on a real corpus: every Claude session carried one project name, so
+// `--project` could not separate seven repositories, and the file relevance work
+// in #542 collided across all of them.
+//
+// The paths a session touched say where the work actually was. Of the sessions
+// with project-shaped paths, 8 of 9 have one dominant repository.
+
+// projectFromPaths returns the repository most of a session's file activity
+// happened in, or "" when there is no clear winner. A majority is required
+// rather than a plurality on purpose: a session that genuinely spans two repos
+// should keep its directory-derived name instead of being filed under whichever
+// one it touched marginally more.
+func projectFromPaths(ms []model.Message) string {
+	counts := map[string]int{}
+	total := 0
+	for _, m := range ms {
+		if m.Role != RoleFiles {
+			continue
+		}
+		for _, p := range strings.Split(m.Text, "\n") {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			if agentScratch(p) {
+				continue
+			}
+			root := repoRoot(filepath.Dir(p))
+			if root == "" {
+				continue
+			}
+			counts[root]++
+			total++
+		}
+	}
+	if total < 3 {
+		return "" // too little evidence to override anything
+	}
+	best, n := "", 0
+	for r, c := range counts {
+		if c > n {
+			best, n = r, c
+		}
+	}
+	if float64(n) < 0.6*float64(total) {
+		return ""
+	}
+	segs := strings.Split(strings.Trim(best, string(filepath.Separator)), string(filepath.Separator))
+	if len(segs) >= 2 {
+		return filepath.Join(segs[len(segs)-2], segs[len(segs)-1])
+	}
+	return filepath.Base(best)
+}
+
+// agentScratch drops the agent's own working area. A scratch clone under
+// ~/.claude can hold more edits than the repository it was cloned from, and
+// naming a session after it would be worse than the directory-derived name it
+// replaces — measured: one session came out as `scratchpad/deja-push` instead
+// of `goprojects/deja-vu`.
+// The markers name the agent's own areas rather than a location. Excluding all
+// of /tmp would be simpler and wrong: a repository can live there, and it is
+// still that person's project.
+func agentScratch(p string) bool {
+	for _, seg := range []string{"/.claude/", "/scratchpad/", "/tasks/", "/.cache/", "/claude-501/"} {
+		if strings.Contains(p, seg) {
+			return true
+		}
+	}
+	return false
+}
+
+var repoRootCache sync.Map
+
+// repoRoot walks up until it finds a .git, which is what makes a directory a
+// project rather than a folder. Cached because one session touches the same few
+// directories hundreds of times.
+func repoRoot(dir string) string {
+	if dir == "" || dir == "/" {
+		return ""
+	}
+	if v, ok := repoRootCache.Load(dir); ok {
+		return v.(string)
+	}
+	root := ""
+	for d := dir; d != "/" && d != "." && d != ""; d = filepath.Dir(d) {
+		if fi, err := os.Stat(filepath.Join(d, ".git")); err == nil && (fi.IsDir() || fi.Mode().IsRegular()) {
+			root = d
+			break
+		}
+	}
+	repoRootCache.Store(dir, root)
+	return root
+}

--- a/internal/sources/project_paths_test.go
+++ b/internal/sources/project_paths_test.go
@@ -1,0 +1,90 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func filesMsg(paths ...string) model.Message {
+	t := ""
+	for i, p := range paths {
+		if i > 0 {
+			t += "\n"
+		}
+		t += p
+	}
+	return model.Message{Role: RoleFiles, Text: t}
+}
+
+// A repo is a directory with a .git in it; a folder is not. The fixture builds
+// two so the majority rule has something to choose between.
+func repoFixture(t *testing.T) (string, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	for _, name := range []string{"alpha", "beta"} {
+		if err := os.MkdirAll(filepath.Join(tmp, name, ".git"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(tmp, name, "internal"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return filepath.Join(tmp, "alpha"), filepath.Join(tmp, "beta")
+}
+
+func TestProjectFromPathsTakesTheMajorityRepo(t *testing.T) {
+	a, b := repoFixture(t)
+	ms := []model.Message{
+		filesMsg(filepath.Join(a, "internal", "x.go"), filepath.Join(a, "internal", "y.go")),
+		filesMsg(filepath.Join(a, "main.go")),
+		filesMsg(filepath.Join(b, "main.go")),
+	}
+	got := projectFromPaths(ms)
+	want := filepath.Join(filepath.Base(filepath.Dir(a)), "alpha")
+	if got != want {
+		t.Fatalf("project = %q, want %q", got, want)
+	}
+}
+
+// A session genuinely split between two repositories should keep whatever name
+// it already had rather than be filed under a coin flip.
+func TestProjectFromPathsDeclinesWithoutAMajority(t *testing.T) {
+	a, b := repoFixture(t)
+	ms := []model.Message{
+		filesMsg(filepath.Join(a, "one.go"), filepath.Join(a, "two.go")),
+		filesMsg(filepath.Join(b, "one.go"), filepath.Join(b, "two.go")),
+	}
+	if got := projectFromPaths(ms); got != "" {
+		t.Fatalf("project = %q, want no answer", got)
+	}
+}
+
+func TestProjectFromPathsIgnoresTheAgentsOwnFiles(t *testing.T) {
+	a, _ := repoFixture(t)
+	ms := []model.Message{
+		filesMsg("/Users/x/.claude/projects/-Users-x/scratchpad/probe.py"),
+		filesMsg("/private/tmp/claude-501/-Users-x/tasks/run.output"),
+		filesMsg(filepath.Join(a, "main.go")),
+	}
+	// One real path is not three, so there is not enough evidence to override.
+	if got := projectFromPaths(ms); got != "" {
+		t.Fatalf("project = %q, want no answer from one real path", got)
+	}
+	if !agentScratch("/Users/x/.claude/projects/p/scratchpad/probe.py") {
+		t.Fatal("a scratch clone under .claude must not count as a project")
+	}
+}
+
+func TestProjectFromPathsNeedsEvidence(t *testing.T) {
+	a, _ := repoFixture(t)
+	ms := []model.Message{filesMsg(filepath.Join(a, "main.go"))}
+	if got := projectFromPaths(ms); got != "" {
+		t.Fatalf("project = %q, want no answer from a single file", got)
+	}
+	if got := projectFromPaths(nil); got != "" {
+		t.Fatalf("project = %q, want no answer with no files", got)
+	}
+}


### PR DESCRIPTION
Found while building #542, where `--project deja` matched almost nothing.

## The problem

A Claude session takes its project from the directory the transcript lives in — which is the directory the agent was started from. Start one agent from a home directory, as anyone working across several repositories does, and **every session on the machine is filed under one name**.

On this corpus that name is `Users/shulcz`, covering work in seven different repositories. `--project` cannot separate them, `deja stats` groups them as one, and the file-relevance work in #542 collided across all of them.

## The fix

The paths a session touched say where the work was — and since #558 they are in the index. A session is renamed after the repository that holds the majority of its file activity.

```
before: Users/shulcz          (11 sessions, whatever they were about)
after:  goprojects/deja-vu     3
        Users/shulcz          10
```

Three sessions now carry the repository they were actually about. The rest keep their directory-derived name, because they do not have enough path evidence — most of my editing goes through the shell rather than an edit tool, which is the same coverage gap #534 measured from the other side.

## The rules, and why each exists

- **A repository is a directory with a `.git` in it.** Walking up to find one is what separates a project from a folder; cached, since a session touches the same few directories hundreds of times.
- **A majority, not a plurality.** A session genuinely split across two repos keeps its old name rather than being filed under a coin flip.
- **At least three file references**, so one stray path cannot rename a session.
- **The agent's own areas do not count.** A scratch clone under `~/.claude` can hold more edits than the repository it was cloned from: before this rule one session came out as `scratchpad/deja-push` instead of `goprojects/deja-vu`. The exclusion names the agent's directories rather than locations — excluding all of `/tmp` would be simpler and wrong, since a repository can live there.

That last rule came from a failing test rather than from foresight: `t.TempDir()` on macOS returns a path under `/var/folders`, which my first over-broad filter excluded, and the fixture could not be built. The narrower rule is better for real corpora too.

## Gates

`rankdiff` **0 of 260 positions**, decisionbench 8/8 · 8/8 · 4/4 · 3/3, full suite green.