### PR TITLE
fix: the hook names a store deja could not read

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -240,6 +240,9 @@ func runHookContext(dir string, plain bool) error {
 					line = fmt.Sprintf("deja: the index needs rebuilding and %s is not writable — `deja index` says what to change", filepath.Dir(dir))
 				}
 			}
+			if note := unreadableStoreNote(dir); storeNoteIsNews(dir, note) {
+				line = joinNotes(note, line)
+			}
 			line = joinNotes(rewireNote(rewired), line)
 			if line != "" {
 				var resp sessionStartHookResponse
@@ -317,12 +320,66 @@ func runHookContext(dir string, plain bool) error {
 			resp.SystemMessage = joinNotes(rewireNote(rewired), st.line())
 		}
 	}
+	if note := unreadableStoreNote(dir); storeNoteIsNews(dir, note) {
+		resp.SystemMessage = joinNotes(note, resp.SystemMessage)
+	}
 	b, err := json.Marshal(resp)
 	if err != nil {
 		return nil
 	}
 	fmt.Fprintln(os.Stdout, string(b))
 	return nil
+}
+
+// unreadableStoreNote names a store deja could not read in full. A newcomer's
+// first contact is the agent, not the CLI: `deja index` and `deja doctor` both
+// explain a locked directory, and neither is what someone who installed deja
+// and went back to their agent ever runs, so the project simply had no memory
+// and nothing said why (#917). The count is already in the manifest, so this
+// costs one read of what the hook path has read anyway.
+func unreadableStoreNote(dir string) string {
+	var names []string
+	total := 0
+	health := index.IngestHealth(dir)
+	for _, h := range sortedHarnesses(health) {
+		e := health[h]
+		if e.FailedFiles == 0 {
+			continue
+		}
+		total += e.FailedFiles
+		name := h
+		if h == "deja" {
+			name = "your notes"
+		}
+		names = append(names, name)
+	}
+	if total == 0 {
+		return ""
+	}
+	return fmt.Sprintf("deja: %d path%s in %s could not be read — sessions are missing from recall; `deja doctor` names %s",
+		total, pluralS(total), strings.Join(names, ", "), pluralWhich(total))
+}
+
+// storeNoteIsNews keeps the line above from becoming wallpaper: it is repeated
+// only when the count changes, or once a day while it stands.
+func storeNoteIsNews(dir, note string) bool {
+	if note == "" {
+		return false
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(note))
+	sum := fmt.Sprintf("%x", h.Sum64())
+	p := dir + ".storenote"
+	if b, err := os.ReadFile(p); err == nil {
+		parts := strings.Fields(string(b))
+		if len(parts) == 2 && parts[0] == sum {
+			if ts, err := strconv.ParseInt(parts[1], 10, 64); err == nil && time.Since(time.Unix(ts, 0)) < 24*time.Hour {
+				return false
+			}
+		}
+	}
+	_ = os.WriteFile(p, []byte(sum+" "+strconv.FormatInt(time.Now().Unix(), 10)), 0o600)
+	return true
 }
 
 // receiptIsNews reports whether this digest differs from the one last

--- a/cmd/deja/hook_unreadable_store_test.go
+++ b/cmd/deja/hook_unreadable_store_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// `deja index` and `deja doctor` both name a store deja could not read, and
+// neither is what someone who installed deja and went back to their agent ever
+// runs: the project simply had no memory of those sessions and nothing said
+// why (#917).
+func TestHookNamesAStoreItCouldNotRead(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	open := filepath.Join(root, "-proj")
+	if err := os.MkdirAll(open, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"pool exhausted"},"timestamp":"2026-07-10T10:00:00Z","sessionId":"s1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(open, "a.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	locked := filepath.Join(root, "-locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(locked, "b.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The hook takes the project from the environment when the payload does
+	// not name one; this is the project whose sessions were readable.
+	t.Setenv("CLAUDE_PROJECT_DIR", "/proj")
+
+	message := func(t *testing.T) string {
+		t.Helper()
+		out, err := captureRun(t, "hook-context")
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Nothing to say prints nothing at all, which is the second call here.
+		if strings.TrimSpace(out) == "" {
+			return ""
+		}
+		var resp struct {
+			SystemMessage string `json:"systemMessage"`
+		}
+		if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &resp); err != nil {
+			t.Fatalf("hook output is not JSON: %q (%v)", out, err)
+		}
+		return resp.SystemMessage
+	}
+
+	got := message(t)
+	if !strings.Contains(got, "could not be read") || !strings.Contains(got, "deja doctor") {
+		t.Errorf("the hook said nothing about the locked store: %q", got)
+	}
+	// …and it is not repeated every session: the same standing fact is
+	// wallpaper by the second time.
+	if again := message(t); strings.Contains(again, "could not be read") {
+		t.Errorf("the note repeated on the next session: %q", again)
+	}
+}


### PR DESCRIPTION
`deja index` and `deja doctor` both explain a locked store directory. Neither is what someone who installed deja and went back to their agent ever runs, so that project simply had no memory of those sessions and nothing named a cause — the common macOS case where the terminal lacks Full Disk Access.

The count is already in the manifest (`IngestHealth`), so the hook says it without a scan, and repeats it only when the count changes or once a day.

Closes #917.