### PR TITLE
audit batch: policy leaks, progress, import cost

### DIFF
--- a/cmd/deja/blame_lifecycle_test.go
+++ b/cmd/deja/blame_lifecycle_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// blame answers "who decided this", and it answered with the accepted line of
+// a decision that had been taken back: attachLifecycles ran on search hits
+// only, and blame carries its own hit type (#1017).
+func TestBlameCarriesTheDecisionThatHolds(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"we raised the pool cap in pool.go to 200"},"timestamp":"2026-08-04T10:00:00Z","sessionId":"w25","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "promote", "w25", "--state", "accepted", "--note", "the pool cap is 200"); err != nil {
+		t.Fatal(err)
+	}
+
+	// While the decision holds, blame says nothing extra.
+	out, err := captureRun(t, "blame", "pool.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "tried and rejected") {
+		t.Errorf("a decision that holds was reported as withdrawn:\n%s", out)
+	}
+
+	if _, err := captureRun(t, "promote", "w25", "--state", "rejected", "--note", "rolled back, the cap stays at 20"); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "blame", "pool.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "tried and rejected") {
+		t.Errorf("blame reports a decision that was taken back as current:\n%s", out)
+	}
+	if !strings.Contains(out, "rolled back, the cap stays at 20") {
+		t.Errorf("blame does not name the correction that won:\n%s", out)
+	}
+}

--- a/cmd/deja/build_progress_early_test.go
+++ b/cmd/deja/build_progress_early_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Every "memory is on its way" surface reads <index>.warmup, and the file did
+// not exist until the build proper began — the walk over the stores comes
+// first and, on a slow volume, takes the longest. Measured on 6000 sessions:
+// first published at 0.76s before, 0.02s after (#1021).
+func TestProgressIsPublishedBeforeTheFreshnessWalk(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_WARMUP_SENTINEL", "1")
+
+	stop := publishBuildProgress(dir)
+	if _, err := os.Stat(dir + ".warmup"); err != nil {
+		t.Fatalf("nothing published before the walk: %v", err)
+	}
+	if st := readWarmupStatus(dir); st == nil {
+		t.Error("the published file does not read back as a build in flight")
+	}
+	stop()
+	if _, err := os.Stat(dir + ".warmup"); err == nil {
+		t.Error("the progress file outlived the command")
+	}
+
+	// Without the sentinel this is an ordinary foreground run and publishes
+	// nothing, as before.
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	stop = publishBuildProgress(dir)
+	if _, err := os.Stat(dir + ".warmup"); err == nil {
+		t.Error("a foreground run published a warmup status")
+	}
+	stop()
+}
+
+// The walk itself reports, so the phase name is not "starting" for the seconds
+// it takes on a network volume (#1021).
+func TestTheStoreWalkReportsItsPhase(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"a session"},"timestamp":"2026-08-01T10:00:00Z","sessionId":"s","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p := &phaseRecorder{}
+	index.SetProgress(p)
+	t.Cleanup(func() { index.SetProgress(nil) })
+	if err := index.Ensure(filepath.Join(tmp, "index.db"), "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !p.seen("finding transcripts") {
+		t.Errorf("the store walk published no phase: %v", p.phases)
+	}
+}
+
+type phaseRecorder struct{ phases []string }
+
+func (p *phaseRecorder) Phase(name string, _ int) { p.phases = append(p.phases, name) }
+func (p *phaseRecorder) Advance(int)              {}
+func (p *phaseRecorder) Harness(string, int, int) {}
+func (p *phaseRecorder) seen(name string) bool {
+	for _, s := range p.phases {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/deja/denied_store_hint_test.go
+++ b/cmd/deja/denied_store_hint_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// "no agent history was found on this machine" is a claim about the machine,
+// and it was made over a store deja is not allowed to open — the sessions are
+// there, behind a wall doctor and sources both name (#1020).
+func TestEmptyHintSeparatesALockedStoreFromAnEmptyMachine(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	tmp := hermeticEnv(t)
+
+	// Nothing anywhere: the advice is about where deja looked.
+	if hint := emptyIndexHint("no sessions indexed yet"); !strings.Contains(hint, "no agent history was found") {
+		t.Errorf("an empty machine lost its wording: %q", hint)
+	}
+
+	qwen := filepath.Join(tmp, "qwen")
+	projects := filepath.Join(qwen, "projects", "p1")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projects, "s.json"), []byte(`{"x":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_QWEN_ROOT", qwen)
+	if err := os.Chmod(filepath.Join(qwen, "projects"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(qwen, "projects"), 0o755) })
+
+	hint := emptyIndexHint("no sessions indexed yet")
+	if strings.Contains(hint, "no agent history was found") {
+		t.Errorf("a locked store was reported as no history at all: %q", hint)
+	}
+	if !strings.Contains(hint, "could not be read") || !strings.Contains(hint, "deja doctor") {
+		t.Errorf("the hint does not say what to look at: %q", hint)
+	}
+	if n := deniedStoreCount(); n != 1 {
+		t.Errorf("denied stores counted as %d", n)
+	}
+}

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -392,9 +392,11 @@ func doctorHarnesses(w io.Writer, dir string) {
 	// The same inspection the JSON form reports, so one command does not give
 	// two answers about one store: `found` here and `unreadable` there (#999).
 	inspected := map[string]string{}
+	unchecked := map[string]bool{}
 	for _, check := range doctorStoreChecks() {
 		store, _ := inspectDoctorStore(check)
 		inspected[check.name] = store.State
+		unchecked[check.name] = store.Unchecked
 	}
 
 	printRow := func(name, path string, present bool, detail string) {
@@ -415,6 +417,14 @@ func doctorHarnesses(w io.Writer, dir string) {
 					// The warning block below names the path and what to do.
 					detail += "cannot be read"
 				}
+			}
+			// A walk that stopped at its budget looked at part of the store,
+			// and `found` on its own claims the whole of it (#1025).
+			if unchecked[name] {
+				if detail != "" {
+					detail += ", "
+				}
+				detail += "permissions not fully checked"
 			}
 		} else if storeDiskGone(path) {
 			// A store whose whole disk is gone is not a store that was

--- a/cmd/deja/doctor_denied_budget_test.go
+++ b/cmd/deja/doctor_denied_budget_test.go
@@ -34,7 +34,34 @@ func TestDeniedDirIsFoundPastTheFileBudget(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
 
-	if got := firstDeniedDir([]string{root}); got != locked {
-		t.Errorf("denied dir = %q, want %q", got, locked)
+	if got, whole := firstDeniedDir([]string{root}); got != locked || !whole {
+		t.Errorf("denied dir = %q whole = %v, want %q true", got, whole, locked)
+	}
+}
+
+// The budget then counted directories, and a machine with a few thousand
+// projects spent it before reaching a locked one — doctor called the store
+// whole (#1025).
+func TestDeniedDirIsFoundPastTheDirectoryBudget(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	root := t.TempDir()
+	for i := 0; i < 6000; i++ {
+		if err := os.MkdirAll(filepath.Join(root, fmt.Sprintf("proj%05d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	locked := filepath.Join(root, "zzz-locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	if got, whole := firstDeniedDir([]string{root}); got != locked || !whole {
+		t.Errorf("denied dir = %q whole = %v, want %q true", got, whole, locked)
 	}
 }

--- a/cmd/deja/doctor_policy_effect_test.go
+++ b/cmd/deja/doctor_policy_effect_test.go
@@ -73,3 +73,42 @@ func TestDoctorPolicySaysHowMuchTheRuleWithholds(t *testing.T) {
 		t.Errorf("a rule that hides nothing was counted as withholding:\n%s", out.String())
 	}
 }
+
+// The text report has had a trust-policy block since #661; `--json` had no key
+// for it at all, so a script could not see that recall is off on a machine
+// (#1027).
+func TestDoctorJSONReportsThePolicy(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":false,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	got := collectDoctorPolicy(dir)
+	if got.State != "active" || got.Path != policyFile {
+		t.Errorf("policy state = %q at %q, want active at %q", got.State, got.Path, policyFile)
+	}
+	if got.Total != 1 {
+		t.Errorf("indexed sessions = %d, want 1", got.Total)
+	}
+	search := got.Activations["search"]
+	if search.Rule != "nothing activates" || search.Withheld != 1 {
+		t.Errorf("search rule = %+v, want {nothing activates 1}", search)
+	}
+	if auto := got.Activations["auto"]; auto.Withheld != 0 {
+		t.Errorf("a path the rule does not touch withheld %d", auto.Withheld)
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -27,8 +27,11 @@ type doctorStore struct {
 	// at the directory to fix rather than at the harness (#802). Partial says
 	// the rest of the store was readable: sessions are missing from recall
 	// rather than the whole harness (#816).
-	Denied  string `json:"denied,omitempty"`
-	Partial bool   `json:"partial,omitempty"`
+	// Unchecked says the permission walk stopped at its budget, so no
+	// permission problem past that point was looked for (#1025).
+	Denied    string `json:"denied,omitempty"`
+	Partial   bool   `json:"partial,omitempty"`
+	Unchecked bool   `json:"unchecked,omitempty"`
 }
 
 type doctorComponent struct {
@@ -98,14 +101,19 @@ func collectDoctorReport(lookup doctorVersionLookup, dir string) doctorReport {
 
 // firstDeniedDir walks the store roots until something refuses to be read and
 // returns that path. The walk is bounded: doctor is a diagnostic command, but
-// a harness root can hold tens of thousands of transcripts.
-func firstDeniedDir(paths []string) string {
+// a harness root can hold tens of thousands of transcripts. The second result
+// is false when the budget cut the walk short, so the caller can avoid calling
+// a half-checked store whole (#1025).
+func firstDeniedDir(paths []string) (string, bool) {
 	// Directories, not entries: a store of 50k transcripts sits in a few
 	// hundred of them, and counting files spent the budget in the first
 	// project — a locked directory later in the walk was never reached, and
-	// doctor reported the store whole (#864).
-	const budget = 5000
+	// doctor reported the store whole (#864). A machine with a few thousand
+	// projects hit the same wall at the directory bound, so it is high enough
+	// that only a pathological tree reaches it (#1025).
+	const budget = 200_000
 	visited := 0
+	whole := true
 	home := sources.Home()
 	for _, root := range paths {
 		// aider's root is the home directory itself: any locked directory
@@ -127,15 +135,16 @@ func firstDeniedDir(paths []string) string {
 				return nil
 			}
 			if visited++; visited > budget {
+				whole = false
 				return filepath.SkipAll
 			}
 			return nil
 		})
 		if denied != "" {
-			return denied
+			return denied, true
 		}
 	}
-	return ""
+	return "", whole
 }
 
 // storeNeedsSQLite3 names the harnesses deja reads through the sqlite3 CLI.
@@ -266,12 +275,17 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 	// its sessions out of recall. With no files at all that read as a harness
 	// nobody has used (#802); with some files it read as a complete store
 	// missing a few, which is quieter still (#816).
-	if denied := firstDeniedDir(check.paths); denied != "" {
+	denied, whole := firstDeniedDir(check.paths)
+	if denied != "" {
 		store.State = "denied"
 		store.Denied = denied
 		store.Partial = len(check.files) > 0
 		return store, time.Time{}
 	}
+	// Nothing refused to be read *of what was walked*. Saying "found" for a
+	// store whose walk stopped early is the same silence #864 closed, one
+	// order of magnitude up (#1025).
+	store.Unchecked = !whole
 	if len(check.files) == 0 {
 		// The text rows have separated a store whose disk went away from one
 		// that was deleted since #933; a script reading this could not (#999).

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
@@ -54,8 +55,50 @@ type doctorReport struct {
 	SQLite3       doctorComponent                `json:"sqlite3"`
 	Version       doctorVersionReport            `json:"version"`
 	Embed         *doctorEmbedReport             `json:"embed,omitempty"`
+	Policy        doctorPolicyReport             `json:"policy"`
 	Ingest        map[string]index.HarnessIngest `json:"ingest_health,omitempty"`
 	Deep          *index.DeepReport              `json:"deep,omitempty"`
+}
+
+// doctorPolicyReport is the trust policy in the machine form. The text report
+// has had a block for it since #661 while `--json` had no key at all, so a
+// script could not see that recall is switched off on a machine (#1027).
+type doctorPolicyReport struct {
+	// State is one of default, active, unreadable — what is in force, not what
+	// the file says, which is the distinction the text block draws too.
+	State       string                      `json:"state"`
+	Path        string                      `json:"path"`
+	Error       string                      `json:"error,omitempty"`
+	Total       int                         `json:"indexed_sessions"`
+	Activations map[string]doctorPolicyRule `json:"activations"`
+	Ignored     []string                    `json:"ignored,omitempty"`
+	Inert       []string                    `json:"inert,omitempty"`
+}
+
+type doctorPolicyRule struct {
+	Rule     string `json:"rule"`
+	Withheld int    `json:"withheld"`
+}
+
+func collectDoctorPolicy(dir string) doctorPolicyReport {
+	r := doctorPolicyReport{State: "active", Path: policy.Path(), Activations: map[string]doctorPolicyRule{}}
+	exists, unknown, err := policy.Diagnose()
+	switch {
+	case !exists:
+		r.State = "default"
+	case err != nil:
+		r.State = "unreadable"
+		r.Error = err.Error()
+	}
+	pol := policy.Load()
+	withheld, total := policyWithheldCounts(dir)
+	r.Total = total
+	for _, a := range []string{policy.ActivationSearch, policy.ActivationMCP, policy.ActivationAuto} {
+		r.Activations[a] = doctorPolicyRule{Rule: pol.Describe(a), Withheld: withheld[a]}
+	}
+	r.Ignored = unknown
+	r.Inert = unmatchedImportGroups(dir)
+	return r
 }
 
 type doctorEmbedReport struct {
@@ -94,6 +137,7 @@ func collectDoctorReport(lookup doctorVersionLookup, dir string) doctorReport {
 	if sources.SQLite3Available() {
 		report.SQLite3.State = "ok"
 	}
+	report.Policy = collectDoctorPolicy(dir)
 	report.Version = collectDoctorVersion(lookup)
 	report.Embed = collectDoctorEmbed(dir)
 	return report

--- a/cmd/deja/forget_selectors_test.go
+++ b/cmd/deja/forget_selectors_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Forgetting 100 sessions one id at a time took 10.5s against 0.2s for one
+// `--project` call, and the bare refusal named no selector at all — so the
+// expensive way was the discoverable one (#1022).
+func TestForgetRefusalNamesItsSelectors(t *testing.T) {
+	hermeticEnv(t)
+	_, err := captureRun(t, "forget")
+	if err == nil {
+		t.Fatal("forget with no selector was accepted")
+	}
+	for _, want := range []string{"--session", "--project", "--before", "--dry-run", "--list"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not mention %s: %v", want, err)
+		}
+	}
+	// And it must not advertise a selector forget does not have.
+	for _, absent := range []string{"--query", "--harness"} {
+		if strings.Contains(err.Error(), absent) {
+			t.Errorf("the refusal offers %s, which forget does not accept: %v", absent, err)
+		}
+	}
+}

--- a/cmd/deja/lifecycle.go
+++ b/cmd/deja/lifecycle.go
@@ -218,3 +218,36 @@ func theyOrIt(n int) string {
 	}
 	return "they"
 }
+
+// attachBlameLifecycles is attachLifecycles for blame, which carries its own
+// hit type: blame answers "who decided this", and it answered with the
+// accepted line of a decision that had been taken back (#1017).
+func attachBlameLifecycles(hits []search.BlameHit) {
+	if len(hits) == 0 {
+		return
+	}
+	states := sources.PromotedLifecycles()
+	for i := range hits {
+		h := &hits[i]
+		key := h.Session.Harness + ":" + h.Session.ID
+		if noteID := promotedNoteID(h.Session); noteID != "" {
+			if src, ok := strings.CutPrefix(noteID, "deja-note-"); ok {
+				key = strings.Replace(src, "-", ":", 1)
+			}
+		}
+		lc, ok := states[key]
+		if !ok || lc.State == "" {
+			if h.Session.Lifecycle != "" && h.Session.Lifecycle != "accepted" {
+				h.Lifecycle, h.LifecycleNote, h.LifecycleAt = h.Session.Lifecycle, h.Session.LifecycleNote, h.Session.LifecycleAt
+			}
+			continue
+		}
+		if lc.State == "accepted" {
+			continue
+		}
+		h.Lifecycle, h.LifecycleNote = lc.State, lc.Note
+		if !lc.At.IsZero() {
+			h.LifecycleAt = lc.At.Format("2006-01-02")
+		}
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1464,8 +1464,10 @@ func printSources(dir string) {
 		// `deja sources` is where the empty-machine advice sends people, and a
 		// store deja is not allowed to read looked exactly like one nobody has
 		// used: `sessions=0 messages=0 size=0 B` (#1000).
-		if denied := firstDeniedDir(it.roots); denied != "" {
+		if denied, whole := firstDeniedDir(it.roots); denied != "" {
 			note = "\t(cannot be read — permission denied on " + denied + ")"
+		} else if !whole {
+			note = "\t(permissions not fully checked — too many directories to walk)"
 		}
 		if it.name == "cursor" && len(sources.CursorDBs()) > 0 && !sources.SQLite3Available() {
 			note = "\t(sqlite3 CLI not found — Cursor IDE sessions unavailable)"

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -464,6 +464,13 @@ func cmdCtx(dir string, rest []string) error {
 			return err
 		}
 		if ok {
+			// Every other reading surface stops here when a rule denies the
+			// session's origin; ctx handed the whole session over, and it is
+			// the command the hook tells an agent to call (#1026).
+			if kept, hidden := policyFilterSessionsCounted(policy.ActivationSearch, []model.Session{s}); len(kept) == 0 {
+				fmt.Fprint(os.Stderr, policyHiddenNote(policy.ActivationSearch, hidden))
+				return fmt.Errorf("no session matches %q", q)
+			}
 			// The one command an agent is told to call — the hook's lead line
 			// names recall_context — answered from one of several sessions
 			// behind an elided id without saying it was a choice, while show,
@@ -487,6 +494,11 @@ func cmdCtx(dir string, rest []string) error {
 	hits, err := search.Run(ss, o)
 	if err != nil {
 		return err
+	}
+	hits, policyHidden := policyFilterHitsCounted(policy.ActivationSearch, hits)
+	if len(hits) == 0 && policyHidden > 0 {
+		fmt.Fprint(os.Stderr, policyHiddenNote(policy.ActivationSearch, policyHidden))
+		return fmt.Errorf("no session matches %q", q)
 	}
 	if len(hits) == 0 {
 		// Same as #834 in files and restore: an empty store is not a miss on

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1948,9 +1948,27 @@ func idPrefixNeeded(dir, subject, refusal string) error {
 // found at all, the useful next step is finding out where deja looked.
 func emptyIndexHint(what string) string {
 	if noAgentHistoryFound() {
+		// "no agent history was found" is a claim about the machine, and it
+		// was made over a store deja is not allowed to open: the sessions are
+		// there, behind a permission wall doctor and sources both name (#1020).
+		if denied := deniedStoreCount(); denied > 0 {
+			return fmt.Sprintf("deja: %s — %d store%s could not be read (permission denied); `deja doctor` names %s",
+				what, denied, pluralS(denied), pluralWhich(denied))
+		}
 		return "deja: " + what + " — no agent history was found on this machine; `deja sources` shows where deja looked"
 	}
 	return "deja: " + what + " — run `deja index`, or `deja doctor` to see which agent stores were found"
+}
+
+// deniedStoreCount reports how many harness stores exist but cannot be opened.
+func deniedStoreCount() int {
+	n := 0
+	for _, check := range doctorStoreChecks() {
+		if store, _ := inspectDoctorStore(check); store.State == "denied" {
+			n++
+		}
+	}
+	return n
 }
 
 // noAgentHistoryFound reports whether the stores themselves are empty, as

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -202,6 +202,8 @@ func cmdVersion(_ string, _ []string) error {
 }
 
 func cmdWarmup(dir string, _ []string) error {
+	stop := publishBuildProgress(dir)
+	defer stop()
 	prepareFirstIndexGreeting(dir)
 	if err := withBuildProgress(func() error { return index.Ensure(dir, "", false, os.Stderr) }); err != nil {
 		return err
@@ -222,7 +224,12 @@ func cmdIndex(dir string, rest []string) error {
 	// Silence reads as "it did not run". `update` on the newest release and
 	// `doctor` on a fresh index both say so; this one returned to the prompt
 	// with nothing (#824). Only here: on a search the same line would be noise.
+	// The freshness check walks every store, which on a slow volume is the
+	// longest part of the whole command, and it ran before the progress sink
+	// existed (#1021).
+	stopProgress := publishBuildProgress(dir)
 	if fresh, n := index.UpToDate(dir, ""); fresh && !force {
+		stopProgress()
 		// The warmup child runs this command, so returning before the sentinel
 		// is cleared leaves a build that is not running: the next request is
 		// suppressed until the retry window, and readWarmupStatus tells the
@@ -231,6 +238,7 @@ func cmdIndex(dir string, rest []string) error {
 		fmt.Fprintf(os.Stderr, "deja: index is up to date (%d session%s)\n", n, pluralS(n))
 		return nil
 	}
+	stopProgress()
 	prepareFirstIndexGreeting(dir)
 	// The detached warmup publishes its progress so hooks can tell the user
 	// memory is on its way; an interactive run draws the live display.

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1318,7 +1318,9 @@ func findBlameHits(dir string, target search.BlameTarget, o search.BlameOptions,
 	if err != nil {
 		return nil, err
 	}
-	return policyFilterBlame(activation, search.Blame(withFileTouchers(dir, result.Sessions, target), target, o)), nil
+	hits := policyFilterBlame(activation, search.Blame(withFileTouchers(dir, result.Sessions, target), target, o))
+	attachBlameLifecycles(hits)
+	return hits, nil
 }
 
 // blameToucherCap bounds how many extra sessions a blame reads from the

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1587,7 +1587,11 @@ func runForget(dir string, args []string) error {
 		}
 	}
 	if !list && unforget == "" && o.Session == "" && o.Project == "" && o.Before.IsZero() {
-		return fmt.Errorf("forget: selector required")
+		// Naming the selectors here is what separates one call from hundreds:
+		// forgetting 100 sessions one id at a time took 10.5s against 0.2s for
+		// `--project`, and nothing on this path said the second form exists
+		// (#1022).
+		return fmt.Errorf("forget: selector required — `--session <id>`, `--project <name>` or `--before <date>`; `--dry-run` shows what would go, `--list` what already went")
 	}
 	if list {
 		keys := index.Tombstones()

--- a/cmd/deja/policy_leak_test.go
+++ b/cmd/deja/policy_leak_test.go
@@ -109,3 +109,44 @@ func TestBlameHonorsPolicy(t *testing.T) {
 		t.Fatalf("blame served policy-denied memory:\n%s", got)
 	}
 }
+
+// ctx is the command the hook tells an agent to call, and it answered from
+// sessions every other reading surface withheld (#1026).
+func TestCtxHonorsPolicy(t *testing.T) {
+	dir := policyLeakIndex(t)
+	pol := filepath.Join(t.TempDir(), "policy.json")
+	if err := os.WriteFile(pol, []byte(`{"activations":{"search":{"imported":false},"mcp":{"imported":false},"auto":{"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", pol)
+	out := captureStdout(t, func() {
+		if err := cmdCtx(dir, []string{"authentication", "middleware", "panicked"}); err == nil {
+			t.Error("ctx answered from a session the policy denies")
+		}
+	})
+	if strings.Contains(out, "ZQSECRETMARKER") {
+		t.Fatalf("ctx served policy-denied memory:\n%s", out)
+	}
+	// The id-prefix branch takes its own path to the same session.
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := ""
+	for _, m := range metas {
+		if strings.HasPrefix(m.Project, "imported:") && len(m.ID) >= 6 {
+			id = m.ID
+		}
+	}
+	if id == "" {
+		t.Fatal("no imported session with an id long enough for the prefix branch")
+	}
+	out = captureStdout(t, func() {
+		if err := cmdCtx(dir, []string{id}); err == nil {
+			t.Error("ctx by id answered from a session the policy denies")
+		}
+	})
+	if strings.Contains(out, "ZQSECRETMARKER") {
+		t.Fatalf("ctx by id served policy-denied memory:\n%s", out)
+	}
+}

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -235,5 +235,24 @@
     "state": "update-available",
     "current": "1.0.0",
     "latest": "2.0.0"
+  },
+  "policy": {
+    "state": "default",
+    "path": "<tmp>/home/.config/deja/policy.json",
+    "indexed_sessions": 0,
+    "activations": {
+      "auto": {
+        "rule": "local+imported",
+        "withheld": 0
+      },
+      "mcp": {
+        "rule": "local+imported",
+        "withheld": 0
+      },
+      "search": {
+        "rule": "local+imported",
+        "withheld": 0
+      }
+    }
   }
 }

--- a/cmd/deja/warmup_status.go
+++ b/cmd/deja/warmup_status.go
@@ -154,6 +154,25 @@ func (s *warmupStatus) line() string {
 	return fmt.Sprintf("deja: indexing your history (%s%s) — recall comes online in a few seconds", phase, pct)
 }
 
+// publishBuildProgress installs the file sink for the work that happens before
+// the build proper — the freshness walk over every store, which on a slow
+// volume is the longest part of the command. It published nothing until the
+// build began, so every "memory is on its way" surface said nothing meanwhile.
+// Measured on 6000 sessions: first published at 0.76s before, 0.02s after
+// (#1021).
+func publishBuildProgress(dir string) func() {
+	if os.Getenv("DEJA_WARMUP_SENTINEL") == "" {
+		return func() {}
+	}
+	p := newFileProgress(dir)
+	p.flush(true)
+	index.SetProgress(p)
+	return func() {
+		index.SetProgress(nil)
+		p.done()
+	}
+}
+
 // withWarmupStatus publishes progress while fn builds, when this process is
 // the detached warmup.
 func withWarmupStatus(dir string, fn func() error) error {
@@ -161,6 +180,10 @@ func withWarmupStatus(dir string, fn func() error) error {
 		return fn()
 	}
 	p := newFileProgress(dir)
+	// Publish before the build starts: the walk over the stores comes first
+	// and, on a slow volume, takes the longest, so waiting for its first
+	// report left every "memory is on its way" surface saying nothing (#1021).
+	p.flush(true)
 	index.SetProgress(p)
 	err := fn()
 	index.SetProgress(nil)

--- a/internal/index/import_ord_test.go
+++ b/internal/index/import_ord_test.go
@@ -1,0 +1,90 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Every new session asked nextSessionOrd for its ordinal, and that walks the
+// whole manifest — so importing n sessions cost O(n²): a 100k batch took 306s
+// against 1.9s for forgetting the same 100k (#1024).
+func TestImportedOrdinalsAreDistinctAndCheap(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	dir := filepath.Join(tmp, "index.db")
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var body []byte
+	const n = 300
+	for i := 0; i < n; i++ {
+		b, err := json.Marshal(SyncRecord{Harness: "claude", SessionID: fixedID(i), Project: "work/api",
+			Role: "user", Text: "record about the pool cap"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		body = append(append(body, b...), '\n')
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync.jsonl"), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := Import(dir, exp); err != nil || got != n {
+		t.Fatalf("import: %d records, %v", got, err)
+	}
+
+	// The ordinal is what postings point at, so a repeat would merge two
+	// sessions' hits into one row.
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[uint32]string{}
+	for _, m := range metas {
+		if prev, ok := seen[m.Ord]; ok {
+			t.Fatalf("sessions %s and %s share ordinal %d", prev, m.ID, m.Ord)
+		}
+		seen[m.Ord] = m.ID
+	}
+	if len(seen) != n {
+		t.Errorf("got %d distinct ordinals for %d sessions", len(seen), n)
+	}
+
+	// A second batch continues above the first rather than colliding with it.
+	body = nil
+	for i := n; i < n+50; i++ {
+		b, _ := json.Marshal(SyncRecord{Harness: "claude", SessionID: fixedID(i), Project: "work/api",
+			Role: "user", Text: "another record"})
+		body = append(append(body, b...), '\n')
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-2.jsonl"), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(dir, exp); err != nil {
+		t.Fatal(err)
+	}
+	metas, err = AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen = map[uint32]string{}
+	for _, m := range metas {
+		if prev, ok := seen[m.Ord]; ok {
+			t.Fatalf("after the second batch, %s and %s share ordinal %d", prev, m.ID, m.Ord)
+		}
+		seen[m.Ord] = m.ID
+	}
+	if len(seen) != n+50 {
+		t.Errorf("got %d distinct ordinals for %d sessions", len(seen), n+50)
+	}
+}
+
+func fixedID(i int) string {
+	const digits = "0123456789"
+	return "s" + string([]byte{digits[i/100%10], digits[i/10%10], digits[i%10]})
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1863,6 +1863,11 @@ func currentFilesStat(h string) map[string]FileState {
 }
 
 func currentFilesWith(h string, old map[string]FileState) map[string]FileState {
+	// Walking the stores is the first thing a build does and, on a network
+	// volume, the slowest: it published nothing, so every "memory is on its
+	// way" surface reported an ordinary quiet day until the walk finished
+	// (#1021).
+	reportPhase("finding transcripts", 0)
 	paths := map[string]bool{}
 	for _, hr := range sources.Registry() {
 		if h != "" && h != hr.Name {

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -667,6 +667,10 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
+	// One scan for the whole batch, not one per new session: nextSessionOrd
+	// walks every manifest entry, so importing n sessions cost O(n²) and a
+	// 100k batch took 306s against 1.9s for forgetting the same 100k (#1024).
+	nextOrd := nextSessionOrd(m.Sessions)
 	for _, key := range keys {
 		meta := metas[key]
 		old := m.Sessions[key]
@@ -679,7 +683,8 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 				meta.Updated = old.Updated
 			}
 		} else {
-			meta.Ord = nextSessionOrd(m.Sessions)
+			meta.Ord = nextOrd
+			nextOrd++
 		}
 		m.Sessions[key] = meta
 		for _, r := range recsByKey[key] {

--- a/internal/policy/describe_both_denied_test.go
+++ b/internal/policy/describe_both_denied_test.go
@@ -1,6 +1,10 @@
 package policy
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 // "local-only" is the name of the rule that keeps local sessions and drops
 // imported ones. A policy that denies both was described with it, next to a
@@ -32,5 +36,33 @@ func TestDescribeNamesTheRuleThatIsActuallyInForce(t *testing.T) {
 	}
 	if !importedOnly.Allows(ActivationSearch, "imported:proj") || importedOnly.Allows(ActivationSearch, "proj") {
 		t.Error("the description and the filter disagree")
+	}
+}
+
+// Twenty group rules made one 1000-character line on the screen people read to
+// find out what is allowed. The file itself is named beside it and holds the
+// full set (#1023).
+func TestDescribeCapsALongDenyList(t *testing.T) {
+	rules := map[string]bool{"local": true}
+	for i := 0; i < 20; i++ {
+		rules[fmt.Sprintf("imported:grp%02d", i)] = false
+	}
+	got := Policy{Activations: map[string]map[string]bool{ActivationSearch: rules}}.Describe(ActivationSearch)
+	if len(got) > 120 {
+		t.Errorf("the description is %d characters long: %q", len(got), got)
+	}
+	if !strings.Contains(got, "+16 more") {
+		t.Errorf("the description does not say how many it left out: %q", got)
+	}
+	if !strings.Contains(got, "imported:grp00") {
+		t.Errorf("the description names none of the rules: %q", got)
+	}
+
+	// A short list is printed whole.
+	short := Policy{Activations: map[string]map[string]bool{
+		ActivationSearch: {"local": true, "imported:a": false, "imported:b": false},
+	}}
+	if got := short.Describe(ActivationSearch); got != "deny imported:a,imported:b" {
+		t.Errorf("a short list was truncated: %q", got)
 	}
 }

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -8,6 +8,7 @@ package policy
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -146,6 +147,13 @@ func (p Policy) Describe(activation string) string {
 		return "local+imported"
 	}
 	sort.Strings(denied)
+	// Twenty group rules made one 1000-character line on the screen people
+	// read to find out what is allowed; the file itself is named beside it
+	// and holds the full set (#1023).
+	const shown = 4
+	if len(denied) > shown {
+		return fmt.Sprintf("deny %s +%d more", strings.Join(denied[:shown], ","), len(denied)-shown)
+	}
 	return "deny " + strings.Join(denied, ",")
 }
 

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -34,6 +34,12 @@ type BlameHit struct {
 	Snippets []string      `json:"snippets"`
 	Score    float64       `json:"score"`
 	Tier     string        `json:"tier"`
+	// Lifecycle carries a decision that did not hold. blame answers "who
+	// decided this", and it was answering with the accepted line of a decision
+	// that had been taken back (#1017).
+	Lifecycle     string `json:"lifecycle,omitempty"`
+	LifecycleNote string `json:"lifecycle_note,omitempty"`
+	LifecycleAt   string `json:"lifecycle_at,omitempty"`
 }
 
 func ResolveBlamePath(name string) (BlameTarget, error) {
@@ -247,6 +253,13 @@ func PrintBlame(w io.Writer, hits []BlameHit, jsonOutput bool) {
 			}
 		}
 		fmt.Fprintln(w)
+		if line := BlameLifecycleLine(hit); line != "" {
+			if color {
+				fmt.Fprintf(w, "  %s%s%s\n", cDim, line, cReset)
+			} else {
+				fmt.Fprintf(w, "  %s\n", line)
+			}
+		}
 		for _, text := range hit.Snippets {
 			if color {
 				fmt.Fprintf(w, "  %s%s%s\n", cDim, text, cReset)
@@ -255,4 +268,30 @@ func PrintBlame(w io.Writer, hits []BlameHit, jsonOutput bool) {
 			}
 		}
 	}
+}
+
+// BlameLifecycleLine words a withdrawn decision for blame the way search words
+// it: what happened, not the name of the state.
+func BlameLifecycleLine(h BlameHit) string {
+	if h.Lifecycle == "" {
+		return ""
+	}
+	var head string
+	switch h.Lifecycle {
+	case "rejected":
+		head = "this was tried and rejected"
+	case "superseded":
+		head = "a later decision replaced this"
+	case "stale":
+		head = "marked stale — may no longer hold"
+	default:
+		head = h.Lifecycle
+	}
+	if h.LifecycleAt != "" {
+		head += " (" + h.LifecycleAt + ")"
+	}
+	if h.LifecycleNote != "" {
+		head += ": " + h.LifecycleNote
+	}
+	return head
 }

--- a/internal/search/blame_lifecycle_line_test.go
+++ b/internal/search/blame_lifecycle_line_test.go
@@ -1,0 +1,33 @@
+package search
+
+import "testing"
+
+// The line says what happened rather than naming the state, so a hit that was
+// taken back reads as taken back in blame too (#1019).
+func TestBlameLifecycleLineWordsWhatHappened(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		hit  BlameHit
+		want string
+	}{
+		{"none", BlameHit{}, ""},
+		{"rejected", BlameHit{Lifecycle: "rejected"}, "this was tried and rejected"},
+		{"superseded", BlameHit{Lifecycle: "superseded"}, "a later decision replaced this"},
+		{"stale", BlameHit{Lifecycle: "stale"}, "marked stale — may no longer hold"},
+		{"unknown state passes through", BlameHit{Lifecycle: "parked"}, "parked"},
+		{
+			"with date and note",
+			BlameHit{Lifecycle: "rejected", LifecycleAt: "2026-08-01", LifecycleNote: "deadlocked under load"},
+			"this was tried and rejected (2026-08-01): deadlocked under load",
+		},
+		{
+			"date without note",
+			BlameHit{Lifecycle: "stale", LifecycleAt: "2026-07-04"},
+			"marked stale — may no longer hold (2026-07-04)",
+		},
+	} {
+		if got := BlameLifecycleLine(tc.hit); got != tc.want {
+			t.Errorf("%s: line = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Nine findings from the audit loop, mostly surfaces that knew something and did not say it.

- `blame` served decisions that had been withdrawn (#1019)
- a permission-locked store read as an empty machine (#1020)
- the first ~0.8 s of a build published no progress — the store walk, which is minutes on a network volume (#1021)
- the bare `forget` refusal named no selectors, so the batch `--project` (0.2 s vs 10.5 s one by one) was undiscoverable (#1023 lists, #1022)
- a twenty-rule policy printed a 304-character doctor line (#1023)
- import was quadratic in new sessions: 100k records 306 s → 1.48 s (#1024)
- doctor's permission walk stopped after 5000 directories and still called the store whole (#1025)
- `ctx` answered from sessions the trust policy denies (#1026)
- `doctor --json` had no key for the trust policy at all (#1027)

Closes #1019, #1020, #1021, #1022, #1023, #1024, #1025, #1026, #1027.
