### PR TITLE
fix: sync import fails on a path that is not a batch directory

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -874,7 +874,7 @@ func parseBlame(args []string) (string, search.BlameOptions, bool, error) {
 		}
 	}
 	if path == "" {
-		return "", o, false, fmt.Errorf("blame needs path")
+		return "", o, false, fmt.Errorf("blame needs a path — `deja blame internal/index/sync.go` says who last worked on it")
 	}
 	return path, o, jsonOutput, nil
 }
@@ -1072,7 +1072,9 @@ func runForget(dir string, args []string) error {
 				} else if t, e := parseForgetDate(args[i]); e == nil {
 					o.Before = t
 				} else {
-					return fmt.Errorf("forget: invalid before %q", args[i])
+					// --before takes either form, so naming only one of them
+					// leaves the reader guessing which they got wrong.
+					return fmt.Errorf("forget: %q is neither a duration nor a date — try 30d, 12h, or 2026-01-31", args[i])
 				}
 			}
 		default:

--- a/cmd/deja/privacy_test.go
+++ b/cmd/deja/privacy_test.go
@@ -153,3 +153,19 @@ func TestUnforgetBringsTheSessionBackWithoutAFullRebuild(t *testing.T) {
 		t.Errorf("a prefix matching nothing said %q", miss)
 	}
 }
+
+// --before takes a duration or a date, so an error naming neither leaves the
+// reader guessing which one they got wrong (#678).
+func TestForgetBeforeErrorNamesBothForms(t *testing.T) {
+	withTempStores(t)
+	_, err := captureRun(t, "forget", "--before", "yesterdayish")
+	if err == nil {
+		t.Fatal("a bad --before succeeded")
+	}
+	msg := err.Error()
+	for _, want := range []string{"yesterdayish", "30d", "2026-01-31"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q does not mention %q", msg, want)
+		}
+	}
+}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -238,6 +238,20 @@ func Import(dir, inDir string) (int, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
+	// A wrong path used to import nothing and exit 0 — including the case that
+	// matters, a typo for a directory that is right there with records in it
+	// (#678). An empty directory that exists is a different answer and stays a
+	// quiet zero.
+	fi, err := os.Stat(inDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, fmt.Errorf("no such directory: %s", inDir)
+		}
+		return 0, err
+	}
+	if !fi.IsDir() {
+		return 0, fmt.Errorf("%s is a file; sync import wants the directory a `sync export` wrote", inDir)
+	}
 	unlock, err := lockDir(dir)
 	if err != nil {
 		return 0, err

--- a/internal/index/sync_persist_test.go
+++ b/internal/index/sync_persist_test.go
@@ -247,3 +247,41 @@ func TestImportGivesSessionsATitle(t *testing.T) {
 		t.Errorf("titles = %#v", titles)
 	}
 }
+
+// A wrong path imported nothing and exited 0 — including the case that matters,
+// a typo for a directory that is right there with records in it (#678).
+func TestImportRejectsAPathThatIsNotADirectoryOfRecords(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+
+	missing := filepath.Join(tmp, "no-such-batch")
+	_, err := Import(dir, missing)
+	if err == nil {
+		t.Error("importing a directory that does not exist succeeded")
+		// The reader is looking for a typo, so the message has to name the
+		// path they typed rather than repeat Go's stat syntax.
+	} else if !strings.HasPrefix(err.Error(), "no such directory: ") || !strings.Contains(err.Error(), missing) {
+		t.Errorf("error was %q", err)
+	}
+	plain := filepath.Join(tmp, "a-file")
+	if err := os.WriteFile(plain, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(dir, plain); err == nil {
+		t.Error("importing a plain file succeeded")
+	}
+	// An empty directory that exists is a different answer: nothing to import
+	// is not a mistake.
+	empty := filepath.Join(tmp, "empty")
+	if err := os.MkdirAll(empty, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := Import(dir, empty); err != nil || n != 0 {
+		t.Errorf("empty batch: n=%d err=%v — an existing empty directory is not an error", n, err)
+	}
+}


### PR DESCRIPTION
`deja sync import ~/ou` — a typo for `~/out`, which exists and has records — printed "imported 0 records" and exited 0. Same for a path that does not exist at all and for a plain file. Anyone scripting a two-machine setup sees exit 0 and moves on.

An empty directory that exists stays a quiet zero: nothing to import is not a mistake.

Two error messages from the same sweep: `forget --before` now names both accepted forms instead of only saying "invalid before", and `deja blame` with no argument shows a path.

Closes #678