### PR TITLE
docs(json): correct the schema versions the examples show

### DIFF
--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -12,8 +12,9 @@ a `schema_version` field so consumers can detect breaking changes.
   or type change). Consumers should branch on `schema_version` before parsing
   the rest of the envelope.
 - The current version is **2** (constant in `internal/jsonout`).
-- **`deja blame --json`** returns a top-level JSON array. Its element shape is
-  stable; only additive fields inside `session` or hit objects are permitted.
+- **`deja blame --json`** and **`deja log --json`** return a top-level JSON
+  array rather than an envelope, so neither carries `schema_version`. Their
+  element shapes are stable; only additive fields inside them are permitted.
 
 ### What changed in version 2
 
@@ -126,7 +127,7 @@ Recent session metadata uses a versioned envelope and never includes messages:
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "sessions": [
     {
       "harness": "codex",
@@ -151,7 +152,7 @@ return redacted index content in a bounded message window; the default limit is
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "session": {
     "harness": "codex",
     "id": "abc123",
@@ -172,7 +173,7 @@ the end returns an empty `messages` array and a `returned` count of zero.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "total_sessions": 42,
   "total_messages": 318,
   "repeat_questions": 3,
@@ -215,14 +216,15 @@ the end returns an empty `messages` array and a `returned` count of zero.
 }
 ```
 
-Optional fields are omitted when zero or empty. The heatmap grid used by
+Optional fields are omitted when zero or empty — `sidecar_size`, for one,
+appears only after `deja embed` has built a semantic sidecar. The heatmap grid used by
 `--card` is intentionally excluded from `--json` output.
 
 ## `deja doctor --json`
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "stores": [
     {
       "name": "claude",


### PR DESCRIPTION
From the overnight sweep, section C3 — every `--json` output parsed and compared with what the reference documents.

**The versions were wrong.** `last`, `show`, `stats` and `doctor` all print `"schema_version": 2`; the examples for all four showed `1`. Anyone writing an integration would branch on the version the document taught them.

**`deja log --json` returns a bare array**, like `blame`, and so carries no `schema_version`. The stability policy called out `blame` alone, leaving the other one looking like an omission rather than a shape.

**`sidecar_size`** is in the example but absent from real output until `deja embed` has run. The document already said optional fields are omitted; it now names this one, since it is the field most likely to be missed.

Checked at the same time and correct: every `--json` output parses, field names in the `last` and `stats` examples match the real payloads exactly, and `deja show --json` refusing without `--harness` is the documented exact-identity rule rather than a failure.