### PR TITLE
fix: blame sees the sessions that edited the file, not only those that named it

### DIFF
--- a/cmd/deja/blame_touchers_test.go
+++ b/cmd/deja/blame_touchers_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// blame picks candidates with an ordinary search for the file's stem, and the
+// paths a tool call recorded do not answer one — so the session that actually
+// changed the file was invisible while an older one that only mentioned it in
+// passing was the answer (#688).
+func TestBlameFindsSessionsThatOnlyTouchedTheFile(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	write := func(name string, lines ...string) {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	edit := func(path string) string {
+		b, _ := json.Marshal(map[string]any{"file_path": path, "old_string": "a", "new_string": "b"})
+		return `{"type":"assistant","sessionId":"edited","cwd":"/w/p","timestamp":"2026-07-25T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":` + string(b) + `}]}}`
+	}
+	// Says the name, never touches it.
+	write("named.jsonl",
+		`{"type":"user","sessionId":"named","cwd":"/w/p","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"we rewrote pool.go to fix the starvation"}}`)
+	// Touches it, never says the name.
+	write("edited.jsonl",
+		`{"type":"user","sessionId":"edited","cwd":"/w/p","timestamp":"2026-07-25T10:00:00Z","message":{"role":"user","content":"the starvation is back under burst load"}}`,
+		edit(filepath.ToSlash(filepath.Join(tmp, "repo", "pool.go"))))
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	target, err := search.ResolveBlamePath("pool.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hits, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := map[string]bool{}
+	for _, h := range hits {
+		ids[h.Session.ID] = true
+	}
+	if !ids["edited"] {
+		t.Errorf("the session that edited the file is missing: %v", ids)
+	}
+	if !ids["named"] {
+		t.Errorf("the session that named the file is missing: %v", ids)
+	}
+	// Newer work on the same file comes first — that is the question blame answers.
+	if len(hits) > 0 && hits[0].Session.ID != "edited" {
+		t.Errorf("top hit = %q, want the session that actually changed it", hits[0].Session.ID)
+	}
+}
+
+// A blame for a file nobody touched must not drag in unrelated sessions.
+func TestBlameTouchersMatchTheWholeName(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	body := `{"type":"user","sessionId":"e1","cwd":"/w/p","timestamp":"2026-07-25T10:00:00Z","message":{"role":"user","content":"unrelated work"}}` + "\n" +
+		`{"type":"assistant","sessionId":"e1","cwd":"/w/p","timestamp":"2026-07-25T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/poolmanager.go","old_string":"a","new_string":"b"}}]}}` + "\n" +
+		// A path that *contains* the name is not the file: old-pool.go and
+		// pool.go are two files, and substring matching answers for both.
+		`{"type":"assistant","sessionId":"e1","cwd":"/w/p","timestamp":"2026-07-25T10:02:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/old-pool.go","old_string":"a","new_string":"b"}}]}}`
+	if err := os.WriteFile(filepath.Join(root, "e1.jsonl"), []byte(body+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	target, err := search.ResolveBlamePath("pool.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hits, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 0 {
+		t.Errorf("poolmanager.go answered a blame for pool.go: %#v", hits)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -948,7 +948,63 @@ func findBlameHits(dir string, target search.BlameTarget, o search.BlameOptions,
 	if err != nil {
 		return nil, err
 	}
-	return policyFilterBlame(activation, search.Blame(result.Sessions, target, o)), nil
+	return policyFilterBlame(activation, search.Blame(withFileTouchers(dir, result.Sessions, target), target, o)), nil
+}
+
+// blameToucherCap bounds how many extra sessions a blame reads from the
+// manifest. Measured on 500 sessions all touching one file: 0.08s uncapped
+// against 0.02s capped, with the same ten at the top.
+const blameToucherCap = 50
+
+// withFileTouchers adds the sessions that edited or opened the file but never
+// said its name.
+//
+// blame picks its candidates with an ordinary search for the file's stem, and
+// the paths a tool call recorded do not answer one: the newer session that
+// actually changed pool.go was invisible while an older one that only
+// mentioned it in passing was the answer (#688). The manifest already knows
+// which files each session touched, so this costs one metadata read.
+func withFileTouchers(dir string, ss []model.Session, target search.BlameTarget) []model.Session {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return ss
+	}
+	have := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		have[s.Harness+":"+s.ID] = true
+	}
+	base := strings.ToLower(filepath.Base(target.FullPath))
+	// Newest first, so the cap below keeps the sessions a "who last worked on
+	// this" question is actually about.
+	// Identity breaks ties, or which sessions survive the cap depends on Go's
+	// map order and two runs disagree — the same failure as #668.
+	sort.Slice(metas, func(i, j int) bool { return newestFirst(metas[i], metas[j]) })
+	added := 0
+	for _, meta := range metas {
+		// A file like main.go is touched by everything, and each addition is a
+		// record read. Ten hits are printed; this is far more than enough to
+		// rank them.
+		if added >= blameToucherCap {
+			break
+		}
+		key := meta.Harness + ":" + meta.ID
+		if have[key] {
+			continue
+		}
+		for _, p := range meta.Touched {
+			if strings.ToLower(filepath.Base(filepath.FromSlash(p))) != base {
+				continue
+			}
+			full, ok, err := index.FindByIdentity(dir, meta.Harness, meta.ID)
+			if err == nil && ok {
+				ss = append(ss, full)
+				have[key] = true
+				added++
+			}
+			break
+		}
+	}
+	return ss
 }
 func parseDur(s string) (time.Duration, error) {
 	if strings.HasSuffix(s, "d") {

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -58,9 +58,15 @@ func ResolveBlamePath(name string) (BlameTarget, error) {
 }
 
 func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
+	// One clock reading for the whole ranking. Called per session, the decay
+	// differed by nanoseconds between candidates, so sessions with identical
+	// evidence and identical timestamps sorted differently on every run — five
+	// runs, five different top hits once blame started seeing the sessions that
+	// only touched the file (#688).
+	now := time.Now()
 	cut := time.Time{}
 	if o.Since > 0 {
-		cut = time.Now().Add(-o.Since)
+		cut = now.Add(-o.Since)
 	}
 	base := strings.ToLower(filepath.ToSlash(target.Base))
 	forms := blameForms(target.FullPath)
@@ -97,7 +103,7 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 		if projectContainsFile(session.Project, target.FullPath) {
 			score *= 1.35
 		}
-		hit.Score = score * freshnessDecay(session.Updated, time.Now())
+		hit.Score = score * freshnessDecay(session.Updated, now)
 		hits = append(hits, hit)
 	}
 	sort.Slice(hits, func(i, j int) bool {

--- a/internal/search/blame_test.go
+++ b/internal/search/blame_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -109,6 +110,37 @@ func BenchmarkBlameVerification1000Candidates(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		if got := Blame(ss, target, BlameOptions{All: true}); len(got) != len(ss) {
 			b.Fatalf("hits=%d", len(got))
+		}
+	}
+}
+
+// The decay was read from the clock once per session, so candidates with
+// identical evidence and identical timestamps sorted differently on every run
+// — five runs, five different top hits (#688).
+func TestBlameRanksTheSameWayEveryRun(t *testing.T) {
+	day := time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC)
+	var ss []model.Session
+	for i := 0; i < 40; i++ {
+		id := fmt.Sprintf("s%02d", i)
+		ss = append(ss, model.Session{
+			Harness: "claude", ID: id, Project: "p", Updated: day,
+			Messages: []model.Message{{Role: "files", Text: "/repo/main.go", Time: day}},
+		})
+	}
+	target, err := ResolveBlamePath("/repo/main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := Blame(ss, target, BlameOptions{All: true})
+	if len(first) == 0 {
+		t.Fatal("no hits")
+	}
+	for run := 0; run < 20; run++ {
+		got := Blame(ss, target, BlameOptions{All: true})
+		for i := range got {
+			if got[i].Session.ID != first[i].Session.ID {
+				t.Fatalf("run %d position %d: %q, first run had %q", run, i, got[i].Session.ID, first[i].Session.ID)
+			}
 		}
 	}
 }


### PR DESCRIPTION
`deja blame` answers "who last worked on this file", but picked its candidates with a text search for the file's stem — so a session that edited pool.go through a tool call, without ever writing the name, did not exist as far as blame was concerned:

```
$ deja blame pool.go
2026-07-21 · claude · named · we rewrote pool.go to fix the starvation     # only mentions it

$ deja search pool.go --role files
[claude] proj/p · Jul 25 · edited — 1 matches                              # actually changed it
```

The manifest already records which files each session touched, so this is one metadata read. Capped at 50 extra sessions, newest first: measured on 500 sessions all touching one file, 0.08s uncapped against 0.02s capped with an identical answer.

Fixing it exposed a second thing: `Blame` read the clock once per session, so the freshness decay differed by nanoseconds between candidates and sessions with identical evidence ranked differently on every run — five runs, five different top hits. One reading for the whole ranking.

Closes #688