### PR TITLE
fix: keep a promoted note's corrections newest-first after an incremental build

### DIFF
--- a/internal/index/promoted_order_test.go
+++ b/internal/index/promoted_order_test.go
@@ -1,0 +1,76 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// Promoted notes are served newest-first so the latest correction is the answer
+// that holds (#812). An incremental build appends the new lines to what the log
+// already has, so the order came out oldest-first and the correction sat last —
+// the failure #812 was written for (#944).
+func TestPromotedNoteKeepsCorrectionsNewestFirstAfterAnIncrementalBuild(t *testing.T) {
+	tmp := t.TempDir()
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+
+	line := func(ts, state, text string) string {
+		b, err := json.Marshal(map[string]string{
+			"ts": ts, "project": "p", "text": text,
+			"kind": "promoted", "session": "claude:s1", "state": state, "title": "pool cap",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b) + "\n"
+	}
+	body := line("2026-07-12T10:00:00Z", "accepted", "first answer: raise the pool cap to 200") +
+		line("2026-07-13T10:00:00Z", "accepted", "second answer: 50 is enough")
+	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The correction arrives after the index exists, so the next build is
+	// incremental.
+	if err := os.WriteFile(notes, []byte(body+line("2026-07-20T10:00:00Z", "rejected", "rolled back, the cap stays at 20")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	s, ok, err := FindByPrefix(dir, "deja-note-claude-s1")
+	if err != nil || !ok {
+		t.Fatalf("promoted note not found: %v", err)
+	}
+	if len(s.Messages) != 3 {
+		t.Fatalf("got %d messages, want 3", len(s.Messages))
+	}
+	if !strings.Contains(s.Messages[0].Text, "rolled back") {
+		t.Errorf("the note leads with %q, not the newest correction", s.Messages[0].Text)
+	}
+
+	// The search path assembles sessions separately and must agree.
+	ss, err := Search(dir, query.Options{Query: "cap", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, got := range ss {
+		if got.ID != "deja-note-claude-s1" || len(got.Messages) < 2 {
+			continue
+		}
+		if !strings.Contains(got.Messages[0].Text, "rolled back") {
+			t.Errorf("search leads with %q, not the newest correction", got.Messages[0].Text)
+		}
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -881,6 +881,9 @@ func sessionsForMetas(dir string, metas []SessionMeta) ([]model.Session, error) 
 	if err != nil {
 		return nil, err
 	}
+	for i := range out {
+		orderPromotedNote(&out[i])
+	}
 	return out, nil
 }
 
@@ -1124,7 +1127,22 @@ func loadSessionMeta(dir string, m Manifest, meta SessionMeta) (model.Session, b
 	for _, r := range recs {
 		s.Messages = append(s.Messages, model.Message{Role: r.Role, Text: r.Text, Time: r.Time})
 	}
+	orderPromotedNote(&s)
 	return s, true, nil
+}
+
+// orderPromotedNote keeps a promoted note's corrections newest-first. The
+// parser writes them that way (#812), but an incremental build appends the new
+// lines to what the log already holds, so the record order stopped saying which
+// answer holds: the snippet an agent reads led with the answer that had been
+// overturned (#944). Ordering on read fixes indexes already on disk too.
+func orderPromotedNote(s *model.Session) {
+	if s.Harness != "deja" || !strings.HasPrefix(s.ID, "deja-note-") || len(s.Messages) < 2 {
+		return
+	}
+	sort.SliceStable(s.Messages, func(i, j int) bool {
+		return s.Messages[i].Time.After(s.Messages[j].Time)
+	})
 }
 
 func scanRecords(dir string, m Manifest, o query.Options, offsets []int64) ([]model.Session, error) {
@@ -1246,6 +1264,7 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 	}
 	out := make([]model.Session, 0, len(by))
 	for _, s := range by {
+		orderPromotedNote(s)
 		out = append(out, *s)
 	}
 	return out, nil


### PR DESCRIPTION
Promoted notes are served newest-first so the latest correction is the answer that holds (#812). The parser writes them that way; an incremental build appends the new lines to what the record log already holds, so after the first correction the note led with the answer that had been overturned — in `show` and in the search snippet alike.

Ordering happens on read now, which also repairs indexes already on disk without a rebuild.

Closes #944.