### PR TITLE
Stop three surfaces from hiding what a rule or a leftover directory did

### DIFF
--- a/cmd/deja/ctx_whole_session_test.go
+++ b/cmd/deja/ctx_whole_session_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// ctx is the command the hook tells an agent to call. It printed the hit's
+// snippets rather than the session, and a correction rarely repeats the words
+// of the decision it reverses — so the agent was handed a decision that had
+// been withdrawn (#1011).
+func TestCtxCarriesTheWholeDecisionChain(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"we raised the pool cap to 200"},"timestamp":"2026-08-04T10:00:00Z","sessionId":"w25","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "promote", "w25", "--state", "accepted", "--note", "the pool cap is 200"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "promote", "w25", "--state", "rejected", "--note", "rolled back, the cap stays at 20"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "ctx", "pool cap")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "rolled back") {
+		t.Errorf("ctx dropped the correction that reverses the decision:\n%s", out)
+	}
+	if !strings.Contains(out, "the pool cap is 200") {
+		t.Errorf("ctx dropped the decision being corrected:\n%s", out)
+	}
+	if strings.Index(out, "rolled back") > strings.Index(out, "the pool cap is 200") {
+		t.Errorf("the withdrawal is below the decision it takes back:\n%s", out)
+	}
+
+	// An ordinary transcript still answers with what the query asked about.
+	out, err = captureRun(t, "ctx", "raised the pool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "we raised the pool cap to 200") {
+		t.Errorf("ctx on a transcript lost the matching turn:\n%s", out)
+	}
+}

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -975,6 +975,20 @@ func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 	default:
 		fmt.Fprintln(w, "  freshness up to date")
 	}
+	// What the last sync did with this machine's own rules: records that were
+	// dropped because they belong to sessions forgotten here are invisible
+	// afterwards, and a peer who keeps sending them drops them every time
+	// (#1016).
+	if li, ok := readLastImport(dir); ok && (li.Forgot > 0 || li.Own > 0) {
+		parts := []string{fmt.Sprintf("%d record%s in", li.Records, pluralS(li.Records))}
+		if li.Forgot > 0 {
+			parts = append(parts, fmt.Sprintf("%d left out as forgotten here", li.Forgot))
+		}
+		if li.Own > 0 {
+			parts = append(parts, fmt.Sprintf("%d already here word for word", li.Own))
+		}
+		fmt.Fprintf(w, "  last sync %s (%s)\n", strings.Join(parts, ", "), li.At.Local().Format("2006-01-02 15:04"))
+	}
 	health := index.IngestHealth(dir)
 	names := make([]string, 0, len(health))
 	for h, e := range health {

--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -158,6 +158,9 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 	// counting per pass told the reader the rule hides more than the project
 	// holds (#981).
 	hidden := map[string]bool{}
+	// Newest of the withheld ones, so the pick can say it is not the latest
+	// work in this project rather than handing over older work in silence.
+	var hiddenNewest time.Time
 	for _, name := range digest.ProjectNameCandidates(cwd) {
 		ss, err := index.RecentProject(dir, name, 3)
 		if err != nil || len(ss) == 0 {
@@ -175,6 +178,9 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 		for _, s := range ss {
 			if !keptIDs[s.ID] {
 				hidden[s.ID] = true
+				if s.Updated.After(hiddenNewest) {
+					hiddenNewest = s.Updated
+				}
 			}
 		}
 		if len(kept) == 0 {
@@ -190,6 +196,14 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 			return model.Session{}, errors.New(strings.TrimPrefix(policyHiddenNote(policy.ActivationSearch, len(hidden)), "deja: "))
 		}
 		return model.Session{}, idPrefixNeeded(dir, "handoff needs a session to package", "no indexed sessions for this project — pass a session id-prefix (see `deja last`)")
+	}
+	// The pick is deja's, and a rule that removed newer work from the choice
+	// changes what the pick means: handing over a month-old session while
+	// today's is withheld looked exactly like a project nobody has touched
+	// since (#1013).
+	if hiddenNewest.After(newest.Updated) {
+		fmt.Fprintf(os.Stderr, "deja: newer work in this project is withheld by the trust policy (%s: %s) — this is the newest session it allows\n",
+			policy.ActivationSearch, policy.Load().Describe(policy.ActivationSearch))
 	}
 	if len(distinct) > 1 {
 		fmt.Fprintf(os.Stderr, "deja: %d different sessions match this directory's project names — picked the newest; pass an id-prefix to choose (see `deja last`)\n", len(distinct))

--- a/cmd/deja/handoff_policy_test.go
+++ b/cmd/deja/handoff_policy_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 )
@@ -93,5 +94,76 @@ func TestHandoffWithNoIdObeysTheTrustPolicy(t *testing.T) {
 	// (#981).
 	if err != nil && !strings.Contains(err.Error(), "hides 1 matching session ") {
 		t.Errorf("the count is not what the project holds: %v", err)
+	}
+}
+
+// deja's own pick changes meaning when a rule removed newer work from the
+// choice: handing over a month-old session while today's is withheld reads
+// exactly like a project nobody has touched since (#1013).
+func TestHandoffSaysWhenNewerWorkIsWithheld(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"the older local session about the pool cap"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"old","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "old.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "newpeer", Project: "proj", Role: "user",
+		Text: "the newest work on this project, from another machine", Time: time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+	work := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	back, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(work); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(back) })
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	note, err := captureRunStderr(t, "handoff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note, "newer work in this project is withheld") {
+		t.Errorf("handoff packaged older work without saying newer was withheld:\n%s", note)
+	}
+
+	// Without the rule the newest session is the pick, and there is nothing to
+	// warn about.
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(tmp, "no-policy.json"))
+	note, err = captureRunStderr(t, "handoff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(note, "withheld") {
+		t.Errorf("an unrestricted handoff warned about withheld work:\n%s", note)
 	}
 }

--- a/cmd/deja/json_withheld_test.go
+++ b/cmd/deja/json_withheld_test.go
@@ -83,3 +83,68 @@ func TestJSONSaysWhenTheTrustPolicyWithheldRows(t *testing.T) {
 		t.Errorf("the listing returned the wrong rows: %v", got["sessions"])
 	}
 }
+
+// #990 gave search and last the field; stats printed the reason on stderr only,
+// so the third machine form still could not tell a rule from a small store
+// (#1010).
+func TestStatsJSONCarriesTheWithheldCount(t *testing.T) {
+	tmp := hermeticEnv(t)
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "work/api", Role: "user", Text: "peer two about the pool cap"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "stats", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("stats --json is not JSON: %v", err)
+	}
+	if _, ok := m["policy_withheld"]; ok {
+		t.Errorf("an unrestricted report claims withheld rows: %v", m["policy_withheld"])
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	out, err = captureRun(t, "stats", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["policy_withheld"] != float64(1) {
+		t.Errorf("stats --json does not say what the rule kept out: %v", m)
+	}
+	if m["total_sessions"] != float64(1) {
+		t.Errorf("the report counted the hidden session anyway: %v", m["total_sessions"])
+	}
+}

--- a/cmd/deja/last_import_test.go
+++ b/cmd/deja/last_import_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The line an import prints scrolls away; a peer who keeps the batch drops the
+// same records on every sync, and doctor — where someone goes to ask why a
+// peer's work never shows up — kept no record of it (#1016).
+func TestDoctorRemembersWhatTheLastSyncDropped(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "work/api", Role: "user", Text: "peer record about the vault rotation"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	// An ordinary import has nothing to report afterwards.
+	var out bytes.Buffer
+	doctorIndex(&out, inspectDoctorIndex(dir, nil), dir)
+	if strings.Contains(out.String(), "last sync") {
+		t.Errorf("an import that dropped nothing left a note behind:\n%s", out.String())
+	}
+
+	// Forget what arrived, then take the same batch again.
+	id := index.ImportedSessionID("claude", "peer")
+	if _, err := captureRun(t, "forget", "--session", "claude:"+id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	doctorIndex(&out, inspectDoctorIndex(dir, nil), dir)
+	got := out.String()
+	if !strings.Contains(got, "last sync") {
+		t.Errorf("doctor kept no record of what the sync dropped:\n%s", got)
+	}
+	if !strings.Contains(got, "left out as forgotten here") {
+		t.Errorf("the line does not say why the records were dropped:\n%s", got)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2049,6 +2049,12 @@ func ensureError(dir string, err error) error {
 	if errors.Is(err, syscall.ENOSPC) {
 		return fmt.Errorf("no space left where the index is built (%s) — free some room there, or point DEJA_INDEX_DIR at a disk that has it", filepath.Dir(dir))
 	}
+	// Already worded where it was raised — the leftover-swap case names the
+	// directory to remove and the command to rerun, and "ensure:" in front of
+	// it is internal noise (#1009).
+	if strings.HasPrefix(err.Error(), "an earlier index swap left ") {
+		return err
+	}
 	return fmt.Errorf("ensure: %w", err)
 }
 

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -492,7 +492,15 @@ func cmdCtx(dir string, rest []string) error {
 	// session's note arrives as an ordinary hit — and the answer still has to
 	// say the session is gone (#971).
 	noteForgottenSource(hits[0].Session, q)
-	search.PrintContext(os.Stdout, hits[0].Session, q)
+	// The hit carries the matching snippets, not the session: for a promoted
+	// note that meant the correction — which rarely repeats the words of the
+	// decision — was missing, and the command whose whole job is packaging
+	// context handed an agent a decision that had been withdrawn (#1011).
+	whole := hits[0].Session
+	if full, ok, ferr := findByPrefix(dir, whole.ID); ferr == nil && ok {
+		whole = full
+	}
+	search.PrintContext(os.Stdout, whole, q)
 	return nil
 }
 

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1598,7 +1598,11 @@ func runForget(dir string, args []string) error {
 		// session; the undo restored them all and said so afterwards, while the
 		// hint printed beside the list promises one (#961).
 		if n := index.TombstoneMatches(unforget); n > 1 && !allMatches {
-			return fmt.Errorf("%q brings back %d forgotten sessions — `deja forget --list` names them; add --all-matches to restore them all", unforget, n)
+			// "`deja forget --list` names them" sends the reader to a list of
+			// everything this machine ever forgot, where the three that match
+			// are theirs to find. Name them here instead (#1014).
+			return fmt.Errorf("%q brings back %d forgotten sessions (%s) — add --all-matches to restore them all, or name one",
+				unforget, n, joinCapped(index.TombstonesMatching(unforget), 5))
 		}
 		var lifted int
 		if err := withBuildProgress(func() error {
@@ -2251,4 +2255,13 @@ func reachableSessionCount(dir string) (int, int, bool) {
 		}
 	}
 	return reach, len(metas), true
+}
+
+// joinCapped lists at most n items and says how many it left out, so a refusal
+// stays one line on a machine with many tombstones.
+func joinCapped(items []string, n int) string {
+	if len(items) <= n {
+		return strings.Join(items, ", ")
+	}
+	return strings.Join(items[:n], ", ") + fmt.Sprintf(", +%d more", len(items)-n)
 }

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -140,6 +140,7 @@ func runStats(dir string, args []string) error {
 	// The rule that emptied the report is named a line above, so "nothing
 	// indexed yet — run `deja index`" is advice for a state deja is not in:
 	// the same backside `last` grew when it learned to filter (#949, #983).
+	report.PolicyWithheld = policyHidden
 	report.EmptiedByPolicy = report.TotalSessions == 0 && policyHidden > 0
 	if report.TotalSessions == 0 {
 		report.HiddenBySettings = hiddenByOwnSettings()

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/vshulcz/deja-vu/internal/index"
 	"io"
 	"os"
 	"strings"
 
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
@@ -37,6 +38,14 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 		} else {
 			fmt.Fprint(stdout, "deja · indexing your history · recall comes online in a few seconds")
 		}
+		return nil
+	}
+	// A rule that activates nothing turns memory off everywhere, and the line
+	// people always have on screen read the same as an ordinary quiet day:
+	// "no recalls yet today" is true and says nothing about why it will stay
+	// true (#1012).
+	if policy.Load().Describe(policy.ActivationAuto) == "nothing activates" {
+		fmt.Fprint(stdout, withFileMemory(dir, in, "deja · off here · the trust policy activates nothing (`deja doctor`)"))
 		return nil
 	}
 	recalls, bytes, injected := usage.TodayWithInjections(dir)

--- a/cmd/deja/statusline_policy_off_test.go
+++ b/cmd/deja/statusline_policy_off_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A rule that activates nothing turns recall off everywhere, and the line
+// people always have on screen read like an ordinary quiet day — true today,
+// and still true tomorrow for a reason nothing named (#1012).
+func TestStatuslineSaysWhenAPolicyTurnsMemoryOff(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := runStatusline(dir, strings.NewReader("{}"), &out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "off here") {
+		t.Errorf("an unrestricted machine was called off: %q", out.String())
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"auto":{"local":false,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	out.Reset()
+	if err := runStatusline(dir, strings.NewReader("{}"), &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if strings.Contains(got, "no recalls yet today") {
+		t.Errorf("a machine with recall switched off reads as a quiet day: %q", got)
+	}
+	if !strings.Contains(got, "trust policy") {
+		t.Errorf("the line does not name what switched it off: %q", got)
+	}
+
+	// A rule that narrows the auto path is not the same as switching it off:
+	// local sessions still reach the agent.
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"auto":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	if err := runStatusline(dir, strings.NewReader("{}"), &out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "off here") {
+		t.Errorf("a narrowed search path was reported as memory off: %q", out.String())
+	}
+}

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -123,6 +125,11 @@ func runSync(dir string, args []string) error {
 		if own := index.ImportSkippedOwn(); own > 0 {
 			fmt.Fprintf(os.Stdout, "deja: %d record%s were already here word for word — this folder holds a copy of what this machine has\n", own, pluralS(own))
 		}
+		// The count is a fact about this machine's memory, not about one
+		// terminal moment: a peer who keeps sending sessions you forgot drops
+		// records on every sync, and only the line below said so — gone the
+		// moment the terminal scrolls (#1016).
+		recordLastImport(dir, n, index.ImportSkippedForgotten(), index.ImportSkippedOwn())
 		if skipped := index.ImportSkippedForgotten(); skipped > 0 {
 			fmt.Fprintf(os.Stdout, "deja: %d record%s left out — they belong to sessions you forgot here (`deja forget --list`)\n", skipped, pluralS(skipped))
 		}
@@ -156,4 +163,34 @@ func hasSyncBatches(out string) bool {
 		}
 	}
 	return false
+}
+
+// lastImport is the one-line summary doctor reads back.
+type lastImport struct {
+	At      time.Time `json:"at"`
+	Records int       `json:"records"`
+	Forgot  int       `json:"forgotten_left_out,omitempty"`
+	Own     int       `json:"already_here,omitempty"`
+}
+
+func lastImportPath(dir string) string { return dir + ".lastimport" }
+
+func recordLastImport(dir string, records, forgot, own int) {
+	b, err := json.Marshal(lastImport{At: time.Now(), Records: records, Forgot: forgot, Own: own})
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(lastImportPath(dir), b, 0o600)
+}
+
+func readLastImport(dir string) (lastImport, bool) {
+	b, err := os.ReadFile(lastImportPath(dir))
+	if err != nil {
+		return lastImport{}, false
+	}
+	var li lastImport
+	if json.Unmarshal(b, &li) != nil || li.At.IsZero() {
+		return lastImport{}, false
+	}
+	return li, true
 }

--- a/cmd/deja/unforget_names_test.go
+++ b/cmd/deja/unforget_names_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// "`deja forget --list` names them" sent the reader to a list of everything the
+// machine ever forgot, where the ones the refusal meant were theirs to find
+// (#1014).
+func TestUnforgetRefusalNamesTheSessionsItMeans(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"sess0", "sess1", "sess2", "alpha", "beta"} {
+		rec := `{"type":"user","message":{"role":"user","content":"session ` + id + `"},"timestamp":"2026-08-01T10:00:00Z","sessionId":"` + id + `","cwd":"/proj"}` + "\n"
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(rec), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"sess0", "sess1", "sess2", "alpha", "beta"} {
+		if _, err := captureRun(t, "forget", "--session", id); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := captureRun(t, "forget", "--unforget", "claude:sess")
+	if err == nil {
+		t.Fatal("an ambiguous selector was accepted")
+	}
+	for _, want := range []string{"claude:sess0", "claude:sess1", "claude:sess2"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not name %s: %v", want, err)
+		}
+	}
+	// And not the ones it does not mean.
+	if strings.Contains(err.Error(), "claude:alpha") {
+		t.Errorf("the refusal named a session it would not restore: %v", err)
+	}
+	// Naming one still works.
+	if _, err := captureRun(t, "forget", "--unforget", "claude:sess1"); err != nil {
+		t.Errorf("naming one of them was refused: %v", err)
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -30,8 +30,9 @@ from a list of hits:
   used to be readable only as a sentence on stderr.
 - `total` and `capped` — how many sessions matched, and whether a cap hid some.
 - `policy_withheld` — how many matching sessions this machine's trust policy
-  kept out of the answer. Omitted when none were. Present on `search --json`
-  and `last --json`, so an empty result can be told apart from a rule.
+  kept out of the answer. Omitted when none were. Present on `search --json`,
+  `last --json` and `stats --json`, so an empty result can be told apart from a
+  rule.
   Counting the returned hits measures the cap: that figure moves when the
   window's membership changes, whether or not retrieval improved.
   **`capped: false` means the response holds everything that matched, on every

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -464,6 +464,22 @@ func Tombstones() []string {
 // Tombstoned reports whether one exact harness:id has been forgotten here.
 func Tombstoned(key string) bool { return readTombstones()[key] }
 
+// TombstonesMatching lists the forgotten keys a selector would restore, in the
+// order `forget --list` prints them.
+func TombstonesMatching(prefix string) []string {
+	var out []string
+	for key := range readTombstones() {
+		if strings.Contains(key, "\x00") {
+			continue
+		}
+		if tombstoneMatches(key, prefix) {
+			out = append(out, key)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 // TombstoneMatches counts the forgotten sessions a selector would bring back,
 // without touching anything. The undo has to be able to refuse the way forget
 // does: one word restored three sessions and said so afterwards (#961).

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -463,6 +463,13 @@ func swapIndexDir(dir, tmp string) error {
 	old := dir + ".old"
 	_ = os.RemoveAll(old)
 	if err := os.Rename(dir, old); err != nil && !os.IsNotExist(err) {
+		// The parking spot survived the removal above — a leftover from an
+		// interrupted swap whose permissions stop deja from clearing it. The
+		// bare `rename …: file exists` names two paths nobody chose and gives
+		// nothing to do about either (#1009).
+		if _, statErr := os.Stat(old); statErr == nil {
+			return fmt.Errorf("an earlier index swap left %s behind and deja cannot replace it — remove that directory and run `deja index` again", old)
+		}
 		return err
 	}
 	if err := os.Rename(tmp, dir); err != nil {

--- a/internal/index/swap_leftover_test.go
+++ b/internal/index/swap_leftover_test.go
@@ -65,3 +65,40 @@ func TestALeftoverSwapDirectoryIsNamedInsteadOfTheRename(t *testing.T) {
 		t.Errorf("the previous index did not survive the failed swap: %v", statErr)
 	}
 }
+
+// The selector the refusal uses to name what it would restore: content keys
+// ride along with their session and must not be listed as sessions of their
+// own (#1014).
+func TestTombstonesMatchingNamesSessionsOnly(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	set := map[string]bool{
+		"claude:sess0":                        true,
+		"claude:sess1":                        true,
+		"claude:alpha":                        true,
+		"claude:sess0\x00deja-note-day:x:1:2": true,
+	}
+	if err := writeTombstones(set); err != nil {
+		t.Fatal(err)
+	}
+	got := TombstonesMatching("claude:sess")
+	want := []string{"claude:sess0", "claude:sess1"}
+	if len(got) != len(want) {
+		t.Fatalf("matching keys = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("matching keys = %v, want %v", got, want)
+			break
+		}
+	}
+	if n := TombstoneMatches("claude:sess"); n != len(want) {
+		t.Errorf("count %d disagrees with the names %v", n, got)
+	}
+	if got := TombstonesMatching("claude:nothing"); len(got) != 0 {
+		t.Errorf("a selector that matches nothing named %v", got)
+	}
+	if !Tombstoned("claude:alpha") || Tombstoned("claude:absent") {
+		t.Error("Tombstoned disagrees with what was written")
+	}
+}

--- a/internal/index/swap_leftover_test.go
+++ b/internal/index/swap_leftover_test.go
@@ -1,0 +1,67 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// A rebuild parks the old index as <dir>.old and clears it afterwards (#181).
+// A leftover that cannot be removed — an interrupted swap whose directory came
+// back read-only — failed every later rebuild with `rename …: file exists`:
+// two paths nobody chose and nothing to do about either (#1009).
+func TestALeftoverSwapDirectoryIsNamedInsteadOfTheRename(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, "index.db")
+	newer := filepath.Join(tmp, "index.db.tmp")
+	for _, d := range []string{dir, newer} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "records.bin"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The ordinary swap: the leftover is cleared and the new index lands.
+	if err := swapIndexDir(dir, newer); err != nil {
+		t.Fatalf("an ordinary swap failed: %v", err)
+	}
+	if _, err := os.Stat(dir + ".old"); err == nil {
+		t.Error("the parking directory outlived the swap")
+	}
+
+	// A leftover deja cannot remove.
+	old := dir + ".old"
+	if err := os.MkdirAll(filepath.Join(old, "buckets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(old, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(old, 0o700) })
+	if err := os.MkdirAll(newer, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := swapIndexDir(dir, newer)
+	if err == nil {
+		t.Fatal("the swap claimed to succeed over a leftover it cannot replace")
+	}
+	if strings.Contains(err.Error(), "rename") || strings.Contains(err.Error(), "file exists") {
+		t.Errorf("the failure is still the raw syscall: %v", err)
+	}
+	if !strings.Contains(err.Error(), old) || !strings.Contains(err.Error(), "remove that directory") {
+		t.Errorf("the failure does not say what to remove: %v", err)
+	}
+	// The index that was there is still there — nothing was lost to the failed
+	// swap.
+	if _, statErr := os.Stat(filepath.Join(dir, "records.bin")); statErr != nil {
+		t.Errorf("the previous index did not survive the failed swap: %v", statErr)
+	}
+}

--- a/internal/policy/filter_alias_test.go
+++ b/internal/policy/filter_alias_test.go
@@ -1,0 +1,20 @@
+package policy
+
+import "testing"
+
+// Filter built its result with items[:0], so it rewrote the caller's own slice.
+// Callers that read the input afterwards — handoff learns what was withheld
+// that way — saw the kept elements copied over the dropped ones (#1013).
+func TestFilterLeavesTheCallersSliceAlone(t *testing.T) {
+	p := Policy{Activations: map[string]map[string]bool{
+		ActivationSearch: {"local": true, "imported": false},
+	}}
+	items := []string{"imported:tmp/w27", "tmp/w27"}
+	kept := Filter(p, ActivationSearch, items, func(s string) string { return s })
+	if len(kept) != 1 || kept[0] != "tmp/w27" {
+		t.Fatalf("filter kept %v", kept)
+	}
+	if items[0] != "imported:tmp/w27" || items[1] != "tmp/w27" {
+		t.Errorf("the caller's slice was rewritten: %v", items)
+	}
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -151,8 +151,11 @@ func (p Policy) Describe(activation string) string {
 
 // Filter drops the items whose project the policy blocks on this path.
 // projectOf maps an element to its session project name.
+// The result is a new slice: filtering in place rewrote the caller's own
+// input — handoff read the pre-filter list to learn what had been withheld and
+// saw the kept sessions duplicated over it (#1013).
 func Filter[T any](p Policy, activation string, items []T, projectOf func(T) string) []T {
-	out := items[:0]
+	out := make([]T, 0, len(items))
 	for _, it := range items {
 		if p.Allows(activation, projectOf(it)) {
 			out = append(out, it)

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -15,14 +15,18 @@ import (
 )
 
 type Report struct {
-	SchemaVersion   int            `json:"schema_version"`
-	TotalSessions   int            `json:"total_sessions"`
-	TotalMessages   int            `json:"total_messages"`
-	RepeatQuestions int            `json:"repeat_questions,omitempty"`
-	Harnesses       []HarnessStats `json:"harnesses"`
-	TopProjects     []ProjectStats `json:"top_projects"`
-	Monthly         []MonthStats   `json:"monthly"`
-	Heatmap         HeatmapStats   `json:"-"` // card-only presentation data; kept out of the stable --json schema
+	SchemaVersion   int `json:"schema_version"`
+	TotalSessions   int `json:"total_sessions"`
+	TotalMessages   int `json:"total_messages"`
+	RepeatQuestions int `json:"repeat_questions,omitempty"`
+	// PolicyWithheld is how many indexed sessions the trust policy kept out of
+	// this report — the same field `search --json` and `last --json` carry, so
+	// a caller can tell a rule from an empty store (#1010).
+	PolicyWithheld int            `json:"policy_withheld,omitempty"`
+	Harnesses      []HarnessStats `json:"harnesses"`
+	TopProjects    []ProjectStats `json:"top_projects"`
+	Monthly        []MonthStats   `json:"monthly"`
+	Heatmap        HeatmapStats   `json:"-"` // card-only presentation data; kept out of the stable --json schema
 	// EmptiedByPolicy marks a report whose rows were all withheld by the
 	// trust policy, so the empty-index advice is not the right thing to print.
 	EmptiedByPolicy bool `json:"-"`


### PR DESCRIPTION
Six findings from the audit run, all measured on a live index.

- #1009 a leftover `<index>.old` from an interrupted swap failed every rebuild with a raw `rename … file exists`, while doctor called the index up to date
- #1010 `stats --json` was the one machine form without `policy_withheld`
- #1011 `ctx` — the command the hook tells an agent to call — handed over a decision that had been withdrawn, because a correction rarely repeats the words it reverses
- #1012 statusline read the same whether memory was flowing or a rule had switched it off entirely
- #1013 handoff packaged older work while newer sat withheld; underneath, `policy.Filter` rewrote the caller's slice, so the withheld count came out zero
- #1014 the `--unforget` refusal pointed at a list of everything the machine ever forgot instead of naming the sessions it meant

Each fix has a test that fails on the old behaviour; mutations checked per fix.
