### PR TITLE
fix: a promoted note serves its latest correction first

### DIFF
--- a/cmd/deja/promote_test.go
+++ b/cmd/deja/promote_test.go
@@ -74,8 +74,11 @@ func TestPromoteCorrectionAppends(t *testing.T) {
 	if !strings.HasSuffix(ss[0].Title, "[superseded]") {
 		t.Fatalf("title must carry the latest state, got %q", ss[0].Title)
 	}
-	if len(ss[0].Messages) != 2 || !strings.Contains(ss[0].Messages[1].Text, "[superseded]") {
-		t.Fatalf("messages must keep the full history: %#v", ss[0].Messages)
+	// Full history, latest first: readers take the first messages, and after a
+	// run of corrections that used to serve the oldest answer (#812).
+	if len(ss[0].Messages) != 2 || !strings.Contains(ss[0].Messages[0].Text, "[superseded]") ||
+		!strings.Contains(ss[0].Messages[1].Text, "[accepted]") {
+		t.Fatalf("messages must keep the full history, newest first: %#v", ss[0].Messages)
 	}
 }
 

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -170,7 +170,15 @@ func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error
 		return nil, err
 	}
 	out := make([]model.Session, 0, len(byDay))
-	for _, s := range byDay {
+	for key, s := range byDay {
+		// A promoted note's corrections append, so file order serves the
+		// oldest one first — and every reader takes the first messages. After
+		// a hundred careful corrections the hook handed the agent the first
+		// answer as fact (#812). Newest first: the latest correction is what
+		// holds, which is what the title already says.
+		if strings.HasPrefix(key, "promoted\x00") && len(s.Messages) > 1 {
+			reverseMessages(s.Messages)
+		}
 		out = append(out, *s)
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -180,6 +188,12 @@ func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error
 		return out[i].Project < out[j].Project
 	})
 	return out, nil
+}
+
+func reverseMessages(ms []model.Message) {
+	for i, j := 0, len(ms)-1; i < j; i, j = i+1, j-1 {
+		ms[i], ms[j] = ms[j], ms[i]
+	}
 }
 
 // NoteStates are the lifecycle states a promoted note may carry.

--- a/internal/sources/notes_corrections_test.go
+++ b/internal/sources/notes_corrections_test.go
@@ -1,0 +1,89 @@
+package sources
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Corrections append, so file order served the oldest one first — and every
+// reader takes the first messages. After a hundred careful corrections the
+// hook handed the agent the first answer as fact (#812).
+func TestPromotedNoteServesTheLatestCorrectionFirst(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	base := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	var lines []string
+	for i := 1; i <= 5; i++ {
+		row := map[string]any{
+			"kind": "promoted", "session": "claude:c1", "project": "p/proj",
+			"title": "davit setpoint", "text": "correction " + strconv.Itoa(i),
+			"src": "claude", "state": "accepted",
+			"ts": base.Add(time.Duration(i) * time.Minute).Format(time.RFC3339Nano),
+		}
+		b, err := json.Marshal(row)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines = append(lines, string(b))
+	}
+	// A plain note in the same file keeps its own order: it is a day's log,
+	// not a decision superseded by the next line.
+	plain, err := json.Marshal(map[string]any{
+		"text": "plain first", "src": "claude", "project": "p/proj",
+		"ts": base.Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plain2, err := json.Marshal(map[string]any{
+		"text": "plain second", "src": "claude", "project": "p/proj",
+		"ts": base.Add(time.Hour).Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines = append(lines, string(plain), string(plain2))
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ss, err := ParseNotesFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var note, log *sessionRef
+	for i := range ss {
+		if strings.HasPrefix(ss[i].ID, "deja-note-") {
+			note = &sessionRef{ss[i].ID, ss[i].Messages}
+		} else {
+			log = &sessionRef{ss[i].ID, ss[i].Messages}
+		}
+	}
+	if note == nil || len(note.msgs) != 5 {
+		t.Fatalf("promoted note: %+v", note)
+	}
+	if !strings.Contains(note.msgs[0].Text, "correction 5") {
+		t.Errorf("first message is %q, want the latest correction", note.msgs[0].Text)
+	}
+	if !strings.Contains(note.msgs[4].Text, "correction 1") {
+		t.Errorf("last message is %q, want the first correction", note.msgs[4].Text)
+	}
+	if log == nil || len(log.msgs) != 2 {
+		t.Fatalf("plain notes: %+v", log)
+	}
+	if !strings.Contains(log.msgs[0].Text, "plain first") {
+		t.Errorf("plain notes were reordered: %q", log.msgs[0].Text)
+	}
+}
+
+type sessionRef struct {
+	id   string
+	msgs []model.Message
+}


### PR DESCRIPTION
One session, 100 corrections, each superseding the last (truth: 200 bar):

```
before: hook-prompt → [accepted] correction 1: setpoint is 101 bar
        search      → corrections 2, 4, 5
after:  hook-prompt → [accepted] correction 100: setpoint is 200 bar
        search      → corrections 99, 97, 96
```

`promote` tells people corrections append, and the title already tracks the latest state — the body did not, so the more carefully someone maintained a note, the more confidently deja served its oldest version. Plain day-log notes keep their own order; only promoted notes reverse. Closes #812.