### PR TITLE
fix: sources rejects arguments instead of ignoring them

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -84,13 +84,22 @@ func loadFileSources() []model.Session {
 type command func(dir string, rest []string) error
 
 var commands = map[string]command{
-	"version":       cmdVersion,
-	"help":          func(_ string, _ []string) error { printUsage(); return nil },
-	"--help":        func(_ string, _ []string) error { printUsage(); return nil },
-	"-h":            func(_ string, _ []string) error { printUsage(); return nil },
-	"--version":     cmdVersion,
-	"-version":      cmdVersion,
-	"sources":       func(dir string, _ []string) error { printSources(dir); return nil },
+	"version":   cmdVersion,
+	"help":      func(_ string, _ []string) error { printUsage(); return nil },
+	"--help":    func(_ string, _ []string) error { printUsage(); return nil },
+	"-h":        func(_ string, _ []string) error { printUsage(); return nil },
+	"--version": cmdVersion,
+	"-version":  cmdVersion,
+	"sources": func(dir string, rest []string) error {
+		// The command takes nothing, and --json exists on seven of its
+		// neighbours — a script that reaches for it here got the
+		// tab-separated table back and parsed it as JSON (#747).
+		for _, a := range rest {
+			return fmt.Errorf("sources takes no arguments — got %q", a)
+		}
+		printSources(dir)
+		return nil
+	},
 	"completion":    func(_ string, rest []string) error { return runCompletion(rest) },
 	"doctor":        func(dir string, rest []string) error { return runDoctor(os.Stdout, rest, doctorLookup, dir) },
 	"warmup":        cmdWarmup,

--- a/cmd/deja/sources_args_test.go
+++ b/cmd/deja/sources_args_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The command takes nothing, and --json exists on seven of its neighbours — a
+// script that reached for it here got the tab-separated table back and parsed
+// it as JSON (#747).
+func TestSourcesRejectsArguments(t *testing.T) {
+	withTempStores(t)
+	for _, arg := range []string{"--json", "--nosuchflag", "extra", "-j"} {
+		_, err := captureRun(t, "sources", arg)
+		if err == nil {
+			t.Errorf("%q was accepted", arg)
+			continue
+		}
+		if !strings.Contains(err.Error(), "takes no arguments") {
+			t.Errorf("%q: %v", arg, err)
+		}
+	}
+	// With nothing to reject it still prints the table.
+	out, err := captureRun(t, "sources")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "claude") {
+		t.Errorf("sources printed %q", out)
+	}
+}


### PR DESCRIPTION
```
$ deja sources --json
claude	/tmp/b19/claude	sessions=1 messages=4 size=703 B redacted=0
```

The command takes no arguments and silently dropped whatever it got. `--json` exists on `last`, `search`, `show`, `stats`, `log`, `doctor` and `blame`, so a script reaching for it here parsed the tab-separated table as JSON.

Third instance of this class after #721 (ctx) and #745 (sync export).

Closes #747