### PR TITLE
feat(compact): hand a compacted session back its own evidence

### DIFF
--- a/cmd/deja/compact.go
+++ b/cmd/deja/compact.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// What a compaction actually costs, measured on 58 transcripts and 43
+// compaction events (#543): 2.59 GB of conversation replaced by 0.72 MB of
+// summary, and the loss is lopsided.
+//
+//	decision sentences   ~77% survive
+//	file paths            9.8%
+//	commands that ran     0.2%
+//	measured numbers      1.9%
+//
+// The compactor is good at what it was built for. The summary remembers what
+// was decided and forgets what the decision rested on — the command that proved
+// it, the file it was in, the number that made it right.
+//
+// That material is exactly what the index started keeping in 0.16.4, and the
+// session it belongs to is the one being compacted. So after a compaction the
+// hook hands the session back its own evidence rather than generic recall.
+const (
+	// compactEvidenceFiles and compactEvidenceCommands bound the block. It is
+	// injected into a context window that was just emptied on purpose; taking a
+	// meaningful bite out of it again would be its own kind of loss.
+	compactEvidenceFiles    = 8
+	compactEvidenceCommands = 8
+	// compactCommandMax is the length past which a command is a pasted script
+	// rather than something worth handing back.
+	compactCommandMax = 120
+)
+
+// compactEvidence describes what a session did before it was compacted, or ""
+// when the session is not in the index yet or recorded nothing worth saying.
+func compactEvidence(dir, sessionID string) string {
+	if sessionID == "" {
+		return ""
+	}
+	s, ok, err := index.FindByID(dir, sessionID)
+	if err != nil || !ok {
+		return ""
+	}
+	files := lastDistinct(s.Messages, "files", compactEvidenceFiles,
+		func(text string) []string { return strings.Split(text, "\n") }, trimPath)
+	commands := lastDistinct(s.Messages, "command", compactEvidenceCommands,
+		func(text string) []string {
+			// A multi-line command is a heredoc or a pasted script. Truncated to
+			// one line it says nothing, and whole it would swallow the block.
+			if strings.Contains(text, "\n") || len(text) > compactCommandMax {
+				return nil
+			}
+			return []string{text}
+		}, func(c string) string { return c })
+	if len(files) == 0 && len(commands) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("What this session did before the compaction, from deja's index — " +
+		"a summary keeps conclusions and drops the specifics they rest on:\n")
+	if len(files) > 0 {
+		fmt.Fprintf(&b, "  files it touched: %s\n", strings.Join(files, ", "))
+	}
+	if len(commands) > 0 {
+		b.WriteString("  commands it ran:\n")
+		for _, c := range commands {
+			fmt.Fprintf(&b, "    %s\n", c)
+		}
+	}
+	return b.String()
+}
+
+// lastDistinct collects the most recent distinct entries of one role, newest
+// first. Recency rather than frequency: after a compaction the useful thing is
+// what the session was doing when the window filled, not what it did an hour
+// earlier.
+func lastDistinct(ms []model.Message, role string, limit int, split func(string) []string, format func(string) string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for i := len(ms) - 1; i >= 0 && len(out) < limit; i-- {
+		if ms[i].Role != role {
+			continue
+		}
+		for _, p := range split(ms[i].Text) {
+			p = strings.TrimSpace(p)
+			if p == "" || seen[p] || isScratch(p) {
+				continue
+			}
+			seen[p] = true
+			out = append(out, format(p))
+			if len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out
+}

--- a/cmd/deja/compact_test.go
+++ b/cmd/deja/compact_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestLastDistinctTakesTheNewestAndDeduplicates(t *testing.T) {
+	ms := []model.Message{
+		{Role: "files", Text: "/w/a.go"},
+		{Role: "user", Text: "/w/ignored.go"},
+		{Role: "files", Text: "/w/b.go\n/w/a.go"},
+		{Role: "files", Text: "/w/c.go"},
+	}
+	got := lastDistinct(ms, "files", 3,
+		func(s string) []string { return strings.Split(s, "\n") },
+		func(s string) string { return s })
+	// Newest first, each path once, and nothing from another role.
+	want := []string{"/w/c.go", "/w/b.go", "/w/a.go"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	if len(lastDistinct(ms, "files", 1, func(s string) []string { return strings.Split(s, "\n") },
+		func(s string) string { return s })) != 1 {
+		t.Fatal("the limit should bound the block")
+	}
+}
+
+func TestLastDistinctDropsAgentScratch(t *testing.T) {
+	ms := []model.Message{{Role: "files", Text: "/Users/x/.claude/notes.md\n/w/real.go"}}
+	got := lastDistinct(ms, "files", 5,
+		func(s string) []string { return strings.Split(s, "\n") },
+		func(s string) string { return s })
+	if len(got) != 1 || got[0] != "/w/real.go" {
+		t.Fatalf("got %v, want the repository file only", got)
+	}
+}
+
+func writeCompactFixture(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	proj := filepath.Join(tmp, "claude", "project")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	line := func(format string, a ...any) { fmt.Fprintf(&b, format+"\n", a...) }
+	line(`{"type":"user","sessionId":"claude-compact","cwd":"/w","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"make the retry loop stop dropping the last attempt"}}`)
+	line(`{"type":"assistant","sessionId":"claude-compact","cwd":"/w","timestamp":"2026-01-02T03:05:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/w/pkg/retry.go"}}]}}`)
+	line(`{"type":"assistant","sessionId":"claude-compact","cwd":"/w","timestamp":"2026-01-02T03:06:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go test ./pkg/ -run Retry -count=3"}}]}}`)
+	// A pasted script: whole it swallows the block, truncated it says nothing.
+	line(`{"type":"assistant","sessionId":"claude-compact","cwd":"/w","timestamp":"2026-01-02T03:07:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"python3 - <<'PY'\nimport os\nprint(os.getcwd())\nPY"}}]}}`)
+	if err := os.WriteFile(filepath.Join(proj, "s.jsonl"), []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return tmp
+}
+
+func TestCompactEvidenceNamesWhatTheSummaryDrops(t *testing.T) {
+	writeCompactFixture(t)
+	got := compactEvidence(index.DefaultDir(), "claude-compact")
+	if got == "" {
+		t.Fatal("a session with files and commands should produce a block")
+	}
+	if !strings.Contains(got, "retry.go") {
+		t.Errorf("the files it touched should be named:\n%s", got)
+	}
+	if !strings.Contains(got, "go test ./pkg/ -run Retry -count=3") {
+		t.Errorf("the command it ran should be named:\n%s", got)
+	}
+	if strings.Contains(got, "<<'PY'") {
+		t.Errorf("a pasted script is not evidence worth handing back:\n%s", got)
+	}
+}
+
+func TestCompactEvidenceSaysNothingWhenItCannot(t *testing.T) {
+	writeCompactFixture(t)
+	dir := index.DefaultDir()
+	if got := compactEvidence(dir, ""); got != "" {
+		t.Errorf("no session id, no block: %q", got)
+	}
+	if got := compactEvidence(dir, "claude-not-indexed-yet"); got != "" {
+		t.Errorf("an unknown session says nothing: %q", got)
+	}
+}
+
+func TestFindByIDFindsWithoutTheHarness(t *testing.T) {
+	writeCompactFixture(t)
+	dir := index.DefaultDir()
+	s, ok, err := index.FindByID(dir, "claude-compact")
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v", ok, err)
+	}
+	if s.Harness != "claude" || len(s.Messages) == 0 {
+		t.Fatalf("got %+v", s.Harness)
+	}
+	if _, ok, _ := index.FindByID(dir, "nope"); ok {
+		t.Fatal("an unknown id should not resolve")
+	}
+	if _, ok, _ := index.FindByID(dir, ""); ok {
+		t.Fatal("an empty id should not resolve")
+	}
+}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -84,7 +84,8 @@ func runHookContext(dir string, plain bool) error {
 	// says which. After a compaction the model just lost its working context,
 	// so the lead line changes to say the memory below survived it.
 	var input struct {
-		Source string `json:"source"`
+		Source    string `json:"source"`
+		SessionID string `json:"session_id"`
 	}
 	_ = json.Unmarshal(readHookStdin(), &input)
 	digest, sessions, raw, taskMatched := cachedHookDigest(dir)
@@ -112,6 +113,13 @@ func runHookContext(dir string, plain bool) error {
 	lead := "The sessions below are from this project's recent history. If any is relevant to what the user asks next, call recall_context with a term from it to pull the full details before acting. If recalled history genuinely helps the task, tell the user in one digest.Short line what deja-vu recalled and how you reused it; otherwise do not mention it.\n"
 	if input.Source == "compact" {
 		lead = "Context was just compacted. The project memory below is from deja's index and survived the compaction; call recall_context with a term from it to restore any details you lost.\n"
+		// The generic digest is about the project. What a compacted session
+		// most needs is its own evidence: measured on this corpus, a summary
+		// keeps ~77% of the decisions and 0.2% of the commands that produced
+		// them (#543).
+		if ev := compactEvidence(dir, input.SessionID); ev != "" {
+			lead += "\n" + ev + "\n"
+		}
 	}
 	digest = lead + digest
 	if tip := limitHandoffTip(dir); tip != "" {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -954,6 +954,35 @@ func FindByIdentity(dir, harness, id string) (model.Session, bool, error) {
 	return loadSessionMeta(dir, m, meta)
 }
 
+// FindByID looks a session up when only its id is known. Hook payloads carry
+// one without naming the harness, and the id is unique in practice: the
+// harnesses that generate them use uuids or their own prefixed ids.
+func FindByID(dir, id string) (model.Session, bool, error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	if id == "" {
+		return model.Session{}, false, nil
+	}
+	unlock, ok, err := tryLockDir(dir)
+	if err != nil {
+		return model.Session{}, false, err
+	}
+	if ok {
+		defer unlock()
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return model.Session{}, false, err
+	}
+	for _, meta := range m.Sessions {
+		if meta.ID == id {
+			return loadSessionMeta(dir, m, meta)
+		}
+	}
+	return model.Session{}, false, nil
+}
+
 func loadSessionMeta(dir string, m Manifest, meta SessionMeta) (model.Session, bool, error) {
 	s := sessionFromMeta(meta)
 	recs, err := recordsForKey(filepath.Join(dir, "records.bin"), tablesFromManifest(m), meta.Harness+":"+meta.ID)


### PR DESCRIPTION
Closes #543.

Measured first, and it moved the design. On 58 transcripts with 43 compaction events — 2.59 GB of conversation replaced by 0.72 MB of summary:

| | before the compaction | still in the summary |
|---|---|---|
| decision sentences | 132 | ~77% |
| file paths | 10,335 | **9.8%** |
| commands that ran | 14,439 | **0.2%** |
| measured numbers (ms, MB, %) | 834 | **1.9%** |

So the compactor is good at what it was built for and the loss is elsewhere: the summary says a fix was chosen and drops the command that proved it, the file it was in, and the number that made it right. That material is what 0.16.4 started indexing, and it belongs to the session being compacted — so on `source: compact` the hook now adds that session's own specifics ahead of the usual project recall:

```
What this session did before the compaction, from deja's index —
a summary keeps conclusions and drops the specifics they rest on:
  files it touched: internal/index/store_io.go, cmd/deja/moved.go, …
  commands it ran:
    $ go test ./internal/index/ -run Posting -count=2
    $ go run ./scripts/rankdiff
```

Bounded to eight files and eight commands, because it is injected into a window that was just emptied on purpose. Pasted scripts and heredocs are dropped — truncated they say nothing, whole they would swallow the block — as is agent scratch.

Also adds `index.FindByID`: hook payloads carry a session id without naming the harness, and `FindByIdentity` needs both.