### PR TITLE
fix: deja last and the first screen keep their order when timestamps tie

### DIFF
--- a/internal/index/recent_order_test.go
+++ b/internal/index/recent_order_test.go
@@ -1,0 +1,86 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+func TestNewestFirstMetaIsATotalOrder(t *testing.T) {
+	early := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	late := early.Add(time.Hour)
+	meta := func(h, id string, at time.Time) SessionMeta {
+		return SessionMeta{Harness: h, ID: id, Updated: at}
+	}
+	cases := []struct {
+		name string
+		a, b SessionMeta
+		want bool
+	}{
+		{"newer first", meta("claude", "z", late), meta("claude", "a", early), true},
+		{"older last", meta("claude", "a", early), meta("claude", "z", late), false},
+		{"tie falls to harness", meta("claude", "z", early), meta("cursor", "a", early), true},
+		{"tie falls to harness, reversed", meta("cursor", "a", early), meta("claude", "z", early), false},
+		{"tie falls to id", meta("claude", "a", early), meta("claude", "b", early), true},
+		{"tie falls to id, reversed", meta("claude", "b", early), meta("claude", "a", early), false},
+		{"identical is not less", meta("claude", "a", early), meta("claude", "a", early), false},
+	}
+	for _, c := range cases {
+		if got := newestFirstMeta(c.a, c.b); got != c.want {
+			t.Errorf("%s: got %v", c.name, got)
+		}
+		s := func(m SessionMeta) model.Session {
+			return model.Session{Harness: m.Harness, ID: m.ID, Updated: m.Updated}
+		}
+		if got := newestFirstSession(s(c.a), s(c.b)); got != c.want {
+			t.Errorf("%s (session): got %v", c.name, got)
+		}
+	}
+}
+
+// A store where several sessions share a stamp — a day's work imported in one
+// go, a harness that stamps per-day, transcripts restored from a backup —
+// reordered itself on every run: six calls to `deja last`, six answers (#713).
+func TestRecentIsStableWhenTimestampsTie(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Enough sessions that map order actually varies between reads.
+	for i := 0; i < 60; i++ {
+		id := "s" + string(rune('a'+i/26)) + string(rune('a'+i%26))
+		body := `{"type":"user","sessionId":"` + id + `","cwd":"/w/p","timestamp":"2026-08-01T09:00:00Z","message":{"role":"user","content":"work ` + id + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(root, id+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	first, err := RecentMatching(dir, 5, query.Options{})
+	if err != nil || len(first) != 5 {
+		t.Fatalf("%d sessions err=%v", len(first), err)
+	}
+	for run := 0; run < 20; run++ {
+		got, err := RecentMatching(dir, 5, query.Options{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range got {
+			if got[i].ID != first[i].ID {
+				t.Fatalf("run %d position %d: %q, first run had %q", run, i, got[i].ID, first[i].ID)
+			}
+		}
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -756,6 +756,34 @@ func SearchWithRecoveryDetailed(dir string, o query.Options, progress io.Writer)
 	return SearchDetailed(dir, o)
 }
 
+// newestFirstMeta orders sessions for every "most recent" answer deja gives.
+//
+// A timestamp alone is not an order. Sessions come out of a map, so a store
+// where several share a stamp — a day's work imported in one go, a harness
+// that stamps per-day, transcripts restored from a backup — reordered itself
+// on every run: six calls to `deja last`, six different answers (#713).
+// Identity breaks the tie because it is the one thing that does not change.
+func newestFirstMeta(a, b SessionMeta) bool {
+	if !a.Updated.Equal(b.Updated) {
+		return a.Updated.After(b.Updated)
+	}
+	if a.Harness != b.Harness {
+		return a.Harness < b.Harness
+	}
+	return a.ID < b.ID
+}
+
+// newestFirstSession is newestFirstMeta for loaded sessions.
+func newestFirstSession(a, b model.Session) bool {
+	if !a.Updated.Equal(b.Updated) {
+		return a.Updated.After(b.Updated)
+	}
+	if a.Harness != b.Harness {
+		return a.Harness < b.Harness
+	}
+	return a.ID < b.ID
+}
+
 func Recent(dir string, n int) ([]model.Session, error) {
 	return RecentMatching(dir, n, query.Options{})
 }
@@ -782,7 +810,7 @@ func RecentMatching(dir string, n int, o query.Options) ([]model.Session, error)
 		}
 		out = append(out, sessionFromMeta(meta))
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Updated.After(out[j].Updated) })
+	sort.Slice(out, func(i, j int) bool { return newestFirstSession(out[i], out[j]) })
 	if n > 0 && len(out) > n {
 		out = out[:n]
 	}
@@ -820,7 +848,7 @@ func RecentProject(dir, project string, n int) ([]model.Session, error) {
 			metas = append(metas, meta)
 		}
 	}
-	sort.Slice(metas, func(i, j int) bool { return metas[i].Updated.After(metas[j].Updated) })
+	sort.Slice(metas, func(i, j int) bool { return newestFirstMeta(metas[i], metas[j]) })
 	if n > 0 && len(metas) > n {
 		metas = metas[:n]
 	}
@@ -884,7 +912,7 @@ func RecentProjects(dir string, projects []string, perName int) ([]model.Session
 				mine = append(mine, meta)
 			}
 		}
-		sort.Slice(mine, func(i, j int) bool { return mine[i].Updated.After(mine[j].Updated) })
+		sort.Slice(mine, func(i, j int) bool { return newestFirstMeta(mine[i], mine[j]) })
 		if perName > 0 && len(mine) > perName {
 			mine = mine[:perName]
 		}
@@ -937,15 +965,7 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 	if len(matches) == 0 {
 		return model.Session{}, false, nil
 	}
-	sort.Slice(matches, func(i, j int) bool {
-		if !matches[i].Updated.Equal(matches[j].Updated) {
-			return matches[i].Updated.After(matches[j].Updated)
-		}
-		if matches[i].Harness != matches[j].Harness {
-			return matches[i].Harness < matches[j].Harness
-		}
-		return matches[i].ID < matches[j].ID
-	})
+	sort.Slice(matches, func(i, j int) bool { return newestFirstMeta(matches[i], matches[j]) })
 	return loadSessionMeta(dir, m, matches[0])
 }
 
@@ -2313,7 +2333,7 @@ func FindAskedTwice(dir string) (AskedTwice, bool) {
 		if len(metas) < 2 {
 			continue
 		}
-		sort.Slice(metas, func(i, j int) bool { return metas[i].Updated.After(metas[j].Updated) })
+		sort.Slice(metas, func(i, j int) bool { return newestFirstMeta(metas[i], metas[j]) })
 		span := metas[0].Updated.Sub(metas[len(metas)-1].Updated)
 		// Time between the askings, not the number of them. The same question
 		// sixteen times in one afternoon is somebody retrying; the same question


### PR DESCRIPTION
A store where sessions share a timestamp — a day's work imported in one go, a harness stamping per-day, transcripts restored from a backup:

```
$ for i in 1 2 3 4 5 6; do deja last 3 | head -1; done
… s0026 …
… s0864 …
… s0368 …
… s0039 …
… s0538 …
… s0765 …
```

Six runs, six answers; the first screen's `recent` block did the same. Search got its tie-break in #668/#711 — these were the remaining places that sorted on a timestamp alone over a Go map.

`deja last` is what people use to find the session they just left.

Closes #713