### PR TITLE
fix(files,restore): say the index is building instead of hanging silently

### DIFF
--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -70,7 +70,7 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 	}
 	q := strings.Join(terms, " ")
 	o := search.Options{Query: q, All: true, Project: project}
-	if err := index.EnsureForSearch(dir, o, false, nil); err != nil {
+	if err := index.EnsureForSearch(dir, o, false, os.Stderr); err != nil {
 		return ensureError(dir, err)
 	}
 	hits, err := index.Search(dir, o)

--- a/cmd/deja/restore.go
+++ b/cmd/deja/restore.go
@@ -108,7 +108,7 @@ func runRestore(dir string, args []string, stdout io.Writer) error {
 func findRestoreSpans(dir string, path string) ([]restoreSpan, error) {
 	base := filepath.Base(path)
 	o := search.Options{Query: base, All: true, Role: "edit"}
-	if err := index.EnsureForSearch(dir, o, false, nil); err != nil {
+	if err := index.EnsureForSearch(dir, o, false, os.Stderr); err != nil {
 		return nil, ensureError(dir, err)
 	}
 	hits, err := index.Search(dir, o)


### PR DESCRIPTION
From the overnight sweep — a loose end noted while checking the empty-store behaviour and confirmed now.

On a machine with no index, six commands were compared:

| command | narrates the build |
|---|---|
| `deja <query>`, `blame`, `last`, `stats` | yes |
| **`files`, `restore`** | **no** |

Both passed `nil` as the progress writer to `EnsureForSearch` while everything else passes `os.Stderr`, so a first run of either sat silent for the length of a full build — 19 s on a 1150-session corpus — with no indication anything was happening.

Narration goes to stderr, so piping either command is unaffected: `deja files` and `deja restore` still print exactly what they printed before on stdout.