### PR TITLE
fix(doctor): stop --deep reporting drift on a healthy index

### DIFF
--- a/internal/index/asked_test.go
+++ b/internal/index/asked_test.go
@@ -260,3 +260,45 @@ func TestForgetDryRunPredictsWhatTheRealRunDoes(t *testing.T) {
 		t.Fatalf("the dry run promised %+v and the real run did %+v", dry, real)
 	}
 }
+
+// deepverify compares what a source parses to what the index holds. It has to
+// count what ingestion would *keep*: a message that is empty, or that strips to
+// empty once deja's own injected recall is removed, is never written — so
+// counting it reported drift on a healthy index and told the reader to rebuild,
+// which reproduces it. Seen on a real codex session: "source parses 6 messages,
+// index holds 5", surviving every rebuild.
+func TestDeepVerifyIgnoresMessagesIngestionWouldDrop(t *testing.T) {
+	msgs := []model.Message{
+		{Role: "user", Text: "a real question about the pool"},
+		{Role: "user", Text: "   "},
+		{Role: "user", Text: ""},
+		{Role: "assistant", Text: "a real answer about pgx"},
+	}
+	seen := msgSeen{}
+	want := 0
+	for _, m := range msgs {
+		if strings.TrimSpace(stripSelfRecall(m.Text)) == "" {
+			continue
+		}
+		if !seen.dup("k", m.Role, m.Time, m.Text) {
+			want++
+		}
+	}
+	if want != 2 {
+		t.Fatalf("counted %d messages, want the two with content", want)
+	}
+	// A genuinely missing message must still count, or the check stops working.
+	seen2 := msgSeen{}
+	n := 0
+	for _, m := range append(msgs, model.Message{Role: "user", Text: "a third real one"}) {
+		if strings.TrimSpace(stripSelfRecall(m.Text)) == "" {
+			continue
+		}
+		if !seen2.dup("k", m.Role, m.Time, m.Text) {
+			n++
+		}
+	}
+	if n != 3 {
+		t.Fatalf("counted %d, want three — real content must never be skipped", n)
+	}
+}

--- a/internal/index/deepverify.go
+++ b/internal/index/deepverify.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
@@ -113,10 +114,16 @@ func DeepVerify(dir string) (DeepReport, error) {
 				report.Findings = append(report.Findings, DeepFinding{Kind: "parse-drift", Detail: key + " parses from " + p + " but is absent from the index"})
 				continue
 			}
-			// Count with the same dedup ingestion applies, so duplicate
-			// messages in the source do not read as lost memory.
+			// Count exactly what ingestion would keep, or the check reports
+			// drift on a healthy index and tells the reader to rebuild — which
+			// reproduces it. Two rules apply beyond dedup: a message that is
+			// empty, or that strips to empty once deja's own injected recall
+			// and harness plumbing are removed (#551), is never written.
 			want := 0
 			for _, msg := range s.Messages {
+				if strings.TrimSpace(stripSelfRecall(msg.Text)) == "" {
+					continue
+				}
 				if !seen.dup(key, msg.Role, msg.Time, msg.Text) {
 					want++
 				}


### PR DESCRIPTION
From the overnight sweep, section A — `deja doctor --deep`.

On this store it reported:

```
drift    [parse-drift] codex:019fa03c-…: source parses 6 messages, index holds 5
status   1 finding — run `deja index --rebuild`
```

Nothing is wrong with that session, and the advice does not help: the finding survives a clean rebuild, because the rebuild drops the same message again. The source has seven textual payloads, two of them empty; ingestion writes neither, and the check counted them as lost memory.

The comparison already accounted for dedup. It now also skips what ingestion skips: a message that is empty, or that strips to empty once deja's own injected recall and harness plumbing are removed (#551).

```
status   index matches sources — no memory lost
```

Exit code goes from 1 to 0 on a healthy index, which matters — `doctor --deep` is the kind of thing people put in a cron job.

Genuine loss still counts: the test pins that a message with content is never skipped, and a source that changed after the build is still reported, as staleness rather than drift.