### PR TITLE
fix: the first build is not a quiet day or a missing index

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -747,6 +747,14 @@ func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 			fmt.Fprintf(w, "  status   building now (%s) — recall comes online in a few seconds\n", st.progress())
 			return
 		}
+		// A build requested moments ago has published no progress yet, and
+		// "run `deja warmup`" tells the reader to start what is already
+		// running — the first build after install is exactly that state
+		// (#925).
+		if warmupJustRequested(dir) {
+			fmt.Fprintln(w, "  status   building now — started moments ago, recall comes online in a few seconds")
+			return
+		}
 		fmt.Fprintln(w, "  status   not built (run `deja warmup`)")
 		return
 	}

--- a/cmd/deja/first_build_surfaces_test.go
+++ b/cmd/deja/first_build_surfaces_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The minute after install: a build has been asked for and has published no
+// progress yet. The statusline called that a quiet day and doctor told the
+// reader to start what was already running — both because they required a
+// manifest that a first build does not have yet (#925).
+func TestFirstBuildIsNotCalledSilenceOrAbsence(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Requested just now; nothing published, no manifest — the first build.
+	if err := os.WriteFile(filepath.Join(dir, "warmup.sentinel"),
+		[]byte(strconv.FormatInt(time.Now().UnixNano(), 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var line bytes.Buffer
+	if err := runStatusline(dir, strings.NewReader(""), &line); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(line.String(), "indexing your history") {
+		t.Errorf("statusline during the first build: %q", line.String())
+	}
+
+	var report bytes.Buffer
+	doctorIndex(&report, doctorComponent{State: "missing", Path: dir}, dir)
+	if !strings.Contains(report.String(), "building now") {
+		t.Errorf("doctor during the first build:\n%s", report.String())
+	}
+	if strings.Contains(report.String(), "run `deja warmup`") {
+		t.Errorf("doctor told the reader to start a build that is running:\n%s", report.String())
+	}
+
+	// An index nobody is building is still called what it is.
+	if err := os.Remove(filepath.Join(dir, "warmup.sentinel")); err != nil {
+		t.Fatal(err)
+	}
+	report.Reset()
+	doctorIndex(&report, doctorComponent{State: "missing", Path: dir}, dir)
+	if !strings.Contains(report.String(), "not built") {
+		t.Errorf("an idle missing index stopped saying so:\n%s", report.String())
+	}
+}

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -28,8 +28,15 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 	// A build asked for moments ago has not published progress yet, and until
 	// it does this said "no recalls yet today" — a normal day, while the index
 	// on disk is one this build cannot read (#879).
-	if warmupJustRequested(dir) && index.HasManifest(dir) {
-		fmt.Fprint(stdout, "deja · rebuilding the index · recall is quiet until it finishes")
+	if warmupJustRequested(dir) {
+		// Requiring a manifest here left the very minute after install — the
+		// first build, no index yet — reading "no recalls yet today", a normal
+		// quiet day (#925). The same guard #909 took off the hook.
+		if index.HasManifest(dir) {
+			fmt.Fprint(stdout, "deja · rebuilding the index · recall is quiet until it finishes")
+		} else {
+			fmt.Fprint(stdout, "deja · indexing your history · recall comes online in a few seconds")
+		}
 		return nil
 	}
 	recalls, bytes, injected := usage.TodayWithInjections(dir)


### PR DESCRIPTION
In the second or so between a build being requested and its first progress being published, the statusline said `deja · no recalls yet today · 0 B injected` and doctor said `not built (run \`deja warmup\`)` — a normal quiet day, and advice to start what is already running. Both surfaces already handle this state (#879, #873) but were gated on a manifest, which the *first* build does not have yet: the minute after install.

Same guard #909 removed from the hook, which is why the hook was the only one saying the truth there.

Closes #925.