### PR TITLE
fix(show): say when a prefix matched more than one session

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -225,6 +225,14 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 	if o.json {
 		return printSessionJSON(os.Stdout, s, o.offset, o.limit, sourceInstance)
 	}
+	// The prefix picks the newest of its matches, which is the right default
+	// and, until now, a silent one: "2" resolved eleven sessions on a real
+	// store and the reader had no way to know they were shown a choice.
+	if o.harness == "" {
+		if n := index.PrefixMatches(dir, o.id); n > 1 {
+			fmt.Fprintf(os.Stderr, "deja: %d sessions start with %q — showing the most recent; use a longer prefix for another\n", n, o.id)
+		}
+	}
 	search.PrintSession(os.Stdout, s)
 	return nil
 }

--- a/internal/index/asked_test.go
+++ b/internal/index/asked_test.go
@@ -162,3 +162,34 @@ func TestFindAskedTwiceStaysQuietWithoutARepeat(t *testing.T) {
 		t.Fatal("an empty store has nothing to say")
 	}
 }
+
+func TestPrefixMatchesCounts(t *testing.T) {
+	dir := askedFixture(t,
+		map[string][]string{
+			"aa1": {"why does the pool exhaust under load?"},
+			"aa2": {"why does the cache stampede?"},
+			"bb1": {"why is the build slow?"},
+		},
+		map[string]string{
+			"aa1": "2026-03-01T10:00:00Z",
+			"aa2": "2026-03-02T10:00:00Z",
+			"bb1": "2026-03-03T10:00:00Z",
+		})
+	if got := PrefixMatches(dir, "aa"); got != 2 {
+		t.Fatalf("PrefixMatches(aa) = %d, want 2", got)
+	}
+	if got := PrefixMatches(dir, "aa1"); got != 1 {
+		t.Fatalf("an exact id matches once, got %d", got)
+	}
+	if got := PrefixMatches(dir, "zz"); got != 0 {
+		t.Fatalf("got %d, want none", got)
+	}
+	if got := PrefixMatches(dir, ""); got != 0 {
+		t.Fatal("an empty prefix is not a question worth answering")
+	}
+	// FindByPrefix keeps picking the newest of the matches.
+	s, ok, err := FindByPrefix(dir, "aa")
+	if err != nil || !ok || s.ID != "aa2" {
+		t.Fatalf("got %q ok=%v err=%v, want the newest match", s.ID, ok, err)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -929,6 +929,31 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 	return loadSessionMeta(dir, m, matches[0])
 }
 
+// PrefixMatches counts the sessions a prefix resolves to. FindByPrefix picks
+// the newest of them, which is the right default and a silent one: a
+// single-character prefix matched eleven sessions on a real store and the
+// reader had no way to know they were looking at a choice rather than at the
+// only answer.
+func PrefixMatches(dir, p string) int {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	if p == "" {
+		return 0
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, meta := range m.Sessions {
+		if strings.HasPrefix(meta.ID, p) {
+			n++
+		}
+	}
+	return n
+}
+
 // FindByIdentity resolves the exact composite identity emitted by machine
 // search and recent output. Unlike the human prefix command, it never guesses
 // between harnesses or accepts a shortened native ID.


### PR DESCRIPTION
From the overnight sweep, section A (boundary arguments).

`deja show 2` printed a session. Thirteen sessions on this store start with `2`; `FindByPrefix` sorts by recency and returns the first, so the reader is shown one of thirteen with nothing to suggest there was a choice — and every subsequent `deja show 2` after a new session lands shows a different one.

Picking the newest stays: it is the right default. It just says so now.

```
deja: 13 sessions start with "2" — showing the most recent; use a longer prefix for another
```

On stderr, so piping `deja show` is unaffected, and only when the prefix is genuinely ambiguous — an exact id prints nothing extra. `--harness` resolves an exact identity and is left alone.