### PR TITLE
fix: the environment block was delivered twice in one session

### DIFF
--- a/cmd/deja/environment.go
+++ b/cmd/deja/environment.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"strings"
@@ -85,6 +89,32 @@ func environmentBlock(dir, activation string) string {
 // this side: an MCP server lives for the whole session.
 var environmentServed sync.Once
 
+// environmentTTL is how long a delivered block suppresses the next one.
+//
+// The hook and the MCP server are separate processes, so a per-process guard
+// cannot see across them: measured on one session, the block arrived twice —
+// once at session start and once on the first recall, five identical lines
+// each time. Fifteen minutes covers "the hook injected, the agent called
+// recall a moment later" without silencing a session that starts an hour on,
+// which gets its own copy from the hook.
+const environmentTTL = 15 * time.Minute
+
+// environmentServedRecently reports whether a block went out within the TTL,
+// and stamps the marker when it has not.
+func environmentServedRecently(dir string) bool {
+	p := filepath.Join(filepath.Dir(dir), filepath.Base(dir)+".envblock")
+	if b, err := os.ReadFile(p); err == nil {
+		if ts, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64); err == nil {
+			if time.Since(time.Unix(ts, 0)) < environmentTTL {
+				return true
+			}
+		}
+	}
+	_ = os.MkdirAll(filepath.Dir(p), 0o700)
+	_ = os.WriteFile(p, []byte(strconv.FormatInt(time.Now().Unix(), 10)), 0o600)
+	return false
+}
+
 // environmentOnce appends the block to the first recall an MCP session serves.
 //
 // The session-start injection reaches the thirteen harnesses deja can wire a
@@ -94,6 +124,9 @@ var environmentServed sync.Once
 func environmentOnce(dir string) string {
 	out := ""
 	environmentServed.Do(func() {
+		if environmentServedRecently(dir) {
+			return
+		}
 		if env := environmentBlock(dir, policy.ActivationMCP); env != "" {
 			out = "\n\n" + env
 		}

--- a/cmd/deja/environment_test.go
+++ b/cmd/deja/environment_test.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/policy"
@@ -153,5 +155,39 @@ func TestEnvironmentBlockDropsWallsBelowThresholdAfterFiltering(t *testing.T) {
 	t.Setenv("DEJA_POLICY_FILE", pol)
 	if got := environmentBlock(dir, policy.ActivationAuto); got != "" {
 		t.Fatalf("a wall survived with all its evidence denied:\n%s", got)
+	}
+}
+
+// The hook and the MCP server are separate processes, so the per-process guard
+// cannot see across them: a session got the block twice, once at start-up and
+// once on its first recall — five identical lines each time, in the context
+// window the block exists to leave room in.
+func TestEnvironmentBlockIsNotDeliveredTwice(t *testing.T) {
+	dir := seedWalls(t, index.FrictionMinSessions)
+	marker := filepath.Join(filepath.Dir(dir), filepath.Base(dir)+".envblock")
+	_ = os.Remove(marker)
+
+	if environmentServedRecently(dir) {
+		t.Fatal("a fresh store must not claim a recent delivery")
+	}
+	// The stamp is written by the first call, so the second sees it.
+	if !environmentServedRecently(dir) {
+		t.Fatal("the delivery was not recorded, so both paths will send it")
+	}
+
+	// An old stamp must not silence a later session for ever.
+	old := time.Now().Add(-environmentTTL - time.Minute).Unix()
+	if err := os.WriteFile(marker, []byte(strconv.FormatInt(old, 10)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if environmentServedRecently(dir) {
+		t.Fatal("a stamp older than the TTL still suppressed the block")
+	}
+	// A corrupt stamp is not a licence to stay silent.
+	if err := os.WriteFile(marker, []byte("not a timestamp"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if environmentServedRecently(dir) {
+		t.Fatal("an unreadable stamp suppressed the block")
 	}
 }

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -445,8 +445,10 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 	// Inside the cached result, not after it: this costs a manifest scan plus
 	// one session read, which is ten times the rest of the hook, and the
 	// clusters it reports change over weeks rather than turns.
-	if env := environmentBlock(dir, policy.ActivationAuto); env != "" {
-		text += "\n" + env + "\n"
+	if !environmentServedRecently(dir) {
+		if env := environmentBlock(dir, policy.ActivationAuto); env != "" {
+			text += "\n" + env + "\n"
+		}
 	}
 	mark("environment")
 	return text, result.Sessions, rawSize(ss), matched


### PR DESCRIPTION
From the audit section on how features behave together — the first check of what a session receives when both delivery paths are live.

A session gets the start-up injection, then the agent calls `recall` itself. Comparing the two, line by line:

```
hook 1082B (3 sessions) · mcp 2977B · shared lines: 5

SHARED This machine, from deja's index of past sessions across every agent used
SHARED - 10 separate sessions hit `command not found: python`
SHARED - 6 separate sessions hit `ModuleNotFoundError: No module named 'yaml'`
SHARED - 6 separate sessions hit `ModuleNotFoundError: No module named 'matplot…`
SHARED These are environment facts, not history: the tool or module is still mi…
```

Every shared line is the environment block, and nothing else overlaps — the recalled sessions and the MCP answer do not repeat each other. `environmentServed` is a `sync.Once`, which is exactly right within one process and useless here: `deja hook-context` and `deja mcp` are different processes.

Four hundred bytes twice is not the cost that matters. The block exists to leave room in a context window, and the same facts arriving from two apparently independent places is the shape that makes a model weight them more, not less.

Now stamped on delivery, with a fifteen-minute suppression: long enough for "the hook injected and the agent called recall a moment later", short enough that a session starting an hour on still gets its own copy. Verified in both orders:

```
hook first → hook has block, mcp does not
mcp first  → mcp has block, hook does not
```

Three mutations, each fails the suite — including a corrupt stamp, which must not become a licence to stay silent for ever.