### PR TITLE
fix: say when the trust policy is why an answer is empty

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -400,7 +400,7 @@ func doctorTools(w io.Writer) {
 // invisible — leaving no place at all to find out what the rules are (#661).
 func doctorPolicy(w io.Writer) {
 	fmt.Fprintln(w, "Trust policy:")
-	exists, err, unknown := policy.Diagnose()
+	exists, unknown, err := policy.Diagnose()
 	if !exists {
 		fmt.Fprintf(w, "  %-12s no file at %s — every origin activates everywhere\n", "default", policy.Path())
 		return

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
@@ -93,6 +94,8 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir strin
 	}
 	fmt.Fprintln(w)
 	doctorTools(w)
+	fmt.Fprintln(w)
+	doctorPolicy(w)
 	fmt.Fprintln(w)
 	doctorMCP(w)
 	fmt.Fprintln(w)
@@ -389,6 +392,33 @@ func doctorTools(w io.Writer) {
 		status = "found"
 	}
 	fmt.Fprintf(w, "  %-12s %s (needed for opencode and Cursor IDE stores)\n", "sqlite3", status)
+}
+
+// doctorPolicy reports the one mechanism that separates local memory from
+// imported. Load falls back to the permissive default on any error, so a
+// malformed file changed nothing and said nothing, and a working one was
+// invisible — leaving no place at all to find out what the rules are (#661).
+func doctorPolicy(w io.Writer) {
+	fmt.Fprintln(w, "Trust policy:")
+	exists, err, unknown := policy.Diagnose()
+	if !exists {
+		fmt.Fprintf(w, "  %-12s no file at %s — every origin activates everywhere\n", "default", policy.Path())
+		return
+	}
+	if err != nil {
+		// The permissive default is what is actually in force, and that is the
+		// part worth saying out loud: the file reads like a restriction.
+		fmt.Fprintf(w, "  %-12s %s: %v\n", "unreadable", policy.Path(), err)
+		fmt.Fprintf(w, "  %-12s every origin activates everywhere until it parses\n", "in force")
+		return
+	}
+	pol := policy.Load()
+	for _, activation := range []string{policy.ActivationSearch, policy.ActivationMCP, policy.ActivationAuto} {
+		fmt.Fprintf(w, "  %-12s %s\n", activation, pol.Describe(activation))
+	}
+	for _, u := range unknown {
+		fmt.Fprintf(w, "  %-12s %q is not an activation or origin deja consults — this rule does nothing\n", "ignored", u)
+	}
 }
 
 func doctorMCP(w io.Writer) {

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -576,3 +576,42 @@ func TestHookContextDoesNotBlockOnSilentStdin(t *testing.T) {
 		t.Fatal("hook-context must not hang when the host never closes stdin (codex does this)")
 	}
 }
+
+// The one mechanism separating local memory from imported was invisible to the
+// command whose job is answering "is my setup right" (#661).
+func TestDoctorReportsThePolicy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+
+	var buf bytes.Buffer
+	doctorPolicy(&buf)
+	if !strings.Contains(buf.String(), "every origin activates everywhere") {
+		t.Errorf("no file: %q", buf.String())
+	}
+
+	buf.Reset()
+	if err := os.WriteFile(path, []byte("{ oops"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	doctorPolicy(&buf)
+	// The permissive default is what is in force, and the file reads like a
+	// restriction — so saying only "unreadable" would leave the wrong belief.
+	for _, want := range []string{"unreadable", "every origin activates everywhere until it parses"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("malformed: %q lacks %q", buf.String(), want)
+		}
+	}
+
+	buf.Reset()
+	body := `{"activations":{"mcp":{"local":false},"nosuch":{"local":false}}}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	doctorPolicy(&buf)
+	for _, want := range []string{"mcp", "deny local", "ignored", "this rule does nothing"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("valid: %q lacks %q", buf.String(), want)
+		}
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -451,7 +451,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 		}
 		hits, o.Total, o.Capped = detailed.Hits, detailed.Total, detailed.Capped
 	}
-	hits = policyFilterHits(policy.ActivationSearch, hits)
+	hits, policyHidden := policyFilterHitsCounted(policy.ActivationSearch, hits)
 	if !o.NoEmbed && os.Getenv("DEJA_EMBED") != "off" {
 		hits = maybeRerank(dir, hits, o, os.Stderr)
 	}
@@ -469,7 +469,13 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 		o.Total = len(hits)
 	}
 	if len(hits) == 0 {
-		printNoMatches(os.Stderr, dir, o.Query)
+		// The policy is named before the generic advice: "try fewer words" is
+		// wrong counsel for someone whose words were fine (#680).
+		if note := policyHiddenNote(policy.ActivationSearch, policyHidden); note != "" {
+			fmt.Fprint(os.Stderr, note)
+		} else {
+			printNoMatches(os.Stderr, dir, o.Query)
+		}
 	}
 	search.Print(os.Stdout, hits, o)
 	return nil

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -398,7 +398,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	} else if hits, err = search.Run(ss, o); err != nil {
 		return "", 0, 0, nil, err
 	}
-	hits = policyFilterHits(policy.ActivationMCP, hits)
+	hits, policyHidden := policyFilterHitsCounted(policy.ActivationMCP, hits)
 	if os.Getenv("DEJA_EMBED") != "off" {
 		hits = maybeRerank(dir, hits, o, os.Stderr)
 	}
@@ -406,7 +406,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	hits, semantic = maybeSemantic(dir, hits, o, os.Stderr)
 	o.Semantic = semantic
 	if len(hits) == 0 {
-		return emptyRecallAnswer(dir, q), 0, 0, nil, nil
+		return emptyRecallAnswerPolicy(dir, q, policyHidden), 0, 0, nil, nil
 	}
 	total := len(hits)
 	if offset > 0 {
@@ -529,14 +529,14 @@ func recallContextResult(dir, q, harness string) (string, int, int64, []string, 
 	} else if hits, err = search.Run(ss, o); err != nil {
 		return "", 0, 0, nil, err
 	}
-	hits = policyFilterHits(policy.ActivationMCP, hits)
+	hits, policyHidden := policyFilterHitsCounted(policy.ActivationMCP, hits)
 	var semantic bool
 	hits, semantic = maybeSemantic(dir, hits, o, os.Stderr)
 	if semantic {
 		o.Tier = search.TierSemantic
 	}
 	if len(hits) == 0 {
-		return emptyRecallAnswer(dir, q), 0, 0, nil, nil
+		return emptyRecallAnswerPolicy(dir, q, policyHidden), 0, 0, nil, nil
 	}
 	var b bytes.Buffer
 	search.PrintContext(&b, hits[0].Session, q)

--- a/cmd/deja/policyfilter.go
+++ b/cmd/deja/policyfilter.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
@@ -8,9 +10,31 @@ import (
 // policyFilterHits drops search hits the trust policy blocks on this
 // activation path. The default policy blocks nothing.
 func policyFilterHits(activation string, hits []search.Hit) []search.Hit {
-	return policy.Filter(policy.Load(), activation, hits, func(h search.Hit) string {
+	kept, _ := policyFilterHitsCounted(activation, hits)
+	return kept
+}
+
+// policyFilterHitsCounted also reports how many hits the policy took away.
+//
+// Without the count, "nothing matched" and "a rule hides it on this path" are
+// the same empty answer — and only the second one is something the reader can
+// act on (#680).
+func policyFilterHitsCounted(activation string, hits []search.Hit) ([]search.Hit, int) {
+	before := len(hits)
+	kept := policy.Filter(policy.Load(), activation, hits, func(h search.Hit) string {
 		return h.Session.Project
 	})
+	return kept, before - len(kept)
+}
+
+// policyHiddenNote is the one line that names the policy when it is the reason
+// an answer is empty.
+func policyHiddenNote(activation string, hidden int) string {
+	if hidden <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("deja: the trust policy hides %d matching session%s on this path (%s: %s) — see %s\n",
+		hidden, pluralS(hidden), activation, policy.Load().Describe(activation), policy.Path())
 }
 
 // policyFilterBlame is policyFilterHits for blame results, which carry whole

--- a/cmd/deja/policyfilter_test.go
+++ b/cmd/deja/policyfilter_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// "Nothing matched" and "a rule hides it on this path" are different facts,
+// and only the second is something the reader can act on (#680).
+func TestPolicyHiddenNoteNamesThePolicy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+	if err := os.WriteFile(path, []byte(`{"activations":{"search":{"local":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	note := policyHiddenNote(policy.ActivationSearch, 3)
+	for _, want := range []string{"3 matching sessions", "search", "deny local", path} {
+		if !strings.Contains(note, want) {
+			t.Errorf("note %q does not mention %q", note, want)
+		}
+	}
+	// Nothing hidden, nothing to say: a line on every empty result is noise.
+	if got := policyHiddenNote(policy.ActivationSearch, 0); got != "" {
+		t.Errorf("said %q with nothing hidden", got)
+	}
+}
+
+// An agent told "no prior sessions matched" concludes the work was never done
+// and starts over.
+func TestEmptyRecallAnswerNamesThePolicy(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(dir, "policy.json"))
+	if err := os.WriteFile(filepath.Join(dir, "policy.json"), []byte(`{"activations":{"mcp":{"local":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hidden := emptyRecallAnswerPolicy(dir, "connection pool", 2)
+	for _, want := range []string{"2 prior sessions matched", "trust policy", "not being shown"} {
+		if !strings.Contains(hidden, want) {
+			t.Errorf("answer %q does not mention %q", hidden, want)
+		}
+	}
+	if plain := emptyRecallAnswerPolicy(dir, "moria", 0); !strings.Contains(plain, "No prior deja sessions matched") {
+		t.Errorf("an ordinary miss said %q", plain)
+	}
+}
+
+func TestPolicyFilterHitsCounts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+	if err := os.WriteFile(path, []byte(`{"activations":{"search":{"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hits := []search.Hit{
+		{Session: model.Session{Project: "local-one"}},
+		{Session: model.Session{Project: "imported:peer/p"}},
+		{Session: model.Session{Project: "imported:other/p"}},
+	}
+	kept, hidden := policyFilterHitsCounted(policy.ActivationSearch, hits)
+	if len(kept) != 1 || hidden != 2 {
+		t.Fatalf("kept %d hidden %d, want 1 and 2", len(kept), hidden)
+	}
+	if kept[0].Session.Project != "local-one" {
+		t.Errorf("kept the wrong one: %q", kept[0].Session.Project)
+	}
+}

--- a/cmd/deja/warmup_status.go
+++ b/cmd/deja/warmup_status.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"os"
 	"path/filepath"
 	"sync"
@@ -179,9 +180,18 @@ func cmdWarmupStatus(dir string, _ []string) error {
 // reach deja only over MCP, so a tool result is the one place they can learn
 // that the first index is still being built. Without this the agent reads a
 // confident negative and tells the user they have no history.
-func emptyRecallAnswer(dir, q string) string {
+func emptyRecallAnswer(dir, q string) string { return emptyRecallAnswerPolicy(dir, q, 0) }
+
+// emptyRecallAnswerPolicy adds the reason when a rule, not the query, is why
+// the answer is empty. An agent told "no prior sessions matched" concludes the
+// work was never done and starts over (#680).
+func emptyRecallAnswerPolicy(dir, q string, hidden int) string {
 	if st := readWarmupStatus(dir); st != nil {
 		return fmt.Sprintf("deja is still building its index (%s). Nothing can be recalled yet — it finishes within a few seconds, so ask again later in this session rather than concluding there is no history.", st.progress())
+	}
+	if hidden > 0 {
+		return fmt.Sprintf("%d prior session%s matched %q, but this machine's trust policy (%s) does not allow them on this path. There is prior work here; it is not being shown.",
+			hidden, pluralS(hidden), q, policy.Load().Describe(policy.ActivationMCP))
 	}
 	return fmt.Sprintf("No prior deja sessions matched %q.", q)
 }

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -128,3 +128,42 @@ func Filter[T any](p Policy, activation string, items []T, projectOf func(T) str
 	}
 	return out
 }
+
+// Diagnose reports what a reader needs to know about the policy file: whether
+// it exists, whether it parses, and which keys it uses that mean nothing.
+//
+// Load deliberately falls back to the permissive default on any error, so a
+// malformed file changes nothing and says nothing — the wrong outcome for the
+// one mechanism separating local memory from imported (#661).
+func Diagnose() (exists bool, err error, unknown []string) {
+	path := Path()
+	b, rerr := os.ReadFile(path)
+	if rerr != nil {
+		if os.IsNotExist(rerr) {
+			return false, nil, nil
+		}
+		return true, rerr, nil
+	}
+	var p Policy
+	if jerr := json.Unmarshal(b, &p); jerr != nil {
+		return true, jerr, nil
+	}
+	// A file that parses but names an activation or origin deja never consults
+	// is silently doing nothing, which reads exactly like a rule that works.
+	for activation, rules := range p.Activations {
+		switch activation {
+		case ActivationSearch, ActivationMCP, ActivationAuto:
+		default:
+			unknown = append(unknown, "activation "+activation)
+			continue
+		}
+		for origin := range rules {
+			if origin == "local" || origin == "imported" || strings.HasPrefix(origin, "imported:") {
+				continue
+			}
+			unknown = append(unknown, activation+"."+origin)
+		}
+	}
+	sort.Strings(unknown)
+	return true, nil, unknown
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -135,18 +135,18 @@ func Filter[T any](p Policy, activation string, items []T, projectOf func(T) str
 // Load deliberately falls back to the permissive default on any error, so a
 // malformed file changes nothing and says nothing — the wrong outcome for the
 // one mechanism separating local memory from imported (#661).
-func Diagnose() (exists bool, err error, unknown []string) {
+func Diagnose() (exists bool, unknown []string, err error) {
 	path := Path()
 	b, rerr := os.ReadFile(path)
 	if rerr != nil {
 		if os.IsNotExist(rerr) {
 			return false, nil, nil
 		}
-		return true, rerr, nil
+		return true, nil, rerr
 	}
 	var p Policy
 	if jerr := json.Unmarshal(b, &p); jerr != nil {
-		return true, jerr, nil
+		return true, nil, jerr
 	}
 	// A file that parses but names an activation or origin deja never consults
 	// is silently doing nothing, which reads exactly like a rule that works.
@@ -165,5 +165,5 @@ func Diagnose() (exists bool, err error, unknown []string) {
 		}
 	}
 	sort.Strings(unknown)
-	return true, nil, unknown
+	return true, unknown, nil
 }

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -107,5 +108,37 @@ func TestFilterDropsBlocked(t *testing.T) {
 	got := Filter(Load(), ActivationSearch, items, func(s string) string { return s })
 	if len(got) != 2 || got[0] != "deja-vu" || got[1] != "other" {
 		t.Fatalf("Filter = %v", got)
+	}
+}
+
+// Load falls back to the permissive default on any error, so a malformed file
+// changed nothing and said nothing (#661). Diagnose is what doctor reads.
+func TestDiagnose(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+
+	if exists, err, unknown := Diagnose(); exists || err != nil || unknown != nil {
+		t.Fatalf("no file: exists=%v err=%v unknown=%v", exists, err, unknown)
+	}
+	if err := os.WriteFile(path, []byte("{ oops"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if exists, err, _ := Diagnose(); !exists || err == nil {
+		t.Fatalf("malformed: exists=%v err=%v", exists, err)
+	}
+	// Rules that name something deja never consults are silently doing nothing,
+	// which reads exactly like a rule that works.
+	body := `{"activations":{"auto":{"nosuchorigin":false},"nosuch":{"local":false},"mcp":{"imported:peer1":false,"local":true}}}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	exists, err, unknown := Diagnose()
+	if !exists || err != nil {
+		t.Fatalf("valid: exists=%v err=%v", exists, err)
+	}
+	want := []string{"activation nosuch", "auto.nosuchorigin"}
+	if strings.Join(unknown, "|") != strings.Join(want, "|") {
+		t.Errorf("unknown = %v, want %v", unknown, want)
 	}
 }

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -118,13 +118,13 @@ func TestDiagnose(t *testing.T) {
 	path := filepath.Join(dir, "policy.json")
 	t.Setenv("DEJA_POLICY_FILE", path)
 
-	if exists, err, unknown := Diagnose(); exists || err != nil || unknown != nil {
+	if exists, unknown, err := Diagnose(); exists || err != nil || unknown != nil {
 		t.Fatalf("no file: exists=%v err=%v unknown=%v", exists, err, unknown)
 	}
 	if err := os.WriteFile(path, []byte("{ oops"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if exists, err, _ := Diagnose(); !exists || err == nil {
+	if exists, _, err := Diagnose(); !exists || err == nil {
 		t.Fatalf("malformed: exists=%v err=%v", exists, err)
 	}
 	// Rules that name something deja never consults are silently doing nothing,
@@ -133,12 +133,27 @@ func TestDiagnose(t *testing.T) {
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	exists, err, unknown := Diagnose()
+	exists, unknown, err := Diagnose()
 	if !exists || err != nil {
 		t.Fatalf("valid: exists=%v err=%v", exists, err)
 	}
 	want := []string{"activation nosuch", "auto.nosuchorigin"}
 	if strings.Join(unknown, "|") != strings.Join(want, "|") {
 		t.Errorf("unknown = %v, want %v", unknown, want)
+	}
+}
+
+// A path that exists but cannot be read as a file — the config directory left
+// where the file should be — is neither "no policy" nor "malformed policy".
+func TestDiagnoseUnreadablePath(t *testing.T) {
+	dir := t.TempDir()
+	asDir := filepath.Join(dir, "policy.json")
+	if err := os.MkdirAll(asDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", asDir)
+	exists, _, err := Diagnose()
+	if !exists || err == nil {
+		t.Fatalf("exists=%v err=%v", exists, err)
 	}
 }


### PR DESCRIPTION
With `{"activations":{"search":{"local":false},"mcp":{"local":false}}}`, three matching sessions answered "no matches in 3 indexed sessions — try fewer words" and, to the agent, "No prior deja sessions matched". Nothing named the policy, and `doctor` — the command whose job is "is my setup right" — never mentioned it either, so there was no second place to find out.

Now:

```
$ deja "connection pool starves"
deja: the trust policy hides 1 matching session on this path (search: deny local) — see ~/.config/deja/policy.json

recall → 1 prior session matched "connection pool starves", but this machine's trust policy (deny local)
         does not allow them on this path. There is prior work here; it is not being shown.

$ deja doctor
Trust policy:
  search       deny local
  mcp          deny local
  auto         local+imported
```

A malformed file says so and states what is actually in force (the permissive default — the file reads like a restriction). Rules naming an activation or origin deja never consults are listed as doing nothing.

Ordinary misses stay quiet.

Closes #680
Closes #661