### PR TITLE
fix: sync export rejects an unknown flag instead of exporting nothing

### DIFF
--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/search"
@@ -23,6 +24,13 @@ func runSync(dir string, args []string) error {
 			if a == "--full" {
 				full = true
 				continue
+			}
+			// A dropped flag fell back to the incremental path, which on a
+			// second run has nothing left to send: `--ful` exported zero
+			// records into an empty directory while the reader believed they
+			// had carried their whole memory to another machine (#745).
+			if strings.HasPrefix(a, "-") {
+				return fmt.Errorf("sync export: unknown flag %q — only --full is accepted", a)
 			}
 			out = a
 		}
@@ -50,6 +58,9 @@ func runSync(dir string, args []string) error {
 		fmt.Fprintf(os.Stderr, "deja: records were redacted at index time (%d masked). pattern redaction is a floor — review the export before moving it; rotate anything that leaked.\n", masked)
 		return nil
 	case "import":
+		for _, a := range args[2:] {
+			return fmt.Errorf("sync import: unexpected argument %q — it takes one directory", a)
+		}
 		n, err := index.Import(dir, args[1])
 		if err != nil {
 			return err

--- a/cmd/deja/sync_flags_test.go
+++ b/cmd/deja/sync_flags_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A dropped flag fell back to the incremental path, which on a second run has
+// nothing left to send: `--ful` exported zero records into an empty directory
+// while the reader believed they had carried their whole memory across (#745).
+func TestSyncExportRejectsUnknownFlags(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	body := `{"type":"user","sessionId":"a1","cwd":"/w/p","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"the retry budget"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "a1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, flag := range []string{"--ful", "--fully", "-full", "--json"} {
+		_, err := captureRun(t, "sync", "export", filepath.Join(tmp, "out-"+flag), flag)
+		if err == nil {
+			t.Errorf("%s was accepted", flag)
+			continue
+		}
+		if !strings.Contains(err.Error(), "unknown flag") {
+			t.Errorf("%s: %v", flag, err)
+		}
+	}
+
+	// The real flag still works, and so does a plain export.
+	if _, err := captureRun(t, "sync", "export", filepath.Join(tmp, "ok-full"), "--full"); err != nil {
+		t.Fatalf("--full: %v", err)
+	}
+	if _, err := captureRun(t, "sync", "export", filepath.Join(tmp, "ok-plain")); err != nil {
+		t.Fatalf("plain: %v", err)
+	}
+	// A stray argument to import is a mistake too — it takes one directory.
+	if _, err := captureRun(t, "sync", "import", filepath.Join(tmp, "ok-full"), "extra"); err == nil ||
+		!strings.Contains(err.Error(), "unexpected argument") {
+		t.Errorf("import with extra arg: %v", err)
+	}
+	if _, err := captureRun(t, "sync", "import", filepath.Join(tmp, "ok-full")); err != nil {
+		t.Errorf("import: %v", err)
+	}
+}


### PR DESCRIPTION
```
$ deja sync export ~/o1          # first export moves the watermark
deja: exported 4 records
$ deja sync export ~/o2 --ful    # typo
deja: exported 0 records
$ ls ~/o2                        # empty
```

The flag was dropped and the command fell back to the incremental path, which had nothing left to send. The user walks away with an empty directory believing they carried their memory to the other machine — in the command whose whole purpose is moving memory between machines.

`sync import` also takes exactly one directory now; a stray second argument was ignored.

Same class as #721, worse consequence: there the reader got a wrong answer, here a wrong belief about a transfer.

Closes #745