### PR TITLE
fix: files, ctx and restore point at the stores on an empty index

### DIFF
--- a/cmd/deja/empty_store_commands_test.go
+++ b/cmd/deja/empty_store_commands_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// An empty store is not a miss on the argument: deja has nothing to look in,
+// and "no sessions mention it" reads as "looked, not there" (#834).
+func TestEmptyStoreAnswersPointAtTheStores(t *testing.T) {
+	hermeticEnv(t)
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"files", []string{"files", "anything"}},
+		{"restore", []string{"restore", "some/file.go"}},
+		{"ctx", []string{"ctx", "anything"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := captureRun(t, tc.args...)
+			msg := out
+			if err != nil {
+				msg += err.Error()
+			}
+			if !strings.Contains(msg, "no agent history was found on this machine") {
+				t.Errorf("empty store answered as a miss on the argument:\n%s", msg)
+			}
+		})
+	}
+
+	// With history, the ordinary answers stay: the store was searched and the
+	// thing genuinely is not in it.
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"the hydraulic pump bearing failed"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"a1","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "a.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"files", []string{"files", "zzzqqq"}},
+		{"restore", []string{"restore", "some/file.go"}},
+		{"ctx", []string{"ctx", "zzzqqqwww"}},
+	} {
+		t.Run(tc.name+" with history", func(t *testing.T) {
+			out, err := captureRun(t, tc.args...)
+			msg := out
+			if err != nil {
+				msg += err.Error()
+			}
+			if strings.Contains(msg, "no agent history") {
+				t.Errorf("a store with history was called empty:\n%s", msg)
+			}
+		})
+	}
+}

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -85,6 +85,13 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 			fmt.Fprintf(stdout, "no sessions mention %q in project %q\n", q, project)
 			return nil
 		}
+		// An empty store is not a miss on the topic: deja has nothing to look
+		// in, and saying "no sessions mention it" reads as "looked, not there"
+		// (#834).
+		if n, err := index.SessionCount(dir); err == nil && n == 0 {
+			fmt.Fprintln(stdout, emptyIndexHint(fmt.Sprintf("no sessions mention %q", q)))
+			return nil
+		}
 		fmt.Fprintf(stdout, "no sessions mention %q\n", q)
 		return nil
 	}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -289,6 +289,9 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 		return err
 	}
 	if !ok {
+		if n, cerr := index.SessionCount(dir); cerr == nil && n == 0 {
+			return errors.New(strings.TrimPrefix(emptyIndexHint(fmt.Sprintf("no session matches %q", o.id)), "deja: "))
+		}
 		return fmt.Errorf("no session matches %q", o.id)
 	}
 	if o.json {
@@ -422,6 +425,11 @@ func cmdCtx(dir string, rest []string) error {
 		return err
 	}
 	if len(hits) == 0 {
+		// Same as #834 in files and restore: an empty store is not a miss on
+		// the query.
+		if n, cerr := index.SessionCount(dir); cerr == nil && n == 0 {
+			return errors.New(strings.TrimPrefix(emptyIndexHint(fmt.Sprintf("no session matches %q", q)), "deja: "))
+		}
 		return fmt.Errorf("no session matches %q", q)
 	}
 	search.PrintContext(os.Stdout, hits[0].Session, q)

--- a/cmd/deja/restore.go
+++ b/cmd/deja/restore.go
@@ -75,6 +75,12 @@ func runRestore(dir string, args []string, stdout io.Writer) error {
 		return err
 	}
 	if len(spans) == 0 {
+		// Same as #834 elsewhere: nothing recorded because nothing is
+		// indexed is a different answer from nothing recorded for this path.
+		if n, err := index.SessionCount(dir); err == nil && n == 0 {
+			fmt.Fprintln(stdout, emptyIndexHint(fmt.Sprintf("no replaced spans recorded for %q", path)))
+			return nil
+		}
 		fmt.Fprintf(stdout, "no replaced spans recorded for %q\n", path)
 		return nil
 	}


### PR DESCRIPTION
Clean machine, nothing indexed:

```
before: deja files anything       → no sessions mention "anything"
        deja ctx anything         → no session matches "anything"
        deja restore some/file.go → no replaced spans recorded for "some/file.go"
after:  … + — no agent history was found on this machine; `deja sources` shows where deja looked
```

`emptyIndexHint` already backs `last`, `blame` and search (#832); these three read as "looked, not there" when there was nothing to look in. Answers on a store with history are unchanged. Closes #834.