### PR TITLE
Make the empty answers and the first screen say what they mean

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -33,6 +33,10 @@ func hermeticEnv(t *testing.T) string {
 	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
 	t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
 	t.Setenv("XDG_CONFIG_HOME", "")
+	// The hook adopts the payload's cwd by exporting CLAUDE_PROJECT_DIR into
+	// the process, so a test that runs it hands every later test a project
+	// directory that no longer exists. Pinned here so it is restored per test.
+	t.Setenv("CLAUDE_PROJECT_DIR", "")
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	// Goose resolves through %APPDATA% on Windows; pin it so the doctor
 	// golden stays OS-neutral.

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -393,6 +393,18 @@ func doctorHarnesses(w io.Writer, dir string) {
 		status := "missing"
 		if present {
 			status = "found"
+			// A directory deja cannot open loses its sessions from recall
+			// without a word — the failure #802/#816 closed, but only in
+			// `doctor --json`, which has said `denied` all along while this
+			// row, the one people read, said `found` (#993).
+			if denied := firstDeniedDir(strings.Split(path, ", ")); denied != "" {
+				status = "denied"
+				if detail != "" {
+					detail += ", "
+				}
+				_ = denied // the warning line below names the path
+				detail += "cannot be read"
+			}
 		} else if storeDiskGone(path) {
 			// A store whose whole disk is gone is not a store that was
 			// deleted, and "missing" on a row of transcripts reads as the

--- a/cmd/deja/doctor_denied_row_test.go
+++ b/cmd/deja/doctor_denied_row_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// A directory deja cannot open loses its sessions from recall, and the row
+// people read called it `found` — the same state `doctor --json` has reported
+// as `denied` since #802/#816 (#993).
+func TestDoctorRowSaysDeniedForAStoreItCannotOpen(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	tmp := hermeticEnv(t)
+	qwen := filepath.Join(tmp, "qwen")
+	projects := filepath.Join(qwen, "projects", "p1")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projects, "s.json"), []byte(`{"x":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_QWEN_ROOT", qwen)
+
+	var out bytes.Buffer
+	doctorHarnesses(&out, filepath.Join(tmp, "index.db"))
+	if row := harnessRow(t, out.String(), "qwen"); !strings.Contains(row, "found") {
+		t.Fatalf("a readable store was not reported as found: %q", row)
+	}
+
+	if err := os.Chmod(filepath.Join(qwen, "projects"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(qwen, "projects"), 0o755) })
+
+	out.Reset()
+	doctorHarnesses(&out, filepath.Join(tmp, "index.db"))
+	row := harnessRow(t, out.String(), "qwen")
+	if strings.Contains(row, "found") {
+		t.Errorf("a store deja cannot open is still called found: %q", row)
+	}
+	if !strings.Contains(row, "denied") {
+		t.Errorf("the row does not name the state: %q", row)
+	}
+	// The row stays short because the warning block, which is built from the
+	// same inspection, names the path and what to do about it.
+	var warn bytes.Buffer
+	printDoctorStoreWarnings(&warn, collectDoctorReport(func() (string, bool) { return "", false }, filepath.Join(tmp, "index.db")).Stores)
+	if !strings.Contains(warn.String(), "permission denied on") {
+		t.Errorf("the warning that names the path is gone:\n%s", warn.String())
+	}
+}

--- a/cmd/deja/empty_notes_history_test.go
+++ b/cmd/deja/empty_notes_history_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The notes file is a store file, and it was counted by existence: an empty one
+// — a note written and later forgotten — made deja answer "run `deja index`"
+// one line under the index run it had just narrated (#996).
+func TestAnEmptyNotesFileIsNotAgentHistory(t *testing.T) {
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	if err := os.WriteFile(notes, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !noAgentHistoryFound() {
+		t.Error("an empty notes file was counted as history")
+	}
+	if err := os.WriteFile(notes, []byte(`{"ts":"2026-08-04T10:00:00Z","project":"p","text":"the ticker window stays at 30s"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if noAgentHistoryFound() {
+		t.Error("a note someone wrote stopped counting as history")
+	}
+	if hint := emptyIndexHint("no matches"); !strings.Contains(hint, "deja index") {
+		t.Errorf("a machine with history lost the advice that fits it: %q", hint)
+	}
+}

--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -189,7 +189,7 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 		if len(hidden) > 0 {
 			return model.Session{}, errors.New(strings.TrimPrefix(policyHiddenNote(policy.ActivationSearch, len(hidden)), "deja: "))
 		}
-		return model.Session{}, fmt.Errorf("no indexed sessions for this project — pass a session id-prefix (see `deja last`)")
+		return model.Session{}, idPrefixNeeded(dir, "handoff needs a session to package", "no indexed sessions for this project — pass a session id-prefix (see `deja last`)")
 	}
 	if len(distinct) > 1 {
 		fmt.Fprintf(os.Stderr, "deja: %d different sessions match this directory's project names — picked the newest; pass an id-prefix to choose (see `deja last`)\n", len(distinct))

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -341,7 +341,7 @@ func runHookContext(dir string, plain bool) error {
 		if r, ok := findReusedMemory(dir); ok {
 			earned = fmt.Sprintf(" · most re-used recently: %q, %d×", trimBriefTitle(r.Title), r.Times)
 		}
-		resp.SystemMessage = joinNotes(rewireNote(rewired), fmt.Sprintf("deja: recalled %d prior session%s %s (~%dKB) — the agent starts already knowing them%s%s%s", sessions, plural, why, (len(digest)+1023)/1024, serviceReceipt(dir), polNote, earned))
+		resp.SystemMessage = joinNotes(rewireNote(rewired), fmt.Sprintf("deja: recalled %d prior session%s %s (%s) — the agent starts already knowing them%s%s%s", sessions, plural, why, humanBytes(int64(len(digest))), serviceReceipt(dir), polNote, earned))
 	}
 	// Nothing to recall yet because the index is still being built: say so
 	// rather than starting in silence. The build runs detached, so the agent

--- a/cmd/deja/hook_size_test.go
+++ b/cmd/deja/hook_size_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -45,6 +46,11 @@ func runHookCapturing(t *testing.T, dir, event string) string {
 // read as "~1KB" while statusline and stats counted the real figure — the one
 // number a reader sees first was the one no command could reproduce (#991).
 func TestHookSizeMatchesWhatTheCountersReport(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The helper swaps the process's stdin and stdout for pipes; on
+		// windows that stalls the hook's own reader instead of returning.
+		t.Skip("stdin/stdout swapping is not reliable on windows")
+	}
 	tmp := hermeticEnv(t)
 	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
 	if err := os.MkdirAll(store, 0o755); err != nil {

--- a/cmd/deja/hook_size_test.go
+++ b/cmd/deja/hook_size_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// runHookCapturing feeds the hook one event on stdin and returns its stdout.
+func runHookCapturing(t *testing.T, dir, event string) string {
+	t.Helper()
+	inR, inW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldIn, oldOut := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = inR, outW
+	defer func() { os.Stdin, os.Stdout = oldIn, oldOut }()
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(outR)
+		done <- string(b)
+	}()
+	go func() {
+		_, _ = inW.Write([]byte(event + "\n"))
+		_ = inW.Close()
+	}()
+	if err := runHookContext(dir, false); err != nil {
+		t.Fatal(err)
+	}
+	_ = outW.Close()
+	return <-done
+}
+
+// The size on the first screen was a ceiling to whole kilobytes, so 631 bytes
+// read as "~1KB" while statusline and stats counted the real figure — the one
+// number a reader sees first was the one no command could reproduce (#991).
+func TestHookSizeMatchesWhatTheCountersReport(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"session about the ticker window and the pool cap"},"timestamp":"2026-08-01T10:00:00Z","sessionId":"w1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "w1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	back, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	work := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(work); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(back) })
+
+	out := runHookCapturing(t, dir, `{"hook_event_name":"SessionStart","session_id":"probe","cwd":"`+work+`"}`)
+	var resp struct {
+		SystemMessage string `json:"systemMessage"`
+		Hook          struct {
+			Context string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("hook output is not JSON: %v\n%s", err, out)
+	}
+	if resp.SystemMessage == "" {
+		t.Skip("no memory to recall in this environment")
+	}
+	if strings.Contains(resp.SystemMessage, "KB)") && !strings.Contains(resp.SystemMessage, ".") {
+		t.Errorf("the size is still rounded to whole kilobytes: %q", resp.SystemMessage)
+	}
+	// The number has to be the same one the counters accumulate.
+	stats, err := captureRun(t, "stats", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var s struct {
+		Recall struct {
+			Bytes int64 `json:"bytes"`
+		} `json:"recall"`
+	}
+	if err := json.Unmarshal([]byte(stats), &s); err != nil {
+		t.Fatal(err)
+	}
+	if want := humanBytes(s.Recall.Bytes); !strings.Contains(resp.SystemMessage, "("+want+")") {
+		t.Errorf("the first screen says something else than stats counts (%s):\n%s", want, resp.SystemMessage)
+	}
+}

--- a/cmd/deja/id_needed_empty_test.go
+++ b/cmd/deja/id_needed_empty_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// "pass a session id-prefix (see `deja last`)" is a step the reader can take
+// and learn nothing from when the store is empty: the listing answers with the
+// emptiness deja already knew about one command earlier (#992).
+func TestIdNeededSaysTheStoreIsEmptyInsteadOfPointingAtTheListing(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, cmd := range []string{"promote", "share", "handoff"} {
+		_, err := captureRun(t, cmd)
+		if err == nil {
+			t.Fatalf("%s accepted an empty store", cmd)
+		}
+		if strings.Contains(err.Error(), "deja last") {
+			t.Errorf("%s sent the reader to a listing that is empty for the same reason: %v", cmd, err)
+		}
+		if !strings.Contains(err.Error(), "nothing is indexed yet") {
+			t.Errorf("%s does not say the store is empty: %v", cmd, err)
+		}
+	}
+
+	// With something indexed the refusal is about the missing argument again,
+	// and the listing is worth reading.
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	_, err := captureRun(t, "promote")
+	if err == nil || !strings.Contains(err.Error(), "deja last") {
+		t.Errorf("with sessions indexed promote stopped naming the listing: %v", err)
+	}
+}

--- a/cmd/deja/json_withheld_test.go
+++ b/cmd/deja/json_withheld_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The reason an answer is empty travelled on stderr only, so a caller reading
+// --json — a script, another agent, our own benchmarks — saw the same object
+// whether the history was empty or a rule withheld every row (#990).
+func TestJSONSaysWhenTheTrustPolicyWithheldRows(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "work/api", Role: "user", Text: "peer two about the pool cap"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	decode := func(t *testing.T, args ...string) map[string]any {
+		t.Helper()
+		out, err := captureRun(t, args...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(out), &m); err != nil {
+			t.Fatalf("%v is not JSON: %v\n%s", args, err, out)
+		}
+		return m
+	}
+
+	// No rule: the field is absent, so nothing changes for existing callers.
+	if got, ok := decode(t, "search", "pool", "--json")["policy_withheld"]; ok {
+		t.Errorf("an unrestricted search reported withheld rows: %v", got)
+	}
+	if got, ok := decode(t, "last", "--json")["policy_withheld"]; ok {
+		t.Errorf("an unrestricted listing reported withheld rows: %v", got)
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	got := decode(t, "search", "pool", "--json")
+	if got["policy_withheld"] != float64(1) {
+		t.Errorf("search --json does not say the rule emptied it: %v", got)
+	}
+	if hits, _ := got["hits"].([]any); len(hits) != 0 {
+		t.Errorf("the hidden hit was returned anyway: %v", got["hits"])
+	}
+	got = decode(t, "last", "--json")
+	if got["policy_withheld"] != float64(1) {
+		t.Errorf("last --json does not say a row was kept out: %v", got)
+	}
+	if ss, _ := got["sessions"].([]any); len(ss) != 1 {
+		t.Errorf("the listing returned the wrong rows: %v", got["sessions"])
+	}
+}

--- a/cmd/deja/lifecycle.go
+++ b/cmd/deja/lifecycle.go
@@ -172,11 +172,24 @@ func demotedNote(hits []search.Hit, moved int) string {
 	if moved == 0 {
 		return ""
 	}
+	// One decision, not one row: a rejected note and the transcript it was
+	// promoted from are both demoted, and counting rows told the reader they
+	// had marked two sessions when they marked one (#997).
+	notes := promotedNoteSources()
+	seen := map[string]bool{}
 	n, elsewhere := 0, 0
 	for _, h := range hits {
 		if h.Lifecycle != lifecycleRejected {
 			continue
 		}
+		key := h.Session.Harness + ":" + h.Session.ID
+		if src, ok := notes[h.Session.ID]; ok {
+			key = src
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
 		n++
 		// "you marked" is wrong for a decision another machine took back: the
 		// state travelled with the note, the judgement was not this reader's

--- a/cmd/deja/lifecycle_test.go
+++ b/cmd/deja/lifecycle_test.go
@@ -244,3 +244,39 @@ func TestDemotedNote(t *testing.T) {
 		t.Errorf("plural note = %q", got)
 	}
 }
+
+// The line attributes a reordering to the person who caused it, so its number
+// is the count of their decisions. A rejected note and the transcript it was
+// promoted from are one decision stored twice, and counting rows grew the
+// number with deja's storage rather than with what the reader did (#997).
+func TestDemotedNoteCountsDecisionsNotRows(t *testing.T) {
+	tmp := t.TempDir()
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	body := `{"ts":"2026-08-04T10:00:00Z","project":"p","text":"rolled back","kind":"promoted","session":"claude:bad","state":"rejected","title":"pool cap"}` + "\n"
+	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hits := []search.Hit{
+		{Session: model.Session{ID: "bad", Harness: "claude", Project: "p"}, Lifecycle: "rejected"},
+		{Session: model.Session{ID: "deja-note-claude-bad", Harness: "deja", Project: "p"}, Lifecycle: "rejected"},
+		{Session: model.Session{ID: "good", Harness: "claude", Project: "p"}},
+	}
+	got := demotedNote(hits, demoteRejected(hits))
+	if !strings.Contains(got, "1 session you marked rejected is below") {
+		t.Errorf("one decision stored twice was counted as %q", got)
+	}
+
+	// Two decisions are still two.
+	body += `{"ts":"2026-08-04T11:00:00Z","project":"p","text":"also wrong","kind":"promoted","session":"claude:worse","state":"rejected","title":"ticker"}` + "\n"
+	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hits = append(hits[:2:2],
+		search.Hit{Session: model.Session{ID: "worse", Harness: "claude", Project: "p"}, Lifecycle: "rejected"},
+		search.Hit{Session: model.Session{ID: "deja-note-claude-worse", Harness: "deja", Project: "p"}, Lifecycle: "rejected"},
+		search.Hit{Session: model.Session{ID: "good", Harness: "claude", Project: "p"}})
+	if got := demotedNote(hits, demoteRejected(hits)); !strings.Contains(got, "2 sessions you marked rejected are below") {
+		t.Errorf("two decisions were counted as %q", got)
+	}
+}

--- a/cmd/deja/machine_output.go
+++ b/cmd/deja/machine_output.go
@@ -11,6 +11,9 @@ import (
 type recentJSON struct {
 	SchemaVersion int             `json:"schema_version"`
 	Sessions      []model.Session `json:"sessions"`
+	// Withheld is how many rows the trust policy kept out of this listing —
+	// the same fact the text form prints on stderr (#990).
+	Withheld int `json:"policy_withheld,omitempty"`
 }
 
 type sessionWindow struct {
@@ -27,6 +30,10 @@ type sessionJSON struct {
 }
 
 func printRecentJSON(w io.Writer, sessions []model.Session, sourceInstance string) error {
+	return printRecentJSONWithheld(w, sessions, sourceInstance, 0)
+}
+
+func printRecentJSONWithheld(w io.Writer, sessions []model.Session, sourceInstance string, withheld int) error {
 	for i := range sessions {
 		sessions[i].Messages = nil
 		sessions[i].SetSource(sourceInstance)
@@ -34,7 +41,7 @@ func printRecentJSON(w io.Writer, sessions []model.Session, sourceInstance strin
 	if sessions == nil {
 		sessions = []model.Session{}
 	}
-	return json.NewEncoder(w).Encode(recentJSON{SchemaVersion: jsonout.Version, Sessions: sessions})
+	return json.NewEncoder(w).Encode(recentJSON{SchemaVersion: jsonout.Version, Sessions: sessions, Withheld: withheld})
 }
 
 // sliceMessages applies --offset and --limit. Both are documented for `deja

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1901,8 +1901,18 @@ func emptyIndexHint(what string) string {
 // opposed to an index that merely has not been built yet.
 func noAgentHistoryFound() bool {
 	for _, check := range doctorStoreChecks() {
-		if store, _ := inspectDoctorStore(check); store.Files > 0 {
-			return false
+		store, _ := inspectDoctorStore(check)
+		if store.Files == 0 {
+			continue
+		}
+		// By content, not by existence: an empty notes file — one `deja
+		// remember` later forgotten, or a file someone touched — counted as
+		// history and turned the answer into "run `deja index`", which is the
+		// one piece of advice this branch exists to avoid (#996).
+		for _, f := range check.files {
+			if fi, err := os.Stat(f); err == nil && fi.Size() > 0 {
+				return false
+			}
 		}
 	}
 	return true

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -484,7 +484,7 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 	}
 	if len(ss) == 0 {
 		if o.JSON {
-			return printRecentJSON(os.Stdout, nil, sourceInstance)
+			return printRecentJSONWithheld(os.Stdout, nil, sourceInstance, policyHidden)
 		}
 		// The rule that emptied the list was named a line above; "no sessions
 		// indexed yet — run `deja index`" is advice for a state deja is not in,
@@ -505,7 +505,7 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 		return nil
 	}
 	if o.JSON {
-		return printRecentJSON(os.Stdout, ss, sourceInstance)
+		return printRecentJSONWithheld(os.Stdout, ss, sourceInstance, policyHidden)
 	}
 	for _, s := range ss {
 		// A session whose timestamp was missing or unparseable carries the Go
@@ -623,6 +623,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 		hits, o.Total, o.Capped = detailed.Hits, detailed.Total, detailed.Capped
 	}
 	hits, policyHidden := policyFilterHitsCounted(policy.ActivationSearch, hits)
+	o.PolicyWithheld = policyHidden
 	if !o.NoEmbed && os.Getenv("DEJA_EMBED") != "off" {
 		hits = maybeRerank(dir, hits, o, os.Stderr)
 	}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -25,6 +25,11 @@ import (
 var version = "dev"
 
 func main() {
+	// A command that lands mid-rebuild waits for the whole of it, and silence
+	// there reads as a hang rather than as a queue (#994).
+	index.LockWaitNotice = func() {
+		fmt.Fprintln(os.Stderr, "deja: another deja is building the index — waiting for it to finish")
+	}
 	stopProfiling := startProfiling()
 	if err := run(os.Args[1:]); err != nil {
 		stopProfiling()

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1866,6 +1866,17 @@ Examples:
 See README.md for the full CLI reference.`)
 }
 
+// idPrefixNeeded is the refusal for a command that needs a session named on the
+// command line. "see `deja last`" is a step the reader can take and learn
+// nothing from when the store is empty: the listing answers with the same
+// emptiness deja already knows about here (#992).
+func idPrefixNeeded(dir, subject, refusal string) error {
+	if n, err := index.SessionCount(dir); err == nil && n == 0 {
+		return errors.New(strings.TrimPrefix(emptyIndexHint(subject+", and nothing is indexed yet"), "deja: "))
+	}
+	return errors.New(refusal)
+}
+
 // emptyIndexHint phrases the nothing-here answer the same way everywhere, and
 // points at the next command rather than leaving the user to guess.
 //

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -61,7 +61,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 		}
 	}
 	if prefix == "" {
-		return fmt.Errorf("promote needs a session id prefix (see `deja last`)")
+		return idPrefixNeeded(dir, "promote needs a session id prefix", "promote needs a session id prefix (see `deja last`)")
 	}
 	if !sources.NoteStates[state] {
 		// Taking a mark back is the state nobody guesses: users reach for

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -349,6 +349,19 @@ func endsWithNewline(path string) bool {
 	return buf[0] == '\n'
 }
 
+// promotedNoteSources maps every promoted note's id to the session it came
+// from, in one pass over the note log.
+func promotedNoteSources() map[string]string {
+	out := map[string]string{}
+	for _, n := range sources.LoadPromotedNotes() {
+		if n.Session == "" {
+			continue
+		}
+		out["deja-note-"+strings.ReplaceAll(n.Session, ":", "-")] = n.Session
+	}
+	return out
+}
+
 // promotedNoteSource maps a promoted note's id back to the session it was
 // promoted from. The id is built by replacing the colon in `harness:id`, which
 // does not invert on its own — harness names carry dashes — so the note log is

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -12,7 +12,7 @@ import (
 
 func runShare(dir string, args []string, w io.Writer) error {
 	if len(args) < 1 {
-		return fmt.Errorf("share needs id-prefix")
+		return idPrefixNeeded(dir, "share needs an id-prefix", "share needs id-prefix")
 	}
 	s, ok, err := findByPrefix(dir, args[0])
 	noteAmbiguousPrefix(dir, args[0], "sharing")

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -29,6 +29,9 @@ from a list of hits:
   sessions deja could find. Counting those as hits overstates recall, and this
   used to be readable only as a sentence on stderr.
 - `total` and `capped` — how many sessions matched, and whether a cap hid some.
+- `policy_withheld` — how many matching sessions this machine's trust policy
+  kept out of the answer. Omitted when none were. Present on `search --json`
+  and `last --json`, so an empty result can be told apart from a rule.
   Counting the returned hits measures the cap: that figure moves when the
   window's membership changes, whether or not retrieval improved.
   **`capped: false` means the response holds everything that matched, on every

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -297,3 +297,21 @@ type bucketEntry struct {
 	off uint64
 	n   uint32
 }
+
+// LockWaitNotice is called once when a write path finds the index locked by
+// another deja and is about to wait for it. Readers never reach it — they take
+// a lock-free snapshot instead — so this is only the case where a command is
+// about to sit still for the length of someone else's build.
+var LockWaitNotice func()
+
+// noteLockWait reports the wait at most once per process, so a command that
+// takes several locks does not repeat itself.
+func noteLockWait() {
+	if LockWaitNotice == nil || lockWaitNoted {
+		return
+	}
+	lockWaitNoted = true
+	LockWaitNotice()
+}
+
+var lockWaitNoted bool

--- a/internal/index/lock_unix.go
+++ b/internal/index/lock_unix.go
@@ -22,9 +22,15 @@ func lockDir(dir string) (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		f.Close()
-		return nil, fmt.Errorf("lock index: %w", err)
+	// Try without blocking first, only to learn whether there is a wait to
+	// report: a reader that lands mid-rebuild sits here for the length of it
+	// and printed nothing, so the command looked hung (#994).
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		noteLockWait()
+		if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+			f.Close()
+			return nil, fmt.Errorf("lock index: %w", err)
+		}
 	}
 	// Under the lock: finish any swap interrupted mid-rename. Running this
 	// before the flock raced a concurrent swap's missing-dir window (#181).

--- a/internal/index/lock_wait_test.go
+++ b/internal/index/lock_wait_test.go
@@ -1,0 +1,51 @@
+package index
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// deja narrates its own builds line by line and said nothing while waiting for
+// someone else's, so a command that landed mid-rebuild sat silent for the
+// length of it and read as hung (#994).
+func TestWaitingForAnotherBuildIsReportedOnce(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	notices := 0
+	old := LockWaitNotice
+	LockWaitNotice = func() { notices++ }
+	t.Cleanup(func() { LockWaitNotice = old; lockWaitNoted = false })
+
+	// A free lock is the ordinary case and must stay quiet.
+	unlock, err := lockDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if notices != 0 {
+		t.Fatalf("an uncontended lock reported a wait: %d", notices)
+	}
+
+	// Held by someone else: the notice fires before the wait.
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		unlock()
+		close(done)
+	}()
+	second, err := lockDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-done
+	second()
+	if notices != 1 {
+		t.Errorf("the wait was not reported exactly once: %d", notices)
+	}
+
+	// A command takes several locks; the reader is told once, not per lock.
+	lockWaitNoted = true
+	noteLockWait()
+	if notices != 1 {
+		t.Errorf("the notice repeated itself: %d", notices)
+	}
+}

--- a/internal/index/lock_wait_test.go
+++ b/internal/index/lock_wait_test.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -10,6 +11,12 @@ import (
 // someone else's, so a command that landed mid-rebuild sat silent for the
 // length of it and read as hung (#994).
 func TestWaitingForAnotherBuildIsReportedOnce(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Byte-range locks are per handle there and the second lockDir in one
+		// process is a different case than two processes; the notice itself is
+		// platform-independent.
+		t.Skip("two locks in one process do not model contention on windows")
+	}
 	dir := filepath.Join(t.TempDir(), "index.db")
 	notices := 0
 	old := LockWaitNotice

--- a/internal/index/lock_windows.go
+++ b/internal/index/lock_windows.go
@@ -36,14 +36,22 @@ func lockDir(dir string) (func(), error) {
 	}
 	h := syscall.Handle(f.Fd())
 	var ol syscall.Overlapped
-	// Without blocking first, only to learn whether there is a wait worth
-	// reporting — see the note in lock_unix.go (#994).
-	if err := lockFileEx(h, lockfileExclusiveLock|lockfileFailImmediately, 0, 1, 0, &ol); err != nil {
-		noteLockWait()
-		if err := lockFileEx(h, lockfileExclusiveLock, 0, 1, 0, &ol); err != nil {
-			f.Close()
-			return nil, fmt.Errorf("lock index: %w", err)
+	// The probe takes its own handle: a failed LOCKFILE_FAIL_IMMEDIATELY on
+	// the handle we are about to block with leaves the lock state on it
+	// ambiguous, and the blocking call that follows never returned. Only to
+	// learn whether there is a wait worth reporting — see lock_unix.go (#994).
+	if probe, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600); err == nil {
+		var pol syscall.Overlapped
+		if lockFileEx(syscall.Handle(probe.Fd()), lockfileExclusiveLock|lockfileFailImmediately, 0, 1, 0, &pol) != nil {
+			noteLockWait()
+		} else {
+			_ = unlockFileEx(syscall.Handle(probe.Fd()), 0, 1, 0, &pol)
 		}
+		_ = probe.Close()
+	}
+	if err := lockFileEx(h, lockfileExclusiveLock, 0, 1, 0, &ol); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("lock index: %w", err)
 	}
 	// Under the lock: finish any swap interrupted mid-rename. Running this
 	// before the lock raced a concurrent swap's missing-dir window (#181).

--- a/internal/index/lock_windows.go
+++ b/internal/index/lock_windows.go
@@ -36,9 +36,14 @@ func lockDir(dir string) (func(), error) {
 	}
 	h := syscall.Handle(f.Fd())
 	var ol syscall.Overlapped
-	if err := lockFileEx(h, lockfileExclusiveLock, 0, 1, 0, &ol); err != nil {
-		f.Close()
-		return nil, fmt.Errorf("lock index: %w", err)
+	// Without blocking first, only to learn whether there is a wait worth
+	// reporting — see the note in lock_unix.go (#994).
+	if err := lockFileEx(h, lockfileExclusiveLock|lockfileFailImmediately, 0, 1, 0, &ol); err != nil {
+		noteLockWait()
+		if err := lockFileEx(h, lockfileExclusiveLock, 0, 1, 0, &ol); err != nil {
+			f.Close()
+			return nil, fmt.Errorf("lock index: %w", err)
+		}
 	}
 	// Under the lock: finish any swap interrupted mid-rename. Running this
 	// before the lock raced a concurrent swap's missing-dir window (#181).

--- a/internal/policy/describe_both_denied_test.go
+++ b/internal/policy/describe_both_denied_test.go
@@ -1,0 +1,36 @@
+package policy
+
+import "testing"
+
+// "local-only" is the name of the rule that keeps local sessions and drops
+// imported ones. A policy that denies both was described with it, next to a
+// count on the same doctor line saying every session was withheld (#995).
+func TestDescribeNamesTheRuleThatIsActuallyInForce(t *testing.T) {
+	both := Policy{Activations: map[string]map[string]bool{
+		ActivationSearch: {"local": false, "imported": false},
+	}}
+	if got := both.Describe(ActivationSearch); got != "nothing activates" {
+		t.Errorf("a policy that denies every origin describes itself as %q", got)
+	}
+	if both.Allows(ActivationSearch, "proj") || both.Allows(ActivationSearch, "imported:proj") {
+		t.Error("a policy that denies every origin let something through")
+	}
+
+	localOnly := Policy{Activations: map[string]map[string]bool{
+		ActivationSearch: {"local": true, "imported": false},
+	}}
+	if got := localOnly.Describe(ActivationSearch); got != "local-only" {
+		t.Errorf("the ordinary rule changed its name: %q", got)
+	}
+	// Denying only `local` keeps the generic form it has always had, and it is
+	// still the rule in force.
+	importedOnly := Policy{Activations: map[string]map[string]bool{
+		ActivationSearch: {"local": false, "imported": true},
+	}}
+	if got := importedOnly.Describe(ActivationSearch); got != "deny local" {
+		t.Errorf("a rule that denies only local describes itself as %q", got)
+	}
+	if !importedOnly.Allows(ActivationSearch, "imported:proj") || importedOnly.Allows(ActivationSearch, "proj") {
+		t.Error("the description and the filter disagree")
+	}
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -114,9 +114,25 @@ func (p Policy) Describe(activation string) string {
 	if rules == nil {
 		return "local+imported"
 	}
+	localOff := false
+	if v, ok := rules["local"]; ok && !v {
+		localOff = true
+	}
+	importedOff := false
 	if v, ok := rules["imported"]; ok && !v {
+		importedOff = true
+	}
+	// A rule that denies both origins was described as "local-only", which is
+	// the name of a different rule — and doctor printed it beside a count that
+	// contradicted it: "local-only — withholds 1 of 1 indexed session" (#995).
+	switch {
+	case localOff && importedOff:
+		return "nothing activates"
+	case importedOff:
 		return "local-only"
 	}
+	// A rule that denies only `local` keeps the generic "deny <origin>" form:
+	// it is one denial among the others below, and two tests pin it (#941).
 	denied := make([]string, 0, len(rules))
 	for origin, allowed := range rules {
 		// A key deja never consults restricts nothing, and naming it here put

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -50,6 +50,10 @@ type Options struct {
 	// survived it. Counting the survivors measures the cap.
 	Total  int
 	Capped bool
+	// PolicyWithheld is how many matching sessions the trust policy kept out
+	// of this answer. The reason travelled on stderr only, so a caller reading
+	// --json could not tell a rule from an empty history (#990).
+	PolicyWithheld int
 	// WithAnswer carries the assistant reply next to a matched user turn.
 	// Agent-facing recall sets it; human CLI output does not, because a person
 	// reading results can open the session.

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -61,6 +61,7 @@ type searchJSONEnvelope struct {
 	// the cap hid any. Counting the returned hits alone measures the cap.
 	Total    int                 `json:"total"`
 	Capped   bool                `json:"capped,omitempty"`
+	Withheld int                 `json:"policy_withheld,omitempty"`
 	Hits     []Hit               `json:"hits"`
 	Fuzzy    bool                `json:"fuzzy,omitempty"`
 	Stemmed  bool                `json:"stemmed,omitempty"`
@@ -744,6 +745,7 @@ func Print(w io.Writer, hits []Hit, o Options) {
 			Tier:          setTier(o),
 			Total:         o.Total,
 			Capped:        o.Capped,
+			Withheld:      o.PolicyWithheld,
 			Hits:          hits,
 			Fuzzy:         o.Fuzzy,
 			Stemmed:       o.Stemmed,


### PR DESCRIPTION
Seven findings from the audit run, all measured on a live index.

- #990 `--json` could not tell a trust rule from an empty history; adds an optional `policy_withheld`
- #991 the first screen rounded its own size up to the nearest KB, disagreeing with statusline and stats
- #992 commands that need a session id sent you to an empty listing
- #993 doctor's store row said `found` for a directory it cannot open (`--json` has said `denied` since #802)
- #994 a command that landed mid-rebuild sat silent for the length of it
- #995 a policy denying both origins was described as `local-only`
- #996 an empty notes file counted as agent history, so the advice became "run `deja index`" one line under the index run
- #997 the demotion line counted rows rather than decisions

Each fix has a test that fails on the old behaviour; mutations checked per fix.
