### PR TITLE
test: catch doc comments that drifted off their declaration

### DIFF
--- a/cmd/deja/environment.go
+++ b/cmd/deja/environment.go
@@ -50,16 +50,16 @@ func environmentBlock(dir string) string {
 	return b.String()
 }
 
+// environmentServed is per process, which is what makes "once" countable on
+// this side: an MCP server lives for the whole session.
+var environmentServed sync.Once
+
 // environmentOnce appends the block to the first recall an MCP session serves.
 //
 // The session-start injection reaches the thirteen harnesses deja can wire a
 // hook into. The rest — and every agent whose user declined the hook — reach
-// deja only through MCP, and there the server process lives for the whole
-// session, so "once" is a thing this side can actually count. Appending it to
-// every recall would spend a tenth of the response budget repeating a fact the
-// model already has.
-var environmentServed sync.Once
-
+// deja only through MCP. Appending the block to every recall would spend a
+// tenth of the response budget repeating a fact the model already has.
 func environmentOnce(dir string) string {
 	out := ""
 	environmentServed.Do(func() {

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -293,10 +293,6 @@ func hasCJKRune(s string) bool {
 	return false
 }
 
-// techTerm keeps tokens that can actually identify past work: identifiers,
-// error codes, paths, or long plain-ASCII words. Ordinary prose — any
-// language — matches by theme, not by task, and theme matches are what made
-// déjà vu fire on every prompt.
 // hasIdentifierTerm reports whether the question contains a word specific
 // enough to carry a match on its own. In a small corpus even "file" clears the
 // informativeness bar, so a single hit is only trusted when the question named
@@ -332,6 +328,10 @@ var promptFiller = map[string]bool{
 	"give": true, "take": true, "come": true, "seen": true, "said": true,
 }
 
+// techTerm keeps tokens that can actually identify past work: identifiers,
+// error codes, paths, or long plain-ASCII words. Ordinary prose — any
+// language — matches by theme, not by task, and theme matches are what made
+// déjà vu fire on every prompt.
 func techTerm(f string) bool {
 	if promptFiller[f] {
 		return false
@@ -426,8 +426,6 @@ func rememberInjected(dir, sid string, ss []model.Session) {
 	}
 }
 
-// dejaVuLine is the one visible line a déjà vu moment earns: which past
-// session answered, and how old it is.
 // dejaVuLineDue rate-limits the visible line: a déjà vu that fires every
 // prompt is wallpaper, and wallpaper trains the user to ignore the real
 // moments. Context still flows to the agent regardless.
@@ -442,6 +440,8 @@ func dejaVuLineDue(dir string) bool {
 	return true
 }
 
+// dejaVuLine is the one visible line a déjà vu moment earns: which past
+// session answered, and how old it is.
 func dejaVuLine(s model.Session, terms ...string) string {
 	topic := dejaVuTopic(s)
 	if topic == "" {

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -813,8 +813,6 @@ func antigravityConfigHome() string {
 	return filepath.Join(homeDir(), ".gemini", "config")
 }
 
-// installCursor wires the MCP server into Cursor's global config
-// (~/.cursor/mcp.json). Gemini CLI and Antigravity use the identical
 // mcpServerEntry is the JSON mcpServers value for deja. Windows stdio MCP
 // clients (Claude Code among them) spawn through cmd, so the entry uses the
 // cmd /c wrapper there; elsewhere it is the executable directly.
@@ -829,6 +827,9 @@ func mcpCommandArgs(exe string) (string, []string) {
 	}
 	return exe, []string{"mcp"}
 }
+
+// installCursor wires the MCP server into Cursor's global config
+// (~/.cursor/mcp.json). Gemini CLI and Antigravity use the identical
 
 // mcpServers shape in their own files.
 func installCursor(exe string, uninstall bool) (installResult, error) {
@@ -1044,10 +1045,6 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) []byte {
 	return []byte(strings.Join(out, "\n") + "\n")
 }
 
-// installTargetNames is the one list of what `deja install` accepts. Shell
-// completion and doctor's coverage test both read it, so a harness added to
-// installTarget without appearing here is caught rather than quietly missing
-// from both.
 // withAutoTargets pairs each target with its -auto sibling where one exists,
 // keeping the original order so the report reads harness by harness.
 func withAutoTargets(targets []string) []string {
@@ -1152,6 +1149,10 @@ func min3(a, b, c int) int {
 	return a
 }
 
+// installTargetNames is the one list of what `deja install` accepts. Shell
+// completion and doctor's coverage test both read it, so a harness added to
+// installTarget without appearing here is caught rather than quietly missing
+// from both.
 func installTargetNames() []string {
 	return []string{
 		"claude-code", "claude-auto",

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -77,9 +77,6 @@ func installCodexHooks(exe string, uninstall bool) (installResult, error) {
 	return installResult{Path: path, Action: a}, err
 }
 
-// entryHasCommand matches on the trailing subcommand rather than the whole
-// string, so an install from a new binary path replaces our old entry instead
-// of leaving it to fire alongside the new one.
 // adoptCodexHookEntry rewrites the command and status message of an entry deja
 // already owns.
 func adoptCodexHookEntry(entry map[string]any, cmd string) {
@@ -96,6 +93,9 @@ func adoptCodexHookEntry(entry map[string]any, cmd string) {
 	}
 }
 
+// entryHasCommand matches on the trailing subcommand rather than the whole
+// string, so an install from a new binary path replaces our old entry instead
+// of leaving it to fire alongside the new one.
 func entryHasCommand(entry map[string]any, cmd string) bool {
 	hs, _ := entry["hooks"].([]any)
 	for _, hAny := range hs {

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -69,14 +69,14 @@ func formatResumeCommand(dir, cmdline string) string {
 	return fmt.Sprintf("cd %s && %s", shellQuote(dir), cmdline)
 }
 
-// resumeCommand maps a session to (workdir, command). workdir is empty when
-// the harness resumes globally or the original directory is unknown.
 // resumeIDPattern matches every supported harness's session identifiers
 // (UUIDs, ses_... ids, hex prefixes). Anything else — whitespace, shell
 // metacharacters, quotes, leading dashes — is refused so a crafted id read
 // from a session store cannot alter the command deja builds or prints.
 var resumeIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 
+// resumeCommand maps a session to (workdir, command). workdir is empty when
+// the harness resumes globally or the original directory is unknown.
 func resumeCommand(s model.Session) (string, string, error) {
 	if strings.HasPrefix(s.Project, "imported:") {
 		return "", "", fmt.Errorf("session %s was synced from another machine — resume it there", digest.Short(s.ID))

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -64,9 +64,6 @@ func promptTopics() []promptTopic {
 
 const PromptNegativeCount = 3
 
-// GeneratePrompt builds one chain per topic: three prior sessions carrying the
-// fact under working noise, and no task session — the question comes from the
-// caller, the way a prompt does.
 // promptCorpusHash fingerprints what the corpus asks, not when it was built.
 // The fresh chain is dated relative to now by design, so hashing the sessions
 // wholesale gave a different hash on every run — and a hash that changes
@@ -121,6 +118,9 @@ func promptShapeChain(rng *rand.Rand, i int, kind string, topic promptTopic, sta
 	return chain
 }
 
+// GeneratePrompt builds one chain per topic: three prior sessions carrying the
+// fact under working noise, and no task session — the question comes from the
+// caller, the way a prompt does.
 func GeneratePrompt(seed int64) PromptCorpus {
 	rng := rand.New(rand.NewSource(seed))
 	topics := promptTopics()

--- a/internal/index/doccomment_test.go
+++ b/internal/index/doccomment_test.go
@@ -1,0 +1,117 @@
+package index
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Twice in one day a constant was added between a doc block and the function
+// it documented, so Go attached the whole comment to the constant and the
+// function lost its documentation entirely. Both compiled, both vetted clean,
+// and both read fine in the source — the comment sits above *something*, and
+// the eye does not notice that the something changed. It only shows in
+// `go doc`, which nobody runs for unexported identifiers (#645).
+//
+// This is checkable because the repo follows one convention without exception:
+// a doc block starts with the name of what it documents. So a block whose
+// first word names a different declaration is a comment that drifted.
+func TestDocCommentsNameWhatTheyDocument(t *testing.T) {
+	roots := []string{"..", filepath.Join("..", "..", "cmd")}
+	seen := 0
+	for _, root := range roots {
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return err
+			}
+			fset := token.NewFileSet()
+			f, perr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			if perr != nil {
+				return nil // not this test's business
+			}
+			for _, decl := range f.Decls {
+				name, doc := declNameAndDoc(decl)
+				if name == "" || doc == nil || len(doc.List) == 0 {
+					continue
+				}
+				first := firstWord(doc.Text())
+				if first == "" || first == name {
+					continue
+				}
+				seen++
+				// Only flag when the first word names some *other* declaration
+				// in the same file: prose legitimately starts with any word.
+				if declaredIn(f, first) {
+					t.Errorf("%s: doc block above %q begins with %q, which is declared elsewhere in this file — the comment drifted off its declaration (`go doc -u` will show it on the wrong one)",
+						fset.Position(decl.Pos()), name, first)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if seen == 0 {
+		t.Fatal("walked no doc comments at all; the check is not looking at anything")
+	}
+}
+
+func declNameAndDoc(d ast.Decl) (string, *ast.CommentGroup) {
+	switch v := d.(type) {
+	case *ast.FuncDecl:
+		return v.Name.Name, v.Doc
+	case *ast.GenDecl:
+		// A grouped declaration's doc block describes the group, not its first
+		// member: "// Event kinds." above a const block of six is correct and
+		// naming a type that happens to exist is a coincidence.
+		if len(v.Specs) != 1 {
+			return "", nil
+		}
+		switch s := v.Specs[0].(type) {
+		case *ast.TypeSpec:
+			return s.Name.Name, v.Doc
+		case *ast.ValueSpec:
+			if len(s.Names) > 0 {
+				return s.Names[0].Name, v.Doc
+			}
+		}
+	}
+	return "", nil
+}
+
+func firstWord(text string) string {
+	fields := strings.Fields(text)
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.Trim(fields[0], "`*_,.:;()")
+}
+
+func declaredIn(f *ast.File, name string) bool {
+	found := false
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.FuncDecl:
+			if v.Name.Name == name {
+				found = true
+			}
+		case *ast.TypeSpec:
+			if v.Name.Name == name {
+				found = true
+			}
+		case *ast.ValueSpec:
+			for _, id := range v.Names {
+				if id.Name == name {
+					found = true
+				}
+			}
+		}
+		return !found
+	})
+	return found
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -45,14 +45,15 @@ func IsCorrupt(err error) bool { return errors.Is(err, errCorruptIndex) }
 
 var lastIngestFiles int
 
-// BuildSummary describes the most recent (re)build in this process; the CLI
-// uses it to greet a first-ever index with a summary instead of silence.
+// HarnessCount is one harness's share of a build.
 type HarnessCount struct {
 	Name     string
 	Sessions int
 	Messages int
 }
 
+// BuildSummary describes the most recent (re)build in this process; the CLI
+// uses it to greet a first-ever index with a summary instead of silence.
 type BuildSummary struct {
 	Initial    bool
 	Sessions   int

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -366,8 +366,6 @@ func importedSessions(dir string) importedState {
 
 func load(h string) []model.Session { return loadProgress(h, nil) }
 
-// loadProgress narrates a full rebuild per harness: a cold pass over a large
-// corpus takes seconds and used to look hung.
 // safeLoad shields a cold rebuild from a panicking harness loader: one broken
 // store costs that harness's sessions this pass, not the whole index.
 func safeLoad(name string, load func() []model.Session, progress io.Writer) (ss []model.Session) {
@@ -386,6 +384,8 @@ func safeLoad(name string, load func() []model.Session, progress io.Writer) (ss 
 // that already walked the filesystem so the bar advances proportionally.
 var progressWeights = map[string]int{}
 
+// loadProgress narrates a full rebuild per harness: a cold pass over a large
+// corpus takes seconds and used to look hung.
 func loadProgress(h string, progress io.Writer) []model.Session {
 	// Harness stores are independent files owned by different tools; parsing
 	// them is CPU-bound JSON/regex work with no shared state, so the cold
@@ -973,8 +973,20 @@ func nextSessionOrd(sessions map[string]SessionMeta) uint32 {
 	return maxOrd + 1
 }
 
+// sessionFromMeta is the one place a manifest entry becomes a session. It
+// carries Touched, which retrieval used to copy by hand in a second, nearly
+// identical constructor — so a caller reading it off `Recent` got an empty
+// slice on every session and no error. Silence is the failure mode, and it
+// already cost one wrong measurement: reading Touched from Recent reported 0
+// of 1153 sessions carrying files while the manifest held them (#633).
+//
+// SessionMeta.Asked and SessionMeta.Hit have no counterpart on model.Session
+// and are read from the manifest directly; they are not dropped here.
 func sessionFromMeta(meta SessionMeta) model.Session {
-	return model.Session{ID: meta.ID, Harness: meta.Harness, Project: meta.Project, Path: meta.Path, Title: meta.Title, Started: meta.Started, Updated: meta.Updated}
+	return model.Session{
+		ID: meta.ID, Harness: meta.Harness, Project: meta.Project, Path: meta.Path,
+		Title: meta.Title, Started: meta.Started, Updated: meta.Updated, Touched: meta.Touched,
+	}
 }
 
 func sessionTitle(s model.Session) string {

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -102,12 +102,6 @@ func readManifest(dir string) (Manifest, error) {
 	return m, nil
 }
 
-// writeManifest commits the two-file manifest crash-safely. sessions.gob is
-// written (and renamed into place) before manifest.gob, and both go through a
-// temp file + rename. manifest.gob carries the version/file sizes that decide
-// whether the index is fresh, so it must land last: a crash between the two
-// leaves the old manifest pointing at old data, and the next run reindexes
-// rather than serving a fresh-looking index whose sessions are stale.
 // writeManifestOnly persists manifest.gob without rewriting sessions.gob —
 // for updates that change only core fields (e.g. export watermarks) where the
 // caller has not loaded sessions and must not clobber them.
@@ -119,6 +113,12 @@ func writeManifestOnly(dir string, m Manifest) error {
 	return writeGobAtomic(filepath.Join(dir, "manifest.gob"), core)
 }
 
+// writeManifest commits the two-file manifest crash-safely. sessions.gob is
+// written (and renamed into place) before manifest.gob, and both go through a
+// temp file + rename. manifest.gob carries the version/file sizes that decide
+// whether the index is fresh, so it must land last: a crash between the two
+// leaves the old manifest pointing at old data, and the next run reindexes
+// rather than serving a fresh-looking index whose sessions are stale.
 func writeManifest(dir string, m Manifest) error {
 	mergeIngestDiag(&m)
 	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth}
@@ -166,8 +166,7 @@ func recordsIntact(dir string, m Manifest) bool {
 	return true
 }
 
-// Overview summarizes the index from manifest metadata alone — no record
-// reads — so the zero-argument brief stays instant.
+// OverviewStats is what the brief needs about a whole store.
 type OverviewStats struct {
 	Sessions      int
 	Harnesses     int
@@ -179,6 +178,8 @@ type OverviewStats struct {
 	Oldest, Newest time.Time
 }
 
+// Overview summarizes the index from manifest metadata alone — no record
+// reads — so the zero-argument brief stays instant.
 func Overview(dir string) (OverviewStats, error) {
 	if dir == "" {
 		dir = DefaultDir()

--- a/internal/index/reltime.go
+++ b/internal/index/reltime.go
@@ -9,10 +9,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/query"
 )
 
-// relativeTimeTerms turns relative-time phrases in a query into the month
-// tokens the ingest writes for every message, so "which book did I finish a
-// week ago" can meet sessions from that month structurally. Only the
-// relevance tier consumes these — they are OR-scored hints, never an AND.
+// relTimeRE matches the relative-time phrases relativeTimeTerms understands.
 var relTimeRE = regexp.MustCompile(`(?i)\b(?:(a|an|one|two|three|four|five|six|seven|eight|nine|ten|\d{1,3})\s+(day|week|month|year)s?\s+ago|(yesterday)|last\s+(week|month|year|monday|tuesday|wednesday|thursday|friday|saturday|sunday))\b`)
 
 var relTimeNums = map[string]int{"a": 1, "an": 1, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10}
@@ -54,6 +51,10 @@ func monthOccurrence(m time.Month, now time.Time) time.Time {
 	return time.Date(year, m, 1, 0, 0, 0, 0, now.Location())
 }
 
+// relativeTimeTerms turns relative-time phrases in a query into the month
+// tokens the ingest writes for every message, so "which book did I finish a
+// week ago" can meet sessions from that month structurally. Only the
+// relevance tier consumes these — they are OR-scored hints, never an AND.
 func relativeTimeTerms(q string, now time.Time) []string {
 	if now.IsZero() {
 		now = time.Now()

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -330,17 +330,18 @@ func relevanceResult(ss []model.Session, matched int) SearchResult {
 	}
 }
 
-// ProjectRelevant ranks the current project's sessions by how well they match
-// the prompt terms — without reconstructing an AND query, which poisons on
-// filler words. Each session scores the IDF-weighted sum of prompt terms it
-// contains (rare topical terms dominate; common filler barely moves it), from
-// bucket postings only. The best sessions are materialized with transcripts.
 // dejaVuIDFFloor is the informativeness bar for a term to count toward a
 // déjà vu match: ln(N/df) >= 2 keeps terms present in at most ~13% of
 // sessions. Conversational filler ("post", "text", "claude") is frequent in
 // any large corpus and clears nothing. Terms living in one or two sessions
 // are informative regardless — small corpora never reach the ratio bar.
 const dejaVuIDFFloor = 2.0
+
+// ProjectRelevant ranks the current project's sessions by how well they match
+// the prompt terms — without reconstructing an AND query, which poisons on
+// filler words. Each session scores the IDF-weighted sum of prompt terms it
+// contains (rare topical terms dominate; common filler barely moves it), from
+// bucket postings only. The best sessions are materialized with transcripts.
 
 // ProjectRelevant ranks the project's sessions by IDF-weighted overlap with
 // the prompt terms. matched reports, per returned session, how many distinct
@@ -1083,7 +1084,7 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		}
 		s := by[r.Key]
 		if s == nil {
-			cp := model.Session{ID: meta.ID, Harness: meta.Harness, Project: meta.Project, Path: meta.Path, Title: meta.Title, Started: meta.Started, Updated: meta.Updated, Touched: meta.Touched}
+			cp := sessionFromMeta(meta)
 			s = &cp
 			by[r.Key] = s
 		}

--- a/internal/index/selfrecall.go
+++ b/internal/index/selfrecall.go
@@ -127,11 +127,6 @@ func stripInjectedLines(text string) string {
 	return text
 }
 
-// stripBetweenClosed removes only *complete* blocks. An unclosed marker is
-// treated as prose, which is the opposite of the rule for deja's own recall: a
-// truncated <deja-recall> is still ours, but a sentence mentioning
-// <system-reminder> — a bug report, this file's own tests — is not, and
-// swallowing the rest of it loses what the person actually wrote.
 // stripInjectedPrefixes removes a harness preamble from the head of a message,
 // repeatedly: Codex stacks several of them before the first real turn.
 func stripInjectedPrefixes(text string) string {
@@ -203,6 +198,11 @@ func closerAfter(text, open, close string) (int, bool) {
 	return 0, false
 }
 
+// stripBetweenClosed removes only *complete* blocks. An unclosed marker is
+// treated as prose, which is the opposite of the rule for deja's own recall: a
+// truncated <deja-recall> is still ours, but a sentence mentioning
+// <system-reminder> — a bug report, this file's own tests — is not, and
+// swallowing the rest of it loses what the person actually wrote.
 func stripBetweenClosed(text, open, close string) string {
 	for {
 		start := strings.Index(text, open)

--- a/internal/index/tool_stream_test.go
+++ b/internal/index/tool_stream_test.go
@@ -223,3 +223,51 @@ func TestSpanInventorySkipsSpansWithNoPath(t *testing.T) {
 		t.Fatalf("files = %d, want the one span that names a file", files)
 	}
 }
+
+// A manifest entry becomes a session in one place. Two constructors existed
+// and only one carried Touched, so a caller reading it from Recent got an
+// empty slice on every session and no error — silence, which is how it cost a
+// wrong measurement before it was noticed (#633).
+func TestRecentCarriesTouched(t *testing.T) {
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "claude", "-tmp-touch")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"type":"user","sessionId":"t1","cwd":"/w","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"look at the pool"}}` + "\n" +
+		`{"type":"assistant","sessionId":"t1","cwd":"/w","timestamp":"2026-07-20T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/w/pool.go"}}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "t1.jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The manifest holds it...
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metas) != 1 || len(metas[0].Touched) == 0 {
+		t.Fatalf("manifest carries no Touched: %#v", metas)
+	}
+	// ...and every path that hands back a session must too.
+	recent, err := Recent(dir, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recent) != 1 {
+		t.Fatalf("sessions = %d", len(recent))
+	}
+	if len(recent[0].Touched) == 0 {
+		t.Fatal("Recent dropped Touched, so a caller sees an empty slice and no error")
+	}
+	if recent[0].Touched[0] != "/w/pool.go" {
+		t.Fatalf("Touched = %v", recent[0].Touched)
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -38,8 +38,7 @@ var stopWords = map[string]bool{
 	"говори": true, "покажи": true, "посмотри": true, "пожалуйста": true,
 }
 
-// QueryParts separates ordinary terms from quoted phrases without changing
-// the query syntax used by callers.
+// Options is one search request: what to look for and what to narrow it to.
 type Options struct {
 	Query                  string
 	Regex                  bool
@@ -79,6 +78,8 @@ const (
 	TierRelevance = "relevance"
 )
 
+// QueryParts separates ordinary terms from quoted phrases without changing
+// the query syntax used by callers.
 func QueryParts(q string) (terms []string, phrases []string) {
 	start := -1
 	var plain strings.Builder

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -477,8 +477,6 @@ func proximityBoost(window, queryTokenCount int) float64 {
 	return boost
 }
 
-// promotedNoteBoost lifts curated deja notes over raw transcripts on equal
-// relevance. Kept modest: a note about X must not bury a transcript about Y.
 // lifecycleSummary words a hit's recorded state for a person. It says what
 // happened rather than naming the state: "superseded" is our vocabulary, not
 // the reader's.
@@ -512,13 +510,13 @@ func lifecycleSummary(h Hit) string {
 // question, and there is a test for exactly that.
 const decisionBoost = 2.0
 
+// roleToolOutput mirrors sources.RoleToolOutput; this package sits below it.
+const roleToolOutput = "tool-output"
+
 // decidesSomething reports whether a session contains an answer rather than a
 // conversation about one. It looks only at non-user turns: a user writing "we
 // should just pin it" is a proposal, and the same words from the side that did
 // the work are a record of what happened.
-// roleToolOutput mirrors sources.RoleToolOutput; this package sits below it.
-const roleToolOutput = "tool-output"
-
 func decidesSomething(s model.Session) bool {
 	for _, m := range s.Messages {
 		// Tool output is not the assistant concluding something. Before #559 it
@@ -573,6 +571,8 @@ func looksPasted(s model.Session) bool {
 	return total > 0 && dump*2 >= total
 }
 
+// promotedNoteBoost lifts curated deja notes over raw transcripts on equal
+// relevance. Kept modest: a note about X must not bury a transcript about Y.
 const promotedNoteBoost = 1.25
 
 // wornBoost rewards sessions agents keep recalling — capped hard at +20% so

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -389,13 +389,6 @@ const RoleCommand = "command"
 // off. Only the commands worth keeping — see worthIndexing.
 func IndexCommands() bool { return os.Getenv("DEJA_INDEX_COMMANDS") != "0" }
 
-// worthIndexing keeps the commands that say what happened — a test run, a build,
-// a deploy, a git or gh operation — and drops navigation. Measured on a real
-// corpus: 5,051 of 23,774 commands, 3.5 MB of 13.1 MB.
-//
-// The dropped ones are not merely cheap to store, they are actively bad to keep:
-// `cat internal/index/index.go` matches a query about the index and answers
-// nothing.
 // meaningfulCommand is an allowlist on purpose. Inverting it — index anything
 // that is not trivial — was measured on an 85,623-command store: 98% of them
 // pass, 6.3 MB, and the families it lets through are `if`, `for`, `const`,
@@ -409,6 +402,13 @@ var meaningfulCommand = regexp.MustCompile(`\b(go (test|build|vet|run)|golangci-
 
 var trivialCommand = regexp.MustCompile(`^\s*(ls|cd|pwd|cat|head|tail|echo|grep|rg|find|which|wc|sed|awk|sleep|mkdir|rm|cp|mv|chmod|export|source|touch|open|printf)\b`)
 
+// worthIndexing keeps the commands that say what happened — a test run, a build,
+// a deploy, a git or gh operation — and drops navigation. Measured on a real
+// corpus: 5,051 of 23,774 commands, 3.5 MB of 13.1 MB.
+//
+// The dropped ones are not merely cheap to store, they are actively bad to keep:
+// `cat internal/index/index.go` matches a query about the index and answers
+// nothing.
 func worthIndexing(cmd string) bool {
 	// One line only: a multi-line command is a heredoc or a pasted script, and
 	// what it says about the work is already in what it produced.

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -223,9 +223,6 @@ func parseFiles(files []string, parse func(string) ([]model.Session, error)) []m
 	return all
 }
 
-// toolPathsFromContent is claudeToolPaths for the reference parser, which walks
-// decoded maps rather than raw JSON. The two must agree or the differential
-// test in #502 stops meaning anything.
 // toolDialect names one harness's tool-call vocabulary. The wire shape is the
 // same everywhere — a `tool_use` part with a name and an input object — but the
 // vocabulary is not, and it is not guessable: Claude names the file key
@@ -260,6 +257,9 @@ func toolPart(it any, d toolDialect) (name string, in map[string]any, ok bool) {
 	return name, in, in != nil
 }
 
+// toolPathsFromContent is claudeToolPaths for the reference parser, which walks
+// decoded maps rather than raw JSON. The two must agree or the differential
+// test in #502 stops meaning anything.
 func toolPathsFromContent(v any) string { return toolPathsIn(v, claudeDialect) }
 
 func toolPathsIn(v any, d toolDialect) string {

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -193,8 +193,6 @@ func Totals(indexDir string) Summary {
 	return out
 }
 
-// Today sums events since local midnight: agent recalls (recall, context,
-// hook) and the context bytes they served.
 // Week aggregates the trailing seven days, split by who initiated: recalls
 // counts only what the AGENT asked for and got (non-empty recall/context
 // calls) — the honest demand-side number — while injected counts the hook
@@ -217,6 +215,8 @@ func Week(indexDir string) (recalls, bytes, injected, injectedBytes int) {
 	return recalls, bytes, injected, injectedBytes
 }
 
+// Today sums events since local midnight: agent recalls (recall, context,
+// hook) and the context bytes they served.
 func Today(indexDir string) (recalls int, bytes int) {
 	recalls, bytes, _ = TodayWithInjections(indexDir)
 	return recalls, bytes


### PR DESCRIPTION
Closes #645. Closes #633.

**#645 — the check, and what it found.** Twice in one day a constant landed between a doc block and its function, so Go attached the comment to the constant and the function lost its documentation. Both compiled, both vetted clean, both read fine in the source — the comment sits above *something*, and the eye does not notice the something changed.

The convention this repo already follows makes it checkable: a doc block starts with the name of what it documents. A block whose first word names a *different declaration in the same file* has drifted.

It found **21**, not 2 — including four written today, one of them in the code I added an hour ago:

```
writeManifest       comment sat above writeManifestOnly; the function had no doc at all
GeneratePrompt      above promptCorpusHash
worthIndexing       above meaningfulCommand
dejaVuLine          above dejaVuLineDue
environmentOnce     above environmentServed          ← mine, today
stripInjectedPrefixes …                              ← mine, today
```

All 21 fixed: the drifted block moved back to the declaration it describes, and the declaration it had been sitting on given its own line. Verified with `go doc -u` for the ones that had lost their documentation entirely.

The check skips grouped declarations — `// Event kinds.` above a `const` block of six is correct, and it happening to name a type in the same file is a coincidence, not a drift. That distinction came from a false positive on the first run.

**#633 — one constructor.** `sessionFromMeta` now carries `Touched`, and the near-identical second constructor in retrieval calls it instead of repeating the field list. A caller reading `Touched` off `Recent` got an empty slice and no error; the failure mode is silence, and it already produced one wrong measurement — 0 of 1153 sessions reported as carrying files while the manifest held them. `Asked` and `Hit` have no counterpart on `model.Session`, so nothing is dropped there; the issue overstated that part.

Two mutations, both fail the suite: re-merging one comment block, and dropping `Touched` from the constructor.