### PR TITLE
fix: relative dates use the reader's zone

### DIFF
--- a/internal/search/relative_date_test.go
+++ b/internal/search/relative_date_test.go
@@ -1,0 +1,44 @@
+package search
+
+import (
+	"testing"
+	"time"
+)
+
+// Work done at 00:30 local time is stored as 21:30 UTC the day before, and
+// taking its calendar date in UTC made this morning read as "1d ago" — while
+// the counter above it, which compares instants, said "today" (#767).
+func TestRelativeDateUsesTheReadersZone(t *testing.T) {
+	now := time.Now()
+	local := now.Location()
+
+	// This morning, just after local midnight, expressed in UTC.
+	morning := time.Date(now.Year(), now.Month(), now.Day(), 0, 30, 0, 0, local)
+	if !morning.Before(now) {
+		t.Skip("run before 00:30 local time")
+	}
+	if got := relativeDate(morning.UTC()); got != "today" {
+		t.Errorf("this morning in UTC = %q, want \"today\"", got)
+	}
+	if got := relativeDate(morning); got != "today" {
+		t.Errorf("this morning in local time = %q", got)
+	}
+
+	// Late yesterday evening is still yesterday however it is stored.
+	evening := time.Date(now.Year(), now.Month(), now.Day(), 23, 30, 0, 0, local).AddDate(0, 0, -1)
+	for _, ts := range []time.Time{evening, evening.UTC()} {
+		if got := relativeDate(ts); got != "1d ago" {
+			t.Errorf("yesterday evening (%v) = %q, want \"1d ago\"", ts.Location(), got)
+		}
+	}
+
+	// A far-off zone must not shift the answer either.
+	kiritimati := time.FixedZone("LINT", 14*3600)
+	if got := relativeDate(morning.In(kiritimati)); got != "today" {
+		t.Errorf("this morning in UTC+14 = %q", got)
+	}
+	baker := time.FixedZone("AoE", -12*3600)
+	if got := relativeDate(morning.In(baker)); got != "today" {
+		t.Errorf("this morning in UTC-12 = %q", got)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1050,6 +1050,11 @@ func harnessTag(h string, color bool) string {
 
 func relativeDate(t time.Time) string {
 	now := time.Now()
+	// In the reader's zone, not the timestamp's: work done at 00:30 local time
+	// is stored as 21:30 UTC the day before, and taking its calendar date in
+	// UTC made this morning read as "1d ago" — while the counter above it, which
+	// compares instants, said "today" (#767).
+	t = t.In(now.Location())
 	y1, m1, d1 := now.Date()
 	y2, m2, d2 := t.Date()
 	today := time.Date(y1, m1, d1, 0, 0, 0, 0, now.Location())


### PR DESCRIPTION
Work done at 00:30 local time is stored as 21:30 UTC the previous day, and the first screen contradicted itself:

```
today      1 session
recent     [claude] proj/p · 1d ago · work right after local midnight
```

The counter compares instants against local midnight and was right. `relativeDate` took the calendar date of the timestamp *in its own zone* and compared it to today's date locally.

Anyone east of UTC saw this for every session started between midnight and their offset — three hours a day at UTC+3, ten at UTC+10.

Closes #767