### PR TITLE
fix(codex): panic on a tool result without a call_id

### DIFF
--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -159,9 +159,13 @@ func codexCallOutput(s *model.Session, payload map[string]any, calls map[string]
 	if out == "" {
 		return
 	}
-	if m := codexExit.FindStringSubmatch(out); m != nil {
+	// The id is read with the comma-ok form on purpose: a record without a
+	// call_id is not an error, and asserting it bare turns one into a panic
+	// that takes the whole parse down.
+	id, _ := payload["call_id"].(string)
+	if m := codexExit.FindStringSubmatch(out); m != nil && id != "" {
 		if code, err := strconv.Atoi(m[1]); err == nil && code > 0 {
-			if i, ok := calls[payload["call_id"].(string)]; ok && i < len(s.Messages) {
+			if i, ok := calls[id]; ok && i < len(s.Messages) {
 				s.Messages[i].Text += fmt.Sprintf("  → exit %d", code)
 			}
 		}
@@ -196,6 +200,7 @@ func codexPatch(s *model.Session, payload map[string]any, cwd string, t time.Tim
 		return
 	}
 	var files []string
+	seen := map[string]bool{}
 	removed := map[string][]string{}
 	current := ""
 	for _, line := range strings.Split(body, "\n") {
@@ -204,7 +209,10 @@ func codexPatch(s *model.Session, payload map[string]any, cwd string, t time.Tim
 			if cwd != "" && !filepath.IsAbs(current) {
 				current = filepath.Join(cwd, current)
 			}
-			files = append(files, current)
+			if !seen[current] {
+				seen[current] = true
+				files = append(files, current)
+			}
 			continue
 		}
 		// A removed line, not the "--- a/x" header of a unified diff: this

--- a/internal/sources/codex_test.go
+++ b/internal/sources/codex_test.go
@@ -85,3 +85,39 @@ func TestCodexWorkRecordsRespectTheirSwitches(t *testing.T) {
 		}
 	}
 }
+
+// A rollout record without a call_id is not an error. Asserting the id bare
+// turned one into a panic that took the whole parse of the session down, and
+// no test caught it because every call in the local corpus had an id.
+func TestCodexOutputWithoutCallIDDoesNotPanic(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "rollout-2026-07-31T00-00-00-nc.jsonl")
+	lines := []string{
+		`{"timestamp":"2026-07-31T00:00:00Z","type":"session_meta","payload":{"session_id":"nc","cwd":"/w"}}`,
+		`{"timestamp":"2026-07-31T00:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"hi"}]}}`,
+		`{"timestamp":"2026-07-31T00:00:02Z","type":"response_item","payload":{"type":"function_call_output","output":"Process exited with code 1\nOutput:\nboom\n"}}`,
+		`{"timestamp":"2026-07-31T00:00:03Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"go test ./...\"}"}}`,
+		`{"timestamp":"2026-07-31T00:00:04Z","type":"response_item","payload":{"type":"function_call_output","call_id":123,"output":"Exit code: 2\nOutput:\nno\n"}}`,
+	}
+	if err := os.WriteFile(p, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseCodexRollout(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d", len(ss))
+	}
+	// The output still lands; only the exit annotation is lost, which is the
+	// right degradation for a record that names no call.
+	var out int
+	for _, m := range ss[0].Messages {
+		if m.Role == RoleToolOutput {
+			out++
+		}
+	}
+	if out != 2 {
+		t.Fatalf("tool output records = %d, want 2", out)
+	}
+}

--- a/internal/sources/decoder_junk_test.go
+++ b/internal/sources/decoder_junk_test.go
@@ -1,0 +1,57 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Malformed and half-typed records of every shape the new decoders touch.
+func TestCodexAndCursorSurviveJunk(t *testing.T) {
+	dir := t.TempDir()
+	codex := []string{
+		`{"timestamp":"2026-07-31T00:00:00Z","type":"session_meta","payload":{"session_id":"j","cwd":"/w"}}`,
+		`{"timestamp":"x","type":"response_item","payload":{"type":"function_call","name":"exec_command"}}`,
+		`{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"not json"}}`,
+		`{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":null}"}}`,
+		`{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":123}}`,
+		`{"type":"response_item","payload":{"type":"function_call_output","output":null}}`,
+		`{"type":"response_item","payload":{"type":"function_call_output","output":"Output:\n"}}`,
+		`{"type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch"}}`,
+		`{"type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","input":""}}`,
+		`{"type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","input":"*** Begin Patch\n-orphan removal with no file header\n*** End Patch"}}`,
+		`{"type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","input":"*** Update File: \n-x"}}`,
+		`{"type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","input":123}}`,
+		`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"keep one"}]}}`,
+	}
+	p := filepath.Join(dir, "rollout-2026-07-31T00-00-00-junk.jsonl")
+	if err := os.WriteFile(p, []byte(strings.Join(codex, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseCodexRollout(p); err != nil {
+		t.Fatal(err)
+	}
+
+	cdir := filepath.Join(dir, "projects", "Users-me-app", "agent-transcripts", "junk")
+	if err := os.MkdirAll(cdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cursor := []string{
+		`{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Read"}]}}`,
+		`{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":null}]}}`,
+		`{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"path":123}}]}}`,
+		`{"role":"assistant","message":{"content":[{"type":"tool_use","name":"StrReplace","input":{"path":"/a","old_string":null}}]}}`,
+		`{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":null}}]}}`,
+		`{"role":"assistant","message":{"content":"a plain string, not a list"}}`,
+		`{"role":"assistant","message":{"content":[{"type":"tool_use","name":"StrReplace","input":{"path":"/a","edits":"not a list"}}]}}`,
+		`{"role":"user","message":{"content":[{"type":"text","text":"keep one"}]}}`,
+	}
+	cp := filepath.Join(cdir, "junk.jsonl")
+	if err := os.WriteFile(cp, []byte(strings.Join(cursor, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseCursorTranscript(cp); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Closes #630. My own bug from #629, an hour old.

`payload["call_id"].(string)` asserted bare: a record without an id panics instead of being skipped, and the whole session fails to parse. Every call in my corpus has an id, so the unit tests and a full reindex both passed.

Fixed with the comma-ok form, plus a junk-record test for both decoders added in #628 and #629 — null inputs, wrong types, patches with no file header, content that is a string instead of a list. That test fails against the old code.

Also dedupes the file paths a patch names; Claude's extractor does and this one did not.