### PR TITLE
fix: three status messages report a state the tool is not in

### DIFF
--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -70,7 +70,7 @@ func opencodeConfigHome() string {
 }
 
 func guidanceText(harness string) string {
-	if harness == "claude-code" || harness == "claude" || harness == "antigravity" || harness == "copilot" || harness == "pi" {
+	if guidanceOwnsWholeFile(harness) {
 		body := guidanceBody
 		if harness == "copilot" {
 			body = "deja does not index Copilot history. It is a consumer: use the deja MCP tools to search memory from the other harnesses.\n\n" + guidanceBody
@@ -200,12 +200,6 @@ func guidanceHarness(harness string) string {
 	}
 }
 
-// guidanceStatus reports whether deja's guidance is in that file, not whether
-// the file exists. Anyone who keeps their own AGENTS.md was told deja had
-// written guidance there when nothing from deja had ever been installed
-// (#637). Install writes a marked block, so the marker is the thing to look
-// for — and "the file is there but ours is not" is a different answer from
-// "there is no file", because only the first means someone else owns it.
 // guidanceOwnsWholeFile reports whether install writes the whole file rather
 // than a marked block inside someone else's. A skill file lives in deja's own
 // directory and has no marker in it; AGENTS.md and its siblings belong to the
@@ -226,6 +220,10 @@ func guidanceOwnsWholeFile(harness string) bool {
 // answer from "there is no file", because only the first means someone else
 // owns it. A skill file deja writes whole has no marker and does not need one.
 func guidanceStatus(harness string) string {
+	// One form throughout: the path lookup took the raw name and the
+	// whole-file check took the normalised one, so the function contradicted
+	// itself about which it accepts.
+	harness = guidanceHarness(harness)
 	path := guidancePath(harness)
 	if path == "" {
 		return "unsupported"
@@ -234,7 +232,13 @@ func guidanceStatus(harness string) string {
 	if err != nil {
 		return "missing"
 	}
-	if guidanceOwnsWholeFile(guidanceHarness(harness)) || strings.Contains(string(b), guidanceStart) {
+	// An empty file is an interrupted write, not guidance — the one shape
+	// where "the file exists" still fails to mean "we wrote it" even in a
+	// directory deja owns.
+	if len(strings.TrimSpace(string(b))) == 0 {
+		return "absent"
+	}
+	if guidanceOwnsWholeFile(harness) || strings.Contains(string(b), guidanceStart) {
 		return "written"
 	}
 	return "absent"

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -106,7 +106,7 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 		return installResult{}, err
 	}
 	var next []byte
-	if harness == "claude-code" || harness == "claude" || harness == "antigravity" || harness == "copilot" || harness == "pi" {
+	if guidanceOwnsWholeFile(harness) {
 		if uninstall {
 			if len(old) == 0 {
 				return installResult{Path: path, Action: "unchanged"}, nil
@@ -200,15 +200,44 @@ func guidanceHarness(harness string) string {
 	}
 }
 
+// guidanceStatus reports whether deja's guidance is in that file, not whether
+// the file exists. Anyone who keeps their own AGENTS.md was told deja had
+// written guidance there when nothing from deja had ever been installed
+// (#637). Install writes a marked block, so the marker is the thing to look
+// for — and "the file is there but ours is not" is a different answer from
+// "there is no file", because only the first means someone else owns it.
+// guidanceOwnsWholeFile reports whether install writes the whole file rather
+// than a marked block inside someone else's. A skill file lives in deja's own
+// directory and has no marker in it; AGENTS.md and its siblings belong to the
+// user, and deja only ever appends a marked block there.
+func guidanceOwnsWholeFile(harness string) bool {
+	switch harness {
+	case "claude-code", "claude", "antigravity", "copilot", "pi":
+		return true
+	}
+	return false
+}
+
+// guidanceStatus reports whether deja's guidance is in that file, not merely
+// whether the file exists. Anyone who keeps their own AGENTS.md was told deja
+// had written guidance there when nothing from deja had ever been installed
+// (#637). Install leaves a marked block in a shared file, so the marker is
+// what to look for — and "the file is there but ours is not" is a different
+// answer from "there is no file", because only the first means someone else
+// owns it. A skill file deja writes whole has no marker and does not need one.
 func guidanceStatus(harness string) string {
 	path := guidancePath(harness)
 	if path == "" {
 		return "unsupported"
 	}
-	if _, err := os.Stat(path); err == nil {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "missing"
+	}
+	if guidanceOwnsWholeFile(guidanceHarness(harness)) || strings.Contains(string(b), guidanceStart) {
 		return "written"
 	}
-	return "missing"
+	return "absent"
 }
 
 func guidanceResult(harness string, uninstall bool) (installResult, error) {

--- a/cmd/deja/guidance_test.go
+++ b/cmd/deja/guidance_test.go
@@ -285,3 +285,54 @@ func TestInstallGuidanceSkillErrorBranches(t *testing.T) {
 		t.Fatalf("antigravity re-uninstall = %#v err=%v", r, err)
 	}
 }
+
+// Guidance is "written" when deja's block is in the file, not when the file
+// exists. Anyone keeping their own AGENTS.md was told deja had written
+// guidance there on a machine where install had never run (#637).
+func TestGuidanceStatusReadsTheMarkerNotTheFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+
+	if got := guidanceStatus("codex"); got != "missing" {
+		t.Fatalf("no file at all: got %q", got)
+	}
+	if err := os.WriteFile(path, []byte("# my own agents file\n\nnothing from deja\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := guidanceStatus("codex"); got != "absent" {
+		t.Fatalf("someone else's file: got %q, want absent", got)
+	}
+	if err := os.WriteFile(path, []byte("# mine\n\n"+guidanceStart+"\nbody\n"+guidanceEnd+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := guidanceStatus("codex"); got != "written" {
+		t.Fatalf("our block is in it: got %q", got)
+	}
+}
+
+// A skill file is deja's own, written whole, and carries no marker — so the
+// marker check must not apply to it.
+func TestGuidanceStatusForAFileDejaOwnsWhole(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	skill := filepath.Join(home, ".claude", "skills", "deja-history")
+	if err := os.MkdirAll(skill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := guidanceStatus("claude-code"); got != "missing" {
+		t.Fatalf("no skill file: got %q", got)
+	}
+	if err := os.WriteFile(filepath.Join(skill, "SKILL.md"), []byte("---\nname: deja-history\n---\n\nbody with no marker\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := guidanceStatus("claude-code"); got != "written" {
+		t.Fatalf("a skill file deja wrote whole: got %q, want written", got)
+	}
+}

--- a/cmd/deja/guidance_test.go
+++ b/cmd/deja/guidance_test.go
@@ -317,7 +317,10 @@ func TestGuidanceStatusReadsTheMarkerNotTheFile(t *testing.T) {
 }
 
 // A skill file is deja's own, written whole, and carries no marker — so the
-// marker check must not apply to it.
+// marker check must not apply to it. This is a guard for the carve-out rather
+// than a test of the #637 fix: it passes against the old stat-only behaviour
+// too, and it exists so that behaviour cannot be restored by accident when
+// the marker check moves.
 func TestGuidanceStatusForAFileDejaOwnsWhole(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -334,5 +337,51 @@ func TestGuidanceStatusForAFileDejaOwnsWhole(t *testing.T) {
 	}
 	if got := guidanceStatus("claude-code"); got != "written" {
 		t.Fatalf("a skill file deja wrote whole: got %q, want written", got)
+	}
+	// An empty file is an interrupted write, not guidance — the one shape
+	// where existence still fails to mean "we wrote it" in a directory deja
+	// owns.
+	if err := os.WriteFile(filepath.Join(skill, "SKILL.md"), []byte("  \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := guidanceStatus("claude-code"); got != "absent" {
+		t.Fatalf("an empty skill file: got %q, want absent", got)
+	}
+}
+
+// Every harness whose guidance is a file deja writes whole, so none of them
+// can be dropped from the helper unnoticed — and the helper must name exactly
+// the set the install path branches on, or doctor starts lying again.
+func TestGuidanceOwnsWholeFileMatchesTheInstallPath(t *testing.T) {
+	for _, h := range []string{"claude-code", "claude", "antigravity", "copilot", "pi"} {
+		if !guidanceOwnsWholeFile(h) {
+			t.Errorf("%q is written whole by installGuidance", h)
+		}
+		// guidanceText branches on the same helper: a whole-file harness gets
+		// skill frontmatter, never the marker pair.
+		if txt := guidanceText(h); strings.Contains(txt, guidanceStart) {
+			t.Errorf("%q got marker text for a file deja owns whole", h)
+		}
+	}
+	for _, h := range []string{"codex", "opencode", "gemini", "qwen", "kimi", "grok"} {
+		if guidanceOwnsWholeFile(h) {
+			t.Errorf("%q shares its file with the user", h)
+		}
+		if txt := guidanceText(h); !strings.Contains(txt, guidanceStart) {
+			t.Errorf("%q must get a marked block, not a whole file", h)
+		}
+	}
+}
+
+// The path lookup took the raw name while the whole-file check took the
+// normalised one, so the function contradicted itself about what it accepts.
+func TestGuidanceStatusAcceptsAliases(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	for _, alias := range []string{"opencode-auto", "codex-auto", "claude-auto"} {
+		if got := guidanceStatus(alias); got == "unsupported" {
+			t.Errorf("%q resolves to a real harness but reported %q", alias, got)
+		}
 	}
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -339,6 +339,14 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 		if o.JSON {
 			return printRecentJSON(os.Stdout, nil, sourceInstance)
 		}
+		// "Run deja index" is advice for an empty store. With a filter set it
+		// is advice for a state the tool is not in: indexing changes nothing
+		// and doctor reports the stores as found. Name what emptied the result
+		// instead (#637).
+		if where := activeFilters(o); where != "" {
+			fmt.Fprintf(os.Stderr, "deja: no sessions match %s\n", where)
+			return nil
+		}
 		fmt.Fprintln(os.Stderr, emptyIndexHint("no sessions indexed yet"))
 		return nil
 	}
@@ -453,7 +461,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 		o.Total = len(hits)
 	}
 	if len(hits) == 0 {
-		printNoMatches(os.Stderr, o.Query, len(ss))
+		printNoMatches(os.Stderr, dir, o.Query)
 	}
 	search.Print(os.Stdout, hits, o)
 	return nil
@@ -478,8 +486,48 @@ func printStemmed(w io.Writer, variants map[string][]string) {
 	}
 }
 
-func printNoMatches(w io.Writer, q string, n int) {
-	fmt.Fprintf(w, "deja: no matches in %d indexed sessions — try fewer words or --re (query %q)\n", n, q)
+// printNoMatches says how big the store actually is, not how many sessions the
+// query happened to load.
+//
+// On the index-backed path the loaded set is empty by definition when nothing
+// matched, so this printed "no matches in 0 indexed sessions" for a perfectly
+// healthy index — and internal/index/manifest.go reserves that exact sentence
+// as the signature of a corrupt store, on the grounds that a reader told the
+// index holds zero sessions concludes the tool is broken rather than that
+// their query missed. It fired on every ordinary miss, so the signature could
+// not be used to recognise the failure it was written for (#637).
+func printNoMatches(w io.Writer, dir, q string) {
+	if n, err := index.SessionCount(dir); err == nil {
+		fmt.Fprintf(w, "deja: no matches in %d indexed session%s — try fewer words or --re (query %q)\n", n, pluralS(n), q)
+		return
+	}
+	fmt.Fprintf(w, "deja: no matches — try fewer words or --re (query %q)\n", q)
+}
+
+// activeFilters names the filters a caller set, so an empty result can say
+// which of them emptied it rather than blaming the index.
+func activeFilters(o search.Options) string {
+	var parts []string
+	if o.Harness != "" {
+		parts = append(parts, fmt.Sprintf("harness %q", o.Harness))
+	}
+	if o.Project != "" {
+		parts = append(parts, fmt.Sprintf("project %q", o.Project))
+	}
+	if o.Role != "" {
+		parts = append(parts, fmt.Sprintf("role %q", o.Role))
+	}
+	if o.Since != 0 {
+		parts = append(parts, fmt.Sprintf("since %s", o.Since))
+	}
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	default:
+		return strings.Join(parts[:len(parts)-1], ", ") + " and " + parts[len(parts)-1]
+	}
 }
 
 func clearWarmupSentinel() {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -324,7 +324,7 @@ func cmdCtx(dir string, rest []string) error {
 }
 
 func cmdLast(dir string, rest []string, sourceInstance string) error {
-	n, o, err := parseLast(rest)
+	n, o, sinceRaw, err := parseLast(rest)
 	if err != nil {
 		return err
 	}
@@ -343,7 +343,7 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 		// is advice for a state the tool is not in: indexing changes nothing
 		// and doctor reports the stores as found. Name what emptied the result
 		// instead (#637).
-		if where := activeFilters(o); where != "" {
+		if where := activeFilters(o, sinceRaw); where != "" {
 			fmt.Fprintf(os.Stderr, "deja: no sessions match %s\n", where)
 			return nil
 		}
@@ -505,8 +505,9 @@ func printNoMatches(w io.Writer, dir, q string) {
 }
 
 // activeFilters names the filters a caller set, so an empty result can say
-// which of them emptied it rather than blaming the index.
-func activeFilters(o search.Options) string {
+// which of them emptied it rather than blaming the index. sinceRaw carries
+// what the reader actually typed: "168h0m0s" is not the flag they passed.
+func activeFilters(o search.Options, sinceRaw string) string {
 	var parts []string
 	if o.Harness != "" {
 		parts = append(parts, fmt.Sprintf("harness %q", o.Harness))
@@ -517,8 +518,16 @@ func activeFilters(o search.Options) string {
 	if o.Role != "" {
 		parts = append(parts, fmt.Sprintf("role %q", o.Role))
 	}
-	if o.Since != 0 {
-		parts = append(parts, fmt.Sprintf("since %s", o.Since))
+	// The same predicate filterRecentSources uses. parseDur accepts a negative
+	// duration, and a negative Since filters nothing — naming it would report a
+	// filter that was never applied and hide the empty-store advice, which is
+	// the right answer there.
+	if o.Since > 0 {
+		since := sinceRaw
+		if since == "" {
+			since = o.Since.String()
+		}
+		parts = append(parts, "since "+since)
 	}
 	switch len(parts) {
 	case 0:
@@ -608,7 +617,8 @@ func recentMatching(dir string, n int, o search.Options) ([]model.Session, error
 	return search.Recent(ss, n), nil
 }
 
-func parseLast(args []string) (int, search.Options, error) {
+func parseLast(args []string) (int, search.Options, string, error) {
+	sinceRaw := ""
 	n := 10
 	seenN := false
 	o := search.Options{}
@@ -619,7 +629,7 @@ func parseLast(args []string) (int, search.Options, error) {
 			o.JSON = true
 		case "--harness", "--project", "--since", "--role":
 			if i+1 >= len(args) {
-				return n, o, fmt.Errorf("%s needs value", a)
+				return n, o, sinceRaw, fmt.Errorf("%s needs value", a)
 			}
 			i++
 			v := args[i]
@@ -633,13 +643,14 @@ func parseLast(args []string) (int, search.Options, error) {
 			default:
 				d, err := parseDur(v)
 				if err != nil {
-					return n, o, err
+					return n, o, sinceRaw, err
 				}
 				o.Since = d
+				sinceRaw = v
 			}
 		default:
 			if strings.HasPrefix(a, "-") {
-				return n, o, fmt.Errorf("last: unknown flag %q", a)
+				return n, o, sinceRaw, fmt.Errorf("last: unknown flag %q", a)
 			}
 			if !seenN {
 				if x, err := strconv.Atoi(a); err == nil {
@@ -649,7 +660,7 @@ func parseLast(args []string) (int, search.Options, error) {
 			}
 		}
 	}
-	return n, o, nil
+	return n, o, sinceRaw, nil
 }
 
 func filterRecentSources(ss []model.Session, o search.Options) []model.Session {

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -295,11 +295,11 @@ func TestLastFiltersSinceAndRole(t *testing.T) {
 }
 
 func TestLastParserAndSourceFilters(t *testing.T) {
-	n, o, raw, err := parseLast([]string{"25", "--harness", "codex", "--project", "api"})
+	n, o, _, err := parseLast([]string{"25", "--harness", "codex", "--project", "api"})
 	if err != nil || n != 25 || o.Harness != "codex" || o.Project != "api" {
 		t.Fatalf("parseLast = n:%d options:%#v err:%v", n, o, err)
 	}
-	n, o, raw, err = parseLast([]string{"5", "--since", "7d", "--role", "assistant"})
+	n, o, raw, err := parseLast([]string{"5", "--since", "7d", "--role", "assistant"})
 	if err != nil || n != 5 || o.Since != 7*24*time.Hour || o.Role != "assistant" {
 		t.Fatalf("parseLast since/role = n:%d options:%#v err:%v", n, o, err)
 	}

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -295,25 +295,29 @@ func TestLastFiltersSinceAndRole(t *testing.T) {
 }
 
 func TestLastParserAndSourceFilters(t *testing.T) {
-	n, o, err := parseLast([]string{"25", "--harness", "codex", "--project", "api"})
+	n, o, raw, err := parseLast([]string{"25", "--harness", "codex", "--project", "api"})
 	if err != nil || n != 25 || o.Harness != "codex" || o.Project != "api" {
 		t.Fatalf("parseLast = n:%d options:%#v err:%v", n, o, err)
 	}
-	n, o, err = parseLast([]string{"5", "--since", "7d", "--role", "assistant"})
+	n, o, raw, err = parseLast([]string{"5", "--since", "7d", "--role", "assistant"})
 	if err != nil || n != 5 || o.Since != 7*24*time.Hour || o.Role != "assistant" {
 		t.Fatalf("parseLast since/role = n:%d options:%#v err:%v", n, o, err)
 	}
-	n, o, err = parseLast([]string{"bad"})
-	if err != nil || n != 10 || o.Harness != "" || o.Project != "" {
-		t.Fatalf("parseLast compatibility = n:%d options:%#v err:%v", n, o, err)
+	// The raw flag comes back so an empty result can echo what was typed.
+	if raw != "7d" {
+		t.Fatalf("sinceRaw = %q, want the flag as typed", raw)
 	}
-	if _, _, err := parseLast([]string{"--unknown"}); err == nil || !strings.Contains(err.Error(), "unknown flag") {
+	n, o, raw, err = parseLast([]string{"bad"})
+	if err != nil || n != 10 || o.Harness != "" || o.Project != "" || raw != "" {
+		t.Fatalf("parseLast compatibility = n:%d options:%#v raw:%q err:%v", n, o, raw, err)
+	}
+	if _, _, _, err := parseLast([]string{"--unknown"}); err == nil || !strings.Contains(err.Error(), "unknown flag") {
 		t.Fatalf("parseLast unknown flag err=%v", err)
 	}
-	if _, _, err := parseLast([]string{"--harness"}); err == nil || !strings.Contains(err.Error(), "--harness needs value") {
+	if _, _, _, err := parseLast([]string{"--harness"}); err == nil || !strings.Contains(err.Error(), "--harness needs value") {
 		t.Fatalf("parseLast missing harness err=%v", err)
 	}
-	if _, _, err := parseLast([]string{"--since", "bad"}); err == nil {
+	if _, _, _, err := parseLast([]string{"--since", "bad"}); err == nil {
 		t.Fatalf("parseLast bad since err=%v", err)
 	}
 
@@ -596,16 +600,39 @@ func TestPrintNoMatchesReportsTheStoreSize(t *testing.T) {
 }
 
 func TestActiveFiltersNamesWhatEmptiedTheResult(t *testing.T) {
-	if got := activeFilters(search.Options{}); got != "" {
+	if got := activeFilters(search.Options{}, ""); got != "" {
 		t.Fatalf("no filters set, got %q", got)
 	}
-	if got := activeFilters(search.Options{Harness: "codex"}); got != `harness "codex"` {
-		t.Fatalf("got %q", got)
+	// Each filter alone, so none of them can be deleted unnoticed.
+	for _, c := range []struct {
+		o    search.Options
+		want string
+	}{
+		{search.Options{Harness: "codex"}, `harness "codex"`},
+		{search.Options{Project: "api-gateway"}, `project "api-gateway"`},
+		{search.Options{Role: "command"}, `role "command"`},
+		{search.Options{Since: 24 * time.Hour}, "since 24h0m0s"},
+	} {
+		if got := activeFilters(c.o, ""); got != c.want {
+			t.Errorf("got %q, want %q", got, c.want)
+		}
 	}
-	got := activeFilters(search.Options{Harness: "codex", Role: "command", Since: 24 * time.Hour})
-	if !strings.Contains(got, `harness "codex"`) || !strings.Contains(got, `role "command"`) ||
-		!strings.Contains(got, "since 24h") || !strings.Contains(got, " and ") {
-		t.Fatalf("got %q", got)
+	got := activeFilters(search.Options{Harness: "codex", Project: "api", Role: "command", Since: 24 * time.Hour}, "7d")
+	for _, want := range []string{`harness "codex"`, `project "api"`, `role "command"`, "since 7d", " and "} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q missing from %q", want, got)
+		}
+	}
+	// What the reader typed, not Go duration syntax: they passed 7d, not
+	// 168h0m0s.
+	if strings.Contains(got, "168h") {
+		t.Errorf("echoed the parsed duration instead of the flag: %q", got)
+	}
+	// parseDur accepts a negative, and filterRecentSources applies no time
+	// filter for one — so naming it would report a filter that never ran and
+	// suppress the empty-store advice, which is the right answer there.
+	if got := activeFilters(search.Options{Since: -time.Hour}, "-1h"); got != "" {
+		t.Errorf("named a filter that was never applied: %q", got)
 	}
 }
 
@@ -1172,5 +1199,46 @@ func TestLastWithFiltersNamesTheFilter(t *testing.T) {
 	}
 	if !strings.Contains(out, "no sessions indexed yet") {
 		t.Fatalf("lost the empty-store advice: %q", out)
+	}
+}
+
+// SessionCount must count sessions, not files: a store where one file holds
+// several sessions is the shape that tells them apart, and the fixture the
+// no-match message uses has one of each.
+func TestSessionCountCountsSessionsNotFiles(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-c")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	// Two files carry a session; two more are scanned and carry none, so the
+	// file count and the session count cannot be confused for each other.
+	for _, sid := range []string{"c1", "c2"} {
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/w/c","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"work in ` + sid + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"empty1.jsonl", "empty2.jsonl"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	n, err := index.SessionCount(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("SessionCount = %d, want the 2 sessions across 4 scanned files", n)
+	}
+	var b bytes.Buffer
+	printNoMatches(&b, dir, "nothing")
+	if !strings.Contains(b.String(), "in 2 indexed sessions") {
+		t.Fatalf("message = %q", b.String())
 	}
 }

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -33,6 +33,26 @@ func withTempStores(t *testing.T) string {
 	return h
 }
 
+// captureRunStderr is captureRun for the channel advice goes to.
+func captureRunStderr(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	err = run(args)
+	_ = w.Close()
+	os.Stderr = old
+	return <-done, err
+}
+
 func captureRun(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 	old := os.Stdout
@@ -551,12 +571,41 @@ func TestStemmedOutputIsDeterministic(t *testing.T) {
 	}
 }
 
-func TestPrintNoMatchesHelpfulMessage(t *testing.T) {
+// The count is the size of the store, not the size of whatever the query
+// loaded — which on the index-backed path is zero by definition when nothing
+// matched. "no matches in 0 indexed sessions" is reserved in
+// internal/index/manifest.go as the signature of a corrupt store, and it was
+// printing on every ordinary miss (#637).
+func TestPrintNoMatchesReportsTheStoreSize(t *testing.T) {
+	dir := seedBriefIndex(t)
 	var b bytes.Buffer
-	printNoMatches(&b, "jwt refresh token", 3)
+	printNoMatches(&b, dir, "jwt refresh token")
 	out := b.String()
-	if !strings.Contains(out, `deja: no matches in 3 indexed sessions — try fewer words or --re`) || !strings.Contains(out, `query "jwt refresh token"`) {
+	if strings.Contains(out, "in 0 indexed session") {
+		t.Fatalf("printed the corruption signature for a healthy index: %q", out)
+	}
+	if !strings.Contains(out, "in 1 indexed session ") || !strings.Contains(out, `query "jwt refresh token"`) {
 		t.Fatalf("bad no-match message: %q", out)
+	}
+	// No index at all: say nothing rather than a wrong number.
+	var b2 bytes.Buffer
+	printNoMatches(&b2, filepath.Join(t.TempDir(), "gone"), "q")
+	if strings.Contains(b2.String(), "indexed session") {
+		t.Fatalf("invented a count with no index: %q", b2.String())
+	}
+}
+
+func TestActiveFiltersNamesWhatEmptiedTheResult(t *testing.T) {
+	if got := activeFilters(search.Options{}); got != "" {
+		t.Fatalf("no filters set, got %q", got)
+	}
+	if got := activeFilters(search.Options{Harness: "codex"}); got != `harness "codex"` {
+		t.Fatalf("got %q", got)
+	}
+	got := activeFilters(search.Options{Harness: "codex", Role: "command", Since: 24 * time.Hour})
+	if !strings.Contains(got, `harness "codex"`) || !strings.Contains(got, `role "command"`) ||
+		!strings.Contains(got, "since 24h") || !strings.Contains(got, " and ") {
+		t.Fatalf("got %q", got)
 	}
 }
 
@@ -1093,5 +1142,35 @@ func TestSearchFlagsAcceptTheEqualsForm(t *testing.T) {
 	// An unknown flag with a value is still an unknown flag, not a query term.
 	if _, err := parseSearch([]string{"--nope=1", "needle"}); err == nil {
 		t.Log("unknown --flag=value is treated as a query term; acceptable, but worth knowing")
+	}
+}
+
+// "run deja index" is advice for an empty store. With a filter set it is
+// advice for a state the tool is not in: indexing changes nothing and doctor
+// reports the stores as found (#637).
+func TestLastWithFiltersNamesTheFilter(t *testing.T) {
+	dir := seedBriefIndex(t)
+	_ = dir
+	out, err := captureRunStderr(t, "last", "3", "--harness", "nosuchharness")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "no sessions indexed yet") {
+		t.Fatalf("blamed the index for a filter: %q", out)
+	}
+	if !strings.Contains(out, `harness "nosuchharness"`) {
+		t.Fatalf("did not name the filter: %q", out)
+	}
+	// Unfiltered on an empty store keeps the original advice, which is right
+	// for the fresh-install case it was written for.
+	empty := t.TempDir()
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(empty, "index.db"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(empty, "none"))
+	out, err = captureRunStderr(t, "last", "3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "no sessions indexed yet") {
+		t.Fatalf("lost the empty-store advice: %q", out)
 	}
 }

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -227,3 +227,17 @@ func AllMeta(dir string) ([]SessionMeta, error) {
 	}
 	return out, nil
 }
+
+// SessionCount reports how many sessions the store holds, without reading a
+// record. A caller reporting an empty result needs the size of the corpus, not
+// the size of whatever it just loaded.
+func SessionCount(dir string) (int, error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return 0, err
+	}
+	return len(m.Sessions), nil
+}

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -150,9 +150,13 @@ func recordsIntact(dir string, m Manifest) bool {
 	// The postings live in buckets/, and losing that directory is not
 	// hypothetical: a partial copy, an interrupted sync, a `find -delete` that
 	// caught too much. The manifest survives, so the index reads as built and
-	// up to date while every search answers "no matches in 0 indexed sessions"
-	// — the one failure a memory tool must not present as an empty result,
-	// because the reader concludes it is useless rather than broken.
+	// up to date while every search answers with nothing — the one failure a
+	// memory tool must not present as an empty result, because the reader
+	// concludes it is useless rather than broken.
+	//
+	// This check is the detector. The wording of the empty-result message
+	// never was: it said "no matches in 0 indexed sessions" on every ordinary
+	// miss too, and since #637 it reports the manifest count instead.
 	if len(m.Sessions) > 0 {
 		bi, err := os.Stat(filepath.Join(dir, "buckets"))
 		if err != nil || !bi.IsDir() {


### PR DESCRIPTION
Closes #637. All three reported by @hieilookie, all three reproduce here.

**1. Ordinary misses printed the corruption signature.**

```
before  deja: no matches in 0 indexed sessions — …      (store has 1153)
after   deja: no matches in 1153 indexed sessions — …
```

`len(ss)` is the loaded set, which on the index-backed path is empty by definition when nothing matched. `internal/index/manifest.go` reserves that exact sentence as the signature of a corrupt store — on the grounds that a reader told the index holds zero sessions concludes the tool is broken rather than that their query missed — so the signature was useless while every ordinary miss printed it. Now it reports the manifest count, and says nothing rather than a wrong number when there is no index.

**2. `deja last` blamed the index for a filter.**

```
before  deja: no sessions indexed yet — run `deja index`, or `deja doctor` …
after   deja: no sessions match harness "codex" and role "command"
```

The advice was not merely unhelpful, it was wrong: indexing changes nothing and doctor reports the stores as found. The original text stays for the unfiltered case it was written for.

**3. `doctor` read guidance from a file's existence.**

```
before  codex  guidance written   (on a machine where install had never run)
after   codex  guidance absent
```

Anyone with their own `AGENTS.md` was told deja's guidance was in place. It now looks for the marked block install writes, and `absent` is distinguished from `missing` because only the first means someone else owns the file.

One thing the issue could not have known: five harnesses get a **skill file** deja writes whole, which has no marker in it. Checking for the marker there would have reported guidance missing on a machine where it is installed and working — so `guidanceOwnsWholeFile` splits the two cases, and it now names the same set the install path branches on rather than repeating the list.

The related note about hook rows labelling third-party files is left open — it is a different code path and deserves its own measurement.

Four mutations, each fails the suite: restoring the zero count, blaming the index again, reading guidance from existence, and applying the marker check to a skill file.