### PR TITLE
fix: forget --project clears borrowed note titles and names what it dropped

### DIFF
--- a/cmd/deja/forget_notes_test.go
+++ b/cmd/deja/forget_notes_test.go
@@ -45,7 +45,11 @@ func TestForgetByProjectClearsBorrowedTitlesAndNamesTheNotes(t *testing.T) {
 
 	// The dry run has to warn about the notes too — it exists to answer "how
 	// much am I about to lose", and the notes are the part worth keeping.
-	dry, err := captureRun(t, "forget", "--project", "proj/p", "--dry-run")
+	// The project name is derived from the store's directory layout, so it
+	// carries the platform's separator — hard-coding "proj/p" passes on unix
+	// and matches nothing on Windows.
+	project := projectOf(t, dir, "a1")
+	dry, err := captureRun(t, "forget", "--project", project, "--dry-run")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +57,7 @@ func TestForgetByProjectClearsBorrowedTitlesAndNamesTheNotes(t *testing.T) {
 		t.Errorf("dry run does not mention the note: %q", dry)
 	}
 
-	out, err := captureRun(t, "forget", "--project", "proj/p")
+	out, err := captureRun(t, "forget", "--project", project)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +108,7 @@ func TestForgetLeavesOtherProjectsNotesAlone(t *testing.T) {
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := captureRun(t, "forget", "--project", "proj/p"); err != nil {
+	if _, err := captureRun(t, "forget", "--project", projectOf(t, index.DefaultDir(), "a1")); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(notes)
@@ -114,4 +118,21 @@ func TestForgetLeavesOtherProjectsNotesAlone(t *testing.T) {
 	if !strings.Contains(string(b), "a title from another project") {
 		t.Errorf("cleared a title belonging to a project that was not forgotten:\n%s", b)
 	}
+}
+
+// projectOf reads a session's project back out of the manifest, so a test can
+// name it the way this platform recorded it.
+func projectOf(t *testing.T, dir, id string) string {
+	t.Helper()
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range metas {
+		if m.ID == id {
+			return m.Project
+		}
+	}
+	t.Fatalf("session %q not in the manifest", id)
+	return ""
 }

--- a/cmd/deja/forget_notes_test.go
+++ b/cmd/deja/forget_notes_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The #666 cleanup keyed off --session, so --project and --before left the
+// borrowed line — a customer name, in the case that found this — sitting in
+// notes.jsonl after the project was forgotten (#690).
+func TestForgetByProjectClearsBorrowedTitlesAndNamesTheNotes(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	other := filepath.Join(tmp, "claude", "proj-q")
+	for _, d := range []string{root, other} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	write := func(dir, sid, text string) {
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/w/` + filepath.Base(dir) + `","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(dir, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(root, "a1", "the payroll export for ACME-4471")
+	write(root, "a2", "the payroll retry path")
+	write(other, "b1", "unrelated caching work")
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "promote", "a1", "--state", "accepted", "--note", "batch the export nightly"); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The dry run has to warn about the notes too — it exists to answer "how
+	// much am I about to lose", and the notes are the part worth keeping.
+	dry, err := captureRun(t, "forget", "--project", "proj/p", "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(dry, "1 of them is a promoted note") {
+		t.Errorf("dry run does not mention the note: %q", dry)
+	}
+
+	out, err := captureRun(t, "forget", "--project", "proj/p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "cleared the borrowed title") {
+		t.Errorf("forget --project said %q", out)
+	}
+	// The count folds notes and transcripts together, so it has to say which
+	// is which: the notes are what the reader deliberately kept.
+	// Two raw sessions and one note: the exact split, not just the words
+	// "promoted note" — the line above already contains those.
+	if !strings.Contains(out, "1 of them is a promoted note") {
+		t.Errorf("report does not distinguish notes: %q", out)
+	}
+	if !strings.Contains(out, "sessions dropped: 3") {
+		t.Errorf("dropped count changed: %q", out)
+	}
+	b, err := os.ReadFile(filepath.Join(tmp, "notes.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "ACME-4471") {
+		t.Errorf("the forgotten project's first line survived on disk:\n%s", b)
+	}
+	if !strings.Contains(string(b), "batch the export nightly") {
+		t.Errorf("the decision was destroyed:\n%s", b)
+	}
+}
+
+// A project that was never promoted from must not have its notes touched.
+func TestForgetLeavesOtherProjectsNotesAlone(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	body := `{"type":"user","sessionId":"a1","cwd":"/w/p","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"the payroll export"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "a1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	notes := filepath.Join(tmp, "notes.jsonl")
+	keep := map[string]any{"ts": "2026-07-21T10:00:00Z", "project": "elsewhere", "text": "someone else's decision",
+		"kind": "promoted", "session": "claude:zz9", "state": "accepted", "title": "a title from another project"}
+	line, _ := json.Marshal(keep)
+	if err := os.WriteFile(notes, append(line, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "forget", "--project", "proj/p"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(notes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "a title from another project") {
+		t.Errorf("cleared a title belonging to a project that was not forgotten:\n%s", b)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1202,15 +1202,29 @@ func runForget(dir string, args []string) error {
 	if o.DryRun {
 		fmt.Fprintf(os.Stdout, "dry run — nothing was changed\nwould drop: %d session(s), %d message(s)\nwould add: %d tombstone(s)\n",
 			result.Sessions, result.Messages, result.Tombstones)
+		if result.Notes > 0 {
+			fmt.Fprintf(os.Stdout, "%d of them %s promoted note%s — the decisions you kept, not raw sessions\n",
+				result.Notes, verbWere(result.Notes), pluralS(result.Notes))
+		}
 		return nil
 	}
 	// A promoted note borrows the source session's first line as its title, and
 	// the note is a separate record — so forgetting a session left that line on
 	// screen in `deja last` (#666). The note stays; only the borrowed title
 	// goes, and the parser falls back to "promoted from <src>".
-	if result.Sessions > 0 && o.Session != "" {
+	//
+	// Matching on the keys that were actually dropped rather than on the
+	// selector: --project and --before drop sessions too, and keying off
+	// o.Session left the borrowed line — a customer name, in the case that
+	// found this — sitting in notes.jsonl after the project was forgotten
+	// (#690).
+	if len(result.Keys) > 0 {
+		dropped := make(map[string]bool, len(result.Keys))
+		for _, k := range result.Keys {
+			dropped[k] = true
+		}
 		if n, err := sources.ForgetPromotedTitles(func(src string) bool {
-			return strings.Contains(src, o.Session)
+			return dropped[src]
 		}); err == nil && n > 0 {
 			fmt.Fprintf(os.Stdout, "cleared the borrowed title from %d promoted note%s\n", n, pluralS(n))
 		}
@@ -1224,7 +1238,22 @@ func runForget(dir string, args []string) error {
 		return nil
 	}
 	fmt.Fprintf(os.Stdout, "sessions dropped: %d\nmessages dropped: %d\ntombstones added: %d\n", result.Sessions, result.Messages, result.Tombstones)
+	// The notes are decisions the reader deliberately kept, so folding them
+	// into the session count reads as "four conversations" when half of it is
+	// their own writing (#690).
+	if result.Notes > 0 {
+		fmt.Fprintf(os.Stdout, "%d of them %s promoted note%s — the decisions you kept, not raw sessions\n",
+			result.Notes, verbWere(result.Notes), pluralS(result.Notes))
+	}
 	return nil
+}
+
+// verbWere keeps "1 of them are promoted notes" off the screen.
+func verbWere(n int) string {
+	if n == 1 {
+		return "is a"
+	}
+	return "are"
 }
 
 // forgetSelector names what the caller asked to forget, so the empty answer

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -23,6 +23,15 @@ type ForgetResult struct {
 	Sessions   int
 	Messages   int
 	Tombstones int
+	// Keys of the sessions that matched, harness:id. The caller needs them to
+	// clean up what lives outside the index — the titles promoted notes
+	// borrowed from these sessions (#666, #690).
+	Keys []string
+	// Notes is how many of Sessions were promoted notes rather than raw
+	// transcripts. They are the decisions the user deliberately kept, so one
+	// combined number reads as "four conversations" when half of it is their
+	// own записи.
+	Notes int
 }
 
 func privacyDir() string {
@@ -196,6 +205,10 @@ func Forget(dir string, o ForgetOptions) (ForgetResult, error) {
 		}
 		matched[key] = true
 		result.Sessions++
+		result.Keys = append(result.Keys, key)
+		if meta.Harness == "deja" {
+			result.Notes++
+		}
 		if !dead[key] {
 			result.Tombstones++
 		}
@@ -206,6 +219,7 @@ func Forget(dir string, o ForgetOptions) (ForgetResult, error) {
 	if result.Sessions == 0 {
 		return result, nil
 	}
+	sort.Strings(result.Keys)
 	// Count the messages on the dry run too. It is the same single pass over
 	// records, and without it `--dry-run` answers "0 messages" to the only
 	// question it exists to answer: how much am I about to lose.

--- a/internal/index/privacy_test.go
+++ b/internal/index/privacy_test.go
@@ -135,7 +135,8 @@ func TestTombstonePersistenceAndForgetNoop(t *testing.T) {
 		t.Fatal(err)
 	}
 	result, err := Forget(dir, ForgetOptions{Project: "missing"})
-	if err != nil || result != (ForgetResult{}) {
+	if err != nil || result.Sessions != 0 || result.Messages != 0 || result.Tombstones != 0 ||
+		result.Notes != 0 || len(result.Keys) != 0 {
 		t.Fatalf("no-op forget=%#v err=%v", result, err)
 	}
 }


### PR DESCRIPTION
Two things in one output.

The #666 cleanup ran only for `forget --session`, so `--project` (and `--before`) left the borrowed line on disk:

```
$ deja forget --project proj/p
sessions dropped: 4
$ cat ~/.local/share/deja/notes.jsonl
{... "session":"claude:a1", "title":"the payroll export for ACME-4471" ...}
```

Matching is now on the keys actually dropped rather than on the selector.

And "sessions dropped: 4" counted two transcripts and two promoted notes without distinguishing them. The notes are the decisions the reader deliberately kept, so both the real run and `--dry-run` now say `1 of them is a promoted note — the decisions you kept, not raw sessions`.

Closes #690