### PR TITLE
fix: hooks ask for a rebuild when the index is from another format version

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -280,6 +280,13 @@ func cachedHookDigest(dir string) (string, int, int64, []string) {
 	if strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL"))) == search.RecallOff {
 		return "", 0, 0, nil
 	}
+	// Before the cache read: a hit returns without reaching the version guard
+	// in hookDigestResult, so an index left behind by an upgrade was served
+	// stale and never rebuilt (#777). The cached digest is still the user's
+	// own history, so serve it — just ask for the rebuild too.
+	if index.HasManifest(dir) && !index.IsCurrentVersion(dir) {
+		requestWarmup(dir)
+	}
 	gate := hookGate()
 	p := hookCachePath(dir, cwd)
 	if b, err := os.ReadFile(p); err == nil {

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -94,7 +94,11 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	if len(terms) < 2 {
 		return nil
 	}
-	if !index.HasManifest(dir) {
+	// Version, not just presence: terms hash into buckets an index from
+	// another format never wrote, so a stale store answers every prompt with
+	// nothing and looks exactly like a user with no history (#777).
+	if !index.HasManifest(dir) || !index.IsCurrentVersion(dir) {
+		requestWarmup(dir)
 		return nil
 	}
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")

--- a/cmd/deja/hook_stale_format_test.go
+++ b/cmd/deja/hook_stale_format_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"encoding/gob"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// An index left behind by an older format answers every prompt with nothing,
+// which is indistinguishable from a user with no history — and neither hook
+// asked for the rebuild that would fix it (#777).
+func TestStaleFormatHooksAskForARebuild(t *testing.T) {
+	hermeticEnv(t)
+	// hermeticEnv suppresses the warmup spawn; the point here is whether the
+	// hooks ask for one at all, so let the request through. The spawned child
+	// is this test binary, which exits without work.
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	dir := filepath.Join(t.TempDir(), "idx")
+	writeStaleFormatIndex(t, dir)
+	if !index.HasManifest(dir) {
+		t.Fatal("fixture has no manifest")
+	}
+	if index.IsCurrentVersion(dir) {
+		t.Fatal("fixture claims the current format version")
+	}
+
+	sentinel := filepath.Join(dir, "warmup.sentinel")
+	if err := runHookPromptMode(dir, strings.NewReader(`{"session_id":"s","prompt":"zeppelin throttle regulator"}`), &bytes.Buffer{}, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("hook-prompt did not request a rebuild on a stale-format index: %v", err)
+	}
+	if err := os.Remove(sentinel); err != nil {
+		t.Fatal(err)
+	}
+
+	// A cached digest returns before the guard inside hookDigestResult, so the
+	// request has to happen ahead of the cache read — and the cached digest is
+	// the user's own history, so it must still be served.
+	cwd, _ := os.Getwd()
+	writeHookCache(dir, cwd, "an earlier digest", 1, 10, nil)
+	if d, _, _, _ := cachedHookDigest(dir); d == "" {
+		t.Error("a cache hit stopped serving the user's own history")
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("a cache hit swallowed the rebuild request: %v", err)
+	}
+}
+
+// writeStaleFormatIndex writes what an upgrade leaves behind: a readable
+// manifest whose format version is not this build's.
+func writeStaleFormatIndex(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name string, v any) {
+		var buf bytes.Buffer
+		if err := gob.NewEncoder(&buf).Encode(v); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), buf.Bytes(), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("manifest.gob", struct {
+		Version int
+		BuiltAt time.Time
+	}{Version: 1, BuiltAt: time.Now()})
+	write("sessions.gob", map[string]index.SessionMeta{})
+}

--- a/cmd/deja/hook_stale_format_test.go
+++ b/cmd/deja/hook_stale_format_test.go
@@ -17,10 +17,14 @@ import (
 // asked for the rebuild that would fix it (#777).
 func TestStaleFormatHooksAskForARebuild(t *testing.T) {
 	hermeticEnv(t)
-	// hermeticEnv suppresses the warmup spawn; the point here is whether the
-	// hooks ask for one at all, so let the request through. The spawned child
-	// is this test binary, which exits without work.
+	// hermeticEnv suppresses the request entirely; the point here is whether
+	// the hooks ask for one at all, so let it through and count the spawn
+	// instead of starting a real child.
 	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	spawned := 0
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(_, _ string) error { spawned++; return nil }
+	t.Cleanup(func() { spawnWarmup = oldSpawn })
 	dir := filepath.Join(t.TempDir(), "idx")
 	writeStaleFormatIndex(t, dir)
 	if !index.HasManifest(dir) {
@@ -30,14 +34,13 @@ func TestStaleFormatHooksAskForARebuild(t *testing.T) {
 		t.Fatal("fixture claims the current format version")
 	}
 
-	sentinel := filepath.Join(dir, "warmup.sentinel")
 	if err := runHookPromptMode(dir, strings.NewReader(`{"session_id":"s","prompt":"zeppelin throttle regulator"}`), &bytes.Buffer{}, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(sentinel); err != nil {
-		t.Errorf("hook-prompt did not request a rebuild on a stale-format index: %v", err)
+	if spawned != 1 {
+		t.Errorf("hook-prompt requested %d rebuilds on a stale-format index, want 1", spawned)
 	}
-	if err := os.Remove(sentinel); err != nil {
+	if err := os.Remove(filepath.Join(dir, "warmup.sentinel")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -49,8 +52,8 @@ func TestStaleFormatHooksAskForARebuild(t *testing.T) {
 	if d, _, _, _ := cachedHookDigest(dir); d == "" {
 		t.Error("a cache hit stopped serving the user's own history")
 	}
-	if _, err := os.Stat(sentinel); err != nil {
-		t.Errorf("a cache hit swallowed the rebuild request: %v", err)
+	if spawned != 2 {
+		t.Errorf("a cache hit swallowed the rebuild request: %d spawns, want 2", spawned)
 	}
 }
 


### PR DESCRIPTION
Index written at format 19, read by a build at format 21:

```
before: hook-prompt → (nothing), no warmup.sentinel, manifest untouched after 3 runs
after:  hook-prompt → (nothing) + rebuild to 21; next prompt recalls
```

Two halves: `runHookPromptMode` checked `HasManifest` only, so terms hashed into buckets the old index never wrote and every prompt matched nothing; and `cachedHookDigest` returned on a cache hit before reaching the guard in `hookDigestResult`, so the warmup was never requested there either. The cached digest is still the user's own history, so it is still served — the rebuild is just requested alongside. Closes #777.