### PR TITLE
fix: say which words matched on their own when nothing matched together

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/query"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -614,6 +615,27 @@ func printStemmed(w io.Writer, variants map[string][]string) {
 	}
 }
 
+// termCountLine names the terms that do match on their own, so "try fewer
+// words" says which. It stays quiet when every term is already unknown to the
+// store — there is nothing to drop then, and a row of zeroes is noise.
+func termCountLine(dir, q string) string {
+	terms := query.Tokens(q)
+	if len(terms) < 2 || len(terms) > 6 {
+		return ""
+	}
+	counts := index.TermSessionCounts(dir, terms)
+	var parts []string
+	for _, t := range terms {
+		if counts[t] > 0 {
+			parts = append(parts, fmt.Sprintf("%q in %d", t, counts[t]))
+		}
+	}
+	if len(parts) == 0 || len(parts) == len(terms) && len(terms) > 3 {
+		return ""
+	}
+	return fmt.Sprintf("deja: on their own: %s — no session has them together\n", strings.Join(parts, ", "))
+}
+
 // printNoMatches says how big the store actually is, not how many sessions the
 // query happened to load.
 //
@@ -629,6 +651,11 @@ func printNoMatches(w io.Writer, dir, q string) {
 		fmt.Fprintf(w, "deja: no matches in %d indexed session%s — try fewer words or --re (query %q)\n", n, pluralS(n), q)
 	} else {
 		fmt.Fprintf(w, "deja: no matches — try fewer words or --re (query %q)\n", q)
+	}
+	// Which word to drop is the reader's next question, and deja read the
+	// per-term counts to decide there was no intersection (#826).
+	if line := termCountLine(dir, q); line != "" {
+		fmt.Fprint(w, line)
 	}
 	// The first thing anyone types is a guess at a command name, and a wrong
 	// guess falls through to search — where the advice is to use fewer words,

--- a/cmd/deja/term_counts_test.go
+++ b/cmd/deja/term_counts_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// "try fewer words" is right in direction and empty in content: the reader has
+// to guess which of their words to drop, while deja read the per-term counts to
+// decide there was no intersection (#826).
+func TestNoMatchesNamesTheTermsThatMatchAlone(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lines := []string{
+		`{"type":"user","message":{"role":"user","content":"the sewage macerator showed blockage"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"a1","cwd":"/proj"}`,
+		`{"type":"user","message":{"role":"user","content":"the bilge pump impeller was worn"},"timestamp":"2026-07-02T10:00:00Z","sessionId":"a2","cwd":"/proj"}`,
+	}
+	if err := os.WriteFile(filepath.Join(store, "a.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := indexDirForTest()
+	got := termCountLine(dir, "macerator pump")
+	if !strings.Contains(got, `"macerator" in 1`) || !strings.Contains(got, `"pump" in 1`) {
+		t.Errorf("the counts are not named: %q", got)
+	}
+	if !strings.Contains(got, "no session has them together") {
+		t.Errorf("the line does not say what it means: %q", got)
+	}
+
+	// One known word, one not: name the one that can be kept.
+	mixed := termCountLine(dir, "macerator zzzqqq")
+	if !strings.Contains(mixed, `"macerator" in 1`) || strings.Contains(mixed, "zzzqqq") {
+		t.Errorf("mixed query: %q", mixed)
+	}
+
+	// Nothing to drop: every term is unknown, and a row of zeroes is noise.
+	if got := termCountLine(dir, "zzzqqq wwwqqq"); got != "" {
+		t.Errorf("a query of unknown words got a line: %q", got)
+	}
+	// A single term has nothing to intersect with.
+	if got := termCountLine(dir, "macerator"); got != "" {
+		t.Errorf("a one-word query got a line: %q", got)
+	}
+	// And the whole no-match path still prints its own line.
+	out, err := captureRunStderr(t, "macerator", "zzzqqq")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "on their own") {
+		t.Errorf("the counts line did not reach the no-match output:\n%s", out)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1360,6 +1360,30 @@ func postingsFor(dir, tok string) ([]posting, error) {
 	return readBucketToken(filepath.Join(dir, "buckets", bucket(tok)+".bin"), tok)
 }
 
+// TermSessionCounts says how many sessions each term appears in on its own.
+// When an AND query finds no intersection, "try fewer words" is right in
+// direction and empty in content — the reader has to guess which of their words
+// to drop, while deja already read these counts to decide there was none (#826).
+func TermSessionCounts(dir string, terms []string) map[string]int {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	out := make(map[string]int, len(terms))
+	for _, t := range terms {
+		key := "t" + t
+		posts, err := postingsFor(dir, key)
+		if err != nil {
+			continue
+		}
+		seen := map[uint32]bool{}
+		for _, p := range posts {
+			seen[p.Sid] = true
+		}
+		out[t] = len(seen)
+	}
+	return out
+}
+
 func intersectPostings(dir string, keys []string) ([]posting, error) {
 	if len(keys) == 0 {
 		return nil, nil


### PR DESCRIPTION
```
before: deja: no matches in 205 indexed sessions — try fewer words or --re (query "macerator pump")
after:  … + deja: on their own: "macerator" in 10, "pump" in 15 — no session has them together
```

Three or more terms already explain themselves (`no exact match; showing sessions ranked by relevance`, `ignoring "zzzqqq" — no session matches it together with the rest`); two terms got advice with no content. Quiet when every term is unknown to the store — there is nothing to drop then. Closes #826.