### PR TITLE
feat(restore): recover a span an agent replaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | **Share** | `deja share <id>` — hand a colleague a sanitized digest of a session, secrets already scrubbed |
 | **Remember** | `deja remember "text"` or MCP `remember` — keep durable decisions and conclusions |
 | **Blame** | `deja blame <path>` — which sessions touched this file, what was decided and why |
+| **Restore** | `deja restore <path>` — hand back a span an agent replaced, from the `old_string` its edit recorded; never writes over the original |
 | **Files** | `deja files <topic>` — the other direction: which files the work on a subject actually touched, ranked by how specific they are to it |
 | **Semantic** | optional: point `deja embed` at a local Ollama/LM Studio and rephrased queries still hit |
 
@@ -157,6 +158,7 @@ $ deja "jwt refresh token"
 | `deja <query>` | Search all histories. Multi-word = AND, common English filler words are ignored, substrings match (`code` finds `opencode`), and double-quoted phrases require contiguous text; zero-result queries try word forms before close spellings. `--re`, `--harness`, `--project`, `--since 30d`, `--role`, `--limit`, `--json`. |
 | `deja ctx <query>` | Compact markdown digest of the best match — pipe it into a prompt. |
 | `deja blame <path>` | Find sessions that discussed a file, newest and most specific first. `--json`, `--all`, and the usual filters are supported. |
+| `deja restore <path>` | List the spans an agent replaced in that file, newest first, and print or write one back with `--span n [-o file]`. Output is what the agent recorded, not the file, and a span that passed through redaction says so. |
 | `deja files <topic>` | Which files were opened or edited while that subject was being worked on. Ranked by how specific a file is to the topic, so a file every session touches does not win. `--project`, `--limit`. |
 | `deja share <id>` | Sanitized session digest for a colleague: secrets redacted, tool noise stripped. |
 | `deja stats` | Headline counts, totals, per-harness split, top projects, monthly sparkline. `--json` too. |

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -120,6 +120,7 @@ var commands = map[string]command{
 	"resume":          func(dir string, rest []string) error { return runResume(dir, rest, os.Stdout) },
 	"handoff":         func(dir string, rest []string) error { return runHandoff(dir, rest, os.Stdout) },
 	"files":           func(dir string, rest []string) error { return runFiles(dir, rest, os.Stdout) },
+	"restore":         func(dir string, rest []string) error { return runRestore(dir, rest, os.Stdout) },
 	"log":             runLog,
 	"sync":            runSync,
 	"ctx":             cmdCtx,

--- a/cmd/deja/restore.go
+++ b/cmd/deja/restore.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// `deja restore <path>` hands back a span an agent replaced.
+//
+// The premise people expect is whole-file recovery from what the agent read.
+// The corpus says otherwise: reads are partial and line-decorated, while every
+// Edit call carries `old_string` — the exact bytes that stopped existing — with
+// the path beside it. 3,836 such spans across 862 files here, for 1.09 MB.
+//
+// Two rules the output never breaks. It is what the agent recorded, not the
+// file, and it says so. And it never writes to the path it recovered: restoring
+// over live work is the same class of mistake this is meant to undo.
+const restoreMaxSessions = 400
+
+type restoreSpan struct {
+	when    time.Time
+	session string
+	harness string
+	body    string
+}
+
+func runRestore(dir string, args []string, stdout io.Writer) error {
+	path := ""
+	want := 0
+	out := ""
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--span":
+			if i+1 < len(args) {
+				i++
+				n, err := strconv.Atoi(args[i])
+				if err != nil || n <= 0 {
+					return fmt.Errorf("restore: --span wants a positive number, got %q", args[i])
+				}
+				want = n
+			}
+		case "-o", "--out":
+			if i+1 < len(args) {
+				i++
+				out = args[i]
+			}
+		default:
+			if !strings.HasPrefix(args[i], "-") && path == "" {
+				path = args[i]
+			}
+		}
+	}
+	if path == "" {
+		return fmt.Errorf("usage: deja restore <path> [--span n] [-o file]")
+	}
+
+	spans, err := findRestoreSpans(dir, path)
+	if err != nil {
+		return err
+	}
+	if len(spans) == 0 {
+		fmt.Fprintf(stdout, "no replaced spans recorded for %q\n", path)
+		return nil
+	}
+	if want == 0 {
+		fmt.Fprintf(stdout, "%d replaced spans recorded for %s\n", len(spans), path)
+		for i, s := range spans {
+			fmt.Fprintf(stdout, "  %d  %s  %s %s  %d B replaced%s\n",
+				i+1, s.when.Format("Jan 02 15:04"), s.harness, shortID(s.session),
+				len(s.body), redactionNote(s.body))
+		}
+		fmt.Fprintf(stdout, "\ndeja restore %s --span 1 -o recovered.txt\n", path)
+		return nil
+	}
+	if want > len(spans) {
+		return fmt.Errorf("restore: span %d of %d", want, len(spans))
+	}
+	span := spans[want-1]
+	if out == "" {
+		fmt.Fprint(stdout, span.body)
+		if !strings.HasSuffix(span.body, "\n") {
+			fmt.Fprintln(stdout)
+		}
+		return nil
+	}
+	// Never the original path: this exists because something overwrote work,
+	// and writing back over it would repeat the mistake.
+	if sameFile(out, path) {
+		return fmt.Errorf("restore: refusing to write over %s — pick another -o", path)
+	}
+	if err := os.WriteFile(out, []byte(span.body), 0o600); err != nil {
+		return fmt.Errorf("restore: %w", err)
+	}
+	fmt.Fprintf(stdout, "wrote %d B to %s — this is what the agent recorded, not the file%s\n",
+		len(span.body), out, redactionNote(span.body))
+	return nil
+}
+
+func findRestoreSpans(dir string, path string) ([]restoreSpan, error) {
+	base := filepath.Base(path)
+	o := search.Options{Query: base, All: true, Role: "edit"}
+	if err := index.EnsureForSearch(dir, o, false, nil); err != nil {
+		return nil, fmt.Errorf("ensure: %w", err)
+	}
+	hits, err := index.Search(dir, o)
+	if err != nil {
+		return nil, fmt.Errorf("search: %w", err)
+	}
+	if len(hits) > restoreMaxSessions {
+		hits = hits[:restoreMaxSessions]
+	}
+	var spans []restoreSpan
+	for _, h := range hits {
+		full, ok, err := index.FindByIdentity(dir, h.Harness, h.ID)
+		if err != nil || !ok {
+			continue
+		}
+		for _, m := range full.Messages {
+			if m.Role != "edit" {
+				continue
+			}
+			recorded, body, found := strings.Cut(m.Text, "\n")
+			if !found || !pathMatches(recorded, path) {
+				continue
+			}
+			spans = append(spans, restoreSpan{when: m.Time, session: h.ID, harness: h.Harness, body: body})
+		}
+	}
+	// Newest first: the span someone wants back is almost always the last one
+	// that was replaced.
+	sort.Slice(spans, func(i, j int) bool { return spans[i].when.After(spans[j].when) })
+	return spans, nil
+}
+
+// pathMatches accepts what someone would actually type — a bare file name, a
+// suffix of the path, or the whole thing.
+func pathMatches(recorded, want string) bool {
+	recorded = filepath.ToSlash(recorded)
+	want = filepath.ToSlash(want)
+	if recorded == want {
+		return true
+	}
+	if strings.HasSuffix(recorded, "/"+strings.TrimPrefix(want, "/")) {
+		return true
+	}
+	return filepath.Base(recorded) == want
+}
+
+// redactionNote flags a span that passed through redaction, because restoring
+// it byte for byte would put a placeholder where a credential was.
+func redactionNote(body string) string {
+	if strings.Contains(body, "[redacted:") {
+		return "  (contains a redaction placeholder — not byte-exact)"
+	}
+	return ""
+}
+
+func sameFile(a, b string) bool {
+	ap, err1 := filepath.Abs(a)
+	bp, err2 := filepath.Abs(b)
+	return err1 == nil && err2 == nil && ap == bp
+}
+
+func shortID(id string) string {
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}

--- a/cmd/deja/restore_test.go
+++ b/cmd/deja/restore_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeEditFixture(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	proj := filepath.Join(tmp, "claude", "project")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	line := func(format string, a ...any) { fmt.Fprintf(&b, format+"\n", a...) }
+	line(`{"type":"user","sessionId":"claude-edit","cwd":"/w","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"clean up the retry helper"}}`)
+	line(`{"type":"assistant","sessionId":"claude-edit","cwd":"/w","timestamp":"2026-01-02T03:05:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/w/pkg/retry.go","old_string":"func retry() error {\n\treturn nil\n}"}}]}}`)
+	line(`{"type":"assistant","sessionId":"claude-edit","cwd":"/w","timestamp":"2026-01-02T03:06:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"MultiEdit","input":{"file_path":"/w/pkg/retry.go","edits":[{"old_string":"const backoff = 1"},{"old_string":"const ceiling = 9"}]}}]}}`)
+	if err := os.WriteFile(filepath.Join(proj, "s.jsonl"), []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return tmp
+}
+
+func TestRestoreListsAndWritesSpans(t *testing.T) {
+	writeEditFixture(t)
+	out, err := captureRun(t, "restore", "retry.go")
+	if err != nil {
+		t.Fatalf("restore: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "3 replaced spans") {
+		t.Fatalf("want three spans including the MultiEdit sub-edits, got:\n%s", out)
+	}
+
+	// Newest first, so the MultiEdit spans lead and the function body is last.
+	out, err = captureRun(t, "restore", "retry.go", "--span", "3")
+	if err != nil {
+		t.Fatalf("restore --span: %v", err)
+	}
+	if !strings.Contains(out, "func retry() error {") || !strings.Contains(out, "return nil") {
+		t.Fatalf("span should come back byte for byte, got:\n%s", out)
+	}
+
+	dst := filepath.Join(t.TempDir(), "recovered.txt")
+	out, err = captureRun(t, "restore", "retry.go", "--span", "3", "-o", dst)
+	if err != nil {
+		t.Fatalf("restore -o: %v", err)
+	}
+	body, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "func retry() error {\n\treturn nil\n}" {
+		t.Fatalf("recovered file = %q", body)
+	}
+	if !strings.Contains(out, "not the file") {
+		t.Fatalf("output must say what it is handing back, got %q", out)
+	}
+}
+
+func TestRestoreRefusesToWriteOverTheOriginal(t *testing.T) {
+	writeEditFixture(t)
+	// Same path in and out: this command exists because something overwrote
+	// work, so it must not do the same.
+	err := runRestore(os.Getenv("DEJA_INDEX_DIR"), []string{"retry.go", "--span", "1", "-o", "retry.go"}, os.Stdout)
+	if err == nil || !strings.Contains(err.Error(), "refusing") {
+		t.Fatalf("want a refusal, got %v", err)
+	}
+}
+
+func TestRestoreUnknownPathAndBadArgs(t *testing.T) {
+	writeEditFixture(t)
+	out, err := captureRun(t, "restore", "nothing-here.go")
+	if err != nil || !strings.Contains(out, "no replaced spans") {
+		t.Fatalf("out=%q err=%v", out, err)
+	}
+	if err := runRestore(t.TempDir(), nil, os.Stdout); err == nil {
+		t.Fatal("no path should be a usage error")
+	}
+	if err := runRestore(t.TempDir(), []string{"a.go", "--span", "x"}, os.Stdout); err == nil {
+		t.Fatal("--span wants a number")
+	}
+	if err := runRestore(os.Getenv("DEJA_INDEX_DIR"), []string{"retry.go", "--span", "99"}, os.Stdout); err == nil {
+		t.Fatal("out of range span should fail")
+	}
+}
+
+func TestPathMatches(t *testing.T) {
+	if !pathMatches("/w/pkg/retry.go", "retry.go") {
+		t.Error("a bare file name should match")
+	}
+	if !pathMatches("/w/pkg/retry.go", "pkg/retry.go") {
+		t.Error("a path suffix should match")
+	}
+	if !pathMatches("/w/pkg/retry.go", "/w/pkg/retry.go") {
+		t.Error("the whole path should match")
+	}
+	if pathMatches("/w/pkg/retry.go", "other.go") {
+		t.Error("a different file should not match")
+	}
+	if pathMatches("/w/pkgretry.go", "retry.go") {
+		t.Error("a suffix that is not a path segment should not match")
+	}
+}
+
+func TestRedactionNote(t *testing.T) {
+	if redactionNote("token = [redacted:credential]") == "" {
+		t.Error("a redacted span must be flagged, restoring it is not byte-exact")
+	}
+	if redactionNote("func x() {}") != "" {
+		t.Error("clean spans carry no note")
+	}
+}
+
+func TestShortID(t *testing.T) {
+	if got := shortID("abcdefghijklmnop"); got != "abcdefghijkl" {
+		t.Fatalf("got %q", got)
+	}
+	if got := shortID("short"); got != "short" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -299,7 +299,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 					return err
 				}
 				writtenMessages++
-				push(tokenJob{text: text, offset: off, sid: m.Sessions[key].Ord, when: msg.Time, tool: isToolRole(msg.Role)})
+				push(tokenJob{text: tokenizedPart(msg.Role, text), offset: off, sid: m.Sessions[key].Ord, when: msg.Time, tool: isToolRole(msg.Role)})
 			}
 		}
 		return nil
@@ -525,7 +525,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 					return err
 				}
 				writtenMessages++
-				push(tokenJob{text: text, offset: off, sid: m.Sessions[key].Ord, when: msg.Time, tool: isToolRole(msg.Role)})
+				push(tokenJob{text: tokenizedPart(msg.Role, text), offset: off, sid: m.Sessions[key].Ord, when: msg.Time, tool: isToolRole(msg.Role)})
 			}
 		}
 		return nil
@@ -622,6 +622,21 @@ func dateTokens(when time.Time) []string {
 		"t" + when.Format("2006"),
 		"t" + when.Format("2006-01"),
 	}
+}
+
+// tokenizedPart is what of a record earns postings. For most records that is
+// the whole text; for a replaced span it is only the path on the first line.
+// Nobody searches for the body of a span — `deja restore` finds it by path —
+// and indexing 1 MB of source code puts every `func` and `return` in it into
+// the postings, which cost the median query 0.5 ms for nothing.
+func tokenizedPart(role, text string) string {
+	if role != roleEdit {
+		return text
+	}
+	if i := strings.IndexByte(text, '\n'); i >= 0 {
+		return text[:i]
+	}
+	return text
 }
 
 func addIndexKeys(buckets bucketPostings, text string, off int64, sid uint32, when time.Time, tool bool) {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -980,12 +980,15 @@ const roleCommand = "command"
 // roleToolOutput mirrors sources.RoleToolOutput.
 const roleToolOutput = "tool-output"
 
+// roleEdit mirrors sources.RoleEdit.
+const roleEdit = "edit"
+
 // isToolRole says whether a record holds the work rather than the talk about
 // it. Tool records are bulk-repetitive by nature — the same command, the same
 // paths, session after session — so a query that matches one matches hundreds,
 // and the per-session bound has to spend its budget on speech first.
 func isToolRole(role string) bool {
-	return role == roleFiles || role == roleCommand || role == roleToolOutput
+	return role == roleFiles || role == roleCommand || role == roleToolOutput || role == roleEdit
 }
 
 func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []int64, variants map[string][]string) ([]model.Session, error) {
@@ -1016,6 +1019,12 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		}
 		// Same rule for commands: an invocation is an action, not an answer.
 		if r.Role == roleCommand && o.Role != roleCommand {
+			return
+		}
+		// A replaced span is the file's old contents, not a statement about
+		// anything. It is stored so `deja restore` can find it and served only
+		// when asked for by role.
+		if r.Role == roleEdit && o.Role != roleEdit {
 			return
 		}
 		s := by[r.Key]

--- a/internal/index/tool_postings_test.go
+++ b/internal/index/tool_postings_test.go
@@ -88,3 +88,17 @@ func TestIsToolRole(t *testing.T) {
 		}
 	}
 }
+
+func TestTokenizedPartIndexesOnlyThePathOfASpan(t *testing.T) {
+	span := "/w/pkg/retry.go\nfunc retry() error {\n\treturn nil\n}"
+	if got := tokenizedPart(roleEdit, span); got != "/w/pkg/retry.go" {
+		t.Fatalf("got %q, want the path alone", got)
+	}
+	if got := tokenizedPart("user", span); got != span {
+		t.Fatal("speech is indexed whole")
+	}
+	// A span with no body still has to yield its path rather than nothing.
+	if got := tokenizedPart(roleEdit, "/w/only.go"); got != "/w/only.go" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -101,6 +101,11 @@ func parseClaudeGenericFromOffset(path string, offset int64) ([]model.Session, e
 					s.Messages = append(s.Messages, model.Message{Role: RoleFiles, Text: p, Time: t})
 				}
 			}
+			if IndexEdits() {
+				for _, e := range editSpansFromContent(msg["content"]) {
+					s.Messages = append(s.Messages, model.Message{Role: RoleEdit, Text: e, Time: t})
+				}
+			}
 			if IndexCommands() {
 				for _, cmd := range commandsFromContent(msg["content"]) {
 					s.Messages = append(s.Messages, model.Message{Role: RoleCommand, Text: cmd, Time: t})

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -82,6 +82,11 @@ func parseClaudeTypedFromOffset(path string, offset int64) ([]model.Session, err
 					s.Messages = append(s.Messages, model.Message{Role: RoleFiles, Text: p, Time: t})
 				}
 			}
+			if IndexEdits() {
+				for _, e := range claudeEditSpans(v.Message.Content) {
+					s.Messages = append(s.Messages, model.Message{Role: RoleEdit, Text: e, Time: t})
+				}
+			}
 			if IndexCommands() {
 				for _, cmd := range claudeCommands(v.Message.Content) {
 					s.Messages = append(s.Messages, model.Message{Role: RoleCommand, Text: cmd, Time: t})
@@ -305,6 +310,72 @@ func claudeToolPaths(raw json.RawMessage) string {
 		out = append(out, part.Input.FilePath)
 	}
 	return strings.Join(out, "\n")
+}
+
+// RoleEdit holds a span an agent replaced, with the file it belonged to on the
+// first line. It is the one part of a transcript that cannot be reconstructed
+// from anything else: `old_string` is the exact bytes that stopped existing,
+// and on this corpus it is 3,836 spans across 862 files for 1.09 MB.
+const RoleEdit = "edit"
+
+// IndexEdits reports whether replaced spans are indexed. On by default for the
+// same reason as paths: a recovery feature nobody enabled recovers nothing.
+func IndexEdits() bool { return os.Getenv("DEJA_INDEX_EDITS") != "0" }
+
+// editSpanMax bounds a single stored span. The measured maximum is 8.5 KB and
+// p90 is 578 B; the bound is there so one pathological patch cannot put a
+// megabyte of someone else's file into the index.
+const editSpanMax = 32 * 1024
+
+// claudeEditSpans returns "path\nreplaced bytes" for every edit in a turn,
+// including the sub-edits of a MultiEdit call.
+func claudeEditSpans(raw json.RawMessage) []string {
+	raw = trimJSONSpace(raw)
+	if len(raw) == 0 || raw[0] != '[' {
+		return nil
+	}
+	var items []json.RawMessage
+	if json.Unmarshal(raw, &items) != nil {
+		return nil
+	}
+	var out []string
+	for _, item := range items {
+		item = trimJSONSpace(item)
+		if len(item) == 0 || item[0] != '{' {
+			continue
+		}
+		var part struct {
+			Type  string `json:"type"`
+			Input struct {
+				FilePath  string `json:"file_path"`
+				OldString string `json:"old_string"`
+				Edits     []struct {
+					OldString string `json:"old_string"`
+				} `json:"edits"`
+			} `json:"input"`
+		}
+		if json.Unmarshal(item, &part) != nil || part.Type != "tool_use" {
+			continue
+		}
+		path := part.Input.FilePath
+		if path == "" {
+			continue
+		}
+		spans := []string{part.Input.OldString}
+		for _, e := range part.Input.Edits {
+			spans = append(spans, e.OldString)
+		}
+		for _, span := range spans {
+			if span == "" {
+				continue
+			}
+			if len(span) > editSpanMax {
+				span = span[:editSpanMax]
+			}
+			out = append(out, path+"\n"+span)
+		}
+	}
+	return out
 }
 
 // RoleCommand marks a command that ran. Tool *output* has always been indexed —

--- a/internal/sources/project_paths.go
+++ b/internal/sources/project_paths.go
@@ -98,11 +98,19 @@ func repoRoot(dir string) string {
 		return v.(string)
 	}
 	root := ""
-	for d := dir; d != "/" && d != "." && d != ""; d = filepath.Dir(d) {
+	// Stop when the parent stops changing rather than on "/": on Windows the
+	// walk ends at `D:\`, whose parent is itself, and a unix-root check spins
+	// there until the process is killed.
+	for d := dir; d != "." && d != ""; {
 		if fi, err := os.Stat(filepath.Join(d, ".git")); err == nil && (fi.IsDir() || fi.Mode().IsRegular()) {
 			root = d
 			break
 		}
+		up := filepath.Dir(d)
+		if up == d {
+			break
+		}
+		d = up
 	}
 	repoRootCache.Store(dir, root)
 	return root

--- a/internal/sources/project_paths_test.go
+++ b/internal/sources/project_paths_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/model"
 )
@@ -86,5 +87,20 @@ func TestProjectFromPathsNeedsEvidence(t *testing.T) {
 	}
 	if got := projectFromPaths(nil); got != "" {
 		t.Fatalf("project = %q, want no answer with no files", got)
+	}
+}
+
+func TestRepoRootTerminatesAtTheVolumeRoot(t *testing.T) {
+	// The walk used to stop only at "/", so on Windows it spun forever at the
+	// volume root. A timeout rather than an assertion: the failure mode is a
+	// hang, and it only reproduces on the OS whose root is not "/".
+	done := make(chan string, 1)
+	go func() {
+		done <- repoRoot(filepath.Join(filepath.VolumeName(os.TempDir())+string(filepath.Separator), "nowhere", "deep"))
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("repoRoot did not terminate at the volume root")
 	}
 }

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -256,6 +256,51 @@ func toolPathsFromContent(v any) string {
 	return strings.Join(out, "\n")
 }
 
+// editSpansFromContent is claudeEditSpans for the reference parser.
+func editSpansFromContent(v any) []string {
+	items, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, it := range items {
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		if t, _ := m["type"].(string); t != "tool_use" {
+			continue
+		}
+		in, _ := m["input"].(map[string]any)
+		path, _ := in["file_path"].(string)
+		if path == "" {
+			continue
+		}
+		old, _ := in["old_string"].(string)
+		spans := []string{old}
+		if edits, ok := in["edits"].([]any); ok {
+			for _, e := range edits {
+				em, ok := e.(map[string]any)
+				if !ok {
+					continue
+				}
+				o, _ := em["old_string"].(string)
+				spans = append(spans, o)
+			}
+		}
+		for _, span := range spans {
+			if span == "" {
+				continue
+			}
+			if len(span) > editSpanMax {
+				span = span[:editSpanMax]
+			}
+			out = append(out, path+"\n"+span)
+		}
+	}
+	return out
+}
+
 // commandsFromContent is claudeCommands for the reference parser.
 func commandsFromContent(v any) []string {
 	items, ok := v.([]any)


### PR DESCRIPTION
Closes #537, and takes the next slice of #547.

Whole-file recovery from `Read` output does not survive contact with the corpus — reads are partial and line-decorated. `Edit` is the better material: every call carries `old_string`, the exact bytes that stopped existing, with the path next to it. 3,836 spans across 862 files here.

```
$ deja restore store_io.go
5 replaced spans recorded for store_io.go
  1  Jul 26 14:05  claude 2fc1d1ef-59f  24 B replaced
  ...
$ deja restore store_io.go --span 5
func readBucketToken(p, tok string) ([]posting, error) {
        entries, f, err := openBucketDir(p)
```

Index 74 → 76 MB. Search latency unchanged — 2.35/2.05 ms median without spans against 2.09/2.13 ms with them, interleaved — because only the path line earns postings; indexing span bodies cost ~0.5 ms per query for tokens nobody searches. decisionbench 8/8 · 8/8 · 4/4 · 3/3, recall@5 1.00.

It never writes over the path it recovered, it labels output as what the agent recorded rather than the file, and it flags a span that passed through redaction as not byte-exact.