### PR TITLE
chore(packaging): pin scoop/winget manifests to 0.16.5

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,12 +1,12 @@
 {
     "architecture": {
         "64bit": {
-            "hash": "e5cdeb6d81ea7720ad4894c2b9e2059d68a44ac9497c4d01cb9d8a2a7f395fc4",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.4/deja-vu_0.16.4_windows_amd64.zip"
+            "hash": "aa9821b114d6244172f58f5ee779f4ee559e12eb56afdd7e594c31c1c218114a",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.5/deja-vu_0.16.5_windows_amd64.zip"
         },
         "arm64": {
-            "hash": "2e59ec860cee6ed1ca7694a37414aedce84395cbb0011df117318d06e2d5ff94",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.4/deja-vu_0.16.4_windows_arm64.zip"
+            "hash": "81cdabeca829b2896cd7d9e51faab7f8f7fe6f8c9997a370607a5f99c9d2be7e",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.5/deja-vu_0.16.5_windows_arm64.zip"
         }
     },
     "autoupdate": {
@@ -24,5 +24,5 @@
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
-    "version": "0.16.4"
+    "version": "0.16.5"
 }

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.4
+PackageVersion: 0.16.5
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.4/deja-vu_0.16.4_windows_amd64.zip
-  InstallerSha256: E5CDEB6D81EA7720AD4894C2B9E2059D68A44AC9497C4D01CB9D8A2A7F395FC4
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.5/deja-vu_0.16.5_windows_amd64.zip
+  InstallerSha256: AA9821B114D6244172F58F5EE779F4EE559E12EB56AFDD7E594C31C1C218114A
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.4/deja-vu_0.16.4_windows_arm64.zip
-  InstallerSha256: 2E59EC860CEE6ED1CA7694A37414AEDCE84395CBB0011DF117318D06E2D5FF94
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.5/deja-vu_0.16.5_windows_arm64.zip
+  InstallerSha256: 81CDABECA829B2896CD7D9E51FAAB7F8F7FE6F8C9997A370607A5F99C9D2BE7E
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.4
+PackageVersion: 0.16.5
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.4/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.5/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.4
+PackageVersion: 0.16.5
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Version and checksums from the v0.16.5 release artifacts.