### PR TITLE
fix: name the imported origin group honestly and flag rules that match nothing

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -87,7 +87,7 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir strin
 	fmt.Fprintln(w)
 	doctorTools(w)
 	fmt.Fprintln(w)
-	doctorPolicy(w)
+	doctorPolicy(w, dir)
 	fmt.Fprintln(w)
 	doctorMCP(w)
 	fmt.Fprintln(w)
@@ -586,11 +586,40 @@ func doctorTools(w io.Writer) {
 	fmt.Fprintf(w, "  %-12s %s (needed for changed-file notes, worktree names and the task signal)\n", "git", gitStatus)
 }
 
+// unmatchedImportGroups lists imported:<group> rules that no session in the
+// index answers to.
+func unmatchedImportGroups(dir string) []string {
+	pol := policy.Load()
+	present := map[string]bool{}
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return nil
+	}
+	for _, m := range metas {
+		if o := policy.Origin(m.Project); strings.HasPrefix(o, "imported:") {
+			present[o] = true
+		}
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, rules := range pol.Activations {
+		for origin, allowed := range rules {
+			if allowed || !strings.HasPrefix(origin, "imported:") || present[origin] || seen[origin] {
+				continue
+			}
+			seen[origin] = true
+			out = append(out, origin)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 // doctorPolicy reports the one mechanism that separates local memory from
 // imported. Load falls back to the permissive default on any error, so a
 // malformed file changed nothing and said nothing, and a working one was
 // invisible — leaving no place at all to find out what the rules are (#661).
-func doctorPolicy(w io.Writer) {
+func doctorPolicy(w io.Writer, dir string) {
 	fmt.Fprintln(w, "Trust policy:")
 	exists, unknown, err := policy.Diagnose()
 	if !exists {
@@ -622,6 +651,13 @@ func doctorPolicy(w io.Writer) {
 	}
 	for _, u := range unknown {
 		fmt.Fprintf(w, "  %-12s %q is not an activation or origin deja consults — this rule does nothing\n", "ignored", u)
+	}
+	// An `imported:x` rule has the right shape and still matches nothing when
+	// no session came from a project starting with x — the group is a project
+	// prefix from the exporting machine, not a machine name, and a rule
+	// written for a machine reads as in force forever (#955).
+	for _, g := range unmatchedImportGroups(dir) {
+		fmt.Fprintf(w, "  %-12s %q matches nothing in this index — the part after `imported:` is the first path component of the project on the machine it came from, not that machine's name\n", "inert", g)
 	}
 }
 

--- a/cmd/deja/doctor_inert_rule_test.go
+++ b/cmd/deja/doctor_inert_rule_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// `imported:x` has the shape of a rule deja consults, so #941's check passes it
+// even when x is a machine name — and the part after the colon is the first
+// path component of the project on the machine the session came from, never a
+// machine name. Such a rule reads as in force forever (#955).
+func TestDoctorNamesAnImportRuleThatMatchesNothing(t *testing.T) {
+	tmp := hermeticEnv(t)
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "p1", Project: "work/api", Role: "user", Text: "peer note"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported:laptop":false,"imported:work":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	var out bytes.Buffer
+	doctorPolicy(&out, dir)
+	got := out.String()
+	if !strings.Contains(got, `"imported:laptop" matches nothing`) {
+		t.Errorf("a rule that can never fire is reported as in force:\n%s", got)
+	}
+	// The one that does match is not called inert.
+	if strings.Contains(got, `"imported:work" matches nothing`) {
+		t.Errorf("a rule that hides a session was called inert:\n%s", got)
+	}
+}

--- a/cmd/deja/doctor_policy_env_test.go
+++ b/cmd/deja/doctor_policy_env_test.go
@@ -16,14 +16,14 @@ func TestDoctorPolicySeesTheEnvironmentOverride(t *testing.T) {
 	t.Setenv("DEJA_POLICY_FILE", filepath.Join(tmp, "no-such-policy.json"))
 
 	var out bytes.Buffer
-	doctorPolicy(&out)
+	doctorPolicy(&out, filepath.Join(tmp, "index.db"))
 	if !strings.Contains(out.String(), "every origin activates everywhere") {
 		t.Errorf("an unrestricted machine stopped saying so:\n%s", out.String())
 	}
 
 	t.Setenv("DEJA_AUTORECALL_LOCAL_ONLY", "1")
 	out.Reset()
-	doctorPolicy(&out)
+	doctorPolicy(&out, filepath.Join(tmp, "index.db"))
 	got := out.String()
 	if strings.Contains(got, "every origin activates everywhere") {
 		t.Errorf("doctor called a restricted machine unrestricted:\n%s", got)

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -591,7 +591,7 @@ func TestDoctorReportsThePolicy(t *testing.T) {
 	t.Setenv("DEJA_POLICY_FILE", path)
 
 	var buf bytes.Buffer
-	doctorPolicy(&buf)
+	doctorPolicy(&buf, t.TempDir())
 	if !strings.Contains(buf.String(), "every origin activates everywhere") {
 		t.Errorf("no file: %q", buf.String())
 	}
@@ -600,7 +600,7 @@ func TestDoctorReportsThePolicy(t *testing.T) {
 	if err := os.WriteFile(path, []byte("{ oops"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	doctorPolicy(&buf)
+	doctorPolicy(&buf, t.TempDir())
 	// The permissive default is what is in force, and the file reads like a
 	// restriction — so saying only "unreadable" would leave the wrong belief.
 	for _, want := range []string{"unreadable", "every origin activates everywhere until it parses"} {
@@ -614,7 +614,7 @@ func TestDoctorReportsThePolicy(t *testing.T) {
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	doctorPolicy(&buf)
+	doctorPolicy(&buf, t.TempDir())
 	for _, want := range []string{"mcp", "deny local", "ignored", "this rule does nothing"} {
 		if !strings.Contains(buf.String(), want) {
 			t.Errorf("valid: %q lacks %q", buf.String(), want)

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,7 +1,7 @@
 // Package policy decides what memory activates where. Recall crossing a
 // machine boundary was the launch thread's top concern; instead of one env
 // var, a small explicit table: per activation (search, mcp, auto), which
-// origins (local, imported, imported:<peer>) may inject. Defaults allow
+// origins (local, imported, imported:<group>) may inject. Defaults allow
 // everything, matching prior behavior; DEJA_AUTORECALL_LOCAL_ONLY=1 stays as
 // an alias for denying imported memory on the auto path.
 package policy
@@ -23,8 +23,12 @@ const (
 )
 
 // Policy maps activation → origin rules. A missing activation allows every
-// origin. Origin keys: "local", "imported" (any peer), "imported:<peer>"
-// (most specific wins).
+// origin. Origin keys: "local", "imported" (anything that arrived by sync) and
+// "imported:<group>", where group is the first path component of the project
+// the session had on the machine it came from — a sync batch carries no machine
+// identity, so this is a project grouping and not a peer name, which is how it
+// was described until a rule written for a machine turned out to be accepted,
+// displayed and never matched (#955). Most specific wins.
 type Policy struct {
 	Activations map[string]map[string]bool `json:"activations,omitempty"`
 }
@@ -60,7 +64,10 @@ func Load() Policy {
 	return p
 }
 
-// Origin classifies a session's project name.
+// Origin classifies a session's project name. Everything local is "local";
+// anything that arrived by sync is "imported", and additionally
+// "imported:<group>" when its source project had a path, so a group of another
+// machine's projects can be addressed on its own (#955).
 func Origin(project string) string {
 	if peer, ok := strings.CutPrefix(project, "imported:"); ok {
 		if i := strings.IndexByte(peer, '/'); i > 0 {
@@ -72,7 +79,7 @@ func Origin(project string) string {
 }
 
 // Allows reports whether memory from the session's origin may activate on
-// this path. Most specific rule wins: imported:<peer> over imported over the
+// this path. Most specific rule wins: imported:<group> over imported over the
 // activation default (allow).
 func (p Policy) Allows(activation, project string) bool {
 	rules := p.Activations[activation]


### PR DESCRIPTION
The policy called its keys `local`, `imported` and `imported:<peer>`, but `Origin` returns the first path component of the project the session had on the machine it came from — a sync batch carries no machine identity at all:

```
imported:work/api        → "imported:work"
imported:solo            → "imported"
work/api                 → "local"
```

So a rule written for a machine (`imported:laptop`) is accepted, printed by doctor as in force, and never matches. The vocabulary now says group rather than peer, and doctor names a rule that answers to nothing in this index:

```
  search       deny imported:laptop,imported:work
  inert        "imported:laptop" matches nothing in this index — the part after `imported:` is the first path component of the project on the machine it came from, not that machine's name
```

Behaviour of rules that do match is unchanged.

Closes #955.