### PR TITLE
fix(cli): say what to change when the index cannot be written

### DIFF
--- a/cmd/deja/empty_advice_test.go
+++ b/cmd/deja/empty_advice_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"io/fs"
 	"strings"
 	"testing"
 	"time"
@@ -52,5 +54,29 @@ func TestParseDurExplainsItselfOnJunk(t *testing.T) {
 		if !strings.Contains(err.Error(), "30d") {
 			t.Errorf("parseDur(%q) should say what is accepted: %v", in, err)
 		}
+	}
+}
+
+func TestEnsureErrorSaysWhatToChange(t *testing.T) {
+	// A denied write surfaced as `ensure: open /…/index.db.lock: permission
+	// denied` — an internal lock path and a syscall error, neither of which
+	// tells the reader what to do.
+	err := ensureError("/some/index.db", fs.ErrPermission)
+	if err == nil {
+		t.Fatal("want an error")
+	}
+	got := err.Error()
+	for _, want := range []string{"/some/index.db", "permissions", "DEJA_INDEX_DIR"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("message should mention %q: %s", want, got)
+		}
+	}
+	if strings.Contains(got, ".lock") {
+		t.Errorf("the lock file is deja's business, not the reader's: %s", got)
+	}
+	// Anything else keeps its original wording rather than being guessed at.
+	other := ensureError("/x", errors.New("disk on fire"))
+	if !strings.Contains(other.Error(), "disk on fire") {
+		t.Errorf("unrelated failures must not be rewritten: %v", other)
 	}
 }

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -71,7 +71,7 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 	q := strings.Join(terms, " ")
 	o := search.Options{Query: q, All: true, Project: project}
 	if err := index.EnsureForSearch(dir, o, false, nil); err != nil {
-		return fmt.Errorf("ensure: %w", err)
+		return ensureError(dir, err)
 	}
 	hits, err := index.Search(dir, o)
 	if err != nil {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -385,7 +387,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	o.RecallWorn = usage.WornSessions(dir)
 	prepareFirstIndexGreeting(dir)
 	if err := withBuildProgress(func() error { return index.EnsureForSearch(dir, o, force, os.Stderr) }); err != nil {
-		return fmt.Errorf("ensure: %w", err)
+		return ensureError(dir, err)
 	}
 	maybeFirstIndexGreeting(dir)
 	result, err := index.SearchWithRecoveryDetailed(dir, o, os.Stderr)
@@ -1071,6 +1073,20 @@ func noAgentHistoryFound() bool {
 		}
 	}
 	return true
+}
+
+// ensureError turns an index-build failure into something a reader can act on.
+// A denied write surfaced as `ensure: open /…/index.db.lock: permission denied`
+// — the path of an internal lock file and a syscall error, which says nothing
+// about what to change.
+func ensureError(dir string, err error) error {
+	if errors.Is(err, fs.ErrPermission) {
+		if dir == "" {
+			dir = index.DefaultDir()
+		}
+		return fmt.Errorf("cannot write the index at %s — check the directory's permissions, or point DEJA_INDEX_DIR somewhere writable", dir)
+	}
+	return fmt.Errorf("ensure: %w", err)
 }
 
 // searchValueFlags take a value, so "--flag=value" has to become two arguments

--- a/cmd/deja/restore.go
+++ b/cmd/deja/restore.go
@@ -109,7 +109,7 @@ func findRestoreSpans(dir string, path string) ([]restoreSpan, error) {
 	base := filepath.Base(path)
 	o := search.Options{Query: base, All: true, Role: "edit"}
 	if err := index.EnsureForSearch(dir, o, false, nil); err != nil {
-		return nil, fmt.Errorf("ensure: %w", err)
+		return nil, ensureError(dir, err)
 	}
 	hits, err := index.Search(dir, o)
 	if err != nil {


### PR DESCRIPTION
From the overnight sweep, section D (permissions).

Pointing `DEJA_INDEX_DIR` at an unwritable location gave:

```
deja: ensure: open /var/…/newidx.lock: permission denied
```

The lock file is deja's own bookkeeping and means nothing to the reader; the message names it and not the thing to fix. Now:

```
deja: cannot write the index at /var/…/newidx — check the directory's permissions, or point DEJA_INDEX_DIR somewhere writable
```

All three call sites — search, `files`, `restore` — share the helper. Failures that are not permission-related keep their original wording rather than being guessed at.

A read-only index that already exists still serves searches, which is deliberate and unchanged.