### PR TITLE
fix: sessions stamped in the future are not today's work

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -84,6 +84,14 @@ func runBrief(dir string, w io.Writer) error {
 		fmt.Fprintln(w, week)
 	}
 
+	// Sessions ahead of the clock sit at the top of "recent" with dates that
+	// have not happened, and the counters above deliberately leave them out —
+	// so the screen has to say they exist, or the two disagree with no
+	// explanation (#696).
+	if ov.Future > 0 {
+		fmt.Fprintf(w, "ahead      %d session%s stamped later than this machine's clock\n", ov.Future, pluralS(ov.Future))
+	}
+
 	// Read the index as-is: the brief must never trigger a rebuild or let
 	// indexing narration tear through its layout.
 	if recent, err := index.RecentMatching(dir, 3, search.Options{}); err == nil && len(recent) > 0 {

--- a/cmd/deja/brief_future_test.go
+++ b/cmd/deja/brief_future_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The counters deliberately leave the future out, so the screen has to say
+// those sessions exist — otherwise "recent" shows dates that have not happened
+// above counters that do not mention them (#696).
+func TestBriefNamesSessionsAheadOfTheClock(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	now := time.Now()
+	write := func(sid string, at time.Time) {
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/w/p","timestamp":"` +
+			at.UTC().Format(time.RFC3339) + `","message":{"role":"user","content":"work in ` + sid + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("now", now.Add(-time.Hour))
+	write("ahead", now.AddDate(0, 0, 6))
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "stamped later than this machine's clock") {
+		t.Errorf("brief does not mention the future session:\n%s", buf.String())
+	}
+	// A store with none of them says nothing extra.
+	if err := os.Remove(filepath.Join(root, "ahead.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "ahead") {
+		t.Errorf("clean store mentions the future:\n%s", buf.String())
+	}
+}

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -176,6 +176,11 @@ type OverviewStats struct {
 	// older than a week has nothing to say under "today" and "this week", and
 	// two zero lines is a poor way to open the first screen someone sees.
 	Oldest, Newest time.Time
+	// Future counts sessions stamped after now. A wrong clock, a transcript
+	// written in another timezone, a harness stamping UTC while the reader is
+	// behind it — all produce them, and counting them as today's work made the
+	// first screen's top line wrong upward and only upward (#696).
+	Future int
 }
 
 // Overview summarizes the index from manifest metadata alone — no record
@@ -191,12 +196,19 @@ func Overview(dir string) (OverviewStats, error) {
 	var o OverviewStats
 	now := time.Now()
 	day := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	// now bounds both counters from above. Without it every session ahead of
+	// the clock was today's, this week's, and the newest thing in the store —
+	// permanently (#696). The bound is now rather than tomorrow's midnight on
+	// purpose: work that has not happened yet is not today's work either.
 	week := now.AddDate(0, 0, -7)
 	hs := map[string]bool{}
 	for _, meta := range m.Sessions {
 		o.Sessions++
 		hs[meta.Harness] = true
-		if meta.Updated.After(day) {
+		if meta.Updated.After(now) {
+			o.Future++
+		}
+		if meta.Updated.After(day) && !meta.Updated.After(now) {
 			o.SessionsToday++
 		}
 		if o.Oldest.IsZero() || (!meta.Updated.IsZero() && meta.Updated.Before(o.Oldest)) {
@@ -205,7 +217,7 @@ func Overview(dir string) (OverviewStats, error) {
 		if meta.Updated.After(o.Newest) {
 			o.Newest = meta.Updated
 		}
-		if meta.Updated.After(week) {
+		if meta.Updated.After(week) && !meta.Updated.After(now) {
 			o.SessionsWeek++
 		}
 	}

--- a/internal/index/overview_future_test.go
+++ b/internal/index/overview_future_test.go
@@ -1,0 +1,74 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The counters tested Updated.After(midnight) with no upper bound, so anything
+// ahead of the clock was today's work, this week's, and the newest thing in the
+// store — permanently. On a 10k-session store that read "today 2222" (#696).
+func TestOverviewExcludesSessionsFromTheFuture(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	sessions := map[string]SessionMeta{
+		"claude:today":     {ID: "today", Harness: "claude", Updated: now.Add(-2 * time.Hour)},
+		"claude:yesterday": {ID: "yesterday", Harness: "claude", Updated: now.AddDate(0, 0, -1)},
+		"claude:lastmonth": {ID: "lastmonth", Harness: "claude", Updated: now.AddDate(0, -1, 0)},
+		// Just inside the week, so narrowing the window shows up too.
+		"claude:sixdays": {ID: "sixdays", Harness: "claude", Updated: now.Add(-6*24*time.Hour - 12*time.Hour)},
+		// Just outside the week, so widening the window shows up.
+		"claude:eightdays": {ID: "eightdays", Harness: "claude", Updated: now.Add(-7*24*time.Hour - 12*time.Hour)},
+		"claude:soon":      {ID: "soon", Harness: "claude", Updated: now.Add(3 * time.Hour)},
+		"claude:nextweek":  {ID: "nextweek", Harness: "claude", Updated: now.AddDate(0, 0, 6)},
+		"claude:nextyear":  {ID: "nextyear", Harness: "claude", Updated: now.AddDate(1, 0, 0)},
+	}
+	if err := writeManifest(dir, Manifest{Version: version, Files: map[string]FileState{}, Sessions: sessions}); err != nil {
+		t.Fatal(err)
+	}
+	ov, err := Overview(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ov.Sessions != 8 {
+		t.Errorf("sessions = %d, want 8 — the future ones still exist", ov.Sessions)
+	}
+	if ov.SessionsToday != 1 {
+		t.Errorf("today = %d, want 1", ov.SessionsToday)
+	}
+	if ov.SessionsWeek != 3 {
+		t.Errorf("this week = %d, want 3", ov.SessionsWeek)
+	}
+	// A session three hours from now is still ahead of the clock, even though
+	// it falls on today's date.
+	if ov.Future != 3 {
+		t.Errorf("future = %d, want 3", ov.Future)
+	}
+}
+
+func TestOverviewWithNoFutureSessionsSaysNothing(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	sessions := map[string]SessionMeta{
+		"claude:a": {ID: "a", Harness: "claude", Updated: now.Add(-time.Hour)},
+		"claude:b": {ID: "b", Harness: "claude", Updated: now.AddDate(0, 0, -3)},
+	}
+	if err := writeManifest(dir, Manifest{Version: version, Files: map[string]FileState{}, Sessions: sessions}); err != nil {
+		t.Fatal(err)
+	}
+	ov, err := Overview(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ov.Future != 0 || ov.SessionsToday != 1 || ov.SessionsWeek != 2 {
+		t.Errorf("ov = %+v", ov)
+	}
+}


### PR DESCRIPTION
Four sessions — one today, one yesterday, one six days ahead, one next year:

```
today      3 sessions
this week  4 sessions
recent     [claude] proj/p · Sep 5 2027 · work in future_year
```

The counters tested `Updated.After(midnight)` with no upper bound, so anything ahead of the clock was today's work, this week's, and the top of "recent" permanently. On the 10k-session store I was using to measure scale, this read "today 2222 sessions".

A wrong clock, a transcript written in another timezone, or a harness stamping UTC while the reader is behind it all produce these.

```
today      1 session
this week  2 sessions · 0 recalls
ahead      3 sessions stamped later than this machine's clock
```

The bound is *now* rather than tomorrow's midnight: work that has not happened is not today's work either. Stores without such sessions print nothing extra.

Closes #696