### PR TITLE
feat(opencode): index what commands printed, and whether they succeeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ limits, trust assumptions, and release verification.
 
 Custom locations via `DEJA_CLAUDE_ROOT`, `DEJA_CODEX_ROOT`, `DEJA_OPENCODE_DB`, `DEJA_AIDER_ROOTS`, `DEJA_GEMINI_ROOT`, `DEJA_CURSOR_ROOT`, `DEJA_CURSOR_CLI_ROOT`, `DEJA_ANTIGRAVITY_ROOT`, `DEJA_GROK_ROOT`, `DEJA_QWEN_ROOT`, `DEJA_INDEX_DIR`. Each agent's own relocation variable is honored too: `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `GEMINI_CLI_HOME`, `CURSOR_CONFIG_DIR`, `GROK_HOME`, `AIDER_CHAT_HISTORY_FILE`, and `XDG_DATA_HOME` for opencode on Linux.
 
-deja also indexes what the agent did — the file paths its tool calls named, the commands it ran, and the spans its edits replaced. Each can be turned off at ingest: `DEJA_INDEX_PATHS=0`, `DEJA_INDEX_COMMANDS=0`, `DEJA_INDEX_EDITS=0`. They go through the same redaction pass as conversation text.
+deja also indexes what the agent did — the file paths its tool calls named, the commands it ran with their exit status, what those commands printed, and the spans its edits replaced. Each can be turned off at ingest: `DEJA_INDEX_PATHS=0`, `DEJA_INDEX_COMMANDS=0`, `DEJA_INDEX_EDITS=0`, `DEJA_INDEX_TOOL_OUTPUT=0`. They go through the same redaction pass as conversation text.
 
 `DEJA_RECALL=safe` is the default: SessionStart recall stays in the current project, filters weak or duplicate results, prefers the last 90 days, and injects at most 2KB. `DEJA_RECALL=aggressive` searches across projects and raises the injection cap to 4KB. `DEJA_RECALL=off` disables SessionStart recall output.
 

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -24,8 +24,9 @@ tools printed, and the exact spans its edits replaced. Replaced spans are
 verbatim source from the user's own files, kept so a lost change can be handed
 back. All of it goes through the same redaction pass as conversation text, which
 matters more here than elsewhere: command output carries credentials far more
-often than prose does. `DEJA_INDEX_PATHS=0`, `DEJA_INDEX_COMMANDS=0` and
-`DEJA_INDEX_EDITS=0` each disable one of these at ingest.
+often than prose does. `DEJA_INDEX_PATHS=0`, `DEJA_INDEX_COMMANDS=0`,
+`DEJA_INDEX_EDITS=0` and `DEJA_INDEX_TOOL_OUTPUT=0` each disable one of these at
+ingest.
 
 ### Local writes
 

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -631,13 +631,78 @@ func dateTokens(when time.Time) []string {
 // and indexing 1 MB of source code puts every `func` and `return` in it into
 // the postings, which cost the median query 0.5 ms for nothing.
 func tokenizedPart(role, text string) string {
-	if role != roleEdit {
+	switch role {
+	case roleEdit:
+		if i := strings.IndexByte(text, '\n'); i >= 0 {
+			return text[:i]
+		}
 		return text
-	}
-	if i := strings.IndexByte(text, '\n'); i >= 0 {
-		return text[:i]
+	case roleToolOutput:
+		return signalLines(text)
 	}
 	return text
+}
+
+// signalLines keeps the part of a command's output anyone would search for.
+//
+// A build log is mostly progress: files compiled, tests named, packages
+// downloaded. Measured over 147,575 lines of real output, 3% carry an error or
+// a warning and they are 7% of the bytes — the rest is noise that nobody
+// queries and that doubles the sessions a common word matches. Indexing all of
+// it took the commonest word in a 1150-session store from 22 ms to 59 ms.
+//
+// The full text is still stored and still served: this decides what earns
+// postings, exactly as a replaced span stores its body and indexes its path.
+func signalLines(text string) string {
+	if len(text) < signalFloor {
+		return text
+	}
+	var b strings.Builder
+	b.Grow(len(text) / 8)
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		if !signalLine(line) {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+		// The line after a verdict is usually what the verdict was about — the
+		// assertion, the missing symbol, the path. Keeping the marker and
+		// dropping the explanation made a test name unfindable while its
+		// "--- FAIL" line was indexed.
+		if i+1 < len(lines) && !signalLine(lines[i+1]) {
+			b.WriteString(lines[i+1])
+			b.WriteByte('\n')
+		}
+	}
+	if b.Len() == 0 {
+		// Nothing matched: index the head rather than nothing, so a short
+		// unusual output is still findable.
+		if len(text) > signalFloor {
+			return text[:signalFloor]
+		}
+		return text
+	}
+	return b.String()
+}
+
+// signalFloor is the length below which output is indexed whole. A short
+// output is usually the answer to something — a test run, a failed build, a
+// one-line error — and filtering it costs recall on exactly the queries this
+// data exists to serve. Only the long logs get filtered: measured on a real
+// store, outputs above this threshold are 7% of the records and 74% of the
+// bytes, and they are where the posting explosion comes from.
+const signalFloor = 8192
+
+func signalLine(l string) bool {
+	for _, p := range []string{"FAIL", "fail", "Error", "error", "panic:", "fatal",
+		"Traceback", "not found", "undefined", "cannot", "refused", "denied",
+		"timeout", "exit status", "warning", "WARN", "Exception", "No such"} {
+		if strings.Contains(l, p) {
+			return true
+		}
+	}
+	return false
 }
 
 func addIndexKeys(buckets bucketPostings, text string, off int64, sid uint32, when time.Time, tool bool) {

--- a/internal/index/tool_postings_test.go
+++ b/internal/index/tool_postings_test.go
@@ -133,3 +133,56 @@ func TestTopTouchedFilesIsCapped(t *testing.T) {
 		t.Fatalf("stored %d paths, want the cap of %d", len(got), touchedFileCap)
 	}
 }
+
+// Tool output is indexed whole below a threshold and filtered above it. A short
+// output is usually the answer to something; a 50 KB build log is progress
+// nobody searches, and indexing all of it took the commonest word on a
+// 1150-session store from 22 ms to 57 ms.
+func TestSignalLinesKeepsShortOutputWhole(t *testing.T) {
+	short := "--- FAIL: TestRetry (0.01s)\n    retry_test.go:42: got 3 want 4\nFAIL\tpkg\t0.1s"
+	if got := tokenizedPart(roleToolOutput, short); got != short {
+		t.Fatalf("short output must be indexed whole:\n%s", got)
+	}
+}
+
+func TestSignalLinesFiltersLongLogs(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < 400; i++ {
+		fmt.Fprintf(&b, "downloading github.com/example/module/v%d\n", i)
+	}
+	b.WriteString("--- FAIL: TestRetry (0.01s)\n")
+	b.WriteString("    retry_test.go:42: got 3 want 4\n")
+	got := tokenizedPart(roleToolOutput, b.String())
+	if len(got) >= b.Len() {
+		t.Fatalf("a long log should shrink: %d of %d bytes", len(got), b.Len())
+	}
+	// The verdict and the line explaining it both survive.
+	if !strings.Contains(got, "--- FAIL: TestRetry") {
+		t.Error("the verdict must be indexed")
+	}
+	if !strings.Contains(got, "retry_test.go:42") {
+		t.Error("the line after a verdict is what it was about")
+	}
+	if strings.Contains(got, "downloading github.com/example/module/v200") {
+		t.Error("progress lines are what the filter exists to drop")
+	}
+}
+
+func TestSignalLinesFallsBackWhenNothingMatches(t *testing.T) {
+	// A long output with no error-shaped line still has to be findable.
+	quiet := strings.Repeat("all quiet on the build front\n", 500)
+	got := tokenizedPart(roleToolOutput, quiet)
+	if got == "" {
+		t.Fatal("indexing nothing makes the record unreachable")
+	}
+	if len(got) > signalFloor+64 {
+		t.Fatalf("the fallback should be bounded, got %d bytes", len(got))
+	}
+}
+
+func TestSignalLinesLeavesOtherRolesAlone(t *testing.T) {
+	long := strings.Repeat("a sentence someone actually typed. ", 500)
+	if got := tokenizedPart("assistant", long); got != long {
+		t.Fatal("speech is indexed whole however long it is")
+	}
+}

--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -94,6 +95,13 @@ func ParseOpencodeDBWhere(db, where string, limit int) ([]model.Session, error) 
 		`json_extract(p.data,'$.state.input.filePath') as path,` +
 		`json_extract(p.data,'$.state.input.command') as cmd,` +
 		`json_extract(p.data,'$.state.input.patchText') as patch,` +
+		// The output of a bash call and its exit status. Only bash: `read`
+		// output is 119 MB of file contents on this store against 49 MB of
+		// command output, and #547 measured file bodies as the weakest slice
+		// deja could index. What a command printed is where the errors live.
+		`case when json_extract(p.data,'$.tool')='bash' ` +
+		`then json_extract(p.data,'$.state.output') end as out,` +
+		`json_extract(p.data,'$.state.metadata.exit') as exit,` +
 		`json_extract(p.data,'$.time.start') as pt,` +
 		`json_extract(m.data,'$.time.created') as mt ` +
 		`from session s join message m on m.session_id=s.id join part p on p.message_id=m.id ` +
@@ -180,10 +188,28 @@ func ParseOpencodeDBWhere(db, where string, limit int) ([]model.Session, error) 
 			s.Messages = append(s.Messages, model.Message{Role: RoleFiles, Text: path, Time: t})
 			continue
 		}
-		if cmd := str(r["cmd"]); cmd != "" && IndexCommands() && worthIndexing(cmd) {
+		if cmd := str(r["cmd"]); cmd != "" {
 			t := partTime(r)
-			s.Touch(t)
-			s.Messages = append(s.Messages, model.Message{Role: RoleCommand, Text: "$ " + cmd, Time: t})
+			if IndexCommands() && worthIndexing(cmd) {
+				// A non-zero exit rides with the command. opencode records it on
+				// 99% of runs, which is the one thing Claude's transcripts
+				// cannot give: there the verdict has to be inferred from output
+				// text and only ~17% of runs can be scored. Zero is left off —
+				// it is the common case, and saying so on 18,000 records would
+				// be noise rather than information.
+				line := "$ " + cmd
+				if code := exitCode(r["exit"]); code > 0 {
+					line += fmt.Sprintf("  → exit %d", code)
+				}
+				s.Touch(t)
+				s.Messages = append(s.Messages, model.Message{Role: RoleCommand, Text: line, Time: t})
+			}
+			// The output is a separate record under the same role Claude's tool
+			// results use, so `--role tool-output` means the same thing on both.
+			if out := str(r["out"]); out != "" && IndexToolOutput() {
+				s.Touch(t)
+				s.Messages = append(s.Messages, model.Message{Role: RoleToolOutput, Text: out, Time: t})
+			}
 			continue
 		}
 		if patch := str(r["patch"]); patch != "" && IndexEdits() {
@@ -312,4 +338,32 @@ func patchSpans(patch string) []string {
 	}
 	flush()
 	return out
+}
+
+// IndexToolOutput reports whether what a command printed is indexed. On by
+// default: it is where errors live, and every feature that reasons about what
+// went wrong needs it. Off is for people who want a smaller index — measured at
+// 49 MB of bash output on a 1150-session store.
+func IndexToolOutput() bool { return os.Getenv("DEJA_INDEX_TOOL_OUTPUT") != "0" }
+
+// exitCode reads the status opencode records for a command. sqlite3 -json
+// hands numbers back as json.Number or float64 depending on the shape.
+func exitCode(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case json.Number:
+		i, err := n.Int64()
+		if err != nil {
+			return 0
+		}
+		return int(i)
+	case string:
+		i, err := strconv.Atoi(n)
+		if err != nil {
+			return 0
+		}
+		return i
+	}
+	return 0
 }

--- a/internal/sources/opencode_test.go
+++ b/internal/sources/opencode_test.go
@@ -114,3 +114,66 @@ insert into part values('p3','m1','{"type":"tool","tool":"apply_patch","state":{
 		t.Fatalf("edits = %v", edits)
 	}
 }
+
+func TestOpencodeIndexesCommandOutputAndExitStatus(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	tmp := t.TempDir()
+	db := filepath.Join(tmp, "opencode.db")
+	script := `create table session(id text, directory text, time_created any, time_updated any);
+create table message(id text, session_id text, time_created any, data text);
+create table part(id text, message_id text, data text);
+insert into session values('s1','/w','2026-01-02T03:00:00Z','2026-01-03T03:00:00Z');
+insert into message values('m1','s1',1767409200000,'{"role":"assistant"}');
+insert into part values('p1','m1','{"type":"tool","tool":"bash","state":{"input":{"command":"go test ./pkg/"},"output":"--- FAIL: TestRetry\nFAIL\tpkg 0.1s","metadata":{"exit":1}},"time":{"start":"2026-01-02T03:00:00Z"}}');
+insert into part values('p2','m1','{"type":"tool","tool":"bash","state":{"input":{"command":"go build ./..."},"output":"","metadata":{"exit":0}},"time":{"start":"2026-01-02T03:00:01Z"}}');
+insert into part values('p3','m1','{"type":"tool","tool":"read","state":{"input":{"filePath":"/w/big.go"},"output":"package main\n// thousands of lines of file content"},"time":{"start":"2026-01-02T03:00:02Z"}}');`
+	if out, err := exec.Command("sqlite3", db, script).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite setup: %v %s", err, out)
+	}
+	ss, err := ParseOpencodeDB(db)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("len=%d err=%v", len(ss), err)
+	}
+	var cmds, outs []string
+	for _, m := range ss[0].Messages {
+		switch m.Role {
+		case RoleCommand:
+			cmds = append(cmds, m.Text)
+		case RoleToolOutput:
+			outs = append(outs, m.Text)
+		}
+	}
+	// A failure carries its status; a success does not — saying "exit 0" on
+	// every passing run is noise, and zero is the default reading.
+	if len(cmds) != 2 {
+		t.Fatalf("commands = %v", cmds)
+	}
+	if !strings.Contains(cmds[0], "→ exit 1") {
+		t.Errorf("a non-zero exit belongs on the command: %q", cmds[0])
+	}
+	if strings.Contains(cmds[1], "exit") {
+		t.Errorf("a successful run needs no annotation: %q", cmds[1])
+	}
+	// The output of a command is indexed; the body of a file read is not —
+	// file contents are 119 MB against 49 MB of command output on a real store.
+	if len(outs) != 1 || !strings.Contains(outs[0], "--- FAIL") {
+		t.Fatalf("tool output = %v", outs)
+	}
+	for _, o := range outs {
+		if strings.Contains(o, "thousands of lines") {
+			t.Error("read bodies must not be indexed as tool output")
+		}
+	}
+}
+
+func TestExitCodeReadsEveryShapeSQLiteEmits(t *testing.T) {
+	for in, want := range map[any]int{
+		float64(1): 1, float64(0): 0, "127": 127, "": 0, nil: 0, "junk": 0,
+	} {
+		if got := exitCode(in); got != want {
+			t.Errorf("exitCode(%#v) = %d, want %d", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes the largest slice of #595, and unblocks #539.

**Coverage.** `tool-output` existed for **19 sessions out of 1,149** — all Claude — while being 36% of the index by stored text. opencode records the same material for 362 more:

| | before | after |
|---|---|---|
| sessions with tool output | 19 | **381 (33%)** |

**And an outcome that is a fact rather than a guess.** opencode stores `state.metadata.exit`; a non-zero status now rides on the command record (`$ go test ./... → exit 1`). Zero is left off — saying so on 18,000 passing runs is noise. Re-running #539's kill condition:

| harness | test runs | scored |
|---|---|---|
| opencode | 707 | **707 (100%)** |
| claude | 474 | 0 — no exit status exists to read |

**`read` output is deliberately excluded.** It is 119 MB of file contents on this store against 49 MB of command output, and #547 measured file bodies as the weakest thing deja could index. What a command printed is where the errors are.

**Cost, measured interleaved.** Index 83 → 110 MB, build 19 → 28 s, search median 2.2 → 2.7 ms, p90 22 → 41 ms.

The p90 needed work: indexing every line took it to 57 ms, because a build log is mostly progress and doubled the sessions a common word matches. Two filters were tried. Filtering all output cut p90 to 38 ms but lost recall on the exact queries this data exists for — a test name went from 9 sessions to 4. Filtering **only outputs above 8 KB** keeps recall (`ModuleNotFoundError` 23 → 23, `command not found` 42 → 39) and still takes p90 to 41 ms: those outputs are 7% of the records and 74% of the bytes. Below the threshold everything is indexed whole.

Full text is always stored either way — this decides what earns postings, the same trade a replaced span makes by storing its body and indexing its path.

`DEJA_INDEX_TOOL_OUTPUT=0` turns it off, which also answers #614: tool output was the only record kind without a switch.