### PR TITLE
fix(roo): say why nothing was wired instead of "unchanged roo"

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -128,7 +128,11 @@ func runInstall(dir string, args []string, uninstall bool) error {
 		if banner {
 			done = append(done, lineItem{t, r.Action, shortHome(r.Path)})
 		} else {
-			fmt.Printf("%s: %s %s\n", t, r.Action, r.Path)
+			if r.Path == "" {
+				fmt.Printf("%s: %s\n", t, r.Action)
+			} else {
+				fmt.Printf("%s: %s %s\n", t, r.Action, r.Path)
+			}
 		}
 		if !uninstall && t != "statusline" {
 			mcpCount++

--- a/cmd/deja/install_roo.go
+++ b/cmd/deja/install_roo.go
@@ -45,7 +45,11 @@ func installRoo(exe string, uninstall bool) (installResult, error) {
 		}
 	}
 	if !wrote && last.Path == "" {
-		return installResult{Path: "roo", Action: "unchanged"}, nil
+		// No host has ever run Roo here, so there is no settings file to write
+		// into and creating one would leave configuration for an editor that is
+		// not installed. Say that, rather than "unchanged roo", which names a
+		// path that does not exist and explains nothing.
+		return installResult{Action: "no Roo host found — open Roo in VS Code once, then re-run"}, nil
 	}
 	return last, nil
 }

--- a/cmd/deja/install_roo_test.go
+++ b/cmd/deja/install_roo_test.go
@@ -103,3 +103,20 @@ func TestRooGuidanceGoesToGlobalRules(t *testing.T) {
 		t.Fatalf("uninstall left the block:\n%s", b)
 	}
 }
+
+// Roo only writes MCP settings into hosts it has actually run in, so on a
+// machine without one nothing is written — and the message used to be
+// "unchanged roo", naming a path that does not exist and explaining nothing.
+func TestRooSaysWhyNothingWasWritten(t *testing.T) {
+	hermeticEnv(t)
+	res, err := installRoo("/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Path != "" {
+		t.Fatalf("no host means no path to report, got %q", res.Path)
+	}
+	if !strings.Contains(res.Action, "no Roo host") {
+		t.Fatalf("the reader needs to know why: %q", res.Action)
+	}
+}


### PR DESCRIPTION
From the overnight sweep, section B7 across the harnesses that get used least — where the previous two nights' real findings (antigravity, grok) also came from.

`deja install roo` on a machine where Roo has never run printed:

```
roo: guidance created ~/.roo/rules/deja.md
roo: unchanged roo
```

The behaviour is deliberate and right — Roo's MCP settings live inside a VS Code host's storage, and creating that directory would leave configuration for an editor that is not installed. The message is the problem: `roo` is not a path, `unchanged` is not what happened, and the reader cannot tell whether the install worked.

```
roo: no Roo host found — open Roo in VS Code once, then re-run
```

With a host present the behaviour is unchanged, verified against a fixture host directory.

Checked at the same time across pi, openclaw, kimi, cline, goose and copilot: each writes a real config, and every file written — six JSON, one YAML — parses.