### PR TITLE
fix: Describe skips policy keys deja never consults

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -94,6 +94,12 @@ func (p Policy) Allows(activation, project string) bool {
 	return true
 }
 
+// consultedOrigin reports whether a rule key is one Origin can produce. Rules
+// are keyed by origin; a project name looks like a rule and is not one.
+func consultedOrigin(origin string) bool {
+	return origin == "local" || origin == "imported" || strings.HasPrefix(origin, "imported:")
+}
+
 // Describe names the active rule set for receipts and `deja log`, so the
 // audit trail explains itself. The default policy reads "local+imported".
 func (p Policy) Describe(activation string) string {
@@ -106,7 +112,10 @@ func (p Policy) Describe(activation string) string {
 	}
 	denied := make([]string, 0, len(rules))
 	for origin, allowed := range rules {
-		if !allowed {
+		// A key deja never consults restricts nothing, and naming it here put
+		// two claims on one screen: "deny tmp/other" from this line and "this
+		// rule does nothing" from Diagnose's, three lines down (#941).
+		if !allowed && consultedOrigin(origin) {
 			denied = append(denied, origin)
 		}
 	}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -157,3 +157,24 @@ func TestDiagnoseUnreadablePath(t *testing.T) {
 		t.Fatalf("exists=%v err=%v", exists, err)
 	}
 }
+
+// A key deja never consults restricts nothing, and naming it in the summary put
+// two claims on one screen: "deny tmp/other" here and "this rule does nothing"
+// from Diagnose three lines down (#941).
+func TestDescribeSkipsKeysDejaNeverConsults(t *testing.T) {
+	p := Policy{Activations: map[string]map[string]bool{
+		ActivationSearch: {"local": true, "tmp/other": false},
+	}}
+	if got := p.Describe(ActivationSearch); got != "local+imported" {
+		t.Errorf("Describe with a project-shaped key = %q, want the unrestricted summary", got)
+	}
+	// Real rules still show, including a single machine.
+	p.Activations[ActivationSearch]["imported:laptop"] = false
+	if got := p.Describe(ActivationSearch); got != "deny imported:laptop" {
+		t.Errorf("Describe dropped a rule it does consult: %q", got)
+	}
+	p.Activations[ActivationSearch]["imported"] = false
+	if got := p.Describe(ActivationSearch); got != "local-only" {
+		t.Errorf("Describe stopped naming local-only: %q", got)
+	}
+}


### PR DESCRIPTION
A policy that names a project instead of an origin — `{"search":{"tmp/other":false}}` — made doctor claim both things at once: `search deny tmp/other` from `Describe` and `"search.tmp/other" … this rule does nothing` from `Diagnose`. Search behaved as the second line said.

`Describe` now summarises only the keys it consults, so the `ignored` line is the single claim on screen. Real rules — `imported`, `imported:<machine>` — read as before.

Closes #941.