### PR TITLE
fix: last honours the trust policy

### DIFF
--- a/cmd/deja/last_policy_test.go
+++ b/cmd/deja/last_policy_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The listing is titles and project names, which is what the trust policy
+// exists to keep off the screen — and it was the one path that never consulted
+// it, while `search` under the same rule refused and said so (#937).
+func TestLastHonoursTheTrustPolicy(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer9", Project: "secret-client/api", Role: "user", Text: "CONFIDENTIAL peer title: migrating the vault tokens"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	// Without a policy the peer's title is listed, which is the point of the
+	// command.
+	out, err := captureRun(t, "last")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "CONFIDENTIAL peer title") {
+		t.Fatalf("the imported session was not listed at all:\n%s", out)
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	out, err = captureRun(t, "last")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "CONFIDENTIAL peer title") || strings.Contains(out, "secret-client") {
+		t.Errorf("the listing leaked a session the policy hides:\n%s", out)
+	}
+	if !strings.Contains(out, "local work on the ticker window") {
+		t.Errorf("the listing dropped the local session too:\n%s", out)
+	}
+	// And it says what it withheld rather than quietly showing less.
+	note, err := captureRunStderr(t, "last")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note, "trust policy hides") {
+		t.Errorf("nothing said the policy withheld a row: %q", note)
+	}
+
+	// The JSON form is the same data and must not be the way around it.
+	raw, err := captureRun(t, "last", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(raw, "secret-client") {
+		t.Errorf("--json leaked what the text form hides:\n%s", raw)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -467,9 +467,17 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 	if err != nil {
 		return err
 	}
+	// The listing is titles and project names, which is exactly what the trust
+	// policy exists to keep off the screen — and it was the one path that never
+	// consulted it, while `search` under the same rule refused and said so
+	// (#937). Listing counts as browsing: the search activation governs it.
+	ss, policyHidden := policyFilterSessionsCounted(policy.ActivationSearch, ss)
 	// Printing nothing at all and exiting 0 leaves no way to tell whether the
 	// command worked, found nothing, or failed silently — which is what a
 	// fresh install sees. blame already answers this shape of question.
+	if note := policyHiddenNote(policy.ActivationSearch, policyHidden); note != "" {
+		fmt.Fprintln(os.Stderr, note)
+	}
 	if len(ss) == 0 {
 		if o.JSON {
 			return printRecentJSON(os.Stdout, nil, sourceInstance)

--- a/cmd/deja/policyfilter.go
+++ b/cmd/deja/policyfilter.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/vshulcz/deja-vu/internal/model"
 
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
@@ -43,4 +44,14 @@ func policyFilterBlame(activation string, hits []search.BlameHit) []search.Blame
 	return policy.Filter(policy.Load(), activation, hits, func(h search.BlameHit) string {
 		return h.Session.Project
 	})
+}
+
+// policyFilterSessionsCounted is the same gate for paths that carry sessions
+// rather than hits — the listing, whose whole output is titles (#937).
+func policyFilterSessionsCounted(activation string, ss []model.Session) ([]model.Session, int) {
+	before := len(ss)
+	kept := policy.Filter(policy.Load(), activation, ss, func(s model.Session) string {
+		return s.Project
+	})
+	return kept, before - len(kept)
 }


### PR DESCRIPTION
With imported origins denied on every activation, `search` refused and named the rule while `deja last` printed the peer's project and the first line of its content. The listing built its rows straight off the manifest and never consulted the policy — and a listing is titles and project names, which is what the policy is for.

Listing counts as browsing, so the search activation governs it; `--json` goes through the same gate, and the withheld count is reported the way search reports it.

Closes #937.