### PR TITLE
fix(forget): make --dry-run tell the truth about what it did and would do

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -935,6 +935,14 @@ func runForget(dir string, args []string) error {
 	if err != nil {
 		return err
 	}
+	// A dry run changes nothing, so reporting it in the past tense — the same
+	// three lines the real command prints — tells the reader their sessions are
+	// gone when they are not.
+	if o.DryRun {
+		fmt.Fprintf(os.Stdout, "dry run — nothing was changed\nwould drop: %d session(s), %d message(s)\nwould add: %d tombstone(s)\n",
+			result.Sessions, result.Messages, result.Tombstones)
+		return nil
+	}
 	fmt.Fprintf(os.Stdout, "sessions dropped: %d\nmessages dropped: %d\ntombstones added: %d\n", result.Sessions, result.Messages, result.Tombstones)
 	return nil
 }

--- a/internal/index/asked_test.go
+++ b/internal/index/asked_test.go
@@ -227,3 +227,36 @@ func TestMissingBucketsForcesARebuild(t *testing.T) {
 		t.Fatal("a healthy index must not be reported as broken")
 	}
 }
+
+// `forget --dry-run` exists to answer "how much am I about to lose". It used to
+// return zero messages, because the count ran after the dry-run branch, and to
+// report its result in the past tense as though the deletion had happened.
+func TestForgetDryRunPredictsWhatTheRealRunDoes(t *testing.T) {
+	mk := func() string {
+		return askedFixture(t,
+			map[string][]string{
+				"keep": {"why does the cache stampede under load?"},
+				"drop": {"why does the pool exhaust under load?"},
+			},
+			map[string]string{"keep": "2026-03-01T10:00:00Z", "drop": "2026-03-02T10:00:00Z"})
+	}
+	dir := mk()
+	dry, err := Forget(dir, ForgetOptions{Session: "drop", DryRun: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dry.Sessions != 1 || dry.Messages != 1 || dry.Tombstones != 1 {
+		t.Fatalf("dry run reported %+v, want one of each", dry)
+	}
+	// Nothing may have changed.
+	if _, ok, _ := FindByID(dir, "drop"); !ok {
+		t.Fatal("a dry run must leave the session in place")
+	}
+	real, err := Forget(dir, ForgetOptions{Session: "drop"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if real.Sessions != dry.Sessions || real.Messages != dry.Messages {
+		t.Fatalf("the dry run promised %+v and the real run did %+v", dry, real)
+	}
+}

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -203,13 +203,19 @@ func Forget(dir string, o ForgetOptions) (ForgetResult, error) {
 			dead[key] = true
 		}
 	}
-	if o.DryRun || result.Sessions == 0 {
+	if result.Sessions == 0 {
 		return result, nil
 	}
+	// Count the messages on the dry run too. It is the same single pass over
+	// records, and without it `--dry-run` answers "0 messages" to the only
+	// question it exists to answer: how much am I about to lose.
 	for _, r := range readRecordsForForget(dir) {
 		if matched[r.Record.Key] {
 			result.Messages++
 		}
+	}
+	if o.DryRun {
+		return result, nil
 	}
 	// Persist tombstones before the rebuild: a crash between the two must
 	// leave sessions forgotten, not resurrect them on the next index pass.


### PR DESCRIPTION
From the overnight sweep, section A — `deja forget` across its selectors.

`--dry-run` changes nothing, correctly: no tombstone file appears and the index is untouched. It then printed the same three lines the real command prints:

```
sessions dropped: 1
messages dropped: 0
tombstones added: 1
```

All past tense, for something that did not happen. Someone checking before a destructive command has every reason to read that as done.

And the message count was **wrong**: zero, because the pass over records ran after the dry-run branch returned. That is the one number `--dry-run` exists to provide — how much am I about to lose — and it answered nothing.

```
dry run — nothing was changed
would drop: 1 session(s), 1 message(s)
would add: 1 tombstone(s)
```

The count is the same single pass the real run makes. A test now pins dry run and real run to the same numbers, and checks the session is still there afterwards.

Verified in the same pass and correct: the real `forget` drops the session, the tombstone survives `index --rebuild` so it cannot be resurrected from source, and `--list` shows it.