### PR TITLE
Stop a forgotten note and a shared folder from coming back around

### DIFF
--- a/cmd/deja/import_proof_test.go
+++ b/cmd/deja/import_proof_test.go
@@ -147,3 +147,70 @@ func TestImportProofDoesNotLeaveTheDateSlotEmpty(t *testing.T) {
 		t.Errorf("a session with no date does not say so the way `last` does:\n%s", proof)
 	}
 }
+
+// The block is headed "from the machine you came from" and was built from the
+// recent list, so this machine's own sessions stood in as evidence a transfer
+// had landed — and under a rule that hides imported rows they were all that
+// was left (#988).
+func TestImportProofShowsOnlyWhatArrived(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "work/api", Role: "user", Text: "peer three about the ticker"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	proof, err := captureRunStderr(t, "sync", "import", exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(proof, "peer three about the ticker") {
+		t.Errorf("the proof does not show what arrived:\n%s", proof)
+	}
+	if strings.Contains(proof, "local work on the ticker window") {
+		t.Errorf("a session that was here before the transfer is offered as proof of it:\n%s", proof)
+	}
+
+	// With every arrived row hidden by a rule, the reader gets the rule — not
+	// this machine's own sessions under someone else's heading.
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+	b2, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer2", Project: "work/api", Role: "user", Text: "another peer line"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-y.jsonl"), append(b2, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	proof, err = captureRunStderr(t, "sync", "import", exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(proof, "local work on the ticker window") {
+		t.Errorf("the proof fell back to local sessions under the import heading:\n%s", proof)
+	}
+	if !strings.Contains(proof, "trust policy") {
+		t.Errorf("nothing named the rule that emptied the proof:\n%s", proof)
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
@@ -250,13 +251,35 @@ func printInstallProof(dir string) { printMemoryProof(dir, "deja already knows t
 // printMemoryProof is that same proof under a caller's heading. `sync import`
 // ends the move to a new machine and said only "imported 59000 records" —
 // deja's own unit, and nothing a person can check (#929).
-func printMemoryProof(dir, heading string) {
+func printMemoryProof(dir, heading string) { printMemoryProofOf(dir, heading, nil) }
+
+// printMemoryProofOf is the proof narrowed to the rows a caller can honestly
+// claim. `sync import` says "from the machine you came from" and was handed
+// the recent list, so on a batch that added nothing visible it offered this
+// machine's own sessions as the evidence a transfer had landed (#988).
+func printMemoryProofOf(dir, heading string, keep func(model.Session) bool) {
 	if !index.HasManifest(dir) {
 		return
 	}
-	recent, err := index.Recent(dir, 12)
+	want := 12
+	if keep != nil {
+		want = 60
+	}
+	recent, err := index.Recent(dir, want)
 	if err != nil || len(recent) == 0 {
 		return
+	}
+	if keep != nil {
+		var only []model.Session
+		for _, s := range recent {
+			if keep(s) {
+				only = append(only, s)
+			}
+		}
+		recent = only
+		if len(recent) == 0 {
+			return
+		}
 	}
 	// The proof is a listing, and a listing obeys the trust policy (#937). On a
 	// machine whose rule keeps imported sessions out of recall this block was

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -738,7 +738,18 @@ func printNoMatches(w io.Writer, dir, q string) {
 		fmt.Fprintf(w, "deja: nothing to search for in %q — every word in it is too short to look up\n", q)
 		return
 	}
-	if n, err := index.SessionCount(dir); err == nil {
+	// The size worth naming is the part of the store this path may read. Under
+	// a trust rule the two differ, and "no matches in 1 indexed session — try
+	// fewer words" sent the reader after a wording problem in a session the
+	// rule never let search open (#986).
+	if reach, total, ok := reachableSessionCount(dir); ok && reach == 0 && total > 0 {
+		fmt.Fprintf(w, "deja: no matches for %q\n", q)
+		fmt.Fprintf(w, "deja: the trust policy withholds every indexed session from this path (%s: %s) — see %s\n",
+			policy.ActivationSearch, policy.Load().Describe(policy.ActivationSearch), policy.Path())
+		return
+	} else if ok {
+		fmt.Fprintf(w, "deja: no matches in %d indexed session%s — try fewer words or --re (query %q)\n", reach, pluralS(reach), q)
+	} else if n, err := index.SessionCount(dir); err == nil {
 		fmt.Fprintf(w, "deja: no matches in %d indexed session%s — try fewer words or --re (query %q)\n", n, pluralS(n), q)
 	} else {
 		fmt.Fprintf(w, "deja: no matches — try fewer words or --re (query %q)\n", q)
@@ -2140,4 +2151,21 @@ func forgetKeyOf(dir string, o index.ForgetOptions) string {
 		}
 	}
 	return ""
+}
+
+// reachableSessionCount reports how many indexed sessions the search
+// activation may read, and how many are indexed in all.
+func reachableSessionCount(dir string) (int, int, bool) {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return 0, 0, false
+	}
+	pol := policy.Load()
+	reach := 0
+	for _, m := range metas {
+		if pol.Allows(policy.ActivationSearch, m.Project) {
+			reach++
+		}
+	}
+	return reach, len(metas), true
 }

--- a/cmd/deja/search_policy_scope_test.go
+++ b/cmd/deja/search_policy_scope_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// "no matches in 1 indexed session — try fewer words" is advice about wording
+// for a session the rule never let search open: the count named the whole
+// store rather than the part this path may read (#986).
+func TestNoMatchesCountsWhatSearchMayRead(t *testing.T) {
+	tmp := hermeticEnv(t)
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "work/api", Role: "user", Text: "peer work on the vault rotation"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	// Without a rule the miss is a wording problem and reads like one.
+	var out bytes.Buffer
+	printNoMatches(&out, dir, "ticker window")
+	if !strings.Contains(out.String(), "no matches in 1 indexed session") {
+		t.Errorf("an ordinary miss lost its count:\n%s", out.String())
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	out.Reset()
+	printNoMatches(&out, dir, "ticker window")
+	got := out.String()
+	if strings.Contains(got, "try fewer words") {
+		t.Errorf("the reader was sent after their wording:\n%s", got)
+	}
+	if !strings.Contains(got, "trust policy") {
+		t.Errorf("nothing named the rule that emptied the search path:\n%s", got)
+	}
+	if strings.Contains(got, "in 1 indexed session") {
+		t.Errorf("the count still names sessions search cannot read:\n%s", got)
+	}
+}

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -117,9 +117,11 @@ func runSync(dir string, args []string) error {
 		// "imported 0 records" alone reads as an empty batch (#968).
 		// A shared folder is an outbox as well as an inbox, so a batch this
 		// machine wrote comes back to it. Saying nothing made "imported 0
-		// records" read as a failed transfer (#987).
+		// records" read as a failed transfer (#987). The claim is what deja
+		// checked — the same session, instant and text — not who wrote it: a
+		// batch carries no machine id (#955).
 		if own := index.ImportSkippedOwn(); own > 0 {
-			fmt.Fprintf(os.Stdout, "deja: %d record%s in this folder were written by this machine — already here\n", own, pluralS(own))
+			fmt.Fprintf(os.Stdout, "deja: %d record%s were already here word for word — this folder holds a copy of what this machine has\n", own, pluralS(own))
 		}
 		if skipped := index.ImportSkippedForgotten(); skipped > 0 {
 			fmt.Fprintf(os.Stdout, "deja: %d record%s left out — they belong to sessions you forgot here (`deja forget --list`)\n", skipped, pluralS(skipped))

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
@@ -132,7 +133,9 @@ func runSync(dir string, args []string) error {
 		}
 		// The end of a move to a new machine is the same moment as an install,
 		// and install proves it with real lines rather than a count (#929).
-		printMemoryProof(dir, "deja now knows, from the machine you came from:")
+		printMemoryProofOf(dir, "deja now knows, from the machine you came from:", func(s model.Session) bool {
+			return strings.HasPrefix(s.Project, "imported:")
+		})
 		return nil
 	default:
 		return fmt.Errorf("unknown sync command %q", args[0])

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -114,6 +114,12 @@ func runSync(dir string, args []string) error {
 		// Whether or not anything arrived: a batch that is entirely someone
 		// else's copy of what this machine forgot imports zero records, and
 		// "imported 0 records" alone reads as an empty batch (#968).
+		// A shared folder is an outbox as well as an inbox, so a batch this
+		// machine wrote comes back to it. Saying nothing made "imported 0
+		// records" read as a failed transfer (#987).
+		if own := index.ImportSkippedOwn(); own > 0 {
+			fmt.Fprintf(os.Stdout, "deja: %d record%s in this folder were written by this machine — already here\n", own, pluralS(own))
+		}
 		if skipped := index.ImportSkippedForgotten(); skipped > 0 {
 			fmt.Fprintf(os.Stdout, "deja: %d record%s left out — they belong to sessions you forgot here (`deja forget --list`)\n", skipped, pluralS(skipped))
 		}

--- a/internal/index/forget_note_content_test.go
+++ b/internal/index/forget_note_content_test.go
@@ -1,0 +1,90 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A note has no id that survives the crossing: buckets are the reader's local
+// day (#911), so the peer sends the same line under an id this machine has
+// never seen and the tombstone missed it — deja announced back the line that
+// was just deleted (#985).
+func TestAForgottenNoteStaysGoneWhenAPeerSendsTheirOwnBucket(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	when := time.Date(2026, 8, 4, 10, 32, 12, 0, time.UTC)
+	body := `{"ts":"` + when.Format(time.RFC3339Nano) + `","project":"x29","text":"the ticker window stays at 30s"}` + "\n"
+	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	local := ""
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range metas {
+		if strings.HasPrefix(m.ID, "deja-20") {
+			local = m.ID
+		}
+	}
+	if local == "" {
+		t.Fatal("the note did not land in a day bucket")
+	}
+	if _, err := Forget(dir, ForgetOptions{Session: "deja:" + local}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The peer's copy: same text, same instant, their rendering of the day.
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(SyncRecord{Harness: "deja", SessionID: "deja-2026-08-03-x29",
+		Project: "x29", Role: "user", Text: "the ticker window stays at 30s", Time: when})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	n, err := Import(dir, exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("the forgotten note came back under the peer's bucket: %d records", n)
+	}
+	if ImportSkippedForgotten() != 1 {
+		t.Errorf("the drop was not reported as a forgotten one: %d", ImportSkippedForgotten())
+	}
+
+	// The list someone reads names the note once, not once per record.
+	for _, k := range Tombstones() {
+		if strings.Contains(k, "\x00") {
+			t.Errorf("a content key reached the list people read: %q", k)
+		}
+	}
+	if got := TombstoneMatches("deja:" + local); got != 1 {
+		t.Errorf("one forgotten note counted as %d sessions", got)
+	}
+
+	// Bringing it back has to bring back what the peer still sends, or the
+	// next import would drop it in silence.
+	if lifted, err := Unforget(dir, "deja:"+local, nil); err != nil || lifted != 1 {
+		t.Fatalf("unforget lifted %d: %v", lifted, err)
+	}
+	if n, err := Import(dir, exp); err != nil || n != 1 {
+		t.Errorf("after unforget the peer's copy still could not land: %d records, %v", n, err)
+	}
+}

--- a/internal/index/import_own_batch_test.go
+++ b/internal/index/import_own_batch_test.go
@@ -1,0 +1,80 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A shared folder is an outbox as well as an inbox: the machine that wrote a
+// batch imports that same directory, and its own records came back as a second
+// "imported" copy of every session it holds (#987).
+func TestImportSkipsThisMachinesOwnBatch(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	claude := filepath.Join(tmp, "claude", "-tmp-x31")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	rec := `{"type":"user","message":{"role":"user","content":"first session about the pool cap"},"timestamp":"2026-07-12T10:00:00Z","sessionId":"b31","cwd":"/tmp/x31"}` + "\n"
+	if err := os.WriteFile(filepath.Join(claude, "s.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	shared := filepath.Join(tmp, "shared")
+	if err := os.MkdirAll(shared, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ExportFull(dir, shared); err != nil {
+		t.Fatal(err)
+	}
+	n, err := Import(dir, shared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("this machine imported its own batch: %d records", n)
+	}
+	if ImportSkippedOwn() == 0 {
+		t.Errorf("the own-copy drop was not reported")
+	}
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range metas {
+		if strings.HasPrefix(m.Project, "imported:") {
+			t.Errorf("a session of this machine came back as imported: %s · %s", m.Project, m.ID)
+		}
+	}
+
+	// The backside: a peer sends genuinely new lines for a session id this
+	// machine also holds, and those must still land.
+	peer := filepath.Join(tmp, "from-peer")
+	if err := os.MkdirAll(peer, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(SyncRecord{Harness: "claude", SessionID: "b31", Project: "tmp/x31", Role: "user",
+		Text: "a new line the peer added to the same session", Time: time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(peer, "deja-sync-p.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := Import(dir, peer); err != nil || n != 1 {
+		t.Errorf("a peer's new line for a shared session id was dropped: %d records, %v", n, err)
+	}
+	if ImportSkippedOwn() != 0 {
+		t.Errorf("a peer's line was counted as this machine's own: %d", ImportSkippedOwn())
+	}
+}

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -3,6 +3,7 @@ package index
 import (
 	"bufio"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"os"
 	"path/filepath"
@@ -389,13 +390,33 @@ func Forget(dir string, o ForgetOptions) (ForgetResult, error) {
 	// Count the messages on the dry run too. It is the same single pass over
 	// records, and without it `--dry-run` answers "0 messages" to the only
 	// question it exists to answer: how much am I about to lose.
+	// A note forgotten here is forgotten as text, not as a day: the peer who
+	// still holds it sends it under their own bucket id, which was a key this
+	// index had never seen — and deja announced the line the reader had just
+	// deleted (#985). The content key is the one #977 already dedupes on.
+	var contentKeys []string
 	for _, r := range readRecordsForForget(dir) {
-		if matched[r.Record.Key] {
-			result.Messages++
+		if !matched[r.Record.Key] {
+			continue
+		}
+		result.Messages++
+		meta, ok := m.Sessions[r.Record.Key]
+		if !ok || meta.Harness != "deja" || !strings.HasPrefix(meta.ID, "deja-20") {
+			continue
+		}
+		th := fnv.New64a()
+		_, _ = th.Write([]byte(r.Record.Text))
+		key := dayBucketKey(SyncRecord{Harness: "deja", SessionID: meta.ID, Project: meta.Project,
+			Role: r.Record.Role, Time: r.Record.Time}, th.Sum64())
+		if key != "" {
+			contentKeys = append(contentKeys, r.Record.Key+"\x00"+key)
 		}
 	}
 	if o.DryRun {
 		return result, nil
+	}
+	for _, k := range contentKeys {
+		dead[k] = true
 	}
 	// Persist tombstones before the rebuild: a crash between the two must
 	// leave sessions forgotten, not resurrect them on the next index pass.
@@ -429,6 +450,11 @@ func Tombstones() []string {
 	set := readTombstones()
 	out := make([]string, 0, len(set))
 	for key := range set {
+		// Content keys hang off the session they were recorded with; the list
+		// is what someone reads and unforgets by name.
+		if strings.Contains(key, "\x00") {
+			continue
+		}
 		out = append(out, key)
 	}
 	sort.Strings(out)
@@ -444,6 +470,11 @@ func Tombstoned(key string) bool { return readTombstones()[key] }
 func TombstoneMatches(prefix string) int {
 	n := 0
 	for key := range readTombstones() {
+		// Content keys ride along with their session and are lifted with it;
+		// counting them told the reader one note was two sessions.
+		if strings.Contains(key, "\x00") {
+			continue
+		}
 		if tombstoneMatches(key, prefix) {
 			n++
 		}
@@ -484,6 +515,15 @@ func Unforget(dir, prefix string, progress io.Writer) (int, error) {
 	set := readTombstones()
 	lifted := 0
 	for key := range set {
+		session, _, hasContent := strings.Cut(key, "\x00")
+		if hasContent {
+			// Bringing a note back has to bring back the copies a peer may
+			// still send, or the next import would drop them silently.
+			if tombstoneMatches(session, prefix) {
+				delete(set, key)
+			}
+			continue
+		}
 		if tombstoneMatches(key, prefix) {
 			delete(set, key)
 			lifted++

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -326,10 +326,40 @@ func Import(dir, inDir string) (int, error) {
 	metas := map[string]SessionMeta{}
 	titleAt := map[string]time.Time{} // key -> time of the turn the title came from
 	titleRankOf := map[string]int{}   // key -> how good that turn was as a title
+	// A shared folder is both an outbox and an inbox: the machine that wrote a
+	// batch also runs `sync import` on that directory, and its own records came
+	// back as a second, "imported" copy of every session and note it had
+	// (#987). Recognised by content, so a peer's genuinely new lines in a
+	// session this machine also holds still land.
+	localContent := map[string]bool{}
+	localSessions := map[string]bool{}
+	for _, meta := range m.Sessions {
+		if meta.OrigID == "" {
+			localSessions[meta.Harness+":"+meta.ID] = true
+		}
+	}
+	localContentLoaded := false
+	loadLocalContent := func() {
+		if localContentLoaded {
+			return
+		}
+		localContentLoaded = true
+		for _, r := range readRecordsForForget(dir) {
+			meta, ok := m.Sessions[r.Record.Key]
+			if !ok || meta.OrigID != "" {
+				continue
+			}
+			th := fnv.New64a()
+			_, _ = th.Write([]byte(r.Record.Text))
+			localContent[recordContentKey(meta.Harness, meta.ID, r.Record.Role, r.Record.Time, th.Sum64())] = true
+		}
+	}
 	added := 0
 	var skipped []string
+	ownSkipped := 0
 	forgottenSkipped := 0
 	defer func() { lastImportSkippedForgotten = forgottenSkipped }()
+	defer func() { lastImportSkippedOwn = ownSkipped }()
 	for _, p := range paths {
 		// A file is imported whole or not at all, so what it contributed is
 		// remembered before it is read and rolled back if it turns out to be
@@ -399,6 +429,13 @@ func Import(dir, inDir string) (int, error) {
 			// not the identity of what it holds: after that machine changes
 			// zone the same note arrives under a new bucket and every peer
 			// grew a second copy (#977). Key those on what does not move.
+			if localSessions[sr.Harness+":"+sr.SessionID] {
+				loadLocalContent()
+				if localContent[recordContentKey(sr.Harness, sr.SessionID, sr.Role, sr.Time, th.Sum64())] {
+					ownSkipped++
+					return nil
+				}
+			}
 			if bucket := dayBucketKey(sr, th.Sum64()); bucket != "" {
 				if m.ImportedRecords[bucket] {
 					return nil
@@ -676,6 +713,19 @@ func shortHash(s string) string {
 	h := sha1.Sum([]byte(s))
 	return strings.TrimLeft(hex.EncodeToString(h[:])[:12], "-")
 }
+
+// recordContentKey identifies one line of one session by what it says rather
+// than by which copy of it this is.
+func recordContentKey(harness, sessionID, role string, at time.Time, textHash uint64) string {
+	return harness + ":" + sessionID + ":" + at.UTC().Format(time.RFC3339Nano) + ":" + role + ":" + strconv.FormatUint(textHash, 16)
+}
+
+// lastImportSkippedOwn holds how many records the last Import recognised as
+// this machine's own copies coming home from a shared folder.
+var lastImportSkippedOwn int
+
+// ImportSkippedOwn reports that count.
+func ImportSkippedOwn() int { return lastImportSkippedOwn }
 
 func ImportedSessionID(harness, sessionID string) string {
 	return "imported-" + shortHash(harness+":"+sessionID)

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -296,6 +296,14 @@ func Import(dir, inDir string) (int, error) {
 	}
 	defer unlock()
 	dead := readTombstones()
+	// Content tombstones are recorded against the session they came from, so
+	// they are read back once here rather than scanned per record.
+	deadContent := map[string]bool{}
+	for k := range dead {
+		if _, content, ok := strings.Cut(k, "\x00"); ok {
+			deadContent[content] = true
+		}
+	}
 	ex := sources.NewExcluder()
 	if !HasManifest(dir) {
 		if err := initEmptyIndex(dir); err != nil {
@@ -393,6 +401,13 @@ func Import(dir, inDir string) (int, error) {
 			// grew a second copy (#977). Key those on what does not move.
 			if bucket := dayBucketKey(sr, th.Sum64()); bucket != "" {
 				if m.ImportedRecords[bucket] {
+					return nil
+				}
+				// Forgotten as text: the sending machine renders the day its
+				// own way, so a note this machine dropped arrives under a
+				// bucket id no tombstone here has ever named (#985).
+				if deadContent[bucket] {
+					forgottenSkipped++
 					return nil
 				}
 				dedupe = bucket


### PR DESCRIPTION
Four findings from the audit run, all measured on a live index.

- #985 a forgotten note came back from a peer under their own bucket id — notes have no id that survives the crossing, so forget now records the content key sync already dedupes on
- #986 search blamed your wording for a rule that hid the whole index
- #987 importing a shared folder duplicated everything the machine had put there — a shared folder is both outbox and inbox
- #988 the import proof offered sessions that were already here as evidence a transfer had landed

Each fix has a test that fails on the old behaviour; mutations checked per fix.
