### PR TITLE
fix: derive a title for imported sessions

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -995,14 +995,22 @@ func sessionTitle(s model.Session) string {
 			continue
 		}
 		t := strings.TrimSpace(msg.Text)
-		if t == "" || strings.HasPrefix(t, "<local-command") || strings.HasPrefix(t, "<command-") ||
-			strings.HasPrefix(t, "<task-notification") || strings.HasPrefix(t, "<teammate-message") ||
-			strings.HasPrefix(t, "Caveat:") {
+		if !titleWorthy(t) {
 			continue
 		}
 		return truncateTitle(t, 60)
 	}
 	return ""
+}
+
+// titleWorthy reports whether a user turn is the sentence a person would
+// recognise the session by. Harness plumbing arrives with the user role — a
+// slash command's expansion, a task notification, the compaction caveat — and
+// naming a session after one of those is how the titles in #636 happened.
+func titleWorthy(t string) bool {
+	return t != "" && !strings.HasPrefix(t, "<local-command") && !strings.HasPrefix(t, "<command-") &&
+		!strings.HasPrefix(t, "<task-notification") && !strings.HasPrefix(t, "<teammate-message") &&
+		!strings.HasPrefix(t, "Caveat:")
 }
 
 func truncateTitle(s string, n int) string {

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -264,6 +264,7 @@ func Import(dir, inDir string) (int, error) {
 	sort.Strings(paths)
 	recsByKey := map[string][]Record{}
 	metas := map[string]SessionMeta{}
+	titleAt := map[string]time.Time{} // key -> time of the turn the title came from
 	added := 0
 	for _, p := range paths {
 		if err := readSyncFile(p, func(sr SyncRecord) error {
@@ -306,6 +307,17 @@ func Import(dir, inDir string) (int, error) {
 			}
 			if sr.Time.After(meta.Updated) {
 				meta.Updated = sr.Time
+			}
+			// The title does not travel in the record stream, and without it the
+			// receiving machine's `last` is a column of hashes — the content
+			// arrived, the one line that makes the list readable did not (#670).
+			// Derive it the way ingest does, from the earliest user turn that is
+			// speech rather than harness plumbing.
+			if sr.Role == "user" && titleWorthy(strings.TrimSpace(text)) {
+				if at, seen := titleAt[key]; !seen || (!sr.Time.IsZero() && sr.Time.Before(at)) {
+					meta.Title = truncateTitle(strings.TrimSpace(text), 60)
+					titleAt[key] = sr.Time
+				}
 			}
 			metas[key] = meta
 			m.ImportedRecords[dedupe] = true

--- a/internal/index/sync_persist_test.go
+++ b/internal/index/sync_persist_test.go
@@ -191,3 +191,59 @@ func TestImportKeepsSameTimestampMessages(t *testing.T) {
 		t.Fatalf("re-import n=%d err=%v", n, err)
 	}
 }
+
+// The title does not travel in the record stream. Without deriving one, the
+// receiving machine's `deja last` is a column of hashes even though the whole
+// conversation arrived (#670).
+func TestImportGivesSessionsATitle(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	base := time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC)
+	batch := filepath.Join(tmp, "batch")
+	writeSyncBatch(t, batch, []SyncRecord{
+		// Out of order on purpose, and the first user turn by time is harness
+		// plumbing: the title must be the earliest turn a person would
+		// recognise, not the earliest record in the file.
+		{Harness: "claude", SessionID: "s1", Project: "p", Role: "assistant", Text: "capped at three", Time: base.Add(2 * time.Minute)},
+		{Harness: "claude", SessionID: "s1", Project: "p", Role: "user", Text: "and what about jitter", Time: base.Add(3 * time.Minute)},
+		{Harness: "claude", SessionID: "s1", Project: "p", Role: "user", Text: "the retry storm on checkout", Time: base.Add(time.Minute)},
+		{Harness: "claude", SessionID: "s1", Project: "p", Role: "user", Text: "<local-command-stdout>ok</local-command-stdout>", Time: base},
+		// A session whose only user turns are plumbing keeps no title rather
+		// than being named after a slash command's output.
+		{Harness: "claude", SessionID: "s2", Project: "p", Role: "user", Text: "<command-name>/clear</command-name>", Time: base},
+		{Harness: "claude", SessionID: "s2", Project: "p", Role: "assistant", Text: "cleared", Time: base.Add(time.Minute)},
+	})
+	if _, err := Import(dir, batch); err != nil {
+		t.Fatal(err)
+	}
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	titles := map[string]string{}
+	for _, m := range metas {
+		titles[m.ID] = m.Title
+	}
+	if len(titles) != 2 {
+		t.Fatalf("expected two imported sessions, got %#v", titles)
+	}
+	var withTitle, blank int
+	for _, ti := range titles {
+		switch ti {
+		case "the retry storm on checkout":
+			withTitle++
+		case "":
+			blank++
+		default:
+			t.Errorf("unexpected title %q", ti)
+		}
+	}
+	if withTitle != 1 || blank != 1 {
+		t.Errorf("titles = %#v", titles)
+	}
+}


### PR DESCRIPTION
After `sync import`, every session showed up as `[claude · imported:proj/p · imported-c5c5879b423e]` with no title — the content had arrived (`show` printed the full conversation) but the one line that makes `deja last` readable had not.

Titles are not in the record stream, so the importer derives one the way ingest does: the earliest user turn that is speech rather than harness plumbing. That filter is now shared between the two paths.

Closes #670