### PR TITLE
feat(files): which files a topic's work actually touched

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | **Share** | `deja share <id>` — hand a colleague a sanitized digest of a session, secrets already scrubbed |
 | **Remember** | `deja remember "text"` or MCP `remember` — keep durable decisions and conclusions |
 | **Blame** | `deja blame <path>` — which sessions touched this file, what was decided and why |
+| **Files** | `deja files <topic>` — the other direction: which files the work on a subject actually touched, ranked by how specific they are to it |
 | **Semantic** | optional: point `deja embed` at a local Ollama/LM Studio and rephrased queries still hit |
 
 ## Privacy
@@ -156,6 +157,7 @@ $ deja "jwt refresh token"
 | `deja <query>` | Search all histories. Multi-word = AND, common English filler words are ignored, substrings match (`code` finds `opencode`), and double-quoted phrases require contiguous text; zero-result queries try word forms before close spellings. `--re`, `--harness`, `--project`, `--since 30d`, `--role`, `--limit`, `--json`. |
 | `deja ctx <query>` | Compact markdown digest of the best match — pipe it into a prompt. |
 | `deja blame <path>` | Find sessions that discussed a file, newest and most specific first. `--json`, `--all`, and the usual filters are supported. |
+| `deja files <topic>` | Which files were opened or edited while that subject was being worked on. Ranked by how specific a file is to the topic, so a file every session touches does not win. `--project`, `--limit`. |
 | `deja share <id>` | Sanitized session digest for a colleague: secrets redacted, tool noise stripped. |
 | `deja stats` | Headline counts, totals, per-harness split, top projects, monthly sparkline. `--json` too. |
 | `deja doctor [--json]` | Self-diagnosis: store parse state, sqlite3 presence, MCP wiring per agent, index health, version; `--json` emits the same checks for scripts. |

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -47,7 +48,11 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		case "--limit":
 			if i+1 < len(args) {
 				i++
-				fmt.Sscanf(args[i], "%d", &limit)
+				n, err := strconv.Atoi(args[i])
+				if err != nil || n <= 0 {
+					return fmt.Errorf("files: --limit wants a positive number, got %q", args[i])
+				}
+				limit = n
 			}
 		case "--project":
 			if i+1 < len(args) {
@@ -95,8 +100,13 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		if err != nil || !ok {
 			continue
 		}
-		hitTimes := topicTimes(meaningful(full.Messages), needles)
-		if len(hitTimes) == 0 {
+		// The window is counted over speech and file events only. Tool output is
+		// two thirds of the records in a session, so a raw message count would be
+		// a few seconds of one command — far too narrow to connect a subject to
+		// the files it was about.
+		msgs := meaningful(full.Messages)
+		hit := topicTimes(msgs, needles)
+		if len(hit) == 0 {
 			// The search tier that produced this hit can be semantic, so a session
 			// can arrive without the words ever being said in it. Counting its
 			// files would put a one-off touch from an unrelated project at the top
@@ -104,12 +114,6 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 			continue
 		}
 		scanned++
-		// The window is counted over speech and file events only. Tool output is
-		// two thirds of the records in a session, so twenty raw messages can be
-		// a few seconds of one command — far too narrow to connect a subject to
-		// the files it was about.
-		msgs := meaningful(full.Messages)
-		hit := hitTimes
 		seenHere := map[string]bool{}
 		nearHere := map[string]bool{}
 		for _, m := range msgs {
@@ -245,10 +249,12 @@ func lowerAll(in []string) []string {
 // output, a probe script written to measure something. They are touched
 // constantly while a subject is being worked on, so they outrank the code on
 // proximity alone, and they are not what anyone means by "which files matter".
-// Same class as the harness plumbing filtered in #551.
+// Same class as the harness plumbing filtered in #551. The markers are
+// agent-specific on purpose: excluding all of /tmp also excludes a repository
+// someone happens to have checked out there.
 func isScratch(p string) bool {
 	for _, seg := range []string{
-		"/scratchpad/", "/tasks/", "/.claude/", "/tmp/", "/var/folders/",
+		"/scratchpad/", "/tasks/", "/.claude/", "/.cache/", "/claude-501/",
 		"/node_modules/", "/.git/", "/testdata/fixtures/",
 	} {
 		if strings.Contains(p, seg) {

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -279,12 +279,19 @@ func inRepository(p string) bool {
 }
 
 func inRepositoryUncached(p string) bool {
-	for d := filepath.Dir(p); d != "/" && d != "." && d != ""; d = filepath.Dir(d) {
+	// Stop when the parent stops changing rather than on "/": on Windows the
+	// walk ends at `D:\`, whose parent is itself, and comparing against the
+	// unix root spins there forever.
+	for d := filepath.Dir(p); ; {
 		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
 			return true
 		}
+		up := filepath.Dir(d)
+		if up == d || up == "." {
+			return false
+		}
+		d = up
 	}
-	return false
 }
 
 var repoCheck sync.Map

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// `deja files <topic>` answers which files a piece of work actually touched.
+//
+// The obvious implementation — aggregate every file a matching session touched
+// — does not work, and the failure is instructive: one long session touches two
+// hundred files across a dozen subjects, so every topic returned the same five
+// files. Measured that way, five queries produced one correct answer.
+//
+// What works is proximity in time. A file counts when it was opened or edited
+// near the place the topic was discussed. On five hand-checked topics that
+// gives two exactly right ("sing-box" returns the singbox service and renderer,
+// "marzban" the bot's own files), one plausible, one weak, and one honest
+// refusal — a topic said in a single session with no file beside it prints that
+// rather than guessing.
+const (
+	// filesWindow is how long either side of a topic mention still counts as
+	// the same piece of work. Time, not message count: two thirds of a
+	// session's records are tool output, so twenty messages can be a few
+	// seconds of one command.
+	filesWindow      = 20 * time.Minute
+	filesMaxSessions = 250
+)
+
+func runFiles(dir string, args []string, stdout io.Writer) error {
+	var terms []string
+	limit := 10
+	project := ""
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--limit":
+			if i+1 < len(args) {
+				i++
+				fmt.Sscanf(args[i], "%d", &limit)
+			}
+		case "--project":
+			if i+1 < len(args) {
+				i++
+				project = args[i]
+			}
+		default:
+			if !strings.HasPrefix(args[i], "-") {
+				terms = append(terms, args[i])
+			}
+		}
+	}
+	if len(terms) == 0 {
+		return fmt.Errorf("usage: deja files <topic> [--project name] [--limit n]")
+	}
+	q := strings.Join(terms, " ")
+	o := search.Options{Query: q, All: true, Project: project}
+	if err := index.EnsureForSearch(dir, o, false, nil); err != nil {
+		return fmt.Errorf("ensure: %w", err)
+	}
+	hits, err := index.Search(dir, o)
+	if err != nil {
+		return fmt.Errorf("search: %w", err)
+	}
+	if len(hits) == 0 {
+		fmt.Fprintf(stdout, "no sessions mention %q\n", q)
+		return nil
+	}
+	if len(hits) > filesMaxSessions {
+		hits = hits[:filesMaxSessions]
+	}
+
+	// The words the person typed, not the expanded variant list: that one runs
+	// to eighteen stemmed forms for a two-word query, and requiring most of them
+	// in one message matches nothing.
+	needles := lowerAll(terms)
+	near := map[string]int{}         // path -> times touched near the topic
+	nearSessions := map[string]int{} // path -> how many sessions touched it near the topic
+	total := map[string]int{}        // path -> times touched anywhere in these sessions
+	sessions := map[string]int{}     // path -> how many sessions touched it
+	scanned := 0
+
+	for _, h := range hits {
+		full, ok, err := index.FindByIdentity(dir, h.Harness, h.ID)
+		if err != nil || !ok {
+			continue
+		}
+		hitTimes := topicTimes(meaningful(full.Messages), needles)
+		if len(hitTimes) == 0 {
+			// The search tier that produced this hit can be semantic, so a session
+			// can arrive without the words ever being said in it. Counting its
+			// files would put a one-off touch from an unrelated project at the top
+			// on perfect specificity.
+			continue
+		}
+		scanned++
+		// The window is counted over speech and file events only. Tool output is
+		// two thirds of the records in a session, so twenty raw messages can be
+		// a few seconds of one command — far too narrow to connect a subject to
+		// the files it was about.
+		msgs := meaningful(full.Messages)
+		hit := hitTimes
+		seenHere := map[string]bool{}
+		nearHere := map[string]bool{}
+		for _, m := range msgs {
+			if m.Role != "files" {
+				continue
+			}
+			for _, p := range strings.Split(m.Text, "\n") {
+				p = strings.TrimSpace(p)
+				if p == "" || isScratch(p) || !inRepository(p) {
+					continue
+				}
+				total[p]++
+				if !seenHere[p] {
+					seenHere[p] = true
+					sessions[p]++
+				}
+				if withinTime(m.Time, hit, filesWindow) {
+					near[p]++
+					if !nearHere[p] {
+						nearHere[p] = true
+						nearSessions[p]++
+					}
+				}
+			}
+		}
+	}
+	if len(near) == 0 {
+		fmt.Fprintf(stdout, "%d sessions mention %q, none of them recorded a file near it\n", scanned, q)
+		return nil
+	}
+
+	type row struct {
+		path  string
+		score float64
+		n     int
+	}
+	var rows []row
+	for p, n := range near {
+		// A file touched near the topic and nowhere else is specific to it. One
+		// touched in every session — main.go, a test helper — is not, however
+		// often it appears next to the words.
+		// Sessions, not occurrences. A file opened forty times inside one long
+		// session is one piece of evidence; a file opened once in four separate
+		// sessions about the subject is four. Counting occurrences let the
+		// noisiest session decide the answer — on this corpus, whichever session
+		// happened to be *measuring* the topic.
+		specificity := float64(n) / float64(total[p])
+		// Touches as well as sessions: a file opened once beside the subject has
+		// perfect specificity and no evidence behind it, which is how an unrelated
+		// repo's dependabot.yml reached the top of the first run.
+		rows = append(rows, row{p, float64(nearSessions[p]) * specificity * math.Log(1+float64(n)) * math.Log(1+float64(scanned)/float64(sessions[p])), n})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].score == rows[j].score {
+			return rows[i].path < rows[j].path
+		}
+		return rows[i].score > rows[j].score
+	})
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	fmt.Fprintf(stdout, "files touched while working on %q — %d sessions\n", q, scanned)
+	for _, r := range rows {
+		fmt.Fprintf(stdout, "  %-56s %d\n", trimPath(r.path), r.n)
+	}
+	return nil
+}
+
+// meaningful drops tool output, which carries no subject of its own and would
+// otherwise dominate the positions the window is measured in.
+func meaningful(ms []model.Message) []model.Message {
+	out := make([]model.Message, 0, len(ms))
+	for _, m := range ms {
+		if m.Role == "tool-output" || m.Role == "command" {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// topicTimes returns when the topic was discussed.
+func topicTimes(ms []model.Message, needles []string) []time.Time {
+	if len(needles) == 0 {
+		return nil
+	}
+	// Half the words, at least one. Requiring every word in a single message is
+	// the exact-tier rule, and it is wrong here: a turn that says "the block
+	// layout" while the query says "block compression" is still that work.
+	want := (len(needles) + 1) / 2
+	var out []time.Time
+	for _, m := range ms {
+		if m.Role == "files" || m.Role == "command" || m.Time.IsZero() {
+			continue
+		}
+		low := strings.ToLower(m.Text)
+		n := 0
+		for _, t := range needles {
+			if strings.Contains(low, t) {
+				n++
+			}
+		}
+		if n >= want {
+			out = append(out, m.Time)
+		}
+	}
+	return out
+}
+
+func withinTime(t time.Time, at []time.Time, w time.Duration) bool {
+	if t.IsZero() {
+		return false
+	}
+	for _, p := range at {
+		if d := t.Sub(p); d < w && d > -w {
+			return true
+		}
+	}
+	return false
+}
+
+func lowerAll(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if len(s) > 2 {
+			out = append(out, strings.ToLower(s))
+		}
+	}
+	return out
+}
+
+// isScratch drops the agent's own working files — a scratchpad note, a task
+// output, a probe script written to measure something. They are touched
+// constantly while a subject is being worked on, so they outrank the code on
+// proximity alone, and they are not what anyone means by "which files matter".
+// Same class as the harness plumbing filtered in #551.
+func isScratch(p string) bool {
+	for _, seg := range []string{
+		"/scratchpad/", "/tasks/", "/.claude/", "/tmp/", "/var/folders/",
+		"/node_modules/", "/.git/", "/testdata/fixtures/",
+	} {
+		if strings.Contains(p, seg) {
+			return true
+		}
+	}
+	return strings.HasSuffix(p, ".output") || strings.HasSuffix(p, ".log")
+}
+
+// inRepository keeps files that belong to a project. A probe script in a
+// working directory, a note beside the repo, a downloaded sample — all get
+// touched while a subject is being worked on and none of them is what anyone
+// means by "which files matter".
+func inRepository(p string) bool {
+	dir := filepath.Dir(p)
+	if v, ok := repoCheck.Load(dir); ok {
+		return v.(bool)
+	}
+	found := inRepositoryUncached(p)
+	repoCheck.Store(dir, found)
+	return found
+}
+
+func inRepositoryUncached(p string) bool {
+	for d := filepath.Dir(p); d != "/" && d != "." && d != ""; d = filepath.Dir(d) {
+		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+var repoCheck sync.Map
+
+// trimPath keeps the tail that identifies a file without the home directory in
+// front of it.
+func trimPath(p string) string {
+	parts := strings.Split(filepath.Clean(p), string(filepath.Separator))
+	if len(parts) > 4 {
+		return strings.Join(parts[len(parts)-4:], "/")
+	}
+	return strings.TrimPrefix(p, "/")
+}

--- a/cmd/deja/files_cli_test.go
+++ b/cmd/deja/files_cli_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFilesFixture lays down a claude session that discusses one subject and
+// opens files while doing it, inside a directory that looks like a repository.
+func writeFilesFixture(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	repo := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	proj := filepath.Join(tmp, "claude", "project")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	line := func(format string, a ...any) {
+		fmt.Fprintf(&b, format+"\n", a...)
+	}
+	line(`{"type":"user","sessionId":"claude-files","cwd":%q,"timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"the frobnicator retry loop is wrong"}}`, repo)
+	// Two files opened right after the subject came up, one of them twice.
+	for i, p := range []string{"retry.go", "retry.go", "loop.go"} {
+		line(`{"type":"assistant","sessionId":"claude-files","cwd":%q,"timestamp":"2026-01-02T03:0%d:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":%q}}]}}`,
+			repo, 5+i, filepath.Join(repo, p))
+	}
+	// A file opened hours later, while something else was being discussed.
+	line(`{"type":"user","sessionId":"claude-files","cwd":%q,"timestamp":"2026-01-02T09:00:00Z","message":{"role":"user","content":"unrelated packaging work"}}`, repo)
+	line(`{"type":"assistant","sessionId":"claude-files","cwd":%q,"timestamp":"2026-01-02T09:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":%q}}]}}`,
+		repo, filepath.Join(repo, "packaging.go"))
+	if err := os.WriteFile(filepath.Join(proj, "s.jsonl"), []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return repo
+}
+
+func TestFilesCommandRanksNearbyTouches(t *testing.T) {
+	writeFilesFixture(t)
+	out, err := captureRun(t, "files", "frobnicator", "retry")
+	if err != nil {
+		t.Fatalf("files: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "retry.go") || !strings.Contains(out, "loop.go") {
+		t.Fatalf("want the files opened beside the subject, got:\n%s", out)
+	}
+	if strings.Contains(out, "packaging.go") {
+		t.Fatalf("a file touched hours later is different work, got:\n%s", out)
+	}
+	if strings.Index(out, "retry.go") > strings.Index(out, "loop.go") {
+		t.Fatalf("the file touched twice should rank first, got:\n%s", out)
+	}
+}
+
+func TestFilesCommandSaysWhenNothingIsNear(t *testing.T) {
+	writeFilesFixture(t)
+	out, err := captureRun(t, "files", "packaging")
+	if err != nil {
+		t.Fatalf("files: %v", err)
+	}
+	// The subject exists and a file was opened a minute later, so this is the
+	// hit path; the refusal path is a subject nobody discussed.
+	if out == "" {
+		t.Fatal("expected some output")
+	}
+	out, err = captureRun(t, "files", "quantumfluxcapacitor")
+	if err != nil {
+		t.Fatalf("files: %v", err)
+	}
+	if !strings.Contains(out, "no sessions mention") && !strings.Contains(out, "none of them recorded") {
+		t.Fatalf("want an honest refusal, got %q", out)
+	}
+}
+
+func TestFilesCommandArgumentErrors(t *testing.T) {
+	hermeticEnv(t)
+	if err := runFiles(t.TempDir(), nil, os.Stdout); err == nil {
+		t.Fatal("no topic should be a usage error")
+	}
+	if err := runFiles(t.TempDir(), []string{"topic", "--limit", "zero"}, os.Stdout); err == nil {
+		t.Fatal("--limit wants a number")
+	}
+}

--- a/cmd/deja/files_test.go
+++ b/cmd/deja/files_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestTopicTimesNeedsHalfTheWords(t *testing.T) {
+	at := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	ms := []model.Message{
+		{Role: "user", Text: "the block compression floor", Time: at},
+		{Role: "user", Text: "unrelated talk", Time: at.Add(time.Minute)},
+		{Role: "files", Text: "/repo/block.go", Time: at},
+		{Role: "assistant", Text: "no timestamp here"},
+	}
+	got := topicTimes(ms, []string{"block", "compression"})
+	if len(got) != 1 || !got[0].Equal(at) {
+		t.Fatalf("want the one message that carries the words, got %v", got)
+	}
+	// Half the words is enough: a turn saying "block layout" is still that work.
+	if len(topicTimes(ms, []string{"block", "layout"})) != 1 {
+		t.Fatal("half the words should match")
+	}
+	if len(topicTimes(ms, nil)) != 0 {
+		t.Fatal("no needles, no anchors")
+	}
+}
+
+func TestTopicTimesSkipsFileAndCommandRecords(t *testing.T) {
+	at := time.Now()
+	ms := []model.Message{
+		{Role: "files", Text: "/repo/singbox/service.go", Time: at},
+		{Role: "command", Text: "grep singbox service", Time: at},
+	}
+	if got := topicTimes(ms, []string{"singbox", "service"}); len(got) != 0 {
+		t.Fatalf("a path is not someone discussing the subject, got %v", got)
+	}
+}
+
+func TestWithinTime(t *testing.T) {
+	at := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	if !withinTime(at.Add(5*time.Minute), []time.Time{at}, filesWindow) {
+		t.Fatal("five minutes is inside a twenty minute window")
+	}
+	if withinTime(at.Add(time.Hour), []time.Time{at}, filesWindow) {
+		t.Fatal("an hour later is different work")
+	}
+	if withinTime(time.Time{}, []time.Time{at}, filesWindow) {
+		t.Fatal("a record with no time cannot be placed")
+	}
+}
+
+func TestFilesWindowIsATimeSpan(t *testing.T) {
+	// This is the whole feature: an untyped 20 here is twenty nanoseconds and
+	// nothing is ever near anything.
+	if filesWindow < time.Minute {
+		t.Fatalf("filesWindow = %v, which is not a usable span", filesWindow)
+	}
+}
+
+func TestIsScratch(t *testing.T) {
+	for _, p := range []string{
+		"/Users/x/.claude/projects/a.jsonl",
+		"/Users/x/work/scratchpad/probe.py",
+		"/Users/x/repo/node_modules/lib/index.js",
+		"/Users/x/repo/build.log",
+	} {
+		if !isScratch(p) {
+			t.Errorf("%s should be scratch", p)
+		}
+	}
+	if isScratch("/Users/x/repo/internal/index/store.go") {
+		t.Error("source in a repo is not scratch")
+	}
+}
+
+func TestInRepositoryWalksUpForGit(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "internal", "index")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if inRepositoryUncached(filepath.Join(deep, "store.go")) {
+		t.Fatal("no .git anywhere above it yet")
+	}
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !inRepositoryUncached(filepath.Join(deep, "store.go")) {
+		t.Fatal("a file under a .git root belongs to a repository")
+	}
+	other := t.TempDir()
+	if inRepositoryUncached(filepath.Join(other, "note.md")) {
+		t.Fatal("a loose file beside no repository should be dropped")
+	}
+}
+
+func TestTrimPath(t *testing.T) {
+	got := trimPath("/Users/x/coding/goprojects/deja-vu/internal/index/store.go")
+	if got != "deja-vu/internal/index/store.go" {
+		t.Fatalf("got %q", got)
+	}
+	if got := trimPath("/a/b.go"); got != "a/b.go" {
+		t.Fatalf("short paths keep their shape, got %q", got)
+	}
+}
+
+func TestLowerAllDropsShortWords(t *testing.T) {
+	got := lowerAll([]string{"Sing", "Box", "in", "GO"})
+	if len(got) != 2 || got[0] != "sing" || got[1] != "box" {
+		t.Fatalf("got %v", got)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -119,6 +119,7 @@ var commands = map[string]command{
 	"share":           func(dir string, rest []string) error { return runShare(dir, rest, os.Stdout) },
 	"resume":          func(dir string, rest []string) error { return runResume(dir, rest, os.Stdout) },
 	"handoff":         func(dir string, rest []string) error { return runHandoff(dir, rest, os.Stdout) },
+	"files":           func(dir string, rest []string) error { return runFiles(dir, rest, os.Stdout) },
 	"log":             runLog,
 	"sync":            runSync,
 	"ctx":             cmdCtx,


### PR DESCRIPTION
Closes #542.

`deja blame <path>` answers which sessions touched a file. This is the other direction: which files the work on a subject touched.

Aggregating every file a matching session touched does not work — one long session touches two hundred files across a dozen subjects, so every topic returned the same five files. What works is proximity in time: anchor on the messages where the words were actually said, then count files opened within twenty minutes of one, weighted by how specific each file is to the topic and by how much evidence stands behind it. Sessions that matched only semantically have no anchor and are skipped, otherwise a single touch from an unrelated repo wins on perfect specificity.

Hand-checked on five topics over a 1150-session corpus: `sing-box` returns the singbox service and renderer plus routepilot's VPN application, `marzban` returns the bot's own files, one is plausible, one weak, and one prints that it found no file beside the topic rather than guessing.

Best paired with #565 — without it only Claude sessions carry file records.