### PR TITLE
fix: document the six flags deja help was missing

### DIFF
--- a/cmd/deja/help_flags_test.go
+++ b/cmd/deja/help_flags_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Four flags documented in usage did not work (#623, #625, #709, #717) and six
+// working flags were undocumented (#757). Both directions are mechanical, so
+// check them mechanically.
+func TestHelpDocumentsEveryAcceptedFlag(t *testing.T) {
+	help := captureHelp(t)
+	documented := map[string]bool{}
+	for _, f := range regexp.MustCompile(`--[a-z][a-z-]*`).FindAllString(help, -1) {
+		documented[f] = true
+	}
+
+	sources, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted := map[string][]string{}
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`case "(--[a-z][a-z-]*)"`),
+		regexp.MustCompile(`a == "(--[a-z][a-z-]*)"`),
+		regexp.MustCompile(`args\[i\] == "(--[a-z][a-z-]*)"`),
+	}
+	for _, path := range sources {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, re := range patterns {
+			for _, m := range re.FindAllStringSubmatch(string(b), -1) {
+				accepted[m[1]] = append(accepted[m[1]], path)
+			}
+		}
+	}
+	for flag, where := range accepted {
+		if !documented[flag] {
+			t.Errorf("%s is accepted in %v but not in `deja help`", flag, where)
+		}
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1453,11 +1453,11 @@ Usage:
   deja handoff [--to <agent>] [id-prefix] [--exec]
   deja hook-prompt   (UserPromptSubmit hook: relevance recall per prompt)
   deja hook-antigravity (Antigravity PreInvocation hook: inject on first turn)
-  deja view          (browse your memory: sessions, recalls, notes — one local HTML)
+  deja view [--no-open]  (browse your memory: sessions, recalls, notes — one local HTML)
   deja ctx <query|id-prefix>
   deja blame <path> [--all] [--json] [--project name] [--harness name] [--since 30d]
   deja files <topic> [--project name] [--limit n]
-  deja restore <path> [--span n] [-o file] [--force]
+  deja restore <path> [--span n] [-o|--out file] [--force]
   deja friction [--limit n]
   deja sync export <dir> [--full]
   deja sync import <dir>
@@ -1467,16 +1467,16 @@ Usage:
   deja completion <bash|zsh|fish>
   deja forget --session <id-prefix> [--project <substring>] [--before <duration|date>] [--dry-run]
   deja forget --list | --unforget <id>
-  deja doctor [--json] [--deep]
+  deja doctor [--json] [--deep] [--offline]
   deja warmup
   deja index [--rebuild]
   deja embed
-  deja bench recall [--json]
+  deja bench recall|context|prompt [--json] [--seed n]
   deja log [n] [--last] [--json]
   deja statusline
-  deja stats [--json] [--impact] [--card [path]] [--html [path]]
-	deja remember "text" [--project name]
-  deja promote <id-prefix> [--state accepted|rejected|superseded|stale] [--note "text"] [--to path]
+  deja stats [--json] [--impact] [--redaction] [--card [path]] [--html [path]]
+	deja remember "text" [--project name] [--tag name]
+  deja promote <id-prefix> [--state accepted|rejected|superseded|stale] [--note "text"] [--tag name] [--to path]
   deja mcp
   deja version
   deja update [--force]


### PR DESCRIPTION
Cross-checking every flag the parsers accept against `deja help`:

```
accepted but undocumented: --no-open --offline --out --redaction --seed --tag
```

All six work. `--redaction` was in the README; the other five were nowhere. The reverse direction was already clean — nothing in help is missing from the parsers.

The new test walks both lists mechanically. Four flags documented-but-broken (#623, #625, #709, #717) and six working-but-undocumented came out of this family; neither direction should need a person to notice again.

Closes #757