### PR TITLE
fix: keep result-line ids distinguishable and resolvable

### DIFF
--- a/internal/index/find_substring_test.go
+++ b/internal/index/find_substring_test.go
@@ -1,0 +1,50 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Result lines elide the middle of a long id, so what a reader copies out of a
+// search is a head and a tail rather than a prefix (#707).
+func TestFindByPrefixFallsBackToASubstring(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"00000000-0001-4a1b-9c2d-000000000001", "00000000-0002-4a1b-9c2d-000000000002"} {
+		body := `{"type":"user","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"work in ` + id + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(root, id+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The tail alone, as it appears after the ellipsis in a result line.
+	s, ok, err := FindByPrefix(dir, "0000000002")
+	if err != nil || !ok {
+		t.Fatalf("substring lookup: ok=%v err=%v", ok, err)
+	}
+	if s.ID != "00000000-0002-4a1b-9c2d-000000000002" {
+		t.Errorf("resolved %q", s.ID)
+	}
+	// A real prefix still wins outright.
+	s, ok, err = FindByPrefix(dir, "00000000-0001")
+	if err != nil || !ok || s.ID != "00000000-0001-4a1b-9c2d-000000000001" {
+		t.Fatalf("prefix lookup: %q ok=%v err=%v", s.ID, ok, err)
+	}
+	// Nothing matching stays nothing.
+	if _, ok, err := FindByPrefix(dir, "not-in-this-store"); err != nil || ok {
+		t.Errorf("ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -924,9 +924,28 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 		}
 	}
 	if len(matches) == 0 {
+		// Result lines elide the middle of a long id, so what a reader copies
+		// out of a search is a head and a tail rather than a prefix (#707).
+		// Falling back to a substring match costs nothing when the prefix
+		// worked and saves the copy-paste when it did not.
+		for _, meta := range m.Sessions {
+			if strings.Contains(meta.ID, p) {
+				matches = append(matches, meta)
+			}
+		}
+	}
+	if len(matches) == 0 {
 		return model.Session{}, false, nil
 	}
-	sort.Slice(matches, func(i, j int) bool { return matches[i].Updated.After(matches[j].Updated) })
+	sort.Slice(matches, func(i, j int) bool {
+		if !matches[i].Updated.Equal(matches[j].Updated) {
+			return matches[i].Updated.After(matches[j].Updated)
+		}
+		if matches[i].Harness != matches[j].Harness {
+			return matches[i].Harness < matches[j].Harness
+		}
+		return matches[i].ID < matches[j].ID
+	})
 	return loadSessionMeta(dir, m, matches[0])
 }
 

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -955,11 +955,23 @@ func countAllVariants(low string, toks []string, variants map[string][]string) i
 	}
 	return total
 }
+
+// short keeps a result line narrow without destroying the one field that
+// identifies the session.
+//
+// A flat 12-character cut printed `deja-note-cl` for every promoted note and
+// `00000000-000` for UUID sessions — twelve identical rows in one answer, and
+// the cut string is what a reader copies into `deja show` (#707). Ids are
+// meaningful at both ends, so the middle goes.
 func short(s string) string {
-	if len(s) > 12 {
-		return s[:12]
+	const width = 20
+	r := []rune(s)
+	if len(r) <= width {
+		return s
 	}
-	return s
+	head := width/2 - 1
+	tail := width - head - 1
+	return string(r[:head]) + "…" + string(r[len(r)-tail:])
 }
 func highlight(s, q string, isRe bool, color bool) string {
 	if !color {

--- a/internal/search/short_id_test.go
+++ b/internal/search/short_id_test.go
@@ -1,0 +1,43 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// A flat 12-character cut printed `deja-note-cl` for every promoted note and
+// `00000000-000` for UUID sessions — twelve identical rows in one answer
+// (#707).
+func TestShortKeepsIDsDistinguishable(t *testing.T) {
+	notes := []string{"deja-note-claude-s0089", "deja-note-claude-s0023", "deja-note-claude-s0139"}
+	seen := map[string]bool{}
+	for _, id := range notes {
+		got := short(id)
+		if seen[got] {
+			t.Errorf("%q collides with an earlier id: %q", id, got)
+		}
+		seen[got] = true
+		if !strings.HasSuffix(got, id[len(id)-4:]) {
+			t.Errorf("short(%q) = %q — the distinguishing tail is gone", id, got)
+		}
+	}
+	uuid := "00000000-0003-4a1b-9c2d-000000000003"
+	if got := short(uuid); got == short("00000000-0002-4a1b-9c2d-000000000002") {
+		t.Errorf("two UUIDs shortened to the same string: %q", got)
+	}
+	// Short ids are printed whole.
+	for _, id := range []string{"", "s0001", "abc-123-xyz"} {
+		if got := short(id); got != id {
+			t.Errorf("short(%q) = %q, want it unchanged", id, got)
+		}
+	}
+	// The line stays narrow: that is what the function is for.
+	if got := short(strings.Repeat("x", 80)); len([]rune(got)) > 20 {
+		t.Errorf("short() returned %d runes", len([]rune(got)))
+	}
+	// Runes, not bytes: cutting mid-character would print a replacement glyph.
+	cyr := strings.Repeat("сессия", 6)
+	if got := short(cyr); !strings.ContainsRune(got, '…') || strings.ContainsRune(got, '�') {
+		t.Errorf("short(%q) = %q", cyr, got)
+	}
+}


### PR DESCRIPTION
On a store with promoted notes, twelve of fifteen result rows were the same string:

```
[deja] proj/p · Jul 4 · deja-note-cl — 4 matches
[deja] proj/p · Jul 4 · deja-note-cl — 2 matches
[claude] proj/p · Jul 24 · 00000000-000 — 2 matches
```

Ids are meaningful at both ends, so the middle goes instead:

```
[deja] proj/p · Jul 4 · deja-note…aude-s0089 — 4 matches
[claude] proj/p · Jul 24 · 00000000-…0000000003 — 2 matches
```

That leaves what a reader copies as a head and a tail rather than a prefix, so `show`/`resume`/`promote` fall back to a substring match when the prefix finds nothing. A real prefix still wins outright, and the tie-break between equally recent matches is now identity rather than map order.

Closes #707