### PR TITLE
fix: hooks ask for a rebuild when the index is damaged

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -284,7 +284,7 @@ func cachedHookDigest(dir string) (string, int, int64, []string) {
 	// in hookDigestResult, so an index left behind by an upgrade was served
 	// stale and never rebuilt (#777). The cached digest is still the user's
 	// own history, so serve it — just ask for the rebuild too.
-	if index.HasManifest(dir) && !index.IsCurrentVersion(dir) {
+	if index.HasManifest(dir) && (!index.IsCurrentVersion(dir) || index.Damaged(dir)) {
 		requestWarmup(dir)
 	}
 	gate := hookGate()
@@ -383,7 +383,9 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 	// A store from an older index version must be rebuilt before it is read:
 	// this path never calls Ensure, so otherwise the first prompts after an
 	// upgrade recall nothing and say nothing about why.
-	if !index.HasManifest(dir) || !index.IsCurrentVersion(dir) {
+	// Damaged as well as stale: a kill during a write leaves records the
+	// manifest still describes, and this path answers from them (#800).
+	if !index.HasManifest(dir) || !index.IsCurrentVersion(dir) || index.Damaged(dir) {
 		requestWarmup(dir)
 		return "", 0, 0, nil
 	}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -97,7 +97,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// Version, not just presence: terms hash into buckets an index from
 	// another format never wrote, so a stale store answers every prompt with
 	// nothing and looks exactly like a user with no history (#777).
-	if !index.HasManifest(dir) || !index.IsCurrentVersion(dir) {
+	if !index.HasManifest(dir) || !index.IsCurrentVersion(dir) || index.Damaged(dir) {
 		requestWarmup(dir)
 		return nil
 	}

--- a/cmd/deja/hook_stale_format_test.go
+++ b/cmd/deja/hook_stale_format_test.go
@@ -57,6 +57,63 @@ func TestStaleFormatHooksAskForARebuild(t *testing.T) {
 	}
 }
 
+// A kill during a write leaves records the manifest still describes, and the
+// hooks answered from them — silently, without asking for the rebuild that
+// doctor already knows is needed (#800).
+func TestDamagedIndexHooksAskForARebuild(t *testing.T) {
+	hermeticEnv(t)
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	spawned := 0
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(_, _ string) error { spawned++; return nil }
+	t.Cleanup(func() { spawnWarmup = oldSpawn })
+
+	dir := filepath.Join(t.TempDir(), "idx")
+	// hermeticEnv points the claude reader at DEJA_CLAUDE_ROOT, not $HOME.
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"anemometer mast bracket sheared at the weld"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"r1","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "a.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if index.Damaged(dir) {
+		t.Fatal("a freshly built index reports damage")
+	}
+
+	records := filepath.Join(dir, "records.bin")
+	fi, err := os.Stat(records)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Truncate(records, fi.Size()/3); err != nil {
+		t.Fatal(err)
+	}
+	if !index.Damaged(dir) {
+		t.Fatal("a truncated records.bin is not reported as damage")
+	}
+
+	if err := runHookPromptMode(dir, strings.NewReader(`{"session_id":"s","prompt":"anemometer mast bracket sheared"}`), &bytes.Buffer{}, false); err != nil {
+		t.Fatal(err)
+	}
+	if spawned != 1 {
+		t.Errorf("hook-prompt requested %d rebuilds on a damaged index, want 1", spawned)
+	}
+	if err := os.Remove(filepath.Join(dir, "warmup.sentinel")); err != nil {
+		t.Fatal(err)
+	}
+	if d, _, _, _ := hookDigestResult(dir); d != "" {
+		t.Errorf("hook-context answered from a damaged index: %q", d)
+	}
+	if spawned != 2 {
+		t.Errorf("hook-context requested %d rebuilds, want 2", spawned)
+	}
+}
+
 // writeStaleFormatIndex writes what an upgrade leaves behind: a readable
 // manifest whose format version is not this build's.
 func writeStaleFormatIndex(t *testing.T, dir string) {


### PR DESCRIPTION
`records.bin` truncated, which is what a kill mid-write leaves:

```
before: hook-prompt → (nothing), hook-context → (nothing), no warmup.sentinel
after:  hook-prompt → (nothing) + rebuild requested; next prompt recalls
```

`index.Damaged` (#735) already existed and doctor reports it — the hook paths just did not consult it, so on a machine where deja only ever runs from hooks, recall stayed dead until someone typed a search. Same hole #777 closed for a stale format version, reached through a different door. Closes #800.