### PR TITLE
fix: covering line bounds by when the oldest work began

### DIFF
--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -230,8 +230,16 @@ func Overview(dir string) (OverviewStats, error) {
 		if meta.Updated.After(day) && !meta.Updated.After(now) {
 			o.SessionsToday++
 		}
-		if o.Oldest.IsZero() || (!meta.Updated.IsZero() && meta.Updated.Before(o.Oldest)) {
-			o.Oldest = meta.Updated
+		// Started, not Updated: the earliest bound is when the oldest work
+		// began. A session that ran from January to March last touched the
+		// index in March, and taking that as the floor hid two months of its
+		// own transcript (#786).
+		from := meta.Started
+		if from.IsZero() {
+			from = meta.Updated
+		}
+		if o.Oldest.IsZero() || (!from.IsZero() && from.Before(o.Oldest)) {
+			o.Oldest = from
 		}
 		if meta.Updated.After(o.Newest) {
 			o.Newest = meta.Updated

--- a/internal/index/overview_range_test.go
+++ b/internal/index/overview_range_test.go
@@ -1,0 +1,50 @@
+package index
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// The "covering" line answers how far back a memory goes, and long-running
+// sessions are the ones carrying the old history. Deriving the floor from the
+// last activity hid everything before it (#786).
+func TestOverviewCoversWhenTheOldestWorkBegan(t *testing.T) {
+	_, dir := allHarnessEnv(t)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	started := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+	updated := time.Date(2026, 3, 20, 10, 0, 0, 0, time.UTC)
+	m := Manifest{Version: version, Files: map[string]FileState{}, Sessions: map[string]SessionMeta{
+		"claude:long":  {ID: "long", Harness: "claude", Started: started, Updated: updated},
+		"claude:short": {ID: "short", Harness: "claude", Started: updated, Updated: updated},
+	}}
+	if err := writeManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	ov, err := Overview(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ov.Oldest.Equal(started) {
+		t.Errorf("oldest = %s, want the earliest start %s", ov.Oldest, started)
+	}
+	if !ov.Newest.Equal(updated) {
+		t.Errorf("newest = %s, want %s", ov.Newest, updated)
+	}
+
+	// A session whose start never made it into the manifest still has to bound
+	// the range, or an older store reports no coverage at all.
+	m.Sessions = map[string]SessionMeta{"claude:nostart": {ID: "nostart", Harness: "claude", Updated: updated}}
+	if err := writeManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	ov, err = Overview(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ov.Oldest.Equal(updated) {
+		t.Errorf("oldest = %s, want the fallback %s", ov.Oldest, updated)
+	}
+}


### PR DESCRIPTION
One session that ran January to March, on a store with a quiet week:

```
before: covering   Mar 20 2026 → Mar 20 2026   (deja stats: Range 2026-01-05 → 2026-03-20)
after:  covering   Jan 5 2026 → Mar 20 2026
```

`Overview` took `Oldest` from `meta.Updated`, i.e. the earliest last-activity, while the line exists to say how far back the memory goes. Falls back to `Updated` when a session carries no start. Closes #786.