### PR TITLE
fix: handoff with no id obeys the trust policy

### DIFF
--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
@@ -151,17 +153,30 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 	}
 	var newest model.Session
 	distinct := map[string]bool{}
+	hidden := 0
 	for _, name := range digest.ProjectNameCandidates(cwd) {
-		ss, err := index.RecentProject(dir, name, 1)
+		ss, err := index.RecentProject(dir, name, 3)
 		if err != nil || len(ss) == 0 {
 			continue
 		}
-		distinct[ss[0].ID] = true
-		if ss[0].Updated.After(newest.Updated) {
-			newest = ss[0]
+		// Nobody named this session — deja is choosing it, which is what a
+		// listing does and what a listing filters (#937). Without this the
+		// pick landed on a session the rule keeps out of recall and packaged
+		// its content for another agent (#953).
+		kept, dropped := policyFilterSessionsCounted(policy.ActivationSearch, ss)
+		hidden += dropped
+		if len(kept) == 0 {
+			continue
+		}
+		distinct[kept[0].ID] = true
+		if kept[0].Updated.After(newest.Updated) {
+			newest = kept[0]
 		}
 	}
 	if newest.ID == "" {
+		if hidden > 0 {
+			return model.Session{}, errors.New(strings.TrimPrefix(policyHiddenNote(policy.ActivationSearch, hidden), "deja: "))
+		}
 		return model.Session{}, fmt.Errorf("no indexed sessions for this project — pass a session id-prefix (see `deja last`)")
 	}
 	if len(distinct) > 1 {

--- a/cmd/deja/handoff_policy_test.go
+++ b/cmd/deja/handoff_policy_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Nobody names the session in `deja handoff` with no id — deja chooses it, the
+// way a listing does, and a listing obeys the trust policy (#937). Without the
+// gate the pick landed on a session the rule keeps out of recall and packaged
+// its content for another agent (#953).
+func TestHandoffWithNoIdObeysTheTrustPolicy(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Newer than the local one, so it wins any recency contest.
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "proj", Role: "user", Text: "PEER SECRET: the vault rotation runs at 03:00"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+	// handoff takes the project from the working directory, so the test has to
+	// stand in one whose name matches.
+	work := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	back, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(work); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(back) })
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	s, err := handoffSource(dir, "")
+	if err != nil {
+		t.Fatalf("handoff found nothing to hand off: %v", err)
+	}
+	if strings.HasPrefix(s.Project, "imported:") {
+		t.Errorf("handoff picked a session the policy hides: %s · %s", s.Project, s.ID)
+	}
+
+	// With the local session gone, every candidate is hidden: the reader gets
+	// the rule, not someone else's work.
+	if err := os.Remove(filepath.Join(store, "loc.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := handoffSource(dir, ""); err == nil || !strings.Contains(err.Error(), "trust policy") {
+		t.Errorf("with everything hidden, handoff said: %v", err)
+	}
+}


### PR DESCRIPTION
`deja handoff` without an id chooses a session by itself. On a machine whose rule denies imported origins it chose the hidden one and packaged its content for another agent, while the allowed local session in the same project sat right there.

That is a selection, not an explicit lookup (#943): the same kind of choice a listing makes, and listings filter (#937). When every candidate is hidden the caller now gets the rule instead of someone else's work.

Closes #953.