### PR TITLE
fix: import says how many sessions arrived and names a few

### DIFF
--- a/cmd/deja/import_proof_test.go
+++ b/cmd/deja/import_proof_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The end of a move to a new machine said "imported N records" and nothing
+// else: records are deja's own unit, and the person watching has no way to
+// check the number. Install ends the same moment with real lines out of the
+// history it just indexed (#929).
+func TestImportSaysWhatArrivedAndProvesIt(t *testing.T) {
+	tmp := hermeticEnv(t)
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var batch strings.Builder
+	for _, s := range []struct{ id, project, text string }{
+		{"r1", "api", "the connection pool ran dry behind pgbouncer"},
+		{"r2", "web", "the anemometer reading drifted after the ticker change"},
+	} {
+		b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: s.id, Project: s.project, Role: "user", Text: s.text})
+		if err != nil {
+			t.Fatal(err)
+		}
+		batch.WriteString(string(b) + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), []byte(batch.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "sync", "import", exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "2 sessions from another machine") {
+		t.Errorf("import counted only records: %q", out)
+	}
+	proof, err := captureRunStderr(t, "sync", "import", exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Nothing new arrived the second time, so there is nothing to prove.
+	if strings.Contains(proof, "deja now knows") {
+		t.Errorf("a no-op import still claimed an arrival: %q", proof)
+	}
+}
+
+// The proof itself: the lines are the sessions that just came, named where the
+// reader can recognise them.
+func TestImportProofNamesRealSessions(t *testing.T) {
+	tmp := hermeticEnv(t)
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "r1", Project: "api", Role: "user", Text: "the connection pool ran dry behind pgbouncer"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	proof, err := captureRunStderr(t, "sync", "import", exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(proof, "deja now knows") || !strings.Contains(proof, "pgbouncer") {
+		t.Errorf("import proved nothing:\n%s", proof)
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -244,7 +244,12 @@ func installIndexWarmup(dir string, mcp, hooks, guidance int, summary bool) {
 // printInstallProof shows the "starts full" moment right in the install: a
 // few real sessions deja already indexed from this machine's history, so the
 // value is visible before the first agent session ever runs.
-func printInstallProof(dir string) {
+func printInstallProof(dir string) { printMemoryProof(dir, "deja already knows this machine:") }
+
+// printMemoryProof is that same proof under a caller's heading. `sync import`
+// ends the move to a new machine and said only "imported 59000 records" —
+// deja's own unit, and nothing a person can check (#929).
+func printMemoryProof(dir, heading string) {
 	if !index.HasManifest(dir) {
 		return
 	}
@@ -283,7 +288,7 @@ func printInstallProof(dir string) {
 	if len(lines) == 0 {
 		return
 	}
-	fmt.Fprintln(os.Stderr, "\ndeja already knows this machine:")
+	fmt.Fprintln(os.Stderr, "\n"+heading)
 	for _, l := range lines {
 		fmt.Fprintln(os.Stderr, l)
 	}

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -12,6 +12,16 @@ import (
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
+// importedSessionTotal counts the sessions this index holds that came from
+// another machine.
+func importedSessionTotal(dir string) int {
+	total := 0
+	for _, n := range index.ImportedSessionCounts(dir) {
+		total += n
+	}
+	return total
+}
+
 func runSync(dir string, args []string) error {
 	if len(args) < 2 {
 		return fmt.Errorf("sync needs export <dir>, import <dir>, or ssh <host>")
@@ -81,19 +91,30 @@ func runSync(dir string, args []string) error {
 		for _, a := range args[2:] {
 			return fmt.Errorf("sync import: unexpected argument %q — it takes one directory", a)
 		}
+		sessionsBefore := importedSessionTotal(dir)
 		n, err := index.Import(dir, args[1])
 		// What arrived is printed first even when a file was refused: the
 		// records that made it are in, and the reader needs both halves
 		// (#891).
 		if n > 0 {
-			fmt.Fprintf(os.Stdout, "deja: imported %d records\n", n)
+			// Sessions, not only records: "records" is deja's unit, and what
+			// arrived is what doctor and every other surface counts (#929).
+			line := fmt.Sprintf("deja: imported %d records", n)
+			if before, after := sessionsBefore, importedSessionTotal(dir); after > before {
+				line += fmt.Sprintf(" — %d sessions from another machine", after-before)
+			}
+			fmt.Fprintln(os.Stdout, line)
 		}
 		if err != nil {
 			return err
 		}
 		if n == 0 {
 			fmt.Fprintln(os.Stdout, "deja: imported 0 records")
+			return nil
 		}
+		// The end of a move to a new machine is the same moment as an install,
+		// and install proves it with real lines rather than a count (#929).
+		printMemoryProof(dir, "deja now knows, from the machine you came from:")
 		return nil
 	default:
 		return fmt.Errorf("unknown sync command %q", args[0])


### PR DESCRIPTION
The last step of moving to a new machine printed `deja: imported 59000 records` and nothing else. Records are deja's unit; what arrived is 52 sessions, which is what `doctor` and every other surface counts.

`install` already ends the same moment properly — a count, three real lines out of the history, one thing to try — so import now reuses it. A no-op import proves nothing, as before.

Closes #929.