### PR TITLE
feat: deja friction — errors that recur across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | **Blame** | `deja blame <path>` — which sessions touched this file, what was decided and why |
 | **Restore** | `deja restore <path>` — hand back a span an agent replaced, from the `old_string` its edit recorded; never writes over the original |
 | **Files** | `deja files <topic>` — the other direction: which files the work on a subject actually touched, ranked by how specific they are to it |
+| **Friction** | `deja friction` — the errors this machine keeps hitting across sessions: a missing tool, an uninstalled module, a command that does not exist here |
 | **Semantic** | optional: point `deja embed` at a local Ollama/LM Studio and rephrased queries still hit |
 
 ## Privacy
@@ -169,6 +170,7 @@ $ deja "jwt refresh token"
 | `deja blame <path>` | Find sessions that discussed a file, newest and most specific first. `--json`, `--all`, and the usual filters are supported. |
 | `deja restore <path>` | List the spans an agent replaced in that file, newest first, and print or write one back with `--span n [-o file]`. Output is what the agent recorded, not the file, and a span that passed through redaction says so. |
 | `deja files <topic>` | Which files were opened or edited while that subject was being worked on. Ranked by how specific a file is to the topic, so a file every session touches does not win. `--project`, `--limit`. |
+| `deja friction` | Errors that hit three or more separate sessions, newest occurrence and harnesses named. Specific failures only — a missing binary, an uninstalled Python module — not `Traceback` or `exit status 1`. `--limit`. |
 | `deja share <id>` | Sanitized session digest for a colleague: secrets redacted, tool noise stripped. |
 | `deja stats` | Headline counts, totals, per-harness split, top projects, monthly sparkline. `--json` too. |
 | `deja doctor [--json]` | Self-diagnosis: store parse state, sqlite3 presence, MCP wiring per agent, index health, version; `--json` emits the same checks for scripts. |

--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -39,7 +39,7 @@ _deja_completion() {
     command="${COMP_WORDS[1]}"
     action="${COMP_WORDS[2]}"
 
-    local commands="blame bench completion ctx doctor embed files forget handoff help index install last log mcp promote remember restore resume share show sources stats statusline sync uninstall update version view warmup"
+    local commands="blame bench completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume share show sources stats statusline sync uninstall update version view warmup"
     local harnesses="claude codex opencode aider gemini cursor antigravity grok qwen pi copilot deja"
     local install_targets="%INSTALL_TARGETS% --all --auto"
 
@@ -151,6 +151,7 @@ _deja() {
     'completion:generate shell completion'
     'ctx:print a compact context digest'
     'files:which files the work on a topic touched'
+    'friction:errors this machine keeps hitting across sessions'
     'doctor:diagnose local stores and wiring'
     'promote:distill a session into a curated note'
     'embed:build the semantic sidecar'
@@ -257,7 +258,7 @@ const fishCompletion = `function __deja_needs_command
     test (count (commandline -opc)) -eq 1
 end
 
-complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed files forget handoff help index install last log mcp promote remember restore resume share show sources stats statusline sync uninstall update version view warmup'
+complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume share show sources stats statusline sync uninstall update version view warmup'
 complete -c deja -n '__deja_needs_command' -l json -d 'Print JSON'
 complete -c deja -n '__deja_needs_command' -l re -d 'Interpret query as a regular expression'
 complete -c deja -n '__deja_needs_command' -l all -d 'Include all results'

--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// `deja friction` names what this machine keeps tripping over.
+//
+// The idea started as "remember the dead ends" (#527) — abandoned engineering
+// approaches an agent should be warned away from. Measured twice, that is not
+// what a corpus contains. What recurs across sessions is a tool missing from
+// the machine, a Python module never installed, a command that does not exist
+// on this platform. Every one of the eight most-recurring error lines on a
+// 1150-session store is that, and five appear in more than one harness.
+//
+// So this reports friction, not knowledge, and it is deliberately a small
+// claim: the same specific error, in N separate sessions.
+const (
+	// frictionMinSessions is how many separate sessions must hit an error
+	// before it is worth saying. Twice is a coincidence; three times is the
+	// machine telling you something.
+	frictionMinSessions = 3
+	// frictionMaxSessions bounds the read. Errors that recur do so early and
+	// often; scanning the whole store to find a third occurrence is not worth
+	// the wait on a command someone runs interactively.
+	frictionMaxSessions = 600
+	frictionLineMin     = 20
+	frictionLineMax     = 120
+)
+
+func runFriction(dir string, args []string, stdout io.Writer) error {
+	limit := 10
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--limit" && i+1 < len(args) {
+			i++
+			n, err := strconv.Atoi(args[i])
+			if err != nil || n <= 0 {
+				return fmt.Errorf("friction: --limit wants a positive number, got %q", args[i])
+			}
+			limit = n
+		}
+	}
+	if err := index.Ensure(dir, "", false, os.Stderr); err != nil {
+		return ensureError(dir, err)
+	}
+	metas, err := index.Recent(dir, frictionMaxSessions)
+	if err != nil {
+		return fmt.Errorf("friction: %w", err)
+	}
+
+	type seen struct {
+		sessions map[string]bool
+		harness  map[string]bool
+		last     time.Time
+	}
+	found := map[string]*seen{}
+	for _, m := range metas {
+		full, ok, err := index.FindByIdentity(dir, m.Harness, m.ID)
+		if err != nil || !ok {
+			continue
+		}
+		key := m.Harness + ":" + m.ID
+		for _, msg := range full.Messages {
+			if msg.Role != "tool-output" {
+				continue
+			}
+			for _, line := range strings.Split(msg.Text, "\n") {
+				line = normalizeFriction(line)
+				if !frictionLine(line) {
+					continue
+				}
+				s := found[line]
+				if s == nil {
+					s = &seen{sessions: map[string]bool{}, harness: map[string]bool{}}
+					found[line] = s
+				}
+				s.sessions[key] = true
+				s.harness[m.Harness] = true
+				if msg.Time.After(s.last) {
+					s.last = msg.Time
+				}
+			}
+		}
+	}
+
+	type row struct {
+		line      string
+		when      time.Time
+		n         int
+		harnesses []string
+	}
+	var rows []row
+	for line, s := range found {
+		if len(s.sessions) < frictionMinSessions {
+			continue
+		}
+		hs := make([]string, 0, len(s.harness))
+		for h := range s.harness {
+			hs = append(hs, h)
+		}
+		sort.Strings(hs)
+		rows = append(rows, row{line, s.last, len(s.sessions), hs})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].n != rows[j].n {
+			return rows[i].n > rows[j].n
+		}
+		return rows[i].line < rows[j].line
+	})
+	if len(rows) == 0 {
+		fmt.Fprintf(stdout, "nothing recurring in %d sessions — no error hit %d separate sessions\n",
+			len(metas), frictionMinSessions)
+		return nil
+	}
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	fmt.Fprintf(stdout, "what this machine keeps tripping over — %d sessions read\n", len(metas))
+	for _, r := range rows {
+		where := strings.Join(r.harnesses, ", ")
+		fmt.Fprintf(stdout, "  %2d sessions  %s\n", r.n, trimFriction(r.line))
+		fmt.Fprintf(stdout, "               %s", where)
+		if !r.when.IsZero() {
+			fmt.Fprintf(stdout, " · last %s", r.when.Local().Format("Jan 2"))
+		}
+		fmt.Fprintln(stdout)
+	}
+	return nil
+}
+
+// normalizeFriction strips the shell's position prefix so the same missing
+// command counts once. `zsh:1: command not found: timeout` and
+// `(eval):2: command not found: timeout` are one piece of friction; left
+// alone they were three separate rows, each below the threshold that would
+// have reported any of them.
+func normalizeFriction(l string) string {
+	l = strings.TrimSpace(l)
+	// The prefix is `<where>:<line>: `, where <where> is a shell name or an
+	// `(eval)`/`(anon)` marker. Only strip it when the middle field is a
+	// number — `Error: cannot find x: y` must keep its shape.
+	first := strings.Index(l, ":")
+	if first <= 0 || first > 16 {
+		return l
+	}
+	rest := l[first+1:]
+	second := strings.Index(rest, ": ")
+	if second <= 0 {
+		return l
+	}
+	if _, err := strconv.Atoi(rest[:second]); err != nil {
+		return l
+	}
+	return strings.TrimSpace(rest[second+2:])
+}
+
+// frictionLine keeps the error shapes that name something specific. The
+// generic ones carry no information — every Python failure prints `Traceback
+// (most recent call last):`, and clustering those put an empty line at the top
+// of every measurement this feature was built from.
+func frictionLine(l string) bool {
+	if len(l) < frictionLineMin || len(l) > frictionLineMax {
+		return false
+	}
+	for _, generic := range []string{
+		"Traceback (most recent", "Error: ", "error: ", "FAIL\t", "--- FAIL",
+	} {
+		if strings.HasPrefix(l, generic) {
+			return false
+		}
+	}
+	// Tool output carries source as often as it carries results — a `cat` of a
+	// script, a diff, a heredoc. An `echo "App not found: $APP"` inside a
+	// deploy script reached second place on the first run: it is a line about
+	// an error, not an error.
+	for _, source := range []string{"echo ", "\"", "$(", "=~", "print("} {
+		if strings.Contains(l, source) {
+			return false
+		}
+	}
+	// This command's own output is tool output in the next session, and every
+	// line of it contains an error by construction. Drop the report shape so
+	// running it does not slowly teach it about itself.
+	if i := strings.Index(l, " sessions  "); i > 0 {
+		if _, err := strconv.Atoi(strings.TrimSpace(l[:i])); err == nil {
+			return false
+		}
+	}
+	for _, p := range []string{
+		"command not found", "ModuleNotFoundError", "No module named",
+		"not found: ", "cannot find", "no such file or directory",
+		"undefined:", "connection refused", "permission denied",
+	} {
+		if strings.Contains(l, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func trimFriction(l string) string {
+	if len(l) > 76 {
+		return l[:76] + "…"
+	}
+	return l
+}

--- a/cmd/deja/friction_test.go
+++ b/cmd/deja/friction_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+func TestFrictionLineKeepsSpecificErrors(t *testing.T) {
+	for _, l := range []string{
+		"zsh:1: command not found: shellcheck",
+		"ModuleNotFoundError: No module named 'yaml'",
+		"internal/index/store.go:41:2: undefined: signalLines",
+		"dial tcp 127.0.0.1:5432: connect: connection refused",
+	} {
+		if !frictionLine(normalizeFriction(l)) {
+			t.Errorf("dropped a specific error: %q", l)
+		}
+	}
+	for _, l := range []string{
+		"Traceback (most recent call last):",
+		"Error: exit status 1",
+		"--- FAIL: TestThing (0.01s)",
+		"not found",                          // too short to name anything
+		`echo "❌ App not found: $APP"`,       // source, not a result
+		`  9 sessions  command not found: x`, // this command's own output
+		"ok  github.com/vshulcz/deja-vu/internal/index  1.2s",
+	} {
+		if frictionLine(normalizeFriction(l)) {
+			t.Errorf("kept a line that names nothing: %q", l)
+		}
+	}
+}
+
+// The same missing command reaches the corpus under three shell prefixes. Left
+// unnormalized each lands below the threshold and none of them is ever
+// reported, which is the bug this function exists for.
+func TestNormalizeFrictionStripsShellPosition(t *testing.T) {
+	want := "command not found: timeout"
+	for _, l := range []string{
+		"zsh:1: command not found: timeout",
+		"(eval):2: command not found: timeout",
+		"  bash:15: command not found: timeout  ",
+	} {
+		if got := normalizeFriction(l); got != want {
+			t.Errorf("normalize(%q) = %q, want %q", l, got, want)
+		}
+	}
+	// A colon that is not a line number keeps the line intact — a Go compile
+	// error names its file and column and both matter.
+	for _, l := range []string{
+		"sh: tsc: command not found",
+		"Error: cannot find module x: y",
+		"ModuleNotFoundError: No module named 'PIL'",
+	} {
+		if got := normalizeFriction(l); got != l {
+			t.Errorf("normalize(%q) = %q, want it unchanged", l, got)
+		}
+	}
+}
+
+func TestTrimFriction(t *testing.T) {
+	long := strings.Repeat("x", 90)
+	got := trimFriction(long)
+	if len([]rune(got)) != 77 || !strings.HasSuffix(got, "…") {
+		t.Fatalf("got %d runes: %q", len([]rune(got)), got)
+	}
+	if got := trimFriction("short"); got != "short" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// writeFrictionCorpus lays down n claude sessions that each hit the same error,
+// plus one that does not.
+func writeFrictionCorpus(t *testing.T, root string, n int) {
+	t.Helper()
+	proj := filepath.Join(root, "projects", "repo")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(sid, role, text string) string {
+		b, err := json.Marshal(map[string]any{
+			"type": role, "sessionId": sid, "cwd": "/repo",
+			"timestamp": "2026-07-30T03:04:05Z",
+			"message":   map[string]any{"role": role, "content": text},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+	for i := 0; i < n; i++ {
+		sid := fmt.Sprintf("frict%02d", i)
+		rows := []string{
+			line(sid, "user", "run the deploy script for the staging cluster"),
+			line(sid, "assistant", "running it now"),
+			`{"type":"user","sessionId":"` + sid + `","cwd":"/repo",` +
+				`"timestamp":"2026-07-30T03:05:05Z","message":{"role":"user","content":` +
+				`[{"type":"tool_result","content":"zsh:1: command not found: shellcheck\nexit status 127"}]}}`,
+		}
+		p := filepath.Join(proj, sid+".jsonl")
+		if err := os.WriteFile(p, []byte(strings.Join(rows, "\n")+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sid := "clean01"
+	rows := []string{
+		line(sid, "user", "review the block layout change"),
+		line(sid, "assistant", "looks right"),
+	}
+	if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(strings.Join(rows, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func frictionEnv(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(t.TempDir(), "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(t.TempDir(), "opencode.db"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+	return root
+}
+
+func TestFrictionReportsRecurringErrors(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, frictionMinSessions)
+	var buf bytes.Buffer
+	if err := runFriction(index.DefaultDir(), nil, &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "command not found: shellcheck") {
+		t.Fatalf("the recurring error is missing:\n%s", out)
+	}
+	if !strings.Contains(out, "claude") {
+		t.Fatalf("the harness is missing:\n%s", out)
+	}
+	if !strings.Contains(out, fmt.Sprintf("%d sessions", frictionMinSessions)) {
+		t.Fatalf("wrong session count:\n%s", out)
+	}
+	// exit status 127 sits beside the error in every one of those sessions and
+	// says nothing about what is missing.
+	if strings.Contains(out, "exit status") {
+		t.Fatalf("a generic line was reported:\n%s", out)
+	}
+}
+
+// Twice is a coincidence. Reporting it would make the command noise on any
+// store, which is the whole reason for the threshold.
+func TestFrictionStaysQuietBelowThreshold(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, frictionMinSessions-1)
+	var buf bytes.Buffer
+	if err := runFriction(index.DefaultDir(), nil, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "nothing recurring") {
+		t.Fatalf("want the empty state, got:\n%s", buf.String())
+	}
+}
+
+func TestFrictionLimit(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, frictionMinSessions)
+	var buf bytes.Buffer
+	if err := runFriction(index.DefaultDir(), []string{"--limit", "1"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if err := runFriction(index.DefaultDir(), []string{"--limit", "0"}, &buf); err == nil {
+		t.Fatal("--limit 0 accepted")
+	}
+	if err := runFriction(index.DefaultDir(), []string{"--limit", "many"}, &buf); err == nil {
+		t.Fatal("--limit many accepted")
+	}
+}
+
+func TestFrictionOnBlockedIndex(t *testing.T) {
+	frictionEnv(t)
+	blocked := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocked, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(blocked, "child"))
+	if err := runFriction(index.DefaultDir(), nil, &bytes.Buffer{}); err == nil {
+		t.Fatal("friction accepted a blocked index")
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -123,6 +123,7 @@ var commands = map[string]command{
 	"handoff":         func(dir string, rest []string) error { return runHandoff(dir, rest, os.Stdout) },
 	"files":           func(dir string, rest []string) error { return runFiles(dir, rest, os.Stdout) },
 	"restore":         func(dir string, rest []string) error { return runRestore(dir, rest, os.Stdout) },
+	"friction":        func(dir string, rest []string) error { return runFriction(dir, rest, os.Stdout) },
 	"log":             runLog,
 	"sync":            runSync,
 	"ctx":             cmdCtx,
@@ -1032,6 +1033,8 @@ Usage:
   deja view          (browse your memory: sessions, recalls, notes — one local HTML)
   deja ctx <query|id-prefix>
   deja blame <path> [--all] [--json] [--project name] [--harness name] [--since 30d]
+  deja files <topic> [--project name] [--limit n]
+  deja friction [--limit n]
   deja sync export <dir> [--full]
   deja sync import <dir>
   deja sync ssh <host> [--pull] [--full]

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -59,6 +59,7 @@
 <tr><td><code>deja ctx "query"</code></td><td>Print a context digest to stdout (for piping into an agent).</td></tr>
 <tr><td><code>deja blame &lt;path&gt;</code></td><td>Sessions that discussed a file, most specific first.</td></tr>
 <tr><td><code>deja files &lt;topic&gt;</code></td><td>Which files were opened or edited while that subject was being worked on, ranked by how specific each one is to it. <code>--project</code>, <code>--limit</code>.</td></tr>
+<tr><td><code>deja friction</code></td><td>Errors that recur across three or more separate sessions, with the harnesses that hit them and the newest occurrence. Specific failures only — a missing binary, an uninstalled module — not generic <code>Traceback</code> lines. <code>--limit</code>.</td></tr>
 <tr><td><code>deja restore &lt;path&gt;</code></td><td>Spans an agent replaced in that file, newest first; <code>--span n</code> prints one and <code>-o file</code> writes it. Never writes over the original, and flags a span that passed through redaction.</td></tr>
 <tr><td><code>deja remember "text"</code></td><td>Store a durable note. <code>--project</code> optional; <code>--tag</code> (repeatable) attaches keywords that boost matching queries.</td></tr>
 <tr><td><code>deja forget</code></td><td>Remove sessions by <code>--session</code>/<code>--project</code>/<code>--before</code>; <code>--dry-run</code>, <code>--list</code>, <code>--unforget</code>.</td></tr>


### PR DESCRIPTION
Closes #527.

#527 asked for "remember the dead ends" — abandoned engineering approaches. Measured twice on a 1150-session store, that is not what recurs. What recurs is environment: a binary missing from the machine, a Python module never installed, a command that does not exist on this platform. So the command reports that instead, and makes a small claim — the same specific error, in N separate sessions.

```
what this machine keeps tripping over — 600 sessions read
   9 sessions  command not found: timeout
               claude, opencode · last Jul 31
   8 sessions  ModuleNotFoundError: No module named 'yaml'
               claude, opencode · last Jul 31
   4 sessions  ModuleNotFoundError: No module named 'PIL'
               claude, opencode · last Jul 19
```

Two things the first run got wrong and this fixes: `zsh:1:` / `(eval):2:` prefixes split one missing command into three rows that each fell below the threshold, and an `echo "App not found: $APP"` from a deploy script placed second — tool output carries source as often as results.

Only viable now because #621 landed opencode tool output; before it, tool-output was 19 sessions and all Claude.

Also adds `deja files` to the usage block, which #542 missed.