### PR TITLE
fix: forget --list names the way back

### DIFF
--- a/cmd/deja/forget_list_way_back_test.go
+++ b/cmd/deja/forget_list_way_back_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The list is where someone who dropped more than they meant to lands, and it
+// named no way back: `--unforget` was in `deja help` only, and the hint for a
+// guessed `deja unforget` pointed at this same list (#919).
+func TestForgetListNamesTheWayBack(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"pool exhausted"},"timestamp":"2026-07-10T10:00:00Z","sessionId":"ab12-one","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "a.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "forget", "--session", "ab12"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The ids stay on stdout so the list is still pipeable; the way back is a
+	// note beside it.
+	ids, err := captureRun(t, "forget", "--list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(ids, "--unforget") {
+		t.Errorf("the id list is no longer just ids:\n%s", ids)
+	}
+	note, err := captureRunStderr(t, "forget", "--list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note, "--unforget") {
+		t.Errorf("the list does not name the way back: %q", note)
+	}
+
+	// Nothing forgotten, nothing to say.
+	if _, err := captureRunStderr(t, "forget", "--unforget", "claude:ab12-one"); err != nil {
+		t.Fatal(err)
+	}
+	if note, err := captureRunStderr(t, "forget", "--list"); err != nil {
+		t.Fatal(err)
+	} else if strings.Contains(note, "--unforget") {
+		t.Errorf("an empty list still advises an undo: %q", note)
+	}
+
+	// And the wrong guess with a real answer behind it names that answer
+	// rather than the list alone.
+	if got := commandHint("unforget"); !strings.Contains(got, "forget --unforget") {
+		t.Errorf("the guess hint does not name the command: %q", got)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -792,6 +792,12 @@ func commandHint(q string) string {
 	if near == "" {
 		return ""
 	}
+	// "unforget" is the one wrong guess with a real answer behind it, and
+	// `deja forget` alone sends the reader back to a list that used to name
+	// nothing (#919).
+	if strings.EqualFold(first, "unforget") {
+		return "deja: \"unforget\" is not a command — `deja forget --unforget <id>` is, and `deja forget --list` names the ids\n"
+	}
 	return fmt.Sprintf("deja: %q is not a command — did you mean `deja %s`?\n", first, near)
 }
 
@@ -1477,8 +1483,16 @@ func runForget(dir string, args []string) error {
 		return fmt.Errorf("forget: selector required")
 	}
 	if list {
-		for _, key := range index.Tombstones() {
+		keys := index.Tombstones()
+		for _, key := range keys {
 			fmt.Fprintln(os.Stdout, key)
+		}
+		// The list is where someone who dropped more than they meant to lands,
+		// and it named no way back: `--unforget` lived in `deja help` only, and
+		// the hint for a guessed `deja unforget` pointed at this same list
+		// (#919).
+		if len(keys) > 0 {
+			fmt.Fprintf(os.Stderr, "deja: `deja forget --unforget %s` brings one back and rebuilds the index\n", keys[0])
 		}
 		return nil
 	}


### PR DESCRIPTION
Someone who drops more than they meant to lands on `deja forget --list`, which printed ids and nothing else; `--unforget` lived in `deja help` only, and guessing `deja unforget` sent them back to the same list.

The ids stay on stdout so the list is still pipeable — the undo line goes to stderr, and only when something is actually forgotten.

Closes #919.