### PR TITLE
docs: describe what deja now indexes, and what the first run does

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,13 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | **Sync** | `deja sync ssh laptop` — your memory follows you between machines, append-only, idempotent, no cloud in the middle |
 | **Handoff** | `deja handoff --to codex` — stuck in one agent? package the live context and continue in another: `codex "$(deja handoff --to codex)"`; fourteen harnesses can be started directly, the rest print the prompt to paste |
 | **Auto-recall** | `install --auto` adds a SessionStart hook: relevant memory lands in context before you ask — ranked by the files your repo is touching, ~120 ms on a 1000-session index; Claude Code also captures the current transcript before compaction |
+| **Indexes the work** | not just the talk about it: the files each turn opened, the commands that ran, and the exact spans an edit replaced — the part every summary throws away |
+| **After a compaction** | the summary keeps what was decided and drops what it rested on — measured over 43 compactions: 77% of decisions survive, 0.2% of the commands. deja hands the session its own specifics back: what it ran, and where |
+| **Has the ground moved** | a hit says *4 files this session touched have changed since* when they have, and says nothing when it cannot tell — no claim that anything is unchanged |
 | **Déjà vu moments** | When a prompt matches work your history already answered, deja announces it — *you have been here* — with the session and its age, and counts the moment in `deja stats` |
 | **Redaction** | API keys, JWTs, private keys are stripped at index time — the cache is safe to keep |
 | **View** | `deja view` — your whole memory in one local HTML: sessions, the recall audit trail, curated notes; no server, nothing leaves the machine |
+| **Starts full** | `deja` on a fresh install builds the index and shows what it found — every agent, every project, and a question you have asked in more than one session |
 | **Stats** | `deja stats` — your agent work, wrapped; `--impact` reports only counted numbers: recalls served, session starts that began with memory, served-vs-raw ratio |
 | **Promote** | `deja promote <id>` — distill a session into a curated note with provenance, `--tag` keywords and a lifecycle state (accepted / rejected / superseded / stale); notes outrank raw transcripts, and promoting over an existing accepted note surfaces the conflict |
 | **Trust scopes** | `policy.json` decides what memory activates where: search / MCP / auto × local / imported / per-peer; receipts and `deja log` name the rule |
@@ -319,6 +323,8 @@ limits, trust assumptions, and release verification.
 <!-- matrix:end -->
 
 Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_AIDER_ROOTS`, `DEJA_GEMINI_ROOT`, `DEJA_CURSOR_ROOT`, `DEJA_CURSOR_CLI_ROOT`, `DEJA_ANTIGRAVITY_ROOT`, `DEJA_GROK_ROOT`, `DEJA_QWEN_ROOT`, `DEJA_INDEX_DIR`. Each agent's own relocation variable is honored too: `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `GEMINI_CLI_HOME`, `CURSOR_CONFIG_DIR`, `GROK_HOME`, `AIDER_CHAT_HISTORY_FILE`, and `XDG_DATA_HOME` for opencode on Linux.
+
+deja also indexes what the agent did — the file paths its tool calls named, the commands it ran, and the spans its edits replaced. Each can be turned off at ingest: `DEJA_INDEX_PATHS=0`, `DEJA_INDEX_COMMANDS=0`, `DEJA_INDEX_EDITS=0`. They go through the same redaction pass as conversation text.
 
 `DEJA_RECALL=safe` is the default: SessionStart recall stays in the current project, filters weak or duplicate results, prefers the last 90 days, and injects at most 2KB. `DEJA_RECALL=aggressive` searches across projects and raises the injection cap to 4KB. `DEJA_RECALL=off` disables SessionStart recall output.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,8 +32,21 @@ Default path: `~/.cache/deja/index.db`.
 Files:
 
 - `records.bin`: length-prefixed records. Each record stores session key, source path, role, text, and timestamp.
-- `buckets/*.bin`: token bucket files. A token maps to compact postings: record offset plus session ordinal.
-- `manifest.gob` / `sessions.gob`: index version, source file state, redaction counters, sync export watermarks, imported-record dedupe keys, session metadata (including ordinals), build time, and search scope.
+- `buckets/*.bin`: token bucket files. A token maps to compact postings: record offset, session ordinal, and one bit marking the posting as a work record.
+- `manifest.gob` / `sessions.gob`: index version, source file state, redaction counters, sync export watermarks, imported-record dedupe keys, session metadata (including ordinals, the files a session touched most, and hashes of the questions it asked), build time, and search scope.
+
+### Roles
+
+Beyond `user`, `assistant` and `developer`, records carry what the agent did:
+
+| role | holds |
+| --- | --- |
+| `tool-output` | what a tool printed. Claude files this under the user role in its own transcripts, which is why it used to arrive labelled as something a person said |
+| `files` | the paths a turn opened or edited |
+| `command` | a shell command worth keeping — an allowlist of build, test, VCS and deployment tooling, single-line only |
+| `edit` | a span an edit replaced: the path on the first line, the exact removed bytes after it. Only the path earns postings, since nothing searches the body |
+
+These are indexed and searchable by `--role`, and served in ordinary results only when asked for by role: a path that happens to contain the words of a question is not an answer to it. The postings carry a bit for them so the per-session read bound can spend its budget on speech first.
 
 ## Secret redaction
 

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -18,6 +18,15 @@ Indexing reads session messages and metadata needed for search, including
 session IDs, project paths, titles, roles, and timestamps. It does not modify
 the source session stores.
 
+It also reads what the agent did, from the tool calls the same transcripts
+record: the file paths a turn named, the shell commands it ran, the text its
+tools printed, and the exact spans its edits replaced. Replaced spans are
+verbatim source from the user's own files, kept so a lost change can be handed
+back. All of it goes through the same redaction pass as conversation text, which
+matters more here than elsewhere: command output carries credentials far more
+often than prose does. `DEJA_INDEX_PATHS=0`, `DEJA_INDEX_COMMANDS=0` and
+`DEJA_INDEX_EDITS=0` each disable one of these at ingest.
+
 ### Local writes
 
 The default index is `~/.cache/deja/index.db`; `DEJA_INDEX_DIR` changes that
@@ -26,8 +35,9 @@ location. The directory contains:
 - `records.bin`, with redacted message records;
 - `buckets/*.bin`, with token postings into those records;
 - `manifest.gob` and `sessions.gob`, with source file state, session metadata,
-  redaction counts by rule, sync watermarks, and imported-record deduplication
-  keys.
+  redaction counts by rule, sync watermarks, imported-record deduplication keys,
+  the few files each session touched most, and hashes — not text — of the
+  questions it asked.
 
 Privacy control files are primary data, not cache data: the XDG-aware
 `~/.config/deja/tombstones` list prevents forgotten source sessions from being

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -63,10 +63,10 @@ npm  install -g @vshulcz/deja-vu
 go   install github.com/vshulcz/deja-vu/cmd/deja@latest</pre>
 <p>Desktop apps that install MCP servers as bundles take the <code>.mcpb</code> file published with every release — one per platform, carrying the binary, so nothing else is needed. Open it and the app installs the server. Terminal agents use <code>deja install</code>, described under <a href="harnesses.html">harnesses</a>.</p>
 <h2>Search your history</h2>
-<p>The first search builds the index automatically from every agent history it finds — retroactively, including sessions from before you installed deja.</p>
+<p>Running <code>deja</code> on its own builds the index from every agent history it finds — retroactively, including sessions from before you installed it — and then shows what it found: the harnesses, the projects, and a question you have asked in more than one session. <code>deja install</code> does the same while wiring your agents, so the first agent turn is instant rather than paying for the build.</p>
 <pre>deja "connection pool exhausted"
 deja "have we dealt with jwt refresh rotation before"</pre>
-<div class="note">No <code>deja index</code> step is required — any search, recall, or install builds and refreshes the index as needed.</div>
+<div class="note">No <code>deja index</code> step is required — any search, recall, or install builds and refreshes the index as needed. Pass <code>--no-index</code> to <code>deja install</code> if you are scripting an install and want to defer the build.</div>
 <h2>Wire it into your agents</h2>
 <pre>deja install --all      # MCP recall for every agent found on this machine
 deja install --auto     # same, plus session-start auto-recall where supported</pre>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -54,6 +54,8 @@
 
 <h1>Privacy</h1>
 <p>deja indexes credential-bearing histories, so privacy is a first-order concern, not an afterthought.</p>
+<h2>What gets indexed</h2>
+<p>The conversation, and what the agent did while having it: the file paths its tool calls named, the commands it ran, the spans its edits replaced, and what its tools printed. That last part is why redaction matters — command output carries far more credentials than prose does — and every one of these paths goes through the same redaction pass as the conversation itself. Replaced spans are source code from your own files; they are stored so <code>deja restore</code> can hand work back, and they stay on the machine like everything else.</p>
 <h2>Local by default</h2>
 <p>Indexing and search have no network path. The index and its usage sidecar never leave the machine. Network access happens only when you run <code>deja update</code>, <code>deja sync ssh</code>, or the <code>doctor</code> version check (which <code>--offline</code> disables).</p>
 <h2>Redaction</h2>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -59,7 +59,7 @@
 <li><b>Tokens</b> — <code>deja connection pool</code> matches records containing both words (AND).</li>
 <li><b>Phrases</b> — <code>deja '"connection pool exhausted"'</code> requires the exact contiguous phrase.</li>
 <li><b>Regex</b> — <code>deja --re "timeout|deadline exceeded"</code>.</li>
-<li><b>Filters</b> — <code>--harness</code>, <code>--project</code>, <code>--since 30d</code>, <code>--role assistant</code>.</li>
+<li><b>Filters</b> — <code>--harness</code>, <code>--project</code>, <code>--since 30d</code>, <code>--role assistant</code>. Beyond the conversation roles, the index keeps what the agent did: <code>--role files</code> for the paths a turn opened, <code>--role command</code> for the commands that ran, <code>--role edit</code> for the spans an edit replaced, <code>--role tool-output</code> for what a tool printed. These are searchable but stay out of ordinary results, since a path that happens to contain the words of a question is not an answer to it.</li>
 </ul>
 <h2>When nothing matches exactly</h2>
 <p>On zero results deja widens the net in order, and marks how each hit was found:</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -378,12 +378,14 @@ footer .spacer{flex:1}
       <dt>deja "query"</dt><dd>search everything your agents ever wrote — phrases, fuzzy, semantic tiers. <span class="dim">Retroactive: months of logs from before you installed it.</span></dd>
       <dt>recall / recall_context</dt><dd>MCP tools, answers under ~4 KB. A fix found in Codex is recalled inside Claude Code.</dd>
       <dt>deja blame &lt;path&gt;</dt><dd>which sessions touched this file, what was decided and why. <span class="dim">git blame, but for the discussions behind the code.</span></dd>
+      <dt>deja restore &lt;path&gt;</dt><dd>a span an agent replaced, handed back from the edit that replaced it. <span class="dim">Never writes over the original.</span></dd>
+      <dt>deja files &lt;topic&gt;</dt><dd>which files the work on a subject actually touched — the other direction from blame.</dd>
       <dt>deja handoff --to codex</dt><dd>stuck in one agent? package the live context and continue in another.</dd>
       <dt>deja remember "text"</dt><dd>keep durable decisions next to the recalled history — same index, same redaction.</dd>
       <dt>deja sync ssh laptop</dt><dd>memory follows you between machines. Watermarked, idempotent, no cloud in the middle.</dd>
       <dt>deja share &lt;id&gt;</dt><dd>hand a colleague a sanitized digest — problem, key conclusions, secrets already scrubbed.</dd>
       <dt>deja view</dt><dd>your whole memory in one local HTML — sessions, recalls, notes. <span class="dim">No server; nothing leaves the machine.</span></dd>
-      <dt>deja stats</dt><dd>sessions, top projects, activity sparkline. <span class="dim">Your agent year, one screenshot.</span></dd>
+      <dt>deja stats</dt><dd>sessions, top projects, activity sparkline. <span class="dim">Totals per harness, per project, per month.</span></dd>
       <dt>deja log</dt><dd>audit trail: what was recalled or injected, when, into which agent — <span class="dim">--last prints the exact digest an agent received.</span></dd>
       <dt>deja</dt><dd>bare, on a terminal: the living brief — today's sessions, recalls served, déjà vu moments, a suggested search from your own history.</dd>
     </dl>


### PR DESCRIPTION
Documentation had not caught up with 0.16.4 and the work since.

- **README** gains the four capabilities that had no entry: indexing the work rather than only the talk about it, what happens after a compaction, the moved-since annotation, and what a fresh install shows. Plus the three ingest toggles.
- **Privacy guide** gets a *What gets indexed* section. This matters more than the other edits: command output carries credentials far more often than prose, and replaced spans are verbatim source from the user's own files. Both go through the same redaction pass, and that should be stated where people look for it rather than inferred.
- **Security model** describes the same scope, names the toggles, and corrects the manifest description — it now carries the files each session touched and hashes, not text, of the questions it asked.
- **Architecture** documents the roles table and the tool bit in the posting format.
- **Search guide** documents `--role files|command|edit|tool-output`.
- **Getting started** replaces "the first search builds the index" with what actually happens now: `deja` builds and shows the brief, and install builds too, with `--no-index` to defer.
- Drops a marketing-flavoured line from the landing page ("your agent year, one screenshot") in favour of what the command prints.