### PR TITLE
docs: refresh the measured numbers and document six missing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="assets/logo.svg" width="340" alt="deja-vu"></p>
 
-<p align="center"><strong>Your agents already solved this. deja finds it.</strong><br>Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk &mdash; months of history from before you installed it &mdash; searches 3.3&nbsp;GB in ~1&nbsp;ms, serves it back to any agent over MCP, and moves with you between machines over SSH. One zero-dependency binary, fully local.</p>
+<p align="center"><strong>Your agents already solved this. deja finds it.</strong><br>Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk &mdash; months of history from before you installed it &mdash; searches 3.5&nbsp;GB in ~1.5&nbsp;ms, serves it back to any agent over MCP, and moves with you between machines over SSH. One zero-dependency binary, fully local.</p>
 
 <p align="center"><strong>84.9% hit@1</strong> on LongMemEval-S retrieval &mdash; no LLM, no embeddings, no API key. <a href="https://vshulcz.github.io/deja-vu/guide/benchmarks.html">Harness in-repo, run it yourself.</a></p>
 
@@ -20,7 +20,7 @@
 <p align="center"><em>Every line is quoted from two real Claude Code sessions &mdash; the same question, the same agent, once without memory and once with deja. Nobody searched anything: the agent called deja itself.</em></p>
 
 <p align="center">
-<b>84.9% hit@1</b> on LongMemEval-S &middot; <b>69.8%</b> on LoCoMo &middot; <b>zero</b> LLM calls, zero embeddings, zero API keys &middot; <b>~1&nbsp;ms</b> median search over 3.3&nbsp;GB<br>
+<b>84.9% hit@1</b> on LongMemEval-S &middot; <b>69.8%</b> on LoCoMo &middot; <b>zero</b> LLM calls, zero embeddings, zero API keys &middot; <b>~1.5&nbsp;ms</b> median search over 3.5&nbsp;GB<br>
 <sub>Both harnesses ship in this repo and run on the public datasets in minutes — <a href="https://vshulcz.github.io/deja-vu/guide/benchmarks.html">check the numbers yourself</a>.</sub>
 </p>
 
@@ -338,9 +338,9 @@ Measured on a real corpus — 1,250+ sessions, ~3.3GB across three harnesses:
 
 | Measurement | Result |
 | --- | --- |
-| Warm search | **~1.3 ms** median, ~17 ms on the most common word in the store (`go run ./scripts/searchbench`) |
+| Warm search | **~1.5 ms** median, ~14 ms on the most common word in the store (`go run ./scripts/searchbench`) |
 | Cold index (once) | ~10 s |
-| Index size | ~2.4% of corpus |
+| Index size | ~2.3% of corpus |
 
 The index is incremental: when a session file grows, only that file is re-read.
 

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -66,6 +66,12 @@
 <tr><td><code>deja</code></td><td>Bare, on a terminal: the living brief — today's activity, recalls served, déjà vu moments, a suggested search from your own history.</td></tr>
 <tr><td><code>deja log</code></td><td>Audit trail: recent recalls and injections; <code>--last</code> prints the most recent injected digest verbatim; <code>--json</code>.</td></tr>
 <tr><td><code>deja last [n]</code></td><td>Recent sessions. <code>--project</code>, <code>--harness</code>, <code>--since</code>, <code>--role</code>, <code>--json</code>.</td></tr>
+<tr><td><code>deja resume &lt;id&gt;</code></td><td>Reopen a session in the agent that wrote it. Prints the command; <code>--exec</code> runs it.</td></tr>
+<tr><td><code>deja warmup</code></td><td>Build or refresh the index without searching — for a shell profile or a provisioning script.</td></tr>
+<tr><td><code>deja statusline</code></td><td>One line for an agent's status bar: today's sessions and what deja has served.</td></tr>
+<tr><td><code>deja completion &lt;bash|zsh|fish&gt;</code></td><td>Print a completion script for your shell.</td></tr>
+<tr><td><code>deja uninstall &lt;target|--all&gt;</code></td><td>Remove deja's wiring from an agent. Other servers in shared config files are left alone.</td></tr>
+<tr><td><code>deja version</code></td><td>Print the version.</td></tr>
 <tr><td><code>deja sources</code></td><td>Discovered stores per harness, with redaction counts.</td></tr>
 <tr><td><code>deja install &lt;target|--all|--auto&gt;</code></td><td>Wire MCP recall (and hooks) into your agents.</td></tr>
 <tr><td><code>deja embed</code></td><td>Build the semantic vector sidecar from a local endpoint.</td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -362,7 +362,7 @@ footer .spacer{flex:1}
   <div class="bench">
     <table>
       <tr><td class="n">~200×</td><td class="c">fewer tokens to working context than grepping the raw logs, at equal fact coverage</td></tr>
-      <tr><td class="n">~1 ms</td><td class="c">median warm search over gigabytes of history; ~17 ms on the most common word</td></tr>
+      <tr><td class="n">~1.5 ms</td><td class="c">median warm search over gigabytes of history; ~14 ms on the most common word</td></tr>
       <tr><td class="n">~50 ms</td><td class="c">session-start hook on a 1000-session index — memory lands before you type</td></tr>
       <tr><td class="n">84.9%</td><td class="c">hit@1 on LongMemEval-S session retrieval (94.3% hit@5) — no LLM, no embeddings, harness in-repo</td></tr>
       <tr><td class="n">16</td><td class="c">coding agents indexed into one retroactive memory</td></tr>
@@ -427,9 +427,9 @@ footer .spacer{flex:1}
 
 <section class="reveal">
   <div class="stats">
-    <div class="stat"><b>~1 ms</b><span>median warm search over ~3.3 GB</span></div>
+    <div class="stat"><b>~1.5 ms</b><span>median warm search over ~3.5 GB</span></div>
     <div class="stat"><b>~10 s</b><span>cold index, once</span></div>
-    <div class="stat"><b>~2.4%</b><span>index size vs corpus</span></div>
+    <div class="stat"><b>~2.3%</b><span>index size vs corpus</span></div>
     <div class="stat"><b>0</b><span>runtime dependencies</span></div>
   </div>
 </section>


### PR DESCRIPTION
From the overnight sweep, section G — every published number re-measured against today's binary, every documented example run verbatim.

**Numbers had drifted** as the corpus grew. Re-measured with `scripts/searchbench` on the 1150-session store:

| claim | was | measured now |
|---|---|---|
| corpus searched | 3.3 GB | **3.5 GB** |
| median warm search | ~1.3 ms | **~1.5 ms** |
| commonest word in the store | ~17 ms | **~14 ms** |
| index size vs corpus | 2.4% | **2.3%** |

Two of these moved in our favour and two against; all four are now what the harness prints.

**Six commands were documented nowhere on the site**: `resume`, `warmup`, `statusline`, `completion`, `uninstall`, `version`. Diffing `deja help` against every page under `docs/` found them; all 26 user-facing commands are now covered.

Checked and **not** changed: every README example runs and exits cleanly, the internal links resolve (the `/deja-vu/…` paths in 404.html are the Pages base and are correct), and the animated install panel on the landing page is an illustration with internally consistent figures rather than a claim about a specific machine.