### PR TITLE
fix: name the package each manager actually ships

### DIFF
--- a/cmd/deja/update.go
+++ b/cmd/deja/update.go
@@ -265,13 +265,17 @@ func packageManagerOwning(exe string) (manager, command string) {
 	case strings.Contains(p, "/Cellar/"), strings.Contains(lower, "/homebrew/"), strings.Contains(lower, "/linuxbrew/"):
 		return "Homebrew", "brew upgrade deja-vu"
 	case strings.Contains(lower, "/scoop/apps/"):
-		return "scoop", "scoop update deja"
+		return "scoop", "scoop update deja-vu"
 	case strings.HasPrefix(p, "/nix/store/"):
 		return "Nix", "nix profile upgrade deja"
 	case strings.Contains(lower, "/winget/packages/"):
-		return "winget", "winget upgrade deja"
+		return "winget", "winget upgrade vshulcz.deja-vu"
 	case strings.Contains(p, "/node_modules/"):
-		return "npm", "npm update -g deja-vu"
+		// The name each manager knows the package by, not the name of the
+		// binary: `npm update -g deja-vu` is a 404 against the registry, and
+		// the whole point of the line is that it is run instead of --force
+		// (#915).
+		return "npm", "npm update -g @vshulcz/deja-vu"
 	}
 	return "", ""
 }

--- a/cmd/deja/update_manager_names_test.go
+++ b/cmd/deja/update_manager_names_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The upgrade line exists so the user runs it instead of --force, so a name
+// that resolves to nothing sends them straight back to overwriting a managed
+// binary: `npm update -g deja-vu` answered 404 while the published package is
+// `@vshulcz/deja-vu` (#915). These names live in the shipped manifests, so the
+// advice is checked against them rather than against a second copy of the
+// string.
+func TestManagerAdviceNamesThePackageTheManifestsShip(t *testing.T) {
+	repo := filepath.Join("..", "..")
+
+	scoop, err := filepath.Glob(filepath.Join(repo, "packaging", "scoop", "*.json"))
+	if err != nil || len(scoop) != 1 {
+		t.Fatalf("scoop manifests = %v (%v), want exactly one", scoop, err)
+	}
+	app := strings.TrimSuffix(filepath.Base(scoop[0]), ".json")
+	if _, cmd := packageManagerOwning(`C:\Users\v\scoop\apps\deja\current\deja.exe`); cmd != "scoop update "+app {
+		t.Errorf("scoop advice = %q, manifest ships %q", cmd, app)
+	}
+
+	winget, err := os.ReadFile(filepath.Join(repo, "packaging", "winget", "vshulcz.deja-vu.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := ""
+	for _, line := range strings.Split(string(winget), "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "PackageIdentifier:"); ok {
+			id = strings.TrimSpace(rest)
+			break
+		}
+	}
+	if id == "" {
+		t.Fatal("no PackageIdentifier in the winget manifest")
+	}
+	if _, cmd := packageManagerOwning(`C:\Users\v\AppData\Local\winget\packages\vshulcz.deja-vu\deja.exe`); cmd != "winget upgrade "+id {
+		t.Errorf("winget advice = %q, manifest ships %q", cmd, id)
+	}
+
+	// npm's name is the one in the package it publishes, scope included.
+	pkg, err := os.ReadFile(filepath.Join(repo, "npm", "package.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := ""
+	for _, line := range strings.Split(string(pkg), "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), `"name":`); ok {
+			name = strings.Trim(strings.TrimSpace(rest), `",`)
+			break
+		}
+	}
+	if name == "" {
+		t.Fatal("no name in npm/package.json")
+	}
+	if _, cmd := packageManagerOwning("/usr/lib/node_modules/deja-vu/bin/deja"); cmd != "npm update -g "+name {
+		t.Errorf("npm advice = %q, the package publishes %q", cmd, name)
+	}
+}

--- a/cmd/deja/update_manager_test.go
+++ b/cmd/deja/update_manager_test.go
@@ -21,12 +21,15 @@ func TestUpdateDefersToThePackageManagerThatOwnsTheBinary(t *testing.T) {
 	}{
 		{"/opt/homebrew/Cellar/deja-vu/0.16.5/bin/deja", "Homebrew", "brew upgrade deja-vu"},
 		{"/home/linuxbrew/.linuxbrew/bin/deja", "Homebrew", "brew upgrade deja-vu"},
-		{`C:\Users\v\scoop\apps\deja\current\deja.exe`, "scoop", "scoop update deja"},
+		{`C:\Users\v\scoop\apps\deja\current\deja.exe`, "scoop", "scoop update deja-vu"},
 		{"/nix/store/abc123-deja-0.16.5/bin/deja", "Nix", "nix profile upgrade deja"},
 		// README has promised this since the npm package shipped: "deja update
 		// is for standalone installs. Homebrew and npm installs update through
 		// the package manager." Nothing enforced it.
-		{"/usr/lib/node_modules/deja-vu/bin/deja", "npm", "npm update -g deja-vu"},
+		// The name the registry knows, not the name of the binary: `npm update
+		// -g deja-vu` answers 404, and the published package is scoped (#915).
+		{"/usr/lib/node_modules/deja-vu/bin/deja", "npm", "npm update -g @vshulcz/deja-vu"},
+		{`C:\Users\v\AppData\Local\winget\packages\vshulcz.deja-vu\deja.exe`, "winget", "winget upgrade vshulcz.deja-vu"},
 	}
 	for _, tc := range cases {
 		var out bytes.Buffer


### PR DESCRIPTION
`deja update` on an npm install tells the user to run `npm update -g deja-vu`, which is a 404 — the published package is `@vshulcz/deja-vu`. scoop and winget advice disagreed with this repo's own manifests too (`deja` vs `deja-vu` / `vshulcz.deja-vu`).

The new test reads the names out of `packaging/` and `npm/package.json` instead of hard-coding a second copy, so a rename in the manifests can't drift away from the advice again.

Closes #915.