### PR TITLE
fix: keep notes without a project and promoted notes without a state

### DIFF
--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -110,18 +110,30 @@ func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error
 		project, _ := m["project"].(string)
 		text, _ := m["text"].(string)
 		t, parseErr := time.Parse(time.RFC3339Nano, ts)
-		if parseErr != nil || strings.TrimSpace(project) == "" || strings.TrimSpace(text) == "" {
+		if parseErr != nil || strings.TrimSpace(text) == "" {
 			return
 		}
+		// A note written before deja recorded a project — or by a caller that
+		// omitted it — is still the user's own decision, and the one class of
+		// content deja cannot re-derive from anything else. It used to vanish
+		// at index time with nothing reported (#771).
 		project = strings.TrimSpace(project)
+		if project == "" {
+			project = "notes"
+		}
 		if kind, _ := m["kind"].(string); kind == "promoted" {
 			// One session per promoted source session; corrections append as
 			// further messages and the title tracks the latest state.
 			src, _ := m["session"].(string)
 			state, _ := m["state"].(string)
 			title, _ := m["title"].(string)
-			if src == "" || !NoteStates[state] {
+			if src == "" {
 				return
+			}
+			// Older promoted notes carry no state; the state is how the note is
+			// labelled, not whether it is a note (#771).
+			if !NoteStates[state] {
+				state = "accepted"
 			}
 			key := "promoted\x00" + src
 			s := byDay[key]

--- a/internal/sources/notes_compat_test.go
+++ b/internal/sources/notes_compat_test.go
@@ -1,0 +1,60 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Both shapes were written by deja itself in earlier versions, and both
+// vanished at index time with nothing reported — the user's own decisions are
+// the one class of content deja cannot re-derive (#771).
+func TestParseNotesKeepsOlderShapes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	lines := []string{
+		`{"ts":"2026-07-20T10:00:00Z","project":"proj/p","text":"an old plain note"}`,
+		`{"ts":"2026-07-21T10:00:00Z","project":"proj/p","text":"a promoted note with no state","kind":"promoted","session":"claude:t1"}`,
+		`{"ts":"2026-07-22T10:00:00Z","text":"a note with no project at all"}`,
+		// Still rejected: a promoted note with no source has nothing to attach
+		// to, and an empty body is not a note.
+		`{"ts":"2026-07-23T10:00:00Z","project":"p","text":"orphan","kind":"promoted"}`,
+		`{"ts":"2026-07-24T10:00:00Z","project":"p","text":"   "}`,
+		`{"ts":"not a date","project":"p","text":"unparseable stamp"}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseNotesFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var texts []string
+	for _, s := range ss {
+		for _, m := range s.Messages {
+			texts = append(texts, m.Text)
+		}
+	}
+	joined := strings.Join(texts, "\n")
+	for _, want := range []string{"an old plain note", "a promoted note with no state", "a note with no project at all"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("dropped %q:\n%s", want, joined)
+		}
+	}
+	for _, unwanted := range []string{"orphan", "unparseable stamp"} {
+		if strings.Contains(joined, unwanted) {
+			t.Errorf("kept %q, which has nothing to attach to", unwanted)
+		}
+	}
+	// A note with no project is filed under one rather than losing its home.
+	var found bool
+	for _, s := range ss {
+		if s.Project == "notes" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the project-less note has no project: %#v", ss)
+	}
+}


### PR DESCRIPTION
Three notes in a `notes.jsonl`, one indexed:

```
{"project":"proj/p","text":"a promoted note with no state","kind":"promoted","session":"claude:t1"}
→ nothing
{"text":"a note with no project at all"}
→ nothing
{"project":"proj/p","text":"a plain note that should work"}
→ deja: notes: 1 session, 1 message
```

Both dropped shapes were written by deja itself in earlier versions. Nothing reported them — `doctor` is silent and the ingest counter just shows a smaller number. These are the user's own written decisions, the one class of content deja cannot re-derive from anything else.

A missing state now means `accepted` (the state labels a note, it does not decide whether it is one), and a note with no project is filed under `notes`. Still rejected: a promoted note with no source session, an empty body, an unparseable timestamp.

Closes #771