### PR TITLE
fix: singular counts in the lines a first run prints

### DIFF
--- a/cmd/deja/bench.go
+++ b/cmd/deja/bench.go
@@ -255,7 +255,7 @@ func benchmarkTempDir() (string, error) {
 }
 
 func printBenchReport(w io.Writer, report benchReport) {
-	fmt.Fprintf(w, "deja bench recall\ncorpus: %d sessions, %d queries\n", report.Sessions, report.Queries)
+	fmt.Fprintf(w, "deja bench recall\ncorpus: %d session%s, %d quer%s\n", report.Sessions, pluralS(report.Sessions), report.Queries, pluralY(report.Queries))
 	fmt.Fprintln(w, "mode    recall@5  recall@10  median latency")
 	fmt.Fprintf(w, "lexical %.2f      %.2f       %.2f ms\n", report.Lexical.RecallAt5, report.Lexical.RecallAt10, report.Lexical.MedianMS)
 	if report.Hybrid != nil {

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -162,6 +162,14 @@ func verbS(n int) string {
 	return ""
 }
 
+// pluralY is pluralS for words ending in -y: one query, two queries.
+func pluralY(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}
+
 func pluralS(n int) string {
 	if n == 1 {
 		return ""

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -191,14 +191,14 @@ func installIndexWarmup(dir string, mcp, hooks, guidance int, summary bool) {
 	if !summary {
 		if built {
 			b := index.LastBuild
-			fmt.Fprintf(os.Stderr, "index: built (%d sessions, %d messages)\n", b.Sessions, b.Messages)
+			fmt.Fprintf(os.Stderr, "index: built (%d session%s, %d message%s)\n", b.Sessions, pluralS(b.Sessions), b.Messages, pluralS(b.Messages))
 		}
 		return
 	}
 	fmt.Fprintf(os.Stderr, "installed: %d MCP, %d hooks, %d guidance files\n", mcp, hooks, guidance)
 	if built {
 		b := index.LastBuild
-		fmt.Fprintf(os.Stderr, "index: built (%d sessions, %d messages)\n", b.Sessions, b.Messages)
+		fmt.Fprintf(os.Stderr, "index: built (%d session%s, %d message%s)\n", b.Sessions, pluralS(b.Sessions), b.Messages, pluralS(b.Messages))
 	} else if !index.HasManifest(dir) && detected > 0 {
 		fmt.Fprintln(os.Stderr, "next: run `deja index` to finish building memory")
 	} else if !index.HasManifest(dir) {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -200,7 +200,7 @@ func cmdIndex(dir string, rest []string) error {
 	// of it: the indexer counted every session on disk while the manifest held
 	// fewer, and nothing connected the two numbers (#698).
 	if n := index.ReportCollisions(); n > 0 {
-		fmt.Fprintf(os.Stderr, "deja: %d session%s share an id with another transcript — each pair is filed under one project, the one whose file sorts first\n", n, pluralS(n))
+		fmt.Fprintf(os.Stderr, "deja: %d session%s %s an id with another transcript — each pair is filed under one project, the one whose file sorts first\n", n, pluralS(n), verbShare(n))
 	}
 	maybeFirstIndexGreeting(dir)
 	return nil
@@ -1314,6 +1314,14 @@ func runForget(dir string, args []string) error {
 			result.Notes, verbWere(result.Notes), pluralS(result.Notes))
 	}
 	return nil
+}
+
+// verbShare keeps "1 session share" off the screen.
+func verbShare(n int) string {
+	if n == 1 {
+		return "shares"
+	}
+	return "share"
 }
 
 // verbWere keeps "1 of them are promoted notes" off the screen.

--- a/cmd/deja/moved.go
+++ b/cmd/deja/moved.go
@@ -148,7 +148,7 @@ func movedNote(r movedReport) string {
 	if r.Changed == 1 {
 		return "  1 file this session touched has changed since"
 	}
-	return fmt.Sprintf("  %d files this session touched have changed since", r.Changed)
+	return fmt.Sprintf("  %d file%s this session touched have changed since", r.Changed, pluralS(r.Changed))
 }
 
 // attachMoved annotates the hits that are actually going to be read. Only the

--- a/cmd/deja/plural_test.go
+++ b/cmd/deja/plural_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+// "1 sessions" is the first line anyone sees from deja, and "1 session share"
+// was mine from this audit (#737).
+func TestPluralHelpers(t *testing.T) {
+	for _, c := range []struct {
+		n           int
+		s, y, share string
+	}{
+		{0, "s", "ies", "share"},
+		{1, "", "y", "shares"},
+		{2, "s", "ies", "share"},
+		{11, "s", "ies", "share"},
+	} {
+		if got := pluralS(c.n); got != c.s {
+			t.Errorf("pluralS(%d) = %q, want %q", c.n, got, c.s)
+		}
+		if got := pluralY(c.n); got != c.y {
+			t.Errorf("pluralY(%d) = %q, want %q", c.n, got, c.y)
+		}
+		if got := verbShare(c.n); got != c.share {
+			t.Errorf("verbShare(%d) = %q, want %q", c.n, got, c.share)
+		}
+	}
+}

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -294,7 +294,7 @@ func printStats(w io.Writer, r stats.Report) {
 		fmt.Fprintf(w, "  Credited aloud   agents said \"deja-vu recalled\" %d times (%d this week)\n", r.AgentCredits, r.WeekCredits)
 	}
 	if r.HandoffsIn > 0 {
-		fmt.Fprintf(w, "  Handoffs         %d sessions started from a handoff\n", r.HandoffsIn)
+		fmt.Fprintf(w, "  Handoffs         %d session%s started from a handoff\n", r.HandoffsIn, pluralS(r.HandoffsIn))
 	}
 	fmt.Fprintf(w, "  Injections       %d · %d sessions · %s\n", r.Recall.Injections, r.Recall.InjectedSessions, humanBytes(int64(r.Recall.InjectedBytes)))
 	fmt.Fprintf(w, "  Empty results    %.1f%%\n", r.Recall.EmptyResultRate*100)

--- a/cmd/deja/stats_helpers.go
+++ b/cmd/deja/stats_helpers.go
@@ -60,7 +60,7 @@ func sshSyncTip(dir string, ss []model.Session) string {
 		return ""
 	}
 	_ = os.WriteFile(sentinel, []byte("shown"), 0o600)
-	return fmt.Sprintf("tip: %d sessions mention ssh — if you work across machines, `deja sync ssh <host>` carries this memory along (shown once)", sshSessions)
+	return fmt.Sprintf("tip: %d session%s mention ssh — if you work across machines, `deja sync ssh <host>` carries this memory along (shown once)", sshSessions, pluralS(sshSessions))
 }
 
 // rawSize is the transcript volume a set of served sessions represents — the

--- a/cmd/deja/stats_impact.go
+++ b/cmd/deja/stats_impact.go
@@ -48,7 +48,7 @@ func printImpact(w io.Writer, r usage.ImpactReport, jsonOut bool) error {
 		}
 	}
 	if r.ReusedTwice > 0 {
-		fmt.Fprintf(w, "  knowledge re-used  %d sessions recalled 2+ times — fixes that keep paying\n", r.ReusedTwice)
+		fmt.Fprintf(w, "  knowledge re-used  %d session%s recalled 2+ times — fixes that keep paying\n", r.ReusedTwice, pluralS(r.ReusedTwice))
 	}
 	if r.DejaVuMoments > 0 {
 		fmt.Fprintf(w, "  déjà vu moments    %d prompts matched work you had already done\n", r.DejaVuMoments)

--- a/cmd/deja/stats_impact_test.go
+++ b/cmd/deja/stats_impact_test.go
@@ -26,7 +26,7 @@ func TestStatsImpactCountsAndArithmetic(t *testing.T) {
 	for _, want := range []string{
 		"2 agent-initiated recalls",
 		"1 session starts began with project memory",
-		"1 sessions recalled 2+ times",
+		"1 session recalled 2+ times",
 		"1 prompts matched work",
 		"50× less",
 	} {

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -441,7 +441,7 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 			if label == "deja" {
 				label = "notes"
 			}
-			fmt.Fprintf(progress, "deja: %s: %d sessions, %d messages\n", label, len(r.ss), msgs)
+			fmt.Fprintf(progress, "deja: %s: %d session%s, %d message%s\n", label, len(r.ss), pluralS(len(r.ss)), msgs, pluralS(msgs))
 		}
 	}
 	return ss
@@ -1047,6 +1047,14 @@ func attributeSession(held SessionMeta, s model.Session) (owns, collided bool) {
 		return true, false
 	}
 	return s.Path < held.Path, true
+}
+
+// pluralS keeps "1 sessions" off the first line anyone sees from deja (#737).
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }
 
 func sessionTitle(s model.Session) string {

--- a/internal/index/plural_test.go
+++ b/internal/index/plural_test.go
@@ -1,0 +1,12 @@
+package index
+
+import "testing"
+
+// The indexing line is the first output anyone sees from deja (#737).
+func TestPluralS(t *testing.T) {
+	for n, want := range map[int]string{0: "s", 1: "", 2: "s", 42: "s"} {
+		if got := pluralS(n); got != want {
+			t.Errorf("pluralS(%d) = %q, want %q", n, got, want)
+		}
+	}
+}


### PR DESCRIPTION
```
deja: claude: 1 sessions, 2 messages
deja: 1 session share an id with another transcript
```

The indexing line is the first output anyone sees from deja; the collision line is mine from #698. Both now agree with their counts, along with the neighbours that had the same shape — the ssh tip, moved files, handoffs, re-used sessions, and the bench corpus line.

Closes #737