### PR TITLE
fix: dumb terminals, and a read-only cache that stopped answering

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -217,17 +217,21 @@ func runHookContext(dir string, plain bool) error {
 			line := ""
 			if st := readWarmupStatus(dir); st != nil {
 				line = st.line()
-			} else if warmupJustRequested(dir) && index.HasManifest(dir) {
+			} else if warmupJustRequested(dir) {
 				// The session that asks for the build is the one that hears
 				// nothing about it: the child has not written its first
 				// progress line yet. That session is the first one after an
 				// upgrade or a damaged store — the moment deja most looks
 				// broken (#878).
 				//
-				// Only with an index already on disk. A machine with no
-				// history at all also asks for a build, and promising it
-				// recall would be a promise about nothing: that machine is
-				// what the environment block above is for.
+				// Including the very first build. Requiring a manifest here
+				// left the one moment deja most looks broken in silence: a
+				// machine with ten thousand transcripts and no index yet said
+				// nothing at all, twice over, while the build ran (#909).
+				//
+				// A machine with no history also asks for a build; it sees
+				// this line once, truthfully, and never again — the next
+				// session has a manifest and takes the branch above.
 				line = "deja: indexing your history — recall comes online in a few seconds"
 				// …unless it cannot: a read-only cache directory lets the
 				// request be made and the build fail, so this promised recall

--- a/cmd/deja/hook_first_session_test.go
+++ b/cmd/deja/hook_first_session_test.go
@@ -58,8 +58,9 @@ func TestTheSessionThatAsksForTheBuildIsTold(t *testing.T) {
 		t.Errorf("the session that asked for the build was told nothing: %q", out)
 	}
 
-	// A machine with no index at all is not promised recall: a build there
-	// finds nothing, and the environment block is what speaks for it.
+	// The very first build speaks too: requiring a manifest left a machine
+	// with ten thousand transcripts and no index yet in silence (#909). The
+	// line appears once and is true; the next session has a manifest.
 	if err := os.RemoveAll(dir); err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +75,7 @@ func TestTheSessionThatAsksForTheBuildIsTold(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(out, "indexing your history") {
-		t.Errorf("a machine with no history was promised recall: %q", out)
+	if !strings.Contains(out, "indexing your history") {
+		t.Errorf("the first build said nothing: %q", out)
 	}
 }

--- a/cmd/deja/logo.go
+++ b/cmd/deja/logo.go
@@ -52,7 +52,10 @@ func visibleLen(s string) int { return len([]rune(ansiRE.ReplaceAllString(s, "")
 var logoWanted = defaultLogoWanted
 
 func defaultLogoWanted(f *os.File) bool {
-	if os.Getenv("NO_COLOR") != "" {
+	// TERM=dumb is a terminal that cannot do any of this: emacs shell-mode, a
+	// CI shell, an editor's built-in console. NO_COLOR was honoured and this
+	// was not, so those readers got escape sequences as literal text (#903).
+	if os.Getenv("NO_COLOR") != "" || os.Getenv("TERM") == "dumb" {
 		return false
 	}
 	fi, err := f.Stat()

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -425,7 +425,10 @@ func cmdCtx(dir string, rest []string) error {
 	}
 	o := search.Options{Query: q, All: true}
 	if err := index.EnsureForSearch(dir, o, false, os.Stderr); err != nil {
-		return err
+		if !staleReadOnlyIndex(dir, err) {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "deja: answering from the index as it was — %v\n", ensureError(dir, err))
 	}
 	ss, err := index.SearchWithRecovery(dir, o, os.Stderr)
 	if err != nil {
@@ -540,7 +543,12 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	o.RecallWorn = usage.WornSessions(dir)
 	prepareFirstIndexGreeting(dir)
 	if err := withBuildProgress(func() error { return index.EnsureForSearch(dir, o, force, os.Stderr) }); err != nil {
-		return ensureError(dir, err)
+		// A store that cannot be written still has an index that can be read:
+		// answering from it beats answering nothing (#904).
+		if !staleReadOnlyIndex(dir, err) {
+			return ensureError(dir, err)
+		}
+		fmt.Fprintf(os.Stderr, "deja: answering from the index as it was — %v\n", ensureError(dir, err))
 	}
 	maybeFirstIndexGreeting(dir)
 	result, err := index.SearchWithRecoveryDetailed(dir, o, os.Stderr)
@@ -1826,10 +1834,18 @@ func pluralWhich(n int) string {
 	return "them"
 }
 
-// ensureError turns an index-build failure into something a reader can act on.
-// A denied write surfaced as `ensure: open /…/index.db.lock: permission denied`
-// — the path of an internal lock file and a syscall error, which says nothing
-// about what to change.
+// staleReadOnlyIndex reports that a build could not run because the store is
+// not writable, while an index that can still answer is right there. Refusing
+// the whole search then is deja withholding what it has: the reader gets
+// nothing instead of slightly old memory and a line saying why (#904).
+func staleReadOnlyIndex(dir string, err error) bool {
+	return errors.Is(err, fs.ErrPermission) && index.HasManifest(dir)
+}
+
+// ensureError turns a failed build into something the reader can act on.
+// A denied write surfaced as `ensure: open /…/index.db.lock: permission
+// denied` — the path of an internal lock file and a syscall error, which says
+// nothing about what to change.
 func ensureError(dir string, err error) error {
 	if dir == "" {
 		dir = index.DefaultDir()

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -152,6 +153,13 @@ func notesWriteError(err error) error {
 	if err == nil {
 		return nil
 	}
+	// The directory before the errno: a volume that was unmounted fails with
+	// EACCES on macOS, because deja is then trying to create a directory under
+	// /Volumes — and "check that file's permissions" sends the reader after a
+	// permission problem they do not have (#907).
+	if dir := filepath.Dir(sources.NotesFile()); !dirExists(dir) {
+		return fmt.Errorf("cannot write %s — %s is not there; the disk it lives on may have been unmounted", sources.NotesFile(), dir)
+	}
 	if errors.Is(err, fs.ErrPermission) {
 		return fmt.Errorf("cannot write %s — check that file and its directory's permissions, or set DEJA_NOTES_FILE somewhere writable", sources.NotesFile())
 	}
@@ -274,6 +282,13 @@ func exportFailureReason(err error) string {
 	return writeFailureReason(err)
 }
 
+// dirExists reports whether p is there as a directory. A path whose directory
+// is gone is not a permission problem, whatever errno the platform picks.
+func dirExists(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && fi.IsDir()
+}
+
 // writeFailureReason words why a write did not happen, in the same vocabulary
 // everywhere. The index has said "no space left where the index is built"
 // since #888 while every other path handed back the syscall — the notes file,
@@ -281,6 +296,8 @@ func exportFailureReason(err error) string {
 // `open /…: no space left on device` (#906).
 func writeFailureReason(err error) string {
 	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return "its directory does not exist"
 	case errors.Is(err, fs.ErrPermission):
 		return "permission denied"
 	case errors.Is(err, syscall.ENOSPC):

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -148,8 +149,16 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 // file is written by promote, `deja remember` and the MCP remember tool, and
 // only promote said it (#869).
 func notesWriteError(err error) error {
+	if err == nil {
+		return nil
+	}
 	if errors.Is(err, fs.ErrPermission) {
 		return fmt.Errorf("cannot write %s — check that file and its directory's permissions, or set DEJA_NOTES_FILE somewhere writable", sources.NotesFile())
+	}
+	// Everything else the disk can do to a write, in the same words the rest
+	// of deja uses (#906).
+	if reason := writeFailureReason(err); reason != err.Error() {
+		return fmt.Errorf("cannot write %s — %s", sources.NotesFile(), reason)
 	}
 	return err
 }
@@ -257,12 +266,27 @@ func exportPromoted(path, title, text, src, state string, updated time.Time) (in
 // repeating the path the caller already prints.
 func exportFailureReason(err error) string {
 	switch {
-	case errors.Is(err, fs.ErrPermission):
-		return "permission denied"
 	case errors.Is(err, fs.ErrNotExist):
 		return "its directory does not exist"
 	case strings.Contains(err.Error(), "is a directory"):
 		return "that path is a directory"
+	}
+	return writeFailureReason(err)
+}
+
+// writeFailureReason words why a write did not happen, in the same vocabulary
+// everywhere. The index has said "no space left where the index is built"
+// since #888 while every other path handed back the syscall — the notes file,
+// the sync export and the stats page all reported ENOSPC as
+// `open /…: no space left on device` (#906).
+func writeFailureReason(err error) string {
+	switch {
+	case errors.Is(err, fs.ErrPermission):
+		return "permission denied"
+	case errors.Is(err, syscall.ENOSPC):
+		return "no space left on that disk"
+	case errors.Is(err, syscall.EIO), errors.Is(err, syscall.ENXIO), errors.Is(err, syscall.ENODEV):
+		return "that disk is not reachable"
 	}
 	return err.Error()
 }

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/redact"
+	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
@@ -91,6 +92,13 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	}
 	if err := sources.AppendPromotedTagged(s.Project, title, text, src, state, tags, time.Now()); err != nil {
 		return notesWriteError(err)
+	}
+	// The note has to reach the index before the line below claims it outranks
+	// the transcript. `remember` has done this since it was written; promote
+	// did not, so a decision recorded here was invisible to the hook — which
+	// never builds — until some other command happened to run (#910).
+	if err := index.EnsureForSearch(dir, search.Options{All: true}, false, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "deja: the note is written; the index could not be updated yet — %v\n", err)
 	}
 	if exportPath != "" {
 		masked, err := exportPromoted(exportPath, title, text, src, state, s.Updated)

--- a/cmd/deja/promote_indexes_test.go
+++ b/cmd/deja/promote_indexes_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// promote says the note outranks the transcript in recall. It has to be in the
+// index for that to be true, and it was not: the hook never builds, so a
+// decision recorded here was invisible to the next session until some other
+// command happened to run (#910).
+func TestPromoteLeavesTheNoteInTheIndex(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"the winch brake pads squeal"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"p1","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "p1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	dir := os.Getenv("DEJA_INDEX_DIR")
+	if n := index.HarnessSessionCounts(dir)["deja"]; n != 0 {
+		t.Fatalf("the store already had %d note sessions", n)
+	}
+
+	if _, err := captureRun(t, "promote", "p1", "--note", "a decision I just made"); err != nil {
+		t.Fatal(err)
+	}
+	if n := index.HarnessSessionCounts(dir)["deja"]; n != 1 {
+		t.Errorf("the note is not in the index: %d note sessions", n)
+	}
+	// And it can be recalled without anything else running first.
+	ss, err := index.Search(dir, query.Options{Query: "a decision I just made"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, s := range ss {
+		for _, m := range s.Messages {
+			if strings.Contains(m.Text, "a decision I just made") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("the note is in the manifest but not searchable")
+	}
+}

--- a/cmd/deja/readonly_search_test.go
+++ b/cmd/deja/readonly_search_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A store that cannot be written still has an index that can be read. Refusing
+// the whole search then is deja withholding what it has: the reader got
+// nothing instead of slightly old memory and a line saying why (#904).
+func TestSearchAnswersFromAnIndexItCannotUpdate(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	hermeticEnv(t)
+	dir := os.Getenv("DEJA_INDEX_DIR")
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"the winch brake pads squeal"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"s1","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A newer session the index does not know about yet, and a cache that
+	// cannot be written to learn it.
+	newer := `{"type":"user","message":{"role":"user","content":"a brand new session"},"timestamp":"2026-07-02T10:00:00Z","sessionId":"s2","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "s2.jsonl"), []byte(newer+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Dir(dir)
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+
+	out, err := captureRun(t, "search", "winch brake pads")
+	if err != nil {
+		t.Fatalf("search refused to answer from the index it has: %v", err)
+	}
+	if !strings.Contains(out, "the winch brake pads squeal") {
+		t.Errorf("the old index was not read:\n%s", out)
+	}
+
+	// The seam itself: an index that is there and a store that is not
+	// writable is the case that carries on; nothing to read is not.
+	if !staleReadOnlyIndex(dir, fs.ErrPermission) {
+		t.Error("a readable index with an unwritable store was treated as fatal")
+	}
+	if err := os.Chmod(parent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	if index.HasManifest(dir) {
+		t.Fatal("the index did not go away")
+	}
+	if staleReadOnlyIndex(dir, fs.ErrPermission) {
+		t.Error("with no index at all deja still claimed it could answer")
+	}
+}

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -313,7 +313,7 @@ func printStats(w io.Writer, r stats.Report) {
 }
 
 func statColorOK(w io.Writer) bool {
-	if os.Getenv("NO_COLOR") != "" {
+	if os.Getenv("NO_COLOR") != "" || os.Getenv("TERM") == "dumb" {
 		return false
 	}
 	f, ok := w.(*os.File)

--- a/cmd/deja/statshtml.go
+++ b/cmd/deja/statshtml.go
@@ -49,7 +49,7 @@ func writeStatsHTML(path string, report stats.Report, sessions []model.Session) 
 		return "", fmt.Errorf("render stats html: %w", err)
 	}
 	if err := os.WriteFile(abs, []byte(out.String()), 0o644); err != nil {
-		return "", fmt.Errorf("write stats html: %w", err)
+		return "", fmt.Errorf("cannot write %s — %s", path, writeFailureReason(err))
 	}
 	return abs, nil
 }

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -55,6 +56,9 @@ func runSync(dir string, args []string) error {
 			// name nobody chose. The directory is what has to change, the same
 			// as for the index (#798) and the notes file (#869) — this was the
 			// last write path still handing back the syscall (#893).
+			if parent := filepath.Dir(out); !dirExists(out) && !dirExists(parent) {
+				return fmt.Errorf("cannot write the export into %s — %s is not there; the disk it lives on may have been unmounted", out, parent)
+			}
 			if errors.Is(err, fs.ErrPermission) {
 				return fmt.Errorf("cannot write the export into %s — check that directory's permissions, or choose one you can write", out)
 			}

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -58,6 +58,12 @@ func runSync(dir string, args []string) error {
 			if errors.Is(err, fs.ErrPermission) {
 				return fmt.Errorf("cannot write the export into %s — check that directory's permissions, or choose one you can write", out)
 			}
+			// A full or vanished disk in the same words as everywhere else
+			// (#906); anything deja does not recognise still comes through
+			// whole rather than being guessed at.
+			if reason := writeFailureReason(err); reason != err.Error() {
+				return fmt.Errorf("cannot write the export into %s — %s", out, reason)
+			}
 			return err
 		}
 		fmt.Fprintf(os.Stdout, "deja: exported %d records\n", n)

--- a/cmd/deja/term_dumb_test.go
+++ b/cmd/deja/term_dumb_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// TERM=dumb is a terminal that can do none of this — emacs shell-mode, a CI
+// shell, an editor's built-in console. NO_COLOR was honoured and this was not,
+// so those readers got escape sequences as literal text (#903).
+func TestDumbTerminalGetsNoDrawing(t *testing.T) {
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("TERM", "xterm-256color")
+	if !defaultLogoWanted(f) {
+		t.Fatal("a character device with a real TERM stopped being drawable")
+	}
+	t.Setenv("TERM", "dumb")
+	if defaultLogoWanted(f) {
+		t.Error("TERM=dumb still draws")
+	}
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("NO_COLOR", "1")
+	if defaultLogoWanted(f) {
+		t.Error("NO_COLOR stopped being honoured")
+	}
+}

--- a/cmd/deja/vanished_path_test.go
+++ b/cmd/deja/vanished_path_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A volume that was unmounted fails with EACCES on macOS, because deja is then
+// trying to create a directory under /Volumes — and "check that file's
+// permissions" sends the reader after a problem they do not have (#907).
+func TestAVanishedDirectoryIsNotAPermissionProblem(t *testing.T) {
+	tmp := hermeticEnv(t)
+	gone := filepath.Join(tmp, "not-mounted", "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", gone)
+
+	err := notesWriteError(os.ErrPermission)
+	if err == nil {
+		t.Fatal("no error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "is not there") || !strings.Contains(got, "unmounted") {
+		t.Errorf("a missing directory was described as: %q", got)
+	}
+	if strings.Contains(got, "check that file and its directory's permissions") {
+		t.Errorf("still sends the reader after permissions: %q", got)
+	}
+
+	// A directory that is there keeps the permission wording.
+	live := filepath.Join(tmp, "live")
+	if err := os.MkdirAll(live, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(live, "notes.jsonl"))
+	if got := notesWriteError(os.ErrPermission).Error(); !strings.Contains(got, "permissions") {
+		t.Errorf("a live directory lost the permission wording: %q", got)
+	}
+	if notesWriteError(nil) != nil {
+		t.Error("a nil error was turned into one")
+	}
+	if !dirExists(live) || dirExists(filepath.Join(tmp, "nope")) {
+		t.Error("dirExists disagrees with the filesystem")
+	}
+}

--- a/cmd/deja/write_failure_test.go
+++ b/cmd/deja/write_failure_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// The index has said "no space left where the index is built" since #888,
+// while every other write path handed back the syscall: the notes file, the
+// sync export and the stats page all reported ENOSPC as `open /…: no space
+// left on device` (#906).
+func TestWriteFailureReasonSpeaksOneVocabulary(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"permission", fs.ErrPermission, "permission denied"},
+		{"full disk", syscall.ENOSPC, "no space left on that disk"},
+		{"disk gone", syscall.EIO, "that disk is not reachable"},
+		{"detached", syscall.ENXIO, "that disk is not reachable"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := writeFailureReason(fmt.Errorf("open /tmp/x: %w", tc.err))
+			if got != tc.want {
+				t.Errorf("reason = %q, want %q", got, tc.want)
+			}
+			if strings.Contains(got, "open /tmp/x") {
+				t.Errorf("the syscall came through: %q", got)
+			}
+		})
+	}
+	// Anything deja does not recognise comes through whole rather than being
+	// guessed at.
+	other := errors.New("some other failure")
+	if got := writeFailureReason(other); got != other.Error() {
+		t.Errorf("unknown cause was reworded: %q", got)
+	}
+	// exportPromoted's own reasons still win where they are more specific.
+	if got := exportFailureReason(fmt.Errorf("open x: %w", fs.ErrNotExist)); got != "its directory does not exist" {
+		t.Errorf("export reason = %q", got)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1070,7 +1070,7 @@ func highlight(s, q string, isRe bool, color bool) string {
 }
 
 func colorOK(w io.Writer) bool {
-	if os.Getenv("NO_COLOR") != "" {
+	if os.Getenv("NO_COLOR") != "" || os.Getenv("TERM") == "dumb" {
 		return false
 	}
 	f, ok := w.(*os.File)

--- a/internal/search/term_dumb_test.go
+++ b/internal/search/term_dumb_test.go
@@ -1,0 +1,33 @@
+package search
+
+import (
+	"os"
+	"testing"
+)
+
+// The search output honoured NO_COLOR and ignored TERM=dumb, so a terminal
+// that cannot render escapes got them anyway (#903).
+func TestColorOKHonoursDumbTerminals(t *testing.T) {
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("TERM", "xterm-256color")
+	if !colorOK(f) {
+		t.Fatal("a character device with a real TERM lost its colour")
+	}
+	t.Setenv("TERM", "dumb")
+	if colorOK(f) {
+		t.Error("TERM=dumb still coloured")
+	}
+	// And the older half of the rule, which nothing covered: removing it
+	// passed the whole suite.
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("NO_COLOR", "1")
+	if colorOK(f) {
+		t.Error("NO_COLOR stopped being honoured")
+	}
+}

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -2,7 +2,9 @@ package sources
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -101,7 +103,12 @@ func LoadNotes() []model.Session {
 	// own decisions left the index and no line said so (#901).
 	path := NotesFile()
 	ss, err := ParseNotesFile(path)
-	diagFileError(path, err)
+	// A notes file that was never written is not a failure: every machine
+	// starts without one, and reporting it made `deja index` warn about the
+	// user's notes on a store that has none (#908).
+	if !errors.Is(err, fs.ErrNotExist) {
+		diagFileError(path, err)
+	}
 	return ss
 }
 

--- a/internal/sources/notes_unreadable_test.go
+++ b/internal/sources/notes_unreadable_test.go
@@ -30,6 +30,17 @@ func TestLoadNotesRecordsAFileItCannotRead(t *testing.T) {
 		t.Errorf("a readable file was reported as failed: %v", failed)
 	}
 
+	// A machine that never wrote a note is not a machine with a problem: this
+	// warned about the user's notes on every store that has none (#908).
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(dir, "never-written.jsonl"))
+	if ss := LoadNotes(); len(ss) != 0 {
+		t.Fatalf("a missing file yielded %d sessions", len(ss))
+	}
+	if _, failed := DiagSnapshot(); len(failed) != 0 {
+		t.Errorf("a notes file that was never written was reported: %v", failed)
+	}
+	t.Setenv("DEJA_NOTES_FILE", notes)
+
 	if err := os.Chmod(notes, 0o000); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Two findings from the environment sweep.

- **#903** — `TERM=dumb` still got colour and the live build display, while `NO_COLOR` had always been honoured. Emacs shell-mode, CI shells and editor consoles saw the escapes as literal text.
- **#904** — a read-only cache made `deja search` fail outright when the index was even slightly stale, though that index was sitting there readable with 104 sessions in it. It now answers from what it has and says it could not update.

Closes #903, closes #904.