### PR TITLE
fix: doctor says when a zone change regrouped the note days

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -339,6 +339,45 @@ func storeDiskGone(path string) bool {
 	return true
 }
 
+// noteBucketsRegrouped counts the day buckets in the index that this machine
+// would not build now. Notes are grouped by
+// the reader's day (#911), so a laptop that changed zones regroups them on the
+// next rebuild: nothing is lost, but an id that was shared or pasted somewhere
+// keeps resolving and starts naming a different note (#935).
+func noteBucketsRegrouped(dir string) int {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return 0
+	}
+	type span struct{ started, updated time.Time }
+	indexed := map[string]span{}
+	for _, m := range metas {
+		if m.Harness == "deja" {
+			indexed[m.ID] = span{m.Started, m.Updated}
+		}
+	}
+	if len(indexed) == 0 {
+		return 0
+	}
+	here := map[string]span{}
+	for _, s := range sources.LoadNotes() {
+		here[s.ID] = span{s.Started, s.Updated}
+	}
+	if len(here) == 0 {
+		return 0
+	}
+	// Notes written since the build only add buckets or extend them forward; a
+	// bucket that vanished, or that now starts at a different note, means the
+	// days were cut somewhere else — which is what a changed zone does.
+	moved := 0
+	for id, in := range indexed {
+		if h, ok := here[id]; !ok || !h.started.Equal(in.started) {
+			moved++
+		}
+	}
+	return moved
+}
+
 func doctorHarnesses(w io.Writer, dir string) {
 	fmt.Fprintln(w, "Harness stores:")
 	sqlite := sources.SQLite3Available()
@@ -457,6 +496,10 @@ func doctorHarnesses(w io.Writer, dir string) {
 	copilotRoot := sources.CopilotRoot()
 	printFiles("copilot", copilotRoot, doctorExists(copilotRoot), sources.CopilotSessionFiles())
 	printRow("deja", sources.NotesFile(), doctorFilePresent(sources.NotesFile()), "notes")
+	if n := noteBucketsRegrouped(dir); n > 0 {
+		fmt.Fprintf(w, "  warning      %s of notes in the index %s not what this machine would build now — the zone changed, so the days regrouped; `deja index` renames them\n",
+			doctorCount(n, "day"), verbIs(n))
+	}
 }
 
 func doctorSQLiteDetail(db string, sqlite bool) string {

--- a/cmd/deja/note_zone_drift_test.go
+++ b/cmd/deja/note_zone_drift_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Notes are grouped by the reader's day (#911), so a laptop that changed zones
+// regroups them on the next rebuild. Nothing is lost, but an id that was shared
+// or pasted somewhere keeps resolving and starts naming a different note, and
+// nothing said the days had moved (#935).
+func TestDoctorSaysWhenNoteDaysRegrouped(t *testing.T) {
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	// 09:30 and 23:30 on the same day in UTC+3 — one bucket there, two once
+	// the machine is west of UTC.
+	body := `{"ts":"2026-08-02T06:30:00Z","project":"t","text":"morning: the pool cap is 20"}` + "\n" +
+		`{"ts":"2026-08-02T20:30:00Z","project":"t","text":"late: the ticker window stays at 30s"}` + "\n"
+	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_NOTES_FILE", notes)
+
+	saved := time.Local
+	t.Cleanup(func() { time.Local = saved })
+
+	time.Local = time.FixedZone("east", 3*60*60)
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	doctorHarnesses(&out, dir)
+	if strings.Contains(out.String(), "regrouped") {
+		t.Errorf("an index read in the zone it was built in complained:\n%s", out.String())
+	}
+
+	// The same index, now read seven hours west: the morning note belongs to
+	// the previous day here.
+	time.Local = time.FixedZone("west", -7*60*60)
+	out.Reset()
+	doctorHarnesses(&out, dir)
+	if !strings.Contains(out.String(), "regrouped") {
+		t.Errorf("nothing said the days moved:\n%s", out.String())
+	}
+
+	// A note written since the build is growth, not regrouping: it must not
+	// raise the warning.
+	time.Local = time.FixedZone("east", 3*60*60)
+	if err := os.WriteFile(notes, []byte(body+`{"ts":"2026-08-03T06:30:00Z","project":"t","text":"today: rotate the certificate"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	doctorHarnesses(&out, dir)
+	if strings.Contains(out.String(), "regrouped") {
+		t.Errorf("a note added since the build was called a regrouping:\n%s", out.String())
+	}
+}


### PR DESCRIPTION
Notes are grouped by the reader's day (#911), so a laptop that flies from UTC+3 to UTC−7 regroups them on the next rebuild: two buckets become three, and `deja show deja-2026-08-02-…` keeps working while naming a different note than it did yesterday. That cost was named in #912 and nothing on screen mentioned it.

doctor now compares the buckets in the index with the ones this machine would build now and says so once. Notes written since the build only extend buckets forward, so ordinary staleness stays quiet.

Closes #935.