### PR TITLE
fix: impact stops calling a larger digest "distilled (0× less)"

### DIFF
--- a/cmd/deja/stats_impact.go
+++ b/cmd/deja/stats_impact.go
@@ -12,7 +12,10 @@ import (
 // Every line is counted from this machine's usage log; the closing note says
 // exactly what was counted so nobody has to take the numbers on faith.
 func runStatsImpact(w io.Writer, dir string, jsonOut bool) error {
-	r := usage.Impact(dir)
+	return printImpact(w, usage.Impact(dir), jsonOut)
+}
+
+func printImpact(w io.Writer, r usage.ImpactReport, jsonOut bool) error {
 	if jsonOut {
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
@@ -26,9 +29,23 @@ func runStatsImpact(w io.Writer, dir string, jsonOut bool) error {
 	fmt.Fprintf(w, "  recalls served     %d agent-initiated recalls returned matches\n", r.Recalls)
 	fmt.Fprintf(w, "  memory at start    %d session starts began with project memory\n", r.Injections)
 	if r.RawBytes > 0 && r.ServedBytes > 0 {
+		// The frame, the header and the session lines cost more than the text
+		// they wrap when sessions are short — which is exactly the state a new
+		// user is in when they first run this. Calling that "distilled (0×
+		// less)" claims a saving that did not happen, and prints a ratio no
+		// one can read (#731).
 		ratio := float64(r.RawBytes) / float64(r.ServedBytes)
-		fmt.Fprintf(w, "  context distilled  %s served instead of %s of raw transcripts (%.0f× less)\n",
-			humanBytes(int64(r.ServedBytes)), humanBytes(r.RawBytes), ratio)
+		switch {
+		case ratio >= 2:
+			fmt.Fprintf(w, "  context distilled  %s served instead of %s of raw transcripts (%.0f× less)\n",
+				humanBytes(int64(r.ServedBytes)), humanBytes(r.RawBytes), ratio)
+		case ratio >= 1:
+			fmt.Fprintf(w, "  context served     %s from %s of raw transcripts\n",
+				humanBytes(int64(r.ServedBytes)), humanBytes(r.RawBytes))
+		default:
+			fmt.Fprintf(w, "  context served     %s from %s of raw transcripts — short sessions, so the digest frame costs more than the text\n",
+				humanBytes(int64(r.ServedBytes)), humanBytes(r.RawBytes))
+		}
 	}
 	if r.ReusedTwice > 0 {
 		fmt.Fprintf(w, "  knowledge re-used  %d sessions recalled 2+ times — fixes that keep paying\n", r.ReusedTwice)

--- a/cmd/deja/stats_impact_ratio_test.go
+++ b/cmd/deja/stats_impact_ratio_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// The frame costs more than the text when sessions are short, and calling that
+// "distilled (0× less)" claims a saving that did not happen (#731).
+func TestImpactLineMatchesTheRatio(t *testing.T) {
+	cases := []struct {
+		name          string
+		served        int
+		raw           int64
+		want, notWant string
+	}{
+		{"real distillation", 4_000, 200_000, "50× less", ""},
+		{"barely any saving", 4_000, 5_000, "3.9 KB from 4.9 KB", "× less"},
+		{"frame costs more", 1_404, 50, "the digest frame costs more", "context distilled"},
+	}
+	for _, c := range cases {
+		var b strings.Builder
+		r := usage.ImpactReport{Recalls: 1, ServedBytes: c.served, RawBytes: c.raw}
+		if err := printImpact(&b, r, false); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(b.String(), c.want) {
+			t.Errorf("%s: %q does not contain %q", c.name, b.String(), c.want)
+		}
+		if c.notWant != "" && strings.Contains(b.String(), c.notWant) {
+			t.Errorf("%s: %q still says %q", c.name, b.String(), c.notWant)
+		}
+		if strings.Contains(b.String(), "(0× less)") {
+			t.Errorf("%s printed an unreadable ratio: %q", c.name, b.String())
+		}
+	}
+}


### PR DESCRIPTION
On a store of short sessions:

```
  context distilled  1.4 KB served instead of 50 B of raw transcripts (0× less)
```

More was served than existed in raw form. Nothing was distilled, and "0×" is not a number anyone can read — the frame, header and session lines cost more than the text they wrap when sessions are short, which is exactly the state a new user is in when they first run `--impact`.

```
  context served     1.4 KB from 50 B of raw transcripts — short sessions, so the digest frame costs more than the text
```

A real saving still reads as one (`50× less`); a marginal one just states both numbers.

Closes #731