### PR TITLE
fix: re-derive session titles left over from older rules

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -25,7 +25,11 @@ import (
 // 21: Codex sessions are keyed on the ThreadId rather than the SessionId
 // (#635), so every existing Codex entry has the wrong identity, and the
 // harness preamble Codex injects as a user turn is stripped (#636).
-const version = 21
+// 22: titles are derived by the rules from #671, #693 and #770. Those three
+// shipped without a bump, so indexes built under the old rules kept the titles
+// they derived then — incremental ingest reuses SessionMeta for a file it has
+// already read, and no ordinary `deja index` re-derives it (#784).
+const version = 22
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/title_rederive_test.go
+++ b/internal/index/title_rederive_test.go
@@ -1,0 +1,59 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// Incremental ingest reuses SessionMeta for a file it has already read, so a
+// title derived under older rules survives every ordinary `deja index`. Three
+// title fixes shipped without a format bump and left blank titles in place
+// (#784); the bump is the repair, and this pins that the repair works.
+func TestStaleFormatRederivesTitles(t *testing.T) {
+	root, dir := allHarnessEnv(t)
+	claudeFile := filepath.Join(root, "claude", "-tmp-p", "s.jsonl")
+	write(t, claudeFile, claudeLine("s1", "2026-01-02T03:04:05Z", "ballast pump controller retries twice"))
+
+	o := search.Options{Query: "ballast", All: true}
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta, ok := m.Sessions["claude:s1"]
+	if !ok {
+		t.Fatalf("session not in manifest: %v", m.Sessions)
+	}
+	if meta.Title == "" {
+		t.Fatal("no title to lose")
+	}
+
+	// What an index built by an older binary holds: a readable store whose
+	// titles came from rules this build no longer uses.
+	meta.Title = ""
+	m.Sessions["claude:s1"] = meta
+	m.Version = version - 1
+	if err := writeManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	// Touching nothing else: the transcript is unchanged, which is exactly the
+	// case incremental ingest skips.
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, err = readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := m.Sessions["claude:s1"].Title; got == "" {
+		t.Error("an index from an older format kept its blank title")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "records.bin")); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Incremental ingest reuses `SessionMeta` for an unchanged file, so titles derived under the rules from before #671/#693/#770 survive every ordinary `deja index`:

```
before: deja index && deja last → [claude · n8/proj · 2026-07-22 · onlyassistant]
after:  deja last              → [claude · … · onlyassistant] I will refactor the ballast pump controller now
```

Only `--rebuild` or a fresh index dir fixed it, and nothing said so. Bumps the format version, which is the mechanism that already exists for exactly this. Closes #784.