### PR TITLE
fix(sources): keep MCP tool results that arrive as content blocks

### DIFF
--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -180,16 +180,16 @@ func claudeTextKind(raw json.RawMessage) (string, bool) {
 			continue
 		}
 		var part struct {
-			Type    string `json:"type"`
-			Text    string `json:"text"`
-			Content string `json:"content"`
+			Type    string          `json:"type"`
+			Text    string          `json:"text"`
+			Content json.RawMessage `json:"content"`
 		}
 		if json.Unmarshal(item, &part) != nil {
 			continue
 		}
 		chunk := part.Text
 		if chunk == "" {
-			chunk = part.Content
+			chunk = claudeContentText(part.Content)
 		}
 		if part.Type == "tool_result" {
 			sawToolResult = true
@@ -205,6 +205,50 @@ func claudeTextKind(raw json.RawMessage) (string, bool) {
 		b.WriteString(chunk)
 	}
 	return b.String(), sawToolResult && !sawSpeech
+}
+
+// claudeContentText reads an item's content field. Most tool results carry it
+// as a plain string, but an MCP tool's result is an array of blocks with the
+// text one level down — decoding it as a string failed the whole item, so
+// every MCP tool output vanished from the index (76 records on one real
+// store). Blocks without text, images among them, contribute nothing.
+func claudeContentText(raw json.RawMessage) string {
+	raw = trimJSONSpace(raw)
+	if len(raw) == 0 {
+		return ""
+	}
+	if raw[0] == '"' {
+		var s string
+		if json.Unmarshal(raw, &s) != nil {
+			return ""
+		}
+		return s
+	}
+	if raw[0] != '[' {
+		return ""
+	}
+	var items []json.RawMessage
+	if json.Unmarshal(raw, &items) != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, item := range items {
+		item = trimJSONSpace(item)
+		if len(item) == 0 || item[0] != '{' {
+			continue
+		}
+		var block struct {
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(item, &block) != nil || block.Text == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(block.Text)
+	}
+	return b.String()
 }
 
 func trimJSONSpace(b []byte) []byte {

--- a/internal/sources/claude_decode_test.go
+++ b/internal/sources/claude_decode_test.go
@@ -82,6 +82,12 @@ func TestTypedClaudeParserMatchesTheGenericOne(t *testing.T) {
 		"unicode.jsonl": {
 			`{"type":"user","sessionId":"s10","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"кириллица 中文 emoji 🙂 \"quoted\" \\ backslash"}}`,
 		},
+		// MCP tool results carry content as an array of blocks rather than a
+		// string; the text lives one level down.
+		"tool-result-blocks.jsonl": {
+			`{"type":"user","sessionId":"s11","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"text","text":"3 tests failed"}]}]}}`,
+			`{"type":"user","sessionId":"s11","timestamp":"2026-01-02T03:04:06Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t2","content":[{"type":"image","source":{"type":"base64","data":"AAAA"}}]}]}}`,
+		},
 	}
 	for name, lines := range cases {
 		path := filepath.Join(dir, name)
@@ -98,6 +104,33 @@ func TestTypedClaudeParserMatchesTheGenericOne(t *testing.T) {
 			t.Fatalf("%s: errors differ: %v vs %v", name, wantErr, gotErr)
 		}
 		sameSessions(t, want, got, name)
+	}
+}
+
+// End to end: a user line whose only content is a block-array tool result must
+// produce a tool-output record, not vanish from the session.
+func TestBlockToolResultBecomesARecord(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.jsonl")
+	line := `{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"text","text":"chapter marked"}]}]}}`
+	if err := os.WriteFile(path, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parsers := map[string]func(string, int64) ([]model.Session, error){
+		"typed":   parseClaudeTypedFromOffset,
+		"generic": parseClaudeGenericFromOffset,
+	}
+	for name, parse := range parsers {
+		ss, err := parse(path, 0)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if len(ss) != 1 || len(ss[0].Messages) != 1 {
+			t.Fatalf("%s: sessions = %+v", name, ss)
+		}
+		if m := ss[0].Messages[0]; m.Role != RoleToolOutput || m.Text != "chapter marked" {
+			t.Fatalf("%s: message = %+v", name, m)
+		}
 	}
 }
 

--- a/internal/sources/tool_output_role_test.go
+++ b/internal/sources/tool_output_role_test.go
@@ -39,6 +39,84 @@ func TestPlainAndEmptyShapesAreSpeech(t *testing.T) {
 	}
 }
 
+// An MCP tool's result arrives as an array of content blocks, not a string —
+// {"type":"tool_result","content":[{"type":"text","text":…}]} — and both
+// parsers dropped the item whole: the text never reached the index and the
+// label never applied. Measured on one real store: 76 records lost that way.
+func TestToolResultContentBlocksAreKept(t *testing.T) {
+	line := `[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"text","text":"3 tests failed"},{"type":"image","source":{"type":"base64"}},{"type":"text","text":"in auth_test.go"}]}]`
+	txt, isTool := claudeTextKind(json.RawMessage(line))
+	if txt != "3 tests failed\nin auth_test.go" {
+		t.Fatalf("text = %q", txt)
+	}
+	if !isTool {
+		t.Fatal("a block-array tool result must be labelled as tool output")
+	}
+	var v any
+	if err := json.Unmarshal([]byte(line), &v); err != nil {
+		t.Fatal(err)
+	}
+	gtxt, gTool := textFromContentKind(v)
+	if gtxt != txt || gTool != isTool {
+		t.Fatalf("generic (%q, %v) disagrees with typed (%q, %v)", gtxt, gTool, txt, isTool)
+	}
+}
+
+// Speech still wins a mixed message when the tool result is block-shaped.
+func TestMixedMessageWithBlockResultStaysSpeech(t *testing.T) {
+	line := `[{"type":"text","text":"ran the suite"},{"type":"tool_result","content":[{"type":"text","text":"ok"}]}]`
+	txt, isTool := claudeTextKind(json.RawMessage(line))
+	if isTool {
+		t.Fatal("a message containing speech must not be labelled tool output")
+	}
+	if txt != "ran the suite\nok" {
+		t.Fatalf("text = %q", txt)
+	}
+}
+
+// An image-only result has nothing worth indexing and must stay empty rather
+// than become a blank record — but it is still a tool result for the label.
+func TestImageOnlyBlockResultStaysEmpty(t *testing.T) {
+	txt, isTool := claudeTextKind(json.RawMessage(`[{"type":"tool_result","content":[{"type":"image","source":{"type":"base64","data":"AAAA"}}]}]`))
+	if txt != "" {
+		t.Fatalf("text = %q, want empty", txt)
+	}
+	if !isTool {
+		t.Fatal("still a tool result, even with nothing to keep")
+	}
+}
+
+// The content field takes junk shapes too — numbers, objects, bare strings in
+// the block list, broken nesting. They must cost nothing, and the two parsers
+// must read them identically.
+func TestContentBlockJunkIsTolerated(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{`123`, ""},
+		{`{"nested":"object"}`, ""},
+		{`["a bare string in the blocks"]`, ""},
+		{`[{"type":"text","text":123}]`, ""},
+		{`[{"type":"text"},{"type":"text","text":"kept"}]`, "kept"},
+		{`[not json`, ""},
+		{`"unterminated`, ""},
+		{`"plain"`, "plain"},
+	}
+	for _, c := range cases {
+		if got := claudeContentText(json.RawMessage(c.raw)); got != c.want {
+			t.Errorf("typed claudeContentText(%s) = %q, want %q", c.raw, got, c.want)
+		}
+		var v any
+		if json.Unmarshal([]byte(c.raw), &v) != nil {
+			v = nil // undecodable content never reaches the generic parser as a value
+		}
+		if got := contentText(v); got != c.want {
+			t.Errorf("generic contentText(%s) = %q, want %q", c.raw, got, c.want)
+		}
+	}
+}
+
 // The reference parser must agree with the typed one, or the differential test
 // in #502 stops meaning anything.
 func TestBothParsersAgreeOnTheLabel(t *testing.T) {

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -55,12 +55,19 @@ func unixGuess(n int64) time.Time {
 // textFromContentKind is textFromContent plus the attribution question: did
 // everything it joined come from tool results? Claude files those inside `user`
 // messages, and labelling them as speech was wrong for 89% of that role (#559).
+//
+// It joins items itself rather than delegating to textFromContent because a
+// Claude item's content is not always a string: an MCP tool's result is an
+// array of blocks with the text one level down, and the string-only read
+// dropped those. Only the Claude path reads that shape; the other harnesses
+// keep textFromContent as it was.
 func textFromContentKind(v any) (string, bool) {
 	c, ok := v.([]any)
 	if !ok {
 		return textFromContent(v), false
 	}
 	var sawTool, sawSpeech bool
+	var b strings.Builder
 	for _, it := range c {
 		m, ok := it.(map[string]any)
 		if !ok {
@@ -68,14 +75,50 @@ func textFromContentKind(v any) (string, bool) {
 		}
 		typ, _ := m["type"].(string)
 		txt, _ := m["text"].(string)
-		str, _ := m["content"].(string)
+		if txt == "" {
+			txt = contentText(m["content"])
+		}
 		if typ == "tool_result" {
 			sawTool = true
-		} else if txt != "" || str != "" {
+		} else if txt != "" {
 			sawSpeech = true
 		}
+		if txt == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(txt)
 	}
-	return textFromContent(v), sawTool && !sawSpeech
+	return b.String(), sawTool && !sawSpeech
+}
+
+// contentText is claudeContentText for the reference parser: a content field
+// holds a plain string, or an array of blocks whose text sits one level down.
+func contentText(v any) string {
+	switch c := v.(type) {
+	case string:
+		return c
+	case []any:
+		var b strings.Builder
+		for _, it := range c {
+			m, ok := it.(map[string]any)
+			if !ok {
+				continue
+			}
+			txt, _ := m["text"].(string)
+			if txt == "" {
+				continue
+			}
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(txt)
+		}
+		return b.String()
+	}
+	return ""
 }
 
 func textFromContent(v any) string {


### PR DESCRIPTION
## Summary
MCP tools return `tool_result` content as a list of content blocks instead of a plain string. Both Claude parsers only handle the string form, so anything block shaped fails to decode and never makes it into the index. On my machine this was losing 76 records worth of MCP tool output. Both parsers now accept both forms.

## Test plan
- Added a fixture with block form content and tests covering the string and block cases in both parsers
- `go test ./...` passes on Windows