### PR TITLE
fix: doctor names the missing sqlite3 CLI instead of blaming the store

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -82,17 +82,7 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir strin
 		return deepDriftErr(deepReport)
 	}
 	doctorHarnesses(w)
-	for _, store := range report.Stores {
-		switch store.State {
-		case "parsed-zero":
-			fmt.Fprintf(w, "  warning      %s files found but newest parsed to zero\n", store.Name)
-		case "unreadable":
-			// The store is there and deja cannot read it — usually a harness
-			// that changed its format. Silence here reads as "you have no
-			// history with that agent".
-			fmt.Fprintf(w, "  warning      %s store cannot be read — its format may have changed; please report it\n", store.Name)
-		}
-	}
+	printDoctorStoreWarnings(w, report.Stores)
 	fmt.Fprintln(w)
 	doctorTools(w)
 	fmt.Fprintln(w)
@@ -272,6 +262,26 @@ func unplacedFiles(root string, seen []string) int {
 		return nil
 	})
 	return extra
+}
+
+// printDoctorStoreWarnings says what deja could not read and why.
+func printDoctorStoreWarnings(w io.Writer, stores []doctorStore) {
+	for _, store := range stores {
+		switch store.State {
+		case "parsed-zero":
+			fmt.Fprintf(w, "  warning      %s files found but newest parsed to zero\n", store.Name)
+		case "unreadable":
+			// The store is there and deja cannot read it — usually a harness
+			// that changed its format. Silence here reads as "you have no
+			// history with that agent".
+			fmt.Fprintf(w, "  warning      %s store cannot be read — its format may have changed; please report it\n", store.Name)
+		case "needs-sqlite3":
+			// Not a format change: the parser could not run at all. Saying so
+			// points at installing one package instead of at a bug report
+			// against the harness (#792).
+			fmt.Fprintf(w, "  warning      %s store needs the sqlite3 CLI — install it, then run `deja index`\n", store.Name)
+		}
+	}
 }
 
 func doctorHarnesses(w io.Writer) {

--- a/cmd/deja/doctor_parsed_zero_test.go
+++ b/cmd/deja/doctor_parsed_zero_test.go
@@ -60,7 +60,10 @@ func TestDoctorReportsAnUnreadableStore(t *testing.T) {
 		t.Fatal(err)
 	}
 	failing := doctorStoreCheck{
-		name:  "goose",
+		// A file-backed harness: for the five deja reads through the sqlite3
+		// CLI a parse failure on a machine without it means the tool, not the
+		// format (#792), and the subject here is the format case.
+		name:  "cline",
 		paths: []string{dir},
 		files: []string{path},
 		parse: func(string) ([]model.Session, error) { return nil, errUnreadableStore },

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -89,6 +89,15 @@ func collectDoctorReport(lookup doctorVersionLookup, dir string) doctorReport {
 	return report
 }
 
+// storeNeedsSQLite3 names the harnesses deja reads through the sqlite3 CLI.
+func storeNeedsSQLite3(name string) bool {
+	switch name {
+	case "opencode", "cursor", "grok", "hermes", "goose":
+		return true
+	}
+	return false
+}
+
 func collectDoctorEmbed(dir string) *doctorEmbedReport {
 	r := &doctorEmbedReport{State: "unavailable"}
 	reachable := false
@@ -208,6 +217,14 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 	_ = f.Close()
 	sessions, parseErr := check.parse(newest)
 	store.State = "ok"
+	// A parser that could not run is not a store that could not be understood.
+	// Without this, removing the sqlite3 CLI told the user their harness had
+	// changed its format and asked them to report it — two lines above deja
+	// naming the missing CLI itself (#792).
+	if parseErr != nil && storeNeedsSQLite3(check.name) && !sources.SQLite3Available() {
+		store.State = "needs-sqlite3"
+		return store, mod
+	}
 	// A parser that refuses to read the store is the loudest thing doctor can
 	// learn, and it used to be discarded: a harness that changed its schema
 	// showed up here as a healthy store while its recall was empty.

--- a/cmd/deja/doctor_sqlite_test.go
+++ b/cmd/deja/doctor_sqlite_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Removing the sqlite3 CLI told the user their harness had changed its format
+// and asked them to report it — two lines above deja naming the missing CLI
+// itself (#792).
+func TestDoctorSeparatesAMissingToolFromAChangedFormat(t *testing.T) {
+	for _, name := range []string{"opencode", "cursor", "grok", "hermes", "goose"} {
+		if !storeNeedsSQLite3(name) {
+			t.Errorf("%s reads through the sqlite3 CLI but is not listed", name)
+		}
+	}
+	for _, name := range []string{"claude", "codex", "gemini", "deja"} {
+		if storeNeedsSQLite3(name) {
+			t.Errorf("%s does not use sqlite3 but is listed as needing it", name)
+		}
+	}
+
+	// The state itself, not just its wording: a parser that could not run must
+	// not be filed as a store deja could not understand.
+	dir := t.TempDir()
+	db := filepath.Join(dir, "opencode.db")
+	if err := os.WriteFile(db, []byte("SQLite format 3\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir) // no sqlite3 anywhere on it
+	failed := func(string) ([]model.Session, error) {
+		return nil, errors.New("exec: \"sqlite3\": executable file not found in $PATH")
+	}
+	store, _ := inspectDoctorStore(doctorStoreCheck{name: "opencode", paths: []string{db}, files: []string{db}, parse: failed})
+	if store.State != "needs-sqlite3" {
+		t.Errorf("state = %q, want needs-sqlite3", store.State)
+	}
+	// A harness that reads plain files is still an unreadable store.
+	store, _ = inspectDoctorStore(doctorStoreCheck{name: "claude", paths: []string{db}, files: []string{db}, parse: failed})
+	if store.State != "unreadable" {
+		t.Errorf("state = %q, want unreadable", store.State)
+	}
+
+	var out strings.Builder
+	printDoctorStoreWarnings(&out, []doctorStore{
+		{Name: "opencode", State: "needs-sqlite3"},
+		{Name: "cline", State: "unreadable"},
+		{Name: "codex", State: "parsed-zero"},
+		{Name: "claude", State: "ok"},
+	})
+	got := out.String()
+	if !strings.Contains(got, "opencode store needs the sqlite3 CLI") {
+		t.Errorf("missing tool not named:\n%s", got)
+	}
+	if strings.Contains(got, "opencode store cannot be read") {
+		t.Errorf("a missing tool is still reported as a format change:\n%s", got)
+	}
+	if !strings.Contains(got, "cline store cannot be read") {
+		t.Errorf("a genuinely unreadable store lost its warning:\n%s", got)
+	}
+	if !strings.Contains(got, "codex files found but newest parsed to zero") {
+		t.Errorf("parsed-zero lost its warning:\n%s", got)
+	}
+	if strings.Contains(got, "claude") {
+		t.Errorf("a healthy store was warned about:\n%s", got)
+	}
+}


### PR DESCRIPTION
Healthy opencode store, sqlite3 off PATH:

```
before: warning  opencode store cannot be read — its format may have changed; please report it
after:  warning  opencode store needs the sqlite3 CLI — install it, then run `deja index`
```

The same doctor run already prints "sqlite3 not found" two lines below, so the old wording sent people to file a bug against their harness instead of installing one package. Applies to the five stores deja reads through the CLI; a store that genuinely fails to parse still reports a possible format change. Closes #792.