### PR TITLE
fix: name the filter that emptied a search, and stop hinting on short words

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -499,10 +499,15 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	}
 	if len(hits) == 0 {
 		// The policy is named before the generic advice: "try fewer words" is
-		// wrong counsel for someone whose words were fine (#680).
-		if note := policyHiddenNote(policy.ActivationSearch, policyHidden); note != "" {
+		// wrong counsel for someone whose words were fine (#680). A filter the
+		// caller set is the same kind of fact, and `deja last` has named it all
+		// along (#715).
+		switch note := policyHiddenNote(policy.ActivationSearch, policyHidden); {
+		case note != "":
 			fmt.Fprint(os.Stderr, note)
-		} else {
+		case activeFilters(o, "") != "":
+			fmt.Fprintf(os.Stderr, "deja: %q matched nothing under %s\n", o.Query, activeFilters(o, ""))
+		default:
 			printNoMatches(os.Stderr, dir, o.Query)
 		}
 	}
@@ -585,6 +590,13 @@ func commandHint(q string) string {
 		return ""
 	}
 	low := strings.ToLower(first)
+	// A one- or two-letter word is a word, not a mistyped command name. Any
+	// prefix counts as "near" — so "a" reached `deja aider` and every sentence
+	// starting with a short word got a hint (#715, my own regression from
+	// #674).
+	if len([]rune(low)) < 4 {
+		return ""
+	}
 	if _, ok := commands[low]; ok {
 		return "" // reached search only because it was used as a word
 	}

--- a/cmd/deja/search_empty_test.go
+++ b/cmd/deja/search_empty_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// "Try fewer words" is advice for a different problem when a filter the caller
+// set is what emptied the result — `deja last` has named it all along (#715).
+func TestEmptySearchNamesTheFilter(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	body := `{"type":"user","sessionId":"a1","cwd":"/w/p","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"the connection pool starves"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "a1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRunStderr(t, "connection", "--since", "1h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "matched nothing under since") {
+		t.Errorf("--since: %q", out)
+	}
+	if strings.Contains(out, "try fewer words") {
+		t.Errorf("--since still gave the generic advice: %q", out)
+	}
+
+	out, err = captureRunStderr(t, "connection", "--project", "nosuch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `project "nosuch"`) {
+		t.Errorf("--project: %q", out)
+	}
+
+	// An ordinary miss keeps the ordinary advice.
+	out, err = captureRunStderr(t, "moria")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "try fewer words") {
+		t.Errorf("plain miss: %q", out)
+	}
+}
+
+// The hint from #674 was supposed to catch `stat` and `serch`, not every
+// sentence starting with a short word (#715).
+func TestCommandHintIgnoresShortFirstWords(t *testing.T) {
+	for _, q := range []string{
+		"a very long query that no session will ever contain",
+		"a",
+		"is the pool starving",
+		"do we cap retries",
+	} {
+		if got := commandHint(q); got != "" {
+			t.Errorf("%q produced %q", q, got)
+		}
+	}
+	// The ones it exists for still work.
+	for _, q := range []string{"stat", "serch pool", "shwo abc", "lasr"} {
+		if got := commandHint(q); got == "" {
+			t.Errorf("%q produced no hint", q)
+		}
+	}
+}


### PR DESCRIPTION
Two problems in the same empty-result path, found while walking the search surface (B1).

A filter the caller set was not named, though `deja last` has named it all along:

```
$ deja connection --since 1h
deja: no matches in 4 indexed sessions — try fewer words or --re   →
deja: "connection" matched nothing under since 1h0m0s
```

And the command hint from #674 fired on ordinary queries, because any prefix counted as "near":

```
$ deja "a very long query that no session will ever contain"
deja: "a" is not a command — did you mean `deja aider`?   →   (nothing)
```

My own regression. First words shorter than four characters no longer produce a hint; `stat`, `serch`, `shwo`, `lasr` still do.

Closes #715