### PR TITLE
fix: unforget reports what it restored and rebuilds so the session comes back

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ session tombstones so a later `deja index` cannot restore them from source
 history. Tombstones are stored at `~/.config/deja/tombstones` (or
 `$XDG_CONFIG_HOME/deja/tombstones`) and mirrored beside the index, so losing
 either one does not resurrect what you forgot; use `--dry-run`, `--list`, or
-`--unforget`.
+`--unforget`. `--unforget` lifts the tombstone and rebuilds, so the session is
+searchable again straight away — the transcript on disk never changed, and an
+incremental pass would skip it.
 Ingest exclusions are one case-insensitive project pattern per line in
 `~/.config/deja/exclude` (XDG-aware), or comma-separated in
 `DEJA_EXCLUDE_PROJECTS`. `deja stats --redaction` reports redactions by

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1044,7 +1044,23 @@ func runForget(dir string, args []string) error {
 		return nil
 	}
 	if unforget != "" {
-		return index.Unforget(unforget)
+		lifted, err := index.Unforget(unforget)
+		if err != nil {
+			return err
+		}
+		if lifted == 0 {
+			fmt.Fprintf(os.Stdout, "no tombstone matches %q — `deja forget --list` shows what is forgotten\n", unforget)
+			return nil
+		}
+		// The transcript on disk has not changed since it was indexed, so the
+		// incremental pass skips it and the session stays invisible — which is
+		// every ordinary run of `deja index` (#672). Rebuild here instead, so
+		// the command that says "restored" has actually restored something.
+		if err := withBuildProgress(func() error { return index.Ensure(dir, "", true, os.Stderr) }); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stdout, "restored %d session%s and rebuilt the index\n", lifted, pluralS(lifted))
+		return nil
 	}
 	result, err := index.Forget(dir, o)
 	if err != nil {

--- a/cmd/deja/privacy_test.go
+++ b/cmd/deja/privacy_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/embed"
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
 )
 
 func TestPrivacyCommandFlags(t *testing.T) {
@@ -112,5 +113,43 @@ func TestSourcesReportsActiveExclusions(t *testing.T) {
 	out, err := captureRun(t, "sources")
 	if err != nil || !strings.Contains(out, "excluded-patterns=1") || !strings.Contains(out, "excluded-sessions=") {
 		t.Fatalf("sources=%q err=%v", out, err)
+	}
+}
+
+// The transcript on disk does not change when a session is forgotten, so the
+// incremental pass — every ordinary `deja index` — skips it and the session
+// stays invisible after unforget. Only a full rebuild brought it back (#672).
+func TestUnforgetBringsTheSessionBackWithoutAFullRebuild(t *testing.T) {
+	seedTouchedIndex(t, 2, "/w/t/shared.go")
+	dir := index.DefaultDir()
+	before, err := index.Search(dir, search.Options{Query: "pool sizing", All: true})
+	if err != nil || len(before) != 2 {
+		t.Fatalf("seed: %d sessions err=%v", len(before), err)
+	}
+	if _, err := captureRun(t, "forget", "--session", "t00"); err != nil {
+		t.Fatal(err)
+	}
+	gone, err := index.Search(dir, search.Options{Query: "pool sizing", All: true})
+	if err != nil || len(gone) != 1 {
+		t.Fatalf("after forget: %d sessions err=%v", len(gone), err)
+	}
+	out, err := captureRun(t, "forget", "--unforget", "t00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "restored 1 session") {
+		t.Errorf("unforget said %q — nothing tells the reader it worked", out)
+	}
+	// No `deja index` in between: the command has to leave the index usable.
+	back, err := index.Search(dir, search.Options{Query: "pool sizing", All: true})
+	if err != nil || len(back) != 2 {
+		t.Fatalf("after unforget: %d sessions err=%v — the session did not come back", len(back), err)
+	}
+	miss, err := captureRun(t, "forget", "--unforget", "nothing-like-this")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(miss, "no tombstone matches") {
+		t.Errorf("a prefix matching nothing said %q", miss)
 	}
 }

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -255,12 +255,16 @@ func Tombstones() []string {
 	return out
 }
 
-func Unforget(prefix string) error {
+// Unforget lifts tombstones and reports how many it lifted. The count is not
+// bookkeeping: the command printed nothing at all, so "restored one session"
+// and "that prefix matched nothing" looked identical (#672).
+func Unforget(prefix string) (int, error) {
 	set := readTombstones()
 	// A prefix containing ':' is a key/harness-scoped prefix (claude:abc,
 	// z:); a bare prefix is an id-prefix symmetric with forget --session, so
 	// "c" cannot resurrect every claude/codex/cursor session at once.
 	scoped := strings.ContainsRune(prefix, ':')
+	lifted := 0
 	for key := range set {
 		var match bool
 		if scoped {
@@ -274,9 +278,13 @@ func Unforget(prefix string) error {
 		}
 		if match {
 			delete(set, key)
+			lifted++
 		}
 	}
-	return writeTombstones(set)
+	if lifted == 0 {
+		return 0, nil
+	}
+	return lifted, writeTombstones(set)
 }
 
 func RedactionReport(dir string) (RedactionStats, error) { return Redactions(dir) }

--- a/internal/index/privacy_test.go
+++ b/internal/index/privacy_test.go
@@ -58,7 +58,7 @@ func TestForgetTombstoneLifecycle(t *testing.T) {
 	if got := Tombstones(); len(got) != 1 || got[0] != "claude:abc123" {
 		t.Fatalf("tombstones=%v", got)
 	}
-	if err := Unforget("abc123"); err != nil {
+	if _, err := Unforget("abc123"); err != nil {
 		t.Fatal(err)
 	}
 	if len(Tombstones()) != 0 {
@@ -114,13 +114,13 @@ func TestTombstonePersistenceAndForgetNoop(t *testing.T) {
 	if got := Tombstones(); len(got) != 2 || got[0] != "a:first" || got[1] != "z:last" {
 		t.Fatalf("tombstones=%v", got)
 	}
-	if err := Unforget("first"); err != nil {
+	if _, err := Unforget("first"); err != nil {
 		t.Fatal(err)
 	}
 	if got := Tombstones(); len(got) != 1 || got[0] != "z:last" {
 		t.Fatalf("after suffix unforget=%v", got)
 	}
-	if err := Unforget("z:"); err != nil {
+	if _, err := Unforget("z:"); err != nil {
 		t.Fatal(err)
 	}
 	if len(Tombstones()) != 0 {
@@ -206,24 +206,62 @@ func TestUnforgetDoesNotOverMatchHarness(t *testing.T) {
 		t.Fatal(err)
 	}
 	// A bare "c" is an id-prefix: it must NOT resurrect whole harnesses.
-	if err := Unforget("c"); err != nil {
+	if _, err := Unforget("c"); err != nil {
 		t.Fatal(err)
 	}
 	if got := len(Tombstones()); got != 3 {
 		t.Fatalf("bare prefix c wrongly matched harnesses: %v", Tombstones())
 	}
 	// An id-prefix that really matches an id works.
-	if err := Unforget("ab"); err != nil {
+	if _, err := Unforget("ab"); err != nil {
 		t.Fatal(err)
 	}
 	if got := len(Tombstones()); got != 1 {
 		t.Fatalf("id-prefix ab: %v", Tombstones())
 	}
 	// A harness-scoped prefix still works.
-	if err := Unforget("cursor:"); err != nil {
+	if _, err := Unforget("cursor:"); err != nil {
 		t.Fatal(err)
 	}
 	if len(Tombstones()) != 0 {
 		t.Fatalf("harness scope left: %v", Tombstones())
+	}
+}
+
+// The command printed nothing at all, so "restored one session" and "that
+// prefix matched nothing" looked the same to the person running it (#672).
+func TestUnforgetReportsHowManyItLifted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("XDG_CONFIG_HOME", "")
+	if err := writeTombstones(map[string]bool{"claude:a1": true, "claude:a2": true, "cursor:b1": true}); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := Unforget("claude:"); err != nil || n != 2 {
+		t.Fatalf("lifted %d err=%v, want 2", n, err)
+	}
+	if n, err := Unforget("claude:"); err != nil || n != 0 {
+		t.Fatalf("second run lifted %d err=%v, want 0", n, err)
+	}
+	// A prefix that matches nothing must not rewrite the file: on a crash
+	// between write and rename it would take every other tombstone with it,
+	// and there is nothing to change.
+	before, err := os.Stat(tombstonePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n, err := Unforget("nosuch"); err != nil || n != 0 {
+		t.Fatalf("a prefix matching nothing lifted %d err=%v", n, err)
+	}
+	after, err := os.Stat(tombstonePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Errorf("rewrote the tombstone file for a no-op")
+	}
+	// The one that was never named is still forgotten.
+	if got := Tombstones(); len(got) != 1 || got[0] != "cursor:b1" {
+		t.Fatalf("tombstones = %v", got)
 	}
 }


### PR DESCRIPTION
`forget --unforget` lifted the tombstone and then left no way to tell:

```
$ deja forget --unforget claude:gone1      # no output
$ deja search payroll                      # nothing
$ deja index                                # incremental: file unchanged, skipped
$ deja search payroll                      # still nothing
```

Only `rm -rf` on the index brought it back. Now the command says how many tombstones it lifted (or that the prefix matched nothing) and rebuilds, so the session is searchable when it returns.

Closes #672