### PR TITLE
fix: say when the index is being rebuilt, and stop treating future dates as now

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -334,12 +334,17 @@ func doctorHarnesses(w io.Writer, dir string) {
 		if present {
 			status = "found"
 		}
-		if present {
-			if n, ok := indexed[name]; ok {
-				if detail != "" {
-					detail += ", "
-				}
-				detail += doctorCount(n, "indexed session")
+		// Also when the store is missing: a machine whose history arrived by
+		// `sync import` has no files at all, and doctor said nothing about the
+		// sessions it does hold — the only surface that names them was stats
+		// (#892).
+		if n, ok := indexed[name]; ok {
+			if detail != "" {
+				detail += ", "
+			}
+			detail += doctorCount(n, "indexed session")
+			if !present {
+				detail += " from elsewhere"
 			}
 		}
 		line := fmt.Sprintf("  %-12s %-8s %s", name, status, path)

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -708,9 +708,9 @@ func doctorTOMLWired(path string) bool {
 	return false
 }
 
-// indexOlderFormat is a variable so a test can put doctor in front of an index
-// this build cannot read without shipping a manifest writer.
-var indexOlderFormat = index.OlderFormat
+// indexFormatDirection is a variable so a test can put doctor in front of an
+// index this build cannot read without shipping a manifest writer.
+var indexFormatDirection = index.FormatDirection
 
 func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 	fmt.Fprintln(w, "Index:")
@@ -744,8 +744,13 @@ func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 	// hook paths refuse it and ask for a rebuild, which is why memory goes
 	// quiet after an upgrade. doctor called that "up to date" — the one
 	// command someone runs to find out why nothing is recalled (#877).
-	if indexOlderFormat(dir) {
+	switch indexFormatDirection(dir) {
+	case -1:
 		fmt.Fprintln(w, "  format   written by an older deja — this build cannot read it; the next session rebuilds it, or run `deja index` now")
+	case 1:
+		// The binary was rolled back, not the index. Saying "older" here sent
+		// that reader looking in the wrong direction (#890).
+		fmt.Fprintln(w, "  format   written by a newer deja than this one — this build rebuilds it in its own format; upgrading again rebuilds it back")
 	}
 	// A store whose postings vanished or whose record log was truncated cannot
 	// answer anything, and said "up to date" until #735. The next search

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -328,6 +328,7 @@ func doctorHarnesses(w io.Writer, dir string) {
 	// reuses a thread id — and the difference is invisible in a row that only
 	// counts files (#861).
 	indexed := index.HarnessSessionCounts(dir)
+	fromElsewhere := index.ImportedSessionCounts(dir)
 
 	printRow := func(name, path string, present bool, detail string) {
 		status := "missing"
@@ -342,9 +343,18 @@ func doctorHarnesses(w io.Writer, dir string) {
 			if detail != "" {
 				detail += ", "
 			}
-			detail += doctorCount(n, "indexed session")
-			if !present {
-				detail += " from elsewhere"
+			// Local and imported counted apart: on a store with both, "3
+			// files, 8 indexed sessions" reads as a miscount, and the reader
+			// who learned from #861 that files-against-sessions shows
+			// collapsing has no way to read the other direction (#894).
+			imported := fromElsewhere[name]
+			switch imported {
+			case 0:
+				detail += doctorCount(n, "indexed session")
+			case n:
+				detail += doctorCount(n, "indexed session") + " from elsewhere"
+			default:
+				detail += doctorCount(n-imported, "indexed session") + fmt.Sprintf(", %d more from elsewhere", imported)
 			}
 		}
 		line := fmt.Sprintf("  %-12s %-8s %s", name, status, path)

--- a/cmd/deja/doctor_format_test.go
+++ b/cmd/deja/doctor_format_test.go
@@ -37,9 +37,9 @@ func TestDoctorNamesAnIndexFromAnOlderFormat(t *testing.T) {
 	}
 
 	// An index this build cannot read.
-	saved := indexOlderFormat
-	indexOlderFormat = func(string) bool { return true }
-	t.Cleanup(func() { indexOlderFormat = saved })
+	saved := indexFormatDirection
+	indexFormatDirection = func(string) int { return -1 }
+	t.Cleanup(func() { indexFormatDirection = saved })
 	out.Reset()
 	doctorIndex(&out, doctorComponent{State: "ok", Path: dir}, dir)
 	got := out.String()
@@ -48,5 +48,40 @@ func TestDoctorNamesAnIndexFromAnOlderFormat(t *testing.T) {
 	}
 	if !strings.Contains(got, "deja index") {
 		t.Errorf("doctor does not say what to do:\n%s", got)
+	}
+}
+
+// The direction matters: an index from a newer deja means the binary was
+// rolled back, and calling it old sends that reader the wrong way (#890).
+func TestDoctorTellsAnOldIndexFromANewOne(t *testing.T) {
+	hermeticEnv(t)
+	dir := t.TempDir()
+	saved := indexFormatDirection
+	t.Cleanup(func() { indexFormatDirection = saved })
+
+	line := func(direction int) string {
+		indexFormatDirection = func(string) int { return direction }
+		var out bytes.Buffer
+		doctorIndex(&out, doctorComponent{State: "ok", Path: dir}, dir)
+		for _, l := range strings.Split(out.String(), "\n") {
+			if strings.Contains(l, "format ") {
+				return l
+			}
+		}
+		return ""
+	}
+
+	if got := line(-1); !strings.Contains(got, "written by an older deja") {
+		t.Errorf("older index: %q", got)
+	}
+	got := line(1)
+	if !strings.Contains(got, "written by a newer deja") {
+		t.Errorf("newer index: %q", got)
+	}
+	if strings.Contains(got, "older") {
+		t.Errorf("a rolled-back binary was told its index is old: %q", got)
+	}
+	if got := line(0); got != "" {
+		t.Errorf("a matching format still printed: %q", got)
 	}
 }

--- a/cmd/deja/doctor_indexed_sessions_test.go
+++ b/cmd/deja/doctor_indexed_sessions_test.go
@@ -41,6 +41,17 @@ func TestDoctorRowCountsIndexedSessions(t *testing.T) {
 		t.Errorf("row does not show both counts: %q", row)
 	}
 
+	// A harness whose store is not on this machine but whose sessions are in
+	// the index — everything arrived by `sync import` — is named too, and said
+	// to have come from elsewhere (#892).
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "gone"))
+	buf.Reset()
+	doctorHarnesses(&buf, dir)
+	if row := harnessRow(t, buf.String(), "qwen"); !strings.Contains(row, "1 indexed session from elsewhere") {
+		t.Errorf("a store that is only in the index says nothing: %q", row)
+	}
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
+
 	// A harness with nothing in the index says nothing rather than "0": the
 	// row is about what deja found, and a zero there reads as a failure.
 	buf.Reset()

--- a/cmd/deja/doctor_indexed_sessions_test.go
+++ b/cmd/deja/doctor_indexed_sessions_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,10 +48,41 @@ func TestDoctorRowCountsIndexedSessions(t *testing.T) {
 	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "gone"))
 	buf.Reset()
 	doctorHarnesses(&buf, dir)
-	if row := harnessRow(t, buf.String(), "qwen"); !strings.Contains(row, "1 indexed session from elsewhere") {
+	// The store is not where deja looks any more, but the session in the index
+	// is still this machine's own: the count is named without claiming it came
+	// from another machine (#892, narrowed by #894).
+	if row := harnessRow(t, buf.String(), "qwen"); !strings.Contains(row, "1 indexed session") {
 		t.Errorf("a store that is only in the index says nothing: %q", row)
+	} else if strings.Contains(row, "from elsewhere") {
+		t.Errorf("a local session was called imported: %q", row)
 	}
 	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
+
+	// A store that has both: the two are counted apart, because "2 files, 4
+	// indexed sessions" reads as a miscount (#894).
+	exp := filepath.Join(tmp, "export")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var batch strings.Builder
+	for _, id := range []string{"r1", "r2"} {
+		b, err := json.Marshal(index.SyncRecord{Harness: "qwen", SessionID: id, Project: "remote", Role: "user", Text: "a remote session about the seal"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		batch.WriteString(string(b) + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), []byte(batch.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := index.Import(dir, exp); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	doctorHarnesses(&buf, dir)
+	if row := harnessRow(t, buf.String(), "qwen"); !strings.Contains(row, "1 indexed session, 2 more from elsewhere") {
+		t.Errorf("mixed store does not separate the two: %q", row)
+	}
 
 	// A harness with nothing in the index says nothing rather than "0": the
 	// row is about what deja found, and a zero there reads as a failure.

--- a/cmd/deja/ensure_error_test.go
+++ b/cmd/deja/ensure_error_test.go
@@ -36,3 +36,25 @@ func TestEnsureErrorNamesWhatToFix(t *testing.T) {
 		t.Errorf("unknown cause was swallowed: %q", got)
 	}
 }
+
+// A volume that went away mid-write — an unmounted disk, a network share that
+// dropped — arrived as `write /…/index.db.tmp/records.bin: input/output
+// error`, which tells the reader neither that the disk is gone nor what to do
+// (#899).
+func TestEnsureErrorNamesAnUnreachableDisk(t *testing.T) {
+	dir := filepath.Join("/Volumes", "somewhere", "index.db")
+	for _, errno := range []syscall.Errno{syscall.EIO, syscall.ENXIO, syscall.ENODEV} {
+		got := ensureError(dir, fmt.Errorf("write %s: %w", filepath.Join(dir+".tmp", "records.bin"), errno)).Error()
+		if !strings.Contains(got, "not reachable") || !strings.Contains(got, filepath.Dir(dir)) {
+			t.Errorf("%v: %q", errno, got)
+		}
+		if strings.Contains(got, "records.bin") {
+			t.Errorf("%v names an internal path: %q", errno, got)
+		}
+	}
+	// A full disk keeps its own answer: the room is there, it is just used up.
+	full := ensureError(dir, fmt.Errorf("write x: %w", syscall.ENOSPC)).Error()
+	if !strings.Contains(full, "no space left") {
+		t.Errorf("full disk lost its message: %q", full)
+	}
+}

--- a/cmd/deja/ensure_error_test.go
+++ b/cmd/deja/ensure_error_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// A full disk arrived as `ensure: write /…/index.db.tmp/records.bin: no space
+// left on device` — an internal path nobody can act on, and the same shape
+// #798 replaced for permissions (#888).
+func TestEnsureErrorNamesWhatToFix(t *testing.T) {
+	dir := filepath.Join("/tmp", "store", "index.db")
+
+	full := ensureError(dir, fmt.Errorf("write %s: %w", filepath.Join(dir+".tmp", "records.bin"), syscall.ENOSPC))
+	got := full.Error()
+	if !strings.Contains(got, "no space left where the index is built") || !strings.Contains(got, filepath.Dir(dir)) {
+		t.Errorf("full disk: %q", got)
+	}
+	if strings.Contains(got, "records.bin") || strings.Contains(got, ".tmp") {
+		t.Errorf("full disk names an internal path: %q", got)
+	}
+
+	denied := ensureError(dir, fmt.Errorf("mkdir: %w", fs.ErrPermission)).Error()
+	if !strings.Contains(denied, "check the directory's permissions") || !strings.Contains(denied, dir) {
+		t.Errorf("permission: %q", denied)
+	}
+
+	// Anything else still comes through whole rather than being guessed at.
+	other := errors.New("some other failure")
+	if got := ensureError(dir, other).Error(); !strings.Contains(got, "some other failure") {
+		t.Errorf("unknown cause was swallowed: %q", got)
+	}
+}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -168,10 +168,26 @@ func runHookContext(dir string, plain bool) error {
 		// whereas the plain path is injected into the model's context, where
 		// a progress line is noise.
 		if !plain {
+			line := ""
 			if st := readWarmupStatus(dir); st != nil {
+				line = st.line()
+			} else if warmupJustRequested(dir) && index.HasManifest(dir) {
+				// The session that asks for the build is the one that hears
+				// nothing about it: the child has not written its first
+				// progress line yet. That session is the first one after an
+				// upgrade or a damaged store — the moment deja most looks
+				// broken (#878).
+				//
+				// Only with an index already on disk. A machine with no
+				// history at all also asks for a build, and promising it
+				// recall would be a promise about nothing: that machine is
+				// what the environment block above is for.
+				line = "deja: indexing your history — recall comes online in a few seconds"
+			}
+			if line != "" {
 				var resp sessionStartHookResponse
 				resp.HookSpecificOutput.HookEventName = "SessionStart"
-				resp.SystemMessage = st.line()
+				resp.SystemMessage = line
 				if b, err := json.Marshal(resp); err == nil {
 					fmt.Fprintln(os.Stdout, string(b))
 				}
@@ -543,6 +559,21 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 // harness — and far shorter than warmupRetryAfter, which was the whole wait a
 // killed build used to cost.
 const warmupDeadAfter = 2 * time.Minute
+
+// warmupJustRequested reports that a build was asked for moments ago and has
+// not published progress yet. The sentinel carries the time of the request,
+// which is exactly what this needs.
+func warmupJustRequested(dir string) bool {
+	b, err := os.ReadFile(filepath.Join(dir, "warmup.sentinel"))
+	if err != nil {
+		return false
+	}
+	stamp, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		return false
+	}
+	return time.Since(time.Unix(0, stamp)) < warmupStatusStale
+}
 
 // warmupLooksDead reports whether the build the sentinel stands for has
 // stopped without clearing it. A warmup killed mid-build — a closed laptop, an

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -116,6 +116,27 @@ func runHookPrecompact(dir string) {
 	requestWarmup(dir)
 }
 
+// joinNotes puts a maintenance line ahead of the memory line without letting
+// an empty one leave a stray separator.
+func joinNotes(a, b string) string {
+	switch {
+	case a == "":
+		return b
+	case b == "":
+		return a
+	}
+	return a + "\n" + b
+}
+
+// rewireNote is the one line a session start spends on maintenance: which
+// targets were rewritten when the binary moved or upgraded.
+func rewireNote(targets []string) string {
+	if len(targets) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("deja: refreshed its wiring for %s after an upgrade — any hand-edited command there was replaced", strings.Join(targets, ", "))
+}
+
 // runHookContext prints session-start context. plain=false emits the Claude
 // Code / Codex hook JSON envelope; plain=true prints the bare digest for
 // hosts that inject raw text (the opencode plugin).
@@ -123,9 +144,13 @@ func runHookContext(dir string, plain bool) error {
 	// A session start is the one moment deja is guaranteed to run on every
 	// harness, which makes it the only reliable place to repair wiring left
 	// behind by an older binary. It costs one small file read when nothing
-	// changed, and it says nothing: the user asked for memory, not for
-	// maintenance notes.
-	refreshWiringAfterUpgrade()
+	// changed.
+	//
+	// When it does change something it says so, once: the rewrite replaces
+	// whatever those commands held, including a wrapper someone put there on
+	// purpose, and silently reverting a person's edit is not a maintenance
+	// note anybody can act on afterwards (#886).
+	rewired := refreshWiringAfterUpgrade()
 	// SessionStart fires for startup, resume, clear and compact; the payload
 	// says which. After a compaction the model just lost its working context,
 	// so the lead line changes to say the memory below survived it.
@@ -184,6 +209,7 @@ func runHookContext(dir string, plain bool) error {
 				// what the environment block above is for.
 				line = "deja: indexing your history — recall comes online in a few seconds"
 			}
+			line = joinNotes(rewireNote(rewired), line)
 			if line != "" {
 				var resp sessionStartHookResponse
 				resp.HookSpecificOutput.HookEventName = "SessionStart"
@@ -250,14 +276,14 @@ func runHookContext(dir string, plain bool) error {
 		if r, ok := findReusedMemory(dir); ok {
 			earned = fmt.Sprintf(" · most re-used recently: %q, %d×", trimBriefTitle(r.Title), r.Times)
 		}
-		resp.SystemMessage = fmt.Sprintf("deja: recalled %d prior session%s %s (~%dKB) — the agent starts already knowing them%s%s%s", sessions, plural, why, (len(digest)+1023)/1024, serviceReceipt(dir), polNote, earned)
+		resp.SystemMessage = joinNotes(rewireNote(rewired), fmt.Sprintf("deja: recalled %d prior session%s %s (~%dKB) — the agent starts already knowing them%s%s%s", sessions, plural, why, (len(digest)+1023)/1024, serviceReceipt(dir), polNote, earned))
 	}
 	// Nothing to recall yet because the index is still being built: say so
 	// rather than starting in silence. The build runs detached, so the agent
 	// is already usable — this only explains why memory is not here yet.
 	if resp.SystemMessage == "" {
 		if st := readWarmupStatus(dir); st != nil {
-			resp.SystemMessage = st.line()
+			resp.SystemMessage = joinNotes(rewireNote(rewired), st.line())
 		}
 	}
 	b, err := json.Marshal(resp)

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -128,6 +128,23 @@ func joinNotes(a, b string) string {
 	return a + "\n" + b
 }
 
+// indexDirWritable reports whether a rebuild could write where the index
+// lives. Ensure builds into a sibling directory and renames it over the old
+// one, so the parent is what has to be writable — not the index directory
+// itself, which is why a store can rebuild fine while its own directory is
+// read-only.
+func indexDirWritable(dir string) bool {
+	parent := filepath.Dir(dir)
+	f, err := os.CreateTemp(parent, ".deja-probe-")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+	return true
+}
+
 // rewireNote is the one line a session start spends on maintenance: which
 // targets were rewritten when the binary moved or upgraded.
 func rewireNote(targets []string) string {
@@ -208,6 +225,12 @@ func runHookContext(dir string, plain bool) error {
 				// recall would be a promise about nothing: that machine is
 				// what the environment block above is for.
 				line = "deja: indexing your history — recall comes online in a few seconds"
+				// …unless it cannot: a read-only cache directory lets the
+				// request be made and the build fail, so this promised recall
+				// "in a few seconds" on every session forever (#887).
+				if !indexDirWritable(dir) {
+					line = fmt.Sprintf("deja: the index needs rebuilding and %s is not writable — `deja index` says what to change", filepath.Dir(dir))
+				}
 			}
 			line = joinNotes(rewireNote(rewired), line)
 			if line != "" {

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -151,7 +151,11 @@ func rewireNote(targets []string) string {
 	if len(targets) == 0 {
 		return ""
 	}
-	return fmt.Sprintf("deja: refreshed its wiring for %s after an upgrade — any hand-edited command there was replaced", strings.Join(targets, ", "))
+	// States what happened rather than guessing why: on a routine upgrade
+	// nothing was hand-edited, and claiming an edit was destroyed reads as an
+	// accusation. Someone who did edit those commands still learns that they
+	// were rewritten, and where to put the change instead.
+	return fmt.Sprintf("deja: rewrote its wiring for %s after an upgrade — `deja install` is what writes those commands", strings.Join(targets, ", "))
 }
 
 // runHookContext prints session-start context. plain=false emits the Claude

--- a/cmd/deja/hook_first_session_test.go
+++ b/cmd/deja/hook_first_session_test.go
@@ -17,6 +17,11 @@ import (
 func TestTheSessionThatAsksForTheBuildIsTold(t *testing.T) {
 	tmp := hermeticEnv(t)
 	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	// Never the real thing: on Windows a detached child holds deja.test.exe
+	// open and `go test` fails to remove it after the run.
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(_, _ string) error { return nil }
+	t.Cleanup(func() { spawnWarmup = oldSpawn })
 	dir := os.Getenv("DEJA_INDEX_DIR")
 	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
 	if err := os.MkdirAll(store, 0o755); err != nil {

--- a/cmd/deja/hook_first_session_test.go
+++ b/cmd/deja/hook_first_session_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The session that asks for the rebuild is the one that hears nothing about
+// it: the warmup child has not written its first progress line yet. That is
+// the first session after an upgrade or a damaged store — the moment deja most
+// looks broken (#878).
+func TestTheSessionThatAsksForTheBuildIsTold(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	dir := os.Getenv("DEJA_INDEX_DIR")
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"pool exhausted"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"s1","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A build was just requested and has published nothing yet.
+	if err := os.WriteFile(filepath.Join(dir, "warmup.sentinel"),
+		[]byte(strconv.FormatInt(time.Now().UnixNano(), 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Remove(warmupStatusPath(dir))
+	// Nothing to recall for this cwd, which is the state the message is for.
+	t.Setenv("CLAUDE_PROJECT_DIR", filepath.Join(tmp, "elsewhere"))
+
+	out, err := captureRun(t, "hook-context")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var resp struct {
+		SystemMessage string `json:"systemMessage"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("hook output is not JSON: %q", out)
+	}
+	if !strings.Contains(resp.SystemMessage, "indexing your history") {
+		t.Errorf("the session that asked for the build was told nothing: %q", out)
+	}
+
+	// A machine with no index at all is not promised recall: a build there
+	// finds nothing, and the environment block is what speaks for it.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "warmup.sentinel"),
+		[]byte(strconv.FormatInt(time.Now().UnixNano(), 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "hook-context")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "indexing your history") {
+		t.Errorf("a machine with no history was promised recall: %q", out)
+	}
+}

--- a/cmd/deja/hook_readonly_test.go
+++ b/cmd/deja/hook_readonly_test.go
@@ -19,6 +19,11 @@ func TestTheHookDoesNotPromiseARebuildItCannotDo(t *testing.T) {
 	}
 	tmp := hermeticEnv(t)
 	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	// Never the real thing: on Windows a detached child holds deja.test.exe
+	// open and `go test` fails to remove it after the run.
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(_, _ string) error { return nil }
+	t.Cleanup(func() { spawnWarmup = oldSpawn })
 	cache := filepath.Join(tmp, "cache")
 	dir := filepath.Join(cache, "index.db")
 	if err := os.MkdirAll(dir, 0o700); err != nil {

--- a/cmd/deja/hook_readonly_test.go
+++ b/cmd/deja/hook_readonly_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A read-only cache directory lets the rebuild be requested and then fail, so
+// the hook promised recall "in a few seconds" on every session forever (#887).
+func TestTheHookDoesNotPromiseARebuildItCannotDo(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	cache := filepath.Join(tmp, "cache")
+	dir := filepath.Join(cache, "index.db")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	// A build was asked for and has published nothing yet: without the probe
+	// this is the state that prints the promise.
+	if err := os.WriteFile(filepath.Join(dir, "warmup.sentinel"),
+		[]byte(strconv.FormatInt(time.Now().UnixNano(), 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"pool exhausted"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"s1","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Remove(warmupStatusPath(dir))
+	if err := os.WriteFile(filepath.Join(dir, "warmup.sentinel"),
+		[]byte(strconv.FormatInt(time.Now().UnixNano(), 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", filepath.Join(tmp, "elsewhere"))
+
+	message := func() string {
+		out, err := captureRun(t, "hook-context")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var resp struct {
+			SystemMessage string `json:"systemMessage"`
+		}
+		if out == "" {
+			return ""
+		}
+		if err := json.Unmarshal([]byte(out), &resp); err != nil {
+			t.Fatalf("hook output is not JSON: %q", out)
+		}
+		return resp.SystemMessage
+	}
+
+	if got := message(); !strings.Contains(got, "indexing your history") {
+		t.Fatalf("a writable cache lost the promise: %q", got)
+	}
+
+	if err := os.Chmod(cache, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(cache, 0o700) })
+	got := message()
+	if strings.Contains(got, "comes online in a few seconds") {
+		t.Errorf("promised a rebuild that cannot run: %q", got)
+	}
+	if !strings.Contains(got, "is not writable") || !strings.Contains(got, cache) {
+		t.Errorf("does not name what to change: %q", got)
+	}
+}

--- a/cmd/deja/index_summary_test.go
+++ b/cmd/deja/index_summary_test.go
@@ -32,6 +32,11 @@ func TestRebuildOnATerminalSaysWhatItIndexed(t *testing.T) {
 	// hermeticEnv points the warmup sentinel at a guard path for every test in
 	// this package; this case is the ordinary interactive run.
 	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	// Never the real thing: on Windows a detached child holds deja.test.exe
+	// open and `go test` fails to remove it after the run.
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(_, _ string) error { return nil }
+	t.Cleanup(func() { spawnWarmup = oldSpawn })
 
 	saved := logoWanted
 	logoWanted = func(*os.File) bool { return true }

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -119,15 +119,26 @@ func runInstall(dir string, args []string, uninstall bool) error {
 	guidanceCount := 0
 	mcpCount := 0
 	hookCount := 0
+	// One target that refuses to be written used to end the run, so an
+	// uninstall stopped halfway: the hooks were gone, one guidance file was
+	// left behind, and the reader was handed a syscall for a path they did not
+	// choose. Everything else is still done, and what could not be is named at
+	// the end (#902).
+	var refused []string
+	note := func(t string, err error) {
+		refused = append(refused, fmt.Sprintf("%s: %v", t, err))
+	}
 	for _, t := range targets {
 		r, err := installTarget(t, exe, uninstall)
 		if err != nil {
-			return err
+			note(t, err)
+			continue
 		}
 		if guidance {
 			gr, err := guidanceResult(t, uninstall)
 			if err != nil {
-				return err
+				note(t, err)
+				continue
 			}
 			if gr.Path != "" && !banner {
 				fmt.Println(guidanceOutput(t, gr))
@@ -154,6 +165,14 @@ func runInstall(dir string, args []string, uninstall bool) error {
 		if !uninstall && strings.HasSuffix(t, "-auto") {
 			hookCount++
 		}
+	}
+	if len(refused) > 0 {
+		verb := "install"
+		if uninstall {
+			verb = "uninstall"
+		}
+		return fmt.Errorf("%s finished what it could; %d target%s refused: %s — check those paths' permissions and run it again",
+			verb, len(refused), pluralS(len(refused)), strings.Join(refused, "; "))
 	}
 	// Every install builds, not only --auto and --all. Installing is the one
 	// moment a person has already accepted a wait — they just ran an installer

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1825,11 +1825,18 @@ func pluralWhich(n int) string {
 // — the path of an internal lock file and a syscall error, which says nothing
 // about what to change.
 func ensureError(dir string, err error) error {
+	if dir == "" {
+		dir = index.DefaultDir()
+	}
 	if errors.Is(err, fs.ErrPermission) {
-		if dir == "" {
-			dir = index.DefaultDir()
-		}
 		return fmt.Errorf("cannot write the index at %s — check the directory's permissions, or point DEJA_INDEX_DIR somewhere writable", dir)
+	}
+	// A full disk arrived as `ensure: write /…/index.db.tmp/records.bin: no
+	// space left on device`: an internal path nobody can act on, and the same
+	// shape #798 replaced for permissions. The build needs room beside the
+	// index, so the directory to free is the one named here (#888).
+	if errors.Is(err, syscall.ENOSPC) {
+		return fmt.Errorf("no space left where the index is built (%s) — free some room there, or point DEJA_INDEX_DIR at a disk that has it", filepath.Dir(dir))
 	}
 	return fmt.Errorf("ensure: %w", err)
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1835,6 +1835,13 @@ func ensureError(dir string, err error) error {
 	// space left on device`: an internal path nobody can act on, and the same
 	// shape #798 replaced for permissions. The build needs room beside the
 	// index, so the directory to free is the one named here (#888).
+	// A volume that went away mid-write — an unmounted disk, a network share
+	// that dropped — arrives as `write /…/index.db.tmp/records.bin:
+	// input/output error`: the same internal path as #888, and a reader who
+	// cannot tell that the disk is simply gone (#899).
+	if errors.Is(err, syscall.EIO) || errors.Is(err, syscall.ENXIO) || errors.Is(err, syscall.ENODEV) {
+		return fmt.Errorf("the index directory is not reachable (%s) — the disk it lives on may have been unmounted or dropped; reconnect it, or point DEJA_INDEX_DIR somewhere local", filepath.Dir(dir))
+	}
 	if errors.Is(err, syscall.ENOSPC) {
 		return fmt.Errorf("no space left where the index is built (%s) — free some room there, or point DEJA_INDEX_DIR at a disk that has it", filepath.Dir(dir))
 	}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -484,6 +484,14 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 			// on the day before the other two screens did (#849).
 			when = s.Updated.Local().Format("2006-01-02")
 		}
+		// A day of notes is one session whose id *is* a date, minted in UTC.
+		// Converting its timestamp to the reader's zone put a different day on
+		// the line than the id it sits next to — and the id a reader rebuilt
+		// from what they saw matched nothing (#883).
+		if day, ok := search.NoteBucketDay(s); ok {
+			when = day
+		}
+
 		fmt.Printf("[%s · %s · %s · %s]", s.Harness, s.Project, when, s.ID)
 		title := s.Title
 		if title == "" {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -251,8 +251,14 @@ func cmdIndex(dir string, rest []string) error {
 		if e.FailedFiles == 0 {
 			continue
 		}
+		// "deja: deja: 1 path could not be read" is the notes file, and reads
+		// like a stutter. It is the user's own writing, so it says so (#901).
+		name := h
+		if h == "deja" {
+			name = "your notes"
+		}
 		fmt.Fprintf(os.Stderr, "deja: %s: %d path%s could not be read — `deja doctor` names %s\n",
-			h, e.FailedFiles, pluralS(e.FailedFiles), pluralWhich(e.FailedFiles))
+			name, e.FailedFiles, pluralS(e.FailedFiles), pluralWhich(e.FailedFiles))
 	}
 	// The parse count and the indexed count differ by exactly these, and this
 	// is where both are on screen (#868).

--- a/cmd/deja/mcp_instructions.go
+++ b/cmd/deja/mcp_instructions.go
@@ -1,6 +1,10 @@
 package main
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
 
 // mcpInstructions is returned from the MCP initialize handshake. Hosts that
 // support the field put it in the system prompt, which gives us an auto-recall
@@ -14,6 +18,11 @@ func mcpInstructions(dir string) string {
 		b.WriteString(" The index is still building (")
 		b.WriteString(s.progress())
 		b.WriteString("); recall works now but covers more history as it finishes.")
+	} else if warmupJustRequested(dir) && index.HasManifest(dir) {
+		// Thirteen of the sixteen harnesses have no hook and read this and
+		// nothing else. A rebuild that has not reported yet left them with the
+		// ordinary instructions and an index this build cannot read (#879).
+		b.WriteString(" The index is being rebuilt right now; recall covers more history once it finishes.")
 	}
 	return b.String()
 }

--- a/cmd/deja/note_bucket_day_test.go
+++ b/cmd/deja/note_bucket_day_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // A day of notes is one session whose id *is* a date, minted in UTC. Reading
@@ -13,7 +14,12 @@ import (
 // nothing (#883).
 func TestANoteBucketShowsTheDayItsIdNames(t *testing.T) {
 	tmp := hermeticEnv(t)
-	t.Setenv("TZ", "Europe/Moscow")
+	// time.Local is resolved once at process start, so TZ= in the environment
+	// does not move it. The bug only shows outside UTC, and CI runs in UTC —
+	// so the zone is set on the package's clock and restored after.
+	savedLocal := time.Local
+	time.Local = time.FixedZone("test+03", 3*60*60)
+	t.Cleanup(func() { time.Local = savedLocal })
 	notes := filepath.Join(tmp, "notes.jsonl")
 	body := `{"ts":"2026-07-16T21:01:00Z","project":"edge","text":"note just after midnight in Moscow"}` + "\n"
 	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {

--- a/cmd/deja/note_bucket_day_test.go
+++ b/cmd/deja/note_bucket_day_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A day of notes is one session whose id *is* a date, minted in UTC. Reading
+// its timestamp in the reader's zone put a different day on the line than the
+// id sitting beside it, and an id rebuilt from what the reader saw matched
+// nothing (#883).
+func TestANoteBucketShowsTheDayItsIdNames(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("TZ", "Europe/Moscow")
+	notes := filepath.Join(tmp, "notes.jsonl")
+	body := `{"ts":"2026-07-16T21:01:00Z","project":"edge","text":"note just after midnight in Moscow"}` + "\n"
+	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "last")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "deja-2026-07-16-edge") {
+		t.Fatalf("bucket id changed: %q", out)
+	}
+	// The date on the line is the date in the id, not the reader's rendering
+	// of a moment inside it.
+	if !strings.Contains(out, "2026-07-16 · deja-2026-07-16-edge") {
+		t.Errorf("line and id disagree:\n%s", out)
+	}
+
+	// A transcript is still shown in the reader's zone: the rule is about
+	// deja's own day buckets, not about every session (#849).
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Its id even looks like a bucket id: the rule keys on the harness, not on
+	// the shape of the string.
+	line := `{"type":"user","message":{"role":"user","content":"pool exhausted"},"timestamp":"2026-07-16T21:01:00Z","sessionId":"deja-2026-07-16-lookalike","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "last")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "2026-07-17 · deja-2026-07-16-lookalike") {
+		t.Errorf("a transcript stopped following the reader's zone:\n%s", out)
+	}
+}

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -120,7 +120,10 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	if exportPath != "" {
 		fmt.Fprintf(stdout, "exported to %s\n", exportPath)
 	}
-	fmt.Fprintln(stdout, "the note now outranks the raw transcript in recall; corrections append with `deja promote", prefix, "--state <state>`")
+	// The id deja resolved, not the one the reader typed: a prefix that stood
+	// for several sessions would send the correction to whichever is newest —
+	// measured, that was a different session from the one just marked (#884).
+	fmt.Fprintln(stdout, "the note now outranks the raw transcript in recall; corrections append with `deja promote", s.ID, "--state <state>`")
 	return nil
 }
 

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/redact"
 	"github.com/vshulcz/deja-vu/internal/sources"
@@ -108,6 +109,19 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	fmt.Fprintf(stdout, "promoted %s as %s: %s\n", src, state, title)
 	if line := markTakenBack(src, state, prior); line != "" {
 		fmt.Fprintln(stdout, line)
+	}
+	// Taking a decision back is the same moment forget is: the machines that
+	// already have this session keep the note as it was, and deja knows which
+	// ones (#898). Only for the states that withdraw something — an ordinary
+	// `accepted` is not a retraction.
+	if state != "accepted" {
+		if peers, exported := index.PushedTo(dir, s.Harness, s.ID); len(peers) > 0 || exported {
+			where := "another machine"
+			if len(peers) > 0 {
+				where = strings.Join(peers, ", ")
+			}
+			fmt.Fprintf(stdout, "already sent to %s — this mark stays here; a copy over there still reads as it did\n", where)
+		}
 	}
 	if state == "accepted" {
 		all := sources.LoadPromotedNotes()

--- a/cmd/deja/promote_exported_test.go
+++ b/cmd/deja/promote_exported_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Taking a decision back is the same moment forget is: the machines that
+// already have this session keep the note as it was. forget has said so since
+// #788; promote said nothing (#898).
+func TestPromoteSaysWhenTheSessionAlreadyLeft(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"the winch brake pads squeal"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"w1","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "w1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	dir := os.Getenv("DEJA_INDEX_DIR")
+
+	// Nothing has left yet: a retraction says nothing about elsewhere.
+	out, err := captureRun(t, "promote", "w1", "--state", "rejected", "--note", "did not hold")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "already sent") {
+		t.Errorf("a session that never left was called sent:\n%s", out)
+	}
+
+	if _, err := index.ExportFull(dir, filepath.Join(tmp, "export")); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err = captureRun(t, "promote", "w1", "--state", "superseded", "--note", "replaced")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "already sent") || !strings.Contains(out, "still reads as it did") {
+		t.Errorf("a retraction after an export said nothing about the copies:\n%s", out)
+	}
+
+	// Accepting is not a retraction: no line.
+	out, err = captureRun(t, "promote", "w1", "--state", "accepted", "--note", "back on")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "already sent") {
+		t.Errorf("accepting was treated as a retraction:\n%s", out)
+	}
+}

--- a/cmd/deja/promote_hint_test.go
+++ b/cmd/deja/promote_hint_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// promote prints how to correct the mark it just made. It echoed the selector
+// the reader typed, so a prefix that stood for several sessions sent the
+// correction to whichever is newest — a different session from the one just
+// marked (#884).
+func TestPromoteHintNamesTheSessionItMarked(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct{ id, when string }{
+		{"deja-2026-08-01-hyper-service", "2026-08-01T10:00:00Z"},
+		{"deja-2026-08-01-super-service", "2026-07-30T10:00:00Z"},
+	} {
+		line := `{"type":"user","message":{"role":"user","content":"pool exhausted in ` + tc.id + `"},"timestamp":"` + tc.when + `","sessionId":"` + tc.id + `","cwd":"/proj"}`
+		if err := os.WriteFile(filepath.Join(store, tc.id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "promote", "deja-2026…er-service", "--state", "rejected", "--note", "did not hold")
+	if err != nil {
+		t.Fatal(err)
+	}
+	marked := "deja-2026-08-01-hyper-service"
+	if !strings.Contains(out, "promoted claude:"+marked) {
+		t.Fatalf("promoted a different session:\n%s", out)
+	}
+	if !strings.Contains(out, "deja promote "+marked+" --state") {
+		t.Errorf("the correction hint does not name the session that was marked:\n%s", out)
+	}
+	if strings.Contains(out, "deja promote deja-2026…er-service --state") {
+		t.Errorf("the hint hands back the ambiguous selector:\n%s", out)
+	}
+}

--- a/cmd/deja/rewire_notice_test.go
+++ b/cmd/deja/rewire_notice_test.go
@@ -16,7 +16,7 @@ func TestRewireNoteNamesWhatWasRewritten(t *testing.T) {
 		t.Errorf("a session that repaired nothing still said something: %q", got)
 	}
 	got := rewireNote([]string{"claude-auto", "codex"})
-	for _, want := range []string{"claude-auto, codex", "hand-edited command there was replaced"} {
+	for _, want := range []string{"claude-auto, codex", "`deja install` is what writes those commands"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("note does not mention %q: %q", want, got)
 		}
@@ -52,7 +52,7 @@ func TestTheHookReportsAWiringRepairWithNothingElseToSay(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, "refreshed its wiring for claude-auto") {
+	if !strings.Contains(out, "rewrote its wiring for claude-auto") {
 		t.Errorf("the session that rewrote the wiring said nothing:\n%s", out)
 	}
 }

--- a/cmd/deja/rewire_notice_test.go
+++ b/cmd/deja/rewire_notice_test.go
@@ -36,6 +36,11 @@ func TestRewireNoteNamesWhatWasRewritten(t *testing.T) {
 func TestTheHookReportsAWiringRepairWithNothingElseToSay(t *testing.T) {
 	tmp := hermeticEnv(t)
 	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	// Never the real thing: on Windows a detached child holds deja.test.exe
+	// open and `go test` fails to remove it after the run.
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(_, _ string) error { return nil }
+	t.Cleanup(func() { spawnWarmup = oldSpawn })
 	cfg := filepath.Join(tmp, "config")
 	t.Setenv("XDG_CONFIG_HOME", cfg)
 	if err := os.MkdirAll(filepath.Join(cfg, "deja"), 0o700); err != nil {

--- a/cmd/deja/rewire_notice_test.go
+++ b/cmd/deja/rewire_notice_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The repair rewrites the commands it manages, including a wrapper someone put
+// there on purpose. It ran in silence, so the edit came back replaced with no
+// word about it (#886).
+func TestRewireNoteNamesWhatWasRewritten(t *testing.T) {
+	if got := rewireNote(nil); got != "" {
+		t.Errorf("a session that repaired nothing still said something: %q", got)
+	}
+	got := rewireNote([]string{"claude-auto", "codex"})
+	for _, want := range []string{"claude-auto, codex", "hand-edited command there was replaced"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("note does not mention %q: %q", want, got)
+		}
+	}
+	// The maintenance line goes ahead of the memory line, and neither is lost.
+	joined := joinNotes(got, "deja: recalled 3 prior sessions")
+	if !strings.HasPrefix(joined, got) || !strings.HasSuffix(joined, "recalled 3 prior sessions") {
+		t.Errorf("joined note = %q", joined)
+	}
+	if joinNotes("", "only memory") != "only memory" || joinNotes("only maintenance", "") != "only maintenance" {
+		t.Error("an empty half left a separator behind")
+	}
+}
+
+// And it reaches the hook's output on the session where nothing else is being
+// said — which is exactly the session that repaired the wiring.
+func TestTheHookReportsAWiringRepairWithNothingElseToSay(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	cfg := filepath.Join(tmp, "config")
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	if err := os.MkdirAll(filepath.Join(cfg, "deja"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(wiringState{Version: "older", Targets: []string{"claude-auto"}, Exe: filepath.Join(tmp, "old-deja"), Home: os.Getenv("HOME")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wiringStatePath(), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "hook-context")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "refreshed its wiring for claude-auto") {
+		t.Errorf("the session that rewrote the wiring said nothing:\n%s", out)
+	}
+}

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/vshulcz/deja-vu/internal/index"
 	"io"
 	"os"
 	"strings"
@@ -22,6 +23,13 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 	// instead of leaving them to wonder why recall is quiet.
 	if st := readWarmupStatus(dir); st != nil {
 		fmt.Fprintf(stdout, "deja %s %s", warmupBar(st), st.progress())
+		return nil
+	}
+	// A build asked for moments ago has not published progress yet, and until
+	// it does this said "no recalls yet today" — a normal day, while the index
+	// on disk is one this build cannot read (#879).
+	if warmupJustRequested(dir) && index.HasManifest(dir) {
+		fmt.Fprint(stdout, "deja · rebuilding the index · recall is quiet until it finishes")
 		return nil
 	}
 	recalls, bytes, injected := usage.TodayWithInjections(dir)

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -48,6 +50,14 @@ func runSync(dir string, args []string) error {
 			n, err = index.Export(dir, out)
 		}
 		if err != nil {
+			// `open …/deja-sync-b9849e838232-1785639771368128000.jsonl:
+			// permission denied` names a file deja was about to create, with a
+			// name nobody chose. The directory is what has to change, the same
+			// as for the index (#798) and the notes file (#869) — this was the
+			// last write path still handing back the syscall (#893).
+			if errors.Is(err, fs.ErrPermission) {
+				return fmt.Errorf("cannot write the export into %s — check that directory's permissions, or choose one you can write", out)
+			}
 			return err
 		}
 		fmt.Fprintf(os.Stdout, "deja: exported %d records\n", n)

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -62,10 +62,18 @@ func runSync(dir string, args []string) error {
 			return fmt.Errorf("sync import: unexpected argument %q — it takes one directory", a)
 		}
 		n, err := index.Import(dir, args[1])
+		// What arrived is printed first even when a file was refused: the
+		// records that made it are in, and the reader needs both halves
+		// (#891).
+		if n > 0 {
+			fmt.Fprintf(os.Stdout, "deja: imported %d records\n", n)
+		}
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(os.Stdout, "deja: imported %d records\n", n)
+		if n == 0 {
+			fmt.Fprintln(os.Stdout, "deja: imported 0 records")
+		}
 		return nil
 	default:
 		return fmt.Errorf("unknown sync command %q", args[0])

--- a/cmd/deja/sync_export_denied_test.go
+++ b/cmd/deja/sync_export_denied_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The last write path still handing back a syscall: `open …/deja-sync-3e5cfa…
+// .jsonl: permission denied` names a file deja was about to create, with a
+// name nobody chose (#893).
+func TestSyncExportIntoAnUnwritableDirectorySaysWhatToFix(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"pool exhausted"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"s1","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(tmp, "export")
+	if err := os.MkdirAll(out, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(out, 0o700) })
+
+	_, err := captureRun(t, "sync", "export", "--full", out)
+	if err == nil {
+		t.Fatal("an export into an unwritable directory succeeded")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "cannot write the export into "+out) {
+		t.Errorf("does not name the directory: %q", got)
+	}
+	if strings.Contains(got, "deja-sync-") {
+		t.Errorf("names a file deja was about to create: %q", got)
+	}
+
+	// And the refusal left the watermarks alone: everything is still owed.
+	if err := os.Chmod(out, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	n, err := index.Export(os.Getenv("DEJA_INDEX_DIR"), out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n == 0 {
+		t.Error("the failed export moved the watermark")
+	}
+}

--- a/cmd/deja/uninstall_partial_test.go
+++ b/cmd/deja/uninstall_partial_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// One target that refuses to be written used to end the run: an uninstall
+// stopped at the first locked path, left every other harness wired, and handed
+// back a syscall for a file nobody chose (#902).
+func TestUninstallFinishesTheTargetsItCan(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	home := hermeticEnv(t)
+	_ = home
+	if _, err := captureRun(t, "install", "claude-auto"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "codex-auto"); err != nil {
+		t.Fatal(err)
+	}
+	// install writes into the real codex home under HOME, not DEJA_CODEX_ROOT:
+	// that variable relocates reads only.
+	codexHooks := filepath.Join(os.Getenv("HOME"), ".codex", "hooks.json")
+	before, err := os.ReadFile(codexHooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(before), "deja") {
+		t.Fatalf("codex was not wired: %s", before)
+	}
+
+	guidance := filepath.Join(os.Getenv("HOME"), ".claude", "skills", "deja-history")
+	if err := os.Chmod(guidance, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(guidance, 0o700) })
+
+	_, err = captureRun(t, "uninstall", "--all")
+	if err == nil {
+		t.Fatal("a locked guidance directory was not reported")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "finished what it could") || !strings.Contains(got, "refused") {
+		t.Errorf("error does not say what happened: %q", got)
+	}
+	if !strings.Contains(got, "permission denied") {
+		t.Errorf("error does not name the cause: %q", got)
+	}
+
+	// The rest of the run still happened.
+	after, err := os.ReadFile(codexHooks)
+	if err == nil && strings.Contains(string(after), "deja") {
+		t.Errorf("codex stayed wired because another target refused: %s", after)
+	}
+}

--- a/cmd/deja/warmup_future_status_test.go
+++ b/cmd/deja/warmup_future_status_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A status stamped ahead of the clock made time.Since negative, so it never
+// went stale: every surface said "indexing your history" with no build running
+// (#889).
+func TestWarmupStatusAheadOfTheClockIsNotBelievedForever(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	write := func(offset time.Duration) {
+		st := warmupStatus{Phase: "reading sessions", Total: 10, Done: 4,
+			Started: time.Now().UnixNano(), Updated: time.Now().Add(offset).UnixNano()}
+		b, err := json.Marshal(st)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(warmupStatusPath(dir), b, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write(0)
+	if readWarmupStatus(dir) == nil {
+		t.Fatal("a fresh status was dropped")
+	}
+	// A few seconds ahead is ordinary skew between a parent and its detached
+	// child, and still a live build.
+	write(5 * time.Second)
+	if readWarmupStatus(dir) == nil {
+		t.Error("a status five seconds ahead was dropped")
+	}
+	// A day ahead is not a build in flight.
+	write(24 * time.Hour)
+	if st := readWarmupStatus(dir); st != nil {
+		t.Errorf("a status stamped a day ahead was believed: %+v", st)
+	}
+	// And the old direction still holds.
+	write(-time.Hour)
+	if st := readWarmupStatus(dir); st != nil {
+		t.Errorf("an hour-old status was believed: %+v", st)
+	}
+}

--- a/cmd/deja/warmup_status.go
+++ b/cmd/deja/warmup_status.go
@@ -112,7 +112,11 @@ func readWarmupStatus(dir string) *warmupStatus {
 	if json.Unmarshal(b, &st) != nil || st.Updated == 0 {
 		return nil
 	}
-	if time.Since(time.Unix(0, st.Updated)) > warmupStatusStale {
+	// Ahead of the clock counts as stale, not as fresh forever: time.Since is
+	// negative there, so a status stamped in the future — a skewed clock, a
+	// file copied from another machine — kept every surface saying "indexing
+	// your history" with no build running (#889).
+	if age := time.Since(time.Unix(0, st.Updated)); age > warmupStatusStale || age < -warmupStatusStale {
 		return nil
 	}
 	return &st

--- a/cmd/deja/warmup_surfaces_test.go
+++ b/cmd/deja/warmup_surfaces_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// doctor and the hook both say when the index is being rebuilt; the statusline
+// said "no recalls yet today" and the MCP instructions said nothing at all —
+// a normal day, while the index on disk is one this build cannot read (#879).
+func TestEverySurfaceSaysWhenTheIndexIsBeingRebuilt(t *testing.T) {
+	hermeticEnv(t)
+	dir := os.Getenv("DEJA_INDEX_DIR")
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"pool exhausted"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"s1","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	statusline := func() string {
+		var out bytes.Buffer
+		if err := runStatusline(dir, strings.NewReader(`{"session_id":"x","cwd":"/proj"}`), &out); err != nil {
+			t.Fatal(err)
+		}
+		return out.String()
+	}
+
+	// Healthy: neither surface mentions a build.
+	if got := statusline(); strings.Contains(got, "rebuilding") {
+		t.Errorf("a healthy index was called a rebuild: %q", got)
+	}
+	if got := mcpInstructions(dir); strings.Contains(got, "being rebuilt") {
+		t.Errorf("a healthy index was called a rebuild: %q", got)
+	}
+
+	// A build asked for moments ago that has not published progress yet.
+	if err := os.WriteFile(filepath.Join(dir, "warmup.sentinel"),
+		[]byte(strconv.FormatInt(time.Now().UnixNano(), 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Remove(warmupStatusPath(dir))
+
+	if got := statusline(); !strings.Contains(got, "rebuilding the index") {
+		t.Errorf("statusline claims an ordinary day during a rebuild: %q", got)
+	}
+	if got := mcpInstructions(dir); !strings.Contains(got, "being rebuilt right now") {
+		t.Errorf("MCP instructions say nothing about the rebuild: %q", got)
+	}
+
+	// A machine with no index is not told its index is being rebuilt.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "warmup.sentinel"),
+		[]byte(strconv.FormatInt(time.Now().UnixNano(), 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := statusline(); strings.Contains(got, "rebuilding") {
+		t.Errorf("a machine with no index was told about a rebuild: %q", got)
+	}
+	if got := mcpInstructions(dir); strings.Contains(got, "being rebuilt") {
+		t.Errorf("a machine with no index was told about a rebuild: %q", got)
+	}
+}

--- a/cmd/deja/wiring_home_test.go
+++ b/cmd/deja/wiring_home_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The repair derives every path from the environment it runs in. A process
+// whose HOME points elsewhere while the record is still visible — sudo with a
+// preserved XDG_CONFIG_HOME, a container, an su session — wrote a fresh set of
+// configs into a home nobody installed into, left the real ones pointing at
+// the old binary, and marked the record repaired (#885).
+func TestWiringRepairStaysInTheHomeItWasWrittenFor(t *testing.T) {
+	tmp := hermeticEnv(t)
+	cfg := filepath.Join(tmp, "config")
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	if err := os.MkdirAll(filepath.Join(cfg, "deja"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	elsewhere := filepath.Join(tmp, "other-home")
+	if err := os.MkdirAll(elsewhere, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(home string) {
+		b, err := json.Marshal(wiringState{Version: "older", Targets: []string{"claude-auto"}, Exe: filepath.Join(tmp, "old-deja"), Home: home})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(wiringStatePath(), b, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The record belongs to another home: nothing is repaired, nothing spreads.
+	write(elsewhere)
+	if changed := refreshWiringAfterUpgrade(); len(changed) != 0 {
+		t.Errorf("repair ran in a home it was not written for: %v", changed)
+	}
+	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".claude", "settings.json")); !os.IsNotExist(err) {
+		t.Errorf("configs were written into a home nobody installed into: %v", err)
+	}
+
+	// The record belongs to this home: the repair runs as before.
+	write(os.Getenv("HOME"))
+	if changed := refreshWiringAfterUpgrade(); len(changed) == 0 {
+		t.Error("the repair stopped working in its own home")
+	}
+
+	// A record from before this field exists: repaired, as it always was. The
+	// config is removed first so the repair has something to write — after the
+	// case above it already points at this binary.
+	if err := os.RemoveAll(filepath.Join(os.Getenv("HOME"), ".claude")); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(wiringState{Version: "older", Targets: []string{"claude-auto"}, Exe: filepath.Join(tmp, "old-deja")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wiringStatePath(), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if changed := refreshWiringAfterUpgrade(); len(changed) == 0 {
+		t.Error("a record written before the home field stopped being repaired")
+	}
+}

--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -20,6 +20,13 @@ import (
 type wiringState struct {
 	Version string   `json:"version"`
 	Targets []string `json:"targets"`
+	// Home is the home directory the targets were written under. The repair
+	// derives every path from the environment it runs in, so a process whose
+	// HOME points elsewhere while the record is still visible — sudo with a
+	// preserved XDG_CONFIG_HOME, a container, an su session — wrote a fresh
+	// set of configs into a home nobody installed into, left the real ones
+	// pointing at the old binary, and marked the record repaired (#885).
+	Home string `json:"home,omitempty"`
 	// Exe is the binary path the configs were written with. A move without a
 	// version change is ordinary — a relink, a reinstall of the same release,
 	// a `go install` over a manual download — and left every config pointing
@@ -79,7 +86,7 @@ func recordWiring(targets []string, uninstall bool) {
 			return
 		}
 	}
-	st = wiringState{Version: version, Targets: kept, Exe: exe}
+	st = wiringState{Version: version, Targets: kept, Exe: exe, Home: homeDir()}
 	b, err := json.MarshalIndent(st, "", "  ")
 	if err != nil {
 		return
@@ -111,6 +118,11 @@ func refreshWiringAfterUpgrade() []string {
 	// Either the version or the path: a binary that moved writes the same
 	// version into configs that now name a file which is not there (#773).
 	if st.Version == version && (st.Exe == "" || st.Exe == exe) {
+		return nil
+	}
+	// Only the home the targets were written under: this repairs, it does not
+	// spread (#885).
+	if st.Home != "" && st.Home != homeDir() {
 		return nil
 	}
 	var changed []string

--- a/internal/index/empty_sessions_test.go
+++ b/internal/index/empty_sessions_test.go
@@ -80,3 +80,26 @@ func TestOlderFormatOnlyReportsAReadableOldIndex(t *testing.T) {
 		t.Error("an unreadable manifest was called an older format")
 	}
 }
+
+// FormatDirection has to name which side is behind, not merely that the two
+// differ (#890).
+func TestFormatDirection(t *testing.T) {
+	dir := t.TempDir()
+	if got := FormatDirection(dir); got != 0 {
+		t.Errorf("no manifest = %d, want 0", got)
+	}
+	for _, tc := range []struct {
+		v    int
+		want int
+	}{{version, 0}, {version - 1, -1}, {version + 1, 1}} {
+		if err := writeManifest(dir, Manifest{Version: tc.v, Sessions: map[string]SessionMeta{}}); err != nil {
+			t.Fatal(err)
+		}
+		if got := FormatDirection(dir); got != tc.want {
+			t.Errorf("version %d = %d, want %d", tc.v, got, tc.want)
+		}
+		if got, want := OlderFormat(dir), tc.want != 0; got != want {
+			t.Errorf("OlderFormat at version %d = %v", tc.v, got)
+		}
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1308,6 +1308,17 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 			removed[p] = true
 		}
 	}
+	// A store on a disk that is not mounted looks exactly like a store whose
+	// files were deleted, and the sessions it held leave the index — after
+	// which every surface reads "no agent history was found on this machine".
+	// The files are still there, on a disk that is not, and reconnecting it
+	// restores them; that is what this says (#900).
+	if progress != nil {
+		for _, gone := range missingTrees(removed) {
+			fmt.Fprintf(progress, "deja: %s is gone, and %d indexed file%s with it — if that disk is simply not mounted, reconnect it and run `deja index`\n",
+				gone.dir, gone.files, pluralFiles(gone.files))
+		}
+	}
 	if len(changed) == 0 && len(removed) == 0 {
 		lastIngestFiles = 0
 		return nil
@@ -1778,6 +1789,49 @@ func priorFiles(m Manifest, err error) map[string]FileState {
 		return nil
 	}
 	return m.Files
+}
+
+// missingTree is a directory that vanished along with everything under it.
+type missingTree struct {
+	dir   string
+	files int
+}
+
+// missingTrees groups files that disappeared by the outermost directory that
+// is no longer there. One deleted file has an existing parent and is reported
+// as nothing; a whole store that went away with its disk is one line.
+func missingTrees(removed map[string]bool) []missingTree {
+	byDir := map[string]int{}
+	for p := range removed {
+		dir := filepath.Dir(p)
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			continue
+		}
+		for {
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			if _, err := os.Stat(parent); !os.IsNotExist(err) {
+				break
+			}
+			dir = parent
+		}
+		byDir[dir]++
+	}
+	out := make([]missingTree, 0, len(byDir))
+	for dir, n := range byDir {
+		out = append(out, missingTree{dir: dir, files: n})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].dir < out[j].dir })
+	return out
+}
+
+func pluralFiles(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }
 
 func currentFiles(h string) map[string]FileState {

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -24,12 +24,31 @@ func IsCurrentVersion(dir string) bool {
 // format this build no longer understands. Distinct from IsCurrentVersion,
 // which cannot tell an old index from an unreadable one — and doctor must not
 // call a corrupt manifest "an older deja" (#877).
-func OlderFormat(dir string) bool {
+func OlderFormat(dir string) bool { return FormatDirection(dir) != 0 }
+
+// FormatDirection reports how the index on disk relates to this build's
+// format: -1 when it was written by an older deja, +1 by a newer one, 0 when
+// it matches or cannot be read.
+//
+// The direction matters because the fix differs. An older index is rebuilt and
+// forgotten; a newer one means the binary was rolled back — a bad release
+// reverted, `brew switch`, a pinned version in CI — and telling that reader
+// their index is old sends them looking in the wrong place (#890).
+func FormatDirection(dir string) int {
 	if dir == "" {
 		dir = DefaultDir()
 	}
 	m, err := readManifest(dir)
-	return err == nil && m.Version != version
+	if err != nil {
+		return 0
+	}
+	switch {
+	case m.Version < version:
+		return -1
+	case m.Version > version:
+		return 1
+	}
+	return 0
 }
 
 func HasManifest(dir string) bool {

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -51,6 +51,27 @@ func FormatDirection(dir string) int {
 	return 0
 }
 
+// ImportedSessionCounts reports how many of each harness's indexed sessions
+// arrived from another machine. doctor prints files beside sessions, and on a
+// store that has both, more sessions than files reads as a miscount unless the
+// difference is named (#894).
+func ImportedSessionCounts(dir string) map[string]int {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		return nil
+	}
+	out := map[string]int{}
+	for _, meta := range m.Sessions {
+		if strings.HasPrefix(meta.ID, "imported-") {
+			out[meta.Harness]++
+		}
+	}
+	return out
+}
+
 func HasManifest(dir string) bool {
 	if dir == "" {
 		dir = DefaultDir()

--- a/internal/index/missing_tree_test.go
+++ b/internal/index/missing_tree_test.go
@@ -1,0 +1,57 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A store on a disk that is not mounted looks exactly like a store whose files
+// were deleted: the sessions leave the index and every surface then reads "no
+// agent history was found on this machine" (#900).
+func TestMissingTreesNamesADirectoryThatWentAwayWhole(t *testing.T) {
+	root := t.TempDir()
+	live := filepath.Join(root, "live", "proj")
+	if err := os.MkdirAll(live, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	deleted := filepath.Join(live, "gone.jsonl")
+	if err := os.WriteFile(deleted, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(deleted); err != nil {
+		t.Fatal(err)
+	}
+
+	// One file gone from a directory that is still there: an ordinary
+	// removal, and nothing to say about it.
+	if got := missingTrees(map[string]bool{deleted: true}); len(got) != 0 {
+		t.Errorf("an ordinary deletion was reported as a missing tree: %+v", got)
+	}
+
+	// A whole tree gone: reported once, at the outermost directory that is no
+	// longer there, with the count under it.
+	vanished := filepath.Join(root, "volume", "claude", "proj")
+	files := map[string]bool{
+		filepath.Join(vanished, "a.jsonl"): true,
+		filepath.Join(vanished, "b.jsonl"): true,
+		filepath.Join(vanished, "c.jsonl"): true,
+	}
+	got := missingTrees(files)
+	if len(got) != 1 {
+		t.Fatalf("missing trees = %+v, want one", got)
+	}
+	if got[0].dir != filepath.Join(root, "volume") {
+		t.Errorf("reported %q, want the outermost directory that is gone", got[0].dir)
+	}
+	if got[0].files != 3 {
+		t.Errorf("counted %d files, want 3", got[0].files)
+	}
+	if s := pluralFiles(1); s != "" {
+		t.Errorf("one file pluralised: %q", s)
+	}
+	if s := pluralFiles(3); !strings.HasPrefix(s, "s") {
+		t.Errorf("three files not pluralised: %q", s)
+	}
+}

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -87,6 +87,25 @@ func pushedTo(m Manifest, matched map[string]bool) ([]string, bool) {
 	return out, unnamed
 }
 
+// PushedTo reports where one session's records have already gone: named peers
+// and whether an unnamed directory export carried it. forget says this when it
+// drops a session (#788); taking a decision back is the same moment for the
+// same reason, and promote said nothing (#898).
+func PushedTo(dir, harness, id string) ([]string, bool) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		return nil, false
+	}
+	key := harness + ":" + id
+	if _, ok := m.Sessions[key]; !ok {
+		return nil, false
+	}
+	return pushedTo(m, map[string]bool{key: true})
+}
+
 func privacyDir() string {
 	base := os.Getenv("XDG_CONFIG_HOME")
 	if base == "" {

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -294,6 +294,7 @@ func Import(dir, inDir string) (int, error) {
 			rank:   make(map[string]int, len(titleRankOf)),
 			added:  added,
 		}
+		fileDedupe := &before.dedupe
 		for k, v := range recsByKey {
 			before.counts[k] = len(v)
 		}
@@ -374,6 +375,7 @@ func Import(dir, inDir string) (int, error) {
 			}
 			metas[key] = meta
 			m.ImportedRecords[dedupe] = true
+			*fileDedupe = append(*fileDedupe, dedupe)
 			added++
 			return nil
 		}); err != nil {
@@ -389,6 +391,9 @@ func Import(dir, inDir string) (int, error) {
 					continue
 				}
 				recsByKey[k] = recsByKey[k][:n]
+			}
+			for _, k := range before.dedupe {
+				delete(m.ImportedRecords, k)
 			}
 			restoreMap(metas, before.metas)
 			restoreMap(titleAt, before.at)
@@ -416,6 +421,11 @@ type importSnapshot struct {
 	metas  map[string]SessionMeta
 	at     map[string]time.Time
 	rank   map[string]int
+	// dedupe keys added while reading this file. Without taking these back a
+	// refused file left its records out of the index and marked as already
+	// imported, so the retry after fixing the file brought nothing and the
+	// records were lost for good (#897).
+	dedupe []string
 	added  int
 }
 

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -311,6 +311,15 @@ func Import(dir, inDir string) (int, error) {
 			if sr.Harness == "" || origID == "" {
 				return nil
 			}
+			// The same rule the local ingest applies: a message that strips to
+			// empty is not a message, and a session with nothing but those is
+			// not a session. deja's own exports never carry them, but a
+			// hand-made batch or one from a build older than #868 does — and
+			// they came back in as blank lines in `last` and rows in every
+			// counter (#896).
+			if strings.TrimSpace(sr.Text) == "" {
+				return nil
+			}
 			// Key includes role and a text hash: two messages can legally share
 			// a timestamp (aider stamps a whole session with its start time).
 			// The legacy time-only key is still honored so batches imported by

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -281,7 +281,31 @@ func Import(dir, inDir string) (int, error) {
 	titleAt := map[string]time.Time{} // key -> time of the turn the title came from
 	titleRankOf := map[string]int{}   // key -> how good that turn was as a title
 	added := 0
+	var skipped []string
 	for _, p := range paths {
+		// A file is imported whole or not at all, so what it contributed is
+		// remembered before it is read and rolled back if it turns out to be
+		// truncated: half a transfer is the one outcome nobody can reason
+		// about afterwards (#891).
+		before := importSnapshot{
+			counts: make(map[string]int, len(recsByKey)),
+			metas:  make(map[string]SessionMeta, len(metas)),
+			at:     make(map[string]time.Time, len(titleAt)),
+			rank:   make(map[string]int, len(titleRankOf)),
+			added:  added,
+		}
+		for k, v := range recsByKey {
+			before.counts[k] = len(v)
+		}
+		for k, v := range metas {
+			before.metas[k] = v
+		}
+		for k, v := range titleAt {
+			before.at[k] = v
+		}
+		for k, v := range titleRankOf {
+			before.rank[k] = v
+		}
 		if err := readSyncFile(p, func(sr SyncRecord) error {
 			origID := sr.SessionID
 			if sr.Harness == "" || origID == "" {
@@ -344,16 +368,70 @@ func Import(dir, inDir string) (int, error) {
 			added++
 			return nil
 		}); err != nil {
-			return added, err
+			// One unreadable file used to stop the whole directory, so a valid
+			// export sitting beside a truncated one never arrived and the
+			// reader was told only about a stray character (#891). The file is
+			// still refused whole; the others are not held hostage to it.
+			skipped = append(skipped, err.Error())
+			for k := range recsByKey {
+				n := before.counts[k]
+				if n == 0 {
+					delete(recsByKey, k)
+					continue
+				}
+				recsByKey[k] = recsByKey[k][:n]
+			}
+			restoreMap(metas, before.metas)
+			restoreMap(titleAt, before.at)
+			restoreMap(titleRankOf, before.rank)
+			added = before.added
+			continue
 		}
 	}
 	if added == 0 {
-		return 0, writeManifest(dir, m)
+		if err := writeManifest(dir, m); err != nil {
+			return 0, err
+		}
+		return 0, skippedError(skipped)
 	}
 	if err := appendImportedRecords(dir, &m, recsByKey, metas); err != nil {
 		return added, err
 	}
-	return added, nil
+	return added, skippedError(skipped)
+}
+
+// importSnapshot is what one file had contributed before it was read, so a
+// file that turns out to be unreadable can be taken back out.
+type importSnapshot struct {
+	counts map[string]int
+	metas  map[string]SessionMeta
+	at     map[string]time.Time
+	rank   map[string]int
+	added  int
+}
+
+func restoreMap[V any](live, saved map[string]V) {
+	for k := range live {
+		if _, ok := saved[k]; !ok {
+			delete(live, k)
+		}
+	}
+	for k, v := range saved {
+		live[k] = v
+	}
+}
+
+// skippedError reports the files an import could not read, after the ones it
+// could are already in. Callers print the count they imported and this
+// alongside it.
+func skippedError(skipped []string) error {
+	if len(skipped) == 0 {
+		return nil
+	}
+	if len(skipped) == 1 {
+		return fmt.Errorf("nothing was imported from 1 file: %s", skipped[0])
+	}
+	return fmt.Errorf("nothing was imported from %d files: %s", len(skipped), strings.Join(skipped, "; "))
 }
 
 func initEmptyIndex(dir string) error {
@@ -391,10 +469,16 @@ func readSyncFile(path string, fn func(SyncRecord) error) error {
 	defer func() { _ = f.Close() }()
 	s := bufio.NewScanner(f)
 	s.Buffer(make([]byte, 64*1024), 8*1024*1024)
+	line := 0
 	for s.Scan() {
+		line++
 		var rec SyncRecord
 		if err := json.Unmarshal(s.Bytes(), &rec); err != nil {
-			return fmt.Errorf("%s: %w", filepath.Base(path), err)
+			// The line number, because "invalid character 'o' in literal null"
+			// on a file of thousands is not something anyone can act on. The
+			// file is still refused whole: a half-imported transfer is worse
+			// than one the reader can retry (#891).
+			return fmt.Errorf("%s line %d is not a record deja wrote: %w", filepath.Base(path), line, err)
 		}
 		if err := fn(rec); err != nil {
 			return err

--- a/internal/index/sync_partial_test.go
+++ b/internal/index/sync_partial_test.go
@@ -128,3 +128,60 @@ func TestImportDropsRecordsWithNothingInThem(t *testing.T) {
 		t.Errorf("messages in the index = %q, want only the real one", texts)
 	}
 }
+
+// Refusing a file has to take back everything it contributed, including the
+// marks that say its records were already imported. Without that the records
+// were out of the index and marked as in, so the retry after fixing the file
+// brought nothing and they were lost for good (#897).
+func TestRetryAfterAFixedFileBringsExactlyWhatWasMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	in := filepath.Join(home, "export")
+	if err := os.MkdirAll(in, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := func(id, text string) string {
+		b, err := json.Marshal(SyncRecord{Harness: "claude", SessionID: id, Project: "p", Role: "user", Text: text})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b) + "\n"
+	}
+	good := filepath.Join(in, "a-good.jsonl")
+	broken := filepath.Join(in, "b-broken.jsonl")
+	if err := os.WriteFile(good, []byte(rec("g1", "a good record")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	body := rec("b1", "the first record of the broken file") + rec("b2", "the second one") + "not json\n"
+	if err := os.WriteFile(broken, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(home, "idx")
+	n, err := Import(dir, in)
+	if err == nil {
+		t.Fatal("the broken file was not reported")
+	}
+	if n != 1 {
+		t.Fatalf("first import brought %d records, want the good file's one", n)
+	}
+
+	// The file is repaired and the transfer retried.
+	if err := os.WriteFile(broken, []byte(rec("b1", "the first record of the broken file")+rec("b2", "the second one")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	n, err = Import(dir, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Errorf("retry brought %d records, want the two that were missing", n)
+	}
+	if again, err := Import(dir, in); err != nil || again != 0 {
+		t.Errorf("a third run brought %d records (err %v), want none", again, err)
+	}
+	if counts := HarnessSessionCounts(dir); counts["claude"] != 3 {
+		t.Errorf("index holds %d claude sessions, want 3", counts["claude"])
+	}
+}

--- a/internal/index/sync_partial_test.go
+++ b/internal/index/sync_partial_test.go
@@ -72,3 +72,59 @@ func TestImportKeepsGoingPastAFileItCannotRead(t *testing.T) {
 		t.Errorf("half of a refused file was imported: %q", joined)
 	}
 }
+
+// deja's own exports never carry a record whose text strips to empty — the
+// local ingest drops them (#868) — but a hand-made batch or one from an older
+// build does, and they arrived as sessions: blank lines in `last`, rows in
+// every counter (#896).
+func TestImportDropsRecordsWithNothingInThem(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	in := filepath.Join(home, "export")
+	if err := os.MkdirAll(in, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var batch strings.Builder
+	for _, tc := range []struct{ id, text string }{
+		{"r1", "a real remote record"},
+		{"r2", "   "},
+		{"r3", ""},
+		{"r4", "\n\t "},
+	} {
+		b, err := json.Marshal(SyncRecord{Harness: "claude", SessionID: tc.id, Project: "p", Role: "user", Text: tc.text})
+		if err != nil {
+			t.Fatal(err)
+		}
+		batch.WriteString(string(b) + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(in, "deja-sync-y.jsonl"), []byte(batch.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(home, "idx")
+	n, err := Import(dir, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("imported %d records, want only the one with something in it", n)
+	}
+	counts := HarnessSessionCounts(dir)
+	if counts["claude"] != 1 {
+		t.Errorf("manifest holds %d claude sessions, want 1", counts["claude"])
+	}
+	ss, err := Search(dir, query.Options{All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var texts []string
+	for _, s := range ss {
+		for _, m := range s.Messages {
+			texts = append(texts, m.Text)
+		}
+	}
+	if len(texts) != 1 || texts[0] != "a real remote record" {
+		t.Errorf("messages in the index = %q, want only the real one", texts)
+	}
+}

--- a/internal/index/sync_partial_test.go
+++ b/internal/index/sync_partial_test.go
@@ -1,0 +1,74 @@
+package index
+
+import (
+	"encoding/json"
+	"github.com/vshulcz/deja-vu/internal/query"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// One unreadable file used to stop the whole directory, so a valid export
+// sitting beside a truncated one never arrived — and the reader was told only
+// about a stray character, with no line and no word about what did import
+// (#891).
+func TestImportKeepsGoingPastAFileItCannotRead(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	in := filepath.Join(home, "export")
+	if err := os.MkdirAll(in, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := func(id, text string) string {
+		b, err := json.Marshal(SyncRecord{Harness: "claude", SessionID: id, Project: "p", Role: "user", Text: text})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+	if err := os.WriteFile(filepath.Join(in, "a-broken.jsonl"),
+		[]byte(rec("s1", "before the break")+"\nnot json at all\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(in, "b-good.jsonl"),
+		[]byte(rec("s2", "the good file")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(home, "idx")
+	n, err := Import(dir, in)
+	if err == nil {
+		t.Fatal("a file that could not be read was not reported")
+	}
+	if n == 0 {
+		t.Error("the good file was held hostage to the broken one")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "a-broken.jsonl line 2") {
+		t.Errorf("error does not say where: %q", got)
+	}
+	if !strings.Contains(got, "nothing was imported from 1 file") {
+		t.Errorf("error does not say what was skipped: %q", got)
+	}
+
+	ss, err := Search(dir, query.Options{All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var texts []string
+	for _, s := range ss {
+		for _, m := range s.Messages {
+			texts = append(texts, m.Text)
+		}
+	}
+	joined := strings.Join(texts, "|")
+	if !strings.Contains(joined, "the good file") {
+		t.Errorf("the good file did not arrive: %q", joined)
+	}
+	// All or nothing per file: the half before the bad line stays out.
+	if strings.Contains(joined, "before the break") {
+		t.Errorf("half of a refused file was imported: %q", joined)
+	}
+}

--- a/internal/search/future_test.go
+++ b/internal/search/future_test.go
@@ -1,0 +1,48 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A transcript stamped ahead of the clock is newer than everything, so one bad
+// timestamp labelled every real session in the project as an earlier attempt —
+// and the digest called it "today" while search printed its real date (#880).
+func TestASessionDatedAheadIsNotTodayAndSupersedesNothing(t *testing.T) {
+	now := time.Now()
+	future := stalenessSession("fut1", "api", "connection pool exhausted under load", now.AddDate(1, 0, 0))
+	today := stalenessSession("today1", "api", "connection pool exhausted under load", now.Add(-2*time.Hour))
+	old := stalenessSession("old1", "api", "connection pool exhausted under load", now.AddDate(0, 0, -30))
+
+	hits, err := Run([]model.Session{future, today, old}, Options{Query: "connection pool exhausted", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]Hit{}
+	for _, h := range hits {
+		byID[h.Session.ID] = h
+	}
+	if got := byID["today1"].Superseded; got != "" {
+		t.Errorf("today's work was superseded by a session dated ahead: %q", got)
+	}
+	// A real one still supersedes: the guard is about the future, not about
+	// the label.
+	if byID["old1"].Superseded == "" {
+		t.Error("a month-old session stopped being marked")
+	}
+
+	if got := relativeDay(future.Updated, now); !strings.HasPrefix(got, "dated ") {
+		t.Errorf("a session a year ahead reads as %q", got)
+	}
+	if got := relativeDay(today.Updated, now); got != "today" {
+		t.Errorf("today reads as %q", got)
+	}
+	// A day ahead is clock skew, and reading it as today is the kind answer —
+	// the behaviour TestAutoRecallProvenanceDates has always asserted.
+	if got := relativeDay(now.AddDate(0, 0, 1), now); got != "today" {
+		t.Errorf("a day ahead reads as %q, want today", got)
+	}
+}

--- a/internal/search/future_test.go
+++ b/internal/search/future_test.go
@@ -48,3 +48,42 @@ func TestASessionDatedAheadIsNotTodayAndSupersedesNothing(t *testing.T) {
 		t.Errorf("a day ahead reads as %q, want today", got)
 	}
 }
+
+// NoteBucketDay decides which lines get the bucket's own date, so its refusals
+// matter as much as its hits: a transcript, a short id, a shape that only looks
+// like a date (#883).
+func TestNoteBucketDayRefusals(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		harness string
+		id      string
+		want    string
+	}{
+		{"note", notesHarness, "deja-2026-07-16-edge", "2026-07-16"},
+		{"transcript with a bucket-shaped id", "claude", "deja-2026-07-16-edge", ""},
+		{"note with a short id", notesHarness, "deja-2026", ""},
+		{"note with an unparsable day", notesHarness, "deja-2026-13-99-edge", ""},
+		{"note with another prefix", notesHarness, "note-2026-07-16-edge", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := NoteBucketDay(model.Session{Harness: tc.harness, ID: tc.id})
+			if tc.want == "" {
+				if ok {
+					t.Fatalf("accepted %q as a bucket day: %q", tc.id, got)
+				}
+				return
+			}
+			if !ok || got != tc.want {
+				t.Fatalf("day = %q, %v; want %q", got, ok, tc.want)
+			}
+		})
+	}
+	// A day that cannot be parsed anchors nowhere rather than at the epoch's
+	// midday.
+	if got := noteBucketNoon("not-a-day"); !got.IsZero() {
+		t.Errorf("unparsable day anchored at %v", got)
+	}
+	if got := noteBucketNoon("2026-07-16"); got.Hour() != 12 {
+		t.Errorf("bucket anchored at %v, want midday", got)
+	}
+}

--- a/internal/search/future_test.go
+++ b/internal/search/future_test.go
@@ -14,7 +14,9 @@ import (
 func TestASessionDatedAheadIsNotTodayAndSupersedesNothing(t *testing.T) {
 	now := time.Now()
 	future := stalenessSession("fut1", "api", "connection pool exhausted under load", now.AddDate(1, 0, 0))
-	today := stalenessSession("today1", "api", "connection pool exhausted under load", now.Add(-2*time.Hour))
+	// now itself, not "a couple of hours ago": at 00:30 UTC that is yesterday,
+	// and this assertion is about the calendar day, not the offset.
+	today := stalenessSession("today1", "api", "connection pool exhausted under load", now)
 	old := stalenessSession("old1", "api", "connection pool exhausted under load", now.AddDate(0, 0, -30))
 
 	hits, err := Run([]model.Session{future, today, old}, Options{Query: "connection pool exhausted", All: true})

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -255,7 +255,15 @@ func relativeDay(updated, now time.Time) string {
 		return "yesterday"
 	default:
 		if days < 0 {
-			return "today"
+			// A day ahead is clock skew — a container, a zone, a machine that
+			// woke up wrong — and calling it today is the kind reading. A year
+			// ahead is not skew: it sat at the top of injected memory wearing
+			// today's date, and the model has no way to doubt it (#880).
+			// `search` prints the real date for both.
+			if days >= -1 {
+				return "today"
+			}
+			return "dated " + updatedDate.Format("2006-01-02")
 		}
 		return fmt.Sprintf("%d days ago", days)
 	}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -350,6 +350,12 @@ func markEarlierAttempts(hits []Hit) {
 			if !b.Session.Updated.After(a.Session.Updated.Add(24 * time.Hour)) {
 				continue
 			}
+			// …and it must have happened. A transcript stamped ahead of the
+			// clock is newer than everything, so one bad timestamp labelled
+			// every real session in the project as an earlier attempt (#880).
+			if b.Session.Updated.After(time.Now()) {
+				continue
+			}
 			if snippetOverlap(sets[i], sets[j]) < 0.6 {
 				continue
 			}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -384,6 +384,35 @@ func snippetOverlap(a, b map[string]bool) float64 {
 // RelativeDate is the human "3w ago" form used in listings and digests.
 func RelativeDate(t time.Time) string { return relativeDate(t) }
 
+// noteBucketNoon anchors a bucket day at midday in the reader's zone, so the
+// relative wording ("today", "3d ago") is computed from the day the id names
+// and no hour of the clock can push it onto a neighbouring date.
+func noteBucketNoon(day string) time.Time {
+	t, err := time.ParseInLocation("2006-01-02", day, time.Local)
+	if err != nil {
+		return time.Time{}
+	}
+	return t.Add(12 * time.Hour)
+}
+
+// NoteBucketDay returns the day a note bucket's id encodes, when the session is
+// one. The id is deja-YYYY-MM-DD-<project>: the bucket itself rather than a
+// moment inside it, so it reads the same for every reader (#883).
+func NoteBucketDay(s model.Session) (string, bool) {
+	if s.Harness != notesHarness || !strings.HasPrefix(s.ID, "deja-") {
+		return "", false
+	}
+	rest := strings.TrimPrefix(s.ID, "deja-")
+	if len(rest) < 10 {
+		return "", false
+	}
+	day := rest[:10]
+	if _, err := time.Parse("2006-01-02", day); err != nil {
+		return "", false
+	}
+	return day, true
+}
+
 func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLength float64, queryTokenCount int, worn map[string]int) []Hit {
 	emptyQuery := queryTokenCount == 0
 	now := time.Now()
@@ -728,6 +757,12 @@ func Print(w io.Writer, hits []Hit, o Options) {
 		d := "-"
 		if !h.Session.Updated.IsZero() {
 			d = relativeDate(h.Session.Updated)
+		}
+		// A day of notes is one session whose id *is* a date, minted in UTC.
+		// The reader's zone put a different day on the line than the id beside
+		// it, and only for deja's own buckets (#883).
+		if day, ok := NoteBucketDay(h.Session); ok {
+			d = relativeDate(noteBucketNoon(day))
 		}
 		if color {
 			fmt.Fprintf(w, "%s%s %-10s %s %s %s %s %s%s%d matches%s%s\n", cBold, harnessTag(h.Session.Harness, true), h.Session.Project, cDim+"·"+cReset+cBold, d, cDim+"·"+cReset+cBold, short(h.Session.ID), cDim+"— "+cReset, cBold, h.Count, cReset, tierLabel(h))

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -95,7 +95,13 @@ func AppendNoteTagged(project, text string, tags []string, now time.Time) error 
 }
 
 func LoadNotes() []model.Session {
-	ss, _ := ParseNotesFile(NotesFile())
+	// The error is recorded, not swallowed: notes are read straight here
+	// rather than through parseFiles, so a notes file the process cannot read
+	// looked exactly like one with nothing in it — 43 sessions of the user's
+	// own decisions left the index and no line said so (#901).
+	path := NotesFile()
+	ss, err := ParseNotesFile(path)
+	diagFileError(path, err)
 	return ss
 }
 

--- a/internal/sources/notes_unreadable_test.go
+++ b/internal/sources/notes_unreadable_test.go
@@ -1,0 +1,44 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// Notes are read straight rather than through parseFiles, so the error was
+// dropped on the floor: a notes file the process cannot read looked exactly
+// like one with nothing in it, and the user's own decisions left the index
+// without a word (#901).
+func TestLoadNotesRecordsAFileItCannotRead(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("file permissions do not deny reads here")
+	}
+	dir := t.TempDir()
+	notes := filepath.Join(dir, "notes.jsonl")
+	if err := os.WriteFile(notes, []byte(`{"ts":"2026-08-01T10:00:00Z","project":"p","text":"a decision"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_NOTES_FILE", notes)
+
+	DiagSnapshot() // clear anything a neighbour left behind
+	if ss := LoadNotes(); len(ss) != 1 {
+		t.Fatalf("readable notes loaded %d sessions, want 1", len(ss))
+	}
+	if _, failed := DiagSnapshot(); len(failed) != 0 {
+		t.Errorf("a readable file was reported as failed: %v", failed)
+	}
+
+	if err := os.Chmod(notes, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(notes, 0o600) })
+	if ss := LoadNotes(); len(ss) != 0 {
+		t.Fatalf("an unreadable file yielded %d sessions", len(ss))
+	}
+	_, failed := DiagSnapshot()
+	if len(failed) != 1 || failed[notes] == "" {
+		t.Errorf("the unreadable notes file was not reported: %v", failed)
+	}
+}


### PR DESCRIPTION
Four findings from the audit sweep of what each surface says in each index state.

- **#878** — the session that *requests* a rebuild was the one told nothing about it: the warmup child has not published progress yet, so the first session after an upgrade or a damaged store was silent.
- **#879** — the statusline said `no recalls yet today` and the MCP instructions said nothing at all during that same window, while doctor and the hook both spoke.
- **#880** — a transcript stamped ahead of the clock read as `today` in the digest the model reads, and superseded every real session in the project.

Closes #878, closes #879, closes #880.