### PR TITLE
fix(index): serve speech before tool records in the per-session bound

### DIFF
--- a/internal/index/coverage_recover_test.go
+++ b/internal/index/coverage_recover_test.go
@@ -352,7 +352,7 @@ func TestUpdateIndexAppendNonCorruptErrorWrapped(t *testing.T) {
 
 func TestAddIndexKeysDedupBranch(t *testing.T) {
 	buckets := bucketPostings{}
-	addIndexKeys(buckets, "alpha alpha alpha", 5, 1, time.Time{})
+	addIndexKeys(buckets, "alpha alpha alpha", 5, 1, time.Time{}, false)
 	total := 0
 	for _, toks := range buckets {
 		for _, posts := range toks {

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -19,7 +19,7 @@ import (
 // the copies it already holds.
 // 18: file paths from tool calls are indexed (#558). An index built before this
 // has none of them, so it is rebuilt rather than reused.
-const version = 18
+const version = 19
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message
@@ -165,6 +165,12 @@ type OffsetRecord struct {
 type posting struct {
 	Off int64
 	Sid uint32
+	// Tool marks a posting that came from a tool record — a command, a path, a
+	// tool result — rather than from something a person or the agent said. The
+	// bit rides in the posting because the per-session cap has to choose which
+	// postings to keep *before* any record is read, which is the whole point of
+	// the cap.
+	Tool bool
 }
 
 type SearchResult struct {
@@ -205,6 +211,7 @@ type tokenJob struct {
 	offset int64
 	sid    uint32
 	when   time.Time
+	tool   bool
 }
 
 type bucketPostings map[string]map[string][]posting

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -299,7 +299,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 					return err
 				}
 				writtenMessages++
-				push(tokenJob{text: text, offset: off, sid: m.Sessions[key].Ord, when: msg.Time})
+				push(tokenJob{text: text, offset: off, sid: m.Sessions[key].Ord, when: msg.Time, tool: isToolRole(msg.Role)})
 			}
 		}
 		return nil
@@ -525,7 +525,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 					return err
 				}
 				writtenMessages++
-				push(tokenJob{text: text, offset: off, sid: m.Sessions[key].Ord, when: msg.Time})
+				push(tokenJob{text: text, offset: off, sid: m.Sessions[key].Ord, when: msg.Time, tool: isToolRole(msg.Role)})
 			}
 		}
 		return nil
@@ -574,7 +574,7 @@ func indexTextParallel(feed func(push func(tokenJob)) error) (bucketPostings, er
 			defer wg.Done()
 			for batch := range jobs {
 				for _, job := range batch {
-					addIndexKeys(partials[i], job.text, job.offset, job.sid, job.when)
+					addIndexKeys(partials[i], job.text, job.offset, job.sid, job.when, job.tool)
 				}
 			}
 		}()
@@ -624,7 +624,7 @@ func dateTokens(when time.Time) []string {
 	}
 }
 
-func addIndexKeys(buckets bucketPostings, text string, off int64, sid uint32, when time.Time) {
+func addIndexKeys(buckets bucketPostings, text string, off int64, sid uint32, when time.Time, tool bool) {
 	seen := map[string]bool{}
 	for _, tok := range append(indexKeys(text), dateTokens(when)...) {
 		if seen[tok] {
@@ -635,7 +635,7 @@ func addIndexKeys(buckets bucketPostings, text string, off int64, sid uint32, wh
 		if buckets[b] == nil {
 			buckets[b] = map[string][]posting{}
 		}
-		buckets[b][tok] = append(buckets[b][tok], posting{Off: off, Sid: sid})
+		buckets[b][tok] = append(buckets[b][tok], posting{Off: off, Sid: sid, Tool: tool})
 	}
 }
 

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -977,6 +977,17 @@ const roleFiles = "files"
 // roleCommand mirrors sources.RoleCommand.
 const roleCommand = "command"
 
+// roleToolOutput mirrors sources.RoleToolOutput.
+const roleToolOutput = "tool-output"
+
+// isToolRole says whether a record holds the work rather than the talk about
+// it. Tool records are bulk-repetitive by nature — the same command, the same
+// paths, session after session — so a query that matches one matches hundreds,
+// and the per-session bound has to spend its budget on speech first.
+func isToolRole(role string) bool {
+	return role == roleFiles || role == roleCommand || role == roleToolOutput
+}
+
 func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []int64, variants map[string][]string) ([]model.Session, error) {
 	by := map[string]*model.Session{}
 	add := func(r Record) {
@@ -1080,9 +1091,13 @@ func capPostingsPerSession(posts []posting, n int) []posting {
 		return posts
 	}
 	bySid := make(map[uint32]int, 16)
+	speechBySid := make(map[uint32]int, 16)
 	over := false
 	for _, p := range posts {
 		bySid[p.Sid]++
+		if !p.Tool {
+			speechBySid[p.Sid]++
+		}
 		if bySid[p.Sid] > n {
 			over = true
 		}
@@ -1090,18 +1105,33 @@ func capPostingsPerSession(posts []posting, n int) []posting {
 	if !over {
 		return posts
 	}
+	// Speech first, tool records with whatever budget is left. A long session
+	// holds thousands of matching command lines and a handful of sentences about
+	// the subject; sampling the two together spends the budget on the commands
+	// and the sentence that would have ranked the session is never read.
 	seen := make(map[uint32]int, len(bySid))
+	seenTool := make(map[uint32]int, len(bySid))
 	out := make([]posting, 0, len(posts))
 	for _, p := range posts {
-		total := bySid[p.Sid]
-		if total <= n {
+		if bySid[p.Sid] <= n {
 			out = append(out, p)
 			continue
 		}
-		i := seen[p.Sid]
-		seen[p.Sid] = i + 1
-		// Keep index i when it lands on one of n evenly spaced slots.
-		if i*n/total != (i+1)*n/total {
+		budget, total, counter := n, speechBySid[p.Sid], seen
+		if p.Tool {
+			budget, total, counter = n-speechBySid[p.Sid], bySid[p.Sid]-speechBySid[p.Sid], seenTool
+			if budget <= 0 {
+				continue
+			}
+		}
+		if total <= budget {
+			out = append(out, p)
+			continue
+		}
+		i := counter[p.Sid]
+		counter[p.Sid] = i + 1
+		// Keep index i when it lands on one of budget evenly spaced slots.
+		if i*budget/total != (i+1)*budget/total {
 			out = append(out, p)
 		}
 	}

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -688,7 +688,14 @@ func encodePostings(posts []posting) []byte {
 	var prev int64
 	for _, p := range s {
 		b = binary.AppendUvarint(b, uint64(p.Off-prev))
-		b = binary.AppendUvarint(b, uint64(p.Sid))
+		// The tool bit rides in the low bit of the session field: a separate
+		// varint would cost a byte on every posting in the store, and the shift
+		// costs nothing until a corpus passes two billion sessions.
+		v := uint64(p.Sid) << 1
+		if p.Tool {
+			v |= 1
+		}
+		b = binary.AppendUvarint(b, v)
 		prev = p.Off
 	}
 	return b
@@ -708,7 +715,7 @@ func decodePostings(b []byte) []posting {
 		if n <= 0 {
 			return out
 		}
-		out = append(out, posting{Off: prev, Sid: uint32(sid)})
+		out = append(out, posting{Off: prev, Sid: uint32(sid >> 1), Tool: sid&1 == 1})
 		b = b[n:]
 	}
 	return out

--- a/internal/index/tool_postings_test.go
+++ b/internal/index/tool_postings_test.go
@@ -1,0 +1,90 @@
+package index
+
+import "testing"
+
+func TestPostingRoundTripCarriesTheToolBit(t *testing.T) {
+	in := []posting{
+		{Off: 10, Sid: 1},
+		{Off: 4096, Sid: 1, Tool: true},
+		{Off: 1 << 20, Sid: 70000, Tool: true},
+		{Off: 1<<20 + 3, Sid: 70000},
+	}
+	got := decodePostings(encodePostings(in))
+	if len(got) != len(in) {
+		t.Fatalf("got %d postings, want %d", len(got), len(in))
+	}
+	for i, p := range got {
+		if p != in[i] {
+			t.Fatalf("posting %d = %+v, want %+v", i, p, in[i])
+		}
+	}
+}
+
+func TestCapKeepsSpeechBeforeToolRecords(t *testing.T) {
+	// One session, four sentences and ninety-six command lines. Reading only
+	// half the session's postings must not spend the whole budget on commands.
+	var posts []posting
+	for i := 0; i < 4; i++ {
+		posts = append(posts, posting{Off: int64(i), Sid: 7})
+	}
+	for i := 0; i < 96; i++ {
+		posts = append(posts, posting{Off: int64(100 + i), Sid: 7, Tool: true})
+	}
+	got := capPostingsPerSession(posts, 50)
+	speech, tool := 0, 0
+	for _, p := range got {
+		if p.Tool {
+			tool++
+		} else {
+			speech++
+		}
+	}
+	if speech != 4 {
+		t.Fatalf("kept %d of 4 speech postings", speech)
+	}
+	if want := 46; tool != want {
+		t.Fatalf("kept %d tool postings, want %d", tool, want)
+	}
+}
+
+func TestCapSpendsEverythingOnSpeechWhenThereIsEnoughOfIt(t *testing.T) {
+	var posts []posting
+	for i := 0; i < 80; i++ {
+		posts = append(posts, posting{Off: int64(i), Sid: 3})
+	}
+	for i := 0; i < 80; i++ {
+		posts = append(posts, posting{Off: int64(1000 + i), Sid: 3, Tool: true})
+	}
+	got := capPostingsPerSession(posts, 20)
+	for _, p := range got {
+		if p.Tool {
+			t.Fatal("speech alone fills the budget, no tool posting should survive")
+		}
+	}
+	if len(got) != 20 {
+		t.Fatalf("kept %d postings, want 20", len(got))
+	}
+}
+
+func TestCapLeavesSmallSessionsAlone(t *testing.T) {
+	posts := []posting{
+		{Off: 1, Sid: 2, Tool: true},
+		{Off: 2, Sid: 2},
+	}
+	if got := capPostingsPerSession(posts, 64); len(got) != 2 {
+		t.Fatalf("a session under the bound keeps every posting, got %d", len(got))
+	}
+}
+
+func TestIsToolRole(t *testing.T) {
+	for _, r := range []string{roleFiles, roleCommand, roleToolOutput} {
+		if !isToolRole(r) {
+			t.Errorf("%q should be a tool role", r)
+		}
+	}
+	for _, r := range []string{"user", "assistant", "developer"} {
+		if isToolRole(r) {
+			t.Errorf("%q is speech", r)
+		}
+	}
+}


### PR DESCRIPTION
Closes #567.

`capPostingsPerSession` sampled evenly across everything a session matched, with no way to tell a sentence from a command line. Since paths and commands are indexed by default, a long session spent its whole read budget on tool records and the message that would have ranked it was never read.

The bit rides in the low bit of the session varint — a separate field would cost a byte on every posting in the store — and speech is served first, tool records take what is left. Manifest version 18 → 19.

Measured on a 1150-session store with `scripts/rankdiff`, tool records on vs off:

| | order changes | score noise |
|---|---|---|
| before | 22 of 207 lines | — |
| after | **0** | 4th decimal, from BM25 corpus statistics |

Search latency pays for the extra records either way: median 1.34 → 1.91 ms, p90 23.4 → 26.7 ms. decisionbench 8/8 · 8/8 · 4/4 · 3/3, recall@5 1.00.