### PR TITLE
fix: forget names the kind of notes it is dropping

### DIFF
--- a/cmd/deja/forget_note_kinds_test.go
+++ b/cmd/deja/forget_note_kinds_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Everything deja files under its own harness counted as a "promoted note", so
+// forgetting a day of `remember` notes named something the reader had never
+// done (#957).
+func TestForgetNamesTheKindOfNotesItIsDropping(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		result index.ForgetResult
+		want   string
+		avoid  string
+	}{
+		{"only day buckets", index.ForgetResult{Sessions: 1, Notes: 1}, "a day of your own notes", "promoted"},
+		{"several day buckets", index.ForgetResult{Sessions: 2, Notes: 2}, "2 days of your own notes", "promoted"},
+		{"only promoted", index.ForgetResult{Sessions: 1, Notes: 1, Promoted: 1}, "promoted note", "day of your own"},
+		{"both kinds", index.ForgetResult{Sessions: 4, Notes: 3, Promoted: 1}, "1 promoted, 2 days of notes", ""},
+		{"no notes at all", index.ForgetResult{Sessions: 2}, "", "note"},
+	} {
+		got := forgetNotesLine(tc.result)
+		if tc.want == "" {
+			if got != "" {
+				t.Errorf("%s: said %q about sessions that are not notes", tc.name, got)
+			}
+			continue
+		}
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("%s: %q does not say %q", tc.name, got, tc.want)
+		}
+		if tc.avoid != "" && strings.Contains(got, tc.avoid) {
+			t.Errorf("%s: %q claims %q", tc.name, got, tc.avoid)
+		}
+		// No doubled articles from composing the sentence.
+		if strings.Contains(got, "a a ") || strings.Contains(got, "is 1 ") {
+			t.Errorf("%s: reads badly: %q", tc.name, got)
+		}
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1563,9 +1563,8 @@ func runForget(dir string, args []string) error {
 				fmt.Fprintln(os.Stdout, scope.Error())
 			}
 		}
-		if result.Notes > 0 {
-			fmt.Fprintf(os.Stdout, "%d of them %s promoted note%s — the decisions you kept, not raw sessions\n",
-				result.Notes, verbWere(result.Notes), pluralS(result.Notes))
+		if line := forgetNotesLine(result); line != "" {
+			fmt.Fprintln(os.Stdout, line)
 		}
 		return nil
 	}
@@ -1939,4 +1938,35 @@ func splitEqualsForms(args []string) []string {
 		out = append(out, a)
 	}
 	return out
+}
+
+// forgetNotesLine says how much of what is going is the user's own writing.
+// Everything deja files under its own harness counted as a "promoted note",
+// so forgetting a day of `remember` notes named something the reader had never
+// done (#957).
+func forgetNotesLine(result index.ForgetResult) string {
+	switch {
+	case result.Notes == 0:
+		return ""
+	case result.Promoted == result.Notes:
+		return fmt.Sprintf("%d of them %s promoted note%s — the decisions you kept, not raw sessions",
+			result.Notes, verbWere(result.Notes), pluralS(result.Notes))
+	case result.Promoted == 0:
+		if result.Notes == 1 {
+			return "1 of them is a day of your own notes, not raw sessions"
+		}
+		return fmt.Sprintf("%d of them are %s of your own notes, not raw sessions",
+			result.Notes, dayWord(result.Notes))
+	default:
+		return fmt.Sprintf("%d of them %s your own writing — %d promoted, %s of notes — not raw sessions",
+			result.Notes, verbWere(result.Notes), result.Promoted, dayWord(result.Notes-result.Promoted))
+	}
+}
+
+// dayWord names day buckets the way the reader wrote them: by the day.
+func dayWord(n int) string {
+	if n == 1 {
+		return "a day"
+	}
+	return fmt.Sprintf("%d days", n)
 }

--- a/internal/index/forget_promoted_count_test.go
+++ b/internal/index/forget_promoted_count_test.go
@@ -1,0 +1,51 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Forget counts the user's own writing apart from transcripts, and the two
+// shapes deja files under its own harness are not the same thing: a day bucket
+// comes from `remember`, a deja-note- session from `promote`. Calling a day of
+// notes a promoted note names something the reader may never have done (#957).
+func TestForgetCountsPromotedNotesApartFromDayBuckets(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+
+	store := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"s1","timestamp":"2026-07-11T10:00:00Z","cwd":"/p","message":{"role":"user","content":"a session about the ticker"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"ts":"2026-07-12T09:00:00Z","project":"p","text":"a note of my own"}` + "\n" +
+		`{"ts":"2026-07-12T10:00:00Z","project":"p","text":"the decision that held","kind":"promoted","session":"claude:s1","state":"accepted","title":"decision"}` + "\n"
+	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Forget(dir, ForgetOptions{Project: "p", DryRun: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Notes != 2 {
+		t.Fatalf("counted %d of the user's own sessions, want 2 (a day bucket and a promoted note)", got.Notes)
+	}
+	if got.Promoted != 1 {
+		t.Errorf("counted %d promoted notes, want 1 — the day bucket is not one", got.Promoted)
+	}
+}

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -28,11 +28,13 @@ type ForgetResult struct {
 	// clean up what lives outside the index — the titles promoted notes
 	// borrowed from these sessions (#666, #690).
 	Keys []string
-	// Notes is how many of Sessions were promoted notes rather than raw
-	// transcripts. They are the decisions the user deliberately kept, so one
-	// combined number reads as "four conversations" when half of it is their
-	// own writing.
-	Notes int
+	// Notes is how many of Sessions were the user's own writing rather than raw
+	// transcripts, so one combined number does not read as "four
+	// conversations" when half of it is theirs. Promoted counts the part of it
+	// that came from `deja promote`: calling a day of `remember` notes a
+	// promoted note names something the reader never did (#957).
+	Notes    int
+	Promoted int
 	// Peers names the hosts a forgotten session was already pushed to, and
 	// Exported reports the same for unnamed directory exports. Forgetting
 	// removes the local copy and keeps the session out of later pushes, but it
@@ -363,6 +365,9 @@ func Forget(dir string, o ForgetOptions) (ForgetResult, error) {
 		result.Keys = append(result.Keys, key)
 		if meta.Harness == "deja" {
 			result.Notes++
+			if strings.HasPrefix(meta.ID, "deja-note-") {
+				result.Promoted++
+			}
 		}
 		if !dead[key] {
 			result.Tombstones++


### PR DESCRIPTION
`forget` counted every session under the `deja` harness as a promoted note, so dropping a day bucket written by `deja remember` said "1 of them is a promoted note — the decisions you kept". Someone who has never run `deja promote` reads that as deja deleting something they did not make.

```
day bucket:   1 of them is a day of your own notes, not raw sessions
promoted:     1 of them is a promoted note — the decisions you kept, not raw sessions
both kinds:   3 of them are your own writing — 1 promoted, 2 days of notes — not raw sessions
```

Closes #957.