### PR TITLE
feat(onboarding): build the index on install, and on a bare first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ deja install --all     # MCP recall for every agent it finds on this machine
 deja install --auto    # same, plus session-start auto-recall where supported
 ```
 
+Install also builds the index from the histories it finds, so the first agent
+session after it is instant rather than paying for the build. `--no-index`
+skips that for scripted installs; running `deja` with nothing indexed builds it
+too.
+
 Claude Code users can skip that step and install everything as a plugin instead:
 
 ```sh

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -14,10 +14,28 @@ import (
 // Manifest metadata and the usage sidecar only — it must feel instant.
 // Pipes and scripts still get the usage text; `deja help` always works.
 func runBrief(dir string, w io.Writer) error {
+	justGreeted := false
 	ov, err := index.Overview(dir)
 	if err != nil || ov.Sessions == 0 {
-		printUsage()
-		return nil
+		// Nothing indexed yet. Printing usage here is what a fresh install used
+		// to do, and it is the wrong answer to `deja`: the reader has just
+		// installed the thing and gets forty lines of command syntax instead of
+		// one fact about their own work. Build the index — the progress display
+		// and the per-harness summary already exist — and show the brief.
+		if !index.HasManifest(dir) {
+			greeted, err := buildForFirstRun(dir)
+			if err != nil {
+				return err
+			}
+			justGreeted = greeted
+			if ov, err = index.Overview(dir); err != nil {
+				return err
+			}
+		}
+		if ov.Sessions == 0 {
+			printNoHistory(w)
+			return nil
+		}
 	}
 	color := statColorOK(os.Stdout)
 	bold, dim, reset := "", "", ""
@@ -64,7 +82,10 @@ func runBrief(dir string, w io.Writer) error {
 		}
 	}
 
-	if q := suggestFirstQuery(dir); q != "" {
+	// The greeting printed on a first build already ends with this exact
+	// suggestion. Printing it twice on the one screen that has to be legible
+	// is worse than not printing it at all.
+	if q := suggestFirstQuery(dir); q != "" && !justGreeted {
 		fmt.Fprintf(w, "try        %sdeja \"%s\"%s %s(from your own history)%s\n", bold, q, reset, dim, reset)
 	}
 	fmt.Fprintf(w, "%smore       deja log · deja stats · deja help%s\n", dim, reset)
@@ -84,4 +105,34 @@ func trimBriefTitle(t string) string {
 		return string(r[:44]) + "…"
 	}
 	return t
+}
+
+// buildForFirstRun indexes with the same narration `deja warmup` uses, so the
+// wait is legible and ends in the per-harness summary rather than in silence.
+// It reports whether the greeting was actually printed, so the brief does not
+// repeat the suggestion the greeting already ends with.
+func buildForFirstRun(dir string) (bool, error) {
+	prepareFirstIndexGreeting(dir)
+	if err := withBuildProgress(func() error { return index.Ensure(dir, "", false, os.Stderr) }); err != nil {
+		return false, err
+	}
+	before := index.LastBuild
+	maybeFirstIndexGreeting(dir)
+	return before.Initial && before.Messages > 0 && logoWanted(os.Stdout), nil
+}
+
+// printNoHistory is the honest empty state: the index built and found nothing.
+// It names where deja looked, because the usual cause is that the agent stores
+// live somewhere this machine does not have.
+func printNoHistory(w io.Writer) {
+	fmt.Fprintln(w, "deja-vu "+version+" · no agent history found yet")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "deja reads the session stores your agents already write —")
+	fmt.Fprintln(w, "Claude Code, Codex, opencode, Cursor, Gemini, Copilot and ten more.")
+	fmt.Fprintln(w, "Nothing was found on this machine, which usually means no agent has")
+	fmt.Fprintln(w, "run here yet, or its store lives somewhere else.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  deja sources     what was looked for, and where")
+	fmt.Fprintln(w, "  deja doctor      check the setup")
+	fmt.Fprintln(w, "  deja help        every command")
 }

--- a/cmd/deja/first_run_test.go
+++ b/cmd/deja/first_run_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The first command a new user runs is `deja`. Before this, with nothing
+// indexed, it printed forty lines of usage; these tests pin the two honest
+// answers — build and show, or say plainly that nothing was found.
+
+func TestFirstRunBuildsTheIndexAndBriefs(t *testing.T) {
+	tmp := hermeticEnv(t)
+	proj := filepath.Join(tmp, "claude", "project")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"claude-first","cwd":"/w","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"the retry loop drops the last attempt"}}`
+	if err := os.WriteFile(filepath.Join(proj, "s.jsonl"), []byte(line+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if index.HasManifest(dir) {
+		t.Fatal("test starts with an index, which is not the case under test")
+	}
+
+	var out bytes.Buffer
+	if err := runBrief(dir, &out); err != nil {
+		t.Fatalf("brief: %v", err)
+	}
+	if !index.HasManifest(dir) {
+		t.Fatal("the first run should have built the index")
+	}
+	got := out.String()
+	if !strings.Contains(got, "deja-vu") || !strings.Contains(got, "1 session") {
+		t.Fatalf("want a brief over the freshly built index, got:\n%s", got)
+	}
+	if strings.Contains(got, "Usage:") {
+		t.Fatalf("usage should not be the answer to a bare command:\n%s", got)
+	}
+}
+
+func TestFirstRunSaysSoWhenThereIsNoHistory(t *testing.T) {
+	// Hermetic env with no stores at all: the build finds nothing, and the
+	// answer has to name where deja looked rather than dumping command syntax.
+	hermeticEnv(t)
+	var out bytes.Buffer
+	if err := runBrief(index.DefaultDir(), &out); err != nil {
+		t.Fatalf("brief: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "no agent history found") {
+		t.Fatalf("got:\n%s", got)
+	}
+	for _, want := range []string{"deja sources", "deja doctor", "deja help"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the empty state should point at %q", want)
+		}
+	}
+	if strings.Contains(got, "deja [flags] <query>") {
+		t.Fatalf("usage block leaked into the empty state:\n%s", got)
+	}
+}
+
+func TestBriefLeavesAnExistingIndexAlone(t *testing.T) {
+	tmp := hermeticEnv(t)
+	proj := filepath.Join(tmp, "claude", "project")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"claude-x","cwd":"/w","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"pgbouncer prepared statements"}}`
+	if err := os.WriteFile(filepath.Join(proj, "s.jsonl"), []byte(line+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	var first bytes.Buffer
+	if err := runBrief(dir, &first); err != nil {
+		t.Fatal(err)
+	}
+	// A second run must not rebuild: the brief reads the index as it stands.
+	before, err := os.Stat(filepath.Join(dir, "manifest.gob"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var second bytes.Buffer
+	if err := runBrief(dir, &second); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(filepath.Join(dir, "manifest.gob"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Fatal("the brief rebuilt an index that already existed")
+	}
+}
+
+func TestInstallSkipsTheBuildWhenAsked(t *testing.T) {
+	tmp := hermeticEnv(t)
+	proj := filepath.Join(tmp, "claude", "project")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"claude-y","cwd":"/w","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"scripted install"}}`
+	if err := os.WriteFile(filepath.Join(proj, "s.jsonl"), []byte(line+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := runInstall(dir, []string{"claude", "--no-index", "--no-guidance"}, false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if index.HasManifest(dir) {
+		t.Fatal("--no-index should leave the build for later")
+	}
+}
+
+func TestInstallBuildsTheIndex(t *testing.T) {
+	tmp := hermeticEnv(t)
+	proj := filepath.Join(tmp, "claude", "project")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"claude-z","cwd":"/w","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"index at install time"}}`
+	if err := os.WriteFile(filepath.Join(proj, "s.jsonl"), []byte(line+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := runInstall(dir, []string{"claude", "--no-guidance"}, false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !index.HasManifest(dir) {
+		t.Fatal("install should leave a usable index behind")
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -19,10 +19,16 @@ type installResult struct{ Path, Action string }
 
 func runInstall(dir string, args []string, uninstall bool) error {
 	guidance := true
+	noIndex := false
 	var targetArgs []string
 	for _, arg := range args {
 		if arg == "--no-guidance" {
 			guidance = false
+			continue
+		}
+		// For scripted installs that do not want to spend the build here.
+		if arg == "--no-index" {
+			noIndex = true
 			continue
 		}
 		targetArgs = append(targetArgs, arg)
@@ -131,8 +137,13 @@ func runInstall(dir string, args []string, uninstall bool) error {
 			hookCount++
 		}
 	}
-	if !uninstall && (targetArgs[0] == "--auto" || targetArgs[0] == "--all") {
-		installIndexWarmup(dir, mcpCount, hookCount, guidanceCount)
+	// Every install builds, not only --auto and --all. Installing is the one
+	// moment a person has already accepted a wait — they just ran an installer
+	// — and spending the build here is what keeps the first real use, usually
+	// the first agent turn, instant.
+	if !uninstall && !noIndex {
+		installIndexWarmup(dir, mcpCount, hookCount, guidanceCount,
+			targetArgs[0] == "--auto" || targetArgs[0] == "--all")
 	}
 	if banner {
 		info := append(brandInfo(), "")
@@ -153,7 +164,7 @@ func runInstall(dir string, args []string, uninstall bool) error {
 	return nil
 }
 
-func installIndexWarmup(dir string, mcp, hooks, guidance int) {
+func installIndexWarmup(dir string, mcp, hooks, guidance int, summary bool) {
 	built := false
 	detected := 0
 	if !index.HasManifest(dir) {
@@ -161,12 +172,22 @@ func installIndexWarmup(dir string, mcp, hooks, guidance int) {
 			store, _ := inspectDoctorStore(check)
 			if store.Files > 0 {
 				detected++
-				if err := index.Ensure(dir, "", false, os.Stderr); err == nil {
-					built = true
-				}
+				// With the progress display, so twenty seconds of silence does
+				// not look like a hang on the very first command.
+				prepareFirstIndexGreeting(dir)
+				err := withBuildProgress(func() error { return index.Ensure(dir, "", false, os.Stderr) })
+				index.SuppressHarnessNarration = false
+				built = err == nil
 				break
 			}
 		}
+	}
+	if !summary {
+		if built {
+			b := index.LastBuild
+			fmt.Fprintf(os.Stderr, "index: built (%d sessions, %d messages)\n", b.Sessions, b.Messages)
+		}
+		return
 	}
 	fmt.Fprintf(os.Stderr, "installed: %d MCP, %d hooks, %d guidance files\n", mcp, hooks, guidance)
 	if built {


### PR DESCRIPTION
Closes #572, closes #573.

On a machine with no index, `deja` printed forty lines of usage — command syntax as the answer to the first command a person runs after installing. It now builds the index and prints the brief. The pieces already existed and were only reachable through `deja warmup`: the progress display, the per-harness summary, the suggested query drawn from the user's own history.

```
antigravity     393 messages · 8 sessions
claude        72414 messages · 55 sessions
opencode      44397 messages · 977 sessions
...
indexed 116054 messages across 15 agents
try it on your own history:  deja "..."

deja-vu · 1150 sessions across 15 agents
today      3 sessions
this week  145 sessions · 0 recalls
recent     [claude] goprojects/deja-vu · today · ...
```

When the build finds nothing, the answer names where deja looked and what to run next, rather than falling back to usage.

Install builds too, and not only for `--auto`/`--all` as before — installing is the moment a person has already accepted a wait, and spending the build there is what keeps the first agent turn instant. `--no-index` opts out for scripted installs. The build now runs behind the progress display, so it is not twenty silent seconds.

Also drops a duplicate: the greeting and the brief both ended with the same suggested query.