### PR TITLE
audit batch: forget cost, advice that does not run, disk-gone messages

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -393,10 +393,12 @@ func doctorHarnesses(w io.Writer, dir string) {
 	// two answers about one store: `found` here and `unreadable` there (#999).
 	inspected := map[string]string{}
 	unchecked := map[string]bool{}
+	partly := map[string]bool{}
 	for _, check := range doctorStoreChecks() {
 		store, _ := inspectDoctorStore(check)
 		inspected[check.name] = store.State
 		unchecked[check.name] = store.Unchecked
+		partly[check.name] = store.Partial
 	}
 
 	printRow := func(name, path string, present bool, detail string) {
@@ -415,7 +417,14 @@ func doctorHarnesses(w io.Writer, dir string) {
 						detail += ", "
 					}
 					// The warning block below names the path and what to do.
-					detail += "cannot be read"
+					// Whole or in part: the row folded both into "cannot be
+					// read" while the warning under it and the search above
+					// said the store still answers (#1034, #816).
+					if partly[name] {
+						detail += "partly unreadable"
+					} else {
+						detail += "cannot be read"
+					}
 				}
 			}
 			// A walk that stopped at its budget looked at part of the store,

--- a/cmd/deja/doctor_denied_test.go
+++ b/cmd/deja/doctor_denied_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
@@ -87,5 +88,53 @@ func TestDoctorSeparatesADeniedStoreFromAChangedFormat(t *testing.T) {
 	}
 	if store, _ := inspectDoctorStore(broken); store.State != "unreadable" {
 		t.Errorf("state = %q, want unreadable", store.State)
+	}
+}
+
+// The warning under the row has said "only partly readable" since #816, and
+// `doctor --json` carries `partial` — the row itself folded both states into
+// "cannot be read", over a store that search was still answering from (#1034).
+func TestDoctorRowSeparatesAPartlyReadableStore(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	tmp := hermeticEnv(t)
+	root := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"the widget alignment"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"s1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "s.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	locked := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	var out strings.Builder
+	doctorHarnesses(&out, dir)
+	row := ""
+	for _, line := range strings.Split(out.String(), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "claude ") {
+			row = line
+		}
+	}
+	if row == "" {
+		t.Fatalf("no claude row:\n%s", out.String())
+	}
+	if !strings.Contains(row, "partly unreadable") {
+		t.Errorf("the row does not say the store is only partly unreadable: %q", row)
+	}
+	if strings.Contains(row, "cannot be read") {
+		t.Errorf("the row still calls a partly readable store unreadable: %q", row)
 	}
 }

--- a/cmd/deja/forget_notes_test.go
+++ b/cmd/deja/forget_notes_test.go
@@ -94,6 +94,11 @@ func TestForgetByProjectClearsBorrowedTitlesAndNamesTheNotes(t *testing.T) {
 	if !strings.Contains(string(b), "batch the export nightly") {
 		t.Errorf("the decision was destroyed:\n%s", b)
 	}
+	// The dropped set holds the notes' own rows too, and turning one of those
+	// into an id produced `deja-note-deja-deja-note-…`, which matches nothing.
+	if strings.Contains(out, "deja-note-deja-") {
+		t.Errorf("the advice offers an id built from a note's own row: %q", out)
+	}
 	// Last, because it removes the note: the id the line offers has to be a
 	// selector that works, and the note's own row is already out of the index.
 	gone, err := captureRun(t, "forget", "--session", noteID)

--- a/cmd/deja/forget_notes_test.go
+++ b/cmd/deja/forget_notes_test.go
@@ -64,6 +64,16 @@ func TestForgetByProjectClearsBorrowedTitlesAndNamesTheNotes(t *testing.T) {
 	if !strings.Contains(out, "cleared the borrowed title") {
 		t.Errorf("forget --project said %q", out)
 	}
+	// The line offered `--session deja-note-…`, an id that matches nothing,
+	// while the command was holding the real one (#1030). Whatever it names
+	// has to be a selector the reader can paste back.
+	if strings.Contains(out, "deja-note-…") {
+		t.Errorf("the advice still elides the id: %q", out)
+	}
+	noteID := "deja-note-claude-a1"
+	if !strings.Contains(out, "`deja forget --session "+noteID+"`") {
+		t.Errorf("the advice does not name the note it just cleared: %q", out)
+	}
 	// The count folds notes and transcripts together, so it has to say which
 	// is which: the notes are what the reader deliberately kept.
 	// Two raw sessions and one note: the exact split, not just the words
@@ -83,6 +93,22 @@ func TestForgetByProjectClearsBorrowedTitlesAndNamesTheNotes(t *testing.T) {
 	}
 	if !strings.Contains(string(b), "batch the export nightly") {
 		t.Errorf("the decision was destroyed:\n%s", b)
+	}
+	// Last, because it removes the note: the id the line offers has to be a
+	// selector that works, and the note's own row is already out of the index.
+	gone, err := captureRun(t, "forget", "--session", noteID)
+	if err != nil {
+		t.Fatalf("the id the line offered does not run: %v", err)
+	}
+	if !strings.Contains(gone, "removed 1 promoted note") {
+		t.Errorf("running the advised command removed nothing: %q", gone)
+	}
+	b, err = os.ReadFile(filepath.Join(tmp, "notes.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "batch the export nightly") {
+		t.Errorf("the advised command left the note on disk:\n%s", b)
 	}
 }
 

--- a/cmd/deja/forget_prefix_scope_test.go
+++ b/cmd/deja/forget_prefix_scope_test.go
@@ -47,3 +47,42 @@ func TestForgetRefusesAWideSelectorWithoutDroppingAnything(t *testing.T) {
 		t.Fatalf("tombstones = %v, want only claude:s1", got)
 	}
 }
+
+// The refusal sends the reader to `--dry-run`, and the dry run counted what
+// `--all-matches` would drop — a number the command as typed never produces
+// (#1032).
+func TestAmbiguousDryRunPreviewsTheCommandAsTyped(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"s1", "s10", "s11"} {
+		line := `{"type":"user","message":{"role":"user","content":"pool exhausted ` + id + `"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"` + id + `","cwd":"/proj"}`
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "forget", "--session", "s", "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "as it stands this run drops nothing") {
+		t.Errorf("the dry run does not say the command as typed drops nothing:\n%s", out)
+	}
+	if !strings.Contains(out, "with --all-matches it would drop: 3 session(s)") {
+		t.Errorf("the dry run does not say whose 3 sessions those are:\n%s", out)
+	}
+	// The unambiguous form keeps its plain wording — nothing to qualify there.
+	one, err := captureRun(t, "forget", "--session", "s1", "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(one, "would drop: 1 session(s)") || strings.Contains(one, "as it stands") {
+		t.Errorf("an exact id got the ambiguous wording:\n%s", one)
+	}
+}

--- a/cmd/deja/forget_unwritable_test.go
+++ b/cmd/deja/forget_unwritable_test.go
@@ -106,3 +106,57 @@ func TestForgetProbeErrorIsWordedLikeEveryOther(t *testing.T) {
 		t.Errorf("the wording is still a syscall: %v", err)
 	}
 }
+
+// forget writes the tombstone file before anything else, and a read-only
+// ~/.config/deja arrived as "check the index directory's permissions" — a
+// directory that was writable, so the suggested fix changed nothing (#1031).
+func TestForgetNamesTheTombstoneFileItCannotWrite(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("file permissions do not deny writes here")
+	}
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"the decision about the retry counter"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"s21","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s21.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	privacy := filepath.Join(os.Getenv("HOME"), ".config", "deja")
+	if err := os.MkdirAll(privacy, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tombstones := filepath.Join(privacy, "tombstones")
+	if err := os.WriteFile(tombstones, nil, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(privacy, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(privacy, 0o700) })
+
+	_, err := captureRun(t, "forget", "--session", "claude:s21")
+	if err == nil {
+		t.Fatal("forget did not refuse with an unwritable tombstone file")
+	}
+	if !strings.Contains(err.Error(), tombstones) {
+		t.Errorf("the refusal does not name the file it could not write: %v", err)
+	}
+	if strings.Contains(err.Error(), "DEJA_INDEX_DIR") {
+		t.Errorf("the refusal sends the reader at the index instead: %v", err)
+	}
+	// The refusal is only worth anything if nothing was dropped.
+	out, err := captureRun(t, "last")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "s21") {
+		t.Errorf("the session went away under a refused forget: %q", out)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -529,9 +529,17 @@ func cmdCtx(dir string, rest []string) error {
 // deja knows them here, and the ellipsis sent the reader to `deja last` to
 // look up what this command was already holding (#1030).
 func clearedNoteIDs(keys []string) string {
+	// Only keys a note was actually promoted from: the dropped set also holds
+	// the notes' own rows, and turning one of those into an id produced
+	// `deja-note-deja-deja-note-claude-s1`, which matches nothing.
+	known := promotedNoteSources()
 	ids := make([]string, 0, len(keys))
 	for _, k := range keys {
-		ids = append(ids, "deja-note-"+strings.ReplaceAll(k, ":", "-"))
+		id := "deja-note-" + strings.ReplaceAll(k, ":", "-")
+		if _, ok := known[id]; !ok {
+			continue
+		}
+		ids = append(ids, id)
 	}
 	sort.Strings(ids)
 	const shown = 3

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1711,15 +1711,23 @@ func runForget(dir string, args []string) error {
 		return ensureError(dir, err)
 	}
 	if o.DryRun {
-		fmt.Fprintf(os.Stdout, "dry run — nothing was changed\nwould drop: %d session(s), %d message(s)\nwould add: %d tombstone(s)\n",
-			result.Sessions, result.Messages, result.Tombstones)
 		// The dry run is where someone checks the scope, so it says the same
 		// thing the real run would refuse with rather than erroring: nothing
 		// is being changed here, and the note is the answer they came for.
+		// It goes above the counts, and the counts say whose run they are:
+		// under an ambiguous selector the numbers were those of
+		// `--all-matches`, while the command as typed drops nothing (#1032).
+		scope := error(nil)
 		if o.Session != "" {
-			if scope := forgetScopeRefusal(o.Session, result.Sessions, allMatches); scope != nil {
-				fmt.Fprintln(os.Stdout, scope.Error())
-			}
+			scope = forgetScopeRefusal(o.Session, result.Sessions, allMatches)
+		}
+		if scope != nil {
+			fmt.Fprintln(os.Stdout, scope.Error())
+			fmt.Fprintf(os.Stdout, "dry run — nothing was changed\nas it stands this run drops nothing; with --all-matches it would drop: %d session(s), %d message(s)\nwould add: %d tombstone(s)\n",
+				result.Sessions, result.Messages, result.Tombstones)
+		} else {
+			fmt.Fprintf(os.Stdout, "dry run — nothing was changed\nwould drop: %d session(s), %d message(s)\nwould add: %d tombstone(s)\n",
+				result.Sessions, result.Messages, result.Tombstones)
 		}
 		if line := forgetNotesLine(result); line != "" {
 			fmt.Fprintln(os.Stdout, line)

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -524,6 +524,23 @@ func cmdCtx(dir string, rest []string) error {
 	return nil
 }
 
+// clearedNoteIDs names the notes whose borrowed title was just cleared. The
+// line used to offer `--session deja-note-…`, an id that matches nothing —
+// deja knows them here, and the ellipsis sent the reader to `deja last` to
+// look up what this command was already holding (#1030).
+func clearedNoteIDs(keys []string) string {
+	ids := make([]string, 0, len(keys))
+	for _, k := range keys {
+		ids = append(ids, "deja-note-"+strings.ReplaceAll(k, ":", "-"))
+	}
+	sort.Strings(ids)
+	const shown = 3
+	if len(ids) > shown {
+		return strings.Join(ids[:shown], "`, `") + fmt.Sprintf("` and %d more", len(ids)-shown)
+	}
+	return strings.Join(ids, "`, `")
+}
+
 func cmdLast(dir string, rest []string, sourceInstance string) error {
 	n, o, sinceRaw, err := parseLast(rest)
 	if err != nil {
@@ -1767,8 +1784,16 @@ func runForget(dir string, args []string) error {
 			// reason the raw session was safe to forget (#666) — so say that
 			// its content is still there rather than let the line read as
 			// "the note was handled" (#841).
-			fmt.Fprintf(os.Stdout, "cleared the borrowed title from %d promoted note%s; %s still holds what you wrote there — `deja forget --session deja-note-…` removes it\n",
-				n, pluralS(n), sources.NotesFile())
+			// The ids, not an ellipsis: this line knows which notes it just
+			// cleared, and `deja forget --session deja-note-…` matched
+			// nothing — it sent the reader to `deja last` to look up
+			// something the command was already holding (#1030).
+			what := "it"
+			if n > 1 {
+				what = "them"
+			}
+			fmt.Fprintf(os.Stdout, "cleared the borrowed title from %d promoted note%s; %s still holds what you wrote there — `deja forget --session %s` removes %s\n",
+				n, pluralS(n), sources.NotesFile(), clearedNoteIDs(result.Keys), what)
 		}
 	}
 	// Nothing matched is a different answer from nothing was dropped: the
@@ -1776,6 +1801,18 @@ func runForget(dir string, args []string) error {
 	// successful removal of zero leaves the reader believing they deleted
 	// something that is in fact still there under a different id.
 	if result.Sessions == 0 && result.Messages == 0 {
+		// A note whose own project was forgotten keeps its line in
+		// notes.jsonl while its index row is gone, and the id the forget
+		// line offers then matched nothing at all — the file, not the
+		// index, is what holds a note (#1030).
+		if o.Session != "" {
+			if gone, err := sources.ForgetPromotedNotes(func(noteID string) bool {
+				return noteID == strings.TrimPrefix(o.Session, "deja:")
+			}); err == nil && gone > 0 {
+				fmt.Fprintf(os.Stdout, "removed %d promoted note%s from %s\n", gone, pluralS(gone), sources.NotesFile())
+				return nil
+			}
+		}
 		fmt.Fprintf(os.Stdout, "nothing matched %s — no session was dropped\n", forgetSelector(o))
 		return nil
 	}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2111,6 +2111,16 @@ func staleReadOnlyIndex(dir string, err error) bool {
 	return errors.Is(err, fs.ErrPermission) && index.HasManifest(dir)
 }
 
+// deniedPath names the file a permission error was actually about, so the fix
+// deja suggests points at it rather than at the index directory (#1031).
+func deniedPath(err error) string {
+	var pe *fs.PathError
+	if errors.As(err, &pe) {
+		return pe.Path
+	}
+	return ""
+}
+
 // ensureError turns a failed build into something the reader can act on.
 // A denied write surfaced as `ensure: open /…/index.db.lock: permission
 // denied` — the path of an internal lock file and a syscall error, which says
@@ -2127,6 +2137,13 @@ func ensureError(dir string, err error) error {
 		// permissions of a directory that no longer exists (#931).
 		if parent := filepath.Dir(dir); !dirExists(dir) && !dirExists(parent) {
 			return fmt.Errorf("the index directory is not there (%s) — the disk it lives on may have been unmounted; reconnect it, or point DEJA_INDEX_DIR somewhere local", parent)
+		}
+		// The denial is not always about the index: forget writes the
+		// tombstone file first, and a read-only ~/.config/deja arrived here
+		// as "check the index directory", which was writable — the reader was
+		// sent to change a permission that was already right (#1031, #808).
+		if p := deniedPath(err); p != "" && !strings.HasPrefix(p, dir) {
+			return fmt.Errorf("cannot write %s — check that file's permissions", p)
 		}
 		return fmt.Errorf("cannot write the index at %s — check the directory's permissions, or point DEJA_INDEX_DIR somewhere writable", dir)
 	}

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -84,7 +84,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 		// source is forgotten: both routes then refused, and "promote the
 		// source session instead" named something that is gone for good — the
 		// note froze at whatever state it held (#979).
-		origin, noteTitle, isPromoted := promotedNoteSource(s.ID)
+		origin, noteTitle, noteBody, isPromoted := promotedNoteSource(s.ID)
 		if !isPromoted {
 			return fmt.Errorf("%q is a note you wrote, not a session — `deja remember` adds to it", prefix)
 		}
@@ -93,6 +93,13 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 		// forget clears the borrowed one that line is "promoted from <src>" —
 		// which would be echoed back as the title of the correction.
 		s.Title = noteTitle
+		// And its body is the note as it was written. Distilling the note's
+		// own rows instead re-rendered "[accepted] asked: … · outcome: …" and
+		// wrote that back as the correction's text, one wrapper deeper each
+		// time — visible once forget had cleared the borrowed title (#1033).
+		if noteBody != "" && strings.TrimSpace(noteText) == "" {
+			noteText = noteBody
+		}
 	}
 	text := strings.TrimSpace(noteText)
 	if text == "" {
@@ -366,8 +373,8 @@ func promotedNoteSources() map[string]string {
 // promoted from. The id is built by replacing the colon in `harness:id`, which
 // does not invert on its own — harness names carry dashes — so the note log is
 // the authority.
-func promotedNoteSource(noteID string) (string, string, bool) {
-	src, title, found := "", "", false
+func promotedNoteSource(noteID string) (string, string, string, bool) {
+	src, title, body, found := "", "", "", false
 	for _, n := range sources.LoadPromotedNotes() {
 		if n.Session == "" || "deja-note-"+strings.ReplaceAll(n.Session, ":", "-") != noteID {
 			continue
@@ -376,6 +383,9 @@ func promotedNoteSource(noteID string) (string, string, bool) {
 		if t := strings.TrimSpace(n.Title); t != "" {
 			title = t
 		}
+		if b := strings.TrimSpace(n.Text); b != "" {
+			body = b
+		}
 	}
-	return src, title, found
+	return src, title, body, found
 }

--- a/cmd/deja/promote_forgotten_source_test.go
+++ b/cmd/deja/promote_forgotten_source_test.go
@@ -84,3 +84,43 @@ func TestCorrectionReachesANoteWhoseSourceIsForgotten(t *testing.T) {
 		t.Errorf("the refusal does not say what the id is: %v", err)
 	}
 }
+
+// #979 made the correction reach the note; without --note it then distilled
+// the note's own rows, so `[accepted] asked: … · outcome: …` came back as the
+// text of the correction, one wrapper deeper each time (#1033).
+func TestCorrectionWithoutANoteCarriesTheNoteText(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"how should we shard the write queue"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"shard1","cwd":"/proj"}` + "\n" +
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"decided to shard by tenant id"}]},"timestamp":"2026-07-11T10:05:00Z","sessionId":"shard1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "promote", "shard1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "forget", "--session", "claude:shard1"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "promote", "deja-note-claude-shard1", "--state", "superseded")
+	if err != nil {
+		t.Fatalf("the correction was refused: %v", err)
+	}
+	if strings.Contains(out, "[accepted]") {
+		t.Errorf("the correction wrapped the note's own rendered line:\n%s", out)
+	}
+	if strings.Count(out, "asked:") > 1 {
+		t.Errorf("the correction repeats the note inside itself:\n%s", out)
+	}
+	if !strings.Contains(out, "shard by tenant") {
+		t.Errorf("the correction lost the decision it carries:\n%s", out)
+	}
+}

--- a/cmd/deja/statscard.go
+++ b/cmd/deja/statscard.go
@@ -19,7 +19,10 @@ func writeStatsCard(path string, report stats.Report) (string, error) {
 		return "", fmt.Errorf("stats card path: %w", err)
 	}
 	if err := os.WriteFile(abs, []byte(renderStatsCard(report)), 0o644); err != nil {
-		return "", fmt.Errorf("write stats card: %w", err)
+		// An unplugged disk arrived as `open /Volumes/…/card.png.svg: no such
+		// file or directory` — an internal path and a syscall, the shape
+		// #893/#907 replaced on the other writing paths (#1036).
+		return "", fmt.Errorf("cannot write the stats card to %s — %s", abs, writeFailureReason(err))
 	}
 	return abs, nil
 }

--- a/cmd/deja/statscard_test.go
+++ b/cmd/deja/statscard_test.go
@@ -161,3 +161,20 @@ func TestHandoffsReceivedCountedFromIndex(t *testing.T) {
 		t.Fatalf("HandoffsIn = %d, want 1", r.HandoffsIn)
 	}
 }
+
+// A path on a disk that is not there came back as `write stats card: open
+// /Volumes/…/card.png.svg: no such file or directory` — an internal path and a
+// syscall, the shape #893/#907 replaced on the other writing paths (#1036).
+func TestWriteStatsCardSaysWhatIsWrongWithThePath(t *testing.T) {
+	gone := filepath.Join(t.TempDir(), "no-such-dir", "card.png")
+	_, err := writeStatsCard(gone, stats.Report{})
+	if err == nil {
+		t.Fatal("writing into a directory that does not exist did not fail")
+	}
+	if !strings.Contains(err.Error(), "its directory does not exist") {
+		t.Errorf("the error does not say what is wrong: %v", err)
+	}
+	if strings.Contains(err.Error(), "no such file or directory") {
+		t.Errorf("the syscall is still handed back: %v", err)
+	}
+}

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -90,11 +90,16 @@ func runSync(dir string, args []string) error {
 		if n == 0 && !full && !hasSyncBatches(out) {
 			fmt.Fprintf(os.Stdout, "deja: nothing has changed since the last export, and this folder holds no batch from this machine — `deja sync export %s --full` sends everything\n", out)
 		}
-		masked := 0
-		if rs, rerr := index.Redactions(dir); rerr == nil {
-			masked = rs.Total
+		// Only when something was written: on a watermarked sync most runs
+		// send nothing, and the line asked the reader to review a file that
+		// does not exist (#1035).
+		if n > 0 {
+			masked := 0
+			if rs, rerr := index.Redactions(dir); rerr == nil {
+				masked = rs.Total
+			}
+			fmt.Fprintf(os.Stderr, "deja: records were redacted at index time (%d masked). pattern redaction is a floor — review the export before moving it; rotate anything that leaked.\n", masked)
 		}
-		fmt.Fprintf(os.Stderr, "deja: records were redacted at index time (%d masked). pattern redaction is a floor — review the export before moving it; rotate anything that leaked.\n", masked)
 		return nil
 	case "import":
 		for _, a := range args[2:] {

--- a/cmd/deja/sync_second_peer_test.go
+++ b/cmd/deja/sync_second_peer_test.go
@@ -79,3 +79,54 @@ func TestExportToASecondDestinationSaysWhyItIsEmpty(t *testing.T) {
 		t.Errorf("a filled destination kept being told to resend:\n%s", out)
 	}
 }
+
+// On a watermarked sync most runs send nothing, so the run that sends nothing
+// is the one people see most — and it asked them to review an export it had
+// not written (#1035).
+func TestANoOpExportDoesNotWarnAboutAFileItDidNotWrite(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(tmp, "to-laptop")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// The run that writes a batch keeps the warning: that file is real.
+	first, err := captureRunStderr(t, "sync", "export", out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(first, "review the export before moving it") {
+		t.Errorf("an export that wrote a batch dropped the redaction warning:\n%s", first)
+	}
+
+	before, err := os.ReadDir(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := captureRunStderr(t, "sync", "export", out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(second, "review the export before moving it") {
+		t.Errorf("a no-op export still points at a file it did not write:\n%s", second)
+	}
+	after, err := os.ReadDir(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) {
+		t.Errorf("the no-op export wrote %d files, want %d", len(after), len(before))
+	}
+}

--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -175,7 +175,9 @@ func writeViewHTML(dir, out string) (string, error) {
 		return "", fmt.Errorf("render view: %w", err)
 	}
 	if err := os.WriteFile(abs, []byte(b.String()), 0o644); err != nil {
-		return "", err
+		// A path on a disk that is gone came back as the bare syscall, which
+		// says nothing about what to change (#1036).
+		return "", fmt.Errorf("cannot write the view to %s — %s", abs, writeFailureReason(err))
 	}
 	return abs, nil
 }

--- a/cmd/deja/view_test.go
+++ b/cmd/deja/view_test.go
@@ -67,3 +67,23 @@ func TestViewPreviewCap(t *testing.T) {
 		t.Fatalf("preview exceeds cap: %d", len(got))
 	}
 }
+
+// Same as the stats card: the view handed back the bare syscall when its
+// target sat on a disk that is gone (#1036).
+func TestViewSaysWhatIsWrongWithThePath(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	_, err := writeViewHTML(dir, filepath.Join(tmp, "no-such-dir", "m.html"))
+	if err == nil {
+		t.Fatal("writing into a directory that does not exist did not fail")
+	}
+	if !strings.Contains(err.Error(), "its directory does not exist") {
+		t.Errorf("the error does not say what is wrong: %v", err)
+	}
+	if strings.Contains(err.Error(), "no such file or directory") {
+		t.Errorf("the syscall is still handed back: %v", err)
+	}
+}

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -198,6 +199,37 @@ func writeTombstones(set map[string]bool) error {
 	return nil
 }
 
+// appendTombstones adds keys to the set on disk without reading or rewriting
+// what is already there. Forget only ever grows the set, and the full rewrite
+// was the whole cost of the command on a machine with a large history (#1029).
+func appendTombstones(keys []string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	if err := os.MkdirAll(privacyDir(), 0o700); err != nil {
+		return err
+	}
+	sort.Strings(keys)
+	var buf bytes.Buffer
+	for _, key := range keys {
+		buf.WriteString(key)
+		buf.WriteByte('\n')
+	}
+	f, err := os.OpenFile(tombstonePath(), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
 func writeTombstoneMirror(keys []string) error {
 	return writeTombstoneMirrorAt("", keys)
 }
@@ -344,6 +376,7 @@ func Forget(dir string, o ForgetOptions) (ForgetResult, error) {
 		return ForgetResult{}, err
 	}
 	dead := readTombstones()
+	var added []string
 	matched := map[string]bool{}
 	result := ForgetResult{}
 	// An id that names a session exactly means that session. Prefix matching
@@ -377,6 +410,9 @@ func Forget(dir string, o ForgetOptions) (ForgetResult, error) {
 		}
 		if !dead[key] {
 			result.Tombstones++
+			if !o.DryRun {
+				added = append(added, key)
+			}
 		}
 		if !o.DryRun {
 			dead[key] = true
@@ -416,11 +452,19 @@ func Forget(dir string, o ForgetOptions) (ForgetResult, error) {
 		return result, nil
 	}
 	for _, k := range contentKeys {
+		if !dead[k] {
+			added = append(added, k)
+		}
 		dead[k] = true
 	}
 	// Persist tombstones before the rebuild: a crash between the two must
 	// leave sessions forgotten, not resurrect them on the next index pass.
-	if err := writeTombstones(dead); err != nil {
+	// Appending the new keys rather than rewriting the whole set: the set only
+	// grows here, and rewriting it cost 4.9 s of a 6.6 s forget once a machine
+	// had forgotten a million note lines (#1029). A torn append loses the keys
+	// it was in the middle of writing, which is the same outcome as crashing a
+	// moment earlier; unforget, which removes keys, still rewrites in full.
+	if err := appendTombstones(added); err != nil {
 		return result, err
 	}
 	if err := rebuildWithTombstones(dir, "", "", currentFiles(""), nil, dead); err != nil {

--- a/internal/index/privacy_append_test.go
+++ b/internal/index/privacy_append_test.go
@@ -1,0 +1,38 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// forget only grows the tombstone set, and rewriting the whole file was the
+// cost of the command on a machine with a large history (#1029). Appending
+// must leave the set readable and complete.
+func TestAppendTombstonesKeepsEarlierKeys(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := appendTombstones([]string{"claude:b", "claude:a"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := appendTombstones([]string{"claude:c"}); err != nil {
+		t.Fatal(err)
+	}
+	// A no-op call must not create noise in the file.
+	if err := appendTombstones(nil); err != nil {
+		t.Fatal(err)
+	}
+	got := readTombstones()
+	for _, want := range []string{"claude:a", "claude:b", "claude:c"} {
+		if !got[want] {
+			t.Errorf("%q missing from the set after append: %v", want, got)
+		}
+	}
+	raw, err := os.ReadFile(filepath.Join(privacyDir(), "tombstones"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lines := strings.Count(string(raw), "\n"); lines != 3 {
+		t.Errorf("file holds %d lines, want 3:\n%s", lines, raw)
+	}
+}


### PR DESCRIPTION
Eight findings from the audit loop.

- forget paid for everything the machine had ever forgotten: 1M tombstones turned a 1.7 s forget into 6.6 s, now 3.6 s (#1029)
- forget offered `--session deja-note-…`, an id that matches nothing, and a note whose project was forgotten could not be removed at all (#1030)
- a denied tombstone write was reported as an unwritable index directory, which was writable (#1031)
- the ambiguous-forget dry run previewed `--all-matches` while the command as typed drops nothing (#1032)
- a correction on a note whose source was forgotten wrapped the note's own text, one layer deeper each time (#1033)
- doctor's row called a partly readable store unreadable while the warning under it and search said otherwise (#1034)
- a no-op `sync export` warned about reviewing a file it did not write — the most common line on a watermarked sync (#1035)
- `view --out` and `stats --card` on a vanished disk handed back the syscall (#1036)

Closes #1029, #1030, #1031, #1032, #1033, #1034, #1035, #1036.
