### PR TITLE
fix: review notes from the signal-tail change

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -643,6 +643,11 @@ func tokenizedPart(role, text string) string {
 	return text
 }
 
+// signalTail is how much of the end of an unmatched output is kept beside the
+// head. Half the head: measured on a 1637-output store it adds 1.6 MB to the
+// postings, and the end of a long output is where a failure states itself.
+const signalTail = signalFloor / 2
+
 // signalLines keeps the part of a command's output anyone would search for.
 //
 // A build log is mostly progress: files compiled, tests named, packages
@@ -653,11 +658,6 @@ func tokenizedPart(role, text string) string {
 //
 // The full text is still stored and still served: this decides what earns
 // postings, exactly as a replaced span stores its body and indexes its path.
-// signalTail is how much of the end of an unmatched output is kept beside the
-// head. Half the head: measured on a 1637-output store it adds 1.6 MB to the
-// postings, and the end of a long output is where a failure states itself.
-const signalTail = signalFloor / 2
-
 func signalLines(text string) string {
 	if len(text) < signalFloor {
 		return text

--- a/internal/index/tool_postings_test.go
+++ b/internal/index/tool_postings_test.go
@@ -175,9 +175,12 @@ func TestSignalLinesFallsBackWhenNothingMatches(t *testing.T) {
 	if got == "" {
 		t.Fatal("indexing nothing makes the record unreachable")
 	}
-	// Head plus tail since #614: the head alone is the least informative part
-	// of exactly the records that matched nothing.
-	if len(got) > signalFloor+signalTail+64 {
+	// A literal, not signalFloor+signalTail: written in terms of the constant
+	// it is meant to bound, this assertion passes for any value of signalTail
+	// — including signalFloor*8. The tail is pinned from the other side by
+	// TestSignalLinesKeepsBothEndsWhenNothingMatches, but a bound that cannot
+	// discriminate should not look like one.
+	if len(got) > 13000 {
 		t.Fatalf("the fallback should be bounded, got %d bytes", len(got))
 	}
 }
@@ -208,6 +211,15 @@ func TestSignalLinesKeepsBothEndsWhenNothingMatches(t *testing.T) {
 	}
 	if !strings.Contains(got, "TAILTOKEN") {
 		t.Error("dropped the tail, so the end of a long output stays unreachable")
+	}
+	// In order: a reader of the indexed text should meet the output the way it
+	// was written. Reversing the splice indexes the same content, so only an
+	// assertion catches it.
+	if strings.Index(got, "HEADTOKEN") > strings.Index(got, "TAILTOKEN") {
+		t.Errorf("tail spliced ahead of head: %.60q", got)
+	}
+	if !strings.HasPrefix(got, "HEADTOKEN") {
+		t.Errorf("the head is no longer the prefix: %.60q", got)
 	}
 	// Both ends, not the whole thing: the byte saving is the reason the filter
 	// exists.


### PR DESCRIPTION
Post-merge review of #643 found three small things. All three fixed here; none was worth a revert.

1. **The `signalLines` doc block detached.** The new `signalTail` const landed between the comment and the function, so `go doc -u ./internal/index signalLines` printed a bare signature and the const inherited a paragraph about something else. Second instance of this exact slip in a day — filed as #645 with a suggested AST check, since a third is likely.

2. **A bound that could not discriminate.** `TestSignalLinesFallsBackWhenNothingMatches` asserted `len(got) > signalFloor+signalTail+64` — written in terms of the constant it was meant to bound, so it passed for any value, including `signalFloor*8`. It is a literal now. Worth recording that the reviewer checked whether that let a runaway tail through and it did not: `TestSignalLinesKeepsBothEndsWhenNothingMatches` catches it from the other side, on "the filter stopped filtering". The tail was pinned; it was just not the assertion that looked like it.

3. **The splice order was unasserted.** Reversing head and tail left the whole package green — the indexed content is identical, so only an assertion catches it. Both mutations now fail.

The rest of the review confirmed the change with measurements I had not made: +1.30 MB of indexed tool-output bytes (+17.6% of that role, +0.83% of every key in the index), 70% of the 9,719 tokens that gain postings gain exactly one, and the largest single-token gain is 69 — so no common word gets slower. The posting-cap worry I had flagged as unchecked is structurally impossible: `capPostingsPerSession` gives speech the full budget first, and doubling the tool footprint evicts no speech at all.