### PR TITLE
fix: report a store that is only partly readable

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -279,8 +279,14 @@ func printDoctorStoreWarnings(w io.Writer, stores []doctorStore) {
 		case "denied":
 			// Not a format change and not an empty history: deja is not
 			// allowed to read the files. On macOS this is usually Full Disk
-			// Access rather than the file mode (#802).
-			fmt.Fprintf(w, "  warning      %s store cannot be read — permission denied on %s; check its permissions (on macOS, also Full Disk Access for your terminal)\n", store.Name, store.Denied)
+			// Access rather than the file mode (#802). A store that is only
+			// partly unreadable loses sessions from recall while looking whole
+			// everywhere else, so it says which half it is (#816).
+			what := "store cannot be read"
+			if store.Partial {
+				what = "store is only partly readable — some sessions are missing from recall"
+			}
+			fmt.Fprintf(w, "  warning      %s %s — permission denied on %s; check its permissions (on macOS, also Full Disk Access for your terminal)\n", store.Name, what, store.Denied)
 		case "needs-sqlite3":
 			// Not a format change: the parser could not run at all. Saying so
 			// points at installing one package instead of at a bug report

--- a/cmd/deja/doctor_denied_test.go
+++ b/cmd/deja/doctor_denied_test.go
@@ -49,6 +49,23 @@ func TestDoctorSeparatesADeniedStoreFromAChangedFormat(t *testing.T) {
 		t.Errorf("a permission problem is still reported as a format change:\n%s", got)
 	}
 
+	// Some files readable, one directory not: the store is only partly
+	// readable, which is quieter than losing it all — sessions disappear from
+	// recall while everything else looks whole (#816).
+	readable := filepath.Join(root, "seen.jsonl")
+	if err := os.WriteFile(readable, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	partial, _ := inspectDoctorStore(doctorStoreCheck{name: "codex", paths: []string{root}, files: []string{readable}, parse: nil})
+	if partial.State != "denied" || !partial.Partial {
+		t.Fatalf("state = %q partial = %v, want denied and partial", partial.State, partial.Partial)
+	}
+	var partialOut strings.Builder
+	printDoctorStoreWarnings(&partialOut, []doctorStore{partial})
+	if !strings.Contains(partialOut.String(), "only partly readable") {
+		t.Errorf("the partial case does not say so:\n%s", partialOut.String())
+	}
+
 	// A readable store with nothing in it stays quiet: "no history" is not a
 	// problem to warn about.
 	empty := filepath.Join(root, "empty")

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -24,8 +24,11 @@ type doctorStore struct {
 	Paths []string `json:"paths"`
 	Files int      `json:"files"`
 	// Denied names the path that refused to be read, so the warning can point
-	// at the directory to fix rather than at the harness (#802).
-	Denied string `json:"denied,omitempty"`
+	// at the directory to fix rather than at the harness (#802). Partial says
+	// the rest of the store was readable: sessions are missing from recall
+	// rather than the whole harness (#816).
+	Denied  string `json:"denied,omitempty"`
+	Partial bool   `json:"partial,omitempty"`
 }
 
 type doctorComponent struct {
@@ -246,14 +249,17 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 			}
 		}
 	}
+	// The file collectors swallow EACCES, so a locked directory silently takes
+	// its sessions out of recall. With no files at all that read as a harness
+	// nobody has used (#802); with some files it read as a complete store
+	// missing a few, which is quieter still (#816).
+	if denied := firstDeniedDir(check.paths); denied != "" {
+		store.State = "denied"
+		store.Denied = denied
+		store.Partial = len(check.files) > 0
+		return store, time.Time{}
+	}
 	if len(check.files) == 0 {
-		// The file collectors swallow EACCES, so a readable root with a
-		// locked subdirectory produced "found (0 files)" — the same answer as
-		// a harness nobody has used (#802).
-		if denied := firstDeniedDir(check.paths); denied != "" {
-			store.State = "denied"
-			store.Denied = denied
-		}
 		return store, time.Time{}
 	}
 	newest, mod := newestDoctorFile(check.files)

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -107,7 +107,10 @@ func TestDoctorStoreStates(t *testing.T) {
 		})
 	}
 
-	file := filepath.Join(tmp, "session.jsonl")
+	// Its own directory: tmp still holds the locked one above, and a store root
+	// containing it is reported as denied now (#816).
+	parseRoot := t.TempDir()
+	file := filepath.Join(parseRoot, "session.jsonl")
 	// The file has to look like a transcript: a store whose newest file holds
 	// no conversation at all is an unused session, not a parse failure.
 	if err := os.WriteFile(file, []byte(`{"type":"user","message":{"role":"user","content":"hi"}}`+"\n"), 0o600); err != nil {
@@ -122,7 +125,7 @@ func TestDoctorStoreStates(t *testing.T) {
 		{"parsed-zero", func(string) ([]model.Session, error) { return nil, nil }, "parsed-zero"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, _ := inspectDoctorStore(doctorStoreCheck{name: "x", paths: []string{tmp}, files: []string{file}, parse: tc.parse})
+			got, _ := inspectDoctorStore(doctorStoreCheck{name: "x", paths: []string{parseRoot}, files: []string{file}, parse: tc.parse})
 			if got.State != tc.want {
 				t.Fatalf("state = %q, want %q", got.State, tc.want)
 			}


### PR DESCRIPTION
One harness root, one unreadable subdirectory, sessions in both:

```
before: deja index → claude: 1 session, 1 message   (was 2)
        deja doctor → no warning; claude found … (2 files), was 3
after:  warning  claude store is only partly readable — some sessions are missing from recall —
                 permission denied on …/projects/locked; check its permissions
                 (on macOS, also Full Disk Access for your terminal)
```

#802 covered the all-or-nothing case; the partial one is likelier — one project directory restored with wrong ownership — and quieter, since the only trace was a file count nobody has memorised. Closes #816.