### PR TITLE
fix: log --json returns [] on an empty log, and a number is not a flag

### DIFF
--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -28,8 +28,13 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 			last = true
 		default:
 			x, err := strconv.Atoi(a)
-			if err != nil || x <= 0 {
+			if err != nil {
 				return fmt.Errorf("log: unknown flag %q", a)
+			}
+			// A number is not a flag, and saying so sends the reader looking
+			// for a flag they never typed (#733).
+			if x <= 0 {
+				return fmt.Errorf("log: how many entries to show must be positive, got %q", a)
 			}
 			n = x
 		}
@@ -56,6 +61,13 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 	}
 	events := usage.Events(dir, n)
 	if jsonOut {
+		// A nil slice encodes as null, and null is not an empty list: len()
+		// raises, iteration raises, `jq '.[]'` errors. Every other
+		// machine-readable output in deja keeps its shape when there is
+		// nothing to report, and this is the one a script polls (#733).
+		if events == nil {
+			events = []usage.Event{}
+		}
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		return enc.Encode(events)

--- a/cmd/deja/log_json_test.go
+++ b/cmd/deja/log_json_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// null is not an empty list: len() raises, iteration raises, `jq '.[]'`
+// errors. Every other machine-readable output in deja keeps its shape when
+// there is nothing to report, and this is the one a script polls (#733).
+func TestLogJSONIsAlwaysAList(t *testing.T) {
+	withTempStores(t)
+	var buf strings.Builder
+	if err := runLogTo(&buf, t.TempDir(), []string{"--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var events []map[string]any
+	if err := json.Unmarshal([]byte(buf.String()), &events); err != nil {
+		t.Fatalf("empty log is not a list: %q (%v)", buf.String(), err)
+	}
+	if events == nil {
+		t.Errorf("decoded to nil from %q", buf.String())
+	}
+	if len(events) != 0 {
+		t.Errorf("empty log returned %d events", len(events))
+	}
+	if strings.TrimSpace(buf.String()) != "[]" {
+		t.Errorf("empty log printed %q", strings.TrimSpace(buf.String()))
+	}
+}
+
+// A number is not a flag, and saying so sends the reader looking for a flag
+// they never typed.
+func TestLogRejectsANonPositiveCountAsACount(t *testing.T) {
+	withTempStores(t)
+	var buf strings.Builder
+	err := runLogTo(&buf, t.TempDir(), []string{"0"})
+	if err == nil || !strings.Contains(err.Error(), "must be positive") {
+		t.Errorf("log 0: %v", err)
+	}
+	if err != nil && strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("log 0 still called a number a flag: %v", err)
+	}
+	// A word that is not a number is still an unknown flag.
+	err = runLogTo(&buf, t.TempDir(), []string{"abc"})
+	if err == nil || !strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("log abc: %v", err)
+	}
+	// A valid count still works.
+	buf.Reset()
+	if err := runLogTo(&buf, t.TempDir(), []string{"5"}); err != nil {
+		t.Errorf("log 5: %v", err)
+	}
+}


### PR DESCRIPTION
```
$ deja log --json          # nothing recorded yet
null
```

`null` is not an empty list: `len()` raises, iteration raises, `jq '.[]'` errors. `last --json` answers `{"sessions":[]}`, `search --json` answers `{"hits":[]}` — and `log --json` is the one a script polls, since it is how you watch what the agent was given.

Same command, smaller thing: a numeric argument out of range was reported as a flag, sending the reader to look for a flag they never typed.

```
$ deja log 0
deja: log: unknown flag "0"   →   deja: log: how many entries to show must be positive, got "0"
```

A word that is not a number is still an unknown flag.

Closes #733