### PR TITLE
fix: two more messages that describe a state the tool is not in

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -831,7 +831,15 @@ func runBlame(dir string, args []string) error {
 		return nil
 	}
 	if len(hits) == 0 {
-		fmt.Fprintln(os.Stderr, emptyIndexHint("no sessions mention "+target.Base))
+		// "run deja index" is advice for an empty store. With sessions in the
+		// index it is advice for a state the tool is not in — indexing changes
+		// nothing and doctor reports the stores as found — and it sends the
+		// reader to fix an index that is fine (#637, same shape).
+		if n, err := index.SessionCount(dir); err == nil && n > 0 {
+			fmt.Fprintf(os.Stderr, "deja: no sessions mention %s — searched %d indexed session%s\n", target.Base, n, pluralS(n))
+		} else {
+			fmt.Fprintln(os.Stderr, emptyIndexHint("no sessions mention "+target.Base))
+		}
 		return nil
 	}
 	search.PrintBlame(os.Stdout, hits, false)
@@ -1029,8 +1037,35 @@ func runForget(dir string, args []string) error {
 			result.Sessions, result.Messages, result.Tombstones)
 		return nil
 	}
+	// Nothing matched is a different answer from nothing was dropped: the
+	// first means the selector found no session, and reporting it as a
+	// successful removal of zero leaves the reader believing they deleted
+	// something that is in fact still there under a different id.
+	if result.Sessions == 0 && result.Messages == 0 {
+		fmt.Fprintf(os.Stdout, "nothing matched %s — no session was dropped\n", forgetSelector(o))
+		return nil
+	}
 	fmt.Fprintf(os.Stdout, "sessions dropped: %d\nmessages dropped: %d\ntombstones added: %d\n", result.Sessions, result.Messages, result.Tombstones)
 	return nil
+}
+
+// forgetSelector names what the caller asked to forget, so the empty answer
+// says which selector came back empty.
+func forgetSelector(o index.ForgetOptions) string {
+	var parts []string
+	if o.Session != "" {
+		parts = append(parts, fmt.Sprintf("session %q", o.Session))
+	}
+	if o.Project != "" {
+		parts = append(parts, fmt.Sprintf("project %q", o.Project))
+	}
+	if !o.Before.IsZero() {
+		parts = append(parts, "before "+o.Before.Format("2006-01-02"))
+	}
+	if len(parts) == 0 {
+		return "the given selector"
+	}
+	return strings.Join(parts, " and ")
 }
 
 func parseForgetDate(s string) (time.Time, error) {

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -1242,3 +1242,54 @@ func TestSessionCountCountsSessionsNotFiles(t *testing.T) {
 		t.Fatalf("message = %q", b.String())
 	}
 }
+
+// "run deja index" is advice for an empty store. With sessions indexed it
+// describes a state the tool is not in, and it sends the reader to fix an
+// index that is fine — the same shape as #637, found by walking every command
+// with a nonsense argument.
+func TestBlameDoesNotBlameTheIndexWhenItIsFull(t *testing.T) {
+	dir := seedBriefIndex(t)
+	_ = dir
+	out, err := captureRunStderr(t, "blame", "/nowhere/nothing.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "run `deja index`") {
+		t.Fatalf("told the reader to rebuild a healthy index: %q", out)
+	}
+	if !strings.Contains(out, "searched 1 indexed session") {
+		t.Fatalf("does not say what was searched: %q", out)
+	}
+}
+
+// Nothing matched is a different answer from nothing was dropped: reporting a
+// missing session as a successful removal of zero leaves the reader believing
+// they deleted something that is still there under another id.
+func TestForgetSaysWhenNothingMatched(t *testing.T) {
+	seedBriefIndex(t)
+	out, err := captureRun(t, "forget", "--session", "no-such-session")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "sessions dropped") {
+		t.Fatalf("reported a removal that did not happen: %q", out)
+	}
+	if !strings.Contains(out, "nothing matched") || !strings.Contains(out, `session "no-such-session"`) {
+		t.Fatalf("does not name the selector that came back empty: %q", out)
+	}
+}
+
+func TestForgetSelectorNamesEverySelector(t *testing.T) {
+	if got := forgetSelector(index.ForgetOptions{Session: "abc"}); got != `session "abc"` {
+		t.Fatalf("got %q", got)
+	}
+	got := forgetSelector(index.ForgetOptions{Session: "abc", Project: "api", Before: time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)})
+	for _, want := range []string{`session "abc"`, `project "api"`, "before 2026-07-20"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q missing from %q", want, got)
+		}
+	}
+	if got := forgetSelector(index.ForgetOptions{}); got == "" {
+		t.Fatal("an empty selector still needs a name")
+	}
+}


### PR DESCRIPTION
Found by walking every command with a nonsense argument, which is the audit step that should have existed before a contributor filed #637.

```
before  deja blame /nope/nothing.go
        no sessions mention nothing.go — run `deja index`, or `deja doctor` …
after   no sessions mention nothing.go — searched 123 indexed sessions
```

The index had 123 sessions. Rebuilding changes nothing and doctor reports the stores as found, so the advice sent the reader to fix something that was not broken. The empty-store text is kept for the empty store, where it is right — verified with a genuinely empty one.

```
before  deja forget --session no-such-session
        sessions dropped: 0
after   nothing matched session "no-such-session" — no session was dropped
```

"Dropped: 0" reads as a successful removal. Someone forgetting a session by a mistyped id would believe it was gone while it is still there under the right id — for a command whose whole purpose is removing things, that is the worst possible ambiguity.

Both mutations fail the suite.

#649 merged alongside this: the injected-preamble class in cursor and gemini, and deja indexing its own recall back through gemini's `<hook_context>` wrapper.