### PR TITLE
fix: hooks carry the rejection with the session it belongs to

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -452,12 +452,19 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 		}
 	}
 	mark("task-scores")
+	// A rejected session belongs last, and the mark has to travel with it: the
+	// block listed the correction as a separate item and left the session it
+	// corrects unmarked (#761).
+	ss, rejectedWarning := orderForInjection(ss)
 	result := search.BuildAutoRecall(ss, search.AutoRecallOptions{Mode: mode, ProjectNames: names, TaskScores: scores})
 	mark("build-digest")
 	if result.Sessions == 0 {
 		matched = nil
 	}
 	text := result.Text
+	if rejectedWarning != "" && result.Sessions > 0 {
+		text = rejectedWarning + text
+	}
 	// Inside the cached result, not after it: this costs a manifest scan plus
 	// one session read, which is ten times the rest of the hook, and the
 	// clusters it reports change over weeks rather than turns.

--- a/cmd/deja/hook_lifecycle.go
+++ b/cmd/deja/hook_lifecycle.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// orderForInjection puts the sessions a person marked rejected last and
+// returns the warning that has to travel with them.
+//
+// recall attaches a correction to the session it belongs to (#684, #694). The
+// two paths that inject unprompted did not: the session-start block listed the
+// note as a separate item and left the session unmarked, and hook-prompt
+// served a rejected session as an equal answer (#761). The hooks are what the
+// agent reads before it does anything.
+func orderForInjection(ss []model.Session) ([]model.Session, string) {
+	states := sources.PromotedLifecycles()
+	if len(states) == 0 {
+		return ss, ""
+	}
+	rejected := func(s model.Session) (string, bool) {
+		lc, ok := states[s.Harness+":"+s.ID]
+		if !ok || lc.State != lifecycleRejected {
+			return "", false
+		}
+		return lc.Note, true
+	}
+	out := append([]model.Session(nil), ss...)
+	sort.SliceStable(out, func(i, j int) bool {
+		_, ri := rejected(out[i])
+		_, rj := rejected(out[j])
+		return !ri && rj
+	})
+	var warn []string
+	for _, s := range out {
+		note, ok := rejected(s)
+		if !ok {
+			continue
+		}
+		line := fmt.Sprintf("session %s was tried and rejected", s.ID)
+		if note != "" {
+			line += ": " + note
+		}
+		warn = append(warn, line)
+	}
+	if len(warn) == 0 {
+		return out, ""
+	}
+	return out, "Some of this was rejected — " + strings.Join(warn, "; ") + ".\n"
+}

--- a/cmd/deja/hook_lifecycle_test.go
+++ b/cmd/deja/hook_lifecycle_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// recall attaches a correction to the session it belongs to (#684, #694); the
+// two paths that inject unprompted did not — the block listed the note as a
+// separate item and hook-prompt served a rejected session as an equal answer
+// (#761).
+func TestOrderForInjection(t *testing.T) {
+	tmp := t.TempDir()
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	body := `{"ts":"2026-08-01T10:00:00Z","project":"p","text":"nitrile swelled, do not use","kind":"promoted","session":"claude:bad","state":"rejected"}` + "\n"
+	if err := os.WriteFile(notes, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ss := []model.Session{
+		{Harness: "claude", ID: "bad", Project: "p"},
+		{Harness: "claude", ID: "good", Project: "p"},
+	}
+	got, warn := orderForInjection(ss)
+	if got[0].ID != "good" || got[1].ID != "bad" {
+		t.Errorf("order = %s, %s", got[0].ID, got[1].ID)
+	}
+	if !strings.Contains(warn, "session bad was tried and rejected") || !strings.Contains(warn, "nitrile swelled") {
+		t.Errorf("warning = %q", warn)
+	}
+
+	// Nothing marked: no reordering, no warning. A line on every injection is
+	// noise the agent learns to skip.
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "empty.jsonl"))
+	got, warn = orderForInjection(ss)
+	if got[0].ID != "bad" || warn != "" {
+		t.Errorf("clean store: order %s, warn %q", got[0].ID, warn)
+	}
+
+	// Other states are not rejections: superseded says "this was true once",
+	// which is still the record of how the answer was reached.
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	if err := os.WriteFile(notes, []byte(strings.Replace(body, `"rejected"`, `"superseded"`, 1)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, warn = orderForInjection(ss)
+	if got[0].ID != "bad" || warn != "" {
+		t.Errorf("superseded: order %s, warn %q", got[0].ID, warn)
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -161,6 +161,9 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	if len(ss) == 0 {
 		return nil
 	}
+	// A rejected session is not an equal answer, and the mark has to travel
+	// with it into the block the agent reads (#761).
+	ss, rejectedWarning := orderForInjection(ss)
 	rememberInjected(dir, input.SessionID, ss)
 	// "You have been here" on the strength of one word teaches the user to
 	// ignore the line. The recall itself still goes in.
@@ -169,7 +172,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	if strings.TrimSpace(digest) == "" {
 		return nil
 	}
-	lead := "deja found prior sessions matching this request. If one genuinely helps, use it and tell the user in one digest.Short line what deja-vu recalled; otherwise ignore silently.\n"
+	lead := "deja found prior sessions matching this request. If one genuinely helps, use it and tell the user in one digest.Short line what deja-vu recalled; otherwise ignore silently.\n" + rejectedWarning
 	out := frameRecall(lead + digest + citationLine(ss[0]))
 	usage.RecordDigestTerms(dir, usage.KindDejaVu, out, len(ss), rawSize(ss), terms, sessionIDs(ss)...)
 	if plain {


### PR DESCRIPTION
With one session marked rejected, MCP recall attaches the mark to it (#684, #694). The two paths that inject unprompted did not.

The session-start block listed the note as a separate item and left the session unmarked:

```
- Session: **proj/p** `deja-note-claude-bad`
  - User: [rejected] nitrile swelled, do not use (from claude:bad, …)
- Session: **proj/p** `bad`
  - User: the zeppelin gasket seal was replaced with nitrile
```

`hook-prompt` had no mark at all. Both now put rejected sessions last and prefix the block:

```
Some of this was rejected — session bad was tried and rejected: nitrile swelled, do not use.
```

Only `rejected` does this; `superseded` and `stale` say "this was true once", which is still the record of how the current answer was reached. A store with no corrections gets no extra line.

Closes #761