### PR TITLE
feat(brief): show a question this store has been asked before

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -82,6 +82,14 @@ func runBrief(dir string, w io.Writer) error {
 		}
 	}
 
+	// The one line on this screen that says something a person could not have
+	// noticed themselves: a question they asked in more than one session. A
+	// count of sessions is reporting; this is the thing the tool is for.
+	if a, ok := index.FindAskedTwice(dir); ok {
+		fmt.Fprintf(w, "asked      %s%s%s\n", bold, trimBriefTitle(a.Text), reset)
+		fmt.Fprintf(w, "before     %s%s%s\n", dim, askedWhen(a), reset)
+	}
+
 	// The greeting printed on a first build already ends with this exact
 	// suggestion. Printing it twice on the one screen that has to be legible
 	// is worse than not printing it at all.
@@ -135,4 +143,26 @@ func printNoHistory(w io.Writer) {
 	fmt.Fprintln(w, "  deja sources     what was looked for, and where")
 	fmt.Fprintln(w, "  deja doctor      check the setup")
 	fmt.Fprintln(w, "  deja help        every command")
+}
+
+// askedWhen says how far apart the askings were, which is the point of the
+// line: the same question in May and again in June is worth a reader's
+// attention in a way that "asked 4 times" is not.
+func askedWhen(a index.AskedTwice) string {
+	n := len(a.Sessions)
+	newest := a.Sessions[0].Updated
+	oldest := a.Sessions[n-1].Updated
+	span := fmt.Sprintf("%s → %s", oldest.Format("Jan 2"), search.RelativeDate(newest))
+	project := a.Sessions[0].Project
+	for _, m := range a.Sessions {
+		if m.Project != project {
+			project = ""
+			break
+		}
+	}
+	times := fmt.Sprintf("%d sessions", n)
+	if project != "" && project != "-" {
+		times += " in " + project
+	}
+	return times + " · " + span
 }

--- a/internal/index/asked_test.go
+++ b/internal/index/asked_test.go
@@ -1,0 +1,164 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestLooksLikeQuestion(t *testing.T) {
+	for _, s := range []string{
+		"did we fix the jwks cache stampede before?",
+		"why does the pool exhaust under load",
+		"сколько по времени займут такие прогоны",
+		"репозиторий готов к публикации?",
+	} {
+		if !looksLikeQuestion(s) {
+			t.Errorf("%q is a question", s)
+		}
+	}
+	// Instructions to an agent repeat verbatim across sessions by construction,
+	// which is exactly why they must not count as questions someone asked.
+	for _, s := range []string{
+		"Use the deja recall tool to search for: openclaw harness",
+		"Call the build_check tool with scope all",
+		"Reply with only the raw JSON returned by the tool",
+		"Continue if you have next steps, or stop and ask for clarification",
+		"",
+		"   ",
+	} {
+		if looksLikeQuestion(s) {
+			t.Errorf("%q is not a question someone asked", s)
+		}
+	}
+}
+
+func TestNotAskedRejectsHarnessText(t *testing.T) {
+	for _, s := range []string{
+		"<system-reminder>do the thing</system-reminder>",
+		"[Request interrupted by user]",
+		"The following tool was executed by the user",
+		"This session is being continued from a previous conversation",
+		"Continue from where you left off.",
+		"<deja-recall>...</deja-recall>",
+	} {
+		if !notAsked(s) {
+			t.Errorf("%q is written by a harness, not a person", s)
+		}
+	}
+	if notAsked("why is the index rebuilding on every run?") {
+		t.Error("a real question should survive")
+	}
+}
+
+func TestQuestionStemNeedsSubstance(t *testing.T) {
+	if got := questionStem("Why  does THE pool exhaust, under load?"); got != "why does the pool exhaust under load" {
+		t.Fatalf("got %q", got)
+	}
+	if questionStem("ok thanks") != "" {
+		t.Fatal("four words or fewer is not a question worth matching")
+	}
+}
+
+func TestAskedHashesAreStableAndBounded(t *testing.T) {
+	q := "why does the connection pool exhaust under load?"
+	a := askedHashes([]model.Message{{Role: "user", Text: q}})
+	b := askedHashes([]model.Message{{Role: "user", Text: "  WHY does the connection POOL exhaust, under load? "}})
+	if len(a) != 1 || len(b) != 1 || a[0] != b[0] {
+		t.Fatalf("the same question asked twice must hash alike: %v vs %v", a, b)
+	}
+	// Assistant turns are not questions the user asked.
+	if got := askedHashes([]model.Message{{Role: "assistant", Text: q}}); len(got) != 0 {
+		t.Fatalf("got %v", got)
+	}
+	var many []model.Message
+	for i := 0; i < 30; i++ {
+		many = append(many, model.Message{Role: "user", Text: "why does thing number " + string(rune('a'+i)) + " fail here?"})
+	}
+	if got := askedHashes(many); len(got) != askedQuestionCap {
+		t.Fatalf("stored %d hashes, want the cap of %d", len(got), askedQuestionCap)
+	}
+	// The same question twice in one session is one question.
+	if got := askedHashes([]model.Message{{Role: "user", Text: q}, {Role: "user", Text: q}}); len(got) != 1 {
+		t.Fatalf("got %v", got)
+	}
+}
+
+// askedFixture writes real transcripts and indexes them, the way the other
+// tests in this package do: FindAskedTwice reads the manifest the ingest wrote,
+// so a hand-built store would test something else.
+func askedFixture(t *testing.T, sessions map[string][]string, when map[string]string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "claude", "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for id, msgs := range sessions {
+		var b strings.Builder
+		for _, m := range msgs {
+			fmt.Fprintf(&b, `{"type":"user","sessionId":%q,"cwd":"/tmp/app","timestamp":%q,"message":{"role":"user","content":%q}}`+"\n",
+				id, when[id], m)
+		}
+		if err := os.WriteFile(filepath.Join(proj, id+".jsonl"), []byte(b.String()), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestFindAskedTwicePicksTheWidestSpan(t *testing.T) {
+	// The same question two months apart, and another asked twice in one
+	// afternoon. The second is a person retrying; the first is the one worth a
+	// line on a screen.
+	q := "why does the connection pool exhaust under load?"
+	flaky := "how do i make the flaky test stop failing?"
+	dir := askedFixture(t,
+		map[string][]string{
+			"a": {q},
+			"b": {q},
+			"c": {flaky},
+			"d": {flaky},
+		},
+		map[string]string{
+			"a": "2026-03-01T10:00:00Z",
+			"b": "2026-05-01T10:00:00Z",
+			"c": "2026-05-02T10:00:00Z",
+			"d": "2026-05-02T14:00:00Z",
+		})
+	got, ok := FindAskedTwice(dir)
+	if !ok {
+		t.Fatal("a question asked two months apart should be found")
+	}
+	if got.Text != q {
+		t.Fatalf("got %q", got.Text)
+	}
+	if len(got.Sessions) != 2 || !got.Sessions[0].Updated.After(got.Sessions[1].Updated) {
+		t.Fatalf("sessions should come back newest first: %+v", got.Sessions)
+	}
+}
+
+func TestFindAskedTwiceStaysQuietWithoutARepeat(t *testing.T) {
+	dir := askedFixture(t,
+		map[string][]string{"a": {"why does the pool exhaust under load?"}},
+		map[string]string{"a": "2026-03-01T10:00:00Z"})
+	if _, ok := FindAskedTwice(dir); ok {
+		t.Fatal("one asking is not a repeat")
+	}
+	if _, ok := FindAskedTwice(t.TempDir()); ok {
+		t.Fatal("an empty store has nothing to say")
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -88,6 +88,13 @@ type SessionMeta struct {
 	ID, Harness, Project, Path, Title string
 	Started, Updated                  time.Time
 	Ord                               uint32
+	// Asked holds hashes of the substantial questions this session opened with.
+	// Hashes rather than text: the text of six questions per session would add
+	// a third of a megabyte to a manifest that is read on every search, and the
+	// only thing a caller needs from it is whether two sessions asked the same
+	// thing. The text is recovered from the two or three sessions that matched,
+	// which is a bounded cost paid once, on a screen a person is reading.
+	Asked []uint64 `json:",omitempty"`
 	// Touched holds the few files this session worked on most, so a caller can
 	// ask about them without loading the session. Reading one back cost 130-220
 	// ms, which is not a price worth paying for a footnote under a search hit.
@@ -100,6 +107,9 @@ type SessionMeta struct {
 // something useful about a session, small enough that a store of a thousand
 // sessions pays kilobytes for it.
 const touchedFileCap = 6
+
+// askedQuestionCap bounds the hashes stored per session.
+const askedQuestionCap = 8
 
 type Manifest struct {
 	Version          int                    `json:"version"`

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -720,7 +721,7 @@ func metaForSession(s model.Session) SessionMeta {
 	// composer name, the first user message — and are persisted in
 	// sessions.gob, so they need the same scrubbing as record text.
 	title, _ = redact.Text(title)
-	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, Started: s.Started, Updated: s.Updated, Touched: topTouchedFiles(s.Messages)}
+	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, Started: s.Started, Updated: s.Updated, Touched: topTouchedFiles(s.Messages), Asked: askedHashes(s.Messages)}
 }
 
 // agentOwnedFile drops the agent's own working files. They are touched
@@ -735,6 +736,106 @@ func agentOwnedFile(p string) bool {
 		}
 	}
 	return strings.HasSuffix(p, ".log") || strings.HasSuffix(p, ".output")
+}
+
+// askedHashes fingerprints the substantial things a person asked in a session.
+// Short turns are excluded the way stats excludes them: "ok" and "continue"
+// repeat in every session and mean nothing.
+func askedHashes(ms []model.Message) []uint64 {
+	var out []uint64
+	seen := map[uint64]bool{}
+	for _, m := range ms {
+		if m.Role != "user" {
+			continue
+		}
+		if notAsked(m.Text) || !looksLikeQuestion(m.Text) {
+			continue
+		}
+		stem := questionStem(m.Text)
+		if stem == "" {
+			continue
+		}
+		h := fnv.New64a()
+		_, _ = h.Write([]byte(stem))
+		v := h.Sum64()
+		if seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+		if len(out) >= askedQuestionCap {
+			break
+		}
+	}
+	return out
+}
+
+// notAsked rejects the text a harness writes under the user role: hook
+// envelopes, interruption notices, resume preambles, the compaction summary.
+// It repeats across sessions by construction, so without this the most
+// "repeated question" in any store is a piece of plumbing — measured: the first
+// candidate this produced was "The following tool was executed by the user",
+// spanning April to July.
+func notAsked(text string) bool {
+	t := strings.TrimSpace(text)
+	for _, p := range []string{
+		"<local-command", "<command-", "<task-notification", "<teammate-message",
+		"<bash-", "<system-reminder", "<deja-recall", "Caveat:",
+		"[Request interrupted", "The following tool was executed",
+		"This session is being continued", "Continue from where you left off",
+	} {
+		if strings.HasPrefix(t, p) {
+			return true
+		}
+	}
+	return strings.Contains(t, "no visible output")
+}
+
+// looksLikeQuestion keeps this to things a person actually asked. Without it
+// the candidates a real store produces are overwhelmingly instructions to an
+// agent — "Use the X tool", "Call Y with scope all", "Reply with only the raw
+// JSON" — which repeat verbatim by construction and say nothing about the work.
+//
+// A question mark, or an interrogative opening in either language deja sees
+// most. This under-includes on purpose: a missed repeat costs a line on one
+// screen, a wrong one costs the reader's trust in the screen.
+func looksLikeQuestion(text string) bool {
+	t := strings.TrimSpace(text)
+	if strings.Contains(t, "?") || strings.Contains(t, "？") {
+		return true
+	}
+	fields := strings.Fields(t)
+	if len(fields) == 0 {
+		return false
+	}
+	first := strings.Trim(strings.ToLower(fields[0]), ",.:;!\"'")
+	switch first {
+	case "what", "why", "how", "when", "where", "which", "who", "whose",
+		"did", "does", "do", "is", "are", "was", "were", "can", "should", "would",
+		"что", "чем", "почему", "зачем", "как", "какой", "какая", "какие", "когда",
+		"где", "куда", "откуда", "сколько", "кто", "чей", "можно", "нужно", "надо":
+		return true
+	}
+	return false
+}
+
+// questionStem folds a message to the form two askings of the same question
+// share: lowercase, letters and digits only. Fewer than five words is not a
+// question worth matching on.
+func questionStem(text string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(text) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte(' ')
+		}
+	}
+	fields := strings.Fields(b.String())
+	if len(fields) < 5 {
+		return ""
+	}
+	return strings.Join(fields, " ")
 }
 
 // topTouchedFiles returns the files a session worked on most, busiest first.

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -2201,3 +2201,91 @@ func isCyrToken(term string) bool {
 	}
 	return false
 }
+
+// askedMinSpan is how far apart two askings must be to mean anything.
+const askedMinSpan = 48 * time.Hour
+
+// AskedTwice is one question this store has been asked in more than one
+// session, with the sessions that asked it, newest first. Empty when nothing
+// repeats — which is the honest answer for a store a few days old.
+type AskedTwice struct {
+	Text     string
+	Sessions []SessionMeta
+}
+
+// FindAskedTwice picks the question worth showing: the one asked in the most
+// sessions, and among equals the one spanning the longest stretch of time. A
+// thing asked twice in one afternoon is a person working; the same thing asked
+// in March and again in July is the thing this tool exists for.
+//
+// The search runs entirely over the manifest. Only the matching sessions are
+// read back, and only to recover the text the hashes stand for.
+func FindAskedTwice(dir string) (AskedTwice, bool) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return AskedTwice{}, false
+	}
+	byHash := map[uint64][]SessionMeta{}
+	for _, meta := range m.Sessions {
+		for _, h := range meta.Asked {
+			byHash[h] = append(byHash[h], meta)
+		}
+	}
+	var best []SessionMeta
+	var bestSpan time.Duration
+	var bestHash uint64
+	for h, metas := range byHash {
+		if len(metas) < 2 {
+			continue
+		}
+		sort.Slice(metas, func(i, j int) bool { return metas[i].Updated.After(metas[j].Updated) })
+		span := metas[0].Updated.Sub(metas[len(metas)-1].Updated)
+		// Time between the askings, not the number of them. The same question
+		// sixteen times in one afternoon is somebody retrying; the same question
+		// in March and again in July is the thing worth showing. Below a couple
+		// of days it is the former.
+		if span < askedMinSpan {
+			continue
+		}
+		if span > bestSpan || (span == bestSpan && len(metas) > len(best)) {
+			best, bestSpan, bestHash = metas, span, h
+		}
+	}
+	if len(best) < 2 {
+		return AskedTwice{}, false
+	}
+	text := askedTextFor(dir, m, best, bestHash)
+	if text == "" {
+		return AskedTwice{}, false
+	}
+	return AskedTwice{Text: text, Sessions: best}, true
+}
+
+// askedTextFor recovers what a hash stood for by reading back the sessions that
+// carry it, stopping at the first one that yields the question.
+func askedTextFor(dir string, m Manifest, metas []SessionMeta, want uint64) string {
+	for _, meta := range metas {
+		s, ok, err := loadSessionMeta(dir, m, meta)
+		if err != nil || !ok {
+			continue
+		}
+		for _, msg := range s.Messages {
+			if msg.Role != "user" {
+				continue
+			}
+			stem := questionStem(msg.Text)
+			if stem == "" {
+				continue
+			}
+			h := fnv.New64a()
+			_, _ = h.Write([]byte(stem))
+			if h.Sum64() == want {
+				return strings.TrimSpace(msg.Text)
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Closes #574.

The brief reported sessions, agents and dates — all countable from the filesystem. This adds the one line that says something the reader could not have noticed themselves:

```
asked      репозиторий готов к публикации? все отлично …
before     4 sessions in mpc-autoscaler · May 21 → Jun 16
```

**Cost.** Question hashes ride in `SessionMeta`, so finding a repeat is a pass over the manifest with no record reads; only the matching sessions are read back, and only to recover the text a hash stands for. Hashes rather than text because storing six questions per session would add a third of a megabyte to a manifest read on every search. The field is additive — an older index decodes with it empty and the line simply does not appear.

**Two things the measurement changed.**

Ranking is by *time between askings*, not by how many times. The first candidate this produced was a demo fixture asked sixteen times in one afternoon — that is a person retrying, not something worth showing. Below 48 hours apart, it says nothing.

Then the top candidate by span became `The following tool was executed by the user`, spanning April to July, and after filtering harness text: `Continue if you have next steps, or stop and ask for clarification`. Listing every candidate on a real store showed why — they are overwhelmingly instructions to an agent (`Use the X tool`, `Call Y with scope all`, `Reply with only the raw JSON`), which repeat verbatim by construction. So only text shaped like a question counts: a question mark, or an interrogative opening in English or Russian. That under-includes on purpose — a missed repeat costs one line, a wrong one costs the reader's trust in the screen.