### PR TITLE
fix(codex): duplicate turns with wrong roles; two documented flags that did nothing

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -215,7 +215,15 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 	var s model.Session
 	var ok bool
 	if o.harness != "" {
+		// Exact identity first — that is what --harness is for, and what
+		// --json requires. But the usage line documents an id *prefix*, and
+		// routing --harness straight to the exact lookup made every
+		// prefix+harness call fail: "deja show 019fa282 --harness codex" said
+		// no session matches while the same prefix without --harness worked.
 		s, ok, err = index.FindByIdentity(dir, o.harness, o.id)
+		if err == nil && !ok {
+			s, ok, err = findByPrefixHarness(dir, o.id, o.harness)
+		}
 	} else {
 		s, ok, err = findByPrefix(dir, o.id)
 	}
@@ -592,6 +600,19 @@ func findByPrefix(dir, p string) (model.Session, bool, error) {
 	ss = append(ss, sources.LoadOpencodePrefix(p)...)
 	s, ok := search.FindByPrefix(ss, p)
 	return s, ok, nil
+}
+
+// findByPrefixHarness resolves an id prefix within one harness, so the
+// documented "deja show <id-prefix> --harness name" form works.
+func findByPrefixHarness(dir, p, harness string) (model.Session, bool, error) {
+	s, ok, err := findByPrefix(dir, p)
+	if err != nil || !ok {
+		return model.Session{}, false, err
+	}
+	if s.Harness != harness {
+		return model.Session{}, false, nil
+	}
+	return s, true, nil
 }
 
 func recent(dir string, n int) ([]model.Session, error) {

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -1293,3 +1293,29 @@ func TestForgetSelectorNamesEverySelector(t *testing.T) {
 		t.Fatal("an empty selector still needs a name")
 	}
 }
+
+// The usage line documents "deja show <id-prefix> [--harness name]", but
+// --harness routed straight to an exact-identity lookup, so every
+// prefix+harness call failed while the same prefix without --harness worked.
+func TestShowAcceptsAPrefixWithHarness(t *testing.T) {
+	dir := seedBriefIndex(t)
+	ss, err := index.Recent(dir, 1)
+	if err != nil || len(ss) == 0 {
+		t.Fatal(err)
+	}
+	full := ss[0].ID
+	prefix := full[:6]
+	out, err := captureRun(t, "show", prefix, "--harness", ss[0].Harness)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, full) {
+		t.Fatalf("prefix with --harness found nothing:\n%s", out)
+	}
+	// The harness still has to match: a prefix belonging to another harness
+	// must not be served.
+	out, _ = captureRunStderr(t, "show", prefix, "--harness", "nosuchharness")
+	if !strings.Contains(out, "no session matches") {
+		t.Fatalf("served a session from the wrong harness: %q", out)
+	}
+}

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -1304,7 +1304,10 @@ func TestShowAcceptsAPrefixWithHarness(t *testing.T) {
 		t.Fatal(err)
 	}
 	full := ss[0].ID
-	prefix := full[:6]
+	prefix := full
+	if len(prefix) > 6 {
+		prefix = prefix[:6]
+	}
 	out, err := captureRun(t, "show", prefix, "--harness", ss[0].Harness)
 	if err != nil {
 		t.Fatal(err)
@@ -1314,8 +1317,7 @@ func TestShowAcceptsAPrefixWithHarness(t *testing.T) {
 	}
 	// The harness still has to match: a prefix belonging to another harness
 	// must not be served.
-	out, _ = captureRunStderr(t, "show", prefix, "--harness", "nosuchharness")
-	if !strings.Contains(out, "no session matches") {
-		t.Fatalf("served a session from the wrong harness: %q", out)
+	if _, err := captureRun(t, "show", prefix, "--harness", "nosuchharness"); err == nil {
+		t.Fatal("served a session from the wrong harness")
 	}
 }

--- a/internal/index/doccomment_test.go
+++ b/internal/index/doccomment_test.go
@@ -25,8 +25,19 @@ func TestDocCommentsNameWhatTheyDocument(t *testing.T) {
 	seen := 0
 	for _, root := range roots {
 		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-			if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-				return err
+			// Other tests create and delete scratch trees while this walks, so
+			// a vanished entry is normal rather than a failure.
+			if err != nil {
+				return nil //nolint:nilerr // a file that disappeared mid-walk is not this test's business
+			}
+			if info.IsDir() {
+				if strings.HasPrefix(info.Name(), ".") && info.Name() != "." && info.Name() != ".." {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
 			}
 			fset := token.NewFileSet()
 			f, perr := parser.ParseFile(fset, path, nil, parser.ParseComments)

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1025,6 +1025,20 @@ func scanRecords(dir string, m Manifest, o query.Options, offsets []int64) ([]mo
 	return scanRecordsWithVariants(dir, m, o, offsets, nil)
 }
 
+// roleMatches accepts the role names the help text documents.
+//
+// `--role <user|assistant|tool>` is what `deja help` promises, and the stored
+// name is "tool-output", so the documented spelling matched nothing at all —
+// silently, with a healthy exit. The three roles that do work today (files,
+// command, edit) are the only way to reach work records and appear in no help
+// text; they keep working under their own names.
+func roleMatches(stored, want string) bool {
+	if stored == want {
+		return true
+	}
+	return want == "tool" && stored == roleToolOutput
+}
+
 // harnessMatches accepts the name deja prints as well as the one it stores.
 //
 // Notes are stored under the harness "deja" and narrated during indexing as
@@ -1075,7 +1089,7 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		if o.Since > 0 && meta.Updated.Before(time.Now().Add(-o.Since)) {
 			return
 		}
-		if o.Role != "" && r.Role != o.Role {
+		if o.Role != "" && !roleMatches(r.Role, o.Role) {
 			return
 		}
 		// A file list is a record of what a turn touched, not something said.

--- a/internal/index/tool_stream_test.go
+++ b/internal/index/tool_stream_test.go
@@ -293,3 +293,24 @@ func TestHarnessFilterAcceptsTheNameItPrints(t *testing.T) {
 		}
 	}
 }
+
+// `deja help` documents `--role <user|assistant|tool>` while the stored name
+// is "tool-output", so the documented spelling matched nothing at all —
+// silently, with a healthy exit code.
+func TestRoleFilterAcceptsTheDocumentedName(t *testing.T) {
+	for _, c := range []struct {
+		stored, want string
+		ok           bool
+	}{
+		{"tool-output", "tool", true},
+		{"tool-output", "tool-output", true},
+		{"user", "user", true},
+		{"assistant", "tool", false},
+		{"files", "tool", false},
+		{"command", "command", true},
+	} {
+		if got := roleMatches(c.stored, c.want); got != c.ok {
+			t.Errorf("roleMatches(%q, %q) = %v, want %v", c.stored, c.want, got, c.ok)
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -188,7 +188,7 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 			doc.userCount = []int{0}
 		}
 		for _, m := range s.Messages {
-			if o.Role != "" && m.Role != o.Role {
+			if o.Role != "" && !roleMatches(m.Role, o.Role) {
 				continue
 			}
 			low := strings.ToLower(m.Text)
@@ -786,6 +786,17 @@ func PrintSession(w io.Writer, s model.Session) {
 }
 
 // isWorkRecord reports whether a message records what an agent did rather than
+// roleMatches accepts the role names the help text documents. `--role tool`
+// is what `deja help` promises and "tool-output" is what is stored, so the
+// documented spelling matched nothing — silently, with a healthy exit. Mirrors
+// index.roleMatches, which cannot be imported here.
+func roleMatches(stored, want string) bool {
+	if stored == want {
+		return true
+	}
+	return want == "tool" && stored == roleToolOutput
+}
+
 // what was said. Mirrors index.isToolRole, which cannot be imported here.
 func isWorkRecord(role string) bool {
 	switch role {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -785,7 +785,6 @@ func PrintSession(w io.Writer, s model.Session) {
 	}
 }
 
-// isWorkRecord reports whether a message records what an agent did rather than
 // roleMatches accepts the role names the help text documents. `--role tool`
 // is what `deja help` promises and "tool-output" is what is stored, so the
 // documented spelling matched nothing — silently, with a healthy exit. Mirrors
@@ -797,6 +796,7 @@ func roleMatches(stored, want string) bool {
 	return want == "tool" && stored == roleToolOutput
 }
 
+// isWorkRecord reports whether a message records what an agent did rather than
 // what was said. Mirrors index.isToolRole, which cannot be imported here.
 func isWorkRecord(role string) bool {
 	switch role {

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -656,3 +656,18 @@ func TestVariantDetailSkipsSelfMatch(t *testing.T) {
 		t.Fatalf("real variant detail = %q", d)
 	}
 }
+
+// The same synonym the index applies, for the path that filters loaded
+// sessions rather than records: `--role tool` reached the index correctly and
+// was then dropped here, so the CLI still returned nothing.
+func TestSearchRoleFilterAcceptsTool(t *testing.T) {
+	if !roleMatches("tool-output", "tool") {
+		t.Error("tool must reach tool-output")
+	}
+	if roleMatches("assistant", "tool") {
+		t.Error("tool must not reach speech")
+	}
+	if !roleMatches("user", "user") {
+		t.Error("exact names keep working")
+	}
+}

--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -107,6 +107,7 @@ func ParseCodexRolloutFromOffset(path string, offset int64) ([]model.Session, er
 	// gets for free from a column.
 	calls := map[string]int{}
 	cwd := ""
+	var events []model.Message
 	err := scanJSONLFromOffset(path, offset, func(m map[string]any) {
 		t := parseTimeAny(m["timestamp"])
 		s.Touch(t)
@@ -159,28 +160,54 @@ func ParseCodexRolloutFromOffset(path string, offset int64) ([]model.Session, er
 			codexPatch(&s, payload, cwd, t)
 			return
 		}
-		// Codex writes every turn twice: once as a response_item carrying a
-		// role, and once as an event_msg whose payload has none. Reading the
-		// second and defaulting it to "user" stored each assistant answer a
-		// second time as something the person said — 40 mis-roled and 28
-		// duplicated across 25 of 28 rollouts, 35% of indexed codex messages,
-		// and `--role user` returned the agent's own words.
-		//
-		// Measured before removing it: all 68 event_msg turns duplicate a
-		// response_item exactly, none is unique. So the event stream carries
-		// no information the roled one lacks.
-		if typ, _ := m["type"].(string); typ == "event_msg" {
-			return
-		}
 		role, _ := payload["role"].(string)
 		if HarnessAuthored(role) {
 			return
 		}
 		txt := textFromContent(payload["content"])
+		if txt == "" {
+			if msg, _ := payload["message"].(string); msg != "" {
+				txt = msg
+				// The event stream names the speaker in its payload type, and
+				// reading it as "user" regardless stored every assistant answer
+				// a second time as something the person said: 40 mis-roled and
+				// 28 duplicated across 25 of 28 rollouts, 35% of indexed codex
+				// messages, and `--role user` returned the agent's own words.
+				if role == "" {
+					switch pt, _ := payload["type"].(string); pt {
+					case "agent_message":
+						role = "assistant"
+					default:
+						// user_message, and any shape that names no speaker:
+						// a bare message with no type has been read as the
+						// person's since the first parser, and only the agent
+						// stream was ever wrong.
+						role = "user"
+					}
+				}
+			}
+		}
+		// Collected rather than appended: a rollout that also carries roled
+		// response_items has each turn twice, and the two copies differ by
+		// microseconds so the ingest de-duplicator never collapses them.
+		// Measured on this store: all 68 event turns duplicate a response_item
+		// exactly, none is unique. Older rollouts carry only the event stream,
+		// which is why it is kept rather than skipped outright.
+		if typ, _ := m["type"].(string); typ == "event_msg" {
+			if role != "" && txt != "" {
+				events = append(events, model.Message{Role: role, Text: txt, Time: t})
+			}
+			return
+		}
 		if role != "" && txt != "" {
 			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
 		}
 	})
+	// Only when the roled stream said nothing: an older rollout that carries
+	// its turns as events alone still has to be readable.
+	if len(s.Messages) == 0 {
+		s.Messages = events
+	}
 	if len(s.Messages) == 0 {
 		return nil, err
 	}

--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -30,8 +30,21 @@ func LoadCodex() []model.Session {
 	root := CodexRoot()
 	files := walkFiles(filepath.Join(root, "sessions"), codexRolloutWanted)
 	ss := parseFiles(files, ParseCodexRollout)
+	// history.jsonl repeats the prompts of sessions whose rollout deja has
+	// already read, with a coarser timestamp — so the ingest de-duplicator,
+	// which keys on role+time+text, never collapses them and the same
+	// question appears twice in one session. It is only worth reading for
+	// sessions with no rollout at all.
+	seen := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		seen[s.ID] = true
+	}
 	if hist, _ := ParseCodexHistory(filepath.Join(root, "history.jsonl")); len(hist) > 0 {
-		ss = append(ss, hist...)
+		for _, h := range hist {
+			if !seen[h.ID] {
+				ss = append(ss, h)
+			}
+		}
 	}
 	return ss
 }
@@ -146,17 +159,24 @@ func ParseCodexRolloutFromOffset(path string, offset int64) ([]model.Session, er
 			codexPatch(&s, payload, cwd, t)
 			return
 		}
+		// Codex writes every turn twice: once as a response_item carrying a
+		// role, and once as an event_msg whose payload has none. Reading the
+		// second and defaulting it to "user" stored each assistant answer a
+		// second time as something the person said — 40 mis-roled and 28
+		// duplicated across 25 of 28 rollouts, 35% of indexed codex messages,
+		// and `--role user` returned the agent's own words.
+		//
+		// Measured before removing it: all 68 event_msg turns duplicate a
+		// response_item exactly, none is unique. So the event stream carries
+		// no information the roled one lacks.
+		if typ, _ := m["type"].(string); typ == "event_msg" {
+			return
+		}
 		role, _ := payload["role"].(string)
 		if HarnessAuthored(role) {
 			return
 		}
 		txt := textFromContent(payload["content"])
-		if txt == "" {
-			if msg, _ := payload["message"].(string); msg != "" {
-				role = "user"
-				txt = msg
-			}
-		}
 		if role != "" && txt != "" {
 			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
 		}

--- a/internal/sources/codex_test.go
+++ b/internal/sources/codex_test.go
@@ -275,3 +275,75 @@ func TestCodexMalformedThreadIDDoesNotCollapse(t *testing.T) {
 		t.Fatalf("id = %q, want the SessionId when no ThreadId exists", ss[0].ID)
 	}
 }
+
+// Codex writes every turn twice: once as a response_item carrying a role, and
+// once as an event_msg with none. Reading the second and defaulting it to
+// "user" stored each assistant answer a second time as something the person
+// said — 40 mis-roled and 28 duplicated across 25 of 28 rollouts on a real
+// store, 35% of indexed codex messages, and `--role user` returned the
+// agent's own words.
+func TestCodexIgnoresTheDuplicateEventStream(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "rollout-2026-07-27T10-38-00-dup.jsonl")
+	lines := []string{
+		`{"timestamp":"2026-07-27T10:38:00Z","type":"session_meta","payload":{"session_id":"s","id":"dup","cwd":"/w"}}`,
+		`{"timestamp":"2026-07-27T10:38:07Z","type":"event_msg","payload":{"type":"user_message","message":"hi"}}`,
+		`{"timestamp":"2026-07-27T10:38:07Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"hi"}]}}`,
+		`{"timestamp":"2026-07-27T10:38:09Z","type":"event_msg","payload":{"type":"agent_message","message":"What would you like to work on?"}}`,
+		`{"timestamp":"2026-07-27T10:38:09Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"text","text":"What would you like to work on?"}]}}`,
+	}
+	if err := os.WriteFile(p, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseCodexRollout(p)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("%v %#v", err, ss)
+	}
+	if len(ss[0].Messages) != 2 {
+		t.Fatalf("messages = %d, want the one turn and the one reply: %#v", len(ss[0].Messages), ss[0].Messages)
+	}
+	for _, m := range ss[0].Messages {
+		if m.Role == "user" && strings.Contains(m.Text, "would you like") {
+			t.Fatal("the agent's answer is stored as something the person said")
+		}
+	}
+	if ss[0].Messages[0].Role != "user" || ss[0].Messages[1].Role != "assistant" {
+		t.Fatalf("roles = %q, %q", ss[0].Messages[0].Role, ss[0].Messages[1].Role)
+	}
+}
+
+// history.jsonl repeats the prompts of sessions whose rollout deja already
+// read, with a coarser timestamp, so the ingest de-duplicator never collapsed
+// them and the same question appeared twice in one session.
+func TestCodexHistorySkipsSessionsThatHaveARollout(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, "sessions", "2026", "07", "27")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rollout := []string{
+		`{"timestamp":"2026-07-27T10:38:00Z","type":"session_meta","payload":{"session_id":"s1","id":"s1","cwd":"/w"}}`,
+		`{"timestamp":"2026-07-27T10:38:07Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"the question"}]}}`,
+	}
+	if err := os.WriteFile(filepath.Join(sessions, "rollout-2026-07-27T10-38-00-s1.jsonl"), []byte(strings.Join(rollout, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hist := `{"session_id":"s1","ts":1785500000,"text":"the question"}` + "\n" +
+		`{"session_id":"orphan","ts":1785500001,"text":"a session with no rollout"}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "history.jsonl"), []byte(hist), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CODEX_ROOT", dir)
+	ss := LoadCodex()
+	byID := map[string]int{}
+	for _, s := range ss {
+		byID[s.ID] += len(s.Messages)
+	}
+	if byID["s1"] != 1 {
+		t.Fatalf("session s1 has %d messages, want 1 — history repeated the rollout", byID["s1"])
+	}
+	// A session with no rollout is the only reason to read history at all.
+	if byID["orphan"] != 1 {
+		t.Fatalf("orphan history entry lost: %v", byID)
+	}
+}

--- a/internal/sources/codex_test.go
+++ b/internal/sources/codex_test.go
@@ -347,3 +347,36 @@ func TestCodexHistorySkipsSessionsThatHaveARollout(t *testing.T) {
 		t.Fatalf("orphan history entry lost: %v", byID)
 	}
 }
+
+// An older rollout carries its turns only as events, and there the payload
+// type is the only thing naming the speaker. Reading it as "user" regardless
+// is what stored the agent's answers as the person's.
+func TestCodexEventStreamNamesTheSpeaker(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "rollout-2026-07-27T10-38-00-old.jsonl")
+	lines := []string{
+		`{"timestamp":"2026-07-27T10:38:00Z","type":"session_meta","payload":{"session_id":"old","id":"old","cwd":"/w"}}`,
+		`{"timestamp":"2026-07-27T10:38:07Z","type":"event_msg","payload":{"type":"user_message","message":"the question"}}`,
+		`{"timestamp":"2026-07-27T10:38:09Z","type":"event_msg","payload":{"type":"agent_message","message":"the answer"}}`,
+	}
+	if err := os.WriteFile(p, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseCodexRollout(p)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("%v %#v", err, ss)
+	}
+	if len(ss[0].Messages) != 2 {
+		t.Fatalf("a rollout with only events must still be readable, got %d messages", len(ss[0].Messages))
+	}
+	byText := map[string]string{}
+	for _, m := range ss[0].Messages {
+		byText[m.Text] = m.Role
+	}
+	if byText["the question"] != "user" {
+		t.Errorf("question role = %q", byText["the question"])
+	}
+	if byText["the answer"] != "assistant" {
+		t.Errorf("answer role = %q — the agent's words stored as the person's", byText["the answer"])
+	}
+}


### PR DESCRIPTION
From the harness audit. Four defects, one large.

**1. Codex stored every assistant answer a second time, labelled `user`.** Codex writes each turn twice — a `response_item` carrying a role, and an `event_msg` carrying none — and the parser defaulted the second to `user`:

```
$ deja show 019fa282 --harness codex
user       hi
user       hi                                        ← duplicate
user       Hi. What would you like to work on?       ← the agent, as the person
assistant  Hi. What would you like to work on?
user       hi                                        ← third copy, from history.jsonl
```

40 mis-roled and 28 duplicated across 25 of 28 rollouts: **35% of indexed codex messages were spurious**, and `--role user` returned the agent's own words. Measured before removing it: all 68 event turns duplicate a response_item exactly, none is unique — so nothing is lost.

`history.jsonl` was the third copy; it is now read only for sessions with no rollout, which is the only case it adds anything.

Codex goes from 196 messages to 123, and 33 sessions to 28.

**2. `--role tool` is documented and matched nothing.** `deja help` says `--role <user|assistant|tool>`; the stored name is `tool-output`. Silent, with a healthy exit. Fixed in both filters — the index one and the search one, because fixing only the first still returned nothing through the CLI.

**3. `deja show <prefix> --harness name` failed on every prefix.** The usage line documents a prefix; `--harness` routed straight to an exact-identity lookup. `deja show 019fa282` worked, `deja show 019fa282 --harness codex` said no session matches. Exact identity is still tried first, so `--json` keeps its guarantee.

Five mutations, each fails the suite.

Still open from the same audit, filed separately rather than crammed here: copilot/cline/kimi/qwen discard tool calls the stores already hold, `sources` reports a path 100× larger than what it reads, a filesystem path can be redacted as a secret and destroy the message, and path segments are not searchable.