### PR TITLE
fix(install): name what was probably meant on an unknown target

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -400,7 +400,7 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 	case "statusline":
 		return installStatusline(exe, uninstall)
 	default:
-		return installResult{}, fmt.Errorf("unknown target %q", target)
+		return installResult{}, unknownTargetError(target)
 	}
 }
 
@@ -1081,6 +1081,75 @@ func withAutoTargets(targets []string) []string {
 		}
 	}
 	return out
+}
+
+// unknownTargetError names what would have worked. There are two dozen targets
+// and the difference between them is a few characters, so a bare "unknown
+// target" leaves someone who typed `claud` guessing — while `deja completion`
+// two commands away lists its three valid values.
+func unknownTargetError(target string) error {
+	names := installTargetNames()
+	if near := nearestTarget(target, names); near != "" {
+		return fmt.Errorf("unknown target %q — did you mean %q? (`deja install --all` wires every agent it finds)", target, near)
+	}
+	return fmt.Errorf("unknown target %q — try one of: %s, or --all / --auto", target, strings.Join(names, ", "))
+}
+
+// nearestTarget finds a target within one edit of what was typed, which covers
+// the ways a name is actually got wrong: a dropped letter, a doubled one, a
+// transposition.
+func nearestTarget(typed string, names []string) string {
+	typed = strings.ToLower(strings.TrimSpace(typed))
+	if typed == "" {
+		return ""
+	}
+	// A truncated name is the commonest miss — `claud` for claude-code — and it
+	// is far from the full string by edit distance, so check prefixes first.
+	for _, n := range names {
+		if strings.HasPrefix(n, typed) {
+			return n
+		}
+	}
+	best, bestDist := "", 3
+	for _, n := range names {
+		if d := editDistance(typed, n); d < bestDist {
+			best, bestDist = n, d
+		}
+	}
+	return best
+}
+
+func editDistance(a, b string) int {
+	if a == b {
+		return 0
+	}
+	prev := make([]int, len(b)+1)
+	cur := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		cur[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			cur[j] = min3(cur[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(b)]
+}
+
+func min3(a, b, c int) int {
+	if b < a {
+		a = b
+	}
+	if c < a {
+		a = c
+	}
+	return a
 }
 
 func installTargetNames() []string {

--- a/cmd/deja/install_target_test.go
+++ b/cmd/deja/install_target_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Two dozen targets differ by a few characters, so a bare "unknown target"
+// left someone who typed `claud` with nowhere to go — while `deja completion`
+// has always listed its three valid values.
+func TestUnknownTargetSuggestsWhatWasMeant(t *testing.T) {
+	for typed, want := range map[string]string{
+		"claud":   "claude-code",
+		"opencde": "opencode",
+		"cursorr": "cursor",
+		"gemin":   "gemini",
+		"qwn":     "qwen",
+	} {
+		got := unknownTargetError(typed).Error()
+		if !strings.Contains(got, want) {
+			t.Errorf("install %q should suggest %q: %s", typed, want, got)
+		}
+	}
+	// Nothing close: list what would work rather than guessing.
+	full := unknownTargetError("zzzz").Error()
+	if strings.Contains(full, "did you mean") {
+		t.Errorf("no near match should mean no guess: %s", full)
+	}
+	for _, want := range []string{"claude-code", "codex", "--all"} {
+		if !strings.Contains(full, want) {
+			t.Errorf("the list should name %q: %s", want, full)
+		}
+	}
+}
+
+func TestEditDistance(t *testing.T) {
+	cases := map[[2]string]int{
+		{"", ""}: 0, {"a", ""}: 1, {"", "ab"}: 2,
+		{"cursor", "cursor"}: 0, {"cursorr", "cursor"}: 1,
+		{"qwen", "qwn"}: 1, {"kitten", "sitting"}: 3,
+	}
+	for in, want := range cases {
+		if got := editDistance(in[0], in[1]); got != want {
+			t.Errorf("editDistance(%q, %q) = %d, want %d", in[0], in[1], got, want)
+		}
+	}
+}


### PR DESCRIPTION
From the overnight sweep, section E8 — reading every error message the commands can print.

`deja install claud` answered:

```
deja: unknown target "claud"
```

Two dozen targets differ from each other by a few characters, so that leaves the reader guessing — while `deja completion zsh2` two commands away has always answered *"want bash, zsh, or fish"*.

```
deja: unknown target "claud" — did you mean "claude-code"? (`deja install --all` wires every agent it finds)
deja: unknown target "zzz" — try one of: claude-code, claude-auto, codex, …, or --all / --auto
```

Prefix first, then edit distance within two. Prefix matters because a truncated name is the commonest miss and is *far* from the full string by edit distance — `claud` to `claude-code` is six edits. Nothing close means no guess at all, just the list.