### PR TITLE
fix(completion): offer the commands that shipped without one

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -39,7 +39,7 @@ _deja_completion() {
     command="${COMP_WORDS[1]}"
     action="${COMP_WORDS[2]}"
 
-    local commands="blame bench completion ctx doctor embed forget handoff index install last log mcp promote remember resume share show sources stats statusline sync uninstall update version warmup"
+    local commands="blame bench completion ctx doctor embed files forget handoff help index install last log mcp promote remember restore resume share show sources stats statusline sync uninstall update version view warmup"
     local harnesses="claude codex opencode aider gemini cursor antigravity grok qwen pi copilot deja"
     local install_targets="%INSTALL_TARGETS% --all --auto"
 
@@ -150,22 +150,26 @@ _deja() {
     'bench:run benchmarks'
     'completion:generate shell completion'
     'ctx:print a compact context digest'
+    'files:which files the work on a topic touched'
     'doctor:diagnose local stores and wiring'
     'promote:distill a session into a curated note'
     'embed:build the semantic sidecar'
     'forget:remove indexed sessions'
     'handoff:continue a session in another agent'
+    'help:print the command reference'
     'index:build or refresh the index'
     'install:wire deja into an agent'
     'last:list recent sessions'
     'log:show what deja served to agents'
     'mcp:serve the MCP protocol'
     'remember:store a durable note'
+    'restore:hand back a span an agent replaced'
     'resume:reopen a session'
     'share:print a sanitized session digest'
     'show:print a session'
     'sources:list discovered stores'
     'stats:print usage statistics'
+    'view:browse your memory in one local HTML page'
     'statusline:print status bar data'
     'sync:move memory between machines'
     'uninstall:remove deja agent wiring'
@@ -253,7 +257,7 @@ const fishCompletion = `function __deja_needs_command
     test (count (commandline -opc)) -eq 1
 end
 
-complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed forget handoff index install last log mcp promote remember resume share show sources stats statusline sync uninstall update version warmup'
+complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed files forget handoff help index install last log mcp promote remember restore resume share show sources stats statusline sync uninstall update version view warmup'
 complete -c deja -n '__deja_needs_command' -l json -d 'Print JSON'
 complete -c deja -n '__deja_needs_command' -l re -d 'Interpret query as a regular expression'
 complete -c deja -n '__deja_needs_command' -l all -d 'Include all results'

--- a/cmd/deja/completion_coverage_test.go
+++ b/cmd/deja/completion_coverage_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The completions are hand-maintained lists, so a new command reaches users
+// without one unless something checks. `files` and `restore` shipped in 0.16.4
+// and 0.16.5 and were in none of the three shells.
+func TestCompletionsListEveryUserFacingCommand(t *testing.T) {
+	// Hooks are invoked by agents, not typed; warmup-status is internal.
+	internal := map[string]bool{
+		"hook-context": true, "hook-prompt": true, "hook-precompact": true,
+		"hook-antigravity": true, "hook-goose": true, "hook-refresh": true,
+		"warmup-status": true, "mcp": true,
+	}
+	shells := map[string]string{
+		"bash": bashCompletion,
+		"zsh":  zshCompletion,
+		"fish": fishCompletion,
+	}
+	for name := range commands {
+		if internal[name] || strings.HasPrefix(name, "-") {
+			continue
+		}
+		for shell, script := range shells {
+			if !strings.Contains(script, name) {
+				t.Errorf("%s completion does not offer %q", shell, name)
+			}
+		}
+	}
+	// And the reverse: a completion offering something that no longer exists
+	// teaches a wrong command.
+	for _, name := range []string{"files", "restore", "view"} {
+		if _, ok := commands[name]; !ok {
+			t.Errorf("%q is completed but not dispatched", name)
+		}
+	}
+}


### PR DESCRIPTION
From the overnight sweep, section A.

`deja files` and `deja restore` shipped in 0.16.4/0.16.5 and appear in **none** of the three shell completions. `view` and `help` were missing too — the lists are hand-written and nothing compared them with the dispatcher.

Diffing `commands` against each completion found exactly four user-facing gaps (the rest of the difference is hooks, which agents invoke and nobody types). All three shells now offer them, and a test keeps the lists honest — it caught `help` missing from zsh after I had already patched bash and fish by hand.

`bash -n` and `zsh -n` still parse the generated scripts.