### PR TITLE
fix: update leaves a source build alone unless forced

### DIFF
--- a/cmd/deja/coverage_update2_test.go
+++ b/cmd/deja/coverage_update2_test.go
@@ -314,7 +314,7 @@ func TestPerformUpdateSuccessUnknownVersionAndPermissionBranches(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = os.Chmod(dir, 0o755) }()
-	err = performUpdate(updateConfig{currentVersion: "dev", goos: "linux", goarch: "amd64", executable: dest, latestURL: testLatestReleaseURL, download: download}, io.Discard)
+	err = performUpdate(updateConfig{force: true, currentVersion: "dev", goos: "linux", goarch: "amd64", executable: dest, latestURL: testLatestReleaseURL, download: download}, io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "replace") || !strings.Contains(err.Error(), "rerun with permission") {
 		t.Fatalf("permission-denied replace err = %v", err)
 	}

--- a/cmd/deja/coverage_update_test.go
+++ b/cmd/deja/coverage_update_test.go
@@ -178,7 +178,7 @@ func TestPerformUpdateAssetAndChecksumLookupErrors(t *testing.T) {
 	if err := os.WriteFile(target, []byte("old"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cfg := updateConfig{currentVersion: "dev", goos: "linux", goarch: "amd64", executable: target, latestURL: testLatestReleaseURL}
+	cfg := updateConfig{force: true, currentVersion: "dev", goos: "linux", goarch: "amd64", executable: target, latestURL: testLatestReleaseURL}
 
 	noAsset := cfg
 	noAsset.download = func(url string, limit int64, label string) ([]byte, error) {
@@ -248,6 +248,7 @@ func TestPerformUpdateExtractAndInstallErrors(t *testing.T) {
 	emptyArchive := makeUpdateArchive(t, "linux", "not-"+binaryName, []byte("x"))
 	sum := fmt.Sprintf("%x", sha256.Sum256(emptyArchive))
 	cfg := updateConfig{
+		force:          true,
 		currentVersion: "dev",
 		goos:           "linux",
 		goarch:         "amd64",

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1450,7 +1450,7 @@ Usage:
   deja promote <id-prefix> [--state accepted|rejected|superseded|stale] [--note "text"] [--to path]
   deja mcp
   deja version
-  deja update
+  deja update [--force]
   deja install <claude-code|codex|opencode|cursor|gemini|antigravity|grok|qwen|kimi|cline|statusline|--all|--auto>
   deja uninstall <claude-code|codex|opencode|cursor|gemini|antigravity|grok|qwen|kimi|statusline|--all|--auto>
 

--- a/cmd/deja/update.go
+++ b/cmd/deja/update.go
@@ -94,6 +94,9 @@ func newHTTPUpdateDownloader(client *http.Client) updateDownloader {
 }
 
 type updateConfig struct {
+	// force replaces a source build with the latest release; without it a dev
+	// binary is left alone (#751).
+	force          bool
 	currentVersion string
 	goos           string
 	goarch         string
@@ -103,8 +106,13 @@ type updateConfig struct {
 }
 
 func runUpdate(args []string, out io.Writer) error {
-	if len(args) != 0 {
-		return fmt.Errorf("update takes no arguments")
+	force := false
+	for _, a := range args {
+		if a == "--force" {
+			force = true
+			continue
+		}
+		return fmt.Errorf("update takes no arguments except --force, got %q", a)
 	}
 	executable, err := os.Executable()
 	if err != nil {
@@ -114,6 +122,7 @@ func runUpdate(args []string, out io.Writer) error {
 		executable = resolved
 	}
 	return performUpdate(updateConfig{
+		force:          force,
 		currentVersion: version,
 		goos:           runtime.GOOS,
 		goarch:         runtime.GOARCH,
@@ -147,6 +156,13 @@ func performUpdate(cfg updateConfig, out io.Writer) error {
 		return fmt.Errorf("latest release did not include a tag")
 	}
 	current := normalizeUpdateVersion(cfg.currentVersion)
+	// A binary built from source is by definition ahead of the newest tag —
+	// it is whatever the person just compiled — so replacing it in place is a
+	// downgrade that discards their build (#751).
+	if current == "dev" && !cfg.force {
+		fmt.Fprintf(out, "this binary was built from source (dev), and the latest release is v%s — `deja update --force` replaces it anyway\n", latest)
+		return nil
+	}
 	if current != "" && current != "dev" {
 		if order, ok := compareUpdateVersions(current, latest); ok {
 			switch {

--- a/cmd/deja/update_dev_test.go
+++ b/cmd/deja/update_dev_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A binary built from source is by definition ahead of the newest tag — it is
+// whatever the person just compiled — so replacing it in place is a downgrade
+// that discards their build (#751).
+func TestPerformUpdateLeavesADevBuildAlone(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "deja")
+	if err := os.WriteFile(target, []byte("source build"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	download, requests := newUpdateDownloader(t, "1.2.0", "linux", "amd64", []byte("release binary"), false)
+
+	var out bytes.Buffer
+	if err := performUpdate(updateConfig{
+		currentVersion: "dev",
+		goos:           "linux",
+		goarch:         "amd64",
+		executable:     target,
+		latestURL:      testLatestReleaseURL,
+		download:       download,
+	}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(target); string(got) != "source build" {
+		t.Errorf("the source build was replaced by %q", got)
+	}
+	if !strings.Contains(out.String(), "built from source") || !strings.Contains(out.String(), "--force") {
+		t.Errorf("output = %q", out.String())
+	}
+	// Only the release listing was fetched, not the asset.
+	if requests.Load() != 1 {
+		t.Errorf("requests = %d — it downloaded the release", requests.Load())
+	}
+}
+
+func TestPerformUpdateForcedOnADevBuild(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "deja")
+	if err := os.WriteFile(target, []byte("source build"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	download, _ := newUpdateDownloader(t, "1.2.0", "linux", "amd64", []byte("release binary"), false)
+
+	var out bytes.Buffer
+	if err := performUpdate(updateConfig{
+		force:          true,
+		currentVersion: "dev",
+		goos:           "linux",
+		goarch:         "amd64",
+		executable:     target,
+		latestURL:      testLatestReleaseURL,
+		download:       download,
+	}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(target); string(got) != "release binary" {
+		t.Errorf("--force did not replace the binary: %q", got)
+	}
+}
+
+func TestRunUpdateRejectsUnknownFlags(t *testing.T) {
+	var out bytes.Buffer
+	err := runUpdate([]string{"--nosuchflag"}, &out)
+	if err == nil || !strings.Contains(err.Error(), "except --force") {
+		t.Errorf("err = %v", err)
+	}
+}

--- a/cmd/deja/update_test.go
+++ b/cmd/deja/update_test.go
@@ -139,6 +139,9 @@ func TestPerformUpdateChecksumFailurePreservesBinary(t *testing.T) {
 	download, _ := newUpdateDownloader(t, "1.2.0", "linux", "amd64", []byte("new binary"), true)
 
 	err := performUpdate(updateConfig{
+		// The subject here is the checksum guard, not the dev-build policy
+		// added in #751.
+		force:          true,
 		currentVersion: "dev",
 		goos:           "linux",
 		goarch:         "amd64",


### PR DESCRIPTION
```
$ go build -o /tmp/du ./cmd/deja && /tmp/du version
deja dev
$ /tmp/du update
updated deja dev -> v0.16.5 at /tmp/du
```

A binary built from source is by definition ahead of the newest tag — it is whatever the person just compiled — and it was replaced in place with no confirmation. It cost me a running audit binary twice today.

```
this binary was built from source (dev), and the latest release is v0.16.5 — `deja update --force` replaces it anyway
```

Three existing tests used `currentVersion: "dev"` to reach the download path; their subject is the checksum guard and the asset lookup, so they now pass `force: true`.

Closes #751