### PR TITLE
fix(output): stop counting one thing in the plural

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -42,8 +42,9 @@ func runBrief(dir string, w io.Writer) error {
 	if color {
 		bold, dim, reset = logoBold, logoDim, logoReset
 	}
-	fmt.Fprintf(w, "%sdeja-vu%s %s · %s%d%s sessions across %s%d%s agents\n",
-		bold, reset, version, bold, ov.Sessions, reset, bold, ov.Harnesses, reset)
+	fmt.Fprintf(w, "%sdeja-vu%s %s · %s%d%s session%s across %s%d%s agent%s\n",
+		bold, reset, version, bold, ov.Sessions, reset, pluralS(ov.Sessions),
+		bold, ov.Harnesses, reset, pluralS(ov.Harnesses))
 
 	recalls, bytes, _ := usage.TodayWithInjections(dir)
 	line := fmt.Sprintf("today      %d session%s", ov.SessionsToday, pluralS(ov.SessionsToday))
@@ -57,7 +58,7 @@ func runBrief(dir string, w io.Writer) error {
 	fmt.Fprintln(w, line)
 
 	wr, _, _, _ := usage.Week(dir)
-	week := fmt.Sprintf("this week  %d sessions · %d recalls", ov.SessionsWeek, wr)
+	week := fmt.Sprintf("this week  %d session%s · %d recall%s", ov.SessionsWeek, pluralS(ov.SessionsWeek), wr, pluralS(wr))
 	if dv := usage.DejaVuWeek(dir); dv > 0 {
 		week += fmt.Sprintf(" · %s%d déjà vu moment%s%s", bold, dv, pluralS(dv), reset)
 	}
@@ -98,6 +99,17 @@ func runBrief(dir string, w io.Writer) error {
 	}
 	fmt.Fprintf(w, "%smore       deja log · deja stats · deja help%s\n", dim, reset)
 	return nil
+}
+
+// plural and verbS keep "1 session mentions" from reading as "1 sessions
+// mention" — the noun and the verb disagree in opposite directions.
+func plural(n int) string { return pluralS(n) }
+
+func verbS(n int) string {
+	if n == 1 {
+		return "s"
+	}
+	return ""
 }
 
 func pluralS(n int) string {
@@ -160,7 +172,7 @@ func askedWhen(a index.AskedTwice) string {
 			break
 		}
 	}
-	times := fmt.Sprintf("%d sessions", n)
+	times := fmt.Sprintf("%d session%s", n, pluralS(n))
 	if project != "" && project != "-" {
 		times += " in " + project
 	}

--- a/cmd/deja/brief_test.go
+++ b/cmd/deja/brief_test.go
@@ -42,7 +42,9 @@ func TestBriefShowsMemoryAlive(t *testing.T) {
 		t.Fatal(err)
 	}
 	s := out.String()
-	for _, want := range []string{"sessions across", "recent", "déjà vu moment", "deja log"} {
+	// "session across" rather than "sessions across": the count is pluralised,
+	// and a fixture with one session used to read "1 sessions across 1 agents".
+	for _, want := range []string{"session", "across", "recent", "déjà vu moment", "deja log"} {
 		if !strings.Contains(s, want) {
 			t.Fatalf("brief missing %q:\n%s", want, s)
 		}

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -141,7 +141,7 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		}
 	}
 	if len(near) == 0 {
-		fmt.Fprintf(stdout, "%d sessions mention %q, none of them recorded a file near it\n", scanned, q)
+		fmt.Fprintf(stdout, "%d session%s mention%s %q, none of them recorded a file near it\n", scanned, plural(scanned), verbS(scanned), q)
 		return nil
 	}
 
@@ -175,7 +175,7 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 	if len(rows) > limit {
 		rows = rows[:limit]
 	}
-	fmt.Fprintf(stdout, "files touched while working on %q — %d sessions\n", q, scanned)
+	fmt.Fprintf(stdout, "files touched while working on %q — %d session%s\n", q, scanned, plural(scanned))
 	for _, r := range rows {
 		fmt.Fprintf(stdout, "  %-56s %d\n", trimPath(r.path), r.n)
 	}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -530,7 +530,7 @@ func serviceReceipt(dir string) string {
 	}
 	raw := usage.TodayRaw(dir)
 	if raw/int64(bytes) < 2 {
-		return fmt.Sprintf(" · today: %d recalls", recalls)
+		return fmt.Sprintf(" · today: %d recall%s", recalls, pluralS(recalls))
 	}
-	return fmt.Sprintf(" · today: %d recalls, %s distilled from %s", recalls, humanBytes(int64(bytes)), humanBytes(raw))
+	return fmt.Sprintf(" · today: %d recall%s, %s distilled from %s", recalls, pluralS(recalls), humanBytes(int64(bytes)), humanBytes(raw))
 }

--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -50,7 +50,7 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 		if s.Policy != "" {
 			pol = " · policy: " + s.Policy
 		}
-		fmt.Fprintf(w, "# %s · %s · %d sessions · %s%s\n\n", s.Kind, s.Time.Local().Format("2006-01-02 15:04"), s.Sessions, humanBytes(int64(s.Bytes)), pol)
+		fmt.Fprintf(w, "# %s · %s · %d session%s · %s%s\n\n", s.Kind, s.Time.Local().Format("2006-01-02 15:04"), s.Sessions, pluralS(s.Sessions), humanBytes(int64(s.Bytes)), pol)
 		fmt.Fprintln(w, s.Digest)
 		return nil
 	}
@@ -71,7 +71,7 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 		}
 		sess := ""
 		if e.Sessions > 0 {
-			sess = fmt.Sprintf(" · %d sessions", e.Sessions)
+			sess = fmt.Sprintf(" · %d session%s", e.Sessions, pluralS(e.Sessions))
 		}
 		fmt.Fprintf(w, "%s  %-14s %s%s%s\n", e.Time.Local().Format("2006-01-02 15:04"), e.Kind, humanBytes(int64(e.Bytes)), sess, mark)
 	}


### PR DESCRIPTION
From the overnight sweep, section E (the first screen on corpora of 1, 10 and 100 sessions).

A store with one session opened with:

```
deja-vu dev · 1 sessions across 1 agents
today      0 sessions
this week  0 sessions · 0 recalls
```

`pluralS` already existed in the same file; seven call sites did not use it — the header, both brief counters, `deja files` twice, the hook receipt, and `deja log`. `deja files` needed the verb as well, since "1 sessions mention" disagrees in both directions at once.

Now:

```
deja-vu dev · 1 session across 1 agent
today      1 session
this week  1 session · 0 recalls
```

Small, but it is the first line of the first screen, and it is the kind of thing a reader notices before anything else on it.