### PR TITLE
fix: point at --harness when two sessions share an id

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -256,7 +256,15 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 	// store and the reader had no way to know they were shown a choice.
 	if o.harness == "" {
 		if n := index.PrefixMatches(dir, o.id); n > 1 {
-			fmt.Fprintf(os.Stderr, "deja: %d sessions start with %q — showing the most recent; use a longer prefix for another\n", n, o.id)
+			// When the matches are the same id in different harnesses there is
+			// no longer prefix to reach for, and --harness is the only thing
+			// that separates them (#719).
+			if hs := index.PrefixHarnesses(dir, o.id); len(hs) > 1 {
+				fmt.Fprintf(os.Stderr, "deja: %d sessions share the id %q — showing the most recent; use --harness %s\n",
+					len(hs), o.id, strings.Join(hs, "|"))
+			} else {
+				fmt.Fprintf(os.Stderr, "deja: %d sessions start with %q — showing the most recent; use a longer prefix for another\n", n, o.id)
+			}
 		}
 	}
 	search.PrintSession(os.Stdout, s)

--- a/cmd/deja/show_ambiguous_test.go
+++ b/cmd/deja/show_ambiguous_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// "Use a longer prefix" cannot be followed when the ids are the same string;
+// --harness is the only thing that separates them (#719).
+func TestShowNamesHarnessWhenIDsAreShared(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude", "proj-p")
+	qwen := filepath.Join(tmp, "qwen", "projects", "proj-z", "chats")
+	for _, d := range []string{claude, qwen} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
+	write := func(p, body string) {
+		if err := os.WriteFile(p, []byte(body+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(claude, "abc12345.jsonl"),
+		`{"type":"user","sessionId":"abc12345","cwd":"/w/p","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"claude side"}}`)
+	write(filepath.Join(claude, "abc99999.jsonl"),
+		`{"type":"user","sessionId":"abc99999","cwd":"/w/p","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"other claude session"}}`)
+	write(filepath.Join(qwen, "abc12345.jsonl"),
+		`{"type":"user","sessionId":"abc12345","timestamp":"2026-07-25T10:00:00Z","message":{"role":"user","parts":[{"text":"qwen side"}]}}`)
+	// A session whose whole id is also a prefix of the others: the prefix is
+	// ambiguous, the id is not, and only the longer-prefix advice fits.
+	write(filepath.Join(claude, "abc.jsonl"),
+		`{"type":"user","sessionId":"abc","cwd":"/w/p","timestamp":"2026-07-19T10:00:00Z","message":{"role":"user","content":"the short one"}}`)
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	shared, err := captureRunStderr(t, "show", "abc12345")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(shared, "share the id") || !strings.Contains(shared, "--harness claude|qwen") {
+		t.Errorf("shared id: %q", shared)
+	}
+	if strings.Contains(shared, "longer prefix") {
+		t.Errorf("still advised a longer prefix: %q", shared)
+	}
+
+	// An ordinary ambiguous prefix keeps the advice that works there — even
+	// when that prefix is itself one session's whole id.
+	prefix, err := captureRunStderr(t, "show", "abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(prefix, "longer prefix") {
+		t.Errorf("prefix case: %q", prefix)
+	}
+	if strings.Contains(prefix, "share the id") {
+		t.Errorf("a unique id was reported as shared: %q", prefix)
+	}
+
+	// One match, no chatter.
+	quiet, err := captureRunStderr(t, "show", "abc99999")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(quiet, "sessions") {
+		t.Errorf("unambiguous id said %q", quiet)
+	}
+}

--- a/internal/index/prefix_harnesses_test.go
+++ b/internal/index/prefix_harnesses_test.go
@@ -1,0 +1,59 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Two harnesses can carry the same id, and there the advice "use a longer
+// prefix" cannot be followed — the ids are the same string (#719).
+func TestPrefixHarnesses(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	claude := filepath.Join(tmp, "claude", "proj-p")
+	qwen := filepath.Join(tmp, "qwen", "projects", "proj-z", "chats")
+	for _, d := range []string{claude, qwen} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(path, body string) {
+		if err := os.WriteFile(path, []byte(body+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(claude, "abc12345.jsonl"),
+		`{"type":"user","sessionId":"abc12345","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"claude side"}}`)
+	write(filepath.Join(claude, "abc99999.jsonl"),
+		`{"type":"user","sessionId":"abc99999","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"other claude session"}}`)
+	write(filepath.Join(qwen, "abc12345.jsonl"),
+		`{"type":"user","sessionId":"abc12345","timestamp":"2026-07-25T10:00:00Z","message":{"role":"user","parts":[{"text":"qwen side"}]}}`)
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := PrefixHarnesses(dir, "abc12345"); strings.Join(got, "|") != "claude|qwen" {
+		t.Errorf("shared id → %v", got)
+	}
+	// A prefix is not an id: "abc" matches three sessions but names none.
+	if got := PrefixHarnesses(dir, "abc"); len(got) != 0 {
+		t.Errorf("prefix → %v", got)
+	}
+	if got := PrefixHarnesses(dir, "abc99999"); strings.Join(got, "|") != "claude" {
+		t.Errorf("unique id → %v", got)
+	}
+	if got := PrefixHarnesses(dir, ""); got != nil {
+		t.Errorf("empty → %v", got)
+	}
+	if got := PrefixHarnesses(dir, "nothing-like-this"); len(got) != 0 {
+		t.Errorf("missing → %v", got)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -994,6 +994,34 @@ func PrefixMatches(dir, p string) int {
 	return n
 }
 
+// PrefixHarnesses names the harnesses holding a session whose id is exactly the
+// given string.
+//
+// Two harnesses can carry the same id — that is what #698 is about, and it
+// happens naturally when a transcript is copied between tools. There the advice
+// "use a longer prefix" cannot be followed, because the ids are the same
+// string; --harness is the only thing that separates them (#719).
+func PrefixHarnesses(dir, id string) []string {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	if id == "" {
+		return nil
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, meta := range m.Sessions {
+		if meta.ID == id {
+			out = append(out, meta.Harness)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 // FindByIdentity resolves the exact composite identity emitted by machine
 // search and recent output. Unlike the human prefix command, it never guesses
 // between harnesses or accepts a shortened native ID.


### PR DESCRIPTION
Two harnesses can carry the same id — that is what #698 is about, and it happens naturally when a transcript is copied between tools:

```
$ deja show abc12345
deja: 2 sessions start with "abc12345" — showing the most recent; use a longer prefix for another
```

There is no longer prefix; the ids are the same string. The advice cannot be followed and the thing that works is not mentioned:

```
deja: 2 sessions share the id "abc12345" — showing the most recent; use --harness claude|qwen
```

An ordinary ambiguous prefix keeps the longer-prefix advice, including the case where the prefix is itself one session's whole id.

Closes #719