### PR TITLE
fix: the fallback title takes the earliest turn, matching import

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1058,32 +1058,44 @@ func pluralS(n int) string {
 }
 
 func sessionTitle(s model.Session) string {
-	for _, msg := range s.Messages {
-		if msg.Role != "user" {
+	// A user turn always wins; the assistant's opening line fills in when
+	// there is none — a session the agent opened itself, or one whose prompts
+	// are all harness plumbing. The alternative was the blank line these
+	// printed in `deja last` and on the first screen (#692).
+	if t := earliestTitle(s.Messages, "user"); t != "" {
+		return t
+	}
+	return earliestTitle(s.Messages, "assistant")
+}
+
+// earliestTitle picks the first turn of a role by the clock, falling back to
+// file order for records that carry no time.
+//
+// Taking whichever line sat first in the file disagreed with the import path,
+// which grew this fallback in #692 and orders by time — so one store titled
+// locally and the same store imported elsewhere could disagree (#769).
+func earliestTitle(ms []model.Message, role string) string {
+	best := ""
+	var bestAt time.Time
+	for _, msg := range ms {
+		if msg.Role != role {
 			continue
 		}
 		t := strings.TrimSpace(msg.Text)
 		if !titleWorthy(t) {
 			continue
 		}
-		return truncateTitle(t, 60)
-	}
-	// No user turn worth naming the session after: a session the agent opened
-	// itself, or one whose prompts are all harness plumbing. The assistant's
-	// first sentence is a worse title than the question that prompted it, and
-	// it is far better than the blank line these sessions used to print in
-	// `deja last` and on the first screen (#692).
-	for _, msg := range s.Messages {
-		if msg.Role != "assistant" {
+		switch {
+		case best == "":
+		case bestAt.IsZero(), msg.Time.IsZero():
+			// Nothing to compare: the first one found stands.
+			continue
+		case !msg.Time.Before(bestAt):
 			continue
 		}
-		t := strings.TrimSpace(msg.Text)
-		if !titleWorthy(t) {
-			continue
-		}
-		return truncateTitle(t, 60)
+		best, bestAt = truncateTitle(t, 60), msg.Time
 	}
-	return ""
+	return best
 }
 
 // titleWorthy reports whether a user turn is the sentence a person would

--- a/internal/index/title_order_test.go
+++ b/internal/index/title_order_test.go
@@ -1,0 +1,64 @@
+package index
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Taking whichever line sat first in the file disagreed with the import path,
+// which orders by time — so one store titled locally and the same store
+// imported elsewhere could disagree (#769).
+func TestSessionTitleTakesTheEarliestTurn(t *testing.T) {
+	at := time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC)
+	msg := func(role, text string, min int) model.Message {
+		return model.Message{Role: role, Text: text, Time: at.Add(time.Duration(min) * time.Minute)}
+	}
+	cases := []struct {
+		name string
+		msgs []model.Message
+		want string
+	}{
+		{"assistant turns stored out of order", []model.Message{
+			msg("assistant", "and then we rolled the migration back", 5),
+			msg("assistant", "started the zeppelin migration", 0),
+		}, "started the zeppelin migration"},
+		{"user turns stored out of order", []model.Message{
+			msg("user", "and what about the rollback", 5),
+			msg("user", "how do we start the migration", 0),
+		}, "how do we start the migration"},
+		{"a user turn still beats an earlier assistant one", []model.Message{
+			msg("assistant", "capped the pool at 200", 0),
+			msg("user", "the pool starves under load", 5),
+		}, "the pool starves under load"},
+		// No clock at all: file order is the only order there is.
+		{"no timestamps", []model.Message{
+			{Role: "assistant", Text: "first assistant line with no clock"},
+			{Role: "assistant", Text: "second assistant line with no clock"},
+		}, "first assistant line with no clock"},
+		// A mix: the undated line must not displace a dated one that came
+		// first, and must not be treated as time zero either.
+		{"dated first, undated after", []model.Message{
+			msg("assistant", "dated opening line", 0),
+			{Role: "assistant", Text: "undated line that follows"},
+		}, "dated opening line"},
+		{"undated first, dated after", []model.Message{
+			{Role: "assistant", Text: "undated opening line"},
+			msg("assistant", "dated line that follows", 5),
+		}, "undated opening line"},
+		// Plumbing is skipped whatever its position.
+		{"earliest is plumbing", []model.Message{
+			msg("user", "<local-command-stdout>ok</local-command-stdout>", 0),
+			msg("user", "the real question", 5),
+		}, "the real question"},
+		{"nothing worth naming", []model.Message{
+			msg("tool-output", "panic: boom", 0),
+		}, ""},
+	}
+	for _, c := range cases {
+		if got := sessionTitle(model.Session{Messages: c.msgs}); got != c.want {
+			t.Errorf("%s: got %q, want %q", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
A session whose assistant turns are stored out of order was titled by whichever line sat first in the file:

```
[claude · proj/p · 2026-07-30 · rev] and then we rolled the migration back
```

The session opens with "started the zeppelin migration" — an earlier timestamp. The import path, which grew the same fallback in #692, orders by time, so one store titled locally and the same store imported elsewhere could disagree. That divergence is what #670 was about.

Records with no clock keep file order: it is the only order they have.

Closes #769