### PR TITLE
fix: a listing emptied by the trust policy is not an unindexed store

### DIFF
--- a/cmd/deja/last_policy_test.go
+++ b/cmd/deja/last_policy_test.go
@@ -86,3 +86,44 @@ func TestLastHonoursTheTrustPolicy(t *testing.T) {
 		t.Errorf("--json leaked what the text form hides:\n%s", raw)
 	}
 }
+
+// The rule that emptied the listing is named a line above, so "no sessions
+// indexed yet — run `deja index`" is advice for a state deja is not in: the
+// backside of teaching the listing to filter at all (#949).
+func TestLastEmptiedByPolicyDoesNotAdviseAnIndexRun(t *testing.T) {
+	tmp := hermeticEnv(t)
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "api", Role: "user", Text: "peer text"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	out, err := captureRunStderr(t, "last")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "trust policy hides") {
+		t.Errorf("the listing did not name the rule that emptied it: %q", out)
+	}
+	if strings.Contains(out, "no sessions indexed yet") {
+		t.Errorf("a store full of filtered sessions was called unindexed: %q", out)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -482,6 +482,13 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 		if o.JSON {
 			return printRecentJSON(os.Stdout, nil, sourceInstance)
 		}
+		// The rule that emptied the list was named a line above; "no sessions
+		// indexed yet — run `deja index`" is advice for a state deja is not in,
+		// and the backside of teaching the listing to filter at all (#937,
+		// #949).
+		if policyHidden > 0 {
+			return nil
+		}
 		// "Run deja index" is advice for an empty store. With a filter set it
 		// is advice for a state the tool is not in: indexing changes nothing
 		// and doctor reports the stores as found. Name what emptied the result


### PR DESCRIPTION
On a machine whose sessions all arrived by sync, with imported origins denied, `deja last` printed the policy line and then `no sessions indexed yet — run \`deja index\``. The store is not empty; every row was filtered by the rule named one line above, and `deja index` changes nothing.

Backside of #937, which taught the listing to filter but left its empty-result branch assuming empty means unindexed. An actually empty store still gets the original advice.

Closes #949.