### PR TITLE
fix: last prints a dash instead of 0001-01-01

### DIFF
--- a/cmd/deja/last_zerotime_test.go
+++ b/cmd/deja/last_zerotime_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A session whose timestamp was missing or unparseable carries the Go zero
+// time, and "0001-01-01" reads as corrupted data rather than as a missing
+// field (#765).
+func TestLastPrintsADashForAMissingTimestamp(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	write := func(name, line string) {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("notime.jsonl", `{"type":"user","sessionId":"notime","cwd":"/w/p","message":{"role":"user","content":"a session with no timestamp field at all"}}`)
+	write("ok.jsonl", `{"type":"user","sessionId":"ok","cwd":"/w/p","timestamp":"2026-07-30T10:00:00Z","message":{"role":"user","content":"an ordinary session"}}`)
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "last", "5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "0001-01-01") {
+		t.Errorf("printed the zero date:\n%s", out)
+	}
+	if !strings.Contains(out, "· - · notime") {
+		t.Errorf("no dash for the undated session:\n%s", out)
+	}
+	// The dated one still shows its date.
+	if !strings.Contains(out, "2026-07-30 · ok") {
+		t.Errorf("dated session lost its date:\n%s", out)
+	}
+	// JSON keeps the raw value: a machine reader wants the field as stored.
+	jsonOut, err := captureRun(t, "last", "5", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(jsonOut, "0001-01-01T00:00:00Z") {
+		t.Errorf("json lost the zero time:\n%s", jsonOut)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -413,7 +413,16 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 		return printRecentJSON(os.Stdout, ss, sourceInstance)
 	}
 	for _, s := range ss {
-		fmt.Printf("[%s · %s · %s · %s]", s.Harness, s.Project, s.Updated.Format("2006-01-02"), s.ID)
+		// A session whose timestamp was missing or unparseable carries the Go
+		// zero time, and "0001-01-01" reads as corrupted data rather than as a
+		// missing field. Search prints a dash here and the first screen leaves
+		// such sessions out of its range; this was the one place that did not
+		// follow the convention (#765).
+		when := "-"
+		if !s.Updated.IsZero() {
+			when = s.Updated.Format("2006-01-02")
+		}
+		fmt.Printf("[%s · %s · %s · %s]", s.Harness, s.Project, when, s.ID)
 		title := s.Title
 		if title == "" {
 			title = firstUserTitle(s)


### PR DESCRIPTION
A session whose `timestamp` is missing or in an unaccepted format reaches the index with a zero time, and three commands showed it three ways:

```
$ deja last
[claude · proj/p · 0001-01-01 · notime] a session with no timestamp field at all
$ deja "no timestamp"
[claude] proj/p     · - · notime — 2 matches
$ deja show notime
# claude · proj/p · notime
```

Search prints a dash, `show` omits the line, and the first screen leaves such sessions out of its "covering" range — the convention exists and `last` was the one place not following it.

`--json` still carries the raw value: a machine reader wants the field as stored.

Closes #765