### PR TITLE
Make codex install honour CODEX_HOME instead of the real ~/.codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `install`/`uninstall` write the codex SessionStart hook to `CODEX_HOME` (via `sources.CodexHome()`) instead of a raw `~/.codex`, so a sandboxed install stays sandboxed and a non-default codex home gets its hooks where codex reads them. Every other codex path already honoured it. (#850)
+
 ## [0.16.7] - 2026-08-03
 
 Two weeks spent on the trust policy and on the states a machine gets into when

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -17,8 +17,11 @@ import (
 // We merge one SessionStart entry into ~/.codex/hooks.json and leave
 // everything else in the file alone.
 func installCodexHooks(exe string, uninstall bool) (installResult, error) {
-	h, _ := os.UserHomeDir()
-	path := filepath.Join(h, ".codex", "hooks.json")
+	// Use CodexHome() (honours CODEX_HOME / DEJA_CODEX_ROOT) rather than a raw
+	// ~/.codex join, so a sandboxed install stays sandboxed and a non-default
+	// codex home gets its hooks written where codex actually reads them. Every
+	// other codex path already goes through it (e.g. doctor.go). See #850.
+	path := filepath.Join(sources.CodexHome(), "hooks.json")
 	old, _ := os.ReadFile(path)
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {

--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -182,3 +182,32 @@ func TestPrintInstallProofListsDistinctProjects(t *testing.T) {
 		t.Fatalf("projects not deduped: %q", out)
 	}
 }
+
+// TestInstallCodexHooksHonoursCodexHome pins #850: install must write to
+// CODEX_HOME (via sources.CodexHome()), not a raw ~/.codex, so a sandboxed
+// install cannot edit the operator's real config. HOME and CODEX_HOME point at
+// distinct dirs; the hooks file must land under CODEX_HOME and not under HOME.
+func TestInstallCodexHooksHonoursCodexHome(t *testing.T) {
+	home := t.TempDir()
+	codexHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("CODEX_HOME", codexHome)
+
+	r, err := installCodexHooks("/usr/local/bin/deja", false)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	want := filepath.Join(codexHome, "hooks.json")
+	if r.Path != want {
+		t.Errorf("install wrote to %q, want %q (CODEX_HOME must be honoured)", r.Path, want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("no hooks.json under CODEX_HOME: %v", err)
+	}
+	// The real (HOME-based) ~/.codex must be left untouched.
+	if _, err := os.Stat(filepath.Join(home, ".codex", "hooks.json")); !os.IsNotExist(err) {
+		t.Errorf("install wrote to HOME/.codex despite CODEX_HOME being set (err=%v)", err)
+	}
+}


### PR DESCRIPTION
## What

Route the codex SessionStart hook path through `sources.CodexHome()` so
`install`/`uninstall` honour `CODEX_HOME` (and `DEJA_CODEX_ROOT`) instead of
always editing a raw `~/.codex/hooks.json`.

## Why

Fixes #850.

`installCodexHooks` (`cmd/deja/install_auto.go`) built the path as
`filepath.Join(os.UserHomeDir(), ".codex", "hooks.json")`, while every other
codex path (`doctor.go`, `install.go`, `guidance.go`) goes through
`sources.CodexHome()`. Consequences:

- a sandboxed install/uninstall (with `CODEX_HOME` set to a temp dir) could not
  actually be sandboxed — it edited the operator's own `~/.codex/hooks.json` and
  stripped deja's SessionStart hook from it;
- anyone whose codex home is not `~/.codex` got hooks written to a directory
  codex does not read.

The fix mirrors `doctor.go`'s existing `filepath.Join(sources.CodexHome(),
"hooks.json")`. `CodexHome()` (not `CodexRoot()`) is correct here: `CodexRoot`'s
own doc says `DEJA_CODEX_ROOT` "overrides it without affecting where install
writes".

## Verification

`golang:1.25`, pure Go (no CGO). `gofmt`/`go vet` clean. New born-failing test
`TestInstallCodexHooksHonoursCodexHome` sets `HOME` and `CODEX_HOME` to distinct
temp dirs and asserts the hook lands under `CODEX_HOME`, not `HOME/.codex`.

### RED → GREEN

**RED** (fix reverted to the raw `~/.codex` join, test only):

```
--- FAIL: TestInstallCodexHooksHonoursCodexHome
    install_auto_test.go:204: install wrote to ".../001/.codex/hooks.json", want ".../002/hooks.json" (CODEX_HOME must be honoured)
    install_auto_test.go:207: no hooks.json under CODEX_HOME: ... no such file or directory
    install_auto_test.go:211: install wrote to HOME/.codex despite CODEX_HOME being set
```

The existing codex install tests (`TestInstallCodexHooksMergeAndUninstall`,
`TestInstallCodexHooksErrorsAndMissingUninstall`) still pass in RED — they only
set `HOME` — so the new test is what pins the regression.

**GREEN** (with the fix): all `TestInstallCodexHooks*` pass; `go build ./...` and
`go vet ./cmd/deja/` clean.

(Note: a full `go test ./...` in a container has env-sensitive failures unrelated
to this change — permission-negative tests under a root container, and
`HOME`-isolation/endpoint bench tests — which fail identically on unmodified
`main`.)

## Changelog

Added an `## [Unreleased] → ### Fixed` entry for #850.
