### PR TITLE
fix(cli): give advice that leads somewhere on an empty store

### DIFF
--- a/cmd/deja/empty_advice_test.go
+++ b/cmd/deja/empty_advice_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEmptyIndexHintPointsAtTheRightNextStep(t *testing.T) {
+	// Hermetic env: no store has any files, so the honest answer is that there
+	// is no history here — not that the index needs building, which every path
+	// reaching this message has just done.
+	hermeticEnv(t)
+	got := emptyIndexHint("nothing indexed yet")
+	if !strings.Contains(got, "no agent history was found") {
+		t.Fatalf("got %q", got)
+	}
+	if strings.Contains(got, "run `deja index`") {
+		t.Fatalf("advising a rebuild after a rebuild sends the reader in a circle: %q", got)
+	}
+	if !strings.Contains(got, "deja sources") {
+		t.Fatalf("the reader needs somewhere to go: %q", got)
+	}
+}
+
+func TestParseDurAcceptsWhatDejaDocuments(t *testing.T) {
+	for in, want := range map[string]time.Duration{
+		"30d": 30 * 24 * time.Hour,
+		"12h": 12 * time.Hour,
+		"90m": 90 * time.Minute,
+		"45s": 45 * time.Second,
+	} {
+		got, err := parseDur(in)
+		if err != nil || got != want {
+			t.Errorf("parseDur(%q) = %v, %v; want %v", in, got, err, want)
+		}
+	}
+}
+
+func TestParseDurExplainsItselfOnJunk(t *testing.T) {
+	for _, in := range []string{"abc", "7x", "", "d", "-", "30 d"} {
+		_, err := parseDur(in)
+		if err == nil {
+			t.Errorf("parseDur(%q) should fail", in)
+			continue
+		}
+		// time.ParseDuration's own wording names Go's syntax and never mentions
+		// days, which is the unit this flag is usually given.
+		if strings.Contains(err.Error(), "time: invalid duration") {
+			t.Errorf("parseDur(%q) leaked the stdlib message: %v", in, err)
+		}
+		if !strings.Contains(err.Error(), "30d") {
+			t.Errorf("parseDur(%q) should say what is accepted: %v", in, err)
+		}
+	}
+}

--- a/cmd/deja/empty_state_test.go
+++ b/cmd/deja/empty_state_test.go
@@ -24,7 +24,10 @@ func TestStatsSaysWhatIsMissingWhenNothingIsIndexed(t *testing.T) {
 			t.Fatalf("empty section %q printed over an empty index:\n%s", heading, got)
 		}
 	}
-	if !strings.Contains(got, "deja index") {
+	// Which next step depends on why it is empty — a rebuild when stores exist,
+	// `deja sources` when there is no agent history at all — so assert that one
+	// is offered rather than pinning the wording.
+	if !strings.Contains(got, "deja index") && !strings.Contains(got, "deja sources") {
 		t.Fatalf("no next step offered:\n%s", got)
 	}
 }

--- a/cmd/deja/empty_state_test.go
+++ b/cmd/deja/empty_state_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"github.com/vshulcz/deja-vu/internal/stats"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -42,6 +43,14 @@ func TestStatsStillPrintsSectionsWithData(t *testing.T) {
 }
 
 func TestEmptyIndexHintNamesTheNextCommand(t *testing.T) {
+	// With a store present but nothing indexed from it, a rebuild is the right
+	// advice. The other branch — no history anywhere — is covered in
+	// empty_advice_test.go, where repeating the build would achieve nothing.
+	dir := t.TempDir()
+	t.Setenv("DEJA_CLAUDE_ROOT", dir)
+	writeClaudeFixture(t, filepath.Join(dir, "proj", "s.jsonl"), "s", []string{
+		`{"type":"user","sessionId":"s","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"anything at all"}}`,
+	})
 	got := emptyIndexHint("no sessions indexed yet")
 	for _, want := range []string{"no sessions indexed yet", "deja index", "deja doctor"} {
 		if !strings.Contains(got, want) {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -739,7 +739,7 @@ func runBlame(dir string, args []string) error {
 		return nil
 	}
 	if len(hits) == 0 {
-		fmt.Fprintf(os.Stderr, "deja: no sessions mention %s; run deja index if the index is stale\n", target.Base)
+		fmt.Fprintln(os.Stderr, emptyIndexHint("no sessions mention "+target.Base))
 		return nil
 	}
 	search.PrintBlame(os.Stdout, hits, false)
@@ -760,9 +760,22 @@ func findBlameHits(dir string, target search.BlameTarget, o search.BlameOptions,
 func parseDur(s string) (time.Duration, error) {
 	if strings.HasSuffix(s, "d") {
 		n, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
-		return time.Duration(n) * 24 * time.Hour, err
+		if err != nil {
+			return 0, durationError(s)
+		}
+		return time.Duration(n) * 24 * time.Hour, nil
 	}
-	return time.ParseDuration(s)
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		// time.ParseDuration's own message names Go's syntax, not deja's, and
+		// it does not mention days — which is the unit people reach for here.
+		return 0, durationError(s)
+	}
+	return d, nil
+}
+
+func durationError(s string) error {
+	return fmt.Errorf("%q is not a duration deja understands — try 30d, 12h, or 90m", s)
 }
 
 func printSources(dir string) {
@@ -1028,8 +1041,28 @@ See README.md for the full CLI reference.`)
 
 // emptyIndexHint phrases the nothing-here answer the same way everywhere, and
 // points at the next command rather than leaving the user to guess.
+//
+// Which command depends on why it is empty. Every path that reaches here has
+// already built the index — the build narration prints a line above this one —
+// so telling someone to run `deja index` sends them to do again what just
+// happened, and they are left where they started. When no agent history was
+// found at all, the useful next step is finding out where deja looked.
 func emptyIndexHint(what string) string {
+	if noAgentHistoryFound() {
+		return "deja: " + what + " — no agent history was found on this machine; `deja sources` shows where deja looked"
+	}
 	return "deja: " + what + " — run `deja index`, or `deja doctor` to see which agent stores were found"
+}
+
+// noAgentHistoryFound reports whether the stores themselves are empty, as
+// opposed to an index that merely has not been built yet.
+func noAgentHistoryFound() bool {
+	for _, check := range doctorStoreChecks() {
+		if store, _ := inspectDoctorStore(check); store.Files > 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // searchValueFlags take a value, so "--flag=value" has to become two arguments

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -74,7 +74,7 @@ func TestRunDispatcherSyntheticFixtures(t *testing.T) {
 		{"stats", []string{"stats"}, "deja stats", ""},
 		{"ctx missing", []string{"ctx"}, "", "ctx needs query"},
 		{"show missing", []string{"show"}, "", "show needs id-prefix"},
-		{"bad duration", []string{"--since", "nope", "needle"}, "", "invalid duration"},
+		{"bad duration", []string{"--since", "nope", "needle"}, "", "not a duration deja understands"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
From the overnight sweep, section A (every command against an empty store).

**`run deja index` after deja just indexed.** `deja last`, `deja stats` and `deja blame` all end with *run `deja index`* — printed directly below the build narration that says the index was just built. Following the advice repeats what already happened and leaves the reader exactly where they were. When the stores themselves hold nothing, the honest answer is that there is no agent history on this machine, and the useful next step is seeing where deja looked:

```
deja: no sessions indexed yet — no agent history was found on this machine; `deja sources` shows where deja looked
```

The old wording stays for the case it was written for: stores present, index not built.

**`--since abc` leaked Go's own error.** `time: invalid duration "abc"` names Go's syntax and never mentions days, which is the unit this flag is usually given. Now: `"abc" is not a duration deja understands — try 30d, 12h, or 90m`.

The test that pinned the old wording is updated rather than deleted: it now builds a store so it exercises the branch it was written for.