### PR TITLE
fix: name the rebuild window instead of the missing manifest

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -27,10 +27,27 @@ func main() {
 	stopProfiling := startProfiling()
 	if err := run(os.Args[1:]); err != nil {
 		stopProfiling()
-		fmt.Fprintln(os.Stderr, "deja:", err)
+		fmt.Fprintln(os.Stderr, "deja:", rebuildWindowError(err))
 		os.Exit(1)
 	}
 	stopProfiling()
+}
+
+// rebuildInProgress is a seam: a test can put the process in the window
+// without racing a real rebuild.
+var rebuildInProgress = index.RebuildInProgress
+
+// rebuildWindowError names the one state that looks like a broken store and is
+// not: a rebuild recreates the index directory, and a reader that lands in that
+// window gets `open …/manifest.gob: no such file or directory` (#822).
+func rebuildWindowError(err error) error {
+	if !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	if !rebuildInProgress(index.DefaultDir()) {
+		return err
+	}
+	return fmt.Errorf("the index is being rebuilt right now — run this again in a moment")
 }
 
 func loadAll(h string) []model.Session {

--- a/cmd/deja/rebuild_window_test.go
+++ b/cmd/deja/rebuild_window_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A rebuild recreates the index directory, so a reader can land in a window
+// where the manifest does not exist and get the syscall for it — a moment
+// mistaken for a broken store (#822).
+func TestRebuildWindowErrorNamesTheRebuild(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	missing := &fs.PathError{Op: "open", Path: filepath.Join(dir, "manifest.gob"), Err: fs.ErrNotExist}
+
+	// Nobody holding the lock: the error is what it says it is.
+	if got := rebuildWindowError(missing); got != error(missing) {
+		t.Errorf("with no rebuild running: %v", got)
+	}
+
+	// A rebuild running: the same error is that window.
+	old := rebuildInProgress
+	rebuildInProgress = func(string) bool { return true }
+	got := rebuildWindowError(missing)
+	if !strings.Contains(got.Error(), "being rebuilt") {
+		t.Errorf("during a rebuild: %v", got)
+	}
+	if strings.Contains(got.Error(), "manifest.gob") {
+		t.Errorf("the internal file is still named: %v", got)
+	}
+
+	// Any other failure passes through untouched — including while a rebuild
+	// is running, which is the case that catches a check on the wrong half.
+	other := errors.New("i/o error")
+	rebuildInProgress = func(string) bool { return true }
+	defer func() { rebuildInProgress = old }()
+	if got := rebuildWindowError(other); got != other {
+		t.Errorf("an unrelated error was rewritten during a rebuild: %v", got)
+	}
+}

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -185,6 +185,25 @@ func Damaged(dir string) bool {
 	return !recordsIntact(dir, m)
 }
 
+// RebuildInProgress reports whether another process holds the index lock. A
+// rebuild recreates the directory, so a reader can land in a window where the
+// manifest does not exist and get the syscall for it — a moment mistaken for a
+// broken store (#822).
+func RebuildInProgress(dir string) bool {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	unlock, ok, err := tryLockDir(dir)
+	if err != nil {
+		return false
+	}
+	if ok {
+		unlock()
+		return false
+	}
+	return true
+}
+
 // OverviewStats is what the brief needs about a whole store.
 type OverviewStats struct {
 	Sessions      int

--- a/internal/index/rebuild_progress_test.go
+++ b/internal/index/rebuild_progress_test.go
@@ -1,0 +1,25 @@
+package index
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The predicate behind the one state that looks like a broken store and is
+// not: a rebuild holds the lock while it recreates the directory (#822).
+func TestRebuildInProgressFollowsTheLock(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	if RebuildInProgress(dir) {
+		t.Error("an idle index reports a rebuild")
+	}
+	unlock, err := lockDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Held by this process: flock is per-process, so the probe sees it free.
+	// What matters is that releasing and re-taking works and nothing panics.
+	unlock()
+	if RebuildInProgress(dir) {
+		t.Error("a released lock still reports a rebuild")
+	}
+}


### PR DESCRIPTION
`deja index --rebuild` in one terminal, `deja show` in another — one run in ten landed in the window where the directory is being recreated:

```
before: deja: open /tmp/q4/idx/manifest.gob: no such file or directory
after:  deja: the index is being rebuilt right now — run this again in a moment
```

Reproduced deterministically by holding the index lock and removing the manifest. Not a case for blocking: `FindByPrefix` takes the lock non-blocking on purpose, because a hook that waits out a twelve-second rebuild is worse than one that says nothing. Only a missing file *while the lock is held* is rewritten; every other error passes through. Closes #822.