### PR TITLE
fix: accept a session id the way it is pasted

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -291,6 +291,9 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 	if err != nil {
 		return err
 	}
+	// An id arrives from a chat wrapped in quotes or backticks and with the
+	// harness deja itself printed in front of it (#921).
+	o.id = index.PastedSelector(o.id)
 	if o.id == "" {
 		return fmt.Errorf("show needs id-prefix")
 	}
@@ -1451,11 +1454,11 @@ func runForget(dir string, args []string) error {
 			i++
 			switch args[i-1] {
 			case "--session":
-				o.Session = args[i]
+				o.Session = index.PastedSelector(args[i])
 			case "--project":
 				o.Project = args[i]
 			case "--unforget":
-				unforget = args[i]
+				unforget = index.PastedSelector(args[i])
 			case "--before":
 				if d, err := parseDur(args[i]); err == nil {
 					// "older than 0 days" is the whole store, and the typo that

--- a/cmd/deja/pasted_selector_test.go
+++ b/cmd/deja/pasted_selector_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// An id arrives from a chat wrapped in quotes or backticks, and off deja's own
+// screen with the harness in front of it: `forget --list`, the undo line beside
+// it and promote's receipts all print `harness:id`. `show` refused that form
+// and `forget --session` accepted it while matching nothing (#921).
+func TestAPastedIdIsAccepted(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const id = "a1b2c3d4-1111-4000-8000-d6e7f8a9b0c1"
+	rec := `{"type":"user","message":{"role":"user","content":"pool exhausted"},"timestamp":"2026-07-10T10:00:00Z","sessionId":"` + id + `","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "a.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, sel := range []string{
+		id,
+		"claude:" + id,
+		`"` + id + `"`,
+		"'" + id + "'",
+		"`claude:" + id + "`",
+		"  " + id + "  ",
+	} {
+		out, err := captureRun(t, "show", sel)
+		if err != nil {
+			t.Errorf("show %q: %v", sel, err)
+			continue
+		}
+		if !strings.Contains(out, id) {
+			t.Errorf("show %q found nothing:\n%s", sel, out)
+		}
+	}
+
+	// The harness in front of the id is honoured, not ignored: another
+	// harness's name means another session.
+	if _, err := captureRun(t, "show", "codex:"+id); err == nil {
+		t.Error("show accepted an id under the wrong harness")
+	}
+
+	// And the same shape selects for forget rather than silently matching
+	// nothing.
+	out, err := captureRun(t, "forget", "--session", "claude:"+id, "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "would drop: 1 session(s)") {
+		t.Errorf("forget --session harness:id matched nothing:\n%s", out)
+	}
+}

--- a/internal/index/pasted_selector_test.go
+++ b/internal/index/pasted_selector_test.go
@@ -1,0 +1,66 @@
+package index
+
+import "testing"
+
+// What a paste carries around an id: a chat wraps it in quotes or backticks,
+// and deja's own screens print `harness:id` (#921).
+func TestPastedSelectorStripsWhatAPasteCarries(t *testing.T) {
+	const id = "a1b2c3d4-1111-4000-8000-d6e7f8a9b0c1"
+	for _, tc := range []struct{ in, want string }{
+		{id, id},
+		{"  " + id + "  ", id},
+		{`"` + id + `"`, id},
+		{"'" + id + "'", id},
+		{"`" + id + "`", id},
+		{"“" + id + "”", id},
+		{"‘" + id + "’", id},
+		{"`\"" + id + "\"`", id},
+		// Not a wrapping pair: a quote on one side is part of what was typed.
+		{`"` + id, `"` + id},
+		{"", ""},
+		{`"`, `"`},
+	} {
+		if got := PastedSelector(tc.in); got != tc.want {
+			t.Errorf("PastedSelector(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSplitSelectorTakesOnlyAHarnessPrefix(t *testing.T) {
+	for _, tc := range []struct{ in, harness, id string }{
+		{"claude:abc", "claude", "abc"},
+		{"cursor-cli:abc", "cursor-cli", "abc"},
+		{"abc", "", "abc"},
+		// A colon at either end names no harness and no id.
+		{":abc", "", ":abc"},
+		{"claude:", "", "claude:"},
+		// A left side that merely looks harness-shaped is split too — the
+		// callers try the whole string first and then require the harness to
+		// equal the session's own, so a split like this simply matches
+		// nothing.
+		{"2026-08-03T10:00:00Z", "2026-08-03T10", "00:00Z"},
+		// A space is not part of any harness name.
+		{"a b:c", "", "a b:c"},
+	} {
+		h, id := splitSelector(tc.in)
+		if h != tc.harness || id != tc.id {
+			t.Errorf("splitSelector(%q) = (%q, %q), want (%q, %q)", tc.in, h, id, tc.harness, tc.id)
+		}
+	}
+}
+
+// A session answers to its id, to the elided form, and to the harness:id shape
+// — but only under its own harness.
+func TestSelectorMatchesHonoursTheHarness(t *testing.T) {
+	meta := SessionMeta{ID: "a1b2c3d4-1111", Harness: "claude"}
+	for _, sel := range []string{"a1b2c3d4-1111", "a1b2", "claude:a1b2", "CLAUDE:a1b2c3d4-1111"} {
+		if !selectorMatches(meta, sel) {
+			t.Errorf("%q did not match", sel)
+		}
+	}
+	for _, sel := range []string{"codex:a1b2", "b1b2", "claude:zzz"} {
+		if selectorMatches(meta, sel) {
+			t.Errorf("%q matched and should not have", sel)
+		}
+	}
+}

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -247,7 +247,7 @@ func sessionMatches(meta SessionMeta, o ForgetOptions) bool {
 	// middle of a long one, and forget was the last command that would not take
 	// what the reader copied off the screen — answering "nothing was changed"
 	// on a session that is there (#855).
-	if o.Session != "" && !strings.HasPrefix(meta.ID, o.Session) && !idMatchesElided(meta.ID, o.Session) {
+	if o.Session != "" && !selectorMatches(meta, o.Session) {
 		return false
 	}
 	if o.Project != "" && !strings.Contains(strings.ToLower(meta.Project), strings.ToLower(o.Project)) {
@@ -257,6 +257,69 @@ func sessionMatches(meta SessionMeta, o ForgetOptions) bool {
 		return false
 	}
 	return o.Session != "" || o.Project != "" || !o.Before.IsZero()
+}
+
+// selectorMatches reports whether a session answers to what someone typed or
+// pasted. Beyond the id prefix and the elided form (#855), that includes the
+// `harness:id` shape deja prints itself — in `forget --list`, in the undo line
+// beside it, and in promote's receipts — which `show` refused and
+// `forget --session` accepted while matching nothing (#921).
+func selectorMatches(meta SessionMeta, sel string) bool {
+	if strings.HasPrefix(meta.ID, sel) || idMatchesElided(meta.ID, sel) {
+		return true
+	}
+	harness, id := splitSelector(sel)
+	if harness == "" || !strings.EqualFold(meta.Harness, harness) {
+		return false
+	}
+	return strings.HasPrefix(meta.ID, id) || idMatchesElided(meta.ID, id)
+}
+
+// splitSelector takes the `harness:` off a pasted selector. The whole string is
+// always tried first, so an id that happens to carry a colon keeps working;
+// this only widens what matches.
+func splitSelector(sel string) (harness, id string) {
+	i := strings.IndexByte(sel, ':')
+	if i <= 0 || i == len(sel)-1 {
+		return "", sel
+	}
+	for _, r := range sel[:i] {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+		default:
+			return "", sel
+		}
+	}
+	return sel[:i], sel[i+1:]
+}
+
+// PastedSelector strips what a paste carries around an id: surrounding
+// whitespace and one wrapping pair of quotes or backticks. An id copied out of
+// a chat arrives dressed like that, and every reading command refused it
+// (#921).
+func PastedSelector(raw string) string {
+	s := strings.TrimSpace(raw)
+	for len(s) >= 2 {
+		first, last := s[0], s[len(s)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') || (first == '`' && last == '`') {
+			s = strings.TrimSpace(s[1 : len(s)-1])
+			continue
+		}
+		if q, ok := strings.CutPrefix(s, "\u201c"); ok {
+			if q, ok := strings.CutSuffix(q, "\u201d"); ok {
+				s = strings.TrimSpace(q)
+				continue
+			}
+		}
+		if q, ok := strings.CutPrefix(s, "\u2018"); ok {
+			if q, ok := strings.CutSuffix(q, "\u2019"); ok {
+				s = strings.TrimSpace(q)
+				continue
+			}
+		}
+		break
+	}
+	return s
 }
 
 func Forget(dir string, o ForgetOptions) (ForgetResult, error) {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -958,6 +958,17 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 			}
 		}
 	}
+	// Last: the `harness:id` shape deja prints in `forget --list` and in
+	// promote's receipts, which every reading command refused (#921).
+	if len(matches) == 0 {
+		if harness, id := splitSelector(p); harness != "" {
+			for _, meta := range m.Sessions {
+				if strings.EqualFold(meta.Harness, harness) && (strings.HasPrefix(meta.ID, id) || idLooselyMatches(meta.ID, id)) {
+					matches = append(matches, meta)
+				}
+			}
+		}
+	}
 	if len(matches) == 0 {
 		return model.Session{}, false, nil
 	}


### PR DESCRIPTION
An id copied out of a chat carries quotes, backticks or spaces, and an id copied off deja's own screen carries the harness in front of it — `forget --list`, the undo line beside it and promote's receipts all print `harness:id`. `show` refused every one of those, and `forget --session` accepted `claude:<id>` while matching nothing at all.

The whole string is still tried first, so an id that happens to contain a colon keeps working, and the harness has to match the session's own — `codex:<claude id>` still finds nothing.

Closes #921.