### PR TITLE
fix: keep the tombstone until unforget's rebuild succeeds

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1301,20 +1301,17 @@ func runForget(dir string, args []string) error {
 		return nil
 	}
 	if unforget != "" {
-		lifted, err := index.Unforget(unforget)
-		if err != nil {
+		var lifted int
+		if err := withBuildProgress(func() error {
+			var err error
+			lifted, err = index.Unforget(dir, unforget, os.Stderr)
+			return err
+		}); err != nil {
 			return err
 		}
 		if lifted == 0 {
 			fmt.Fprintf(os.Stdout, "no tombstone matches %q — `deja forget --list` shows what is forgotten\n", unforget)
 			return nil
-		}
-		// The transcript on disk has not changed since it was indexed, so the
-		// incremental pass skips it and the session stays invisible — which is
-		// every ordinary run of `deja index` (#672). Rebuild here instead, so
-		// the command that says "restored" has actually restored something.
-		if err := withBuildProgress(func() error { return index.Ensure(dir, "", true, os.Stderr) }); err != nil {
-			return err
 		}
 		fmt.Fprintf(os.Stdout, "restored %d session%s and rebuilt the index\n", lifted, pluralS(lifted))
 		return nil

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -3,6 +3,7 @@ package index
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -325,7 +326,14 @@ func Tombstones() []string {
 // Unforget lifts tombstones and reports how many it lifted. The count is not
 // bookkeeping: the command printed nothing at all, so "restored one session"
 // and "that prefix matched nothing" looked identical (#672).
-func Unforget(prefix string) (int, error) {
+// Unforget lifts the tombstones matching prefix and rebuilds so the sessions
+// come back. The rebuild runs first and the reduced tombstone set is persisted
+// only once it succeeds: interrupted the other way round, the tombstone that
+// would let a retry work was already gone while the index had not been rebuilt
+// yet, and nothing on the machine could say the session was missing (#810).
+// A crash in the remaining window leaves the session present but still listed
+// by `forget --list`, which is visible and fixed by running unforget again.
+func Unforget(dir, prefix string, progress io.Writer) (int, error) {
 	set := readTombstones()
 	// A prefix containing ':' is a key/harness-scoped prefix (claude:abc,
 	// z:); a bare prefix is an id-prefix symmetric with forget --session, so
@@ -351,7 +359,31 @@ func Unforget(prefix string) (int, error) {
 	if lifted == 0 {
 		return 0, nil
 	}
-	return lifted, writeTombstones(set)
+	// The transcript on disk has not changed since it was indexed, so an
+	// incremental pass would skip it and the session would stay invisible
+	// (#672) — hence a full rebuild, with the lifted tombstones already gone
+	// from the set this pass applies.
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	unlock, err := lockDir(dir)
+	if err != nil {
+		return 0, err
+	}
+	defer unlock()
+	if err := rebuildWithTombstones(dir, "", "", currentFiles(""), progress, set); err != nil {
+		return 0, err
+	}
+	if err := writeTombstones(set); err != nil {
+		return lifted, err
+	}
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	_ = writeTombstoneMirrorAt(dir, keys)
+	return lifted, nil
 }
 
 func RedactionReport(dir string) (RedactionStats, error) { return Redactions(dir) }

--- a/internal/index/privacy_test.go
+++ b/internal/index/privacy_test.go
@@ -58,7 +58,7 @@ func TestForgetTombstoneLifecycle(t *testing.T) {
 	if got := Tombstones(); len(got) != 1 || got[0] != "claude:abc123" {
 		t.Fatalf("tombstones=%v", got)
 	}
-	if _, err := Unforget("abc123"); err != nil {
+	if _, err := Unforget("", "abc123", nil); err != nil {
 		t.Fatal(err)
 	}
 	if len(Tombstones()) != 0 {
@@ -114,13 +114,13 @@ func TestTombstonePersistenceAndForgetNoop(t *testing.T) {
 	if got := Tombstones(); len(got) != 2 || got[0] != "a:first" || got[1] != "z:last" {
 		t.Fatalf("tombstones=%v", got)
 	}
-	if _, err := Unforget("first"); err != nil {
+	if _, err := Unforget("", "first", nil); err != nil {
 		t.Fatal(err)
 	}
 	if got := Tombstones(); len(got) != 1 || got[0] != "z:last" {
 		t.Fatalf("after suffix unforget=%v", got)
 	}
-	if _, err := Unforget("z:"); err != nil {
+	if _, err := Unforget("", "z:", nil); err != nil {
 		t.Fatal(err)
 	}
 	if len(Tombstones()) != 0 {
@@ -207,21 +207,21 @@ func TestUnforgetDoesNotOverMatchHarness(t *testing.T) {
 		t.Fatal(err)
 	}
 	// A bare "c" is an id-prefix: it must NOT resurrect whole harnesses.
-	if _, err := Unforget("c"); err != nil {
+	if _, err := Unforget("", "c", nil); err != nil {
 		t.Fatal(err)
 	}
 	if got := len(Tombstones()); got != 3 {
 		t.Fatalf("bare prefix c wrongly matched harnesses: %v", Tombstones())
 	}
 	// An id-prefix that really matches an id works.
-	if _, err := Unforget("ab"); err != nil {
+	if _, err := Unforget("", "ab", nil); err != nil {
 		t.Fatal(err)
 	}
 	if got := len(Tombstones()); got != 1 {
 		t.Fatalf("id-prefix ab: %v", Tombstones())
 	}
 	// A harness-scoped prefix still works.
-	if _, err := Unforget("cursor:"); err != nil {
+	if _, err := Unforget("", "cursor:", nil); err != nil {
 		t.Fatal(err)
 	}
 	if len(Tombstones()) != 0 {
@@ -238,10 +238,10 @@ func TestUnforgetReportsHowManyItLifted(t *testing.T) {
 	if err := writeTombstones(map[string]bool{"claude:a1": true, "claude:a2": true, "cursor:b1": true}); err != nil {
 		t.Fatal(err)
 	}
-	if n, err := Unforget("claude:"); err != nil || n != 2 {
+	if n, err := Unforget("", "claude:", nil); err != nil || n != 2 {
 		t.Fatalf("lifted %d err=%v, want 2", n, err)
 	}
-	if n, err := Unforget("claude:"); err != nil || n != 0 {
+	if n, err := Unforget("", "claude:", nil); err != nil || n != 0 {
 		t.Fatalf("second run lifted %d err=%v, want 0", n, err)
 	}
 	// A prefix that matches nothing must not rewrite the file: on a crash
@@ -251,7 +251,7 @@ func TestUnforgetReportsHowManyItLifted(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if n, err := Unforget("nosuch"); err != nil || n != 0 {
+	if n, err := Unforget("", "nosuch", nil); err != nil || n != 0 {
 		t.Fatalf("a prefix matching nothing lifted %d err=%v", n, err)
 	}
 	after, err := os.Stat(tombstonePath())

--- a/internal/index/unforget_order_test.go
+++ b/internal/index/unforget_order_test.go
@@ -1,0 +1,77 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func contains(keys []string, want string) bool {
+	for _, k := range keys {
+		if k == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Interrupted the other way round, the tombstone that would let a retry work
+// was already gone while the index had not been rebuilt yet, and nothing on
+// the machine could say the session was missing (#810).
+func TestUnforgetKeepsTheTombstoneUntilTheRebuildSucceeds(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	root, dir := allHarnessEnv(t)
+	write(t, filepath.Join(root, "claude", "-tmp-p", "s.jsonl"),
+		claudeLine("s1", "2026-01-02T03:04:05Z", "manneedle here"))
+	o := search.Options{Query: "manneedle", All: true}
+	if err := EnsureForSearch(dir, o, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Forget(dir, ForgetOptions{Session: "s1"}); err != nil {
+		t.Fatal(err)
+	}
+	if !contains(Tombstones(), "claude:s1") {
+		t.Fatalf("tombstones = %v, want the forgotten session", Tombstones())
+	}
+
+	// A rebuild that cannot finish. The parent, not the index directory
+	// itself: a rebuild recreates that directory, so locking it changes
+	// nothing.
+	parent := filepath.Dir(dir)
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	restore := func() { _ = os.Chmod(parent, 0o700) }
+	defer restore()
+	if _, err := Unforget(dir, "claude:s1", nil); err == nil {
+		t.Fatal("unforget reported success with an unwritable index")
+	}
+	if !contains(Tombstones(), "claude:s1") {
+		t.Errorf("tombstones = %v after a failed rebuild, want the session still forgotten", Tombstones())
+	}
+	restore()
+
+	// And the retry works, which is the whole point of keeping it.
+	lifted, err := Unforget(dir, "claude:s1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lifted != 1 {
+		t.Errorf("lifted = %d, want 1", lifted)
+	}
+	if contains(Tombstones(), "claude:s1") {
+		t.Errorf("tombstones = %v after a successful unforget, want it gone", Tombstones())
+	}
+	hits, err := Search(dir, o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Error("the restored session is not searchable")
+	}
+}


### PR DESCRIPTION
Kill `deja forget --unforget` 60 ms in, during the rebuild it triggers:

```
before: forget --list → empty          # deja believes nothing is forgotten
        deja "session 101 …"  → not found
        deja index && deja stats → Sessions 400   # incremental has nothing to do
        deja doctor → status built                # no complaint
after:  forget --list → claude:p5s102  # still forgotten, visibly
        forget --unforget … → restored 1 session and rebuilt the index
```

The old order wrote the reduced tombstone set first and rebuilt second, so an interrupt left a state nothing could describe and only `index --rebuild` could fix — with nothing suggesting it. `Forget` orders the two the other way on purpose; the same reasoning inverted says the tombstone should outlive the rebuild. Closes #810.