### PR TITLE
feat(search): say when the files a session touched have moved since

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -437,6 +437,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	// there is no way to know how the filters would have treated the hidden
 	// ones, so the pre-cap figure stands and `capped` says to distrust it.
 	attachLifecycles(hits)
+	attachMoved(hits)
 	if !o.Capped {
 		o.Total = len(hits)
 	}

--- a/cmd/deja/moved.go
+++ b/cmd/deja/moved.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// A recalled session says what was discussed. What it cannot say by itself is
+// whether the ground has moved since — and that is the objection deja gets
+// every time it is discussed publicly.
+//
+// The version of this in #531 wanted to name *the* file a decision was about
+// and warn on it. Measured on 551 sessions, the linkage is good enough to be
+// interesting and not good enough to be authoritative: 37% of sessions record
+// no path at all, 28% name a file that no longer exists on disk, and picking
+// the single most-touched file is right about half the time by hand-check.
+//
+// So the claim is rewritten to one that needs no guessing and is true by
+// construction: of the files this session touched, this many have commits since
+// it ended. No claim is made about which file mattered, and — deliberately — no
+// claim is made that anything is *unchanged*, because silence here means "we
+// could not tell" far more often than it means "nothing moved".
+const (
+	// movedFileBudget bounds how many files one hit will ask git about. The
+	// median session touches a handful; the largest in this corpus touched
+	// 1,397, and asking about all of them would cost a minute per search.
+	movedFileBudget = 6
+	// movedGitBudget is the whole annotation's wall-clock allowance. Search
+	// itself is ~2 ms, so this is by far the expensive part and it has to be
+	// bounded rather than merely fast — the lesson from #516.
+	movedGitBudget = 600 * time.Millisecond
+	// movedHitBudget is one hit's share of it.
+	// One cold git invocation on a large repository does not finish in 200 ms,
+	// and a budget that quietly produces nothing is worse than no annotation.
+	movedHitBudget = 400 * time.Millisecond
+	// movedRepoBudget bounds how many repositories one hit will ask about. A
+	// session that ranged over five checkouts is not one whose files a footnote
+	// can summarise anyway.
+	movedRepoBudget = 2
+	// movedMinAge is how old a session must be before the question is worth
+	// asking at all.
+	movedMinAge = 12 * time.Hour
+)
+
+type movedReport struct {
+	Changed int // files with commits since the session
+	Looked  int // files actually asked about
+}
+
+// filesMovedSince counts how many of a session's files have commits after it
+// ended. One git invocation per repository, not per file: asking about six
+// files separately cost half a second on a command whose search takes thirty
+// milliseconds, which is not a price a reader agreed to pay for a footnote.
+//
+// It is deliberately conservative: a file it cannot resolve, cannot stat, or
+// that no longer exists is not counted either way.
+func filesMovedSince(paths []string, since time.Time, budget time.Duration) movedReport {
+	if since.IsZero() || len(paths) == 0 {
+		return movedReport{}
+	}
+	// Nothing can have been committed after a session that ended minutes ago,
+	// and the hits a reader sees first are usually today's. Skipping those
+	// keeps the common search exactly as fast as it was.
+	if time.Since(since) < movedMinAge {
+		return movedReport{}
+	}
+	byRepo := map[string][]string{}
+	var r movedReport
+	for _, p := range paths {
+		if len(byRepo) > movedRepoBudget {
+			break
+		}
+		fi, err := os.Stat(p)
+		if err != nil {
+			// Gone or unreadable. It may have been renamed, or the whole
+			// checkout may live somewhere else now; either way this is not
+			// something to make a claim about.
+			continue
+		}
+		// A file older on disk than the session cannot have changed since it,
+		// and answering that costs a stat rather than a fork. A checkout resets
+		// mtime and sends a file down the git path unnecessarily, which costs
+		// time and never produces a wrong answer.
+		if !fi.ModTime().After(since) {
+			r.Looked++
+			continue
+		}
+		root := gitRootOf(p)
+		if root == "" {
+			continue
+		}
+		if len(byRepo[root]) >= movedFileBudget {
+			continue
+		}
+		byRepo[root] = append(byRepo[root], p)
+		r.Looked++
+	}
+	if len(byRepo) == 0 {
+		return r
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+	for root, files := range byRepo {
+		args := append([]string{"-C", root, "log", "--format=", "--name-only",
+			"--since=" + since.UTC().Format(time.RFC3339), "--"}, files...)
+		out, err := exec.CommandContext(ctx, "git", args...).Output()
+		if err != nil {
+			continue
+		}
+		seen := map[string]bool{}
+		for _, line := range strings.Split(string(out), "\n") {
+			if line = strings.TrimSpace(line); line != "" {
+				seen[line] = true
+			}
+		}
+		r.Changed += len(seen)
+	}
+	return r
+}
+
+func gitRootOf(p string) string {
+	for d := filepath.Dir(p); d != "." && d != ""; {
+		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
+			return d
+		}
+		up := filepath.Dir(d)
+		if up == d {
+			return ""
+		}
+		d = up
+	}
+	return ""
+}
+
+// movedNote is the line printed under a hit, or "" when there is nothing
+// honest to say.
+func movedNote(r movedReport) string {
+	if r.Changed == 0 {
+		return ""
+	}
+	if r.Changed == 1 {
+		return "  1 file this session touched has changed since"
+	}
+	return fmt.Sprintf("  %d files this session touched have changed since", r.Changed)
+}
+
+// attachMoved annotates the hits that are actually going to be read. Only the
+// first few: the annotation costs a git call per file, and a reader who scrolls
+// past hit ten is not waiting on this line.
+func attachMoved(hits []search.Hit) {
+	if len(hits) == 0 || os.Getenv("DEJA_MOVED") == "0" {
+		return
+	}
+	// Per hit, not shared: the first hit is often the longest session in the
+	// store, and a single budget for all of them let it spend the whole
+	// allowance on its own files while later hits — the ones a reader is
+	// comparing it against — silently got nothing.
+	deadline := time.Now().Add(movedGitBudget)
+	for i := range hits {
+		if i >= movedAnnotatedHits || time.Now().After(deadline) {
+			return
+		}
+		paths := hits[i].Session.Touched
+		if len(paths) == 0 {
+			continue
+		}
+		since := hits[i].Session.Updated
+		hits[i].Moved = movedNote(filesMovedSince(paths, since, movedHitBudget))
+	}
+}
+
+// movedAnnotatedHits is how many hits get the annotation at all.
+const movedAnnotatedHits = 3

--- a/cmd/deja/moved_test.go
+++ b/cmd/deja/moved_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func gitRepoWithCommit(t *testing.T) (root, file string, committed time.Time) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root = t.TempDir()
+	file = filepath.Join(root, "app.go")
+	if err := os.WriteFile(file, []byte("package app\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run := func(args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	run("add", "app.go")
+	run("commit", "-qm", "first")
+	return root, file, time.Now()
+}
+
+func TestFilesMovedSinceCountsCommitsAfterTheSession(t *testing.T) {
+	_, file, _ := gitRepoWithCommit(t)
+	// The session ended a day before the commit, so the file moved under it.
+	since := time.Now().Add(-24 * time.Hour)
+	r := filesMovedSince([]string{file}, since, 5*time.Second)
+	if r.Changed != 1 {
+		t.Fatalf("changed=%d looked=%d, want one file changed", r.Changed, r.Looked)
+	}
+	if movedNote(r) != "  1 file this session touched has changed since" {
+		t.Fatalf("note = %q", movedNote(r))
+	}
+}
+
+func TestFilesMovedSinceStaysSilentOnFreshSessions(t *testing.T) {
+	_, file, _ := gitRepoWithCommit(t)
+	// Nothing can have been committed after a session that ended a minute ago,
+	// and asking would cost a fork on the common search.
+	r := filesMovedSince([]string{file}, time.Now().Add(-time.Minute), 5*time.Second)
+	if r.Changed != 0 || r.Looked != 0 {
+		t.Fatalf("%+v, want no work done at all", r)
+	}
+}
+
+func TestFilesMovedSinceSkipsFilesOlderThanTheSession(t *testing.T) {
+	_, file, _ := gitRepoWithCommit(t)
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(file, old, old); err != nil {
+		t.Fatal(err)
+	}
+	// mtime before the session: it cannot have changed since, and the answer
+	// costs a stat rather than a git invocation.
+	r := filesMovedSince([]string{file}, time.Now().Add(-24*time.Hour), 5*time.Second)
+	if r.Changed != 0 {
+		t.Fatalf("changed=%d, want the mtime shortcut to answer", r.Changed)
+	}
+	if r.Looked != 1 {
+		t.Fatalf("looked=%d, want the file counted as considered", r.Looked)
+	}
+}
+
+func TestFilesMovedSinceIgnoresWhatItCannotResolve(t *testing.T) {
+	// A path that no longer exists says nothing in either direction: it may
+	// have been renamed, or the checkout may live elsewhere now.
+	r := filesMovedSince([]string{filepath.Join(t.TempDir(), "gone.go")},
+		time.Now().Add(-24*time.Hour), time.Second)
+	if r.Changed != 0 || r.Looked != 0 {
+		t.Fatalf("%+v, want silence", r)
+	}
+	if movedNote(r) != "" {
+		t.Fatalf("note = %q, want nothing", movedNote(r))
+	}
+	if got := filesMovedSince(nil, time.Now().Add(-time.Hour), time.Second); got.Looked != 0 {
+		t.Fatal("no paths, no work")
+	}
+	if got := filesMovedSince([]string{"/x"}, time.Time{}, time.Second); got.Looked != 0 {
+		t.Fatal("a session with no end time cannot be compared against")
+	}
+}
+
+func TestMovedNoteWording(t *testing.T) {
+	if movedNote(movedReport{}) != "" {
+		t.Fatal("nothing changed, nothing said")
+	}
+	if got := movedNote(movedReport{Changed: 4, Looked: 6}); got != "  4 files this session touched have changed since" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestGitRootOfWalksUpAndTerminates(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := gitRootOf(filepath.Join(deep, "x.go")); got != "" {
+		t.Fatalf("no repository above it, got %q", got)
+	}
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := gitRootOf(filepath.Join(deep, "x.go")); got != root {
+		t.Fatalf("got %q, want %q", got, root)
+	}
+	// Terminates at the volume root rather than spinning there, which is the
+	// Windows failure this shape of loop keeps producing.
+	done := make(chan string, 1)
+	go func() {
+		done <- gitRootOf(filepath.Join(filepath.VolumeName(os.TempDir())+string(filepath.Separator), "nowhere", "x.go"))
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("gitRootOf did not terminate")
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -88,7 +88,18 @@ type SessionMeta struct {
 	ID, Harness, Project, Path, Title string
 	Started, Updated                  time.Time
 	Ord                               uint32
+	// Touched holds the few files this session worked on most, so a caller can
+	// ask about them without loading the session. Reading one back cost 130-220
+	// ms, which is not a price worth paying for a footnote under a search hit.
+	// The field is additive: a manifest written before it existed decodes with
+	// it empty and the caller degrades to saying nothing.
+	Touched []string `json:",omitempty"`
 }
+
+// touchedFileCap bounds what goes in SessionMeta.Touched. Enough to say
+// something useful about a session, small enough that a store of a thousand
+// sessions pays kilobytes for it.
+const touchedFileCap = 6
 
 type Manifest struct {
 	Version          int                    `json:"version"`

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -720,7 +720,53 @@ func metaForSession(s model.Session) SessionMeta {
 	// composer name, the first user message — and are persisted in
 	// sessions.gob, so they need the same scrubbing as record text.
 	title, _ = redact.Text(title)
-	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, Started: s.Started, Updated: s.Updated}
+	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, Started: s.Started, Updated: s.Updated, Touched: topTouchedFiles(s.Messages)}
+}
+
+// agentOwnedFile drops the agent's own working files. They are touched
+// constantly while a subject is being worked on, so left in they take the top
+// slots from the source that was actually being changed — measured: the six
+// stored paths held no repository file at all for a session whose work was
+// entirely in one.
+func agentOwnedFile(p string) bool {
+	for _, seg := range []string{"/scratchpad/", "/tasks/", "/.claude/", "/.cache/", "/claude-501/", "/node_modules/", "/.git/"} {
+		if strings.Contains(p, seg) {
+			return true
+		}
+	}
+	return strings.HasSuffix(p, ".log") || strings.HasSuffix(p, ".output")
+}
+
+// topTouchedFiles returns the files a session worked on most, busiest first.
+func topTouchedFiles(ms []model.Message) []string {
+	count := map[string]int{}
+	for _, m := range ms {
+		if m.Role != roleFiles {
+			continue
+		}
+		for _, p := range strings.Split(m.Text, "\n") {
+			if p = strings.TrimSpace(p); p != "" && !agentOwnedFile(p) {
+				count[p]++
+			}
+		}
+	}
+	if len(count) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(count))
+	for p := range count {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if count[out[i]] != count[out[j]] {
+			return count[out[i]] > count[out[j]]
+		}
+		return out[i] < out[j]
+	})
+	if len(out) > touchedFileCap {
+		out = out[:touchedFileCap]
+	}
+	return out
 }
 
 func metaWithOrd(meta SessionMeta, ord uint32) SessionMeta {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1029,7 +1029,7 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		}
 		s := by[r.Key]
 		if s == nil {
-			cp := model.Session{ID: meta.ID, Harness: meta.Harness, Project: meta.Project, Path: meta.Path, Title: meta.Title, Started: meta.Started, Updated: meta.Updated}
+			cp := model.Session{ID: meta.ID, Harness: meta.Harness, Project: meta.Project, Path: meta.Path, Title: meta.Title, Started: meta.Started, Updated: meta.Updated, Touched: meta.Touched}
 			s = &cp
 			by[r.Key] = s
 		}

--- a/internal/index/tool_postings_test.go
+++ b/internal/index/tool_postings_test.go
@@ -1,6 +1,12 @@
 package index
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
 
 func TestPostingRoundTripCarriesTheToolBit(t *testing.T) {
 	in := []posting{
@@ -100,5 +106,30 @@ func TestTokenizedPartIndexesOnlyThePathOfASpan(t *testing.T) {
 	// A span with no body still has to yield its path rather than nothing.
 	if got := tokenizedPart(roleEdit, "/w/only.go"); got != "/w/only.go" {
 		t.Fatalf("got %q", got)
+	}
+}
+
+func TestTopTouchedFilesRanksAndFiltersAgentFiles(t *testing.T) {
+	ms := []model.Message{
+		{Role: roleFiles, Text: "/w/app.go\n/w/app.go"},
+		{Role: roleFiles, Text: "/w/app.go\n/w/util.go\n/Users/x/.claude/notes.md\n/w/build.log"},
+		{Role: "user", Text: "/w/never.go"},
+	}
+	got := topTouchedFiles(ms)
+	if len(got) != 2 || got[0] != "/w/app.go" || got[1] != "/w/util.go" {
+		t.Fatalf("got %v, want the busiest repository files only", got)
+	}
+	if topTouchedFiles(nil) != nil {
+		t.Fatal("no file records, nothing stored")
+	}
+}
+
+func TestTopTouchedFilesIsCapped(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < 40; i++ {
+		fmt.Fprintf(&b, "/w/f%02d.go\n", i)
+	}
+	if got := topTouchedFiles([]model.Message{{Role: roleFiles, Text: b.String()}}); len(got) != touchedFileCap {
+		t.Fatalf("stored %d paths, want the cap of %d", len(got), touchedFileCap)
 	}
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -21,6 +21,11 @@ type Session struct {
 	Updated  time.Time `json:"updated"`
 	Messages []Message `json:"messages,omitempty"`
 	Source   *Source   `json:"source,omitempty"`
+	// Touched lists the few files this session worked on most. Parsers do not
+	// set it; the index fills it from what it stored, so a caller holding a
+	// search result can ask a cheap question about those files without reading
+	// the session back.
+	Touched []string `json:"touched,omitempty"`
 }
 
 // Source identifies where a session entered this deja index. Instance is an

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -84,6 +84,10 @@ type Hit struct {
 	// decision was rejected, superseded or has gone stale. A hit on a raw
 	// transcript used to arrive with no trace of that, so a decision someone
 	// had explicitly reverted came back reading like current truth.
+	// Moved is set by the CLI when some of the files this session touched have
+	// commits since it ended. Computing it means forking git, which this
+	// package does not do, so it arrives filled in rather than derived here.
+	Moved         string `json:"moved,omitempty"`
 	Lifecycle     string `json:"lifecycle,omitempty"`
 	LifecycleNote string `json:"lifecycle_note,omitempty"`
 	LifecycleAt   string `json:"lifecycle_at,omitempty"`
@@ -707,6 +711,13 @@ func Print(w io.Writer, hits []Hit, o Options) {
 			note := "  " + lifecycleSummary(h)
 			if color {
 				note = cOrange + note + cReset
+			}
+			fmt.Fprintln(w, note)
+		}
+		if h.Moved != "" {
+			note := h.Moved
+			if color {
+				note = cDim + note + cReset
 			}
 			fmt.Fprintln(w, note)
 		}


### PR DESCRIPTION
Closes #531.

The shape in the issue — name *the* file a decision was about and warn on it — does not survive measurement. On 551 sessions with the tool paths now indexed:

| | |
|---|---|
| record no path at all | 203 (37%) |
| name a file that no longer exists on disk | 154 (28%) |
| resolve, unchanged since | 89 (16%) |
| resolve, changed since | 84 (15%) |

And picking the single most-touched file is right about half the time by hand-check on twelve — better than the prose linkage this replaces, not good enough to be authoritative.

So the claim is rewritten to one that needs no guessing and is true by construction: **`4 files this session touched have changed since`**. Deliberately no "unchanged" claim in the other direction, because silence means "cannot tell" far more often than "nothing moved", and the issue is right that a quiet case which carries no information makes the loud one meaningless.

Cost. The first cut read each hit's session back to find its files and forked git per file: **550 ms on a command whose search takes 30 ms**. Now the session's busiest files ride in the manifest, so the annotation is free of I/O, one git invocation covers a whole repository, and a session younger than 12 h is skipped outright. Measured on 1150 sessions: 74 ms vs 75 ms when the hits are recent, 98 ms vs 29 ms when one of them is from May and really has moved.

The manifest field is additive — an index built before this decodes with it empty and the annotation simply does not appear until the next rebuild, so no version bump and no forced reindex on top of 0.16.4's.