### PR TITLE
fix: deja help names search

### DIFF
--- a/cmd/deja/help_coverage_test.go
+++ b/cmd/deja/help_coverage_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// `search` was dispatched and undocumented, the same omission #749 found in the
+// completions and from the same cause: it comes from the switch in run(), not
+// from the commands map, so lists built from that map miss it (#753).
+func TestHelpNamesEveryDispatchedCommand(t *testing.T) {
+	// Plumbing invoked by harnesses, and the wrappers whose bare form is a
+	// search rather than a command.
+	internal := map[string]bool{
+		"warmup-status": true, "help": true, "aider": true, "goose": true,
+		"--help": true, "-h": true, "--version": true, "-version": true,
+	}
+	var names []string
+	for name := range commands {
+		if strings.HasPrefix(name, "hook-") || internal[name] {
+			continue
+		}
+		names = append(names, name)
+	}
+	names = append(names, "search", "show", "last")
+
+	help := captureHelp(t)
+	line := regexp.MustCompile(`(?m)^\s+deja ([a-z][a-z0-9-]*)`)
+	documented := map[string]bool{}
+	for _, m := range line.FindAllStringSubmatch(help, -1) {
+		documented[m[1]] = true
+	}
+	for _, name := range names {
+		if !documented[name] {
+			t.Errorf("deja help does not name %q", name)
+		}
+	}
+	// And the reverse: help must not teach a command that no longer exists.
+	for name := range documented {
+		if _, ok := commands[name]; ok {
+			continue
+		}
+		switch name {
+		case "search", "show", "last", "aider", "goose":
+		default:
+			t.Errorf("deja help names %q, which is not dispatched", name)
+		}
+	}
+}
+
+func captureHelp(t *testing.T) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var b bytes.Buffer
+		_, _ = io.Copy(&b, r)
+		done <- b.String()
+	}()
+	printUsage()
+	_ = w.Close()
+	os.Stdout = old
+	return <-done
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1418,6 +1418,7 @@ func printUsage() {
 
 Usage:
   deja [flags] <query>
+  deja search [flags] <query>   (same, but a query may start with a dash)
   deja show <id-prefix> [--json --harness name] [--offset n] [--limit n]
   deja share <id-prefix>
   deja resume <id-prefix> [--exec]


### PR DESCRIPTION
`search` is dispatched and was never named in `deja help`. The bare `deja <query>` form is documented and is the right default, but it cannot serve one case:

```
$ deja "--retry budget"
deja: no matches in 1 indexed session — try fewer words or --re
$ deja search retry
[claude] proj/p · Jul 20 · a1 — 1 matches
```

Same omission as #749 in the shell completions, from the same cause: `search` comes from the switch in `run()` rather than the `commands` map, so anything built from that map misses it. The new test walks both, in both directions — a command that vanishes from the code but stays in help teaches a command that does not exist.

Closes #753