### PR TITLE
fix: uninstall no longer creates configs it was asked to clean

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -18,6 +18,8 @@ import (
 type installResult struct{ Path, Action string }
 
 func runInstall(dir string, args []string, uninstall bool) error {
+	removingWiring = uninstall
+	defer func() { removingWiring = false }()
 	guidance := true
 	noIndex := false
 	var targetArgs []string
@@ -480,9 +482,23 @@ func backupOnce(path string) error {
 	return os.WriteFile(bak, b, 0o600)
 }
 
+// removingWiring is set for the length of an uninstall run. Thirty-seven call
+// sites write configs through writeIfChanged, and on the uninstall path each
+// one computes "the file without deja in it" — which, for a file that does not
+// exist, is an empty config it then creates (#676). The flag is process-wide
+// because the command is: one run, one direction.
+var removingWiring bool
+
 func writeIfChanged(path string, old, next []byte) (string, error) {
 	if bytes.Equal(old, next) {
 		return "unchanged", nil
+	}
+	// Removing something must not leave more behind than it found. A file that
+	// is not there has nothing in it to remove.
+	if removingWiring {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return "unchanged", nil
+		}
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", err
@@ -533,6 +549,11 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 	}
 	m, _ := root["mcpServers"].(map[string]any)
 	if m == nil {
+		// Adding the empty block on the way out rewrites a config that never
+		// mentioned deja, and leaves a .bak of it besides (#676).
+		if uninstall {
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
 		m = map[string]any{}
 		root["mcpServers"] = m
 	}
@@ -850,6 +871,11 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 	}
 	m, _ := root["mcpServers"].(map[string]any)
 	if m == nil {
+		// Adding the empty block on the way out rewrites a config that never
+		// mentioned deja, and leaves a .bak of it besides (#676).
+		if uninstall {
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
 		m = map[string]any{}
 		root["mcpServers"] = m
 	}
@@ -914,6 +940,11 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 	}
 	m, _ := root["mcpServers"].(map[string]any)
 	if m == nil {
+		// Adding the empty block on the way out rewrites a config that never
+		// mentioned deja, and leaves a .bak of it besides (#676).
+		if uninstall {
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
 		m = map[string]any{}
 		root["mcpServers"] = m
 	}

--- a/cmd/deja/install_test.go
+++ b/cmd/deja/install_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Removing something must not leave more behind than it found. On the
+// uninstall path every target computes "the config without deja in it", which
+// for a file that does not exist is an empty config it then creates (#676).
+func TestUninstallCreatesNothingOnAMachineThatNeverHadDeja(t *testing.T) {
+	hermeticEnv(t)
+	// The harnesses are installed; deja never was.
+	for _, d := range []string{".claude", ".codex"} {
+		if err := os.MkdirAll(filepath.Join(os.Getenv("HOME"), d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A config that exists but never mentioned deja: the empty mcpServers block
+	// used to be added to it on the way out, with a .bak of it besides.
+	claudeJSON := filepath.Join(os.Getenv("HOME"), ".claude.json")
+	const untouched = "{\n  \"editorMode\": \"vim\"\n}\n"
+	if err := os.WriteFile(claudeJSON, []byte(untouched), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before := filesUnder(t, os.Getenv("HOME"))
+	if _, err := captureRun(t, "uninstall", "--all"); err != nil {
+		t.Fatal(err)
+	}
+	after := filesUnder(t, os.Getenv("HOME"))
+	for p := range after {
+		if !before[p] {
+			t.Errorf("uninstall created %s", p)
+		}
+	}
+	got, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != untouched {
+		t.Errorf("uninstall rewrote a config that never mentioned deja:\n%s", got)
+	}
+}
+
+func filesUnder(t *testing.T, root string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	if err := filepath.Walk(root, func(p string, fi os.FileInfo, err error) error {
+		if err != nil || fi.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, p)
+		out[filepath.ToSlash(rel)] = true
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// The other direction still has to work: what install wired, uninstall removes.
+func TestUninstallStillRemovesWhatInstallWrote(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	for _, d := range []string{".claude", ".codex"} {
+		if err := os.MkdirAll(filepath.Join(home, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRun(t, "install", "--all", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(filesMentioning(t, home, "deja")); n == 0 {
+		t.Fatal("install wrote nothing that mentions deja")
+	}
+	if _, err := captureRun(t, "uninstall", "--all"); err != nil {
+		t.Fatal(err)
+	}
+	if left := filesMentioning(t, home, "\"deja\""); len(left) > 0 {
+		t.Errorf("uninstall left deja wired in %v", left)
+	}
+}
+
+func filesMentioning(t *testing.T, root, needle string) []string {
+	t.Helper()
+	var out []string
+	_ = filepath.Walk(root, func(p string, fi os.FileInfo, err error) error {
+		if err != nil || fi.IsDir() || strings.HasSuffix(p, ".bak") {
+			return nil
+		}
+		// The store's own state is not wiring: notes, the index, the record of
+		// what was installed.
+		if strings.Contains(filepath.ToSlash(p), "/.config/deja/") || strings.Contains(filepath.ToSlash(p), "/deja/notes") {
+			return nil
+		}
+		b, err := os.ReadFile(p)
+		if err == nil && strings.Contains(string(b), needle) {
+			rel, _ := filepath.Rel(root, p)
+			out = append(out, filepath.ToSlash(rel))
+		}
+		return nil
+	})
+	return out
+}

--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -61,6 +61,14 @@ func recordWiring(targets []string, uninstall bool) {
 		}
 	}
 	sort.Strings(kept)
+	// Uninstalling everything on a machine that was never wired would otherwise
+	// create the record on the way out — a file left behind by the command that
+	// removes things (#676).
+	if len(kept) == 0 {
+		if _, err := os.Stat(wiringStatePath()); os.IsNotExist(err) {
+			return
+		}
+	}
 	st = wiringState{Version: version, Targets: kept}
 	b, err := json.MarshalIndent(st, "", "  ")
 	if err != nil {


### PR DESCRIPTION
`deja uninstall --all` on a machine that never had deja installed wrote `~/.claude/settings.json` (`{}`), `~/.codex/hooks.json` (`{}`), a `~/.claude.json.bak`, and the wiring record — and reported "created" while doing it.

Removing something must not leave more behind than it found. On the uninstall path a file that is not there has nothing in it to remove, and a config that never mentioned deja is not ours to rewrite.

The other direction is covered too: what install wires, uninstall still removes.

Closes #676