### PR TITLE
fix: an empty result names the states the user created

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -525,6 +525,26 @@ func printNoMatches(w io.Writer, dir, q string) {
 	if hint := commandHint(q); hint != "" {
 		fmt.Fprint(w, hint)
 	}
+	if note := hiddenByOwnSettings(); note != "" {
+		fmt.Fprint(w, note)
+	}
+}
+
+// hiddenByOwnSettings names the states the reader created themselves and can
+// undo. "Forgotten", "excluded by my own pattern" and "never happened" were one
+// answer, and "try fewer words" is wrong counsel for the first two (#686).
+func hiddenByOwnSettings() string {
+	var parts []string
+	if n := len(index.Tombstones()); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d session%s forgotten (`deja forget --list`)", n, pluralS(n)))
+	}
+	if pats := sources.ExclusionPatterns(); len(pats) > 0 {
+		parts = append(parts, fmt.Sprintf("%d project pattern%s excluded from indexing (%s)", len(pats), pluralS(len(pats)), sources.ExcludePath()))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "deja: this machine also has " + strings.Join(parts, ", ") + "\n"
 }
 
 // commandHint reads an empty search as a possible mistyped subcommand. It

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -1357,3 +1357,42 @@ func TestCommandHint(t *testing.T) {
 		}
 	}
 }
+
+// "Forgotten", "excluded by my own pattern" and "never happened" were one
+// answer, and "try fewer words" is wrong counsel for the first two (#686).
+func TestHiddenByOwnSettings(t *testing.T) {
+	withTempStores(t)
+	// Nothing configured: nothing to say. A line on every empty result is
+	// noise that teaches people to skip the last line.
+	if got := hiddenByOwnSettings(); got != "" {
+		t.Errorf("clean machine said %q", got)
+	}
+
+	cfg := filepath.Join(os.Getenv("HOME"), ".config", "deja")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg, "exclude"), []byte("secret\nclientwork\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := hiddenByOwnSettings()
+	if !strings.Contains(got, "2 project patterns excluded") || !strings.Contains(got, "exclude") {
+		t.Errorf("exclude only: %q", got)
+	}
+	if strings.Contains(got, "forgotten") {
+		t.Errorf("claimed forgotten sessions with no tombstones: %q", got)
+	}
+
+	// A real forget, so the tombstone is written the way the command writes it.
+	seedTouchedIndex(t, 2, "/w/t/shared.go")
+	if err := os.WriteFile(filepath.Join(cfg, "exclude"), []byte("secret\nclientwork\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "forget", "--session", "t00"); err != nil {
+		t.Fatal(err)
+	}
+	got = hiddenByOwnSettings()
+	if !strings.Contains(got, "forgotten") || !strings.Contains(got, "deja forget --list") {
+		t.Errorf("after forget: %q", got)
+	}
+}


### PR DESCRIPTION
Three causes, one answer: a session the user forgot, a project their own exclude pattern skips, and a subject that never existed all printed "no matches — try fewer words or --re".

The first two are states the reader made and can undo, and now the empty result says so:

```
deja: no matches in 1 indexed session — try fewer words or --re (query "payroll")
deja: this machine also has 1 session forgotten (`deja forget --list`), 1 project pattern excluded from indexing (~/.config/deja/exclude)
```

A machine with neither configured says nothing extra. Pairs with #680, which did the same for the trust policy.

Closes #686