### PR TITLE
fix: the environment block bypassed the policy table

### DIFF
--- a/cmd/deja/environment.go
+++ b/cmd/deja/environment.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"strings"
 	"sync"
 
@@ -28,11 +30,40 @@ const (
 
 // environmentBlock names what the machine keeps failing on, or "" when nothing
 // has failed in enough separate sessions to be worth an agent's attention.
-func environmentBlock(dir string) string {
+//
+// activation is the path asking. Every other recall route runs its results
+// through the policy table, and this one did not: a user who denied `mcp` still
+// received error text drawn from the sessions that denial had just hidden, plus
+// the harnesses and dates behind it (#659). The block reads the manifest
+// directly, so nothing upstream could have filtered it.
+func environmentBlock(dir, activation string) string {
+	// Origin is a property of the sessions the walls came from, so the gate has
+	// to be per wall rather than one check up front: a machine can hold both
+	// local and imported sessions hitting the same error.
+	pol := policy.Load()
 	walls := index.TopFriction(dir, environmentWalls)
 	if len(walls) == 0 {
 		return ""
 	}
+	var allowed []index.Friction
+	for _, w := range walls {
+		var keep []index.SessionMeta
+		for _, s := range w.Sessions {
+			if pol.Allows(activation, s.Project) {
+				keep = append(keep, s)
+			}
+		}
+		// The count is what the reader acts on, so a wall whose evidence is
+		// mostly hidden must not keep claiming the full number.
+		if len(keep) >= index.FrictionMinSessions {
+			w.Sessions = keep
+			allowed = append(allowed, w)
+		}
+	}
+	if len(allowed) == 0 {
+		return ""
+	}
+	walls = allowed
 	var b strings.Builder
 	b.WriteString("This machine, from deja's index of past sessions across every agent used here:\n")
 	for _, w := range walls {
@@ -63,7 +94,7 @@ var environmentServed sync.Once
 func environmentOnce(dir string) string {
 	out := ""
 	environmentServed.Do(func() {
-		if env := environmentBlock(dir); env != "" {
+		if env := environmentBlock(dir, policy.ActivationMCP); env != "" {
 			out = "\n\n" + env
 		}
 	})

--- a/cmd/deja/environment_test.go
+++ b/cmd/deja/environment_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
 )
 
 // seedWalls lays down n sessions that each hit the same two errors.
@@ -42,7 +43,7 @@ func seedWalls(t *testing.T, n int) string {
 
 func TestEnvironmentBlockNamesWallsAndWhatToDo(t *testing.T) {
 	dir := seedWalls(t, index.FrictionMinSessions)
-	got := environmentBlock(dir)
+	got := environmentBlock(dir, policy.ActivationAuto)
 	for _, want := range []string{
 		"command not found: shellcheck",
 		"No module named 'yaml'",
@@ -67,7 +68,7 @@ func TestEnvironmentBlockNamesWallsAndWhatToDo(t *testing.T) {
 // explicit that a noisy warning gets the feature turned off.
 func TestEnvironmentBlockSilentBelowThreshold(t *testing.T) {
 	dir := seedWalls(t, index.FrictionMinSessions-1)
-	if got := environmentBlock(dir); got != "" {
+	if got := environmentBlock(dir, policy.ActivationAuto); got != "" {
 		t.Fatalf("want silence, got:\n%s", got)
 	}
 }
@@ -115,5 +116,42 @@ func TestEnvironmentServedOncePerMCPSession(t *testing.T) {
 	}
 	if strings.Contains(second, "This machine") {
 		t.Fatalf("second recall repeats the block:\n%s", second)
+	}
+}
+
+// Every other recall path runs its results through the policy table. This one
+// read the manifest directly, so a user who denied a path still received error
+// text drawn from the sessions that denial had just hidden (#659).
+func TestEnvironmentBlockObeysThePolicy(t *testing.T) {
+	dir := seedWalls(t, index.FrictionMinSessions)
+	if environmentBlock(dir, policy.ActivationMCP) == "" {
+		t.Fatal("nothing to test: the block is empty before any policy is applied")
+	}
+	pol := filepath.Join(t.TempDir(), "policy.json")
+	if err := os.WriteFile(pol, []byte(`{"activations":{"mcp":{"local":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", pol)
+	if got := environmentBlock(dir, policy.ActivationMCP); got != "" {
+		t.Fatalf("denied path still received machine facts drawn from hidden sessions:\n%s", got)
+	}
+	// A rule denying one path must not silence the others.
+	if environmentBlock(dir, policy.ActivationAuto) == "" {
+		t.Fatal("denying mcp also silenced auto")
+	}
+}
+
+// The count is what a reader acts on, so a wall whose evidence is mostly
+// hidden must not keep claiming the full number.
+func TestEnvironmentBlockDropsWallsBelowThresholdAfterFiltering(t *testing.T) {
+	dir := seedWalls(t, index.FrictionMinSessions)
+	pol := filepath.Join(t.TempDir(), "policy.json")
+	// Deny every origin the seeded sessions could have.
+	if err := os.WriteFile(pol, []byte(`{"activations":{"auto":{"*":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", pol)
+	if got := environmentBlock(dir, policy.ActivationAuto); got != "" {
+		t.Fatalf("a wall survived with all its evidence denied:\n%s", got)
 	}
 }

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -94,7 +94,7 @@ func runHookContext(dir string, plain bool) error {
 		// checkout — and exactly where knowing what this machine is missing
 		// helps most. The block is about the machine, not the project, so it
 		// does not depend on the digest having found anything.
-		if env := environmentBlock(dir); env != "" {
+		if env := environmentBlock(dir, policy.ActivationAuto); env != "" {
 			out := frameRecall(env)
 			usage.RecordDigestPolicy(dir, usage.KindHook, out, 0, 0, policy.Load().Describe(policy.ActivationAuto))
 			if plain {
@@ -445,7 +445,7 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 	// Inside the cached result, not after it: this costs a manifest scan plus
 	// one session read, which is ten times the rest of the hook, and the
 	// clusters it reports change over weeks rather than turns.
-	if env := environmentBlock(dir); env != "" {
+	if env := environmentBlock(dir, policy.ActivationAuto); env != "" {
 		text += "\n" + env + "\n"
 	}
 	mark("environment")


### PR DESCRIPTION
Closes #659. Found by running the policy rules rather than reading them — the first time that section of the audit has been exercised.

```
$ cat policy.json
{"activations":{"mcp":{"local":false}}}

$ mcp recall "pgbouncer"
No prior deja sessions matched "pgbouncer".            ← policy hid them, correctly
This machine, from deja's index of past sessions…
- 10 separate sessions hit `command not found: python` ← from the same hidden sessions
```

`policyFilterHits` guards both MCP entry points and search. The environment block is built from `index.TopFriction`, which reads the manifest directly, so nothing upstream could filter it — a user who denied a path still received error text out of the denied sessions.

The gate is per wall rather than one check up front, because origin is a property of the sessions a wall was counted from: a machine can hold both local and imported sessions hitting the same error. And a wall whose evidence is mostly hidden is dropped rather than shrunk — the count is what a reader acts on, so it must not keep claiming a number the policy no longer supports.

```
after   mcp denied → block is empty
        auto allowed → block intact (denying one path does not silence the others)
```

Two mutations, both fail the suite.

This is mine, from #632. The block reads material that predates any thought about origin, and I added it without asking which paths are allowed to carry it.

**Still open from the same section, filed separately:** `doctor` knows nothing about policy at all — a malformed file is silently ignored (recall correctly falls back to the default, but nobody is told), and a valid one is invisible, so there is no way to see which rules are in force.