### PR TITLE
fix: say what period "Recalls served" covers

### DIFF
--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -279,7 +279,13 @@ func printStats(w io.Writer, r stats.Report) {
 	fmt.Fprintf(w, "  Busiest day      %s · %d messages\n", valueOrDash(r.BusiestDay.Date), r.BusiestDay.Messages)
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "%sRecall%s\n", bold, reset)
-	fmt.Fprintf(w, "  Recalls served   %d\n", r.Recall.Recalls)
+	// The log keeps the last 14 days once it passes 1MB, so the count is not a
+	// lifetime total — saying since when keeps it from reading like one (#763).
+	if since := r.Recall.Since; !since.IsZero() {
+		fmt.Fprintf(w, "  Recalls served   %d since %s\n", r.Recall.Recalls, since.Local().Format("Jan 2"))
+	} else {
+		fmt.Fprintf(w, "  Recalls served   %d\n", r.Recall.Recalls)
+	}
 	if r.Recall.RawBytes > 0 && r.Recall.Bytes > 0 {
 		ratio := r.Recall.RawBytes / int64(r.Recall.Bytes)
 		if ratio >= 2 {

--- a/cmd/deja/stats_since_test.go
+++ b/cmd/deja/stats_since_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/stats"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// "Recalls served" fell from 8100 to 101 when the log rotated, with nothing
+// saying why (#763).
+func TestStatsSaysSinceWhenTheLogHasAStart(t *testing.T) {
+	var buf bytes.Buffer
+	since := time.Date(2026, 6, 22, 10, 0, 0, 0, time.UTC)
+	printStats(&buf, stats.Report{TotalSessions: 1, Recall: usage.Summary{Recalls: 101, Since: since}})
+	if !strings.Contains(buf.String(), "Recalls served   101 since Jun 22") {
+		t.Errorf("output: %q", recallLine(buf.String()))
+	}
+
+	// No events, no period: an invented date would be worse than none. The
+	// report needs a session for stats to print its body at all.
+	buf.Reset()
+	printStats(&buf, stats.Report{TotalSessions: 1, Recall: usage.Summary{}})
+	if !strings.Contains(buf.String(), "Recalls served   0\n") {
+		t.Errorf("empty log: %q", recallLine(buf.String()))
+	}
+}
+
+func recallLine(out string) string {
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(l, "Recalls served") {
+			return l
+		}
+	}
+	return out
+}

--- a/internal/usage/since_test.go
+++ b/internal/usage/since_test.go
@@ -1,0 +1,47 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The log is rewritten past 1MB keeping the last 14 days, so a count with no
+// period attached reads as a lifetime total and then falls by orders of
+// magnitude when that happens (#763).
+func TestTotalsReportsTheOldestEventItCounted(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	p := Path(dir)
+	old := time.Now().UTC().AddDate(0, 0, -30)
+	mid := time.Now().UTC().AddDate(0, 0, -3)
+	var lines []byte
+	for _, at := range []time.Time{mid, old, mid} {
+		b, err := json.Marshal(Event{Time: at, Kind: KindRecall, Bytes: 100, Sessions: 1})
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines = append(lines, append(b, '\n')...)
+	}
+	if err := os.WriteFile(p, lines, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := Totals(dir)
+	if got.Recalls != 3 {
+		t.Fatalf("recalls = %d", got.Recalls)
+	}
+	// The oldest, not the first line: a log is appended to, but rotation and
+	// clock changes can leave it out of order.
+	if !got.Since.Equal(old) {
+		t.Errorf("since = %v, want %v", got.Since, old)
+	}
+
+	// An empty log has no period to report.
+	if err := os.WriteFile(p, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := Totals(dir); !got.Since.IsZero() || got.Recalls != 0 {
+		t.Errorf("empty log: since=%v recalls=%d", got.Since, got.Recalls)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -55,6 +55,11 @@ type Summary struct {
 	RawBytes         int64   `json:"raw_bytes,omitempty"`
 	DejaVuMoments    int     `json:"dejavu_moments,omitempty"`
 	EmptyResultRate  float64 `json:"empty_result_rate"`
+	// Since is the oldest event still in the log. The log is rewritten past
+	// 1MB keeping the last 14 days, so a count with no period attached reads
+	// as a lifetime total and then falls by orders of magnitude when that
+	// happens (#763).
+	Since time.Time `json:"since,omitempty"`
 }
 
 const (
@@ -171,6 +176,9 @@ func Totals(indexDir string) Summary {
 	var out Summary
 	empty := 0
 	for _, e := range read(Path(indexDir)) {
+		if out.Since.IsZero() || (!e.Time.IsZero() && e.Time.Before(out.Since)) {
+			out.Since = e.Time
+		}
 		switch e.Kind {
 		case KindRecall, KindContext, KindBlame:
 			out.Recalls++


### PR DESCRIPTION
The usage log is rewritten past 1 MB keeping the last 14 days, and `deja stats` reported the count with no period attached:

```
Recalls served 8100      # log at 1.3 MB
(one more recall triggers the rotation)
Recalls served 101
```

The number a user watches to decide whether memory is paying off went backwards by two orders of magnitude. It now says since when:

```
Recalls served   101 since Aug 1
Recalls served   7 since Jun 22
```

An empty log prints no date — an invented one would be worse than none.

Closes #763