### PR TITLE
fix: keep work records and harness noise out of what people read

### DIFF
--- a/cmd/deja/stats_metrics.go
+++ b/cmd/deja/stats_metrics.go
@@ -13,7 +13,11 @@ func statsHeadline(r stats.Report) string {
 		parts = append(parts, fmt.Sprintf("%s sessions indexed", formatStatNumber(r.TotalSessions)))
 	}
 	if r.Recall.Recalls > 0 {
-		parts = append(parts, fmt.Sprintf("memory served %s times", formatStatNumber(r.Recall.Recalls)))
+		served := "times"
+		if r.Recall.Recalls == 1 {
+			served = "time"
+		}
+		parts = append(parts, fmt.Sprintf("memory served %s %s", formatStatNumber(r.Recall.Recalls), served))
 	}
 	if r.RepeatQuestions > 0 {
 		parts = append(parts, fmt.Sprintf("%s questions asked more than once", formatStatNumber(r.RepeatQuestions)))

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -111,6 +111,10 @@ const touchedFileCap = 6
 // askedQuestionCap bounds the hashes stored per session.
 const askedQuestionCap = 8
 
+// askedMaxRunes is how long a thing someone asked can be. Beyond this it is a
+// report, a paste, or an instruction with a question buried in it.
+const askedMaxRunes = 240
+
 type Manifest struct {
 	Version          int                    `json:"version"`
 	Files            map[string]FileState   `json:"files"`

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -801,7 +801,14 @@ func notAsked(text string) bool {
 // screen, a wrong one costs the reader's trust in the screen.
 func looksLikeQuestion(text string) bool {
 	t := strings.TrimSpace(text)
-	if strings.Contains(t, "?") || strings.Contains(t, "？") {
+	// A person's question is short. A pasted report that happens to contain a
+	// question mark two paragraphs in is not one, and shown truncated on a
+	// screen it reads as noise — measured: the first candidate to survive the
+	// earlier version was a 900-character critique of some charts.
+	if len([]rune(t)) > askedMaxRunes {
+		return false
+	}
+	if strings.HasSuffix(t, "?") || strings.HasSuffix(t, "？") {
 		return true
 	}
 	fields := strings.Fields(t)

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -201,6 +201,17 @@ func autoRecallSession(s model.Session, now time.Time, provenance bool) string {
 	if problem == "" && len(conclusions) == 0 {
 		return ""
 	}
+	// A harness smoke test is a real session and gets indexed like any other:
+	// "Reply with the single word OK" → "OK". Injected into an agent's context
+	// it teaches the reader that deja recalls worthless things.
+	//
+	// The test is deliberately narrow — a prompt asking for a token back,
+	// answered with a token. An earlier version cut on total length instead and
+	// dropped a one-line question with a short answer, which is memory worth
+	// having.
+	if isSmokeTest(problem, conclusions) {
+		return ""
+	}
 	var b strings.Builder
 	if provenance {
 		fmt.Fprintf(&b, "✓ recalled from %s session · %s\n", s.Harness, relativeDay(s.Updated, now))
@@ -267,4 +278,32 @@ func firstLine(s string, n int) string {
 		return s
 	}
 	return strings.TrimSpace(string(r[:n])) + "…"
+}
+
+// smokeAnswerMax is how short a reply has to be to read as a token rather than
+// an answer: "OK", "5", "NONE".
+const smokeAnswerMax = 20
+
+// smokeAsks are the openings of a prompt that asks for a token back.
+var smokeAsks = []string{
+	"reply with", "respond with", "answer with", "output only", "print only",
+	"quote the first", "say the word", "скажи ", "ответь ", "напиши слово",
+}
+
+// isSmokeTest reports whether a session is a harness check rather than work.
+func isSmokeTest(problem string, conclusions []string) bool {
+	total := 0
+	for _, c := range conclusions {
+		total += len(c)
+	}
+	if total > smokeAnswerMax {
+		return false
+	}
+	low := strings.ToLower(strings.TrimSpace(problem))
+	for _, p := range smokeAsks {
+		if strings.HasPrefix(low, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/search/recall_test.go
+++ b/internal/search/recall_test.go
@@ -1,0 +1,25 @@
+package search
+
+import "testing"
+
+func TestIsSmokeTestKeepsRealSessions(t *testing.T) {
+	if !isSmokeTest("Reply with the single word OK.", []string{"OK"}) {
+		t.Error("a token asked for and a token returned is a harness check")
+	}
+	if !isSmokeTest("скажи ок", []string{"Ок!"}) {
+		t.Error("same in Russian")
+	}
+	// A short but real exchange is memory worth having.
+	if isSmokeTest("why does the pool exhaust under load?", []string{"pgx caches statements per connection"}) {
+		t.Error("a real question with a real answer must survive")
+	}
+	// A question with no answer recorded is still what someone asked.
+	if isSmokeTest("the original digest content marker_alpha", nil) {
+		t.Error("no reply is not the same as a token reply")
+	}
+	// The prompt shape alone is not enough: a real answer means real work.
+	if isSmokeTest("reply with your assessment of the retry budget", []string{
+		"the budget is wrong: it retries four times inside a one second deadline"}) {
+		t.Error("a substantial answer means this was not a smoke test")
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -785,6 +785,16 @@ func PrintSession(w io.Writer, s model.Session) {
 	}
 }
 
+// isWorkRecord reports whether a message records what an agent did rather than
+// what was said. Mirrors index.isToolRole, which cannot be imported here.
+func isWorkRecord(role string) bool {
+	switch role {
+	case roleToolOutput, "files", "command", "edit":
+		return true
+	}
+	return false
+}
+
 func PrintContext(w io.Writer, s model.Session, query string) {
 	fmt.Fprintf(w, "# deja context: %s · %s · %s", s.Harness, s.Project, s.ID)
 	if !s.Updated.IsZero() {
@@ -814,6 +824,15 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 	for _, m := range s.Messages {
 		if written >= budget {
 			break
+		}
+		// A digest is what someone pipes into a prompt, so it carries the
+		// conversation. The work records — tool output, the files a turn
+		// touched, the commands it ran, the spans it replaced — are indexed and
+		// searchable by role, and they are not what anyone means by context.
+		// Before they were labelled honestly (#560) they arrived as `user` and
+		// filled this with `## tool-output` blocks.
+		if isWorkRecord(m.Role) {
+			continue
 		}
 		ok, matched := include(m)
 		if !ok {

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -345,6 +345,45 @@ func TrimRunes(s string, n int) string {
 	return string(r[:n-1]) + "…"
 }
 
+// AskedByAPerson keeps this count to questions a person asked. Without it the
+// number is mostly harness plumbing and instructions to an agent — "Use the X
+// tool", "Reply with only the raw JSON" — which repeat verbatim by
+// construction. The brief applies the same rule (index.FindAskedTwice), and two
+// screens reporting the same claim under different rules is worse than either.
+func AskedByAPerson(text string) bool {
+	t := strings.TrimSpace(text)
+	if Noise(t) || len([]rune(t)) > askedMaxRunes {
+		return false
+	}
+	for _, p := range []string{
+		"<deja-recall", "[Request interrupted", "The following tool was executed",
+		"This session is being continued", "Continue from where you left off",
+	} {
+		if strings.HasPrefix(t, p) {
+			return false
+		}
+	}
+	if strings.HasSuffix(t, "?") || strings.HasSuffix(t, "？") {
+		return true
+	}
+	fields := strings.Fields(t)
+	if len(fields) == 0 {
+		return false
+	}
+	switch strings.Trim(strings.ToLower(fields[0]), ",.:;!\"'") {
+	case "what", "why", "how", "when", "where", "which", "who", "whose",
+		"did", "does", "do", "is", "are", "was", "were", "can", "should", "would",
+		"что", "чем", "почему", "зачем", "как", "какой", "какая", "какие", "когда",
+		"где", "куда", "откуда", "сколько", "кто", "чей", "можно", "нужно", "надо":
+		return true
+	}
+	return false
+}
+
+// askedMaxRunes mirrors the index-side bound: past this it is a report or a
+// paste with a question mark somewhere in it.
+const askedMaxRunes = 240
+
 // RepeatQuestions is a corpus proxy because the usage sidecar does not store query text.
 func RepeatQuestions(ss []model.Session) int {
 	// Exact stem match only: questionStemFor already folds case and
@@ -354,7 +393,7 @@ func RepeatQuestions(ss []model.Session) int {
 	for _, s := range ss {
 		seen := map[string]bool{}
 		for _, m := range s.Messages {
-			if m.Role != "user" {
+			if m.Role != "user" || !AskedByAPerson(m.Text) {
 				continue
 			}
 			stem := questionStemFor(m.Text)

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -1,0 +1,49 @@
+package stats
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestAskedByAPersonSeparatesQuestionsFromPlumbing(t *testing.T) {
+	for _, s := range []string{
+		"why does the pool exhaust under load?",
+		"сколько по времени займут такие прогоны?",
+		"how do we handle the retry budget",
+	} {
+		if !AskedByAPerson(s) {
+			t.Errorf("%q is a question a person asked", s)
+		}
+	}
+	for _, s := range []string{
+		"Use the deja recall tool to search for: openclaw harness",
+		"Reply with only the raw JSON returned by the tool",
+		"<system-reminder>something</system-reminder>",
+		"The following tool was executed by the user",
+		"Continue if you have next steps, or stop and ask for clarification",
+		strings.Repeat("a long pasted report ", 40) + "why is it slow?",
+		"",
+	} {
+		if AskedByAPerson(s) {
+			t.Errorf("%q should not count as a question someone asked", s)
+		}
+	}
+}
+
+func TestRepeatQuestionsCountsOnlyRealRepeats(t *testing.T) {
+	q := "why does the connection pool exhaust under load?"
+	tmpl := "Use the build tool with scope all and report back"
+	mk := func(id string, texts ...string) model.Session {
+		s := model.Session{ID: id, Harness: "claude"}
+		for _, t := range texts {
+			s.Messages = append(s.Messages, model.Message{Role: "user", Text: t})
+		}
+		return s
+	}
+	ss := []model.Session{mk("a", q, tmpl), mk("b", q, tmpl), mk("c", tmpl)}
+	if got := RepeatQuestions(ss); got != 1 {
+		t.Fatalf("got %d, want the one question and not the template", got)
+	}
+}


### PR DESCRIPTION
A pass over everything 0.16.4 added, on a 1150-session store. Four real defects, each with the measurement that found it.

**`deja ctx` was mostly tool output.** The digest people pipe into a prompt opened with `## tool-output` blocks — before tool output was labelled honestly (#560) it arrived as `user` and was skipped by accident. Work records — tool output, files touched, commands run, spans replaced — are indexed and searchable by role, and they are not what anyone means by context.

**The repeated-question line could show a paste.** It required a question mark anywhere in the text, so a 900-character critique with one question in the middle qualified and displayed truncated to nonsense. Now the question mark has to end the message, or an interrogative has to open it, and anything past 240 characters is a report rather than a question.

**`deja stats` said 79 questions asked more than once. The honest number is 13.** The other 66 were harness plumbing and instructions to an agent — `Use the X tool`, `Reply with only the raw JSON` — which repeat verbatim by construction. The brief already filtered these; two screens reporting the same claim under different rules is worse than either, so the rule now lives in one place.

**Injected recall included harness smoke tests.** `Reply with the single word OK` → `OK` is a real session and gets indexed like any other; injected into an agent's context it teaches the reader that deja recalls worthless things. The filter is narrow on purpose: a prompt asking for a token back, answered with a token. A first attempt cut on total length instead and broke four tests by dropping a one-line question with a short answer — which is memory worth having.

Also fixes `memory served 1 times`.

Gates: LongMemEval-S 84.9% hit@1 / 94.3% hit@5 / MRR 0.891, decisionbench 8/8 · 8/8 · 4/4 · 3/3, recall@5 1.00, total coverage 88.1%.