### PR TITLE
fix: a misspelled search flag is an error, not part of the query

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -922,6 +922,13 @@ func parseSearch(args []string) (search.Options, error) {
 				o.Since = d
 			}
 		default:
+			// A query may legitimately start with a dash — `deja search
+			// "--retry budget"` is a real search. A token one edit away from a
+			// real flag is not: folding `--limti` into the query turned a
+			// working search into "you have no such memory" (#755).
+			if near := nearestSearchFlag(a); near != "" {
+				return o, fmt.Errorf("unknown flag %q — did you mean %s?", a, near)
+			}
 			q = append(q, a)
 		}
 	}
@@ -930,6 +937,27 @@ func parseSearch(args []string) (search.Options, error) {
 		return o, fmt.Errorf("query required")
 	}
 	return o, nil
+}
+
+// searchFlags is every flag the bare search form accepts, for the typo check.
+var searchFlags = []string{
+	"--json", "--re", "--all", "--no-embed", "--rebuild",
+	"--harness", "--project", "--since", "--role", "--limit",
+}
+
+// nearestSearchFlag names the flag a token was probably meant to be. It stays
+// silent unless the token looks like a flag and is within one edit of a real
+// one, so ordinary queries — including those containing a dash — are untouched.
+func nearestSearchFlag(a string) string {
+	if !strings.HasPrefix(a, "--") || len([]rune(a)) < 4 {
+		return ""
+	}
+	for _, f := range searchFlags {
+		if a == f {
+			return ""
+		}
+	}
+	return nearestTarget(a, searchFlags)
 }
 
 func parseBlame(args []string) (string, search.BlameOptions, bool, error) {

--- a/cmd/deja/search_flag_typo_test.go
+++ b/cmd/deja/search_flag_typo_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Folding a misspelled flag into the query turned a working search into "you
+// have no such memory" (#755).
+func TestNearestSearchFlag(t *testing.T) {
+	typos := map[string]string{
+		"--limti":   "--limit",
+		"--projekt": "--project",
+		"--harnes":  "--harness",
+		"--jsonn":   "--json",
+		"--rol":     "--role",
+	}
+	for typo, want := range typos {
+		if got := nearestSearchFlag(typo); got != want {
+			t.Errorf("nearestSearchFlag(%q) = %q, want %q", typo, got, want)
+		}
+	}
+	// A query may legitimately contain a dash, and a real flag is not a typo.
+	for _, ok := range []string{
+		"--retry", "--json", "--limit", "--re", "--all",
+		"pool", "-x", "--", "--zzzzzzzz", "--nosuchflag",
+	} {
+		if got := nearestSearchFlag(ok); got != "" {
+			t.Errorf("nearestSearchFlag(%q) = %q, want silence", ok, got)
+		}
+	}
+}
+
+func TestParseSearchRejectsAMisspelledFlag(t *testing.T) {
+	if _, err := parseSearch([]string{"pool", "--limti", "5"}); err == nil ||
+		!strings.Contains(err.Error(), "did you mean --limit") {
+		t.Errorf("err = %v", err)
+	}
+	// The query survives when nothing looks like a typo.
+	o, err := parseSearch([]string{"--retry", "budget"})
+	if err != nil || o.Query != "--retry budget" {
+		t.Errorf("query = %q err = %v", o.Query, err)
+	}
+	o, err = parseSearch([]string{"pool", "--limit", "5"})
+	if err != nil || o.Limit != 5 || o.Query != "pool" {
+		t.Errorf("limit = %d query = %q err = %v", o.Limit, o.Query, err)
+	}
+}


### PR DESCRIPTION
```
$ deja pool --limti 5
deja: no matches in 3 indexed sessions — try fewer words or --re (query "pool --limti 5")
$ deja pool --limit 5
[claude] proj/p · Jul 20 · caveat — 1 matches
```

A typo turned a working search into "you have no such memory", in the command people run most.

Rejecting everything that starts with a dash would be wrong — a query may contain one, and #753 documents `deja search` for exactly that case. So only a token within one edit of a real flag is refused:

```
deja: unknown flag "--limti" — did you mean --limit?
$ deja "--retry budget"     # still a query
$ deja pool --nosuchflag    # still a query
```

Fourth instance of this class after #721 (ctx), #745 (sync export) and #747 (sources).

Closes #755