### PR TITLE
fix: say when a rejected session was moved below the rest

### DIFF
--- a/cmd/deja/lifecycle.go
+++ b/cmd/deja/lifecycle.go
@@ -85,7 +85,7 @@ func lifecycleLine(h search.Hit) string {
 // Only rejected demotes. superseded and stale say "this was true once", which
 // is still the best record of how the current answer was reached; rejected
 // says "this did not work".
-func demoteRejected(hits []search.Hit) {
+func demoteRejected(hits []search.Hit) int {
 	var rejected []search.Hit
 	for _, h := range hits {
 		if h.Lifecycle == lifecycleRejected {
@@ -93,7 +93,7 @@ func demoteRejected(hits []search.Hit) {
 		}
 	}
 	if len(rejected) == 0 {
-		return
+		return 0
 	}
 	for i := range hits {
 		h := &hits[i]
@@ -109,7 +109,45 @@ func demoteRejected(hits []search.Hit) {
 			}
 		}
 	}
+	before := make([]string, len(hits))
+	for i, h := range hits {
+		before[i] = h.Session.Harness + ":" + h.Session.ID
+	}
 	sort.SliceStable(hits, func(i, j int) bool {
 		return hits[i].Lifecycle != lifecycleRejected && hits[j].Lifecycle == lifecycleRejected
 	})
+	moved := 0
+	for i, h := range hits {
+		if before[i] != h.Session.Harness+":"+h.Session.ID {
+			moved++
+		}
+	}
+	return moved
+}
+
+// demotedNote is the line that says the order was changed, and by whom.
+//
+// Read top-down, an older session above a newer one with no explanation is
+// what a broken ranking looks like; the reason sat four lines further down,
+// attached to the result that moved (#694). deja narrates the other times it
+// changes what it returns — word forms, ignored terms, the trust policy — and
+// a reordering the reader themselves caused is the same kind of fact.
+func demotedNote(hits []search.Hit, moved int) string {
+	if moved == 0 {
+		return ""
+	}
+	n := 0
+	for _, h := range hits {
+		if h.Lifecycle == lifecycleRejected {
+			n++
+		}
+	}
+	return fmt.Sprintf("%d session%s you marked rejected %s below the rest", n, pluralS(n), verbWere2(n))
+}
+
+func verbWere2(n int) string {
+	if n == 1 {
+		return "is"
+	}
+	return "are"
 }

--- a/cmd/deja/lifecycle_test.go
+++ b/cmd/deja/lifecycle_test.go
@@ -118,7 +118,7 @@ func TestDemoteRejected(t *testing.T) {
 		{Session: model.Session{ID: "bad", Project: "p", Updated: newer}, Lifecycle: "rejected"},
 		{Session: model.Session{ID: "good", Project: "p", Updated: older}, Superseded: "2026-07-28"},
 	}
-	demoteRejected(hits)
+	_ = demoteRejected(hits)
 	if hits[0].Session.ID != "good" || hits[1].Session.ID != "bad" {
 		t.Fatalf("order = %s, %s", hits[0].Session.ID, hits[1].Session.ID)
 	}
@@ -140,7 +140,7 @@ func TestDemoteRejectedLeavesOtherStatesAlone(t *testing.T) {
 			{Session: model.Session{ID: "first", Project: "p"}, Lifecycle: state},
 			{Session: model.Session{ID: "second", Project: "p"}},
 		}
-		demoteRejected(hits)
+		_ = demoteRejected(hits)
 		if hits[0].Session.ID != "first" {
 			t.Errorf("state %q reordered the hits", state)
 		}
@@ -153,7 +153,7 @@ func TestDemoteRejectedLeavesOtherStatesAlone(t *testing.T) {
 		{Session: model.Session{ID: "a", Project: "p"}, Lifecycle: "rejected", Superseded: "2026-07-28"},
 		{Session: model.Session{ID: "b", Project: "p", Updated: day}, Lifecycle: "rejected"},
 	}
-	demoteRejected(hits)
+	_ = demoteRejected(hits)
 	if hits[0].Session.ID != "a" || hits[0].Superseded != "2026-07-28" {
 		t.Errorf("all-rejected set was rewritten: %#v", hits)
 	}
@@ -176,7 +176,7 @@ func TestDemoteRejectedKeepsTheRankingOrder(t *testing.T) {
 		}
 		hits = append(hits, h)
 	}
-	demoteRejected(hits)
+	_ = demoteRejected(hits)
 	var got []string
 	for _, h := range hits {
 		if h.Lifecycle != "rejected" {
@@ -201,11 +201,46 @@ func TestDemoteRejectedMatchesTheRightRival(t *testing.T) {
 		{Session: model.Session{ID: "other", Project: "elsewhere", Updated: newer}, Lifecycle: "rejected"},
 		{Session: model.Session{ID: "mine", Project: "p"}, Superseded: "2026-07-28"},
 	}
-	demoteRejected(hits)
+	_ = demoteRejected(hits)
 	if hits[0].Session.ID != "mine" {
 		t.Fatalf("order = %s", hits[0].Session.ID)
 	}
 	if hits[0].Superseded != "2026-07-28" {
 		t.Errorf("cleared the label using another project's rejection")
+	}
+}
+
+// Read top-down, an older session above a newer one with no explanation is
+// what a broken ranking looks like; the reason sat four lines further down,
+// attached to the result that moved (#694).
+func TestDemotedNote(t *testing.T) {
+	hits := []search.Hit{
+		{Session: model.Session{ID: "bad", Project: "p"}, Lifecycle: "rejected"},
+		{Session: model.Session{ID: "good", Project: "p"}},
+	}
+	moved := demoteRejected(hits)
+	if moved == 0 {
+		t.Fatal("nothing moved")
+	}
+	note := demotedNote(hits, moved)
+	if !strings.Contains(note, "1 session you marked rejected is below") {
+		t.Errorf("note = %q", note)
+	}
+	// Nothing moved, nothing to explain: a line on every result is noise.
+	quiet := []search.Hit{
+		{Session: model.Session{ID: "a", Project: "p"}},
+		{Session: model.Session{ID: "b", Project: "p"}, Lifecycle: "rejected"},
+	}
+	if got := demotedNote(quiet, demoteRejected(quiet)); got != "" {
+		t.Errorf("already in order, said %q", got)
+	}
+	// Plural, and counting the rejected hits rather than the moves.
+	many := []search.Hit{
+		{Session: model.Session{ID: "x", Project: "p"}, Lifecycle: "rejected"},
+		{Session: model.Session{ID: "y", Project: "p"}, Lifecycle: "rejected"},
+		{Session: model.Session{ID: "z", Project: "p"}},
+	}
+	if got := demotedNote(many, demoteRejected(many)); !strings.Contains(got, "2 sessions you marked rejected are below") {
+		t.Errorf("plural note = %q", got)
 	}
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -464,10 +464,13 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	// there is no way to know how the filters would have treated the hidden
 	// ones, so the pre-cap figure stands and `capped` says to distrust it.
 	attachLifecycles(hits)
-	demoteRejected(hits)
+	demoted := demoteRejected(hits)
 	attachMoved(hits)
 	if !o.Capped {
 		o.Total = len(hits)
+	}
+	if note := demotedNote(hits, demoted); note != "" {
+		fmt.Fprintf(os.Stderr, "deja: %s\n", note)
 	}
 	if len(hits) == 0 {
 		// The policy is named before the generic advice: "try fewer words" is

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -432,7 +432,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	}
 	attachAnswers(dir, hits)
 	attachLifecycles(hits)
-	demoteRejected(hits)
+	demoted := demoteRejected(hits)
 	var b strings.Builder
 	served := 0
 	if stale {
@@ -444,6 +444,9 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		fmt.Fprintf(&b, "No exact match; using close spellings: %s\n", strings.Join(fuzzySummary(result.Variants), ", "))
 	} else if result.Tier == search.TierRelevance {
 		fmt.Fprintln(&b, "No exact match; sessions ranked by relevance to the whole query.")
+	}
+	if note := demotedNote(hits, demoted); note != "" {
+		fmt.Fprintln(&b, note+" — read the order as the user's judgement, not as recency.")
 	}
 	if offset > 0 {
 		fmt.Fprintf(&b, "deja recall for %q (matches %d-%d of %d)\n", q, offset+1, offset+len(hits), total)


### PR DESCRIPTION
After #684 the order is right, but read top-down the first thing a person sees is an older session above a newer one with nothing explaining it — which is what a broken ranking looks like. The explanation was four lines further down, attached to the other result.

```
deja: 1 session you marked rejected is below the rest
[claude] proj/p · Jul 20 · good — 9 matches
...

recall → 1 session you marked rejected is below the rest — read the order as
         the user's judgement, not as recency.
```

Silent when nothing moved. deja already narrates word forms, ignored terms and the trust policy; a reordering the reader caused is the same kind of fact.

Closes #694