### PR TITLE
fix: the import proof obeys the trust policy

### DIFF
--- a/cmd/deja/import_proof_test.go
+++ b/cmd/deja/import_proof_test.go
@@ -75,3 +75,44 @@ func TestImportProofNamesRealSessions(t *testing.T) {
 		t.Errorf("import proved nothing:\n%s", proof)
 	}
 }
+
+// The proof is a listing, and a listing obeys the trust policy: on a machine
+// whose rule keeps imported sessions out of recall it was printing their
+// project and first line, then closing with "ask your agent about any of these
+// — it will remember", which is what the rule prevents (#951).
+func TestImportProofObeysTheTrustPolicy(t *testing.T) {
+	tmp := hermeticEnv(t)
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "api", Role: "user", Text: "PEER SECRET: the vault rotation runs at 03:00"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	proof, err := captureRunStderr(t, "sync", "import", exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(proof, "PEER SECRET") || strings.Contains(proof, "it will remember") {
+		t.Errorf("the proof printed what the policy hides:\n%s", proof)
+	}
+	if !strings.Contains(proof, "trust policy hides") {
+		t.Errorf("the proof says nothing about why it is empty:\n%s", proof)
+	}
+	// The count still reaches the reader, so the import is not silent.
+	out, err := captureRun(t, "sync", "import", exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = out
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
@@ -255,6 +256,18 @@ func printMemoryProof(dir, heading string) {
 	}
 	recent, err := index.Recent(dir, 12)
 	if err != nil || len(recent) == 0 {
+		return
+	}
+	// The proof is a listing, and a listing obeys the trust policy (#937). On a
+	// machine whose rule keeps imported sessions out of recall this block was
+	// printing their project and first line, and closing with "ask your agent
+	// about any of these — it will remember", which is exactly what the rule
+	// prevents (#951).
+	recent, hidden := policyFilterSessionsCounted(policy.ActivationSearch, recent)
+	if len(recent) == 0 {
+		if hidden > 0 {
+			fmt.Fprintf(os.Stderr, "\n%s\n", policyHiddenNote(policy.ActivationSearch, hidden))
+		}
 		return
 	}
 	seenProject := map[string]bool{}


### PR DESCRIPTION
On a machine whose policy denies imported origins, `sync import` still ended with the proof block from #930 — the peer's project, the first line of its content, and "ask your agent about any of these — it will remember", which is exactly what the rule prevents. Every other surface withholds that content (#937).

The block now goes through the same gate as the listing. When the rule withholds everything that arrived, the reader gets the count and the rule instead of the content, so the import is still not silent.

Closes #951.