### PR TITLE
fix: forget says where the session was already pushed

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1360,6 +1360,14 @@ func runForget(dir string, args []string) error {
 		return nil
 	}
 	fmt.Fprintf(os.Stdout, "sessions dropped: %d\nmessages dropped: %d\ntombstones added: %d\n", result.Sessions, result.Messages, result.Tombstones)
+	// Forgetting keeps the session out of later pushes but cannot reach a
+	// machine that already has it. Three lines about what was dropped read as
+	// "it is gone everywhere" to someone forgetting a customer name (#788).
+	if len(result.Peers) > 0 {
+		fmt.Fprintf(os.Stdout, "already pushed to %s — forgetting here does not remove it there\n", strings.Join(result.Peers, ", "))
+	} else if result.Exported {
+		fmt.Fprintln(os.Stdout, "already exported once — forgetting here does not remove copies elsewhere")
+	}
 	// The notes are decisions the reader deliberately kept, so folding them
 	// into the session count reads as "four conversations" when half of it is
 	// their own writing (#690).

--- a/internal/index/forget_pushed_test.go
+++ b/internal/index/forget_pushed_test.go
@@ -1,0 +1,46 @@
+package index
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Forgetting removes the local copy and keeps the session out of later pushes,
+// but a machine that already has it keeps it. Saying nothing read as "it is
+// gone everywhere" to someone forgetting a customer name (#788).
+func TestForgetReportsWhereItWasAlreadyPushed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "store.jsonl")
+	started := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	m := Manifest{Sessions: map[string]SessionMeta{
+		"claude:s1": {ID: "s1", Harness: "claude", Path: path, Started: started, Updated: started},
+	}}
+	matched := map[string]bool{"claude:s1": true}
+
+	// Nothing pushed anywhere.
+	if peers, exported := pushedTo(m, matched); len(peers) != 0 || exported {
+		t.Errorf("with no watermarks: peers=%v exported=%v", peers, exported)
+	}
+
+	// A directory export carries no peer name.
+	m.ExportWatermarks = map[string]int64{path: started.UnixNano()}
+	if peers, exported := pushedTo(m, matched); len(peers) != 0 || !exported {
+		t.Errorf("after a directory export: peers=%v exported=%v", peers, exported)
+	}
+
+	// Named peers are named, and a watermark older than the session is not a
+	// push of it.
+	m.ExportWatermarks = map[string]int64{
+		"mini\x00" + path:  started.UnixNano(),
+		"work\x00" + path:  started.Add(time.Hour).UnixNano(),
+		"older\x00" + path: started.Add(-time.Hour).UnixNano(),
+	}
+	peers, exported := pushedTo(m, matched)
+	if exported {
+		t.Error("named peers were reported as an unnamed export")
+	}
+	if len(peers) != 2 || peers[0] != "mini" || peers[1] != "work" {
+		t.Errorf("peers = %v, want [mini work]", peers)
+	}
+}

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -30,8 +30,60 @@ type ForgetResult struct {
 	// Notes is how many of Sessions were promoted notes rather than raw
 	// transcripts. They are the decisions the user deliberately kept, so one
 	// combined number reads as "four conversations" when half of it is their
-	// own записи.
+	// own writing.
 	Notes int
+	// Peers names the hosts a forgotten session was already pushed to, and
+	// Exported reports the same for unnamed directory exports. Forgetting
+	// removes the local copy and keeps the session out of later pushes, but it
+	// cannot reach a machine that already has it — and saying nothing read as
+	// "it is gone everywhere" (#788).
+	Peers    []string
+	Exported bool
+}
+
+// pushedTo reports where records from the matched sessions have already gone.
+// A watermark at or past a session's earliest record means that session was in
+// a push: watermarks are keyed by peer and by the source file, and a session's
+// Path is that source.
+func pushedTo(m Manifest, matched map[string]bool) ([]string, bool) {
+	if len(m.ExportWatermarks) == 0 {
+		return nil, false
+	}
+	peers := map[string]bool{}
+	unnamed := false
+	for key := range matched {
+		meta, ok := m.Sessions[key]
+		if !ok {
+			continue
+		}
+		from := meta.Started
+		if from.IsZero() {
+			from = meta.Updated
+		}
+		for wk, wm := range m.ExportWatermarks {
+			peer, source, named := strings.Cut(wk, "\x00")
+			if !named {
+				peer, source = "", wk
+			}
+			if source != meta.Path && source != key {
+				continue
+			}
+			if from.IsZero() || wm < from.UnixNano() {
+				continue
+			}
+			if peer == "" {
+				unnamed = true
+			} else {
+				peers[peer] = true
+			}
+		}
+	}
+	out := make([]string, 0, len(peers))
+	for p := range peers {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out, unnamed
 }
 
 func privacyDir() string {
@@ -220,6 +272,7 @@ func Forget(dir string, o ForgetOptions) (ForgetResult, error) {
 		return result, nil
 	}
 	sort.Strings(result.Keys)
+	result.Peers, result.Exported = pushedTo(m, matched)
 	// Count the messages on the dry run too. It is the same single pass over
 	// records, and without it `--dry-run` answers "0 messages" to the only
 	// question it exists to answer: how much am I about to lose.


### PR DESCRIPTION
`forget` correctly keeps the session out of later exports, but a machine that already imported it keeps its copy and neither side said so:

```
before: sessions dropped: 1 / messages dropped: 1 / tombstones added: 1
after:  … + already pushed to mini — forgetting here does not remove it there
        … + already exported once — forgetting here does not remove copies elsewhere  (directory export)
```

Watermarks are already keyed by peer, so this is a read of what the manifest holds. Closes #788.