### PR TITLE
fix: show honours --offset and --limit without --json

### DIFF
--- a/cmd/deja/machine_output.go
+++ b/cmd/deja/machine_output.go
@@ -37,8 +37,12 @@ func printRecentJSON(w io.Writer, sessions []model.Session, sourceInstance strin
 	return json.NewEncoder(w).Encode(recentJSON{SchemaVersion: jsonout.Version, Sessions: sessions})
 }
 
-func printSessionJSON(w io.Writer, session model.Session, offset, limit int, sourceInstance string) error {
-	total := len(session.Messages)
+// sliceMessages applies --offset and --limit. Both are documented for `deja
+// show` and, until #709, only the JSON path honoured them: the human-readable
+// output printed the whole session, which on a 200k-message transcript is
+// 600 001 lines and exactly what --limit exists to avoid.
+func sliceMessages(ms []model.Message, offset, limit int) []model.Message {
+	total := len(ms)
 	if offset > total {
 		offset = total
 	}
@@ -46,7 +50,12 @@ func printSessionJSON(w io.Writer, session model.Session, offset, limit int, sou
 	if end > total {
 		end = total
 	}
-	session.Messages = session.Messages[offset:end]
+	return ms[offset:end]
+}
+
+func printSessionJSON(w io.Writer, session model.Session, offset, limit int, sourceInstance string) error {
+	total := len(session.Messages)
+	session.Messages = sliceMessages(session.Messages, offset, limit)
 	session.SetSource(sourceInstance)
 	return json.NewEncoder(w).Encode(sessionJSON{
 		SchemaVersion: jsonout.Version,

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -244,6 +244,13 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 	if o.json {
 		return printSessionJSON(os.Stdout, s, o.offset, o.limit, sourceInstance)
 	}
+	if o.sliced {
+		// Both flags are documented for `show` and only the JSON path honoured
+		// them; the text output printed the whole session (#709).
+		s.Messages = sliceMessages(s.Messages, o.offset, o.limit)
+	} else if n := len(s.Messages); n > showLargeSession {
+		fmt.Fprintf(os.Stderr, "deja: %d messages — `--offset n --limit n` reads a slice\n", n)
+	}
 	// The prefix picks the newest of its matches, which is the right default
 	// and, until now, a silent one: "2" resolved eleven sessions on a real
 	// store and the reader had no way to know they were shown a choice.
@@ -260,7 +267,15 @@ type showOptions struct {
 	id, harness   string
 	json          bool
 	offset, limit int
+	// sliced records that the reader asked for a slice, as opposed to the
+	// JSON default: applying 50 to the text output would silently truncate
+	// `deja show` for everyone who reads a session whole (#709).
+	sliced bool
 }
+
+// showLargeSession is where `deja show` mentions the flags that read a slice.
+// A 200k-message transcript prints 600 001 lines.
+const showLargeSession = 1000
 
 func parseShow(args []string) (showOptions, error) {
 	o := showOptions{limit: 50}
@@ -283,8 +298,10 @@ func parseShow(args []string) (showOptions, error) {
 			}
 			if a == "--offset" {
 				o.offset = n
+				o.sliced = true
 			} else {
 				o.limit = n
+				o.sliced = true
 			}
 		default:
 			if strings.HasPrefix(a, "-") {

--- a/cmd/deja/show_slice_test.go
+++ b/cmd/deja/show_slice_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestSliceMessages(t *testing.T) {
+	ms := make([]model.Message, 10)
+	for i := range ms {
+		ms[i] = model.Message{Text: string(rune('a' + i))}
+	}
+	cases := []struct {
+		offset, limit int
+		want          string
+	}{
+		{0, 3, "abc"},
+		{7, 5, "hij"},
+		{0, 50, "abcdefghij"},
+		{10, 5, ""},
+		// Past the end is empty, not a panic: --offset takes any number the
+		// reader types.
+		{99, 5, ""},
+	}
+	for _, c := range cases {
+		var b strings.Builder
+		for _, m := range sliceMessages(ms, c.offset, c.limit) {
+			b.WriteString(m.Text)
+		}
+		if b.String() != c.want {
+			t.Errorf("offset=%d limit=%d → %q, want %q", c.offset, c.limit, b.String(), c.want)
+		}
+	}
+}
+
+// Both flags are documented for `deja show`, and only the JSON path honoured
+// them — the text output printed the whole session (#709).
+// sliceMessages must survive an offset past the end — --offset takes any
+// number the reader types.
+func TestSliceMessagesPastTheEnd(t *testing.T) {
+	ms := []model.Message{{Text: "a"}, {Text: "b"}}
+	for _, off := range []int{2, 3, 1000} {
+		if got := sliceMessages(ms, off, 5); len(got) != 0 {
+			t.Errorf("offset %d returned %d messages", off, len(got))
+		}
+	}
+}
+
+func TestShowHonoursOffsetAndLimitInTextOutput(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	var lines []string
+	for i := 0; i < 10; i++ {
+		lines = append(lines, `{"type":"user","sessionId":"ten","cwd":"/w/p","timestamp":"2026-07-21T10:0`+
+			string(rune('0'+i))+`:00Z","message":{"role":"user","content":"message number `+string(rune('0'+i))+`"}}`)
+	}
+	if err := os.WriteFile(filepath.Join(root, "ten.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	count := func(out string) int { return strings.Count(out, "message number") }
+
+	whole, err := captureRun(t, "show", "ten")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No flags: the session is printed whole, or every reader who pipes
+	// `deja show` into a pager silently loses the tail. A ten-message session
+	// is also too small to be worth mentioning the slice flags for.
+	if got := count(whole); got != 10 {
+		t.Errorf("show without flags returned %d messages", got)
+	}
+	quiet, err := captureRunStderr(t, "show", "ten")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(quiet, "reads a slice") {
+		t.Errorf("a ten-message session suggested slicing: %q", quiet)
+	}
+	limited, err := captureRun(t, "show", "ten", "--limit", "3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := count(limited); got != 3 {
+		t.Errorf("--limit 3 returned %d messages", got)
+	}
+	offset, err := captureRun(t, "show", "ten", "--offset", "7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := count(offset); got != 3 || !strings.Contains(offset, "message number 7") || strings.Contains(offset, "message number 6") {
+		t.Errorf("--offset 7 returned %d messages: %q", got, offset)
+	}
+	both, err := captureRun(t, "show", "ten", "--offset", "7", "--limit", "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := count(both); got != 2 {
+		t.Errorf("--offset 7 --limit 2 returned %d messages", got)
+	}
+}


### PR DESCRIPTION
`deja show <id> [--offset n] [--limit n]` documents both flags, and the human-readable output ignored them:

```
$ deja show ten --limit 3 | grep -c 'message number'
10
$ deja show ten --offset 7 | grep -c 'message number'
10
```

With `--json` they worked exactly as documented. This matters most where the flags matter most: `deja show` on a 200k-message session prints 600 001 lines.

Without either flag the session still prints whole — applying the JSON default of 50 would silently truncate it for everyone who reads a session end to end. A session above 1000 messages now mentions the flags on stderr.

Third instance of this class in the audit, after `--role tool` (#623) and `show <prefix> --harness` (#625).

Closes #709