### PR TITLE
fix: install names the targets it found

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -36,10 +36,19 @@ func runInstall(dir string, args []string, uninstall bool) error {
 		targetArgs = append(targetArgs, arg)
 	}
 	if len(targetArgs) != 1 {
+		// The first command a new machine runs, so a bare word they have to go
+		// look up is the worst possible answer. Every other command in this
+		// position prints the shape it wants (#830), and this one can do
+		// better still: name the agents actually present here.
+		verb := "install"
 		if uninstall {
-			return fmt.Errorf("uninstall needs target")
+			verb = "uninstall"
 		}
-		return fmt.Errorf("install needs target")
+		if found := existingTargets(); len(found) > 0 {
+			sort.Strings(found)
+			return fmt.Errorf("%s needs a target — found here: %s (or --all, --auto)", verb, strings.Join(found, ", "))
+		}
+		return fmt.Errorf("%s needs a target — no agent config found here; `deja help` lists every target deja knows", verb)
 	}
 	targets := []string{targetArgs[0]}
 	if targetArgs[0] == "--auto" {

--- a/cmd/deja/install_statusline_test.go
+++ b/cmd/deja/install_statusline_test.go
@@ -105,11 +105,11 @@ func TestInstallTargetErrorsAndAliases(t *testing.T) {
 		t.Fatalf("unknown target err = %v", err)
 	}
 	for _, args := range [][]string{nil, {"a", "b"}} {
-		if err := runInstall(index.DefaultDir(), args, false); err == nil || !strings.Contains(err.Error(), "install needs target") {
+		if err := runInstall(index.DefaultDir(), args, false); err == nil || !strings.Contains(err.Error(), "install needs a target") {
 			t.Fatalf("install args %v err = %v", args, err)
 		}
 	}
-	if err := runInstall(index.DefaultDir(), nil, true); err == nil || !strings.Contains(err.Error(), "uninstall needs target") {
+	if err := runInstall(index.DefaultDir(), nil, true); err == nil || !strings.Contains(err.Error(), "uninstall needs a target") {
 		t.Fatalf("uninstall err = %v", err)
 	}
 

--- a/cmd/deja/install_target_test.go
+++ b/cmd/deja/install_target_test.go
@@ -1,47 +1,47 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-// Two dozen targets differ by a few characters, so a bare "unknown target"
-// left someone who typed `claud` with nowhere to go — while `deja completion`
-// has always listed its three valid values.
-func TestUnknownTargetSuggestsWhatWasMeant(t *testing.T) {
-	for typed, want := range map[string]string{
-		"claud":   "claude-code",
-		"opencde": "opencode",
-		"cursorr": "cursor",
-		"gemin":   "gemini",
-		"qwn":     "qwen",
-	} {
-		got := unknownTargetError(typed).Error()
-		if !strings.Contains(got, want) {
-			t.Errorf("install %q should suggest %q: %s", typed, want, got)
-		}
-	}
-	// Nothing close: list what would work rather than guessing.
-	full := unknownTargetError("zzzz").Error()
-	if strings.Contains(full, "did you mean") {
-		t.Errorf("no near match should mean no guess: %s", full)
-	}
-	for _, want := range []string{"claude-code", "codex", "--all"} {
-		if !strings.Contains(full, want) {
-			t.Errorf("the list should name %q: %s", want, full)
-		}
-	}
-}
+// The first command a new machine runs, and it answered with a word the reader
+// has to go look up (#830).
+func TestInstallWithoutATargetNamesWhatIsHere(t *testing.T) {
+	hermeticEnv(t)
 
-func TestEditDistance(t *testing.T) {
-	cases := map[[2]string]int{
-		{"", ""}: 0, {"a", ""}: 1, {"", "ab"}: 2,
-		{"cursor", "cursor"}: 0, {"cursorr", "cursor"}: 1,
-		{"qwen", "qwn"}: 1, {"kitten", "sitting"}: 3,
+	// Nothing installed: point at the list rather than at nothing.
+	err := runInstall(t.TempDir(), nil, false)
+	if err == nil {
+		t.Fatal("install with no target succeeded")
 	}
-	for in, want := range cases {
-		if got := editDistance(in[0], in[1]); got != want {
-			t.Errorf("editDistance(%q, %q) = %d, want %d", in[0], in[1], got, want)
+	if !strings.Contains(err.Error(), "deja help") {
+		t.Errorf("a bare machine gets no pointer: %v", err)
+	}
+
+	// Agents present: name them, and the two bulk flags the README uses.
+	home := os.Getenv("HOME")
+	for _, d := range []string{".claude", ".codex"} {
+		if err := os.MkdirAll(filepath.Join(home, d), 0o755); err != nil {
+			t.Fatal(err)
 		}
+	}
+	err = runInstall(t.TempDir(), nil, false)
+	if err == nil {
+		t.Fatal("install with no target succeeded")
+	}
+	msg := err.Error()
+	for _, want := range []string{"claude-code", "codex", "--all", "--auto"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message does not name %q: %v", want, err)
+		}
+	}
+
+	// uninstall says uninstall, not install.
+	err = runInstall(t.TempDir(), nil, true)
+	if err == nil || !strings.HasPrefix(err.Error(), "uninstall") {
+		t.Errorf("uninstall error = %v", err)
 	}
 }


### PR DESCRIPTION
```
before: $ deja install
        deja: install needs target
after:  $ deja install                 # agents present
        deja: install needs a target — found here: claude-code, codex (or --all, --auto)
        $ deja install                 # clean machine
        deja: install needs a target — no agent config found here; `deja help` lists every target deja knows
```

`deja help` has the full list and the README's examples use `--all`/`--auto`, but the error named none of it — on the first command a new user types. `files`, `restore` and `blame` all print the shape they want; this one can also name what is actually on the machine. Closes #830.