### PR TITLE
fix: count a promoted note that has no source session

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -713,7 +713,10 @@ func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 	sort.Strings(names)
 	for _, h := range names {
 		e := health[h]
-		fmt.Fprintf(w, "  ingest   %s: %d malformed lines skipped, %d files failed — see `deja doctor --json`\n", h, e.MalformedLines, e.FailedFiles)
+		// "malformed" covered only unparseable lines; valid JSON deja cannot
+		// use is skipped just as invisibly, and the reader needs the same
+		// warning either way (#814).
+		fmt.Fprintf(w, "  ingest   %s: %d unusable lines skipped, %d files failed — see `deja doctor --json`\n", h, e.MalformedLines, e.FailedFiles)
 	}
 }
 

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -128,6 +128,11 @@ func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error
 			state, _ := m["state"].(string)
 			title, _ := m["title"].(string)
 			if src == "" {
+				// Valid JSON deja cannot use: a promoted note has nothing to
+				// attach to without its source session. Dropping it is right,
+				// counting it as dropped is the part that was missing — the
+				// line vanished with no trace anywhere (#814).
+				diagMalformedLine(path)
 				return
 			}
 			// Older promoted notes carry no state; the state is how the note is

--- a/internal/sources/notes_compat_test.go
+++ b/internal/sources/notes_compat_test.go
@@ -47,6 +47,13 @@ func TestParseNotesKeepsOlderShapes(t *testing.T) {
 			t.Errorf("kept %q, which has nothing to attach to", unwanted)
 		}
 	}
+	// Dropping it is right; dropping it invisibly is not. A promoted line with
+	// no source used to leave no trace at all — not in the index, not in the
+	// skipped count (#814).
+	malformed, _ := DiagSnapshot()
+	if malformed[path] == 0 {
+		t.Errorf("a promoted note with no source was dropped without being counted")
+	}
 	// A note with no project is filed under one rather than losing its home.
 	var found bool
 	for _, s := range ss {


### PR DESCRIPTION
A hand-written `kind:"promoted"` line with text but no `session`:

```
before: deja index → notes: 2 sessions, 4 messages
        deja doctor → ingest deja: 2 malformed lines skipped
        (the line is in neither number, and nowhere else)
after:  deja doctor → ingest deja: 3 unusable lines skipped, 0 files failed
```

Dropping it stays right — a promoted note has nothing to attach to without its source, which is what the test from #771 says. What was missing is that it left no trace at all, and the diagnostics comment is explicit that "not found because it never happened" and "not found because ingestion skipped it" must not look identical. The doctor line now says "unusable" rather than "malformed", since valid JSON deja cannot use is skipped just as invisibly. Closes #814.