### PR TITLE
feat(brief): say what the index covers instead of two zeros

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -47,7 +47,14 @@ func runBrief(dir string, w io.Writer) error {
 		bold, ov.Harnesses, reset, pluralS(ov.Harnesses))
 
 	recalls, bytes, _ := usage.TodayWithInjections(dir)
-	quietWeek := ov.SessionsToday == 0 && ov.SessionsWeek == 0 && !ov.Oldest.IsZero()
+	weekRecalls, _, _, _ := usage.Week(dir)
+	dejaVu := usage.DejaVuWeek(dir)
+	// Only when the week has nothing at all to report. Recalls and déjà vu
+	// moments are counted from usage, not from session age, so a store whose
+	// sessions are old can still have served memory this week — and hiding that
+	// was exactly the wrong trade.
+	quietWeek := ov.SessionsToday == 0 && ov.SessionsWeek == 0 &&
+		recalls == 0 && weekRecalls == 0 && dejaVu == 0 && !ov.Oldest.IsZero()
 	line := fmt.Sprintf("today      %d session%s", ov.SessionsToday, pluralS(ov.SessionsToday))
 	if recalls > 0 {
 		line += fmt.Sprintf(" · %d recall%s served (%s", recalls, pluralS(recalls), humanBytes(int64(bytes)))
@@ -60,8 +67,8 @@ func runBrief(dir string, w io.Writer) error {
 		fmt.Fprintln(w, line)
 	}
 
-	wr, _, _, _ := usage.Week(dir)
-	if ov.SessionsToday == 0 && ov.SessionsWeek == 0 && !ov.Oldest.IsZero() {
+	wr := weekRecalls
+	if quietWeek {
 		// Nothing this week. Two zero lines is the worst possible opening for
 		// someone whose agent history is real but older — and the interesting
 		// fact is right there: how far back the memory goes.
@@ -69,8 +76,8 @@ func runBrief(dir string, w io.Writer) error {
 			ov.Oldest.Local().Format("Jan 2 2006"), ov.Newest.Local().Format("Jan 2 2006"), reset)
 	} else {
 		week := fmt.Sprintf("this week  %d session%s · %d recall%s", ov.SessionsWeek, pluralS(ov.SessionsWeek), wr, pluralS(wr))
-		if dv := usage.DejaVuWeek(dir); dv > 0 {
-			week += fmt.Sprintf(" · %s%d déjà vu moment%s%s", bold, dv, pluralS(dv), reset)
+		if dejaVu > 0 {
+			week += fmt.Sprintf(" · %s%d déjà vu moment%s%s", bold, dejaVu, pluralS(dejaVu), reset)
 		}
 		fmt.Fprintln(w, week)
 	}

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -47,6 +47,7 @@ func runBrief(dir string, w io.Writer) error {
 		bold, ov.Harnesses, reset, pluralS(ov.Harnesses))
 
 	recalls, bytes, _ := usage.TodayWithInjections(dir)
+	quietWeek := ov.SessionsToday == 0 && ov.SessionsWeek == 0 && !ov.Oldest.IsZero()
 	line := fmt.Sprintf("today      %d session%s", ov.SessionsToday, pluralS(ov.SessionsToday))
 	if recalls > 0 {
 		line += fmt.Sprintf(" · %d recall%s served (%s", recalls, pluralS(recalls), humanBytes(int64(bytes)))
@@ -55,14 +56,24 @@ func runBrief(dir string, w io.Writer) error {
 		}
 		line += ")"
 	}
-	fmt.Fprintln(w, line)
+	if !quietWeek {
+		fmt.Fprintln(w, line)
+	}
 
 	wr, _, _, _ := usage.Week(dir)
-	week := fmt.Sprintf("this week  %d session%s · %d recall%s", ov.SessionsWeek, pluralS(ov.SessionsWeek), wr, pluralS(wr))
-	if dv := usage.DejaVuWeek(dir); dv > 0 {
-		week += fmt.Sprintf(" · %s%d déjà vu moment%s%s", bold, dv, pluralS(dv), reset)
+	if ov.SessionsToday == 0 && ov.SessionsWeek == 0 && !ov.Oldest.IsZero() {
+		// Nothing this week. Two zero lines is the worst possible opening for
+		// someone whose agent history is real but older — and the interesting
+		// fact is right there: how far back the memory goes.
+		fmt.Fprintf(w, "covering   %s%s → %s%s\n", bold,
+			ov.Oldest.Local().Format("Jan 2 2006"), ov.Newest.Local().Format("Jan 2 2006"), reset)
+	} else {
+		week := fmt.Sprintf("this week  %d session%s · %d recall%s", ov.SessionsWeek, pluralS(ov.SessionsWeek), wr, pluralS(wr))
+		if dv := usage.DejaVuWeek(dir); dv > 0 {
+			week += fmt.Sprintf(" · %s%d déjà vu moment%s%s", bold, dv, pluralS(dv), reset)
+		}
+		fmt.Fprintln(w, week)
 	}
-	fmt.Fprintln(w, week)
 
 	// Read the index as-is: the brief must never trigger a rebuild or let
 	// indexing narration tear through its layout.

--- a/cmd/deja/brief_test.go
+++ b/cmd/deja/brief_test.go
@@ -88,3 +88,39 @@ func TestDejaVuLineShape(t *testing.T) {
 		t.Fatalf("dejaVuLine = %q", line)
 	}
 }
+
+// A store whose work is all older than a week opened with two zero lines —
+// "today 0 sessions" and "this week 0 sessions · 0 recalls" — which is the
+// worst possible first screen for someone whose history is real but not recent.
+func TestBriefReplacesAQuietWeekWithTheSpanItHolds(t *testing.T) {
+	tmp := hermeticEnv(t)
+	proj := filepath.Join(tmp, "claude", "proj")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i, day := range []string{"11", "13", "15"} {
+		line := `{"type":"user","sessionId":"s` + day + `","cwd":"/w","timestamp":"2026-04-` + day +
+			`T03:04:05Z","message":{"role":"user","content":"why does the pool exhaust under load ` +
+			string(rune('a'+i)) + `?"}}`
+		if err := os.WriteFile(filepath.Join(proj, "s"+day+".jsonl"), []byte(line+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := runBrief(dir, &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "covering") || !strings.Contains(got, "Apr 11 2026") {
+		t.Fatalf("want the span the index holds:\n%s", got)
+	}
+	for _, unwanted := range []string{"today      0", "this week  0"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("a zero line survived: %q\n%s", unwanted, got)
+		}
+	}
+}

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -169,6 +169,10 @@ type OverviewStats struct {
 	Harnesses     int
 	SessionsToday int
 	SessionsWeek  int
+	// Oldest and Newest bound what the index holds. A store whose work is all
+	// older than a week has nothing to say under "today" and "this week", and
+	// two zero lines is a poor way to open the first screen someone sees.
+	Oldest, Newest time.Time
 }
 
 func Overview(dir string) (OverviewStats, error) {
@@ -189,6 +193,12 @@ func Overview(dir string) (OverviewStats, error) {
 		hs[meta.Harness] = true
 		if meta.Updated.After(day) {
 			o.SessionsToday++
+		}
+		if o.Oldest.IsZero() || (!meta.Updated.IsZero() && meta.Updated.Before(o.Oldest)) {
+			o.Oldest = meta.Updated
+		}
+		if meta.Updated.After(o.Newest) {
+			o.Newest = meta.Updated
 		}
 		if meta.Updated.After(week) {
 			o.SessionsWeek++


### PR DESCRIPTION
From the overnight sweep, section E1 — the case a new user is most likely to land in.

Install deja on a machine whose agent history is real but a few weeks old and the first screen opens with:

```
deja-vu · 5 sessions across 1 agent
today      0 sessions
this week  0 sessions · 0 recalls
recent     [claude] proj · Apr 15 · why does the connection pool exhaust…
```

Two lines of nothing, in the two most prominent positions. The interesting fact was available all along — how far back the memory goes:

```
deja-vu · 5 sessions across 1 agent
covering   Apr 11 2026 → Apr 15 2026
recent     [claude] proj · Apr 15 · why does the connection pool exhaust…
```

Only when both counters are zero; an active store keeps today's and this week's lines exactly as they were, verified against the 1148-session index.