### PR TITLE
fix: the hook reports a running build on machines with environment facts

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -161,6 +161,26 @@ func rewireNote(targets []string) string {
 // runHookContext prints session-start context. plain=false emits the Claude
 // Code / Codex hook JSON envelope; plain=true prints the bare digest for
 // hosts that inject raw text (the opencode plugin).
+// buildNotice is what a session start says while a build runs: the published
+// progress if there is any, the bare promise if the build was only just asked
+// for, and the reason instead when the index cannot be written at all. It is
+// shared with the environment-facts path, which returned before ever reaching
+// it — so a machine that had environment facts heard nothing at all through an
+// entire post-upgrade rebuild, while the statusline showed the progress bar
+// (#927).
+func buildNotice(dir string) string {
+	if st := readWarmupStatus(dir); st != nil {
+		return st.line()
+	}
+	if !warmupJustRequested(dir) {
+		return ""
+	}
+	if !indexDirWritable(dir) {
+		return fmt.Sprintf("deja: the index needs rebuilding and %s is not writable — `deja index` says what to change", filepath.Dir(dir))
+	}
+	return "deja: indexing your history — recall comes online in a few seconds"
+}
+
 func runHookContext(dir string, plain bool) error {
 	// A session start is the one moment deja is guaranteed to run on every
 	// harness, which makes it the only reliable place to repair wiring left
@@ -202,6 +222,10 @@ func runHookContext(dir string, plain bool) error {
 			var resp sessionStartHookResponse
 			resp.HookSpecificOutput.HookEventName = "SessionStart"
 			resp.HookSpecificOutput.AdditionalContext = out
+			// The environment block is not the project's memory, and while a
+			// build runs it is all there is: without this the whole rebuild
+			// passed in silence on any machine with facts to report (#927).
+			resp.SystemMessage = joinNotes(rewireNote(rewired), buildNotice(dir))
 			if b, err := json.Marshal(resp); err == nil {
 				fmt.Fprintln(os.Stdout, string(b))
 			}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -158,9 +158,6 @@ func rewireNote(targets []string) string {
 	return fmt.Sprintf("deja: rewrote its wiring for %s after an upgrade — `deja install` is what writes those commands", strings.Join(targets, ", "))
 }
 
-// runHookContext prints session-start context. plain=false emits the Claude
-// Code / Codex hook JSON envelope; plain=true prints the bare digest for
-// hosts that inject raw text (the opencode plugin).
 // buildNotice is what a session start says while a build runs: the published
 // progress if there is any, the bare promise if the build was only just asked
 // for, and the reason instead when the index cannot be written at all. It is
@@ -181,6 +178,9 @@ func buildNotice(dir string) string {
 	return "deja: indexing your history — recall comes online in a few seconds"
 }
 
+// runHookContext prints session-start context. plain=false emits the Claude
+// Code / Codex hook JSON envelope; plain=true prints the bare digest for
+// hosts that inject raw text (the opencode plugin).
 func runHookContext(dir string, plain bool) error {
 	// A session start is the one moment deja is guaranteed to run on every
 	// harness, which makes it the only reliable place to repair wiring left

--- a/cmd/deja/hook_rebuild_notice_test.go
+++ b/cmd/deja/hook_rebuild_notice_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// While a build runs the digest is empty, and a machine with environment facts
+// took an early return that never reached the "a build is running" branch: the
+// whole post-upgrade rebuild passed in silence on exactly the stores where it
+// takes longest (#927).
+func TestHookReportsTheBuildEvenWhenItHasOnlyEnvironmentFacts(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	store := filepath.Join(root, "-elsewhere")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Sessions from another project, each hitting the same missing tool: that
+	// is what the environment block is built from, and none of it is this
+	// project's memory.
+	var b strings.Builder
+	for i := 0; i < 4; i++ {
+		id := "env" + strconv.Itoa(i)
+		b.Reset()
+		b.WriteString(`{"type":"user","message":{"role":"user","content":"run the thing"},"timestamp":"2026-07-0` + strconv.Itoa(i+1) + `T10:00:00Z","sessionId":"` + id + `","cwd":"/elsewhere"}` + "\n")
+		// Claude files tool results inside user messages, and friction is
+		// counted from tool output only.
+		b.WriteString(`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"zsh:1: command not found: shellcheck"}]},"timestamp":"2026-07-0` + strconv.Itoa(i+1) + `T10:01:00Z","sessionId":"` + id + `","cwd":"/elsewhere"}` + "\n")
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(b.String()), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	// A build asked for just now, nothing published yet — the first session
+	// after an upgrade.
+	if err := os.WriteFile(filepath.Join(dir, "warmup.sentinel"),
+		[]byte(strconv.FormatInt(time.Now().UnixNano(), 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", "/proj")
+
+	out, err := captureRun(t, "hook-context")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var resp struct {
+		SystemMessage string `json:"systemMessage"`
+		Hook          struct {
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &resp); err != nil {
+		t.Fatalf("hook output is not JSON: %q (%v)", out, err)
+	}
+	if !strings.Contains(resp.Hook.AdditionalContext, "command not found: shellcheck") {
+		t.Fatalf("this is not the environment-facts path:\n%s", resp.Hook.AdditionalContext)
+	}
+	if !strings.Contains(resp.SystemMessage, "indexing your history") {
+		t.Errorf("the rebuild passed in silence: %q", resp.SystemMessage)
+	}
+}


### PR DESCRIPTION
While a build runs the digest is empty, and the hook then emits the environment-facts block and returns — before the branch that reports the build (#878, #909). So a machine with no facts to report was told "indexing your history", and a machine that has been used for a while was told nothing at all, for the entire rebuild, while the statusline showed the progress bar.

Measured on a 59278-message store with an index written by an older deja: three sessions, the first two with an empty systemMessage.

Closes #927.