### PR TITLE
audit wave 7: status-line trust-policy leak

### DIFF
--- a/cmd/deja/blame_test.go
+++ b/cmd/deja/blame_test.go
@@ -80,3 +80,42 @@ func TestBlameCLIAndMCP(t *testing.T) {
 		t.Fatal("mcp blame accepted blocked index")
 	}
 }
+
+// The file was edited, but the only session that touched it is one a rule
+// withholds. blame said "no sessions mention it" — looked-and-absent, when the
+// rule hid it. search, last and files name the rule (#686, #680).
+func TestBlameNamesTheTrustPolicyOnAnEmptyResult(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// An imported session edited token.go; no local session touches it.
+	var batch []byte
+	for _, r := range []index.SyncRecord{
+		{Harness: "claude", SessionID: "peer", Project: "svc", Role: "user", Text: "the token rotation work"},
+		{Harness: "claude", SessionID: "peer", Project: "svc", Role: "files", Text: filepath.Join(tmp, "repo", "token.go")},
+	} {
+		b, err := json.Marshal(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		batch = append(batch, append(b, '\n')...)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync.jsonl"), batch, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	writePolicy(t, `{"activations":{"search":{"imported":false}}}`)
+	out, _ := captureRunStderr(t, "blame", "token.go")
+	if !strings.Contains(out, "trust policy") {
+		t.Errorf("blame did not name the rule that emptied the result:\n%s", out)
+	}
+	if strings.Contains(out, "no sessions mention") {
+		t.Errorf("blame still reads as looked-and-absent when a rule hid the match:\n%s", out)
+	}
+}

--- a/cmd/deja/blame_touchers_test.go
+++ b/cmd/deja/blame_touchers_test.go
@@ -46,7 +46,7 @@ func TestBlameFindsSessionsThatOnlyTouchedTheFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hits, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
+	hits, _, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestBlameTouchersMatchTheWholeName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hits, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
+	hits, _, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestBlameFindsASessionThatBothMentionsAndTouchesTheFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hits, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
+	hits, _, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -82,8 +82,15 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 	// listed a peer's file paths under a rule that withholds imported content —
 	// browsing is the search activation, as it is for search, last and blame
 	// (#1026).
-	hits, _ = policyFilterSessionsCounted(policy.ActivationSearch, hits)
+	hits, hidden := policyFilterSessionsCounted(policy.ActivationSearch, hits)
 	if len(hits) == 0 {
+		// The topic did match — a rule withheld it. Saying "no sessions
+		// mention it" reads as looked-and-absent, the same misread search and
+		// last already avoid by naming the rule (#686, #680).
+		if note := policyHiddenNote(policy.ActivationSearch, hidden); note != "" {
+			fmt.Fprint(stdout, note)
+			return nil
+		}
 		// A filter the caller set is not the topic's fault: three sessions can
 		// mention it and still be absent because they are in another project
 		// (#727, the same shape as #715 in search).

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
@@ -77,6 +78,11 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("search: %w", err)
 	}
+	// index.Search does not gate; the cmd layer does. Without this, `files`
+	// listed a peer's file paths under a rule that withholds imported content —
+	// browsing is the search activation, as it is for search, last and blame
+	// (#1026).
+	hits, _ = policyFilterSessionsCounted(policy.ActivationSearch, hits)
 	if len(hits) == 0 {
 		// A filter the caller set is not the topic's fault: three sessions can
 		// mention it and still be absent because they are in another project

--- a/cmd/deja/files_cli_test.go
+++ b/cmd/deja/files_cli_test.go
@@ -138,3 +138,42 @@ func TestFilesDistinguishesFilteredFromAbsent(t *testing.T) {
 		t.Fatalf("the empty case lost its wording:\n%s", out.String())
 	}
 }
+
+// `files` lists the paths a session opened, so a trust rule that withholds a
+// peer's content must hold here too — it read imported file paths aloud while
+// search, blame and restore all refused (#1026).
+func TestFilesCommandHonoursTrustPolicy(t *testing.T) {
+	repo := writeFilesFixture(t) // a local session touching retry.go under repo
+	cfg := filepath.Join(filepath.Dir(filepath.Dir(repo)), "config")
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	// A peer's session opened a file under the same repo, arriving by sync.
+	tmp := filepath.Dir(repo)
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	peer := `{"harness":"claude","session_id":"peer","project":"svc","role":"user","text":"the frobnicator retry loop, peer take","time":"2026-03-01T10:00:00Z"}` + "\n" +
+		`{"harness":"claude","session_id":"peer","project":"svc","role":"files","text":"` + filepath.Join(repo, "peer_secret.go") + `","time":"2026-03-01T10:00:30Z"}` + "\n"
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync.jsonl"), []byte(peer), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	writePolicy(t, `{"activations":{"search":{"imported":true}}}`)
+	if out, _ := captureRun(t, "files", "frobnicator", "retry"); !strings.Contains(out, "peer_secret.go") {
+		t.Fatalf("imported file did not surface under an allowing rule:\n%s", out)
+	}
+	writePolicy(t, `{"activations":{"search":{"imported":false}}}`)
+	out, _ := captureRun(t, "files", "frobnicator", "retry")
+	if strings.Contains(out, "peer_secret.go") {
+		t.Errorf("files leaked a peer's file path under deny-imported:\n%s", out)
+	}
+	if !strings.Contains(out, "retry.go") {
+		t.Errorf("files over-blocked the local session under deny-imported:\n%s", out)
+	}
+}

--- a/cmd/deja/files_cli_test.go
+++ b/cmd/deja/files_cli_test.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"bytes"
-
+	"encoding/json"
 	"fmt"
-	"github.com/vshulcz/deja-vu/internal/index"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
 )
 
 // writeFilesFixture lays down a claude session that discusses one subject and
@@ -155,9 +157,21 @@ func TestFilesCommandHonoursTrustPolicy(t *testing.T) {
 	if err := os.MkdirAll(exp, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	peer := `{"harness":"claude","session_id":"peer","project":"svc","role":"user","text":"the frobnicator retry loop, peer take","time":"2026-03-01T10:00:00Z"}` + "\n" +
-		`{"harness":"claude","session_id":"peer","project":"svc","role":"files","text":"` + filepath.Join(repo, "peer_secret.go") + `","time":"2026-03-01T10:00:30Z"}` + "\n"
-	if err := os.WriteFile(filepath.Join(exp, "deja-sync.jsonl"), []byte(peer), 0o644); err != nil {
+	// Build the records with json.Marshal so the file path — which carries
+	// backslashes on Windows — is escaped, not hand-spliced into a raw string.
+	at := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	var peer []byte
+	for _, r := range []index.SyncRecord{
+		{Harness: "claude", SessionID: "peer", Project: "svc", Role: "user", Text: "the frobnicator retry loop, peer take", Time: at},
+		{Harness: "claude", SessionID: "peer", Project: "svc", Role: "files", Text: filepath.Join(repo, "peer_secret.go"), Time: at.Add(30 * time.Second)},
+	} {
+		b, err := json.Marshal(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		peer = append(peer, append(b, '\n')...)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync.jsonl"), peer, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := captureRun(t, "sync", "import", exp); err != nil {

--- a/cmd/deja/files_cli_test.go
+++ b/cmd/deja/files_cli_test.go
@@ -191,3 +191,48 @@ func TestFilesCommandHonoursTrustPolicy(t *testing.T) {
 		t.Errorf("files over-blocked the local session under deny-imported:\n%s", out)
 	}
 }
+
+// When the only session that mentions the topic is one a rule withholds,
+// `files` used to say "no sessions mention it" — looked-and-absent, when the
+// truth is the rule hid it. search and last already name the rule (#686, #680).
+func TestFilesCommandNamesTheTrustPolicyOnAnEmptyResult(t *testing.T) {
+	tmp := hermeticEnv(t)
+	cfg := filepath.Join(tmp, "config")
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	repo := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The only match is an imported session; no local session mentions it.
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	var batch []byte
+	for _, r := range []index.SyncRecord{
+		{Harness: "claude", SessionID: "peer", Project: "svc", Role: "user", Text: "the frobnicator retry loop", Time: at},
+		{Harness: "claude", SessionID: "peer", Project: "svc", Role: "files", Text: filepath.Join(repo, "retry.go"), Time: at.Add(30 * time.Second)},
+	} {
+		b, err := json.Marshal(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		batch = append(batch, append(b, '\n')...)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync.jsonl"), batch, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	writePolicy(t, `{"activations":{"search":{"imported":false}}}`)
+	out, _ := captureRun(t, "files", "frobnicator", "retry")
+	if !strings.Contains(out, "trust policy") {
+		t.Errorf("files did not name the rule that emptied the result:\n%s", out)
+	}
+	if strings.Contains(out, "no sessions mention") {
+		t.Errorf("files still reads as looked-and-absent when a rule hid the match:\n%s", out)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1623,7 +1623,7 @@ func runBlame(dir string, args []string) error {
 	if err != nil {
 		return err
 	}
-	hits, err := findBlameHits(dir, target, o, policy.ActivationSearch, os.Stderr)
+	hits, hidden, err := findBlameHits(dir, target, o, policy.ActivationSearch, os.Stderr)
 	if err != nil {
 		return fmt.Errorf("blame search: %w", err)
 	}
@@ -1632,6 +1632,13 @@ func runBlame(dir string, args []string) error {
 		return nil
 	}
 	if len(hits) == 0 {
+		// The file was edited — a rule withheld the session that touched it.
+		// "no sessions mention it" reads as looked-and-absent, the misread
+		// search and last already avoid by naming the rule (#686, #680).
+		if note := policyHiddenNote(policy.ActivationSearch, hidden); note != "" {
+			fmt.Fprint(os.Stderr, note)
+			return nil
+		}
 		// "run deja index" is advice for an empty store. With sessions in the
 		// index it is advice for a state the tool is not in — indexing changes
 		// nothing and doctor reports the stores as found — and it sends the
@@ -1647,18 +1654,19 @@ func runBlame(dir string, args []string) error {
 	return nil
 }
 
-func findBlameHits(dir string, target search.BlameTarget, o search.BlameOptions, activation string, progress io.Writer) ([]search.BlameHit, error) {
+func findBlameHits(dir string, target search.BlameTarget, o search.BlameOptions, activation string, progress io.Writer) ([]search.BlameHit, int, error) {
 	query := search.Options{Query: target.Stem, Harness: o.Harness, Project: o.Project, Since: o.Since, All: true}
 	if err := index.EnsureForSearch(dir, query, false, progress); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	result, err := index.SearchWithRecoveryDetailed(dir, query, progress)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	hits := policyFilterBlame(activation, search.Blame(withFileTouchers(dir, result.Sessions, target), target, o))
+	all := search.Blame(withFileTouchers(dir, result.Sessions, target), target, o)
+	hits := policyFilterBlame(activation, all)
 	attachBlameLifecycles(hits)
-	return hits, nil
+	return hits, len(all) - len(hits), nil
 }
 
 // blameToucherCap bounds how many extra sessions a blame reads from the

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -287,7 +287,7 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 	if err != nil {
 		return "", 0, err
 	}
-	hits, err := findBlameHits(dir, target, o, policy.ActivationMCP, mcpProgress())
+	hits, _, err := findBlameHits(dir, target, o, policy.ActivationMCP, mcpProgress())
 	if err != nil {
 		return "", 0, err
 	}

--- a/cmd/deja/statusline_memory.go
+++ b/cmd/deja/statusline_memory.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
@@ -117,8 +118,21 @@ func statuslineMemory(dir string, in transcriptSource) (fileMemory, bool) {
 	// written from scratch, which by definition no earlier session touched;
 	// stopping there was silent for 41 of 676 sessions on a real store that
 	// had memory to report one entry down.
+	// The bar names an earlier session by title, so a trust rule that withholds
+	// a peer's content has to hold here too — otherwise the status line was the
+	// one place an imported session's title showed through while search, blame
+	// and restore all refused (#1026). The bar is a browsing surface the reader
+	// watches, so it gates on the search activation like those do.
+	pol := policy.Load()
 	for _, here := range self.Touched {
 		others := sessionsTouching(metas, here, self)
+		kept := others[:0]
+		for _, m := range others {
+			if pol.Allows(policy.ActivationSearch, m.Project) {
+				kept = append(kept, m)
+			}
+		}
+		others = kept
 		if len(others) == 0 {
 			continue
 		}

--- a/cmd/deja/statusline_memory_test.go
+++ b/cmd/deja/statusline_memory_test.go
@@ -74,6 +74,57 @@ func TestStatuslineMemoryNamesTheFileAndTheEarlierSession(t *testing.T) {
 	}
 }
 
+// The status line names an earlier session by title, so a trust rule that
+// withholds a peer's content must hold here too — it was the one surface an
+// imported session's title showed through while search, blame and restore all
+// refused (#1026).
+func TestStatuslineMemoryHonoursTrustPolicy(t *testing.T) {
+	tmp := hermeticEnv(t)
+	cfg := filepath.Join(tmp, "config")
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	root := filepath.Join(tmp, "claude", "proj-w")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The current, local session edits /w/pkg/cache.go.
+	cur := filepath.Join(root, "cur.jsonl")
+	body := `{"type":"user","sessionId":"cur","cwd":"/w","timestamp":"2026-05-02T10:00:00Z","message":{"role":"user","content":"cache work"}}` + "\n" +
+		`{"type":"assistant","sessionId":"cur","cwd":"/w","timestamp":"2026-05-02T10:00:05Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/w/pkg/cache.go","old_string":"x"}}]}}` + "\n"
+	if err := os.WriteFile(cur, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	// A peer's session touched the same absolute path, arriving by sync.
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	peer := `{"harness":"claude","session_id":"peer","project":"svc","role":"user","text":"IMPORTEDFILE a peer's cache fix"}` + "\n" +
+		`{"harness":"claude","session_id":"peer","project":"svc","role":"files","text":"/w/pkg/cache.go"}` + "\n"
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync.jsonl"), []byte(peer), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	in := transcriptSource{TranscriptPath: cur}
+
+	// Allowed: the peer's session is the earlier one the bar names.
+	writePolicy(t, `{"activations":{"search":{"imported":true}}}`)
+	if m, ok := statuslineMemory(dir, in); !ok || !strings.Contains(m.Title, "IMPORTEDFILE") {
+		t.Fatalf("imported file-memory did not surface under an allowing rule: ok=%v title=%q", ok, m.Title)
+	}
+	// Denied: no other session is allowed, so the bar stays silent rather than
+	// naming the peer.
+	writePolicy(t, `{"activations":{"search":{"imported":false}}}`)
+	if m, ok := statuslineMemory(dir, in); ok {
+		t.Errorf("status line leaked an imported session's title under deny-imported: %q", m.Title)
+	}
+}
+
 // newestOtherUpdated is the newest Updated among sessions that are not id.
 func newestOtherUpdated(t *testing.T, dir, id string) time.Time {
 	t.Helper()

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -252,6 +252,12 @@ func claudeContentText(raw json.RawMessage) string {
 }
 
 func trimJSONSpace(b []byte) []byte {
+	// A UTF-8 BOM on the first line of a transcript makes its JSON invalid, so
+	// the opening turn — usually the session's own question — was dropped while
+	// the rest of the session indexed (some Windows editors write the mark).
+	if len(b) >= 3 && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF {
+		b = b[3:]
+	}
 	for len(b) > 0 && (b[0] == ' ' || b[0] == '\t' || b[0] == '\n' || b[0] == '\r') {
 		b = b[1:]
 	}

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -25,6 +25,30 @@ func TestParseClaudeFile(t *testing.T) {
 	}
 }
 
+// A UTF-8 BOM on the first line of a transcript made its JSON invalid, so the
+// opening turn was dropped while the rest of the session indexed. Some Windows
+// editors write the mark; deja strips it.
+func TestParseSkipsAUTF8BOMOnTheFirstLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bom.jsonl")
+	body := []byte("\xef\xbb\xbf" +
+		`{"type":"user","sessionId":"bom","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"the very first turn"}}` + "\n" +
+		`{"type":"assistant","sessionId":"bom","timestamp":"2026-01-02T03:05:05Z","message":{"role":"assistant","content":"the reply"}}` + "\n")
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseClaudeFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || len(ss[0].Messages) != 2 {
+		t.Fatalf("BOM dropped a turn: %#v", ss)
+	}
+	if ss[0].Messages[0].Text != "the very first turn" {
+		t.Fatalf("first turn = %q, want the BOM-prefixed opening turn", ss[0].Messages[0].Text)
+	}
+}
+
 func TestLoadersOffsetsAndUtilityVariants(t *testing.T) {
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -172,13 +172,16 @@ func scanJSONLFromOffset(path string, offset int64, fn func(map[string]any)) err
 	r := bufio.NewReaderSize(f, 1024*1024)
 	for {
 		line, err := r.ReadBytes('\n')
-		if len(line) > 0 {
+		// A UTF-8 BOM on the first line would fail the JSON decode below, so the
+		// opening turn was dropped; trimJSONSpace strips it (and surrounding
+		// space) the way the claude decode path already does.
+		if line = trimJSONSpace(line); len(line) > 0 {
 			var m map[string]any
 			d := json.NewDecoder(strings.NewReader(string(line)))
 			d.UseNumber()
 			if d.Decode(&m) == nil {
 				fn(m)
-			} else if len(strings.TrimSpace(string(line))) > 0 {
+			} else {
 				diagMalformedLine(path)
 			}
 		}


### PR DESCRIPTION
Continues the audit past #1122. First fix: the status line's file-memory named an imported session's title in the bar even under deny-imported — the same leak class as show/share/handoff/restore (#1026). Gated on the search activation, with a regression test.

More audit fixes will land here as the sweep continues.