### PR TITLE
fix: update defers to the package manager that owns the binary

### DIFF
--- a/cmd/deja/update.go
+++ b/cmd/deja/update.go
@@ -142,6 +142,10 @@ func performUpdate(cfg updateConfig, out io.Writer) error {
 	if _, _, err := updateAssetNames("version", cfg.goos, cfg.goarch); err != nil {
 		return err
 	}
+	if mgr, cmd := packageManagerOwning(cfg.executable); mgr != "" && !cfg.force {
+		fmt.Fprintf(out, "this binary is managed by %s — `%s` keeps its records straight; `deja update --force` writes over it, and the next %s run puts the old one back\n", mgr, cmd, mgr)
+		return nil
+	}
 
 	body, err := cfg.download(cfg.latestURL, maxReleaseJSON, "latest release")
 	if err != nil {
@@ -228,6 +232,30 @@ func performUpdate(cfg updateConfig, out io.Writer) error {
 	}
 	fmt.Fprintf(out, "updated deja %s -> v%s at %s\n", from, latest, cfg.executable)
 	return nil
+}
+
+// packageManagerOwning reports the package manager whose tree the binary lives
+// in. Writing into that tree succeeds and then quietly comes undone: the
+// manager still records the old version and its next upgrade overwrites the
+// file (#775).
+func packageManagerOwning(exe string) (manager, command string) {
+	// Backslashes explicitly: a Windows path can be inspected on any platform,
+	// and filepath.ToSlash only rewrites the separator of the running OS.
+	p := strings.ReplaceAll(filepath.ToSlash(exe), "\\", "/")
+	lower := strings.ToLower(p)
+	switch {
+	case strings.Contains(p, "/Cellar/"), strings.Contains(lower, "/homebrew/"), strings.Contains(lower, "/linuxbrew/"):
+		return "Homebrew", "brew upgrade deja-vu"
+	case strings.Contains(lower, "/scoop/apps/"):
+		return "scoop", "scoop update deja"
+	case strings.HasPrefix(p, "/nix/store/"):
+		return "Nix", "nix profile upgrade deja"
+	case strings.Contains(lower, "/winget/packages/"):
+		return "winget", "winget upgrade deja"
+	case strings.Contains(p, "/node_modules/"):
+		return "npm", "npm update -g deja-vu"
+	}
+	return "", ""
 }
 
 func normalizeUpdateVersion(v string) string {

--- a/cmd/deja/update_manager_test.go
+++ b/cmd/deja/update_manager_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Writing into a package manager's tree succeeds and then comes undone: the
+// manager still records the old version and its next upgrade overwrites the
+// file, so the user sees an update that did not stick (#775).
+var errStopUpdateForTest = errors.New("stop")
+
+func TestUpdateDefersToThePackageManagerThatOwnsTheBinary(t *testing.T) {
+	cases := []struct {
+		exe     string
+		manager string
+		command string
+	}{
+		{"/opt/homebrew/Cellar/deja-vu/0.16.5/bin/deja", "Homebrew", "brew upgrade deja-vu"},
+		{"/home/linuxbrew/.linuxbrew/bin/deja", "Homebrew", "brew upgrade deja-vu"},
+		{`C:\Users\v\scoop\apps\deja\current\deja.exe`, "scoop", "scoop update deja"},
+		{"/nix/store/abc123-deja-0.16.5/bin/deja", "Nix", "nix profile upgrade deja"},
+		// README has promised this since the npm package shipped: "deja update
+		// is for standalone installs. Homebrew and npm installs update through
+		// the package manager." Nothing enforced it.
+		{"/usr/lib/node_modules/deja-vu/bin/deja", "npm", "npm update -g deja-vu"},
+	}
+	for _, tc := range cases {
+		var out bytes.Buffer
+		err := performUpdate(updateConfig{
+			currentVersion: "0.1.0",
+			goos:           "linux",
+			goarch:         "amd64",
+			executable:     tc.exe,
+			download: func(string, int64, string) ([]byte, error) {
+				t.Errorf("%s: downloaded a release for a managed binary", tc.exe)
+				return nil, nil
+			},
+		}, &out)
+		if err != nil {
+			t.Errorf("%s: %v", tc.exe, err)
+		}
+		if !strings.Contains(out.String(), tc.manager) || !strings.Contains(out.String(), tc.command) {
+			t.Errorf("%s: want %q and %q, got %q", tc.exe, tc.manager, tc.command, out.String())
+		}
+	}
+
+	// --force is the documented escape hatch, so it must still reach the
+	// download; and an ordinary path must not be mistaken for a managed one.
+	for _, tc := range []struct {
+		name string
+		cfg  updateConfig
+	}{
+		{"force", updateConfig{force: true, currentVersion: "0.1.0", goos: "linux", goarch: "amd64", executable: "/opt/homebrew/Cellar/deja-vu/0.16.5/bin/deja"}},
+		{"plain path", updateConfig{currentVersion: "0.1.0", goos: "linux", goarch: "amd64", executable: filepath.Join("/usr", "local", "bin", "deja")}},
+	} {
+		reached := false
+		var out bytes.Buffer
+		_ = performUpdate(updateConfig{
+			force: tc.cfg.force, currentVersion: tc.cfg.currentVersion,
+			goos: tc.cfg.goos, goarch: tc.cfg.goarch, executable: tc.cfg.executable,
+			download: func(string, int64, string) ([]byte, error) {
+				reached = true
+				return nil, errStopUpdateForTest
+			},
+		}, &out)
+		if !reached {
+			t.Errorf("%s: stopped before the download: %q", tc.name, out.String())
+		}
+	}
+}


### PR DESCRIPTION
README says `deja update` is for standalone installs, but nothing enforced it: inside a Cellar the write succeeded, Homebrew kept recording the old version, and its next upgrade silently reverted the binary.

```
before: updated deja dev -> v0.16.5 at /tmp/n3/Cellar/deja/0.15.2/bin/deja
after:  this binary is managed by Homebrew — `brew upgrade deja-vu` keeps its records straight; …
```

Covers Homebrew, scoop, Nix, winget, npm. `--force` still writes. Closes #775.