### PR TITLE
Fix ten memory-lifecycle and trust-policy holes

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -586,6 +586,25 @@ func doctorTools(w io.Writer) {
 	fmt.Fprintf(w, "  %-12s %s (needed for changed-file notes, worktree names and the task signal)\n", "git", gitStatus)
 }
 
+// policyWithheldCounts reports, per activation, how many indexed sessions the
+// policy in force keeps off that path, and how many are indexed in all.
+func policyWithheldCounts(dir string) (map[string]int, int) {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return nil, 0
+	}
+	pol := policy.Load()
+	out := map[string]int{}
+	for _, activation := range []string{policy.ActivationSearch, policy.ActivationMCP, policy.ActivationAuto} {
+		for _, m := range metas {
+			if !pol.Allows(activation, m.Project) {
+				out[activation]++
+			}
+		}
+	}
+	return out, len(metas)
+}
+
 // unmatchedImportGroups lists imported:<group> rules that no session in the
 // index answers to.
 func unmatchedImportGroups(dir string) []string {
@@ -629,8 +648,13 @@ func doctorPolicy(w io.Writer, dir string) {
 		// allowed (#939).
 		if pol := policy.Load(); pol.Describe(policy.ActivationAuto) != "local+imported" {
 			fmt.Fprintf(w, "  %-12s no file at %s\n", "default", policy.Path())
+			withheld, total := policyWithheldCounts(dir)
 			for _, activation := range []string{policy.ActivationSearch, policy.ActivationMCP, policy.ActivationAuto} {
-				fmt.Fprintf(w, "  %-12s %s\n", activation, pol.Describe(activation))
+				line := pol.Describe(activation)
+				if n := withheld[activation]; n > 0 {
+					line += fmt.Sprintf(" — withholds %d of %d indexed session%s", n, total, pluralS(total))
+				}
+				fmt.Fprintf(w, "  %-12s %s\n", activation, line)
 			}
 			fmt.Fprintf(w, "  %-12s DEJA_AUTORECALL_LOCAL_ONLY is set in this environment\n", "from env")
 			return
@@ -646,8 +670,16 @@ func doctorPolicy(w io.Writer, dir string) {
 		return
 	}
 	pol := policy.Load()
+	withheld, total := policyWithheldCounts(dir)
 	for _, activation := range []string{policy.ActivationSearch, policy.ActivationMCP, policy.ActivationAuto} {
-		fmt.Fprintf(w, "  %-12s %s\n", activation, pol.Describe(activation))
+		line := pol.Describe(activation)
+		// The rule's text is not its effect. `search local-only` reads the
+		// same whether it withholds nothing or the whole index, and doctor is
+		// where someone checks that the rule does what they meant (#978).
+		if n := withheld[activation]; n > 0 {
+			line += fmt.Sprintf(" — withholds %d of %d indexed session%s", n, total, pluralS(total))
+		}
+		fmt.Fprintf(w, "  %-12s %s\n", activation, line)
 	}
 	for _, u := range unknown {
 		fmt.Fprintf(w, "  %-12s %q is not an activation or origin deja consults — this rule does nothing\n", "ignored", u)

--- a/cmd/deja/doctor_policy_effect_test.go
+++ b/cmd/deja/doctor_policy_effect_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// doctor prints the rule's text, and the text is not its effect: `search
+// local-only` reads the same whether it withholds nothing or the whole index,
+// while every other surface says what it kept back (#978).
+func TestDoctorPolicySaysHowMuchTheRuleWithholds(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer9", Project: "work/api", Role: "user", Text: "peer work on the vault rotation"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	var out bytes.Buffer
+	doctorPolicy(&out, dir)
+	got := out.String()
+	if !strings.Contains(got, "withholds 1 of 2 indexed sessions") {
+		t.Errorf("doctor does not say what the rule keeps back:\n%s", got)
+	}
+	// The paths the rule leaves alone must not claim to withhold anything.
+	for _, line := range strings.Split(got, "\n") {
+		if strings.Contains(line, "local+imported") && strings.Contains(line, "withholds") {
+			t.Errorf("an unrestricted path was said to withhold rows: %q", line)
+		}
+	}
+
+	// A rule that matches nothing in this index is the case the count exists
+	// to separate from a rule that empties it.
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported:nobody":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	doctorPolicy(&out, dir)
+	if strings.Contains(out.String(), "withholds") {
+		t.Errorf("a rule that hides nothing was counted as withholding:\n%s", out.String())
+	}
+}

--- a/cmd/deja/forget_unwritable_test.go
+++ b/cmd/deja/forget_unwritable_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The tombstone is written before the rebuild that takes the records out. When
+// the index cannot be written, forget handed back `mkdir /…/idx.tmp: permission
+// denied` and left the reader believing the session was gone while search kept
+// returning it (#976).
+func TestForgetSaysWhatIsStillVisibleWhenTheIndexCannotBeWritten(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"the decision about the retry counter"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"s19","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s19.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Join(tmp, "ro")
+	dir := filepath.Join(parent, "index.db")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parent, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(parent, 0o755)
+		_ = os.Chmod(dir, 0o755)
+	})
+
+	_, err := captureRun(t, "forget", "--session", "s19")
+	if err == nil {
+		t.Fatal("forget reported success with an index it could not write")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, ".tmp") || strings.Contains(msg, "mkdir") {
+		t.Errorf("the failure names an internal path: %q", msg)
+	}
+	if !strings.Contains(msg, "check the directory's permissions") {
+		t.Errorf("the failure does not say what to change: %q", msg)
+	}
+	if !strings.Contains(msg, "still in the index") {
+		t.Errorf("the failure does not say the session is still visible: %q", msg)
+	}
+}

--- a/cmd/deja/forget_unwritable_test.go
+++ b/cmd/deja/forget_unwritable_test.go
@@ -91,30 +91,18 @@ func TestForgetKeyOfNamesTheSessionASelectorReached(t *testing.T) {
 }
 
 // The dry probe that decides the scope refusal fails the same ways the real
-// pass does; handing its syscall back was the shape #798 replaced everywhere
-// else (#976).
-func TestForgetOnAVanishedIndexDiskNamesTheDisk(t *testing.T) {
+// pass does, and its error went out raw: on an ejected volume `deja forget`
+// answered `mkdir /Volumes/dejaidx: permission denied` (#976). Measured on a
+// real HFS+ image; here the same shape is exercised through ensureError, which
+// is what the probe now uses.
+func TestForgetProbeErrorIsWordedLikeEveryOther(t *testing.T) {
 	tmp := hermeticEnv(t)
-	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
-	if err := os.MkdirAll(store, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	rec := `{"type":"user","message":{"role":"user","content":"a session about the vault"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"s22","cwd":"/proj"}` + "\n"
-	if err := os.WriteFile(filepath.Join(store, "s22.jsonl"), []byte(rec), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	// A mount point that is not there: the index directory and its parent are
-	// both missing, which is what an ejected volume leaves behind.
-	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "gone-volume", "index.db"))
-
-	_, err := captureRun(t, "forget", "--session", "s22")
-	if err == nil {
-		t.Fatal("forget reported success against a vanished disk")
-	}
-	if !strings.Contains(err.Error(), "is not there") || !strings.Contains(err.Error(), "unmounted") {
-		t.Errorf("the failure does not name the disk: %q", err.Error())
+	gone := filepath.Join(tmp, "gone-volume", "index.db")
+	err := ensureError(gone, os.ErrPermission)
+	if err == nil || !strings.Contains(err.Error(), "is not there") {
+		t.Errorf("a vanished mount point is worded as: %v", err)
 	}
 	if strings.Contains(err.Error(), "mkdir") {
-		t.Errorf("the failure is still a syscall: %q", err.Error())
+		t.Errorf("the wording is still a syscall: %v", err)
 	}
 }

--- a/cmd/deja/forget_unwritable_test.go
+++ b/cmd/deja/forget_unwritable_test.go
@@ -62,3 +62,30 @@ func TestForgetSaysWhatIsStillVisibleWhenTheIndexCannotBeWritten(t *testing.T) {
 		t.Errorf("the failure does not say the session is still visible: %q", msg)
 	}
 }
+
+// forgetKeyOf answers "which session did this selector reach", which is what
+// lets the failure above say whether the tombstone landed (#976).
+func TestForgetKeyOfNamesTheSessionASelectorReached(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"a session"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"abc123","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "abc123.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := forgetKeyOf(dir, index.ForgetOptions{Session: "abc"}); got != "claude:abc123" {
+		t.Errorf("forgetKeyOf(prefix) = %q, want claude:abc123", got)
+	}
+	if got := forgetKeyOf(dir, index.ForgetOptions{Session: "nothing-like-it"}); got != "" {
+		t.Errorf("a selector matching nothing named %q", got)
+	}
+	if got := forgetKeyOf(dir, index.ForgetOptions{Project: "proj"}); got != "" {
+		t.Errorf("a project selector named a single session: %q", got)
+	}
+}

--- a/cmd/deja/forget_unwritable_test.go
+++ b/cmd/deja/forget_unwritable_test.go
@@ -89,3 +89,32 @@ func TestForgetKeyOfNamesTheSessionASelectorReached(t *testing.T) {
 		t.Errorf("a project selector named a single session: %q", got)
 	}
 }
+
+// The dry probe that decides the scope refusal fails the same ways the real
+// pass does; handing its syscall back was the shape #798 replaced everywhere
+// else (#976).
+func TestForgetOnAVanishedIndexDiskNamesTheDisk(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"a session about the vault"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"s22","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s22.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A mount point that is not there: the index directory and its parent are
+	// both missing, which is what an ejected volume leaves behind.
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "gone-volume", "index.db"))
+
+	_, err := captureRun(t, "forget", "--session", "s22")
+	if err == nil {
+		t.Fatal("forget reported success against a vanished disk")
+	}
+	if !strings.Contains(err.Error(), "is not there") || !strings.Contains(err.Error(), "unmounted") {
+		t.Errorf("the failure does not name the disk: %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "mkdir") {
+		t.Errorf("the failure is still a syscall: %q", err.Error())
+	}
+}

--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -153,7 +153,11 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 	}
 	var newest model.Session
 	distinct := map[string]bool{}
-	hidden := 0
+	// By session, not by pass: a directory yields several project-name
+	// candidates and the same session answers to more than one of them, so
+	// counting per pass told the reader the rule hides more than the project
+	// holds (#981).
+	hidden := map[string]bool{}
 	for _, name := range digest.ProjectNameCandidates(cwd) {
 		ss, err := index.RecentProject(dir, name, 3)
 		if err != nil || len(ss) == 0 {
@@ -163,8 +167,16 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 		// listing does and what a listing filters (#937). Without this the
 		// pick landed on a session the rule keeps out of recall and packaged
 		// its content for another agent (#953).
-		kept, dropped := policyFilterSessionsCounted(policy.ActivationSearch, ss)
-		hidden += dropped
+		kept, _ := policyFilterSessionsCounted(policy.ActivationSearch, ss)
+		keptIDs := map[string]bool{}
+		for _, k := range kept {
+			keptIDs[k.ID] = true
+		}
+		for _, s := range ss {
+			if !keptIDs[s.ID] {
+				hidden[s.ID] = true
+			}
+		}
 		if len(kept) == 0 {
 			continue
 		}
@@ -174,8 +186,8 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 		}
 	}
 	if newest.ID == "" {
-		if hidden > 0 {
-			return model.Session{}, errors.New(strings.TrimPrefix(policyHiddenNote(policy.ActivationSearch, hidden), "deja: "))
+		if len(hidden) > 0 {
+			return model.Session{}, errors.New(strings.TrimPrefix(policyHiddenNote(policy.ActivationSearch, len(hidden)), "deja: "))
 		}
 		return model.Session{}, fmt.Errorf("no indexed sessions for this project — pass a session id-prefix (see `deja last`)")
 	}

--- a/cmd/deja/handoff_policy_test.go
+++ b/cmd/deja/handoff_policy_test.go
@@ -29,7 +29,10 @@ func TestHandoffWithNoIdObeysTheTrustPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Newer than the local one, so it wins any recency contest.
-	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "proj", Role: "user", Text: "PEER SECRET: the vault rotation runs at 03:00"})
+	// Project "work/proj" under a directory of the same shape: it answers to
+	// two of the name candidates the directory yields, which is what the
+	// count has to survive (#981).
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "work/proj", Role: "user", Text: "PEER SECRET: the vault rotation runs at 03:00"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +48,7 @@ func TestHandoffWithNoIdObeysTheTrustPolicy(t *testing.T) {
 	}
 	// handoff takes the project from the working directory, so the test has to
 	// stand in one whose name matches.
-	work := filepath.Join(tmp, "proj")
+	work := filepath.Join(tmp, "work", "proj")
 	if err := os.MkdirAll(work, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +83,15 @@ func TestHandoffWithNoIdObeysTheTrustPolicy(t *testing.T) {
 	if err := index.Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := handoffSource(dir, ""); err == nil || !strings.Contains(err.Error(), "trust policy") {
+	_, err = handoffSource(dir, "")
+	if err == nil || !strings.Contains(err.Error(), "trust policy") {
 		t.Errorf("with everything hidden, handoff said: %v", err)
+	}
+	// One session is hidden here, and a directory answers to several project
+	// names — the count is the only thing telling the reader how much the rule
+	// holds back, and per-pass addition named more than the project holds
+	// (#981).
+	if err != nil && !strings.Contains(err.Error(), "hides 1 matching session ") {
+		t.Errorf("the count is not what the project holds: %v", err)
 	}
 }

--- a/cmd/deja/lifecycle.go
+++ b/cmd/deja/lifecycle.go
@@ -31,6 +31,14 @@ func attachLifecycles(hits []search.Hit) {
 	for i := range hits {
 		h := &hits[i]
 		key := h.Session.Harness + ":" + h.Session.ID
+		// A promoted note is filed under its own id, so the state — which is a
+		// property of the decision, not of the transcript — never reached it.
+		// Recall shows the lines that matched, and a rejection whose words are
+		// not in the query simply did not appear: the agent was handed the
+		// accepted line of a decision that had been taken back (#974).
+		if src, ok := strings.CutPrefix(h.Session.ID, "deja-note-"); ok && h.Session.Harness == "deja" {
+			key = strings.Replace(src, "-", ":", 1)
+		}
 		lc, ok := states[key]
 		if !ok || lc.State == "" || lc.State == "accepted" {
 			continue

--- a/cmd/deja/lifecycle.go
+++ b/cmd/deja/lifecycle.go
@@ -5,11 +5,28 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
 const lifecycleRejected = "rejected"
+
+// promotedNoteID returns the id a promoted note has on the machine that made
+// it: after a sync the local id is imported-<hash>, and every rule written for
+// notes keys on the deja-note- shape (#975).
+func promotedNoteID(s model.Session) string {
+	if s.Harness != "deja" {
+		return ""
+	}
+	if strings.HasPrefix(s.ID, "deja-note-") {
+		return s.ID
+	}
+	if strings.HasPrefix(s.OrigID, "deja-note-") {
+		return s.OrigID
+	}
+	return ""
+}
 
 // attachLifecycles marks hits whose decision was later rejected, superseded or
 // left to go stale.
@@ -24,10 +41,10 @@ func attachLifecycles(hits []search.Hit) {
 	if len(hits) == 0 {
 		return
 	}
+	// An empty local table is not "nothing to attach": a note that arrived by
+	// sync carries its state in the index, because the states themselves live
+	// in the other machine's notes.jsonl and never travel (#975).
 	states := sources.PromotedLifecycles()
-	if len(states) == 0 {
-		return
-	}
 	for i := range hits {
 		h := &hits[i]
 		key := h.Session.Harness + ":" + h.Session.ID
@@ -36,11 +53,22 @@ func attachLifecycles(hits []search.Hit) {
 		// Recall shows the lines that matched, and a rejection whose words are
 		// not in the query simply did not appear: the agent was handed the
 		// accepted line of a decision that had been taken back (#974).
-		if src, ok := strings.CutPrefix(h.Session.ID, "deja-note-"); ok && h.Session.Harness == "deja" {
-			key = strings.Replace(src, "-", ":", 1)
+		if noteID := promotedNoteID(h.Session); noteID != "" {
+			if src, ok := strings.CutPrefix(noteID, "deja-note-"); ok {
+				key = strings.Replace(src, "-", ":", 1)
+			}
 		}
 		lc, ok := states[key]
-		if !ok || lc.State == "" || lc.State == "accepted" {
+		if !ok || lc.State == "" {
+			// An imported note brought its state with it: the machine that
+			// made the decision keeps the states, and notes.jsonl does not
+			// travel (#975).
+			if h.Session.Lifecycle != "" && h.Session.Lifecycle != "accepted" {
+				h.Lifecycle, h.LifecycleNote, h.LifecycleAt = h.Session.Lifecycle, h.Session.LifecycleNote, h.Session.LifecycleAt
+			}
+			continue
+		}
+		if lc.State == "accepted" {
 			continue
 		}
 		h.Lifecycle = lc.State
@@ -144,11 +172,21 @@ func demotedNote(hits []search.Hit, moved int) string {
 	if moved == 0 {
 		return ""
 	}
-	n := 0
+	n, elsewhere := 0, 0
 	for _, h := range hits {
-		if h.Lifecycle == lifecycleRejected {
-			n++
+		if h.Lifecycle != lifecycleRejected {
+			continue
 		}
+		n++
+		// "you marked" is wrong for a decision another machine took back: the
+		// state travelled with the note, the judgement was not this reader's
+		// (#975).
+		if strings.HasPrefix(h.Session.Project, "imported:") {
+			elsewhere++
+		}
+	}
+	if elsewhere == n {
+		return fmt.Sprintf("%d session%s marked rejected on the machine %s came from %s below the rest", n, pluralS(n), theyOrIt(n), verbWere2(n))
 	}
 	return fmt.Sprintf("%d session%s you marked rejected %s below the rest", n, pluralS(n), verbWere2(n))
 }
@@ -158,4 +196,12 @@ func verbWere2(n int) string {
 		return "is"
 	}
 	return "are"
+}
+
+// theyOrIt keeps the sentence about other machines readable for one and many.
+func theyOrIt(n int) string {
+	if n == 1 {
+		return "it"
+	}
+	return "they"
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1944,17 +1944,12 @@ func ensureError(dir string, err error) error {
 	if dir == "" {
 		dir = index.DefaultDir()
 	}
-	// Before permissions: a volume that was ejected takes its mount point with
-	// it, and creating that point back fails with EPERM on macOS — so the
-	// errno says permissions while the disk is simply gone. The same trap the
-	// notes and export paths hit (#893, #906), and the reader is sent to check
-	// the permissions of a directory that no longer exists (#931).
 	if errors.Is(err, fs.ErrPermission) {
 		// An ejected volume takes its mount point with it, and creating that
 		// point back fails with EPERM on macOS — so the errno says permissions
-		// while the disk is simply gone, and the reader is sent to check the
-		// permissions of a directory that no longer exists. The same check the
-		// notes and export paths make (#893, #906, #931).
+		// while the disk is simply gone. The same trap the notes and export
+		// paths hit (#893, #906), and the reader is sent to check the
+		// permissions of a directory that no longer exists (#931).
 		if parent := filepath.Dir(dir); !dirExists(dir) && !dirExists(parent) {
 			return fmt.Errorf("the index directory is not there (%s) — the disk it lives on may have been unmounted; reconnect it, or point DEJA_INDEX_DIR somewhere local", parent)
 		}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1571,7 +1571,10 @@ func runForget(dir string, args []string) error {
 		probe.DryRun = true
 		pr, perr := index.Forget(dir, probe)
 		if perr != nil {
-			return perr
+			// The probe fails the same ways the real pass does — a vanished
+			// volume, a read-only cache — and handing its syscall back was the
+			// shape #798 replaced everywhere else.
+			return ensureError(dir, perr)
 		}
 		if o.Session != "" {
 			if err := forgetScopeRefusal(o.Session, pr.Sessions, allMatches); err != nil {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1582,7 +1582,14 @@ func runForget(dir string, args []string) error {
 	}
 	result, err := index.Forget(dir, o)
 	if err != nil {
-		return err
+		// The tombstone is already written; what failed is the rebuild that
+		// takes the records out. Handing back `mkdir /…/idx.tmp: permission
+		// denied` names an internal path and leaves the reader believing the
+		// session is gone while search still returns it (#976).
+		if !o.DryRun && index.Tombstoned(forgetKeyOf(dir, o)) {
+			return fmt.Errorf("%v\nthe session is marked forgotten and is still in the index until it can be rebuilt — search keeps returning it until then", ensureError(dir, err))
+		}
+		return ensureError(dir, err)
 	}
 	if o.DryRun {
 		fmt.Fprintf(os.Stdout, "dry run — nothing was changed\nwould drop: %d session(s), %d message(s)\nwould add: %d tombstone(s)\n",
@@ -2117,4 +2124,22 @@ func noteForgottenSource(s model.Session, selector string) {
 		return
 	}
 	fmt.Fprintf(os.Stderr, "deja: %s is forgotten — this is the note promoted from it; `deja forget --list` names what is gone\n", key)
+}
+
+// forgetKeyOf names the exact session a selector reached, so a failed forget
+// can tell whether the tombstone landed (#976).
+func forgetKeyOf(dir string, o index.ForgetOptions) string {
+	if o.Session == "" {
+		return ""
+	}
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return ""
+	}
+	for _, m := range metas {
+		if index.SelectorMatches(m, o.Session) {
+			return m.Harness + ":" + m.ID
+		}
+	}
+	return ""
 }

--- a/cmd/deja/note_state_travels_test.go
+++ b/cmd/deja/note_state_travels_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// A promoted note is filed under its own id, so the lifecycle state — a
+// property of the decision, not of the transcript — never reached it. Recall
+// shows the lines that matched, and a rejection whose words are not in the
+// query never appeared: the agent was handed the accepted line of a decision
+// that had been taken back (#974).
+func TestAPromotedNoteCarriesItsOwnState(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"decision about the pool cap"},"timestamp":"2026-07-12T10:00:00Z","sessionId":"s1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "promote", "s1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "promote", "s1", "--state", "rejected", "--note", "not after all"); err != nil {
+		t.Fatal(err)
+	}
+
+	hits := []search.Hit{
+		{Session: model.Session{Harness: "deja", ID: "deja-note-claude-s1"}},
+		{Session: model.Session{Harness: "claude", ID: "s1"}},
+	}
+	attachLifecycles(hits)
+	if hits[0].Lifecycle != "rejected" {
+		t.Errorf("the note carries lifecycle %q, want rejected", hits[0].Lifecycle)
+	}
+	if hits[1].Lifecycle != "rejected" {
+		t.Errorf("the transcript stopped carrying its state: %q", hits[1].Lifecycle)
+	}
+	if !strings.Contains(lifecycleLine(hits[0]), "tried and rejected") {
+		t.Errorf("the note's line does not say what happened: %q", lifecycleLine(hits[0]))
+	}
+	// An ordinary session with no decision on it stays unmarked.
+	other := []search.Hit{{Session: model.Session{Harness: "claude", ID: "unrelated"}}}
+	attachLifecycles(other)
+	if other[0].Lifecycle != "" {
+		t.Errorf("an unrelated session was marked %q", other[0].Lifecycle)
+	}
+}

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -77,14 +77,27 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	if !ok {
 		return fmt.Errorf("no session matches %q", prefix)
 	}
+	src := s.Harness + ":" + s.ID
 	if s.Harness == "deja" {
-		return fmt.Errorf("%q is already a note — promote the source session instead", prefix)
+		// A correction on a promoted note is what `promote` tells you to write,
+		// and the id in that hint stops resolving to the transcript once the
+		// source is forgotten: both routes then refused, and "promote the
+		// source session instead" named something that is gone for good — the
+		// note froze at whatever state it held (#979).
+		origin, noteTitle, isPromoted := promotedNoteSource(s.ID)
+		if !isPromoted {
+			return fmt.Errorf("%q is a note you wrote, not a session — `deja remember` adds to it", prefix)
+		}
+		src = origin
+		// The session's title here is the note's own display line, and once
+		// forget clears the borrowed one that line is "promoted from <src>" —
+		// which would be echoed back as the title of the correction.
+		s.Title = noteTitle
 	}
 	text := strings.TrimSpace(noteText)
 	if text == "" {
 		text = distillSession(s)
 	}
-	src := s.Harness + ":" + s.ID
 	prior := sources.PromotedLifecycles()[src]
 	title := strings.TrimSpace(s.Title)
 	if title == "" {
@@ -334,4 +347,22 @@ func endsWithNewline(path string) bool {
 		return true
 	}
 	return buf[0] == '\n'
+}
+
+// promotedNoteSource maps a promoted note's id back to the session it was
+// promoted from. The id is built by replacing the colon in `harness:id`, which
+// does not invert on its own — harness names carry dashes — so the note log is
+// the authority.
+func promotedNoteSource(noteID string) (string, string, bool) {
+	src, title, found := "", "", false
+	for _, n := range sources.LoadPromotedNotes() {
+		if n.Session == "" || "deja-note-"+strings.ReplaceAll(n.Session, ":", "-") != noteID {
+			continue
+		}
+		src, found = n.Session, true
+		if t := strings.TrimSpace(n.Title); t != "" {
+			title = t
+		}
+	}
+	return src, title, found
 }

--- a/cmd/deja/promote_forgotten_source_test.go
+++ b/cmd/deja/promote_forgotten_source_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The note outlives the session it came from — that is what forget promises
+// when it keeps it. But the id promote hands out for corrections then resolves
+// to the note, both routes refused, and the advice named a session that is gone
+// for good: the note froze at `accepted` and recall kept serving a withdrawn
+// decision (#979).
+func TestCorrectionReachesANoteWhoseSourceIsForgotten(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"should we raise the pool cap"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"srcx","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "promote", "srcx", "--state", "accepted", "--note", "pool cap goes to 200"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "forget", "--session", "srcx"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "promote", "srcx", "--state", "rejected", "--note", "rolled back, the cap stays at 20")
+	if err != nil {
+		t.Fatalf("the correction was refused: %v", err)
+	}
+	if !strings.Contains(out, "as rejected") {
+		t.Errorf("the correction did not land:\n%s", out)
+	}
+	// It belongs to the note the decision lives in, not to a second one, and
+	// it leads — the withdrawal is the answer that holds.
+	shown, err := captureRun(t, "show", "deja-note-claude-srcx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(shown, "rolled back") || !strings.Contains(shown, "pool cap goes to 200") {
+		t.Errorf("the note lost one of the two marks:\n%s", shown)
+	}
+	if strings.Index(shown, "rolled back") > strings.Index(shown, "pool cap goes to 200") {
+		t.Errorf("the correction sits behind the mark it takes back:\n%s", shown)
+	}
+	// The title of a note whose borrowed one forget cleared must not be the
+	// display fallback echoed back at the reader.
+	if strings.Contains(out, "promoted from claude:srcx") {
+		t.Errorf("the correction took the note's display line as its title:\n%s", out)
+	}
+
+	// The backside: a note someone wrote with `remember` is not a promotion,
+	// and turning it into one would invent a source session.
+	if _, err := captureRun(t, "remember", "plain note about the cert"); err != nil {
+		t.Fatal(err)
+	}
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	day := ""
+	for _, m := range metas {
+		if strings.HasPrefix(m.ID, "deja-20") {
+			day = m.ID
+		}
+	}
+	if day == "" {
+		t.Fatal("no day note to try")
+	}
+	if _, err := captureRun(t, "promote", day, "--state", "rejected"); err == nil {
+		t.Errorf("a note written by hand was promoted as if it had a source session")
+	} else if !strings.Contains(err.Error(), "not a session") {
+		t.Errorf("the refusal does not say what the id is: %v", err)
+	}
+}

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -131,6 +131,10 @@ func runStats(dir string, args []string) error {
 		fmt.Fprintln(os.Stderr, note)
 	}
 	report := stats.Build(stats.Filter(ss, options), time.Now())
+	// The rule that emptied the report is named a line above, so "nothing
+	// indexed yet — run `deja index`" is advice for a state deja is not in:
+	// the same backside `last` grew when it learned to filter (#949, #983).
+	report.EmptiedByPolicy = report.TotalSessions == 0 && policyHidden > 0
 	// Replaced spans are kept out of ordinary retrieval, so they are not in
 	// the sessions above and take a pass of their own.
 	if spans, files, err := index.SpanInventory(dir); err == nil {
@@ -223,6 +227,12 @@ func printStats(w io.Writer, r stats.Report) {
 	// Section headings over an empty index read as a broken report rather
 	// than an empty one. Say what is missing and stop.
 	if r.TotalSessions == 0 {
+		if r.EmptiedByPolicy {
+			// The rule is named on stderr a line above; repeating "run `deja
+			// index`" here sends the reader after a build that changes nothing.
+			fmt.Fprintln(w, "deja: nothing to report — the trust policy withholds every indexed session from this path")
+			return
+		}
 		fmt.Fprintln(w, emptyIndexHint("nothing indexed yet"))
 		return
 	}

--- a/cmd/deja/stats_policy_test.go
+++ b/cmd/deja/stats_policy_test.go
@@ -70,3 +70,58 @@ func TestStatsObeysTheTrustPolicy(t *testing.T) {
 		t.Errorf("stats dropped sessions without saying why: %q", note)
 	}
 }
+
+// The rule that emptied the report is named a line above, so "nothing indexed
+// yet — run `deja index`" is advice for a state deja is not in: the backside
+// `last` grew in #949 and stats kept (#983).
+func TestStatsEmptiedByPolicyDoesNotAdviseAnIndexRun(t *testing.T) {
+	tmp := hermeticEnv(t)
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "work/api", Role: "user", Text: "peer work on the vault"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	out, err := captureRun(t, "stats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "nothing indexed yet") {
+		t.Errorf("an index full of withheld sessions was called unbuilt:\n%s", out)
+	}
+	if !strings.Contains(out, "trust policy") {
+		t.Errorf("stats does not name the rule that emptied it:\n%s", out)
+	}
+
+	// A machine with nothing indexed keeps the advice that fits it.
+	tmp2 := hermeticEnv(t)
+	dir2 := filepath.Join(tmp2, "index.db")
+	if err := index.Ensure(dir2, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "stats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "nothing indexed yet") {
+		t.Errorf("an empty index lost its advice:\n%s", out)
+	}
+}

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -81,6 +81,12 @@ func runSync(dir string, args []string) error {
 			return err
 		}
 		fmt.Fprintf(os.Stdout, "deja: exported %d records\n", n)
+		// A watermark is per machine, not per destination: the second peer you
+		// hand memory to gets an empty folder and the same "exported 0
+		// records" that means "you are up to date" at the first one (#982).
+		if n == 0 && !full && !hasSyncBatches(out) {
+			fmt.Fprintf(os.Stdout, "deja: nothing has changed since the last export, and this folder holds no batch from this machine — `deja sync export %s --full` sends everything\n", out)
+		}
 		masked := 0
 		if rs, rerr := index.Redactions(dir); rerr == nil {
 			masked = rs.Total
@@ -125,4 +131,18 @@ func runSync(dir string, args []string) error {
 	default:
 		return fmt.Errorf("unknown sync command %q", args[0])
 	}
+}
+
+// hasSyncBatches reports whether a directory already holds exported batches.
+func hasSyncBatches(out string) bool {
+	entries, err := os.ReadDir(out)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), "deja-sync-") && strings.HasSuffix(e.Name(), ".jsonl") {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/deja/sync_second_peer_test.go
+++ b/cmd/deja/sync_second_peer_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The watermark is per machine, not per destination: the second peer someone
+// hands memory to gets an empty folder and the same "exported 0 records" that
+// means "you are up to date" at the first one (#982).
+func TestExportToASecondDestinationSaysWhyItIsEmpty(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	first := filepath.Join(tmp, "to-laptop")
+	if err := os.MkdirAll(first, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "sync", "export", first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "exported 1 records") {
+		t.Fatalf("the first export did not carry the session:\n%s", out)
+	}
+	// Same destination again is the up-to-date case and must stay quiet about
+	// --full: there is nothing to send there.
+	out, err = captureRun(t, "sync", "export", first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "--full") {
+		t.Errorf("a destination that already holds the batch was told to resend:\n%s", out)
+	}
+
+	second := filepath.Join(tmp, "to-desktop")
+	if err := os.MkdirAll(second, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "sync", "export", second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "--full") {
+		t.Errorf("an empty second destination said nothing about how to fill it:\n%s", out)
+	}
+	entries, err := os.ReadDir(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("the incremental export wrote something after all: %v", entries)
+	}
+
+	// And --full fills it, after which the folder is up to date like any other.
+	if _, err := captureRun(t, "sync", "export", second, "--full"); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "sync", "export", second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "--full") {
+		t.Errorf("a filled destination kept being told to resend:\n%s", out)
+	}
+}

--- a/cmd/deja/testmain_test.go
+++ b/cmd/deja/testmain_test.go
@@ -24,8 +24,11 @@ func TestMain(m *testing.M) {
 		"XDG_CONFIG_HOME":         "",
 		"XDG_DATA_HOME":           "",
 		"APPDATA":                 filepath.Join(root, "AppData", "Roaming"),
-		"DEJA_NOTES_FILE":         "",
-		"DEJA_SOURCE_INSTANCE":    "",
+		// A developer with DEJA_INDEX_DIR exported reads their own index
+		// here, and the suite went red on their machine only.
+		"DEJA_INDEX_DIR":       "",
+		"DEJA_NOTES_FILE":      "",
+		"DEJA_SOURCE_INSTANCE": "",
 		// Guard: hook tests must never spawn a real detached warmup —
 		// os.Executable() inside tests is the test binary itself.
 		"DEJA_WARMUP_SENTINEL":  filepath.Join(root, "warmup-guard"),

--- a/internal/index/grok_test.go
+++ b/internal/index/grok_test.go
@@ -21,7 +21,10 @@ func TestMain(m *testing.M) {
 		// Tombstones and the exclude list live under XDG_CONFIG_HOME. A
 		// developer who has it set would otherwise have the suite write into
 		// their real ~/.config/deja.
-		"XDG_CONFIG_HOME":       filepath.Join(root, "config"),
+		"XDG_CONFIG_HOME": filepath.Join(root, "config"),
+		// A developer with DEJA_INDEX_DIR exported reads their own index
+		// here, and the suite went red on their machine only.
+		"DEJA_INDEX_DIR":        "",
 		"DEJA_EXCLUDE_PROJECTS": "",
 		"DEJA_CLAUDE_ROOT":      filepath.Join(root, "claude"),
 		"DEJA_CODEX_ROOT":       filepath.Join(root, "codex"),

--- a/internal/index/import_forgotten_again_test.go
+++ b/internal/index/import_forgotten_again_test.go
@@ -1,0 +1,55 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A peer who still holds the batch hands it over again, which is the ordinary
+// case — the same folder synced twice. The record is dropped for two reasons at
+// once, and only one of them is worth saying: the dedupe ledger answered first,
+// so the import went silent exactly when it had something to report, while a
+// wiped-and-rebuilt index said it (#980).
+func TestReimportOfAForgottenSessionStillSaysItWasLeftOut(t *testing.T) {
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, "index.db")
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(SyncRecord{Harness: "claude", SessionID: "solo", Project: "work/api", Role: "user", Text: "peer record about the vault rotation"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	n, err := Import(dir, exp)
+	if err != nil || n != 1 {
+		t.Fatalf("first import: %d records, %v", n, err)
+	}
+	if ImportSkippedForgotten() != 0 {
+		t.Fatalf("a fresh batch was reported as forgotten: %d", ImportSkippedForgotten())
+	}
+
+	id := ImportedSessionID("claude", "solo")
+	if _, err := Forget(dir, ForgetOptions{Session: "claude:" + id}); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err = Import(dir, exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("a forgotten session came back: %d records", n)
+	}
+	if got := ImportSkippedForgotten(); got != 1 {
+		t.Errorf("the re-import dropped the record silently: skipped=%d", got)
+	}
+}

--- a/internal/index/import_forgotten_again_test.go
+++ b/internal/index/import_forgotten_again_test.go
@@ -14,6 +14,9 @@ import (
 // wiped-and-rebuilt index said it (#980).
 func TestReimportOfAForgottenSessionStillSaysItWasLeftOut(t *testing.T) {
 	tmp := t.TempDir()
+	// Tombstones live under XDG_CONFIG_HOME, which the package shares: one
+	// left behind here reads as forgotten in every test that runs after.
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
 	dir := filepath.Join(tmp, "index.db")
 	exp := filepath.Join(tmp, "transfer")
 	if err := os.MkdirAll(exp, 0o755); err != nil {

--- a/internal/index/imported_note_state_test.go
+++ b/internal/index/imported_note_state_test.go
@@ -1,0 +1,102 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The states of promoted notes live in notes.jsonl, which never travels, and
+// import renames every session to imported-<hash>. So a decision retracted on
+// one machine arrived on the other as an accepted line with the newest
+// correction last (#975).
+func TestImportedNoteKeepsItsStateAndOrder(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var batch []byte
+	for _, r := range []SyncRecord{
+		{Harness: "deja", SessionID: "deja-note-claude-a18", Project: "p", Role: "user", Text: "[accepted] asked: raise the pool cap · outcome: raised (from claude:a18, 2026-08-04)"},
+		{Harness: "deja", SessionID: "deja-note-claude-a18", Project: "p", Role: "user", Text: "[rejected] made it worse (from claude:a18, 2026-08-04)"},
+	} {
+		b, err := json.Marshal(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		batch = append(batch, append(b, '\n')...)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), batch, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if _, err := Import(dir, exp); err != nil {
+		t.Fatal(err)
+	}
+
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, m := range metas {
+		if m.Harness != "deja" {
+			continue
+		}
+		found = true
+		if m.OrigID != "deja-note-claude-a18" {
+			t.Errorf("the imported note forgot what it was: OrigID = %q", m.OrigID)
+		}
+		if m.Lifecycle != "rejected" {
+			t.Errorf("the retraction did not travel: lifecycle = %q", m.Lifecycle)
+		}
+		if !IsPromotedNote(m.Harness, m.ID, m.OrigID) {
+			t.Errorf("an imported promoted note is not recognised as one: %s", m.ID)
+		}
+		s, ok, err := FindByPrefix(dir, m.ID)
+		if err != nil || !ok {
+			t.Fatalf("cannot read the imported note back: %v", err)
+		}
+		if len(s.Messages) != 2 {
+			t.Fatalf("got %d messages, want 2", len(s.Messages))
+		}
+		if got := s.Messages[0].Text; got[:10] != "[rejected]" {
+			t.Errorf("the note leads with %q, not the newest correction", got)
+		}
+	}
+	if !found {
+		t.Fatal("no imported note in the index")
+	}
+}
+
+// The state prefix is the only copy that crosses a machine boundary, so it has
+// to be read exactly: anything that is not one of deja's states is text, not a
+// state (#975).
+func TestNoteStateFromText(t *testing.T) {
+	for _, tc := range []struct {
+		in, state, note string
+		ok              bool
+	}{
+		{"[rejected] made it worse", "rejected", "made it worse", true},
+		{"[accepted] asked: … · outcome: …", "accepted", "asked: … · outcome: …", true},
+		{"[superseded] replaced by the other one", "superseded", "replaced by the other one", true},
+		{"[stale]", "stale", "", true},
+		{"[approved-by-ceo] not a state deja knows", "", "", false},
+		{"no bracket at all", "", "", false},
+		{"[]", "", "", false},
+		{"[unterminated", "", "", false},
+	} {
+		state, note, ok := noteStateFromText(tc.in)
+		if state != tc.state || note != tc.note || ok != tc.ok {
+			t.Errorf("noteStateFromText(%q) = (%q, %q, %v), want (%q, %q, %v)", tc.in, state, note, ok, tc.state, tc.note, tc.ok)
+		}
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -118,6 +118,19 @@ type SessionMeta struct {
 	// took two conversations from two projects (#970). Additive: a manifest
 	// written before this decodes with it false.
 	Shared bool `json:",omitempty"`
+	// OrigID is the id a session had on the machine it came from. Import
+	// renames every session to imported-<hash>, so a promoted note stopped
+	// looking like one the moment it crossed a machine boundary and every rule
+	// written for notes — newest correction first, the decision's state —
+	// silently stopped applying (#975). Additive: older manifests decode with
+	// it empty.
+	OrigID string `json:",omitempty"`
+	// Lifecycle is the state of a promoted note that arrived by sync. The
+	// local states live in notes.jsonl, which the other machine does not have,
+	// so a decision retracted there read as accepted here (#975).
+	Lifecycle     string `json:",omitempty"`
+	LifecycleNote string `json:",omitempty"`
+	LifecycleAt   string `json:",omitempty"`
 	// Hit holds hashes of the specific errors this session tripped over, so
 	// the first screen can name a wall the machine keeps running into without
 	// reading a single session. Same trade as Asked: the text is recovered

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1087,6 +1087,7 @@ func sessionFromMeta(meta SessionMeta) model.Session {
 	return model.Session{
 		ID: meta.ID, Harness: meta.Harness, Project: meta.Project, Path: meta.Path,
 		Title: meta.Title, Started: meta.Started, Updated: meta.Updated, Touched: meta.Touched,
+		OrigID: meta.OrigID, Lifecycle: meta.Lifecycle, LifecycleNote: meta.LifecycleNote, LifecycleAt: meta.LifecycleAt,
 	}
 }
 

--- a/internal/index/note_dedupe_test.go
+++ b/internal/index/note_dedupe_test.go
@@ -1,0 +1,89 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// A day bucket's id is the sending machine's rendering of a date, not the
+// identity of what it holds. After that machine changed zone the same note
+// arrived under a new bucket and every peer grew a second copy (#977).
+func TestANoteDoesNotArriveTwiceUnderTwoBucketIds(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name string, recs ...SyncRecord) {
+		t.Helper()
+		var batch []byte
+		for _, r := range recs {
+			b, err := json.Marshal(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			batch = append(batch, append(b, '\n')...)
+		}
+		if err := os.WriteFile(filepath.Join(exp, name), batch, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	const text = "note written next morning"
+	// The same note, exported before and after the sender changed zone: same
+	// project, same timestamp, different bucket.
+	write("deja-sync-a.jsonl", SyncRecord{Harness: "deja", SessionID: "deja-2026-07-13-p", Project: "p", Role: "user", Text: text})
+	dir := filepath.Join(tmp, "index.db")
+	if _, err := Import(dir, exp); err != nil {
+		t.Fatal(err)
+	}
+	write("deja-sync-b.jsonl", SyncRecord{Harness: "deja", SessionID: "deja-2026-07-12-p", Project: "p", Role: "user", Text: text})
+	if _, err := Import(dir, exp); err != nil {
+		t.Fatal(err)
+	}
+
+	ss, err := Search(dir, query.Options{Query: "next morning", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Errorf("the same note landed in %d sessions, want 1", len(ss))
+	}
+
+	// A different note in the same bucket is not a duplicate.
+	write("deja-sync-c.jsonl", SyncRecord{Harness: "deja", SessionID: "deja-2026-07-12-p", Project: "p", Role: "user", Text: "a different note entirely"})
+	if _, err := Import(dir, exp); err != nil {
+		t.Fatal(err)
+	}
+	ss, err = Search(dir, query.Options{Query: "different note entirely", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) == 0 {
+		t.Error("a genuinely new note was dropped as a duplicate")
+	}
+	// And an ordinary session still dedupes on its own id.
+	write("deja-sync-d.jsonl", SyncRecord{Harness: "claude", SessionID: "s1", Project: "p", Role: "user", Text: "an ordinary transcript line"})
+	if _, err := Import(dir, exp); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(dir, exp); err != nil {
+		t.Fatal(err)
+	}
+	ss, err = Search(dir, query.Options{Query: "ordinary transcript line", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Errorf("an ordinary session landed in %d sessions, want 1", len(ss))
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1131,17 +1131,34 @@ func loadSessionMeta(dir string, m Manifest, meta SessionMeta) (model.Session, b
 	return s, true, nil
 }
 
+// IsPromotedNote reports whether a session is a promoted note, on this machine
+// or on the one it came from. Import renames sessions to imported-<hash>, so
+// the id alone stops answering the question after a sync (#975).
+func IsPromotedNote(harness, id, origID string) bool {
+	if harness != "deja" {
+		return false
+	}
+	return strings.HasPrefix(id, "deja-note-") || strings.HasPrefix(origID, "deja-note-")
+}
+
 // orderPromotedNote keeps a promoted note's corrections newest-first. The
 // parser writes them that way (#812), but an incremental build appends the new
 // lines to what the log already holds, so the record order stopped saying which
 // answer holds: the snippet an agent reads led with the answer that had been
 // overturned (#944). Ordering on read fixes indexes already on disk too.
 func orderPromotedNote(s *model.Session) {
-	if s.Harness != "deja" || !strings.HasPrefix(s.ID, "deja-note-") || len(s.Messages) < 2 {
+	if !IsPromotedNote(s.Harness, s.ID, s.OrigID) || len(s.Messages) < 2 {
 		return
 	}
+	// Newest first by time; when a batch carries no timestamps — a hand-made
+	// one, or an older export — the file order is the record: the parser
+	// reverses it for the same reason (#812, #975).
 	sort.SliceStable(s.Messages, func(i, j int) bool {
-		return s.Messages[i].Time.After(s.Messages[j].Time)
+		a, b := s.Messages[i], s.Messages[j]
+		if a.Time.Equal(b.Time) {
+			return i > j
+		}
+		return a.Time.After(b.Time)
 	})
 }
 

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -243,6 +243,26 @@ var lastImportSkippedForgotten int
 // leave alone (#968).
 func ImportSkippedForgotten() int { return lastImportSkippedForgotten }
 
+// noteStateFromText reads the state a promoted note's line carries. deja writes
+// them as "[accepted] …" or "[rejected] did not hold", and that prefix is the
+// only copy of the state that crosses a machine boundary (#975).
+func noteStateFromText(text string) (state, note string, ok bool) {
+	if !strings.HasPrefix(text, "[") {
+		return "", "", false
+	}
+	end := strings.IndexByte(text, ']')
+	if end <= 1 {
+		return "", "", false
+	}
+	state = text[1:end]
+	switch state {
+	case "accepted", "rejected", "superseded", "stale":
+	default:
+		return "", "", false
+	}
+	return state, strings.TrimSpace(text[end+1:]), true
+}
+
 func Import(dir, inDir string) (int, error) {
 	if dir == "" {
 		dir = DefaultDir()
@@ -366,7 +386,7 @@ func Import(dir, inDir string) (int, error) {
 			recsByKey[key] = append(recsByKey[key], Record{Key: key, Role: sr.Role, Text: text, Time: sr.Time, SourcePath: syncImportPath})
 			meta := metas[key]
 			if meta.ID == "" {
-				meta = SessionMeta{ID: importID, Harness: sr.Harness, Project: "imported:" + sr.Project, Path: syncImportPath}
+				meta = SessionMeta{ID: importID, Harness: sr.Harness, Project: "imported:" + sr.Project, Path: syncImportPath, OrigID: origID}
 			}
 			if meta.Started.IsZero() || (!sr.Time.IsZero() && sr.Time.Before(meta.Started)) {
 				meta.Started = sr.Time
@@ -388,6 +408,18 @@ func Import(dir, inDir string) (int, error) {
 					meta.Title = truncateTitle(strings.TrimSpace(text), 60)
 					titleAt[key] = sr.Time
 					titleRankOf[key] = rank
+				}
+			}
+			// A promoted note carries its state in the text: "[rejected] …".
+			// The states themselves live in the other machine's notes.jsonl,
+			// which never travels, so without reading them here a decision
+			// retracted there reads as accepted on this machine (#975).
+			if strings.HasPrefix(origID, "deja-note-") {
+				if st, note, ok := noteStateFromText(sr.Text); ok {
+					meta.Lifecycle, meta.LifecycleNote = st, note
+					if !sr.Time.IsZero() {
+						meta.LifecycleAt = sr.Time.Format("2006-01-02")
+					}
 				}
 			}
 			metas[key] = meta

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -263,6 +263,15 @@ func noteStateFromText(text string) (state, note string, ok bool) {
 	return state, strings.TrimSpace(text[end+1:]), true
 }
 
+// dayBucketKey identifies a note in a day bucket without the bucket id. Empty
+// for anything else, so ordinary sessions keep the key they have always had.
+func dayBucketKey(sr SyncRecord, textHash uint64) string {
+	if sr.Harness != "deja" || !strings.HasPrefix(sr.SessionID, "deja-20") {
+		return ""
+	}
+	return "deja-note-day:" + sr.Project + ":" + sr.Time.UTC().Format(time.RFC3339Nano) + ":" + sr.Role + ":" + strconv.FormatUint(textHash, 16)
+}
+
 func Import(dir, inDir string) (int, error) {
 	if dir == "" {
 		dir = DefaultDir()
@@ -360,6 +369,16 @@ func Import(dir, inDir string) (int, error) {
 			th := fnv.New64a()
 			_, _ = th.Write([]byte(sr.Text))
 			dedupe := legacy + ":" + sr.Role + ":" + strconv.FormatUint(th.Sum64(), 16)
+			// A day bucket's id is the sending machine's rendering of a date,
+			// not the identity of what it holds: after that machine changes
+			// zone the same note arrives under a new bucket and every peer
+			// grew a second copy (#977). Key those on what does not move.
+			if bucket := dayBucketKey(sr, th.Sum64()); bucket != "" {
+				if m.ImportedRecords[bucket] {
+					return nil
+				}
+				dedupe = bucket
+			}
 			if m.ImportedRecords[dedupe] || m.ImportedRecords[legacy] {
 				return nil
 			}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -361,6 +361,24 @@ func Import(dir, inDir string) (int, error) {
 			if strings.TrimSpace(sr.Text) == "" {
 				return nil
 			}
+			importID := ImportedSessionID(sr.Harness, origID)
+			// Forgetting is primary data, not cache: a tombstoned session
+			// must stay dead even when the peer still holds the batch and
+			// this index was wiped and rebuilt.
+			//
+			// Both keys, because a session forgotten here was forgotten under
+			// its own id: checking only the imported one let a peer's copy walk
+			// the same text back into local search under a new id, while
+			// `forget --list` still called it forgotten (#968).
+			//
+			// Ahead of the dedupe ledger, which answers first for the ordinary
+			// case — the same batch handed over twice. Both drop the record;
+			// only this one knows why, and behind the ledger the import went
+			// silent exactly when the peer re-sent what you forgot (#980).
+			if dead[sr.Harness+":"+importID] || dead[sr.Harness+":"+origID] {
+				forgottenSkipped++
+				return nil
+			}
 			// Key includes role and a text hash: two messages can legally share
 			// a timestamp (aider stamps a whole session with its start time).
 			// The legacy time-only key is still honored so batches imported by
@@ -380,19 +398,6 @@ func Import(dir, inDir string) (int, error) {
 				dedupe = bucket
 			}
 			if m.ImportedRecords[dedupe] || m.ImportedRecords[legacy] {
-				return nil
-			}
-			importID := ImportedSessionID(sr.Harness, origID)
-			// Forgetting is primary data, not cache: a tombstoned session
-			// must stay dead even when the peer still holds the batch and
-			// this index was wiped and rebuilt.
-			//
-			// Both keys, because a session forgotten here was forgotten under
-			// its own id: checking only the imported one let a peer's copy walk
-			// the same text back into local search under a new id, while
-			// `forget --list` still called it forgotten (#968).
-			if dead[sr.Harness+":"+importID] || dead[sr.Harness+":"+origID] {
-				forgottenSkipped++
 				return nil
 			}
 			// The exclude list keeps a project out of this machine's memory;

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -26,6 +26,17 @@ type Session struct {
 	// search result can ask a cheap question about those files without reading
 	// the session back.
 	Touched []string `json:"touched,omitempty"`
+	// OrigID is the id this session had on the machine it came from, when it
+	// arrived by sync. Import renames sessions to imported-<hash>, so a
+	// promoted note stopped looking like one across a machine boundary and the
+	// rules written for notes stopped applying to it (#975).
+	OrigID string `json:"orig_id,omitempty"`
+	// Lifecycle carries the state of a promoted note that arrived by sync: the
+	// states live in the other machine's notes.jsonl, which never travels
+	// (#975).
+	Lifecycle     string `json:"lifecycle,omitempty"`
+	LifecycleNote string `json:"lifecycle_note,omitempty"`
+	LifecycleAt   string `json:"lifecycle_at,omitempty"`
 }
 
 // Source identifies where a session entered this deja index. Instance is an

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -23,6 +23,9 @@ type Report struct {
 	TopProjects     []ProjectStats `json:"top_projects"`
 	Monthly         []MonthStats   `json:"monthly"`
 	Heatmap         HeatmapStats   `json:"-"` // card-only presentation data; kept out of the stable --json schema
+	// EmptiedByPolicy marks a report whose rows were all withheld by the
+	// trust policy, so the empty-index advice is not the right thing to print.
+	EmptiedByPolicy bool           `json:"-"`
 	Sparkline       string         `json:"sparkline"`
 	DateRange       DateRangeStats `json:"date_range"`
 	Longest         SessionStat    `json:"longest_session"`


### PR DESCRIPTION
Ten findings from an audit run, all measured on a live index.

- #974 a promoted note lost its state on the way to another machine
- #975 the state and order of a promoted note did not survive a sync
- #976 forget handed back a raw mkdir errno when the index was unwritable
- #977 a note arrived twice under two bucket ids after a zone change
- #978 doctor printed the trust rule but never what it withholds
- #979 a promoted note froze at its last state once the source session was forgotten
- #980 re-importing a batch you forgot went silent about it
- #981 handoff counted hidden sessions once per project-name candidate
- #982 exporting to a second machine wrote an empty folder and said nothing
- #983 stats told you to build an index it already had

Each fix has a test that fails on the old behaviour; mutations checked per fix.
