### PR TITLE
chore(packaging): pin scoop/winget manifests to 0.16.4

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,12 +1,12 @@
 {
     "architecture": {
         "64bit": {
-            "hash": "ba7d97644a01a4d770d4c212dfa812c749c3784217bbc9a047abf3d838fdf905",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.3/deja-vu_0.16.3_windows_amd64.zip"
+            "hash": "e5cdeb6d81ea7720ad4894c2b9e2059d68a44ac9497c4d01cb9d8a2a7f395fc4",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.4/deja-vu_0.16.4_windows_amd64.zip"
         },
         "arm64": {
-            "hash": "0a2e3b02bebccc76f30d70ec02318fd862ae90a26323296f76ccd170f2f85946",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.3/deja-vu_0.16.3_windows_arm64.zip"
+            "hash": "2e59ec860cee6ed1ca7694a37414aedce84395cbb0011df117318d06e2d5ff94",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.4/deja-vu_0.16.4_windows_arm64.zip"
         }
     },
     "autoupdate": {
@@ -24,5 +24,5 @@
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
-    "version": "0.16.3"
+    "version": "0.16.4"
 }

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.3
+PackageVersion: 0.16.4
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.3/deja-vu_0.16.3_windows_amd64.zip
-  InstallerSha256: BA7D97644A01A4D770D4C212DFA812C749C3784217BBC9A047ABF3D838FDF905
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.4/deja-vu_0.16.4_windows_amd64.zip
+  InstallerSha256: E5CDEB6D81EA7720AD4894C2B9E2059D68A44AC9497C4D01CB9D8A2A7F395FC4
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.3/deja-vu_0.16.3_windows_arm64.zip
-  InstallerSha256: 0A2E3B02BEBCCC76F30D70EC02318FD862AE90A26323296F76CCD170F2F85946
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.4/deja-vu_0.16.4_windows_arm64.zip
+  InstallerSha256: 2E59EC860CEE6ED1CA7694A37414AEDCE84395CBB0011DF117318D06E2D5FF94
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.3
+PackageVersion: 0.16.4
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.3/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.4/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.3
+PackageVersion: 0.16.4
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Version and checksums from the v0.16.4 release artifacts.