### PR TITLE
feat: give the environment facts to the agent, not to the CLI user

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | **Blame** | `deja blame <path>` — which sessions touched this file, what was decided and why |
 | **Restore** | `deja restore <path>` — hand back a span an agent replaced, from the `old_string` its edit recorded; never writes over the original |
 | **Files** | `deja files <topic>` — the other direction: which files the work on a subject actually touched, ranked by how specific they are to it |
-| **Friction** | `deja friction` — the errors this machine keeps hitting across sessions: a missing tool, an uninstalled module, a command that does not exist here |
+| **Friction** | `deja friction` — the errors this machine keeps hitting across sessions: a missing tool, an uninstalled module, a command that does not exist here. The same facts reach your agent by itself, once per session, so it stops rediscovering them one failed command at a time |
 | **Semantic** | optional: point `deja embed` at a local Ollama/LM Studio and rephrased queries still hit |
 
 ## Privacy

--- a/cmd/deja/environment.go
+++ b/cmd/deja/environment.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The commands built on the work records — `deja friction`, `deja files` —
+// answer a person at a keyboard, and an agent will never run them. This block
+// puts the same knowledge where an agent cannot miss it: the session-start
+// injection every harness already receives.
+//
+// It is deliberately the narrowest true claim deja can make. Not "you tried
+// this approach and reverted it", which is an accusation and has to be right
+// (#541 died on exactly that); just what this machine is missing, counted from
+// the transcripts themselves. `timeout` is absent on macOS and nine separate
+// sessions rediscovered it one failed command at a time.
+const (
+	// environmentWalls is how many to name. Three is what fits in a glance and
+	// what a stable set looks like: these clusters change over weeks, not
+	// turns, so the block is not a nag that fires per action.
+	environmentWalls = 3
+	environmentMax   = 96
+)
+
+// environmentBlock names what the machine keeps failing on, or "" when nothing
+// has failed in enough separate sessions to be worth an agent's attention.
+func environmentBlock(dir string) string {
+	walls := index.TopFriction(dir, environmentWalls)
+	if len(walls) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("This machine, from deja's index of past sessions across every agent used here:\n")
+	for _, w := range walls {
+		text := w.Text
+		if len(text) > environmentMax {
+			text = text[:environmentMax] + "…"
+		}
+		fmt.Fprintf(&b, "- %d separate sessions hit `%s`\n", len(w.Sessions), text)
+	}
+	// Without this line the block reads as trivia. With it the model has
+	// something to do differently on its next tool call, which is the only
+	// reason the block is here.
+	b.WriteString("These are environment facts, not history: the tool or module is still missing. " +
+		"Check or use an alternative before running into them again.")
+	return b.String()
+}
+
+// environmentOnce appends the block to the first recall an MCP session serves.
+//
+// The session-start injection reaches the thirteen harnesses deja can wire a
+// hook into. The rest — and every agent whose user declined the hook — reach
+// deja only through MCP, and there the server process lives for the whole
+// session, so "once" is a thing this side can actually count. Appending it to
+// every recall would spend a tenth of the response budget repeating a fact the
+// model already has.
+var environmentServed sync.Once
+
+func environmentOnce(dir string) string {
+	out := ""
+	environmentServed.Do(func() {
+		if env := environmentBlock(dir); env != "" {
+			out = "\n\n" + env
+		}
+	})
+	return out
+}

--- a/cmd/deja/environment_test.go
+++ b/cmd/deja/environment_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// seedWalls lays down n sessions that each hit the same two errors.
+func seedWalls(t *testing.T, n int) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-w")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	for i := 0; i < n; i++ {
+		sid := fmt.Sprintf("w%02d", i)
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/w/w","timestamp":"2026-07-2` +
+			fmt.Sprint(i%10) + `T10:00:00Z","message":{"role":"user","content":"run the checks"}}` + "\n" +
+			`{"type":"user","sessionId":"` + sid + `","cwd":"/w/w","timestamp":"2026-07-2` +
+			fmt.Sprint(i%10) + `T10:05:00Z","message":{"role":"user","content":[{"type":"tool_result",` +
+			`"content":"zsh:1: command not found: shellcheck\nModuleNotFoundError: No module named 'yaml'"}]}}` + "\n"
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestEnvironmentBlockNamesWallsAndWhatToDo(t *testing.T) {
+	dir := seedWalls(t, index.FrictionMinSessions)
+	got := environmentBlock(dir)
+	for _, want := range []string{
+		"command not found: shellcheck",
+		"No module named 'yaml'",
+		fmt.Sprintf("%d separate sessions", index.FrictionMinSessions),
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("block missing %q:\n%s", want, got)
+		}
+	}
+	// Without an instruction the block is trivia the model skims past.
+	if !strings.Contains(got, "alternative") {
+		t.Errorf("block says nothing to do about it:\n%s", got)
+	}
+	// Three is what fits in a glance; a longer list is a nag.
+	if n := strings.Count(got, "\n- "); n > environmentWalls {
+		t.Errorf("named %d walls, cap is %d", n, environmentWalls)
+	}
+}
+
+// Silence is the right answer on a machine that has not failed the same way
+// three times: a block that fires on one-off errors is noise, and #582 is
+// explicit that a noisy warning gets the feature turned off.
+func TestEnvironmentBlockSilentBelowThreshold(t *testing.T) {
+	dir := seedWalls(t, index.FrictionMinSessions-1)
+	if got := environmentBlock(dir); got != "" {
+		t.Fatalf("want silence, got:\n%s", got)
+	}
+}
+
+func TestEnvironmentReachesTheSessionStartInjection(t *testing.T) {
+	dir := seedWalls(t, index.FrictionMinSessions)
+	// Through the hook itself, not the digest helper: a checkout with no
+	// session of its own returns an empty digest, and the block must survive
+	// that path — it is about the machine, not the project.
+	var out bytes.Buffer
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	hookErr := runHookContext(dir, true)
+	os.Stdout = stdout
+	_ = w.Close()
+	_, _ = out.ReadFrom(r)
+	if hookErr != nil {
+		t.Fatal(hookErr)
+	}
+	if !strings.Contains(out.String(), "command not found: shellcheck") {
+		t.Fatalf("the injection carries no environment block:\n%s", out.String())
+	}
+}
+
+// The thirteen harnesses with a wired hook get the block at session start;
+// everything else reaches deja through MCP, where the server process lives for
+// the whole session — so it is served once and not on every recall.
+func TestEnvironmentServedOncePerMCPSession(t *testing.T) {
+	dir := seedWalls(t, index.FrictionMinSessions)
+	environmentServed = sync.Once{}
+	first, err := callMCPTool(dir, "recall", json.RawMessage(`{"query":"checks","limit":2}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := callMCPTool(dir, "recall", json.RawMessage(`{"query":"checks","limit":2}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(first, "This machine") {
+		t.Fatalf("first recall carries no block:\n%s", first)
+	}
+	if strings.Contains(second, "This machine") {
+		t.Fatalf("second recall repeats the block:\n%s", second)
+	}
+}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -90,6 +90,25 @@ func runHookContext(dir string, plain bool) error {
 	_ = json.Unmarshal(readHookStdin(), &input)
 	digest, sessions, raw, taskMatched := cachedHookDigest(dir)
 	if digest == "" {
+		// No session from this project, which is the usual state in a new
+		// checkout — and exactly where knowing what this machine is missing
+		// helps most. The block is about the machine, not the project, so it
+		// does not depend on the digest having found anything.
+		if env := environmentBlock(dir); env != "" {
+			out := frameRecall(env)
+			usage.RecordDigestPolicy(dir, usage.KindHook, out, 0, 0, policy.Load().Describe(policy.ActivationAuto))
+			if plain {
+				fmt.Fprintln(os.Stdout, out)
+				return nil
+			}
+			var resp sessionStartHookResponse
+			resp.HookSpecificOutput.HookEventName = "SessionStart"
+			resp.HookSpecificOutput.AdditionalContext = out
+			if b, err := json.Marshal(resp); err == nil {
+				fmt.Fprintln(os.Stdout, string(b))
+			}
+			return nil
+		}
 		// A first build (or one forced by a new index format) is running in
 		// the background. It never blocks the agent, but starting in silence
 		// looks like deja is simply not working — so say what is happening.
@@ -414,7 +433,15 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 	if result.Sessions == 0 {
 		matched = nil
 	}
-	return result.Text, result.Sessions, rawSize(ss), matched
+	text := result.Text
+	// Inside the cached result, not after it: this costs a manifest scan plus
+	// one session read, which is ten times the rest of the hook, and the
+	// clusters it reports change over weeks rather than turns.
+	if env := environmentBlock(dir); env != "" {
+		text += "\n" + env + "\n"
+	}
+	mark("environment")
+	return text, result.Sessions, rawSize(ss), matched
 }
 
 func requestWarmup(dir string) {

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -180,7 +180,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		}
 		text, sessions, raw, ids, err := recallTextResult(dir, a.Query, a.Harness, int(a.Limit), int(a.Offset), 4096-recallFrameOverhead)
 		if err == nil {
-			text = frameRecall(text)
+			text = frameRecall(text) + environmentOnce(dir)
 			usage.RecordServedSessions(dir, usage.KindRecall, len(text), sessions, sessions == 0, raw, ids)
 			usage.SnapshotPolicy(dir, usage.KindRecall, text, sessions, policy.Load().Describe(policy.ActivationMCP))
 		}

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -63,6 +63,7 @@
 </tbody></table>
 <h2>Auto-recall</h2>
 <p><code>deja install --auto</code> adds a SessionStart hook (Claude Code, Codex, an opencode plugin). Relevant project memory is injected before you ask — read-only, capped at 2&nbsp;KB, framed as untrusted historical data so it never acts as an instruction. It also fires right after a context compaction, re-anchoring the model in what it just lost.</p>
+<p>The same injection carries what this machine keeps failing on: an error that hit three or more separate sessions — a binary that is not installed, a Python module that was never added — counted from the transcripts themselves. Agents rediscover those one failed command at a time, so the block says the count and what to do instead. It is served once per session, appears at session start where a hook is wired and on the first <code>recall</code> where only MCP is, and stays silent until something has failed in three separate sessions.</p>
 <h2>Windows</h2>
 <div class="note">On Windows, stdio MCP clients spawn through <code>cmd /c deja mcp</code>. <code>deja install</code> writes that form automatically.</div>
 

--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -151,17 +151,27 @@ func frictionHashes(ms []model.Message) []uint64 {
 	return out
 }
 
-// FindFriction picks the wall worth showing: the one the most separate
-// sessions hit. It runs over the manifest alone, so a caller on the first
-// screen pays nothing for it; only the sessions that carry the winning hash
-// are read back, and only to recover the text the hash stands for.
+// FindFriction picks the wall worth showing on a screen with room for one.
 func FindFriction(dir string) (Friction, bool) {
+	out := TopFriction(dir, 1)
+	if len(out) == 0 {
+		return Friction{}, false
+	}
+	return out[0], true
+}
+
+// TopFriction returns the walls this machine keeps running into, most-hit
+// first. It runs over the manifest alone, so a caller on the first screen or
+// in a session-start hook pays nothing for the search; only the sessions
+// carrying a winning hash are read back, and only to recover the text the
+// hash stands for.
+func TopFriction(dir string, n int) []Friction {
 	if dir == "" {
 		dir = DefaultDir()
 	}
 	m, err := readManifestCached(dir)
 	if err != nil {
-		return Friction{}, false
+		return nil
 	}
 	byHash := map[uint64][]SessionMeta{}
 	for _, meta := range m.Sessions {
@@ -169,27 +179,51 @@ func FindFriction(dir string) (Friction, bool) {
 			byHash[h] = append(byHash[h], meta)
 		}
 	}
-	var best []SessionMeta
-	var bestHash uint64
+	type cluster struct {
+		hash  uint64
+		metas []SessionMeta
+	}
+	var cs []cluster
 	for h, metas := range byHash {
 		if len(metas) < FrictionMinSessions {
 			continue
 		}
-		// Most sessions wins; among equals the one hit most recently, because
-		// a wall the machine stopped running into is history, not friction.
-		if len(metas) > len(best) || (len(metas) == len(best) && newestOf(metas).After(newestOf(best))) {
-			best, bestHash = metas, h
+		sort.Slice(metas, func(i, j int) bool { return metas[i].Updated.After(metas[j].Updated) })
+		cs = append(cs, cluster{h, metas})
+	}
+	sort.Slice(cs, func(i, j int) bool {
+		if len(cs[i].metas) != len(cs[j].metas) {
+			return len(cs[i].metas) > len(cs[j].metas)
 		}
+		// A wall the machine stopped running into is history, not friction.
+		if !cs[i].metas[0].Updated.Equal(cs[j].metas[0].Updated) {
+			return cs[i].metas[0].Updated.After(cs[j].metas[0].Updated)
+		}
+		return cs[i].hash < cs[j].hash
+	})
+	if n > 0 && len(cs) > n {
+		cs = cs[:n]
 	}
-	if len(best) < FrictionMinSessions {
-		return Friction{}, false
+	// Recover every winning text in one pass per session rather than one pass
+	// per wall: the same session usually carries several of them.
+	want := map[uint64]string{}
+	for _, c := range cs {
+		want[c.hash] = ""
 	}
-	sort.Slice(best, func(i, j int) bool { return best[i].Updated.After(best[j].Updated) })
-	text := frictionTextFor(dir, m, best, bestHash)
-	if text == "" {
-		return Friction{}, false
+	for _, c := range cs {
+		if want[c.hash] != "" {
+			continue
+		}
+		frictionTexts(dir, m, c.metas, want, c.hash)
 	}
-	return Friction{Text: text, Sessions: best, Last: best[0].Updated}, true
+	var out []Friction
+	for _, c := range cs {
+		if want[c.hash] == "" {
+			continue
+		}
+		out = append(out, Friction{Text: want[c.hash], Sessions: c.metas, Last: c.metas[0].Updated})
+	}
+	return out
 }
 
 func newestOf(ms []SessionMeta) time.Time {
@@ -202,9 +236,11 @@ func newestOf(ms []SessionMeta) time.Time {
 	return out
 }
 
-// frictionTextFor recovers what a hash stood for by reading back the sessions
-// that carry it, stopping at the first one that yields the line.
-func frictionTextFor(dir string, m Manifest, metas []SessionMeta, want uint64) string {
+// frictionTexts recovers what the wanted hashes stood for by reading back the
+// sessions that carry one of them, filling in every hash a session yields —
+// one session usually carries several walls, and reading it once per wall was
+// the difference between one lookup and N.
+func frictionTexts(dir string, m Manifest, metas []SessionMeta, want map[uint64]string, target uint64) {
 	for _, meta := range metas {
 		s, ok, err := loadSessionMeta(dir, m, meta)
 		if err != nil || !ok {
@@ -216,11 +252,19 @@ func frictionTextFor(dir string, m Manifest, metas []SessionMeta, want uint64) s
 			}
 			for _, line := range strings.Split(msg.Text, "\n") {
 				line, ok := FrictionLine(line)
-				if ok && frictionHash(line) == want {
-					return line
+				if !ok {
+					continue
+				}
+				h := frictionHash(line)
+				if cur, wanted := want[h]; wanted && cur == "" {
+					want[h] = line
 				}
 			}
 		}
+		// Stop on this cluster's own text, not on any text: a session can fill
+		// in a neighbour's hash while carrying nothing for this one.
+		if want[target] != "" {
+			return
+		}
 	}
-	return ""
 }


### PR DESCRIPTION
Closes #582.

`deja friction` and `deja files` answer a person at a keyboard. An agent will never run them, which makes them a set of functions rather than something that makes the agent better. This puts the same knowledge where an agent cannot miss it.

```
This machine, from deja's index of past sessions across every agent used here:
- 11 separate sessions hit `ModuleNotFoundError: No module named 'yaml'`
- 10 separate sessions hit `command not found: python`
- 9 separate sessions hit `command not found: timeout`
These are environment facts, not history: the tool or module is still missing.
Check or use an alternative before running into them again.
```

**Both channels, so every harness is covered.** The session-start injection reaches the thirteen deja can wire a hook into; everything else reaches deja over MCP, where the server process lives for the whole session — so it is appended to the first `recall` and not to the rest. 400 bytes, once.

**The two bars #582 sets.** It cannot be a nag: these clusters change over weeks, not turns, and the block is served once per session, capped at three walls, silent until something has failed in three *separate* sessions. It cannot be wrong: this is the narrowest true claim available — not "you tried this approach and reverted it", which is an accusation and is what killed #541, just what the machine is missing, counted from the transcripts.

Two things found while building it:

- **The block must survive an empty digest.** A checkout with no sessions of its own returned nothing at all — and that is exactly where knowing what the machine is missing helps most. It is about the machine, not the project. There is a test that goes through the hook rather than the digest helper, because the helper never sees that path.
- **Cost.** Computed after the cache, the hook went from ~15 ms to 130 ms on every session start. It is now inside the cached digest: 50–60 ms warm, and the stale-while-revalidate path already there does the rest.

`index.TopFriction` replaces the single-wall lookup and recovers every winning text in one pass per session rather than one per wall.