### PR TITLE
Say the same thing about an index that cannot be written, and explain two dates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
   test:
     name: test / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # windows runs the suite about four times slower than the others and had
+    # grown into the 20-minute cap: the run was cancelled a second after the
+    # last package passed.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/cmd/deja/bucket_day_note_test.go
+++ b/cmd/deja/bucket_day_note_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A day bucket's date is the day the index was built in; the times inside are
+// this machine's. Read in another zone the two disagree, and the screen that
+// shows them together said nothing (#1006).
+func TestBucketDayIsExplainedOnlyWhenItDiffers(t *testing.T) {
+	at := time.Date(2026, 8, 4, 6, 30, 0, 0, time.UTC)
+	s := model.Session{Harness: "deja", ID: "deja-2026-08-04-w20", Project: "w20",
+		Messages: []model.Message{{Role: "user", Text: "morning: the pool cap is 20", Time: at}}}
+
+	saved := time.Local
+	t.Cleanup(func() { time.Local = saved })
+
+	// Read where the record falls on the day the id names: no line.
+	time.Local = time.UTC
+	if note := bucketDayNote(s); note != "" {
+		t.Errorf("a bucket read in its own zone was explained anyway: %q", note)
+	}
+
+	// Seven hours west, the same record is the previous day.
+	time.Local = time.FixedZone("west", -7*60*60)
+	note := bucketDayNote(s)
+	if note == "" {
+		t.Fatal("nothing explains an id dated a day after the line inside it")
+	}
+	if !strings.Contains(note, "2026-08-04") || !strings.Contains(note, "day the index was built in") {
+		t.Errorf("the note does not say what the id's date is: %q", note)
+	}
+
+	// A transcript whose id merely looks like a bucket is not one: only deja's
+	// own notes are grouped by day.
+	other := s
+	other.Harness = "claude"
+	if n := bucketDayNote(other); n != "" {
+		t.Errorf("a transcript picked up the bucket note: %q", n)
+	}
+}

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -969,6 +969,9 @@ func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 		} else {
 			fmt.Fprintf(w, "  freshness %d stores changed since last build — run `deja index`\n", idx.StaleStores)
 		}
+	case "stale-readonly":
+		fmt.Fprintf(w, "  freshness %s changed since last build, and the index cannot be written — check the permissions on %s, or point DEJA_INDEX_DIR somewhere writable\n",
+			doctorCount(idx.StaleStores, "store"), filepath.Dir(idx.Path))
 	default:
 		fmt.Fprintln(w, "  freshness up to date")
 	}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -351,6 +351,13 @@ func inspectDoctorIndex(dir string, storeMods []time.Time) doctorComponent {
 	}
 	if result.StaleStores > 0 {
 		result.State = "stale"
+		// "run `deja index`" is the advice attached to `stale`, and it cannot
+		// be followed when the index cannot be written: the build fails with
+		// the same permission error every time. search says so on this exact
+		// state; doctor called it ordinary staleness (#1004).
+		if !indexDirWritable(dir) {
+			result.State = "stale-readonly"
+		}
 	}
 	return result
 }

--- a/cmd/deja/forgotten_empty_listing_test.go
+++ b/cmd/deja/forgotten_empty_listing_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// An index emptied by the reader's own forget is not an unbuilt one, and "run
+// `deja index`" cannot bring a tombstoned session back. search has said so
+// since #844; the two listing screens read it as data loss (#1007).
+func TestListingsSayWhenTheStoreWasEmptiedByAForget(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"the ticker window stays at 30s"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "forget", "--session", "loc"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, cmd := range []string{"last", "stats"} {
+		out, err := captureRunStderr(t, cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		combined := out
+		if cmd == "stats" {
+			text, err := captureRun(t, cmd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			combined += text
+		}
+		if !strings.Contains(combined, "forgotten") {
+			t.Errorf("%s does not say the store was emptied by a forget:\n%s", cmd, combined)
+		}
+		if strings.Contains(combined, "run `deja index`") {
+			t.Errorf("%s advises a build that cannot bring it back:\n%s", cmd, combined)
+		}
+	}
+}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -354,6 +354,12 @@ func runHookContext(dir string, plain bool) error {
 	if note := unreadableStoreNote(dir); storeNoteIsNews(dir, note) {
 		resp.SystemMessage = joinNotes(note, resp.SystemMessage)
 	}
+	// An index that is behind and cannot be written stays behind. "the agent
+	// starts already knowing them" was printed over a picture missing today's
+	// work, and this path said nothing — search names the same state (#1005).
+	if note := staleReadOnlyNote(dir); note != "" {
+		resp.SystemMessage = joinNotes(note, resp.SystemMessage)
+	}
 	b, err := json.Marshal(resp)
 	if err != nil {
 		return nil
@@ -863,4 +869,33 @@ func serviceReceipt(dir string) string {
 		return fmt.Sprintf(" · today: %d recall%s", recalls, pluralS(recalls))
 	}
 	return fmt.Sprintf(" · today: %d recall%s, %s distilled from %s", recalls, pluralS(recalls), humanBytes(int64(bytes)), humanBytes(raw))
+}
+
+// staleReadOnlyNote is the one line for an index that is behind and cannot
+// catch up: the store has newer sessions and the directory the rebuild would
+// write is not writable. Costs one manifest stat plus one temp-file probe, and
+// only when the index is already known to be behind.
+func staleReadOnlyNote(dir string) string {
+	if indexCanCatchUp(dir) {
+		return ""
+	}
+	return fmt.Sprintf("deja: this is the index as it was — it cannot be updated because %s is not writable", filepath.Dir(dir))
+}
+
+// indexCanCatchUp reports whether the index is either current or able to
+// become current. False only for the one state search already names: newer
+// sessions on disk and nowhere to write the result.
+func indexCanCatchUp(dir string) bool {
+	// Writability first: it is one temp file, while UpToDate walks every
+	// store. Measured on 6000 sessions, asking the expensive question first
+	// cost 25ms on every session start; this way the ordinary machine pays
+	// nothing (#1005).
+	if indexDirWritable(dir) {
+		return true
+	}
+	if !index.HasManifest(dir) {
+		return true
+	}
+	fresh, _ := index.UpToDate(dir, "")
+	return fresh
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -535,6 +535,13 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 			fmt.Fprintf(os.Stderr, "deja: no sessions match %s\n", where)
 			return nil
 		}
+		// "run `deja index`" cannot bring back what the reader forgot, and on a
+		// store emptied by their own settings it is the wrong instruction —
+		// search has said so since #844; the listing did not (#1007).
+		if note := hiddenByOwnSettings(); note != "" {
+			fmt.Fprint(os.Stderr, "deja: no sessions indexed yet\n"+note)
+			return nil
+		}
 		fmt.Fprintln(os.Stderr, emptyIndexHint("no sessions indexed yet"))
 		return nil
 	}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -339,8 +339,37 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 	if o.harness == "" {
 		noteAmbiguousPrefix(dir, o.id, "showing")
 	}
+	// A day bucket's date is the day the index was built in, not the moment a
+	// line was written: read in another zone, `show` lists a record dated the
+	// day before the id says, and nothing connected the two (#1006).
+	if note := bucketDayNote(s); note != "" {
+		fmt.Fprintln(os.Stderr, note)
+	}
 	search.PrintSession(os.Stdout, s)
 	return nil
+}
+
+// bucketDayNote explains a note bucket's date when the records inside it fall
+// on a different local day than the id claims — and stays silent otherwise, so
+// the ordinary case gains no line.
+func bucketDayNote(s model.Session) string {
+	if s.Harness != "deja" || !strings.HasPrefix(s.ID, "deja-20") {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(s.ID, "deja-"), "-")
+	if len(parts) < 3 {
+		return ""
+	}
+	day := strings.Join(parts[:3], "-")
+	for _, m := range s.Messages {
+		if m.Time.IsZero() {
+			continue
+		}
+		if m.Time.Local().Format("2006-01-02") != day {
+			return fmt.Sprintf("deja: %s in this id is the day the index was built in; the times below are this machine's — `deja index` regroups them", day)
+		}
+	}
+	return ""
 }
 
 type showOptions struct {

--- a/cmd/deja/stale_readonly_note_test.go
+++ b/cmd/deja/stale_readonly_note_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// An index that is behind and cannot be written stays behind. search names the
+// state; the hook told the agent it "starts already knowing" a picture missing
+// today's work, and MCP answered a confident negative about work that is on
+// disk (#1005).
+func TestTheAgentIsToldWhenTheIndexCannotCatchUp(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Join(tmp, "locked")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(parent, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Current and writable: nothing to say, on either surface.
+	if note := staleReadOnlyNote(dir); note != "" {
+		t.Errorf("a healthy index produced a warning: %q", note)
+	}
+	if got := emptyRecallAnswer(dir, "nothing"); !strings.Contains(got, "No prior deja sessions matched") {
+		t.Errorf("the ordinary empty answer changed: %q", got)
+	}
+
+	// A session deja cannot index, and nowhere to write the result.
+	newer := `{"type":"user","message":{"role":"user","content":"a session added after the parent was locked"},"timestamp":"2026-08-04T12:00:00Z","sessionId":"new","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "new.jsonl"), []byte(newer), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	note := staleReadOnlyNote(dir)
+	if !strings.Contains(note, "cannot be updated") {
+		t.Errorf("the hook says nothing about an index that cannot catch up: %q", note)
+	}
+	if !strings.Contains(note, parent) {
+		t.Errorf("the note does not name what to change: %q", note)
+	}
+	got := emptyRecallAnswer(dir, "third session")
+	if strings.Contains(got, "No prior deja sessions matched") {
+		t.Errorf("MCP answers a confident negative over an index that cannot catch up: %q", got)
+	}
+	if !strings.Contains(got, "may be missing") {
+		t.Errorf("the MCP answer does not say what it might be missing: %q", got)
+	}
+
+	// Writable again — even while stale — is the ordinary case: the build will
+	// happen on the next command, so neither surface warns.
+	if err := os.Chmod(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if note := staleReadOnlyNote(dir); note != "" {
+		t.Errorf("a stale but writable index warned anyway: %q", note)
+	}
+}

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -141,6 +141,9 @@ func runStats(dir string, args []string) error {
 	// indexed yet — run `deja index`" is advice for a state deja is not in:
 	// the same backside `last` grew when it learned to filter (#949, #983).
 	report.EmptiedByPolicy = report.TotalSessions == 0 && policyHidden > 0
+	if report.TotalSessions == 0 {
+		report.HiddenBySettings = hiddenByOwnSettings()
+	}
 	// Replaced spans are kept out of ordinary retrieval, so they are not in
 	// the sessions above and take a pass of their own.
 	if spans, files, err := index.SpanInventory(dir); err == nil {
@@ -237,6 +240,10 @@ func printStats(w io.Writer, r stats.Report) {
 			// The rule is named on stderr a line above; repeating "run `deja
 			// index`" here sends the reader after a build that changes nothing.
 			fmt.Fprintln(w, "deja: nothing to report — the trust policy withholds every indexed session from this path")
+			return
+		}
+		if r.HiddenBySettings != "" {
+			fmt.Fprint(w, "deja: nothing indexed yet\n"+r.HiddenBySettings)
 			return
 		}
 		fmt.Fprintln(w, emptyIndexHint("nothing indexed yet"))

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -112,14 +112,20 @@ func runStats(dir string, args []string) error {
 		progress = io.Discard
 	}
 	if err := index.Ensure(dir, "", false, progress); err != nil {
-		return err
+		// `mkdir …/idx.tmp: permission denied` names a path nobody chose and a
+		// syscall nobody can act on. index and search have worded this since
+		// #798; stats was the one screen still handing it back raw (#1004).
+		return ensureError(dir, err)
 	}
 	if redaction {
 		return printRedactionReport(dir, jsonOut)
 	}
 	ss, err := index.SearchWithRecovery(dir, search.Options{All: true}, progress)
 	if err != nil {
-		return err
+		// `mkdir …/idx.tmp: permission denied` names a path nobody chose and a
+		// syscall nobody can act on. index and search have worded this since
+		// #798; stats was the one screen still handing it back raw (#1004).
+		return ensureError(dir, err)
 	}
 	// stats is the one screen deja calls "wrapped for sharing", and it was
 	// naming projects the trust policy keeps off every other surface — the

--- a/cmd/deja/unwritable_index_states_test.go
+++ b/cmd/deja/unwritable_index_states_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// One state, three stories: search worded it, stats handed back the syscall,
+// and doctor called it ordinary staleness and advised the one command that
+// cannot succeed here (#1004).
+func TestAnUnwritableIndexReadsTheSameEverywhere(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Join(tmp, "locked")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(parent, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// A store that changed after the build, and no way to write the result.
+	newer := `{"type":"user","message":{"role":"user","content":"a session added after the parent was locked"},"timestamp":"2026-08-04T12:00:00Z","sessionId":"new","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "new.jsonl"), []byte(newer), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	_, err := captureRun(t, "stats")
+	if err == nil {
+		t.Fatal("stats did not fail on an index it cannot write")
+	}
+	if strings.Contains(err.Error(), "mkdir") || strings.Contains(err.Error(), ".tmp") {
+		t.Errorf("stats hands back the syscall: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cannot write the index") {
+		t.Errorf("stats does not word the failure like the other paths: %v", err)
+	}
+
+	var out bytes.Buffer
+	doctorIndexSection(t, &out, dir)
+	line := ""
+	for _, l := range strings.Split(out.String(), "\n") {
+		if strings.Contains(l, "freshness") {
+			line = l
+		}
+	}
+	if !strings.Contains(line, "cannot be written") {
+		t.Errorf("doctor calls an unwritable index ordinarily stale: %q", line)
+	}
+	if strings.Contains(line, "run `deja index`") {
+		t.Errorf("doctor advises the command that fails in this state: %q", line)
+	}
+
+	// With the directory writable again the ordinary advice comes back.
+	if err := os.Chmod(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	doctorIndexSection(t, &out, dir)
+	if !strings.Contains(out.String(), "run `deja index`") {
+		t.Errorf("a writable index lost the advice that fits it:\n%s", out.String())
+	}
+}
+
+func doctorIndexSection(t *testing.T, out *bytes.Buffer, dir string) {
+	t.Helper()
+	if err := runDoctor(out, nil, stubLookup("1.0.0", true), dir); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/deja/warmup_status.go
+++ b/cmd/deja/warmup_status.go
@@ -197,5 +197,12 @@ func emptyRecallAnswerPolicy(dir, q string, hidden int) string {
 		return fmt.Sprintf("%d prior session%s matched %q, but this machine's trust policy (%s) does not allow them on this path. There is prior work here; it is not being shown.",
 			hidden, pluralS(hidden), q, policy.Load().Describe(policy.ActivationMCP))
 	}
+	// A confident negative over an index that is behind and cannot catch up:
+	// the session is on disk, deja simply could not add it. The hook says this
+	// at session start; over MCP it is the only place to say it (#1005).
+	if !indexCanCatchUp(dir) {
+		return fmt.Sprintf("No indexed session matched %q — the index is behind and cannot be updated (%s is not writable), so recent work may be missing from this answer.",
+			q, filepath.Dir(dir))
+	}
 	return fmt.Sprintf("No prior deja sessions matched %q.", q)
 }

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -25,19 +25,22 @@ type Report struct {
 	Heatmap         HeatmapStats   `json:"-"` // card-only presentation data; kept out of the stable --json schema
 	// EmptiedByPolicy marks a report whose rows were all withheld by the
 	// trust policy, so the empty-index advice is not the right thing to print.
-	EmptiedByPolicy bool           `json:"-"`
-	Sparkline       string         `json:"sparkline"`
-	DateRange       DateRangeStats `json:"date_range"`
-	Longest         SessionStat    `json:"longest_session"`
-	BusiestDay      DayStat        `json:"busiest_day"`
-	Recall          usage.Summary  `json:"recall"`
-	WeekRecalls     int            `json:"week_recalls"`
-	WeekBytes       int            `json:"week_bytes"`
-	WeekInjected    int            `json:"week_injected"`
-	HandoffsIn      int            `json:"handoffs_received"`
-	AgentCredits    int            `json:"agent_credits"`
-	WeekCredits     int            `json:"week_agent_credits"`
-	SidecarSize     int64          `json:"sidecar_size,omitempty"`
+	EmptiedByPolicy bool `json:"-"`
+	// HiddenBySettings is the reader's own tombstones and exclusions, when
+	// those are why the report is empty.
+	HiddenBySettings string         `json:"-"`
+	Sparkline        string         `json:"sparkline"`
+	DateRange        DateRangeStats `json:"date_range"`
+	Longest          SessionStat    `json:"longest_session"`
+	BusiestDay       DayStat        `json:"busiest_day"`
+	Recall           usage.Summary  `json:"recall"`
+	WeekRecalls      int            `json:"week_recalls"`
+	WeekBytes        int            `json:"week_bytes"`
+	WeekInjected     int            `json:"week_injected"`
+	HandoffsIn       int            `json:"handoffs_received"`
+	AgentCredits     int            `json:"agent_credits"`
+	WeekCredits      int            `json:"week_agent_credits"`
+	SidecarSize      int64          `json:"sidecar_size,omitempty"`
 	// Spans and SpanFiles are what `deja restore` can hand back: the exact
 	// bytes an agent replaced, which no other tool keeps. Filled by the
 	// caller, not by Build — replaced spans are deliberately kept out of


### PR DESCRIPTION
Four findings from the audit run, all measured on a live index.

- #1004 one unwritable index, three stories: search worded it, stats handed back the syscall, doctor called it ordinary staleness and advised the command that fails
- #1005 the agent was not told when the index cannot catch up — the hook promised a full picture and MCP answered a confident negative about work that is on disk (cost of the check: 62 → 63 ms on 6000 sessions)
- #1006 a note bucket's date and the times inside it disagreed with no explanation when the index is read in another zone
- #1007 `last` and `stats` read the reader's own forget as an empty machine

Each fix has a test that fails on the old behaviour; mutations checked per fix.
