### PR TITLE
fix: name a session after the assistant when no user turn can

### DIFF
--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -221,7 +221,9 @@ func TestLastFiltersProjectAndHarness(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, "[claude · gamma · 2026-01-05 · claude-gamma]") || strings.Contains(out, "assistant-only memory") {
+	// No user turn: the assistant's first sentence is the title, because the
+	// alternative is a row that says nothing at all (#692).
+	if !strings.Contains(out, "[claude · gamma · 2026-01-05 · claude-gamma] assistant-only memory") {
 		t.Fatalf("title-less last output = %q", out)
 	}
 

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -751,7 +751,10 @@ func TestRequestedPureCheapIndexCoverageBranches(t *testing.T) {
 		{name: "command", s: model.Session{Messages: []model.Message{{Role: "user", Text: "<command-name>"}, {Role: "user", Text: "next"}}}, want: "next"},
 		{name: "task notification", s: model.Session{Messages: []model.Message{{Role: "user", Text: "<task-notification z"}, {Role: "user", Text: "task"}}}, want: "task"},
 		{name: "teammate", s: model.Session{Messages: []model.Message{{Role: "user", Text: "<teammate-message z"}, {Role: "user", Text: "team"}}}, want: "team"},
-		{name: "caveat", s: model.Session{Messages: []model.Message{{Role: "user", Text: "Caveat: noisy"}, {Role: "assistant", Text: "skip"}}}, want: ""},
+		// The caveat is not a title, and with no other user turn the assistant's
+		// first sentence fills in rather than leaving a blank line (#692).
+		{name: "caveat", s: model.Session{Messages: []model.Message{{Role: "user", Text: "Caveat: noisy"}, {Role: "assistant", Text: "skip"}}}, want: "skip"},
+		{name: "nothing worth naming", s: model.Session{Messages: []model.Message{{Role: "tool-output", Text: "panic: boom"}}}, want: ""},
 	} {
 		t.Run("title "+tc.name, func(t *testing.T) {
 			if got := sessionTitle(tc.s); got != tc.want {

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1000,6 +1000,21 @@ func sessionTitle(s model.Session) string {
 		}
 		return truncateTitle(t, 60)
 	}
+	// No user turn worth naming the session after: a session the agent opened
+	// itself, or one whose prompts are all harness plumbing. The assistant's
+	// first sentence is a worse title than the question that prompted it, and
+	// it is far better than the blank line these sessions used to print in
+	// `deja last` and on the first screen (#692).
+	for _, msg := range s.Messages {
+		if msg.Role != "assistant" {
+			continue
+		}
+		t := strings.TrimSpace(msg.Text)
+		if !titleWorthy(t) {
+			continue
+		}
+		return truncateTitle(t, 60)
+	}
 	return ""
 }
 

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -279,6 +279,7 @@ func Import(dir, inDir string) (int, error) {
 	recsByKey := map[string][]Record{}
 	metas := map[string]SessionMeta{}
 	titleAt := map[string]time.Time{} // key -> time of the turn the title came from
+	titleRankOf := map[string]int{}   // key -> how good that turn was as a title
 	added := 0
 	for _, p := range paths {
 		if err := readSyncFile(p, func(sr SyncRecord) error {
@@ -327,10 +328,15 @@ func Import(dir, inDir string) (int, error) {
 			// arrived, the one line that makes the list readable did not (#670).
 			// Derive it the way ingest does, from the earliest user turn that is
 			// speech rather than harness plumbing.
-			if sr.Role == "user" && titleWorthy(strings.TrimSpace(text)) {
-				if at, seen := titleAt[key]; !seen || (!sr.Time.IsZero() && sr.Time.Before(at)) {
+			// A user turn always wins; the assistant's first sentence fills in
+			// when there is none, the same order ingest uses (#692).
+			if rank := titleRank(sr.Role); rank > 0 && titleWorthy(strings.TrimSpace(text)) {
+				better := rank > titleRankOf[key]
+				sameRank := rank == titleRankOf[key] && !sr.Time.IsZero() && sr.Time.Before(titleAt[key])
+				if _, seen := titleAt[key]; !seen || better || sameRank {
 					meta.Title = truncateTitle(strings.TrimSpace(text), 60)
 					titleAt[key] = sr.Time
+					titleRankOf[key] = rank
 				}
 			}
 			metas[key] = meta
@@ -363,6 +369,18 @@ func initEmptyIndex(dir string) error {
 	}
 	m := Manifest{Version: version, Files: currentFiles(""), Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), ExportWatermarks: map[string]int64{}, ImportedRecords: map[string]bool{}}
 	return writeManifest(dir, m)
+}
+
+// titleRank orders the roles a title may come from: a user turn beats the
+// assistant's, and nothing else is a title at all.
+func titleRank(role string) int {
+	switch role {
+	case "user":
+		return 2
+	case "assistant":
+		return 1
+	}
+	return 0
 }
 
 func readSyncFile(path string, fn func(SyncRecord) error) error {

--- a/internal/index/sync_persist_test.go
+++ b/internal/index/sync_persist_test.go
@@ -213,10 +213,17 @@ func TestImportGivesSessionsATitle(t *testing.T) {
 		{Harness: "claude", SessionID: "s1", Project: "p", Role: "user", Text: "and what about jitter", Time: base.Add(3 * time.Minute)},
 		{Harness: "claude", SessionID: "s1", Project: "p", Role: "user", Text: "the retry storm on checkout", Time: base.Add(time.Minute)},
 		{Harness: "claude", SessionID: "s1", Project: "p", Role: "user", Text: "<local-command-stdout>ok</local-command-stdout>", Time: base},
-		// A session whose only user turns are plumbing keeps no title rather
-		// than being named after a slash command's output.
+		// A session whose only user turns are plumbing falls back to the
+		// assistant's first sentence rather than printing a blank line (#692).
 		{Harness: "claude", SessionID: "s2", Project: "p", Role: "user", Text: "<command-name>/clear</command-name>", Time: base},
-		{Harness: "claude", SessionID: "s2", Project: "p", Role: "assistant", Text: "cleared", Time: base.Add(time.Minute)},
+		{Harness: "claude", SessionID: "s2", Project: "p", Role: "assistant", Text: "cleared the branch", Time: base.Add(time.Minute)},
+		// Even when the assistant spoke first, a later user turn still wins.
+		{Harness: "claude", SessionID: "s3", Project: "p", Role: "assistant", Text: "capped the pool", Time: base},
+		{Harness: "claude", SessionID: "s3", Project: "p", Role: "user", Text: "the pool starves", Time: base.Add(time.Minute)},
+		// Two assistant turns: the earlier one is the title, or the last record
+		// in the file decides instead of the clock.
+		{Harness: "claude", SessionID: "s4", Project: "p", Role: "assistant", Text: "started the migration", Time: base},
+		{Harness: "claude", SessionID: "s4", Project: "p", Role: "assistant", Text: "and then rolled it back", Time: base.Add(2 * time.Minute)},
 	})
 	if _, err := Import(dir, batch); err != nil {
 		t.Fatal(err)
@@ -229,22 +236,17 @@ func TestImportGivesSessionsATitle(t *testing.T) {
 	for _, m := range metas {
 		titles[m.ID] = m.Title
 	}
-	if len(titles) != 2 {
-		t.Fatalf("expected two imported sessions, got %#v", titles)
+	if len(titles) != 4 {
+		t.Fatalf("expected four imported sessions, got %#v", titles)
 	}
-	var withTitle, blank int
+	seen := map[string]bool{}
 	for _, ti := range titles {
-		switch ti {
-		case "the retry storm on checkout":
-			withTitle++
-		case "":
-			blank++
-		default:
-			t.Errorf("unexpected title %q", ti)
-		}
+		seen[ti] = true
 	}
-	if withTitle != 1 || blank != 1 {
-		t.Errorf("titles = %#v", titles)
+	for _, want := range []string{"the retry storm on checkout", "cleared the branch", "the pool starves", "started the migration"} {
+		if !seen[want] {
+			t.Errorf("title %q missing from %#v", want, titles)
+		}
 	}
 }
 

--- a/internal/index/title_fallback_test.go
+++ b/internal/index/title_fallback_test.go
@@ -1,0 +1,50 @@
+package index
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A session the agent opened itself, or one whose prompts are all harness
+// plumbing, printed a blank line in `deja last` and on the first screen — three
+// of four rows carrying no information at all (#692).
+func TestSessionTitleFallsBackToTheAssistant(t *testing.T) {
+	at := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+	msg := func(role, text string, min int) model.Message {
+		return model.Message{Role: role, Text: text, Time: at.Add(time.Duration(min) * time.Minute)}
+	}
+	cases := []struct {
+		name string
+		msgs []model.Message
+		want string
+	}{
+		{"user turn wins", []model.Message{
+			msg("assistant", "capped the pool at 200", 0),
+			msg("user", "the pool starves under load", 1),
+		}, "the pool starves under load"},
+		{"no user turn at all", []model.Message{
+			msg("assistant", "only assistant speech here", 0),
+		}, "only assistant speech here"},
+		{"user turns are all plumbing", []model.Message{
+			msg("user", "<local-command-stdout>ok</local-command-stdout>", 0),
+			msg("assistant", "done", 1),
+		}, "done"},
+		{"assistant plumbing is skipped too", []model.Message{
+			msg("assistant", "<command-name>/clear</command-name>", 0),
+			msg("assistant", "cleared it", 1),
+		}, "cleared it"},
+		// Tool output is not speech: naming a session after a stack trace is
+		// how the titles in #636 happened.
+		{"nothing worth naming", []model.Message{
+			msg("tool-output", "panic: runtime error", 0),
+			msg("files", "/repo/pool.go", 1),
+		}, ""},
+	}
+	for _, c := range cases {
+		if got := sessionTitle(model.Session{Messages: c.msgs}); got != c.want {
+			t.Errorf("%s: got %q, want %q", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
A session whose only speech is the assistant's — or whose user turns are all harness plumbing — had no title, and the row printed for it was empty:

```
[claude · proj/p · 2026-07-24 · normal] the vacuum takes eleven minutes
[claude · proj/p · 2026-07-23 · empty]
[claude · proj/p · 2026-07-22 · plumbOnly]
[claude · proj/p · 2026-07-21 · noUser]
```

Three of four rows on the first screen a new user sees carried no information, though the sessions contain "only assistant speech here", "done", "ok".

A user turn still wins whenever there is one; the assistant's first sentence is the fallback. Import follows the same order, so a session titled locally and the same session imported elsewhere agree.

Closes #692