### PR TITLE
fix: doctor names a permission problem instead of blaming the store

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -276,6 +276,11 @@ func printDoctorStoreWarnings(w io.Writer, stores []doctorStore) {
 			// that changed its format. Silence here reads as "you have no
 			// history with that agent".
 			fmt.Fprintf(w, "  warning      %s store cannot be read — its format may have changed; please report it\n", store.Name)
+		case "denied":
+			// Not a format change and not an empty history: deja is not
+			// allowed to read the files. On macOS this is usually Full Disk
+			// Access rather than the file mode (#802).
+			fmt.Fprintf(w, "  warning      %s store cannot be read — permission denied on %s; check its permissions (on macOS, also Full Disk Access for your terminal)\n", store.Name, store.Denied)
 		case "needs-sqlite3":
 			// Not a format change: the parser could not run at all. Saying so
 			// points at installing one package instead of at a bug report

--- a/cmd/deja/doctor_denied_test.go
+++ b/cmd/deja/doctor_denied_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A store deja is not allowed to read was reported as a harness that changed
+// its format — or, when only a subdirectory was locked, as a store with no
+// history at all (#802).
+func TestDoctorSeparatesADeniedStoreFromAChangedFormat(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	root := t.TempDir()
+	locked := filepath.Join(root, "sessions")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(locked, "s.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	// No files reached the collector, exactly as the walk leaves it.
+	store, _ := inspectDoctorStore(doctorStoreCheck{name: "codex", paths: []string{root}, files: nil, parse: nil})
+	if store.State != "denied" {
+		t.Fatalf("state = %q, want denied", store.State)
+	}
+	if store.Denied != locked {
+		t.Errorf("denied path = %q, want %q", store.Denied, locked)
+	}
+
+	var out strings.Builder
+	printDoctorStoreWarnings(&out, []doctorStore{store})
+	got := out.String()
+	if !strings.Contains(got, "permission denied on "+locked) {
+		t.Errorf("warning does not name the directory:\n%s", got)
+	}
+	if strings.Contains(got, "format may have changed") {
+		t.Errorf("a permission problem is still reported as a format change:\n%s", got)
+	}
+
+	// A readable store with nothing in it stays quiet: "no history" is not a
+	// problem to warn about.
+	empty := filepath.Join(root, "empty")
+	if err := os.MkdirAll(empty, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if store, _ := inspectDoctorStore(doctorStoreCheck{name: "codex", paths: []string{empty}, files: nil, parse: nil}); store.State == "denied" {
+		t.Errorf("an empty readable store was reported as denied")
+	}
+
+	// And a store that reads fine but fails to parse is still a format report.
+	file := filepath.Join(empty, "s.jsonl")
+	if err := os.WriteFile(file, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	broken := doctorStoreCheck{
+		name: "codex", paths: []string{empty}, files: []string{file},
+		parse: func(string) ([]model.Session, error) { return nil, errUnreadableStore },
+	}
+	if store, _ := inspectDoctorStore(broken); store.State != "unreadable" {
+		t.Errorf("state = %q, want unreadable", store.State)
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -22,6 +23,9 @@ type doctorStore struct {
 	State string   `json:"state"`
 	Paths []string `json:"paths"`
 	Files int      `json:"files"`
+	// Denied names the path that refused to be read, so the warning can point
+	// at the directory to fix rather than at the harness (#802).
+	Denied string `json:"denied,omitempty"`
 }
 
 type doctorComponent struct {
@@ -87,6 +91,44 @@ func collectDoctorReport(lookup doctorVersionLookup, dir string) doctorReport {
 	report.Version = collectDoctorVersion(lookup)
 	report.Embed = collectDoctorEmbed(dir)
 	return report
+}
+
+// firstDeniedDir walks the store roots until something refuses to be read and
+// returns that path. The walk is bounded: doctor is a diagnostic command, but
+// a harness root can hold tens of thousands of transcripts.
+func firstDeniedDir(paths []string) string {
+	const budget = 5000
+	visited := 0
+	home := sources.Home()
+	for _, root := range paths {
+		// aider's root is the home directory itself: any locked directory
+		// anywhere under $HOME would be blamed on aider, and the walk would
+		// cost the whole tree.
+		if root == "" || root == home {
+			continue
+		}
+		denied := ""
+		_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+			if visited++; visited > budget {
+				return filepath.SkipAll
+			}
+			if err != nil {
+				if os.IsPermission(err) {
+					denied = p
+					return filepath.SkipAll
+				}
+				return nil
+			}
+			if !d.IsDir() {
+				return nil
+			}
+			return nil
+		})
+		if denied != "" {
+			return denied
+		}
+	}
+	return ""
 }
 
 // storeNeedsSQLite3 names the harnesses deja reads through the sqlite3 CLI.
@@ -179,7 +221,8 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 		fi, err := os.Stat(path)
 		if err != nil {
 			if os.IsPermission(err) {
-				store.State = "unreadable"
+				store.State = "denied"
+				store.Denied = path
 				return store, time.Time{}
 			}
 			continue
@@ -188,7 +231,8 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 			f, err := os.Open(path)
 			if err != nil {
 				if os.IsPermission(err) {
-					store.State = "unreadable"
+					store.State = "denied"
+					store.Denied = path
 					return store, time.Time{}
 				}
 				continue
@@ -196,12 +240,20 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 			_, err = f.Readdirnames(1)
 			_ = f.Close()
 			if err != nil && err != io.EOF && os.IsPermission(err) {
-				store.State = "unreadable"
+				store.State = "denied"
+				store.Denied = path
 				return store, time.Time{}
 			}
 		}
 	}
 	if len(check.files) == 0 {
+		// The file collectors swallow EACCES, so a readable root with a
+		// locked subdirectory produced "found (0 files)" — the same answer as
+		// a harness nobody has used (#802).
+		if denied := firstDeniedDir(check.paths); denied != "" {
+			store.State = "denied"
+			store.Denied = denied
+		}
 		return store, time.Time{}
 	}
 	newest, mod := newestDoctorFile(check.files)

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -92,8 +92,11 @@ func TestDoctorStoreStates(t *testing.T) {
 		want  string
 	}{
 		{"missing", doctorStoreCheck{name: "x", paths: []string{filepath.Join(tmp, "missing")}}, "missing"},
-		{"empty", doctorStoreCheck{name: "x", paths: []string{tmp}}, "missing"},
-		{"unreadable", doctorStoreCheck{name: "x", paths: []string{unreadable}}, "unreadable"},
+		// Its own directory: a root holding a locked subdirectory is reported
+		// as denied now, which is the point of #802 and not what this case is
+		// about.
+		{"empty", doctorStoreCheck{name: "x", paths: []string{t.TempDir()}}, "missing"},
+		{"denied", doctorStoreCheck{name: "x", paths: []string{unreadable}}, "denied"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Two depths, same cause — deja is not allowed to read the store:

```
before (root 000):    warning  codex store cannot be read — its format may have changed; please report it
before (subdir 000):  (nothing; `codex found … (0 files)`)
after (both):         warning  codex store cannot be read — permission denied on /tmp/p6/.codex/sessions;
                               check its permissions (on macOS, also Full Disk Access for your terminal)
```

Ordinary states: a root-owned directory, a restored backup with wrong ownership, a store under `~/Library/Application Support` without Full Disk Access. The file collectors swallow `EACCES`, so the empty-files case now probes the store roots — skipping aider's root, which is $HOME itself, so a locked directory anywhere in home is not blamed on it. Closes #802.