### PR TITLE
fix: files names the project filter and marks truncated paths

### DIFF
--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -78,6 +78,13 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		return fmt.Errorf("search: %w", err)
 	}
 	if len(hits) == 0 {
+		// A filter the caller set is not the topic's fault: three sessions can
+		// mention it and still be absent because they are in another project
+		// (#727, the same shape as #715 in search).
+		if project != "" {
+			fmt.Fprintf(stdout, "no sessions mention %q in project %q\n", q, project)
+			return nil
+		}
 		fmt.Fprintf(stdout, "no sessions mention %q\n", q)
 		return nil
 	}
@@ -315,12 +322,21 @@ var repoCheck sync.Map
 
 // trimPath keeps the tail that identifies a file without the home directory in
 // front of it.
+//
+// The cut is marked: two files under /tmp/b7/repo printed as "tmp/b7/repo/x.go"
+// and "b7/repo/internal/y.go", which read as relative paths starting in
+// different places rather than as one tree with its head removed (#727).
 func trimPath(p string) string {
 	parts := strings.Split(filepath.Clean(p), string(filepath.Separator))
-	if len(parts) > 4 {
-		return strings.Join(parts[len(parts)-4:], "/")
+	// Clean leaves an empty first element for an absolute path. Dropping it is
+	// not a truncation, so it must not draw an ellipsis.
+	if len(parts) > 0 && parts[0] == "" {
+		parts = parts[1:]
 	}
-	return strings.TrimPrefix(p, "/")
+	if len(parts) > 4 {
+		return "…/" + strings.Join(parts[len(parts)-4:], "/")
+	}
+	return strings.Join(parts, "/")
 }
 
 // verbIs keeps "1 file is" from reading as "1 file are".

--- a/cmd/deja/files_test.go
+++ b/cmd/deja/files_test.go
@@ -100,8 +100,10 @@ func TestInRepositoryWalksUpForGit(t *testing.T) {
 }
 
 func TestTrimPath(t *testing.T) {
+	// The head that was dropped is marked, or two files under one directory
+	// read as relative paths starting in different places (#727).
 	got := trimPath("/Users/x/coding/goprojects/deja-vu/internal/index/store.go")
-	if got != "deja-vu/internal/index/store.go" {
+	if got != "…/deja-vu/internal/index/store.go" {
 		t.Fatalf("got %q", got)
 	}
 	if got := trimPath("/a/b.go"); got != "a/b.go" {

--- a/cmd/deja/files_trim_test.go
+++ b/cmd/deja/files_trim_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Two files under one directory printed as "tmp/b7/repo/x.go" and
+// "b7/repo/internal/y.go", which read as relative paths starting in different
+// places rather than as one tree with its head removed (#727).
+func TestTrimPathMarksTheCut(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/tmp/b7/repo/retry.go", "tmp/b7/repo/retry.go"},
+		{"/tmp/b7/repo/internal/backoff.go", "…/b7/repo/internal/backoff.go"},
+		{"/a/b/c/d/e/f/g.go", "…/d/e/f/g.go"},
+		{"retry.go", "retry.go"},
+		{"repo/retry.go", "repo/retry.go"},
+		// Four segments is the limit, and dropping the empty root of an
+		// absolute path is not a truncation.
+		{"/a/b/c/d.go", "a/b/c/d.go"},
+		{"/a/b/c/d/e.go", "…/b/c/d/e.go"},
+	}
+	for _, c := range cases {
+		if got := trimPath(c.in); got != c.want {
+			t.Errorf("trimPath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// A filter the caller set is not the topic's fault: sessions can mention it and
+// still be absent because they are in another project (#727).
+func TestFilesEmptyAnswerNamesTheProjectFilter(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	body := `{"type":"user","sessionId":"s1","cwd":"/w/p","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"the retry storm on checkout"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "s1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	var buf strings.Builder
+	if err := runFiles(index.DefaultDir(), []string{"retry", "--project", "nosuch"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), `in project "nosuch"`) {
+		t.Errorf("filtered answer: %q", buf.String())
+	}
+	buf.Reset()
+	if err := runFiles(index.DefaultDir(), []string{"nothing-like-this"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "in project") {
+		t.Errorf("unfiltered answer mentions a project: %q", buf.String())
+	}
+}


### PR DESCRIPTION
`deja files retry --project nosuch` answered "no sessions mention \"retry\"" — they do, the filter removed them. Same shape as #715, fixed there for search.

Second thing in the same output: paths are cut to their last four segments with nothing marking the cut, so two files under `/tmp/b7/repo` printed as `tmp/b7/repo/retry.go` and `b7/repo/internal/backoff.go` — reading as relative paths that start in different places.

```
  tmp/b7/repo/retry.go              2
  …/b7/repo/internal/backoff.go     1
```

Dropping the empty root of an absolute path is not a truncation and draws no ellipsis.

Closes #727