### PR TITLE
fix: unforget refuses a prefix that reaches several sessions

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1520,6 +1520,12 @@ func runForget(dir string, args []string) error {
 		return nil
 	}
 	if unforget != "" {
+		// The destructive direction refuses a prefix that reaches more than one
+		// session; the undo restored them all and said so afterwards, while the
+		// hint printed beside the list promises one (#961).
+		if n := index.TombstoneMatches(unforget); n > 1 && !allMatches {
+			return fmt.Errorf("%q brings back %d forgotten sessions — `deja forget --list` names them; add --all-matches to restore them all", unforget, n)
+		}
 		var lifted int
 		if err := withBuildProgress(func() error {
 			var err error

--- a/cmd/deja/unforget_scope_test.go
+++ b/cmd/deja/unforget_scope_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// forget refuses a prefix that reaches more than one session; the undo restored
+// them all and reported the count afterwards, while the hint beside the list
+// promises that it brings one back (#961).
+func TestUnforgetRefusesAPrefixThatReachesSeveral(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i, id := range []string{"ab-one", "ab-two", "zz-other"} {
+		rec := `{"type":"user","message":{"role":"user","content":"session ` + id + `"},"timestamp":"2026-07-1` + string(rune('1'+i)) + `T10:00:00Z","sessionId":"` + id + `","cwd":"/proj"}` + "\n"
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(rec), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "forget", "--session", "ab", "--all-matches"); err != nil {
+		t.Fatal(err)
+	}
+	if n := index.TombstoneMatches("ab"); n != 2 {
+		t.Fatalf("forgot %d sessions, want 2", n)
+	}
+
+	// The undo refuses the same shape the delete refuses.
+	if _, err := captureRun(t, "forget", "--unforget", "ab"); err == nil {
+		t.Error("unforget restored several sessions from one prefix without asking")
+	} else if !strings.Contains(err.Error(), "--all-matches") {
+		t.Errorf("the refusal does not name the way to do it anyway: %v", err)
+	}
+	if n := index.TombstoneMatches("ab"); n != 2 {
+		t.Errorf("the refused undo still restored something: %d tombstones left", n)
+	}
+
+	// Asked for explicitly, it does the lot.
+	if _, err := captureRunStderr(t, "forget", "--unforget", "ab", "--all-matches"); err != nil {
+		t.Fatal(err)
+	}
+	if n := index.TombstoneMatches("ab"); n != 0 {
+		t.Errorf("--all-matches left %d tombstones", n)
+	}
+
+	// One id is still one command.
+	if _, err := captureRunStderr(t, "forget", "--session", "ab-one"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "forget", "--unforget", "claude:ab-one"); err != nil {
+		t.Errorf("restoring a single session was refused: %v", err)
+	}
+}

--- a/internal/index/forget_promoted_count_test.go
+++ b/internal/index/forget_promoted_count_test.go
@@ -49,3 +49,53 @@ func TestForgetCountsPromotedNotesApartFromDayBuckets(t *testing.T) {
 		t.Errorf("counted %d promoted notes, want 1 — the day bucket is not one", got.Promoted)
 	}
 }
+
+// The undo has to be able to refuse the way forget does, so the count and the
+// action share one selector (#961).
+func TestTombstoneMatchesCountsWhatUnforgetWouldLift(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+
+	store := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i, id := range []string{"ab-one", "ab-two", "zz-other"} {
+		rec := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-07-1` + string(rune('1'+i)) + `T10:00:00Z","cwd":"/p","message":{"role":"user","content":"session ` + id + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(rec), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Forget(dir, ForgetOptions{Session: "ab"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if n := TombstoneMatches("ab"); n != 2 {
+		t.Errorf("TombstoneMatches(\"ab\") = %d, want 2", n)
+	}
+	if n := TombstoneMatches("claude:"); n != 2 {
+		t.Errorf("a harness-scoped prefix counted %d, want 2", n)
+	}
+	if n := TombstoneMatches("claude:ab-one"); n != 1 {
+		t.Errorf("one exact key counted %d, want 1", n)
+	}
+	if n := TombstoneMatches("nothing-like-this"); n != 0 {
+		t.Errorf("a selector matching nothing counted %d", n)
+	}
+	// And what it counted is what Unforget lifts.
+	lifted, err := Unforget(dir, "ab", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lifted != 2 {
+		t.Errorf("Unforget lifted %d where the count said 2", lifted)
+	}
+}

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -430,9 +430,41 @@ func Tombstones() []string {
 	return out
 }
 
+// TombstoneMatches counts the forgotten sessions a selector would bring back,
+// without touching anything. The undo has to be able to refuse the way forget
+// does: one word restored three sessions and said so afterwards (#961).
+func TombstoneMatches(prefix string) int {
+	n := 0
+	for key := range readTombstones() {
+		if tombstoneMatches(key, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+// tombstoneMatches is the selector Unforget applies, factored out so the count
+// and the action cannot drift apart.
+func tombstoneMatches(key, prefix string) bool {
+	// A prefix containing ':' is a key/harness-scoped prefix (claude:abc, z:);
+	// a bare prefix is an id-prefix symmetric with forget --session, so "c"
+	// cannot resurrect every claude/codex/cursor session at once.
+	if strings.ContainsRune(prefix, ':') {
+		return strings.HasPrefix(key, prefix)
+	}
+	id := key
+	if i := strings.IndexByte(key, ':'); i >= 0 {
+		id = key[i+1:]
+	}
+	// Same widening as the forget selector: the id a reader copies off a
+	// result line carries the elision (#855).
+	return key == prefix || strings.HasPrefix(id, prefix) || idMatchesElided(id, prefix)
+}
+
 // Unforget lifts tombstones and reports how many it lifted. The count is not
 // bookkeeping: the command printed nothing at all, so "restored one session"
 // and "that prefix matched nothing" looked identical (#672).
+//
 // Unforget lifts the tombstones matching prefix and rebuilds so the sessions
 // come back. The rebuild runs first and the reduced tombstone set is persisted
 // only once it succeeds: interrupted the other way round, the tombstone that
@@ -442,25 +474,9 @@ func Tombstones() []string {
 // by `forget --list`, which is visible and fixed by running unforget again.
 func Unforget(dir, prefix string, progress io.Writer) (int, error) {
 	set := readTombstones()
-	// A prefix containing ':' is a key/harness-scoped prefix (claude:abc,
-	// z:); a bare prefix is an id-prefix symmetric with forget --session, so
-	// "c" cannot resurrect every claude/codex/cursor session at once.
-	scoped := strings.ContainsRune(prefix, ':')
 	lifted := 0
 	for key := range set {
-		var match bool
-		if scoped {
-			match = strings.HasPrefix(key, prefix)
-		} else {
-			id := key
-			if i := strings.IndexByte(key, ':'); i >= 0 {
-				id = key[i+1:]
-			}
-			// Same widening as the forget selector: the id a reader copies off
-			// a result line carries the elision (#855).
-			match = key == prefix || strings.HasPrefix(id, prefix) || idMatchesElided(id, prefix)
-		}
-		if match {
+		if tombstoneMatches(key, prefix) {
 			delete(set, key)
 			lifted++
 		}


### PR DESCRIPTION
`deja forget --session ab` refuses a prefix that reaches three sessions and names `--all-matches`. `deja forget --unforget ab` restored all three and reported the count afterwards — and `--unforget claude:` did it for a whole harness — while the hint printed beside `forget --list` says that form "brings one back".

Restoring is the safe direction for data, not for a decision to forget. The undo now refuses the same shape the delete refuses, and `--all-matches` does the lot.

Closes #961.