### PR TITLE
fix: resume and handoff name a session that exists

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -544,7 +544,9 @@ func TestShareStatsResumeAndSyncEdgeBranches(t *testing.T) {
 	if !strings.Contains(b.String(), "deja stats") {
 		t.Fatalf("stats output = %q", b.String())
 	}
-	if got := digest.Short("123456789012345"); got != "123456789012" {
+	// The middle goes, not the tail: an error naming a session has to name one
+	// that exists (#741).
+	if got := digest.Short("123456789012345678901234567890"); !strings.HasPrefix(got, "123456789") || !strings.HasSuffix(got, "7890") {
 		t.Fatalf("digest.Short long = %q", got)
 	}
 	if got := claudeProjectDirFor(model.Session{Path: filepath.Join(t.TempDir(), "plain.jsonl")}); got != "" {

--- a/internal/digest/coverage_gaps_test.go
+++ b/internal/digest/coverage_gaps_test.go
@@ -39,7 +39,10 @@ func TestUTF8SafeCutLandsOnRuneBoundaries(t *testing.T) {
 }
 
 func TestShortTrimsIdentifiers(t *testing.T) {
-	if got := Short("2fc1d1ef-59f0-4044-b986-ba349e11c53c"); got != "2fc1d1ef-59f" {
+	// Both ends survive: a UUID cut to its head names no session, and the
+	// message that prints it is telling the reader which one was refused
+	// (#741).
+	if got := Short("2fc1d1ef-59f0-4044-b986-ba349e11c53c"); got != "2fc1d1ef-…349e11c53c" {
 		t.Fatalf("Short() = %q", got)
 	}
 	if got := Short("abc"); got != "abc" {

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -435,11 +435,21 @@ func tailSection(s model.Session, budget int) string {
 	return strings.TrimSpace(b.String())
 }
 
+// Short keeps an id readable in a line without destroying the thing it names.
+//
+// A flat cut printed "deja-2026-08" for a note whose id is
+// "deja-2026-08-01-ops/db" — an id no session has, in an error message telling
+// the reader which session was refused (#741). Ids are meaningful at both ends,
+// so the middle goes; #707 made the same change for search result lines.
 func Short(s string) string {
-	if len(s) > 12 {
-		return s[:12]
+	const width = 20
+	r := []rune(s)
+	if len(r) <= width {
+		return s
 	}
-	return s
+	head := width/2 - 1
+	tail := width - head - 1
+	return string(r[:head]) + "…" + string(r[len(r)-tail:])
 }
 
 // decisionMarkers spot conclusion-bearing assistant messages in tool-heavy

--- a/internal/digest/short_test.go
+++ b/internal/digest/short_test.go
@@ -1,0 +1,35 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+)
+
+// A flat cut printed "deja-2026-08" for a note whose id is
+// "deja-2026-08-01-ops/db" — an id no session has, in the error telling the
+// reader which session was refused (#741).
+func TestShortKeepsBothEnds(t *testing.T) {
+	long := "deja-2026-08-01-ops/db"
+	got := Short(long)
+	if !strings.HasPrefix(got, "deja-2026") || !strings.HasSuffix(got, "ops/db") {
+		t.Errorf("Short(%q) = %q — an end is missing", long, got)
+	}
+	if len([]rune(got)) > 20 {
+		t.Errorf("Short returned %d runes: %q", len([]rune(got)), got)
+	}
+	// Two ids that differ only in the middle must not collapse together.
+	if Short("deja-2026-08-01-ops/db") == Short("deja-2026-09-14-ops/db") {
+		t.Error("two ids shortened to the same string")
+	}
+	// Short ids are printed whole.
+	for _, id := range []string{"", "a1", "deja-note-claude-a1"} {
+		if got := Short(id); got != id {
+			t.Errorf("Short(%q) = %q, want it unchanged", id, got)
+		}
+	}
+	// Runes, not bytes: cutting mid-character would print a replacement glyph.
+	cyr := strings.Repeat("сессия", 6)
+	if got := Short(cyr); strings.ContainsRune(got, '�') {
+		t.Errorf("Short(%q) = %q", cyr, got)
+	}
+}


### PR DESCRIPTION
```
$ deja resume 'deja-2026-08-01-ops/db'
deja: session id "deja-2026-08" contains characters deja will not place in a command
```

The refusal is right — a slash has no business in a shell command deja prints. The id is not: `deja-2026-08` is the first twelve characters, and no session has it. `handoff` cut its header the same way.

Ids are meaningful at both ends, so the middle goes — the same change #707 made for search result lines:

```
deja: session id "deja-2026…-01-ops/db" contains characters deja will not place in a command
```

Closes #741