### PR TITLE
chore: pin scoop and winget to 0.16.7

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,12 +1,12 @@
 {
     "architecture": {
         "64bit": {
-            "hash": "4142ad58bdd4ddf05948145374b4b349a25bf1f883611dfd7d978702fd8ab2aa",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.6/deja-vu_0.16.6_windows_amd64.zip"
+            "hash": "5bb5978d5127e6fd4c8e87631bc833b2968492538a16ba19d792282ae5c3ca1c",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.7/deja-vu_0.16.7_windows_amd64.zip"
         },
         "arm64": {
-            "hash": "1da73f9bfef8586f89a604e11839ec5de3e6df0c51a349133133f54cbbd0a2b2",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.6/deja-vu_0.16.6_windows_arm64.zip"
+            "hash": "3c61ebe847c2a1deb11cb35eb1dae8bddf3cddc33404df8f488b6d15301ec89a",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.7/deja-vu_0.16.7_windows_arm64.zip"
         }
     },
     "autoupdate": {
@@ -24,5 +24,5 @@
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
-    "version": "0.16.6"
+    "version": "0.16.7"
 }

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.6
+PackageVersion: 0.16.7
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.6/deja-vu_0.16.6_windows_amd64.zip
-  InstallerSha256: 4142AD58BDD4DDF05948145374B4B349A25BF1F883611DFD7D978702FD8AB2AA
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.7/deja-vu_0.16.7_windows_amd64.zip
+  InstallerSha256: 5BB5978D5127E6FD4C8E87631BC833B2968492538A16BA19D792282AE5C3CA1C
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.6/deja-vu_0.16.6_windows_arm64.zip
-  InstallerSha256: 1DA73F9BFEF8586F89A604E11839EC5DE3E6DF0C51A349133133F54CBBD0A2B2
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.7/deja-vu_0.16.7_windows_arm64.zip
+  InstallerSha256: 3C61EBE847C2A1DEB11CB35EB1DAE8BDDF3CDDC33404DF8F488B6D15301EC89A
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.6
+PackageVersion: 0.16.7
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.6/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.7/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.6
+PackageVersion: 0.16.7
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Post-release pin; CI's manifest check was failing on every branch until this lands.