### PR TITLE
fix: blame keeps a session that both mentions and edits the file

### DIFF
--- a/cmd/deja/blame_touchers_test.go
+++ b/cmd/deja/blame_touchers_test.go
@@ -98,3 +98,46 @@ func TestBlameTouchersMatchTheWholeName(t *testing.T) {
 		t.Errorf("poolmanager.go answered a blame for pool.go: %#v", hits)
 	}
 }
+
+// Search returns sessions with only their matching messages attached, so one
+// that matched on speech arrives with its `files` record stripped — and #688
+// skipped it as "already present". Mentioning the subject in the same session
+// therefore removed it from that file's blame (#723).
+func TestBlameFindsASessionThatBothMentionsAndTouchesTheFile(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	edited := filepath.ToSlash(filepath.Join(tmp, "repo", "internal", "parser.go"))
+	b, _ := json.Marshal(map[string]any{"file_path": edited, "old_string": "a", "new_string": "b"})
+	body := `{"type":"user","sessionId":"s2","cwd":"/w/p","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"the parser choked on a nested block"}}` + "\n" +
+		`{"type":"assistant","sessionId":"s2","cwd":"/w/p","timestamp":"2026-07-21T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":` + string(b) + `}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "s2.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	target, err := search.ResolveBlamePath("parser.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hits, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 || hits[0].Session.ID != "s2" {
+		t.Fatalf("hits = %#v — the session that edited the file is missing", hits)
+	}
+	// One session, one row: replacing the trimmed copy must not duplicate it.
+	seen := map[string]int{}
+	for _, h := range hits {
+		seen[h.Session.ID]++
+	}
+	if seen["s2"] != 1 {
+		t.Errorf("session appears %d times", seen["s2"])
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1030,9 +1030,14 @@ func withFileTouchers(dir string, ss []model.Session, target search.BlameTarget)
 	if err != nil {
 		return ss
 	}
-	have := make(map[string]bool, len(ss))
-	for _, s := range ss {
-		have[s.Harness+":"+s.ID] = true
+	// Where each session sits, not merely whether it is here: search returns
+	// sessions with only their matching messages attached, so one that matched
+	// on speech arrives with its `files` record stripped. Skipping it as
+	// "already present" is how mentioning the subject removed a session from
+	// its own file's blame (#723) — it has to be replaced by the full record.
+	at := make(map[string]int, len(ss))
+	for i, s := range ss {
+		at[s.Harness+":"+s.ID] = i
 	}
 	base := strings.ToLower(filepath.Base(target.FullPath))
 	// Newest first, so the cap below keeps the sessions a "who last worked on
@@ -1049,17 +1054,19 @@ func withFileTouchers(dir string, ss []model.Session, target search.BlameTarget)
 			break
 		}
 		key := meta.Harness + ":" + meta.ID
-		if have[key] {
-			continue
-		}
 		for _, p := range meta.Touched {
 			if strings.ToLower(filepath.Base(filepath.FromSlash(p))) != base {
 				continue
 			}
 			full, ok, err := index.FindByIdentity(dir, meta.Harness, meta.ID)
 			if err == nil && ok {
-				ss = append(ss, full)
-				have[key] = true
+				// The manifest is keyed by identity, so each session reaches
+				// this once — there is no second visit to record a position for.
+				if i, present := at[key]; present {
+					ss[i] = full
+				} else {
+					ss = append(ss, full)
+				}
 				added++
 			}
 			break


### PR DESCRIPTION
One session, one file it edited, two variants of its first line:

```
"the tokenizer choked on a nested block" + edits internal/parser.go
$ deja blame parser.go   → 2026-07-21 · claude · s2 · …          ✅

"the parser choked on a nested block"   + edits internal/parser.go
$ deja blame parser.go   → deja: no sessions mention parser.go   ❌
```

Mentioning the subject *removed* the session from blame. Search returns sessions with only their matching messages attached, so when "parser" matched the spoken line the session arrived with its `files` record stripped — and #688 skipped it as already present. It is now replaced by the full record rather than skipped.

The more a session discusses a file, the likelier it was to be excluded from that file's blame.

Closes #723