### PR TITLE
fix(sources): list the four harnesses it had fallen behind on

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -814,6 +814,10 @@ func printSources(dir string) {
 		{"goose", filepath.Join(sources.GooseRoot(), "sessions"), []string{filepath.Join(sources.GooseRoot(), "sessions")}, sources.LoadGoose},
 		{"hermes", sources.HermesProfilesRoot(), []string{sources.HermesProfilesRoot()}, sources.LoadHermes},
 		{"copilot", sources.CopilotRoot(), []string{sources.CopilotRoot()}, sources.LoadCopilot},
+		{"cline", sources.ClineSessionsDir(), append([]string{sources.ClineSessionsDir()}, sources.ClineLegacyRoots()...), sources.LoadCline},
+		{"roo", strings.Join(sources.RooRoots(), string(os.PathListSeparator)), sources.RooRoots(), sources.LoadRoo},
+		{"pi", sources.PiRoot(), []string{sources.PiRoot()}, sources.LoadPi},
+		{"openclaw", sources.OpenClawRoot(), []string{sources.OpenClawRoot()}, sources.LoadOpenClaw},
 		{"deja", sources.NotesFile(), []string{sources.NotesFile()}, sources.LoadNotes},
 	}
 	for _, it := range items {

--- a/cmd/deja/sources_coverage_test.go
+++ b/cmd/deja/sources_coverage_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// `deja sources` answers "where did deja look", and the empty-state advice
+// points people at it. Its harness list was hand-maintained and had fallen four
+// behind the registry: cline, roo, pi and openclaw were absent while their
+// sessions — 33 of them here — sat in the index.
+func TestSourcesListsEveryHarnessInTheRegistry(t *testing.T) {
+	hermeticEnv(t)
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var b bytes.Buffer
+		_, _ = b.ReadFrom(r)
+		done <- b.String()
+	}()
+	printSources(t.TempDir())
+	_ = w.Close()
+	os.Stdout = old
+	out := <-done
+
+	for _, h := range sources.Registry() {
+		if !strings.Contains(out, h.Name) {
+			t.Errorf("deja sources never mentions %q, so nobody can tell whether deja looked there", h.Name)
+		}
+	}
+}


### PR DESCRIPTION
From the overnight sweep, section A — comparing `deja sources` with `deja doctor`.

`sources` listed 14 stores; doctor found 17. Missing: **cline, pi, openclaw** — and `roo`, which has no store on this machine so it could not be seen empirically. Their sessions are in the index: cline 15, openclaw 13, pi 5.

That matters more than a cosmetic omission. `deja sources` is the command that answers *where did deja look*, and since #598 it is where the empty-state message sends someone who found nothing: "no agent history was found on this machine; `deja sources` shows where deja looked". Pointing at a list that omits four harnesses is worse than not pointing anywhere.

The list was hand-maintained beside a registry that already knows every harness — the same shape as #599, where the shell completions had fallen four commands behind. A test now walks `sources.Registry()` and fails if any name is missing from the output, so the two cannot drift apart again.