### PR TITLE
fix(redact): a secret quoted in prose survived into the index

### DIFF
--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -32,9 +32,20 @@ var (
 	// x-api-key) and, in JSON, a closing quote can sit between the key and the
 	// delimiter ("api_key": "..."). Tolerate both so env-var and JSON forms are
 	// caught, not just a bare `api_key=`.
-	genericKVRE  = regexp.MustCompile(`(?i)\b([\w.-]{0,64}?(?:api[_-]?key|secret|token|passwd|password|authorization))(\s*['"]?\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=._-]{16,})(['"]?)`)
-	bearerRE     = regexp.MustCompile(`(?i)\b(Bearer|Basic)(\s+)([A-Za-z0-9._~+/=-]{16,})`)
-	pemPrivateRE = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----.*?-----END [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----`)
+	genericKVRE = regexp.MustCompile(`(?i)\b([\w.-]{0,64}?(?:api[_-]?key|secret|token|passwd|password|authorization))(\s*['"]?\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=._-]{16,})(['"]?)`)
+	bearerRE    = regexp.MustCompile(`(?i)\b(Bearer|Basic)(\s+)([A-Za-z0-9._~+/=-]{16,})`)
+	// A secret named in prose and quoted rather than assigned. Tool output is
+	// full of this shape — `password authentication failed for user "admin"
+	// with password "S3cr3tP@ssw0rd!"` — and genericKVRE cannot reach it:
+	// there is no `=` or `:`, the value carries punctuation its class excludes,
+	// and at 15 characters it is under the 16-char floor. Measured: five of six
+	// planted secret forms were redacted at ingest and this one sat in
+	// records.bin in the clear, visible through `deja show`.
+	//
+	// The quotes are what make it safe to be this loose: "password
+	// authentication failed" has no quoted value and matches nothing.
+	quotedSecretRE = regexp.MustCompile(`(?i)\b(password|passwd|pwd|secret|token|api[_-]?key)(\s+(?:is\s+|was\s+|for\s+)?)(["'` + "`" + `])([^"'` + "`" + `\n]{6,80})(["'` + "`" + `])`)
+	pemPrivateRE   = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----.*?-----END [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----`)
 	// Provider prefixes. sk- allows internal hyphens/underscores so modern
 	// hyphenated formats (sk-ant-…, sk-proj-…) are covered, not just legacy
 	// sk-<alnum> keys. xai- stays alphanumeric-only: real xAI keys have no
@@ -139,6 +150,14 @@ func Text(s string) (string, Counts) {
 	}
 	if strings.Contains(s, "AKIA") || strings.Contains(s, "ASIA") {
 		s = replaceWhole(s, awsAccessKeyRE, "aws-access-key", counts)
+	}
+	if strings.Contains(lower, "password") || strings.Contains(lower, "passwd") ||
+		strings.Contains(lower, "pwd") || strings.Contains(lower, "secret") ||
+		strings.Contains(lower, "token") || strings.Contains(lower, "api key") ||
+		strings.Contains(lower, "api_key") || strings.Contains(lower, "apikey") {
+		s = replaceSubmatch(s, quotedSecretRE, "quoted-secret", counts, func(m []string) string {
+			return m[1] + m[2] + m[3] + "[redacted:quoted-secret]" + m[5]
+		})
 	}
 	if strings.Contains(lower, "bearer") || strings.Contains(lower, "basic ") {
 		s = replaceSubmatch(s, bearerRE, "bearer-token", counts, func(m []string) string {

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -224,3 +224,43 @@ func TestEntropySkipsAlreadyRedacted(t *testing.T) {
 		t.Fatalf("double redaction: %q %v", out, counts)
 	}
 }
+
+// A secret named in prose and quoted rather than assigned. Tool output is full
+// of this shape, and the key=value rule cannot reach it: no delimiter, value
+// punctuation outside its character class, and under its length floor.
+// Measured with six planted secret forms — five were redacted at ingest and
+// this one sat in records.bin in the clear, readable through `deja show`.
+func TestQuotedSecretsAreRedacted(t *testing.T) {
+	for _, c := range []struct{ in, gone string }{
+		{`password authentication failed for user "admin" with password "S3cr3tP@ssw0rd!"`, "S3cr3tP@ssw0rd!"},
+		{`the password is "hunter2secret"`, "hunter2secret"},
+		{`token 'ghp_abcdefghijklmno'`, "ghp_abcdefghijklmno"},
+		{"api_key `sk-abcdefghijklmnop`", "sk-abcdefghijklmnop"},
+	} {
+		got, _ := Text(c.in)
+		if strings.Contains(got, c.gone) {
+			t.Errorf("secret survived: %q -> %q", c.in, got)
+		}
+		if !strings.Contains(got, "[redacted:") {
+			t.Errorf("nothing was marked as removed: %q", got)
+		}
+	}
+}
+
+// The quotes are what make the rule safe to be loose about delimiters. Prose
+// that merely mentions a secret must survive intact — an over-eager redactor
+// destroys the message, which is its own failure (#653).
+func TestQuotedSecretRuleLeavesProseAlone(t *testing.T) {
+	for _, in := range []string{
+		`password authentication failed for user admin`,
+		`we discussed the password policy at length`,
+		`set a token in the config before running`,
+		`the secret is that there is no secret`,
+		`connection to server failed: FATAL: role "postgres" does not exist`,
+	} {
+		got, _ := Text(in)
+		if got != in {
+			t.Errorf("altered ordinary prose:\n  in  %q\n  out %q", in, got)
+		}
+	}
+}


### PR DESCRIPTION
From the audit section on privacy, checking all eight secret forms against every outgoing surface — including the three added today.

Planted six shapes in a session and looked at what reached the index:

```
aws access key   redacted
github token     redacted
JWT              redacted
url password     redacted
RSA private key  redacted
password in an error message   IN THE CLEAR
```

```
$ deja show sec1 --harness claude
psql: error: … password authentication failed for user "admin" with password "S3cr3tP@ssw0rd!"
```

`genericKVRE` could not reach it three ways over: no `=` or `:` delimiter, punctuation (`@`, `!`) outside its value class, and 15 characters against a 16-character floor. Tool output is full of this shape — a failure that quotes the credential it failed with.

The quotes are what make a looser rule safe. `password authentication failed for user admin` has no quoted value and matches nothing; so do "the password policy", "set a token in the config", and `role "postgres" does not exist` — where the quoted word follows `role`, not a secret name. There is a test for each, because an over-eager redactor destroys the message, which is its own failure (#653 is exactly that).

**Surface sweep, after the fix: 0 of 11 CLI surfaces and 0 of 6 agent surfaces leak.** The agent side was clean before as well — `recall`, `recall_context`, `blame`, the session-start injection, the environment block and the statusline memory line all came back clean, which matters because the last two are mine from today and read tool output and titles directly.

Mutation: removing the rule fails the suite.