### PR TITLE
fix: at equal rank the local session comes before an imported one

### DIFF
--- a/internal/search/local_tie_test.go
+++ b/internal/search/local_tie_test.go
@@ -1,0 +1,70 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestIsLocalProject(t *testing.T) {
+	for _, c := range []struct {
+		project string
+		want    bool
+	}{
+		{"myproj/99", true},
+		{"", true},
+		{"imported:peerproj/9", false},
+		{"imported:", false},
+		// Not the prefix: a local project may legitimately be named after the
+		// word.
+		{"imported-notes", true},
+		{"my/imported:thing", true},
+	} {
+		if got := isLocalProject(c.project); got != c.want {
+			t.Errorf("isLocalProject(%q) = %v", c.project, got)
+		}
+	}
+}
+
+// Same evidence, same moment: the tie used to fall to the id, and
+// "imported-…" sorts ahead of most session ids — so a peer's copy outranked
+// the local session for no reason anyone chose (#711).
+func TestEqualHitsPreferTheLocalSession(t *testing.T) {
+	at := time.Date(2026, 8, 1, 5, 42, 1, 0, time.UTC)
+	hits := []Hit{
+		{Session: model.Session{ID: "imported-19c23b9cfc52", Project: "imported:peerproj/9", Updated: at}, Score: 3},
+		{Session: model.Session{ID: "tie-local", Project: "myproj/99", Updated: at}, Score: 3},
+	}
+	sortHits(hits)
+	got := hits
+	if got[0].Session.ID != "tie-local" {
+		t.Errorf("order = %q, %q", got[0].Session.ID, got[1].Session.ID)
+	}
+
+	// Reversed input, same answer.
+	hits = []Hit{hits[1], hits[0]}
+	sortHits(hits)
+	if got := hits; got[0].Session.ID != "tie-local" {
+		t.Errorf("reversed order = %q", got[0].Session.ID)
+	}
+
+	// Two local sessions still fall back to the id, and a better score still
+	// wins outright over locality.
+	hits = []Hit{
+		{Session: model.Session{ID: "b", Project: "p", Updated: at}, Score: 3},
+		{Session: model.Session{ID: "a", Project: "p", Updated: at}, Score: 3},
+	}
+	sortHits(hits)
+	if got := hits; got[0].Session.ID != "a" {
+		t.Errorf("two local: %q", got[0].Session.ID)
+	}
+	hits = []Hit{
+		{Session: model.Session{ID: "local", Project: "p", Updated: at}, Score: 1},
+		{Session: model.Session{ID: "peer", Project: "imported:x/y", Updated: at}, Score: 9},
+	}
+	sortHits(hits)
+	if got := hits; got[0].Session.ID != "peer" {
+		t.Errorf("score must win over locality: %q", got[0].Session.ID)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -419,16 +419,34 @@ func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLengt
 		doc.hit.Score = score
 		hits = append(hits, doc.hit)
 	}
+	sortHits(hits)
+	return hits
+}
+
+// sortHits orders a ranked result set.
+func sortHits(hits []Hit) {
 	sort.Slice(hits, func(i, j int) bool {
 		if hits[i].Score == hits[j].Score {
 			if hits[i].Session.Updated.Equal(hits[j].Session.Updated) {
+				// Same evidence, same moment: prefer this machine's own work.
+				// The tie used to fall to the id, and "imported-…" sorts ahead
+				// of most session ids — so a peer's copy outranked the local
+				// session for no reason anyone chose (#711).
+				if li, lj := isLocalProject(hits[i].Session.Project), isLocalProject(hits[j].Session.Project); li != lj {
+					return li
+				}
 				return hits[i].Session.ID < hits[j].Session.ID
 			}
 			return hits[i].Session.Updated.After(hits[j].Session.Updated)
 		}
 		return hits[i].Score > hits[j].Score
 	})
-	return hits
+}
+
+// isLocalProject reports whether a session came from this machine. Imported
+// sessions carry the peer prefix the sync path gives them.
+func isLocalProject(project string) bool {
+	return !strings.HasPrefix(project, "imported:")
 }
 
 func freshnessDecay(updated, now time.Time) float64 {


### PR DESCRIPTION
Two sessions with identical text and the same timestamp, one local and one imported:

```
[claude] imported:peerproj/9 · today · imported-…c23b9cfc52 — 3 matches
[claude] myproj/99           · today · tie-local          — 3 matches
```

Eight runs, same order — not map order: the tie falls to the id, and `imported-…` sorts ahead of most session ids. At equal evidence and equal recency the local session is the better answer; ranking alphabetically by an id nobody chose is not a decision.

Score still wins outright over locality, and two local sessions still fall back to the id.

LongMemEval unchanged: 84.9% hit@1, 94.3% hit@5, MRR 0.891 over 470 questions.

Measured on 2000 local + 200 imported sessions; imported memory does not crowd out local memory otherwise — 0 of 20 in `last`, 1 of 15 in a search, 0 of 5 in recall.

Closes #711