### PR TITLE
fix: index says when there is nothing to do

### DIFF
--- a/cmd/deja/index_uptodate_test.go
+++ b/cmd/deja/index_uptodate_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Silence reads as "it did not run". `update` on the newest release and
+// `doctor` on a fresh index both say so; this one returned to the prompt with
+// nothing (#824).
+func TestIndexSaysWhenThereIsNothingToDo(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"rudder trunk seal"},"timestamp":"2026-07-04T10:00:00Z","sessionId":"u9","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "a.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := captureRunStderr(t, "index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(first, "up to date") {
+		t.Errorf("the first build claimed there was nothing to do:\n%s", first)
+	}
+
+	second, err := captureRunStderr(t, "index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(second, "up to date") {
+		t.Errorf("a no-op run said nothing:\n%s", second)
+	}
+
+	// --rebuild is explicit work, never "nothing to do".
+	forced, err := captureRunStderr(t, "index", "--rebuild")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(forced, "up to date") {
+		t.Errorf("--rebuild reported nothing to do:\n%s", forced)
+	}
+
+	// And the line belongs to `index` alone: a search that finds the index
+	// fresh must not narrate it.
+	found, err := captureRunStderr(t, "--all", "rudder")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(found, "up to date") {
+		t.Errorf("a search narrated the index state:\n%s", found)
+	}
+
+	if fresh, n := index.UpToDate(indexDirForTest(), ""); !fresh || n == 0 {
+		t.Errorf("UpToDate = %v, %d", fresh, n)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -213,6 +213,13 @@ func cmdIndex(dir string, rest []string) error {
 		}
 		return fmt.Errorf("index: unknown flag %q", a)
 	}
+	// Silence reads as "it did not run". `update` on the newest release and
+	// `doctor` on a fresh index both say so; this one returned to the prompt
+	// with nothing (#824). Only here: on a search the same line would be noise.
+	if fresh, n := index.UpToDate(dir, ""); fresh && !force {
+		fmt.Fprintf(os.Stderr, "deja: index is up to date (%d session%s)\n", n, pluralS(n))
+		return nil
+	}
 	prepareFirstIndexGreeting(dir)
 	// The detached warmup publishes its progress so hooks can tell the user
 	// memory is on its way; an interactive run draws the live display.

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -101,6 +101,28 @@ func mergeIngestDiag(m *Manifest) {
 	}
 }
 
+// UpToDate reports whether Ensure would do nothing, and how many sessions the
+// index holds. Only `deja index` asks: silence reads as "it did not run", but
+// saying it on every search would be noise on a line nobody asked about (#824).
+func UpToDate(dir string, harness string) (bool, int) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	prior, err := readManifest(dir)
+	if err != nil {
+		return false, 0
+	}
+	want := currentFilesReusing(harness, priorFiles(prior, err))
+	scope := ""
+	if harness != "" {
+		scope = harness
+	}
+	if !manifestFresh(prior, want, scope) || !recordsIntact(dir, prior) {
+		return false, len(prior.Sessions)
+	}
+	return true, len(prior.Sessions)
+}
+
 func Ensure(dir string, harness string, force bool, progress io.Writer) error {
 	if dir == "" {
 		dir = DefaultDir()


### PR DESCRIPTION
```
before: $ deja index      # store unchanged
        $                 # nothing, exit 0
after:  $ deja index
        deja: index is up to date (9 sessions)
```

`update` on the newest release and `doctor` on a fresh index both say so; `index` returned to the prompt with no output, which reads as "it did not run". `--rebuild` still rebuilds, and the line belongs to `index` alone — a search that finds the index fresh stays quiet. Closes #824.