### PR TITLE
fix: handoff no longer warns that a session is "11d old old"

### DIFF
--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -73,7 +73,9 @@ func runHandoff(dir string, args []string, stdout io.Writer) error {
 	}
 	fmt.Fprintf(os.Stderr, "deja: handing off %s · %s · %s · %s\n", s.Harness, s.Project, digest.Short(s.ID), age)
 	if !s.Updated.IsZero() && time.Since(s.Updated) > 7*24*time.Hour {
-		fmt.Fprintf(os.Stderr, "deja: note — this session is %s old; if you meant newer work, pass an id-prefix (see `deja last`)\n", age)
+		// humanAge already ends in "old"; appending the word again printed
+		// "this session is 11d old old" (#743).
+		fmt.Fprintf(os.Stderr, "deja: note — this session is %s; if you meant newer work, pass an id-prefix (see `deja last`)\n", age)
 	}
 	digest := digest.Handoff(s, handoffBudget)
 	usage.RecordDigest(dir, usage.KindHandoff, digest, 1, rawSize([]model.Session{s}))

--- a/cmd/deja/handoff_age_test.go
+++ b/cmd/deja/handoff_age_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// humanAge already ends in "old", and the warning appended the word again:
+// "this session is 11d old old" (#743).
+func TestHumanAgeReadsAsASentence(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Minute, "30m old"},
+		{5 * time.Hour, "5h old"},
+		{11 * 24 * time.Hour, "11d old"},
+	}
+	for _, c := range cases {
+		got := humanAge(c.d)
+		if got != c.want {
+			t.Errorf("humanAge(%v) = %q, want %q", c.d, got, c.want)
+		}
+		// The warning interpolates this verbatim, so it must not need another
+		// word after it.
+		line := "this session is " + got + ";"
+		if strings.Contains(line, "old old") {
+			t.Errorf("warning would read %q", line)
+		}
+	}
+}
+
+func TestHandoffStaleWarningReadsAsASentence(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	old := time.Now().AddDate(0, 0, -11).UTC().Format(time.RFC3339)
+	body := `{"type":"user","sessionId":"a1","cwd":"/w/p","timestamp":"` + old + `","message":{"role":"user","content":"the retry budget keeps blowing up"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "a1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRunStderr(t, "handoff", "a1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "this session is 11d old;") {
+		t.Errorf("warning: %q", out)
+	}
+	if strings.Contains(out, "old old") {
+		t.Errorf("still doubled: %q", out)
+	}
+}


### PR DESCRIPTION
```
deja: handing off claude · proj/p · a1 · 11d old
deja: note — this session is 11d old old; if you meant newer work, pass an id-prefix
```

`humanAge` already returns "11d old" — the receipt line above reads correctly because it does not add the word.

Closes #743