### PR TITLE
fix: index says which harness it skipped for a missing sqlite3

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -428,6 +428,13 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 	var ss []model.Session
 	for _, r := range results {
 		if len(r.ss) == 0 {
+			// A harness deja can see but could not read is worth a line: an
+			// index run that narrates every store it read and stays silent
+			// about the one it skipped makes an empty deja look like an empty
+			// history (#794).
+			if reason := sources.SkipReason(r.name); reason != "" && progress != nil && !SuppressHarnessNarration {
+				fmt.Fprintf(progress, "deja: %s: skipped — %s\n", r.name, reason)
+			}
 			continue
 		}
 		ss = append(ss, r.ss...)

--- a/internal/sources/skip.go
+++ b/internal/sources/skip.go
@@ -1,0 +1,31 @@
+package sources
+
+// SkipReason says why a harness deja can see on disk produced nothing. Today
+// that is only a missing sqlite3 CLI: five stores are read through it, and an
+// index run that names every harness it read while staying silent about the
+// one it could not made an empty deja look like an empty history (#794).
+//
+// It returns "" when there is nothing to explain — including on a machine that
+// never used the harness, where a note about a tool would be noise.
+func SkipReason(harness string) string {
+	if SQLite3Available() {
+		return ""
+	}
+	var present bool
+	switch harness {
+	case "opencode":
+		present = fileExists(OpencodeDB())
+	case "cursor":
+		present = len(CursorDBs()) > 0
+	case "grok":
+		present = fileExists(GrokDB())
+	case "hermes":
+		present = len(HermesDBs()) > 0
+	case "goose":
+		present = fileExists(GooseDB())
+	}
+	if !present {
+		return ""
+	}
+	return "sqlite3 CLI not found"
+}

--- a/internal/sources/skip_test.go
+++ b/internal/sources/skip_test.go
@@ -1,0 +1,55 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// An index run narrates every store it read; staying silent about the one it
+// could not made an empty deja look like an empty history (#794). The note
+// must stay off on a machine that never used the harness, where it would be
+// noise about a tool nobody needs.
+func TestSkipReasonNamesTheMissingToolOnlyWhenTheStoreIsThere(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("PATH", home) // no sqlite3 on it
+	if SQLite3Available() {
+		t.Skip("sqlite3 still resolvable")
+	}
+
+	for _, h := range []string{"opencode", "cursor", "grok", "hermes", "goose", "claude"} {
+		if got := SkipReason(h); got != "" {
+			t.Errorf("%s with no store on disk: %q, want no note", h, got)
+		}
+	}
+
+	db := OpencodeDB()
+	if err := os.MkdirAll(filepath.Dir(db), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(db, []byte("SQLite format 3\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := SkipReason("opencode"); got != "sqlite3 CLI not found" {
+		t.Errorf("opencode with a store and no CLI: %q", got)
+	}
+	// A harness deja reads without the CLI is never explained away by it.
+	if got := SkipReason("claude"); got != "" {
+		t.Errorf("claude: %q, want no note", got)
+	}
+}
+
+// With the CLI present there is nothing to explain, store or no store.
+func TestSkipReasonSilentWhenTheToolIsThere(t *testing.T) {
+	if !SQLite3Available() {
+		t.Skip("no sqlite3 on this machine")
+	}
+	for _, h := range []string{"opencode", "cursor", "grok", "hermes", "goose"} {
+		if got := SkipReason(h); got != "" {
+			t.Errorf("%s: %q, want no note", h, got)
+		}
+	}
+}


### PR DESCRIPTION
A machine whose only store is opencode, sqlite3 off PATH:

```
before: deja: indexing sessions into ~/idx ...
        (then: no matches in 0 indexed sessions)
after:  deja: indexing sessions into ~/idx ...
        deja: opencode: skipped — sqlite3 CLI not found
```

Covers the five stores read through the CLI, and only when the store file is actually there — a machine that never used them stays quiet. Wording follows what `deja sources` already says. Closes #794.