### PR TITLE
perf: read friction in one pass over the record log

### DIFF
--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -28,10 +28,6 @@ const (
 	// before it is worth saying. Twice is a coincidence; three times is the
 	// machine telling you something.
 	frictionMinSessions = 3
-	// frictionMaxSessions bounds the read. Errors that recur do so early and
-	// often; scanning the whole store to find a third occurrence is not worth
-	// the wait on a command someone runs interactively.
-	frictionMaxSessions = 600
 	frictionLineMin     = 20
 	frictionLineMax     = 120
 )
@@ -51,44 +47,37 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 	if err := index.Ensure(dir, "", false, os.Stderr); err != nil {
 		return ensureError(dir, err)
 	}
-	metas, err := index.Recent(dir, frictionMaxSessions)
-	if err != nil {
-		return fmt.Errorf("friction: %w", err)
-	}
-
 	type seen struct {
 		sessions map[string]bool
 		harness  map[string]bool
 		last     time.Time
 	}
 	found := map[string]*seen{}
-	for _, m := range metas {
-		full, ok, err := index.FindByIdentity(dir, m.Harness, m.ID)
-		if err != nil || !ok {
-			continue
-		}
-		key := m.Harness + ":" + m.ID
-		for _, msg := range full.Messages {
-			if msg.Role != "tool-output" {
+	sessions := map[string]bool{}
+	// One pass over the record log rather than a load per session: loading by
+	// identity walks the whole log each time, which put this command at 2m46s
+	// on a 1150-session store.
+	if err := index.EachToolOutput(dir, func(meta index.SessionMeta, r index.Record) {
+		key := meta.Harness + ":" + meta.ID
+		sessions[key] = true
+		for _, line := range strings.Split(r.Text, "\n") {
+			line = normalizeFriction(line)
+			if !frictionLine(line) {
 				continue
 			}
-			for _, line := range strings.Split(msg.Text, "\n") {
-				line = normalizeFriction(line)
-				if !frictionLine(line) {
-					continue
-				}
-				s := found[line]
-				if s == nil {
-					s = &seen{sessions: map[string]bool{}, harness: map[string]bool{}}
-					found[line] = s
-				}
-				s.sessions[key] = true
-				s.harness[m.Harness] = true
-				if msg.Time.After(s.last) {
-					s.last = msg.Time
-				}
+			s := found[line]
+			if s == nil {
+				s = &seen{sessions: map[string]bool{}, harness: map[string]bool{}}
+				found[line] = s
+			}
+			s.sessions[key] = true
+			s.harness[meta.Harness] = true
+			if r.Time.After(s.last) {
+				s.last = r.Time
 			}
 		}
+	}); err != nil {
+		return fmt.Errorf("friction: %w", err)
 	}
 
 	type row struct {
@@ -116,14 +105,14 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 		return rows[i].line < rows[j].line
 	})
 	if len(rows) == 0 {
-		fmt.Fprintf(stdout, "nothing recurring in %d sessions — no error hit %d separate sessions\n",
-			len(metas), frictionMinSessions)
+		fmt.Fprintf(stdout, "nothing recurring in %d session%s — no error hit %d separate sessions\n",
+			len(sessions), pluralS(len(sessions)), frictionMinSessions)
 		return nil
 	}
 	if len(rows) > limit {
 		rows = rows[:limit]
 	}
-	fmt.Fprintf(stdout, "what this machine keeps tripping over — %d sessions read\n", len(metas))
+	fmt.Fprintf(stdout, "what this machine keeps tripping over — %d session%s read\n", len(sessions), pluralS(len(sessions)))
 	for _, r := range rows {
 		where := strings.Join(r.harnesses, ", ")
 		fmt.Fprintf(stdout, "  %2d sessions  %s\n", r.n, trimFriction(r.line))

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -898,3 +898,25 @@ func decodeRecordIn(b []byte, rel int, t *recordTables) (Record, bool) {
 	r, err := decodeRecord(b[rel+4:rel+4+int(size)], t)
 	return r, err == nil
 }
+
+// EachToolOutput streams every tool-output record in the store together with
+// the session it came from.
+//
+// The alternative is loading each session by identity and reading its
+// messages, which is what `deja friction` did first: 600 sessions took 2m46s,
+// because every lookup walks the whole log. One pass over records.bin, keyed
+// by the manifest, is the same data in a single scan.
+func EachToolOutput(dir string, fn func(SessionMeta, Record)) error {
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return err
+	}
+	return eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
+		if r.Role != roleToolOutput {
+			return
+		}
+		if meta, ok := m.Sessions[r.Key]; ok {
+			fn(meta, r)
+		}
+	})
+}

--- a/internal/index/tool_stream_test.go
+++ b/internal/index/tool_stream_test.go
@@ -1,0 +1,61 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEachToolOutputStreamsOnlyToolRecords(t *testing.T) {
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "claude", "-tmp-stream")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lines := []string{
+		`{"type":"user","sessionId":"s1","cwd":"/w","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"run the deploy script"}}`,
+		`{"type":"user","sessionId":"s1","cwd":"/w","timestamp":"2026-01-02T03:05:05Z","message":{"role":"user","content":[{"type":"tool_result","content":"zsh:1: command not found: shellcheck"}]}}`,
+	}
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var got []Record
+	var harness string
+	if err := EachToolOutput(dir, func(m SessionMeta, r Record) {
+		got = append(got, r)
+		harness = m.Harness
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want the one tool-output record, got %d: %#v", len(got), got)
+	}
+	if !strings.Contains(got[0].Text, "shellcheck") {
+		t.Fatalf("wrong record: %q", got[0].Text)
+	}
+	// The session is what makes the record countable — a caller clustering
+	// errors needs to know which session and which harness hit it.
+	if harness != "claude" {
+		t.Fatalf("harness = %q", harness)
+	}
+	if got[0].Time.IsZero() {
+		t.Fatal("a record with no time cannot be dated on a report")
+	}
+}
+
+func TestEachToolOutputOnMissingStore(t *testing.T) {
+	if err := EachToolOutput(filepath.Join(t.TempDir(), "nope"), func(SessionMeta, Record) {}); err == nil {
+		t.Fatal("a missing store should report an error")
+	}
+}


### PR DESCRIPTION
Closes #623.

`deja friction` loaded each session by identity, and every lookup walks the whole log.

```
before  2m46s   600 sessions read (the cap existed to make that bearable)
after   0.4s    381 sessions with tool output, whole store
```

Removing the cap changes the output as well as the speed — counts rise and three clusters appear that the recent-600 window had cut off, including `No module named pytest` in six sessions.

`index.EachToolOutput` is the new streaming pass; it hands back the record and the session it belongs to, which is what a caller clustering errors needs.