### PR TITLE
fix: name the cause when a borrowed title cannot be cleared

### DIFF
--- a/cmd/deja/forget_failure_cause_test.go
+++ b/cmd/deja/forget_failure_cause_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The advice line named permissions unconditionally, so on a full disk it sent
+// the reader to chmod a file that was already writable (#808).
+func TestForgetNamesTheCauseItCouldNotClearTheTitle(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"permission", fs.ErrPermission, "fix that file's permissions"},
+		{"no space", syscall.ENOSPC, "free some space on that filesystem"},
+		{"anything else", errors.New("i/o error"), "clear the problem above"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := forgetTitleFix(tc.err); got != tc.want {
+				t.Errorf("fix = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A failed rewrite must not damage the notes file. The leftover temp file the
+// same failure used to leave behind needs a full filesystem to reproduce, so
+// it is verified by hand rather than here (#808).
+func TestForgetPromotedTitlesKeepsTheNotesFileOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	notes := filepath.Join(dir, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	line := `{"kind":"promoted","session":"claude:s1","project":"p","title":"acme yard job","text":"t","src":"claude","state":"accepted","ts":"2026-07-01T10:00:00Z"}`
+	if err := os.WriteFile(notes, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A directory in the temp file's place: the write cannot succeed.
+	if err := os.Mkdir(notes+".tmp", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sources.ForgetPromotedTitles(func(src string) bool { return src == "claude:s1" }); err == nil {
+		t.Fatal("the rewrite reported success")
+	}
+	after, err := os.ReadFile(notes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(after), "acme yard job") {
+		t.Error("the notes file lost content on a failed rewrite")
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -1360,7 +1361,10 @@ func runForget(dir string, args []string) error {
 			// disk, which is the one thing the privacy command must not do
 			// (#804).
 			fmt.Fprintf(os.Stdout, "could not clear the title borrowed from the forgotten session%s: %v\n", pluralS(len(result.Keys)), err)
-			fmt.Fprintf(os.Stdout, "it is still in %s — fix that file's permissions and run this again\n", sources.NotesFile())
+			// Name the fix by the cause: on a full disk the first version of
+			// this line sent people to chmod a file that was already writable
+			// (#808).
+			fmt.Fprintf(os.Stdout, "it is still in %s — %s and run this again\n", sources.NotesFile(), forgetTitleFix(err))
 		case n > 0:
 			fmt.Fprintf(os.Stdout, "cleared the borrowed title from %d promoted note%s\n", n, pluralS(n))
 		}
@@ -1565,6 +1569,19 @@ func noAgentHistoryFound() bool {
 		}
 	}
 	return true
+}
+
+// forgetTitleFix names the fix by the cause. The first version of this line
+// said "permissions" whatever had happened, so a full disk sent the reader to
+// chmod a file that was already writable (#808).
+func forgetTitleFix(err error) string {
+	switch {
+	case errors.Is(err, fs.ErrPermission):
+		return "fix that file's permissions"
+	case errors.Is(err, syscall.ENOSPC):
+		return "free some space on that filesystem"
+	}
+	return "clear the problem above"
 }
 
 // ensureError turns an index-build failure into something a reader can act on.

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -394,6 +394,9 @@ func ForgetPromotedTitles(match func(session string) bool) (int, error) {
 	}
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, []byte(strings.Join(lines, "\n")), 0o600); err != nil {
+		// A rewrite that ran out of room left its temp file behind, on the
+		// filesystem that just filled up (#808).
+		_ = os.Remove(tmp)
 		return 0, err
 	}
 	if err := os.Rename(tmp, path); err != nil {


### PR DESCRIPTION
Measured on a full filesystem (2 MB ram disk, 532 KB of notes, 150 KB free):

```
before: could not clear the title …: write …/notes.jsonl.tmp: no space left on device
        it is still in …/notes.jsonl — fix that file's permissions and run this again
        $ ls → notes.jsonl.tmp (0 bytes, left behind)
after:  it is still in …/notes.jsonl — free some space on that filesystem and run this again
        $ ls → no temp file
```

Both are mine from #804/#666. The good half of the same run: `notes.jsonl` came through untouched — 2002 lines, none malformed — so temp+rename holds under ENOSPC. Closes #808.