### PR TITLE
fix: forget clears the title a promoted note borrowed from the session

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1058,6 +1058,17 @@ func runForget(dir string, args []string) error {
 			result.Sessions, result.Messages, result.Tombstones)
 		return nil
 	}
+	// A promoted note borrows the source session's first line as its title, and
+	// the note is a separate record — so forgetting a session left that line on
+	// screen in `deja last` (#666). The note stays; only the borrowed title
+	// goes, and the parser falls back to "promoted from <src>".
+	if result.Sessions > 0 && o.Session != "" {
+		if n, err := sources.ForgetPromotedTitles(func(src string) bool {
+			return strings.Contains(src, o.Session)
+		}); err == nil && n > 0 {
+			fmt.Fprintf(os.Stdout, "cleared the borrowed title from %d promoted note%s\n", n, pluralS(n))
+		}
+	}
 	// Nothing matched is a different answer from nothing was dropped: the
 	// first means the selector found no session, and reporting it as a
 	// successful removal of zero leaves the reader believing they deleted

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -328,3 +328,64 @@ func noteWordSet(s string) map[string]bool {
 	}
 	return out
 }
+
+// ForgetPromotedTitles strips the source session's opening line from every
+// promoted note whose provenance matches.
+//
+// `promote` copies that line into the note as its title, and the note is a
+// separate record, so `forget --session` removed the session and left its
+// first sentence on screen in `deja last` — the sentence most likely to carry
+// a customer name or a ticket id (#666).
+//
+// The note itself survives: the decision it was promoted for is often the
+// reason the raw session was safe to forget. Only the borrowed title goes; the
+// parser already falls back to "promoted from <src>" when it is absent.
+func ForgetPromotedTitles(match func(session string) bool) (int, error) {
+	path := NotesFile()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	lines := strings.Split(string(b), "\n")
+	changed := 0
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var m map[string]any
+		if json.Unmarshal([]byte(line), &m) != nil {
+			continue
+		}
+		if kind, _ := m["kind"].(string); kind != "promoted" {
+			continue
+		}
+		src, _ := m["session"].(string)
+		if src == "" || !match(src) {
+			continue
+		}
+		if title, _ := m["title"].(string); title == "" {
+			continue
+		}
+		delete(m, "title")
+		out, err := json.Marshal(m)
+		if err != nil {
+			continue
+		}
+		lines[i] = string(out)
+		changed++
+	}
+	if changed == 0 {
+		return 0, nil
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(strings.Join(lines, "\n")), 0o600); err != nil {
+		return 0, err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return 0, err
+	}
+	return changed, nil
+}

--- a/internal/sources/notes_test.go
+++ b/internal/sources/notes_test.go
@@ -118,3 +118,87 @@ func TestConflictingNotes(t *testing.T) {
 		t.Fatalf("weak overlap conflicted: %+v", got)
 	}
 }
+
+// `promote` copies the source session's first line into the note as its title.
+// The note is a separate record, so `forget --session` removed the session and
+// left that line visible in `deja last` — the sentence most likely to carry a
+// customer name or a ticket id (#666).
+func TestForgetPromotedTitles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", path)
+	lines := []string{
+		`{"ts":"2026-07-21T10:00:00Z","project":"p","text":"cap retries at 3","kind":"promoted","session":"claude:ps1","state":"accepted","title":"our customer ACME-4471 hit the retry storm"}`,
+		`{"ts":"2026-07-21T10:00:00Z","project":"p","text":"other decision","kind":"promoted","session":"claude:other","state":"accepted","title":"an unrelated session title"}`,
+		`{"ts":"2026-07-21T10:00:00Z","project":"p","text":"a plain note","kind":"note"}`,
+		// A note of another kind that happens to name the same session: only
+		// `promote` borrows a title, so only promoted notes lose one.
+		`{"ts":"2026-07-21T10:00:00Z","project":"p","text":"a linked note","kind":"note","session":"claude:ps1","title":"a title this command must not touch"}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	n, err := ForgetPromotedTitles(func(src string) bool { return strings.Contains(src, "ps1") })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("cleared %d titles, want 1", n)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	if strings.Contains(got, "ACME-4471") {
+		t.Errorf("the forgotten session's first line survived:\n%s", got)
+	}
+	// The decision it was promoted for is often why the raw session was safe
+	// to forget — the note itself must stay.
+	if !strings.Contains(got, "cap retries at 3") {
+		t.Errorf("the promoted decision was destroyed:\n%s", got)
+	}
+	// Unrelated notes are untouched, including plain ones.
+	if !strings.Contains(got, "an unrelated session title") || !strings.Contains(got, "a plain note") ||
+		!strings.Contains(got, "a title this command must not touch") {
+		t.Errorf("touched a note it should not have:\n%s", got)
+	}
+	// Idempotent: a second run has nothing left to clear.
+	if again, err := ForgetPromotedTitles(func(src string) bool { return strings.Contains(src, "ps1") }); err != nil || again != 0 {
+		t.Fatalf("second run cleared %d, err %v", again, err)
+	}
+}
+
+// Nothing matched must leave the file alone. Rewriting it in place for a
+// no-op risks the notes of every other session on a crash between write and
+// rename, for no change at all.
+func TestForgetPromotedTitlesLeavesTheFileAloneWhenNothingMatches(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", path)
+	line := `{"ts":"2026-07-21T10:00:00Z","project":"p","text":"d","kind":"promoted","session":"claude:other","title":"t"}`
+	if err := os.WriteFile(path, []byte(line+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n, err := ForgetPromotedTitles(func(string) bool { return false }); err != nil || n != 0 {
+		t.Fatalf("n=%d err=%v", n, err)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Errorf("rewrote the notes file for a no-op: %v -> %v", before.ModTime(), after.ModTime())
+	}
+}
+
+func TestForgetPromotedTitlesWithNoNotesFile(t *testing.T) {
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(t.TempDir(), "missing.jsonl"))
+	if n, err := ForgetPromotedTitles(func(string) bool { return true }); err != nil || n != 0 {
+		t.Fatalf("n=%d err=%v — a missing notes file is not an error", n, err)
+	}
+}


### PR DESCRIPTION
`promote` copies the source session's first line into the note as its title. The note is a separate record, so `forget --session` dropped the session and left that line on screen in `deja last` — the sentence most likely to carry a customer name or a ticket id.

The decision the note was promoted for is often why the raw session was safe to forget, so the note itself stays; only the borrowed title goes and the parser falls back to `promoted from <src>`.

Closes #666