### PR TITLE
fix: index reports a directory it could not read

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -722,7 +722,8 @@ func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 		// "malformed" covered only unparseable lines; valid JSON deja cannot
 		// use is skipped just as invisibly, and the reader needs the same
 		// warning either way (#814).
-		fmt.Fprintf(w, "  ingest   %s: %d unusable lines skipped, %d files failed — see `deja doctor --json`\n", h, e.MalformedLines, e.FailedFiles)
+		fmt.Fprintf(w, "  ingest   %s: %d unusable line%s skipped, %d path%s unreadable — see `deja doctor --json`\n",
+			h, e.MalformedLines, pluralS(e.MalformedLines), e.FailedFiles, pluralS(e.FailedFiles))
 	}
 }
 

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -213,6 +213,17 @@ func cmdIndex(dir string, rest []string) error {
 	// holds them, so one project name covers both. Silence was the worst part
 	// of it: the indexer counted every session on disk while the manifest held
 	// fewer, and nothing connected the two numbers (#698).
+	// A store deja could not read loses its sessions from recall, and the index
+	// run is where someone is looking at the counts — doctor knowing about it
+	// is not the same as saying it here (#818).
+	for _, h := range sortedHarnesses(index.IngestHealth(dir)) {
+		e := index.IngestHealth(dir)[h]
+		if e.FailedFiles == 0 {
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "deja: %s: %d path%s could not be read — `deja doctor` names %s\n",
+			h, e.FailedFiles, pluralS(e.FailedFiles), pluralWhich(e.FailedFiles))
+	}
 	if n := index.ReportCollisions(); n > 0 {
 		fmt.Fprintf(os.Stderr, "deja: %d session%s %s an id with another transcript — each pair is filed under one project, the one whose file sorts first\n", n, pluralS(n), verbShare(n))
 	}
@@ -1579,6 +1590,25 @@ func forgetTitleFix(err error) string {
 		return "free some space on that filesystem"
 	}
 	return "clear the problem above"
+}
+
+// sortedHarnesses orders the ingest-health entries so a run reports them the
+// same way twice.
+func sortedHarnesses(m map[string]index.HarnessIngest) []string {
+	out := make([]string, 0, len(m))
+	for h := range m {
+		out = append(out, h)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// pluralWhich matches the pronoun to the count in the ingest warning.
+func pluralWhich(n int) string {
+	if n == 1 {
+		return "it"
+	}
+	return "them"
 }
 
 // ensureError turns an index-build failure into something a reader can act on.

--- a/internal/index/denied_dir_test.go
+++ b/internal/index/denied_dir_test.go
@@ -1,0 +1,63 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// A directory the process cannot read takes its sessions out of recall, and
+// nothing downstream could attribute it: the walk dropped EACCES, and a
+// diagnostic path with no transcript extension matched no harness (#818).
+func TestUnreadableDirectoryIsAttributedToItsHarness(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	root, dir := allHarnessEnv(t)
+	write(t, filepath.Join(root, "claude", "-tmp-open", "s.jsonl"),
+		claudeLine("s1", "2026-01-02T03:04:05Z", "manneedle here"))
+	locked := filepath.Join(root, "claude", "-tmp-locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(locked, "s.jsonl"),
+		claudeLine("s2", "2026-01-03T03:04:05Z", "manneedle in the locked half"))
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	if err := EnsureForSearch(dir, search.Options{Query: "manneedle", All: true}, true, nil); err != nil {
+		t.Fatal(err)
+	}
+	health := IngestHealth(dir)
+	e, ok := health["claude"]
+	if !ok {
+		t.Fatalf("no ingest health for claude: %v", health)
+	}
+	if e.FailedFiles == 0 {
+		t.Errorf("the unreadable directory was not counted: %+v", e)
+	}
+	if e.LastError == "" {
+		t.Errorf("no error text recorded: %+v", e)
+	}
+}
+
+// The mapping a directory needs: transcript matchers reject it, so what a
+// transcript inside it would be is the question that answers.
+func TestHarnessForPathHandlesDirectories(t *testing.T) {
+	root, _ := allHarnessEnv(t)
+	claudeDir := filepath.Join(root, "claude", "-tmp-p")
+	if got := harnessForPath(claudeDir); got == "" {
+		t.Errorf("a directory under the claude root mapped to no harness")
+	}
+	if got := harnessForPath(filepath.Join(claudeDir, "s.jsonl")); got == "" {
+		t.Errorf("a transcript under the claude root mapped to no harness")
+	}
+	if got := harnessForPath(filepath.Join(t.TempDir(), "elsewhere")); got != "" {
+		t.Errorf("an unrelated directory mapped to %q", got)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1657,7 +1657,24 @@ func parseAppendedFile(harness, p string, old FileState) (ss []model.Session, er
 
 // harnessForPath reports the fine-grained source kind for a path (claude,
 // codex-history, cursor-db, ...) via the sources registry, or "" if none.
-func harnessForPath(p string) string { return sources.KindForPath(p) }
+// harnessForPath maps an ingest-diagnostic path to the harness it belongs to.
+// A directory has no transcript extension, so the matchers reject it outright;
+// asking what a transcript inside it would be is the same question the walk
+// was already answering (#818).
+func harnessForPath(p string) string {
+	if h := sources.KindForPath(p); h != "" {
+		return h
+	}
+	if filepath.Ext(p) != "" {
+		return ""
+	}
+	for _, name := range []string{"probe.jsonl", "probe.json", "probe.md"} {
+		if h := sources.KindForPath(filepath.Join(p, name)); h != "" {
+			return h
+		}
+	}
+	return ""
+}
 
 func setOpencodeLastUpdated(files map[string]FileState, sessions map[string]SessionMeta) {
 	setStoreLastUpdated(files, sessions, "opencode", sources.OpencodeDB())

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -151,7 +151,17 @@ func scanJSONLFromOffset(path string, offset int64, fn func(map[string]any)) err
 func walkFiles(root string, pred func(string) bool) []string {
 	var out []string
 	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
-		if err == nil && d.Type()&os.ModeSymlink == 0 && !d.IsDir() && pred(p) {
+		if err != nil {
+			// A directory the process cannot read takes its sessions out of
+			// recall. Dropping the error here left the index run with nothing
+			// to say: the only sign was a file count nobody has memorised
+			// (#816, and the ingest half of it #818).
+			if os.IsPermission(err) {
+				diagFileError(p, err)
+			}
+			return nil
+		}
+		if d.Type()&os.ModeSymlink == 0 && !d.IsDir() && pred(p) {
 			out = append(out, p)
 		}
 		return nil


### PR DESCRIPTION
```
before: deja index → claude: 1 session, 1 message        (was 2, nothing else said)
after:  deja index → claude: 1 session, 1 message
                     claude: 1 path could not be read — `deja doctor` names it
        deja doctor → ingest claude: 0 unusable lines skipped, 1 path unreadable
```

`walkFiles` dropped `EACCES` so nothing downstream could attribute it, and `harnessForPath` ran diagnostic paths through the transcript matchers, which reject a directory — asking what a transcript inside it would be is the same question the walk was already answering. Doctor's line also said "1 files failed". Closes #818.