### PR TITLE
fix(files): distinguish a filtered file from a file that was never recorded

### DIFF
--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -89,6 +89,7 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 	// to eighteen stemmed forms for a two-word query, and requiring most of them
 	// in one message matches nothing.
 	needles := lowerAll(terms)
+	filtered := 0                    // recorded paths dropped by the repository filter
 	near := map[string]int{}         // path -> times touched near the topic
 	nearSessions := map[string]int{} // path -> how many sessions touched it near the topic
 	total := map[string]int{}        // path -> times touched anywhere in these sessions
@@ -122,7 +123,16 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 			}
 			for _, p := range strings.Split(m.Text, "\n") {
 				p = strings.TrimSpace(p)
-				if p == "" || isScratch(p) || !inRepository(p) {
+				if p == "" || isScratch(p) {
+					continue
+				}
+				if !inRepository(p) {
+					// Recorded, but not under a repository on this disk today.
+					// Usually a probe script; sometimes a repo that was
+					// archived, renamed, or lives on a volume that is not
+					// mounted. Counted rather than forgotten, so the empty
+					// answer can say which of the two happened (#664).
+					filtered++
 					continue
 				}
 				total[p]++
@@ -141,6 +151,13 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		}
 	}
 	if len(near) == 0 {
+		// "Recorded nothing" and "recorded files this build will not show" are
+		// different answers, and only the first is a fact about the past.
+		if filtered > 0 {
+			fmt.Fprintf(stdout, "%d session%s mention%s %q; %d recorded file%s %s not under a repository on this disk — moved, archived, or an unmounted volume\n",
+				scanned, plural(scanned), verbS(scanned), q, filtered, plural(filtered), verbIs(filtered))
+			return nil
+		}
 		fmt.Fprintf(stdout, "%d session%s mention%s %q, none of them recorded a file near it\n", scanned, plural(scanned), verbS(scanned), q)
 		return nil
 	}
@@ -304,4 +321,12 @@ func trimPath(p string) string {
 		return strings.Join(parts[len(parts)-4:], "/")
 	}
 	return strings.TrimPrefix(p, "/")
+}
+
+// verbIs keeps "1 file is" from reading as "1 file are".
+func verbIs(n int) string {
+	if n == 1 {
+		return "is"
+	}
+	return "are"
 }

--- a/cmd/deja/files_cli_test.go
+++ b/cmd/deja/files_cli_test.go
@@ -103,7 +103,10 @@ func TestFilesDistinguishesFilteredFromAbsent(t *testing.T) {
 	}
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	// A path that was recorded but has no .git above it now.
-	gone := filepath.Join(tmp, "vanished-repo", "pipeline.go")
+	// Forward slashes: the path is embedded in JSON, and a Windows separator
+	// would be read as an escape sequence, so the file record never forms and
+	// the test would pass for the wrong reason.
+	gone := filepath.ToSlash(filepath.Join(tmp, "vanished-repo", "pipeline.go"))
 	body := `{"type":"user","sessionId":"f1","cwd":"/w/f","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"fix the widget pipeline retry"}}` + "\n" +
 		`{"type":"assistant","sessionId":"f1","cwd":"/w/f","timestamp":"2026-07-21T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"` + gone + `"}}]}}` + "\n"
 	if err := os.WriteFile(filepath.Join(root, "f1.jsonl"), []byte(body), 0o644); err != nil {

--- a/cmd/deja/files_cli_test.go
+++ b/cmd/deja/files_cli_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
+
 	"fmt"
+	"github.com/vshulcz/deja-vu/internal/index"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,5 +88,50 @@ func TestFilesCommandArgumentErrors(t *testing.T) {
 	}
 	if err := runFiles(t.TempDir(), []string{"topic", "--limit", "zero"}, os.Stdout); err == nil {
 		t.Fatal("--limit wants a number")
+	}
+}
+
+// `friction`, `restore` and `stats` all agree that a file was worked on;
+// `files` said no file was ever recorded. It was — the path simply is not
+// under a repository on this disk today, which is a fact about the disk rather
+// than about the past (#664).
+func TestFilesDistinguishesFilteredFromAbsent(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-f")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	// A path that was recorded but has no .git above it now.
+	gone := filepath.Join(tmp, "vanished-repo", "pipeline.go")
+	body := `{"type":"user","sessionId":"f1","cwd":"/w/f","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"fix the widget pipeline retry"}}` + "\n" +
+		`{"type":"assistant","sessionId":"f1","cwd":"/w/f","timestamp":"2026-07-21T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"` + gone + `"}}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "f1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := runFiles(dir, []string{"pipeline"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if strings.Contains(got, "none of them recorded a file") {
+		t.Fatalf("claimed nothing was recorded when a file was:\n%s", got)
+	}
+	if !strings.Contains(got, "not under a repository") {
+		t.Fatalf("does not say why the file is missing from the answer:\n%s", got)
+	}
+
+	// And the genuinely-empty case keeps its own wording.
+	out.Reset()
+	if err := runFiles(dir, []string{"nothing-mentions-this"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "none of them recorded a file") &&
+		!strings.Contains(out.String(), "no sessions mention") {
+		t.Fatalf("the empty case lost its wording:\n%s", out.String())
 	}
 }


### PR DESCRIPTION
Closes #664. Found checking that four commands agree about one session.

```
$ deja friction
   3 sessions  command not found: widgetctl                  ← agrees
$ deja restore pipeline.go
3 replaced spans recorded for pipeline.go                     ← agrees
$ deja stats
Recover   3 spans your agents replaced, across 1 file        ← agrees
$ deja files pipeline
3 sessions mention "pipeline", none of them recorded a file near it   ← contradicts
```

The records exist. `files` drops them in `inRepository`, which stats the path **today** and keeps only what sits under a `.git` directory now. Shown directly:

```
$ deja files pipeline
  tmp/x1-repo/pipeline.go        1
$ rm -rf /tmp/x1-repo
$ deja files pipeline
1 session mentions "pipeline", none of them recorded a file near it
```

The filter itself is right and stays — a probe script beside a repo is not what anyone means by "which files matter". What was wrong is the sentence: "none of them recorded a file" is a claim about the past, and the truth was "files were recorded and this build declined to show them". Same class as #637.

```
after   1 session mentions "pipeline"; 1 recorded file is not under a repository
        on this disk — moved, archived, or an unmounted volume
```

The genuinely-empty case keeps its old wording, with a test for each. Two mutations fail the suite.

Left in the issue rather than fixed here: whether the record should be trusted over the filesystem when a path was recorded as a repository file at the time. That changes what the command returns, so it needs its own measurement — this only stops the message from being false.