### PR TITLE
fix: hooks use the cwd the harness sends

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -86,8 +86,14 @@ func runHookContext(dir string, plain bool) error {
 	var input struct {
 		Source    string `json:"source"`
 		SessionID string `json:"session_id"`
+		CWD       string `json:"cwd"`
 	}
 	_ = json.Unmarshal(readHookStdin(), &input)
+	// The harness tells us which project this is; deja read only the
+	// environment, so a host that sends the payload without exporting
+	// CLAUDE_PROJECT_DIR got no memory at all — indistinguishable from having
+	// none (#759).
+	adoptHookCWD(input.CWD)
 	digest, sessions, raw, taskMatched := cachedHookDigest(dir)
 	if digest == "" {
 		// No session from this project, which is the usual state in a new
@@ -254,6 +260,16 @@ func hookCachePath(dir, cwd string) string {
 func hookGate() string {
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL")))
 	return mode + "|" + policy.Load().Describe(policy.ActivationAuto)
+}
+
+// adoptHookCWD takes the working directory out of a hook payload when the
+// environment does not already name one. The harness knows the project; the
+// environment variable is a Claude Code convenience the others do not share.
+func adoptHookCWD(cwd string) {
+	if cwd == "" || os.Getenv("CLAUDE_PROJECT_DIR") != "" {
+		return
+	}
+	_ = os.Setenv("CLAUDE_PROJECT_DIR", cwd)
 }
 
 func cachedHookDigest(dir string) (string, int, int64, []string) {

--- a/cmd/deja/hook_cwd_test.go
+++ b/cmd/deja/hook_cwd_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The harness names the project in its payload; deja read only the
+// environment, so a host that sends `cwd` without exporting
+// CLAUDE_PROJECT_DIR recalled nothing — indistinguishable from having no
+// memory (#759).
+func TestAdoptHookCWD(t *testing.T) {
+	t.Run("takes the payload when the environment is silent", func(t *testing.T) {
+		t.Setenv("CLAUDE_PROJECT_DIR", "")
+		adoptHookCWD("/w/from-payload")
+		if got := os.Getenv("CLAUDE_PROJECT_DIR"); got != "/w/from-payload" {
+			t.Errorf("CLAUDE_PROJECT_DIR = %q", got)
+		}
+	})
+	t.Run("never overrides an explicit environment", func(t *testing.T) {
+		t.Setenv("CLAUDE_PROJECT_DIR", "/w/from-env")
+		adoptHookCWD("/w/from-payload")
+		if got := os.Getenv("CLAUDE_PROJECT_DIR"); got != "/w/from-env" {
+			t.Errorf("payload overrode the environment: %q", got)
+		}
+	})
+	t.Run("an empty payload changes nothing", func(t *testing.T) {
+		t.Setenv("CLAUDE_PROJECT_DIR", "")
+		adoptHookCWD("")
+		if got := os.Getenv("CLAUDE_PROJECT_DIR"); got != "" {
+			t.Errorf("CLAUDE_PROJECT_DIR = %q", got)
+		}
+	})
+}
+
+// End to end: the payload alone must be enough for both hooks.
+func TestHooksRecallFromPayloadCWD(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("CLAUDE_PROJECT_DIR", "")
+	at := time.Now().AddDate(0, 0, -2).UTC().Format(time.RFC3339)
+	body := `{"type":"user","sessionId":"a1","cwd":"` + filepath.ToSlash(root) + `","timestamp":"` + at + `","message":{"role":"user","content":"the retry budget keeps blowing up under load"}}` + "\n" +
+		`{"type":"assistant","sessionId":"a1","cwd":"` + filepath.ToSlash(root) + `","timestamp":"` + at + `","message":{"role":"assistant","content":[{"type":"text","text":"decision: cap retries at three"}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "a1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	payload := `{"prompt":"the retry budget keeps blowing up","cwd":"` + filepath.ToSlash(root) + `"}`
+	if err := runHookPromptMode(dir, strings.NewReader(payload), &out, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "retry budget") {
+		t.Errorf("hook-prompt recalled nothing from the payload cwd: %q", out.String())
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -36,6 +36,10 @@ const dejaVuMinAge = 15 * time.Minute
 type promptHookInput struct {
 	Prompt    hookPromptText `json:"prompt"`
 	SessionID string         `json:"session_id"`
+	// CWD is what the harness says the project is. Reading only the
+	// environment meant a host that sends the payload without exporting
+	// CLAUDE_PROJECT_DIR recalled nothing (#759).
+	CWD string `json:"cwd"`
 }
 
 // hookPromptText reads a prompt that arrives either as a string (Claude Code,
@@ -85,6 +89,7 @@ func runHookPrompt(dir string, stdin io.Reader, stdout io.Writer) error {
 func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool) error {
 	var input promptHookInput
 	_ = json.NewDecoder(io.LimitReader(stdin, 1<<20)).Decode(&input)
+	adoptHookCWD(input.CWD)
 	terms := promptSearchTerms(string(input.Prompt))
 	if len(terms) < 2 {
 		return nil


### PR DESCRIPTION
`hook-prompt` and `hook-context` resolved the project from `CLAUDE_PROJECT_DIR` or the process working directory, and dropped the `cwd` field in the payload:

```
$ echo '{"prompt":"the retry budget keeps blowing up","cwd":"…/proj-p"}' | deja hook-prompt
(nothing)
$ echo '{"prompt":"the retry budget keeps blowing up"}' | CLAUDE_PROJECT_DIR=…/proj-p deja hook-prompt
{"systemMessage":"deja-vu: you have been here — …"}
```

Claude Code's UserPromptSubmit payload is `{session_id, transcript_path, cwd, prompt}` and SessionStart carries `cwd` too. It works today because Claude Code also exports the variable; a harness that sends the payload without it — or any wrapper running the hook from another directory — got no memory, which is indistinguishable from having none.

The environment still wins when it is set: it is the explicit signal.

Closes #759