### PR TITLE
check: an explicit, off-by-default plan check, plus the harness to re-measure it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
   test:
     name: test / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # windows runs the suite about four times slower than the others and had
+    # grown into the 20-minute cap: the run was cancelled a second after the
+    # last package passed.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `install`/`uninstall` write the codex SessionStart hook to `CODEX_HOME` (via `sources.CodexHome()`) instead of a raw `~/.codex`, so a sandboxed install stays sandboxed and a non-default codex home gets its hooks where codex reads them. Every other codex path already honoured it. (#850)
+
 ## [0.16.7] - 2026-08-03
 
 Two weeks spent on the trust policy and on the states a machine gets into when

--- a/cmd/deja/blame_lifecycle_test.go
+++ b/cmd/deja/blame_lifecycle_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// blame answers "who decided this", and it answered with the accepted line of
+// a decision that had been taken back: attachLifecycles ran on search hits
+// only, and blame carries its own hit type (#1017).
+func TestBlameCarriesTheDecisionThatHolds(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"we raised the pool cap in pool.go to 200"},"timestamp":"2026-08-04T10:00:00Z","sessionId":"w25","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "promote", "w25", "--state", "accepted", "--note", "the pool cap is 200"); err != nil {
+		t.Fatal(err)
+	}
+
+	// While the decision holds, blame says nothing extra.
+	out, err := captureRun(t, "blame", "pool.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "tried and rejected") {
+		t.Errorf("a decision that holds was reported as withdrawn:\n%s", out)
+	}
+
+	if _, err := captureRun(t, "promote", "w25", "--state", "rejected", "--note", "rolled back, the cap stays at 20"); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "blame", "pool.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "tried and rejected") {
+		t.Errorf("blame reports a decision that was taken back as current:\n%s", out)
+	}
+	if !strings.Contains(out, "rolled back, the cap stays at 20") {
+		t.Errorf("blame does not name the correction that won:\n%s", out)
+	}
+}

--- a/cmd/deja/bucket_day_note_test.go
+++ b/cmd/deja/bucket_day_note_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A day bucket's date is the day the index was built in; the times inside are
+// this machine's. Read in another zone the two disagree, and the screen that
+// shows them together said nothing (#1006).
+func TestBucketDayIsExplainedOnlyWhenItDiffers(t *testing.T) {
+	at := time.Date(2026, 8, 4, 6, 30, 0, 0, time.UTC)
+	s := model.Session{Harness: "deja", ID: "deja-2026-08-04-w20", Project: "w20",
+		Messages: []model.Message{{Role: "user", Text: "morning: the pool cap is 20", Time: at}}}
+
+	saved := time.Local
+	t.Cleanup(func() { time.Local = saved })
+
+	// Read where the record falls on the day the id names: no line.
+	time.Local = time.UTC
+	if note := bucketDayNote(s); note != "" {
+		t.Errorf("a bucket read in its own zone was explained anyway: %q", note)
+	}
+
+	// Seven hours west, the same record is the previous day.
+	time.Local = time.FixedZone("west", -7*60*60)
+	note := bucketDayNote(s)
+	if note == "" {
+		t.Fatal("nothing explains an id dated a day after the line inside it")
+	}
+	if !strings.Contains(note, "2026-08-04") || !strings.Contains(note, "day the index was built in") {
+		t.Errorf("the note does not say what the id's date is: %q", note)
+	}
+
+	// A transcript whose id merely looks like a bucket is not one: only deja's
+	// own notes are grouped by day.
+	other := s
+	other.Harness = "claude"
+	if n := bucketDayNote(other); n != "" {
+		t.Errorf("a transcript picked up the bucket note: %q", n)
+	}
+}

--- a/cmd/deja/build_progress_early_test.go
+++ b/cmd/deja/build_progress_early_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Every "memory is on its way" surface reads <index>.warmup, and the file did
+// not exist until the build proper began — the walk over the stores comes
+// first and, on a slow volume, takes the longest. Measured on 6000 sessions:
+// first published at 0.76s before, 0.02s after (#1021).
+func TestProgressIsPublishedBeforeTheFreshnessWalk(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_WARMUP_SENTINEL", "1")
+
+	stop := publishBuildProgress(dir)
+	if _, err := os.Stat(dir + ".warmup"); err != nil {
+		t.Fatalf("nothing published before the walk: %v", err)
+	}
+	if st := readWarmupStatus(dir); st == nil {
+		t.Error("the published file does not read back as a build in flight")
+	}
+	stop()
+	if _, err := os.Stat(dir + ".warmup"); err == nil {
+		t.Error("the progress file outlived the command")
+	}
+
+	// Without the sentinel this is an ordinary foreground run and publishes
+	// nothing, as before.
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	stop = publishBuildProgress(dir)
+	if _, err := os.Stat(dir + ".warmup"); err == nil {
+		t.Error("a foreground run published a warmup status")
+	}
+	stop()
+}
+
+// The walk itself reports, so the phase name is not "starting" for the seconds
+// it takes on a network volume (#1021).
+func TestTheStoreWalkReportsItsPhase(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"a session"},"timestamp":"2026-08-01T10:00:00Z","sessionId":"s","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p := &phaseRecorder{}
+	index.SetProgress(p)
+	t.Cleanup(func() { index.SetProgress(nil) })
+	if err := index.Ensure(filepath.Join(tmp, "index.db"), "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !p.seen("finding transcripts") {
+		t.Errorf("the store walk published no phase: %v", p.phases)
+	}
+}
+
+type phaseRecorder struct{ phases []string }
+
+func (p *phaseRecorder) Phase(name string, _ int) { p.phases = append(p.phases, name) }
+func (p *phaseRecorder) Advance(int)              {}
+func (p *phaseRecorder) Harness(string, int, int) {}
+func (p *phaseRecorder) seen(name string) bool {
+	for _, s := range p.phases {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/deja/check.go
+++ b/cmd/deja/check.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+// runCheck is the human-facing form of the plan hook. It deliberately calls
+// planFindings directly so measured precision reflects the injected path.
+// The empty session id skips the .hookseen dedupe on purpose: dedupe governs
+// when a finding is delivered twice in one session, not whether it matches,
+// and a measurement run has to see every match.
+func runCheck(dir string, args []string, stdin io.Reader, stdout io.Writer) error {
+	if len(args) != 1 || args[0] != "-" {
+		return fmt.Errorf("check needs '-' to read a plan from stdin")
+	}
+	plan, err := io.ReadAll(stdin)
+	if err != nil {
+		return fmt.Errorf("check: read plan: %w", err)
+	}
+	for _, finding := range planFindings(dir, string(plan), "") {
+		fmt.Fprintln(stdout, finding)
+	}
+	return nil
+}

--- a/cmd/deja/check_test.go
+++ b/cmd/deja/check_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunCheckUsesTheHookPlanCore(t *testing.T) {
+	withPlanLookup(t, samplePlanMatches(`C:\work\repo`))
+	dir := filepath.Join(t.TempDir(), "index.db")
+	plan := "1. Run timeout around deploy_probe"
+
+	var hookOut bytes.Buffer
+	hookInput := `{
+		"hook_event_name":"PreToolUse",
+		"tool_name":"ExitPlanMode",
+		"tool_input":{"plan":"1. Run timeout around deploy_probe"},
+		"session_id":""
+	}`
+	if err := runHookPlan(dir, strings.NewReader(hookInput), &hookOut); err != nil {
+		t.Fatal(err)
+	}
+
+	var resp struct {
+		HookSpecificOutput struct {
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(hookOut.Bytes(), &resp); err != nil {
+		t.Fatalf("hook JSON = %q: %v", hookOut.String(), err)
+	}
+	hookPlain := strings.TrimPrefix(resp.HookSpecificOutput.AdditionalContext, recallFrameHeader)
+	hookPlain = strings.TrimSuffix(hookPlain, recallFrameFooter)
+
+	var checkOut bytes.Buffer
+	if err := runCheck(dir, []string{"-"}, strings.NewReader(plan), &checkOut); err != nil {
+		t.Fatal(err)
+	}
+	checkPlain := strings.TrimSuffix(checkOut.String(), "\n")
+	if checkPlain != hookPlain {
+		t.Fatalf("check and hook differ:\ncheck: %q\nhook:  %q", checkPlain, hookPlain)
+	}
+	if strings.Contains(checkOut.String(), "<deja-recall>") {
+		t.Fatalf("check output contains a recall frame: %q", checkOut.String())
+	}
+	if strings.Count(strings.TrimSpace(checkOut.String()), "\n") != 0 {
+		t.Fatalf("one finding was not printed as one line: %q", checkOut.String())
+	}
+}
+
+func TestRunCheckSilentMiss(t *testing.T) {
+	withPlanLookup(t, nil)
+	var out bytes.Buffer
+	if err := runCheck(
+		filepath.Join(t.TempDir(), "index.db"),
+		[]string{"-"},
+		strings.NewReader("1. Run timeout around deploy_probe"),
+		&out,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("miss produced %q", out.String())
+	}
+}
+
+func TestRunCheckRequiresDash(t *testing.T) {
+	for _, args := range [][]string{
+		nil,
+		{"PLAN.md"},
+		{"-", "extra"},
+	} {
+		var out bytes.Buffer
+		err := runCheck(
+			filepath.Join(t.TempDir(), "index.db"),
+			args,
+			strings.NewReader("1. Run timeout around deploy_probe"),
+			&out,
+		)
+		if err == nil {
+			t.Fatalf("args %v returned no usage error", args)
+		}
+		if !strings.Contains(err.Error(), "check needs '-'") {
+			t.Fatalf("args %v error = %q", args, err)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("args %v produced output %q", args, out.String())
+		}
+	}
+}

--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -39,7 +39,7 @@ _deja_completion() {
     command="${COMP_WORDS[1]}"
     action="${COMP_WORDS[2]}"
 
-    local commands="blame bench completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup"
+    local commands="blame bench check completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup"
     local harnesses="claude codex opencode aider gemini cursor antigravity grok qwen pi copilot deja"
     local install_targets="%INSTALL_TARGETS% --all --auto"
 
@@ -125,7 +125,7 @@ _deja_completion() {
                 COMPREPLY=( $(compgen -d -- "$cur") )
             fi
             ;;
-        ctx|embed|hook-precompact|hook-prompt|mcp|share|show|sources|statusline|update|version|warmup)
+        check|ctx|embed|hook-precompact|hook-prompt|mcp|share|show|sources|statusline|update|version|warmup)
             COMPREPLY=()
             ;;
         *)
@@ -148,6 +148,7 @@ _deja() {
   commands=(
     'blame:find sessions that discussed a file'
     'bench:run benchmarks'
+    'check:read a plan from stdin and print factual co-occurrences'
     'completion:generate shell completion'
     'ctx:print a compact context digest'
     'files:which files the work on a topic touched'
@@ -244,7 +245,7 @@ _deja() {
         _arguments '--pull[pull from the remote]' '--full[transfer all records]' '1:host:'
       fi
       ;;
-    ctx|embed|hook-precompact|hook-prompt|mcp|share|show|sources|statusline|update|version|warmup)
+    check|ctx|embed|hook-precompact|hook-prompt|mcp|share|show|sources|statusline|update|version|warmup)
       ;;
     *)
       _arguments '--json[print JSON]' '--re[interpret query as a regular expression]' '--all[include all results]' '--no-embed[skip semantic reranking]' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(user assistant tool)' '--rebuild[force a full rebuild]'
@@ -259,7 +260,7 @@ const fishCompletion = `function __deja_needs_command
     test (count (commandline -opc)) -eq 1
 end
 
-complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup'
+complete -c deja -n '__deja_needs_command' -a 'blame bench check completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup'
 complete -c deja -n '__deja_needs_command' -l json -d 'Print JSON'
 complete -c deja -n '__deja_needs_command' -l re -d 'Interpret query as a regular expression'
 complete -c deja -n '__deja_needs_command' -l all -d 'Include all results'

--- a/cmd/deja/completion_coverage_test.go
+++ b/cmd/deja/completion_coverage_test.go
@@ -13,7 +13,7 @@ func TestCompletionsListEveryUserFacingCommand(t *testing.T) {
 	internal := map[string]bool{
 		"hook-context": true, "hook-prompt": true, "hook-precompact": true,
 		"hook-antigravity": true, "hook-goose": true, "hook-refresh": true,
-		"warmup-status": true, "mcp": true,
+		"hook-plan": true, "warmup-status": true, "mcp": true,
 	}
 	shells := map[string]string{
 		"bash": bashCompletion,

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -33,6 +33,10 @@ func hermeticEnv(t *testing.T) string {
 	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
 	t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
 	t.Setenv("XDG_CONFIG_HOME", "")
+	// The hook adopts the payload's cwd by exporting CLAUDE_PROJECT_DIR into
+	// the process, so a test that runs it hands every later test a project
+	// directory that no longer exists. Pinned here so it is restored per test.
+	t.Setenv("CLAUDE_PROJECT_DIR", "")
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	// Goose resolves through %APPDATA% on Windows; pin it so the doctor
 	// golden stays OS-neutral.

--- a/cmd/deja/ctx_whole_session_test.go
+++ b/cmd/deja/ctx_whole_session_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// ctx is the command the hook tells an agent to call. It printed the hit's
+// snippets rather than the session, and a correction rarely repeats the words
+// of the decision it reverses — so the agent was handed a decision that had
+// been withdrawn (#1011).
+func TestCtxCarriesTheWholeDecisionChain(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"we raised the pool cap to 200"},"timestamp":"2026-08-04T10:00:00Z","sessionId":"w25","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "promote", "w25", "--state", "accepted", "--note", "the pool cap is 200"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "promote", "w25", "--state", "rejected", "--note", "rolled back, the cap stays at 20"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "ctx", "pool cap")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "rolled back") {
+		t.Errorf("ctx dropped the correction that reverses the decision:\n%s", out)
+	}
+	if !strings.Contains(out, "the pool cap is 200") {
+		t.Errorf("ctx dropped the decision being corrected:\n%s", out)
+	}
+	if strings.Index(out, "rolled back") > strings.Index(out, "the pool cap is 200") {
+		t.Errorf("the withdrawal is below the decision it takes back:\n%s", out)
+	}
+
+	// An ordinary transcript still answers with what the query asked about.
+	out, err = captureRun(t, "ctx", "raised the pool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "we raised the pool cap to 200") {
+		t.Errorf("ctx on a transcript lost the matching turn:\n%s", out)
+	}
+}

--- a/cmd/deja/denied_store_hint_test.go
+++ b/cmd/deja/denied_store_hint_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// "no agent history was found on this machine" is a claim about the machine,
+// and it was made over a store deja is not allowed to open — the sessions are
+// there, behind a wall doctor and sources both name (#1020).
+func TestEmptyHintSeparatesALockedStoreFromAnEmptyMachine(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	tmp := hermeticEnv(t)
+
+	// Nothing anywhere: the advice is about where deja looked.
+	if hint := emptyIndexHint("no sessions indexed yet"); !strings.Contains(hint, "no agent history was found") {
+		t.Errorf("an empty machine lost its wording: %q", hint)
+	}
+
+	qwen := filepath.Join(tmp, "qwen")
+	projects := filepath.Join(qwen, "projects", "p1")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projects, "s.json"), []byte(`{"x":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_QWEN_ROOT", qwen)
+	if err := os.Chmod(filepath.Join(qwen, "projects"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(qwen, "projects"), 0o755) })
+
+	hint := emptyIndexHint("no sessions indexed yet")
+	if strings.Contains(hint, "no agent history was found") {
+		t.Errorf("a locked store was reported as no history at all: %q", hint)
+	}
+	if !strings.Contains(hint, "could not be read") || !strings.Contains(hint, "deja doctor") {
+		t.Errorf("the hint does not say what to look at: %q", hint)
+	}
+	if n := deniedStoreCount(); n != 1 {
+		t.Errorf("denied stores counted as %d", n)
+	}
+}

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -392,9 +392,11 @@ func doctorHarnesses(w io.Writer, dir string) {
 	// The same inspection the JSON form reports, so one command does not give
 	// two answers about one store: `found` here and `unreadable` there (#999).
 	inspected := map[string]string{}
+	unchecked := map[string]bool{}
 	for _, check := range doctorStoreChecks() {
 		store, _ := inspectDoctorStore(check)
 		inspected[check.name] = store.State
+		unchecked[check.name] = store.Unchecked
 	}
 
 	printRow := func(name, path string, present bool, detail string) {
@@ -415,6 +417,14 @@ func doctorHarnesses(w io.Writer, dir string) {
 					// The warning block below names the path and what to do.
 					detail += "cannot be read"
 				}
+			}
+			// A walk that stopped at its budget looked at part of the store,
+			// and `found` on its own claims the whole of it (#1025).
+			if unchecked[name] {
+				if detail != "" {
+					detail += ", "
+				}
+				detail += "permissions not fully checked"
 			}
 		} else if storeDiskGone(path) {
 			// A store whose whole disk is gone is not a store that was

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -969,6 +969,9 @@ func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 		} else {
 			fmt.Fprintf(w, "  freshness %d stores changed since last build — run `deja index`\n", idx.StaleStores)
 		}
+	case "stale-readonly":
+		fmt.Fprintf(w, "  freshness %s changed since last build, and the index cannot be written — check the permissions on %s, or point DEJA_INDEX_DIR somewhere writable\n",
+			doctorCount(idx.StaleStores, "store"), filepath.Dir(idx.Path))
 	default:
 		fmt.Fprintln(w, "  freshness up to date")
 	}

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -393,6 +393,18 @@ func doctorHarnesses(w io.Writer, dir string) {
 		status := "missing"
 		if present {
 			status = "found"
+			// A directory deja cannot open loses its sessions from recall
+			// without a word — the failure #802/#816 closed, but only in
+			// `doctor --json`, which has said `denied` all along while this
+			// row, the one people read, said `found` (#993).
+			if denied := firstDeniedDir(strings.Split(path, ", ")); denied != "" {
+				status = "denied"
+				if detail != "" {
+					detail += ", "
+				}
+				_ = denied // the warning line below names the path
+				detail += "cannot be read"
+			}
 		} else if storeDiskGone(path) {
 			// A store whose whole disk is gone is not a store that was
 			// deleted, and "missing" on a row of transcripts reads as the

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -975,6 +975,20 @@ func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
 	default:
 		fmt.Fprintln(w, "  freshness up to date")
 	}
+	// What the last sync did with this machine's own rules: records that were
+	// dropped because they belong to sessions forgotten here are invisible
+	// afterwards, and a peer who keeps sending them drops them every time
+	// (#1016).
+	if li, ok := readLastImport(dir); ok && (li.Forgot > 0 || li.Own > 0) {
+		parts := []string{fmt.Sprintf("%d record%s in", li.Records, pluralS(li.Records))}
+		if li.Forgot > 0 {
+			parts = append(parts, fmt.Sprintf("%d left out as forgotten here", li.Forgot))
+		}
+		if li.Own > 0 {
+			parts = append(parts, fmt.Sprintf("%d already here word for word", li.Own))
+		}
+		fmt.Fprintf(w, "  last sync %s (%s)\n", strings.Join(parts, ", "), li.At.Local().Format("2006-01-02 15:04"))
+	}
 	health := index.IngestHealth(dir)
 	names := make([]string, 0, len(health))
 	for h, e := range health {

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -389,6 +389,14 @@ func doctorHarnesses(w io.Writer, dir string) {
 	indexed := index.HarnessSessionCounts(dir)
 	fromElsewhere := index.ImportedSessionCounts(dir)
 
+	// The same inspection the JSON form reports, so one command does not give
+	// two answers about one store: `found` here and `unreadable` there (#999).
+	inspected := map[string]string{}
+	for _, check := range doctorStoreChecks() {
+		store, _ := inspectDoctorStore(check)
+		inspected[check.name] = store.State
+	}
+
 	printRow := func(name, path string, present bool, detail string) {
 		status := "missing"
 		if present {
@@ -397,13 +405,16 @@ func doctorHarnesses(w io.Writer, dir string) {
 			// without a word — the failure #802/#816 closed, but only in
 			// `doctor --json`, which has said `denied` all along while this
 			// row, the one people read, said `found` (#993).
-			if denied := firstDeniedDir(strings.Split(path, ", ")); denied != "" {
-				status = "denied"
-				if detail != "" {
-					detail += ", "
+			switch inspected[name] {
+			case "denied", "unreadable", "parsed-zero", "needs-sqlite3":
+				status = inspected[name]
+				if status == "denied" {
+					if detail != "" {
+						detail += ", "
+					}
+					// The warning block below names the path and what to do.
+					detail += "cannot be read"
 				}
-				_ = denied // the warning line below names the path
-				detail += "cannot be read"
 			}
 		} else if storeDiskGone(path) {
 			// A store whose whole disk is gone is not a store that was

--- a/cmd/deja/doctor_denied_budget_test.go
+++ b/cmd/deja/doctor_denied_budget_test.go
@@ -34,7 +34,34 @@ func TestDeniedDirIsFoundPastTheFileBudget(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
 
-	if got := firstDeniedDir([]string{root}); got != locked {
-		t.Errorf("denied dir = %q, want %q", got, locked)
+	if got, whole := firstDeniedDir([]string{root}); got != locked || !whole {
+		t.Errorf("denied dir = %q whole = %v, want %q true", got, whole, locked)
+	}
+}
+
+// The budget then counted directories, and a machine with a few thousand
+// projects spent it before reaching a locked one — doctor called the store
+// whole (#1025).
+func TestDeniedDirIsFoundPastTheDirectoryBudget(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	root := t.TempDir()
+	for i := 0; i < 6000; i++ {
+		if err := os.MkdirAll(filepath.Join(root, fmt.Sprintf("proj%05d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	locked := filepath.Join(root, "zzz-locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	if got, whole := firstDeniedDir([]string{root}); got != locked || !whole {
+		t.Errorf("denied dir = %q whole = %v, want %q true", got, whole, locked)
 	}
 }

--- a/cmd/deja/doctor_denied_row_test.go
+++ b/cmd/deja/doctor_denied_row_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// A directory deja cannot open loses its sessions from recall, and the row
+// people read called it `found` — the same state `doctor --json` has reported
+// as `denied` since #802/#816 (#993).
+func TestDoctorRowSaysDeniedForAStoreItCannotOpen(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	tmp := hermeticEnv(t)
+	qwen := filepath.Join(tmp, "qwen")
+	projects := filepath.Join(qwen, "projects", "p1")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projects, "s.json"), []byte(`{"x":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_QWEN_ROOT", qwen)
+
+	var out bytes.Buffer
+	doctorHarnesses(&out, filepath.Join(tmp, "index.db"))
+	if row := harnessRow(t, out.String(), "qwen"); !strings.Contains(row, "found") {
+		t.Fatalf("a readable store was not reported as found: %q", row)
+	}
+
+	if err := os.Chmod(filepath.Join(qwen, "projects"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(qwen, "projects"), 0o755) })
+
+	out.Reset()
+	doctorHarnesses(&out, filepath.Join(tmp, "index.db"))
+	row := harnessRow(t, out.String(), "qwen")
+	if strings.Contains(row, "found") {
+		t.Errorf("a store deja cannot open is still called found: %q", row)
+	}
+	if !strings.Contains(row, "denied") {
+		t.Errorf("the row does not name the state: %q", row)
+	}
+	// The row stays short because the warning block, which is built from the
+	// same inspection, names the path and what to do about it.
+	var warn bytes.Buffer
+	printDoctorStoreWarnings(&warn, collectDoctorReport(func() (string, bool) { return "", false }, filepath.Join(tmp, "index.db")).Stores)
+	if !strings.Contains(warn.String(), "permission denied on") {
+		t.Errorf("the warning that names the path is gone:\n%s", warn.String())
+	}
+}

--- a/cmd/deja/doctor_policy_effect_test.go
+++ b/cmd/deja/doctor_policy_effect_test.go
@@ -73,3 +73,42 @@ func TestDoctorPolicySaysHowMuchTheRuleWithholds(t *testing.T) {
 		t.Errorf("a rule that hides nothing was counted as withholding:\n%s", out.String())
 	}
 }
+
+// The text report has had a trust-policy block since #661; `--json` had no key
+// for it at all, so a script could not see that recall is off on a machine
+// (#1027).
+func TestDoctorJSONReportsThePolicy(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":false,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	got := collectDoctorPolicy(dir)
+	if got.State != "active" || got.Path != policyFile {
+		t.Errorf("policy state = %q at %q, want active at %q", got.State, got.Path, policyFile)
+	}
+	if got.Total != 1 {
+		t.Errorf("indexed sessions = %d, want 1", got.Total)
+	}
+	search := got.Activations["search"]
+	if search.Rule != "nothing activates" || search.Withheld != 1 {
+		t.Errorf("search rule = %+v, want {nothing activates 1}", search)
+	}
+	if auto := got.Activations["auto"]; auto.Withheld != 0 {
+		t.Errorf("a path the rule does not touch withheld %d", auto.Withheld)
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -187,12 +187,21 @@ func doctorStoreChecks() []doctorStoreCheck {
 		{"pi", []string{sources.PiRoot()}, sources.PiSessionFiles(), sources.ParsePiFile},
 		{"openclaw", []string{sources.OpenClawRoot()}, sources.OpenClawSessionFiles(), sources.ParseOpenClawFile},
 		{"copilot", []string{sources.CopilotRoot()}, sources.CopilotSessionFiles(), sources.ParseCopilotFile},
+		// Both were listed by the text rows and by nothing else: absent here,
+		// `doctor --json` never named them and "no agent history was found on
+		// this machine" was printed on a machine whose history is theirs
+		// (#999).
+		{"cline", []string{sources.ClineSessionsDir()}, sources.ClineSessionFiles(), sources.ParseClineFile},
+		{"roo", sources.RooRoots(), sources.RooTaskFiles(), sources.ParseRooTask},
 		{"deja", []string{sources.NotesFile()}, presentDoctorFile(sources.NotesFile()), sources.ParseNotesFile},
 	}
 }
 
 func presentDoctorFile(path string) []string {
-	if doctorExists(path) {
+	// By content: an empty notes file is not a store with something in it, and
+	// counting it made the two forms of this command disagree about the same
+	// row — `missing` in the text, `ok` in JSON (#999).
+	if fi, err := os.Stat(path); err == nil && !fi.IsDir() && fi.Size() > 0 {
 		return []string{path}
 	}
 	return nil
@@ -264,6 +273,14 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 		return store, time.Time{}
 	}
 	if len(check.files) == 0 {
+		// The text rows have separated a store whose disk went away from one
+		// that was deleted since #933; a script reading this could not (#999).
+		for _, p := range check.paths {
+			if p != "" && storeDiskGone(p) {
+				store.State = "unplugged"
+				break
+			}
+		}
 		return store, time.Time{}
 	}
 	newest, mod := newestDoctorFile(check.files)

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
@@ -27,8 +28,11 @@ type doctorStore struct {
 	// at the directory to fix rather than at the harness (#802). Partial says
 	// the rest of the store was readable: sessions are missing from recall
 	// rather than the whole harness (#816).
-	Denied  string `json:"denied,omitempty"`
-	Partial bool   `json:"partial,omitempty"`
+	// Unchecked says the permission walk stopped at its budget, so no
+	// permission problem past that point was looked for (#1025).
+	Denied    string `json:"denied,omitempty"`
+	Partial   bool   `json:"partial,omitempty"`
+	Unchecked bool   `json:"unchecked,omitempty"`
 }
 
 type doctorComponent struct {
@@ -51,8 +55,50 @@ type doctorReport struct {
 	SQLite3       doctorComponent                `json:"sqlite3"`
 	Version       doctorVersionReport            `json:"version"`
 	Embed         *doctorEmbedReport             `json:"embed,omitempty"`
+	Policy        doctorPolicyReport             `json:"policy"`
 	Ingest        map[string]index.HarnessIngest `json:"ingest_health,omitempty"`
 	Deep          *index.DeepReport              `json:"deep,omitempty"`
+}
+
+// doctorPolicyReport is the trust policy in the machine form. The text report
+// has had a block for it since #661 while `--json` had no key at all, so a
+// script could not see that recall is switched off on a machine (#1027).
+type doctorPolicyReport struct {
+	// State is one of default, active, unreadable — what is in force, not what
+	// the file says, which is the distinction the text block draws too.
+	State       string                      `json:"state"`
+	Path        string                      `json:"path"`
+	Error       string                      `json:"error,omitempty"`
+	Total       int                         `json:"indexed_sessions"`
+	Activations map[string]doctorPolicyRule `json:"activations"`
+	Ignored     []string                    `json:"ignored,omitempty"`
+	Inert       []string                    `json:"inert,omitempty"`
+}
+
+type doctorPolicyRule struct {
+	Rule     string `json:"rule"`
+	Withheld int    `json:"withheld"`
+}
+
+func collectDoctorPolicy(dir string) doctorPolicyReport {
+	r := doctorPolicyReport{State: "active", Path: policy.Path(), Activations: map[string]doctorPolicyRule{}}
+	exists, unknown, err := policy.Diagnose()
+	switch {
+	case !exists:
+		r.State = "default"
+	case err != nil:
+		r.State = "unreadable"
+		r.Error = err.Error()
+	}
+	pol := policy.Load()
+	withheld, total := policyWithheldCounts(dir)
+	r.Total = total
+	for _, a := range []string{policy.ActivationSearch, policy.ActivationMCP, policy.ActivationAuto} {
+		r.Activations[a] = doctorPolicyRule{Rule: pol.Describe(a), Withheld: withheld[a]}
+	}
+	r.Ignored = unknown
+	r.Inert = unmatchedImportGroups(dir)
+	return r
 }
 
 type doctorEmbedReport struct {
@@ -91,6 +137,7 @@ func collectDoctorReport(lookup doctorVersionLookup, dir string) doctorReport {
 	if sources.SQLite3Available() {
 		report.SQLite3.State = "ok"
 	}
+	report.Policy = collectDoctorPolicy(dir)
 	report.Version = collectDoctorVersion(lookup)
 	report.Embed = collectDoctorEmbed(dir)
 	return report
@@ -98,14 +145,19 @@ func collectDoctorReport(lookup doctorVersionLookup, dir string) doctorReport {
 
 // firstDeniedDir walks the store roots until something refuses to be read and
 // returns that path. The walk is bounded: doctor is a diagnostic command, but
-// a harness root can hold tens of thousands of transcripts.
-func firstDeniedDir(paths []string) string {
+// a harness root can hold tens of thousands of transcripts. The second result
+// is false when the budget cut the walk short, so the caller can avoid calling
+// a half-checked store whole (#1025).
+func firstDeniedDir(paths []string) (string, bool) {
 	// Directories, not entries: a store of 50k transcripts sits in a few
 	// hundred of them, and counting files spent the budget in the first
 	// project — a locked directory later in the walk was never reached, and
-	// doctor reported the store whole (#864).
-	const budget = 5000
+	// doctor reported the store whole (#864). A machine with a few thousand
+	// projects hit the same wall at the directory bound, so it is high enough
+	// that only a pathological tree reaches it (#1025).
+	const budget = 200_000
 	visited := 0
+	whole := true
 	home := sources.Home()
 	for _, root := range paths {
 		// aider's root is the home directory itself: any locked directory
@@ -127,15 +179,16 @@ func firstDeniedDir(paths []string) string {
 				return nil
 			}
 			if visited++; visited > budget {
+				whole = false
 				return filepath.SkipAll
 			}
 			return nil
 		})
 		if denied != "" {
-			return denied
+			return denied, true
 		}
 	}
-	return ""
+	return "", whole
 }
 
 // storeNeedsSQLite3 names the harnesses deja reads through the sqlite3 CLI.
@@ -266,12 +319,17 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 	// its sessions out of recall. With no files at all that read as a harness
 	// nobody has used (#802); with some files it read as a complete store
 	// missing a few, which is quieter still (#816).
-	if denied := firstDeniedDir(check.paths); denied != "" {
+	denied, whole := firstDeniedDir(check.paths)
+	if denied != "" {
 		store.State = "denied"
 		store.Denied = denied
 		store.Partial = len(check.files) > 0
 		return store, time.Time{}
 	}
+	// Nothing refused to be read *of what was walked*. Saying "found" for a
+	// store whose walk stopped early is the same silence #864 closed, one
+	// order of magnitude up (#1025).
+	store.Unchecked = !whole
 	if len(check.files) == 0 {
 		// The text rows have separated a store whose disk went away from one
 		// that was deleted since #933; a script reading this could not (#999).

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -351,6 +351,13 @@ func inspectDoctorIndex(dir string, storeMods []time.Time) doctorComponent {
 	}
 	if result.StaleStores > 0 {
 		result.State = "stale"
+		// "run `deja index`" is the advice attached to `stale`, and it cannot
+		// be followed when the index cannot be written: the build fails with
+		// the same permission error every time. search says so on this exact
+		// state; doctor called it ordinary staleness (#1004).
+		if !indexDirWritable(dir) {
+			result.State = "stale-readonly"
+		}
 	}
 	return result
 }

--- a/cmd/deja/doctor_two_forms_test.go
+++ b/cmd/deja/doctor_two_forms_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// One command, two answers about the same store: the text row said `found`
+// where the machine form said `unreadable`, `unplugged` existed only in the
+// text, and cline and roo were in neither the JSON nor the list that decides
+// whether this machine has any history at all (#999).
+func TestDoctorsTwoFormsAgreeAboutEveryStore(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+
+	names := map[string]bool{}
+	for _, check := range doctorStoreChecks() {
+		names[check.name] = true
+	}
+	for _, want := range []string{"cline", "roo"} {
+		if !names[want] {
+			t.Errorf("%s is missing from the store list the JSON form and the history check both read", want)
+		}
+	}
+
+	// A store nobody can parse says so in both forms.
+	oc := filepath.Join(tmp, "opencode.db")
+	if err := os.WriteFile(oc, []byte("not a db"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_OPENCODE_DB", oc)
+
+	var text bytes.Buffer
+	doctorHarnesses(&text, dir)
+	row := harnessRow(t, text.String(), "opencode")
+	if strings.Contains(row, "found") {
+		t.Errorf("the text row calls an unreadable store found: %q", row)
+	}
+
+	var out bytes.Buffer
+	if err := runDoctor(&out, []string{"--json"}, stubLookup("1.0.0", true), dir); err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		Stores []struct {
+			Name  string `json:"name"`
+			State string `json:"state"`
+		} `json:"stores"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	states := map[string]string{}
+	for _, s := range report.Stores {
+		states[s.Name] = s.State
+	}
+	// Without the sqlite3 CLI — which CI on windows does not have — the same
+	// store is `needs-sqlite3`; either way it is not a healthy one, and the
+	// point is that both forms say the same word.
+	switch states["opencode"] {
+	case "unreadable", "needs-sqlite3":
+	default:
+		t.Errorf("the machine form calls it %q", states["opencode"])
+	}
+	if !strings.Contains(row, states["opencode"]) {
+		t.Errorf("the two forms use different words: %q vs %q", row, states["opencode"])
+	}
+
+	// An empty notes file is not a store with something in it, in either form.
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	if err := os.WriteFile(notes, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	if err := runDoctor(&out, []string{"--json"}, stubLookup("1.0.0", true), dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range report.Stores {
+		if s.Name == "deja" && s.State == "ok" {
+			t.Errorf("an empty notes file is reported as a store with content")
+		}
+	}
+}

--- a/cmd/deja/empty_notes_history_test.go
+++ b/cmd/deja/empty_notes_history_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The notes file is a store file, and it was counted by existence: an empty one
+// — a note written and later forgotten — made deja answer "run `deja index`"
+// one line under the index run it had just narrated (#996).
+func TestAnEmptyNotesFileIsNotAgentHistory(t *testing.T) {
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	if err := os.WriteFile(notes, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !noAgentHistoryFound() {
+		t.Error("an empty notes file was counted as history")
+	}
+	if err := os.WriteFile(notes, []byte(`{"ts":"2026-08-04T10:00:00Z","project":"p","text":"the ticker window stays at 30s"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if noAgentHistoryFound() {
+		t.Error("a note someone wrote stopped counting as history")
+	}
+	if hint := emptyIndexHint("no matches"); !strings.Contains(hint, "deja index") {
+		t.Errorf("a machine with history lost the advice that fits it: %q", hint)
+	}
+}

--- a/cmd/deja/forget_selectors_test.go
+++ b/cmd/deja/forget_selectors_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Forgetting 100 sessions one id at a time took 10.5s against 0.2s for one
+// `--project` call, and the bare refusal named no selector at all — so the
+// expensive way was the discoverable one (#1022).
+func TestForgetRefusalNamesItsSelectors(t *testing.T) {
+	hermeticEnv(t)
+	_, err := captureRun(t, "forget")
+	if err == nil {
+		t.Fatal("forget with no selector was accepted")
+	}
+	for _, want := range []string{"--session", "--project", "--before", "--dry-run", "--list"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not mention %s: %v", want, err)
+		}
+	}
+	// And it must not advertise a selector forget does not have.
+	for _, absent := range []string{"--query", "--harness"} {
+		if strings.Contains(err.Error(), absent) {
+			t.Errorf("the refusal offers %s, which forget does not accept: %v", absent, err)
+		}
+	}
+}

--- a/cmd/deja/forgotten_empty_listing_test.go
+++ b/cmd/deja/forgotten_empty_listing_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// An index emptied by the reader's own forget is not an unbuilt one, and "run
+// `deja index`" cannot bring a tombstoned session back. search has said so
+// since #844; the two listing screens read it as data loss (#1007).
+func TestListingsSayWhenTheStoreWasEmptiedByAForget(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"the ticker window stays at 30s"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "forget", "--session", "loc"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, cmd := range []string{"last", "stats"} {
+		out, err := captureRunStderr(t, cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		combined := out
+		if cmd == "stats" {
+			text, err := captureRun(t, cmd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			combined += text
+		}
+		if !strings.Contains(combined, "forgotten") {
+			t.Errorf("%s does not say the store was emptied by a forget:\n%s", cmd, combined)
+		}
+		if strings.Contains(combined, "run `deja index`") {
+			t.Errorf("%s advises a build that cannot bring it back:\n%s", cmd, combined)
+		}
+	}
+}

--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -189,7 +189,7 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 		if len(hidden) > 0 {
 			return model.Session{}, errors.New(strings.TrimPrefix(policyHiddenNote(policy.ActivationSearch, len(hidden)), "deja: "))
 		}
-		return model.Session{}, fmt.Errorf("no indexed sessions for this project — pass a session id-prefix (see `deja last`)")
+		return model.Session{}, idPrefixNeeded(dir, "handoff needs a session to package", "no indexed sessions for this project — pass a session id-prefix (see `deja last`)")
 	}
 	if len(distinct) > 1 {
 		fmt.Fprintf(os.Stderr, "deja: %d different sessions match this directory's project names — picked the newest; pass an id-prefix to choose (see `deja last`)\n", len(distinct))

--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -158,6 +158,9 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 	// counting per pass told the reader the rule hides more than the project
 	// holds (#981).
 	hidden := map[string]bool{}
+	// Newest of the withheld ones, so the pick can say it is not the latest
+	// work in this project rather than handing over older work in silence.
+	var hiddenNewest time.Time
 	for _, name := range digest.ProjectNameCandidates(cwd) {
 		ss, err := index.RecentProject(dir, name, 3)
 		if err != nil || len(ss) == 0 {
@@ -175,6 +178,9 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 		for _, s := range ss {
 			if !keptIDs[s.ID] {
 				hidden[s.ID] = true
+				if s.Updated.After(hiddenNewest) {
+					hiddenNewest = s.Updated
+				}
 			}
 		}
 		if len(kept) == 0 {
@@ -190,6 +196,14 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 			return model.Session{}, errors.New(strings.TrimPrefix(policyHiddenNote(policy.ActivationSearch, len(hidden)), "deja: "))
 		}
 		return model.Session{}, idPrefixNeeded(dir, "handoff needs a session to package", "no indexed sessions for this project — pass a session id-prefix (see `deja last`)")
+	}
+	// The pick is deja's, and a rule that removed newer work from the choice
+	// changes what the pick means: handing over a month-old session while
+	// today's is withheld looked exactly like a project nobody has touched
+	// since (#1013).
+	if hiddenNewest.After(newest.Updated) {
+		fmt.Fprintf(os.Stderr, "deja: newer work in this project is withheld by the trust policy (%s: %s) — this is the newest session it allows\n",
+			policy.ActivationSearch, policy.Load().Describe(policy.ActivationSearch))
 	}
 	if len(distinct) > 1 {
 		fmt.Fprintf(os.Stderr, "deja: %d different sessions match this directory's project names — picked the newest; pass an id-prefix to choose (see `deja last`)\n", len(distinct))

--- a/cmd/deja/handoff_policy_test.go
+++ b/cmd/deja/handoff_policy_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 )
@@ -93,5 +94,76 @@ func TestHandoffWithNoIdObeysTheTrustPolicy(t *testing.T) {
 	// (#981).
 	if err != nil && !strings.Contains(err.Error(), "hides 1 matching session ") {
 		t.Errorf("the count is not what the project holds: %v", err)
+	}
+}
+
+// deja's own pick changes meaning when a rule removed newer work from the
+// choice: handing over a month-old session while today's is withheld reads
+// exactly like a project nobody has touched since (#1013).
+func TestHandoffSaysWhenNewerWorkIsWithheld(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"the older local session about the pool cap"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"old","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "old.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "newpeer", Project: "proj", Role: "user",
+		Text: "the newest work on this project, from another machine", Time: time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+	work := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	back, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(work); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(back) })
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	note, err := captureRunStderr(t, "handoff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note, "newer work in this project is withheld") {
+		t.Errorf("handoff packaged older work without saying newer was withheld:\n%s", note)
+	}
+
+	// Without the rule the newest session is the pick, and there is nothing to
+	// warn about.
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(tmp, "no-policy.json"))
+	note, err = captureRunStderr(t, "handoff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(note, "withheld") {
+		t.Errorf("an unrestricted handoff warned about withheld work:\n%s", note)
 	}
 }

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -354,6 +354,12 @@ func runHookContext(dir string, plain bool) error {
 	if note := unreadableStoreNote(dir); storeNoteIsNews(dir, note) {
 		resp.SystemMessage = joinNotes(note, resp.SystemMessage)
 	}
+	// An index that is behind and cannot be written stays behind. "the agent
+	// starts already knowing them" was printed over a picture missing today's
+	// work, and this path said nothing — search names the same state (#1005).
+	if note := staleReadOnlyNote(dir); note != "" {
+		resp.SystemMessage = joinNotes(note, resp.SystemMessage)
+	}
 	b, err := json.Marshal(resp)
 	if err != nil {
 		return nil
@@ -863,4 +869,33 @@ func serviceReceipt(dir string) string {
 		return fmt.Sprintf(" · today: %d recall%s", recalls, pluralS(recalls))
 	}
 	return fmt.Sprintf(" · today: %d recall%s, %s distilled from %s", recalls, pluralS(recalls), humanBytes(int64(bytes)), humanBytes(raw))
+}
+
+// staleReadOnlyNote is the one line for an index that is behind and cannot
+// catch up: the store has newer sessions and the directory the rebuild would
+// write is not writable. Costs one manifest stat plus one temp-file probe, and
+// only when the index is already known to be behind.
+func staleReadOnlyNote(dir string) string {
+	if indexCanCatchUp(dir) {
+		return ""
+	}
+	return fmt.Sprintf("deja: this is the index as it was — it cannot be updated because %s is not writable", filepath.Dir(dir))
+}
+
+// indexCanCatchUp reports whether the index is either current or able to
+// become current. False only for the one state search already names: newer
+// sessions on disk and nowhere to write the result.
+func indexCanCatchUp(dir string) bool {
+	// Writability first: it is one temp file, while UpToDate walks every
+	// store. Measured on 6000 sessions, asking the expensive question first
+	// cost 25ms on every session start; this way the ordinary machine pays
+	// nothing (#1005).
+	if indexDirWritable(dir) {
+		return true
+	}
+	if !index.HasManifest(dir) {
+		return true
+	}
+	fresh, _ := index.UpToDate(dir, "")
+	return fresh
 }

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -341,7 +341,7 @@ func runHookContext(dir string, plain bool) error {
 		if r, ok := findReusedMemory(dir); ok {
 			earned = fmt.Sprintf(" · most re-used recently: %q, %d×", trimBriefTitle(r.Title), r.Times)
 		}
-		resp.SystemMessage = joinNotes(rewireNote(rewired), fmt.Sprintf("deja: recalled %d prior session%s %s (~%dKB) — the agent starts already knowing them%s%s%s", sessions, plural, why, (len(digest)+1023)/1024, serviceReceipt(dir), polNote, earned))
+		resp.SystemMessage = joinNotes(rewireNote(rewired), fmt.Sprintf("deja: recalled %d prior session%s %s (%s) — the agent starts already knowing them%s%s%s", sessions, plural, why, humanBytes(int64(len(digest))), serviceReceipt(dir), polNote, earned))
 	}
 	// Nothing to recall yet because the index is still being built: say so
 	// rather than starting in silence. The build runs detached, so the agent

--- a/cmd/deja/hook_plan.go
+++ b/cmd/deja/hook_plan.go
@@ -1,0 +1,406 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// planHookBudget is the complete framed payload budget. Findings receive the
+// remainder after the existing untrusted-history frame takes its share.
+const planHookBudget = 2048
+
+const (
+	planFindingLimit = 4
+	planStepLimit    = 3
+	planTermLimit    = 4
+)
+
+type planHookInput struct {
+	HookEventName string `json:"hook_event_name"`
+	ToolName      string `json:"tool_name"`
+	ToolInput     struct {
+		Plan         string `json:"plan"`
+		PlanFilePath string `json:"planFilePath"`
+	} `json:"tool_input"`
+	SessionID string `json:"session_id"`
+	CWD       string `json:"cwd"`
+}
+
+type planFinding struct {
+	line     string
+	sessions []index.SessionMeta
+}
+
+var planIndexReady = func(dir string) bool {
+	return index.HasManifest(dir) &&
+		index.IsCurrentVersion(dir) &&
+		!index.Damaged(dir)
+}
+
+var planFrictionLookup = index.PlanFrictionMatches
+
+// runHookPlan is the ExitPlanMode PreToolUse hook. Silence is the miss
+// contract, including malformed input and an unavailable index.
+func runHookPlan(dir string, stdin io.Reader, stdout io.Writer) error {
+	var input planHookInput
+	_ = json.NewDecoder(bytes.NewReader(readHookPayload(stdin, hookStdinWait))).Decode(&input)
+	// The matcher should guarantee ExitPlanMode, but a hook wired with a
+	// wider matcher must not answer for tools it was never designed to read.
+	if input.ToolName != "ExitPlanMode" {
+		return nil
+	}
+	adoptHookCWD(input.CWD)
+
+	lines := planFindings(dir, input.ToolInput.Plan, input.SessionID)
+	if len(lines) == 0 {
+		return nil
+	}
+
+	var resp sessionStartHookResponse
+	resp.HookSpecificOutput.HookEventName = "PreToolUse"
+	resp.HookSpecificOutput.AdditionalContext = frameRecall(strings.Join(lines, "\n"))
+	b, err := json.Marshal(resp)
+	if err != nil {
+		return nil
+	}
+	fmt.Fprintln(stdout, string(b))
+	return nil
+}
+
+// planFindings is shared verbatim by hook-plan and check. A non-empty session
+// id enables the same cross-hook advisory dedupe used by hook-prompt.
+func planFindings(dir, plan, sessionID string) []string {
+	steps := planSearchSteps(plan)
+	if len(steps) == 0 {
+		return nil
+	}
+
+	pol := policy.Load()
+	seen := alreadyInjected(dir, sessionID)
+	keep := func(meta index.SessionMeta) bool {
+		if !pol.Allows(policy.ActivationAuto, meta.Project) {
+			return false
+		}
+		if sessionID != "" && (meta.ID == sessionID || seen[meta.ID]) {
+			return false
+		}
+		return true
+	}
+
+	// This path never asks for a rebuild. A missing, stale, or damaged
+	// snapshot is a silent miss so plan submission cannot block on indexing.
+	if !planIndexReady(dir) {
+		return nil
+	}
+
+	matches := planFrictionLookup(dir, steps, keep, planFindingLimit)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	var findings []planFinding
+	emittedWalls := map[string]bool{}
+	for _, match := range matches {
+		wallSessions := filterPlanMetas(match.Wall.Sessions, keep, nil)
+		if len(wallSessions) < index.FrictionMinSessions {
+			continue
+		}
+		wallIDs := make(map[string]bool, len(wallSessions))
+		for _, meta := range wallSessions {
+			wallIDs[planMetaKey(meta)] = true
+		}
+		// The wall recurrence is the finding on its own (see PlanCooccurrence
+		// in internal/index/plan.go). A command is only ever a bonus clause,
+		// so a command whose evidence sessions did not survive the policy
+		// filter is dropped rather than taking the whole finding with it.
+		match.Wall.Sessions = wallSessions
+		commandSessions := filterPlanMetas(match.CommandSessions, keep, wallIDs)
+		if len(commandSessions) > 0 && strings.TrimSpace(match.Command) != "" {
+			match.CommandSessions = commandSessions
+		} else {
+			match.Command = ""
+			match.CommandSessions = nil
+		}
+		wallKey := strings.ToLower(strings.TrimSpace(match.Wall.Text))
+		if wallKey == "" || emittedWalls[wallKey] {
+			continue
+		}
+		emittedWalls[wallKey] = true
+
+		line := formatPlanFinding(match)
+		if line == "" {
+			continue
+		}
+		findings = append(findings, planFinding{
+			line:     line,
+			sessions: wallSessions,
+		})
+	}
+
+	findings = budgetPlanFindings(findings, planHookBudget-recallFrameOverhead)
+	if len(findings) == 0 {
+		return nil
+	}
+	if sessionID != "" {
+		rememberPlanFindings(dir, sessionID, findings)
+	}
+
+	lines := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		lines = append(lines, finding.line)
+	}
+	return lines
+}
+
+func filterPlanMetas(metas []index.SessionMeta, keep func(index.SessionMeta) bool, members map[string]bool) []index.SessionMeta {
+	out := make([]index.SessionMeta, 0, len(metas))
+	seen := map[string]bool{}
+	for _, meta := range metas {
+		key := planMetaKey(meta)
+		if seen[key] || !keep(meta) {
+			continue
+		}
+		if members != nil && !members[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, meta)
+	}
+	return out
+}
+
+func planMetaKey(meta index.SessionMeta) string {
+	return meta.Harness + ":" + meta.ID
+}
+
+func rememberPlanFindings(dir, sessionID string, findings []planFinding) {
+	seen := map[string]bool{}
+	var sessions []model.Session
+	for _, finding := range findings {
+		for _, meta := range finding.sessions {
+			if meta.ID == "" || seen[meta.ID] {
+				continue
+			}
+			seen[meta.ID] = true
+			sessions = append(sessions, model.Session{ID: meta.ID})
+		}
+	}
+	rememberInjected(dir, sessionID, sessions)
+}
+
+// extractPlanSteps prefers explicit Markdown steps. Prose lines are considered
+// only when the plan contains no numbered or bulleted items.
+func extractPlanSteps(plan string) []string {
+	lines := strings.Split(strings.ReplaceAll(plan, "\r\n", "\n"), "\n")
+	var listed []string
+	for _, line := range lines {
+		if step, ok := stripPlanMarker(line); ok && step != "" {
+			listed = append(listed, step)
+		}
+	}
+	if len(listed) > 0 {
+		return listed
+	}
+
+	var fallback []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		line = strings.TrimSpace(strings.TrimLeft(line, "#"))
+		if line != "" {
+			fallback = append(fallback, line)
+		}
+	}
+	return fallback
+}
+
+func stripPlanMarker(line string) (string, bool) {
+	s := strings.TrimSpace(line)
+	if len(s) >= 2 {
+		if (s[0] == '-' || s[0] == '*' || s[0] == '+') && unicode.IsSpace(rune(s[1])) {
+			return stripPlanCheckbox(strings.TrimSpace(s[1:])), true
+		}
+	}
+
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	if i == 0 || i >= len(s) || (s[i] != '.' && s[i] != ')') {
+		return "", false
+	}
+	i++
+	if i >= len(s) || !unicode.IsSpace(rune(s[i])) {
+		return "", false
+	}
+	return stripPlanCheckbox(strings.TrimSpace(s[i:])), true
+}
+
+func stripPlanCheckbox(s string) string {
+	if len(s) >= 3 && s[0] == '[' && s[2] == ']' {
+		switch s[1] {
+		case ' ', 'x', 'X':
+			return strings.TrimSpace(s[3:])
+		}
+	}
+	return s
+}
+
+// planSearchSteps returns at most the first three steps carrying enough raw
+// terms to be worth a lookup; whether a term actually counts toward that
+// lookup — rare enough in this corpus, or identifier-shaped and exempt from
+// rarity entirely — is the index layer's call (planIndexedSteps), made
+// against the same 1-or-2 need computed here. Each step is independently
+// capped so one long paragraph cannot dominate candidate selection. The need
+// is two terms, same as auto-recall, except a step naming an identifier
+// (hasIdentifierTerm) needs only one — hook-prompt already trusts a lone
+// identifier hit, and a plan step deserves the same trust.
+func planSearchSteps(plan string) [][]string {
+	var out [][]string
+	for _, step := range extractPlanSteps(plan) {
+		terms := promptSearchTerms(step)
+		if len(terms) > planTermLimit {
+			terms = terms[:planTermLimit]
+		}
+		need := 2
+		if hasIdentifierTerm(terms) {
+			need = 1
+		}
+		if len(terms) < need {
+			continue
+		}
+		out = append(out, terms)
+		if len(out) == planStepLimit {
+			break
+		}
+	}
+	return out
+}
+
+// formatPlanFinding reports the wall recurrence — the fact a census
+// verified (internal/index/plan.go's PlanCooccurrence doc) — and, only when
+// one was actually found, appends the command clause as a bonus, not a
+// requirement.
+func formatPlanFinding(match index.PlanCooccurrence) string {
+	if len(match.Wall.Sessions) < index.FrictionMinSessions ||
+		strings.TrimSpace(match.Wall.Text) == "" {
+		return ""
+	}
+
+	since := ""
+	if oldest := oldestPlanSession(match.Wall.Sessions); !oldest.IsZero() {
+		since = " since " + oldest.Format("2006-01-02")
+	}
+	wall := strconv.Quote(neutralPlanEvidence(match.Wall.Text))
+	line := fmt.Sprintf("wall hit in %d sessions%s: %s", len(match.Wall.Sessions), since, wall)
+
+	if len(match.CommandSessions) == 0 || strings.TrimSpace(match.Command) == "" {
+		return line
+	}
+	command := strconv.Quote(neutralPlanEvidence(match.Command))
+	return fmt.Sprintf(
+		"%s; past sessions also ran %s (%d sessions)",
+		line, command, len(match.CommandSessions),
+	)
+}
+
+func oldestPlanSession(metas []index.SessionMeta) time.Time {
+	var oldest time.Time
+	for _, meta := range metas {
+		if meta.Updated.IsZero() {
+			continue
+		}
+		if oldest.IsZero() || meta.Updated.Before(oldest) {
+			oldest = meta.Updated
+		}
+	}
+	return oldest
+}
+
+var forbiddenPlanClaims = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)conflicts with`),
+	regexp.MustCompile(`(?i)contradicts`),
+	regexp.MustCompile(`(?i)already tried`),
+	regexp.MustCompile(`(?i)was abandoned`),
+}
+
+// neutralPlanEvidence keeps recalled text as quoted evidence without allowing
+// its own wording to turn a co-occurrence report into a judgment.
+func neutralPlanEvidence(text string) string {
+	text = strings.Join(strings.Fields(text), " ")
+	text = neutralizeFrameMarkers(text)
+	for _, pattern := range forbiddenPlanClaims {
+		text = pattern.ReplaceAllString(text, "[historical wording omitted]")
+	}
+	return text
+}
+
+func budgetPlanFindings(findings []planFinding, budget int) []planFinding {
+	if budget <= 0 {
+		return nil
+	}
+	out := make([]planFinding, 0, len(findings))
+	used := 0
+	for _, finding := range findings {
+		line := strings.TrimSpace(finding.line)
+		if line == "" {
+			continue
+		}
+		separator := 0
+		if len(out) > 0 {
+			separator = 1
+		}
+		available := budget - used - separator
+		if available <= 0 {
+			break
+		}
+		if len(line) > available {
+			line = truncatePlanBytes(line, available)
+			if line == "" {
+				break
+			}
+			finding.line = line
+			out = append(out, finding)
+			break
+		}
+		finding.line = line
+		out = append(out, finding)
+		used += separator + len(line)
+	}
+	return out
+}
+
+func truncatePlanBytes(text string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	if len(text) <= limit {
+		return text
+	}
+	const ellipsis = "窶ｦ"
+	if limit <= len(ellipsis) {
+		return ""
+	}
+	end := limit - len(ellipsis)
+	for end > 0 && !utf8.ValidString(text[:end]) {
+		end--
+	}
+	if end == 0 {
+		return ""
+	}
+	return strings.TrimSpace(text[:end]) + ellipsis
+}

--- a/cmd/deja/hook_plan_test.go
+++ b/cmd/deja/hook_plan_test.go
@@ -1,0 +1,900 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+func TestExtractPlanSteps(t *testing.T) {
+	tests := []struct {
+		name string
+		plan string
+		want []string
+	}{
+		{
+			name: "numbered",
+			plan: "## Plan\n1. Update gateway_timeout handling\n2) Test reconnect_loop recovery",
+			want: []string{"Update gateway_timeout handling", "Test reconnect_loop recovery"},
+		},
+		{
+			name: "bulleted",
+			plan: "- Inspect exporter_batch\n* Repair utc_midnight rollover\n+ Add regression coverage",
+			want: []string{"Inspect exporter_batch", "Repair utc_midnight rollover", "Add regression coverage"},
+		},
+		{
+			name: "mixed",
+			plan: "Plan\n1. Inspect auth_cache\n- [ ] Update token_rotation\n2) Test Windows paths",
+			want: []string{"Inspect auth_cache", "Update token_rotation", "Test Windows paths"},
+		},
+		{
+			name: "fallback",
+			plan: "## Inspect gateway_timeout\nRepair reconnect_loop",
+			want: []string{"Inspect gateway_timeout", "Repair reconnect_loop"},
+		},
+		{
+			name: "empty",
+			plan: "\r\n  \n",
+			want: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := extractPlanSteps(test.plan); !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("steps = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPlanSearchStepsCapsTermsAndSteps(t *testing.T) {
+	plan := strings.Join([]string{
+		`1. Inspect C:\work\repo\auth.go gateway_timeout reconnect_loop token_rotation extra_identifier`,
+		"2. Update exporter_batch utc_midnight rollover_guard",
+		"3. Test websocket_reconnect heartbeat_timeout retry_budget",
+		"4. Document deployment_pipeline release_checklist",
+	}, "\n")
+	got := planSearchSteps(plan)
+	if len(got) != planStepLimit {
+		t.Fatalf("steps = %d, want %d: %v", len(got), planStepLimit, got)
+	}
+	for i, terms := range got {
+		if len(terms) < 2 || len(terms) > planTermLimit {
+			t.Fatalf("step %d terms = %v", i, terms)
+		}
+	}
+	// A Windows path is ordinary text to the tokenizer: backslash splits it,
+	// and only the basename survives as a term. Path-aware matching is out of
+	// scope here; this pins the actual behavior so nobody reads more into the
+	// fixture above.
+	joined := strings.Join(got[0], " ")
+	if !strings.Contains(joined, "auth.go") || strings.Contains(joined, `\`) {
+		t.Fatalf("step 0 terms = %v, want the path reduced to its basename token", got[0])
+	}
+}
+
+func TestPlanWeakInputStopsBeforeTheIndex(t *testing.T) {
+	oldReady := planIndexReady
+	oldLookup := planFrictionLookup
+	t.Cleanup(func() {
+		planIndexReady = oldReady
+		planFrictionLookup = oldLookup
+	})
+
+	readyCalls := 0
+	lookupCalls := 0
+	planIndexReady = func(string) bool {
+		readyCalls++
+		return true
+	}
+	planFrictionLookup = func(string, [][]string, func(index.SessionMeta) bool, int) []index.PlanCooccurrence {
+		lookupCalls++
+		return samplePlanMatches("local-project")
+	}
+
+	// "retry" alone is a real tech term but neither long enough nor
+	// symbol-shaped to count as an identifier, so it still needs a second
+	// term it doesn't have.
+	for _, plan := range []string{"", "- ok", "1. retry"} {
+		if got := planFindings(filepath.Join(t.TempDir(), "index.db"), plan, "session"); len(got) != 0 {
+			t.Fatalf("plan %q produced %v", plan, got)
+		}
+	}
+	if readyCalls != 0 || lookupCalls != 0 {
+		t.Fatalf("weak plans touched the index: ready=%d lookup=%d", readyCalls, lookupCalls)
+	}
+}
+
+// TestPlanSearchStepsIdentifierSingleTermAdmitted covers the same rule
+// hook-prompt already applies to auto-recall (hasIdentifierTerm,
+// cmd/deja/hook_prompt.go:319): a step naming something identifier-shaped is
+// specific enough on one word, so it should not need a second term to be
+// searched.
+func TestPlanSearchStepsIdentifierSingleTermAdmitted(t *testing.T) {
+	got := planSearchSteps("1. auth.go")
+	if len(got) != 1 {
+		t.Fatalf("steps = %v, want one admitted step", got)
+	}
+	if len(got[0]) != 1 || got[0][0] != "auth.go" {
+		t.Fatalf("step terms = %v, want [\"auth.go\"]", got[0])
+	}
+}
+
+// TestPlanSearchStepsNonIdentifierSingleTermDropped is the negative half of
+// the case above: an ordinary single word carries no more signal here than
+// it does for auto-recall, so the step is dropped rather than searched.
+func TestPlanSearchStepsNonIdentifierSingleTermDropped(t *testing.T) {
+	if got := planSearchSteps("1. Retry"); len(got) != 0 {
+		t.Fatalf("steps = %v, want none admitted", got)
+	}
+}
+
+func TestPlanPolicyDenyProducesNoOutput(t *testing.T) {
+	policyPath := filepath.Join(t.TempDir(), "policy.json")
+	if err := os.WriteFile(policyPath, []byte(`{"activations":{"auto":{"local":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyPath)
+	withPlanLookup(t, samplePlanMatches(`C:\work\private-repo`))
+
+	got := planFindings(
+		filepath.Join(t.TempDir(), "index.db"),
+		"1. Run timeout around deploy_probe",
+		"agent-session",
+	)
+	if len(got) != 0 {
+		t.Fatalf("denied sessions produced findings: %v", got)
+	}
+}
+
+func TestPlanFindingClaimIsNeutral(t *testing.T) {
+	match := samplePlanMatches("local-project")[0]
+	match.Wall.Text = "build conflicts with the cache and contradicts the manifest"
+	match.Command = "echo already tried and was abandoned"
+
+	got := strings.ToLower(formatPlanFinding(match))
+	for _, forbidden := range []string{
+		"conflicts with",
+		"contradicts",
+		"already tried",
+		"was abandoned",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("finding contains forbidden claim %q: %q", forbidden, got)
+		}
+	}
+	if !strings.HasPrefix(got, "wall hit in 3 sessions since ") {
+		t.Fatalf("finding is not a neutral factual report: %q", got)
+	}
+	if strings.Contains(got, " should ") || strings.Contains(got, " must ") {
+		t.Fatalf("finding commands the reader: %q", got)
+	}
+}
+
+// TestPlanFindingClaimIsNeutralWallOnly is the wall-only counterpart to
+// TestPlanFindingClaimIsNeutral: the forbidden-vocabulary and non-imperative
+// checks apply to the wall clause on its own, since v1.5 lets a finding
+// stand without a command clause at all.
+func TestPlanFindingClaimIsNeutralWallOnly(t *testing.T) {
+	match := samplePlanMatches("local-project")[0]
+	match.Wall.Text = "build conflicts with the cache and contradicts the manifest"
+	match.Command = ""
+	match.CommandSessions = nil
+
+	got := strings.ToLower(formatPlanFinding(match))
+	for _, forbidden := range []string{
+		"conflicts with",
+		"contradicts",
+		"already tried",
+		"was abandoned",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("finding contains forbidden claim %q: %q", forbidden, got)
+		}
+	}
+	if !strings.HasPrefix(got, "wall hit in 3 sessions since ") {
+		t.Fatalf("finding is not a neutral factual report: %q", got)
+	}
+	if strings.Contains(got, "also ran") {
+		t.Fatalf("wall-only finding unexpectedly carries a command clause: %q", got)
+	}
+	if strings.Contains(got, " should ") || strings.Contains(got, " must ") {
+		t.Fatalf("finding commands the reader: %q", got)
+	}
+}
+
+func TestPlanHookBudgetIncludesRecallFrame(t *testing.T) {
+	huge := strings.Repeat("oversized_gateway_failure_ﾎｩ ", 400)
+	findings := []planFinding{
+		{line: "wall hit in 3 sessions: " + huge},
+		{line: "wall hit in 4 sessions: " + huge},
+	}
+	budgeted := budgetPlanFindings(findings, planHookBudget-recallFrameOverhead)
+	if len(budgeted) == 0 {
+		t.Fatal("oversized finding was dropped rather than truncated")
+	}
+	var lines []string
+	for _, finding := range budgeted {
+		lines = append(lines, finding.line)
+	}
+	payload := strings.Join(lines, "\n")
+	framed := frameRecall(payload)
+	if len(payload) > planHookBudget-recallFrameOverhead {
+		t.Fatalf("payload = %d bytes, budget = %d", len(payload), planHookBudget-recallFrameOverhead)
+	}
+	if len(framed) > planHookBudget {
+		t.Fatalf("framed payload = %d bytes, budget = %d", len(framed), planHookBudget)
+	}
+	if !strings.Contains(payload, "窶ｦ") {
+		t.Fatalf("oversized finding was not visibly truncated: %q", payload)
+	}
+}
+
+func TestPlanHookSeenDedupeSuppressesSecondInvocation(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	withPlanLookup(t, samplePlanMatches("local-project"))
+
+	first := planFindings(dir, "1. Run timeout around deploy_probe", "agent-1")
+	if len(first) != 1 {
+		t.Fatalf("first findings = %v", first)
+	}
+	second := planFindings(dir, "1. Run timeout around deploy_probe", "agent-1")
+	if len(second) != 0 {
+		t.Fatalf("second invocation repeated findings: %v", second)
+	}
+	seen := alreadyInjected(dir, "agent-1")
+	for _, id := range []string{"wall-a", "wall-b", "wall-c"} {
+		if !seen[id] {
+			t.Errorf("%s was not recorded in .hookseen: %v", id, seen)
+		}
+	}
+}
+
+func TestPlanHookEmitsEachWallOnce(t *testing.T) {
+	match := samplePlanMatches("local-project")[0]
+	withPlanLookup(t, []index.PlanCooccurrence{match, match})
+
+	got := planFindings(
+		filepath.Join(t.TempDir(), "index.db"),
+		"1. Run timeout around deploy_probe",
+		"",
+	)
+	if len(got) != 1 {
+		t.Fatalf("duplicate wall emitted %d times: %v", len(got), got)
+	}
+}
+
+func TestHookPlanJSONContract(t *testing.T) {
+	t.Run("hit with unknown fields and Windows paths", func(t *testing.T) {
+		withPlanLookup(t, samplePlanMatches(`C:\work\repo`))
+		t.Setenv("CLAUDE_PROJECT_DIR", "")
+
+		input := `{
+			"hook_event_name":"PreToolUse",
+			"tool_name":"ExitPlanMode",
+			"tool_input":{
+				"plan":"1. Run timeout around deploy_probe",
+				"planFilePath":"C:\\work\\repo\\PLAN.md",
+				"future_field":true
+			},
+			"session_id":"",
+			"cwd":"C:\\work\\repo",
+			"unknown_top_level":{"value":1}
+		}`
+		var out bytes.Buffer
+		if err := runHookPlan(filepath.Join(t.TempDir(), "index.db"), strings.NewReader(input), &out); err != nil {
+			t.Fatal(err)
+		}
+		if out.Len() == 0 {
+			t.Fatal("matching hook produced no output")
+		}
+		if strings.Contains(out.String(), "permissionDecision") {
+			t.Fatalf("security-sensitive field appeared in output: %s", out.String())
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(out.Bytes(), &raw); err != nil {
+			t.Fatalf("bad JSON %q: %v", out.String(), err)
+		}
+		if len(raw) != 1 {
+			t.Fatalf("top-level shape = %v", raw)
+		}
+		var envelope struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		}
+		if err := json.Unmarshal(raw["hookSpecificOutput"], &envelope); err != nil {
+			t.Fatal(err)
+		}
+		if envelope.HookEventName != "PreToolUse" {
+			t.Fatalf("event = %q", envelope.HookEventName)
+		}
+		if !strings.HasPrefix(envelope.AdditionalContext, recallFrameHeader) ||
+			!strings.HasSuffix(envelope.AdditionalContext, recallFrameFooter) {
+			t.Fatalf("context is not framed: %q", envelope.AdditionalContext)
+		}
+		if len(envelope.AdditionalContext) > planHookBudget {
+			t.Fatalf("context = %d bytes, budget = %d", len(envelope.AdditionalContext), planHookBudget)
+		}
+	})
+
+	t.Run("miss", func(t *testing.T) {
+		withPlanLookup(t, nil)
+		var out bytes.Buffer
+		err := runHookPlan(
+			filepath.Join(t.TempDir(), "index.db"),
+			strings.NewReader(`{"tool_name":"ExitPlanMode","tool_input":{"plan":"1. Run timeout around deploy_probe"}}`),
+			&out,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("miss produced %q", out.String())
+		}
+	})
+
+	t.Run("other tool", func(t *testing.T) {
+		withPlanLookup(t, samplePlanMatches("local-project"))
+		var out bytes.Buffer
+		err := runHookPlan(
+			filepath.Join(t.TempDir(), "index.db"),
+			strings.NewReader(`{"tool_name":"Bash","tool_input":{"plan":"1. Run timeout around deploy_probe"}}`),
+			&out,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("other tool produced %q", out.String())
+		}
+	})
+
+	t.Run("missing tool input", func(t *testing.T) {
+		withPlanLookup(t, samplePlanMatches("local-project"))
+		var out bytes.Buffer
+		if err := runHookPlan(
+			filepath.Join(t.TempDir(), "index.db"),
+			strings.NewReader(`{"tool_name":"ExitPlanMode","future_field":"accepted"}`),
+			&out,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("missing tool_input produced %q", out.String())
+		}
+	})
+
+	t.Run("missing tool name", func(t *testing.T) {
+		withPlanLookup(t, samplePlanMatches("local-project"))
+		var out bytes.Buffer
+		if err := runHookPlan(
+			filepath.Join(t.TempDir(), "index.db"),
+			strings.NewReader(`{"tool_input":{"plan":"1. Run timeout around deploy_probe"}}`),
+			&out,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("input without tool_name produced %q", out.String())
+		}
+	})
+}
+
+func TestPlanFrictionIndexJoin(t *testing.T) {
+	withStatsStores(t)
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing-policy.json"))
+
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("plan-wall-%d", i)
+		toolID := fmt.Sprintf("tool-plan-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"run the deploy probe"}}`,
+				id, old,
+			),
+			fmt.Sprintf(
+				`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","id":%q,"name":"Bash","input":{"command":"go run ./deploy_probe --timeout 5 --config C:\\work\\repo\\PLAN.md"}}]}}`,
+				id, old, toolID,
+			),
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":%q,"is_error":true,"content":"/bin/sh: timeout: command not found"}]}}`,
+				id, old, toolID,
+			),
+		})
+	}
+
+	// The recurring wall appears in three sessions. Additional unrelated
+	// sessions make its terms clear the same IDF floor used by auto recall.
+	for i := 0; i < 27; i++ {
+		id := fmt.Sprintf("plan-noise-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "noise", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"unrelated color palette discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	steps := planSearchSteps("1. Run timeout around deploy_probe")
+	matches := index.PlanFrictionMatches(
+		index.DefaultDir(),
+		steps,
+		func(index.SessionMeta) bool { return true },
+		4,
+	)
+	if len(matches) == 0 {
+		t.Fatal("manifest wall and command records did not join")
+	}
+	got := matches[0]
+	if len(got.Wall.Sessions) < index.FrictionMinSessions {
+		t.Fatalf("wall sessions = %d", len(got.Wall.Sessions))
+	}
+	if !strings.Contains(strings.ToLower(got.Wall.Text), "timeout") {
+		t.Fatalf("wall = %q", got.Wall.Text)
+	}
+	if !strings.Contains(got.Command, "deploy_probe") {
+		t.Fatalf("command = %q", got.Command)
+	}
+}
+
+// TestPlanFrictionIndexJoinSingleIdentifierTerm covers the join end to end
+// for a plan step that names nothing but a single identifier. The command
+// record here shares only that one term with the step (no second word like
+// "timeout" to fall back on), so the join succeeds only because
+// planCommandForStep's threshold drops to one for an identifier step.
+func TestPlanFrictionIndexJoinSingleIdentifierTerm(t *testing.T) {
+	withStatsStores(t)
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing-policy.json"))
+
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("plan-single-wall-%d", i)
+		toolID := fmt.Sprintf("tool-plan-single-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-single", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"run the deploy probe"}}`,
+				id, old,
+			),
+			fmt.Sprintf(
+				`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","id":%q,"name":"Bash","input":{"command":"go run ./deploy_probe --config C:\\work\\repo\\PLAN.md"}}]}}`,
+				id, old, toolID,
+			),
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":%q,"is_error":true,"content":"/bin/sh: deploy_probe: command not found"}]}}`,
+				id, old, toolID,
+			),
+		})
+	}
+
+	// Same noise volume as TestPlanFrictionIndexJoin: deploy_probe appears in
+	// exactly the three wall sessions, and this many unrelated sessions is
+	// what clears the IDF floor at that document count.
+	for i := 0; i < 27; i++ {
+		id := fmt.Sprintf("plan-single-noise-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "noise-single", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"unrelated color palette discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	steps := planSearchSteps("1. deploy_probe")
+	if len(steps) != 1 || len(steps[0]) != 1 {
+		t.Fatalf("steps = %v, want a single single-term step", steps)
+	}
+	matches := index.PlanFrictionMatches(
+		index.DefaultDir(),
+		steps,
+		func(index.SessionMeta) bool { return true },
+		4,
+	)
+	if len(matches) == 0 {
+		t.Fatal("single-identifier-term step did not join to a command")
+	}
+	got := matches[0]
+	if len(got.Wall.Sessions) < index.FrictionMinSessions {
+		t.Fatalf("wall sessions = %d", len(got.Wall.Sessions))
+	}
+	if !strings.Contains(got.Command, "deploy_probe") {
+		t.Fatalf("command = %q", got.Command)
+	}
+}
+
+// TestPlanFrictionIndexJoinWallOnly is the v1.5 case: a census across real
+// walls found a matching command logged alongside the wall in only 1 of 19
+// carriers, so requiring one would reject nearly every recurrence. Here the
+// wall text itself names the step's term but no carrier's command does —
+// the join must still succeed, with Command left empty.
+func TestPlanFrictionIndexJoinWallOnly(t *testing.T) {
+	withStatsStores(t)
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing-policy.json"))
+
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("plan-wallonly-%d", i)
+		toolID := fmt.Sprintf("tool-plan-wallonly-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-wallonly", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"run the gateway again"}}`,
+				id, old,
+			),
+			// A command is logged, but it shares no term with the plan step —
+			// this is the realistic majority shape, not the 1-in-19 case
+			// where a command happens to name the wall too.
+			fmt.Sprintf(
+				`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","id":%q,"name":"Bash","input":{"command":"echo done"}}]}}`,
+				id, old, toolID,
+			),
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":%q,"is_error":true,"content":"/bin/sh: gateway_timeout: command not found"}]}}`,
+				id, old, toolID,
+			),
+		})
+	}
+
+	// Same noise volume as the other join tests: clears the IDF floor for
+	// gateway_timeout at this document count.
+	for i := 0; i < 27; i++ {
+		id := fmt.Sprintf("plan-wallonly-noise-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "noise-wallonly", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"unrelated color palette discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	steps := planSearchSteps("1. gateway_timeout")
+	if len(steps) != 1 || len(steps[0]) != 1 {
+		t.Fatalf("steps = %v, want a single single-term step", steps)
+	}
+	matches := index.PlanFrictionMatches(
+		index.DefaultDir(),
+		steps,
+		func(index.SessionMeta) bool { return true },
+		4,
+	)
+	if len(matches) == 0 {
+		t.Fatal("wall-only recurrence did not produce a finding")
+	}
+	got := matches[0]
+	if len(got.Wall.Sessions) < index.FrictionMinSessions {
+		t.Fatalf("wall sessions = %d", len(got.Wall.Sessions))
+	}
+	if !strings.Contains(strings.ToLower(got.Wall.Text), "gateway_timeout") {
+		t.Fatalf("wall = %q", got.Wall.Text)
+	}
+	if got.Command != "" || len(got.CommandSessions) != 0 {
+		t.Fatalf("expected no command strengthening, got command=%q sessions=%v", got.Command, got.CommandSessions)
+	}
+
+	line := formatPlanFinding(got)
+	if line == "" {
+		t.Fatal("wall-only match produced no finding line")
+	}
+	if strings.Contains(line, "also ran") {
+		t.Fatalf("wall-only line unexpectedly carries a command clause: %q", line)
+	}
+	if !strings.Contains(line, "gateway_timeout") {
+		t.Fatalf("finding does not name the wall: %q", line)
+	}
+}
+
+// TestPlanFrictionIndexJoinIdentifierMidFloorFires is the v1.7 case: a
+// two-tier floor, not a blanket exemption. A re-measurement against 2,886
+// real sessions found identifier-shaped false-positive anchors (cannot,
+// directory, branch, runner) topping out at idf 0.70 — the v1.6 full
+// exemption let those through — while true anchors (hermes 1.09,
+// hermes-agent 1.21) started at 1.09. Here "pipeline_probe" appears in 7 of
+// 30 sessions: idf = ln(31/8) ≈ 1.35, above planIdentifierIDFFloor (1.0) but
+// below the full dejaVuIDFFloor (2.0) a non-identifier term would need — the
+// join fires only because the term is identifier-shaped and clears the
+// lower bar.
+func TestPlanFrictionIndexJoinIdentifierMidFloorFires(t *testing.T) {
+	withStatsStores(t)
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing-policy.json"))
+
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("plan-anchor-wall-%d", i)
+		toolID := fmt.Sprintf("tool-plan-anchor-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-anchor", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"run pipeline_probe again"}}`,
+				id, old,
+			),
+			fmt.Sprintf(
+				`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","id":%q,"name":"Bash","input":{"command":"go run ./pipeline_probe --config C:\\work\\repo\\PLAN.md"}}]}}`,
+				id, old, toolID,
+			),
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":%q,"is_error":true,"content":"/bin/sh: pipeline_probe: command not found"}]}}`,
+				id, old, toolID,
+			),
+		})
+	}
+
+	// 4 more sessions repeat the same word so it clears 7 of 30 total —
+	// idf ≈ 1.35, inside the [1.0, 2.0) band only an identifier gets.
+	for i := 0; i < 4; i++ {
+		id := fmt.Sprintf("plan-anchor-common-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-anchor-common", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"pipeline_probe discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	// The remaining 23 sessions carry neither term, bringing the corpus to
+	// 30 and the document count to the 31 the idf figure above assumes.
+	for i := 0; i < 23; i++ {
+		id := fmt.Sprintf("plan-anchor-noise-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-anchor-noise", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"unrelated color palette discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	steps := planSearchSteps("1. pipeline_probe")
+	if len(steps) != 1 || len(steps[0]) != 1 {
+		t.Fatalf("steps = %v, want a single single-term step", steps)
+	}
+	matches := index.PlanFrictionMatches(
+		index.DefaultDir(),
+		steps,
+		func(index.SessionMeta) bool { return true },
+		4,
+	)
+	if len(matches) == 0 {
+		t.Fatal("identifier term inside the [1.0, 2.0) band did not join")
+	}
+	got := matches[0]
+	if len(got.Wall.Sessions) < index.FrictionMinSessions {
+		t.Fatalf("wall sessions = %d", len(got.Wall.Sessions))
+	}
+	if !strings.Contains(strings.ToLower(got.Wall.Text), "pipeline_probe") {
+		t.Fatalf("wall = %q", got.Wall.Text)
+	}
+}
+
+// TestPlanFrictionIndexJoinIdentifierBelowFloorSilent is the negative
+// control for the case above: the same identifier-shaped word, spread
+// common enough to drop its idf below planIdentifierIDFFloor (1.0), does not
+// join even though it is identifier-shaped — v1.7 narrows the exemption to a
+// lower bar, it does not remove the bar.
+func TestPlanFrictionIndexJoinIdentifierBelowFloorSilent(t *testing.T) {
+	withStatsStores(t)
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing-policy.json"))
+
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("plan-anchor-lo-wall-%d", i)
+		toolID := fmt.Sprintf("tool-plan-anchor-lo-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-anchor-lo", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"run pipeline_probe again"}}`,
+				id, old,
+			),
+			fmt.Sprintf(
+				`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","id":%q,"name":"Bash","input":{"command":"go run ./pipeline_probe --config C:\\work\\repo\\PLAN.md"}}]}}`,
+				id, old, toolID,
+			),
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":%q,"is_error":true,"content":"/bin/sh: pipeline_probe: command not found"}]}}`,
+				id, old, toolID,
+			),
+		})
+	}
+
+	// 17 more sessions repeat the same word so it clears 20 of 30 total —
+	// idf = ln(31/21) ≈ 0.39, below planIdentifierIDFFloor (1.0).
+	for i := 0; i < 17; i++ {
+		id := fmt.Sprintf("plan-anchor-lo-common-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-anchor-lo-common", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"pipeline_probe discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	for i := 0; i < 10; i++ {
+		id := fmt.Sprintf("plan-anchor-lo-noise-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-anchor-lo-noise", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"unrelated color palette discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	steps := planSearchSteps("1. pipeline_probe")
+	if len(steps) != 1 || len(steps[0]) != 1 {
+		t.Fatalf("steps = %v, want a single single-term step", steps)
+	}
+	matches := index.PlanFrictionMatches(
+		index.DefaultDir(),
+		steps,
+		func(index.SessionMeta) bool { return true },
+		4,
+	)
+	if len(matches) != 0 {
+		t.Fatalf("identifier term below planIdentifierIDFFloor should still be silent, got %v", matches)
+	}
+}
+
+// TestPlanFrictionIndexJoinNonIdentifierStillNeedsTheFloor is the negative
+// control for the case above: two ordinary, non-identifier words made just
+// as common in the corpus do not get the same exemption, so the step yields
+// no anchor terms and the join stays silent — v1.6 narrows the floor for
+// identifier-shaped words specifically, it does not lift it in general.
+func TestPlanFrictionIndexJoinNonIdentifierStillNeedsTheFloor(t *testing.T) {
+	withStatsStores(t)
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing-policy.json"))
+
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("plan-common-wall-%d", i)
+		toolID := fmt.Sprintf("tool-plan-common-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-common", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"cache retry again"}}`,
+				id, old,
+			),
+			fmt.Sprintf(
+				`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","id":%q,"name":"Bash","input":{"command":"echo cache retry done"}}]}}`,
+				id, old, toolID,
+			),
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":%q,"is_error":true,"content":"/bin/sh: cache retry limit exceeded"}]}}`,
+				id, old, toolID,
+			),
+		})
+	}
+
+	// Same 20-of-30 spread as the identifier case above, but with two plain
+	// English words instead of an identifier.
+	for i := 0; i < 17; i++ {
+		id := fmt.Sprintf("plan-common-noise-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-common-noise", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"cache retry discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	for i := 0; i < 10; i++ {
+		id := fmt.Sprintf("plan-common-other-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-common-other", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"unrelated color palette discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	steps := planSearchSteps("1. cache retry")
+	if len(steps) != 1 || len(steps[0]) != 2 {
+		t.Fatalf("steps = %v, want a single two-term step", steps)
+	}
+	matches := index.PlanFrictionMatches(
+		index.DefaultDir(),
+		steps,
+		func(index.SessionMeta) bool { return true },
+		4,
+	)
+	if len(matches) != 0 {
+		t.Fatalf("non-identifier common terms should still fail the floor, got %v", matches)
+	}
+}
+
+func samplePlanMatches(project string) []index.PlanCooccurrence {
+	base := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	sessions := []index.SessionMeta{
+		{ID: "wall-a", Harness: "claude", Project: project, Updated: base},
+		{ID: "wall-b", Harness: "codex", Project: project, Updated: base.Add(24 * time.Hour)},
+		{ID: "wall-c", Harness: "claude", Project: project, Updated: base.Add(48 * time.Hour)},
+	}
+	return []index.PlanCooccurrence{{
+		Wall: index.Friction{
+			Text:     "/bin/sh: timeout: command not found",
+			Sessions: sessions,
+			Last:     sessions[2].Updated,
+		},
+		Command:         `timeout 5 deploy_probe --config C:\work\repo\PLAN.md`,
+		CommandSessions: sessions[:2],
+	}}
+}
+
+func withPlanLookup(t *testing.T, result []index.PlanCooccurrence) {
+	t.Helper()
+	oldReady := planIndexReady
+	oldLookup := planFrictionLookup
+	planIndexReady = func(string) bool { return true }
+	planFrictionLookup = func(
+		_ string,
+		_ [][]string,
+		keep func(index.SessionMeta) bool,
+		limit int,
+	) []index.PlanCooccurrence {
+		var out []index.PlanCooccurrence
+		for _, match := range result {
+			var wall []index.SessionMeta
+			members := map[string]bool{}
+			for _, meta := range match.Wall.Sessions {
+				if keep(meta) {
+					wall = append(wall, meta)
+					members[planMetaKey(meta)] = true
+				}
+			}
+			if len(wall) < index.FrictionMinSessions {
+				continue
+			}
+			var commands []index.SessionMeta
+			for _, meta := range match.CommandSessions {
+				if keep(meta) && members[planMetaKey(meta)] {
+					commands = append(commands, meta)
+				}
+			}
+			if len(commands) == 0 {
+				continue
+			}
+			match.Wall.Sessions = wall
+			match.CommandSessions = commands
+			out = append(out, match)
+			if limit > 0 && len(out) == limit {
+				break
+			}
+		}
+		return out
+	}
+	t.Cleanup(func() {
+		planIndexReady = oldReady
+		planFrictionLookup = oldLookup
+	})
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -479,7 +479,14 @@ func dejaVuLine(s model.Session, terms ...string) string {
 		}
 		why = " · via: " + strings.Join(terms, ", ")
 	}
-	return fmt.Sprintf("deja-vu: you have been here — %q (%s%s)", topic, search.RelativeDate(s.Updated), why)
+	// "you have been here" for a session that arrived from another machine
+	// claims the reader did work they have never seen — the context block
+	// below labels it `imported:` and this line contradicted it (#1001).
+	who := "you have been here"
+	if strings.HasPrefix(s.Project, "imported:") {
+		who = "this was done on another machine"
+	}
+	return fmt.Sprintf("deja-vu: %s — %q (%s%s)", who, topic, search.RelativeDate(s.Updated), why)
 }
 
 // dejaVuTopic picks something a human actually typed. Session titles are the

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -506,3 +506,27 @@ func TestHookPromptSurvivesBytesAfterThePayload(t *testing.T) {
 		}
 	}
 }
+
+// The one line a person reads claimed they had done work that arrived from
+// another machine, while the context block below it labelled the same session
+// `imported:` (#1001).
+func TestDejaVuLineDoesNotClaimAPeersWorkAsYours(t *testing.T) {
+	local := model.Session{ID: "loc", Project: "tmp/w16", Updated: time.Now(),
+		Messages: []model.Message{{Role: "user", Text: "the ticker window stays at 30s"}}}
+	if got := dejaVuLine(local, "ticker"); !strings.Contains(got, "you have been here") {
+		t.Errorf("a local session lost the wording it has always had: %q", got)
+	}
+	peer := local
+	peer.Project = "imported:tmp/w16"
+	got := dejaVuLine(peer, "ticker")
+	if strings.Contains(got, "you have been here") {
+		t.Errorf("a session from another machine is claimed as the reader's own: %q", got)
+	}
+	if !strings.Contains(got, "another machine") {
+		t.Errorf("the line does not say where the session came from: %q", got)
+	}
+	// The rest of the line — the topic and why it fired — is unchanged.
+	if !strings.Contains(got, "ticker window") || !strings.Contains(got, "via: ticker") {
+		t.Errorf("the line lost what it is for: %q", got)
+	}
+}

--- a/cmd/deja/hook_size_test.go
+++ b/cmd/deja/hook_size_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// runHookCapturing feeds the hook one event on stdin and returns its stdout.
+func runHookCapturing(t *testing.T, dir, event string) string {
+	t.Helper()
+	inR, inW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldIn, oldOut := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = inR, outW
+	defer func() { os.Stdin, os.Stdout = oldIn, oldOut }()
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(outR)
+		done <- string(b)
+	}()
+	go func() {
+		_, _ = inW.Write([]byte(event + "\n"))
+		_ = inW.Close()
+	}()
+	if err := runHookContext(dir, false); err != nil {
+		t.Fatal(err)
+	}
+	_ = outW.Close()
+	return <-done
+}
+
+// The size on the first screen was a ceiling to whole kilobytes, so 631 bytes
+// read as "~1KB" while statusline and stats counted the real figure — the one
+// number a reader sees first was the one no command could reproduce (#991).
+func TestHookSizeMatchesWhatTheCountersReport(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The helper swaps the process's stdin and stdout for pipes; on
+		// windows that stalls the hook's own reader instead of returning.
+		t.Skip("stdin/stdout swapping is not reliable on windows")
+	}
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"session about the ticker window and the pool cap"},"timestamp":"2026-08-01T10:00:00Z","sessionId":"w1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "w1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	back, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	work := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(work); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(back) })
+
+	out := runHookCapturing(t, dir, `{"hook_event_name":"SessionStart","session_id":"probe","cwd":"`+work+`"}`)
+	var resp struct {
+		SystemMessage string `json:"systemMessage"`
+		Hook          struct {
+			Context string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("hook output is not JSON: %v\n%s", err, out)
+	}
+	if resp.SystemMessage == "" {
+		t.Skip("no memory to recall in this environment")
+	}
+	if strings.Contains(resp.SystemMessage, "KB)") && !strings.Contains(resp.SystemMessage, ".") {
+		t.Errorf("the size is still rounded to whole kilobytes: %q", resp.SystemMessage)
+	}
+	// The number has to be the same one the counters accumulate.
+	stats, err := captureRun(t, "stats", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var s struct {
+		Recall struct {
+			Bytes int64 `json:"bytes"`
+		} `json:"recall"`
+	}
+	if err := json.Unmarshal([]byte(stats), &s); err != nil {
+		t.Fatal(err)
+	}
+	if want := humanBytes(s.Recall.Bytes); !strings.Contains(resp.SystemMessage, "("+want+")") {
+		t.Errorf("the first screen says something else than stats counts (%s):\n%s", want, resp.SystemMessage)
+	}
+}

--- a/cmd/deja/id_needed_empty_test.go
+++ b/cmd/deja/id_needed_empty_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// "pass a session id-prefix (see `deja last`)" is a step the reader can take
+// and learn nothing from when the store is empty: the listing answers with the
+// emptiness deja already knew about one command earlier (#992).
+func TestIdNeededSaysTheStoreIsEmptyInsteadOfPointingAtTheListing(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, cmd := range []string{"promote", "share", "handoff"} {
+		_, err := captureRun(t, cmd)
+		if err == nil {
+			t.Fatalf("%s accepted an empty store", cmd)
+		}
+		if strings.Contains(err.Error(), "deja last") {
+			t.Errorf("%s sent the reader to a listing that is empty for the same reason: %v", cmd, err)
+		}
+		if !strings.Contains(err.Error(), "nothing is indexed yet") {
+			t.Errorf("%s does not say the store is empty: %v", cmd, err)
+		}
+	}
+
+	// With something indexed the refusal is about the missing argument again,
+	// and the listing is worth reading.
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	_, err := captureRun(t, "promote")
+	if err == nil || !strings.Contains(err.Error(), "deja last") {
+		t.Errorf("with sessions indexed promote stopped naming the listing: %v", err)
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -357,7 +357,10 @@ func installIndexHint(dir string) string {
 		if store.Files > 0 {
 			detected++
 		}
-		if store.State != "missing" && store.State != "empty" {
+		// A store whose disk is not attached is not history found here either;
+		// the text rows have separated the two since #933 and the JSON form
+		// learned to in #999.
+		if store.State != "missing" && store.State != "empty" && store.State != "unplugged" {
 			onlyMissingOrEmpty = false
 		}
 		for _, path := range store.Paths {

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -17,8 +17,11 @@ import (
 // We merge one SessionStart entry into ~/.codex/hooks.json and leave
 // everything else in the file alone.
 func installCodexHooks(exe string, uninstall bool) (installResult, error) {
-	h, _ := os.UserHomeDir()
-	path := filepath.Join(h, ".codex", "hooks.json")
+	// Use CodexHome() (honours CODEX_HOME / DEJA_CODEX_ROOT) rather than a raw
+	// ~/.codex join, so a sandboxed install stays sandboxed and a non-default
+	// codex home gets its hooks written where codex actually reads them. Every
+	// other codex path already goes through it (e.g. doctor.go). See #850.
+	path := filepath.Join(sources.CodexHome(), "hooks.json")
 	old, _ := os.ReadFile(path)
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {

--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -182,3 +182,32 @@ func TestPrintInstallProofListsDistinctProjects(t *testing.T) {
 		t.Fatalf("projects not deduped: %q", out)
 	}
 }
+
+// TestInstallCodexHooksHonoursCodexHome pins #850: install must write to
+// CODEX_HOME (via sources.CodexHome()), not a raw ~/.codex, so a sandboxed
+// install cannot edit the operator's real config. HOME and CODEX_HOME point at
+// distinct dirs; the hooks file must land under CODEX_HOME and not under HOME.
+func TestInstallCodexHooksHonoursCodexHome(t *testing.T) {
+	home := t.TempDir()
+	codexHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("CODEX_HOME", codexHome)
+
+	r, err := installCodexHooks("/usr/local/bin/deja", false)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	want := filepath.Join(codexHome, "hooks.json")
+	if r.Path != want {
+		t.Errorf("install wrote to %q, want %q (CODEX_HOME must be honoured)", r.Path, want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("no hooks.json under CODEX_HOME: %v", err)
+	}
+	// The real (HOME-based) ~/.codex must be left untouched.
+	if _, err := os.Stat(filepath.Join(home, ".codex", "hooks.json")); !os.IsNotExist(err) {
+		t.Errorf("install wrote to HOME/.codex despite CODEX_HOME being set (err=%v)", err)
+	}
+}

--- a/cmd/deja/json_withheld_test.go
+++ b/cmd/deja/json_withheld_test.go
@@ -83,3 +83,68 @@ func TestJSONSaysWhenTheTrustPolicyWithheldRows(t *testing.T) {
 		t.Errorf("the listing returned the wrong rows: %v", got["sessions"])
 	}
 }
+
+// #990 gave search and last the field; stats printed the reason on stderr only,
+// so the third machine form still could not tell a rule from a small store
+// (#1010).
+func TestStatsJSONCarriesTheWithheldCount(t *testing.T) {
+	tmp := hermeticEnv(t)
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "work/api", Role: "user", Text: "peer two about the pool cap"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "stats", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("stats --json is not JSON: %v", err)
+	}
+	if _, ok := m["policy_withheld"]; ok {
+		t.Errorf("an unrestricted report claims withheld rows: %v", m["policy_withheld"])
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	out, err = captureRun(t, "stats", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["policy_withheld"] != float64(1) {
+		t.Errorf("stats --json does not say what the rule kept out: %v", m)
+	}
+	if m["total_sessions"] != float64(1) {
+		t.Errorf("the report counted the hidden session anyway: %v", m["total_sessions"])
+	}
+}

--- a/cmd/deja/json_withheld_test.go
+++ b/cmd/deja/json_withheld_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The reason an answer is empty travelled on stderr only, so a caller reading
+// --json — a script, another agent, our own benchmarks — saw the same object
+// whether the history was empty or a rule withheld every row (#990).
+func TestJSONSaysWhenTheTrustPolicyWithheldRows(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "work/api", Role: "user", Text: "peer two about the pool cap"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	decode := func(t *testing.T, args ...string) map[string]any {
+		t.Helper()
+		out, err := captureRun(t, args...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(out), &m); err != nil {
+			t.Fatalf("%v is not JSON: %v\n%s", args, err, out)
+		}
+		return m
+	}
+
+	// No rule: the field is absent, so nothing changes for existing callers.
+	if got, ok := decode(t, "search", "pool", "--json")["policy_withheld"]; ok {
+		t.Errorf("an unrestricted search reported withheld rows: %v", got)
+	}
+	if got, ok := decode(t, "last", "--json")["policy_withheld"]; ok {
+		t.Errorf("an unrestricted listing reported withheld rows: %v", got)
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	got := decode(t, "search", "pool", "--json")
+	if got["policy_withheld"] != float64(1) {
+		t.Errorf("search --json does not say the rule emptied it: %v", got)
+	}
+	if hits, _ := got["hits"].([]any); len(hits) != 0 {
+		t.Errorf("the hidden hit was returned anyway: %v", got["hits"])
+	}
+	got = decode(t, "last", "--json")
+	if got["policy_withheld"] != float64(1) {
+		t.Errorf("last --json does not say a row was kept out: %v", got)
+	}
+	if ss, _ := got["sessions"].([]any); len(ss) != 1 {
+		t.Errorf("the listing returned the wrong rows: %v", got["sessions"])
+	}
+}

--- a/cmd/deja/last_import_test.go
+++ b/cmd/deja/last_import_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The line an import prints scrolls away; a peer who keeps the batch drops the
+// same records on every sync, and doctor — where someone goes to ask why a
+// peer's work never shows up — kept no record of it (#1016).
+func TestDoctorRemembersWhatTheLastSyncDropped(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{Harness: "claude", SessionID: "peer", Project: "work/api", Role: "user", Text: "peer record about the vault rotation"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+
+	// An ordinary import has nothing to report afterwards.
+	var out bytes.Buffer
+	doctorIndex(&out, inspectDoctorIndex(dir, nil), dir)
+	if strings.Contains(out.String(), "last sync") {
+		t.Errorf("an import that dropped nothing left a note behind:\n%s", out.String())
+	}
+
+	// Forget what arrived, then take the same batch again.
+	id := index.ImportedSessionID("claude", "peer")
+	if _, err := captureRun(t, "forget", "--session", "claude:"+id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	doctorIndex(&out, inspectDoctorIndex(dir, nil), dir)
+	got := out.String()
+	if !strings.Contains(got, "last sync") {
+		t.Errorf("doctor kept no record of what the sync dropped:\n%s", got)
+	}
+	if !strings.Contains(got, "left out as forgotten here") {
+		t.Errorf("the line does not say why the records were dropped:\n%s", got)
+	}
+}

--- a/cmd/deja/lifecycle.go
+++ b/cmd/deja/lifecycle.go
@@ -172,11 +172,24 @@ func demotedNote(hits []search.Hit, moved int) string {
 	if moved == 0 {
 		return ""
 	}
+	// One decision, not one row: a rejected note and the transcript it was
+	// promoted from are both demoted, and counting rows told the reader they
+	// had marked two sessions when they marked one (#997).
+	notes := promotedNoteSources()
+	seen := map[string]bool{}
 	n, elsewhere := 0, 0
 	for _, h := range hits {
 		if h.Lifecycle != lifecycleRejected {
 			continue
 		}
+		key := h.Session.Harness + ":" + h.Session.ID
+		if src, ok := notes[h.Session.ID]; ok {
+			key = src
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
 		n++
 		// "you marked" is wrong for a decision another machine took back: the
 		// state travelled with the note, the judgement was not this reader's

--- a/cmd/deja/lifecycle.go
+++ b/cmd/deja/lifecycle.go
@@ -218,3 +218,36 @@ func theyOrIt(n int) string {
 	}
 	return "they"
 }
+
+// attachBlameLifecycles is attachLifecycles for blame, which carries its own
+// hit type: blame answers "who decided this", and it answered with the
+// accepted line of a decision that had been taken back (#1017).
+func attachBlameLifecycles(hits []search.BlameHit) {
+	if len(hits) == 0 {
+		return
+	}
+	states := sources.PromotedLifecycles()
+	for i := range hits {
+		h := &hits[i]
+		key := h.Session.Harness + ":" + h.Session.ID
+		if noteID := promotedNoteID(h.Session); noteID != "" {
+			if src, ok := strings.CutPrefix(noteID, "deja-note-"); ok {
+				key = strings.Replace(src, "-", ":", 1)
+			}
+		}
+		lc, ok := states[key]
+		if !ok || lc.State == "" {
+			if h.Session.Lifecycle != "" && h.Session.Lifecycle != "accepted" {
+				h.Lifecycle, h.LifecycleNote, h.LifecycleAt = h.Session.Lifecycle, h.Session.LifecycleNote, h.Session.LifecycleAt
+			}
+			continue
+		}
+		if lc.State == "accepted" {
+			continue
+		}
+		h.Lifecycle, h.LifecycleNote = lc.State, lc.Note
+		if !lc.At.IsZero() {
+			h.LifecycleAt = lc.At.Format("2006-01-02")
+		}
+	}
+}

--- a/cmd/deja/lifecycle_test.go
+++ b/cmd/deja/lifecycle_test.go
@@ -244,3 +244,39 @@ func TestDemotedNote(t *testing.T) {
 		t.Errorf("plural note = %q", got)
 	}
 }
+
+// The line attributes a reordering to the person who caused it, so its number
+// is the count of their decisions. A rejected note and the transcript it was
+// promoted from are one decision stored twice, and counting rows grew the
+// number with deja's storage rather than with what the reader did (#997).
+func TestDemotedNoteCountsDecisionsNotRows(t *testing.T) {
+	tmp := t.TempDir()
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	body := `{"ts":"2026-08-04T10:00:00Z","project":"p","text":"rolled back","kind":"promoted","session":"claude:bad","state":"rejected","title":"pool cap"}` + "\n"
+	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hits := []search.Hit{
+		{Session: model.Session{ID: "bad", Harness: "claude", Project: "p"}, Lifecycle: "rejected"},
+		{Session: model.Session{ID: "deja-note-claude-bad", Harness: "deja", Project: "p"}, Lifecycle: "rejected"},
+		{Session: model.Session{ID: "good", Harness: "claude", Project: "p"}},
+	}
+	got := demotedNote(hits, demoteRejected(hits))
+	if !strings.Contains(got, "1 session you marked rejected is below") {
+		t.Errorf("one decision stored twice was counted as %q", got)
+	}
+
+	// Two decisions are still two.
+	body += `{"ts":"2026-08-04T11:00:00Z","project":"p","text":"also wrong","kind":"promoted","session":"claude:worse","state":"rejected","title":"ticker"}` + "\n"
+	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hits = append(hits[:2:2],
+		search.Hit{Session: model.Session{ID: "worse", Harness: "claude", Project: "p"}, Lifecycle: "rejected"},
+		search.Hit{Session: model.Session{ID: "deja-note-claude-worse", Harness: "deja", Project: "p"}, Lifecycle: "rejected"},
+		search.Hit{Session: model.Session{ID: "good", Harness: "claude", Project: "p"}})
+	if got := demotedNote(hits, demoteRejected(hits)); !strings.Contains(got, "2 sessions you marked rejected are below") {
+		t.Errorf("two decisions were counted as %q", got)
+	}
+}

--- a/cmd/deja/machine_output.go
+++ b/cmd/deja/machine_output.go
@@ -11,6 +11,9 @@ import (
 type recentJSON struct {
 	SchemaVersion int             `json:"schema_version"`
 	Sessions      []model.Session `json:"sessions"`
+	// Withheld is how many rows the trust policy kept out of this listing —
+	// the same fact the text form prints on stderr (#990).
+	Withheld int `json:"policy_withheld,omitempty"`
 }
 
 type sessionWindow struct {
@@ -27,6 +30,10 @@ type sessionJSON struct {
 }
 
 func printRecentJSON(w io.Writer, sessions []model.Session, sourceInstance string) error {
+	return printRecentJSONWithheld(w, sessions, sourceInstance, 0)
+}
+
+func printRecentJSONWithheld(w io.Writer, sessions []model.Session, sourceInstance string, withheld int) error {
 	for i := range sessions {
 		sessions[i].Messages = nil
 		sessions[i].SetSource(sourceInstance)
@@ -34,7 +41,7 @@ func printRecentJSON(w io.Writer, sessions []model.Session, sourceInstance strin
 	if sessions == nil {
 		sessions = []model.Session{}
 	}
-	return json.NewEncoder(w).Encode(recentJSON{SchemaVersion: jsonout.Version, Sessions: sessions})
+	return json.NewEncoder(w).Encode(recentJSON{SchemaVersion: jsonout.Version, Sessions: sessions, Withheld: withheld})
 }
 
 // sliceMessages applies --offset and --limit. Both are documented for `deja

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -25,6 +25,11 @@ import (
 var version = "dev"
 
 func main() {
+	// A command that lands mid-rebuild waits for the whole of it, and silence
+	// there reads as a hang rather than as a queue (#994).
+	index.LockWaitNotice = func() {
+		fmt.Fprintln(os.Stderr, "deja: another deja is building the index — waiting for it to finish")
+	}
 	stopProfiling := startProfiling()
 	if err := run(os.Args[1:]); err != nil {
 		stopProfiling()
@@ -484,7 +489,7 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 	}
 	if len(ss) == 0 {
 		if o.JSON {
-			return printRecentJSON(os.Stdout, nil, sourceInstance)
+			return printRecentJSONWithheld(os.Stdout, nil, sourceInstance, policyHidden)
 		}
 		// The rule that emptied the list was named a line above; "no sessions
 		// indexed yet — run `deja index`" is advice for a state deja is not in,
@@ -505,7 +510,7 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 		return nil
 	}
 	if o.JSON {
-		return printRecentJSON(os.Stdout, ss, sourceInstance)
+		return printRecentJSONWithheld(os.Stdout, ss, sourceInstance, policyHidden)
 	}
 	for _, s := range ss {
 		// A session whose timestamp was missing or unparseable carries the Go
@@ -623,6 +628,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 		hits, o.Total, o.Capped = detailed.Hits, detailed.Total, detailed.Capped
 	}
 	hits, policyHidden := policyFilterHitsCounted(policy.ActivationSearch, hits)
+	o.PolicyWithheld = policyHidden
 	if !o.NoEmbed && os.Getenv("DEJA_EMBED") != "off" {
 		hits = maybeRerank(dir, hits, o, os.Stderr)
 	}
@@ -1865,6 +1871,17 @@ Examples:
 See README.md for the full CLI reference.`)
 }
 
+// idPrefixNeeded is the refusal for a command that needs a session named on the
+// command line. "see `deja last`" is a step the reader can take and learn
+// nothing from when the store is empty: the listing answers with the same
+// emptiness deja already knows about here (#992).
+func idPrefixNeeded(dir, subject, refusal string) error {
+	if n, err := index.SessionCount(dir); err == nil && n == 0 {
+		return errors.New(strings.TrimPrefix(emptyIndexHint(subject+", and nothing is indexed yet"), "deja: "))
+	}
+	return errors.New(refusal)
+}
+
 // emptyIndexHint phrases the nothing-here answer the same way everywhere, and
 // points at the next command rather than leaving the user to guess.
 //
@@ -1884,8 +1901,18 @@ func emptyIndexHint(what string) string {
 // opposed to an index that merely has not been built yet.
 func noAgentHistoryFound() bool {
 	for _, check := range doctorStoreChecks() {
-		if store, _ := inspectDoctorStore(check); store.Files > 0 {
-			return false
+		store, _ := inspectDoctorStore(check)
+		if store.Files == 0 {
+			continue
+		}
+		// By content, not by existence: an empty notes file — one `deja
+		// remember` later forgotten, or a file someone touched — counted as
+		// history and turned the answer into "run `deja index`", which is the
+		// one piece of advice this branch exists to avoid (#996).
+		for _, f := range check.files {
+			if fi, err := os.Stat(f); err == nil && fi.Size() > 0 {
+				return false
+			}
 		}
 	}
 	return true

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -339,8 +339,37 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 	if o.harness == "" {
 		noteAmbiguousPrefix(dir, o.id, "showing")
 	}
+	// A day bucket's date is the day the index was built in, not the moment a
+	// line was written: read in another zone, `show` lists a record dated the
+	// day before the id says, and nothing connected the two (#1006).
+	if note := bucketDayNote(s); note != "" {
+		fmt.Fprintln(os.Stderr, note)
+	}
 	search.PrintSession(os.Stdout, s)
 	return nil
+}
+
+// bucketDayNote explains a note bucket's date when the records inside it fall
+// on a different local day than the id claims — and stays silent otherwise, so
+// the ordinary case gains no line.
+func bucketDayNote(s model.Session) string {
+	if s.Harness != "deja" || !strings.HasPrefix(s.ID, "deja-20") {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(s.ID, "deja-"), "-")
+	if len(parts) < 3 {
+		return ""
+	}
+	day := strings.Join(parts[:3], "-")
+	for _, m := range s.Messages {
+		if m.Time.IsZero() {
+			continue
+		}
+		if m.Time.Local().Format("2006-01-02") != day {
+			return fmt.Sprintf("deja: %s in this id is the day the index was built in; the times below are this machine's — `deja index` regroups them", day)
+		}
+	}
+	return ""
 }
 
 type showOptions struct {
@@ -504,6 +533,13 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 		// instead (#637).
 		if where := activeFilters(o, sinceRaw); where != "" {
 			fmt.Fprintf(os.Stderr, "deja: no sessions match %s\n", where)
+			return nil
+		}
+		// "run `deja index`" cannot bring back what the reader forgot, and on a
+		// store emptied by their own settings it is the wrong instruction —
+		// search has said so since #844; the listing did not (#1007).
+		if note := hiddenByOwnSettings(); note != "" {
+			fmt.Fprint(os.Stderr, "deja: no sessions indexed yet\n"+note)
 			return nil
 		}
 		fmt.Fprintln(os.Stderr, emptyIndexHint("no sessions indexed yet"))

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1407,6 +1407,12 @@ func printSources(dir string) {
 			msg += len(s.Messages)
 		}
 		note := ""
+		// `deja sources` is where the empty-machine advice sends people, and a
+		// store deja is not allowed to read looked exactly like one nobody has
+		// used: `sessions=0 messages=0 size=0 B` (#1000).
+		if denied := firstDeniedDir(it.roots); denied != "" {
+			note = "\t(cannot be read — permission denied on " + denied + ")"
+		}
 		if it.name == "cursor" && len(sources.CursorDBs()) > 0 && !sources.SQLite3Available() {
 			note = "\t(sqlite3 CLI not found — Cursor IDE sessions unavailable)"
 		}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -202,6 +202,8 @@ func cmdVersion(_ string, _ []string) error {
 }
 
 func cmdWarmup(dir string, _ []string) error {
+	stop := publishBuildProgress(dir)
+	defer stop()
 	prepareFirstIndexGreeting(dir)
 	if err := withBuildProgress(func() error { return index.Ensure(dir, "", false, os.Stderr) }); err != nil {
 		return err
@@ -222,7 +224,12 @@ func cmdIndex(dir string, rest []string) error {
 	// Silence reads as "it did not run". `update` on the newest release and
 	// `doctor` on a fresh index both say so; this one returned to the prompt
 	// with nothing (#824). Only here: on a search the same line would be noise.
+	// The freshness check walks every store, which on a slow volume is the
+	// longest part of the whole command, and it ran before the progress sink
+	// existed (#1021).
+	stopProgress := publishBuildProgress(dir)
 	if fresh, n := index.UpToDate(dir, ""); fresh && !force {
+		stopProgress()
 		// The warmup child runs this command, so returning before the sentinel
 		// is cleared leaves a build that is not running: the next request is
 		// suppressed until the retry window, and readWarmupStatus tells the
@@ -231,6 +238,7 @@ func cmdIndex(dir string, rest []string) error {
 		fmt.Fprintf(os.Stderr, "deja: index is up to date (%d session%s)\n", n, pluralS(n))
 		return nil
 	}
+	stopProgress()
 	prepareFirstIndexGreeting(dir)
 	// The detached warmup publishes its progress so hooks can tell the user
 	// memory is on its way; an interactive run draws the live display.
@@ -456,6 +464,13 @@ func cmdCtx(dir string, rest []string) error {
 			return err
 		}
 		if ok {
+			// Every other reading surface stops here when a rule denies the
+			// session's origin; ctx handed the whole session over, and it is
+			// the command the hook tells an agent to call (#1026).
+			if kept, hidden := policyFilterSessionsCounted(policy.ActivationSearch, []model.Session{s}); len(kept) == 0 {
+				fmt.Fprint(os.Stderr, policyHiddenNote(policy.ActivationSearch, hidden))
+				return fmt.Errorf("no session matches %q", q)
+			}
 			// The one command an agent is told to call — the hook's lead line
 			// names recall_context — answered from one of several sessions
 			// behind an elided id without saying it was a choice, while show,
@@ -479,6 +494,11 @@ func cmdCtx(dir string, rest []string) error {
 	hits, err := search.Run(ss, o)
 	if err != nil {
 		return err
+	}
+	hits, policyHidden := policyFilterHitsCounted(policy.ActivationSearch, hits)
+	if len(hits) == 0 && policyHidden > 0 {
+		fmt.Fprint(os.Stderr, policyHiddenNote(policy.ActivationSearch, policyHidden))
+		return fmt.Errorf("no session matches %q", q)
 	}
 	if len(hits) == 0 {
 		// Same as #834 in files and restore: an empty store is not a miss on
@@ -1318,7 +1338,9 @@ func findBlameHits(dir string, target search.BlameTarget, o search.BlameOptions,
 	if err != nil {
 		return nil, err
 	}
-	return policyFilterBlame(activation, search.Blame(withFileTouchers(dir, result.Sessions, target), target, o)), nil
+	hits := policyFilterBlame(activation, search.Blame(withFileTouchers(dir, result.Sessions, target), target, o))
+	attachBlameLifecycles(hits)
+	return hits, nil
 }
 
 // blameToucherCap bounds how many extra sessions a blame reads from the
@@ -1454,8 +1476,10 @@ func printSources(dir string) {
 		// `deja sources` is where the empty-machine advice sends people, and a
 		// store deja is not allowed to read looked exactly like one nobody has
 		// used: `sessions=0 messages=0 size=0 B` (#1000).
-		if denied := firstDeniedDir(it.roots); denied != "" {
+		if denied, whole := firstDeniedDir(it.roots); denied != "" {
 			note = "\t(cannot be read — permission denied on " + denied + ")"
+		} else if !whole {
+			note = "\t(permissions not fully checked — too many directories to walk)"
 		}
 		if it.name == "cursor" && len(sources.CursorDBs()) > 0 && !sources.SQLite3Available() {
 			note = "\t(sqlite3 CLI not found — Cursor IDE sessions unavailable)"
@@ -1577,7 +1601,11 @@ func runForget(dir string, args []string) error {
 		}
 	}
 	if !list && unforget == "" && o.Session == "" && o.Project == "" && o.Before.IsZero() {
-		return fmt.Errorf("forget: selector required")
+		// Naming the selectors here is what separates one call from hundreds:
+		// forgetting 100 sessions one id at a time took 10.5s against 0.2s for
+		// `--project`, and nothing on this path said the second form exists
+		// (#1022).
+		return fmt.Errorf("forget: selector required — `--session <id>`, `--project <name>` or `--before <date>`; `--dry-run` shows what would go, `--list` what already went")
 	}
 	if list {
 		keys := index.Tombstones()
@@ -1946,9 +1974,27 @@ func idPrefixNeeded(dir, subject, refusal string) error {
 // found at all, the useful next step is finding out where deja looked.
 func emptyIndexHint(what string) string {
 	if noAgentHistoryFound() {
+		// "no agent history was found" is a claim about the machine, and it
+		// was made over a store deja is not allowed to open: the sessions are
+		// there, behind a permission wall doctor and sources both name (#1020).
+		if denied := deniedStoreCount(); denied > 0 {
+			return fmt.Sprintf("deja: %s — %d store%s could not be read (permission denied); `deja doctor` names %s",
+				what, denied, pluralS(denied), pluralWhich(denied))
+		}
 		return "deja: " + what + " — no agent history was found on this machine; `deja sources` shows where deja looked"
 	}
 	return "deja: " + what + " — run `deja index`, or `deja doctor` to see which agent stores were found"
+}
+
+// deniedStoreCount reports how many harness stores exist but cannot be opened.
+func deniedStoreCount() int {
+	n := 0
+	for _, check := range doctorStoreChecks() {
+		if store, _ := inspectDoctorStore(check); store.State == "denied" {
+			n++
+		}
+	}
+	return n
 }
 
 // noAgentHistoryFound reports whether the stores themselves are empty, as

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -492,7 +492,15 @@ func cmdCtx(dir string, rest []string) error {
 	// session's note arrives as an ordinary hit — and the answer still has to
 	// say the session is gone (#971).
 	noteForgottenSource(hits[0].Session, q)
-	search.PrintContext(os.Stdout, hits[0].Session, q)
+	// The hit carries the matching snippets, not the session: for a promoted
+	// note that meant the correction — which rarely repeats the words of the
+	// decision — was missing, and the command whose whole job is packaging
+	// context handed an agent a decision that had been withdrawn (#1011).
+	whole := hits[0].Session
+	if full, ok, ferr := findByPrefix(dir, whole.ID); ferr == nil && ok {
+		whole = full
+	}
+	search.PrintContext(os.Stdout, whole, q)
 	return nil
 }
 
@@ -1590,7 +1598,11 @@ func runForget(dir string, args []string) error {
 		// session; the undo restored them all and said so afterwards, while the
 		// hint printed beside the list promises one (#961).
 		if n := index.TombstoneMatches(unforget); n > 1 && !allMatches {
-			return fmt.Errorf("%q brings back %d forgotten sessions — `deja forget --list` names them; add --all-matches to restore them all", unforget, n)
+			// "`deja forget --list` names them" sends the reader to a list of
+			// everything this machine ever forgot, where the three that match
+			// are theirs to find. Name them here instead (#1014).
+			return fmt.Errorf("%q brings back %d forgotten sessions (%s) — add --all-matches to restore them all, or name one",
+				unforget, n, joinCapped(index.TombstonesMatching(unforget), 5))
 		}
 		var lifted int
 		if err := withBuildProgress(func() error {
@@ -2049,6 +2061,12 @@ func ensureError(dir string, err error) error {
 	if errors.Is(err, syscall.ENOSPC) {
 		return fmt.Errorf("no space left where the index is built (%s) — free some room there, or point DEJA_INDEX_DIR at a disk that has it", filepath.Dir(dir))
 	}
+	// Already worded where it was raised — the leftover-swap case names the
+	// directory to remove and the command to rerun, and "ensure:" in front of
+	// it is internal noise (#1009).
+	if strings.HasPrefix(err.Error(), "an earlier index swap left ") {
+		return err
+	}
 	return fmt.Errorf("ensure: %w", err)
 }
 
@@ -2237,4 +2255,13 @@ func reachableSessionCount(dir string) (int, int, bool) {
 		}
 	}
 	return reach, len(metas), true
+}
+
+// joinCapped lists at most n items and says how many it left out, so a refusal
+// stays one line on a machine with many tombstones.
+func joinCapped(items []string, n int) string {
+	if len(items) <= n {
+		return strings.Join(items, ", ")
+	}
+	return strings.Join(items[:n], ", ") + fmt.Sprintf(", +%d more", len(items)-n)
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -144,6 +144,12 @@ var commands = map[string]command{
 	"hook-antigravity": func(dir string, _ []string) error {
 		return runHookAntigravity(dir, os.Stdin, os.Stdout)
 	},
+	"hook-plan": func(dir string, _ []string) error {
+		return runHookPlan(dir, os.Stdin, os.Stdout)
+	},
+	"check": func(dir string, rest []string) error {
+		return runCheck(dir, rest, os.Stdin, os.Stdout)
+	},
 	"hook-context":    cmdHookContext,
 	"hook-precompact": func(dir string, _ []string) error { runHookPrecompact(dir); return nil },
 	"hook-refresh":    func(dir string, _ []string) error { runHookRefresh(dir); return nil },
@@ -1896,6 +1902,8 @@ Usage:
   deja handoff [--to <agent>] [id-prefix] [--exec]
   deja hook-prompt   (UserPromptSubmit hook: relevance recall per prompt)
   deja hook-antigravity (Antigravity PreInvocation hook: inject on first turn)
+  deja hook-plan     (PreToolUse ExitPlanMode hook: factual plan/history co-occurrences)
+  deja check -       (read a plan from stdin and print factual co-occurrences)
   deja view [--no-open]  (browse your memory: sessions, recalls, notes — one local HTML)
   deja ctx <query|id-prefix>
   deja blame <path> [--all] [--json] [--project name] [--harness name] [--since 30d]

--- a/cmd/deja/policy_leak_test.go
+++ b/cmd/deja/policy_leak_test.go
@@ -109,3 +109,44 @@ func TestBlameHonorsPolicy(t *testing.T) {
 		t.Fatalf("blame served policy-denied memory:\n%s", got)
 	}
 }
+
+// ctx is the command the hook tells an agent to call, and it answered from
+// sessions every other reading surface withheld (#1026).
+func TestCtxHonorsPolicy(t *testing.T) {
+	dir := policyLeakIndex(t)
+	pol := filepath.Join(t.TempDir(), "policy.json")
+	if err := os.WriteFile(pol, []byte(`{"activations":{"search":{"imported":false},"mcp":{"imported":false},"auto":{"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", pol)
+	out := captureStdout(t, func() {
+		if err := cmdCtx(dir, []string{"authentication", "middleware", "panicked"}); err == nil {
+			t.Error("ctx answered from a session the policy denies")
+		}
+	})
+	if strings.Contains(out, "ZQSECRETMARKER") {
+		t.Fatalf("ctx served policy-denied memory:\n%s", out)
+	}
+	// The id-prefix branch takes its own path to the same session.
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := ""
+	for _, m := range metas {
+		if strings.HasPrefix(m.Project, "imported:") && len(m.ID) >= 6 {
+			id = m.ID
+		}
+	}
+	if id == "" {
+		t.Fatal("no imported session with an id long enough for the prefix branch")
+	}
+	out = captureStdout(t, func() {
+		if err := cmdCtx(dir, []string{id}); err == nil {
+			t.Error("ctx by id answered from a session the policy denies")
+		}
+	})
+	if strings.Contains(out, "ZQSECRETMARKER") {
+		t.Fatalf("ctx by id served policy-denied memory:\n%s", out)
+	}
+}

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -61,7 +61,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 		}
 	}
 	if prefix == "" {
-		return fmt.Errorf("promote needs a session id prefix (see `deja last`)")
+		return idPrefixNeeded(dir, "promote needs a session id prefix", "promote needs a session id prefix (see `deja last`)")
 	}
 	if !sources.NoteStates[state] {
 		// Taking a mark back is the state nobody guesses: users reach for
@@ -347,6 +347,19 @@ func endsWithNewline(path string) bool {
 		return true
 	}
 	return buf[0] == '\n'
+}
+
+// promotedNoteSources maps every promoted note's id to the session it came
+// from, in one pass over the note log.
+func promotedNoteSources() map[string]string {
+	out := map[string]string{}
+	for _, n := range sources.LoadPromotedNotes() {
+		if n.Session == "" {
+			continue
+		}
+		out["deja-note-"+strings.ReplaceAll(n.Session, ":", "-")] = n.Session
+	}
+	return out
 }
 
 // promotedNoteSource maps a promoted note's id back to the session it was

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -14,6 +14,15 @@ func runShare(dir string, args []string, w io.Writer) error {
 	if len(args) < 1 {
 		return idPrefixNeeded(dir, "share needs an id-prefix", "share needs id-prefix")
 	}
+	// Everything after the id used to be ignored, so `deja share <id> --to
+	// out.md` printed the share to the terminal and wrote no file — and said
+	// nothing about either (#1002). promote refuses unknown flags; this is the
+	// same command shape one letter away.
+	for _, a := range args[1:] {
+		if strings.HasPrefix(a, "-") {
+			return fmt.Errorf("share: unknown flag %q — share writes to stdout (redirect it), and `deja promote <id> --to <path>` is the one that writes a file", a)
+		}
+	}
 	s, ok, err := findByPrefix(dir, args[0])
 	noteAmbiguousPrefix(dir, args[0], "sharing")
 	if err != nil {

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -12,7 +12,7 @@ import (
 
 func runShare(dir string, args []string, w io.Writer) error {
 	if len(args) < 1 {
-		return fmt.Errorf("share needs id-prefix")
+		return idPrefixNeeded(dir, "share needs an id-prefix", "share needs id-prefix")
 	}
 	s, ok, err := findByPrefix(dir, args[0])
 	noteAmbiguousPrefix(dir, args[0], "sharing")

--- a/cmd/deja/share_test.go
+++ b/cmd/deja/share_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// promote writes a file with --to; share takes no flags and dropped them, so
+// `deja share <id> --to out.md` printed to the terminal, wrote nothing, and
+// said neither (#1002).
+func TestShareRefusesFlagsItCannotHonour(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(tmp, "out.md")
+	_, err := captureRun(t, "share", "loc", "--to", out)
+	if err == nil {
+		t.Fatalf("share accepted a flag it does not implement, and wrote nothing")
+	}
+	if !strings.Contains(err.Error(), "unknown flag") || !strings.Contains(err.Error(), "promote") {
+		t.Errorf("the refusal does not say what to use instead: %v", err)
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Errorf("share wrote a file after refusing")
+	}
+
+	// The ordinary share is untouched.
+	got, err := captureRun(t, "share", "loc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "deja share: loc") {
+		t.Errorf("plain share stopped working:\n%s", got)
+	}
+}

--- a/cmd/deja/sources_denied_test.go
+++ b/cmd/deja/sources_denied_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// `deja sources` is the command the empty-machine advice names, and a store
+// deja is not allowed to read looked exactly like one nobody has used —
+// `sessions=0 messages=0 size=0 B` and nothing else (#1000).
+func TestSourcesSaysWhenAStoreCannotBeRead(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	tmp := hermeticEnv(t)
+	qwen := filepath.Join(tmp, "qwen")
+	projects := filepath.Join(qwen, "projects", "p1")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projects, "s.json"), []byte(`{"x":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_QWEN_ROOT", qwen)
+
+	out, err := captureRun(t, "sources")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line := storeLine(out, "qwen"); strings.Contains(line, "cannot be read") {
+		t.Fatalf("a readable store was reported as locked: %q", line)
+	}
+
+	if err := os.Chmod(filepath.Join(qwen, "projects"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(qwen, "projects"), 0o755) })
+
+	out, err = captureRun(t, "sources")
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := storeLine(out, "qwen")
+	if !strings.Contains(line, "cannot be read") {
+		t.Errorf("a locked store reads as an empty one: %q", line)
+	}
+	if !strings.Contains(line, "permission denied") {
+		t.Errorf("the line does not say why: %q", line)
+	}
+	// Every other store keeps its plain row.
+	if l := storeLine(out, "claude"); strings.Contains(l, "cannot be read") {
+		t.Errorf("an untouched store picked up the note: %q", l)
+	}
+}
+
+func storeLine(out, name string) string {
+	for _, l := range strings.Split(out, "\n") {
+		if strings.HasPrefix(l, name+"\t") {
+			return l
+		}
+	}
+	return ""
+}

--- a/cmd/deja/stale_readonly_note_test.go
+++ b/cmd/deja/stale_readonly_note_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// An index that is behind and cannot be written stays behind. search names the
+// state; the hook told the agent it "starts already knowing" a picture missing
+// today's work, and MCP answered a confident negative about work that is on
+// disk (#1005).
+func TestTheAgentIsToldWhenTheIndexCannotCatchUp(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Join(tmp, "locked")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(parent, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Current and writable: nothing to say, on either surface.
+	if note := staleReadOnlyNote(dir); note != "" {
+		t.Errorf("a healthy index produced a warning: %q", note)
+	}
+	if got := emptyRecallAnswer(dir, "nothing"); !strings.Contains(got, "No prior deja sessions matched") {
+		t.Errorf("the ordinary empty answer changed: %q", got)
+	}
+
+	// A session deja cannot index, and nowhere to write the result.
+	newer := `{"type":"user","message":{"role":"user","content":"a session added after the parent was locked"},"timestamp":"2026-08-04T12:00:00Z","sessionId":"new","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "new.jsonl"), []byte(newer), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	note := staleReadOnlyNote(dir)
+	if !strings.Contains(note, "cannot be updated") {
+		t.Errorf("the hook says nothing about an index that cannot catch up: %q", note)
+	}
+	if !strings.Contains(note, parent) {
+		t.Errorf("the note does not name what to change: %q", note)
+	}
+	got := emptyRecallAnswer(dir, "third session")
+	if strings.Contains(got, "No prior deja sessions matched") {
+		t.Errorf("MCP answers a confident negative over an index that cannot catch up: %q", got)
+	}
+	if !strings.Contains(got, "may be missing") {
+		t.Errorf("the MCP answer does not say what it might be missing: %q", got)
+	}
+
+	// Writable again — even while stale — is the ordinary case: the build will
+	// happen on the next command, so neither surface warns.
+	if err := os.Chmod(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if note := staleReadOnlyNote(dir); note != "" {
+		t.Errorf("a stale but writable index warned anyway: %q", note)
+	}
+}

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -140,6 +140,7 @@ func runStats(dir string, args []string) error {
 	// The rule that emptied the report is named a line above, so "nothing
 	// indexed yet — run `deja index`" is advice for a state deja is not in:
 	// the same backside `last` grew when it learned to filter (#949, #983).
+	report.PolicyWithheld = policyHidden
 	report.EmptiedByPolicy = report.TotalSessions == 0 && policyHidden > 0
 	if report.TotalSessions == 0 {
 		report.HiddenBySettings = hiddenByOwnSettings()

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -112,14 +112,20 @@ func runStats(dir string, args []string) error {
 		progress = io.Discard
 	}
 	if err := index.Ensure(dir, "", false, progress); err != nil {
-		return err
+		// `mkdir …/idx.tmp: permission denied` names a path nobody chose and a
+		// syscall nobody can act on. index and search have worded this since
+		// #798; stats was the one screen still handing it back raw (#1004).
+		return ensureError(dir, err)
 	}
 	if redaction {
 		return printRedactionReport(dir, jsonOut)
 	}
 	ss, err := index.SearchWithRecovery(dir, search.Options{All: true}, progress)
 	if err != nil {
-		return err
+		// `mkdir …/idx.tmp: permission denied` names a path nobody chose and a
+		// syscall nobody can act on. index and search have worded this since
+		// #798; stats was the one screen still handing it back raw (#1004).
+		return ensureError(dir, err)
 	}
 	// stats is the one screen deja calls "wrapped for sharing", and it was
 	// naming projects the trust policy keeps off every other surface — the
@@ -135,6 +141,9 @@ func runStats(dir string, args []string) error {
 	// indexed yet — run `deja index`" is advice for a state deja is not in:
 	// the same backside `last` grew when it learned to filter (#949, #983).
 	report.EmptiedByPolicy = report.TotalSessions == 0 && policyHidden > 0
+	if report.TotalSessions == 0 {
+		report.HiddenBySettings = hiddenByOwnSettings()
+	}
 	// Replaced spans are kept out of ordinary retrieval, so they are not in
 	// the sessions above and take a pass of their own.
 	if spans, files, err := index.SpanInventory(dir); err == nil {
@@ -231,6 +240,10 @@ func printStats(w io.Writer, r stats.Report) {
 			// The rule is named on stderr a line above; repeating "run `deja
 			// index`" here sends the reader after a build that changes nothing.
 			fmt.Fprintln(w, "deja: nothing to report — the trust policy withholds every indexed session from this path")
+			return
+		}
+		if r.HiddenBySettings != "" {
+			fmt.Fprint(w, "deja: nothing indexed yet\n"+r.HiddenBySettings)
 			return
 		}
 		fmt.Fprintln(w, emptyIndexHint("nothing indexed yet"))

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/vshulcz/deja-vu/internal/index"
 	"io"
 	"os"
 	"strings"
 
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
@@ -37,6 +38,14 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 		} else {
 			fmt.Fprint(stdout, "deja · indexing your history · recall comes online in a few seconds")
 		}
+		return nil
+	}
+	// A rule that activates nothing turns memory off everywhere, and the line
+	// people always have on screen read the same as an ordinary quiet day:
+	// "no recalls yet today" is true and says nothing about why it will stay
+	// true (#1012).
+	if policy.Load().Describe(policy.ActivationAuto) == "nothing activates" {
+		fmt.Fprint(stdout, withFileMemory(dir, in, "deja · off here · the trust policy activates nothing (`deja doctor`)"))
 		return nil
 	}
 	recalls, bytes, injected := usage.TodayWithInjections(dir)

--- a/cmd/deja/statusline_policy_off_test.go
+++ b/cmd/deja/statusline_policy_off_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A rule that activates nothing turns recall off everywhere, and the line
+// people always have on screen read like an ordinary quiet day — true today,
+// and still true tomorrow for a reason nothing named (#1012).
+func TestStatuslineSaysWhenAPolicyTurnsMemoryOff(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := runStatusline(dir, strings.NewReader("{}"), &out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "off here") {
+		t.Errorf("an unrestricted machine was called off: %q", out.String())
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"auto":{"local":false,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	out.Reset()
+	if err := runStatusline(dir, strings.NewReader("{}"), &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if strings.Contains(got, "no recalls yet today") {
+		t.Errorf("a machine with recall switched off reads as a quiet day: %q", got)
+	}
+	if !strings.Contains(got, "trust policy") {
+		t.Errorf("the line does not name what switched it off: %q", got)
+	}
+
+	// A rule that narrows the auto path is not the same as switching it off:
+	// local sessions still reach the agent.
+	if err := os.WriteFile(policyFile, []byte(`{"activations":{"auto":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	if err := runStatusline(dir, strings.NewReader("{}"), &out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "off here") {
+		t.Errorf("a narrowed search path was reported as memory off: %q", out.String())
+	}
+}

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -123,6 +125,11 @@ func runSync(dir string, args []string) error {
 		if own := index.ImportSkippedOwn(); own > 0 {
 			fmt.Fprintf(os.Stdout, "deja: %d record%s were already here word for word — this folder holds a copy of what this machine has\n", own, pluralS(own))
 		}
+		// The count is a fact about this machine's memory, not about one
+		// terminal moment: a peer who keeps sending sessions you forgot drops
+		// records on every sync, and only the line below said so — gone the
+		// moment the terminal scrolls (#1016).
+		recordLastImport(dir, n, index.ImportSkippedForgotten(), index.ImportSkippedOwn())
 		if skipped := index.ImportSkippedForgotten(); skipped > 0 {
 			fmt.Fprintf(os.Stdout, "deja: %d record%s left out — they belong to sessions you forgot here (`deja forget --list`)\n", skipped, pluralS(skipped))
 		}
@@ -156,4 +163,34 @@ func hasSyncBatches(out string) bool {
 		}
 	}
 	return false
+}
+
+// lastImport is the one-line summary doctor reads back.
+type lastImport struct {
+	At      time.Time `json:"at"`
+	Records int       `json:"records"`
+	Forgot  int       `json:"forgotten_left_out,omitempty"`
+	Own     int       `json:"already_here,omitempty"`
+}
+
+func lastImportPath(dir string) string { return dir + ".lastimport" }
+
+func recordLastImport(dir string, records, forgot, own int) {
+	b, err := json.Marshal(lastImport{At: time.Now(), Records: records, Forgot: forgot, Own: own})
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(lastImportPath(dir), b, 0o600)
+}
+
+func readLastImport(dir string) (lastImport, bool) {
+	b, err := os.ReadFile(lastImportPath(dir))
+	if err != nil {
+		return lastImport{}, false
+	}
+	var li lastImport
+	if json.Unmarshal(b, &li) != nil || li.At.IsZero() {
+		return lastImport{}, false
+	}
+	return li, true
 }

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "goose",
-      "state": "missing",
+      "state": "unplugged",
       "paths": [
         "<tmp>/home/.local/share/goose/sessions"
       ],
@@ -102,7 +102,7 @@
     },
     {
       "name": "pi",
-      "state": "missing",
+      "state": "unplugged",
       "paths": [
         "<tmp>/home/.pi/agent/sessions"
       ],
@@ -122,6 +122,20 @@
       "paths": [
         "<tmp>/copilot"
       ],
+      "files": 0
+    },
+    {
+      "name": "cline",
+      "state": "unplugged",
+      "paths": [
+        "<tmp>/home/.cline/data/sessions"
+      ],
+      "files": 0
+    },
+    {
+      "name": "roo",
+      "state": "missing",
+      "paths": null,
       "files": 0
     },
     {

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -235,5 +235,24 @@
     "state": "update-available",
     "current": "1.0.0",
     "latest": "2.0.0"
+  },
+  "policy": {
+    "state": "default",
+    "path": "<tmp>/home/.config/deja/policy.json",
+    "indexed_sessions": 0,
+    "activations": {
+      "auto": {
+        "rule": "local+imported",
+        "withheld": 0
+      },
+      "mcp": {
+        "rule": "local+imported",
+        "withheld": 0
+      },
+      "search": {
+        "rule": "local+imported",
+        "withheld": 0
+      }
+    }
   }
 }

--- a/cmd/deja/unforget_names_test.go
+++ b/cmd/deja/unforget_names_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// "`deja forget --list` names them" sent the reader to a list of everything the
+// machine ever forgot, where the ones the refusal meant were theirs to find
+// (#1014).
+func TestUnforgetRefusalNamesTheSessionsItMeans(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"sess0", "sess1", "sess2", "alpha", "beta"} {
+		rec := `{"type":"user","message":{"role":"user","content":"session ` + id + `"},"timestamp":"2026-08-01T10:00:00Z","sessionId":"` + id + `","cwd":"/proj"}` + "\n"
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(rec), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"sess0", "sess1", "sess2", "alpha", "beta"} {
+		if _, err := captureRun(t, "forget", "--session", id); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := captureRun(t, "forget", "--unforget", "claude:sess")
+	if err == nil {
+		t.Fatal("an ambiguous selector was accepted")
+	}
+	for _, want := range []string{"claude:sess0", "claude:sess1", "claude:sess2"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not name %s: %v", want, err)
+		}
+	}
+	// And not the ones it does not mean.
+	if strings.Contains(err.Error(), "claude:alpha") {
+		t.Errorf("the refusal named a session it would not restore: %v", err)
+	}
+	// Naming one still works.
+	if _, err := captureRun(t, "forget", "--unforget", "claude:sess1"); err != nil {
+		t.Errorf("naming one of them was refused: %v", err)
+	}
+}

--- a/cmd/deja/unwritable_index_states_test.go
+++ b/cmd/deja/unwritable_index_states_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// One state, three stories: search worded it, stats handed back the syscall,
+// and doctor called it ordinary staleness and advised the one command that
+// cannot succeed here (#1004).
+func TestAnUnwritableIndexReadsTheSameEverywhere(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"local work on the ticker window"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"loc","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "loc.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Join(tmp, "locked")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(parent, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// A store that changed after the build, and no way to write the result.
+	newer := `{"type":"user","message":{"role":"user","content":"a session added after the parent was locked"},"timestamp":"2026-08-04T12:00:00Z","sessionId":"new","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "new.jsonl"), []byte(newer), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	_, err := captureRun(t, "stats")
+	if err == nil {
+		t.Fatal("stats did not fail on an index it cannot write")
+	}
+	if strings.Contains(err.Error(), "mkdir") || strings.Contains(err.Error(), ".tmp") {
+		t.Errorf("stats hands back the syscall: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cannot write the index") {
+		t.Errorf("stats does not word the failure like the other paths: %v", err)
+	}
+
+	var out bytes.Buffer
+	doctorIndexSection(t, &out, dir)
+	line := ""
+	for _, l := range strings.Split(out.String(), "\n") {
+		if strings.Contains(l, "freshness") {
+			line = l
+		}
+	}
+	if !strings.Contains(line, "cannot be written") {
+		t.Errorf("doctor calls an unwritable index ordinarily stale: %q", line)
+	}
+	if strings.Contains(line, "run `deja index`") {
+		t.Errorf("doctor advises the command that fails in this state: %q", line)
+	}
+
+	// With the directory writable again the ordinary advice comes back.
+	if err := os.Chmod(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	doctorIndexSection(t, &out, dir)
+	if !strings.Contains(out.String(), "run `deja index`") {
+		t.Errorf("a writable index lost the advice that fits it:\n%s", out.String())
+	}
+}
+
+func doctorIndexSection(t *testing.T, out *bytes.Buffer, dir string) {
+	t.Helper()
+	if err := runDoctor(out, nil, stubLookup("1.0.0", true), dir); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/deja/warmup_status.go
+++ b/cmd/deja/warmup_status.go
@@ -197,5 +197,12 @@ func emptyRecallAnswerPolicy(dir, q string, hidden int) string {
 		return fmt.Sprintf("%d prior session%s matched %q, but this machine's trust policy (%s) does not allow them on this path. There is prior work here; it is not being shown.",
 			hidden, pluralS(hidden), q, policy.Load().Describe(policy.ActivationMCP))
 	}
+	// A confident negative over an index that is behind and cannot catch up:
+	// the session is on disk, deja simply could not add it. The hook says this
+	// at session start; over MCP it is the only place to say it (#1005).
+	if !indexCanCatchUp(dir) {
+		return fmt.Sprintf("No indexed session matched %q — the index is behind and cannot be updated (%s is not writable), so recent work may be missing from this answer.",
+			q, filepath.Dir(dir))
+	}
 	return fmt.Sprintf("No prior deja sessions matched %q.", q)
 }

--- a/cmd/deja/warmup_status.go
+++ b/cmd/deja/warmup_status.go
@@ -154,6 +154,25 @@ func (s *warmupStatus) line() string {
 	return fmt.Sprintf("deja: indexing your history (%s%s) — recall comes online in a few seconds", phase, pct)
 }
 
+// publishBuildProgress installs the file sink for the work that happens before
+// the build proper — the freshness walk over every store, which on a slow
+// volume is the longest part of the command. It published nothing until the
+// build began, so every "memory is on its way" surface said nothing meanwhile.
+// Measured on 6000 sessions: first published at 0.76s before, 0.02s after
+// (#1021).
+func publishBuildProgress(dir string) func() {
+	if os.Getenv("DEJA_WARMUP_SENTINEL") == "" {
+		return func() {}
+	}
+	p := newFileProgress(dir)
+	p.flush(true)
+	index.SetProgress(p)
+	return func() {
+		index.SetProgress(nil)
+		p.done()
+	}
+}
+
 // withWarmupStatus publishes progress while fn builds, when this process is
 // the detached warmup.
 func withWarmupStatus(dir string, fn func() error) error {
@@ -161,6 +180,10 @@ func withWarmupStatus(dir string, fn func() error) error {
 		return fn()
 	}
 	p := newFileProgress(dir)
+	// Publish before the build starts: the walk over the stores comes first
+	// and, on a slow volume, takes the longest, so waiting for its first
+	// report left every "memory is on its way" surface saying nothing (#1021).
+	p.flush(true)
 	index.SetProgress(p)
 	err := fn()
 	index.SetProgress(nil)

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -30,8 +30,9 @@ from a list of hits:
   used to be readable only as a sentence on stderr.
 - `total` and `capped` — how many sessions matched, and whether a cap hid some.
 - `policy_withheld` — how many matching sessions this machine's trust policy
-  kept out of the answer. Omitted when none were. Present on `search --json`
-  and `last --json`, so an empty result can be told apart from a rule.
+  kept out of the answer. Omitted when none were. Present on `search --json`,
+  `last --json` and `stats --json`, so an empty result can be told apart from a
+  rule.
   Counting the returned hits measures the cap: that figure moves when the
   window's membership changes, whether or not retrieval improved.
   **`capped: false` means the response holds everything that matched, on every

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -29,6 +29,9 @@ from a list of hits:
   sessions deja could find. Counting those as hits overstates recall, and this
   used to be readable only as a sentence on stderr.
 - `total` and `capped` — how many sessions matched, and whether a cap hid some.
+- `policy_withheld` — how many matching sessions this machine's trust policy
+  kept out of the answer. Omitted when none were. Present on `search --json`
+  and `last --json`, so an empty result can be told apart from a rule.
   Counting the returned hits measures the cap: that figure moves when the
   window's membership changes, whether or not retrieval improved.
   **`capped: false` means the response holds everything that matched, on every

--- a/internal/index/import_ord_test.go
+++ b/internal/index/import_ord_test.go
@@ -1,0 +1,90 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Every new session asked nextSessionOrd for its ordinal, and that walks the
+// whole manifest — so importing n sessions cost O(n²): a 100k batch took 306s
+// against 1.9s for forgetting the same 100k (#1024).
+func TestImportedOrdinalsAreDistinctAndCheap(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	dir := filepath.Join(tmp, "index.db")
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var body []byte
+	const n = 300
+	for i := 0; i < n; i++ {
+		b, err := json.Marshal(SyncRecord{Harness: "claude", SessionID: fixedID(i), Project: "work/api",
+			Role: "user", Text: "record about the pool cap"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		body = append(append(body, b...), '\n')
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync.jsonl"), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := Import(dir, exp); err != nil || got != n {
+		t.Fatalf("import: %d records, %v", got, err)
+	}
+
+	// The ordinal is what postings point at, so a repeat would merge two
+	// sessions' hits into one row.
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[uint32]string{}
+	for _, m := range metas {
+		if prev, ok := seen[m.Ord]; ok {
+			t.Fatalf("sessions %s and %s share ordinal %d", prev, m.ID, m.Ord)
+		}
+		seen[m.Ord] = m.ID
+	}
+	if len(seen) != n {
+		t.Errorf("got %d distinct ordinals for %d sessions", len(seen), n)
+	}
+
+	// A second batch continues above the first rather than colliding with it.
+	body = nil
+	for i := n; i < n+50; i++ {
+		b, _ := json.Marshal(SyncRecord{Harness: "claude", SessionID: fixedID(i), Project: "work/api",
+			Role: "user", Text: "another record"})
+		body = append(append(body, b...), '\n')
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-2.jsonl"), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(dir, exp); err != nil {
+		t.Fatal(err)
+	}
+	metas, err = AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen = map[uint32]string{}
+	for _, m := range metas {
+		if prev, ok := seen[m.Ord]; ok {
+			t.Fatalf("after the second batch, %s and %s share ordinal %d", prev, m.ID, m.Ord)
+		}
+		seen[m.Ord] = m.ID
+	}
+	if len(seen) != n+50 {
+		t.Errorf("got %d distinct ordinals for %d sessions", len(seen), n+50)
+	}
+}
+
+func fixedID(i int) string {
+	const digits = "0123456789"
+	return "s" + string([]byte{digits[i/100%10], digits[i/10%10], digits[i%10]})
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -297,3 +297,21 @@ type bucketEntry struct {
 	off uint64
 	n   uint32
 }
+
+// LockWaitNotice is called once when a write path finds the index locked by
+// another deja and is about to wait for it. Readers never reach it — they take
+// a lock-free snapshot instead — so this is only the case where a command is
+// about to sit still for the length of someone else's build.
+var LockWaitNotice func()
+
+// noteLockWait reports the wait at most once per process, so a command that
+// takes several locks does not repeat itself.
+func noteLockWait() {
+	if LockWaitNotice == nil || lockWaitNoted {
+		return
+	}
+	lockWaitNoted = true
+	LockWaitNotice()
+}
+
+var lockWaitNoted bool

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1863,6 +1863,11 @@ func currentFilesStat(h string) map[string]FileState {
 }
 
 func currentFilesWith(h string, old map[string]FileState) map[string]FileState {
+	// Walking the stores is the first thing a build does and, on a network
+	// volume, the slowest: it published nothing, so every "memory is on its
+	// way" surface reported an ordinary quiet day until the walk finished
+	// (#1021).
+	reportPhase("finding transcripts", 0)
 	paths := map[string]bool{}
 	for _, hr := range sources.Registry() {
 		if h != "" && h != hr.Name {

--- a/internal/index/lock_unix.go
+++ b/internal/index/lock_unix.go
@@ -22,9 +22,15 @@ func lockDir(dir string) (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		f.Close()
-		return nil, fmt.Errorf("lock index: %w", err)
+	// Try without blocking first, only to learn whether there is a wait to
+	// report: a reader that lands mid-rebuild sits here for the length of it
+	// and printed nothing, so the command looked hung (#994).
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		noteLockWait()
+		if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+			f.Close()
+			return nil, fmt.Errorf("lock index: %w", err)
+		}
 	}
 	// Under the lock: finish any swap interrupted mid-rename. Running this
 	// before the flock raced a concurrent swap's missing-dir window (#181).

--- a/internal/index/lock_wait_test.go
+++ b/internal/index/lock_wait_test.go
@@ -1,0 +1,58 @@
+package index
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// deja narrates its own builds line by line and said nothing while waiting for
+// someone else's, so a command that landed mid-rebuild sat silent for the
+// length of it and read as hung (#994).
+func TestWaitingForAnotherBuildIsReportedOnce(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Byte-range locks are per handle there and the second lockDir in one
+		// process is a different case than two processes; the notice itself is
+		// platform-independent.
+		t.Skip("two locks in one process do not model contention on windows")
+	}
+	dir := filepath.Join(t.TempDir(), "index.db")
+	notices := 0
+	old := LockWaitNotice
+	LockWaitNotice = func() { notices++ }
+	t.Cleanup(func() { LockWaitNotice = old; lockWaitNoted = false })
+
+	// A free lock is the ordinary case and must stay quiet.
+	unlock, err := lockDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if notices != 0 {
+		t.Fatalf("an uncontended lock reported a wait: %d", notices)
+	}
+
+	// Held by someone else: the notice fires before the wait.
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		unlock()
+		close(done)
+	}()
+	second, err := lockDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-done
+	second()
+	if notices != 1 {
+		t.Errorf("the wait was not reported exactly once: %d", notices)
+	}
+
+	// A command takes several locks; the reader is told once, not per lock.
+	lockWaitNoted = true
+	noteLockWait()
+	if notices != 1 {
+		t.Errorf("the notice repeated itself: %d", notices)
+	}
+}

--- a/internal/index/lock_windows.go
+++ b/internal/index/lock_windows.go
@@ -36,6 +36,19 @@ func lockDir(dir string) (func(), error) {
 	}
 	h := syscall.Handle(f.Fd())
 	var ol syscall.Overlapped
+	// The probe takes its own handle: a failed LOCKFILE_FAIL_IMMEDIATELY on
+	// the handle we are about to block with leaves the lock state on it
+	// ambiguous, and the blocking call that follows never returned. Only to
+	// learn whether there is a wait worth reporting — see lock_unix.go (#994).
+	if probe, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600); err == nil {
+		var pol syscall.Overlapped
+		if lockFileEx(syscall.Handle(probe.Fd()), lockfileExclusiveLock|lockfileFailImmediately, 0, 1, 0, &pol) != nil {
+			noteLockWait()
+		} else {
+			_ = unlockFileEx(syscall.Handle(probe.Fd()), 0, 1, 0, &pol)
+		}
+		_ = probe.Close()
+	}
 	if err := lockFileEx(h, lockfileExclusiveLock, 0, 1, 0, &ol); err != nil {
 		f.Close()
 		return nil, fmt.Errorf("lock index: %w", err)

--- a/internal/index/plan.go
+++ b/internal/index/plan.go
@@ -1,0 +1,474 @@
+package index
+
+import (
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// PlanCooccurrence is one factual join between a recurring wall and a plan
+// step's informative terms. The wall side is the claim: a full census found
+// a matching command logged alongside the wall in only 1 of 19 carriers (74%
+// of carriers have zero command records at all), so requiring one would
+// reject nearly every real recurrence. Command and CommandSessions are a
+// strengthening when a matching command happens to exist, not a
+// precondition — Command is "" when none was found.
+type PlanCooccurrence struct {
+	Wall            Friction
+	Command         string
+	CommandSessions []SessionMeta
+}
+
+type planWallCluster struct {
+	hash  uint64
+	metas []SessionMeta
+}
+
+type planIndexedTerm struct {
+	text     string
+	sessions map[uint32]bool
+}
+
+// planIdentifierIDFFloor is the informativeness bar for an identifier-shaped
+// plan term — lower than dejaVuIDFFloor, but not zero. A census of 2,886 real
+// sessions found identifier-shaped false-positive anchors (cannot, directory,
+// branch, runner) topping out at idf 0.70, while true anchors (hermes 1.09,
+// hermes-agent 1.21) started at 1.09; this floor sits in the gap.
+const planIdentifierIDFFloor = 1.0
+
+// PlanFrictionMatches joins existing manifest wall hashes to a plan step's
+// informative terms — the wall text naming one of them is the finding; a
+// matching command record is looked up too but only strengthens it (see
+// PlanCooccurrence). keep is applied before any session is materialized, so
+// callers can enforce activation policy without denied text crossing the
+// boundary.
+//
+// The index is read as-is. This function never builds, repairs, or refreshes
+// it.
+func PlanFrictionMatches(dir string, steps [][]string, keep func(SessionMeta) bool, limit int) []PlanCooccurrence {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	if len(steps) == 0 {
+		return nil
+	}
+
+	unlock, locked, err := tryLockDir(dir)
+	if err != nil {
+		return nil
+	}
+	if locked {
+		defer unlock()
+	}
+
+	manifest, err := readManifestCached(dir)
+	if err != nil || len(manifest.Sessions) == 0 || !recordsIntact(dir, manifest) {
+		return nil
+	}
+
+	clusters := planWallClusters(manifest, keep)
+	if len(clusters) == 0 {
+		return nil
+	}
+
+	indexedSteps, candidates, needs := planIndexedSteps(dir, manifest, steps)
+	if len(indexedSteps) == 0 {
+		return nil
+	}
+
+	// The first cut is manifest and posting only: a wall survives when one of
+	// its carrier sessions has at least the plan step's informative-term
+	// floor. carriers records, per eligible cluster, which of its own metas
+	// were the ones that actually matched — not the whole cluster — so the
+	// session read below stays scoped to what earned it.
+	var eligible []planWallCluster
+	carriers := map[uint64][]SessionMeta{}
+	for _, cluster := range clusters {
+		var hit []SessionMeta
+		for _, meta := range cluster.metas {
+			for step := range indexedSteps {
+				if candidates[step][meta.Ord] {
+					hit = append(hit, meta)
+					break
+				}
+			}
+		}
+		if len(hit) > 0 {
+			eligible = append(eligible, cluster)
+			carriers[cluster.hash] = hit
+		}
+	}
+	if len(eligible) == 0 {
+		return nil
+	}
+
+	// Wall text recovery reads full sessions too, but only this cluster's
+	// own carriers and it stops at the first hit — cheaper than
+	// materializing every candidate session for a command search that most
+	// carriers will never satisfy. Doing it first lets the mandatory
+	// cooccurrence check (the wall text itself naming a plan term) prune the
+	// set before the command pass touches anything.
+	type wallHit struct {
+		cluster planWallCluster
+		text    string
+	}
+	var hits []wallHit
+	candidateMetas := map[string]SessionMeta{}
+	for _, cluster := range eligible {
+		wanted := map[uint64]string{cluster.hash: ""}
+		frictionTexts(dir, manifest, cluster.metas, wanted, cluster.hash)
+		text := wanted[cluster.hash]
+		if text == "" || !planWallSharesTerm(text, indexedSteps) {
+			continue
+		}
+		hits = append(hits, wallHit{cluster: cluster, text: text})
+		for _, meta := range carriers[cluster.hash] {
+			candidateMetas[meta.Harness+":"+meta.ID] = meta
+		}
+	}
+	if len(hits) == 0 {
+		return nil
+	}
+
+	metas := make([]SessionMeta, 0, len(candidateMetas))
+	for _, meta := range candidateMetas {
+		metas = append(metas, meta)
+	}
+	sort.Slice(metas, func(i, j int) bool {
+		return newestFirstMeta(metas[i], metas[j])
+	})
+
+	sessions, err := sessionsForMetas(dir, metas)
+	if err != nil {
+		return nil
+	}
+
+	// No hash-to-command index exists. Materialize only sessions carrying a
+	// wall that already cleared the cooccurrence check, then look for a
+	// stored command carrying the same step's informative terms. This is a
+	// strengthening pass: a step with no matching command simply leaves
+	// Command empty, it does not drop the finding (see PlanCooccurrence).
+	commands := map[string]map[int]string{}
+	for i, session := range sessions {
+		if i >= len(metas) {
+			break
+		}
+		meta := metas[i]
+		key := meta.Harness + ":" + meta.ID
+		for step, terms := range indexedSteps {
+			if !candidates[step][meta.Ord] {
+				continue
+			}
+			if command := planCommandForStep(session, terms, needs[step]); command != "" {
+				if commands[key] == nil {
+					commands[key] = map[int]string{}
+				}
+				commands[key][step] = command
+			}
+		}
+	}
+
+	var out []PlanCooccurrence
+	for _, hit := range hits {
+		command, commandSessions := planWallCommand(
+			hit.text, hit.cluster, indexedSteps, commands,
+		)
+
+		out = append(out, PlanCooccurrence{
+			Wall: Friction{
+				Text:     hit.text,
+				Sessions: hit.cluster.metas,
+				Last:     hit.cluster.metas[0].Updated,
+			},
+			Command:         command,
+			CommandSessions: commandSessions,
+		})
+		if limit > 0 && len(out) == limit {
+			break
+		}
+	}
+	return out
+}
+
+// planWallSharesTerm reports whether the wall's own text names one of the
+// plan's informative terms. This is the cooccurrence claim itself, so unlike
+// a command match it is never optional.
+func planWallSharesTerm(wallText string, steps [][]planIndexedTerm) bool {
+	for _, terms := range steps {
+		for _, term := range terms {
+			if planTextHasTerm(wallText, term.text) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func planWallClusters(manifest Manifest, keep func(SessionMeta) bool) []planWallCluster {
+	byHash := map[uint64][]SessionMeta{}
+	for _, meta := range manifest.Sessions {
+		if keep != nil && !keep(meta) {
+			continue
+		}
+		for _, hash := range meta.Hit {
+			byHash[hash] = append(byHash[hash], meta)
+		}
+	}
+
+	var clusters []planWallCluster
+	for hash, metas := range byHash {
+		if len(metas) < FrictionMinSessions {
+			continue
+		}
+		sort.Slice(metas, func(i, j int) bool {
+			return newestFirstMeta(metas[i], metas[j])
+		})
+		clusters = append(clusters, planWallCluster{hash: hash, metas: metas})
+	}
+	sort.Slice(clusters, func(i, j int) bool {
+		if len(clusters[i].metas) != len(clusters[j].metas) {
+			return len(clusters[i].metas) > len(clusters[j].metas)
+		}
+		left, right := clusters[i].metas[0], clusters[j].metas[0]
+		if !left.Updated.Equal(right.Updated) {
+			return left.Updated.After(right.Updated)
+		}
+		return clusters[i].hash < clusters[j].hash
+	})
+	return clusters
+}
+
+func planIndexedSteps(dir string, manifest Manifest, steps [][]string) ([][]planIndexedTerm, []map[uint32]bool, []int) {
+	var indexed [][]planIndexedTerm
+	var candidates []map[uint32]bool
+	var needs []int
+	totalDocs := float64(len(manifest.Sessions)) + 1
+
+	for _, step := range steps {
+		// A step naming an identifier is as specific on one word as an
+		// ordinary step is on two — cmd/deja's hook-prompt path already
+		// trusts a lone identifier hit, and this join follows the same call
+		// so a plan step doesn't need a stronger bar than a prompt does.
+		need := 2
+		if planHasIdentifierTerm(step) {
+			need = 1
+		}
+
+		seen := map[string]bool{}
+		var terms []planIndexedTerm
+		for _, raw := range step {
+			term := strings.ToLower(strings.TrimSpace(raw))
+			if term == "" || seen[term] {
+				continue
+			}
+			seen[term] = true
+
+			sessions := planTermSessions(dir, term)
+			if len(sessions) == 0 {
+				continue
+			}
+			// A wall's own vocabulary is repeated-work vocabulary, so it is
+			// common by construction — a census against the real corpus
+			// measured "hermes" at idf 1.10 and "pytest" at idf 1.23, both
+			// under the full floor, and every one of ~14 known-good plan
+			// recurrences was lost to it. An identifier is informative by
+			// shape (a name, not a sentence word), not by rarity, so it gets
+			// a lower bar — but not none: re-measured at 2,886 sessions,
+			// identifier-shaped false positives (cannot, directory, branch,
+			// runner) topped out at idf 0.70 while true anchors (hermes
+			// 1.09, hermes-agent 1.21) started at 1.09, so
+			// planIdentifierIDFFloor sits at the gap between them.
+			// Non-identifier terms still need the full floor.
+			floor := dejaVuIDFFloor
+			if planIsIdentifierTerm(term) {
+				floor = planIdentifierIDFFloor
+			}
+			idf := math.Log(totalDocs / float64(len(sessions)+1))
+			if idf < floor && len(sessions) > 2 {
+				continue
+			}
+			terms = append(terms, planIndexedTerm{
+				text:     term,
+				sessions: sessions,
+			})
+		}
+		if len(terms) < need {
+			continue
+		}
+
+		counts := map[uint32]int{}
+		for _, term := range terms {
+			for ord := range term.sessions {
+				counts[ord]++
+			}
+		}
+		matched := map[uint32]bool{}
+		for ord, count := range counts {
+			if count >= need {
+				matched[ord] = true
+			}
+		}
+		if len(matched) == 0 {
+			continue
+		}
+		indexed = append(indexed, terms)
+		candidates = append(candidates, matched)
+		needs = append(needs, need)
+	}
+	return indexed, candidates, needs
+}
+
+// planHasIdentifierTerm reports whether any term in a step is
+// identifier-shaped (see planIsIdentifierTerm). Used to size the step's need
+// (1 term vs. 2) at both the raw-term-selection layer (cmd/deja) and here.
+func planHasIdentifierTerm(terms []string) bool {
+	for _, t := range terms {
+		if planIsIdentifierTerm(t) {
+			return true
+		}
+	}
+	return false
+}
+
+// planIsIdentifierTerm mirrors cmd/deja's hasIdentifierTerm at the single-term
+// level: a term is identifier-shaped when it is long (>=6) or carries a
+// symbol/digit an English word wouldn't. Duplicated rather than imported
+// because cmd/deja depends on internal/index, not the other way around.
+func planIsIdentifierTerm(t string) bool {
+	if len(t) >= 6 {
+		return true
+	}
+	for _, r := range t {
+		if r == '_' || r == '.' || r == '/' || r == '-' || (r >= '0' && r <= '9') {
+			return true
+		}
+	}
+	return false
+}
+
+func planTermSessions(dir, term string) map[uint32]bool {
+	keys := queryKeys(term)
+	if len(keys) == 0 {
+		return nil
+	}
+
+	var intersection map[uint32]bool
+	for _, key := range keys {
+		postings, err := postingsFor(dir, key)
+		if err != nil || len(postings) == 0 {
+			return nil
+		}
+		current := map[uint32]bool{}
+		for _, posting := range postings {
+			current[posting.Sid] = true
+		}
+		if intersection == nil {
+			intersection = current
+			continue
+		}
+		for ord := range intersection {
+			if !current[ord] {
+				delete(intersection, ord)
+			}
+		}
+		if len(intersection) == 0 {
+			return nil
+		}
+	}
+	return intersection
+}
+
+func planCommandForStep(session model.Session, terms []planIndexedTerm, need int) string {
+	best := ""
+	bestMatches := 0
+	for _, message := range session.Messages {
+		if message.Role != roleCommand {
+			continue
+		}
+		command := strings.Join(strings.Fields(message.Text), " ")
+		if command == "" {
+			continue
+		}
+		matched := 0
+		for _, term := range terms {
+			if planTextHasTerm(command, term.text) {
+				matched++
+			}
+		}
+		if matched < need {
+			continue
+		}
+		if matched > bestMatches ||
+			(matched == bestMatches && (best == "" || len(command) < len(best))) ||
+			(matched == bestMatches && len(command) == len(best) && command < best) {
+			best = command
+			bestMatches = matched
+		}
+	}
+	return best
+}
+
+func planWallCommand(
+	wallText string,
+	cluster planWallCluster,
+	steps [][]planIndexedTerm,
+	commands map[string]map[int]string,
+) (string, []SessionMeta) {
+	groups := map[string]map[string]SessionMeta{}
+	for step, terms := range steps {
+		sharesTerm := false
+		for _, term := range terms {
+			if planTextHasTerm(wallText, term.text) {
+				sharesTerm = true
+				break
+			}
+		}
+		if !sharesTerm {
+			continue
+		}
+		for _, meta := range cluster.metas {
+			key := meta.Harness + ":" + meta.ID
+			command := commands[key][step]
+			if command == "" {
+				continue
+			}
+			if groups[command] == nil {
+				groups[command] = map[string]SessionMeta{}
+			}
+			groups[command][key] = meta
+		}
+	}
+
+	best := ""
+	bestCount := 0
+	for command, sessions := range groups {
+		if len(sessions) > bestCount ||
+			(len(sessions) == bestCount && (best == "" || command < best)) {
+			best = command
+			bestCount = len(sessions)
+		}
+	}
+	if best == "" {
+		return "", nil
+	}
+
+	selected := groups[best]
+	out := make([]SessionMeta, 0, len(selected))
+	for _, meta := range cluster.metas {
+		if _, ok := selected[meta.Harness+":"+meta.ID]; ok {
+			out = append(out, meta)
+		}
+	}
+	return best, out
+}
+
+func planTextHasTerm(text, term string) bool {
+	terms, phrases := query.QueryParts(term)
+	if len(terms) == 0 && len(phrases) == 0 {
+		return false
+	}
+	return query.MatchesParts(text, terms, phrases, nil)
+}

--- a/internal/index/plan.go
+++ b/internal/index/plan.go
@@ -10,12 +10,12 @@ import (
 )
 
 // PlanCooccurrence is one factual join between a recurring wall and a plan
-// step's informative terms. The wall side is the claim: a full census found
-// a matching command logged alongside the wall in only 1 of 19 carriers (74%
-// of carriers have zero command records at all), so requiring one would
-// reject nearly every real recurrence. Command and CommandSessions are a
-// strengthening when a matching command happens to exist, not a
-// precondition — Command is "" when none was found.
+// step's informative terms. The wall side is the claim: a census of one
+// personal index found a matching command logged alongside the wall for only
+// 1 of its 19 walls, and 84 of its 110 carrier sessions hold no command
+// record at all, so requiring one would reject nearly every real recurrence.
+// Command and CommandSessions are a strengthening when a matching command
+// happens to exist, not a precondition — Command is "" when none was found.
 type PlanCooccurrence struct {
 	Wall            Friction
 	Command         string

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -464,6 +464,22 @@ func Tombstones() []string {
 // Tombstoned reports whether one exact harness:id has been forgotten here.
 func Tombstoned(key string) bool { return readTombstones()[key] }
 
+// TombstonesMatching lists the forgotten keys a selector would restore, in the
+// order `forget --list` prints them.
+func TombstonesMatching(prefix string) []string {
+	var out []string
+	for key := range readTombstones() {
+		if strings.Contains(key, "\x00") {
+			continue
+		}
+		if tombstoneMatches(key, prefix) {
+			out = append(out, key)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 // TombstoneMatches counts the forgotten sessions a selector would bring back,
 // without touching anything. The undo has to be able to refuse the way forget
 // does: one word restored three sessions and said so afterwards (#961).

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -463,6 +463,13 @@ func swapIndexDir(dir, tmp string) error {
 	old := dir + ".old"
 	_ = os.RemoveAll(old)
 	if err := os.Rename(dir, old); err != nil && !os.IsNotExist(err) {
+		// The parking spot survived the removal above — a leftover from an
+		// interrupted swap whose permissions stop deja from clearing it. The
+		// bare `rename …: file exists` names two paths nobody chose and gives
+		// nothing to do about either (#1009).
+		if _, statErr := os.Stat(old); statErr == nil {
+			return fmt.Errorf("an earlier index swap left %s behind and deja cannot replace it — remove that directory and run `deja index` again", old)
+		}
 		return err
 	}
 	if err := os.Rename(tmp, dir); err != nil {

--- a/internal/index/swap_leftover_test.go
+++ b/internal/index/swap_leftover_test.go
@@ -1,0 +1,104 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// A rebuild parks the old index as <dir>.old and clears it afterwards (#181).
+// A leftover that cannot be removed — an interrupted swap whose directory came
+// back read-only — failed every later rebuild with `rename …: file exists`:
+// two paths nobody chose and nothing to do about either (#1009).
+func TestALeftoverSwapDirectoryIsNamedInsteadOfTheRename(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, "index.db")
+	newer := filepath.Join(tmp, "index.db.tmp")
+	for _, d := range []string{dir, newer} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "records.bin"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The ordinary swap: the leftover is cleared and the new index lands.
+	if err := swapIndexDir(dir, newer); err != nil {
+		t.Fatalf("an ordinary swap failed: %v", err)
+	}
+	if _, err := os.Stat(dir + ".old"); err == nil {
+		t.Error("the parking directory outlived the swap")
+	}
+
+	// A leftover deja cannot remove.
+	old := dir + ".old"
+	if err := os.MkdirAll(filepath.Join(old, "buckets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(old, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(old, 0o700) })
+	if err := os.MkdirAll(newer, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := swapIndexDir(dir, newer)
+	if err == nil {
+		t.Fatal("the swap claimed to succeed over a leftover it cannot replace")
+	}
+	if strings.Contains(err.Error(), "rename") || strings.Contains(err.Error(), "file exists") {
+		t.Errorf("the failure is still the raw syscall: %v", err)
+	}
+	if !strings.Contains(err.Error(), old) || !strings.Contains(err.Error(), "remove that directory") {
+		t.Errorf("the failure does not say what to remove: %v", err)
+	}
+	// The index that was there is still there — nothing was lost to the failed
+	// swap.
+	if _, statErr := os.Stat(filepath.Join(dir, "records.bin")); statErr != nil {
+		t.Errorf("the previous index did not survive the failed swap: %v", statErr)
+	}
+}
+
+// The selector the refusal uses to name what it would restore: content keys
+// ride along with their session and must not be listed as sessions of their
+// own (#1014).
+func TestTombstonesMatchingNamesSessionsOnly(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	set := map[string]bool{
+		"claude:sess0":                        true,
+		"claude:sess1":                        true,
+		"claude:alpha":                        true,
+		"claude:sess0\x00deja-note-day:x:1:2": true,
+	}
+	if err := writeTombstones(set); err != nil {
+		t.Fatal(err)
+	}
+	got := TombstonesMatching("claude:sess")
+	want := []string{"claude:sess0", "claude:sess1"}
+	if len(got) != len(want) {
+		t.Fatalf("matching keys = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("matching keys = %v, want %v", got, want)
+			break
+		}
+	}
+	if n := TombstoneMatches("claude:sess"); n != len(want) {
+		t.Errorf("count %d disagrees with the names %v", n, got)
+	}
+	if got := TombstonesMatching("claude:nothing"); len(got) != 0 {
+		t.Errorf("a selector that matches nothing named %v", got)
+	}
+	if !Tombstoned("claude:alpha") || Tombstoned("claude:absent") {
+		t.Error("Tombstoned disagrees with what was written")
+	}
+}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -667,6 +667,10 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
+	// One scan for the whole batch, not one per new session: nextSessionOrd
+	// walks every manifest entry, so importing n sessions cost O(n²) and a
+	// 100k batch took 306s against 1.9s for forgetting the same 100k (#1024).
+	nextOrd := nextSessionOrd(m.Sessions)
 	for _, key := range keys {
 		meta := metas[key]
 		old := m.Sessions[key]
@@ -679,7 +683,8 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 				meta.Updated = old.Updated
 			}
 		} else {
-			meta.Ord = nextSessionOrd(m.Sessions)
+			meta.Ord = nextOrd
+			nextOrd++
 		}
 		m.Sessions[key] = meta
 		for _, r := range recsByKey[key] {

--- a/internal/policy/describe_both_denied_test.go
+++ b/internal/policy/describe_both_denied_test.go
@@ -1,6 +1,10 @@
 package policy
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 // "local-only" is the name of the rule that keeps local sessions and drops
 // imported ones. A policy that denies both was described with it, next to a
@@ -32,5 +36,33 @@ func TestDescribeNamesTheRuleThatIsActuallyInForce(t *testing.T) {
 	}
 	if !importedOnly.Allows(ActivationSearch, "imported:proj") || importedOnly.Allows(ActivationSearch, "proj") {
 		t.Error("the description and the filter disagree")
+	}
+}
+
+// Twenty group rules made one 1000-character line on the screen people read to
+// find out what is allowed. The file itself is named beside it and holds the
+// full set (#1023).
+func TestDescribeCapsALongDenyList(t *testing.T) {
+	rules := map[string]bool{"local": true}
+	for i := 0; i < 20; i++ {
+		rules[fmt.Sprintf("imported:grp%02d", i)] = false
+	}
+	got := Policy{Activations: map[string]map[string]bool{ActivationSearch: rules}}.Describe(ActivationSearch)
+	if len(got) > 120 {
+		t.Errorf("the description is %d characters long: %q", len(got), got)
+	}
+	if !strings.Contains(got, "+16 more") {
+		t.Errorf("the description does not say how many it left out: %q", got)
+	}
+	if !strings.Contains(got, "imported:grp00") {
+		t.Errorf("the description names none of the rules: %q", got)
+	}
+
+	// A short list is printed whole.
+	short := Policy{Activations: map[string]map[string]bool{
+		ActivationSearch: {"local": true, "imported:a": false, "imported:b": false},
+	}}
+	if got := short.Describe(ActivationSearch); got != "deny imported:a,imported:b" {
+		t.Errorf("a short list was truncated: %q", got)
 	}
 }

--- a/internal/policy/describe_both_denied_test.go
+++ b/internal/policy/describe_both_denied_test.go
@@ -1,0 +1,36 @@
+package policy
+
+import "testing"
+
+// "local-only" is the name of the rule that keeps local sessions and drops
+// imported ones. A policy that denies both was described with it, next to a
+// count on the same doctor line saying every session was withheld (#995).
+func TestDescribeNamesTheRuleThatIsActuallyInForce(t *testing.T) {
+	both := Policy{Activations: map[string]map[string]bool{
+		ActivationSearch: {"local": false, "imported": false},
+	}}
+	if got := both.Describe(ActivationSearch); got != "nothing activates" {
+		t.Errorf("a policy that denies every origin describes itself as %q", got)
+	}
+	if both.Allows(ActivationSearch, "proj") || both.Allows(ActivationSearch, "imported:proj") {
+		t.Error("a policy that denies every origin let something through")
+	}
+
+	localOnly := Policy{Activations: map[string]map[string]bool{
+		ActivationSearch: {"local": true, "imported": false},
+	}}
+	if got := localOnly.Describe(ActivationSearch); got != "local-only" {
+		t.Errorf("the ordinary rule changed its name: %q", got)
+	}
+	// Denying only `local` keeps the generic form it has always had, and it is
+	// still the rule in force.
+	importedOnly := Policy{Activations: map[string]map[string]bool{
+		ActivationSearch: {"local": false, "imported": true},
+	}}
+	if got := importedOnly.Describe(ActivationSearch); got != "deny local" {
+		t.Errorf("a rule that denies only local describes itself as %q", got)
+	}
+	if !importedOnly.Allows(ActivationSearch, "imported:proj") || importedOnly.Allows(ActivationSearch, "proj") {
+		t.Error("the description and the filter disagree")
+	}
+}

--- a/internal/policy/filter_alias_test.go
+++ b/internal/policy/filter_alias_test.go
@@ -1,0 +1,20 @@
+package policy
+
+import "testing"
+
+// Filter built its result with items[:0], so it rewrote the caller's own slice.
+// Callers that read the input afterwards — handoff learns what was withheld
+// that way — saw the kept elements copied over the dropped ones (#1013).
+func TestFilterLeavesTheCallersSliceAlone(t *testing.T) {
+	p := Policy{Activations: map[string]map[string]bool{
+		ActivationSearch: {"local": true, "imported": false},
+	}}
+	items := []string{"imported:tmp/w27", "tmp/w27"}
+	kept := Filter(p, ActivationSearch, items, func(s string) string { return s })
+	if len(kept) != 1 || kept[0] != "tmp/w27" {
+		t.Fatalf("filter kept %v", kept)
+	}
+	if items[0] != "imported:tmp/w27" || items[1] != "tmp/w27" {
+		t.Errorf("the caller's slice was rewritten: %v", items)
+	}
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -8,6 +8,7 @@ package policy
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -146,6 +147,13 @@ func (p Policy) Describe(activation string) string {
 		return "local+imported"
 	}
 	sort.Strings(denied)
+	// Twenty group rules made one 1000-character line on the screen people
+	// read to find out what is allowed; the file itself is named beside it
+	// and holds the full set (#1023).
+	const shown = 4
+	if len(denied) > shown {
+		return fmt.Sprintf("deny %s +%d more", strings.Join(denied[:shown], ","), len(denied)-shown)
+	}
 	return "deny " + strings.Join(denied, ",")
 }
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -114,9 +114,25 @@ func (p Policy) Describe(activation string) string {
 	if rules == nil {
 		return "local+imported"
 	}
+	localOff := false
+	if v, ok := rules["local"]; ok && !v {
+		localOff = true
+	}
+	importedOff := false
 	if v, ok := rules["imported"]; ok && !v {
+		importedOff = true
+	}
+	// A rule that denies both origins was described as "local-only", which is
+	// the name of a different rule — and doctor printed it beside a count that
+	// contradicted it: "local-only — withholds 1 of 1 indexed session" (#995).
+	switch {
+	case localOff && importedOff:
+		return "nothing activates"
+	case importedOff:
 		return "local-only"
 	}
+	// A rule that denies only `local` keeps the generic "deny <origin>" form:
+	// it is one denial among the others below, and two tests pin it (#941).
 	denied := make([]string, 0, len(rules))
 	for origin, allowed := range rules {
 		// A key deja never consults restricts nothing, and naming it here put

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -151,8 +151,11 @@ func (p Policy) Describe(activation string) string {
 
 // Filter drops the items whose project the policy blocks on this path.
 // projectOf maps an element to its session project name.
+// The result is a new slice: filtering in place rewrote the caller's own
+// input — handoff read the pre-filter list to learn what had been withheld and
+// saw the kept sessions duplicated over it (#1013).
 func Filter[T any](p Policy, activation string, items []T, projectOf func(T) string) []T {
-	out := items[:0]
+	out := make([]T, 0, len(items))
 	for _, it := range items {
 		if p.Allows(activation, projectOf(it)) {
 			out = append(out, it)

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -50,6 +50,10 @@ type Options struct {
 	// survived it. Counting the survivors measures the cap.
 	Total  int
 	Capped bool
+	// PolicyWithheld is how many matching sessions the trust policy kept out
+	// of this answer. The reason travelled on stderr only, so a caller reading
+	// --json could not tell a rule from an empty history (#990).
+	PolicyWithheld int
 	// WithAnswer carries the assistant reply next to a matched user turn.
 	// Agent-facing recall sets it; human CLI output does not, because a person
 	// reading results can open the session.

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -34,6 +34,12 @@ type BlameHit struct {
 	Snippets []string      `json:"snippets"`
 	Score    float64       `json:"score"`
 	Tier     string        `json:"tier"`
+	// Lifecycle carries a decision that did not hold. blame answers "who
+	// decided this", and it was answering with the accepted line of a decision
+	// that had been taken back (#1017).
+	Lifecycle     string `json:"lifecycle,omitempty"`
+	LifecycleNote string `json:"lifecycle_note,omitempty"`
+	LifecycleAt   string `json:"lifecycle_at,omitempty"`
 }
 
 func ResolveBlamePath(name string) (BlameTarget, error) {
@@ -247,6 +253,13 @@ func PrintBlame(w io.Writer, hits []BlameHit, jsonOutput bool) {
 			}
 		}
 		fmt.Fprintln(w)
+		if line := BlameLifecycleLine(hit); line != "" {
+			if color {
+				fmt.Fprintf(w, "  %s%s%s\n", cDim, line, cReset)
+			} else {
+				fmt.Fprintf(w, "  %s\n", line)
+			}
+		}
 		for _, text := range hit.Snippets {
 			if color {
 				fmt.Fprintf(w, "  %s%s%s\n", cDim, text, cReset)
@@ -255,4 +268,30 @@ func PrintBlame(w io.Writer, hits []BlameHit, jsonOutput bool) {
 			}
 		}
 	}
+}
+
+// BlameLifecycleLine words a withdrawn decision for blame the way search words
+// it: what happened, not the name of the state.
+func BlameLifecycleLine(h BlameHit) string {
+	if h.Lifecycle == "" {
+		return ""
+	}
+	var head string
+	switch h.Lifecycle {
+	case "rejected":
+		head = "this was tried and rejected"
+	case "superseded":
+		head = "a later decision replaced this"
+	case "stale":
+		head = "marked stale — may no longer hold"
+	default:
+		head = h.Lifecycle
+	}
+	if h.LifecycleAt != "" {
+		head += " (" + h.LifecycleAt + ")"
+	}
+	if h.LifecycleNote != "" {
+		head += ": " + h.LifecycleNote
+	}
+	return head
 }

--- a/internal/search/blame_lifecycle_line_test.go
+++ b/internal/search/blame_lifecycle_line_test.go
@@ -1,0 +1,33 @@
+package search
+
+import "testing"
+
+// The line says what happened rather than naming the state, so a hit that was
+// taken back reads as taken back in blame too (#1019).
+func TestBlameLifecycleLineWordsWhatHappened(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		hit  BlameHit
+		want string
+	}{
+		{"none", BlameHit{}, ""},
+		{"rejected", BlameHit{Lifecycle: "rejected"}, "this was tried and rejected"},
+		{"superseded", BlameHit{Lifecycle: "superseded"}, "a later decision replaced this"},
+		{"stale", BlameHit{Lifecycle: "stale"}, "marked stale — may no longer hold"},
+		{"unknown state passes through", BlameHit{Lifecycle: "parked"}, "parked"},
+		{
+			"with date and note",
+			BlameHit{Lifecycle: "rejected", LifecycleAt: "2026-08-01", LifecycleNote: "deadlocked under load"},
+			"this was tried and rejected (2026-08-01): deadlocked under load",
+		},
+		{
+			"date without note",
+			BlameHit{Lifecycle: "stale", LifecycleAt: "2026-07-04"},
+			"marked stale — may no longer hold (2026-07-04)",
+		},
+	} {
+		if got := BlameLifecycleLine(tc.hit); got != tc.want {
+			t.Errorf("%s: line = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -61,6 +61,7 @@ type searchJSONEnvelope struct {
 	// the cap hid any. Counting the returned hits alone measures the cap.
 	Total    int                 `json:"total"`
 	Capped   bool                `json:"capped,omitempty"`
+	Withheld int                 `json:"policy_withheld,omitempty"`
 	Hits     []Hit               `json:"hits"`
 	Fuzzy    bool                `json:"fuzzy,omitempty"`
 	Stemmed  bool                `json:"stemmed,omitempty"`
@@ -744,6 +745,7 @@ func Print(w io.Writer, hits []Hit, o Options) {
 			Tier:          setTier(o),
 			Total:         o.Total,
 			Capped:        o.Capped,
+			Withheld:      o.PolicyWithheld,
 			Hits:          hits,
 			Fuzzy:         o.Fuzzy,
 			Stemmed:       o.Stemmed,

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -25,19 +25,22 @@ type Report struct {
 	Heatmap         HeatmapStats   `json:"-"` // card-only presentation data; kept out of the stable --json schema
 	// EmptiedByPolicy marks a report whose rows were all withheld by the
 	// trust policy, so the empty-index advice is not the right thing to print.
-	EmptiedByPolicy bool           `json:"-"`
-	Sparkline       string         `json:"sparkline"`
-	DateRange       DateRangeStats `json:"date_range"`
-	Longest         SessionStat    `json:"longest_session"`
-	BusiestDay      DayStat        `json:"busiest_day"`
-	Recall          usage.Summary  `json:"recall"`
-	WeekRecalls     int            `json:"week_recalls"`
-	WeekBytes       int            `json:"week_bytes"`
-	WeekInjected    int            `json:"week_injected"`
-	HandoffsIn      int            `json:"handoffs_received"`
-	AgentCredits    int            `json:"agent_credits"`
-	WeekCredits     int            `json:"week_agent_credits"`
-	SidecarSize     int64          `json:"sidecar_size,omitempty"`
+	EmptiedByPolicy bool `json:"-"`
+	// HiddenBySettings is the reader's own tombstones and exclusions, when
+	// those are why the report is empty.
+	HiddenBySettings string         `json:"-"`
+	Sparkline        string         `json:"sparkline"`
+	DateRange        DateRangeStats `json:"date_range"`
+	Longest          SessionStat    `json:"longest_session"`
+	BusiestDay       DayStat        `json:"busiest_day"`
+	Recall           usage.Summary  `json:"recall"`
+	WeekRecalls      int            `json:"week_recalls"`
+	WeekBytes        int            `json:"week_bytes"`
+	WeekInjected     int            `json:"week_injected"`
+	HandoffsIn       int            `json:"handoffs_received"`
+	AgentCredits     int            `json:"agent_credits"`
+	WeekCredits      int            `json:"week_agent_credits"`
+	SidecarSize      int64          `json:"sidecar_size,omitempty"`
 	// Spans and SpanFiles are what `deja restore` can hand back: the exact
 	// bytes an agent replaced, which no other tool keeps. Filled by the
 	// caller, not by Build — replaced spans are deliberately kept out of

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -15,14 +15,18 @@ import (
 )
 
 type Report struct {
-	SchemaVersion   int            `json:"schema_version"`
-	TotalSessions   int            `json:"total_sessions"`
-	TotalMessages   int            `json:"total_messages"`
-	RepeatQuestions int            `json:"repeat_questions,omitempty"`
-	Harnesses       []HarnessStats `json:"harnesses"`
-	TopProjects     []ProjectStats `json:"top_projects"`
-	Monthly         []MonthStats   `json:"monthly"`
-	Heatmap         HeatmapStats   `json:"-"` // card-only presentation data; kept out of the stable --json schema
+	SchemaVersion   int `json:"schema_version"`
+	TotalSessions   int `json:"total_sessions"`
+	TotalMessages   int `json:"total_messages"`
+	RepeatQuestions int `json:"repeat_questions,omitempty"`
+	// PolicyWithheld is how many indexed sessions the trust policy kept out of
+	// this report — the same field `search --json` and `last --json` carry, so
+	// a caller can tell a rule from an empty store (#1010).
+	PolicyWithheld int            `json:"policy_withheld,omitempty"`
+	Harnesses      []HarnessStats `json:"harnesses"`
+	TopProjects    []ProjectStats `json:"top_projects"`
+	Monthly        []MonthStats   `json:"monthly"`
+	Heatmap        HeatmapStats   `json:"-"` // card-only presentation data; kept out of the stable --json schema
 	// EmptiedByPolicy marks a report whose rows were all withheld by the
 	// trust policy, so the empty-index advice is not the right thing to print.
 	EmptiedByPolicy bool `json:"-"`

--- a/scripts/planbench/main.go
+++ b/scripts/planbench/main.go
@@ -1,0 +1,286 @@
+// Command planbench runs a directory of plans through `deja check -` and
+// reports how often the plan checker fires.
+//
+// It counts fires. It does not say whether a fire was right, and it cannot:
+// precision on this path is a human label — someone who was there, reading the
+// recalled wall against the plan in front of them — and both halves of that
+// judgment are local. The hand-labelled set behind the 6/30 reported on #532
+// came from private transcripts and will never ship, so the numbers in that
+// thread are not reproducible by anyone else. This produces the denominator on
+// a reader's own plans and a reader's own history, and leaves the verdict to
+// the reader.
+//
+// It drives the built binary rather than importing the matcher, which is the
+// one thing the other harnesses here do not do. `deja check -` is the only path
+// that composes what actually fires: step extraction, the index lookup, the
+// trust policy and the payload budget all live in package main beside it, and
+// calling index.PlanFrictionMatches directly would measure a component no user
+// runs — the same reason check exists at all (cmd/deja/check.go).
+//
+//	go build ./cmd/deja
+//	DEJA_INDEX_DIR=~/.cache/deja/index.db go run ./scripts/planbench -plans ./plans [-deja ./deja] [-dump]
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	plans := flag.String("plans", "", "directory of plan files, one plan per file")
+	bin := flag.String("deja", "deja", "deja binary to run — a build of this tree, not whatever is installed")
+	dump := flag.Bool("dump", false, "print each finding verbatim — recalled history text")
+	flag.Parse()
+
+	// No default: the only directory this tool could guess at is someone's own
+	// plans, and a harness that reads a private directory when run bare is a
+	// harness nobody can run bare.
+	if *plans == "" {
+		fmt.Fprintln(os.Stderr, "planbench needs -plans DIR")
+		os.Exit(1)
+	}
+	// Looked up once, before any plan runs: "executable file not found" is a
+	// setup error, and the same line repeated for every file in the directory
+	// buries the one plan that failed for its own reasons.
+	if _, err := exec.LookPath(*bin); err != nil {
+		fmt.Fprintln(os.Stderr, "deja:", err)
+		os.Exit(1)
+	}
+	if err := run(os.Stdout, os.Stderr, *bin, *plans, *dump); err != nil {
+		fmt.Fprintln(os.Stderr, "planbench:", err)
+		os.Exit(1)
+	}
+}
+
+// newCheckCmd is a seam: a test drives a stand-in for deja without building one.
+var newCheckCmd = func(bin string) *exec.Cmd {
+	return exec.Command(bin, "check", "-")
+}
+
+type planResult struct {
+	name     string
+	findings []string
+	// labels are the wall labels this plan cited, in the order the walls were
+	// first seen across the whole run.
+	labels []string
+}
+
+type wall struct {
+	label string
+	text  string
+	plans int
+}
+
+func run(out, errOut io.Writer, bin, dir string, dump bool) error {
+	names, err := planFiles(dir)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "plans %s · %d file%s\n\n", dir, len(names), plural(len(names)))
+
+	byWall := map[string]*wall{}
+	var order []*wall
+	var results []planResult
+	failed := 0
+	for _, name := range names {
+		findings, err := check(bin, filepath.Join(dir, name))
+		if err != nil {
+			fmt.Fprintf(errOut, "%s: %v\n", name, err)
+			failed++
+			continue
+		}
+		r := planResult{name: name, findings: findings}
+		for _, finding := range findings {
+			text := planWall(finding)
+			w := byWall[text]
+			if w == nil {
+				w = &wall{label: fmt.Sprintf("w%d", len(order)+1), text: text}
+				byWall[text] = w
+				order = append(order, w)
+			}
+			// planFindings emits a wall at most once per plan, so counting a
+			// plan per finding here needs no de-duplication of its own.
+			w.plans++
+			r.labels = append(r.labels, w.label)
+		}
+		results = append(results, r)
+	}
+
+	printResults(out, results, dump)
+
+	fired, findings := 0, 0
+	for _, r := range results {
+		if len(r.findings) > 0 {
+			fired++
+		}
+		findings += len(r.findings)
+	}
+	fmt.Fprintf(out, "\n%d plan%s · %d fired (%.1f%%) · %d finding%s · %d distinct wall%s\n",
+		len(results), plural(len(results)), fired, pct(fired, len(results)),
+		findings, plural(findings), len(order), plural(len(order)))
+	// The distinct-wall count is the number to read the finding count against.
+	// Twelve findings drawn from two walls is one recurring problem reported
+	// twelve times, not twelve independent hits, and the two shapes call for
+	// different judgments about whether the feature earns its place.
+	for _, w := range order {
+		fmt.Fprintf(out, "  %-4s cited by %d plan%s\n", w.label, w.plans, plural(w.plans))
+	}
+	if failed > 0 {
+		// A plan that fired nothing is a result — silence is the miss contract
+		// of the hook this measures, so it exits 0 and the tool stays usable in
+		// a loop. A plan that could not be run is not a result.
+		return fmt.Errorf("%d plan%s could not be run", failed, plural(failed))
+	}
+	return nil
+}
+
+func printResults(out io.Writer, results []planResult, dump bool) {
+	width := 12
+	for _, r := range results {
+		if n := len(r.name); n > width {
+			width = n
+		}
+	}
+	if width > 40 {
+		width = 40
+	}
+	for _, r := range results {
+		if len(r.findings) == 0 {
+			fmt.Fprintf(out, "  %-*s  silent\n", width, r.name)
+			continue
+		}
+		fmt.Fprintf(out, "  %-*s  fire · %d finding%s · %s\n",
+			width, r.name, len(r.findings), plural(len(r.findings)), strings.Join(r.labels, " "))
+		// Findings quote a stranger's history back at whoever is reading the
+		// table, which is fine on their own machine and not fine in a pasted
+		// result. Counts and labels by default, text on request — the rule
+		// corpusprobe follows for the same reason.
+		if !dump {
+			continue
+		}
+		for i, finding := range r.findings {
+			fmt.Fprintf(out, "  %-*s  %-4s %s\n", width, "", r.labels[i], finding)
+		}
+	}
+}
+
+// planFiles lists the plans to run. Every regular file counts: plans are
+// Markdown in practice, but nothing in the checker reads an extension, and a
+// harness that filtered on one would report a smaller denominator than the
+// directory holds. Dot files are skipped so a stray .DS_Store is not a plan.
+func planFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	if len(names) == 0 {
+		// Reporting 0/0 for a mistyped directory is the one failure this tool
+		// could hide from a loop that only reads the summary.
+		return nil, fmt.Errorf("no plan files in %s", dir)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// findingPrefix opens every line formatPlanFinding writes
+// (cmd/deja/hook_plan.go). It is the harness's one coupling to the finding
+// text, and it is deliberate: a line that does not start with it did not come
+// from the plan checker.
+const findingPrefix = "wall hit in "
+
+func check(bin, path string) ([]string, error) {
+	plan, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	cmd := newCheckCmd(bin)
+	cmd.Stdin = bytes.NewReader(plan)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return nil, fmt.Errorf("%w: %s", err, msg)
+		}
+		return nil, err
+	}
+	var findings []string
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, findingPrefix) {
+			// The first real run of this harness measured `deja search`. A deja
+			// older than the check subcommand does not fail on `deja check -`:
+			// an unknown first word falls through to search (cmd/deja/main.go),
+			// which ignores stdin, exits 0, and answers every plan with the
+			// same result lines — 47 findings for a one-step plan, and the same
+			// 47 for the next plan. Every finding starts with this prefix
+			// (formatPlanFinding), truncation takes the tail, so a line that
+			// does not is not a finding and the count is not a measurement.
+			//
+			// The line itself is not quoted here: it is whatever that other
+			// command decided to print out of a private history.
+			return nil, fmt.Errorf("printed a line that is not a finding — does %s have the check subcommand from this tree?", bin)
+		}
+		findings = append(findings, line)
+	}
+	return findings, nil
+}
+
+// planWall extracts the wall a finding cites, so the same wall recalled by
+// several plans collapses to one label. formatPlanFinding writes
+// `wall hit in N sessions[ since date]: "wall"` and appends the command clause
+// after a semicolon, so the wall is the first quoted string on the line.
+//
+// A finding trimmed to fit the payload budget can lose its closing quote. Then
+// the whole line is the key, and two truncated findings differing only past the
+// cut count as two walls — this overstates how many distinct walls fired rather
+// than collapsing walls that are not the same.
+func planWall(line string) string {
+	i := strings.Index(line, `"`)
+	if i < 0 {
+		return line
+	}
+	for j := i + 1; j < len(line); j++ {
+		switch line[j] {
+		case '\\':
+			j++
+		case '"':
+			if text, err := strconv.Unquote(line[i : j+1]); err == nil {
+				return text
+			}
+			return line
+		}
+	}
+	return line
+}
+
+func pct(a, b int) float64 {
+	if b == 0 {
+		return 0
+	}
+	return 100 * float64(a) / float64(b)
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/scripts/planbench/main_test.go
+++ b/scripts/planbench/main_test.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHelperDeja is not a test. It is the stand-in for the deja binary: it
+// reads a plan on stdin and prints one finding per line marked FIRE, which is
+// all planbench needs from it, and it exits on EXIT so the failure path can be
+// exercised without a broken install.
+func TestHelperDeja(t *testing.T) {
+	if os.Getenv("PLANBENCH_HELPER") != "1" {
+		return
+	}
+	// Before the test framework writes PASS to the stdout planbench is reading.
+	defer os.Exit(0)
+	plan, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		os.Exit(2)
+	}
+	for _, line := range strings.Split(string(plan), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "EXIT" {
+			fmt.Fprintln(os.Stderr, "deja: check failed")
+			os.Exit(1)
+		}
+		// A deja older than the check subcommand searches for the words
+		// instead, ignores stdin, and exits 0 with result lines.
+		if line == "OLD" {
+			fmt.Println("[claude · a-project · 2026-01-02 · 019fa282] some session title")
+			os.Exit(0)
+		}
+		if finding, ok := strings.CutPrefix(line, "FIRE "); ok {
+			fmt.Println(finding)
+		}
+	}
+}
+
+// useHelper points the harness at the stand-in above.
+func useHelper(t *testing.T) {
+	t.Helper()
+	original := newCheckCmd
+	newCheckCmd = func(string) *exec.Cmd {
+		cmd := exec.Command(os.Args[0], "-test.run=TestHelperDeja")
+		cmd.Env = append(os.Environ(), "PLANBENCH_HELPER=1")
+		return cmd
+	}
+	t.Cleanup(func() { newCheckCmd = original })
+}
+
+// unpad collapses the column padding so a test asserts on what a line says
+// rather than on how wide the longest file name happened to be.
+func unpad(out string) string {
+	lines := strings.Split(out, "\n")
+	for i, line := range lines {
+		lines[i] = strings.Join(strings.Fields(line), " ")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func writePlans(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+const (
+	migrationWall = `wall hit in 3 sessions since 2026-01-02: "the migration lock never released"`
+	timeoutWall   = `wall hit in 2 sessions since 2026-01-05: "the pool timed out"; past sessions also ran "make reset" (2 sessions)`
+)
+
+// The finding count alone reads as independent hits. Twelve findings drawn from
+// two walls is one problem reported twelve times, so the distinct-wall count is
+// the number that decides how to read the rest of the table — and it only works
+// if the same wall reached through different plans collapses to one label.
+func TestRunCountsDistinctWallsNotFindings(t *testing.T) {
+	useHelper(t)
+	dir := writePlans(t, map[string]string{
+		"a.md": "1. do the thing\nFIRE " + migrationWall + "\nFIRE " + timeoutWall + "\n",
+		"b.md": "1. do another thing\nFIRE " + migrationWall + "\n",
+		"c.md": "1. nothing recurs here\n",
+	})
+
+	var out, errOut bytes.Buffer
+	if err := run(&out, &errOut, "deja", dir, false); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := unpad(out.String())
+
+	for _, want := range []string{
+		"a.md fire · 2 findings · w1 w2",
+		"b.md fire · 1 finding · w1",
+		"c.md silent",
+		"3 plans · 2 fired (66.7%) · 3 findings · 2 distinct walls",
+		"w1 cited by 2 plans",
+		"w2 cited by 1 plan",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\n%s", want, got)
+		}
+	}
+	if errOut.Len() != 0 {
+		t.Errorf("stderr = %q, want empty", errOut.String())
+	}
+}
+
+// A finding quotes someone's history back at whoever reads the table, and the
+// table is the part that gets pasted into an issue. Text only on request.
+func TestRunPrintsHistoryTextOnlyWithDump(t *testing.T) {
+	useHelper(t)
+	dir := writePlans(t, map[string]string{
+		"a.md": "1. do the thing\nFIRE " + migrationWall + "\n",
+	})
+
+	var quiet, dumped, errOut bytes.Buffer
+	if err := run(&quiet, &errOut, "deja", dir, false); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.Contains(quiet.String(), "the migration lock never released") {
+		t.Errorf("recalled text printed without -dump\n%s", quiet.String())
+	}
+	if err := run(&dumped, &errOut, "deja", dir, true); err != nil {
+		t.Fatalf("run -dump: %v", err)
+	}
+	if !strings.Contains(dumped.String(), "the migration lock never released") {
+		t.Errorf("-dump printed no finding text\n%s", dumped.String())
+	}
+}
+
+// Silence is the miss contract of the hook this measures, so a run where
+// nothing fires has to exit 0 or the tool cannot be used in a loop. A plan that
+// could not be run is a different thing, and it must not take the rest of the
+// directory with it.
+func TestRunSeparatesSilenceFromFailure(t *testing.T) {
+	useHelper(t)
+	silent := writePlans(t, map[string]string{
+		"a.md": "1. nothing recurs here\n",
+		"b.md": "1. nor here\n",
+	})
+	var out, errOut bytes.Buffer
+	if err := run(&out, &errOut, "deja", silent, false); err != nil {
+		t.Fatalf("a silent run is a result, not an error: %v", err)
+	}
+	if !strings.Contains(out.String(), "2 plans · 0 fired (0.0%) · 0 findings · 0 distinct walls") {
+		t.Errorf("unexpected summary\n%s", out.String())
+	}
+
+	broken := writePlans(t, map[string]string{
+		"a.md": "1. nothing recurs here\n",
+		"b.md": "EXIT\n",
+		"c.md": "1. still measured\nFIRE " + migrationWall + "\n",
+	})
+	out.Reset()
+	errOut.Reset()
+	err := run(&out, &errOut, "deja", broken, false)
+	if err == nil {
+		t.Fatal("a plan that could not be run exited 0")
+	}
+	if !strings.Contains(err.Error(), "1 plan could not be run") {
+		t.Errorf("err = %v", err)
+	}
+	if !strings.Contains(errOut.String(), "b.md:") {
+		t.Errorf("the failing plan was not named: %q", errOut.String())
+	}
+	// The two plans either side of the failure still count.
+	if !strings.Contains(out.String(), "2 plans · 1 fired (50.0%) · 1 finding · 1 distinct wall") {
+		t.Errorf("a failed plan changed the denominator\n%s", out.String())
+	}
+}
+
+// The first real run of this harness measured `deja search`: an installed deja
+// with no check subcommand falls through to search, ignores the plan on stdin,
+// exits 0, and answers every plan with the same result lines. That reads as a
+// fire on every plan, and a one-step plan came back with 47 findings. A run
+// against the wrong binary has to fail, not report a rate.
+func TestRunRefusesOutputThatIsNotAFinding(t *testing.T) {
+	useHelper(t)
+	dir := writePlans(t, map[string]string{"a.md": "OLD\n"})
+
+	var out, errOut bytes.Buffer
+	err := run(&out, &errOut, "deja", dir, false)
+	if err == nil {
+		t.Fatal("search results were counted as findings")
+	}
+	if !strings.Contains(errOut.String(), "not a finding") {
+		t.Errorf("stderr = %q", errOut.String())
+	}
+	// Whatever that other command printed came out of a private history, and
+	// this table gets pasted into issues.
+	if strings.Contains(errOut.String()+out.String(), "019fa282") {
+		t.Errorf("the rejected line was echoed\n%s%s", errOut.String(), out.String())
+	}
+}
+
+// A mistyped -plans is the one failure a loop reading only the summary would
+// never see: 0/0 looks exactly like a directory where nothing fired.
+func TestPlanFilesRefusesADirectoryWithNoPlans(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".DS_Store"), []byte("junk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := planFiles(dir); err == nil {
+		t.Fatal("a directory holding no plan accepted")
+	}
+	if _, err := planFiles(filepath.Join(dir, "missing")); err == nil {
+		t.Fatal("a directory that does not exist accepted")
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.txt"), []byte("1. step"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	names, err := planFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Extension-agnostic on purpose: nothing in the checker reads one.
+	if len(names) != 1 || names[0] != "plan.txt" {
+		t.Errorf("names = %v", names)
+	}
+}
+
+func TestPlanWallReadsTheWallOutOfAFinding(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "wall alone",
+			line: migrationWall,
+			want: "the migration lock never released",
+		},
+		{
+			// The command clause is a bonus on the same line, and grouping by
+			// it would split one wall across the plans that also recalled a
+			// command.
+			name: "command clause ignored",
+			line: timeoutWall,
+			want: "the pool timed out",
+		},
+		{
+			name: "quote inside the wall",
+			line: `wall hit in 2 sessions: "go test said \"FAIL\" again"`,
+			want: `go test said "FAIL" again`,
+		},
+		{
+			// Truncated by the payload budget: no closing quote to unquote.
+			name: "no closing quote",
+			line: `wall hit in 2 sessions: "the migration lock never rele…`,
+			want: `wall hit in 2 sessions: "the migration lock never rele…`,
+		},
+		{
+			name: "no quote at all",
+			line: "wall hit in 2 sessions",
+			want: "wall hit in 2 sessions",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := planWall(tt.line); got != tt.want {
+				t.Errorf("planWall(%q) = %q, want %q", tt.line, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds `deja check -` and `deja hook-plan` as explicit, off-by-default subcommands, plus `scripts/planbench` so the measurement can be repeated on someone else's plans. No install wiring, no hook registration: nothing here fires unless it is called by name.

This is the implementation from #532, opened at your request after the measurement came back short of the kill condition. The numbers are below and they are not overwhelming. I would rather you have the harness and decide than have my summary of it.

## What it does

`deja check -` reads a plan on stdin and prints one line per finding, or nothing. A finding states a co-occurrence and stops there:

```
wall hit in 23 sessions since 2026-07-20: "…: No module named pytest"
```

No contradiction claim, no "you already tried this". #541 is why. The judgement about whether the wall matters to the step is left to whoever reads it.

`deja hook-plan` is the same core behind a PreToolUse/ExitPlanMode shape. It shares one function with `check`, so the numbers below describe the hook path too.

Both honour the auto-activation policy and the existing `.hookseen` dedupe, and neither builds an index: a missing or stale one is a silent miss, because plan submission should not block on indexing.

## The measurement

30 real plans out of my own plan-mode history, against a personal index carrying 19 recurring walls, each hit in 3 or more sessions.

| gate | fires | precision (hand-labeled) |
|---|---|---|
| 2 informative terms, idf >= 2.0 (auto-recall's floor) | 0/30 | — |
| identifier-shaped terms exempt from the floor | 10/30 | ~0.69 |
| two-tier floor: identifier >= 1.0, plain >= 2.0 | 6/30 | 0.58–0.83 |

Only the last row reproduces at this branch. The first two came from earlier gates the code no longer contains.

Read 6/30 with the caveat attached: those six plans are three documents and their revisions, and all 12 findings carry **two** distinct wall strings. So the twelve findings are three documents against two walls, and that is the real size of the sample, not twelve independent judgements. `planbench` prints the distinct-wall count for exactly this reason.

## Two things the measurement taught me

**Wall vocabulary is common by construction.** Walls come from repeated work, so the terms that could anchor one are frequent in the corpus that produced them: the anchors that fired sit at idf 1.08 and 1.22, while ordinary words inside the same wall strings sit at 0.18–0.38. The informative floor built for prompts excludes every one of them. That is why row 1 is 0/30 rather than "a few misses".

The second floor at 1.0 sits in a measured gap (identifier-shaped false anchors topped out at 0.70, true ones started at 1.08), but I picked it on the same 30 plans the precision column reports, so read 0.83 as the optimistic in-sample end. The gap is not a law either: "preview" (1.26) and "denied" (1.85) are equally ordinary words that clear the same floor and simply did not appear in these plans.

**Requiring a command-role join leaves it silent.** 84 of the 110 wall-carrier sessions hold no command records at all, and at most 1 wall of 19 could ever join. So the join is an optional strengthening clause on a finding, never a precondition.

## The harness

```
DEJA_INDEX_DIR=~/.cache/deja/index.db go run ./scripts/planbench -plans ./plans
```

It runs each file in the directory through the built binary and prints fire/silent per plan, then totals: plans, fires, findings, and distinct walls cited. It counts; it does not judge. Precision is a human label, and the tool produces the denominator, not the verdict.

It refuses any output line that is not a finding. That guard exists because an older `deja` on PATH silently answered `check -` as a search (an unknown first word falls through) and reported 47 findings for a one-line plan. A precision harness that measures `deja search` and calls it a fire rate is worse than none.

Point it at a directory of plans only; every regular file counts as one, so a stray `results.tsv` inflates the denominator. Each file is listed, so it is visible, but the headline number moves.

## What I could not verify

`go test -race` does not run here: no C toolchain on this machine, and `-race` requires cgo. CI will be the first place it runs. Everything else in CONTRIBUTING passed: `gofmt -s`, `go vet ./...`, `go build ./cmd/deja`, and the package tests.

`scripts/planbench` ships with a test, which cuts against the note in ci.yml that harnesses under `scripts/` have none by design. I kept it because it pins the search-fallthrough guard above, and because `scripts/` is excluded from the coverage profile so it costs nothing there. If you would rather the directory stay uniform, deleting `main_test.go` loses nothing else.

## Kill condition

0.83 at best, in-sample, on a sample that is really three documents. I did not think that cleared the bar in #532, and I still do not. What changed is that you asked for the code and the harness anyway, so here they are, off by default and easy to delete if the numbers do not hold up on your plans.
