### PR TITLE
fix: show names the missing id before the missing flag

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -346,6 +346,11 @@ func parseShow(args []string) (showOptions, error) {
 			o.id = a
 		}
 	}
+	// The id first: it is what the command is for, and checking the flag ahead
+	// of it cost two runs to learn two missing things (#820).
+	if o.id == "" {
+		return o, fmt.Errorf("show needs id-prefix")
+	}
 	if o.json && o.harness == "" {
 		return o, fmt.Errorf("show --json requires --harness for exact identity")
 	}

--- a/cmd/deja/show_argorder_test.go
+++ b/cmd/deja/show_argorder_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Checking the flag ahead of the argument cost two runs to learn two missing
+// things, in the order deja checks them rather than the order the command
+// reads (#820).
+func TestShowNamesTheMissingIdBeforeTheMissingFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"nothing at all", []string{}, "show needs id-prefix"},
+		{"json without an id", []string{"--json"}, "show needs id-prefix"},
+		{"json with an id", []string{"--json", "s1"}, "requires --harness"},
+		{"harness but no id", []string{"--json", "--harness", "claude"}, "show needs id-prefix"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseShow(tc.args)
+			if err == nil {
+				t.Fatalf("parseShow(%v) returned no error", tc.args)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("parseShow(%v) = %v, want %q", tc.args, err, tc.want)
+			}
+		})
+	}
+
+	// A complete invocation still parses.
+	o, err := parseShow([]string{"--json", "--harness", "claude", "s1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.id != "s1" || o.harness != "claude" || !o.json {
+		t.Errorf("parsed = %+v", o)
+	}
+}


### PR DESCRIPTION
```
before: deja show --json                        → show --json requires --harness for exact identity
        deja show --json --harness claude       → show needs id-prefix
after:  deja show --json                        → show needs id-prefix
        deja show --json s1                     → show --json requires --harness for exact identity
```

The id-prefix is what the command is for, and `files`, `restore` and `blame` each name their argument first. Closes #820.