### PR TITLE
fix: an ambiguous elided id is refused, not silently doubled

### DIFF
--- a/cmd/deja/ambiguous_prefix_notice_test.go
+++ b/cmd/deja/ambiguous_prefix_notice_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// show learned to say when a prefix reached more than one session (#719, #859).
+// promote, handoff, resume and share resolve the same way and picked in
+// silence — promote records a state against whichever one it chose (#872).
+func TestEveryPrefixCommandSaysWhenItPicked(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"deja-2026-08-01-hyper-service", "deja-2026-08-01-super-service"} {
+		line := `{"type":"user","message":{"role":"user","content":"pool exhausted in ` + id + `"},"timestamp":"2026-08-01T10:00:00Z","sessionId":"` + id + `","cwd":"/proj"}`
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	elided := "deja-2026…er-service"
+
+	for _, cmd := range []struct{ name, action string }{
+		{"show", "showing"},
+		{"promote", "promoting"},
+		{"resume", "resuming"},
+		{"share", "sharing"},
+	} {
+		out, err := captureRunStderr(t, cmd.name, elided)
+		if err != nil {
+			t.Fatalf("%s: %v", cmd.name, err)
+		}
+		if !strings.Contains(out, "2 sessions match") || !strings.Contains(out, cmd.action+" the most recent") {
+			t.Errorf("%s picked in silence:\n%s", cmd.name, out)
+		}
+		if !strings.Contains(out, "the line elides") {
+			t.Errorf("%s offers a prefix the reader cannot see:\n%s", cmd.name, out)
+		}
+	}
+
+	// One match, no notice: the line is about a choice having been made.
+	out, err := captureRunStderr(t, "show", "deja-2026-08-01-hyper-service")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "sessions match") {
+		t.Errorf("an unambiguous id was told it was ambiguous:\n%s", out)
+	}
+}

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -82,7 +82,7 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir strin
 		}
 		return deepDriftErr(deepReport)
 	}
-	doctorHarnesses(w)
+	doctorHarnesses(w, dir)
 	printDoctorStoreWarnings(w, report.Stores)
 	fmt.Fprintln(w)
 	doctorTools(w)
@@ -296,14 +296,28 @@ func printDoctorStoreWarnings(w io.Writer, stores []doctorStore) {
 	}
 }
 
-func doctorHarnesses(w io.Writer) {
+func doctorHarnesses(w io.Writer, dir string) {
 	fmt.Fprintln(w, "Harness stores:")
 	sqlite := sources.SQLite3Available()
+
+	// Files are what deja found; sessions are what they became. The two differ
+	// whenever ids collide — a resumed transcript, a copied one, a harness that
+	// reuses a thread id — and the difference is invisible in a row that only
+	// counts files (#861).
+	indexed := index.HarnessSessionCounts(dir)
 
 	printRow := func(name, path string, present bool, detail string) {
 		status := "missing"
 		if present {
 			status = "found"
+		}
+		if present {
+			if n, ok := indexed[name]; ok {
+				if detail != "" {
+					detail += ", "
+				}
+				detail += doctorCount(n, "indexed session")
+			}
 		}
 		line := fmt.Sprintf("  %-12s %-8s %s", name, status, path)
 		if detail != "" {

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -697,6 +697,14 @@ func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 	// boundary in the tool itself, not only in the security docs.
 	fmt.Fprintln(w, "  security plaintext on disk — protected by file permissions only, no encryption or access control")
 	if idx.State == "missing" {
+		// A build already running is not a missing index, and "run `deja
+		// warmup`" tells the reader to start what is under way — doctor is
+		// the command people run when memory looks absent, so this is the
+		// worst place to describe it as absent (#873).
+		if st := readWarmupStatus(dir); st != nil {
+			fmt.Fprintf(w, "  status   building now (%s) — recall comes online in a few seconds\n", st.progress())
+			return
+		}
 		fmt.Fprintln(w, "  status   not built (run `deja warmup`)")
 		return
 	}

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -92,6 +92,10 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir strin
 	doctorMCP(w)
 	fmt.Fprintln(w)
 	doctorHooks(w)
+	// After doctorHooks, not inside it: that function returns early on a
+	// machine without claude settings, which is exactly a machine whose other
+	// harnesses may still be wired to a binary that moved.
+	doctorWiringExe(w)
 	fmt.Fprintln(w)
 	doctorIndex(w, report.Index, dir)
 	fmt.Fprintln(w)
@@ -166,6 +170,25 @@ func doctorHooks(w io.Writer) {
 	fmt.Fprintf(w, "  %-12s %-11s %s\n", "precompact", status, path)
 	doctorCodexHook(w)
 	doctorAutoRecall(w)
+}
+
+// doctorWiringExe reports configs that name a binary which is no longer there.
+//
+// Every hook and MCP entry deja writes holds an absolute path. Move the binary
+// and those configs keep naming the old one: the harness fails to start deja
+// on every session, and doctor happily printed "wired" for a hook that cannot
+// run. The repair from #773 exists but runs from the hook path — the one path
+// a dead binary cannot reach — so doctor is where a person finds out (#876).
+func doctorWiringExe(w io.Writer) {
+	st := readWiringState()
+	if st.Exe == "" || len(st.Targets) == 0 {
+		return
+	}
+	if _, err := os.Stat(st.Exe); err == nil {
+		return
+	}
+	fmt.Fprintf(w, "  %-12s %-11s configs name %s, which is not there — `deja install %s` rewrites them for this binary\n",
+		"wiring", "stale", st.Exe, strings.Join(st.Targets, " "))
 }
 
 // doctorCodexHook reports the codex session-start hook state. Codex gates

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -708,6 +708,10 @@ func doctorTOMLWired(path string) bool {
 	return false
 }
 
+// indexOlderFormat is a variable so a test can put doctor in front of an index
+// this build cannot read without shipping a manifest writer.
+var indexOlderFormat = index.OlderFormat
+
 func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 	fmt.Fprintln(w, "Index:")
 	loc := idx.Path
@@ -736,6 +740,13 @@ func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 		updated = fi.ModTime().Format("2006-01-02 15:04")
 	}
 	fmt.Fprintf(w, "  status   built (size=%s, updated=%s)\n", humanBytes(pathSize(dir)), updated)
+	// An index written by an older format is unreadable to this binary: the
+	// hook paths refuse it and ask for a rebuild, which is why memory goes
+	// quiet after an upgrade. doctor called that "up to date" — the one
+	// command someone runs to find out why nothing is recalled (#877).
+	if indexOlderFormat(dir) {
+		fmt.Fprintln(w, "  format   written by an older deja — this build cannot read it; the next session rebuilds it, or run `deja index` now")
+	}
 	// A store whose postings vanished or whose record log was truncated cannot
 	// answer anything, and said "up to date" until #735. The next search
 	// rebuilds it, which is worth saying too — the reader has not lost memory,

--- a/cmd/deja/doctor_building_test.go
+++ b/cmd/deja/doctor_building_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// doctor is what people run when memory looks absent, and during the first
+// build it called the index missing and told them to start the build that was
+// already running (#873).
+func TestDoctorSaysWhenTheIndexIsBeingBuilt(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "idx")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	status := warmupStatus{Phase: "reading sessions", Total: 100, Done: 42, Started: time.Now().UnixNano(), Updated: time.Now().UnixNano()}
+	b, err := json.Marshal(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(warmupStatusPath(dir), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	doctorIndex(&out, doctorComponent{State: "missing", Path: dir}, dir)
+	got := out.String()
+	if !strings.Contains(got, "building now (reading sessions 42%)") {
+		t.Errorf("doctor does not mention the build in flight:\n%s", got)
+	}
+	if strings.Contains(got, "run `deja warmup`") {
+		t.Errorf("doctor still tells the reader to start what is running:\n%s", got)
+	}
+
+	// With no build running, the advice is the right one.
+	if err := os.Remove(warmupStatusPath(dir)); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	doctorIndex(&out, doctorComponent{State: "missing", Path: dir}, dir)
+	if got := out.String(); !strings.Contains(got, "not built (run `deja warmup`)") {
+		t.Errorf("an index that is really missing lost its advice:\n%s", got)
+	}
+}

--- a/cmd/deja/doctor_denied_budget_test.go
+++ b/cmd/deja/doctor_denied_budget_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// The walk's budget counted every entry, so on a store of tens of thousands of
+// transcripts it was spent inside the first project and a locked directory
+// later in the walk was never reached (#864).
+func TestDeniedDirIsFoundPastTheFileBudget(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	root := t.TempDir()
+	crowd := filepath.Join(root, "aaa-crowded")
+	if err := os.MkdirAll(crowd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 6000; i++ {
+		if err := os.WriteFile(filepath.Join(crowd, fmt.Sprintf("s%d.jsonl", i)), []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	locked := filepath.Join(root, "zzz-locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	if got := firstDeniedDir([]string{root}); got != locked {
+		t.Errorf("denied dir = %q, want %q", got, locked)
+	}
+}

--- a/cmd/deja/doctor_format_test.go
+++ b/cmd/deja/doctor_format_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// An index written by an older format is unreadable to this binary — the hook
+// paths refuse it and ask for a rebuild, which is why memory goes quiet after
+// an upgrade. doctor called that "up to date" (#877).
+func TestDoctorNamesAnIndexFromAnOlderFormat(t *testing.T) {
+	tmp := hermeticEnv(t)
+	chats := filepath.Join(tmp, "qwen", "projects", "proj", "chats")
+	if err := os.MkdirAll(chats, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"q-1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","parts":[{"text":"pool exhausted"}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(chats, "a.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
+	dir := filepath.Join(tmp, "idx")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// A current index says nothing about its format.
+	var out bytes.Buffer
+	doctorIndex(&out, doctorComponent{State: "ok", Path: dir}, dir)
+	if got := out.String(); strings.Contains(got, "older deja") {
+		t.Errorf("a current index was called old:\n%s", got)
+	}
+
+	// An index this build cannot read.
+	saved := indexOlderFormat
+	indexOlderFormat = func(string) bool { return true }
+	t.Cleanup(func() { indexOlderFormat = saved })
+	out.Reset()
+	doctorIndex(&out, doctorComponent{State: "ok", Path: dir}, dir)
+	got := out.String()
+	if !strings.Contains(got, "written by an older deja") {
+		t.Errorf("doctor does not mention the format:\n%s", got)
+	}
+	if !strings.Contains(got, "deja index") {
+		t.Errorf("doctor does not say what to do:\n%s", got)
+	}
+}

--- a/cmd/deja/doctor_indexed_sessions_test.go
+++ b/cmd/deja/doctor_indexed_sessions_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// doctor counted files and stopped there, so a store whose transcripts share
+// ids read exactly like one where every file is its own session: two files,
+// one session, no difference on screen (#861).
+func TestDoctorRowCountsIndexedSessions(t *testing.T) {
+	tmp := hermeticEnv(t)
+	chats := filepath.Join(tmp, "qwen", "projects", "proj", "chats")
+	if err := os.MkdirAll(chats, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(sid, text string) string {
+		return `{"type":"user","sessionId":"` + sid + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","parts":[{"text":"` + text + `"}]}}` + "\n"
+	}
+	for _, f := range []string{"a.jsonl", "b.jsonl"} {
+		if err := os.WriteFile(filepath.Join(chats, f), []byte(line("same-id", "pool exhausted")), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
+
+	dir := filepath.Join(tmp, "idx")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	doctorHarnesses(&buf, dir)
+	row := harnessRow(t, buf.String(), "qwen")
+	if !strings.Contains(row, "2 files") || !strings.Contains(row, "1 indexed session") {
+		t.Errorf("row does not show both counts: %q", row)
+	}
+
+	// A harness with nothing in the index says nothing rather than "0": the
+	// row is about what deja found, and a zero there reads as a failure.
+	buf.Reset()
+	doctorHarnesses(&buf, filepath.Join(tmp, "empty"))
+	if row := harnessRow(t, buf.String(), "qwen"); strings.Contains(row, "indexed session") {
+		t.Errorf("unbuilt index still claims sessions: %q", row)
+	}
+}
+
+func harnessRow(t *testing.T, out, name string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), name+" ") {
+			return line
+		}
+	}
+	t.Fatalf("no %s row in:\n%s", name, out)
+	return ""
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -100,6 +100,10 @@ func collectDoctorReport(lookup doctorVersionLookup, dir string) doctorReport {
 // returns that path. The walk is bounded: doctor is a diagnostic command, but
 // a harness root can hold tens of thousands of transcripts.
 func firstDeniedDir(paths []string) string {
+	// Directories, not entries: a store of 50k transcripts sits in a few
+	// hundred of them, and counting files spent the budget in the first
+	// project — a locked directory later in the walk was never reached, and
+	// doctor reported the store whole (#864).
 	const budget = 5000
 	visited := 0
 	home := sources.Home()
@@ -112,9 +116,6 @@ func firstDeniedDir(paths []string) string {
 		}
 		denied := ""
 		_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
-			if visited++; visited > budget {
-				return filepath.SkipAll
-			}
 			if err != nil {
 				if os.IsPermission(err) {
 					denied = p
@@ -124,6 +125,9 @@ func firstDeniedDir(paths []string) string {
 			}
 			if !d.IsDir() {
 				return nil
+			}
+			if visited++; visited > budget {
+				return filepath.SkipAll
 			}
 			return nil
 		})

--- a/cmd/deja/doctor_unplaced_test.go
+++ b/cmd/deja/doctor_unplaced_test.go
@@ -62,7 +62,7 @@ func TestDoctorHarnessRowSaysNothingWhenEverythingIsPlaced(t *testing.T) {
 	}
 	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
 	var buf bytes.Buffer
-	doctorHarnesses(&buf)
+	doctorHarnesses(&buf, t.TempDir())
 	for _, line := range strings.Split(buf.String(), "\n") {
 		if strings.Contains(line, "qwen") && strings.Contains(line, "not recognised") {
 			t.Errorf("clean store complains: %q", line)
@@ -74,7 +74,7 @@ func TestDoctorHarnessRowSaysNothingWhenEverythingIsPlaced(t *testing.T) {
 		t.Fatal(err)
 	}
 	buf.Reset()
-	doctorHarnesses(&buf)
+	doctorHarnesses(&buf, t.TempDir())
 	found := false
 	for _, line := range strings.Split(buf.String(), "\n") {
 		if strings.Contains(line, "qwen") && strings.Contains(line, "1 not recognised here") {

--- a/cmd/deja/doctor_wiring_exe_test.go
+++ b/cmd/deja/doctor_wiring_exe_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every config deja writes holds an absolute path to the binary. Move it and
+// the harness fails to start deja on every session — while doctor printed
+// "wired" for a hook that cannot run. The repair from #773 runs from the hook
+// path, which is the one path a dead binary cannot reach (#876).
+func TestDoctorNamesConfigsPointingAtAMissingBinary(t *testing.T) {
+	tmp := hermeticEnv(t)
+	cfg := filepath.Join(tmp, "config")
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	if err := os.MkdirAll(filepath.Join(cfg, "deja"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	gone := filepath.Join(tmp, "old", "deja")
+	write := func(exe string) {
+		b, err := json.Marshal(wiringState{Version: "dev", Targets: []string{"claude-auto"}, Exe: exe})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(wiringStatePath(), b, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write(gone)
+	var out bytes.Buffer
+	doctorWiringExe(&out)
+	got := out.String()
+	if !strings.Contains(got, gone) || !strings.Contains(got, "which is not there") {
+		t.Errorf("doctor says nothing about a binary that moved:\n%s", got)
+	}
+	if !strings.Contains(got, "deja install claude-auto") {
+		t.Errorf("doctor does not say how to fix it:\n%s", got)
+	}
+
+	// And the row reaches the command, not only the helper: a doctor that
+	// never calls this is a doctor that still says "wired".
+	full, err := captureRun(t, "doctor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(full, "which is not there") {
+		t.Errorf("`deja doctor` does not mention the moved binary:\n%s", full)
+	}
+
+	// A binary that is where the configs say: nothing to report.
+	here := filepath.Join(tmp, "deja")
+	if err := os.WriteFile(here, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(here)
+	out.Reset()
+	doctorWiringExe(&out)
+	if got := out.String(); got != "" {
+		t.Errorf("a healthy wiring was reported as stale: %q", got)
+	}
+
+	// Nothing wired at all: no row either.
+	b, err := json.Marshal(wiringState{Version: "dev"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wiringStatePath(), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	doctorWiringExe(&out)
+	if got := out.String(); got != "" {
+		t.Errorf("an unwired machine got a wiring row: %q", got)
+	}
+}

--- a/cmd/deja/elided_ambiguous_test.go
+++ b/cmd/deja/elided_ambiguous_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// An id copied off a result line can stand for more than one session, and the
+// characters that would tell them apart are the ones the line elided — so
+// "use a longer prefix" is advice the reader cannot follow, and a destructive
+// command must not drop twice what they named once (#859).
+func TestAnAmbiguousElidedIdIsRefusedAndExplained(t *testing.T) {
+	hermeticEnv(t)
+	notesDir := filepath.Join(t.TempDir(), "notes")
+	if err := os.MkdirAll(notesDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(notesDir, "notes.jsonl"))
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"the davit ram seal"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"s1","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "a.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	// Two notes whose ids share a head and a tail: deja mints them as
+	// deja-<date>-<project>, and "<x>-service" is an ordinary project name.
+	for _, project := range []string{"super-service", "hyper-service"} {
+		if _, err := captureRun(t, "remember", "note about the davit ram seal", "--project", project); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The elided form both notes print.
+	elided := "deja-2026…er-service"
+
+	// show picks one, and says what to do with the other — without offering a
+	// longer prefix, which does not exist here.
+	out, err := captureRunStderr(t, "show", elided)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "prints them whole") {
+		t.Errorf("show did not explain the ambiguity:\n%s", out)
+	}
+	if strings.Contains(out, "use a longer prefix") {
+		t.Errorf("show still offers a prefix the reader cannot see:\n%s", out)
+	}
+
+	// forget refuses rather than dropping both.
+	err = runForget(indexDirForTest(), []string{"--session", elided, "--dry-run"})
+	if err == nil {
+		t.Fatal("forget accepted an ambiguous elided id")
+	}
+	if !strings.Contains(err.Error(), "matches 2 sessions") {
+		t.Errorf("forget did not say how many it matched: %v", err)
+	}
+
+	// An elided id that stands for exactly one session is not ambiguous and
+	// must still work — refusing every elision would undo #855.
+	if _, err := captureRun(t, "remember", "note about the davit ram seal", "--project", "payments-api"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "forget", "--session", "deja-2026…ments-api", "--dry-run")
+	if err != nil {
+		t.Fatalf("an unambiguous elided id was refused: %v", err)
+	}
+	if !strings.Contains(out, "would drop: 1 session") {
+		t.Errorf("an unambiguous elided id stopped matching:\n%s", out)
+	}
+}

--- a/cmd/deja/elided_ambiguous_test.go
+++ b/cmd/deja/elided_ambiguous_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/vshulcz/deja-vu/internal/index"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,13 +57,26 @@ func TestAnAmbiguousElidedIdIsRefusedAndExplained(t *testing.T) {
 		t.Errorf("show still offers a prefix the reader cannot see:\n%s", out)
 	}
 
-	// forget refuses rather than dropping both.
-	err = runForget(indexDirForTest(), []string{"--session", elided, "--dry-run"})
+	// The dry run changes nothing, so it explains the ambiguity instead of
+	// erroring — that is the question someone runs it to answer.
+	dry, err := captureRun(t, "forget", "--session", elided, "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(dry, "matches 2 sessions") {
+		t.Errorf("dry run did not say how many it matched:\n%s", dry)
+	}
+
+	// The real run refuses rather than dropping both.
+	err = runForget(indexDirForTest(), []string{"--session", elided})
 	if err == nil {
 		t.Fatal("forget accepted an ambiguous elided id")
 	}
 	if !strings.Contains(err.Error(), "matches 2 sessions") {
 		t.Errorf("forget did not say how many it matched: %v", err)
+	}
+	if got := index.Tombstones(); len(got) != 0 {
+		t.Fatalf("the refusal still forgot: %v", got)
 	}
 
 	// An elided id that stands for exactly one session is not ambiguous and

--- a/cmd/deja/forget_prefix_scope_test.go
+++ b/cmd/deja/forget_prefix_scope_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The refusal has to happen before anything is written. An earlier version of
+// this check ran after index.Forget and printed "matches 2 sessions" over
+// tombstones it had already added — a refusal that refused nothing (#870).
+func TestForgetRefusesAWideSelectorWithoutDroppingAnything(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"s1", "s10", "s11"} {
+		line := `{"type":"user","message":{"role":"user","content":"pool exhausted ` + id + `"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"` + id + `","cwd":"/proj"}`
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	dir := os.Getenv("DEJA_INDEX_DIR")
+
+	// A prefix with no exact session behind it: refused, and nothing written.
+	if err := runForget(dir, []string{"--session", "s"}); err == nil {
+		t.Fatal("a prefix of three sessions was not refused")
+	}
+	if got := index.Tombstones(); len(got) != 0 {
+		t.Fatalf("the refusal still forgot: %v", got)
+	}
+
+	// An id that names a session exactly means that session, not the two ids
+	// it happens to be a prefix of.
+	if err := runForget(dir, []string{"--session", "s1"}); err != nil {
+		t.Fatalf("exact id refused: %v", err)
+	}
+	got := index.Tombstones()
+	if len(got) != 1 || !strings.HasSuffix(got[0], ":s1") {
+		t.Fatalf("tombstones = %v, want only claude:s1", got)
+	}
+}

--- a/cmd/deja/forget_scope_test.go
+++ b/cmd/deja/forget_scope_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// `--session` takes a prefix, so an id that names one session exactly could
+// still reach every id beside it — twelve sessions for a selector that named
+// one, and the count arrived afterwards, in the past tense (#870).
+func TestForgetScopeRefusal(t *testing.T) {
+	if err := forgetScopeRefusal("s1", 1, false); err != nil {
+		t.Errorf("a single match was refused: %v", err)
+	}
+	err := forgetScopeRefusal("s1", 12, false)
+	if err == nil {
+		t.Fatal("a prefix of twelve sessions was not refused")
+	}
+	got := err.Error()
+	for _, want := range []string{"prefix of 12 sessions", "--dry-run", "--all-matches"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("refusal does not mention %q: %q", want, got)
+		}
+	}
+	// Asked for explicitly, it proceeds.
+	if err := forgetScopeRefusal("s1", 12, true); err != nil {
+		t.Errorf("--all-matches still refused: %v", err)
+	}
+	// An elided id has no longer prefix to offer, so the wording differs and
+	// must not send the reader after one (#859).
+	err = forgetScopeRefusal("deja-2026…er-service", 2, false)
+	if err == nil {
+		t.Fatal("an ambiguous elided id was not refused")
+	}
+	if got := err.Error(); !strings.Contains(got, "the line elides") || strings.Contains(got, "--all-matches") {
+		t.Errorf("elided wording = %q", got)
+	}
+}

--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -136,6 +136,7 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 	}
 	if prefix != "" {
 		s, ok, err := findByPrefix(dir, prefix)
+		noteAmbiguousPrefix(dir, prefix, "handing off")
 		if err != nil {
 			return model.Session{}, err
 		}

--- a/cmd/deja/hook_cache_orphan_test.go
+++ b/cmd/deja/hook_cache_orphan_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The digest cache lives beside the index directory, not inside it, so wiping
+// the index left the hook answering from a snapshot of a store that no longer
+// exists — and asking for nothing, so it kept answering from that snapshot
+// forever. Caches do get wiped: ~/.cache is fair game for cleanup tools and CI
+// images (#874).
+func TestHookAsksForARebuildWhenTheIndexIsGone(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	cwd := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
+	// hermeticEnv marks every test in this package as the warmup child, which
+	// is exactly the process that must not ask for another warmup.
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+
+	entry := hookCacheEntry{At: time.Now(), CWD: cwd, Gate: hookGate(), Digest: "pool exhausted under load", Sessions: 1, Raw: 42}
+	b, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hookCachePath(dir, cwd), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// No index at all: the directory the cache was built from is gone.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	clearWarmupSentinel()
+
+	spawned := 0
+	saved := spawnWarmup
+	spawnWarmup = func(exe, sentinel string) error { spawned++; return nil }
+	t.Cleanup(func() { spawnWarmup = saved })
+
+	digest, sessions, _, _ := cachedHookDigest(dir)
+	if !strings.Contains(digest, "pool exhausted") || sessions != 1 {
+		t.Errorf("the cached digest was dropped rather than served: %q (%d sessions)", digest, sessions)
+	}
+	if spawned == 0 {
+		t.Error("the hook served a store that is gone and asked for no rebuild")
+	}
+
+	// A healthy index asks for nothing: the sentinel exists so a session start
+	// does not spawn a build on every hook (#825).
+	if err := os.MkdirAll(filepath.Join(dir, "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	clearWarmupSentinel()
+	spawned = 0
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	clearWarmupSentinel()
+	cachedHookDigest(dir)
+	if spawned != 0 {
+		t.Errorf("a healthy index still asked for %d rebuild(s)", spawned)
+	}
+}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -537,6 +537,25 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 	return text, result.Sessions, rawSize(ss), matched
 }
 
+// warmupDeadAfter is how long a warmup may go without publishing progress
+// before the next hook treats it as dead and starts another. It is far longer
+// than any gap between progress reports — those come at every phase and every
+// harness — and far shorter than warmupRetryAfter, which was the whole wait a
+// killed build used to cost.
+const warmupDeadAfter = 2 * time.Minute
+
+// warmupLooksDead reports whether the build the sentinel stands for has
+// stopped without clearing it. A warmup killed mid-build — a closed laptop, an
+// OOM, a terminal that took its process group with it — left the sentinel
+// behind, and for the next ten minutes every hook returned nothing, spawned
+// nothing and said nothing (#875).
+func warmupLooksDead(dir string, now time.Time, stamp int64) bool {
+	if st := readWarmupStatus(dir); st != nil {
+		return false
+	}
+	return now.Sub(time.Unix(0, stamp)) > warmupDeadAfter
+}
+
 func requestWarmup(dir string) {
 	if os.Getenv("DEJA_WARMUP_SENTINEL") != "" {
 		return
@@ -553,7 +572,7 @@ func requestWarmup(dir string) {
 		}
 		b, readErr := os.ReadFile(sentinel)
 		stamp, parseErr := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
-		if readErr == nil && parseErr == nil && now.Sub(time.Unix(0, stamp)) < warmupRetryAfter {
+		if readErr == nil && parseErr == nil && now.Sub(time.Unix(0, stamp)) < warmupRetryAfter && !warmupLooksDead(dir, now, stamp) {
 			return
 		}
 		if os.Remove(sentinel) != nil {

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -330,7 +330,12 @@ func cachedHookDigest(dir string) (string, int, int64, []string) {
 	// in hookDigestResult, so an index left behind by an upgrade was served
 	// stale and never rebuilt (#777). The cached digest is still the user's
 	// own history, so serve it — just ask for the rebuild too.
-	if index.HasManifest(dir) && (!index.IsCurrentVersion(dir) || index.Damaged(dir)) {
+	// A deleted index is the same situation with the manifest gone: the cache
+	// answered from a store that no longer exists and asked for nothing, so it
+	// kept serving that snapshot forever — every session recorded after the
+	// deletion invisible to the hook (#874). Caches do get wiped: ~/.cache is
+	// fair game for cleanup tools and CI images.
+	if !index.HasManifest(dir) || !index.IsCurrentVersion(dir) || index.Damaged(dir) {
 		requestWarmup(dir)
 	}
 	gate := hookGate()

--- a/cmd/deja/index_summary_test.go
+++ b/cmd/deja/index_summary_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The live display erases itself when the build ends, so an interactive
+// rebuild left an empty screen: an animation ran for seconds and nothing said
+// what was indexed. Piped output has printed the counts all along (#867).
+func TestRebuildOnATerminalSaysWhatItIndexed(t *testing.T) {
+	tmp := hermeticEnv(t)
+	chats := filepath.Join(tmp, "qwen", "projects", "proj", "chats")
+	if err := os.MkdirAll(chats, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"q-1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","parts":[{"text":"pool exhausted"}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(chats, "a.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
+	dir := filepath.Join(tmp, "idx")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// hermeticEnv points the warmup sentinel at a guard path for every test in
+	// this package; this case is the ordinary interactive run.
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+
+	saved := logoWanted
+	logoWanted = func(*os.File) bool { return true }
+	t.Cleanup(func() { logoWanted = saved })
+
+	run := func(t *testing.T) string {
+		t.Helper()
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		stderr := os.Stderr
+		os.Stderr = w
+		err = cmdIndex(dir, []string{"--rebuild"})
+		os.Stderr = stderr
+		_ = w.Close()
+		out, _ := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(out)
+	}
+
+	got := run(t)
+	if !strings.Contains(got, "indexed 1 session, 1 message") {
+		t.Errorf("rebuild said nothing about what it built:\n%s", got)
+	}
+
+	// Not on the warmup child: nobody is watching its screen, and its output
+	// goes to /dev/null.
+	t.Setenv("DEJA_WARMUP_SENTINEL", filepath.Join(tmp, "sentinel"))
+	if got := run(t); strings.Contains(got, "indexed 1 session") {
+		t.Errorf("the detached warmup narrated to nobody:\n%s", got)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -321,7 +321,14 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 				fmt.Fprintf(os.Stderr, "deja: %d sessions share the id %q — showing the most recent; use --harness %s\n",
 					len(hs), o.id, strings.Join(hs, "|"))
 			} else {
-				fmt.Fprintf(os.Stderr, "deja: %d sessions start with %q — showing the most recent; use a longer prefix for another\n", n, o.id)
+				// "A longer prefix" is not available when the reader copied an
+				// elided id off a result line: the characters that would
+				// disambiguate are the ones the elision replaced (#859).
+				advice := "use a longer prefix for another"
+				if strings.Contains(o.id, "…") {
+					advice = "the ids differ in the middle the line elides — `deja last` prints them whole"
+				}
+				fmt.Fprintf(os.Stderr, "deja: %d sessions match %q — showing the most recent; %s\n", n, o.id, advice)
 			}
 		}
 	}
@@ -1432,6 +1439,13 @@ func runForget(dir string, args []string) error {
 	// A dry run changes nothing, so reporting it in the past tense — the same
 	// three lines the real command prints — tells the reader their sessions are
 	// gone when they are not.
+	// An id copied off a result line can stand for more than one session — the
+	// characters that would tell them apart are the ones the line elided. A
+	// destructive command must not drop twice what the reader named once
+	// (#859).
+	if o.Session != "" && strings.Contains(o.Session, "…") && result.Sessions > 1 {
+		return fmt.Errorf("%q matches %d sessions — the ids differ in the middle the line elides; `deja last` prints them whole", o.Session, result.Sessions)
+	}
 	if o.DryRun {
 		fmt.Fprintf(os.Stdout, "dry run — nothing was changed\nwould drop: %d session(s), %d message(s)\nwould add: %d tombstone(s)\n",
 			result.Sessions, result.Messages, result.Tombstones)

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -254,6 +254,12 @@ func cmdIndex(dir string, rest []string) error {
 		fmt.Fprintf(os.Stderr, "deja: %s: %d path%s could not be read — `deja doctor` names %s\n",
 			h, e.FailedFiles, pluralS(e.FailedFiles), pluralWhich(e.FailedFiles))
 	}
+	// The parse count and the indexed count differ by exactly these, and this
+	// is where both are on screen (#868).
+	if n := index.ReportEmptySessions(); n > 0 {
+		fmt.Fprintf(os.Stderr, "deja: %d transcript%s held no message deja could index — not counted as %s\n",
+			n, pluralS(n), pluralSessionWord(n))
+	}
 	if n := index.ReportCollisions(); n > 0 {
 		fmt.Fprintf(os.Stderr, "deja: %d session%s %s an id with another transcript — each pair is filed under one project, the one whose file sorts first\n", n, pluralS(n), verbShare(n))
 	}
@@ -1746,6 +1752,14 @@ func sortedHarnesses(m map[string]index.HarnessIngest) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// pluralSessionWord words the tail of the empty-transcript line.
+func pluralSessionWord(n int) string {
+	if n == 1 {
+		return "a session"
+	}
+	return "sessions"
 }
 
 // pluralWhich matches the pronoun to the count in the ingest warning.

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -322,28 +322,8 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 	} else if n := len(s.Messages); n > showLargeSession {
 		fmt.Fprintf(os.Stderr, "deja: %d messages — `--offset n --limit n` reads a slice\n", n)
 	}
-	// The prefix picks the newest of its matches, which is the right default
-	// and, until now, a silent one: "2" resolved eleven sessions on a real
-	// store and the reader had no way to know they were shown a choice.
 	if o.harness == "" {
-		if n := index.PrefixMatches(dir, o.id); n > 1 {
-			// When the matches are the same id in different harnesses there is
-			// no longer prefix to reach for, and --harness is the only thing
-			// that separates them (#719).
-			if hs := index.PrefixHarnesses(dir, o.id); len(hs) > 1 {
-				fmt.Fprintf(os.Stderr, "deja: %d sessions share the id %q — showing the most recent; use --harness %s\n",
-					len(hs), o.id, strings.Join(hs, "|"))
-			} else {
-				// "A longer prefix" is not available when the reader copied an
-				// elided id off a result line: the characters that would
-				// disambiguate are the ones the elision replaced (#859).
-				advice := "use a longer prefix for another"
-				if strings.Contains(o.id, "…") {
-					advice = "the ids differ in the middle the line elides — `deja last` prints them whole"
-				}
-				fmt.Fprintf(os.Stderr, "deja: %d sessions match %q — showing the most recent; %s\n", n, o.id, advice)
-			}
-		}
+		noteAmbiguousPrefix(dir, o.id, "showing")
 	}
 	search.PrintSession(os.Stdout, s)
 	return nil
@@ -869,6 +849,36 @@ func isSubcommand(word string) bool {
 		return true
 	}
 	return false
+}
+
+// noteAmbiguousPrefix says when a selector reached more than one session.
+//
+// The prefix picks the newest of its matches, which is the right default and
+// was a silent one: "2" resolved eleven sessions on a real store. `show`
+// learned to say so in #719 and #859; promote, handoff, resume and share
+// resolve the same way and still picked in silence — promote records a state
+// against whichever session it chose (#872).
+func noteAmbiguousPrefix(dir, id, action string) {
+	n := index.PrefixMatches(dir, id)
+	if n <= 1 {
+		return
+	}
+	// When the matches are the same id in different harnesses there is no
+	// longer prefix to reach for, and --harness is the only thing that
+	// separates them (#719).
+	if hs := index.PrefixHarnesses(dir, id); len(hs) > 1 {
+		fmt.Fprintf(os.Stderr, "deja: %d sessions share the id %q — %s the most recent; use --harness %s\n",
+			len(hs), id, action, strings.Join(hs, "|"))
+		return
+	}
+	// "A longer prefix" is not available when the reader copied an elided id
+	// off a result line: the characters that would disambiguate are the ones
+	// the elision replaced (#859).
+	advice := "use a longer prefix for another"
+	if strings.Contains(id, "…") {
+		advice = "the ids differ in the middle the line elides — `deja last` prints them whole"
+	}
+	fmt.Fprintf(os.Stderr, "deja: %d sessions match %q — %s the most recent; %s\n", n, id, action, advice)
 }
 
 func findByPrefix(dir, p string) (model.Session, bool, error) {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -258,6 +258,13 @@ func cmdIndex(dir string, rest []string) error {
 		fmt.Fprintf(os.Stderr, "deja: %d session%s %s an id with another transcript — each pair is filed under one project, the one whose file sorts first\n", n, pluralS(n), verbShare(n))
 	}
 	maybeFirstIndexGreeting(dir)
+	// The live display erases itself on the way out, so a rebuild on a
+	// terminal ended with an empty screen — three seconds of animation and no
+	// record of what was built. Piped output has said it all along; this is
+	// the same two numbers for the reader who watched it happen (#867).
+	if b := index.LastBuild; !b.Initial && b.Messages > 0 && logoWanted(os.Stdout) && os.Getenv("DEJA_WARMUP_SENTINEL") == "" {
+		fmt.Fprintf(os.Stderr, "deja: indexed %d session%s, %d message%s\n", b.Sessions, pluralS(b.Sessions), b.Messages, pluralS(b.Messages))
+	}
 	return nil
 }
 

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1375,9 +1375,28 @@ func printSources(dir string) {
 	fmt.Printf("opencode\t%s\tsessions=%d messages=%d size=%s redacted=%d%s\n", sources.OpencodeDB(), s, m, humanBytes(size), redactions[sources.OpencodeDB()], note)
 }
 
+// forgetScopeRefusal stops a destructive run whose selector reaches further
+// than the reader can have meant.
+//
+// `--session` takes a prefix, which is documented and useful for a day's ids —
+// but it also let one exact-looking id drop twelve sessions, and the count
+// arrived in the past tense afterwards (#870). An id copied off a result line
+// is worse still: the characters that tell the sessions apart are the ones the
+// line elided, so no longer prefix exists to reach for (#859).
+func forgetScopeRefusal(selector string, matches int, allMatches bool) error {
+	if matches <= 1 || allMatches {
+		return nil
+	}
+	if strings.Contains(selector, "…") {
+		return fmt.Errorf("%q matches %d sessions — the ids differ in the middle the line elides; `deja last` prints them whole", selector, matches)
+	}
+	return fmt.Errorf("%q is a prefix of %d sessions — `deja forget --session %s --dry-run` lists what would go; add --all-matches to drop them all", selector, matches, selector)
+}
+
 func runForget(dir string, args []string) error {
 	var o index.ForgetOptions
 	list := false
+	allMatches := false
 	unforget := ""
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -1385,6 +1404,8 @@ func runForget(dir string, args []string) error {
 			list = true
 		case "--dry-run":
 			o.DryRun = true
+		case "--all-matches":
+			allMatches = true
 		case "--session", "--project", "--before", "--unforget":
 			if i+1 >= len(args) {
 				return fmt.Errorf("forget: %s needs value", args[i])
@@ -1445,23 +1466,34 @@ func runForget(dir string, args []string) error {
 		fmt.Fprintf(os.Stdout, "restored %d session%s and rebuilt the index\n", lifted, pluralS(lifted))
 		return nil
 	}
+	// The scope check runs on a dry pass first: a refusal printed after
+	// index.Forget has already written the tombstones is not a refusal.
+	if o.Session != "" && !o.DryRun {
+		probe := o
+		probe.DryRun = true
+		pr, perr := index.Forget(dir, probe)
+		if perr != nil {
+			return perr
+		}
+		if err := forgetScopeRefusal(o.Session, pr.Sessions, allMatches); err != nil {
+			return err
+		}
+	}
 	result, err := index.Forget(dir, o)
 	if err != nil {
 		return err
 	}
-	// A dry run changes nothing, so reporting it in the past tense — the same
-	// three lines the real command prints — tells the reader their sessions are
-	// gone when they are not.
-	// An id copied off a result line can stand for more than one session — the
-	// characters that would tell them apart are the ones the line elided. A
-	// destructive command must not drop twice what the reader named once
-	// (#859).
-	if o.Session != "" && strings.Contains(o.Session, "…") && result.Sessions > 1 {
-		return fmt.Errorf("%q matches %d sessions — the ids differ in the middle the line elides; `deja last` prints them whole", o.Session, result.Sessions)
-	}
 	if o.DryRun {
 		fmt.Fprintf(os.Stdout, "dry run — nothing was changed\nwould drop: %d session(s), %d message(s)\nwould add: %d tombstone(s)\n",
 			result.Sessions, result.Messages, result.Tombstones)
+		// The dry run is where someone checks the scope, so it says the same
+		// thing the real run would refuse with rather than erroring: nothing
+		// is being changed here, and the note is the answer they came for.
+		if o.Session != "" {
+			if scope := forgetScopeRefusal(o.Session, result.Sessions, allMatches); scope != nil {
+				fmt.Fprintln(os.Stdout, scope.Error())
+			}
+		}
 		if result.Notes > 0 {
 			fmt.Fprintf(os.Stdout, "%d of them %s promoted note%s — the decisions you kept, not raw sessions\n",
 				result.Notes, verbWere(result.Notes), pluralS(result.Notes))
@@ -1651,7 +1683,7 @@ Usage:
   deja last [n] [--json] [--project name] [--harness name] [--since duration] [--role user|assistant|tool]
   deja sources
   deja completion <bash|zsh|fish>
-  deja forget --session <id-prefix> [--project <substring>] [--before <duration|date>] [--dry-run]
+  deja forget --session <id-prefix> [--project <substring>] [--before <duration|date>] [--dry-run] [--all-matches]
   deja forget --list | --unforget <id>
   deja doctor [--json] [--deep] [--offline]
   deja warmup

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -250,7 +250,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Project) == "" {
 			a.Project = "notes"
 		}
-		if err := sources.AppendNote(a.Project, a.Text, time.Now()); err != nil {
+		if err := notesWriteError(sources.AppendNote(a.Project, a.Text, time.Now())); err != nil {
 			return "", err
 		}
 		if err := index.EnsureForSearch(dir, search.Options{All: true}, false, mcpProgress()); err != nil {

--- a/cmd/deja/notes_write_error_test.go
+++ b/cmd/deja/notes_write_error_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// Three commands write the notes file — promote, `deja remember` and the MCP
+// remember tool — and only promote said what to do when the write was refused.
+// The other two handed back `open …: permission denied`, over MCP to an agent
+// that has to decide what to tell the user (#869).
+func TestEveryNoteWriterSaysWhatToDoWhenRefused(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("file permissions do not deny writes here")
+	}
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	if err := os.WriteFile(notes, []byte(""), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_NOTES_FILE", notes)
+
+	want := func(t *testing.T, label string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: write into a read-only notes file succeeded", label)
+		}
+		got := err.Error()
+		if !strings.Contains(got, "cannot write "+notes) || !strings.Contains(got, "DEJA_NOTES_FILE") {
+			t.Errorf("%s: %q", label, got)
+		}
+		if strings.HasPrefix(got, "open ") {
+			t.Errorf("%s still returns the raw syscall: %q", label, got)
+		}
+	}
+
+	want(t, "remember", runRemember(filepath.Join(tmp, "idx"), []string{"a decision"}))
+	want(t, "mcp remember", notesWriteError(sources.AppendNote("proj", "a decision", time.Now())))
+	want(t, "promoted note", notesWriteError(sources.AppendPromoted("proj", "t", "b", "claude:x", "accepted", time.Now())))
+
+	// A writable file still writes: the helper only rewords a refusal.
+	if err := os.Chmod(notes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := notesWriteError(sources.AppendNote("proj", "a decision", time.Now())); err != nil {
+		t.Errorf("writable notes file refused: %v", err)
+	}
+}

--- a/cmd/deja/progress.go
+++ b/cmd/deja/progress.go
@@ -189,6 +189,14 @@ func (p *buildProgress) bar() string {
 // withBuildProgress runs fn with a live build display when stdout is a
 // terminal, and unchanged otherwise.
 func withBuildProgress(fn func() error) error {
+	// The detached warmup writes to /dev/null, which is a character device and
+	// so passes for a terminal. The live display then replaced the file sink
+	// withWarmupStatus had just installed and painted its animation into the
+	// device that discards it, leaving every "memory is on its way" line —
+	// hook, statusline, MCP, empty recall — with nothing to read (#862).
+	if os.Getenv("DEJA_WARMUP_SENTINEL") != "" {
+		return fn()
+	}
 	if !logoWanted(os.Stdout) {
 		return fn()
 	}

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -66,6 +66,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 		return fmt.Errorf("promote: state must be accepted, rejected, superseded or stale — `--state accepted` takes an earlier mark back")
 	}
 	s, ok, err := findByPrefix(dir, prefix)
+	noteAmbiguousPrefix(dir, prefix, "promoting")
 	if err != nil {
 		return err
 	}

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -91,7 +91,12 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	if exportPath != "" {
 		masked, err := exportPromoted(exportPath, title, text, src, state, s.Updated)
 		if err != nil {
-			return err
+			// The note is already written by this point, so failing with a bare
+			// syscall told the reader their decision was lost when it was not
+			// — and named a path with nothing to do about it (#871).
+			fmt.Fprintf(stdout, "promoted %s as %s: %s\n", src, state, title)
+			return fmt.Errorf("the note is kept, but %s could not be written (%s) — export it somewhere you can, or read the note back with `deja show %s`",
+				exportPath, exportFailureReason(err), "deja-note-"+strings.ReplaceAll(src, ":", "-"))
 		}
 		// The one outbound path that said nothing: `--to` exists to hand a
 		// decision to someone, and `share` and `sync export` both end with this
@@ -214,10 +219,52 @@ func exportPromoted(path, title, text, src, state string, updated time.Time) (in
 		return 0, err
 	}
 	defer func() { _ = f.Close() }()
+	// The separating blank line is the leading "\n" below, which assumes the
+	// file already ends with one. A markdown file whose last line has no
+	// newline — a hand-written list, most often — got the heading glued to it
+	// (#871).
+	lead := ""
+	if fi, statErr := f.Stat(); statErr == nil && fi.Size() > 0 && !endsWithNewline(path) {
+		lead = "\n"
+	}
 	day := updated.UTC().Format("2006-01-02")
 	if updated.IsZero() {
 		day = time.Now().UTC().Format("2006-01-02")
 	}
-	_, err = fmt.Fprintf(f, "\n## %s\n\n- state: %s\n- source: %s (%s)\n\n%s\n", title, state, src, day, text)
+	_, err = fmt.Fprintf(f, "%s\n## %s\n\n- state: %s\n- source: %s (%s)\n\n%s\n", lead, title, state, src, day, text)
 	return masked, err
+}
+
+// exportFailureReason names why the export path could not be written, without
+// repeating the path the caller already prints.
+func exportFailureReason(err error) string {
+	switch {
+	case errors.Is(err, fs.ErrPermission):
+		return "permission denied"
+	case errors.Is(err, fs.ErrNotExist):
+		return "its directory does not exist"
+	case strings.Contains(err.Error(), "is a directory"):
+		return "that path is a directory"
+	}
+	return err.Error()
+}
+
+// endsWithNewline reports whether the file's last byte is a newline. Reading
+// one byte is cheaper than reading the file, and the answer decides whether
+// the appended section needs its own separator.
+func endsWithNewline(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return true
+	}
+	defer func() { _ = f.Close() }()
+	fi, err := f.Stat()
+	if err != nil || fi.Size() == 0 {
+		return true
+	}
+	buf := make([]byte, 1)
+	if _, err := f.ReadAt(buf, fi.Size()-1); err != nil {
+		return true
+	}
+	return buf[0] == '\n'
 }

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -86,13 +86,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 		title = firstLine(text)
 	}
 	if err := sources.AppendPromotedTagged(s.Project, title, text, src, state, tags, time.Now()); err != nil {
-		// A decision the user wants to keep is what this command exists for,
-		// and `open …: permission denied` names a syscall and nothing to do
-		// about it — while index and forget both say what to change (#806).
-		if errors.Is(err, fs.ErrPermission) {
-			return fmt.Errorf("cannot write %s — check that file and its directory's permissions, or set DEJA_NOTES_FILE somewhere writable", sources.NotesFile())
-		}
-		return err
+		return notesWriteError(err)
 	}
 	if exportPath != "" {
 		masked, err := exportPromoted(exportPath, title, text, src, state, s.Updated)
@@ -133,6 +127,19 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 // clear` are rejected, and `deja forget --session deja-note-…` prints
 // "sessions dropped: 1" while the label survives, because the state is read
 // from the notes file and not from the index (#845).
+// notesWriteError turns a refused write of the notes file into something the
+// reader can act on. A decision someone wants to keep is what these commands
+// exist for, and `open …: permission denied` names a syscall and nothing to do
+// about it — while index and forget both say what to change (#806). The same
+// file is written by promote, `deja remember` and the MCP remember tool, and
+// only promote said it (#869).
+func notesWriteError(err error) error {
+	if errors.Is(err, fs.ErrPermission) {
+		return fmt.Errorf("cannot write %s — check that file and its directory's permissions, or set DEJA_NOTES_FILE somewhere writable", sources.NotesFile())
+	}
+	return err
+}
+
 func markTakenBack(src, state string, prior sources.Lifecycle) string {
 	if state != "accepted" || prior.State == "" || prior.State == "accepted" {
 		return ""

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -118,15 +118,6 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	return nil
 }
 
-// markTakenBack says that an accepted mark cleared the rejected/superseded/
-// stale one before it.
-//
-// The undo works and always did — the latest mark wins, so `--state accepted`
-// drops the label and the demotion — but nothing said so. The measured
-// alternatives all fail, two of them loudly: `--state none` and `--state
-// clear` are rejected, and `deja forget --session deja-note-…` prints
-// "sessions dropped: 1" while the label survives, because the state is read
-// from the notes file and not from the index (#845).
 // notesWriteError turns a refused write of the notes file into something the
 // reader can act on. A decision someone wants to keep is what these commands
 // exist for, and `open …: permission denied` names a syscall and nothing to do
@@ -140,6 +131,15 @@ func notesWriteError(err error) error {
 	return err
 }
 
+// markTakenBack says that an accepted mark cleared the rejected/superseded/
+// stale one before it.
+//
+// The undo works and always did — the latest mark wins, so `--state accepted`
+// drops the label and the demotion — but nothing said so. The measured
+// alternatives all fail, two of them loudly: `--state none` and `--state
+// clear` are rejected, and `deja forget --session deja-note-…` prints
+// "sessions dropped: 1" while the label survives, because the state is read
+// from the notes file and not from the index (#845).
 func markTakenBack(src, state string, prior sources.Lifecycle) string {
 	if state != "accepted" || prior.State == "" || prior.State == "accepted" {
 		return ""

--- a/cmd/deja/promote_export_test.go
+++ b/cmd/deja/promote_export_test.go
@@ -3,53 +3,78 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
-// `--to` exists to hand a decision to someone, and it was the one outbound
-// path that neither ran the redaction pass nor printed the floor `share` and
-// `sync export` both end with (#848).
-func TestPromoteToRedactsAndSaysSo(t *testing.T) {
-	hermeticEnv(t)
-	notesDir := filepath.Join(t.TempDir(), "notes")
-	if err := os.MkdirAll(notesDir, 0o700); err != nil {
+// The heading is separated from what came before by the leading newline of the
+// section, which assumes the file ends with one. A hand-written file whose last
+// line has no newline — a list, most often — got the heading glued to it (#871).
+func TestExportAppendsAfterAFileWithNoTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	glued := filepath.Join(dir, "nonl.md")
+	if err := os.WriteFile(glued, []byte("# Notes\n\n- a line without a newline"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("DEJA_NOTES_FILE", filepath.Join(notesDir, "notes.jsonl"))
-	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
-	if err := os.MkdirAll(store, 0o755); err != nil {
+	if _, err := exportPromoted(glued, "pool exhausted", "raised it", "claude:s1", "accepted", time.Time{}); err != nil {
 		t.Fatal(err)
 	}
-	line := `{"type":"user","message":{"role":"user","content":"the staging credentials live in the vault"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"w3","cwd":"/proj"}`
-	if err := os.WriteFile(filepath.Join(store, "a.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+	got, err := os.ReadFile(glued)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := captureRunStderr(t, "index"); err != nil {
-		t.Fatal(err)
+	if !strings.Contains(string(got), "a line without a newline\n\n## pool exhausted") {
+		t.Errorf("heading is not separated from the file's last line:\n%q", string(got))
 	}
 
-	out := filepath.Join(t.TempDir(), "decision.md")
-	secret := "ghp_abcdefghij0123456789abcdefghij0123"
-	msg, err := captureRunStderr(t, "promote", "w3", "--state", "accepted",
-		"--note", "vault path acme/staging, token "+secret, "--to", out)
+	// A file that does end with a newline keeps exactly one blank line.
+	normal := filepath.Join(dir, "norm.md")
+	if err := os.WriteFile(normal, []byte("# Notes\n\ntext\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := exportPromoted(normal, "pool exhausted", "raised it", "claude:s1", "accepted", time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	got, err = os.ReadFile(normal)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(msg, "pattern redaction is a floor") {
-		t.Errorf("the file handed to someone was written without the floor warning:\n%s", msg)
+	if !strings.Contains(string(got), "text\n\n## pool exhausted") || strings.Contains(string(got), "text\n\n\n") {
+		t.Errorf("normal append changed shape:\n%q", string(got))
 	}
-	body, err := os.ReadFile(out)
-	if err != nil {
+}
+
+// A failed export said "open …: no such file or directory" and nothing else,
+// so a reader whose note had already been written was told their decision was
+// lost (#871).
+func TestExportFailureSaysTheNoteIsKept(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("permission behaviour differs here")
+	}
+	dir := t.TempDir()
+	for _, tc := range []struct{ path, reason string }{
+		{filepath.Join(dir, "nope", "out.md"), "its directory does not exist"},
+		{dir, "that path is a directory"},
+	} {
+		_, err := exportPromoted(tc.path, "t", "b", "claude:s1", "accepted", time.Time{})
+		if err == nil {
+			t.Fatalf("%s: export succeeded", tc.path)
+		}
+		if got := exportFailureReason(err); got != tc.reason {
+			t.Errorf("%s: reason = %q, want %q", tc.path, got, tc.reason)
+		}
+	}
+	ro := filepath.Join(dir, "ro.md")
+	if err := os.WriteFile(ro, []byte("x\n"), 0o400); err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(body), secret) {
-		t.Errorf("the token was written verbatim:\n%s", body)
+	_, err := exportPromoted(ro, "t", "b", "claude:s1", "accepted", time.Time{})
+	if err == nil {
+		t.Fatal("export into a read-only file succeeded")
 	}
-	if !strings.Contains(string(body), "vault path acme/staging") {
-		t.Errorf("the writer's own words were lost:\n%s", body)
-	}
-	if !strings.Contains(string(body), "state: accepted") {
-		t.Errorf("the note lost its state:\n%s", body)
+	if got := exportFailureReason(err); got != "permission denied" {
+		t.Errorf("reason = %q", got)
 	}
 }

--- a/cmd/deja/remember.go
+++ b/cmd/deja/remember.go
@@ -50,7 +50,7 @@ func runRemember(dir string, args []string) error {
 		project = sources.ClaudeProjectName(cwd)
 	}
 	if err := sources.AppendNoteTagged(project, text, tags, time.Now()); err != nil {
-		return err
+		return notesWriteError(err)
 	}
 	if err := index.EnsureForSearch(dir, search.Options{All: true}, false, os.Stderr); err != nil {
 		return err

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -35,6 +35,7 @@ func runResume(dir string, args []string, stdout io.Writer) error {
 		return fmt.Errorf("resume needs id-prefix")
 	}
 	s, ok, err := findByPrefix(dir, prefix)
+	noteAmbiguousPrefix(dir, prefix, "resuming")
 	if err != nil {
 		return err
 	}

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -15,6 +15,7 @@ func runShare(dir string, args []string, w io.Writer) error {
 		return fmt.Errorf("share needs id-prefix")
 	}
 	s, ok, err := findByPrefix(dir, args[0])
+	noteAmbiguousPrefix(dir, args[0], "sharing")
 	if err != nil {
 		return err
 	}

--- a/cmd/deja/update.go
+++ b/cmd/deja/update.go
@@ -219,7 +219,17 @@ func performUpdate(cfg updateConfig, out io.Writer) error {
 	}
 	if err := installUpdateBinary(cfg.executable, binary); err != nil {
 		if errors.Is(err, os.ErrPermission) {
-			return fmt.Errorf("replace %s: %w; rerun with permission to write its install directory or use your package manager", cfg.executable, err)
+			// The raw error names the temporary file deja was about to write,
+			// which does not exist and cannot be acted on; the directory is
+			// what the reader has to change. And when a package manager owns
+			// the binary, deja knows its name and its command — it prints
+			// them when the same command succeeds — so "use your package
+			// manager" was advice deja could have finished (#865).
+			dir := filepath.Dir(cfg.executable)
+			if _, command := packageManagerOwning(cfg.executable); command != "" {
+				return fmt.Errorf("cannot replace %s: no permission to write %s — `%s` updates it, or rerun with permission to write that directory", cfg.executable, dir, command)
+			}
+			return fmt.Errorf("cannot replace %s: no permission to write %s — rerun with permission to write that directory", cfg.executable, dir)
 		}
 		return fmt.Errorf("replace %s: %w", cfg.executable, err)
 	}

--- a/cmd/deja/update.go
+++ b/cmd/deja/update.go
@@ -217,6 +217,14 @@ func performUpdate(cfg updateConfig, out io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("extract %s: %w", archiveName, err)
 	}
+	// Reaching here with a manager-owned binary means the reader passed
+	// --force: the branch above returns otherwise. That is their decision, so
+	// deja writes — but the consequence it spells out without --force is the
+	// one it never mentioned with it, and the next manager run silently puts
+	// the old binary back (#866).
+	if mgr, command := packageManagerOwning(cfg.executable); mgr != "" {
+		fmt.Fprintf(out, "warning: %s manages this binary — the next %s run puts its own version back; `%s` updates it for good\n", mgr, mgr, command)
+	}
 	if err := installUpdateBinary(cfg.executable, binary); err != nil {
 		if errors.Is(err, os.ErrPermission) {
 			// The raw error names the temporary file deja was about to write,

--- a/cmd/deja/update_denied_advice_test.go
+++ b/cmd/deja/update_denied_advice_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// A failed replace named the temporary file deja was about to write — a path
+// that does not exist and cannot be acted on — and finished with "or use your
+// package manager" on a binary whose manager deja can name (#865).
+func TestUpdateDeniedNamesTheDirectoryAndTheManager(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits do not block writes the same way on windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory write permissions")
+	}
+	archiveName, binaryName, err := updateAssetNames("2.0.0", "linux", "amd64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive := makeUpdateArchive(t, "linux", binaryName, []byte("new binary"))
+	sum := fmt.Sprintf("%x", sha256.Sum256(archive))
+	release := []byte(fmt.Sprintf(`{"tag_name":"v2.0.0","assets":[{"name":%q,"browser_download_url":"archive"},{"name":"checksums.txt","browser_download_url":"checksums"}]}`, archiveName))
+	download := func(url string, limit int64, label string) ([]byte, error) {
+		switch label {
+		case "checksums.txt":
+			return []byte(sum + "  " + archiveName + "\n"), nil
+		case archiveName:
+			return archive, nil
+		default:
+			return release, nil
+		}
+	}
+
+	run := func(t *testing.T, dir string) error {
+		t.Helper()
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		dest := filepath.Join(dir, "deja")
+		if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(dir, 0o555); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+		return performUpdate(updateConfig{force: true, currentVersion: "dev", goos: "linux", goarch: "amd64",
+			executable: dest, latestURL: testLatestReleaseURL, download: download}, io.Discard)
+	}
+
+	brewDir := filepath.Join(t.TempDir(), "Cellar", "deja-vu", "0.16.5", "bin")
+	err = run(t, brewDir)
+	if err == nil {
+		t.Fatal("replace into an unwritable directory succeeded")
+	}
+	got := err.Error()
+	if !strings.Contains(got, brewDir) {
+		t.Errorf("message does not name the directory: %q", got)
+	}
+	if !strings.Contains(got, "brew upgrade deja-vu") {
+		t.Errorf("message does not name the manager's command: %q", got)
+	}
+	if strings.Contains(got, ".deja-update-") {
+		t.Errorf("message names the internal temporary file: %q", got)
+	}
+
+	// No manager owns it: the advice stops at the directory rather than
+	// inventing a package manager the reader does not have.
+	plain := filepath.Join(t.TempDir(), "bin")
+	err = run(t, plain)
+	if err == nil {
+		t.Fatal("replace into an unwritable directory succeeded")
+	}
+	got = err.Error()
+	if !strings.Contains(got, plain) {
+		t.Errorf("message does not name the directory: %q", got)
+	}
+	if strings.Contains(got, "package manager") {
+		t.Errorf("unmanaged binary still told to use a package manager: %q", got)
+	}
+}

--- a/cmd/deja/update_force_managed_test.go
+++ b/cmd/deja/update_force_managed_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Without --force deja explains that a manager owns the binary and that the
+// next manager run puts the old one back. With --force it wrote in silence —
+// the consequence was told only to the reader who did not take that path
+// (#866).
+func TestForcedUpdateOverAManagedBinaryWarnsBeforeWriting(t *testing.T) {
+	archiveName, binaryName, err := updateAssetNames("2.0.0", "linux", "amd64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive := makeUpdateArchive(t, "linux", binaryName, []byte("new binary"))
+	sum := fmt.Sprintf("%x", sha256.Sum256(archive))
+	release := []byte(fmt.Sprintf(`{"tag_name":"v2.0.0","assets":[{"name":%q,"browser_download_url":"archive"},{"name":"checksums.txt","browser_download_url":"checksums"}]}`, archiveName))
+	download := func(url string, limit int64, label string) ([]byte, error) {
+		switch label {
+		case "checksums.txt":
+			return []byte(sum + "  " + archiveName + "\n"), nil
+		case archiveName:
+			return archive, nil
+		default:
+			return release, nil
+		}
+	}
+	run := func(t *testing.T, dir string) string {
+		t.Helper()
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		dest := filepath.Join(dir, "deja")
+		if err := os.WriteFile(dest, []byte("old"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		var out bytes.Buffer
+		if err := performUpdate(updateConfig{force: true, currentVersion: "0.16.5", goos: "linux", goarch: "amd64",
+			executable: dest, latestURL: testLatestReleaseURL, download: download}, &out); err != nil {
+			t.Fatal(err)
+		}
+		return out.String()
+	}
+
+	got := run(t, filepath.Join(t.TempDir(), "Cellar", "deja-vu", "0.16.5", "bin"))
+	if !strings.Contains(got, "Homebrew manages this binary") || !strings.Contains(got, "brew upgrade deja-vu") {
+		t.Errorf("forced update over a Homebrew binary said nothing about it:\n%s", got)
+	}
+	// The warning comes before the write is reported, not after it.
+	if i, j := strings.Index(got, "Homebrew manages"), strings.Index(got, "updated deja"); i < 0 || j < 0 || i > j {
+		t.Errorf("warning does not precede the result:\n%s", got)
+	}
+
+	// Nothing owns this one: no warning to give.
+	got = run(t, filepath.Join(t.TempDir(), "bin"))
+	if strings.Contains(got, "manages this binary") {
+		t.Errorf("unmanaged binary warned about a manager:\n%s", got)
+	}
+}

--- a/cmd/deja/warmup_dead_test.go
+++ b/cmd/deja/warmup_dead_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// A warmup killed mid-build leaves its sentinel behind, and the sentinel is
+// what stops the next hook from starting another. For ten minutes every hook
+// then returned nothing, spawned nothing and said nothing (#875).
+func TestAKilledWarmupIsRetriedWithoutWaitingOutTheWindow(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	dir := filepath.Join(tmp, "index.db")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(dir, "warmup.sentinel")
+
+	spawned := 0
+	saved := spawnWarmup
+	spawnWarmup = func(exe, s string) error { spawned++; return nil }
+	t.Cleanup(func() { spawnWarmup = saved })
+
+	writeSentinel := func(age time.Duration) {
+		stamp := time.Now().Add(-age).UnixNano()
+		if err := os.WriteFile(sentinel, []byte(strconv.FormatInt(stamp, 10)+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeStatus := func(age time.Duration) {
+		st := warmupStatus{Phase: "reading sessions", Total: 10, Done: 1, Started: time.Now().UnixNano(), Updated: time.Now().Add(-age).UnixNano()}
+		b, err := json.Marshal(st)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(warmupStatusPath(dir), b, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A build that is running and reporting: no second warmup.
+	writeSentinel(30 * time.Second)
+	writeStatus(0)
+	requestWarmup(dir)
+	if spawned != 0 {
+		t.Errorf("a live build was restarted %d time(s)", spawned)
+	}
+
+	// Same sentinel age, no status at all: still inside the grace period, so
+	// a build that has not published its first report yet is left alone.
+	if err := os.Remove(warmupStatusPath(dir)); err != nil {
+		t.Fatal(err)
+	}
+	requestWarmup(dir)
+	if spawned != 0 {
+		t.Errorf("a build that had not reported yet was restarted %d time(s)", spawned)
+	}
+
+	// Sentinel older than the grace period and nothing reporting: dead.
+	writeSentinel(3 * time.Minute)
+	requestWarmup(dir)
+	if spawned != 1 {
+		t.Errorf("a dead warmup was retried %d time(s), want 1", spawned)
+	}
+	// The sentinel is rewritten, so the next hook does not spawn a third.
+	b, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stamp, err := strconv.ParseInt(string(b[:len(b)-1]), 10, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if age := time.Since(time.Unix(0, stamp)); age > time.Minute {
+		t.Errorf("sentinel was not refreshed: %v old", age)
+	}
+	requestWarmup(dir)
+	if spawned != 1 {
+		t.Errorf("the retry spawned again immediately: %d", spawned)
+	}
+}

--- a/cmd/deja/warmup_publishes_test.go
+++ b/cmd/deja/warmup_publishes_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The warmup child is spawned with stdout on /dev/null, a character device
+// that passes for a terminal — so the live display took over the sink that
+// publishes progress and every "memory is on its way" line had nothing to
+// read (#862).
+func TestWarmupPublishesStatusWhenStdoutLooksLikeATerminal(t *testing.T) {
+	tmp := hermeticEnv(t)
+	chats := filepath.Join(tmp, "qwen", "projects", "proj", "chats")
+	if err := os.MkdirAll(chats, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"q-1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","parts":[{"text":"pool exhausted"}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(chats, "a.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
+	t.Setenv("DEJA_WARMUP_SENTINEL", filepath.Join(tmp, "sentinel"))
+
+	saved := logoWanted
+	logoWanted = func(*os.File) bool { return true }
+	t.Cleanup(func() { logoWanted = saved })
+
+	dir := filepath.Join(tmp, "idx")
+	var published bool
+	err := withWarmupStatus(dir, func() error {
+		return withBuildProgress(func() error {
+			if err := index.Ensure(dir, "", false, nil); err != nil {
+				return err
+			}
+			// Still inside withWarmupStatus, so the file has not been
+			// cleaned up yet: what a reader would have seen mid-build.
+			_, err := os.Stat(warmupStatusPath(dir))
+			published = err == nil
+			return nil
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !published {
+		t.Error("no warmup status was published while the index was building")
+	}
+	// And it is cleaned up: a status left behind tells every later session
+	// that memory is still coming when the build finished long ago.
+	if _, err := os.Stat(warmupStatusPath(dir)); !os.IsNotExist(err) {
+		t.Errorf("warmup status survived the build: %v", err)
+	}
+}

--- a/internal/index/empty_sessions_test.go
+++ b/internal/index/empty_sessions_test.go
@@ -55,3 +55,28 @@ func TestSessionsWithNothingToIndexAreNotCounted(t *testing.T) {
 		t.Errorf("after rebuild manifest holds %d claude sessions, want 1", counts["claude"])
 	}
 }
+
+// OlderFormat must separate an index this build cannot read from one it cannot
+// read at all: doctor says "written by an older deja" on the first, and a
+// corrupt manifest is not that (#877).
+func TestOlderFormatOnlyReportsAReadableOldIndex(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeManifest(dir, Manifest{Version: version, Sessions: map[string]SessionMeta{}}); err != nil {
+		t.Fatal(err)
+	}
+	if OlderFormat(dir) {
+		t.Error("a current index was called old")
+	}
+	if err := writeManifest(dir, Manifest{Version: version - 1, Sessions: map[string]SessionMeta{}}); err != nil {
+		t.Fatal(err)
+	}
+	if !OlderFormat(dir) {
+		t.Error("an index from an older format was not reported")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.gob"), []byte("not a gob"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if OlderFormat(dir) {
+		t.Error("an unreadable manifest was called an older format")
+	}
+}

--- a/internal/index/empty_sessions_test.go
+++ b/internal/index/empty_sessions_test.go
@@ -1,0 +1,57 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A transcript whose every message strips to empty still got a manifest row:
+// `last` printed a blank line for it, `show` printed a bare header, and the
+// counters disagreed — brief and doctor read the manifest, stats reads the
+// records (1159 against 1157 on my store) (#868).
+func TestSessionsWithNothingToIndexAreNotCounted(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	root := filepath.Join(home, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	proj := filepath.Join(root, "-tmp-g")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(proj, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("a.jsonl", `{"type":"user","sessionId":"n1","cwd":"/tmp/g","timestamp":"2026-08-01T10:00:00Z","message":{"role":"user","content":"pool exhausted"}}`+"\n")
+	// Nothing but whitespace: parsed as a message, never written as a record.
+	write("b.jsonl", `{"type":"user","sessionId":"e2","cwd":"/tmp/g","timestamp":"2026-08-01T08:00:00Z","message":{"role":"user","content":"   "}}`+"\n")
+
+	dir := filepath.Join(home, "idx")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := ReportEmptySessions(); n != 1 {
+		t.Errorf("empty transcripts reported = %d, want 1", n)
+	}
+	counts := HarnessSessionCounts(dir)
+	if counts["claude"] != 1 {
+		t.Errorf("manifest holds %d claude sessions, want 1", counts["claude"])
+	}
+	ss, err := Recent(dir, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || ss[0].ID != "n1" {
+		t.Fatalf("recent = %+v, want only n1", ss)
+	}
+	// The session that does have content keeps its row across a rebuild.
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if counts := HarnessSessionCounts(dir); counts["claude"] != 1 {
+		t.Errorf("after rebuild manifest holds %d claude sessions, want 1", counts["claude"])
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -282,6 +282,8 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	preRedactSessions(&m, ss)
 	seenMsgs := msgSeen{}
 	reportPhase("indexing messages", len(ss))
+	wrote := map[string]bool{}
+	var wroteMu sync.Mutex
 	buckets, err := indexTextParallel(func(push func(tokenJob)) error {
 		for _, s := range ss {
 			reportAdvance(1)
@@ -328,6 +330,9 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 				if err != nil {
 					return err
 				}
+				wroteMu.Lock()
+				wrote[key] = true
+				wroteMu.Unlock()
 				writtenMessages++
 				push(tokenJob{text: tokenizedPart(msg.Role, text), offset: off, sid: m.Sessions[key].Ord, when: msg.Time, tool: isToolRole(msg.Role)})
 			}
@@ -341,6 +346,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	if err := rw.Close(); err != nil {
 		return err
 	}
+	dropEmptySessions(&m, wrote)
 	buildCooccur(tmp, ss)
 	reportPhase("writing index", len(buckets))
 	if err := writeBucketsConcurrent(filepath.Join(tmp, "buckets"), buckets); err != nil {
@@ -507,6 +513,30 @@ func rebuildForSearch(dir string, o query.Options, scope string, files map[strin
 	return writeSessionsWithSync(tmp, dir, ss, files, scope, imported)
 }
 
+// dropEmptySessions removes manifest rows that ended up with no records.
+//
+// A session whose every message strips to empty — harness plumbing, a prompt
+// the user never sent — still got a row, so `deja last` printed a blank line
+// for it, `show` printed a header with nothing under it, and the counters
+// disagreed: brief and doctor read the manifest and stats reads the records
+// (1159 against 1157 on my store) (#868).
+func dropEmptySessions(m *Manifest, wrote map[string]bool) {
+	for key := range m.Sessions {
+		if !wrote[key] {
+			delete(m.Sessions, key)
+			emptied.Add(1)
+		}
+	}
+}
+
+// ReportEmptySessions returns how many transcripts held nothing to index since
+// the last build, and clears the counter. The parse count and the indexed
+// count differ by exactly this, and the run is where someone is looking at
+// both numbers.
+func ReportEmptySessions() int {
+	return int(emptied.Swap(0))
+}
+
 func writeSessions(tmp, dir string, ss []model.Session, files map[string]FileState, scope string) error {
 	return writeSessionsWithSync(tmp, dir, ss, files, scope, importedState{})
 }
@@ -530,6 +560,8 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	}
 	seenMsgs := msgSeen{}
 	reportPhase("indexing messages", len(ss))
+	wrote := map[string]bool{}
+	var wroteMu sync.Mutex
 	buckets, err := indexTextParallel(func(push func(tokenJob)) error {
 		for _, s := range ss {
 			reportAdvance(1)
@@ -575,6 +607,9 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 				if err != nil {
 					return err
 				}
+				wroteMu.Lock()
+				wrote[key] = true
+				wroteMu.Unlock()
 				writtenMessages++
 				push(tokenJob{text: tokenizedPart(msg.Role, text), offset: off, sid: m.Sessions[key].Ord, when: msg.Time, tool: isToolRole(msg.Role)})
 			}
@@ -588,6 +623,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	if err := rw.Close(); err != nil {
 		return err
 	}
+	dropEmptySessions(&m, wrote)
 	buildCooccur(tmp, ss)
 	reportPhase("writing index", len(buckets))
 	if err := writeBucketsConcurrent(filepath.Join(tmp, "buckets"), buckets); err != nil {
@@ -1067,6 +1103,7 @@ func sortedKeys[V any](m map[string]V) []string {
 // current build. The two full-build paths index sessions in parallel, so the
 // counter is atomic.
 var collisions atomic.Int64
+var emptied atomic.Int64
 
 // attributeSession decides which of two transcripts sharing an id owns the
 // manifest row, and whether they collided at all. Lexicographically smallest

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -48,6 +48,28 @@ func ManifestBuiltAt(dir string) time.Time {
 	return time.Time{}
 }
 
+// HarnessSessionCounts reports how many indexed sessions each harness holds.
+//
+// doctor counts transcript files; the number of sessions those files became is
+// the other half of the same question, and until now no single command showed
+// both. A harness whose ids collide folds many files into one session — 811
+// codex rollouts into 74 sessions in #635 — and every doctor row still read as
+// a healthy store.
+func HarnessSessionCounts(dir string) map[string]int {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		return nil
+	}
+	out := map[string]int{}
+	for _, meta := range m.Sessions {
+		out[meta.Harness]++
+	}
+	return out
+}
+
 func Redactions(dir string) (RedactionStats, error) {
 	if dir == "" {
 		dir = DefaultDir()

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -20,6 +20,18 @@ func IsCurrentVersion(dir string) bool {
 	return err == nil && m.Version == version
 }
 
+// OlderFormat reports that the index on disk reads, and was written by a
+// format this build no longer understands. Distinct from IsCurrentVersion,
+// which cannot tell an old index from an unreadable one — and doctor must not
+// call a corrupt manifest "an older deja" (#877).
+func OlderFormat(dir string) bool {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifest(dir)
+	return err == nil && m.Version != version
+}
+
 func HasManifest(dir string) bool {
 	if dir == "" {
 		dir = DefaultDir()

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -256,7 +256,23 @@ func Forget(dir string, o ForgetOptions) (ForgetResult, error) {
 	dead := readTombstones()
 	matched := map[string]bool{}
 	result := ForgetResult{}
+	// An id that names a session exactly means that session. Prefix matching
+	// is documented and useful, but it also made `forget --session s1` drop
+	// s1 and every s1x beside it — twelve sessions for a selector that named
+	// one, reported only afterwards (#870).
+	exact := ""
+	if o.Session != "" {
+		for _, meta := range m.Sessions {
+			if meta.ID == o.Session {
+				exact = o.Session
+				break
+			}
+		}
+	}
 	for key, meta := range m.Sessions {
+		if exact != "" && meta.ID != exact {
+			continue
+		}
 		if !sessionMatches(meta, o) {
 			continue
 		}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -303,6 +303,9 @@ func setTier(o Options) string {
 	}
 }
 
+// notesHarness is the pseudo-harness deja files its own notes under.
+const notesHarness = "deja"
+
 // markEarlierAttempts flags hits that look like older passes over the same
 // problem: same project, heavy overlap in what matched, and a newer session
 // above some margin. The old session stays in the results — history is the
@@ -330,6 +333,16 @@ func markEarlierAttempts(hits []Hit) {
 				continue
 			}
 			a, b := hits[i], hits[j]
+			// Notes are not attempts. A day of what someone wrote down is
+			// grouped into one session, so two days of notes about the same
+			// decision overlap by construction — on a store with a thousand
+			// notes this labelled 17 of 20 note hits as work the project had
+			// moved past, including decisions nobody took back. deja already
+			// has a way to say a decision was replaced, and it is the person
+			// saying it: `promote --state superseded` (#863).
+			if a.Session.Harness == notesHarness || b.Session.Harness == notesHarness {
+				continue
+			}
 			if a.Session.Project == "" || a.Session.Project != b.Session.Project {
 				continue
 			}

--- a/internal/search/staleness_test.go
+++ b/internal/search/staleness_test.go
@@ -73,3 +73,41 @@ func TestPrintShowsEarlierAttempt(t *testing.T) {
 		t.Fatalf("print output missing earlier-attempt note: %q", b.String())
 	}
 }
+
+// A day of notes is one session, so two days about the same decision overlap
+// by construction — and the reader was told most of their own decision log
+// was work the project had moved past (#863).
+func TestNotesAreNotEarlierAttempts(t *testing.T) {
+	now := time.Now()
+	oldNote := stalenessSession("deja-day1-api", "api", "decided to keep the connection pool at 50", now.AddDate(0, 0, -30))
+	oldNote.Harness = notesHarness
+	newNote := stalenessSession("deja-day2-api", "api", "decided to keep the connection pool at 50 after review", now.AddDate(0, 0, -1))
+	newNote.Harness = notesHarness
+	// A transcript in the same project still supersedes another transcript:
+	// the exclusion is about notes, not about the whole project.
+	oldSess := stalenessSession("s-old", "api", "decided to keep the connection pool at 50", now.AddDate(0, 0, -30))
+	// A transcript whose only newer rival is a note: writing a note about a
+	// decision is not the project moving past the session that made it.
+	lonely := stalenessSession("s-lonely", "web", "decided to keep the connection pool at 50", now.AddDate(0, 0, -30))
+	lonelyNote := stalenessSession("deja-day2-web", "web", "decided to keep the connection pool at 50 after review", now.AddDate(0, 0, -1))
+	lonelyNote.Harness = notesHarness
+	newSess := stalenessSession("s-new", "api", "decided to keep the connection pool at 50 after review", now.AddDate(0, 0, -1))
+
+	hits, err := Run([]model.Session{oldNote, newNote, oldSess, newSess, lonely, lonelyNote}, Options{Query: "connection pool", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]Hit{}
+	for _, h := range hits {
+		byID[h.Session.ID] = h
+	}
+	if got := byID["deja-day1-api"].Superseded; got != "" {
+		t.Errorf("note labelled an earlier attempt: %q", got)
+	}
+	if byID["s-old"].Superseded == "" {
+		t.Error("an older transcript stopped being marked")
+	}
+	if got := byID["s-lonely"].Superseded; got != "" {
+		t.Errorf("transcript marked as superseded by a note: %q", got)
+	}
+}


### PR DESCRIPTION
Two projects sharing a head and a tail — `super-service` and `hyper-service` — print the same elided id:

```
[deja] hyper-service · today · deja-2026…er-service — 3 matches
[deja] super-service · today · deja-2026…er-service — 3 matches

before: deja show 'deja-2026…er-service'   → … use a longer prefix for another
        deja forget --session '…' --dry-run → would drop: 2 session(s)
after:  deja show                          → … the ids differ in the middle the line elides — `deja last` prints them whole
        deja forget                        → "deja-2026…er-service" matches 2 sessions — …
```

A longer prefix is exactly what the reader does not have. An unambiguous elided id still works, and a plain ambiguous prefix keeps its old advice. Closes #859.