### PR TITLE
perf: cut the first screen from 3.2 s to 0.6 s

### DIFF
--- a/cmd/deja/suggest.go
+++ b/cmd/deja/suggest.go
@@ -15,17 +15,25 @@ import (
 // print after the first index build: counts impress, but seeing your own
 // three-week-old problem come back is the argument. Empty string means "use
 // the generic hint" — a thin corpus never gets a made-up suggestion.
+// Both halves read the user role only. That is what the suggestion is made of
+// — a phrase someone would type — and it is also what makes this affordable on
+// the first screen: tokenizing every message in the store to score a two-word
+// phrase cost 2.2 s of the brief's 3.2 s, against 0.19 s for the turns a person
+// actually wrote (#625).
 func suggestFirstQuery(dir string) string {
-	ss, err := index.SearchWithRecovery(dir, query.Options{All: true}, nil)
+	ss, err := index.SearchWithRecovery(dir, query.Options{All: true, Role: "user"}, nil)
 	if err != nil || len(ss) < 3 {
 		return ""
 	}
-	// Document frequency over every session; candidate phrases only from
-	// recent, human-typed messages.
+	// Document frequency over what was typed across the whole store; candidate
+	// phrases only from the recent part of it.
 	df := map[string]int{}
 	for _, s := range ss {
 		seen := map[string]bool{}
 		for _, m := range s.Messages {
+			if digest.IsAgentArtifact(m.Text) {
+				continue
+			}
 			for _, tok := range suggestTokens(m.Text) {
 				if !seen[tok] {
 					seen[tok] = true

--- a/cmd/deja/suggest_test.go
+++ b/cmd/deja/suggest_test.go
@@ -77,3 +77,47 @@ func TestSuggestPhraseTokensMarksGaps(t *testing.T) {
 		t.Fatalf("got %q, want the dropped word marked", got)
 	}
 }
+
+// The suggestion is scored on what people typed, not on what the agents wrote
+// back. A subject the assistant repeats in every session is still distinctive
+// if the person only raised it twice — and the change that made this true is
+// also what took the line from 2.2 s to 0.19 s (#625).
+func TestSuggestScoresUserTurnsNotAssistantEcho(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-e")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	const now = "2026-07-20T10:00:00Z"
+	user := func(id, text string) string {
+		return `{"type":"user","sessionId":"` + id + `","cwd":"/w/e","timestamp":"` + now +
+			`","message":{"role":"user","content":"` + text + `"}}` + "\n"
+	}
+	assistant := func(id, text string) string {
+		return `{"type":"assistant","sessionId":"` + id + `","cwd":"/w/e","timestamp":"` + now +
+			`","message":{"role":"assistant","content":"` + text + `"}}` + "\n"
+	}
+	// The agent echoes "quantum harvester" in all five sessions; the person
+	// raised it in two. Counting the echo would score it as common and the
+	// suggestion would fall back to filler.
+	files := map[string]string{
+		"e1": user("e1", "quantum harvester latency spike") + assistant("e1", "the quantum harvester is fine"),
+		"e2": user("e2", "quantum harvester retries again") + assistant("e2", "the quantum harvester is fine"),
+		"e3": user("e3", "please update readme wording") + assistant("e3", "the quantum harvester is fine"),
+		"e4": user("e4", "update readme header image") + assistant("e4", "the quantum harvester is fine"),
+		"e5": user("e5", "update readme badges please") + assistant("e5", "the quantum harvester is fine"),
+	}
+	for id, body := range files {
+		if err := os.WriteFile(filepath.Join(root, id+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := suggestFirstQuery(dir); !strings.Contains(got, "quantum") {
+		t.Fatalf("suggestion = %q, want the subject the person raised", got)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -986,12 +986,14 @@ func truncateTitle(s string, n int) string {
 	return strings.TrimSpace(string(r[:n])) + "…"
 }
 
+// recordsForKey collects one session's records. It peeks the key field and
+// skips the body of everything else: decoding all of them to keep a few
+// hundred cost 300 ms per session on an 80 MB log, paid twice on every bare
+// `deja` by the two lines that recover text from a hash (#625).
 func recordsForKey(path string, t *recordTables, key string) ([]Record, error) {
 	var out []Record
-	err := eachRecord(path, t, func(r Record) {
-		if r.Key == key {
-			out = append(out, r)
-		}
+	err := eachRecordForKeys(path, t, map[string]bool{key: true}, func(r Record) {
+		out = append(out, r)
 	})
 	return out, err
 }

--- a/internal/index/tool_stream_test.go
+++ b/internal/index/tool_stream_test.go
@@ -59,3 +59,60 @@ func TestEachToolOutputOnMissingStore(t *testing.T) {
 		t.Fatal("a missing store should report an error")
 	}
 }
+
+// recordsForKey skips the body of records belonging to other sessions. It must
+// still return exactly what a full decode of the log would have returned for
+// this one — the shortcut is a decode it avoids, not a record it drops.
+func TestRecordsForKeyMatchesAFullScan(t *testing.T) {
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "claude", "-tmp-keys")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, sid := range []string{"k1", "k2"} {
+		lines := []string{
+			`{"type":"user","sessionId":"` + sid + `","cwd":"/w","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"first turn in ` + sid + `"}}`,
+			`{"type":"assistant","sessionId":"` + sid + `","cwd":"/w","timestamp":"2026-01-02T03:05:05Z","message":{"role":"assistant","content":"answer for ` + sid + `"}}`,
+		}
+		if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "records.bin")
+	tbl := tablesFromManifest(m)
+	for key := range m.Sessions {
+		var want []Record
+		if err := eachRecord(path, tbl, func(r Record) {
+			if r.Key == key {
+				want = append(want, r)
+			}
+		}); err != nil {
+			t.Fatal(err)
+		}
+		got, err := recordsForKey(path, tbl, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != len(want) || len(want) == 0 {
+			t.Fatalf("%s: got %d records, full scan found %d", key, len(got), len(want))
+		}
+		for i := range want {
+			if got[i].Text != want[i].Text || got[i].Role != want[i].Role || !got[i].Time.Equal(want[i].Time) {
+				t.Fatalf("%s record %d differs: %#v vs %#v", key, i, got[i], want[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #625.

Two things, both on the path of a bare `deja`:

**The `try` line built its document-frequency table from every message in the store** — 95,612 of them, 2.2 s. It now reads the user role only, which is what the suggestion is made of anyway: a phrase a person would type. 0.19 s.

That turns out to be a quality fix too. Scoring the agent's replies means a subject the assistant echoes in every session looks common, so it loses to filler — on the test corpus the old code suggests `please update` where the new one suggests the subject the person actually raised. The test fails against the old behaviour.

**`recordsForKey` decoded every record in the log to keep the few belonging to one session** — 300 ms per call, and the `asked` and `hit` lines each make one. `eachRecordForKeys` already existed for exactly this: peek the key, skip the body. There is an equivalence test asserting it returns what a full scan returns.

```
before  3.2 s
after   0.63 s     same screen, same lines
```

Breakdown of what is left: ~330 ms loading, ~190 ms df, ~95 ms candidates.