### PR TITLE
fix: shell completion offers deja search

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -39,7 +39,7 @@ _deja_completion() {
     command="${COMP_WORDS[1]}"
     action="${COMP_WORDS[2]}"
 
-    local commands="blame bench completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume share show sources stats statusline sync uninstall update version view warmup"
+    local commands="blame bench completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup"
     local harnesses="claude codex opencode aider gemini cursor antigravity grok qwen pi copilot deja"
     local install_targets="%INSTALL_TARGETS% --all --auto"
 
@@ -166,6 +166,7 @@ _deja() {
     'remember:store a durable note'
     'restore:hand back a span an agent replaced'
     'resume:reopen a session'
+    'search:search your history explicitly'
     'share:print a sanitized session digest'
     'show:print a session'
     'sources:list discovered stores'
@@ -258,7 +259,7 @@ const fishCompletion = `function __deja_needs_command
     test (count (commandline -opc)) -eq 1
 end
 
-complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume share show sources stats statusline sync uninstall update version view warmup'
+complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup'
 complete -c deja -n '__deja_needs_command' -l json -d 'Print JSON'
 complete -c deja -n '__deja_needs_command' -l re -d 'Interpret query as a regular expression'
 complete -c deja -n '__deja_needs_command' -l all -d 'Include all results'

--- a/cmd/deja/completion_coverage_test.go
+++ b/cmd/deja/completion_coverage_test.go
@@ -20,7 +20,16 @@ func TestCompletionsListEveryUserFacingCommand(t *testing.T) {
 		"zsh":  zshCompletion,
 		"fish": fishCompletion,
 	}
+	names := make([]string, 0, len(commands))
 	for name := range commands {
+		names = append(names, name)
+	}
+	// The switch in run() handles these before the map is consulted, so the
+	// map alone misses them — which is how `search` stayed out of all three
+	// shells (#749). `aider` and `goose` are deliberately absent: bare
+	// `deja goose` is a search for the word, not a command.
+	names = append(names, "search", "show", "last")
+	for _, name := range names {
 		if internal[name] || strings.HasPrefix(name, "-") {
 			continue
 		}


### PR DESCRIPTION
`search` was in none of the three completions:

```
local commands="blame bench completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume share show sources stats statusline sync uninstall update version view warmup"
```

There is a test that compares the completions against the command table, and it walked `commands` alone — `search`, `show` and `last` are dispatched by the switch in `run()` before that map is consulted, so `search` slipped past it. The test now covers them.

`aider` and `goose` stay out on purpose: bare `deja goose` is a search for the word, not a command.

Closes #749