### PR TITLE
fix: record blame calls so deja log covers what the agent was given

### DIFF
--- a/cmd/deja/blame_extra_test.go
+++ b/cmd/deja/blame_extra_test.go
@@ -25,7 +25,7 @@ func TestBlameErrorAndEmptyBranches(t *testing.T) {
 	if err := runBlame(index.DefaultDir(), []string{"parser.go"}); err == nil {
 		t.Fatal("expected blame error for squatted index dir")
 	}
-	if _, err := blameTextResult(index.DefaultDir(), search.BlameOptions{}, "parser.go", 5); err == nil {
+	if _, _, err := blameTextResult(index.DefaultDir(), search.BlameOptions{}, "parser.go", 5); err == nil {
 		t.Fatal("expected MCP blame error for squatted index dir")
 	}
 	// Healthy empty index: the no-mentions message path.
@@ -34,7 +34,7 @@ func TestBlameErrorAndEmptyBranches(t *testing.T) {
 	if err != nil || out != "" {
 		t.Fatalf("blame on empty index: %v (out=%q)", err, out)
 	}
-	if s, err := blameTextResult(index.DefaultDir(), search.BlameOptions{}, "never-mentioned.go", 5); err != nil || s == "" {
+	if s, _, err := blameTextResult(index.DefaultDir(), search.BlameOptions{}, "never-mentioned.go", 5); err != nil || s == "" {
 		t.Fatalf("mcp empty = %q err=%v", s, err)
 	}
 }

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -226,7 +226,16 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 				return "", err
 			}
 		}
-		return blameTextResult(dir, search.BlameOptions{Harness: a.Harness, Project: a.Project, Since: since, All: a.All}, a.Path, int(a.Limit))
+		text, hits, err := blameTextResult(dir, search.BlameOptions{Harness: a.Harness, Project: a.Project, Since: since, All: a.All}, a.Path, int(a.Limit))
+		if err == nil {
+			// blame answers the agent the way recall does, and hands over more
+			// than either — whole sessions rather than budgeted snippets. Not
+			// recording it left `deja log` understating what the agent was
+			// given (#682).
+			usage.RecordResult(dir, usage.KindBlame, len(text), hits, hits == 0)
+			usage.SnapshotPolicy(dir, usage.KindBlame, text, hits, policy.Load().Describe(policy.ActivationMCP))
+		}
+		return text, err
 	case "remember":
 		var a struct {
 			Text    string `json:"text"`
@@ -253,14 +262,15 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 	}
 }
 
-func blameTextResult(dir string, o search.BlameOptions, path string, limit int) (string, error) {
+// blameTextResult returns the answer and how many sessions it names.
+func blameTextResult(dir string, o search.BlameOptions, path string, limit int) (string, int, error) {
 	target, err := search.ResolveBlamePath(path)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	hits, err := findBlameHits(dir, target, o, policy.ActivationMCP, mcpProgress())
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	if limit <= 0 {
 		limit = 10
@@ -273,7 +283,7 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 	// against the ~4 KB the other tools answer in. The snippets that sit beside
 	// it are the part an agent reads; the full session is one recall_context
 	// away when it genuinely needs it.
-	return string(mustMarshalBlame(hits)), nil
+	return string(mustMarshalBlame(hits)), len(hits), nil
 }
 
 // blameHitJSON is what the MCP blame tool returns: the same shape as the CLI's

--- a/cmd/deja/mcp_blame_log_test.go
+++ b/cmd/deja/mcp_blame_log_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// `deja log` answers "what did deja put in front of the agent". blame hands
+// over more than recall does — whole sessions rather than budgeted snippets —
+// and left no trace at all (#682).
+func TestBlameOverMCPIsRecorded(t *testing.T) {
+	dir := seedBlameIndex(t)
+	before := len(usage.Snapshots(dir, 100))
+	beforeTotals := usage.Totals(dir)
+
+	text, err := callMCPTool(dir, "blame", json.RawMessage(`{"path":"pool.go"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	after := usage.Snapshots(dir, 100)
+	if len(after) != before+1 {
+		t.Fatalf("snapshots %d -> %d, want one more", before, len(after))
+	}
+	last := after[0]
+	if last.Kind != usage.KindBlame {
+		t.Errorf("kind = %q, want %q", last.Kind, usage.KindBlame)
+	}
+	// The recorded size has to be what the agent actually received, or the log
+	// is a story about a different call.
+	if last.Bytes != len(text) {
+		t.Errorf("recorded %d bytes, handed over %d", last.Bytes, len(text))
+	}
+	if last.Digest != text {
+		t.Errorf("digest is not what was handed over:\n%q\n%q", last.Digest, text)
+	}
+	// Two records, two readers: the snapshot carries the text, the usage log
+	// carries the counters the statusline and `deja stats` add up.
+	afterTotals := usage.Totals(dir)
+	if afterTotals.Recalls != beforeTotals.Recalls+1 {
+		t.Errorf("usage recalls %d -> %d, want one more", beforeTotals.Recalls, afterTotals.Recalls)
+	}
+	if afterTotals.Bytes != beforeTotals.Bytes+len(text) {
+		t.Errorf("usage bytes %d -> %d, handed over %d", beforeTotals.Bytes, afterTotals.Bytes, len(text))
+	}
+	if last.Sessions == 0 {
+		t.Errorf("recorded 0 sessions for an answer naming one: %q", text)
+	}
+}
+
+// seedBlameIndex builds a store whose sessions name a file in their speech,
+// which is what blame matches on.
+func seedBlameIndex(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-b")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	body := `{"type":"user","sessionId":"b1","cwd":"/w/b","timestamp":"2026-07-11T10:00:00Z","message":{"role":"user","content":"we rewrote pool.go to fix the starvation"}}` + "\n" +
+		`{"type":"assistant","sessionId":"b1","cwd":"/w/b","timestamp":"2026-07-11T10:01:00Z","message":{"role":"assistant","content":[{"type":"text","text":"capped the pool at 200"}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "b1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}

--- a/cmd/deja/policy_leak_test.go
+++ b/cmd/deja/policy_leak_test.go
@@ -101,7 +101,7 @@ func TestBlameHonorsPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("DEJA_POLICY_FILE", pol)
-	got, err := blameTextResult(dir, search.BlameOptions{All: true}, "handler_test.go", 10)
+	got, _, err := blameTextResult(dir, search.BlameOptions{All: true}, "handler_test.go", 10)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -20,6 +20,11 @@ const (
 	KindContext = "recall_context"
 	KindHook    = "hook"
 	KindSearch  = "search"
+	// KindBlame is the MCP blame tool. It answers the agent like recall does,
+	// and it is the largest thing the server hands over — whole sessions
+	// rather than budgeted snippets — so leaving it out understated what the
+	// agent was given (#682).
+	KindBlame   = "blame"
 	KindHandoff = "handoff"
 	// KindDejaVu marks a per-prompt recall: the user asked something their
 	// own history already answers — the product's namesake moment.
@@ -119,7 +124,7 @@ func TodayWithInjections(indexDir string) (recalls, bytes, injected int) {
 			continue
 		}
 		switch e.Kind {
-		case KindRecall, KindContext:
+		case KindRecall, KindContext, KindBlame:
 			recalls++
 			bytes += e.Bytes
 		case KindHook, KindDejaVu:
@@ -154,7 +159,7 @@ func TodayRaw(indexDir string) int64 {
 			continue
 		}
 		switch e.Kind {
-		case KindRecall, KindContext, KindHook, KindDejaVu:
+		case KindRecall, KindContext, KindBlame, KindHook, KindDejaVu:
 			raw += e.RawBytes
 		}
 	}
@@ -167,7 +172,7 @@ func Totals(indexDir string) Summary {
 	empty := 0
 	for _, e := range read(Path(indexDir)) {
 		switch e.Kind {
-		case KindRecall, KindContext:
+		case KindRecall, KindContext, KindBlame:
 			out.Recalls++
 			out.RecallSessions += e.Sessions
 			out.Bytes += e.Bytes
@@ -204,7 +209,7 @@ func Week(indexDir string) (recalls, bytes, injected, injectedBytes int) {
 			continue
 		}
 		switch e.Kind {
-		case KindRecall, KindContext:
+		case KindRecall, KindContext, KindBlame:
 			recalls++
 			bytes += e.Bytes
 		case KindHook, KindDejaVu:


### PR DESCRIPTION
`deja log` answers "what did deja put in front of the agent". recall and recall_context are recorded to the byte; blame was not recorded at all, though it hands over more than either — whole sessions rather than budgeted snippets.

```
before: 415 B handed to the agent, usage log 5 records → 5
after:  blame  414 B · 1 session
```

Closes #682