### PR TITLE
fix(mcp): stop blame from sending the whole transcript to the agent

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -268,8 +268,54 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 	if !o.All && len(hits) > limit {
 		hits = hits[:limit]
 	}
-	b, err := json.Marshal(hits)
-	return string(b), err
+	// Strip the embedded transcript. A hit carries the whole session, messages
+	// and all, so one blame call returned 495 KB into an agent's context —
+	// against the ~4 KB the other tools answer in. The snippets that sit beside
+	// it are the part an agent reads; the full session is one recall_context
+	// away when it genuinely needs it.
+	return string(mustMarshalBlame(hits)), nil
+}
+
+// blameHitJSON is what the MCP blame tool returns: the same shape as the CLI's
+// --json minus the session's message list.
+type blameHitJSON struct {
+	Session  blameSessionJSON `json:"session"`
+	Title    string           `json:"title,omitempty"`
+	Count    int              `json:"count"`
+	Score    float64          `json:"score"`
+	Tier     string           `json:"tier,omitempty"`
+	Snippets []string         `json:"snippets,omitempty"`
+}
+
+type blameSessionJSON struct {
+	ID      string    `json:"id"`
+	Harness string    `json:"harness"`
+	Project string    `json:"project,omitempty"`
+	Path    string    `json:"path,omitempty"`
+	Title   string    `json:"title,omitempty"`
+	Started time.Time `json:"started,omitempty"`
+	Updated time.Time `json:"updated,omitempty"`
+	Touched []string  `json:"touched,omitempty"`
+}
+
+func mustMarshalBlame(hits []search.BlameHit) []byte {
+	out := make([]blameHitJSON, 0, len(hits))
+	for _, h := range hits {
+		out = append(out, blameHitJSON{
+			Session: blameSessionJSON{
+				ID: h.Session.ID, Harness: h.Session.Harness, Project: h.Session.Project,
+				Path: h.Session.Path, Title: h.Session.Title,
+				Started: h.Session.Started, Updated: h.Session.Updated, Touched: h.Session.Touched,
+			},
+			Title: h.Session.Title, Count: h.Count, Score: h.Score,
+			Tier: h.Tier, Snippets: h.Snippets,
+		})
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return []byte("[]")
+	}
+	return b
 }
 
 // attachAnswers puts the decision next to the question.

--- a/cmd/deja/mcp_blame_test.go
+++ b/cmd/deja/mcp_blame_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// The MCP blame tool used to marshal whole hits, which carry the session's
+// entire message list: one call on a common path returned 495 KB into an
+// agent's context, against the ~4 KB the other tools answer in.
+func TestMCPBlameLeavesTheTranscriptBehind(t *testing.T) {
+	var msgs []model.Message
+	for i := 0; i < 200; i++ {
+		msgs = append(msgs, model.Message{Role: "assistant", Text: strings.Repeat("x", 500)})
+	}
+	hits := []search.BlameHit{{
+		Session: model.Session{
+			ID: "s1", Harness: "claude", Project: "api", Title: "pool exhaustion",
+			Updated: time.Now(), Messages: msgs, Touched: []string{"/w/pool.go"},
+		},
+		Title: "pool exhaustion", Count: 3, Score: 1.5, Tier: "exact",
+		Snippets: []string{"we chose transaction pooling"},
+	}}
+	out := mustMarshalBlame(hits)
+	if len(out) > 4096 {
+		t.Fatalf("blame answered %d bytes for one hit; the transcript is still in there", len(out))
+	}
+	var got []map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	sess := got[0]["session"].(map[string]any)
+	if _, ok := sess["messages"]; ok {
+		t.Fatal("the message list must not travel to an agent")
+	}
+	// Everything an agent reads has to survive.
+	for _, want := range []string{"id", "harness", "project", "title", "touched"} {
+		if _, ok := sess[want]; !ok {
+			t.Errorf("session lost %q", want)
+		}
+	}
+	if len(got[0]["snippets"].([]any)) != 1 {
+		t.Error("snippets are the part an agent actually reads")
+	}
+}


### PR DESCRIPTION
From the overnight sweep, section B10 — calling each MCP tool and measuring what comes back.

Three tools answer in the documented budget. `blame` does not:

| call | before | after |
|---|---|---|
| `blame main.go` | **495,740 B** | 10,386 B |
| `blame main.go limit:3` | 174,411 B | **3,221 B** |
| `blame store_io.go` | 117,146 B | 4,070 B |

`BlameHit` embeds `model.Session`, which carries every message in the session — 52 of them for one hit here. `json.Marshal(hits)` therefore shipped whole transcripts into an agent's context, and `limit` could not help because the bulk is inside each hit rather than in their number. The site promises "answers under ~4 KB".

The tool now returns the same shape minus the message list: session identity, project, path, title, dates, touched files, snippets, count, score, tier. The snippets are the part an agent reads, and `recall_context` is one call away when it genuinely needs the session.

The CLI's `blame --json` is untouched — a script asking for it on purpose is a different consumer from a model with a context window.