### PR TITLE
fix: forget --before refuses an age of zero or less

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ history. Tombstones are stored at `~/.config/deja/tombstones` (or
 either one does not resurrect what you forgot; use `--dry-run`, `--list`, or
 `--unforget`. `--unforget` lifts the tombstone and rebuilds, so the session is
 searchable again straight away — the transcript on disk never changed, and an
-incremental pass would skip it.
+incremental pass would skip it. `--before` takes an age (`30d`) or a date; an age of
+zero or less is refused, because "older than now" is every session.
 Ingest exclusions are one case-insensitive project pattern per line in
 `~/.config/deja/exclude` (XDG-aware), or comma-separated in
 `DEJA_EXCLUDE_PROJECTS`. `deja stats --redaction` reports redactions by

--- a/cmd/deja/forget_before_test.go
+++ b/cmd/deja/forget_before_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// "older than 0 days" is the whole store, and the typo that produces it is 0
+// for 30. A negative duration filters nothing in `last` while deleting
+// everything here (#739).
+func TestForgetBeforeRejectsNonPositiveAges(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	body := `{"type":"user","sessionId":"a1","cwd":"/w/p","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"work about the pool"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "a1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, age := range []string{"0d", "0", "0h", "-5d", "-1h"} {
+		_, err := captureRun(t, "forget", "--before", age, "--dry-run")
+		if err == nil {
+			t.Errorf("--before %s was accepted", age)
+			continue
+		}
+		if !strings.Contains(err.Error(), "which is every session") {
+			t.Errorf("--before %s: %v", age, err)
+		}
+	}
+	// Real ages still work, including sub-day ones.
+	for _, age := range []string{"30d", "1h", "90m", "1s"} {
+		if _, err := captureRun(t, "forget", "--before", age, "--dry-run"); err != nil {
+			t.Errorf("--before %s: %v", age, err)
+		}
+	}
+	// A date is a different form and keeps its own error.
+	if _, err := captureRun(t, "forget", "--before", "2026-01-01", "--dry-run"); err != nil {
+		t.Errorf("date form: %v", err)
+	}
+	if _, err := captureRun(t, "forget", "--before", "yesterdayish", "--dry-run"); err == nil ||
+		!strings.Contains(err.Error(), "neither a duration nor a date") {
+		t.Errorf("garbage form: %v", err)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1219,6 +1219,14 @@ func runForget(dir string, args []string) error {
 				unforget = args[i]
 			case "--before":
 				if d, err := parseDur(args[i]); err == nil {
+					// "older than 0 days" is the whole store, and the typo that
+					// produces it is 0 for 30. The neighbouring value behaves
+					// the opposite way — --before 9999d matches nothing — and a
+					// negative duration filters nothing in `last` while
+					// deleting everything here (#739).
+					if d <= 0 {
+						return fmt.Errorf("forget: --before %s means older than now, which is every session — use a real age like 30d, or --project/--session", args[i])
+					}
 					o.Before = time.Now().Add(-d)
 				} else if t, e := parseForgetDate(args[i]); e == nil {
 					o.Before = t


### PR DESCRIPTION
```
$ deja forget --before 0d
sessions dropped: 4
messages dropped: 4
$ deja last
deja: no sessions indexed yet
```

The whole store, no confirmation. Same for `--before 0`, `--before 0h`, `--before -5d`.

`--before Nd` means "older than N days", so zero means "older than now". The typo that produces it is `0` for `30`, and the neighbouring value behaves the opposite way — `--before 9999d` matches nothing. A negative duration is worse: `deja last --since -5d` filters nothing by design, while `forget --before -5d` deleted everything.

Real ages, including sub-day ones, and the date form are unaffected.

Closes #739