### PR TITLE
fix: the hook's background refresh reindexes before recomputing the digest

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -479,6 +479,15 @@ func runHookRefresh(dir string) {
 	if cwd == "" {
 		cwd, _ = os.Getwd()
 	}
+	// The digest is recomputed from the index, so refreshing it off a stale
+	// index only re-serves the same snapshot: a project whose newest session
+	// reversed an earlier decision kept handing the agent the earlier one for
+	// as long as the user went without running the CLI (#913). This runs
+	// detached, off the startup path, so the incremental build costs the hook
+	// nothing; a directory that cannot be written stays stale, as before.
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		return
+	}
 	digest, sessions, raw, taskMatched := hookDigestResult(dir)
 	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched)
 	_ = os.Remove(hookCachePath(dir, cwd) + ".refreshing")

--- a/cmd/deja/hook_refresh_reindexes_test.go
+++ b/cmd/deja/hook_refresh_reindexes_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The hook's digest is computed from the index, so refreshing it off a stale
+// index re-served the same snapshot: a session that reversed an earlier
+// decision stayed invisible to the agent for as long as the user went without
+// running the CLI (#913).
+func TestHookRefreshRebuildsTheIndexBeforeTheDigest(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	store := filepath.Join(root, "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(sid, ts, text string) []byte {
+		return []byte(`{"type":"user","message":{"role":"user","content":"` + text + `"},"timestamp":"` + ts + `","sessionId":"` + sid + `","cwd":"/proj"}` + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(store, "old.jsonl"), line("old", "2026-06-01T10:00:00Z", "poll interval set to 30 seconds"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "idx")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The store moves on after the build: the decision above is reversed.
+	if err := os.WriteFile(filepath.Join(store, "new.jsonl"), line("new", "2026-07-25T10:00:00Z", "reverted, the poll interval is back to 5 seconds"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := index.SessionCount(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before != 1 {
+		t.Fatalf("index holds %d sessions before the refresh, want 1", before)
+	}
+
+	t.Setenv("CLAUDE_PROJECT_DIR", "/proj")
+	runHookRefresh(dir)
+
+	after, err := index.SessionCount(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != 2 {
+		t.Errorf("index holds %d sessions after the refresh, want 2 — the reversal is still invisible", after)
+	}
+}


### PR DESCRIPTION
The hook's digest is computed from the index, so the detached refresh recomputed it off a stale index and re-served the same snapshot. A project whose newest session reversed an earlier decision kept handing the agent the earlier one — indefinitely in a hook-only harness, since only a CLI run refreshed the index. MCP already heals on its second call.

The rebuild happens in the detached `hook-refresh` child, off the startup path, so the hook's hot path is unchanged; an index directory that cannot be written stays stale exactly as before.

Closes #913.