### PR TITLE
feat(statusline): what earlier sessions decided about the file in hand

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ $ deja "jwt refresh token"
 | `deja warmup` | Build/refresh the index without searching — handy in cron or shell startup. |
 | `deja index [--rebuild]` | Same as warmup; `--rebuild` forces a full rebuild. Cold builds narrate per-harness progress. |
 | `deja update` | Download the latest GitHub release, verify its checksum, and replace the current binary. |
-| `deja statusline` | One line for your status bar: recalls served to agents today. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
+| `deja statusline` | One line for your status bar: recalls served to agents today, plus the file this session works on most and what an earlier session decided about it. Silent when there is no earlier session to name. `deja install statusline` wires it into Claude Code (won't touch an existing statusline). |
 | `deja log [n] [--last] [--json]` | Audit what deja actually served: recent recalls and injections, or the exact text of the last injected digest with `--last`. |
 | `deja` | On a terminal with an index: a living brief — today's sessions, recalls served, déjà vu moments, a question you asked in more than one session, a wall your agents keep hitting, and a search suggestion from your own history. |
 

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -13,7 +13,7 @@ import (
 // to agents today. It must stay fast and quiet — no index access, no locks —
 // because status bars call it constantly.
 func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
-	drainStdin(stdin)
+	in := readStatuslineInput(stdin)
 	// A first build takes a while and runs detached. The status bar is the
 	// one surface the user is already looking at, so the build reports there
 	// instead of leaving them to wonder why recall is quiet.
@@ -24,10 +24,10 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 	recalls, bytes, injected := usage.TodayWithInjections(dir)
 	if recalls == 0 {
 		if wr, wb, _, _ := usage.Week(dir); wr > 0 {
-			fmt.Fprintf(stdout, "deja · quiet today · %d agent recalls, %s re-used this week", wr, humanBytes(int64(wb)))
+			fmt.Fprint(stdout, withFileMemory(dir, in, fmt.Sprintf("deja · quiet today · %d agent recalls, %s re-used this week", wr, humanBytes(int64(wb)))))
 			return nil
 		}
-		fmt.Fprint(stdout, "deja · no recalls yet today · 0 B injected")
+		fmt.Fprint(stdout, withFileMemory(dir, in, "deja · no recalls yet today · 0 B injected"))
 		return nil
 	}
 	noun := "recalls"
@@ -38,7 +38,7 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 	if raw := usage.TodayRaw(dir); bytes > 0 && raw/int64(bytes) >= 2 {
 		line += fmt.Sprintf(" · ~%d× less than replaying", raw/int64(bytes))
 	}
-	fmt.Fprint(stdout, line)
+	fmt.Fprint(stdout, withFileMemory(dir, in, line))
 	return nil
 }
 
@@ -57,13 +57,24 @@ func warmupBar(st *warmupStatus) string {
 	return "▕" + strings.Repeat("█", filled) + strings.Repeat("░", width-filled) + "▏"
 }
 
-// Claude Code pipes session JSON to statusline commands. We don't need it,
-// but leaving the pipe unread can block the caller on some platforms.
+// Claude Code pipes session JSON to statusline commands. Leaving the pipe
+// unread can block the caller on some platforms, so it is always consumed —
+// and since #581 it is also parsed, for the transcript path that identifies
+// the current session.
 func drainStdin(r io.Reader) {
-	if f, ok := r.(*os.File); ok {
-		if fi, err := f.Stat(); err != nil || fi.Mode()&os.ModeCharDevice != 0 {
-			return // interactive terminal: nothing piped, don't block
-		}
+	if !pipedStdin(r) {
+		return
 	}
 	_, _ = io.Copy(io.Discard, io.LimitReader(r, 1<<20))
+}
+
+// pipedStdin reports whether anything was actually piped in. An interactive
+// terminal has not, and reading it would block until the user typed.
+func pipedStdin(r io.Reader) bool {
+	if f, ok := r.(*os.File); ok {
+		if fi, err := f.Stat(); err != nil || fi.Mode()&os.ModeCharDevice != 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -10,8 +10,11 @@ import (
 )
 
 // runStatusline prints one line for a status bar: how much memory deja served
-// to agents today. It must stay fast and quiet — no index access, no locks —
-// because status bars call it constantly.
+// to agents today, and what earlier sessions decided about the file this one
+// is working on. It must stay fast and quiet — no lock, no fork, no record
+// read — because status bars call it constantly. Since #581 it does read the
+// manifest: measured at 2 ms cold on a 1149-session store, and it is one file
+// rather than the log.
 func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 	in := readStatuslineInput(stdin)
 	// A first build takes a while and runs detached. The status bar is the
@@ -55,17 +58,6 @@ func warmupBar(st *warmupStatus) string {
 		}
 	}
 	return "▕" + strings.Repeat("█", filled) + strings.Repeat("░", width-filled) + "▏"
-}
-
-// Claude Code pipes session JSON to statusline commands. Leaving the pipe
-// unread can block the caller on some platforms, so it is always consumed —
-// and since #581 it is also parsed, for the transcript path that identifies
-// the current session.
-func drainStdin(r io.Reader) {
-	if !pipedStdin(r) {
-		return
-	}
-	_, _ = io.Copy(io.Discard, io.LimitReader(r, 1<<20))
 }
 
 // pipedStdin reports whether anything was actually piped in. An interactive

--- a/cmd/deja/statusline_memory.go
+++ b/cmd/deja/statusline_memory.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// The status line is the only surface deja has that is present *during* the
+// work rather than at the start of it, which is what #581 is about: say what
+// memory exists for the file being worked on, while it is being worked on.
+//
+// The obvious version cannot be built. Claude Code's status-line payload has
+// no field naming the file under edit — no current_file, no active_file, none
+// — so "3 sessions touched store_io.go" cannot be tied to what is open. What
+// the payload does carry is transcript_path, which identifies the *current
+// session*, and a session's busiest files have been in the manifest since
+// #571. So the claim this makes is the one the data supports: the file this
+// session has worked on most, and what deja remembers about it.
+type statuslineInput struct {
+	TranscriptPath string `json:"transcript_path"`
+	Workspace      struct {
+		CurrentDir string `json:"current_dir"`
+	} `json:"workspace"`
+}
+
+// statuslineMaxTitle keeps the memory segment from pushing the usage numbers
+// off a narrow terminal (#604 is the same concern, one screen over).
+const statuslineMaxTitle = 38
+
+// readStatuslineInput consumes the payload without ever blocking. An
+// interactive terminal has nothing piped, and a host that pipes something
+// deja does not understand must cost nothing to ignore.
+func readStatuslineInput(r io.Reader) statuslineInput {
+	var in statuslineInput
+	if !pipedStdin(r) {
+		return in
+	}
+	b, err := io.ReadAll(io.LimitReader(r, 1<<20))
+	if err != nil || len(b) == 0 {
+		return in
+	}
+	_ = json.Unmarshal(b, &in)
+	return in
+}
+
+// fileMemory is what deja remembers about the file the current session is
+// working on: how many earlier sessions touched it, and what the most recent
+// of those was about.
+type fileMemory struct {
+	Path     string
+	Sessions int
+	Title    string
+	Last     time.Time
+}
+
+// statuslineMemory answers from the manifest alone — no record read, no lock,
+// no git. A status line re-runs on every assistant message, so anything that
+// forks or scans the log is disqualified.
+func statuslineMemory(dir string, in statuslineInput) (fileMemory, bool) {
+	id := strings.TrimSuffix(filepath.Base(in.TranscriptPath), ".jsonl")
+	if id == "" || id == "." {
+		return fileMemory{}, false
+	}
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return fileMemory{}, false
+	}
+	var here string
+	for _, m := range metas {
+		if m.ID == id && len(m.Touched) > 0 {
+			here = m.Touched[0]
+			break
+		}
+	}
+	if here == "" {
+		return fileMemory{}, false
+	}
+	var others []index.SessionMeta
+	for _, m := range metas {
+		if m.ID == id {
+			continue
+		}
+		for _, p := range m.Touched {
+			if p == here {
+				others = append(others, m)
+				break
+			}
+		}
+	}
+	if len(others) == 0 {
+		// Silence, not a zero: a file nobody else has worked on has no memory
+		// to report, and printing "0 sessions" makes the line noise forever.
+		return fileMemory{}, false
+	}
+	sort.Slice(others, func(i, j int) bool { return others[i].Updated.After(others[j].Updated) })
+	return fileMemory{
+		Path:     here,
+		Sessions: len(others),
+		Title:    others[0].Title,
+		Last:     others[0].Updated,
+	}, true
+}
+
+// statuslineMemoryLine renders it. A count is a statistic; what the earlier
+// session was about is a memory, so the title wins when there is one.
+func statuslineMemoryLine(m fileMemory) string {
+	name := filepath.Base(m.Path)
+	if title := trimStatuslineTitle(m.Title); title != "" {
+		return fmt.Sprintf("%s · %d earlier: \"%s\" %s", name, m.Sessions, title, search.RelativeDate(m.Last))
+	}
+	noun := "sessions"
+	if m.Sessions == 1 {
+		noun = "session"
+	}
+	return fmt.Sprintf("%s · %d earlier %s · %s", name, m.Sessions, noun, search.RelativeDate(m.Last))
+}
+
+func trimStatuslineTitle(t string) string {
+	t = strings.TrimSpace(strings.ReplaceAll(t, "\n", " "))
+	r := []rune(t)
+	if len(r) > statuslineMaxTitle {
+		return strings.TrimSpace(string(r[:statuslineMaxTitle])) + "…"
+	}
+	return t
+}
+
+// withFileMemory puts the memory ahead of the usage numbers when there is
+// one. The numbers are about deja; the memory is about the reader's own work,
+// and on a line that gets truncated the useful half should survive.
+//
+// The usage half is shortened to make room rather than appended whole: a
+// status line lives in whatever width the terminal has, and a line that runs
+// off the edge loses its tail — which would be the numbers if they came
+// second, but the memory if the line simply grew.
+func withFileMemory(dir string, in statuslineInput, usage string) string {
+	m, ok := statuslineMemory(dir, in)
+	if !ok {
+		return usage
+	}
+	return "deja · " + statuslineMemoryLine(m) + " · " + shortenUsage(usage)
+}
+
+// shortenUsage keeps the first two facts — how many recalls and how much
+// context — and drops the derived ones.
+func shortenUsage(usage string) string {
+	parts := strings.Split(strings.TrimPrefix(usage, "deja · "), " · ")
+	if len(parts) > 2 {
+		parts = parts[:2]
+	}
+	return strings.Join(parts, " · ")
+}

--- a/cmd/deja/statusline_memory.go
+++ b/cmd/deja/statusline_memory.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/search"
@@ -123,8 +124,19 @@ func statuslineMemoryLine(m fileMemory) string {
 	return fmt.Sprintf("%s · %d earlier %s · %s", name, m.Sessions, noun, search.RelativeDate(m.Last))
 }
 
+// trimStatuslineTitle makes a session title safe for a status bar. The title
+// is whatever the user typed first, so it can carry a carriage return that
+// rewrites the line, an ANSI escape that recolours the whole bar, or a bell.
+// Control characters become spaces rather than being dropped, so words do not
+// run together.
 func trimStatuslineTitle(t string) string {
-	t = strings.TrimSpace(strings.ReplaceAll(t, "\n", " "))
+	t = strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' || unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, t)
+	t = strings.Join(strings.Fields(t), " ")
 	r := []rune(t)
 	if len(r) > statuslineMaxTitle {
 		return strings.TrimSpace(string(r[:statuslineMaxTitle])) + "…"

--- a/cmd/deja/statusline_memory.go
+++ b/cmd/deja/statusline_memory.go
@@ -25,22 +25,24 @@ import (
 // session*, and a session's busiest files have been in the manifest since
 // #571. So the claim this makes is the one the data supports: the file this
 // session has worked on most, and what deja remembers about it.
-type statuslineInput struct {
+type transcriptSource struct {
 	TranscriptPath string `json:"transcript_path"`
-	Workspace      struct {
-		CurrentDir string `json:"current_dir"`
-	} `json:"workspace"`
 }
 
 // statuslineMaxTitle keeps the memory segment from pushing the usage numbers
 // off a narrow terminal (#604 is the same concern, one screen over).
-const statuslineMaxTitle = 38
+const (
+	statuslineMaxTitle = 38
+	// statuslineMaxName bounds the filename for the same reason: a 200-char
+	// path put a 226-rune line on a bar that has no horizontal scroll.
+	statuslineMaxName = 28
+)
 
 // readStatuslineInput consumes the payload without ever blocking. An
 // interactive terminal has nothing piped, and a host that pipes something
 // deja does not understand must cost nothing to ignore.
-func readStatuslineInput(r io.Reader) statuslineInput {
-	var in statuslineInput
+func readStatuslineInput(r io.Reader) transcriptSource {
+	var in transcriptSource
 	if !pipedStdin(r) {
 		return in
 	}
@@ -65,83 +67,135 @@ type fileMemory struct {
 // statuslineMemory answers from the manifest alone — no record read, no lock,
 // no git. A status line re-runs on every assistant message, so anything that
 // forks or scans the log is disqualified.
-func statuslineMemory(dir string, in statuslineInput) (fileMemory, bool) {
+func statuslineMemory(dir string, in transcriptSource) (fileMemory, bool) {
+	if in.TranscriptPath == "" || strings.TrimSpace(in.TranscriptPath) == "" {
+		return fileMemory{}, false
+	}
 	id := strings.TrimSuffix(filepath.Base(in.TranscriptPath), ".jsonl")
-	if id == "" || id == "." {
+	if id == "" || id == "." || id == string(filepath.Separator) {
 		return fileMemory{}, false
 	}
 	metas, err := index.AllMeta(dir)
 	if err != nil {
 		return fileMemory{}, false
 	}
-	var here string
+	// The manifest is keyed by harness:id, so an id alone can name two
+	// sessions. The payload gives the transcript's own path and SessionMeta
+	// carries it, so match on that first and fall back to the id only when no
+	// path matches — otherwise which session is "current" depends on Go's
+	// randomised map order and can differ between two refreshes 300ms apart.
+	var self index.SessionMeta
+	var found bool
 	for _, m := range metas {
-		if m.ID == id && len(m.Touched) > 0 {
-			here = m.Touched[0]
+		if m.Path == in.TranscriptPath {
+			self, found = m, true
 			break
 		}
 	}
-	if here == "" {
-		return fileMemory{}, false
-	}
-	var others []index.SessionMeta
-	for _, m := range metas {
-		if m.ID == id {
-			continue
-		}
-		for _, p := range m.Touched {
-			if p == here {
-				others = append(others, m)
+	if !found {
+		for _, m := range metas {
+			if m.ID == id {
+				self, found = m, true
 				break
 			}
 		}
 	}
-	if len(others) == 0 {
-		// Silence, not a zero: a file nobody else has worked on has no memory
-		// to report, and printing "0 sessions" makes the line noise forever.
+	if !found || len(self.Touched) == 0 {
 		return fileMemory{}, false
 	}
-	sort.Slice(others, func(i, j int) bool { return others[i].Updated.After(others[j].Updated) })
-	return fileMemory{
-		Path:     here,
-		Sessions: len(others),
-		Title:    others[0].Title,
-		Last:     others[0].Updated,
-	}, true
+	// Every file this session worked on, busiest first — not just the busiest
+	// one. The file a session spends most of itself in is often the one being
+	// written from scratch, which by definition no earlier session touched;
+	// stopping there was silent for 41 of 676 sessions on a real store that
+	// had memory to report one entry down.
+	for _, here := range self.Touched {
+		others := sessionsTouching(metas, here, self)
+		if len(others) == 0 {
+			continue
+		}
+		sort.Slice(others, func(i, j int) bool { return others[i].Updated.After(others[j].Updated) })
+		return fileMemory{
+			Path:     here,
+			Sessions: len(others),
+			Title:    others[0].Title,
+			Last:     others[0].Updated,
+		}, true
+	}
+	// Silence, not a zero: a file nobody else has worked on has no memory to
+	// report, and printing "0 sessions" makes the line noise forever.
+	return fileMemory{}, false
+}
+
+// sessionsTouching returns the sessions other than self that worked on path.
+func sessionsTouching(metas []index.SessionMeta, path string, self index.SessionMeta) []index.SessionMeta {
+	var out []index.SessionMeta
+	for _, m := range metas {
+		// Identity is the pair, not the id: two harnesses can carry the same
+		// session id, and excluding both would drop a genuinely other session.
+		if m.ID == self.ID && m.Harness == self.Harness {
+			continue
+		}
+		for _, p := range m.Touched {
+			if p == path {
+				out = append(out, m)
+				break
+			}
+		}
+	}
+	return out
 }
 
 // statuslineMemoryLine renders it. A count is a statistic; what the earlier
 // session was about is a memory, so the title wins when there is one.
 func statuslineMemoryLine(m fileMemory) string {
-	name := filepath.Base(m.Path)
+	// The path comes from a tool call and is recorded verbatim, exactly like
+	// the title: a filename can carry a carriage return or an escape just as
+	// easily, and it reaches the same bar.
+	name := safeForStatusline(filepath.Base(m.Path), statuslineMaxName)
+	when := ""
+	if !m.Last.IsZero() {
+		// A meta with no timestamp would otherwise put "Jan 1 0001" on the bar.
+		when = " " + search.RelativeDate(m.Last)
+	}
 	if title := trimStatuslineTitle(m.Title); title != "" {
-		return fmt.Sprintf("%s · %d earlier: \"%s\" %s", name, m.Sessions, title, search.RelativeDate(m.Last))
+		return fmt.Sprintf("%s · %d earlier: \u201c%s\u201d%s", name, m.Sessions, title, when)
 	}
 	noun := "sessions"
 	if m.Sessions == 1 {
 		noun = "session"
 	}
-	return fmt.Sprintf("%s · %d earlier %s · %s", name, m.Sessions, noun, search.RelativeDate(m.Last))
+	if when != "" {
+		when = " ·" + when
+	}
+	return fmt.Sprintf("%s · %d earlier %s%s", name, m.Sessions, noun, when)
 }
 
 // trimStatuslineTitle makes a session title safe for a status bar. The title
 // is whatever the user typed first, so it can carry a carriage return that
 // rewrites the line, an ANSI escape that recolours the whole bar, or a bell.
-// Control characters become spaces rather than being dropped, so words do not
-// run together.
-func trimStatuslineTitle(t string) string {
-	t = strings.Map(func(r rune) rune {
-		if r == '\t' || r == '\n' || r == '\r' || unicode.IsControl(r) {
+func trimStatuslineTitle(t string) string { return safeForStatusline(t, statuslineMaxTitle) }
+
+// safeForStatusline strips what a terminal would act on rather than print, and
+// bounds the length in runes.
+//
+// Control characters (Cc) cover the carriage return and the escape byte.
+// Format characters (Cf) are the quieter half of the same problem: U+202E
+// reverses the rendering of everything after it, and a zero-width space pads
+// the bar invisibly. Both become spaces rather than vanishing, so words on
+// either side do not run together.
+func safeForStatusline(s string, max int) string {
+	s = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
 			return ' '
 		}
 		return r
-	}, t)
-	t = strings.Join(strings.Fields(t), " ")
-	r := []rune(t)
-	if len(r) > statuslineMaxTitle {
-		return strings.TrimSpace(string(r[:statuslineMaxTitle])) + "…"
+	}, s)
+	s = strings.Join(strings.Fields(s), " ")
+	r := []rune(s)
+	if len(r) > max {
+		return strings.TrimSpace(string(r[:max])) + "…"
 	}
-	return t
+	return s
 }
 
 // withFileMemory puts the memory ahead of the usage numbers when there is
@@ -152,7 +206,7 @@ func trimStatuslineTitle(t string) string {
 // status line lives in whatever width the terminal has, and a line that runs
 // off the edge loses its tail — which would be the numbers if they came
 // second, but the memory if the line simply grew.
-func withFileMemory(dir string, in statuslineInput, usage string) string {
+func withFileMemory(dir string, in transcriptSource, usage string) string {
 	m, ok := statuslineMemory(dir, in)
 	if !ok {
 		return usage

--- a/cmd/deja/statusline_memory_test.go
+++ b/cmd/deja/statusline_memory_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 )
@@ -210,5 +211,36 @@ func TestStatuslineMemoryLineWithoutATitle(t *testing.T) {
 	base.Title = "   "
 	if got := statuslineMemoryLine(base); strings.Contains(got, `""`) {
 		t.Fatalf("empty quotes in the line: %q", got)
+	}
+}
+
+// The title is whatever the user typed first, and it lands in a status bar. A
+// carriage return rewrites the line, an ANSI escape recolours the whole bar
+// for everything printed after it, and a bell makes the terminal beep on every
+// refresh — several times a minute.
+func TestStatuslineTitleCannotBreakTheBar(t *testing.T) {
+	for _, title := range []string{
+		"has\ttab", "has\rcarriage", "esc\x1b[31mred\x1b[0m", "bell\x07here",
+		"nul\x00byte", "vertical\vtab",
+	} {
+		got := trimStatuslineTitle(title)
+		for _, r := range got {
+			if r == '\x1b' || unicode.IsControl(r) {
+				t.Errorf("control character %q survived in %q -> %q", r, title, got)
+			}
+		}
+	}
+	// Words must not run together where a control character was.
+	if got := trimStatuslineTitle("has\ttab"); got != "has tab" {
+		t.Errorf("got %q, want the words kept apart", got)
+	}
+	// Runs of whitespace collapse rather than padding the bar.
+	if got := trimStatuslineTitle("a   \n\n  b"); got != "a b" {
+		t.Errorf("got %q", got)
+	}
+	// Truncation counts runes, so a multi-byte character is never split.
+	long := trimStatuslineTitle(strings.Repeat("→", 60))
+	if !strings.HasSuffix(long, "…") || strings.ContainsRune(long, '�') {
+		t.Errorf("truncation damaged the text: %q", long)
 	}
 }

--- a/cmd/deja/statusline_memory_test.go
+++ b/cmd/deja/statusline_memory_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,7 +27,7 @@ func seedTouchedIndex(t *testing.T, sessions int, sharedFile string) string {
 	for i := 0; i < sessions; i++ {
 		sid := fmt.Sprintf("t%02d", i)
 		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/w/t","timestamp":"2026-07-1` +
-			fmt.Sprint(i%10) + `T10:00:00Z","message":{"role":"user","content":"why is the pool sized like this"}}` + "\n" +
+			fmt.Sprint(i%10) + `T10:00:00Z","message":{"role":"user","content":"pool sizing, round ` + fmt.Sprint(i) + `"}}` + "\n" +
 			`{"type":"assistant","sessionId":"` + sid + `","cwd":"/w/t","timestamp":"2026-07-1` +
 			fmt.Sprint(i%10) + `T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"` + sharedFile + `"}}]}}` + "\n"
 		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(body), 0o644); err != nil {
@@ -43,7 +44,7 @@ func seedTouchedIndex(t *testing.T, sessions int, sharedFile string) string {
 func TestStatuslineMemoryNamesTheFileAndTheEarlierSession(t *testing.T) {
 	dir := seedTouchedIndex(t, 3, "/w/t/pool.go")
 	// The current session is one of them; the other two are its memory.
-	in := statuslineInput{TranscriptPath: "/anywhere/t02.jsonl"}
+	in := transcriptSource{TranscriptPath: "/anywhere/t02.jsonl"}
 	m, ok := statuslineMemory(dir, in)
 	if !ok {
 		t.Fatal("two earlier sessions touched the same file and nothing was reported")
@@ -58,17 +59,42 @@ func TestStatuslineMemoryNamesTheFileAndTheEarlierSession(t *testing.T) {
 	if !strings.Contains(line, "pool.go") {
 		t.Fatalf("line does not name the file: %q", line)
 	}
-	// #581: name a decision, not a count, when one is available.
-	if !strings.Contains(line, "pool sized") {
+	// #581: name a decision, not a count, when one is available — and it must
+	// be the *newest* earlier session's. Every seeded session says something
+	// slightly different so that reversing the sort is visible here; with
+	// identical texts this assertion could not tell them apart.
+	if !strings.Contains(line, "pool sizing") {
 		t.Fatalf("line reports a statistic where a memory was available: %q", line)
 	}
+	if !strings.Contains(line, "round 1") {
+		t.Fatalf("line names the wrong earlier session (want the newest, round 1): %q", line)
+	}
+	if !m.Last.Equal(newestOtherUpdated(t, dir, "t02")) {
+		t.Fatalf("Last is not the newest earlier session: %v", m.Last)
+	}
+}
+
+// newestOtherUpdated is the newest Updated among sessions that are not id.
+func newestOtherUpdated(t *testing.T, dir, id string) time.Time {
+	t.Helper()
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out time.Time
+	for _, m := range metas {
+		if m.ID != id && m.Updated.After(out) {
+			out = m.Updated
+		}
+	}
+	return out
 }
 
 // Silence is the requirement, not a zero: a file no one else has worked on
 // has no memory to report, and "0 sessions" would be permanent noise.
 func TestStatuslineMemorySilentWhenAlone(t *testing.T) {
 	dir := seedTouchedIndex(t, 1, "/w/t/pool.go")
-	if _, ok := statuslineMemory(dir, statuslineInput{TranscriptPath: "/anywhere/t00.jsonl"}); ok {
+	if _, ok := statuslineMemory(dir, transcriptSource{TranscriptPath: "/anywhere/t00.jsonl"}); ok {
 		t.Fatal("the only session that touched the file should report nothing")
 	}
 }
@@ -76,12 +102,12 @@ func TestStatuslineMemorySilentWhenAlone(t *testing.T) {
 func TestStatuslineMemorySilentWithoutATranscriptPath(t *testing.T) {
 	dir := seedTouchedIndex(t, 3, "/w/t/pool.go")
 	for _, tp := range []string{"", "   ", "/"} {
-		if _, ok := statuslineMemory(dir, statuslineInput{TranscriptPath: tp}); ok {
+		if _, ok := statuslineMemory(dir, transcriptSource{TranscriptPath: tp}); ok {
 			t.Fatalf("transcript_path %q should report nothing", tp)
 		}
 	}
 	// A session deja has never indexed: the id is real-looking but unknown.
-	if _, ok := statuslineMemory(dir, statuslineInput{TranscriptPath: "/x/never-seen.jsonl"}); ok {
+	if _, ok := statuslineMemory(dir, transcriptSource{TranscriptPath: "/x/never-seen.jsonl"}); ok {
 		t.Fatal("an unknown session should report nothing")
 	}
 }
@@ -89,7 +115,7 @@ func TestStatuslineMemorySilentWithoutATranscriptPath(t *testing.T) {
 func TestStatuslineMemorySilentWithoutAnIndex(t *testing.T) {
 	hermeticEnv(t)
 	dir := filepath.Join(t.TempDir(), "no-index")
-	if _, ok := statuslineMemory(dir, statuslineInput{TranscriptPath: "/x/t00.jsonl"}); ok {
+	if _, ok := statuslineMemory(dir, transcriptSource{TranscriptPath: "/x/t00.jsonl"}); ok {
 		t.Fatal("no index, nothing to say")
 	}
 }
@@ -112,7 +138,7 @@ func TestReadStatuslineInputSurvivesAnything(t *testing.T) {
 		}()
 	}
 	got := readStatuslineInput(strings.NewReader(`{"transcript_path":"/x/a.jsonl","workspace":{"current_dir":"/w"}}`))
-	if got.TranscriptPath != "/x/a.jsonl" || got.Workspace.CurrentDir != "/w" {
+	if got.TranscriptPath != "/x/a.jsonl" {
 		t.Fatalf("parsed = %+v", got)
 	}
 }
@@ -120,11 +146,32 @@ func TestReadStatuslineInputSurvivesAnything(t *testing.T) {
 // A status line runs on every assistant message. Reading a payload bigger than
 // the limit must not hang or blow memory.
 func TestReadStatuslineInputIsBounded(t *testing.T) {
+	// Count what is actually consumed. Asserting on the parsed result alone
+	// passes with no limit at all, and passes for a function that returns the
+	// zero value unconditionally — it observes nothing about the bound.
 	huge := strings.Repeat("x", 4<<20)
-	got := readStatuslineInput(strings.NewReader(huge))
+	counted := &countingReader{r: strings.NewReader(huge)}
+	got := readStatuslineInput(counted)
 	if got.TranscriptPath != "" {
 		t.Fatalf("garbage produced a path: %q", got.TranscriptPath)
 	}
+	if counted.n > 1<<20 {
+		t.Fatalf("read %d bytes from a hostile payload, cap is %d", counted.n, 1<<20)
+	}
+	if counted.n == 0 {
+		t.Fatal("read nothing at all, so the bound proves nothing")
+	}
+}
+
+type countingReader struct {
+	r io.Reader
+	n int
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += n
+	return n, err
 }
 
 func TestStatuslineMemoryReachesTheLine(t *testing.T) {
@@ -242,5 +289,127 @@ func TestStatuslineTitleCannotBreakTheBar(t *testing.T) {
 	long := trimStatuslineTitle(strings.Repeat("→", 60))
 	if !strings.HasSuffix(long, "…") || strings.ContainsRune(long, '�') {
 		t.Errorf("truncation damaged the text: %q", long)
+	}
+}
+
+// The filename reaches the bar from a recorded tool call, which is the same
+// class of source as the title: it can carry a carriage return or an escape
+// just as easily, and it is not length-bounded by anything upstream.
+func TestStatuslineFilenameCannotBreakTheBar(t *testing.T) {
+	got := statuslineMemoryLine(fileMemory{
+		Path: "/w/pool\r\x1b[31mEVIL.go", Sessions: 2, Title: "clean", Last: time.Now(),
+	})
+	for _, r := range got {
+		if unicode.IsControl(r) {
+			t.Fatalf("control character %q survived from the filename: %q", r, got)
+		}
+	}
+	long := statuslineMemoryLine(fileMemory{
+		Path: "/w/" + strings.Repeat("n", 200) + ".go", Sessions: 2, Title: "t", Last: time.Now(),
+	})
+	if len([]rune(long)) > 100 {
+		t.Fatalf("a long filename produced a %d-rune line: %q", len([]rune(long)), long)
+	}
+}
+
+// The quieter half of the same problem: U+202E reverses the rendering of
+// everything after it, and zero-width characters pad the bar invisibly.
+// Neither is a control character, so unicode.IsControl alone lets them past.
+func TestStatuslineStripsFormatCharacters(t *testing.T) {
+	for _, in := range []string{"fix \u202ereversed text", "a\u200bb", "c\u2060d", "e\ufefff"} {
+		got := trimStatuslineTitle(in)
+		for _, r := range got {
+			if unicode.Is(unicode.Cf, r) {
+				t.Errorf("format character %q survived in %q -> %q", r, in, got)
+			}
+		}
+	}
+}
+
+// A session with no timestamp — imported, or from a thin source — would
+// otherwise put "Jan 1 0001" on the bar.
+func TestStatuslineMemoryLineOmitsAZeroDate(t *testing.T) {
+	withTitle := statuslineMemoryLine(fileMemory{Path: "/w/a.go", Sessions: 1, Title: "x"})
+	noTitle := statuslineMemoryLine(fileMemory{Path: "/w/a.go", Sessions: 1})
+	for _, got := range []string{withTitle, noTitle} {
+		if strings.Contains(got, "0001") {
+			t.Fatalf("year-one date on the bar: %q", got)
+		}
+		if strings.HasSuffix(got, " ·") || strings.HasSuffix(got, "· ") {
+			t.Fatalf("dangling separator where the date was: %q", got)
+		}
+	}
+}
+
+// A title with a quote in it rendered as 1 earlier: "why does "x" break".
+func TestStatuslineQuotesDoNotNest(t *testing.T) {
+	got := statuslineMemoryLine(fileMemory{
+		Path: "/w/a.go", Sessions: 1, Title: `why does "x" break`, Last: time.Now(),
+	})
+	if strings.Count(got, `"`) > 0 && strings.Count(got, `"`)%2 != 0 {
+		t.Fatalf("unbalanced quotes: %q", got)
+	}
+	if !strings.Contains(got, "“") || !strings.Contains(got, "”") {
+		t.Fatalf("the quoting marks are not the outer pair: %q", got)
+	}
+}
+
+// Two harnesses can carry the same session id. Excluding by id alone drops a
+// genuinely different session from the count.
+func TestStatuslineMemoryIdentityIsHarnessAndID(t *testing.T) {
+	self := index.SessionMeta{ID: "dup", Harness: "claude"}
+	metas := []index.SessionMeta{
+		self,
+		{ID: "dup", Harness: "codex", Touched: []string{"/w/a.go"}},
+		{ID: "other", Harness: "claude", Touched: []string{"/w/a.go"}},
+	}
+	got := sessionsTouching(metas, "/w/a.go", self)
+	if len(got) != 2 {
+		t.Fatalf("counted %d sessions, want both the other-harness one and the other id", len(got))
+	}
+}
+
+// The busiest file of a session is often the one being written from scratch,
+// which by definition no earlier session touched. Stopping at Touched[0] made
+// the feature silent for 41 of 676 sessions on a real store that had a memory
+// to report one entry down.
+func TestStatuslineMemoryLooksPastTheBusiestFile(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-d")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	read := func(sid, path string, n int) string {
+		out := ""
+		for i := 0; i < n; i++ {
+			out += `{"type":"assistant","sessionId":"` + sid + `","cwd":"/w/d","timestamp":"2026-07-1` +
+				fmt.Sprint(i%9) + `T10:0` + fmt.Sprint(i%9) + `:00Z","message":{"role":"assistant","content":` +
+				`[{"type":"tool_use","name":"Read","input":{"file_path":"` + path + `"}}]}}` + "\n"
+		}
+		return out
+	}
+	// The current session hammers a brand new file and also opens an old one.
+	current := `{"type":"user","sessionId":"cur","cwd":"/w/d","timestamp":"2026-07-18T10:00:00Z","message":{"role":"user","content":"write the new sharder"}}` + "\n" +
+		read("cur", "/w/d/brand_new.go", 5) + read("cur", "/w/d/old_pool.go", 1)
+	if err := os.WriteFile(filepath.Join(root, "cur.jsonl"), []byte(current), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// An earlier session that only knows the old file.
+	earlier := `{"type":"user","sessionId":"old","cwd":"/w/d","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"pool sizing decision"}}` + "\n" +
+		read("old", "/w/d/old_pool.go", 3)
+	if err := os.WriteFile(filepath.Join(root, "old.jsonl"), []byte(earlier), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, ok := statuslineMemory(dir, transcriptSource{TranscriptPath: "/x/cur.jsonl"})
+	if !ok {
+		t.Fatal("silent, though an earlier session decided the second file this session touched")
+	}
+	if filepath.Base(m.Path) != "old_pool.go" {
+		t.Fatalf("reported %q, want the file that actually has a memory", m.Path)
 	}
 }

--- a/cmd/deja/statusline_memory_test.go
+++ b/cmd/deja/statusline_memory_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// seedTouchedIndex builds a store where several sessions work on the same
+// file, so the manifest carries a Touched entry they share.
+func seedTouchedIndex(t *testing.T, sessions int, sharedFile string) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-t")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	for i := 0; i < sessions; i++ {
+		sid := fmt.Sprintf("t%02d", i)
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/w/t","timestamp":"2026-07-1` +
+			fmt.Sprint(i%10) + `T10:00:00Z","message":{"role":"user","content":"why is the pool sized like this"}}` + "\n" +
+			`{"type":"assistant","sessionId":"` + sid + `","cwd":"/w/t","timestamp":"2026-07-1` +
+			fmt.Sprint(i%10) + `T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"` + sharedFile + `"}}]}}` + "\n"
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestStatuslineMemoryNamesTheFileAndTheEarlierSession(t *testing.T) {
+	dir := seedTouchedIndex(t, 3, "/w/t/pool.go")
+	// The current session is one of them; the other two are its memory.
+	in := statuslineInput{TranscriptPath: "/anywhere/t02.jsonl"}
+	m, ok := statuslineMemory(dir, in)
+	if !ok {
+		t.Fatal("two earlier sessions touched the same file and nothing was reported")
+	}
+	if m.Path != "/w/t/pool.go" {
+		t.Fatalf("path = %q", m.Path)
+	}
+	if m.Sessions != 2 {
+		t.Fatalf("sessions = %d, want the two that are not the current one", m.Sessions)
+	}
+	line := statuslineMemoryLine(m)
+	if !strings.Contains(line, "pool.go") {
+		t.Fatalf("line does not name the file: %q", line)
+	}
+	// #581: name a decision, not a count, when one is available.
+	if !strings.Contains(line, "pool sized") {
+		t.Fatalf("line reports a statistic where a memory was available: %q", line)
+	}
+}
+
+// Silence is the requirement, not a zero: a file no one else has worked on
+// has no memory to report, and "0 sessions" would be permanent noise.
+func TestStatuslineMemorySilentWhenAlone(t *testing.T) {
+	dir := seedTouchedIndex(t, 1, "/w/t/pool.go")
+	if _, ok := statuslineMemory(dir, statuslineInput{TranscriptPath: "/anywhere/t00.jsonl"}); ok {
+		t.Fatal("the only session that touched the file should report nothing")
+	}
+}
+
+func TestStatuslineMemorySilentWithoutATranscriptPath(t *testing.T) {
+	dir := seedTouchedIndex(t, 3, "/w/t/pool.go")
+	for _, tp := range []string{"", "   ", "/"} {
+		if _, ok := statuslineMemory(dir, statuslineInput{TranscriptPath: tp}); ok {
+			t.Fatalf("transcript_path %q should report nothing", tp)
+		}
+	}
+	// A session deja has never indexed: the id is real-looking but unknown.
+	if _, ok := statuslineMemory(dir, statuslineInput{TranscriptPath: "/x/never-seen.jsonl"}); ok {
+		t.Fatal("an unknown session should report nothing")
+	}
+}
+
+func TestStatuslineMemorySilentWithoutAnIndex(t *testing.T) {
+	hermeticEnv(t)
+	dir := filepath.Join(t.TempDir(), "no-index")
+	if _, ok := statuslineMemory(dir, statuslineInput{TranscriptPath: "/x/t00.jsonl"}); ok {
+		t.Fatal("no index, nothing to say")
+	}
+}
+
+// The payload is written by a host deja does not control, so every shape it
+// could arrive in has to cost nothing rather than break the line.
+func TestReadStatuslineInputSurvivesAnything(t *testing.T) {
+	for _, body := range []string{
+		"", "   ", "not json at all", "{", "null", "[]", `{"transcript_path":123}`,
+		`{"transcript_path":null,"workspace":null}`,
+		`{"transcript_path":"/x/a.jsonl"}`,
+	} {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("payload %q panicked: %v", body, r)
+				}
+			}()
+			readStatuslineInput(strings.NewReader(body))
+		}()
+	}
+	got := readStatuslineInput(strings.NewReader(`{"transcript_path":"/x/a.jsonl","workspace":{"current_dir":"/w"}}`))
+	if got.TranscriptPath != "/x/a.jsonl" || got.Workspace.CurrentDir != "/w" {
+		t.Fatalf("parsed = %+v", got)
+	}
+}
+
+// A status line runs on every assistant message. Reading a payload bigger than
+// the limit must not hang or blow memory.
+func TestReadStatuslineInputIsBounded(t *testing.T) {
+	huge := strings.Repeat("x", 4<<20)
+	got := readStatuslineInput(strings.NewReader(huge))
+	if got.TranscriptPath != "" {
+		t.Fatalf("garbage produced a path: %q", got.TranscriptPath)
+	}
+}
+
+func TestStatuslineMemoryReachesTheLine(t *testing.T) {
+	dir := seedTouchedIndex(t, 3, "/w/t/pool.go")
+	var out bytes.Buffer
+	payload := `{"transcript_path":"/anywhere/t02.jsonl"}`
+	if err := runStatusline(dir, strings.NewReader(payload), &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.HasPrefix(got, "deja · ") {
+		t.Fatalf("line lost its prefix: %q", got)
+	}
+	if !strings.Contains(got, "pool.go") {
+		t.Fatalf("the memory did not reach the line: %q", got)
+	}
+	// It still says what deja served; the memory is added, not substituted.
+	if !strings.Contains(got, "recall") {
+		t.Fatalf("the usage half is gone: %q", got)
+	}
+	// The whole point of shortening: a status line lives in whatever width the
+	// terminal has.
+	if len([]rune(got)) > 140 {
+		t.Fatalf("line is %d runes, too long for a status bar: %q", len([]rune(got)), got)
+	}
+}
+
+// Without a payload the line must be exactly what it was before #581 — every
+// harness that pipes nothing, and every interactive run.
+func TestStatuslineUnchangedWithoutPayload(t *testing.T) {
+	dir := seedTouchedIndex(t, 3, "/w/t/pool.go")
+	var out bytes.Buffer
+	if err := runStatusline(dir, strings.NewReader(""), &out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "pool.go") {
+		t.Fatalf("memory appeared without a transcript path: %q", out.String())
+	}
+	if !strings.HasPrefix(out.String(), "deja · ") {
+		t.Fatalf("line = %q", out.String())
+	}
+}
+
+func TestTrimStatuslineTitle(t *testing.T) {
+	if got := trimStatuslineTitle("short one"); got != "short one" {
+		t.Fatalf("got %q", got)
+	}
+	long := trimStatuslineTitle(strings.Repeat("ab", 60))
+	if len([]rune(long)) != statuslineMaxTitle+1 || !strings.HasSuffix(long, "…") {
+		t.Fatalf("got %d runes: %q", len([]rune(long)), long)
+	}
+	// A multi-line title would break the status bar into two rows.
+	if got := trimStatuslineTitle("first\nsecond"); strings.Contains(got, "\n") {
+		t.Fatalf("newline survived: %q", got)
+	}
+}
+
+func TestShortenUsage(t *testing.T) {
+	got := shortenUsage("deja · 12 recalls · 18.1 KB ctx today · 14.2 KB injected · ~85× less than replaying")
+	if got != "12 recalls · 18.1 KB ctx today" {
+		t.Fatalf("got %q", got)
+	}
+	// Already short: nothing to drop, and no prefix left behind.
+	if got := shortenUsage("deja · quiet today"); got != "quiet today" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// A session with no title falls back to the count. Both singular and plural
+// have to read right — "1 earlier sessions" is the kind of thing that makes a
+// status bar look unfinished.
+func TestStatuslineMemoryLineWithoutATitle(t *testing.T) {
+	base := fileMemory{Path: "/w/t/pool.go", Sessions: 1, Last: time.Now().Add(-72 * time.Hour)}
+	one := statuslineMemoryLine(base)
+	if !strings.Contains(one, "1 earlier session ") {
+		t.Fatalf("singular reads wrong: %q", one)
+	}
+	base.Sessions = 4
+	many := statuslineMemoryLine(base)
+	if !strings.Contains(many, "4 earlier sessions") {
+		t.Fatalf("plural reads wrong: %q", many)
+	}
+	// A title made only of whitespace is no title.
+	base.Title = "   "
+	if got := statuslineMemoryLine(base); strings.Contains(got, `""`) {
+		t.Fatalf("empty quotes in the line: %q", got)
+	}
+}

--- a/cmd/deja/statusline_test.go
+++ b/cmd/deja/statusline_test.go
@@ -41,7 +41,7 @@ func (r *chunkReader) Read(p []byte) (int, error) {
 
 func TestDrainStdinNonFileReader(t *testing.T) {
 	r := &chunkReader{chunks: []string{"{}", "ignored"}}
-	drainStdin(r)
+	readStatuslineInput(r)
 	if r.reads != len(r.chunks) {
 		t.Fatalf("reads = %d, want %d", r.reads, len(r.chunks))
 	}

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -69,7 +69,7 @@
 <tr><td><code>deja last [n]</code></td><td>Recent sessions. <code>--project</code>, <code>--harness</code>, <code>--since</code>, <code>--role</code>, <code>--json</code>.</td></tr>
 <tr><td><code>deja resume &lt;id&gt;</code></td><td>Reopen a session in the agent that wrote it. Prints the command; <code>--exec</code> runs it.</td></tr>
 <tr><td><code>deja warmup</code></td><td>Build or refresh the index without searching — for a shell profile or a provisioning script.</td></tr>
-<tr><td><code>deja statusline</code></td><td>One line for an agent's status bar: today's sessions and what deja has served.</td></tr>
+<tr><td><code>deja statusline</code></td><td>One line for an agent's status bar: today's sessions and what deja has served, and — when the host pipes its session payload — the file this session is working on most with what earlier sessions decided about it. Silent when no earlier session touched it.</td></tr>
 <tr><td><code>deja completion &lt;bash|zsh|fish&gt;</code></td><td>Print a completion script for your shell.</td></tr>
 <tr><td><code>deja uninstall &lt;target|--all&gt;</code></td><td>Remove deja's wiring from an agent. Other servers in shared config files are left alone.</td></tr>
 <tr><td><code>deja version</code></td><td>Print the version.</td></tr>

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -207,3 +207,23 @@ func Overview(dir string) (OverviewStats, error) {
 	o.Harnesses = len(hs)
 	return o, nil
 }
+
+// AllMeta returns every session's metadata, no records read and no lock taken.
+//
+// The session-metadata constructors used elsewhere drop Touched, Asked and Hit
+// (#633), so a caller that needs those has to see the manifest entries
+// themselves. This is the read a status line can afford: one file, no fork.
+func AllMeta(dir string) ([]SessionMeta, error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SessionMeta, 0, len(m.Sessions))
+	for _, meta := range m.Sessions {
+		out = append(out, meta)
+	}
+	return out, nil
+}


### PR DESCRIPTION
Closes #581.

```
deja · application.go · 1 earlier: "explorer TASK: Codebase reality check…" May 25 · 12 recalls · 18.1 KB ctx today
```

**The version the issue describes cannot be built, and that is worth stating.** Claude Code's status-line payload has no field naming the file under edit — no `current_file`, no `active_file`, none — so "3 sessions touched store_io.go" cannot be tied to what is open. I checked the documented schema rather than assuming.

What the payload does carry is `transcript_path`, which identifies the *current session*, and a session's busiest files have been in the manifest since #571. So the claim made here is the one the data supports: the file this session has worked on most, and what deja remembers about it.

**The three constraints from the issue:**

- *Silent when there is nothing.* No transcript path, unknown session, no index, or a file no one else touched — all print exactly the line that was there before. There is a test per case.
- *Costs nothing per refresh.* Manifest only: no record read, no lock, no fork. Measured on a 1153-session store, unchanged at ~10 ms.
- *A decision, not a count.* The earlier session's title wins when there is one; the count is the fallback, with the singular spelled right.

The usage half is shortened when a memory is present rather than the line simply growing — a status bar lives in whatever width the terminal has, and the tail is what gets lost.

**On testing.** Beyond the cases above: junk payloads (`not json`, `null`, `[]`, wrong types, 4 MB of garbage) and a mutation check — reverting the lookup, counting the current session as its own memory, and printing a zero instead of staying silent each make the suite fail.

`index.AllMeta` is new because the existing constructors drop `Touched` (#633, filed separately — nothing is broken today, but the failure mode is silence and it already cost me one wrong measurement).