### PR TITLE
feat(search): name the command behind a mistyped subcommand

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -493,13 +493,35 @@ func printFuzzy(w io.Writer, variants map[string][]string) {
 		keys = append(keys, token)
 	}
 	sort.Strings(keys)
+	hinted := false
 	for _, token := range keys {
 		for _, variant := range variants[token] {
 			if variant != token {
 				fmt.Fprintf(w, "deja: no exact match, trying close spellings: %s -> %s\n", token, variant)
+				// A misspelled subcommand is searched for as a word: `deja
+				// isntall` corrects to "install" and returns sessions that
+				// mention installing, which is not what the typist wanted.
+				// Spelled correctly it would have run the command, so the only
+				// case this fires on is the one where the hint is wanted.
+				if !hinted && isSubcommand(variant) {
+					fmt.Fprintf(w, "deja: `%s` is also a command — run `deja %s` if that is what you meant\n", variant, variant)
+					hinted = true
+				}
 			}
 		}
 	}
+}
+
+// isSubcommand reports whether a word names something deja can run.
+func isSubcommand(word string) bool {
+	if _, ok := commands[word]; ok {
+		return true
+	}
+	switch word {
+	case "show", "last", "help":
+		return true
+	}
+	return false
 }
 
 func findByPrefix(dir, p string) (model.Session, bool, error) {

--- a/cmd/deja/typo_hint_test.go
+++ b/cmd/deja/typo_hint_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// A misspelled subcommand is searched for as a word — `deja isntall` corrects
+// to "install" and returns sessions that mention installing, which is not what
+// the typist wanted. Spelled correctly it would have run the command, so the
+// hint only ever fires on the case where it is wanted.
+func TestFuzzyNamesTheCommandBehindATypo(t *testing.T) {
+	var b bytes.Buffer
+	printFuzzy(&b, map[string][]string{"isntall": {"install"}})
+	got := b.String()
+	if !strings.Contains(got, "isntall -> install") {
+		t.Fatalf("the correction itself must still be reported: %q", got)
+	}
+	if !strings.Contains(got, "deja install") {
+		t.Fatalf("a corrected subcommand should be offered: %q", got)
+	}
+
+	// An ordinary word that happens to be misspelled gets no command hint.
+	b.Reset()
+	printFuzzy(&b, map[string][]string{"pgbouncr": {"pgbouncer"}})
+	if strings.Contains(b.String(), "is also a command") {
+		t.Fatalf("no command is named pgbouncer: %q", b.String())
+	}
+
+	// One hint is enough however many terms were corrected.
+	b.Reset()
+	printFuzzy(&b, map[string][]string{"isntall": {"install"}, "resotre": {"restore"}})
+	if n := strings.Count(b.String(), "is also a command"); n != 1 {
+		t.Fatalf("hinted %d times, want once: %q", n, b.String())
+	}
+}


### PR DESCRIPTION
From the overnight sweep, section A — what an unknown word does.

Bare words are a query, deliberately, so `deja isntall` searches. The fuzzy tier then corrects the spelling and reports it:

```
deja: no exact match, trying close spellings: isntall -> install
```

followed by sessions that mention installing. The search is doing exactly the right thing and the reader wanted something else entirely.

```
deja: no exact match, trying close spellings: isntall -> install
deja: `install` is also a command — run `deja install` if that is what you meant
```

The hint fires only when a *misspelled* term corrects to a subcommand name. Spelled correctly it would have run the command (#429), and an ordinary misspelling like `pgbouncr` names no command, so there is no case where this adds noise to a real query. One hint however many terms were corrected.