### PR TITLE
Make doctor's two forms agree, and stop three lines from lying about provenance

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -389,6 +389,14 @@ func doctorHarnesses(w io.Writer, dir string) {
 	indexed := index.HarnessSessionCounts(dir)
 	fromElsewhere := index.ImportedSessionCounts(dir)
 
+	// The same inspection the JSON form reports, so one command does not give
+	// two answers about one store: `found` here and `unreadable` there (#999).
+	inspected := map[string]string{}
+	for _, check := range doctorStoreChecks() {
+		store, _ := inspectDoctorStore(check)
+		inspected[check.name] = store.State
+	}
+
 	printRow := func(name, path string, present bool, detail string) {
 		status := "missing"
 		if present {
@@ -397,13 +405,16 @@ func doctorHarnesses(w io.Writer, dir string) {
 			// without a word — the failure #802/#816 closed, but only in
 			// `doctor --json`, which has said `denied` all along while this
 			// row, the one people read, said `found` (#993).
-			if denied := firstDeniedDir(strings.Split(path, ", ")); denied != "" {
-				status = "denied"
-				if detail != "" {
-					detail += ", "
+			switch inspected[name] {
+			case "denied", "unreadable", "parsed-zero", "needs-sqlite3":
+				status = inspected[name]
+				if status == "denied" {
+					if detail != "" {
+						detail += ", "
+					}
+					// The warning block below names the path and what to do.
+					detail += "cannot be read"
 				}
-				_ = denied // the warning line below names the path
-				detail += "cannot be read"
 			}
 		} else if storeDiskGone(path) {
 			// A store whose whole disk is gone is not a store that was

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -187,12 +187,21 @@ func doctorStoreChecks() []doctorStoreCheck {
 		{"pi", []string{sources.PiRoot()}, sources.PiSessionFiles(), sources.ParsePiFile},
 		{"openclaw", []string{sources.OpenClawRoot()}, sources.OpenClawSessionFiles(), sources.ParseOpenClawFile},
 		{"copilot", []string{sources.CopilotRoot()}, sources.CopilotSessionFiles(), sources.ParseCopilotFile},
+		// Both were listed by the text rows and by nothing else: absent here,
+		// `doctor --json` never named them and "no agent history was found on
+		// this machine" was printed on a machine whose history is theirs
+		// (#999).
+		{"cline", []string{sources.ClineSessionsDir()}, sources.ClineSessionFiles(), sources.ParseClineFile},
+		{"roo", sources.RooRoots(), sources.RooTaskFiles(), sources.ParseRooTask},
 		{"deja", []string{sources.NotesFile()}, presentDoctorFile(sources.NotesFile()), sources.ParseNotesFile},
 	}
 }
 
 func presentDoctorFile(path string) []string {
-	if doctorExists(path) {
+	// By content: an empty notes file is not a store with something in it, and
+	// counting it made the two forms of this command disagree about the same
+	// row — `missing` in the text, `ok` in JSON (#999).
+	if fi, err := os.Stat(path); err == nil && !fi.IsDir() && fi.Size() > 0 {
 		return []string{path}
 	}
 	return nil
@@ -264,6 +273,14 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 		return store, time.Time{}
 	}
 	if len(check.files) == 0 {
+		// The text rows have separated a store whose disk went away from one
+		// that was deleted since #933; a script reading this could not (#999).
+		for _, p := range check.paths {
+			if p != "" && storeDiskGone(p) {
+				store.State = "unplugged"
+				break
+			}
+		}
 		return store, time.Time{}
 	}
 	newest, mod := newestDoctorFile(check.files)

--- a/cmd/deja/doctor_two_forms_test.go
+++ b/cmd/deja/doctor_two_forms_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// One command, two answers about the same store: the text row said `found`
+// where the machine form said `unreadable`, `unplugged` existed only in the
+// text, and cline and roo were in neither the JSON nor the list that decides
+// whether this machine has any history at all (#999).
+func TestDoctorsTwoFormsAgreeAboutEveryStore(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+
+	names := map[string]bool{}
+	for _, check := range doctorStoreChecks() {
+		names[check.name] = true
+	}
+	for _, want := range []string{"cline", "roo"} {
+		if !names[want] {
+			t.Errorf("%s is missing from the store list the JSON form and the history check both read", want)
+		}
+	}
+
+	// A store nobody can parse says so in both forms.
+	oc := filepath.Join(tmp, "opencode.db")
+	if err := os.WriteFile(oc, []byte("not a db"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_OPENCODE_DB", oc)
+
+	var text bytes.Buffer
+	doctorHarnesses(&text, dir)
+	row := harnessRow(t, text.String(), "opencode")
+	if strings.Contains(row, "found") {
+		t.Errorf("the text row calls an unreadable store found: %q", row)
+	}
+
+	var out bytes.Buffer
+	if err := runDoctor(&out, []string{"--json"}, stubLookup("1.0.0", true), dir); err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		Stores []struct {
+			Name  string `json:"name"`
+			State string `json:"state"`
+		} `json:"stores"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	states := map[string]string{}
+	for _, s := range report.Stores {
+		states[s.Name] = s.State
+	}
+	if states["opencode"] != "unreadable" {
+		t.Errorf("the machine form calls it %q", states["opencode"])
+	}
+	if !strings.Contains(row, states["opencode"]) {
+		t.Errorf("the two forms use different words: %q vs %q", row, states["opencode"])
+	}
+
+	// An empty notes file is not a store with something in it, in either form.
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	if err := os.WriteFile(notes, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	if err := runDoctor(&out, []string{"--json"}, stubLookup("1.0.0", true), dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range report.Stores {
+		if s.Name == "deja" && s.State == "ok" {
+			t.Errorf("an empty notes file is reported as a store with content")
+		}
+	}
+}

--- a/cmd/deja/doctor_two_forms_test.go
+++ b/cmd/deja/doctor_two_forms_test.go
@@ -58,7 +58,12 @@ func TestDoctorsTwoFormsAgreeAboutEveryStore(t *testing.T) {
 	for _, s := range report.Stores {
 		states[s.Name] = s.State
 	}
-	if states["opencode"] != "unreadable" {
+	// Without the sqlite3 CLI — which CI on windows does not have — the same
+	// store is `needs-sqlite3`; either way it is not a healthy one, and the
+	// point is that both forms say the same word.
+	switch states["opencode"] {
+	case "unreadable", "needs-sqlite3":
+	default:
 		t.Errorf("the machine form calls it %q", states["opencode"])
 	}
 	if !strings.Contains(row, states["opencode"]) {

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -479,7 +479,14 @@ func dejaVuLine(s model.Session, terms ...string) string {
 		}
 		why = " · via: " + strings.Join(terms, ", ")
 	}
-	return fmt.Sprintf("deja-vu: you have been here — %q (%s%s)", topic, search.RelativeDate(s.Updated), why)
+	// "you have been here" for a session that arrived from another machine
+	// claims the reader did work they have never seen — the context block
+	// below labels it `imported:` and this line contradicted it (#1001).
+	who := "you have been here"
+	if strings.HasPrefix(s.Project, "imported:") {
+		who = "this was done on another machine"
+	}
+	return fmt.Sprintf("deja-vu: %s — %q (%s%s)", who, topic, search.RelativeDate(s.Updated), why)
 }
 
 // dejaVuTopic picks something a human actually typed. Session titles are the

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -506,3 +506,27 @@ func TestHookPromptSurvivesBytesAfterThePayload(t *testing.T) {
 		}
 	}
 }
+
+// The one line a person reads claimed they had done work that arrived from
+// another machine, while the context block below it labelled the same session
+// `imported:` (#1001).
+func TestDejaVuLineDoesNotClaimAPeersWorkAsYours(t *testing.T) {
+	local := model.Session{ID: "loc", Project: "tmp/w16", Updated: time.Now(),
+		Messages: []model.Message{{Role: "user", Text: "the ticker window stays at 30s"}}}
+	if got := dejaVuLine(local, "ticker"); !strings.Contains(got, "you have been here") {
+		t.Errorf("a local session lost the wording it has always had: %q", got)
+	}
+	peer := local
+	peer.Project = "imported:tmp/w16"
+	got := dejaVuLine(peer, "ticker")
+	if strings.Contains(got, "you have been here") {
+		t.Errorf("a session from another machine is claimed as the reader's own: %q", got)
+	}
+	if !strings.Contains(got, "another machine") {
+		t.Errorf("the line does not say where the session came from: %q", got)
+	}
+	// The rest of the line — the topic and why it fired — is unchanged.
+	if !strings.Contains(got, "ticker window") || !strings.Contains(got, "via: ticker") {
+		t.Errorf("the line lost what it is for: %q", got)
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -357,7 +357,10 @@ func installIndexHint(dir string) string {
 		if store.Files > 0 {
 			detected++
 		}
-		if store.State != "missing" && store.State != "empty" {
+		// A store whose disk is not attached is not history found here either;
+		// the text rows have separated the two since #933 and the JSON form
+		// learned to in #999.
+		if store.State != "missing" && store.State != "empty" && store.State != "unplugged" {
 			onlyMissingOrEmpty = false
 		}
 		for _, path := range store.Paths {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1407,6 +1407,12 @@ func printSources(dir string) {
 			msg += len(s.Messages)
 		}
 		note := ""
+		// `deja sources` is where the empty-machine advice sends people, and a
+		// store deja is not allowed to read looked exactly like one nobody has
+		// used: `sessions=0 messages=0 size=0 B` (#1000).
+		if denied := firstDeniedDir(it.roots); denied != "" {
+			note = "\t(cannot be read — permission denied on " + denied + ")"
+		}
 		if it.name == "cursor" && len(sources.CursorDBs()) > 0 && !sources.SQLite3Available() {
 			note = "\t(sqlite3 CLI not found — Cursor IDE sessions unavailable)"
 		}

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -14,6 +14,15 @@ func runShare(dir string, args []string, w io.Writer) error {
 	if len(args) < 1 {
 		return idPrefixNeeded(dir, "share needs an id-prefix", "share needs id-prefix")
 	}
+	// Everything after the id used to be ignored, so `deja share <id> --to
+	// out.md` printed the share to the terminal and wrote no file — and said
+	// nothing about either (#1002). promote refuses unknown flags; this is the
+	// same command shape one letter away.
+	for _, a := range args[1:] {
+		if strings.HasPrefix(a, "-") {
+			return fmt.Errorf("share: unknown flag %q — share writes to stdout (redirect it), and `deja promote <id> --to <path>` is the one that writes a file", a)
+		}
+	}
 	s, ok, err := findByPrefix(dir, args[0])
 	noteAmbiguousPrefix(dir, args[0], "sharing")
 	if err != nil {

--- a/cmd/deja/share_test.go
+++ b/cmd/deja/share_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// promote writes a file with --to; share takes no flags and dropped them, so
+// `deja share <id> --to out.md` printed to the terminal, wrote nothing, and
+// said neither (#1002).
+func TestShareRefusesFlagsItCannotHonour(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(tmp, "out.md")
+	_, err := captureRun(t, "share", "loc", "--to", out)
+	if err == nil {
+		t.Fatalf("share accepted a flag it does not implement, and wrote nothing")
+	}
+	if !strings.Contains(err.Error(), "unknown flag") || !strings.Contains(err.Error(), "promote") {
+		t.Errorf("the refusal does not say what to use instead: %v", err)
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Errorf("share wrote a file after refusing")
+	}
+
+	// The ordinary share is untouched.
+	got, err := captureRun(t, "share", "loc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "deja share: loc") {
+		t.Errorf("plain share stopped working:\n%s", got)
+	}
+}

--- a/cmd/deja/sources_denied_test.go
+++ b/cmd/deja/sources_denied_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// `deja sources` is the command the empty-machine advice names, and a store
+// deja is not allowed to read looked exactly like one nobody has used —
+// `sessions=0 messages=0 size=0 B` and nothing else (#1000).
+func TestSourcesSaysWhenAStoreCannotBeRead(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	tmp := hermeticEnv(t)
+	qwen := filepath.Join(tmp, "qwen")
+	projects := filepath.Join(qwen, "projects", "p1")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projects, "s.json"), []byte(`{"x":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_QWEN_ROOT", qwen)
+
+	out, err := captureRun(t, "sources")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line := storeLine(out, "qwen"); strings.Contains(line, "cannot be read") {
+		t.Fatalf("a readable store was reported as locked: %q", line)
+	}
+
+	if err := os.Chmod(filepath.Join(qwen, "projects"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(qwen, "projects"), 0o755) })
+
+	out, err = captureRun(t, "sources")
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := storeLine(out, "qwen")
+	if !strings.Contains(line, "cannot be read") {
+		t.Errorf("a locked store reads as an empty one: %q", line)
+	}
+	if !strings.Contains(line, "permission denied") {
+		t.Errorf("the line does not say why: %q", line)
+	}
+	// Every other store keeps its plain row.
+	if l := storeLine(out, "claude"); strings.Contains(l, "cannot be read") {
+		t.Errorf("an untouched store picked up the note: %q", l)
+	}
+}
+
+func storeLine(out, name string) string {
+	for _, l := range strings.Split(out, "\n") {
+		if strings.HasPrefix(l, name+"\t") {
+			return l
+		}
+	}
+	return ""
+}

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "goose",
-      "state": "missing",
+      "state": "unplugged",
       "paths": [
         "<tmp>/home/.local/share/goose/sessions"
       ],
@@ -102,7 +102,7 @@
     },
     {
       "name": "pi",
-      "state": "missing",
+      "state": "unplugged",
       "paths": [
         "<tmp>/home/.pi/agent/sessions"
       ],
@@ -122,6 +122,20 @@
       "paths": [
         "<tmp>/copilot"
       ],
+      "files": 0
+    },
+    {
+      "name": "cline",
+      "state": "unplugged",
+      "paths": [
+        "<tmp>/home/.cline/data/sessions"
+      ],
+      "files": 0
+    },
+    {
+      "name": "roo",
+      "state": "missing",
+      "paths": null,
       "files": 0
     },
     {


### PR DESCRIPTION
Four findings from the audit run, all measured on a live index.

- #999 doctor's text and `--json` disagreed about the same store, and cline and roo were in neither the JSON nor the check that decides whether this machine has any history — so a machine whose history is cline was told it had none
- #1000 `deja sources` — the command the empty-machine advice names — showed a locked store as an unused one
- #1001 the deja-vu line said "you have been here" about a session that arrived from another machine, contradicting the block right below it
- #1002 `share` silently ignored flags, so `deja share <id> --to out.md` printed to the terminal and wrote nothing

Each fix has a test that fails on the old behaviour; mutations checked per fix.
