### PR TITLE
fix(antigravity): stop indexing tool transcripts as speech; give notes a working filter

### DIFF
--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1025,6 +1025,19 @@ func scanRecords(dir string, m Manifest, o query.Options, offsets []int64) ([]mo
 	return scanRecordsWithVariants(dir, m, o, offsets, nil)
 }
 
+// harnessMatches accepts the name deja prints as well as the one it stores.
+//
+// Notes are stored under the harness "deja" and narrated during indexing as
+// "notes" — so `deja index` said "notes: 5 sessions" and `--harness notes`
+// then answered "no sessions match" and exited 0. A filter that rejects the
+// name the tool just printed is a silent miss, which is the worst kind.
+func harnessMatches(stored, want string) bool {
+	if stored == want {
+		return true
+	}
+	return stored == "deja" && want == "notes"
+}
+
 // roleFiles mirrors sources.RoleFiles without importing it: this package sits
 // below sources, not above it.
 const roleFiles = "files"
@@ -1053,7 +1066,7 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		if !ok {
 			return
 		}
-		if o.Harness != "" && meta.Harness != o.Harness {
+		if o.Harness != "" && !harnessMatches(meta.Harness, o.Harness) {
 			return
 		}
 		if o.Project != "" && !strings.Contains(strings.ToLower(meta.Project), strings.ToLower(o.Project)) {
@@ -1211,7 +1224,7 @@ func sessionMetaByOrd(m Manifest) map[uint32]SessionMeta {
 }
 
 func sessionMetaMatches(meta SessionMeta, o query.Options) bool {
-	if o.Harness != "" && meta.Harness != o.Harness {
+	if o.Harness != "" && !harnessMatches(meta.Harness, o.Harness) {
 		return false
 	}
 	if o.Project != "" && !strings.Contains(strings.ToLower(meta.Project), strings.ToLower(o.Project)) {

--- a/internal/index/tool_stream_test.go
+++ b/internal/index/tool_stream_test.go
@@ -271,3 +271,25 @@ func TestRecentCarriesTouched(t *testing.T) {
 		t.Fatalf("Touched = %v", recent[0].Touched)
 	}
 }
+
+// Notes are stored under the harness "deja" and narrated during indexing as
+// "notes", so `deja index` printed "notes: 5 sessions" and `--harness notes`
+// answered "no sessions match" and exited 0. A filter that rejects the name
+// the tool just printed is a silent miss.
+func TestHarnessFilterAcceptsTheNameItPrints(t *testing.T) {
+	for _, c := range []struct {
+		stored, want string
+		ok           bool
+	}{
+		{"deja", "notes", true},
+		{"deja", "deja", true},
+		{"claude", "claude", true},
+		{"claude", "notes", false},
+		{"notes", "deja", false},
+		{"codex", "claude", false},
+	} {
+		if got := harnessMatches(c.stored, c.want); got != c.ok {
+			t.Errorf("harnessMatches(%q, %q) = %v, want %v", c.stored, c.want, got, c.ok)
+		}
+	}
+}

--- a/internal/sources/antigravity.go
+++ b/internal/sources/antigravity.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -57,7 +58,7 @@ func ParseAntigravityFile(path string) ([]model.Session, error) {
 	if id == "" || id == "." || id == string(filepath.Separator) {
 		return nil, nil
 	}
-	s := model.Session{Harness: "antigravity", ID: id, Project: "-", Path: path}
+	s := model.Session{Harness: "antigravity", ID: id, Project: antigravityProject(id), Path: path}
 	err := scanJSONLFromOffset(path, 0, func(m map[string]any) {
 		role := ""
 		source, _ := m["source"].(string)
@@ -87,6 +88,14 @@ func ParseAntigravityFile(path string) ([]model.Session, error) {
 			t = s.Started
 		}
 		s.Touch(t)
+		// A step's kind decides what it is, not its source. Antigravity puts
+		// prose and tool transcripts in the same MODEL stream, and reading
+		// only the source made shell dumps into assistant speech: 333 of 369
+		// MODEL rows on this machine, 90%, ranked as things the agent said.
+		if role == "assistant" {
+			s.Messages = append(s.Messages, antigravityStep(str(m["type"]), text, t)...)
+			return
+		}
 		s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: t})
 	})
 	if len(s.Messages) == 0 {
@@ -106,4 +115,117 @@ func cleanAntigravityUserContent(text string) string {
 	text = antigravityRequestOpenRE.ReplaceAllString(text, "")
 	text = antigravityRequestCloseRE.ReplaceAllString(text, "")
 	return strings.TrimSpace(text)
+}
+
+// antigravityStep turns one MODEL step into the records it actually is.
+//
+// Only PLANNER_RESPONSE is the agent talking — 36 of 369 rows here. The rest
+// are tool transcripts, and they carry the work in a readable header: a
+// RUN_COMMAND names its command on a "Task Description:" line, VIEW_FILE and
+// CODE_ACTION name their file. So the same change that stops shell output
+// being ranked as speech also gives antigravity the file and command records
+// the four supported harnesses have.
+func antigravityStep(kind, text string, t time.Time) []model.Message {
+	if kind == "PLANNER_RESPONSE" || kind == "" {
+		return []model.Message{{Role: "assistant", Text: text, Time: t}}
+	}
+	var out []model.Message
+	switch kind {
+	case "RUN_COMMAND", "GENERIC":
+		if cmd := antigravityField(text, "Task Description:"); cmd != "" && IndexCommands() && worthIndexing(cmd) {
+			out = append(out, model.Message{Role: RoleCommand, Text: "$ " + cmd, Time: t})
+		}
+	case "VIEW_FILE", "CODE_ACTION", "LIST_DIRECTORY":
+		if p := antigravityPath(text); p != "" && IndexToolPaths() {
+			out = append(out, model.Message{Role: RoleFiles, Text: p, Time: t})
+		}
+	}
+	if IndexToolOutput() {
+		if body := antigravityBody(text); body != "" {
+			out = append(out, model.Message{Role: RoleToolOutput, Text: body, Time: t})
+		}
+	}
+	return out
+}
+
+// antigravityField reads a labelled line out of a step's header.
+func antigravityField(text, label string) string {
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if v, ok := strings.CutPrefix(line, label); ok {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+// antigravityPath pulls the file a step names, as a plain path: the transcript
+// writes them as file:// URIs, sometimes in backticks.
+func antigravityPath(text string) string {
+	for _, label := range []string{"File Path:", "Created file", "Edited file", "Modified file"} {
+		v := antigravityField(text, label)
+		if v == "" {
+			continue
+		}
+		v = strings.Trim(v, "`")
+		if i := strings.Index(v, " "); i > 0 && strings.HasPrefix(v, "file://") {
+			v = v[:i]
+		}
+		if p, ok := strings.CutPrefix(v, "file://"); ok {
+			return strings.Trim(p, "`")
+		}
+	}
+	return ""
+}
+
+// antigravityBody drops the timestamps every step opens with. Keeping them
+// leaves records whose whole content is "Created At: … Completed At: …".
+func antigravityBody(text string) string {
+	lines := strings.Split(text, "\n")
+	cut := 0
+	for cut < len(lines) {
+		l := strings.TrimSpace(lines[cut])
+		if l == "" || strings.HasPrefix(l, "Created At:") || strings.HasPrefix(l, "Completed At:") {
+			cut++
+			continue
+		}
+		break
+	}
+	return strings.TrimSpace(strings.Join(lines[cut:], "\n"))
+}
+
+// antigravityProject resolves a conversation to the workspace it belongs to.
+//
+// The parser hardcoded "-" for every session, so antigravity was unreachable
+// from any `--project` query — and the workspace was sitting in plain JSON in
+// a directory deja already walks, no protobuf involved.
+func antigravityProject(id string) string {
+	for _, root := range AntigravityRoots() {
+		p := filepath.Join(root, "cache", "conversation_metadata.json")
+		b, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		var doc struct {
+			Conversations map[string]struct {
+				Summary struct {
+					WorkspaceURIs []string `json:"WorkspaceURIs"`
+				} `json:"summary"`
+			} `json:"conversations"`
+		}
+		if json.Unmarshal(b, &doc) != nil {
+			continue
+		}
+		for key, c := range doc.Conversations {
+			if !strings.HasPrefix(key, id) && !strings.HasPrefix(id, key) {
+				continue
+			}
+			for _, uri := range c.Summary.WorkspaceURIs {
+				if w, ok := strings.CutPrefix(uri, "file://"); ok && w != "" {
+					return projectName(w)
+				}
+			}
+		}
+	}
+	return "-"
 }

--- a/internal/sources/antigravity_test.go
+++ b/internal/sources/antigravity_test.go
@@ -94,3 +94,116 @@ func TestAntigravityRootsGlob(t *testing.T) {
 		t.Fatalf("roots = %v, want %s", roots, want)
 	}
 }
+
+// Antigravity puts prose and tool transcripts in the same MODEL stream, and
+// reading only the source made shell dumps into assistant speech — 333 of 369
+// rows on a real store, 90%, ranked as things the agent said. The step's kind
+// is what separates them, and the same header that identifies a tool step
+// carries the work: a command on "Task Description:", a file on "File Path:".
+func TestAntigravityStepSeparatesProseFromTools(t *testing.T) {
+	dir := t.TempDir()
+	logs := filepath.Join(dir, "brain", "conv-1", ".system_generated", "logs")
+	if err := os.MkdirAll(logs, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The workspace the session belongs to, which the parser used to ignore.
+	cache := filepath.Join(dir, "cache")
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "conversation_metadata.json"),
+		[]byte(`{"conversations":{"conv-1":{"summary":{"WorkspaceURIs":["file:///Users/me/coding/api-gateway"]}}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_ANTIGRAVITY_ROOT", dir)
+	rows := []string{
+		`{"source":"USER_EXPLICIT","type":"USER_REQUEST","created_at":"2026-07-20T10:00:00Z","content":"<USER_REQUEST>\nfix the retry loop\n</USER_REQUEST>"}`,
+		`{"source":"MODEL","type":"PLANNER_RESPONSE","created_at":"2026-07-20T10:01:00Z","content":"I will start by reading the file."}`,
+		`{"source":"MODEL","type":"RUN_COMMAND","created_at":"2026-07-20T10:02:00Z","content":"Created At: 2026-07-20T10:02:00Z\nTask Description: go test ./...\nOutput:\nFAIL\tgithub.com/x/y"}`,
+		`{"source":"MODEL","type":"VIEW_FILE","created_at":"2026-07-20T10:03:00Z","content":"Created At: 2026-07-20T10:03:00Z\nCompleted At: 2026-07-20T10:03:01Z\nFile Path: ` + "`" + `file:///w/app/retry.go` + "`" + `\nTotal Lines: 40"}`,
+		`{"source":"MODEL","type":"GREP_SEARCH","created_at":"2026-07-20T10:04:00Z","content":"Created At: 2026-07-20T10:04:00Z\nCompleted At: 2026-07-20T10:04:00Z"}`,
+	}
+	p := filepath.Join(logs, "transcript.jsonl")
+	if err := os.WriteFile(p, []byte(strings.Join(rows, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseAntigravityFile(p)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("%v %#v", err, ss)
+	}
+	// Reachable by project: every session used to report "-".
+	if ss[0].Project != "api-gateway" {
+		t.Errorf("project = %q, want the workspace from the metadata", ss[0].Project)
+	}
+	byRole := map[string][]string{}
+	for _, m := range ss[0].Messages {
+		byRole[m.Role] = append(byRole[m.Role], m.Text)
+	}
+	// Prose is the only thing that counts as speech.
+	if len(byRole["assistant"]) != 1 || !strings.Contains(byRole["assistant"][0], "reading the file") {
+		t.Errorf("assistant = %q, want only the planner prose", byRole["assistant"])
+	}
+	for _, blob := range byRole["assistant"] {
+		if strings.Contains(blob, "Task Description") || strings.Contains(blob, "File Path") {
+			t.Errorf("a tool transcript is still speech: %q", blob)
+		}
+	}
+	if len(byRole[RoleCommand]) != 1 || byRole[RoleCommand][0] != "$ go test ./..." {
+		t.Errorf("commands = %q", byRole[RoleCommand])
+	}
+	if len(byRole[RoleFiles]) != 1 || byRole[RoleFiles][0] != "/w/app/retry.go" {
+		t.Errorf("files = %q, want the plain path without the file:// scheme or backticks", byRole[RoleFiles])
+	}
+	// A step whose whole body is its own timestamps has nothing to index.
+	for _, out := range byRole[RoleToolOutput] {
+		if strings.HasPrefix(out, "Created At:") || out == "" {
+			t.Errorf("indexed a step with no content but its header: %q", out)
+		}
+	}
+}
+
+func TestAntigravityBodyDropsTheHeader(t *testing.T) {
+	got := antigravityBody("Created At: 2026-07-20T10:02:00Z\nCompleted At: 2026-07-20T10:02:01Z\nthe real output")
+	if got != "the real output" {
+		t.Fatalf("got %q", got)
+	}
+	if got := antigravityBody("Created At: x\nCompleted At: y"); got != "" {
+		t.Fatalf("a header-only step should strip to empty, got %q", got)
+	}
+}
+
+func TestAntigravityPathForms(t *testing.T) {
+	for in, want := range map[string]string{
+		"File Path: `file:///w/a.go`":              "/w/a.go",
+		"File Path: file:///w/b.go":                "/w/b.go",
+		"Created file file:///w/c.md with content": "/w/c.md",
+		"File Path: not-a-uri":                     "",
+	} {
+		if got := antigravityPath(in); got != want {
+			t.Errorf("antigravityPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// Every antigravity session reported project "-", so the harness was
+// unreachable from any --project query — while the workspace sat in plain
+// JSON in a directory deja already walks.
+func TestAntigravityProjectComesFromTheMetadata(t *testing.T) {
+	root := t.TempDir()
+	cache := filepath.Join(root, "cache")
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"conversations":{"conv-1-abc":{"summary":{"WorkspaceURIs":["file:///Users/me/coding/api-gateway"]}}}}`
+	if err := os.WriteFile(filepath.Join(cache, "conversation_metadata.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_ANTIGRAVITY_ROOT", root)
+	if got := antigravityProject("conv-1-abc"); got != "api-gateway" {
+		t.Fatalf("project = %q, want the workspace from the metadata", got)
+	}
+	// A conversation the metadata does not know still has to parse.
+	if got := antigravityProject("never-seen"); got != "-" {
+		t.Fatalf("unknown conversation = %q, want the placeholder", got)
+	}
+}


### PR DESCRIPTION
From the harness-by-harness audit. Three defects, one large.

**1. 90% of antigravity "assistant" messages were shell and file dumps.** The parser switched on `source` (MODEL → assistant) and ignored the `type` that separates prose from tool steps:

```
PLANNER_RESPONSE   36   prose        ← the only speech
RUN_COMMAND       130   tool dump
CODE_ACTION        81   tool dump
VIEW_FILE          63   tool dump
GENERIC            36   tool dump    ← not prose, despite the name
… 333 of 369 rows, 90%
```

`deja "The command completed successfully" --harness antigravity` returned sessions with 169 and 176 matches — command output ranked as things the agent said, competing with real answers on every query.

Now each step becomes what it is. And the header that identifies a tool step carries the work, so the same change gives antigravity the file and command records only four harnesses had:

```
$ deja "venv activate requirements" --harness antigravity --role command
  $ python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt
```

26 commands and the file paths, from `Task Description:` and `File Path:` lines. Steps whose entire body is `Created At: … Completed At: …` are dropped rather than stored as content.

**2. Every antigravity session reported project `-`.** So the harness was unreachable from any `--project` query — while the workspace sat in plain JSON in `conversation_metadata.json`, inside a directory `AntigravityRoots()` already walks. No protobuf needed. All 8 sessions now resolve.

**3. `--harness notes` matched nothing.** Notes are stored as harness `deja` and narrated during indexing as `notes`, so `deja index` printed "notes: 5 sessions" and `deja last --harness notes` answered "no sessions match" and exited 0. A filter that rejects the name the tool just printed is the worst kind of miss — silent, with a success code.

Three mutations, each fails the suite.

Credit where due: 1 and 2 came from an audit agent working through the thin-parser harnesses; it also confirmed goose, pi, openclaw and notes parse exactly against their raw stores, and that ids are stable across independent index builds for all six.