### PR TITLE
fix: index the tail of a long tool output, not only its head

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -653,6 +653,11 @@ func tokenizedPart(role, text string) string {
 //
 // The full text is still stored and still served: this decides what earns
 // postings, exactly as a replaced span stores its body and indexes its path.
+// signalTail is how much of the end of an unmatched output is kept beside the
+// head. Half the head: measured on a 1637-output store it adds 1.6 MB to the
+// postings, and the end of a long output is where a failure states itself.
+const signalTail = signalFloor / 2
+
 func signalLines(text string) string {
 	if len(text) < signalFloor {
 		return text
@@ -676,10 +681,21 @@ func signalLines(text string) string {
 		}
 	}
 	if b.Len() == 0 {
-		// Nothing matched: index the head rather than nothing, so a short
-		// unusual output is still findable.
+		// Nothing matched, which is the common case rather than the safety net:
+		// a contributor measured 234 of 533 filtered records on their store
+		// matching none of the substrings, and found a vendor error — `Model
+		// name is not valid`, present verbatim in 8 rollouts — unrecoverable
+		// because it sat past the head and "not valid" is not "not found"
+		// (#614). The list of substrings is the limit, not its contents, so
+		// the fallback keeps both ends: errors cluster at the end of a long
+		// output, and the head alone is the least informative part of exactly
+		// the records that matched nothing.
 		if len(text) > signalFloor {
-			return text[:signalFloor]
+			head := text[:signalFloor]
+			if len(text) <= signalFloor+signalTail {
+				return text
+			}
+			return head + "\n" + text[len(text)-signalTail:]
 		}
 		return text
 	}

--- a/internal/index/tool_postings_test.go
+++ b/internal/index/tool_postings_test.go
@@ -175,7 +175,9 @@ func TestSignalLinesFallsBackWhenNothingMatches(t *testing.T) {
 	if got == "" {
 		t.Fatal("indexing nothing makes the record unreachable")
 	}
-	if len(got) > signalFloor+64 {
+	// Head plus tail since #614: the head alone is the least informative part
+	// of exactly the records that matched nothing.
+	if len(got) > signalFloor+signalTail+64 {
 		t.Fatalf("the fallback should be bounded, got %d bytes", len(got))
 	}
 }
@@ -184,5 +186,65 @@ func TestSignalLinesLeavesOtherRolesAlone(t *testing.T) {
 	long := strings.Repeat("a sentence someone actually typed. ", 500)
 	if got := tokenizedPart("assistant", long); got != long {
 		t.Fatal("speech is indexed whole however long it is")
+	}
+}
+
+// An output that matches none of the signal substrings used to be indexed by
+// its head alone, and the head is the least informative part of exactly those
+// records. Measured on a 1153-session store: 394 outputs match no signal line,
+// 262 are long enough to have a tail, and 186 of those carry a token the head
+// does not — text no query could reach (#614).
+func TestSignalLinesKeepsBothEndsWhenNothingMatches(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("HEADTOKEN starts here\n")
+	for b.Len() < signalFloor*2 {
+		b.WriteString("ordinary chatter about nothing in particular\n")
+	}
+	b.WriteString("TAILTOKEN the vendor said the model name is not valid\n")
+	got := signalLines(b.String())
+
+	if !strings.Contains(got, "HEADTOKEN") {
+		t.Error("dropped the head")
+	}
+	if !strings.Contains(got, "TAILTOKEN") {
+		t.Error("dropped the tail, so the end of a long output stays unreachable")
+	}
+	// Both ends, not the whole thing: the byte saving is the reason the filter
+	// exists.
+	if len(got) >= b.Len() {
+		t.Fatalf("kept %d of %d bytes — the filter stopped filtering", len(got), b.Len())
+	}
+	if len(got) > signalFloor+signalTail+64 {
+		t.Fatalf("kept %d bytes, budget is %d", len(got), signalFloor+signalTail)
+	}
+}
+
+// Short enough to fit in head plus tail: keep it whole rather than splicing
+// two overlapping halves together.
+func TestSignalLinesKeepsAShortUnmatchedOutputWhole(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("nothing here matches a signal substring\n")
+	for b.Len() < signalFloor+100 {
+		b.WriteString("more ordinary chatter\n")
+	}
+	in := b.String()
+	if got := signalLines(in); got != in {
+		t.Fatalf("spliced a %d-byte output that fits in %d", len(in), signalFloor+signalTail)
+	}
+}
+
+// A matched output is unchanged by any of this.
+func TestSignalLinesUnchangedWhenSomethingMatches(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("--- FAIL: TestThing\n    thing_test.go:12: wrong\n")
+	for b.Len() < signalFloor*2 {
+		b.WriteString("filler line\n")
+	}
+	got := signalLines(b.String())
+	if !strings.Contains(got, "--- FAIL: TestThing") || !strings.Contains(got, "thing_test.go:12") {
+		t.Fatalf("lost the verdict: %q", got)
+	}
+	if strings.Contains(got, "filler line") {
+		t.Error("kept the filler around a matched line")
 	}
 }


### PR DESCRIPTION
Closes #614, on the recall side @hieilookie measured.

Outputs above 8 KB are tokenized down to their error lines, and when no line matches, the fallback kept `text[:8192]`. I chose that as "keep something" without measuring how often it keeps nothing useful — and the contributor's number says it is the common case, not the safety net: 234 of 533 filtered records on their store match none of the substrings. Their example is unarguable: `Model name is not valid`, present verbatim in 8 rollouts, unreachable because it sits past the head and "not valid" is not "not found".

**Measured here, and my first number was wrong.** Counting only short error words said the tail adds something to 5 records out of 394 — which would not have justified this. Counting *any* token the head does not contain:

```
outputs matching no signal line   394
  long enough to have a tail      262
  carrying a tail-only token      186
```

186 records hold text no query could reach. The first measurement undercounted by 37×, because it looked for the vocabulary the filter already knows — which is the exact failure the issue is about.

Cost: 108 MB → 111 MB, 2.8%. The head is not shortened to pay for it; an output that fits in head+tail is kept whole rather than spliced.

This does not close the general problem the contributor names — a list of substrings will never cover what a person remembers a failure as — but it is a strict improvement rather than a new mechanism, which is what they suggested.

Two mutations, both fail the suite: dropping the tail, and splicing an output short enough to keep whole.