### PR TITLE
fix: doctor counts the transcripts it cannot place

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"path"
@@ -246,6 +247,33 @@ func doctorEmbed(w io.Writer, r doctorEmbedReport) {
 	fmt.Fprintf(w, "  sidecar    coverage=%.1f%%\n", r.Coverage)
 }
 
+// unplacedFiles counts transcripts under root that the harness's own filter
+// did not pick up. A harness that changes its layout in a new version presents
+// exactly this way: quietly fewer sessions, no error, and a directory size that
+// still looks right (#701).
+func unplacedFiles(root string, seen []string) int {
+	have := make(map[string]bool, len(seen))
+	for _, p := range seen {
+		have[filepath.Clean(p)] = true
+	}
+	extra := 0
+	_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		switch strings.ToLower(filepath.Ext(p)) {
+		case ".jsonl", ".json":
+		default:
+			return nil
+		}
+		if !have[filepath.Clean(p)] {
+			extra++
+		}
+		return nil
+	})
+	return extra
+}
+
 func doctorHarnesses(w io.Writer) {
 	fmt.Fprintln(w, "Harness stores:")
 	sqlite := sources.SQLite3Available()
@@ -262,11 +290,23 @@ func doctorHarnesses(w io.Writer) {
 		fmt.Fprintln(w, line)
 	}
 
+	// printFiles is printRow for the harnesses that answer with a file list.
+	// The count comes from the same filter the parser uses, so a store whose
+	// layout differs slightly loses those files from every number deja prints
+	// — the one thing `doctor` exists to rule out (#701).
+	printFiles := func(name, path string, present bool, seen []string) {
+		detail := doctorCount(len(seen), "file")
+		if extra := unplacedFiles(path, seen); extra > 0 {
+			detail += fmt.Sprintf(", %d not recognised here", extra)
+		}
+		printRow(name, path, present, detail)
+	}
+
 	claudeRoot := sources.ClaudeRoot()
-	printRow("claude", claudeRoot, doctorExists(claudeRoot), doctorCount(len(sources.ClaudeFiles()), "file"))
+	printFiles("claude", claudeRoot, doctorExists(claudeRoot), sources.ClaudeFiles())
 
 	codexRoot := sources.CodexRoot()
-	printRow("codex", codexRoot, doctorExists(codexRoot), doctorCount(len(sources.CodexFiles()), "file"))
+	printFiles("codex", codexRoot, doctorExists(codexRoot), sources.CodexFiles())
 
 	ocDB := sources.OpencodeDB()
 	printRow("opencode", ocDB, doctorFilePresent(ocDB), doctorSQLiteDetail(ocDB, sqlite))
@@ -274,20 +314,20 @@ func doctorHarnesses(w io.Writer) {
 	printRow("aider", doctorAiderLocation(), len(sources.AiderFiles()) > 0, doctorCount(len(sources.AiderFiles()), "file"))
 
 	geminiRoot := sources.GeminiRoot()
-	printRow("gemini", geminiRoot, doctorExists(geminiRoot), doctorCount(len(sources.GeminiChatFiles()), "file"))
+	printFiles("gemini", geminiRoot, doctorExists(geminiRoot), sources.GeminiChatFiles())
 
 	printRow("cursor", doctorCursorLocation(), doctorCursorPresent(), doctorCursorDetail(sqlite))
 
 	printRow("antigravity", doctorAntigravityLocation(), len(sources.AntigravityRoots()) > 0, doctorCount(len(sources.AntigravityTranscripts()), "file"))
 
 	grokRoot := sources.GrokRoot()
-	printRow("grok", grokRoot, doctorExists(grokRoot), doctorCount(len(sources.GrokSessionFiles()), "file"))
+	printFiles("grok", grokRoot, doctorExists(grokRoot), sources.GrokSessionFiles())
 
 	qwenRoot := filepath.Join(sources.QwenRoot(), "projects")
-	printRow("qwen", qwenRoot, doctorExists(qwenRoot), doctorCount(len(sources.QwenSessionFiles()), "file"))
+	printFiles("qwen", qwenRoot, doctorExists(qwenRoot), sources.QwenSessionFiles())
 
 	kimiRoot := filepath.Join(sources.KimiRoot(), "sessions")
-	printRow("kimi", kimiRoot, doctorExists(kimiRoot), doctorCount(len(sources.KimiSessionFiles()), "file"))
+	printFiles("kimi", kimiRoot, doctorExists(kimiRoot), sources.KimiSessionFiles())
 
 	gooseRoot := filepath.Join(sources.GooseRoot(), "sessions")
 	printRow("goose", gooseRoot, doctorExists(gooseRoot) || doctorFilePresent(sources.GooseDB()), doctorGooseDetail(sqlite))
@@ -311,11 +351,11 @@ func doctorHarnesses(w io.Writer) {
 	printRow("roo", rooLoc, rooFiles > 0, doctorCount(rooFiles, "file"))
 
 	piRoot := sources.PiRoot()
-	printRow("pi", piRoot, doctorExists(piRoot), doctorCount(len(sources.PiSessionFiles()), "file"))
+	printFiles("pi", piRoot, doctorExists(piRoot), sources.PiSessionFiles())
 	openclawRoot := sources.OpenClawRoot()
 	printRow("openclaw", openclawRoot, doctorExists(openclawRoot), doctorCount(len(sources.OpenClawSessionFiles()), "file"))
 	copilotRoot := sources.CopilotRoot()
-	printRow("copilot", copilotRoot, doctorExists(copilotRoot), doctorCount(len(sources.CopilotSessionFiles()), "file"))
+	printFiles("copilot", copilotRoot, doctorExists(copilotRoot), sources.CopilotSessionFiles())
 	printRow("deja", sources.NotesFile(), doctorFilePresent(sources.NotesFile()), "notes")
 }
 

--- a/cmd/deja/doctor_unplaced_test.go
+++ b/cmd/deja/doctor_unplaced_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A harness that changes its layout presents as quietly fewer sessions, no
+// error, and a directory size that still looks right — and doctor, the command
+// that exists to rule that out, counted only what the parser already saw
+// (#701).
+func TestUnplacedFiles(t *testing.T) {
+	root := t.TempDir()
+	mk := func(rel string) string {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	seen := []string{mk("proj/chats/a.jsonl"), mk("proj/chats/b.jsonl")}
+	mk("proj/stray.jsonl")
+	mk("proj/other/deeper.json")
+	// Not a transcript: extensions deja never reads must not be counted as
+	// missed history.
+	mk("proj/notes.md")
+	mk("proj/db.sqlite")
+
+	if got := unplacedFiles(root, seen); got != 2 {
+		t.Errorf("unplaced = %d, want 2", got)
+	}
+	// Everything accounted for: nothing to report.
+	all := append(seen, filepath.Join(root, "proj", "stray.jsonl"), filepath.Join(root, "proj", "other", "deeper.json"))
+	if got := unplacedFiles(root, all); got != 0 {
+		t.Errorf("unplaced = %d with every file seen", got)
+	}
+	// A root that does not exist is not a complaint.
+	if got := unplacedFiles(filepath.Join(root, "nope"), nil); got != 0 {
+		t.Errorf("missing root reported %d", got)
+	}
+	if got := unplacedFiles("", nil); got != 0 {
+		t.Errorf("empty root reported %d", got)
+	}
+}
+
+// The note is only worth printing when something is actually unaccounted for:
+// ", 0 not recognised here" on every harness is noise.
+func TestDoctorHarnessRowSaysNothingWhenEverythingIsPlaced(t *testing.T) {
+	tmp := hermeticEnv(t)
+	qwen := filepath.Join(tmp, "qwen", "projects", "proj", "chats")
+	if err := os.MkdirAll(qwen, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(qwen, "a.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
+	var buf bytes.Buffer
+	doctorHarnesses(&buf)
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(line, "qwen") && strings.Contains(line, "not recognised") {
+			t.Errorf("clean store complains: %q", line)
+		}
+	}
+
+	// One file in the wrong place, and the row says so.
+	if err := os.WriteFile(filepath.Join(tmp, "qwen", "projects", "proj", "stray.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	doctorHarnesses(&buf)
+	found := false
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(line, "qwen") && strings.Contains(line, "1 not recognised here") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("stray file not reported:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
Ten of fifty qwen transcripts sitting one directory up from `chats/`:

```
$ find ~/.qwen/projects -name '*.jsonl' | wc -l
50
$ deja doctor | grep qwen
  qwen         found    ~/.qwen/projects  (40 files)
```

The count came from the same filter the parser uses, so the ten were invisible to the command whose job is answering "is deja seeing my history". That is exactly how a harness changing its layout in a new version would present: quietly fewer sessions, no error, a directory size that still looks right.

```
  qwen         found    ~/.qwen/projects  (40 files, 10 not recognised here)
```

Only .jsonl/.json are counted, and only when something is actually unaccounted for.

Closes #701