### PR TITLE
fix: date note buckets in the reader's zone

### DIFF
--- a/cmd/deja/note_bucket_day_test.go
+++ b/cmd/deja/note_bucket_day_test.go
@@ -8,10 +8,11 @@ import (
 	"time"
 )
 
-// A day of notes is one session whose id *is* a date, minted in UTC. Reading
-// its timestamp in the reader's zone put a different day on the line than the
-// id sitting beside it, and an id rebuilt from what the reader saw matched
-// nothing (#883).
+// A day of notes is one session whose id *is* a date. Reading its timestamp in
+// the reader's zone put a different day on the line than the id sitting beside
+// it, and an id rebuilt from what the reader saw matched nothing (#883). The
+// day both carry is the reader's, so the note sits in the same calendar as the
+// sessions listed around it (#911).
 func TestANoteBucketShowsTheDayItsIdNames(t *testing.T) {
 	tmp := hermeticEnv(t)
 	// time.Local is resolved once at process start, so TZ= in the environment
@@ -34,12 +35,12 @@ func TestANoteBucketShowsTheDayItsIdNames(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, "deja-2026-07-16-edge") {
+	if !strings.Contains(out, "deja-2026-07-17-edge") {
 		t.Fatalf("bucket id changed: %q", out)
 	}
 	// The date on the line is the date in the id, not the reader's rendering
 	// of a moment inside it.
-	if !strings.Contains(out, "2026-07-16 · deja-2026-07-16-edge") {
+	if !strings.Contains(out, "2026-07-17 · deja-2026-07-17-edge") {
 		t.Errorf("line and id disagree:\n%s", out)
 	}
 

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -171,7 +171,12 @@ func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error
 			s.Messages = append(s.Messages, model.Message{Role: "user", Text: body, Time: t})
 			return
 		}
-		day := t.UTC().Format("2006-01-02")
+		// The bucket day is the reader's day, not UTC's. The line is labelled
+		// by the day the id names (#883) while every other line is rendered in
+		// the reader's zone (#849), so east of UTC a note written a quarter of
+		// an hour after a session was dated the day before it and `deja last`
+		// printed its dates out of order (#911).
+		day := t.Local().Format("2006-01-02")
 		key := project + "\x00" + day
 		s := byDay[key]
 		if s == nil {

--- a/internal/sources/notes_local_day_test.go
+++ b/internal/sources/notes_local_day_test.go
@@ -1,0 +1,40 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A note's bucket is labelled by the day its id names (#883) while sessions are
+// dated in the reader's zone (#849). Minting the bucket in UTC put the two
+// calendars in one list: east of UTC a note written a quarter of an hour after
+// a session was dated the day before it (#911).
+func TestNoteBucketFollowsTheReadersDay(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	line := `{"ts":"2026-07-20T23:45:00Z","project":"tz","text":"the anemometer drifted"}` + "\n"
+	if err := os.WriteFile(path, []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_NOTES_FILE", path)
+
+	zone, err := time.LoadLocation("Pacific/Kiritimati") // UTC+14
+	if err != nil {
+		t.Skipf("zone unavailable: %v", err)
+	}
+	saved := time.Local
+	time.Local = zone
+	t.Cleanup(func() { time.Local = saved })
+
+	ss := LoadNotes()
+	if len(ss) != 1 {
+		t.Fatalf("got %d note sessions, want 1", len(ss))
+	}
+	// 23:45 UTC is 13:45 the next day in Kiritimati: that is the day the
+	// reader's other lines carry, so it is the day the bucket carries.
+	if want := "deja-2026-07-21-tz"; ss[0].ID != want {
+		t.Errorf("bucket id = %q, want %q", ss[0].ID, want)
+	}
+}


### PR DESCRIPTION
Note buckets were minted in UTC while every other line is dated locally, so east of UTC a note written 15 minutes after a session showed up dated the day before it and `deja last` printed its dates out of order.

Buckets now take the reader's day: id, label and neighbours agree. Trade-off is that bucket ids move when the machine's zone changes, so a rebuild after travelling regroups a day's notes under a different name.

Closes #911.