### PR TITLE
fix: doctor reports a damaged index instead of calling it up to date

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -660,6 +660,14 @@ func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 		updated = fi.ModTime().Format("2006-01-02 15:04")
 	}
 	fmt.Fprintf(w, "  status   built (size=%s, updated=%s)\n", humanBytes(pathSize(dir)), updated)
+	// A store whose postings vanished or whose record log was truncated cannot
+	// answer anything, and said "up to date" until #735. The next search
+	// rebuilds it, which is worth saying too — the reader has not lost memory,
+	// only this build of the index.
+	if index.Damaged(dir) {
+		fmt.Fprintln(w, "  integrity damaged — records or postings are missing; the next search rebuilds the index")
+		return
+	}
 	switch idx.State {
 	case "stale":
 		if idx.StaleStores == 1 {

--- a/cmd/deja/doctor_damaged_test.go
+++ b/cmd/deja/doctor_damaged_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// doctor's job is answering "is my setup right", and it said "built, up to
+// date" about a store that could not return a single result (#735).
+func TestDoctorReportsADamagedIndex(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	body := `{"type":"user","sessionId":"s1","cwd":"/w/p","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"the retry storm"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "s1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	doctorIndex(&buf, doctorComponent{State: "fresh", Path: dir}, dir)
+	if strings.Contains(buf.String(), "integrity") {
+		t.Errorf("healthy index reported damage:\n%s", buf.String())
+	}
+
+	if err := os.RemoveAll(filepath.Join(dir, "buckets")); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	doctorIndex(&buf, doctorComponent{State: "fresh", Path: dir}, dir)
+	out := buf.String()
+	if !strings.Contains(out, "integrity damaged") {
+		t.Errorf("damaged index reported as healthy:\n%s", out)
+	}
+	// The reader has not lost memory, only this build — say so, or the line
+	// reads as data loss.
+	if !strings.Contains(out, "the next search rebuilds") {
+		t.Errorf("no recovery named:\n%s", out)
+	}
+	// "up to date" must not sit under a damage line.
+	if strings.Contains(out, "freshness up to date") {
+		t.Errorf("still claims freshness:\n%s", out)
+	}
+}

--- a/internal/index/damaged_test.go
+++ b/internal/index/damaged_test.go
@@ -1,0 +1,63 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The next search rebuilds a damaged store, so nothing is lost permanently —
+// what was wrong is the answer doctor gave: "built, up to date" about a store
+// that could not return a single result (#735).
+func TestDamaged(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"type":"user","sessionId":"s1","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"the retry storm"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "s1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if Damaged(dir) {
+		t.Fatal("a freshly built index reported damage")
+	}
+
+	// Postings gone: a partial copy, an interrupted sync, a find -delete.
+	buckets := filepath.Join(dir, "buckets")
+	saved := filepath.Join(tmp, "buckets.bak")
+	if err := os.Rename(buckets, saved); err != nil {
+		t.Fatal(err)
+	}
+	if !Damaged(dir) {
+		t.Error("missing postings not reported")
+	}
+	if err := os.Rename(saved, buckets); err != nil {
+		t.Fatal(err)
+	}
+	if Damaged(dir) {
+		t.Error("restored postings still reported as damage")
+	}
+
+	// A truncated record log.
+	if err := os.Truncate(filepath.Join(dir, "records.bin"), 10); err != nil {
+		t.Fatal(err)
+	}
+	if !Damaged(dir) {
+		t.Error("truncated record log not reported")
+	}
+
+	// No index at all is "not built", which doctor reports on its own.
+	if Damaged(filepath.Join(tmp, "no-such-index")) {
+		t.Error("a missing index reported damage")
+	}
+}

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -166,6 +166,25 @@ func recordsIntact(dir string, m Manifest) bool {
 	return true
 }
 
+// Damaged reports whether the store on disk still holds what the manifest
+// committed — a truncated record log, or postings that went missing to a
+// partial copy or an over-eager delete.
+//
+// The next search rebuilds when this is true, so nothing is lost permanently.
+// What was wrong is the answer `doctor` gave: "built, up to date" about a store
+// that could not return a single result (#735).
+func Damaged(dir string) bool {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		// No readable manifest is "not built", which doctor reports already.
+		return false
+	}
+	return !recordsIntact(dir, m)
+}
+
 // OverviewStats is what the brief needs about a whole store.
 type OverviewStats struct {
 	Sessions      int


### PR DESCRIPTION
```
$ rm -rf ~/.deja/buckets     # postings gone; the index cannot answer anything
$ deja doctor
  status   built (size=2.5 KB, updated=…)
  freshness up to date
```

Same for a truncated `records.bin`. The check already existed — `recordsIntact` is what makes the next search rebuild silently — and `doctor` never consulted it.

```
  status    built (size=2.3 KB, updated=…)
  integrity damaged — records or postings are missing; the next search rebuilds the index
```

The recovery is named on purpose: nothing has been lost except this build of the index, and a bare "damaged" would read as data loss.

Closes #735