### PR TITLE
feat: surface the friction on the first screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ $ deja "jwt refresh token"
 | `deja update` | Download the latest GitHub release, verify its checksum, and replace the current binary. |
 | `deja statusline` | One line for your status bar: recalls served to agents today. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
 | `deja log [n] [--last] [--json]` | Audit what deja actually served: recent recalls and injections, or the exact text of the last injected digest with `--last`. |
-| `deja` | On a terminal with an index: a living brief — today's sessions, recalls served, déjà vu moments, and a search suggestion from your own history. |
+| `deja` | On a terminal with an index: a living brief — today's sessions, recalls served, déjà vu moments, a question you asked in more than one session, a wall your agents keep hitting, and a search suggestion from your own history. |
 
 Stemmed JSON searches set `"stemmed": true` and include the catalog variants used.
 

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -109,6 +109,16 @@ func runBrief(dir string, w io.Writer) error {
 		fmt.Fprintf(w, "before     %s%s%s\n", dim, askedWhen(a), reset)
 	}
 
+	// The other line drawn from the reader's own data rather than from a
+	// counter: a wall this machine keeps running into. Manifest-only, like the
+	// asked line above it — the command that reports the full list reads the
+	// record log, which is a hundred times this screen's budget.
+	if f, ok := index.FindFriction(dir); ok {
+		fmt.Fprintf(w, "hit        %s%s%s\n", bold, trimBriefTitle(f.Text), reset)
+		fmt.Fprintf(w, "again      %s%d sessions · last %s · deja friction%s\n",
+			dim, len(f.Sessions), search.RelativeDate(f.Last), reset)
+	}
+
 	// The greeting printed on a first build already ends with this exact
 	// suggestion. Printing it twice on the one screen that has to be legible
 	// is worse than not printing it at all.

--- a/cmd/deja/brief_test.go
+++ b/cmd/deja/brief_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -122,5 +123,50 @@ func TestBriefReplacesAQuietWeekWithTheSpanItHolds(t *testing.T) {
 		if strings.Contains(got, unwanted) {
 			t.Errorf("a zero line survived: %q\n%s", unwanted, got)
 		}
+	}
+}
+
+// The first screen names a wall and the count beside it; running the command
+// it points at must produce the same number, or the tool reads as broken.
+func TestBriefNamesTheWallAndAgreesWithTheCommand(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-f")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	for i := 0; i < index.FrictionMinSessions; i++ {
+		sid := fmt.Sprintf("wf%02d", i)
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/w/f","timestamp":"2026-07-2` +
+			fmt.Sprint(i) + `T10:00:00Z","message":{"role":"user","content":"run the linters"}}` + "\n" +
+			`{"type":"user","sessionId":"` + sid + `","cwd":"/w/f","timestamp":"2026-07-2` +
+			fmt.Sprint(i) + `T10:05:00Z","message":{"role":"user","content":[{"type":"tool_result",` +
+			`"content":"zsh:` + fmt.Sprint(i+1) + `: command not found: shellcheck"}]}}` + "\n"
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var brief bytes.Buffer
+	if err := runBrief(dir, &brief); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(brief.String(), "command not found: shellcheck") {
+		t.Fatalf("the wall is missing from the first screen:\n%s", brief.String())
+	}
+	want := fmt.Sprintf("%d sessions", index.FrictionMinSessions)
+	if !strings.Contains(brief.String(), want) {
+		t.Fatalf("want %q on the screen:\n%s", want, brief.String())
+	}
+	var cmd bytes.Buffer
+	if err := runFriction(dir, nil, &cmd); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(cmd.String(), want) {
+		t.Fatalf("the command disagrees with the screen:\n%s", cmd.String())
 	}
 }

--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -23,14 +23,6 @@ import (
 //
 // So this reports friction, not knowledge, and it is deliberately a small
 // claim: the same specific error, in N separate sessions.
-const (
-	// frictionMinSessions is how many separate sessions must hit an error
-	// before it is worth saying. Twice is a coincidence; three times is the
-	// machine telling you something.
-	frictionMinSessions = 3
-	frictionLineMin     = 20
-	frictionLineMax     = 120
-)
 
 func runFriction(dir string, args []string, stdout io.Writer) error {
 	limit := 10
@@ -61,8 +53,8 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 		key := meta.Harness + ":" + meta.ID
 		sessions[key] = true
 		for _, line := range strings.Split(r.Text, "\n") {
-			line = normalizeFriction(line)
-			if !frictionLine(line) {
+			line, ok := index.FrictionLine(line)
+			if !ok {
 				continue
 			}
 			s := found[line]
@@ -88,7 +80,7 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 	}
 	var rows []row
 	for line, s := range found {
-		if len(s.sessions) < frictionMinSessions {
+		if len(s.sessions) < index.FrictionMinSessions {
 			continue
 		}
 		hs := make([]string, 0, len(s.harness))
@@ -106,7 +98,7 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 	})
 	if len(rows) == 0 {
 		fmt.Fprintf(stdout, "nothing recurring in %d session%s — no error hit %d separate sessions\n",
-			len(sessions), pluralS(len(sessions)), frictionMinSessions)
+			len(sessions), pluralS(len(sessions)), index.FrictionMinSessions)
 		return nil
 	}
 	if len(rows) > limit {
@@ -123,75 +115,6 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprintln(stdout)
 	}
 	return nil
-}
-
-// normalizeFriction strips the shell's position prefix so the same missing
-// command counts once. `zsh:1: command not found: timeout` and
-// `(eval):2: command not found: timeout` are one piece of friction; left
-// alone they were three separate rows, each below the threshold that would
-// have reported any of them.
-func normalizeFriction(l string) string {
-	l = strings.TrimSpace(l)
-	// The prefix is `<where>:<line>: `, where <where> is a shell name or an
-	// `(eval)`/`(anon)` marker. Only strip it when the middle field is a
-	// number — `Error: cannot find x: y` must keep its shape.
-	first := strings.Index(l, ":")
-	if first <= 0 || first > 16 {
-		return l
-	}
-	rest := l[first+1:]
-	second := strings.Index(rest, ": ")
-	if second <= 0 {
-		return l
-	}
-	if _, err := strconv.Atoi(rest[:second]); err != nil {
-		return l
-	}
-	return strings.TrimSpace(rest[second+2:])
-}
-
-// frictionLine keeps the error shapes that name something specific. The
-// generic ones carry no information — every Python failure prints `Traceback
-// (most recent call last):`, and clustering those put an empty line at the top
-// of every measurement this feature was built from.
-func frictionLine(l string) bool {
-	if len(l) < frictionLineMin || len(l) > frictionLineMax {
-		return false
-	}
-	for _, generic := range []string{
-		"Traceback (most recent", "Error: ", "error: ", "FAIL\t", "--- FAIL",
-	} {
-		if strings.HasPrefix(l, generic) {
-			return false
-		}
-	}
-	// Tool output carries source as often as it carries results — a `cat` of a
-	// script, a diff, a heredoc. An `echo "App not found: $APP"` inside a
-	// deploy script reached second place on the first run: it is a line about
-	// an error, not an error.
-	for _, source := range []string{"echo ", "\"", "$(", "=~", "print("} {
-		if strings.Contains(l, source) {
-			return false
-		}
-	}
-	// This command's own output is tool output in the next session, and every
-	// line of it contains an error by construction. Drop the report shape so
-	// running it does not slowly teach it about itself.
-	if i := strings.Index(l, " sessions  "); i > 0 {
-		if _, err := strconv.Atoi(strings.TrimSpace(l[:i])); err == nil {
-			return false
-		}
-	}
-	for _, p := range []string{
-		"command not found", "ModuleNotFoundError", "No module named",
-		"not found: ", "cannot find", "no such file or directory",
-		"undefined:", "connection refused", "permission denied",
-	} {
-		if strings.Contains(l, p) {
-			return true
-		}
-	}
-	return false
 }
 
 func trimFriction(l string) string {

--- a/cmd/deja/friction_test.go
+++ b/cmd/deja/friction_test.go
@@ -12,59 +12,6 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 )
 
-func TestFrictionLineKeepsSpecificErrors(t *testing.T) {
-	for _, l := range []string{
-		"zsh:1: command not found: shellcheck",
-		"ModuleNotFoundError: No module named 'yaml'",
-		"internal/index/store.go:41:2: undefined: signalLines",
-		"dial tcp 127.0.0.1:5432: connect: connection refused",
-	} {
-		if !frictionLine(normalizeFriction(l)) {
-			t.Errorf("dropped a specific error: %q", l)
-		}
-	}
-	for _, l := range []string{
-		"Traceback (most recent call last):",
-		"Error: exit status 1",
-		"--- FAIL: TestThing (0.01s)",
-		"not found",                          // too short to name anything
-		`echo "❌ App not found: $APP"`,       // source, not a result
-		`  9 sessions  command not found: x`, // this command's own output
-		"ok  github.com/vshulcz/deja-vu/internal/index  1.2s",
-	} {
-		if frictionLine(normalizeFriction(l)) {
-			t.Errorf("kept a line that names nothing: %q", l)
-		}
-	}
-}
-
-// The same missing command reaches the corpus under three shell prefixes. Left
-// unnormalized each lands below the threshold and none of them is ever
-// reported, which is the bug this function exists for.
-func TestNormalizeFrictionStripsShellPosition(t *testing.T) {
-	want := "command not found: timeout"
-	for _, l := range []string{
-		"zsh:1: command not found: timeout",
-		"(eval):2: command not found: timeout",
-		"  bash:15: command not found: timeout  ",
-	} {
-		if got := normalizeFriction(l); got != want {
-			t.Errorf("normalize(%q) = %q, want %q", l, got, want)
-		}
-	}
-	// A colon that is not a line number keeps the line intact — a Go compile
-	// error names its file and column and both matter.
-	for _, l := range []string{
-		"sh: tsc: command not found",
-		"Error: cannot find module x: y",
-		"ModuleNotFoundError: No module named 'PIL'",
-	} {
-		if got := normalizeFriction(l); got != l {
-			t.Errorf("normalize(%q) = %q, want it unchanged", l, got)
-		}
-	}
-}
-
 func TestTrimFriction(t *testing.T) {
 	long := strings.Repeat("x", 90)
 	got := trimFriction(long)
@@ -133,7 +80,7 @@ func frictionEnv(t *testing.T) string {
 
 func TestFrictionReportsRecurringErrors(t *testing.T) {
 	root := frictionEnv(t)
-	writeFrictionCorpus(t, root, frictionMinSessions)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions)
 	var buf bytes.Buffer
 	if err := runFriction(index.DefaultDir(), nil, &buf); err != nil {
 		t.Fatal(err)
@@ -145,7 +92,7 @@ func TestFrictionReportsRecurringErrors(t *testing.T) {
 	if !strings.Contains(out, "claude") {
 		t.Fatalf("the harness is missing:\n%s", out)
 	}
-	if !strings.Contains(out, fmt.Sprintf("%d sessions", frictionMinSessions)) {
+	if !strings.Contains(out, fmt.Sprintf("%d sessions", index.FrictionMinSessions)) {
 		t.Fatalf("wrong session count:\n%s", out)
 	}
 	// exit status 127 sits beside the error in every one of those sessions and
@@ -159,7 +106,7 @@ func TestFrictionReportsRecurringErrors(t *testing.T) {
 // store, which is the whole reason for the threshold.
 func TestFrictionStaysQuietBelowThreshold(t *testing.T) {
 	root := frictionEnv(t)
-	writeFrictionCorpus(t, root, frictionMinSessions-1)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions-1)
 	var buf bytes.Buffer
 	if err := runFriction(index.DefaultDir(), nil, &buf); err != nil {
 		t.Fatal(err)
@@ -171,7 +118,7 @@ func TestFrictionStaysQuietBelowThreshold(t *testing.T) {
 
 func TestFrictionLimit(t *testing.T) {
 	root := frictionEnv(t)
-	writeFrictionCorpus(t, root, frictionMinSessions)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions)
 	var buf bytes.Buffer
 	if err := runFriction(index.DefaultDir(), []string{"--limit", "1"}, &buf); err != nil {
 		t.Fatal(err)

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -64,7 +64,7 @@
 <tr><td><code>deja remember "text"</code></td><td>Store a durable note. <code>--project</code> optional; <code>--tag</code> (repeatable) attaches keywords that boost matching queries.</td></tr>
 <tr><td><code>deja forget</code></td><td>Remove sessions by <code>--session</code>/<code>--project</code>/<code>--before</code>; <code>--dry-run</code>, <code>--list</code>, <code>--unforget</code>.</td></tr>
 <tr><td><code>deja stats</code></td><td>Totals, top projects, activity. <code>--card</code> (SVG), <code>--html</code> (timeline), <code>--redaction</code>, <code>--json</code>. <code>--impact</code> prints the measured impact report (recalls, reuse, distillation ratio) with the arithmetic labeled.</td></tr>
-<tr><td><code>deja</code></td><td>Bare, on a terminal: the living brief — today's activity, recalls served, déjà vu moments, a suggested search from your own history.</td></tr>
+<tr><td><code>deja</code></td><td>Bare, on a terminal: the living brief — today's activity, recalls served, déjà vu moments, a question asked in more than one session, an error several sessions hit, a suggested search from your own history.</td></tr>
 <tr><td><code>deja log</code></td><td>Audit trail: recent recalls and injections; <code>--last</code> prints the most recent injected digest verbatim; <code>--json</code>.</td></tr>
 <tr><td><code>deja last [n]</code></td><td>Recent sessions. <code>--project</code>, <code>--harness</code>, <code>--since</code>, <code>--role</code>, <code>--json</code>.</td></tr>
 <tr><td><code>deja resume &lt;id&gt;</code></td><td>Reopen a session in the agent that wrote it. Prints the command; <code>--exec</code> runs it.</td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -387,7 +387,7 @@ footer .spacer{flex:1}
       <dt>deja view</dt><dd>your whole memory in one local HTML — sessions, recalls, notes. <span class="dim">No server; nothing leaves the machine.</span></dd>
       <dt>deja stats</dt><dd>sessions, top projects, activity sparkline. <span class="dim">Totals per harness, per project, per month.</span></dd>
       <dt>deja log</dt><dd>audit trail: what was recalled or injected, when, into which agent — <span class="dim">--last prints the exact digest an agent received.</span></dd>
-      <dt>deja</dt><dd>bare, on a terminal: the living brief — today's sessions, recalls served, déjà vu moments, a suggested search from your own history.</dd>
+      <dt>deja</dt><dd>bare, on a terminal: the living brief — today's sessions, recalls served, déjà vu moments, a question asked in more than one session, an error several sessions hit, a suggested search from your own history.</dd>
     </dl>
   </div>
   <p class="slead" style="margin-top:16px">Secrets never reach the index: API keys, JWTs, private-key blocks and bare high-entropy values in secret-shaped spots are stripped at ingest — the cache is safe to keep, shares and exports are safe to send.</p>

--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -1,0 +1,226 @@
+package index
+
+import (
+	"hash/fnv"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Friction is what this machine keeps tripping over: one specific error, in
+// several separate sessions.
+//
+// The detection lives here rather than in the command because it runs twice —
+// once over a session being ingested, to fingerprint what it hit, and once
+// over the record log when someone asks. Two copies of these rules would drift,
+// and the first symptom would be a first-screen line the command cannot
+// reproduce.
+type Friction struct {
+	Text     string
+	Sessions []SessionMeta
+	Last     time.Time
+}
+
+const (
+	// frictionSessionCap bounds what one session contributes to the manifest,
+	// and is set high on purpose. The first screen names a count and points at
+	// `deja friction`; a cap low enough to lose a hit makes the two disagree,
+	// which reads as the tool being broken. Measured on 1149 sessions: at 6 the
+	// screen said 8 where the command said 11, at 100 it said 10, and one
+	// session alone carries over a hundred distinct error lines. The whole
+	// field costs 2.7 KB across that corpus — the exactness is nearly free.
+	frictionSessionCap = 256
+	frictionLineMin    = 20
+	frictionLineMax    = 120
+	// FrictionMinSessions is how many separate sessions must hit an error
+	// before it is worth saying. Twice is a coincidence.
+	FrictionMinSessions = 3
+)
+
+// FrictionLine reports whether a line of tool output names something specific
+// that went wrong, and returns it in the form two sessions can be compared on.
+func FrictionLine(l string) (string, bool) {
+	l = normalizeFriction(l)
+	return l, isFriction(l)
+}
+
+// normalizeFriction strips the shell's position prefix so the same missing
+// command counts once. `zsh:1: command not found: timeout` and
+// `(eval):2: command not found: timeout` are one piece of friction; left
+// alone they land below the threshold separately and none is ever reported.
+func normalizeFriction(l string) string {
+	l = strings.TrimSpace(l)
+	// The prefix is `<where>:<line>: `, where <where> is a shell name or an
+	// `(eval)`/`(anon)` marker. Only strip it when the middle field is a
+	// number — `Error: cannot find x: y` must keep its shape.
+	first := strings.Index(l, ":")
+	if first <= 0 || first > 16 {
+		return l
+	}
+	rest := l[first+1:]
+	second := strings.Index(rest, ": ")
+	if second <= 0 {
+		return l
+	}
+	if _, err := strconv.Atoi(rest[:second]); err != nil {
+		return l
+	}
+	return strings.TrimSpace(rest[second+2:])
+}
+
+// isFriction keeps the error shapes that name something specific. The generic
+// ones carry no information — every Python failure prints `Traceback (most
+// recent call last):`, and clustering those put an empty line at the top of
+// every measurement this was built from.
+func isFriction(l string) bool {
+	if len(l) < frictionLineMin || len(l) > frictionLineMax {
+		return false
+	}
+	for _, generic := range []string{
+		"Traceback (most recent", "Error: ", "error: ", "FAIL\t", "--- FAIL",
+	} {
+		if strings.HasPrefix(l, generic) {
+			return false
+		}
+	}
+	// Tool output carries source as often as it carries results — a `cat` of a
+	// script, a diff, a heredoc. An `echo "App not found: $APP"` inside a
+	// deploy script reached second place on the first run: it is a line about
+	// an error, not an error.
+	for _, source := range []string{"echo ", "\"", "$(", "=~", "print("} {
+		if strings.Contains(l, source) {
+			return false
+		}
+	}
+	// deja's own report is tool output in the next session, and every line of
+	// it contains an error by construction. Drop the report shape so running
+	// the command does not slowly teach it about itself.
+	if i := strings.Index(l, " sessions  "); i > 0 {
+		if _, err := strconv.Atoi(strings.TrimSpace(l[:i])); err == nil {
+			return false
+		}
+	}
+	for _, p := range []string{
+		"command not found", "ModuleNotFoundError", "No module named",
+		"not found: ", "cannot find", "no such file or directory",
+		"undefined:", "connection refused", "permission denied",
+	} {
+		if strings.Contains(l, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func frictionHash(line string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(line))
+	return h.Sum64()
+}
+
+// frictionHashes fingerprints what a session tripped over, for the manifest.
+// Hashes rather than text, for the reason SessionMeta.Asked gives: the
+// manifest is read on every search and the only thing a caller needs from it
+// is whether two sessions hit the same wall.
+func frictionHashes(ms []model.Message) []uint64 {
+	var out []uint64
+	seen := map[uint64]bool{}
+	for _, m := range ms {
+		if m.Role != roleToolOutput {
+			continue
+		}
+		for _, line := range strings.Split(m.Text, "\n") {
+			line, ok := FrictionLine(line)
+			if !ok {
+				continue
+			}
+			h := frictionHash(line)
+			if seen[h] {
+				continue
+			}
+			seen[h] = true
+			out = append(out, h)
+			if len(out) >= frictionSessionCap {
+				return out
+			}
+		}
+	}
+	return out
+}
+
+// FindFriction picks the wall worth showing: the one the most separate
+// sessions hit. It runs over the manifest alone, so a caller on the first
+// screen pays nothing for it; only the sessions that carry the winning hash
+// are read back, and only to recover the text the hash stands for.
+func FindFriction(dir string) (Friction, bool) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return Friction{}, false
+	}
+	byHash := map[uint64][]SessionMeta{}
+	for _, meta := range m.Sessions {
+		for _, h := range meta.Hit {
+			byHash[h] = append(byHash[h], meta)
+		}
+	}
+	var best []SessionMeta
+	var bestHash uint64
+	for h, metas := range byHash {
+		if len(metas) < FrictionMinSessions {
+			continue
+		}
+		// Most sessions wins; among equals the one hit most recently, because
+		// a wall the machine stopped running into is history, not friction.
+		if len(metas) > len(best) || (len(metas) == len(best) && newestOf(metas).After(newestOf(best))) {
+			best, bestHash = metas, h
+		}
+	}
+	if len(best) < FrictionMinSessions {
+		return Friction{}, false
+	}
+	sort.Slice(best, func(i, j int) bool { return best[i].Updated.After(best[j].Updated) })
+	text := frictionTextFor(dir, m, best, bestHash)
+	if text == "" {
+		return Friction{}, false
+	}
+	return Friction{Text: text, Sessions: best, Last: best[0].Updated}, true
+}
+
+func newestOf(ms []SessionMeta) time.Time {
+	var out time.Time
+	for _, m := range ms {
+		if m.Updated.After(out) {
+			out = m.Updated
+		}
+	}
+	return out
+}
+
+// frictionTextFor recovers what a hash stood for by reading back the sessions
+// that carry it, stopping at the first one that yields the line.
+func frictionTextFor(dir string, m Manifest, metas []SessionMeta, want uint64) string {
+	for _, meta := range metas {
+		s, ok, err := loadSessionMeta(dir, m, meta)
+		if err != nil || !ok {
+			continue
+		}
+		for _, msg := range s.Messages {
+			if msg.Role != roleToolOutput {
+				continue
+			}
+			for _, line := range strings.Split(msg.Text, "\n") {
+				line, ok := FrictionLine(line)
+				if ok && frictionHash(line) == want {
+					return line
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/internal/index/friction_test.go
+++ b/internal/index/friction_test.go
@@ -1,0 +1,189 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestFrictionLineKeepsSpecificErrors(t *testing.T) {
+	for _, l := range []string{
+		"zsh:1: command not found: shellcheck",
+		"ModuleNotFoundError: No module named 'yaml'",
+		"internal/index/store.go:41:2: undefined: signalLines",
+		"dial tcp 127.0.0.1:5432: connect: connection refused",
+	} {
+		if _, ok := FrictionLine(l); !ok {
+			t.Errorf("dropped a specific error: %q", l)
+		}
+	}
+	for _, l := range []string{
+		"Traceback (most recent call last):",
+		"Error: exit status 1",
+		"--- FAIL: TestThing (0.01s)",
+		"not found",                          // too short to name anything
+		`echo "❌ App not found: $APP"`,       // source, not a result
+		`  9 sessions  command not found: x`, // this command's own output
+		"ok  github.com/vshulcz/deja-vu/internal/index  1.2s",
+	} {
+		if _, ok := FrictionLine(l); ok {
+			t.Errorf("kept a line that names nothing: %q", l)
+		}
+	}
+}
+
+// The same missing command reaches the corpus under three shell prefixes. Left
+// unnormalized each lands below the threshold and none of them is ever
+// reported, which is the bug this function exists for.
+func TestFrictionLineNormalizesShellPosition(t *testing.T) {
+	want := "command not found: timeout"
+	for _, l := range []string{
+		"zsh:1: command not found: timeout",
+		"(eval):2: command not found: timeout",
+		"  bash:15: command not found: timeout  ",
+	} {
+		got, ok := FrictionLine(l)
+		if !ok || got != want {
+			t.Errorf("FrictionLine(%q) = %q, %v; want %q, true", l, got, ok, want)
+		}
+	}
+	// A colon that is not a line number keeps the line intact — a Go compile
+	// error names its file and column and both matter.
+	for _, l := range []string{
+		"sh: tsc: command not found",
+		"ModuleNotFoundError: No module named 'PIL'",
+	} {
+		if got, _ := FrictionLine(l); got != l {
+			t.Errorf("FrictionLine(%q) = %q, want it unchanged", l, got)
+		}
+	}
+}
+
+func TestFrictionHashesFingerprintsToolOutputOnly(t *testing.T) {
+	ms := []model.Message{
+		{Role: "user", Text: "zsh:1: command not found: shellcheck"},
+		{Role: roleToolOutput, Text: "zsh:1: command not found: shellcheck\nexit status 127"},
+		{Role: roleToolOutput, Text: "(eval):9: command not found: shellcheck"},
+	}
+	got := frictionHashes(ms)
+	// Three lines carry the error, but only two are tool output and those two
+	// normalize to the same thing: one session, one piece of evidence.
+	if len(got) != 1 {
+		t.Fatalf("want one hash, got %d", len(got))
+	}
+	if got[0] != frictionHash("command not found: shellcheck") {
+		t.Fatal("the hash is not the one the normalized line produces")
+	}
+	if len(frictionHashes([]model.Message{{Role: "user", Text: "all fine"}})) != 0 {
+		t.Fatal("a session that tripped over nothing should carry nothing")
+	}
+}
+
+func TestFrictionHashesCapped(t *testing.T) {
+	var ms []model.Message
+	for i := 0; i < frictionSessionCap+20; i++ {
+		ms = append(ms, model.Message{
+			Role: roleToolOutput,
+			Text: fmt.Sprintf("zsh:1: command not found: tool-number-%03d", i),
+		})
+	}
+	if got := len(frictionHashes(ms)); got != frictionSessionCap {
+		t.Fatalf("got %d hashes, want the cap %d", got, frictionSessionCap)
+	}
+}
+
+// writeFrictionSessions lays down n claude sessions that each hit the same
+// error under a different shell prefix, so the test also proves normalization
+// survives the round trip through the manifest.
+func writeFrictionSessions(t *testing.T, root string, n int) {
+	t.Helper()
+	proj := filepath.Join(root, "-tmp-friction")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		sid := fmt.Sprintf("fr%02d", i)
+		lines := []string{
+			`{"type":"user","sessionId":"` + sid + `","cwd":"/w","timestamp":"2026-01-0` +
+				fmt.Sprint(i+1) + `T03:04:05Z","message":{"role":"user","content":"run the deploy script"}}`,
+			`{"type":"user","sessionId":"` + sid + `","cwd":"/w","timestamp":"2026-01-0` +
+				fmt.Sprint(i+1) + `T03:05:05Z","message":{"role":"user","content":[{"type":"tool_result",` +
+				`"content":"(eval):` + fmt.Sprint(i+1) + `: command not found: shellcheck"}]}}`,
+		}
+		if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func frictionStore(t *testing.T, sessions int) string {
+	t.Helper()
+	tmp := t.TempDir()
+	claude := filepath.Join(tmp, "claude")
+	writeFrictionSessions(t, claude, sessions)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestFindFrictionOverTheManifest(t *testing.T) {
+	dir := frictionStore(t, FrictionMinSessions)
+	f, ok := FindFriction(dir)
+	if !ok {
+		t.Fatal("three sessions hitting one error should be reported")
+	}
+	if f.Text != "command not found: shellcheck" {
+		t.Fatalf("text = %q", f.Text)
+	}
+	if len(f.Sessions) != FrictionMinSessions {
+		t.Fatalf("sessions = %d", len(f.Sessions))
+	}
+	// Newest first: the date on the screen comes off the head of this list.
+	for i := 1; i < len(f.Sessions); i++ {
+		if f.Sessions[i].Updated.After(f.Sessions[i-1].Updated) {
+			t.Fatal("sessions are not newest first")
+		}
+	}
+	if !f.Last.Equal(f.Sessions[0].Updated) {
+		t.Fatal("Last should be the newest session")
+	}
+}
+
+func TestFindFrictionQuietBelowThreshold(t *testing.T) {
+	dir := frictionStore(t, FrictionMinSessions-1)
+	if _, ok := FindFriction(dir); ok {
+		t.Fatal("two sessions is a coincidence, not friction")
+	}
+}
+
+func TestFindFrictionOnMissingStore(t *testing.T) {
+	if _, ok := FindFriction(filepath.Join(t.TempDir(), "nope")); ok {
+		t.Fatal("no store, nothing to report")
+	}
+}
+
+// Two walls hit by the same number of sessions: the one still being hit wins,
+// because a wall the machine stopped running into is history, not friction.
+func TestNewestOfBreaksTheTie(t *testing.T) {
+	old := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	recent := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	ms := []SessionMeta{{Updated: old}, {Updated: recent}, {Updated: old}}
+	if got := newestOf(ms); !got.Equal(recent) {
+		t.Fatalf("newestOf = %v, want %v", got, recent)
+	}
+	if got := newestOf(nil); !got.IsZero() {
+		t.Fatalf("no sessions, no date, got %v", got)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -19,7 +19,10 @@ import (
 // the copies it already holds.
 // 18: file paths from tool calls are indexed (#558). An index built before this
 // has none of them, so it is rebuilt rather than reused.
-const version = 19
+// 20: opencode tool output is parsed (#621) and each session records what it
+// tripped over (#576). An index built before this has neither, and neither can
+// be derived from what it does hold.
+const version = 20
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message
@@ -101,6 +104,11 @@ type SessionMeta struct {
 	// The field is additive: a manifest written before it existed decodes with
 	// it empty and the caller degrades to saying nothing.
 	Touched []string `json:",omitempty"`
+	// Hit holds hashes of the specific errors this session tripped over, so
+	// the first screen can name a wall the machine keeps running into without
+	// reading a single session. Same trade as Asked: the text is recovered
+	// from the two or three sessions that matched.
+	Hit []uint64 `json:",omitempty"`
 }
 
 // touchedFileCap bounds what goes in SessionMeta.Touched. Enough to say

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -786,7 +786,7 @@ func metaForSession(s model.Session) SessionMeta {
 	// composer name, the first user message — and are persisted in
 	// sessions.gob, so they need the same scrubbing as record text.
 	title, _ = redact.Text(title)
-	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, Started: s.Started, Updated: s.Updated, Touched: topTouchedFiles(s.Messages), Asked: askedHashes(s.Messages)}
+	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, Started: s.Started, Updated: s.Updated, Touched: topTouchedFiles(s.Messages), Asked: askedHashes(s.Messages), Hit: frictionHashes(s.Messages)}
 }
 
 // agentOwnedFile drops the agent's own working files. They are touched


### PR DESCRIPTION
Closes #576.

`deja friction` reads the record log, which is 0.4s — a hundred times what the brief is allowed. So each session now records hashes of what it tripped over, the same trade `SessionMeta.Asked` makes, and the screen clusters them over the manifest:

```
asked      пока на коммит забей, нам нужно подготовить …
before     4 sessions in mpc-autoscaler · May 21 → Jun 16
hit        ModuleNotFoundError: No module named 'yaml'
again      11 sessions · last today · deja friction
```

The per-session cap is 256, which is high on purpose. The screen names a count and points at a command; at a cap of 6 the screen said 8 where the command said 11, at 100 it said 10, and one session in this corpus carries over a hundred distinct error lines. The whole field costs 2.7 KB across 1149 sessions, so the exactness is nearly free — and there is a test that runs both and fails if they disagree.

Detection moved to `internal/index` because it now runs in two places; two copies of these rules would drift, and the first symptom would be a screen the command cannot reproduce.

Index version 20. Worth noting it is overdue for a second reason: #621 taught deja to parse opencode tool output without bumping the version, so anyone who indexed before it has none of that data.

Measured on the way: `FindFriction` is 325 ms, next to `FindAskedTwice` at 270 ms. Bare `deja` totals 3.2 s, but that is `suggestFirstQuery` loading every session in the store — filed as #625, not touched here.