### PR TITLE
perf(index): skip the CJK scan on bodies that contain no CJK

### DIFF
--- a/internal/index/cjk.go
+++ b/internal/index/cjk.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"unicode"
+	"unicode/utf8"
 )
 
 // CJK text carries no spaces, so the base tokenizer collapses whole phrases
@@ -25,6 +26,21 @@ func isCJK(r rune) bool {
 // to 系, which is a content character in 系統 and 關係, so a filter applied
 // after folding could not tell the two apart.
 func cjkBigrams(s string) []string {
+	// indexKeys hands this the whole message body, so a transcript with no CJK in
+	// it would otherwise decode every rune and run all four unicode.Is searches
+	// to build nothing. A CJK rune is never a single UTF-8 byte, so one byte scan
+	// answers the question before any decoding starts.
+	ascii := true
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			ascii = false
+			break
+		}
+	}
+	if ascii {
+		return nil
+	}
+
 	var out []string
 	seen := map[string]bool{}
 	var run []rune

--- a/internal/index/cjk_ascii_test.go
+++ b/internal/index/cjk_ascii_test.go
@@ -1,0 +1,80 @@
+package index
+
+import (
+	"strings"
+	"testing"
+)
+
+// indexKeys calls cjkBigrams on every message body it sees, most of which are
+// diffs, paths, stack traces and English prose with no CJK rune anywhere. This
+// table pins the contract that lets those exit early: what comes back for a
+// string with no CJK run is nothing, whatever else the bytes happen to be.
+//
+// It is also the guard on the byte scan itself. A scan that decided "ASCII" too
+// eagerly would return nil for the CJK rows below; one that never fired would
+// leave the ASCII rows unchanged and quietly cost what it always cost. Only the
+// first failure mode can corrupt an index, and these rows catch it.
+func TestCJKBigramsOnlyFiresOnCJK(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"ascii prose", "the scheduler times out under load", nil},
+		{"ascii symbols and digits", "GOFLAGS=-mod=mod exit(1) 200 OK", nil},
+		{"cyrillic is not CJK", "очередь переполнена", nil},
+		{"latin with accents", "café naïve", nil},
+		{"invalid utf-8", "\xff\xfe\xfd", nil},
+		{"single han keeps its unigram", "茶", []string{"茶"}},
+		{"han run", "装订计数", []string{"装订", "订计", "计数"}},
+		{"han among ascii", "abc装订def", []string{"装订"}},
+		{"runs split by ascii", "装订 abc 计数", []string{"装订", "计数"}},
+		{"repeated bigram appears once", "装订装订", []string{"装订", "订装"}},
+		{"hiragana", "こんにちは", []string{"こん", "んに", "にち", "ちは"}},
+		{"hangul", "한국어", []string{"한국", "국어"}},
+		{"cyrillic next to han", "очередь装订", []string{"装订"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cjkBigrams(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("cjkBigrams(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("cjkBigrams(%q) = %q, want %q", tc.in, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// A body with no CJK in it should not allocate: nothing is built, so nothing
+// needs a heap. This is the part a correctness table cannot see — the table
+// passed before the early exit existed too, because the answer was always nil;
+// what changed is the work done to arrive at it.
+func TestCJKBigramsDoesNotAllocateOnNonCJK(t *testing.T) {
+	body := strings.Repeat("the ingest worker leaks goroutines after a reload. ", 200)
+	if allocs := testing.AllocsPerRun(50, func() { cjkBigrams(body) }); allocs != 0 {
+		t.Errorf("cjkBigrams on a %d-byte ASCII body made %v allocations, want 0", len(body), allocs)
+	}
+}
+
+func BenchmarkCJKBigramsASCII(b *testing.B) {
+	body := strings.Repeat("the ingest worker leaks goroutines after a reload. ", 200)
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		cjkBigrams(body)
+	}
+}
+
+func BenchmarkCJKBigramsCJK(b *testing.B) {
+	body := strings.Repeat("摄取工作进程在重载之后泄漏协程。", 100)
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		cjkBigrams(body)
+	}
+}


### PR DESCRIPTION
Filed alongside an issue with the full measurement; this is the fix half.

## What

`indexKeys` (`internal/index/retrieval.go`) calls `cjkBigrams` on the whole message body with no CJK check in front of it. For a transcript with no CJK rune in it — diffs, paths, stack traces, English prose — every byte is decoded to a rune and put through `isCJK`, which is four `unicode.Is` range searches, to build an empty slice. A CJK rune is never a single UTF-8 byte, so a byte scan settles it before any decoding starts.

## Measurement

At `17864d9`, synthetic 5000-session corpora (Chinese and English, index-aligned vocabularies so they differ in wording and nothing structural), interleaved runs, min of 7, `GOMAXPROCS=2` per the method in #499:

| all-ASCII corpus | build |
|---|---|
| stock | 2.57 s |
| this change | 2.37 s |
| bigram path stubbed out entirely | 2.34 s |

So it recovers essentially all of it. On the all-CJK corpus the change is +0.4%, inside the noise.

CPU profile of the ASCII build, `DEJA_CPUPROFILE`:

| | `cjkBigrams` | `isCJK` | `unicode.Is` | `indexKeys` total |
|---|---|---|---|---|
| stock | 5.17% | 4.39% | 3.88% | 14.99% |
| this change | absent | absent | absent | 7.74% |

Reverse check on the CJK corpus: `isCJK` costs 0.85% there. Nothing terminates early in either case — the difference is per rune. A Han rune matches on the first of the four checks and stays inside the current run; an ASCII rune fails all four and then calls `flush()`. Every character of an English transcript takes the expensive branch, which is why the corpus with no CJK in it is the one that pays.

The three-arm design also rules out binary layout as the cause: this binary keeps the entire implementation and adds ~15 lines, yet lands with the stub rather than with stock.

## Equivalence

Provable rather than measured. For all-ASCII input the original returns nil (no rune passes `isCJK`, `out` stays nil) and so does the fast path, including the empty string and the nil-versus-empty-slice distinction. Any input with a byte >= `utf8.RuneSelf` falls through to the untouched original loop, so CJK, mixed-script and invalid-UTF-8 behaviour is unchanged by construction.

## Tests

`TestCJKBigramsOnlyFiresOnCJK` is a guard on the scan, not on the output — the output table passed before this change too, since the answer was always nil. What it catches is a scan that decides "ASCII" too eagerly: that returns nil for the CJK rows and corrupts an index. The mixed (`abc装订def`), Cyrillic-adjacent (`очередь装订`) and invalid-UTF-8 rows are the ones that would fail.

`TestCJKBigramsDoesNotAllocateOnNonCJK` covers what a correctness table cannot see: that the work is skipped, not just the result empty.

Benchmarks record the shape — 3777 ns/op, 0 allocs on a 10 KB ASCII body against 50107 ns/op, 1409 allocs on a CJK one.

`go test ./... -race -count=1` green (14 packages), `gofmt` and `go vet` clean.

Everything above is reproducible from a synthetic corpus; the generator, the runner, the profile script and the recorded outputs are in the companion issue.