### PR TITLE
fix: stats says what an old store covers instead of drawing twelve empty bars

### DIFF
--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -260,7 +260,18 @@ func printStats(w io.Writer, r stats.Report) {
 	fmt.Fprintln(w)
 
 	fmt.Fprintf(w, "%sLast 12 months%s\n", bold, reset)
-	fmt.Fprintf(w, "  %s  %s\n", r.Sparkline, monthLabels(r.Monthly))
+	// Twelve empty bars is what a broken index looks like, and a store whose
+	// work is simply older than a year draws exactly that. The first screen
+	// already answers this case with the range it does cover (#703).
+	if monthlyTotal(r.Monthly) == 0 {
+		if r.DateRange.Start != "" {
+			fmt.Fprintf(w, "  none — this store covers %s → %s\n", r.DateRange.Start, r.DateRange.End)
+		} else {
+			fmt.Fprintln(w, "  none")
+		}
+	} else {
+		fmt.Fprintf(w, "  %s  %s\n", r.Sparkline, monthLabels(r.Monthly))
+	}
 	fmt.Fprintln(w)
 
 	fmt.Fprintf(w, "%sHighlights%s\n", bold, reset)

--- a/cmd/deja/stats_helpers.go
+++ b/cmd/deja/stats_helpers.go
@@ -10,6 +10,17 @@ import (
 	"github.com/vshulcz/deja-vu/internal/stats"
 )
 
+// monthlyTotal is how much work falls inside the window the sparkline draws.
+// Twelve empty bars is what a broken index looks like, and a store whose work
+// is simply older than a year draws exactly that (#703).
+func monthlyTotal(months []stats.MonthStats) int {
+	n := 0
+	for _, m := range months {
+		n += m.Messages
+	}
+	return n
+}
+
 func monthLabels(months []stats.MonthStats) string {
 	labels := make([]string, 0, len(months))
 	for _, m := range months {

--- a/cmd/deja/stats_sparkline_test.go
+++ b/cmd/deja/stats_sparkline_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/stats"
+)
+
+func TestMonthlyTotal(t *testing.T) {
+	if got := monthlyTotal(nil); got != 0 {
+		t.Errorf("nil = %d", got)
+	}
+	empty := make([]stats.MonthStats, 12)
+	if got := monthlyTotal(empty); got != 0 {
+		t.Errorf("twelve empty months = %d", got)
+	}
+	empty[3].Messages = 5
+	empty[9].Messages = 2
+	if got := monthlyTotal(empty); got != 7 {
+		t.Errorf("total = %d, want 7", got)
+	}
+}
+
+// Twelve empty bars is what a broken index looks like, and a store whose work
+// is simply older than a year drew exactly that (#703).
+func TestStatsSparklineSaysWhatItCoversWhenTheYearIsEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	r := stats.Report{
+		TotalSessions: 4,
+		Monthly:       make([]stats.MonthStats, 12),
+		Sparkline:     "▁▁▁▁▁▁▁▁▁▁▁▁",
+		DateRange:     stats.DateRangeStats{Start: "2025-06-24", End: "2025-06-27"},
+	}
+	printStats(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "none — this store covers 2025-06-24 → 2025-06-27") {
+		t.Errorf("empty year: %q", sparklineSection(out))
+	}
+	if strings.Contains(out, "▁▁▁▁▁▁▁▁▁▁▁▁") {
+		t.Errorf("still drew the empty sparkline: %q", sparklineSection(out))
+	}
+
+	// A store with work inside the window keeps its chart.
+	buf.Reset()
+	r.Monthly[10].Messages = 8
+	r.Sparkline = "▁▁▁▁▁▁▁▁▁▁█▁"
+	printStats(&buf, r)
+	if !strings.Contains(buf.String(), "▁▁▁▁▁▁▁▁▁▁█▁") {
+		t.Errorf("chart lost: %q", sparklineSection(buf.String()))
+	}
+}
+
+func sparklineSection(out string) string {
+	i := strings.Index(out, "Last 12 months")
+	if i < 0 {
+		return out
+	}
+	rest := out[i:]
+	if j := strings.Index(rest, "\n\n"); j > 0 {
+		return rest[:j]
+	}
+	return rest
+}


### PR DESCRIPTION
A store whose newest session is more than a year old:

```
Last 12 months
  ▁▁▁▁▁▁▁▁▁▁▁▁  Sep Oct Nov Dec Jan Feb Mar Apr May Jun Jul Aug
```

Twelve flat bars is what a broken index looks like, two lines below `Range 2025-06-24 → 2025-06-27`. The first screen already handles this case — it prints `covering …` rather than two zero lines — and stats now agrees:

```
Last 12 months
  none — this store covers 2025-06-24 → 2025-06-27
```

Closes #703