### PR TITLE
fix(antigravity): write the skill where antigravity reads it

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -403,7 +403,22 @@ func doctorMCP(w io.Writer) {
 			}
 		}
 		fmt.Fprintf(w, "  %-12s %-14s guidance %-11s %s\n", c.name, status, guidanceStatus(guidanceHarness(c.name)), c.path)
+		if note := doctorWiringNote(c.name); note != "" && status == "wired" {
+			fmt.Fprintf(w, "  %-12s %s\n", "", note)
+		}
 	}
+}
+
+// doctorWiringNote adds what "wired" cannot promise for a given harness. Three
+// CLIs share ~/.grok and read different files; one of them — @vibe-kit/grok-cli
+// — has no user-level MCP config at all, so `grok mcp list` reports nothing no
+// matter what an installer writes to the home directory. Saying "wired" without
+// that caveat is how someone concludes deja is broken.
+func doctorWiringNote(name string) string {
+	if name != "grok" {
+		return ""
+	}
+	return "@vibe-kit/grok-cli reads MCP only from <cwd>/.grok/settings.json — run `grok mcp add deja -c deja -a mcp` in a project to wire that one"
 }
 
 type doctorMCPConfig struct {

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -28,7 +28,13 @@ func guidancePath(harness string) string {
 	case "claude-code", "claude":
 		return filepath.Join(sources.ClaudeConfigDir(), "skills", "deja-history", "SKILL.md")
 	case "antigravity":
-		return filepath.Join(antigravityConfigHome(), "skills", "deja-history", "SKILL.md")
+		// Inside the plugin, not beside it. Antigravity ingests skills/ from a
+		// directory marked by plugin.json — which is what `agy plugin validate`
+		// confirms ("skills: 1 processed") — and a SKILL.md written one level up
+		// is read by nothing. doctor checked the same wrong path, so it reported
+		// guidance missing on a machine where the skill was installed and
+		// working.
+		return filepath.Join(antigravityConfigHome(), "plugins", antigravityPluginName, "skills", "deja-history", "SKILL.md")
 	case "copilot":
 		return filepath.Join(homeDir(), ".copilot", "skills", "deja-history", "SKILL.md")
 	case "pi":
@@ -111,6 +117,17 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 			return installResult{Path: path, Action: "removed"}, nil
 		} else {
 			next = []byte(guidanceText(harness))
+			// A skill inside an antigravity plugin directory is ingested only
+			// when plugin.json marks that directory as a plugin — without it the
+			// whole directory is skipped silently, which `agy plugin validate`
+			// reports as "missing plugin.json". `install antigravity-auto`
+			// writes the marker; plain `install antigravity` did not, so the
+			// guidance landed somewhere nothing would read.
+			if harness == "antigravity" {
+				if err := ensureAntigravityPluginMarker(); err != nil {
+					return installResult{}, err
+				}
+			}
 		}
 	} else {
 		next = []byte(updateGuidanceBlock(string(old), uninstall))

--- a/cmd/deja/guidance_test.go
+++ b/cmd/deja/guidance_test.go
@@ -22,7 +22,10 @@ func TestGuidanceTargetsAreUserLevelAndRespectXDG(t *testing.T) {
 	if got := guidancePath("opencode"); got != filepath.Join(xdg, "opencode", "AGENTS.md") {
 		t.Fatalf("opencode path = %q", got)
 	}
-	if got := guidancePath("antigravity"); got != filepath.Join(home, ".gemini", "config", "skills", "deja-history", "SKILL.md") {
+	// Inside the plugin: antigravity ingests skills/ from a directory marked by
+	// plugin.json, and `agy plugin validate` confirms it there. Beside the
+	// plugin nothing reads it.
+	if got := guidancePath("antigravity"); got != filepath.Join(home, ".gemini", "config", "plugins", "deja", "skills", "deja-history", "SKILL.md") {
 		t.Fatalf("antigravity path = %q", got)
 	}
 	if got := guidancePath("qwen"); got != filepath.Join(home, ".qwen", "QWEN.md") {

--- a/cmd/deja/install_antigravity.go
+++ b/cmd/deja/install_antigravity.go
@@ -71,3 +71,22 @@ func installAntigravityPlugin(exe string, uninstall bool) (installResult, error)
 	}
 	return installResult{Path: dir, Action: a}, nil
 }
+
+// ensureAntigravityPluginMarker writes plugin.json if it is not already there,
+// so a skill installed on its own lands in a directory antigravity recognises.
+// It never rewrites an existing marker: `antigravity-auto` owns that file.
+func ensureAntigravityPluginMarker() error {
+	dir := filepath.Join(antigravityConfigHome(), "plugins", antigravityPluginName)
+	path := filepath.Join(dir, "plugin.json")
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	manifest, err := json.MarshalIndent(map[string]any{"name": antigravityPluginName}, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(manifest, '\n'), 0o600)
+}

--- a/cmd/deja/install_antigravity_test.go
+++ b/cmd/deja/install_antigravity_test.go
@@ -113,3 +113,44 @@ func TestHookAntigravitySurvivesGarbageStdin(t *testing.T) {
 		t.Fatalf("output is not JSON: %q", out.String())
 	}
 }
+
+func TestAntigravityGuidanceLandsInsideThePlugin(t *testing.T) {
+	hermeticEnv(t)
+	if err := runInstall(t.TempDir(), []string{"antigravity"}, false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	dir := filepath.Join(antigravityConfigHome(), "plugins", antigravityPluginName)
+	skill := filepath.Join(dir, "skills", "deja-history", "SKILL.md")
+	if _, err := os.Stat(skill); err != nil {
+		t.Fatalf("the skill has to sit inside the plugin, not beside it: %v", err)
+	}
+	// Antigravity ingests a directory only when plugin.json marks it; without
+	// the marker the skill is skipped in silence.
+	if _, err := os.Stat(filepath.Join(dir, "plugin.json")); err != nil {
+		t.Fatalf("plugin.json must accompany the skill: %v", err)
+	}
+	// And nothing should be written to the path that reads like a plugin root
+	// but is not one.
+	if _, err := os.Stat(filepath.Join(antigravityConfigHome(), "skills")); err == nil {
+		t.Fatal("guidance was also written beside the plugin, where nothing reads it")
+	}
+}
+
+func TestAntigravityMarkerIsNotRewritten(t *testing.T) {
+	hermeticEnv(t)
+	dir := filepath.Join(antigravityConfigHome(), "plugins", antigravityPluginName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	custom := []byte(`{"name":"deja","version":"kept"}` + "\n")
+	if err := os.WriteFile(filepath.Join(dir, "plugin.json"), custom, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureAntigravityPluginMarker(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "plugin.json"))
+	if err != nil || string(got) != string(custom) {
+		t.Fatalf("an existing marker belongs to install_antigravity, got %q", got)
+	}
+}


### PR DESCRIPTION
Found by checking the wiring with the vendor's own CLI rather than with our assumptions about it.

`deja doctor` reported `antigravity guidance missing` on a machine where the skill was installed and working. Both halves were wrong in opposite directions:

- `guidancePath` returned `~/.gemini/config/skills/deja-history/SKILL.md`, one level *above* the plugin. Antigravity ingests `skills/` from inside a directory marked by `plugin.json` — which is what the comment at the top of `install_antigravity.go` already said, and what `agy plugin validate` confirms: `skills: 1 processed`.
- So a fresh `deja install antigravity` wrote a skill nothing would read, while the copy that actually worked sat inside the plugin from an older layout — and doctor, checking the same wrong path, called it missing.

Moving the path surfaced a second gap: plain `install antigravity` does not write `plugin.json` (that belongs to `antigravity-auto`), so the skill landed in a directory the vendor rejects outright — `Error: missing plugin.json`. The guidance write now ensures the marker exists, and never rewrites one that does.

Verified with `agy plugin validate` on a fresh hermetic install: `[ok] … skills: 1 processed`. Uninstall still removes the whole plugin directory.

The test that pinned the old path is updated with the reason, so it does not get restored by someone reading it as intent.