### PR TITLE
fix: the preamble class was not Codex-specific

### DIFF
--- a/internal/index/selfrecall.go
+++ b/internal/index/selfrecall.go
@@ -58,6 +58,14 @@ var injectedBlocks = [][2]string{
 // message, so requiring that costs nothing and stops the filter from eating
 // someone's sentence.
 var injectedPrefixBlocks = [][2]string{
+	// Gemini opens every session with a context block of its own — "This is
+	// the Gemini CLI. We are setting up the context for our chat." — which
+	// titled 9 of 9 sessions on this machine. Same shape as Codex's preamble,
+	// different harness: the class was not Codex-specific and looking only
+	// where a contributor pointed would have left the rest.
+	{"<session_context>", "</session_context>"},
+	// Cursor stamps a timestamp block ahead of the question it wraps.
+	{"<timestamp>", "</timestamp>"},
 	{"<environment_context>", "</environment_context>"},
 	{"<recommended_plugins>", "</recommended_plugins>"},
 	{"<permissions instructions>", "</permissions instructions>"},
@@ -85,10 +93,23 @@ const (
 // closing tag. Matched at line granularity so a line quoting one inside a real
 // message does not take the message with it.
 var injectedLines = []string{
+	// The preamble a harness writes when it resumes a compacted session. It is
+	// the harness explaining itself to the model, and it titled real sessions
+	// on this store.
+	"This session is being continued from a previous conversation",
 	"[Request interrupted by user",
 	"[Your previous response had no visible output",
 	"UserPromptSubmit hook additional context:",
 	"SessionStart hook additional context:",
+}
+
+// unwrapBlocks are wrappers whose *contents* are what the person said. The
+// tags go, the text stays — dropping the block would delete the question.
+// Cursor puts every user turn inside <user_query>; Gemini wraps deja's own
+// injected recall in <hook_context>, which is how deja's output came back
+// through the front door and got indexed as if a person had written it.
+var unwrapBlocks = [][2]string{
+	{"<user_query>", "</user_query>"},
 }
 
 // stripSelfRecall removes every recall block from a message, keeping whatever
@@ -101,6 +122,12 @@ func stripSelfRecall(text string) string {
 	}
 	for _, m := range injectedBlocks {
 		text = stripBetweenClosed(text, m[0], m[1])
+	}
+	// <hook_context> wraps deja's own recall. The recall itself is stripped by
+	// the markers above — including the HTML-escaped form Gemini stores — so
+	// what is left inside the wrapper is whatever the person typed around it.
+	for _, m := range append(unwrapBlocks, [2]string{"<hook_context>", "</hook_context>"}) {
+		text = unwrapBlock(text, m[0], m[1])
 	}
 	text = stripInjectedPrefixes(text)
 	return stripInjectedLines(text)
@@ -196,6 +223,22 @@ func closerAfter(text, open, close string) (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+// unwrapBlock removes a wrapper's tags and keeps what is between them.
+func unwrapBlock(text, open, close string) string {
+	for {
+		start := strings.Index(text, open)
+		if start < 0 {
+			return text
+		}
+		rest := text[start+len(open):]
+		end := strings.Index(rest, close)
+		if end < 0 {
+			return text
+		}
+		text = text[:start] + rest[:end] + rest[end+len(close):]
+	}
 }
 
 // stripBetweenClosed removes only *complete* blocks. An unclosed marker is

--- a/internal/index/selfrecall_test.go
+++ b/internal/index/selfrecall_test.go
@@ -182,3 +182,58 @@ func TestUnclosedPrefixBlockIsLeftAlone(t *testing.T) {
 		t.Fatalf("got %q", got)
 	}
 }
+
+// The preamble class is not Codex-specific. Looking only where a contributor
+// pointed left Cursor and Gemini titling every session with plumbing: 13 of 13
+// and 9 of 9 on this machine.
+func TestStripsCursorAndGeminiWrappers(t *testing.T) {
+	// Cursor wraps the real question; the tags go, the question stays.
+	cursor := "<timestamp>Friday, Jul 31, 2026, 2:07 PM (UTC+3)</timestamp>\n<user_query>\nCreate notes.txt containing alpha\n</user_query>"
+	if got := strings.TrimSpace(stripSelfRecall(cursor)); got != "Create notes.txt containing alpha" {
+		t.Fatalf("cursor: got %q", got)
+	}
+	// Gemini opens with its own context block.
+	gemini := "<session_context>\nThis is the Gemini CLI. We are setting up the context for our chat.\nMy operating system is: darwin\n</session_context>\nwhy is the pool sized like this"
+	if got := strings.TrimSpace(stripSelfRecall(gemini)); got != "why is the pool sized like this" {
+		t.Fatalf("gemini: got %q", got)
+	}
+	// The compaction preamble titled real sessions.
+	compacted := "This session is being continued from a previous conversation that ran out of context.\nfix the retry loop"
+	if got := strings.TrimSpace(stripSelfRecall(compacted)); got != "fix the retry loop" {
+		t.Fatalf("compaction preamble: got %q", got)
+	}
+}
+
+// deja's own injected recall came back through the front door: Gemini stores
+// it wrapped in <hook_context> and HTML-escaped, so the marker filter never
+// saw it and deja indexed its own output as if a person had written it.
+func TestUnwrapsHookContextAroundOwnRecall(t *testing.T) {
+	in := "hi <hook_context>&lt;deja-recall&gt;\nRecalled history from prior sessions.\n1. [claude] proj · abc\n&lt;/deja-recall&gt;</hook_context>"
+	got := strings.TrimSpace(stripSelfRecall(in))
+	if got != "hi" {
+		t.Fatalf("got %q, want only what the person typed", got)
+	}
+	for _, leak := range []string{"deja-recall", "Recalled history", "hook_context"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("%q survived into the index", leak)
+		}
+	}
+}
+
+// Unwrapping keeps text; stripping removes it. A wrapper whose contents are
+// the person's words must never be dropped whole.
+func TestUnwrapBlockKeepsContents(t *testing.T) {
+	if got := unwrapBlock("a <user_query>the question</user_query> b", "<user_query>", "</user_query>"); got != "a the question b" {
+		t.Fatalf("got %q", got)
+	}
+	// Unclosed: leave it alone rather than eating the rest of the message.
+	in := "a <user_query>the question"
+	if got := unwrapBlock(in, "<user_query>", "</user_query>"); got != in {
+		t.Fatalf("got %q", got)
+	}
+	// Repeated wrappers all unwrap.
+	got := unwrapBlock("<user_query>one</user_query> and <user_query>two</user_query>", "<user_query>", "</user_query>")
+	if got != "one and two" {
+		t.Fatalf("got %q", got)
+	}
+}


### PR DESCRIPTION
An outside contributor found this class in Codex (#636) and I fixed it there. I did not check whether it existed anywhere else. It did — in two more harnesses, visible from one command:

```
$ deja last 4 --harness cursor
<timestamp>Friday, Jul 31, 2026, 2:07 PM (UTC+3)</timestamp>…   ×13 of 13
$ deja last 4 --harness gemini
<session_context> This is the Gemini CLI. We are setting up…   ×9 of 9
```

Both now show what the person typed. Cursor's `<user_query>` is unwrapped rather than dropped — the tags go, the question stays.

**The one worth flagging: deja was indexing its own output.** Gemini stores deja's injected recall wrapped in `<hook_context>` and HTML-escaped, so the existing `&lt;deja-recall&gt;` marker never matched inside the wrapper and the block came back through the front door as if a person had written it. That is a memory tool learning from itself. It now unwraps `<hook_context>` before the recall markers run, and `deja "hook_context"` returns nothing where it used to return sessions.

Also: `This session is being continued from a previous conversation` — the compaction preamble — titled real Claude sessions.

Four mutations, each fails the suite. And the doc-comment check from #648 caught me detaching a comment while writing this, which is what it was built for.

**On method.** These were visible to anyone who ran `deja last --harness X` for each harness. I never had. The corpus I validate on is 977 opencode sessions out of 1153, so "I checked" meant "I checked opencode". A full audit of all 17 harnesses against a fixed checklist is running now; this is the first batch of what it finds.