### PR TITLE
fix: say when a query has nothing to look up

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -647,6 +647,16 @@ func termCountLine(dir, q string) string {
 // their query missed. It fired on every ordinary miss, so the signature could
 // not be used to recognise the failure it was written for (#637).
 func printNoMatches(w io.Writer, dir, q string) {
+	// Nothing to look up: very short tokens are dropped and punctuation is
+	// trimmed, so this query never reached the index. "Try fewer words"
+	// cannot be followed with one word, or none (#828). The message does not
+	// state the rule — the cut is on bytes, so "л" and "舵" are long enough
+	// while "p" is not, and a rule that reads false to half the world's
+	// alphabets is worse than none.
+	if len(query.Tokens(q)) == 0 {
+		fmt.Fprintf(w, "deja: nothing to search for in %q — every word in it is too short to look up\n", q)
+		return
+	}
 	if n, err := index.SessionCount(dir); err == nil {
 		fmt.Fprintf(w, "deja: no matches in %d indexed session%s — try fewer words or --re (query %q)\n", n, pluralS(n), q)
 	} else {

--- a/cmd/deja/short_query_test.go
+++ b/cmd/deja/short_query_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Very short tokens are dropped and punctuation is trimmed, so these queries
+// never reach the index — and the answer advised using fewer words, of one
+// word or of none (#828).
+func TestQueryWithNothingToLookUpSaysSo(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"the hydraulic pump bearing failed"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"a1","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "a.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, q := range []string{"p", "a b c", "..."} {
+		out, err := captureRunStderr(t, q)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out, "too short to look up") {
+			t.Errorf("%q: %s", q, out)
+		}
+		if strings.Contains(out, "try fewer words") {
+			t.Errorf("%q still advises fewer words:\n%s", q, out)
+		}
+	}
+
+	// A word the store simply does not have keeps the ordinary answer: there
+	// is something to look up, it just is not there.
+	out, err := captureRunStderr(t, "zzzqqq")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "no matches in") {
+		t.Errorf("an unknown word lost the ordinary miss message:\n%s", out)
+	}
+
+	// The cut is on bytes, so a single Cyrillic or CJK character is long
+	// enough — the message must not fire for them.
+	for _, q := range []string{"л", "舵"} {
+		out, err := captureRunStderr(t, q)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(out, "too short to look up") {
+			t.Errorf("%q was treated as too short:\n%s", q, out)
+		}
+	}
+}


### PR DESCRIPTION
```
before: deja p        → no matches in 205 indexed sessions — try fewer words or --re (query "p")
        deja "a b c"  → same
after:  deja p        → nothing to search for in "p" — every word in it is too short to look up
```

Neighbours were already handled: two characters get the close-spelling ladder (`pu -> pump`), an empty argument gets `query required`. The message states what happened rather than the rule, because the cut is on bytes — `л` and `舵` are long enough while `p` is not, and both still search. Closes #828.