### PR TITLE
fix: doctor reports the policy in force, not the file on disk

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -594,6 +594,18 @@ func doctorPolicy(w io.Writer) {
 	fmt.Fprintln(w, "Trust policy:")
 	exists, unknown, err := policy.Diagnose()
 	if !exists {
+		// …unless the environment restricts it anyway. Deciding on the file's
+		// absence said "every origin activates everywhere" while the auto path
+		// was local-only, on the one screen someone opens to find out what is
+		// allowed (#939).
+		if pol := policy.Load(); pol.Describe(policy.ActivationAuto) != "local+imported" {
+			fmt.Fprintf(w, "  %-12s no file at %s\n", "default", policy.Path())
+			for _, activation := range []string{policy.ActivationSearch, policy.ActivationMCP, policy.ActivationAuto} {
+				fmt.Fprintf(w, "  %-12s %s\n", activation, pol.Describe(activation))
+			}
+			fmt.Fprintf(w, "  %-12s DEJA_AUTORECALL_LOCAL_ONLY is set in this environment\n", "from env")
+			return
+		}
 		fmt.Fprintf(w, "  %-12s no file at %s — every origin activates everywhere\n", "default", policy.Path())
 		return
 	}

--- a/cmd/deja/doctor_policy_env_test.go
+++ b/cmd/deja/doctor_policy_env_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// doctor is the screen someone opens to find out what is allowed, and with no
+// policy file it decided on the file's absence: "every origin activates
+// everywhere", while DEJA_AUTORECALL_LOCAL_ONLY held the auto path to local
+// sessions only (#939).
+func TestDoctorPolicySeesTheEnvironmentOverride(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(tmp, "no-such-policy.json"))
+
+	var out bytes.Buffer
+	doctorPolicy(&out)
+	if !strings.Contains(out.String(), "every origin activates everywhere") {
+		t.Errorf("an unrestricted machine stopped saying so:\n%s", out.String())
+	}
+
+	t.Setenv("DEJA_AUTORECALL_LOCAL_ONLY", "1")
+	out.Reset()
+	doctorPolicy(&out)
+	got := out.String()
+	if strings.Contains(got, "every origin activates everywhere") {
+		t.Errorf("doctor called a restricted machine unrestricted:\n%s", got)
+	}
+	if !strings.Contains(got, "auto") || !strings.Contains(got, "local-only") {
+		t.Errorf("doctor does not name what the environment restricts:\n%s", got)
+	}
+	if !strings.Contains(got, "DEJA_AUTORECALL_LOCAL_ONLY") {
+		t.Errorf("doctor does not say where the rule comes from:\n%s", got)
+	}
+	// The other two paths are untouched by that variable, and saying otherwise
+	// would be its own lie.
+	if !strings.Contains(got, "local+imported") {
+		t.Errorf("doctor restricted paths the variable does not touch:\n%s", got)
+	}
+}


### PR DESCRIPTION
With no policy file, the Trust policy section decided on the file's absence and printed "every origin activates everywhere" — while `DEJA_AUTORECALL_LOCAL_ONLY=1` held the auto path to local sessions and the hook's own receipt said `policy: local-only`. With a file present the same section already saw the override, so doctor contradicted itself depending on whether an unrelated file existed.

It now prints the effective policy per activation and names where the restriction comes from. An unrestricted machine still gets the one-line default.

Closes #939.