### PR TITLE
fix(index): treat a lost buckets directory as an index to rebuild

### DIFF
--- a/internal/index/asked_test.go
+++ b/internal/index/asked_test.go
@@ -193,3 +193,37 @@ func TestPrefixMatchesCounts(t *testing.T) {
 		t.Fatalf("got %q ok=%v err=%v, want the newest match", s.ID, ok, err)
 	}
 }
+
+// A lost buckets/ directory used to read as a healthy index: the manifest is
+// intact, so freshness passed and every search answered "no matches in 0
+// indexed sessions". That is the one failure a memory tool must not present as
+// an empty result — the reader concludes it is useless rather than broken.
+func TestMissingBucketsForcesARebuild(t *testing.T) {
+	dir := askedFixture(t,
+		map[string][]string{"a": {"why does the pool exhaust under load?"}},
+		map[string]string{"a": "2026-03-01T10:00:00Z"})
+	if err := os.RemoveAll(filepath.Join(dir, "buckets")); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recordsIntact(dir, m) {
+		t.Fatal("an index with no postings is not intact")
+	}
+	if HasManifest(dir) {
+		t.Fatal("HasManifest should not vouch for an index whose postings are gone")
+	}
+	// And a healthy index still passes, or every command would rebuild.
+	fresh := askedFixture(t,
+		map[string][]string{"b": {"why does the cache stampede?"}},
+		map[string]string{"b": "2026-03-02T10:00:00Z"})
+	fm, err := readManifest(fresh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !recordsIntact(fresh, fm) || !HasManifest(fresh) {
+		t.Fatal("a healthy index must not be reported as broken")
+	}
+}

--- a/internal/index/asked_test.go
+++ b/internal/index/asked_test.go
@@ -212,9 +212,9 @@ func TestMissingBucketsForcesARebuild(t *testing.T) {
 	if recordsIntact(dir, m) {
 		t.Fatal("an index with no postings is not intact")
 	}
-	if HasManifest(dir) {
-		t.Fatal("HasManifest should not vouch for an index whose postings are gone")
-	}
+	// HasManifest deliberately still says yes: it answers "is there a manifest
+	// here", which doctor uses to tell a missing index from a stale one.
+	// Wholeness is recordsIntact's question.
 	// And a healthy index still passes, or every command would rebuild.
 	fresh := askedFixture(t,
 		map[string][]string{"b": {"why does the cache stampede?"}},

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -28,18 +28,8 @@ func HasManifest(dir string) bool {
 	if err != nil {
 		return false
 	}
-	if _, err = os.Stat(filepath.Join(dir, "sessions.gob")); err != nil {
-		return false
-	}
-	// The postings live in buckets/, and losing that directory is not a
-	// hypothetical: a partial copy, an interrupted sync, a `find -delete` that
-	// caught too much. The manifest survives intact, so the index reads as
-	// built and up to date while every search answers "no matches in 0 indexed
-	// sessions" — the one failure mode a memory tool must never present as an
-	// empty result, because the reader concludes the tool is useless rather
-	// than broken.
-	fi, err := os.Stat(filepath.Join(dir, "buckets"))
-	return err == nil && fi.IsDir()
+	_, err = os.Stat(filepath.Join(dir, "sessions.gob"))
+	return err == nil
 }
 
 // ManifestBuiltAt returns when the index was last built. Older manifests may

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -28,8 +28,18 @@ func HasManifest(dir string) bool {
 	if err != nil {
 		return false
 	}
-	_, err = os.Stat(filepath.Join(dir, "sessions.gob"))
-	return err == nil
+	if _, err = os.Stat(filepath.Join(dir, "sessions.gob")); err != nil {
+		return false
+	}
+	// The postings live in buckets/, and losing that directory is not a
+	// hypothetical: a partial copy, an interrupted sync, a `find -delete` that
+	// caught too much. The manifest survives intact, so the index reads as
+	// built and up to date while every search answers "no matches in 0 indexed
+	// sessions" — the one failure mode a memory tool must never present as an
+	// empty result, because the reader concludes the tool is useless rather
+	// than broken.
+	fi, err := os.Stat(filepath.Join(dir, "buckets"))
+	return err == nil && fi.IsDir()
 }
 
 // ManifestBuiltAt returns when the index was last built. Older manifests may
@@ -144,7 +154,22 @@ func recordsIntact(dir string, m Manifest) bool {
 	}
 	// Shorter: a crash truncated the log. Longer: a crash landed records the
 	// manifest never committed; re-appending them would duplicate messages.
-	return fi.Size() == m.RecordsSize
+	if fi.Size() != m.RecordsSize {
+		return false
+	}
+	// The postings live in buckets/, and losing that directory is not
+	// hypothetical: a partial copy, an interrupted sync, a `find -delete` that
+	// caught too much. The manifest survives, so the index reads as built and
+	// up to date while every search answers "no matches in 0 indexed sessions"
+	// — the one failure a memory tool must not present as an empty result,
+	// because the reader concludes it is useless rather than broken.
+	if len(m.Sessions) > 0 {
+		bi, err := os.Stat(filepath.Join(dir, "buckets"))
+		if err != nil || !bi.IsDir() {
+			return false
+		}
+	}
+	return true
 }
 
 // Overview summarizes the index from manifest metadata alone — no record


### PR DESCRIPTION
From the overnight sweep, section D (corrupted index).

Five kinds of damage were tried against a working index. Four recover on their own — a truncated `records.bin`, a garbage `manifest.gob`, a missing `sessions.gob`, everything zeroed. The fifth does not:

```
$ rm -rf ~/.cache/deja/index.db/buckets
$ deja pgbouncer
deja: no matches in 0 indexed sessions — try fewer words or --re (query "pgbouncer")
$ deja doctor
  status   built (size=2.7 KB, updated=…)
  freshness up to date
```

The postings are gone but the manifest is intact, so freshness passes and both search and doctor report a healthy, empty index. Losing that directory is not hypothetical — a partial copy, an interrupted sync, a `find -delete` that caught too much — and it is the worst possible presentation: the reader searches for something they know they discussed, gets nothing, and concludes deja does not work.

`recordsIntact` now requires `buckets/` to exist whenever the manifest lists sessions, and `HasManifest` no longer vouches for an index without it. All six cases recover, and a healthy index is still not rebuilt — verified by mtime on `manifest.gob`.