### PR TITLE
fix: the hook receipt says when the trust policy withheld a session

### DIFF
--- a/cmd/deja/hook_antigravity.go
+++ b/cmd/deja/hook_antigravity.go
@@ -48,7 +48,7 @@ func runHookAntigravity(dir string, stdin io.Reader, stdout io.Writer) error {
 	if len(input.WorkspacePaths) > 0 && input.WorkspacePaths[0] != "" && os.Getenv("CLAUDE_PROJECT_DIR") == "" {
 		_ = os.Setenv("CLAUDE_PROJECT_DIR", input.WorkspacePaths[0])
 	}
-	digest, sessions, raw, _ := cachedHookDigest(dir)
+	digest, sessions, raw, _, _ := cachedHookDigest(dir)
 	if digest == "" {
 		fmt.Fprintln(stdout, "{}")
 		return nil

--- a/cmd/deja/hook_antigravity_stdin_test.go
+++ b/cmd/deja/hook_antigravity_stdin_test.go
@@ -35,7 +35,7 @@ func TestHookAntigravityBoundsStdinWithoutInjectingOnEveryTurn(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("CLAUDE_PROJECT_DIR", "/proj")
-	if d, _, _, _ := cachedHookDigest(dir); d == "" {
+	if d, _, _, _, _ := cachedHookDigest(dir); d == "" {
 		t.Fatal("fixture has no digest to inject")
 	}
 

--- a/cmd/deja/hook_cache_orphan_test.go
+++ b/cmd/deja/hook_cache_orphan_test.go
@@ -45,7 +45,7 @@ func TestHookAsksForARebuildWhenTheIndexIsGone(t *testing.T) {
 	spawnWarmup = func(exe, sentinel string) error { spawned++; return nil }
 	t.Cleanup(func() { spawnWarmup = saved })
 
-	digest, sessions, _, _ := cachedHookDigest(dir)
+	digest, sessions, _, _, _ := cachedHookDigest(dir)
 	if !strings.Contains(digest, "pool exhausted") || sessions != 1 {
 		t.Errorf("the cached digest was dropped rather than served: %q (%d sessions)", digest, sessions)
 	}

--- a/cmd/deja/hook_cache_test.go
+++ b/cmd/deja/hook_cache_test.go
@@ -28,7 +28,7 @@ func TestCachedHookDigestServesWithinTTLAndInvalidates(t *testing.T) {
 	}
 	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
 
-	d1, s1, _, _ := cachedHookDigest(dir)
+	d1, s1, _, _, _ := cachedHookDigest(dir)
 	if d1 == "" || s1 == 0 {
 		t.Fatal("first call must build a digest")
 	}
@@ -40,7 +40,7 @@ func TestCachedHookDigestServesWithinTTLAndInvalidates(t *testing.T) {
 	if err := index.Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	d2, _, _, _ := cachedHookDigest(dir)
+	d2, _, _, _, _ := cachedHookDigest(dir)
 	if d2 != d1 {
 		t.Fatal("within TTL the cached digest must be served verbatim")
 	}
@@ -60,20 +60,20 @@ func TestCachedHookDigestServesWithinTTLAndInvalidates(t *testing.T) {
 	if err := os.WriteFile(cachePath, nb, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	d3, _, _, _ := cachedHookDigest(dir)
+	d3, _, _, _, _ := cachedHookDigest(dir)
 	if d3 != d1 {
 		t.Fatalf("expired cache must serve stale instantly, got:\n%s", d3)
 	}
 	// The refresh itself must produce the fresh view.
 	runHookRefresh(dir)
-	d3b, _, _, _ := cachedHookDigest(dir)
+	d3b, _, _, _, _ := cachedHookDigest(dir)
 	if !strings.Contains(d3b, "marker_beta") {
 		t.Fatalf("refresh must rebuild with fresh sessions:\n%s", d3b)
 	}
 	d3 = d3b
 	// A different cwd must never reuse another project's cache.
 	t.Setenv("CLAUDE_PROJECT_DIR", filepath.Join(t.TempDir(), "elsewhere"))
-	d4, _, _, _ := cachedHookDigest(dir)
+	d4, _, _, _, _ := cachedHookDigest(dir)
 	if d4 == d3 && d3 != "" {
 		t.Fatal("cache must be scoped to cwd")
 	}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -206,7 +206,7 @@ func runHookContext(dir string, plain bool) error {
 	// CLAUDE_PROJECT_DIR got no memory at all — indistinguishable from having
 	// none (#759).
 	adoptHookCWD(input.CWD)
-	digest, sessions, raw, taskMatched := cachedHookDigest(dir)
+	digest, sessions, raw, taskMatched, withheld := cachedHookDigest(dir)
 	if digest == "" {
 		// No session from this project, which is the usual state in a new
 		// checkout — and exactly where knowing what this machine is missing
@@ -325,6 +325,13 @@ func runHookContext(dir string, plain bool) error {
 		polNote := ""
 		if polName != "local+imported" {
 			polNote = " · policy: " + polName
+			// The line was identical whether the rule hid a session here or
+			// merely existed, so the reader could not tell that memory had
+			// been withheld from this very session — search has said it since
+			// the counter existed (#L-new19).
+			if withheld > 0 {
+				polNote += fmt.Sprintf(" (%s withheld here)", doctorCount(withheld, "session"))
+			}
 		}
 		// A count says deja did something; a name says what. The receipt is
 		// the one place a person reliably sees, so when a piece of work has
@@ -441,9 +448,13 @@ type hookCacheEntry struct {
 	// under. A cache hit returns before either is consulted, so serving an
 	// entry built under different rules would let a cached digest outlive
 	// DEJA_RECALL=off or a policy that now forbids it.
-	Gate        string   `json:"gate,omitempty"`
-	Digest      string   `json:"digest"`
-	Sessions    int      `json:"sessions"`
+	Gate     string `json:"gate,omitempty"`
+	Digest   string `json:"digest"`
+	Sessions int    `json:"sessions"`
+	// Withheld counts the candidates the trust policy dropped for this
+	// digest. Old entries decode as zero, which reads as "nothing withheld"
+	// and is what they meant.
+	Withheld    int      `json:"withheld,omitempty"`
 	Raw         int64    `json:"raw"`
 	TaskMatched []string `json:"task_matched,omitempty"`
 }
@@ -472,13 +483,13 @@ func adoptHookCWD(cwd string) {
 	_ = os.Setenv("CLAUDE_PROJECT_DIR", cwd)
 }
 
-func cachedHookDigest(dir string) (string, int, int64, []string) {
+func cachedHookDigest(dir string) (string, int, int64, []string, int) {
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
 	if cwd == "" {
 		cwd, _ = os.Getwd()
 	}
 	if strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL"))) == search.RecallOff {
-		return "", 0, 0, nil
+		return "", 0, 0, nil, 0
 	}
 	// Before the cache read: a hit returns without reaching the version guard
 	// in hookDigestResult, so an index left behind by an upgrade was served
@@ -502,19 +513,19 @@ func cachedHookDigest(dir string) (string, int, int64, []string) {
 				// the cache off the startup path.
 				requestHookRefresh(dir, cwd)
 			}
-			return e.Digest, e.Sessions, e.Raw, e.TaskMatched
+			return e.Digest, e.Sessions, e.Raw, e.TaskMatched, e.Withheld
 		}
 	}
-	digest, sessions, raw, taskMatched := hookDigestResult(dir)
-	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched)
-	return digest, sessions, raw, taskMatched
+	digest, sessions, raw, taskMatched, withheld := hookDigestResult(dir)
+	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched, withheld)
+	return digest, sessions, raw, taskMatched, withheld
 }
 
-func writeHookCache(dir, cwd, digest string, sessions int, raw int64, taskMatched []string) {
+func writeHookCache(dir, cwd, digest string, sessions int, raw int64, taskMatched []string, withheld int) {
 	if digest == "" {
 		return
 	}
-	if b, err := json.Marshal(hookCacheEntry{At: time.Now(), CWD: cwd, Gate: hookGate(), Digest: digest, Sessions: sessions, Raw: raw, TaskMatched: taskMatched}); err == nil {
+	if b, err := json.Marshal(hookCacheEntry{At: time.Now(), CWD: cwd, Gate: hookGate(), Digest: digest, Sessions: sessions, Raw: raw, TaskMatched: taskMatched, Withheld: withheld}); err == nil {
 		_ = os.WriteFile(hookCachePath(dir, cwd), b, 0o600)
 	}
 }
@@ -569,17 +580,18 @@ func runHookRefresh(dir string) {
 	if err := index.Ensure(dir, "", false, nil); err != nil {
 		return
 	}
-	digest, sessions, raw, taskMatched := hookDigestResult(dir)
-	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched)
+	digest, sessions, raw, taskMatched, withheld := hookDigestResult(dir)
+	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched, withheld)
 	_ = os.Remove(hookCachePath(dir, cwd) + ".refreshing")
 }
 
 func hookDigest(dir string) string {
-	digest, _, _, _ := hookDigestResult(dir)
+	digest, _, _, _, _ := hookDigestResult(dir)
 	return digest
 }
 
-func hookDigestResult(dir string) (string, int, int64, []string) {
+func hookDigestResult(dir string) (string, int, int64, []string, int) {
+	withheld := 0
 	defer func() { _ = recover() }()
 	trace := os.Getenv("DEJA_TRACE") == "1"
 	t0 := time.Now()
@@ -592,7 +604,7 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 	_ = mark
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL")))
 	if mode == search.RecallOff {
-		return "", 0, 0, nil
+		return "", 0, 0, nil, 0
 	}
 	// A store from an older index version must be rebuilt before it is read:
 	// this path never calls Ensure, so otherwise the first prompts after an
@@ -601,14 +613,14 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 	// manifest still describes, and this path answers from them (#800).
 	if !index.HasManifest(dir) || !index.IsCurrentVersion(dir) || index.Damaged(dir) {
 		requestWarmup(dir)
-		return "", 0, 0, nil
+		return "", 0, 0, nil, 0
 	}
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
 	if cwd == "" {
 		var err error
 		cwd, err = os.Getwd()
 		if err != nil {
-			return "", 0, 0, nil
+			return "", 0, 0, nil, 0
 		}
 	}
 	// The two git probes (worktree list for identity, status/log for the
@@ -643,6 +655,7 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 	if got, err := index.RecentProjects(dir, lookupNames, perName); err == nil {
 		for _, s := range got {
 			if !pol.Allows(policy.ActivationAuto, s.Project) {
+				withheld++
 				continue
 			}
 			k := s.Harness + ":" + s.ID
@@ -655,7 +668,7 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 	}
 	mark("load-sessions")
 	if len(ss) == 0 {
-		return "", 0, 0, nil
+		return "", 0, 0, nil, 0
 	}
 	scores, matched := taskScores(ss, taskFiles)
 	sort.Slice(ss, func(i, j int) bool {
@@ -697,7 +710,7 @@ func hookDigestResult(dir string) (string, int, int64, []string) {
 		}
 	}
 	mark("environment")
-	return text, result.Sessions, rawSize(ss), matched
+	return text, result.Sessions, rawSize(ss), matched, withheld
 }
 
 // warmupDeadAfter is how long a warmup may go without publishing progress

--- a/cmd/deja/hook_policy_withheld_test.go
+++ b/cmd/deja/hook_policy_withheld_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The receipt named the policy whenever it was not the default, so the line
+// read the same whether the rule had withheld memory from this very session or
+// merely existed. `search` has reported the count since it had one.
+func TestHookReceiptSaysWhenThePolicyWithheldSomething(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local: the ticker window is 30s"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", "/proj")
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"auto":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	message := func(t *testing.T) string {
+		t.Helper()
+		out, err := captureRun(t, "hook-context")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var resp struct {
+			SystemMessage string `json:"systemMessage"`
+		}
+		if strings.TrimSpace(out) == "" {
+			return ""
+		}
+		if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &resp); err != nil {
+			t.Fatalf("hook output is not JSON: %q (%v)", out, err)
+		}
+		return resp.SystemMessage
+	}
+
+	// The rule is set, but there is nothing imported for it to hide.
+	got := message(t)
+	if !strings.Contains(got, "policy: local-only") {
+		t.Fatalf("the receipt does not name the policy: %q", got)
+	}
+	if strings.Contains(got, "withheld") {
+		t.Errorf("a rule that hid nothing claimed it withheld something: %q", got)
+	}
+
+	// Now a session from another machine, in the same project, which the rule
+	// does hide.
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "proj", Role: "user", Text: "PEER: the ticker window should be 5s"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Remove(dir + ".receipt")
+	for _, p := range mustGlob(t, dir+".hookcache-*") {
+		_ = os.Remove(p)
+	}
+
+	got = message(t)
+	if !strings.Contains(got, "withheld") {
+		t.Errorf("the receipt does not say the rule withheld a session: %q", got)
+	}
+}
+
+func mustGlob(t *testing.T, pattern string) []string {
+	t.Helper()
+	m, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}

--- a/cmd/deja/hook_stale_format_test.go
+++ b/cmd/deja/hook_stale_format_test.go
@@ -48,8 +48,8 @@ func TestStaleFormatHooksAskForARebuild(t *testing.T) {
 	// request has to happen ahead of the cache read — and the cached digest is
 	// the user's own history, so it must still be served.
 	cwd, _ := os.Getwd()
-	writeHookCache(dir, cwd, "an earlier digest", 1, 10, nil)
-	if d, _, _, _ := cachedHookDigest(dir); d == "" {
+	writeHookCache(dir, cwd, "an earlier digest", 1, 10, nil, 0)
+	if d, _, _, _, _ := cachedHookDigest(dir); d == "" {
 		t.Error("a cache hit stopped serving the user's own history")
 	}
 	if spawned != 2 {
@@ -106,7 +106,7 @@ func TestDamagedIndexHooksAskForARebuild(t *testing.T) {
 	if err := os.Remove(filepath.Join(dir, "warmup.sentinel")); err != nil {
 		t.Fatal(err)
 	}
-	if d, _, _, _ := hookDigestResult(dir); d != "" {
+	if d, _, _, _, _ := hookDigestResult(dir); d != "" {
 		t.Errorf("hook-context answered from a damaged index: %q", d)
 	}
 	if spawned != 2 {

--- a/cmd/deja/hook_task_test.go
+++ b/cmd/deja/hook_task_test.go
@@ -137,7 +137,7 @@ func TestHookContextReceiptNamesTaskFiles(t *testing.T) {
 	}
 	t.Setenv("CLAUDE_PROJECT_DIR", repo)
 
-	digest, sessions, _, matched := hookDigestResult(dir)
+	digest, sessions, _, matched, _ := hookDigestResult(dir)
 	if sessions == 0 || digest == "" {
 		t.Fatal("expected recall output")
 	}

--- a/cmd/deja/install_aider.go
+++ b/cmd/deja/install_aider.go
@@ -109,7 +109,7 @@ func refreshAiderContext(dir string) error {
 	// In-process rather than shelling out to hook-context: the wrapper stands
 	// between the user and their editor, and a subprocess here would also make
 	// the installer depend on its own binary being runnable.
-	digest, sessions, _, _ := cachedHookDigest(dir)
+	digest, sessions, _, _, _ := cachedHookDigest(dir)
 	body := digest
 	if sessions > 0 {
 		body = frameRecall(aiderLead + digest)

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -187,7 +187,7 @@ func gooseRecallPath() string {
 }
 
 func refreshGooseHints() error {
-	digest, sessions, _, _ := cachedHookDigest(index.DefaultDir())
+	digest, sessions, _, _, _ := cachedHookDigest(index.DefaultDir())
 	body := digest
 	if sessions > 0 {
 		body = frameRecall(gooseLead + digest)

--- a/cmd/deja/onboarding_test.go
+++ b/cmd/deja/onboarding_test.go
@@ -129,7 +129,7 @@ func TestHookMissingManifestRequestsWarmup(t *testing.T) {
 	oldSpawn := spawnWarmup
 	spawnWarmup = func(_, _ string) error { called = true; return nil }
 	defer func() { spawnWarmup = oldSpawn }()
-	if digest, sessions, _, _ := hookDigestResult(index.DefaultDir()); digest != "" || sessions != 0 {
+	if digest, sessions, _, _, _ := hookDigestResult(index.DefaultDir()); digest != "" || sessions != 0 {
 		t.Fatalf("missing-manifest digest = %q, sessions=%d", digest, sessions)
 	}
 	if !called {

--- a/cmd/deja/policy_leak_test.go
+++ b/cmd/deja/policy_leak_test.go
@@ -46,11 +46,11 @@ func policyLeakIndex(t *testing.T) string {
 // keep injecting after it is set.
 func TestHookCacheHonorsRecallOff(t *testing.T) {
 	dir := policyLeakIndex(t)
-	if d, _, _, _ := cachedHookDigest(dir); d == "" {
+	if d, _, _, _, _ := cachedHookDigest(dir); d == "" {
 		t.Fatal("expected a digest before the kill switch")
 	}
 	t.Setenv("DEJA_RECALL", "off")
-	if d, _, _, _ := cachedHookDigest(dir); d != "" {
+	if d, _, _, _, _ := cachedHookDigest(dir); d != "" {
 		t.Fatalf("cache served a digest with DEJA_RECALL=off:\n%s", d)
 	}
 }
@@ -61,18 +61,18 @@ func TestHookCacheRefusesEntryFromAnotherPolicy(t *testing.T) {
 	dir := policyLeakIndex(t)
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
 	// Warm the cache under the permissive policy.
-	warm, _, _, _ := cachedHookDigest(dir)
+	warm, _, _, _, _ := cachedHookDigest(dir)
 	if warm == "" {
 		t.Fatal("expected a digest to cache")
 	}
 	// Plant a recognizable entry as if it had been built then.
 	planted := "PLANTED-UNDER-OLD-POLICY"
-	writeHookCache(dir, cwd, planted, 1, 10, nil)
-	if got, _, _, _ := cachedHookDigest(dir); got != planted {
+	writeHookCache(dir, cwd, planted, 1, 10, nil, 0)
+	if got, _, _, _, _ := cachedHookDigest(dir); got != planted {
 		t.Fatalf("cache did not serve its own entry back: %q", got)
 	}
 	t.Setenv("DEJA_AUTORECALL_LOCAL_ONLY", "1")
-	if got, _, _, _ := cachedHookDigest(dir); got == planted {
+	if got, _, _, _, _ := cachedHookDigest(dir); got == planted {
 		t.Fatal("cache served an entry built under a policy that no longer applies")
 	}
 }


### PR DESCRIPTION
The session-start receipt appended `· policy: local-only` whenever the policy was not the default — the same line whether the rule had just withheld a candidate from this session or merely existed. `search` has reported the count since it had one (`the trust policy hides 1 matching session on this path`); the hook now does too:

```
rule hid a candidate:  … the agent starts already knowing them · policy: local-only (1 session withheld here)
nothing to hide:       … the agent starts already knowing them · policy: local-only
```

The count travels through the digest cache, so a cache hit reports it as well; entries written before this decode as zero, which is what they meant.