### PR TITLE
fix: last --role tool matches tool output

### DIFF
--- a/cmd/deja/last_role_test.go
+++ b/cmd/deja/last_role_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestSessionHasRoleAcceptsTheDocumentedSpelling(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "asked"},
+		{Role: "tool-output", Text: "ERROR"},
+	}}
+	// `deja help` promises --role tool; "tool-output" is what is stored (#717).
+	for _, role := range []string{"tool", "tool-output", "user"} {
+		if !sessionHasRole(s, role) {
+			t.Errorf("role %q did not match", role)
+		}
+	}
+	for _, role := range []string{"assistant", "files", "nosuch", ""} {
+		if sessionHasRole(s, role) {
+			t.Errorf("role %q matched a session without it", role)
+		}
+	}
+	// The alias is one-way: a session whose only work record is a file list
+	// is not tool output.
+	files := model.Session{Messages: []model.Message{{Role: "files", Text: "/repo/a.go"}}}
+	if sessionHasRole(files, "tool") {
+		t.Error("a files record answered --role tool")
+	}
+}
+
+func TestLastRoleToolFindsToolOutput(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	withTool := `{"type":"user","sessionId":"a1","cwd":"/w/p","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"ran it"}}` + "\n" +
+		`{"type":"user","sessionId":"a1","cwd":"/w/p","timestamp":"2026-07-21T10:01:00Z","message":{"role":"user","content":[{"type":"tool_result","content":"ERROR: boom"}]}}` + "\n"
+	talkOnly := `{"type":"user","sessionId":"b1","cwd":"/w/p","timestamp":"2026-07-22T10:00:00Z","message":{"role":"user","content":"only talk here"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "a1.jsonl"), []byte(withTool), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "b1.jsonl"), []byte(talkOnly), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "last", "9", "--role", "tool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "a1") {
+		t.Errorf("--role tool missed the session with tool output: %q", out)
+	}
+	if strings.Contains(out, "b1") {
+		t.Errorf("--role tool returned a session without tool output: %q", out)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -824,9 +824,13 @@ func filterRecentSources(ss []model.Session, o search.Options) []model.Session {
 	return out
 }
 
+// sessionHasRole accepts the role names the help text documents. `--role tool`
+// is what `deja help` promises and "tool-output" is what is stored, so the
+// documented spelling matched nothing here while `deja search --role tool` —
+// which grew the alias in #623 — worked (#717).
 func sessionHasRole(s model.Session, role string) bool {
 	for _, m := range s.Messages {
-		if m.Role == role {
+		if m.Role == role || (role == "tool" && m.Role == "tool-output") {
 			return true
 		}
 	}


### PR DESCRIPTION
`deja help` documents `--role user|assistant|tool` for `deja last`, and the documented spelling matched nothing:

```
$ deja last --role tool
deja: no sessions match role "tool"
$ deja last --role tool-output
[claude · proj/p · 2026-07-31 · a1] …
$ deja search ERROR --role tool
[claude] proj/p · 1d ago · a1 — 1 matches
```

Search grew the alias in #623; `last` kept comparing the stored role verbatim. The alias is one-way — a `files` record still does not answer `--role tool`.

Fourth instance of this class in the audit, after #623, #625 and #709.

Closes #717