### PR TITLE
chore: pin scoop and winget to 0.16.6

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,12 +1,12 @@
 {
     "architecture": {
         "64bit": {
-            "hash": "aa9821b114d6244172f58f5ee779f4ee559e12eb56afdd7e594c31c1c218114a",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.5/deja-vu_0.16.5_windows_amd64.zip"
+            "hash": "4142ad58bdd4ddf05948145374b4b349a25bf1f883611dfd7d978702fd8ab2aa",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.6/deja-vu_0.16.6_windows_amd64.zip"
         },
         "arm64": {
-            "hash": "81cdabeca829b2896cd7d9e51faab7f8f7fe6f8c9997a370607a5f99c9d2be7e",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.5/deja-vu_0.16.5_windows_arm64.zip"
+            "hash": "1da73f9bfef8586f89a604e11839ec5de3e6df0c51a349133133f54cbbd0a2b2",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.6/deja-vu_0.16.6_windows_arm64.zip"
         }
     },
     "autoupdate": {
@@ -24,5 +24,5 @@
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
-    "version": "0.16.5"
+    "version": "0.16.6"
 }

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.5
+PackageVersion: 0.16.6
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.5/deja-vu_0.16.5_windows_amd64.zip
-  InstallerSha256: AA9821B114D6244172F58F5EE779F4EE559E12EB56AFDD7E594C31C1C218114A
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.6/deja-vu_0.16.6_windows_amd64.zip
+  InstallerSha256: 4142AD58BDD4DDF05948145374B4B349A25BF1F883611DFD7D978702FD8AB2AA
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.5/deja-vu_0.16.5_windows_arm64.zip
-  InstallerSha256: 81CDABECA829B2896CD7D9E51FAAB7F8F7FE6F8C9997A370607A5F99C9D2BE7E
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.6/deja-vu_0.16.6_windows_arm64.zip
+  InstallerSha256: 1DA73F9BFEF8586F89A604E11839EC5DE3E6DF0C51A349133133F54CBBD0A2B2
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.5
+PackageVersion: 0.16.6
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.5/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.6/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.5
+PackageVersion: 0.16.6
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
The manifests carry a version and two hashes that are updated after a release; the check job in CI is what noticed they were still on 0.16.5.