### PR TITLE
fix: doctor lists git alongside sqlite3

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"sort"
@@ -442,6 +443,15 @@ func doctorTools(w io.Writer) {
 		status = "found"
 	}
 	fmt.Fprintf(w, "  %-12s %s (needed for opencode and Cursor IDE stores)\n", "sqlite3", status)
+	// git is not optional decoration: without it a hit loses the line saying
+	// its files have changed since, project names lose worktree identity, and
+	// the session-start hook loses the task signal. All three degrade in
+	// silence, which is fine on a hit and not fine with nowhere to ask (#796).
+	gitStatus := "not found"
+	if _, err := exec.LookPath("git"); err == nil {
+		gitStatus = "found"
+	}
+	fmt.Fprintf(w, "  %-12s %s (needed for changed-file notes, worktree names and the task signal)\n", "git", gitStatus)
 }
 
 // doctorPolicy reports the one mechanism that separates local memory from

--- a/cmd/deja/doctor_git_test.go
+++ b/cmd/deja/doctor_git_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// Without git a hit loses the line saying its files changed since, project
+// names lose worktree identity, and the session-start hook loses the task
+// signal — all in silence, with nowhere to ask why (#796).
+func TestDoctorToolsReportsGit(t *testing.T) {
+	var out strings.Builder
+	doctorTools(&out)
+	got := out.String()
+	if !strings.Contains(got, "git ") {
+		t.Errorf("git is not listed:\n%s", got)
+	}
+	if !strings.Contains(got, "sqlite3") {
+		t.Errorf("sqlite3 lost its row:\n%s", got)
+	}
+
+	_, err := exec.LookPath("git")
+	wantFound := err == nil
+	line := ""
+	for _, l := range strings.Split(got, "\n") {
+		if strings.Contains(l, "git ") {
+			line = l
+		}
+	}
+	// "not found" contains "found", so a substring test passes for either
+	// answer: read the status field itself.
+	status := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "git"))
+	status = strings.TrimSpace(strings.SplitN(status, "(", 2)[0])
+	if wantFound && status != "found" {
+		t.Errorf("git is on PATH but the row says %q", status)
+	}
+	if !wantFound && status != "not found" {
+		t.Errorf("git is not on PATH but the row says %q", status)
+	}
+	if !strings.Contains(line, "changed-file notes") {
+		t.Errorf("the row does not say what git is for: %q", line)
+	}
+}


### PR DESCRIPTION
Without git a hit loses the "N files this session touched have changed since" line, project names lose worktree identity, and the session-start hook loses the task signal — all silently, and `doctor` listed only sqlite3.

```
Tools:
  sqlite3      not found (needed for opencode and Cursor IDE stores)
  git          not found (needed for changed-file notes, worktree names and the task signal)
```

Closes #796.