### PR TITLE
fix: an empty postings directory counts as damage

### DIFF
--- a/internal/index/empty_buckets_test.go
+++ b/internal/index/empty_buckets_test.go
@@ -1,0 +1,59 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// An empty postings directory is the same loss as a missing one — what
+// `rm buckets/*.bin` or a copy that skipped the contents leaves behind. Every
+// check passed, doctor said "built, up to date", and search answered "no
+// matches in N indexed sessions" about text still in the record log (#946).
+func TestAnEmptyBucketDirectoryCountsAsDamage(t *testing.T) {
+	tmp := t.TempDir()
+	store := filepath.Join(tmp, "claude", "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	rec := `{"type":"user","message":{"role":"user","content":"the ticker window is 30s"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"s1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if Damaged(dir) {
+		t.Fatal("a fresh index was called damaged")
+	}
+
+	entries, err := os.ReadDir(filepath.Join(dir, "buckets"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("no bucket files to remove")
+	}
+	for _, e := range entries {
+		if err := os.Remove(filepath.Join(dir, "buckets", e.Name())); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !Damaged(dir) {
+		t.Error("an index with no postings at all was called intact")
+	}
+
+	// And the next search rebuilds rather than reporting the history empty.
+	ss, err := SearchWithRecovery(dir, query.Options{Query: "ticker window"}, os.Stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) == 0 {
+		t.Error("search still answers nothing after the recovery path ran")
+	}
+}

--- a/internal/index/empty_buckets_test.go
+++ b/internal/index/empty_buckets_test.go
@@ -14,18 +14,24 @@ import (
 // matches in N indexed sessions" about text still in the record log (#946).
 func TestAnEmptyBucketDirectoryCountsAsDamage(t *testing.T) {
 	tmp := t.TempDir()
-	store := filepath.Join(tmp, "claude", "-proj")
+	store := filepath.Join(tmp, "claude", "proj-p")
 	if err := os.MkdirAll(store, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// Every root the build consults, or another package's store leaks in and
+	// this index is not the one the test wrote.
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
 	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
 	rec := `{"type":"user","message":{"role":"user","content":"the ticker window is 30s"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"s1","cwd":"/proj"}` + "\n"
 	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(rec), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	dir := filepath.Join(tmp, "index.db")
-	if err := Ensure(dir, "", false, nil); err != nil {
+	if err := Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
 	if Damaged(dir) {

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -205,6 +205,18 @@ func writeManifest(dir string, m Manifest) error {
 	return writeGobAtomic(filepath.Join(dir, "manifest.gob"), core)
 }
 
+// hasBucketFile reports whether the postings directory holds anything at all.
+// It stops at the first entry: the question is emptiness, not the count.
+func hasBucketFile(dir string) bool {
+	f, err := os.Open(dir)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+	names, err := f.Readdirnames(1)
+	return err == nil && len(names) > 0
+}
+
 // recordsIntact reports whether records.bin still holds everything the manifest
 // committed. A shorter file means a crash truncated the record log; the index
 // must rebuild rather than silently return fewer messages.
@@ -234,6 +246,14 @@ func recordsIntact(dir string, m Manifest) bool {
 	if len(m.Sessions) > 0 {
 		bi, err := os.Stat(filepath.Join(dir, "buckets"))
 		if err != nil || !bi.IsDir() {
+			return false
+		}
+		// An empty directory is the same loss as a missing one, and it is what
+		// `rm buckets/*.bin` and a copy that skipped the contents both leave
+		// behind: every check passed, `doctor` said "built, up to date", and
+		// search answered "no matches in 3 indexed sessions" about text that
+		// was still in the record log (#946).
+		if !hasBucketFile(filepath.Join(dir, "buckets")) {
 			return false
 		}
 	}


### PR DESCRIPTION
The damage check (#735) tested that `buckets/` exists as a directory, so an empty one — what `rm buckets/*.bin`, a partial copy or an interrupted sync leaves — passed. `last` and `show` kept working off the manifest and record log, `doctor` said `built`, `deja index` said `up to date`, and `search` reported "no matches in 3 indexed sessions" about text that was still in the log.

Now the next search rebuilds and `doctor` says `integrity damaged`, the way it already does for a truncated log.

Closes #946.