### PR TITLE
fix(codex): thread identity and injected preamble

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -22,7 +22,10 @@ import (
 // 20: opencode tool output is parsed (#621) and each session records what it
 // tripped over (#576). An index built before this has neither, and neither can
 // be derived from what it does hold.
-const version = 20
+// 21: Codex sessions are keyed on the ThreadId rather than the SessionId
+// (#635), so every existing Codex entry has the wrong identity, and the
+// harness preamble Codex injects as a user turn is stripped (#636).
+const version = 21
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/selfrecall.go
+++ b/internal/index/selfrecall.go
@@ -42,6 +42,31 @@ var injectedBlocks = [][2]string{
 	{"<command-name>", "</command-args>"},
 }
 
+// Codex writes its preamble as a user turn rather than under its own role, so
+// a role filter does not reach it. Measured on two stores: it is the first
+// user message in 28 of 28 sessions here and titles 81 of 82 there (#636).
+// Identical in every session and lexically broad — plugin names, tool
+// descriptions, an AGENTS.md persona paragraph — so it outranks real turns on
+// aggregate match count, which makes it a ranking bug rather than a cosmetic
+// one.
+//
+// These are stripped only at the *start* of a message, unlike injectedBlocks.
+// The tags are ordinary enough that a person quotes them: on this store nine
+// Claude sessions contain `<environment_context>` and two contain
+// `<user_instructions>`, every one of them a real turn discussing the very
+// filtering this list implements. A preamble is always the head of the
+// message, so requiring that costs nothing and stops the filter from eating
+// someone's sentence.
+var injectedPrefixBlocks = [][2]string{
+	{"<environment_context>", "</environment_context>"},
+	{"<recommended_plugins>", "</recommended_plugins>"},
+	{"<permissions instructions>", "</permissions instructions>"},
+	{"<skills_instructions>", "</skills_instructions>"},
+	{"<user_instructions>", "</user_instructions>"},
+	{"<INSTRUCTIONS>", "</INSTRUCTIONS>"},
+	{"# AGENTS.md instructions", "</INSTRUCTIONS>"},
+}
+
 // Whole-line markers: a harness note that occupies its own line, with no
 // closing tag. Matched at line granularity so a line quoting one inside a real
 // message does not take the message with it.
@@ -63,6 +88,7 @@ func stripSelfRecall(text string) string {
 	for _, m := range injectedBlocks {
 		text = stripBetweenClosed(text, m[0], m[1])
 	}
+	text = stripInjectedPrefixes(text)
 	return stripInjectedLines(text)
 }
 
@@ -92,6 +118,28 @@ func stripInjectedLines(text string) string {
 // truncated <deja-recall> is still ours, but a sentence mentioning
 // <system-reminder> — a bug report, this file's own tests — is not, and
 // swallowing the rest of it loses what the person actually wrote.
+// stripInjectedPrefixes removes a harness preamble from the head of a message,
+// repeatedly: Codex stacks several of them before the first real turn.
+func stripInjectedPrefixes(text string) string {
+	for again := true; again; {
+		again = false
+		trimmed := strings.TrimSpace(text)
+		for _, m := range injectedPrefixBlocks {
+			if !strings.HasPrefix(trimmed, m[0]) {
+				continue
+			}
+			rel := strings.Index(trimmed[len(m[0]):], m[1])
+			if rel < 0 {
+				continue
+			}
+			text = trimmed[len(m[0])+rel+len(m[1]):]
+			again = true
+			break
+		}
+	}
+	return text
+}
+
 func stripBetweenClosed(text, open, close string) string {
 	for {
 		start := strings.Index(text, open)

--- a/internal/index/selfrecall.go
+++ b/internal/index/selfrecall.go
@@ -63,9 +63,23 @@ var injectedPrefixBlocks = [][2]string{
 	{"<permissions instructions>", "</permissions instructions>"},
 	{"<skills_instructions>", "</skills_instructions>"},
 	{"<user_instructions>", "</user_instructions>"},
-	{"<INSTRUCTIONS>", "</INSTRUCTIONS>"},
-	{"# AGENTS.md instructions", "</INSTRUCTIONS>"},
 }
+
+// agentsHeading is the line Codex writes above the AGENTS.md block it injects,
+// and it needs its own rule rather than a place in the list above.
+//
+// As a plain open/close pair it spans from the heading to the *next*
+// `</INSTRUCTIONS>` anywhere in the message, and the two do not have to belong
+// together. A person writing "# AGENTS.md instructions — how do I stop Codex
+// injecting these? Mine is: <INSTRUCTIONS>be terse</INSTRUCTIONS>" lost the
+// whole question, which is precisely the message someone writes when reporting
+// this bug. Requiring the opening tag to follow the heading immediately makes
+// the span the injected block and nothing else.
+const (
+	agentsHeading = "# AGENTS.md instructions"
+	agentsOpen    = "<INSTRUCTIONS>"
+	agentsClose   = "</INSTRUCTIONS>"
+)
 
 // Whole-line markers: a harness note that occupies its own line, with no
 // closing tag. Matched at line granularity so a line quoting one inside a real
@@ -124,20 +138,69 @@ func stripInjectedPrefixes(text string) string {
 	for again := true; again; {
 		again = false
 		trimmed := strings.TrimSpace(text)
+		if rest, ok := stripAgentsBlock(trimmed); ok {
+			text, again = rest, true
+			continue
+		}
 		for _, m := range injectedPrefixBlocks {
 			if !strings.HasPrefix(trimmed, m[0]) {
 				continue
 			}
-			rel := strings.Index(trimmed[len(m[0]):], m[1])
-			if rel < 0 {
+			end, ok := closerAfter(trimmed, m[0], m[1])
+			if !ok {
 				continue
 			}
-			text = trimmed[len(m[0])+rel+len(m[1]):]
+			text = trimmed[end:]
 			again = true
 			break
 		}
 	}
 	return text
+}
+
+// stripAgentsBlock removes the AGENTS.md preamble, which is a heading followed
+// immediately by the block it introduces. Anything else that begins with the
+// same words is someone talking about it.
+func stripAgentsBlock(trimmed string) (string, bool) {
+	if !strings.HasPrefix(trimmed, agentsHeading) {
+		return "", false
+	}
+	rest := strings.TrimSpace(trimmed[len(agentsHeading):])
+	if !strings.HasPrefix(rest, agentsOpen) {
+		return "", false
+	}
+	end, ok := closerAfter(rest, agentsOpen, agentsClose)
+	if !ok {
+		return "", false
+	}
+	return rest[end:], true
+}
+
+// closerAfter returns the offset just past the closer that matches the opener
+// at the head of text, counting nested copies of the same tag. Without the
+// count, `<T>a<T>b</T>c</T>tail` strips to `c</T>tail` and leaves a dangling
+// closer in the index.
+func closerAfter(text, open, close string) (int, bool) {
+	depth := 1
+	i := len(open)
+	for i < len(text) {
+		nextClose := strings.Index(text[i:], close)
+		if nextClose < 0 {
+			return 0, false
+		}
+		nextOpen := strings.Index(text[i:], open)
+		if nextOpen >= 0 && nextOpen < nextClose {
+			depth++
+			i += nextOpen + len(open)
+			continue
+		}
+		depth--
+		i += nextClose + len(close)
+		if depth == 0 {
+			return i, true
+		}
+	}
+	return 0, false
 }
 
 func stripBetweenClosed(text, open, close string) string {

--- a/internal/index/selfrecall_test.go
+++ b/internal/index/selfrecall_test.go
@@ -121,8 +121,8 @@ func TestStripsCodexPreambleOnlyAtTheHead(t *testing.T) {
 	if strings.TrimSpace(got) != "the actual question" {
 		t.Fatalf("got %q, want only the question", got)
 	}
-	if stripSelfRecall(preamble) != "" && strings.TrimSpace(stripSelfRecall(preamble)) != "" {
-		t.Fatalf("a message that is nothing but preamble should strip to empty, got %q", stripSelfRecall(preamble))
+	if got := strings.TrimSpace(stripSelfRecall(preamble)); got != "" {
+		t.Fatalf("a message that is nothing but preamble should strip to empty, got %q", got)
 	}
 	// A person discussing the tag keeps their sentence.
 	for _, real := range []string{
@@ -138,5 +138,47 @@ func TestStripsCodexPreambleOnlyAtTheHead(t *testing.T) {
 		if got := stripSelfRecall(real); got != real {
 			t.Errorf("ate a real message:\n  in  %q\n  out %q", real, got)
 		}
+	}
+}
+
+// The AGENTS.md heading only introduces the injected block when the block
+// follows it immediately. As a plain open/close pair it spanned to the next
+// </INSTRUCTIONS> anywhere in the message, so a person asking how to stop
+// Codex injecting these lost their entire question — the exact message someone
+// writes when reporting this.
+func TestAgentsHeadingNeedsItsBlockToFollow(t *testing.T) {
+	real := []string{
+		"# AGENTS.md instructions\n\nHow do I stop Codex injecting these? Mine is:\n<INSTRUCTIONS>be terse</INSTRUCTIONS>\n",
+		"# AGENTS.md instructions are confusing.\n\nWhy does the block end with </INSTRUCTIONS>?",
+		"# AGENTS.md instructions\n\nno block at all here",
+	}
+	for _, in := range real {
+		if got := stripSelfRecall(in); got != in {
+			t.Errorf("ate a real message:\n  in  %q\n  out %q", in, got)
+		}
+	}
+	injected := "# AGENTS.md instructions\n\n<INSTRUCTIONS>project rules</INSTRUCTIONS>\nthe real question"
+	if got := strings.TrimSpace(stripSelfRecall(injected)); got != "the real question" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// Nested copies of the same tag must be counted, or the outer closer is left
+// behind in the index.
+func TestPrefixStripCountsNesting(t *testing.T) {
+	got := stripSelfRecall("<environment_context>a<environment_context>b</environment_context>c</environment_context>tail")
+	if got != "tail" {
+		t.Fatalf("got %q, want the whole nested block gone", got)
+	}
+}
+
+// A truncated rollout, or a Codex release that renames a closing tag, leaves
+// an unclosed block. Stripping to the end of the message would delete real
+// text that follows, so the block stays — deliberately, and stated here so a
+// future change to that behaviour is a decision rather than a slip.
+func TestUnclosedPrefixBlockIsLeftAlone(t *testing.T) {
+	in := "<environment_context>\n<cwd>/w</cwd>\nthe file was cut here"
+	if got := stripSelfRecall(in); got != in {
+		t.Fatalf("got %q", got)
 	}
 }

--- a/internal/index/selfrecall_test.go
+++ b/internal/index/selfrecall_test.go
@@ -108,3 +108,35 @@ func TestIndexDoesNotSwallowItsOwnRecall(t *testing.T) {
 		}
 	}
 }
+
+// Codex injects its preamble as a user turn, so it survives any role filter.
+// It is stripped only at the head of a message: the tags are ordinary enough
+// that people quote them, and nine Claude sessions on the store this was
+// measured against do exactly that (#636).
+func TestStripsCodexPreambleOnlyAtTheHead(t *testing.T) {
+	preamble := "<environment_context>\n  <cwd>/w</cwd>\n</environment_context>\n" +
+		"<recommended_plugins>a long list</recommended_plugins>\n" +
+		"# AGENTS.md instructions\n\n<INSTRUCTIONS>project rules</INSTRUCTIONS>\n"
+	got := stripSelfRecall(preamble + "the actual question")
+	if strings.TrimSpace(got) != "the actual question" {
+		t.Fatalf("got %q, want only the question", got)
+	}
+	if stripSelfRecall(preamble) != "" && strings.TrimSpace(stripSelfRecall(preamble)) != "" {
+		t.Fatalf("a message that is nothing but preamble should strip to empty, got %q", stripSelfRecall(preamble))
+	}
+	// A person discussing the tag keeps their sentence.
+	for _, real := range []string{
+		"why does <environment_context> outrank everything?",
+		"the parser should drop <user_instructions> blocks",
+		"see the note about # AGENTS.md instructions in the issue",
+		// A complete pair quoted mid-sentence — the shape that a
+		// strip-anywhere rule eats and a strip-at-the-head rule keeps. Real
+		// messages on this store look exactly like this.
+		"the injected block is <environment_context><cwd>/w</cwd></environment_context> and it wins on match count",
+		"codex sends <recommended_plugins>a list</recommended_plugins> before the first turn",
+	} {
+		if got := stripSelfRecall(real); got != real {
+			t.Errorf("ate a real message:\n  in  %q\n  out %q", real, got)
+		}
+	}
+}

--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -1,8 +1,10 @@
 package sources
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -73,6 +75,20 @@ func ParseCodexRollout(path string) ([]model.Session, error) {
 
 func ParseCodexRolloutFromOffset(path string, offset int64) ([]model.Session, error) {
 	s := model.Session{Harness: "codex", ID: strings.TrimSuffix(strings.TrimPrefix(filepath.Base(path), "rollout-"), ".jsonl"), Project: projectName(filepath.Dir(path)), Path: path}
+	// An appended rollout is parsed from where the last read stopped, so the
+	// session_meta line at the top is never seen again and the id falls back
+	// to the filename — which matches the real ThreadId in 0 of 28 rollouts on
+	// this machine. The session then splits in two and every further turn
+	// lands in the second half, undoing #635 for exactly the sessions someone
+	// is still talking in. One line re-read is cheaper than carrying state.
+	if offset > 0 {
+		if id, cwd := codexRolloutHead(path); id != "" {
+			s.ID = id
+			if cwd != "" {
+				s.Project = projectName(cwd)
+			}
+		}
+	}
 	// A command and its exit code arrive in separate records joined by call_id,
 	// so the command line is annotated after the fact — the same shape opencode
 	// gets for free from a column.
@@ -96,14 +112,22 @@ func ParseCodexRolloutFromOffset(path string, offset int64) ([]model.Session, er
 			// payload.id equals the filename, so this agrees with the id
 			// derived above; it is set explicitly because agreeing by accident
 			// is not the same as agreeing on purpose.
-			if id, _ := payload["id"].(string); id != "" {
-				s.ID = id
-			} else if id, _ := payload["session_id"].(string); id != "" {
-				// Rollouts written before Codex split the two carry only a
-				// SessionId, and without threads there is nothing to collapse:
-				// keeping it preserves the identity those sessions already
-				// have in existing indexes.
-				s.ID = id
+			if id, ok := payload["id"].(string); ok {
+				// Present and a string: the ThreadId, even if empty.
+				if id != "" {
+					s.ID = id
+				}
+			} else if _, present := payload["id"]; !present {
+				// Absent, not malformed. Rollouts written before Codex split
+				// the two carry only a SessionId, and without threads there is
+				// nothing to collapse: keeping it preserves the identity those
+				// sessions already have in existing indexes. A present-but-not-
+				// a-string id is a shape deja does not understand, and falling
+				// back to the SessionId there would silently reintroduce the
+				// collapse (#635) — the filename-derived id stands instead.
+				if id, _ := payload["session_id"].(string); id != "" {
+					s.ID = id
+				}
 			}
 			if c, _ := payload["cwd"].(string); c != "" {
 				cwd = c
@@ -259,4 +283,35 @@ func codexPatch(s *model.Session, payload map[string]any, cwd string, t time.Tim
 		}
 		s.Messages = append(s.Messages, model.Message{Role: RoleEdit, Text: f + "\n" + span, Time: t})
 	}
+}
+
+// codexRolloutHead reads the identity a rollout declares in its first record.
+func codexRolloutHead(path string) (id, cwd string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", ""
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	// The meta record is the first line in every rollout Codex writes; a few
+	// lines of slack costs nothing and covers a format that adds a preamble.
+	for i := 0; i < 8 && sc.Scan(); i++ {
+		var rec struct {
+			Type    string `json:"type"`
+			Payload struct {
+				ID        string `json:"id"`
+				SessionID string `json:"session_id"`
+				CWD       string `json:"cwd"`
+			} `json:"payload"`
+		}
+		if json.Unmarshal(sc.Bytes(), &rec) != nil || rec.Type != "session_meta" {
+			continue
+		}
+		if rec.Payload.ID != "" {
+			return rec.Payload.ID, rec.Payload.CWD
+		}
+		return rec.Payload.SessionID, rec.Payload.CWD
+	}
+	return "", ""
 }

--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -86,7 +86,23 @@ func ParseCodexRolloutFromOffset(path string, offset int64) ([]model.Session, er
 			return
 		}
 		if typ, _ := m["type"].(string); typ == "session_meta" {
-			if id, _ := payload["session_id"].(string); id != "" {
+			// The ThreadId, not the SessionId. One rollout file is one thread;
+			// a session groups every thread that branched from it, so keying on
+			// session_id merges the whole fork tree into a single deja session
+			// and every thread but one becomes unreachable. Measured by a
+			// contributor on a fork-heavy store: 811 rollouts, 811 ThreadIds,
+			// 74 SessionIds — 91% of threads collapsed (#635).
+			//
+			// payload.id equals the filename, so this agrees with the id
+			// derived above; it is set explicitly because agreeing by accident
+			// is not the same as agreeing on purpose.
+			if id, _ := payload["id"].(string); id != "" {
+				s.ID = id
+			} else if id, _ := payload["session_id"].(string); id != "" {
+				// Rollouts written before Codex split the two carry only a
+				// SessionId, and without threads there is nothing to collapse:
+				// keeping it preserves the identity those sessions already
+				// have in existing indexes.
 				s.ID = id
 			}
 			if c, _ := payload["cwd"].(string); c != "" {
@@ -107,6 +123,9 @@ func ParseCodexRolloutFromOffset(path string, offset int64) ([]model.Session, er
 			return
 		}
 		role, _ := payload["role"].(string)
+		if HarnessAuthored(role) {
+			return
+		}
 		txt := textFromContent(payload["content"])
 		if txt == "" {
 			if msg, _ := payload["message"].(string); msg != "" {

--- a/internal/sources/codex_test.go
+++ b/internal/sources/codex_test.go
@@ -202,3 +202,76 @@ func TestHarnessAuthored(t *testing.T) {
 		}
 	}
 }
+
+// An appended rollout is parsed from an offset, so the session_meta line is
+// never read again. Without re-reading the head the id falls back to the
+// filename — which matches the real ThreadId in 0 of 28 rollouts here — and
+// one session becomes two, undoing #635 for the sessions still in use.
+func TestCodexIncrementalParseKeepsTheThreadID(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "rollout-2026-07-31T00-00-00-thread-x.jsonl")
+	head := `{"timestamp":"2026-07-31T00:00:00Z","type":"session_meta","payload":{"session_id":"SESS","id":"thread-x","cwd":"/w/app"}}` + "\n" +
+		`{"timestamp":"2026-07-31T00:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"first"}]}}` + "\n"
+	if err := os.WriteFile(p, []byte(head), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	full, err := ParseCodexRollout(p)
+	if err != nil || len(full) != 1 {
+		t.Fatalf("full parse: %v %#v", err, full)
+	}
+	extra := `{"timestamp":"2026-07-31T00:00:02Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"second"}]}}` + "\n"
+	if err := os.WriteFile(p, []byte(head+extra), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	inc, err := ParseCodexRolloutFromOffset(p, int64(len(head)))
+	if err != nil || len(inc) != 1 {
+		t.Fatalf("offset parse: %v %#v", err, inc)
+	}
+	if inc[0].ID != full[0].ID {
+		t.Fatalf("append split the session: %q then %q", full[0].ID, inc[0].ID)
+	}
+	if inc[0].ID != "thread-x" {
+		t.Fatalf("id = %q, want the ThreadId", inc[0].ID)
+	}
+	// The project comes from the same record and must survive the same way.
+	if inc[0].Project != full[0].Project {
+		t.Fatalf("project changed on append: %q then %q", full[0].Project, inc[0].Project)
+	}
+}
+
+// A present-but-malformed id is a shape deja does not understand. Falling back
+// to the SessionId there would silently reintroduce the collapse #635 fixes,
+// so the filename-derived id stands instead.
+func TestCodexMalformedThreadIDDoesNotCollapse(t *testing.T) {
+	dir := t.TempDir()
+	for _, shape := range []string{`123`, `null`, `{"x":1}`, `""`, `[]`, `true`} {
+		p := filepath.Join(dir, "rollout-2026-07-31T00-00-00-shape.jsonl")
+		body := `{"timestamp":"2026-07-31T00:00:00Z","type":"session_meta","payload":{"session_id":"SHARED","id":` + shape + `,"cwd":"/w"}}` + "\n" +
+			`{"timestamp":"2026-07-31T00:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"x"}]}}` + "\n"
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		ss, err := ParseCodexRollout(p)
+		if err != nil || len(ss) != 1 {
+			t.Fatalf("id %s: %v %#v", shape, err, ss)
+		}
+		if ss[0].ID == "SHARED" {
+			t.Errorf("id %s collapsed onto the SessionId", shape)
+		}
+	}
+	// Absent is different from malformed: an old rollout with only a SessionId
+	// keeps the identity it already has in existing indexes.
+	p := filepath.Join(dir, "rollout-2026-07-31T00-00-00-old.jsonl")
+	body := `{"timestamp":"2026-07-31T00:00:00Z","type":"session_meta","payload":{"session_id":"LEGACY","cwd":"/w"}}` + "\n" +
+		`{"timestamp":"2026-07-31T00:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"x"}]}}` + "\n"
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseCodexRollout(p)
+	if err != nil || len(ss) != 1 {
+		t.Fatal(err)
+	}
+	if ss[0].ID != "LEGACY" {
+		t.Fatalf("id = %q, want the SessionId when no ThreadId exists", ss[0].ID)
+	}
+}

--- a/internal/sources/codex_test.go
+++ b/internal/sources/codex_test.go
@@ -121,3 +121,84 @@ func TestCodexOutputWithoutCallIDDoesNotPanic(t *testing.T) {
 		t.Fatalf("tool output records = %d, want 2", out)
 	}
 }
+
+// One rollout file is one thread; a session groups every thread that branched
+// from it. Keying on the SessionId merges the whole fork tree into a single
+// deja session — measured by a contributor at 811 rollouts collapsing into 74
+// (#635).
+func TestCodexRolloutKeysOnThreadNotSession(t *testing.T) {
+	dir := t.TempDir()
+	var ids []string
+	for _, tid := range []string{"thread-a", "thread-b", "thread-c"} {
+		p := filepath.Join(dir, "rollout-2026-07-31T00-00-00-"+tid+".jsonl")
+		lines := []string{
+			`{"timestamp":"2026-07-31T00:00:00Z","type":"session_meta","payload":{"session_id":"SHARED","id":"` + tid +
+				`","forked_from_id":"thread-a","cwd":"/w"}}`,
+			`{"timestamp":"2026-07-31T00:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"work in ` + tid + `"}]}}`,
+		}
+		if err := os.WriteFile(p, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		ss, err := ParseCodexRollout(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ss) != 1 {
+			t.Fatalf("sessions = %d", len(ss))
+		}
+		ids = append(ids, ss[0].ID)
+	}
+	seen := map[string]bool{}
+	for i, id := range ids {
+		if id == "SHARED" {
+			t.Fatalf("thread %d took the shared SessionId as its identity", i)
+		}
+		if seen[id] {
+			t.Fatalf("two threads share the id %q", id)
+		}
+		seen[id] = true
+	}
+	// The filename carries the ThreadId, so the two agree — but on purpose,
+	// not by accident.
+	if ids[1] != "thread-b" {
+		t.Fatalf("id = %q, want the ThreadId", ids[1])
+	}
+}
+
+// Codex writes its preamble under its own role as well as as a user turn.
+func TestCodexDropsHarnessAuthoredRoles(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "rollout-2026-07-31T00-00-00-dev.jsonl")
+	lines := []string{
+		`{"timestamp":"2026-07-31T00:00:00Z","type":"session_meta","payload":{"session_id":"s","id":"dev","cwd":"/w"}}`,
+		`{"timestamp":"2026-07-31T00:00:01Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"text","text":"You are the Codex CLI, a terminal assistant"}]}}`,
+		`{"timestamp":"2026-07-31T00:00:02Z","type":"response_item","payload":{"type":"message","role":"system","content":[{"type":"text","text":"system framing"}]}}`,
+		`{"timestamp":"2026-07-31T00:00:03Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"the actual question"}]}}`,
+	}
+	if err := os.WriteFile(p, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseCodexRollout(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || len(ss[0].Messages) != 1 {
+		t.Fatalf("messages = %#v", ss)
+	}
+	if ss[0].Messages[0].Text != "the actual question" {
+		t.Fatalf("kept %q", ss[0].Messages[0].Text)
+	}
+}
+
+func TestHarnessAuthored(t *testing.T) {
+	for _, r := range []string{"developer", "system"} {
+		if !HarnessAuthored(r) {
+			t.Errorf("%q is the harness talking to the model", r)
+		}
+	}
+	for _, r := range []string{"user", "assistant", "tool", ""} {
+		if HarnessAuthored(r) {
+			t.Errorf("%q is not harness plumbing", r)
+		}
+	}
+}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -352,3 +352,19 @@ func commandsIn(v any, d toolDialect) []string {
 	}
 	return out
 }
+
+// HarnessAuthored reports whether a role marks text the harness wrote to the
+// model rather than anything a person or the assistant said.
+//
+// #551 removed the Claude-side markers and asked for one place that recognises
+// harness-injected wrappers across parsers instead of a list per parser. This
+// is that place, and Codex is why it now exists: its preamble is not a string
+// to add to a list, it is a whole role. Measured on one store — 28 of 28
+// sessions took their title from it — and on a contributor's, 81 of 82 (#636).
+//
+// It is dropped rather than stored under an ignored role: the text is
+// identical in every session, so it is not memory, and it is lexically broad
+// enough to outrank real turns on aggregate match count.
+func HarnessAuthored(role string) bool {
+	return role == "developer" || role == "system"
+}


### PR DESCRIPTION
Closes #635. Closes #636. Both reported by @hieilookie with measurements from a Codex-heavy store; both reproduce here.

**Identity (#635).** One rollout file is one *thread*; a session groups every thread that branched from it. The parser derived the ThreadId from the filename and then overwrote it with the SessionId, so every thread in a fork tree became the same deja session. Reproduced on the minimal case from the issue — three rollouts, distinct ThreadIds, one shared SessionId:

```
before   deja: codex: 3 sessions      last → 1 row  (SHARED-SESSION)
after    deja: codex: 3 sessions      last → 3 rows (aaa, bbb, ccc)
```

The reporter's store shows the scale: 811 rollouts, 811 ThreadIds, **74** SessionIds. Mine cannot — 28 rollouts, no forks — so that number is theirs, not mine. `payload.session_id` stays as a fallback for rollouts written before Codex split the two, where there are no threads to collapse.

**Preamble (#636).** Codex writes its preamble both under `role: "developer"` and, for the AGENTS.md block, **as a user turn** — which the reporter's suggested role filter would not have reached. Measured here: `developer` is the first role in 28 of 28 files, and the first *user* message is injected plumbing in 28 of 28 as well. Zero real titles.

```
before   # AGENTS.md instructions <INSTRUCTIONS>…   ×28
after    Read main.go, change the word hello…
         prepared statement errors behind pgbouncer…
```

Codex records drop from 310 KB to 28 KB — 91% of what was indexed for that harness was plumbing.

Two parts, per the issue's suggested split: `HarnessAuthored` in `internal/sources` is the one place #551 asked for, and the user-turn preamble is handled by the existing `stripSelfRecall` machinery.

**One thing worth stating.** Those tags are ordinary enough that people quote them: nine Claude sessions on this store contain `<environment_context>` and two contain `<user_instructions>` — every one a real turn discussing this very filtering. Stripping them anywhere in a message ate 6 real records; stripping them only at the *head* removes the same 282 KB of preamble and keeps those. A preamble is always the head of the message, so the restriction costs nothing.

Index version 21: existing Codex entries have the wrong identity and cannot be repaired incrementally.

Four mutations, each fails the suite: keying back on the SessionId, restoring `developer` as content, dropping the preamble strip, and relaxing the head-only rule.