### PR TITLE
fix: doctor calls an unplugged store unplugged

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -319,6 +319,26 @@ func printDoctorStoreWarnings(w io.Writer, stores []doctorStore) {
 	}
 }
 
+// storeDiskGone distinguishes a store whose disk went away from a harness that
+// was never installed. Both leave the path missing; what differs is how much of
+// the way there is missing. `~/.kimi-code/sessions` on a machine without kimi
+// loses one level and its home is right there; a store on an ejected volume
+// loses the whole chain (#933).
+func storeDiskGone(path string) bool {
+	dir := filepath.Dir(path)
+	for i := 0; i < 2; i++ {
+		if dirExists(dir) {
+			return false
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return true
+}
+
 func doctorHarnesses(w io.Writer, dir string) {
 	fmt.Fprintln(w, "Harness stores:")
 	sqlite := sources.SQLite3Available()
@@ -334,6 +354,12 @@ func doctorHarnesses(w io.Writer, dir string) {
 		status := "missing"
 		if present {
 			status = "found"
+		} else if storeDiskGone(path) {
+			// A store whose whole disk is gone is not a store that was
+			// deleted, and "missing" on a row of transcripts reads as the
+			// second thing — the failure #906 fixed on every write path, and
+			// #931 on the index row one screen below this one (#933).
+			status = "unplugged"
 		}
 		// Also when the store is missing: a machine whose history arrived by
 		// `sync import` has no files at all, and doctor said nothing about the
@@ -357,7 +383,7 @@ func doctorHarnesses(w io.Writer, dir string) {
 				detail += doctorCount(n-imported, "indexed session") + fmt.Sprintf(", %d more from elsewhere", imported)
 			}
 		}
-		line := fmt.Sprintf("  %-12s %-8s %s", name, status, path)
+		line := fmt.Sprintf("  %-12s %-9s %s", name, status, path)
 		if detail != "" {
 			line += "  (" + detail + ")"
 		}

--- a/cmd/deja/doctor_unplugged_store_test.go
+++ b/cmd/deja/doctor_unplugged_store_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A store whose disk went away is not a store that was deleted, and "missing"
+// on a row of transcripts reads as the second thing (#933). What separates the
+// two is how much of the way there is gone: a harness that was never installed
+// loses one directory and its home is right there.
+func TestDoctorTellsAnUnpluggedStoreFromAnUninstalledHarness(t *testing.T) {
+	tmp := hermeticEnv(t)
+	home := os.Getenv("HOME")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Never installed: one level missing under a home that is there.
+	if storeDiskGone(filepath.Join(home, ".kimi-code", "sessions")) {
+		t.Error("an uninstalled harness was called unplugged")
+	}
+	// Present: nothing missing at all.
+	present := filepath.Join(home, ".claude", "projects")
+	if err := os.MkdirAll(present, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if storeDiskGone(present) {
+		t.Error("a store that is there was called unplugged")
+	}
+	// Ejected volume: the whole chain is gone.
+	if !storeDiskGone(filepath.Join(tmp, "gone-volume", "home", ".claude", "projects")) {
+		t.Error("a store on a vanished volume was not called unplugged")
+	}
+
+	// And the row says it.
+	t.Setenv("HOME", filepath.Join(tmp, "gone-volume", "home"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "gone-volume", "home", ".claude", "projects"))
+	var out bytes.Buffer
+	doctorHarnesses(&out, filepath.Join(tmp, "index.db"))
+	row := harnessRow(t, out.String(), "claude")
+	if !strings.Contains(row, "unplugged") {
+		t.Errorf("row for a store on a vanished volume: %q", row)
+	}
+}


### PR DESCRIPTION
With the store, index and notes all on a removable volume, ejecting it left `doctor` saying `claude missing …/projects (0 files)` one line above `status not reachable — …the disk it lives on may have been unmounted` (#931). For a row of transcripts "missing" reads as "your history is gone".

The rows now separate a vanished disk from a harness that was never installed by how much of the path is gone — one missing directory under a home that is there is an uninstalled harness; a whole missing chain is an ejected disk. Column widened by one so the longer word still lines up.

Closes #933.