### PR TITLE
fix: two transcripts sharing an id are attributed the same way every build

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -194,6 +194,14 @@ func cmdIndex(dir string, rest []string) error {
 		return err
 	}
 	clearWarmupSentinel()
+	// Two transcripts can carry the same harness:id — two files with the same
+	// name in different projects. Both stay searchable, but one manifest row
+	// holds them, so one project name covers both. Silence was the worst part
+	// of it: the indexer counted every session on disk while the manifest held
+	// fewer, and nothing connected the two numbers (#698).
+	if n := index.ReportCollisions(); n > 0 {
+		fmt.Fprintf(os.Stderr, "deja: %d session%s share an id with another transcript — each pair is filed under one project, the one whose file sorts first\n", n, pluralS(n))
+	}
 	maybeFirstIndexGreeting(dir)
 	return nil
 }

--- a/internal/index/collision_test.go
+++ b/internal/index/collision_test.go
@@ -1,0 +1,198 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// Identity is harness:id and nothing guarantees it is unique: two files named
+// session-1.jsonl in different projects produced one manifest row whose project
+// came from one transcript and whose title came from the other, differently on
+// every build (#698).
+func TestSessionsSharingAnIDAreAttributedTheSameWayEveryBuild(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	for proj, text := range map[string]string{
+		"alpha": "the alpha work on pool sizing",
+		"beta":  "the beta work on cache eviction",
+	} {
+		dir := filepath.Join(tmp, "claude", proj)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := `{"type":"user","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(dir, "session-1.jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	var first []SessionMeta
+	for run := 0; run < 5; run++ {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+		if err := Ensure(dir, "", true, nil); err != nil {
+			t.Fatal(err)
+		}
+		if n := ReportCollisions(); n == 0 {
+			t.Errorf("run %d reported no collision", run)
+		}
+		metas, err := AllMeta(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if run == 0 {
+			first = metas
+			// The file that sorts first owns the row, so the answer does not
+			// depend on which one was read first.
+			if len(metas) != 1 || metas[0].Project != "alpha" {
+				t.Fatalf("metas = %#v", metas)
+			}
+			continue
+		}
+		if len(metas) != len(first) || metas[0].Project != first[0].Project || metas[0].Title != first[0].Title {
+			t.Fatalf("run %d: %#v, first build had %#v", run, metas, first)
+		}
+	}
+	// Both conversations stay searchable — the collision costs attribution,
+	// not content.
+	for _, q := range []string{"alpha work pool", "beta work cache"} {
+		hits, err := Search(dir, search.Options{Query: q, All: true})
+		if err != nil || len(hits) == 0 {
+			t.Errorf("%q: %d hits err=%v", q, len(hits), err)
+		}
+	}
+}
+
+func TestReportCollisionsIsZeroWithoutOne(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "claude", "solo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"type":"user","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"a single conversation"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "only.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(filepath.Join(tmp, "index.db"), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := ReportCollisions(); n != 0 {
+		t.Errorf("reported %d collisions on a clean store", n)
+	}
+}
+
+// The incremental pass walks a map of changed files; unsorted, which session
+// won a shared id depended on that order (#698).
+func TestIncrementalPassAttributesCollisionsTheSameWay(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	write := func(proj, text string) {
+		dir := filepath.Join(tmp, "claude", proj)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := `{"type":"user","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(dir, "session-1.jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	write("alpha", "the alpha work on pool sizing")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	ReportCollisions()
+
+	// Two more projects arrive, both claiming the same id. Neither may take the
+	// row from the transcript that sorts first.
+	write("beta", "the beta work on cache eviction")
+	write("gamma", "the gamma work on token limits")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := ReportCollisions(); n == 0 {
+		t.Error("incremental pass reported no collision")
+	}
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metas) != 1 || metas[0].Project != "alpha" {
+		t.Fatalf("metas = %#v", metas)
+	}
+	// The late arrivals are still searchable: what the collision costs is
+	// attribution, not content.
+	for _, q := range []string{"beta work cache", "gamma work token"} {
+		hits, err := Search(dir, search.Options{Query: q, All: true})
+		if err != nil || len(hits) == 0 {
+			t.Errorf("%q: %d hits err=%v", q, len(hits), err)
+		}
+	}
+}
+
+// Re-indexing one file of a colliding pair must not drop the other. The
+// replacement pass rebuilds the manifest from the files it re-read, so the row
+// held by the transcript that did not change has to be carried over — losing it
+// was how the first attempt at #698 deleted a session.
+func TestReindexingOneHalfOfACollisionKeepsTheOther(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	write := func(proj, text string) {
+		dir := filepath.Join(tmp, "claude", proj)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := `{"type":"user","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(dir, "session-1.jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	write("alpha", "the alpha work on pool sizing")
+	write("beta", "the beta work on cache eviction")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	ReportCollisions()
+
+	// Rewrite beta from scratch — shorter, so it takes the replacement path
+	// rather than the append one.
+	write("beta", "beta rewritten")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metas) != 1 || metas[0].Project != "alpha" || metas[0].Title != "the alpha work on pool sizing" {
+		t.Fatalf("metas = %#v — alpha's row was lost or overwritten", metas)
+	}
+	// The records are a separate matter: they are keyed by harness:id too, so
+	// re-indexing beta drops alpha's text from the postings even though its
+	// row survives. Tracked in #699 — this test pins the row.
+	if _, err := Search(dir, search.Options{Query: "beta rewritten", All: true}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -282,7 +283,13 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 			if ord == 0 {
 				ord = nextSessionOrd(m.Sessions)
 			}
-			m.Sessions[key] = metaWithOrd(metaForSession(s), ord)
+			owns, collided := attributeSession(m.Sessions[key], s)
+			if collided {
+				collisions.Add(1)
+			}
+			if owns {
+				m.Sessions[key] = metaWithOrd(metaForSession(s), ord)
+			}
 			for _, msg := range s.Messages {
 				if seenMsgs.dup(key, msg.Role, msg.Time, msg.Text) {
 					continue
@@ -440,6 +447,14 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 	return ss
 }
 
+// ReportCollisions returns how many transcripts shared an id with another since
+// the last build, and clears the counter. Silence was the worst part of #698:
+// the indexer counted every session on disk while the manifest held fewer, and
+// nothing connected the two numbers.
+func ReportCollisions() int {
+	return int(collisions.Swap(0))
+}
+
 func rebuildForSearch(dir string, o query.Options, scope string, files map[string]FileState, progress io.Writer) error {
 	tmp := dir + ".tmp"
 	_ = os.RemoveAll(tmp)
@@ -509,7 +524,13 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 			if ord == 0 {
 				ord = nextSessionOrd(m.Sessions)
 			}
-			m.Sessions[key] = metaWithOrd(metaForSession(s), ord)
+			owns, collided := attributeSession(m.Sessions[key], s)
+			if collided {
+				collisions.Add(1)
+			}
+			if owns {
+				m.Sessions[key] = metaWithOrd(metaForSession(s), ord)
+			}
 			for _, msg := range s.Messages {
 				if seenMsgs.dup(key, msg.Role, msg.Time, msg.Text) {
 					continue
@@ -989,6 +1010,45 @@ func sessionFromMeta(meta SessionMeta) model.Session {
 	}
 }
 
+// sortedKeys makes a map iteration reproducible.
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// collidedIDs counts sessions that share harness:id with a transcript at a
+// different path.
+//
+// Identity is harness:id and nothing guarantees it is unique: two files named
+// session-1.jsonl in different projects produce one manifest row, and which
+// transcript's project and title it carried used to depend on map order — so
+// the same store described a conversation differently between two builds
+// (#698). Both conversations stay searchable; what is at stake is which
+// project they are filed under, and the trust policy, --project and the
+// exclude patterns all key on that.
+//
+// Qualifying the key with the path was tried and reverted: records already on
+// disk carry the old key, so an incremental pass that reassigned one dropped
+// the session it renamed.
+// collisions counts the transcripts that shared an id with another during the
+// current build. The two full-build paths index sessions in parallel, so the
+// counter is atomic.
+var collisions atomic.Int64
+
+// attributeSession decides which of two transcripts sharing an id owns the
+// manifest row, and whether they collided at all. Lexicographically smallest
+// path wins, so the answer does not depend on which file was read first.
+func attributeSession(held SessionMeta, s model.Session) (owns, collided bool) {
+	if held.Path == "" || s.Path == "" || held.Path == s.Path {
+		return true, false
+	}
+	return s.Path < held.Path, true
+}
+
 func sessionTitle(s model.Session) string {
 	for _, msg := range s.Messages {
 		if msg.Role != "user" {
@@ -1326,7 +1386,20 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 			nextOrd++
 			ord = nextOrd
 		}
-		m.Sessions[key] = metaWithOrd(metaForSession(s), ord)
+		held, ok := m.Sessions[key]
+		if !ok {
+			// The row may exist only in the manifest being replaced.
+			held = old.Sessions[key]
+		}
+		owns, collided := attributeSession(held, s)
+		if collided {
+			collisions.Add(1)
+		}
+		if owns {
+			m.Sessions[key] = metaWithOrd(metaForSession(s), ord)
+		} else if _, present := m.Sessions[key]; !present {
+			m.Sessions[key] = held
+		}
 		for _, msg := range s.Messages {
 			if seenMsgs.dup(key, msg.Role, msg.Time, msg.Text) {
 				continue
@@ -1429,7 +1502,10 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 		m.Sessions = map[string]SessionMeta{}
 	}
 	filesTouched, messages := 0, 0
-	for p := range changed {
+	// Sorted, not map order: two sessions can claim the same harness:id, and
+	// which one wins decided the project a whole conversation was filed under
+	// — differently on every run (#698).
+	for _, p := range sortedKeys(changed) {
 		ss, err := parseAppendedFile(harness, p, old.Files[p])
 		if err != nil {
 			if of, ok := old.Files[p]; ok {
@@ -1453,10 +1529,14 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 			if s.Updated.After(meta.Updated) {
 				meta.Updated = s.Updated
 			}
-			if s.Project != "" && s.Project != "-" {
+			owns, collided := attributeSession(meta, s)
+			if collided {
+				collisions.Add(1)
+			}
+			if s.Project != "" && s.Project != "-" && owns {
 				meta.Project = s.Project
 			}
-			if s.Path != "" {
+			if s.Path != "" && owns {
 				meta.Path = s.Path
 			}
 			if meta.Title == "" {


### PR DESCRIPTION
Two files named `session-1.jsonl` in different projects produce one manifest row. It carried one transcript's project and the other's title, and which was which depended on Go's map order — the same store described a conversation differently between two builds.

```
$ deja index
deja: claude: 2 sessions, 2 messages
$ deja last
[claude · beta · 2026-07-21 · session-1] the alpha work on pool sizing
```

Now the transcript whose path sorts first owns the row, so the answer is the same on every build, and the indexer says it happened:

```
deja: 2 sessions share an id with another transcript — each pair is filed under
      one project, the one whose file sorts first
```

Silence was the worst part: on the 1000-project store I was measuring, 1077 sessions on disk became 1040 rows with nothing connecting the two numbers.

Qualifying the key with the path was tried and reverted — records already on disk carry the old key, so an incremental pass that reassigned one dropped the session it renamed. The remaining half of the problem (re-indexing one transcript erases the other's records) is #699.

Closes #698