### PR TITLE
fix: seven places where deja said something other than what it did

### DIFF
--- a/cmd/deja/forget_shared_row_test.go
+++ b/cmd/deja/forget_shared_row_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Two transcripts can write the same harness:id, and then one manifest row
+// holds both conversations. The build says so once (#698); forget said
+// "1 session" and took two, from two projects (#970).
+func TestForgetSaysWhenARowCoversTwoConversations(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, p := range []struct{ dir, cwd, text string }{
+		{"-proj-a", "/proj-a", "FIRST conversation about the ticker"},
+		{"-proj-b", "/proj-b", "SECOND conversation about the vault"},
+	} {
+		store := filepath.Join(root, p.dir)
+		if err := os.MkdirAll(store, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		rec := `{"type":"user","message":{"role":"user","content":"` + p.text + `"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"dup","cwd":"` + p.cwd + `"}` + "\n"
+		if err := os.WriteFile(filepath.Join(store, "dup.jsonl"), []byte(rec), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "forget", "--session", "dup", "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "more than one conversation") {
+		t.Errorf("the dry run does not say the row holds two conversations:\n%s", out)
+	}
+	out, err = captureRun(t, "forget", "--session", "dup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "more than one conversation") {
+		t.Errorf("forget does not say what it took:\n%s", out)
+	}
+
+	// A row that holds one conversation says nothing extra.
+	store := filepath.Join(root, "-solo")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"a solo conversation"},"timestamp":"2026-07-12T10:00:00Z","sessionId":"solo","cwd":"/solo"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "solo.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "forget", "--session", "solo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "more than one conversation") {
+		t.Errorf("an ordinary session was called a shared row:\n%s", out)
+	}
+}

--- a/cmd/deja/forgotten_source_note_test.go
+++ b/cmd/deja/forgotten_source_note_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Asking for a forgotten session by the id you remember answered with the note
+// promoted from it and said nothing, so the reply looked like the session
+// itself until you noticed the id had changed (#971).
+func TestAskingForAForgottenSessionSaysSo(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"the decision: keep the ticker window at 30s"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"s14","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s14.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "promote", "s14"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "forget", "--session", "s14"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, cmd := range []string{"show", "ctx", "share"} {
+		note, err := captureRunStderr(t, cmd, "s14")
+		if err != nil {
+			t.Fatalf("%s: %v", cmd, err)
+		}
+		if !strings.Contains(note, "is forgotten") {
+			t.Errorf("%s answered with the note and did not say the session is gone: %q", cmd, note)
+		}
+	}
+
+	// Asking for the note itself is not a surprise, and an ordinary query that
+	// lands on it is not asking about the source at all.
+	if note, err := captureRunStderr(t, "show", "deja-note-claude-s14"); err != nil {
+		t.Fatal(err)
+	} else if strings.Contains(note, "is forgotten") {
+		t.Errorf("asking for the note by its own id was answered with a warning: %q", note)
+	}
+	if note, err := captureRunStderr(t, "ctx", "ticker window"); err != nil {
+		t.Fatal(err)
+	} else if strings.Contains(note, "is forgotten") {
+		t.Errorf("an ordinary query was answered with a warning about a session nobody named: %q", note)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1538,7 +1538,17 @@ func runForget(dir string, args []string) error {
 			fmt.Fprintf(os.Stdout, "no tombstone matches %q — `deja forget --list` shows what is forgotten\n", unforget)
 			return nil
 		}
-		fmt.Fprintf(os.Stdout, "restored %d session%s and rebuilt the index\n", lifted, pluralS(lifted))
+		// Lifting a tombstone brings a session back only if the transcript is
+		// still on this machine. An imported one lives only in the index, so
+		// forget took the last copy — and the undo reported a restore that did
+		// not happen (#967).
+		back, gone := restoredSessions(dir, unforget, lifted)
+		if back > 0 {
+			fmt.Fprintf(os.Stdout, "restored %d session%s and rebuilt the index\n", back, pluralS(back))
+		}
+		if gone > 0 {
+			fmt.Fprintf(os.Stdout, "%d of them came from another machine and deja held the only copy — the tombstone is lifted, but the records are gone; `deja sync import` brings them back\n", gone)
+		}
 		return nil
 	}
 	// The scope check runs on a dry pass first: a refusal printed after
@@ -1975,4 +1985,23 @@ func dayWord(n int) string {
 		return "a day"
 	}
 	return fmt.Sprintf("%d days", n)
+}
+
+// restoredSessions splits what a lifted tombstone actually returned from what
+// it could not: a session whose transcript is on this machine is re-read by the
+// rebuild, while an imported one existed only in the index that forget rewrote.
+func restoredSessions(dir, selector string, lifted int) (back, gone int) {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return lifted, 0
+	}
+	for _, m := range metas {
+		if index.SelectorMatches(m, selector) {
+			back++
+		}
+	}
+	if back > lifted {
+		back = lifted
+	}
+	return back, lifted - back
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1543,6 +1543,7 @@ func runForget(dir string, args []string) error {
 		// forget took the last copy — and the undo reported a restore that did
 		// not happen (#967).
 		back, gone := restoredSessions(dir, unforget, lifted)
+		restorePromotedTitles(dir, unforget)
 		if back > 0 {
 			fmt.Fprintf(os.Stdout, "restored %d session%s and rebuilt the index\n", back, pluralS(back))
 		}
@@ -2004,4 +2005,32 @@ func restoredSessions(dir, selector string, lifted int) (back, gone int) {
 		back = lifted
 	}
 	return back, lifted - back
+}
+
+// restorePromotedTitles gives a promoted note back the title it borrowed from a
+// session that has just been restored. forget clears it so the text of a
+// forgotten session does not live on in the note (#666); unforget is the moment
+// that reason stops applying (#969).
+func restorePromotedTitles(dir, selector string) {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return
+	}
+	titles := map[string]string{}
+	for _, m := range metas {
+		if !index.SelectorMatches(m, selector) {
+			continue
+		}
+		s, ok, err := index.FindByPrefix(dir, m.ID)
+		if err != nil || !ok {
+			continue
+		}
+		if t := firstUserTitle(s); t != "" {
+			titles[m.Harness+":"+m.ID] = t
+		}
+	}
+	if len(titles) == 0 {
+		return
+	}
+	_, _ = sources.RestorePromotedTitles(func(src string) string { return titles[src] })
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -454,6 +454,10 @@ func cmdCtx(dir string, rest []string) error {
 		}
 		return fmt.Errorf("no session matches %q", q)
 	}
+	// A short selector never reaches the id branch above, so a forgotten
+	// session's note arrives as an ordinary hit — and the answer still has to
+	// say the session is gone (#971).
+	noteForgottenSource(hits[0].Session, q)
 	search.PrintContext(os.Stdout, hits[0].Session, q)
 	return nil
 }
@@ -935,6 +939,9 @@ func noteAmbiguousPrefix(dir, id, action string) {
 func findByPrefix(dir, p string) (model.Session, bool, error) {
 	if err := index.Ensure(dir, "", false, os.Stderr); err == nil {
 		if s, ok, err := index.FindByPrefix(dir, p); err == nil {
+			if ok {
+				noteForgottenSource(s, p)
+			}
 			return s, ok, nil
 		}
 	}
@@ -2080,4 +2087,34 @@ func sharedRowsAmong(dir string, keys []string) int {
 		}
 	}
 	return n
+}
+
+// noteForgottenSource says when an id lookup landed on the note promoted from a
+// session that has been forgotten. Asking for the session by the id you
+// remember answered with the note and said nothing, so the reply looked like
+// the session itself until you noticed the id had changed (#971).
+func noteForgottenSource(s model.Session, selector string) {
+	if s.Harness != "deja" || !strings.HasPrefix(s.ID, "deja-note-") {
+		return
+	}
+	src, ok := strings.CutPrefix(s.ID, "deja-note-")
+	if !ok || src == "" {
+		return
+	}
+	// The selector named the source, not the note: a reader who typed the note
+	// id knows what they asked for.
+	if strings.HasPrefix(s.ID, selector) {
+		return
+	}
+	key := strings.Replace(src, "-", ":", 1)
+	// Only when the reader named that session: an ordinary topical query that
+	// happens to land on the note is not asking about the forgotten source, and
+	// the line would be noise on every such search.
+	if selector == "" || !strings.Contains(key, selector) {
+		return
+	}
+	if !index.Tombstoned(key) {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "deja: %s is forgotten — this is the note promoted from it; `deja forget --list` names what is gone\n", key)
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1554,16 +1554,24 @@ func runForget(dir string, args []string) error {
 	}
 	// The scope check runs on a dry pass first: a refusal printed after
 	// index.Forget has already written the tombstones is not a refusal.
-	if o.Session != "" && !o.DryRun {
+	//
+	// The same pass answers what is about to go: after the real Forget the rows
+	// are out of the manifest, so a row that covered two conversations can no
+	// longer be recognised (#970).
+	shared := 0
+	if !o.DryRun {
 		probe := o
 		probe.DryRun = true
 		pr, perr := index.Forget(dir, probe)
 		if perr != nil {
 			return perr
 		}
-		if err := forgetScopeRefusal(o.Session, pr.Sessions, allMatches); err != nil {
-			return err
+		if o.Session != "" {
+			if err := forgetScopeRefusal(o.Session, pr.Sessions, allMatches); err != nil {
+				return err
+			}
 		}
+		shared = sharedRowsAmong(dir, pr.Keys)
 	}
 	result, err := index.Forget(dir, o)
 	if err != nil {
@@ -1582,6 +1590,16 @@ func runForget(dir string, args []string) error {
 		}
 		if line := forgetNotesLine(result); line != "" {
 			fmt.Fprintln(os.Stdout, line)
+		}
+		// Two transcripts can write the same harness:id, and then one manifest
+		// row holds both conversations. The build says so once (#698); forget
+		// said "1 session" and took two, from two projects (#970).
+		if o.DryRun {
+			shared = sharedRowsAmong(dir, result.Keys)
+		}
+		if n := shared; n > 0 {
+			fmt.Fprintf(os.Stdout, "%s covered more than one conversation — transcripts that share an id are filed under one row, and both go\n",
+				doctorCount(n, "of them"))
 		}
 		return nil
 	}
@@ -1646,6 +1664,12 @@ func runForget(dir string, args []string) error {
 		return nil
 	}
 	fmt.Fprintf(os.Stdout, "sessions dropped: %d\nmessages dropped: %d\ntombstones added: %d\n", result.Sessions, result.Messages, result.Tombstones)
+	// "1 session" can be two conversations: transcripts that share an id are
+	// filed under one row, and the message count is the only tell (#970).
+	if shared > 0 {
+		fmt.Fprintf(os.Stdout, "%s covered more than one conversation — transcripts that share an id are filed under one row, and both went\n",
+			doctorCount(shared, "of them"))
+	}
 	// Forgetting keeps the session out of later pushes but cannot reach a
 	// machine that already has it. Three lines about what was dropped read as
 	// "it is gone everywhere" to someone forgetting a customer name (#788).
@@ -2033,4 +2057,27 @@ func restorePromotedTitles(dir, selector string) {
 		return
 	}
 	_, _ = sources.RestorePromotedTitles(func(src string) string { return titles[src] })
+}
+
+// sharedRowsAmong counts the manifest rows in keys that hold more than one
+// conversation, so forget can say what it is about to take (#970).
+func sharedRowsAmong(dir string, keys []string) int {
+	if len(keys) == 0 {
+		return 0
+	}
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return 0
+	}
+	want := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		want[k] = true
+	}
+	n := 0
+	for _, m := range metas {
+		if m.Shared && want[m.Harness+":"+m.ID] {
+			n++
+		}
+	}
+	return n
 }

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -178,6 +178,9 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Query) == "" {
 			return "", fmt.Errorf("query required")
 		}
+		if line := buildingNowForAgent(dir); line != "" {
+			return frameRecall(line), nil
+		}
 		text, sessions, raw, ids, err := recallTextResult(dir, a.Query, a.Harness, int(a.Limit), int(a.Offset), 4096-recallFrameOverhead)
 		if err == nil {
 			text = frameRecall(text) + environmentOnce(dir)
@@ -195,6 +198,9 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		}
 		if strings.TrimSpace(a.Query) == "" {
 			return "", fmt.Errorf("query required")
+		}
+		if line := buildingNowForAgent(dir); line != "" {
+			return frameRecall(line), nil
 		}
 		text, sessions, raw, ids, err := recallContextResult(dir, a.Query, a.Harness)
 		if err == nil {
@@ -610,4 +616,22 @@ func (n *mcpNumber) UnmarshalJSON(b []byte) error {
 	}
 	*n = mcpNumber(f)
 	return nil
+}
+
+// buildingNowForAgent explains the one state an agent cannot ask a human about:
+// the index is not there yet because it is being built. Without this the tool
+// call failed with `manifest: open /…/manifest.gob: no such file or directory`
+// — an internal path and an errno, handed to a model as a broken tool (#972).
+// Every other surface says the same thing in words.
+func buildingNowForAgent(dir string) string {
+	if index.HasManifest(dir) {
+		return ""
+	}
+	if st := readWarmupStatus(dir); st != nil {
+		return "deja is indexing this machine's history (" + st.progress() + "). Recall comes online in a few seconds; ask again then."
+	}
+	if index.RebuildInProgress(dir) || warmupJustRequested(dir) {
+		return "deja is indexing this machine's history. Recall comes online in a few seconds; ask again then."
+	}
+	return ""
 }

--- a/cmd/deja/mcp_building_test.go
+++ b/cmd/deja/mcp_building_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The one state an agent cannot ask a human about: the index is not there yet
+// because it is being built. The tool call failed with `manifest: open
+// /…/manifest.gob: no such file or directory` — an internal path and an errno,
+// handed to a model as a broken tool (#972).
+func TestMCPSaysTheIndexIsBeingBuiltInsteadOfFailing(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// A build asked for just now, nothing published yet.
+	if err := os.WriteFile(filepath.Join(dir, "warmup.sentinel"),
+		[]byte(strconv.FormatInt(time.Now().UnixNano(), 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := buildingNowForAgent(dir)
+	if !strings.Contains(got, "indexing") || !strings.Contains(got, "ask again") {
+		t.Errorf("an agent calling recall mid-build is told: %q", got)
+	}
+
+	// With an index in place the answer comes from the index, not from this.
+	if err := os.WriteFile(filepath.Join(dir, "manifest.gob"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := buildingNowForAgent(dir); got != "" {
+		t.Errorf("a built index still claims to be building: %q", got)
+	}
+}

--- a/cmd/deja/mcp_building_test.go
+++ b/cmd/deja/mcp_building_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
 )
 
 // The one state an agent cannot ask a human about: the index is not there yet
@@ -30,8 +32,17 @@ func TestMCPSaysTheIndexIsBeingBuiltInsteadOfFailing(t *testing.T) {
 		t.Errorf("an agent calling recall mid-build is told: %q", got)
 	}
 
-	// With an index in place the answer comes from the index, not from this.
-	if err := os.WriteFile(filepath.Join(dir, "manifest.gob"), []byte("x"), 0o600); err != nil {
+	// With a real index in place the answer comes from the index, not from
+	// this: a hand-made manifest is not one, which is what HasManifest checks.
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"a session"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"s1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
 	if got := buildingNowForAgent(dir); got != "" {

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/embed"
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/stats"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -119,6 +120,15 @@ func runStats(dir string, args []string) error {
 	ss, err := index.SearchWithRecovery(dir, search.Options{All: true}, progress)
 	if err != nil {
 		return err
+	}
+	// stats is the one screen deja calls "wrapped for sharing", and it was
+	// naming projects the trust policy keeps off every other surface — the
+	// other machine's project, in an artifact meant to be shown to someone
+	// (#966). Browsing your own store is the search activation, as in `last`
+	// (#937).
+	ss, policyHidden := policyFilterSessionsCounted(policy.ActivationSearch, ss)
+	if note := policyHiddenNote(policy.ActivationSearch, policyHidden); note != "" {
+		fmt.Fprintln(os.Stderr, note)
 	}
 	report := stats.Build(stats.Filter(ss, options), time.Now())
 	// Replaced spans are kept out of ordinary retrieval, so they are not in

--- a/cmd/deja/stats_policy_test.go
+++ b/cmd/deja/stats_policy_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// stats is the one screen deja calls "wrapped for sharing", and it named the
+// other machine's project while every other surface withheld it (#966).
+func TestStatsObeysTheTrustPolicy(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "p1", Project: "secret/api", Role: "user", Text: "peer text"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "stats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "imported:secret") {
+		t.Fatalf("the imported project is not in stats at all:\n%s", out)
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	out, err = captureRun(t, "stats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "imported:secret") {
+		t.Errorf("stats named a project the policy hides:\n%s", out)
+	}
+	note, err := captureRunStderr(t, "stats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note, "trust policy hides") {
+		t.Errorf("stats dropped sessions without saying why: %q", note)
+	}
+}

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -105,6 +105,12 @@ func runSync(dir string, args []string) error {
 			}
 			fmt.Fprintln(os.Stdout, line)
 		}
+		// Whether or not anything arrived: a batch that is entirely someone
+		// else's copy of what this machine forgot imports zero records, and
+		// "imported 0 records" alone reads as an empty batch (#968).
+		if skipped := index.ImportSkippedForgotten(); skipped > 0 {
+			fmt.Fprintf(os.Stdout, "deja: %d record%s left out — they belong to sessions you forgot here (`deja forget --list`)\n", skipped, pluralS(skipped))
+		}
 		if err != nil {
 			return err
 		}

--- a/cmd/deja/unforget_imported_test.go
+++ b/cmd/deja/unforget_imported_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// An imported session lives only in the index — forget rewrote the log and the
+// rebuild has nothing to re-read, so the undo lifted the tombstone and claimed
+// a restore that did not happen (#967).
+func TestUnforgetSaysWhenAnImportedSessionCannotComeBack(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "p1", Project: "peer/api", Role: "user", Text: "peer text"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+	var imported string
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range metas {
+		if strings.HasPrefix(m.ID, "imported-") {
+			imported = m.ID
+		}
+	}
+	if imported == "" {
+		t.Fatal("no imported session in the index")
+	}
+
+	if _, err := captureRunStderr(t, "forget", "--session", imported); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "forget", "--unforget", "claude:"+imported)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "restored 1 session") {
+		t.Errorf("the undo claimed a restore that did not happen: %q", out)
+	}
+	if !strings.Contains(out, "sync import") {
+		t.Errorf("the undo does not name the way back: %q", out)
+	}
+
+	// A local session still round-trips, and still says so.
+	if _, err := captureRunStderr(t, "forget", "--session", "loc"); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "forget", "--unforget", "claude:loc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "restored 1 session") {
+		t.Errorf("a local session no longer reports its restore: %q", out)
+	}
+}

--- a/cmd/deja/unforget_title_test.go
+++ b/cmd/deja/unforget_title_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// forget clears the title a promoted note borrowed from its source so the
+// forgotten session's first line does not survive in the note (#666). unforget
+// is the moment that reason stops applying, and the title stayed cleared for
+// good (#969).
+func TestUnforgetGivesAPromotedNoteItsBorrowedTitleBack(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"the decision: pool cap stays at 20"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"s11","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s11.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "promote", "s11"); err != nil {
+		t.Fatal(err)
+	}
+
+	title := func(t *testing.T) string {
+		t.Helper()
+		b, err := os.ReadFile(os.Getenv("DEJA_NOTES_FILE"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+			var m map[string]any
+			if json.Unmarshal([]byte(line), &m) != nil {
+				continue
+			}
+			if kind, _ := m["kind"].(string); kind == "promoted" {
+				s, _ := m["title"].(string)
+				return s
+			}
+		}
+		t.Fatal("no promoted note in the file")
+		return ""
+	}
+
+	if got := title(t); !strings.Contains(got, "pool cap") {
+		t.Fatalf("promote did not borrow a title: %q", got)
+	}
+	if _, err := captureRunStderr(t, "forget", "--session", "s11"); err != nil {
+		t.Fatal(err)
+	}
+	if got := title(t); got != "" {
+		t.Fatalf("forget left the borrowed title in place: %q", got)
+	}
+	if _, err := captureRunStderr(t, "forget", "--unforget", "claude:s11"); err != nil {
+		t.Fatal(err)
+	}
+	if got := title(t); !strings.Contains(got, "pool cap") {
+		t.Errorf("the note did not get its title back: %q", got)
+	}
+}

--- a/internal/index/import_forgotten_test.go
+++ b/internal/index/import_forgotten_test.go
@@ -1,0 +1,83 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// A session forgotten here was forgotten under its own id. Import checked only
+// the imported id, so a peer's copy walked the same text back into local search
+// under a new one while `forget --list` still called it forgotten (#968).
+func TestImportLeavesOutSessionsThisMachineForgot(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+
+	store := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"shared","timestamp":"2026-07-11T10:00:00Z","cwd":"/p","message":{"role":"user","content":"the secret I decided to forget"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "shared.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Forget(dir, ForgetOptions{Session: "shared"}); err != nil {
+		t.Fatal(err)
+	}
+
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var batch []byte
+	for _, r := range []SyncRecord{
+		{Harness: "claude", SessionID: "shared", Project: "p", Role: "user", Text: "the secret I decided to forget"},
+		{Harness: "claude", SessionID: "fresh", Project: "p", Role: "user", Text: "a peer session about the ticker"},
+	} {
+		b, err := json.Marshal(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		batch = append(batch, append(b, '\n')...)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), batch, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	added, err := Import(dir, exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if added != 1 {
+		t.Errorf("imported %d records, want 1 — the forgotten one must stay out", added)
+	}
+	if n := ImportSkippedForgotten(); n != 1 {
+		t.Errorf("reported %d records left out, want 1", n)
+	}
+	ss, err := Search(dir, query.Options{Query: "secret I decided to forget", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 0 {
+		t.Errorf("forgotten text came back through a peer's batch: %d sessions", len(ss))
+	}
+	// What the peer has that this machine never forgot still arrives.
+	ss, err = Search(dir, query.Options{Query: "peer session about the ticker", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) == 0 {
+		t.Error("a fresh peer session was dropped too")
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -112,6 +112,12 @@ type SessionMeta struct {
 	// The field is additive: a manifest written before it existed decodes with
 	// it empty and the caller degrades to saying nothing.
 	Touched []string `json:",omitempty"`
+	// Shared marks a row that covers more than one conversation: two
+	// transcripts wrote the same harness:id, so one row holds both. The build
+	// says so once (#698); forget had no way to know, and dropping "1 session"
+	// took two conversations from two projects (#970). Additive: a manifest
+	// written before this decodes with it false.
+	Shared bool `json:",omitempty"`
 	// Hit holds hashes of the specific errors this session tripped over, so
 	// the first screen can name a wall the machine keeps running into without
 	// reading a single session. Same trade as Asked: the text is recovered

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -314,6 +314,9 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 			if owns {
 				m.Sessions[key] = metaWithOrd(metaForSession(s), ord)
 			}
+			if collided {
+				markShared(m.Sessions, key)
+			}
 			for _, msg := range s.Messages {
 				if seenMsgs.dup(key, msg.Role, msg.Time, msg.Text) {
 					continue
@@ -490,6 +493,15 @@ func ReportCollisions() int {
 	return int(collisions.Swap(0))
 }
 
+// markShared records that a manifest row covers more than one conversation, so
+// a later forget can say what it is about to take (#970).
+func markShared(sessions map[string]SessionMeta, key string) {
+	if meta, ok := sessions[key]; ok {
+		meta.Shared = true
+		sessions[key] = meta
+	}
+}
+
 func rebuildForSearch(dir string, o query.Options, scope string, files map[string]FileState, progress io.Writer) error {
 	tmp := dir + ".tmp"
 	_ = os.RemoveAll(tmp)
@@ -591,6 +603,9 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 			}
 			if owns {
 				m.Sessions[key] = metaWithOrd(metaForSession(s), ord)
+			}
+			if collided {
+				markShared(m.Sessions, key)
 			}
 			for _, msg := range s.Messages {
 				if seenMsgs.dup(key, msg.Role, msg.Time, msg.Text) {
@@ -1497,6 +1512,9 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		} else if _, present := m.Sessions[key]; !present {
 			m.Sessions[key] = held
 		}
+		if collided {
+			markShared(m.Sessions, key)
+		}
 		for _, msg := range s.Messages {
 			if seenMsgs.dup(key, msg.Role, msg.Time, msg.Text) {
 				continue
@@ -1629,6 +1647,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 			owns, collided := attributeSession(meta, s)
 			if collided {
 				collisions.Add(1)
+				meta.Shared = true
 			}
 			if s.Project != "" && s.Project != "-" && owns {
 				meta.Project = s.Project

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -435,6 +435,9 @@ func Tombstones() []string {
 	return out
 }
 
+// Tombstoned reports whether one exact harness:id has been forgotten here.
+func Tombstoned(key string) bool { return readTombstones()[key] }
+
 // TombstoneMatches counts the forgotten sessions a selector would bring back,
 // without touching anything. The undo has to be able to refuse the way forget
 // does: one word restored three sessions and said so afterwards (#961).

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -261,6 +261,11 @@ func sessionMatches(meta SessionMeta, o ForgetOptions) bool {
 	return o.Session != "" || o.Project != "" || !o.Before.IsZero()
 }
 
+// SelectorMatches is selectorMatches for callers outside the package: the CLI
+// has to tell what a lifted tombstone actually brought back from what it could
+// not (#967).
+func SelectorMatches(meta SessionMeta, sel string) bool { return selectorMatches(meta, sel) }
+
 // selectorMatches reports whether a session answers to what someone typed or
 // pasted. Beyond the id prefix and the elided form (#855), that includes the
 // `harness:id` shape deja prints itself — in `forget --list`, in the undo line

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -234,13 +234,13 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 	return total, commit, nil
 }
 
-// ImportSkippedForgotten reports how many records the last Import dropped
-// because this machine had forgotten the session they belong to. The count is
-// worth saying: a peer's copy of a forgotten session is exactly what someone
-// expects deja to leave alone (#968).
+// lastImportSkippedForgotten holds how many records the last Import dropped
+// because this machine had forgotten the session they belong to.
 var lastImportSkippedForgotten int
 
-// ImportSkippedForgotten returns that count.
+// ImportSkippedForgotten reports that count. It is worth saying out loud: a
+// peer's copy of a forgotten session is exactly what someone expects deja to
+// leave alone (#968).
 func ImportSkippedForgotten() int { return lastImportSkippedForgotten }
 
 func Import(dir, inDir string) (int, error) {

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -234,6 +234,15 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 	return total, commit, nil
 }
 
+// ImportSkippedForgotten reports how many records the last Import dropped
+// because this machine had forgotten the session they belong to. The count is
+// worth saying: a peer's copy of a forgotten session is exactly what someone
+// expects deja to leave alone (#968).
+var lastImportSkippedForgotten int
+
+// ImportSkippedForgotten returns that count.
+func ImportSkippedForgotten() int { return lastImportSkippedForgotten }
+
 func Import(dir, inDir string) (int, error) {
 	if dir == "" {
 		dir = DefaultDir()
@@ -282,6 +291,8 @@ func Import(dir, inDir string) (int, error) {
 	titleRankOf := map[string]int{}   // key -> how good that turn was as a title
 	added := 0
 	var skipped []string
+	forgottenSkipped := 0
+	defer func() { lastImportSkippedForgotten = forgottenSkipped }()
 	for _, p := range paths {
 		// A file is imported whole or not at all, so what it contributed is
 		// remembered before it is read and rolled back if it turns out to be
@@ -336,7 +347,13 @@ func Import(dir, inDir string) (int, error) {
 			// Forgetting is primary data, not cache: a tombstoned session
 			// must stay dead even when the peer still holds the batch and
 			// this index was wiped and rebuilt.
-			if dead[sr.Harness+":"+importID] {
+			//
+			// Both keys, because a session forgotten here was forgotten under
+			// its own id: checking only the imported one let a peer's copy walk
+			// the same text back into local search under a new id, while
+			// `forget --list` still called it forgotten (#968).
+			if dead[sr.Harness+":"+importID] || dead[sr.Harness+":"+origID] {
+				forgottenSkipped++
 				return nil
 			}
 			// The exclude list keeps a project out of this machine's memory;

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -431,6 +431,33 @@ func ForgetPromotedTitles(match func(session string) bool) (int, error) {
 	})
 }
 
+// RestorePromotedTitles fills the title back in for promoted notes whose source
+// session is available again. `forget` clears it so the forgotten session's
+// first line does not survive in the note (#666); when the session comes back
+// the reason is gone, and without this the note stayed "promoted from <src>"
+// forever — a round trip through forget/unforget left the store worse than it
+// found it (#969).
+func RestorePromotedTitles(titleFor func(session string) string) (int, error) {
+	return rewriteNotes(func(m map[string]any) (map[string]any, bool) {
+		if kind, _ := m["kind"].(string); kind != "promoted" {
+			return m, false
+		}
+		if title, _ := m["title"].(string); title != "" {
+			return m, false
+		}
+		src, _ := m["session"].(string)
+		if src == "" {
+			return m, false
+		}
+		title := titleFor(src)
+		if title == "" {
+			return m, false
+		}
+		m["title"] = title
+		return m, true
+	})
+}
+
 // rewriteNotes applies edit to every note line: it returns the replacement and
 // whether anything changed, and a nil replacement deletes the line. The file is
 // written through temp+rename, and the temp file is removed when the write


### PR DESCRIPTION
One branch, seven measured findings — the windows job is slow, so they travel together.

- **#966** `deja stats` — the screen whose own subtitle is "wrapped for sharing" — counted and named projects the trust policy hides on every other surface.
- **#967** `--unforget` reported `restored 1 session` for an imported session deja no longer had: the transcript lives on the machine it came from, so forget took the last copy. It now says the tombstone is lifted and names `sync import` as the way back.
- **#968** a peer's batch walked forgotten text back into local search under a new id — the tombstone was checked under the imported id only. Both keys now, and the skip is reported.
- **#969** a forget/unforget round trip left a promoted note without the title it borrowed, forever; the reason for clearing it is gone once the session is back.
- **#970** `forget` on an id that two transcripts share said "1 session" and took two conversations. The collision is recorded on the manifest row, and both forms of the command say so.
- **#971** asking for a forgotten session by id quietly answered with the note promoted from it — `show`, `ctx` and `share` alike.
- **#972** an agent's first `recall` during the initial build got `manifest: open …/manifest.gob: no such file or directory` as a tool error. It now gets the same sentence every other surface uses.

Each has a test that fails when its fix is reverted. Coverage floors hold (cmd/deja 90.1, internal/index 90.0).