### PR TITLE
fix: friction recognises the errors machines actually hit

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -95,6 +95,15 @@ func isFriction(l string) bool {
 			return false
 		}
 	}
+	// A comment about an error is source too, and the wider marker list in
+	// #729 made these reachable: `// panic: this is a comment about panics`
+	// became the top wall on a store of shell snippets.
+	for _, comment := range []string{"//", "#", "/*", "*", "--"} {
+		// normalizeFriction has already trimmed the line.
+		if strings.HasPrefix(l, comment) {
+			return false
+		}
+	}
 	// deja's own report is tool output in the next session, and every line of
 	// it contains an error by construction. Drop the report shape so running
 	// the command does not slowly teach it about itself.
@@ -103,12 +112,28 @@ func isFriction(l string) bool {
 			return false
 		}
 	}
+	// The list was nine phrases about things not being found or permitted, and
+	// it matched 3 of 12 ordinary errors on measurement — missing runtime
+	// panics, database timeouts, auth failures and build failures, which is
+	// most of what a machine actually trips over. One miss was capitalisation
+	// alone: curl writes "Connection refused" (#729).
+	low := strings.ToLower(l)
 	for _, p := range []string{
-		"command not found", "ModuleNotFoundError", "No module named",
+		// Not found, not permitted — the original list.
+		"command not found", "modulenotfounderror", "no module named",
 		"not found: ", "cannot find", "no such file or directory",
 		"undefined:", "connection refused", "permission denied",
+		// Crashed.
+		"panic:", "segmentation fault", "exception in thread",
+		"nullpointerexception", "index out of range", "stack overflow",
+		"typeerror:", "referenceerror:", "keyerror:", "attributeerror:",
+		// Refused by a server or a tool, with the tool named.
+		"fatal:", "npm err!", "rpc failed", "timeout expired",
+		"statement timeout", "connection reset", "connection timed out",
+		// Failed to build or run.
+		"] error ", "build failed", "compilation failed", "cannot be resolved",
 	} {
-		if strings.Contains(l, p) {
+		if strings.Contains(low, p) {
 			return true
 		}
 	}

--- a/internal/index/friction_markers_test.go
+++ b/internal/index/friction_markers_test.go
@@ -1,0 +1,46 @@
+package index
+
+import "testing"
+
+// The list was nine phrases about things not being found or permitted, and it
+// matched 3 of 12 ordinary errors — missing runtime panics, database timeouts,
+// auth failures and build failures. One miss was capitalisation alone: curl
+// writes "Connection refused" (#729).
+func TestIsFrictionCoversOrdinaryErrors(t *testing.T) {
+	walls := []string{
+		"bash: pytest: command not found",
+		"go: module github.com/x/y: no such file or directory",
+		"open /etc/secret: permission denied",
+		"panic: runtime error: index out of range [5] with length 3",
+		"ERROR: canceling statement due to statement timeout",
+		"fatal: could not read Username for 'https://github.com'",
+		"npm ERR! code ELIFECYCLE",
+		"make: *** [build] Error 2",
+		"curl: (7) Failed to connect to localhost port 5432: Connection refused",
+		"TypeError: Cannot read properties of undefined (reading 'id')",
+	}
+	for _, l := range walls {
+		if _, ok := FrictionLine(l); !ok {
+			t.Errorf("missed a wall: %q", l)
+		}
+	}
+
+	// Source is not an error, however much it talks about one — a comment
+	// mentioning panic became the top wall once the marker list widened.
+	notWalls := []string{
+		`echo "App not found: $APP"`,
+		`if [ ! -f x ]; then echo "cannot find it"; fi`,
+		`print("permission denied")`,
+		"// panic: this is a comment about panics",
+		"# connection refused happens when the port is closed",
+		"   * panic: in a doc comment",
+		"    // panic: an indented comment",
+		"-- no such file or directory (sql comment)",
+		"  3 sessions  bash: pytest: command not found",
+	}
+	for _, l := range notWalls {
+		if _, ok := FrictionLine(l); ok {
+			t.Errorf("treated source as a wall: %q", l)
+		}
+	}
+}


### PR DESCRIPTION
Twelve errors a machine trips over, each repeated in three sessions:

```
before: 3 of 12   after: 10 of 12
```

Missed before: runtime panics, database timeouts, git auth failures, npm/make build failures, JS type errors. One was capitalisation alone — "connection refused" was on the list and curl writes "Connection refused"; matching is now case-insensitive.

Widening the markers made comments reachable (`// panic: this is a comment about panics` became the top wall on a store of shell snippets), so lines that start as source — `//`, `#`, `/*`, `*`, `--` — are excluded alongside the existing `echo`/quote/`print(` guards. Verified on a store of nothing but such lines: nothing recurring.

Closes #729