### PR TITLE
fix: repair wiring when the binary moved

### DIFF
--- a/cmd/deja/wiring_move_test.go
+++ b/cmd/deja/wiring_move_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Moving a binary without changing its version is ordinary — a relink, a
+// reinstall of the same release, a `go install` over a manual download — and
+// left every config naming a path that no longer exists (#773).
+func TestWiringRepairFollowsAMovedBinary(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "claude-code", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	wired := readWiringState()
+	if wired.Exe == "" {
+		t.Fatal("install recorded no binary path")
+	}
+	if len(wired.Targets) == 0 {
+		t.Fatal("install recorded no targets")
+	}
+
+	// Pretend the binary was somewhere else when the configs were written.
+	wired.Exe = filepath.Join(home, "old-location", "deja")
+	b, err := json.Marshal(wired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wiringStatePath(), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	claudeJSON := filepath.Join(home, ".claude.json")
+	before, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(claudeJSON, []byte(strings.ReplaceAll(string(before), wired.Exe, filepath.Join(home, "old-location", "deja"))), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if changed := refreshWiringAfterUpgrade(); len(changed) == 0 {
+		t.Error("a moved binary did not trigger the repair")
+	}
+	after, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(after), "old-location") {
+		t.Errorf("config still names the old path:\n%s", after)
+	}
+
+	// Nothing moved and nothing upgraded: the repair must stay quiet, or every
+	// session start rewrites the user's configs.
+	if changed := refreshWiringAfterUpgrade(); len(changed) != 0 {
+		t.Errorf("repair ran with nothing to repair: %v", changed)
+	}
+}

--- a/cmd/deja/wiring_move_test.go
+++ b/cmd/deja/wiring_move_test.go
@@ -29,6 +29,7 @@ func TestWiringRepairFollowsAMovedBinary(t *testing.T) {
 	}
 
 	// Pretend the binary was somewhere else when the configs were written.
+	moved := wired.Exe
 	wired.Exe = filepath.Join(home, "old-location", "deja")
 	b, err := json.Marshal(wired)
 	if err != nil {
@@ -42,7 +43,7 @@ func TestWiringRepairFollowsAMovedBinary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(claudeJSON, []byte(strings.ReplaceAll(string(before), wired.Exe, filepath.Join(home, "old-location", "deja"))), 0o644); err != nil {
+	if err := os.WriteFile(claudeJSON, []byte(strings.ReplaceAll(string(before), moved, wired.Exe)), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -20,6 +20,11 @@ import (
 type wiringState struct {
 	Version string   `json:"version"`
 	Targets []string `json:"targets"`
+	// Exe is the binary path the configs were written with. A move without a
+	// version change is ordinary — a relink, a reinstall of the same release,
+	// a `go install` over a manual download — and left every config pointing
+	// at a path that no longer exists (#773).
+	Exe string `json:"exe,omitempty"`
 }
 
 func wiringStatePath() string {
@@ -61,6 +66,11 @@ func recordWiring(targets []string, uninstall bool) {
 		}
 	}
 	sort.Strings(kept)
+	exe, _ := os.Executable()
+	exe, _ = filepath.Abs(exe)
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
 	// Uninstalling everything on a machine that was never wired would otherwise
 	// create the record on the way out — a file left behind by the command that
 	// removes things (#676).
@@ -69,7 +79,7 @@ func recordWiring(targets []string, uninstall bool) {
 			return
 		}
 	}
-	st = wiringState{Version: version, Targets: kept}
+	st = wiringState{Version: version, Targets: kept, Exe: exe}
 	b, err := json.MarshalIndent(st, "", "  ")
 	if err != nil {
 		return
@@ -87,7 +97,7 @@ func recordWiring(targets []string, uninstall bool) {
 // quiet, because a session start is not the place for maintenance chatter.
 func refreshWiringAfterUpgrade() []string {
 	st := readWiringState()
-	if len(st.Targets) == 0 || st.Version == version || version == "" {
+	if len(st.Targets) == 0 || version == "" {
 		return nil
 	}
 	exe, err := os.Executable()
@@ -95,6 +105,14 @@ func refreshWiringAfterUpgrade() []string {
 		return nil
 	}
 	exe, _ = filepath.Abs(exe)
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	// Either the version or the path: a binary that moved writes the same
+	// version into configs that now name a file which is not there (#773).
+	if st.Version == version && (st.Exe == "" || st.Exe == exe) {
+		return nil
+	}
 	var changed []string
 	for _, target := range st.Targets {
 		res, err := installTarget(target, exe, false)


### PR DESCRIPTION
A move without a version bump — a relink, a reinstall of the same release, `go install` over a manual download — left the configs pointing at the old path, and the hook that would fix them is invoked through that path.

`wiring.json` now records the binary path it wired and the repair triggers on either version or path change. Closes #773.