### PR TITLE
fix: an unplugged index disk is not a permissions problem

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -755,6 +755,13 @@ func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 			fmt.Fprintln(w, "  status   building now — started moments ago, recall comes online in a few seconds")
 			return
 		}
+		// An index whose disk was unplugged is not a missing index, and
+		// "run `deja warmup`" points at a path that is not there. doctor is
+		// what someone runs when memory looks broken (#931).
+		if parent := filepath.Dir(dir); !dirExists(parent) {
+			fmt.Fprintf(w, "  status   not reachable — %s is not there; the disk it lives on may have been unmounted\n", parent)
+			return
+		}
 		fmt.Fprintln(w, "  status   not built (run `deja warmup`)")
 		return
 	}

--- a/cmd/deja/empty_advice_test.go
+++ b/cmd/deja/empty_advice_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"io/fs"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -61,12 +62,15 @@ func TestEnsureErrorSaysWhatToChange(t *testing.T) {
 	// A denied write surfaced as `ensure: open /…/index.db.lock: permission
 	// denied` — an internal lock path and a syscall error, neither of which
 	// tells the reader what to do.
-	err := ensureError("/some/index.db", fs.ErrPermission)
+	// The directory has to be one that exists: a path whose parent is gone is
+	// a disk that was unmounted, which says something else entirely (#931).
+	dir := filepath.Join(t.TempDir(), "index.db")
+	err := ensureError(dir, fs.ErrPermission)
 	if err == nil {
 		t.Fatal("want an error")
 	}
 	got := err.Error()
-	for _, want := range []string{"/some/index.db", "permissions", "DEJA_INDEX_DIR"} {
+	for _, want := range []string{dir, "permissions", "DEJA_INDEX_DIR"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("message should mention %q: %s", want, got)
 		}

--- a/cmd/deja/ensure_error_test.go
+++ b/cmd/deja/ensure_error_test.go
@@ -14,7 +14,9 @@ import (
 // left on device` — an internal path nobody can act on, and the same shape
 // #798 replaced for permissions (#888).
 func TestEnsureErrorNamesWhatToFix(t *testing.T) {
-	dir := filepath.Join("/tmp", "store", "index.db")
+	// A directory that is there: one whose parent is gone means the disk was
+	// unmounted, which is its own message (#931).
+	dir := filepath.Join(t.TempDir(), "index.db")
 
 	full := ensureError(dir, fmt.Errorf("write %s: %w", filepath.Join(dir+".tmp", "records.bin"), syscall.ENOSPC))
 	got := full.Error()

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1877,10 +1877,15 @@ func ensureError(dir string, err error) error {
 	// errno says permissions while the disk is simply gone. The same trap the
 	// notes and export paths hit (#893, #906), and the reader is sent to check
 	// the permissions of a directory that no longer exists (#931).
-	if parent := filepath.Dir(dir); !dirExists(dir) && !dirExists(parent) {
-		return fmt.Errorf("the index directory is not there (%s) — the disk it lives on may have been unmounted; reconnect it, or point DEJA_INDEX_DIR somewhere local", parent)
-	}
 	if errors.Is(err, fs.ErrPermission) {
+		// An ejected volume takes its mount point with it, and creating that
+		// point back fails with EPERM on macOS — so the errno says permissions
+		// while the disk is simply gone, and the reader is sent to check the
+		// permissions of a directory that no longer exists. The same check the
+		// notes and export paths make (#893, #906, #931).
+		if parent := filepath.Dir(dir); !dirExists(dir) && !dirExists(parent) {
+			return fmt.Errorf("the index directory is not there (%s) — the disk it lives on may have been unmounted; reconnect it, or point DEJA_INDEX_DIR somewhere local", parent)
+		}
 		return fmt.Errorf("cannot write the index at %s — check the directory's permissions, or point DEJA_INDEX_DIR somewhere writable", dir)
 	}
 	// A full disk arrived as `ensure: write /…/index.db.tmp/records.bin: no

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1872,6 +1872,14 @@ func ensureError(dir string, err error) error {
 	if dir == "" {
 		dir = index.DefaultDir()
 	}
+	// Before permissions: a volume that was ejected takes its mount point with
+	// it, and creating that point back fails with EPERM on macOS — so the
+	// errno says permissions while the disk is simply gone. The same trap the
+	// notes and export paths hit (#893, #906), and the reader is sent to check
+	// the permissions of a directory that no longer exists (#931).
+	if parent := filepath.Dir(dir); !dirExists(dir) && !dirExists(parent) {
+		return fmt.Errorf("the index directory is not there (%s) — the disk it lives on may have been unmounted; reconnect it, or point DEJA_INDEX_DIR somewhere local", parent)
+	}
 	if errors.Is(err, fs.ErrPermission) {
 		return fmt.Errorf("cannot write the index at %s — check the directory's permissions, or point DEJA_INDEX_DIR somewhere writable", dir)
 	}

--- a/cmd/deja/unplugged_index_test.go
+++ b/cmd/deja/unplugged_index_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// A volume that was ejected takes its mount point with it, and creating that
+// point back fails with EPERM on macOS — so the errno said permissions while
+// the disk was simply gone, and doctor called the index missing and told the
+// reader to rebuild it onto a path that is not there (#931).
+func TestAnUnpluggedIndexDiskIsNotPermissionsOrAMissingIndex(t *testing.T) {
+	tmp := hermeticEnv(t)
+	// The parent stands in for the mount point: it is not there at all.
+	dir := filepath.Join(tmp, "gone-volume", "index.db")
+
+	err := ensureError(dir, os.ErrPermission)
+	if err == nil || !strings.Contains(err.Error(), "is not there") || !strings.Contains(err.Error(), "unmounted") {
+		t.Errorf("a vanished mount point was reported as: %v", err)
+	}
+
+	var out bytes.Buffer
+	doctorIndex(&out, doctorComponent{State: "missing", Path: dir}, dir)
+	if !strings.Contains(out.String(), "not reachable") {
+		t.Errorf("doctor on an unreachable index:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "run `deja warmup`") {
+		t.Errorf("doctor told the reader to rebuild onto a path that is not there:\n%s", out.String())
+	}
+
+	// A directory that is there and merely locked is still a permissions
+	// problem, and an index that is simply absent is still "not built".
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	real := filepath.Join(tmp, "here", "index.db")
+	if err := os.MkdirAll(filepath.Dir(real), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureError(real, os.ErrPermission); err == nil || !strings.Contains(err.Error(), "permissions") {
+		t.Errorf("a locked directory stopped being a permissions problem: %v", err)
+	}
+	out.Reset()
+	doctorIndex(&out, doctorComponent{State: "missing", Path: real}, real)
+	if !strings.Contains(out.String(), "not built") {
+		t.Errorf("an absent index stopped saying so:\n%s", out.String())
+	}
+}


### PR DESCRIPTION
With the index on an external volume that gets ejected, `search` said "check the directory's permissions" and `doctor` said "not built (run \`deja warmup\`)" — the permissions are fine and the index is not missing; its disk is gone, and warmup would rebuild onto a path that does not exist.

macOS gives EPERM when the mount point itself is gone, so the errno lies; the notes and export paths already check whether the parent is there before blaming permissions (#893, #906). A locked directory that is there still reports permissions, and an index that is simply absent still says "not built".

Closes #931.