### PR TITLE
check: an explicit, off-by-default plan check, plus the harness to re-measure it

### DIFF
--- a/cmd/deja/check.go
+++ b/cmd/deja/check.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+// runCheck is the human-facing form of the plan hook. It deliberately calls
+// planFindings directly so measured precision reflects the injected path.
+// The empty session id skips the .hookseen dedupe on purpose: dedupe governs
+// when a finding is delivered twice in one session, not whether it matches,
+// and a measurement run has to see every match.
+func runCheck(dir string, args []string, stdin io.Reader, stdout io.Writer) error {
+	if len(args) != 1 || args[0] != "-" {
+		return fmt.Errorf("check needs '-' to read a plan from stdin")
+	}
+	plan, err := io.ReadAll(stdin)
+	if err != nil {
+		return fmt.Errorf("check: read plan: %w", err)
+	}
+	for _, finding := range planFindings(dir, string(plan), "") {
+		fmt.Fprintln(stdout, finding)
+	}
+	return nil
+}

--- a/cmd/deja/check_test.go
+++ b/cmd/deja/check_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunCheckUsesTheHookPlanCore(t *testing.T) {
+	withPlanLookup(t, samplePlanMatches(`C:\work\repo`))
+	dir := filepath.Join(t.TempDir(), "index.db")
+	plan := "1. Run timeout around deploy_probe"
+
+	var hookOut bytes.Buffer
+	hookInput := `{
+		"hook_event_name":"PreToolUse",
+		"tool_name":"ExitPlanMode",
+		"tool_input":{"plan":"1. Run timeout around deploy_probe"},
+		"session_id":""
+	}`
+	if err := runHookPlan(dir, strings.NewReader(hookInput), &hookOut); err != nil {
+		t.Fatal(err)
+	}
+
+	var resp struct {
+		HookSpecificOutput struct {
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(hookOut.Bytes(), &resp); err != nil {
+		t.Fatalf("hook JSON = %q: %v", hookOut.String(), err)
+	}
+	hookPlain := strings.TrimPrefix(resp.HookSpecificOutput.AdditionalContext, recallFrameHeader)
+	hookPlain = strings.TrimSuffix(hookPlain, recallFrameFooter)
+
+	var checkOut bytes.Buffer
+	if err := runCheck(dir, []string{"-"}, strings.NewReader(plan), &checkOut); err != nil {
+		t.Fatal(err)
+	}
+	checkPlain := strings.TrimSuffix(checkOut.String(), "\n")
+	if checkPlain != hookPlain {
+		t.Fatalf("check and hook differ:\ncheck: %q\nhook:  %q", checkPlain, hookPlain)
+	}
+	if strings.Contains(checkOut.String(), "<deja-recall>") {
+		t.Fatalf("check output contains a recall frame: %q", checkOut.String())
+	}
+	if strings.Count(strings.TrimSpace(checkOut.String()), "\n") != 0 {
+		t.Fatalf("one finding was not printed as one line: %q", checkOut.String())
+	}
+}
+
+func TestRunCheckSilentMiss(t *testing.T) {
+	withPlanLookup(t, nil)
+	var out bytes.Buffer
+	if err := runCheck(
+		filepath.Join(t.TempDir(), "index.db"),
+		[]string{"-"},
+		strings.NewReader("1. Run timeout around deploy_probe"),
+		&out,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("miss produced %q", out.String())
+	}
+}
+
+func TestRunCheckRequiresDash(t *testing.T) {
+	for _, args := range [][]string{
+		nil,
+		{"PLAN.md"},
+		{"-", "extra"},
+	} {
+		var out bytes.Buffer
+		err := runCheck(
+			filepath.Join(t.TempDir(), "index.db"),
+			args,
+			strings.NewReader("1. Run timeout around deploy_probe"),
+			&out,
+		)
+		if err == nil {
+			t.Fatalf("args %v returned no usage error", args)
+		}
+		if !strings.Contains(err.Error(), "check needs '-'") {
+			t.Fatalf("args %v error = %q", args, err)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("args %v produced output %q", args, out.String())
+		}
+	}
+}

--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -39,7 +39,7 @@ _deja_completion() {
     command="${COMP_WORDS[1]}"
     action="${COMP_WORDS[2]}"
 
-    local commands="blame bench completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup"
+    local commands="blame bench check completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup"
     local harnesses="claude codex opencode aider gemini cursor antigravity grok qwen pi copilot deja"
     local install_targets="%INSTALL_TARGETS% --all --auto"
 
@@ -125,7 +125,7 @@ _deja_completion() {
                 COMPREPLY=( $(compgen -d -- "$cur") )
             fi
             ;;
-        ctx|embed|hook-precompact|hook-prompt|mcp|share|show|sources|statusline|update|version|warmup)
+        check|ctx|embed|hook-precompact|hook-prompt|mcp|share|show|sources|statusline|update|version|warmup)
             COMPREPLY=()
             ;;
         *)
@@ -148,6 +148,7 @@ _deja() {
   commands=(
     'blame:find sessions that discussed a file'
     'bench:run benchmarks'
+    'check:read a plan from stdin and print factual co-occurrences'
     'completion:generate shell completion'
     'ctx:print a compact context digest'
     'files:which files the work on a topic touched'
@@ -244,7 +245,7 @@ _deja() {
         _arguments '--pull[pull from the remote]' '--full[transfer all records]' '1:host:'
       fi
       ;;
-    ctx|embed|hook-precompact|hook-prompt|mcp|share|show|sources|statusline|update|version|warmup)
+    check|ctx|embed|hook-precompact|hook-prompt|mcp|share|show|sources|statusline|update|version|warmup)
       ;;
     *)
       _arguments '--json[print JSON]' '--re[interpret query as a regular expression]' '--all[include all results]' '--no-embed[skip semantic reranking]' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(user assistant tool)' '--rebuild[force a full rebuild]'
@@ -259,7 +260,7 @@ const fishCompletion = `function __deja_needs_command
     test (count (commandline -opc)) -eq 1
 end
 
-complete -c deja -n '__deja_needs_command' -a 'blame bench completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup'
+complete -c deja -n '__deja_needs_command' -a 'blame bench check completion ctx doctor embed files forget friction handoff help index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup'
 complete -c deja -n '__deja_needs_command' -l json -d 'Print JSON'
 complete -c deja -n '__deja_needs_command' -l re -d 'Interpret query as a regular expression'
 complete -c deja -n '__deja_needs_command' -l all -d 'Include all results'

--- a/cmd/deja/completion_coverage_test.go
+++ b/cmd/deja/completion_coverage_test.go
@@ -13,7 +13,7 @@ func TestCompletionsListEveryUserFacingCommand(t *testing.T) {
 	internal := map[string]bool{
 		"hook-context": true, "hook-prompt": true, "hook-precompact": true,
 		"hook-antigravity": true, "hook-goose": true, "hook-refresh": true,
-		"warmup-status": true, "mcp": true,
+		"hook-plan": true, "warmup-status": true, "mcp": true,
 	}
 	shells := map[string]string{
 		"bash": bashCompletion,

--- a/cmd/deja/hook_plan.go
+++ b/cmd/deja/hook_plan.go
@@ -1,0 +1,406 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// planHookBudget is the complete framed payload budget. Findings receive the
+// remainder after the existing untrusted-history frame takes its share.
+const planHookBudget = 2048
+
+const (
+	planFindingLimit = 4
+	planStepLimit    = 3
+	planTermLimit    = 4
+)
+
+type planHookInput struct {
+	HookEventName string `json:"hook_event_name"`
+	ToolName      string `json:"tool_name"`
+	ToolInput     struct {
+		Plan         string `json:"plan"`
+		PlanFilePath string `json:"planFilePath"`
+	} `json:"tool_input"`
+	SessionID string `json:"session_id"`
+	CWD       string `json:"cwd"`
+}
+
+type planFinding struct {
+	line     string
+	sessions []index.SessionMeta
+}
+
+var planIndexReady = func(dir string) bool {
+	return index.HasManifest(dir) &&
+		index.IsCurrentVersion(dir) &&
+		!index.Damaged(dir)
+}
+
+var planFrictionLookup = index.PlanFrictionMatches
+
+// runHookPlan is the ExitPlanMode PreToolUse hook. Silence is the miss
+// contract, including malformed input and an unavailable index.
+func runHookPlan(dir string, stdin io.Reader, stdout io.Writer) error {
+	var input planHookInput
+	_ = json.NewDecoder(bytes.NewReader(readHookPayload(stdin, hookStdinWait))).Decode(&input)
+	// The matcher should guarantee ExitPlanMode, but a hook wired with a
+	// wider matcher must not answer for tools it was never designed to read.
+	if input.ToolName != "ExitPlanMode" {
+		return nil
+	}
+	adoptHookCWD(input.CWD)
+
+	lines := planFindings(dir, input.ToolInput.Plan, input.SessionID)
+	if len(lines) == 0 {
+		return nil
+	}
+
+	var resp sessionStartHookResponse
+	resp.HookSpecificOutput.HookEventName = "PreToolUse"
+	resp.HookSpecificOutput.AdditionalContext = frameRecall(strings.Join(lines, "\n"))
+	b, err := json.Marshal(resp)
+	if err != nil {
+		return nil
+	}
+	fmt.Fprintln(stdout, string(b))
+	return nil
+}
+
+// planFindings is shared verbatim by hook-plan and check. A non-empty session
+// id enables the same cross-hook advisory dedupe used by hook-prompt.
+func planFindings(dir, plan, sessionID string) []string {
+	steps := planSearchSteps(plan)
+	if len(steps) == 0 {
+		return nil
+	}
+
+	pol := policy.Load()
+	seen := alreadyInjected(dir, sessionID)
+	keep := func(meta index.SessionMeta) bool {
+		if !pol.Allows(policy.ActivationAuto, meta.Project) {
+			return false
+		}
+		if sessionID != "" && (meta.ID == sessionID || seen[meta.ID]) {
+			return false
+		}
+		return true
+	}
+
+	// This path never asks for a rebuild. A missing, stale, or damaged
+	// snapshot is a silent miss so plan submission cannot block on indexing.
+	if !planIndexReady(dir) {
+		return nil
+	}
+
+	matches := planFrictionLookup(dir, steps, keep, planFindingLimit)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	var findings []planFinding
+	emittedWalls := map[string]bool{}
+	for _, match := range matches {
+		wallSessions := filterPlanMetas(match.Wall.Sessions, keep, nil)
+		if len(wallSessions) < index.FrictionMinSessions {
+			continue
+		}
+		wallIDs := make(map[string]bool, len(wallSessions))
+		for _, meta := range wallSessions {
+			wallIDs[planMetaKey(meta)] = true
+		}
+		// The wall recurrence is the finding on its own (see PlanCooccurrence
+		// in internal/index/plan.go). A command is only ever a bonus clause,
+		// so a command whose evidence sessions did not survive the policy
+		// filter is dropped rather than taking the whole finding with it.
+		match.Wall.Sessions = wallSessions
+		commandSessions := filterPlanMetas(match.CommandSessions, keep, wallIDs)
+		if len(commandSessions) > 0 && strings.TrimSpace(match.Command) != "" {
+			match.CommandSessions = commandSessions
+		} else {
+			match.Command = ""
+			match.CommandSessions = nil
+		}
+		wallKey := strings.ToLower(strings.TrimSpace(match.Wall.Text))
+		if wallKey == "" || emittedWalls[wallKey] {
+			continue
+		}
+		emittedWalls[wallKey] = true
+
+		line := formatPlanFinding(match)
+		if line == "" {
+			continue
+		}
+		findings = append(findings, planFinding{
+			line:     line,
+			sessions: wallSessions,
+		})
+	}
+
+	findings = budgetPlanFindings(findings, planHookBudget-recallFrameOverhead)
+	if len(findings) == 0 {
+		return nil
+	}
+	if sessionID != "" {
+		rememberPlanFindings(dir, sessionID, findings)
+	}
+
+	lines := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		lines = append(lines, finding.line)
+	}
+	return lines
+}
+
+func filterPlanMetas(metas []index.SessionMeta, keep func(index.SessionMeta) bool, members map[string]bool) []index.SessionMeta {
+	out := make([]index.SessionMeta, 0, len(metas))
+	seen := map[string]bool{}
+	for _, meta := range metas {
+		key := planMetaKey(meta)
+		if seen[key] || !keep(meta) {
+			continue
+		}
+		if members != nil && !members[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, meta)
+	}
+	return out
+}
+
+func planMetaKey(meta index.SessionMeta) string {
+	return meta.Harness + ":" + meta.ID
+}
+
+func rememberPlanFindings(dir, sessionID string, findings []planFinding) {
+	seen := map[string]bool{}
+	var sessions []model.Session
+	for _, finding := range findings {
+		for _, meta := range finding.sessions {
+			if meta.ID == "" || seen[meta.ID] {
+				continue
+			}
+			seen[meta.ID] = true
+			sessions = append(sessions, model.Session{ID: meta.ID})
+		}
+	}
+	rememberInjected(dir, sessionID, sessions)
+}
+
+// extractPlanSteps prefers explicit Markdown steps. Prose lines are considered
+// only when the plan contains no numbered or bulleted items.
+func extractPlanSteps(plan string) []string {
+	lines := strings.Split(strings.ReplaceAll(plan, "\r\n", "\n"), "\n")
+	var listed []string
+	for _, line := range lines {
+		if step, ok := stripPlanMarker(line); ok && step != "" {
+			listed = append(listed, step)
+		}
+	}
+	if len(listed) > 0 {
+		return listed
+	}
+
+	var fallback []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		line = strings.TrimSpace(strings.TrimLeft(line, "#"))
+		if line != "" {
+			fallback = append(fallback, line)
+		}
+	}
+	return fallback
+}
+
+func stripPlanMarker(line string) (string, bool) {
+	s := strings.TrimSpace(line)
+	if len(s) >= 2 {
+		if (s[0] == '-' || s[0] == '*' || s[0] == '+') && unicode.IsSpace(rune(s[1])) {
+			return stripPlanCheckbox(strings.TrimSpace(s[1:])), true
+		}
+	}
+
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	if i == 0 || i >= len(s) || (s[i] != '.' && s[i] != ')') {
+		return "", false
+	}
+	i++
+	if i >= len(s) || !unicode.IsSpace(rune(s[i])) {
+		return "", false
+	}
+	return stripPlanCheckbox(strings.TrimSpace(s[i:])), true
+}
+
+func stripPlanCheckbox(s string) string {
+	if len(s) >= 3 && s[0] == '[' && s[2] == ']' {
+		switch s[1] {
+		case ' ', 'x', 'X':
+			return strings.TrimSpace(s[3:])
+		}
+	}
+	return s
+}
+
+// planSearchSteps returns at most the first three steps carrying enough raw
+// terms to be worth a lookup; whether a term actually counts toward that
+// lookup — rare enough in this corpus, or identifier-shaped and exempt from
+// rarity entirely — is the index layer's call (planIndexedSteps), made
+// against the same 1-or-2 need computed here. Each step is independently
+// capped so one long paragraph cannot dominate candidate selection. The need
+// is two terms, same as auto-recall, except a step naming an identifier
+// (hasIdentifierTerm) needs only one — hook-prompt already trusts a lone
+// identifier hit, and a plan step deserves the same trust.
+func planSearchSteps(plan string) [][]string {
+	var out [][]string
+	for _, step := range extractPlanSteps(plan) {
+		terms := promptSearchTerms(step)
+		if len(terms) > planTermLimit {
+			terms = terms[:planTermLimit]
+		}
+		need := 2
+		if hasIdentifierTerm(terms) {
+			need = 1
+		}
+		if len(terms) < need {
+			continue
+		}
+		out = append(out, terms)
+		if len(out) == planStepLimit {
+			break
+		}
+	}
+	return out
+}
+
+// formatPlanFinding reports the wall recurrence — the fact a census
+// verified (internal/index/plan.go's PlanCooccurrence doc) — and, only when
+// one was actually found, appends the command clause as a bonus, not a
+// requirement.
+func formatPlanFinding(match index.PlanCooccurrence) string {
+	if len(match.Wall.Sessions) < index.FrictionMinSessions ||
+		strings.TrimSpace(match.Wall.Text) == "" {
+		return ""
+	}
+
+	since := ""
+	if oldest := oldestPlanSession(match.Wall.Sessions); !oldest.IsZero() {
+		since = " since " + oldest.Format("2006-01-02")
+	}
+	wall := strconv.Quote(neutralPlanEvidence(match.Wall.Text))
+	line := fmt.Sprintf("wall hit in %d sessions%s: %s", len(match.Wall.Sessions), since, wall)
+
+	if len(match.CommandSessions) == 0 || strings.TrimSpace(match.Command) == "" {
+		return line
+	}
+	command := strconv.Quote(neutralPlanEvidence(match.Command))
+	return fmt.Sprintf(
+		"%s; past sessions also ran %s (%d sessions)",
+		line, command, len(match.CommandSessions),
+	)
+}
+
+func oldestPlanSession(metas []index.SessionMeta) time.Time {
+	var oldest time.Time
+	for _, meta := range metas {
+		if meta.Updated.IsZero() {
+			continue
+		}
+		if oldest.IsZero() || meta.Updated.Before(oldest) {
+			oldest = meta.Updated
+		}
+	}
+	return oldest
+}
+
+var forbiddenPlanClaims = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)conflicts with`),
+	regexp.MustCompile(`(?i)contradicts`),
+	regexp.MustCompile(`(?i)already tried`),
+	regexp.MustCompile(`(?i)was abandoned`),
+}
+
+// neutralPlanEvidence keeps recalled text as quoted evidence without allowing
+// its own wording to turn a co-occurrence report into a judgment.
+func neutralPlanEvidence(text string) string {
+	text = strings.Join(strings.Fields(text), " ")
+	text = neutralizeFrameMarkers(text)
+	for _, pattern := range forbiddenPlanClaims {
+		text = pattern.ReplaceAllString(text, "[historical wording omitted]")
+	}
+	return text
+}
+
+func budgetPlanFindings(findings []planFinding, budget int) []planFinding {
+	if budget <= 0 {
+		return nil
+	}
+	out := make([]planFinding, 0, len(findings))
+	used := 0
+	for _, finding := range findings {
+		line := strings.TrimSpace(finding.line)
+		if line == "" {
+			continue
+		}
+		separator := 0
+		if len(out) > 0 {
+			separator = 1
+		}
+		available := budget - used - separator
+		if available <= 0 {
+			break
+		}
+		if len(line) > available {
+			line = truncatePlanBytes(line, available)
+			if line == "" {
+				break
+			}
+			finding.line = line
+			out = append(out, finding)
+			break
+		}
+		finding.line = line
+		out = append(out, finding)
+		used += separator + len(line)
+	}
+	return out
+}
+
+func truncatePlanBytes(text string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	if len(text) <= limit {
+		return text
+	}
+	const ellipsis = "窶ｦ"
+	if limit <= len(ellipsis) {
+		return ""
+	}
+	end := limit - len(ellipsis)
+	for end > 0 && !utf8.ValidString(text[:end]) {
+		end--
+	}
+	if end == 0 {
+		return ""
+	}
+	return strings.TrimSpace(text[:end]) + ellipsis
+}

--- a/cmd/deja/hook_plan_test.go
+++ b/cmd/deja/hook_plan_test.go
@@ -1,0 +1,900 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+func TestExtractPlanSteps(t *testing.T) {
+	tests := []struct {
+		name string
+		plan string
+		want []string
+	}{
+		{
+			name: "numbered",
+			plan: "## Plan\n1. Update gateway_timeout handling\n2) Test reconnect_loop recovery",
+			want: []string{"Update gateway_timeout handling", "Test reconnect_loop recovery"},
+		},
+		{
+			name: "bulleted",
+			plan: "- Inspect exporter_batch\n* Repair utc_midnight rollover\n+ Add regression coverage",
+			want: []string{"Inspect exporter_batch", "Repair utc_midnight rollover", "Add regression coverage"},
+		},
+		{
+			name: "mixed",
+			plan: "Plan\n1. Inspect auth_cache\n- [ ] Update token_rotation\n2) Test Windows paths",
+			want: []string{"Inspect auth_cache", "Update token_rotation", "Test Windows paths"},
+		},
+		{
+			name: "fallback",
+			plan: "## Inspect gateway_timeout\nRepair reconnect_loop",
+			want: []string{"Inspect gateway_timeout", "Repair reconnect_loop"},
+		},
+		{
+			name: "empty",
+			plan: "\r\n  \n",
+			want: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := extractPlanSteps(test.plan); !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("steps = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPlanSearchStepsCapsTermsAndSteps(t *testing.T) {
+	plan := strings.Join([]string{
+		`1. Inspect C:\work\repo\auth.go gateway_timeout reconnect_loop token_rotation extra_identifier`,
+		"2. Update exporter_batch utc_midnight rollover_guard",
+		"3. Test websocket_reconnect heartbeat_timeout retry_budget",
+		"4. Document deployment_pipeline release_checklist",
+	}, "\n")
+	got := planSearchSteps(plan)
+	if len(got) != planStepLimit {
+		t.Fatalf("steps = %d, want %d: %v", len(got), planStepLimit, got)
+	}
+	for i, terms := range got {
+		if len(terms) < 2 || len(terms) > planTermLimit {
+			t.Fatalf("step %d terms = %v", i, terms)
+		}
+	}
+	// A Windows path is ordinary text to the tokenizer: backslash splits it,
+	// and only the basename survives as a term. Path-aware matching is out of
+	// scope here; this pins the actual behavior so nobody reads more into the
+	// fixture above.
+	joined := strings.Join(got[0], " ")
+	if !strings.Contains(joined, "auth.go") || strings.Contains(joined, `\`) {
+		t.Fatalf("step 0 terms = %v, want the path reduced to its basename token", got[0])
+	}
+}
+
+func TestPlanWeakInputStopsBeforeTheIndex(t *testing.T) {
+	oldReady := planIndexReady
+	oldLookup := planFrictionLookup
+	t.Cleanup(func() {
+		planIndexReady = oldReady
+		planFrictionLookup = oldLookup
+	})
+
+	readyCalls := 0
+	lookupCalls := 0
+	planIndexReady = func(string) bool {
+		readyCalls++
+		return true
+	}
+	planFrictionLookup = func(string, [][]string, func(index.SessionMeta) bool, int) []index.PlanCooccurrence {
+		lookupCalls++
+		return samplePlanMatches("local-project")
+	}
+
+	// "retry" alone is a real tech term but neither long enough nor
+	// symbol-shaped to count as an identifier, so it still needs a second
+	// term it doesn't have.
+	for _, plan := range []string{"", "- ok", "1. retry"} {
+		if got := planFindings(filepath.Join(t.TempDir(), "index.db"), plan, "session"); len(got) != 0 {
+			t.Fatalf("plan %q produced %v", plan, got)
+		}
+	}
+	if readyCalls != 0 || lookupCalls != 0 {
+		t.Fatalf("weak plans touched the index: ready=%d lookup=%d", readyCalls, lookupCalls)
+	}
+}
+
+// TestPlanSearchStepsIdentifierSingleTermAdmitted covers the same rule
+// hook-prompt already applies to auto-recall (hasIdentifierTerm,
+// cmd/deja/hook_prompt.go:319): a step naming something identifier-shaped is
+// specific enough on one word, so it should not need a second term to be
+// searched.
+func TestPlanSearchStepsIdentifierSingleTermAdmitted(t *testing.T) {
+	got := planSearchSteps("1. auth.go")
+	if len(got) != 1 {
+		t.Fatalf("steps = %v, want one admitted step", got)
+	}
+	if len(got[0]) != 1 || got[0][0] != "auth.go" {
+		t.Fatalf("step terms = %v, want [\"auth.go\"]", got[0])
+	}
+}
+
+// TestPlanSearchStepsNonIdentifierSingleTermDropped is the negative half of
+// the case above: an ordinary single word carries no more signal here than
+// it does for auto-recall, so the step is dropped rather than searched.
+func TestPlanSearchStepsNonIdentifierSingleTermDropped(t *testing.T) {
+	if got := planSearchSteps("1. Retry"); len(got) != 0 {
+		t.Fatalf("steps = %v, want none admitted", got)
+	}
+}
+
+func TestPlanPolicyDenyProducesNoOutput(t *testing.T) {
+	policyPath := filepath.Join(t.TempDir(), "policy.json")
+	if err := os.WriteFile(policyPath, []byte(`{"activations":{"auto":{"local":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyPath)
+	withPlanLookup(t, samplePlanMatches(`C:\work\private-repo`))
+
+	got := planFindings(
+		filepath.Join(t.TempDir(), "index.db"),
+		"1. Run timeout around deploy_probe",
+		"agent-session",
+	)
+	if len(got) != 0 {
+		t.Fatalf("denied sessions produced findings: %v", got)
+	}
+}
+
+func TestPlanFindingClaimIsNeutral(t *testing.T) {
+	match := samplePlanMatches("local-project")[0]
+	match.Wall.Text = "build conflicts with the cache and contradicts the manifest"
+	match.Command = "echo already tried and was abandoned"
+
+	got := strings.ToLower(formatPlanFinding(match))
+	for _, forbidden := range []string{
+		"conflicts with",
+		"contradicts",
+		"already tried",
+		"was abandoned",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("finding contains forbidden claim %q: %q", forbidden, got)
+		}
+	}
+	if !strings.HasPrefix(got, "wall hit in 3 sessions since ") {
+		t.Fatalf("finding is not a neutral factual report: %q", got)
+	}
+	if strings.Contains(got, " should ") || strings.Contains(got, " must ") {
+		t.Fatalf("finding commands the reader: %q", got)
+	}
+}
+
+// TestPlanFindingClaimIsNeutralWallOnly is the wall-only counterpart to
+// TestPlanFindingClaimIsNeutral: the forbidden-vocabulary and non-imperative
+// checks apply to the wall clause on its own, since v1.5 lets a finding
+// stand without a command clause at all.
+func TestPlanFindingClaimIsNeutralWallOnly(t *testing.T) {
+	match := samplePlanMatches("local-project")[0]
+	match.Wall.Text = "build conflicts with the cache and contradicts the manifest"
+	match.Command = ""
+	match.CommandSessions = nil
+
+	got := strings.ToLower(formatPlanFinding(match))
+	for _, forbidden := range []string{
+		"conflicts with",
+		"contradicts",
+		"already tried",
+		"was abandoned",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("finding contains forbidden claim %q: %q", forbidden, got)
+		}
+	}
+	if !strings.HasPrefix(got, "wall hit in 3 sessions since ") {
+		t.Fatalf("finding is not a neutral factual report: %q", got)
+	}
+	if strings.Contains(got, "also ran") {
+		t.Fatalf("wall-only finding unexpectedly carries a command clause: %q", got)
+	}
+	if strings.Contains(got, " should ") || strings.Contains(got, " must ") {
+		t.Fatalf("finding commands the reader: %q", got)
+	}
+}
+
+func TestPlanHookBudgetIncludesRecallFrame(t *testing.T) {
+	huge := strings.Repeat("oversized_gateway_failure_ﾎｩ ", 400)
+	findings := []planFinding{
+		{line: "wall hit in 3 sessions: " + huge},
+		{line: "wall hit in 4 sessions: " + huge},
+	}
+	budgeted := budgetPlanFindings(findings, planHookBudget-recallFrameOverhead)
+	if len(budgeted) == 0 {
+		t.Fatal("oversized finding was dropped rather than truncated")
+	}
+	var lines []string
+	for _, finding := range budgeted {
+		lines = append(lines, finding.line)
+	}
+	payload := strings.Join(lines, "\n")
+	framed := frameRecall(payload)
+	if len(payload) > planHookBudget-recallFrameOverhead {
+		t.Fatalf("payload = %d bytes, budget = %d", len(payload), planHookBudget-recallFrameOverhead)
+	}
+	if len(framed) > planHookBudget {
+		t.Fatalf("framed payload = %d bytes, budget = %d", len(framed), planHookBudget)
+	}
+	if !strings.Contains(payload, "窶ｦ") {
+		t.Fatalf("oversized finding was not visibly truncated: %q", payload)
+	}
+}
+
+func TestPlanHookSeenDedupeSuppressesSecondInvocation(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	withPlanLookup(t, samplePlanMatches("local-project"))
+
+	first := planFindings(dir, "1. Run timeout around deploy_probe", "agent-1")
+	if len(first) != 1 {
+		t.Fatalf("first findings = %v", first)
+	}
+	second := planFindings(dir, "1. Run timeout around deploy_probe", "agent-1")
+	if len(second) != 0 {
+		t.Fatalf("second invocation repeated findings: %v", second)
+	}
+	seen := alreadyInjected(dir, "agent-1")
+	for _, id := range []string{"wall-a", "wall-b", "wall-c"} {
+		if !seen[id] {
+			t.Errorf("%s was not recorded in .hookseen: %v", id, seen)
+		}
+	}
+}
+
+func TestPlanHookEmitsEachWallOnce(t *testing.T) {
+	match := samplePlanMatches("local-project")[0]
+	withPlanLookup(t, []index.PlanCooccurrence{match, match})
+
+	got := planFindings(
+		filepath.Join(t.TempDir(), "index.db"),
+		"1. Run timeout around deploy_probe",
+		"",
+	)
+	if len(got) != 1 {
+		t.Fatalf("duplicate wall emitted %d times: %v", len(got), got)
+	}
+}
+
+func TestHookPlanJSONContract(t *testing.T) {
+	t.Run("hit with unknown fields and Windows paths", func(t *testing.T) {
+		withPlanLookup(t, samplePlanMatches(`C:\work\repo`))
+		t.Setenv("CLAUDE_PROJECT_DIR", "")
+
+		input := `{
+			"hook_event_name":"PreToolUse",
+			"tool_name":"ExitPlanMode",
+			"tool_input":{
+				"plan":"1. Run timeout around deploy_probe",
+				"planFilePath":"C:\\work\\repo\\PLAN.md",
+				"future_field":true
+			},
+			"session_id":"",
+			"cwd":"C:\\work\\repo",
+			"unknown_top_level":{"value":1}
+		}`
+		var out bytes.Buffer
+		if err := runHookPlan(filepath.Join(t.TempDir(), "index.db"), strings.NewReader(input), &out); err != nil {
+			t.Fatal(err)
+		}
+		if out.Len() == 0 {
+			t.Fatal("matching hook produced no output")
+		}
+		if strings.Contains(out.String(), "permissionDecision") {
+			t.Fatalf("security-sensitive field appeared in output: %s", out.String())
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(out.Bytes(), &raw); err != nil {
+			t.Fatalf("bad JSON %q: %v", out.String(), err)
+		}
+		if len(raw) != 1 {
+			t.Fatalf("top-level shape = %v", raw)
+		}
+		var envelope struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		}
+		if err := json.Unmarshal(raw["hookSpecificOutput"], &envelope); err != nil {
+			t.Fatal(err)
+		}
+		if envelope.HookEventName != "PreToolUse" {
+			t.Fatalf("event = %q", envelope.HookEventName)
+		}
+		if !strings.HasPrefix(envelope.AdditionalContext, recallFrameHeader) ||
+			!strings.HasSuffix(envelope.AdditionalContext, recallFrameFooter) {
+			t.Fatalf("context is not framed: %q", envelope.AdditionalContext)
+		}
+		if len(envelope.AdditionalContext) > planHookBudget {
+			t.Fatalf("context = %d bytes, budget = %d", len(envelope.AdditionalContext), planHookBudget)
+		}
+	})
+
+	t.Run("miss", func(t *testing.T) {
+		withPlanLookup(t, nil)
+		var out bytes.Buffer
+		err := runHookPlan(
+			filepath.Join(t.TempDir(), "index.db"),
+			strings.NewReader(`{"tool_name":"ExitPlanMode","tool_input":{"plan":"1. Run timeout around deploy_probe"}}`),
+			&out,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("miss produced %q", out.String())
+		}
+	})
+
+	t.Run("other tool", func(t *testing.T) {
+		withPlanLookup(t, samplePlanMatches("local-project"))
+		var out bytes.Buffer
+		err := runHookPlan(
+			filepath.Join(t.TempDir(), "index.db"),
+			strings.NewReader(`{"tool_name":"Bash","tool_input":{"plan":"1. Run timeout around deploy_probe"}}`),
+			&out,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("other tool produced %q", out.String())
+		}
+	})
+
+	t.Run("missing tool input", func(t *testing.T) {
+		withPlanLookup(t, samplePlanMatches("local-project"))
+		var out bytes.Buffer
+		if err := runHookPlan(
+			filepath.Join(t.TempDir(), "index.db"),
+			strings.NewReader(`{"tool_name":"ExitPlanMode","future_field":"accepted"}`),
+			&out,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("missing tool_input produced %q", out.String())
+		}
+	})
+
+	t.Run("missing tool name", func(t *testing.T) {
+		withPlanLookup(t, samplePlanMatches("local-project"))
+		var out bytes.Buffer
+		if err := runHookPlan(
+			filepath.Join(t.TempDir(), "index.db"),
+			strings.NewReader(`{"tool_input":{"plan":"1. Run timeout around deploy_probe"}}`),
+			&out,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("input without tool_name produced %q", out.String())
+		}
+	})
+}
+
+func TestPlanFrictionIndexJoin(t *testing.T) {
+	withStatsStores(t)
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing-policy.json"))
+
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("plan-wall-%d", i)
+		toolID := fmt.Sprintf("tool-plan-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"run the deploy probe"}}`,
+				id, old,
+			),
+			fmt.Sprintf(
+				`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","id":%q,"name":"Bash","input":{"command":"go run ./deploy_probe --timeout 5 --config C:\\work\\repo\\PLAN.md"}}]}}`,
+				id, old, toolID,
+			),
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":%q,"is_error":true,"content":"/bin/sh: timeout: command not found"}]}}`,
+				id, old, toolID,
+			),
+		})
+	}
+
+	// The recurring wall appears in three sessions. Additional unrelated
+	// sessions make its terms clear the same IDF floor used by auto recall.
+	for i := 0; i < 27; i++ {
+		id := fmt.Sprintf("plan-noise-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "noise", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"unrelated color palette discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	steps := planSearchSteps("1. Run timeout around deploy_probe")
+	matches := index.PlanFrictionMatches(
+		index.DefaultDir(),
+		steps,
+		func(index.SessionMeta) bool { return true },
+		4,
+	)
+	if len(matches) == 0 {
+		t.Fatal("manifest wall and command records did not join")
+	}
+	got := matches[0]
+	if len(got.Wall.Sessions) < index.FrictionMinSessions {
+		t.Fatalf("wall sessions = %d", len(got.Wall.Sessions))
+	}
+	if !strings.Contains(strings.ToLower(got.Wall.Text), "timeout") {
+		t.Fatalf("wall = %q", got.Wall.Text)
+	}
+	if !strings.Contains(got.Command, "deploy_probe") {
+		t.Fatalf("command = %q", got.Command)
+	}
+}
+
+// TestPlanFrictionIndexJoinSingleIdentifierTerm covers the join end to end
+// for a plan step that names nothing but a single identifier. The command
+// record here shares only that one term with the step (no second word like
+// "timeout" to fall back on), so the join succeeds only because
+// planCommandForStep's threshold drops to one for an identifier step.
+func TestPlanFrictionIndexJoinSingleIdentifierTerm(t *testing.T) {
+	withStatsStores(t)
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing-policy.json"))
+
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("plan-single-wall-%d", i)
+		toolID := fmt.Sprintf("tool-plan-single-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-single", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"run the deploy probe"}}`,
+				id, old,
+			),
+			fmt.Sprintf(
+				`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","id":%q,"name":"Bash","input":{"command":"go run ./deploy_probe --config C:\\work\\repo\\PLAN.md"}}]}}`,
+				id, old, toolID,
+			),
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":%q,"is_error":true,"content":"/bin/sh: deploy_probe: command not found"}]}}`,
+				id, old, toolID,
+			),
+		})
+	}
+
+	// Same noise volume as TestPlanFrictionIndexJoin: deploy_probe appears in
+	// exactly the three wall sessions, and this many unrelated sessions is
+	// what clears the IDF floor at that document count.
+	for i := 0; i < 27; i++ {
+		id := fmt.Sprintf("plan-single-noise-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "noise-single", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"unrelated color palette discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	steps := planSearchSteps("1. deploy_probe")
+	if len(steps) != 1 || len(steps[0]) != 1 {
+		t.Fatalf("steps = %v, want a single single-term step", steps)
+	}
+	matches := index.PlanFrictionMatches(
+		index.DefaultDir(),
+		steps,
+		func(index.SessionMeta) bool { return true },
+		4,
+	)
+	if len(matches) == 0 {
+		t.Fatal("single-identifier-term step did not join to a command")
+	}
+	got := matches[0]
+	if len(got.Wall.Sessions) < index.FrictionMinSessions {
+		t.Fatalf("wall sessions = %d", len(got.Wall.Sessions))
+	}
+	if !strings.Contains(got.Command, "deploy_probe") {
+		t.Fatalf("command = %q", got.Command)
+	}
+}
+
+// TestPlanFrictionIndexJoinWallOnly is the v1.5 case: a census across real
+// walls found a matching command logged alongside the wall in only 1 of 19
+// carriers, so requiring one would reject nearly every recurrence. Here the
+// wall text itself names the step's term but no carrier's command does —
+// the join must still succeed, with Command left empty.
+func TestPlanFrictionIndexJoinWallOnly(t *testing.T) {
+	withStatsStores(t)
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing-policy.json"))
+
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("plan-wallonly-%d", i)
+		toolID := fmt.Sprintf("tool-plan-wallonly-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-wallonly", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"run the gateway again"}}`,
+				id, old,
+			),
+			// A command is logged, but it shares no term with the plan step —
+			// this is the realistic majority shape, not the 1-in-19 case
+			// where a command happens to name the wall too.
+			fmt.Sprintf(
+				`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","id":%q,"name":"Bash","input":{"command":"echo done"}}]}}`,
+				id, old, toolID,
+			),
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":%q,"is_error":true,"content":"/bin/sh: gateway_timeout: command not found"}]}}`,
+				id, old, toolID,
+			),
+		})
+	}
+
+	// Same noise volume as the other join tests: clears the IDF floor for
+	// gateway_timeout at this document count.
+	for i := 0; i < 27; i++ {
+		id := fmt.Sprintf("plan-wallonly-noise-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "noise-wallonly", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"unrelated color palette discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	steps := planSearchSteps("1. gateway_timeout")
+	if len(steps) != 1 || len(steps[0]) != 1 {
+		t.Fatalf("steps = %v, want a single single-term step", steps)
+	}
+	matches := index.PlanFrictionMatches(
+		index.DefaultDir(),
+		steps,
+		func(index.SessionMeta) bool { return true },
+		4,
+	)
+	if len(matches) == 0 {
+		t.Fatal("wall-only recurrence did not produce a finding")
+	}
+	got := matches[0]
+	if len(got.Wall.Sessions) < index.FrictionMinSessions {
+		t.Fatalf("wall sessions = %d", len(got.Wall.Sessions))
+	}
+	if !strings.Contains(strings.ToLower(got.Wall.Text), "gateway_timeout") {
+		t.Fatalf("wall = %q", got.Wall.Text)
+	}
+	if got.Command != "" || len(got.CommandSessions) != 0 {
+		t.Fatalf("expected no command strengthening, got command=%q sessions=%v", got.Command, got.CommandSessions)
+	}
+
+	line := formatPlanFinding(got)
+	if line == "" {
+		t.Fatal("wall-only match produced no finding line")
+	}
+	if strings.Contains(line, "also ran") {
+		t.Fatalf("wall-only line unexpectedly carries a command clause: %q", line)
+	}
+	if !strings.Contains(line, "gateway_timeout") {
+		t.Fatalf("finding does not name the wall: %q", line)
+	}
+}
+
+// TestPlanFrictionIndexJoinIdentifierMidFloorFires is the v1.7 case: a
+// two-tier floor, not a blanket exemption. A re-measurement against 2,886
+// real sessions found identifier-shaped false-positive anchors (cannot,
+// directory, branch, runner) topping out at idf 0.70 — the v1.6 full
+// exemption let those through — while true anchors (hermes 1.09,
+// hermes-agent 1.21) started at 1.09. Here "pipeline_probe" appears in 7 of
+// 30 sessions: idf = ln(31/8) ≈ 1.35, above planIdentifierIDFFloor (1.0) but
+// below the full dejaVuIDFFloor (2.0) a non-identifier term would need — the
+// join fires only because the term is identifier-shaped and clears the
+// lower bar.
+func TestPlanFrictionIndexJoinIdentifierMidFloorFires(t *testing.T) {
+	withStatsStores(t)
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing-policy.json"))
+
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("plan-anchor-wall-%d", i)
+		toolID := fmt.Sprintf("tool-plan-anchor-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-anchor", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"run pipeline_probe again"}}`,
+				id, old,
+			),
+			fmt.Sprintf(
+				`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","id":%q,"name":"Bash","input":{"command":"go run ./pipeline_probe --config C:\\work\\repo\\PLAN.md"}}]}}`,
+				id, old, toolID,
+			),
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":%q,"is_error":true,"content":"/bin/sh: pipeline_probe: command not found"}]}}`,
+				id, old, toolID,
+			),
+		})
+	}
+
+	// 4 more sessions repeat the same word so it clears 7 of 30 total —
+	// idf ≈ 1.35, inside the [1.0, 2.0) band only an identifier gets.
+	for i := 0; i < 4; i++ {
+		id := fmt.Sprintf("plan-anchor-common-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-anchor-common", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"pipeline_probe discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	// The remaining 23 sessions carry neither term, bringing the corpus to
+	// 30 and the document count to the 31 the idf figure above assumes.
+	for i := 0; i < 23; i++ {
+		id := fmt.Sprintf("plan-anchor-noise-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-anchor-noise", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"unrelated color palette discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	steps := planSearchSteps("1. pipeline_probe")
+	if len(steps) != 1 || len(steps[0]) != 1 {
+		t.Fatalf("steps = %v, want a single single-term step", steps)
+	}
+	matches := index.PlanFrictionMatches(
+		index.DefaultDir(),
+		steps,
+		func(index.SessionMeta) bool { return true },
+		4,
+	)
+	if len(matches) == 0 {
+		t.Fatal("identifier term inside the [1.0, 2.0) band did not join")
+	}
+	got := matches[0]
+	if len(got.Wall.Sessions) < index.FrictionMinSessions {
+		t.Fatalf("wall sessions = %d", len(got.Wall.Sessions))
+	}
+	if !strings.Contains(strings.ToLower(got.Wall.Text), "pipeline_probe") {
+		t.Fatalf("wall = %q", got.Wall.Text)
+	}
+}
+
+// TestPlanFrictionIndexJoinIdentifierBelowFloorSilent is the negative
+// control for the case above: the same identifier-shaped word, spread
+// common enough to drop its idf below planIdentifierIDFFloor (1.0), does not
+// join even though it is identifier-shaped — v1.7 narrows the exemption to a
+// lower bar, it does not remove the bar.
+func TestPlanFrictionIndexJoinIdentifierBelowFloorSilent(t *testing.T) {
+	withStatsStores(t)
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing-policy.json"))
+
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("plan-anchor-lo-wall-%d", i)
+		toolID := fmt.Sprintf("tool-plan-anchor-lo-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-anchor-lo", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"run pipeline_probe again"}}`,
+				id, old,
+			),
+			fmt.Sprintf(
+				`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","id":%q,"name":"Bash","input":{"command":"go run ./pipeline_probe --config C:\\work\\repo\\PLAN.md"}}]}}`,
+				id, old, toolID,
+			),
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":%q,"is_error":true,"content":"/bin/sh: pipeline_probe: command not found"}]}}`,
+				id, old, toolID,
+			),
+		})
+	}
+
+	// 17 more sessions repeat the same word so it clears 20 of 30 total —
+	// idf = ln(31/21) ≈ 0.39, below planIdentifierIDFFloor (1.0).
+	for i := 0; i < 17; i++ {
+		id := fmt.Sprintf("plan-anchor-lo-common-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-anchor-lo-common", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"pipeline_probe discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	for i := 0; i < 10; i++ {
+		id := fmt.Sprintf("plan-anchor-lo-noise-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-anchor-lo-noise", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"unrelated color palette discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	steps := planSearchSteps("1. pipeline_probe")
+	if len(steps) != 1 || len(steps[0]) != 1 {
+		t.Fatalf("steps = %v, want a single single-term step", steps)
+	}
+	matches := index.PlanFrictionMatches(
+		index.DefaultDir(),
+		steps,
+		func(index.SessionMeta) bool { return true },
+		4,
+	)
+	if len(matches) != 0 {
+		t.Fatalf("identifier term below planIdentifierIDFFloor should still be silent, got %v", matches)
+	}
+}
+
+// TestPlanFrictionIndexJoinNonIdentifierStillNeedsTheFloor is the negative
+// control for the case above: two ordinary, non-identifier words made just
+// as common in the corpus do not get the same exemption, so the step yields
+// no anchor terms and the join stays silent — v1.6 narrows the floor for
+// identifier-shaped words specifically, it does not lift it in general.
+func TestPlanFrictionIndexJoinNonIdentifierStillNeedsTheFloor(t *testing.T) {
+	withStatsStores(t)
+	t.Setenv("DEJA_POLICY_FILE", filepath.Join(t.TempDir(), "missing-policy.json"))
+
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("plan-common-wall-%d", i)
+		toolID := fmt.Sprintf("tool-plan-common-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-common", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"cache retry again"}}`,
+				id, old,
+			),
+			fmt.Sprintf(
+				`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","id":%q,"name":"Bash","input":{"command":"echo cache retry done"}}]}}`,
+				id, old, toolID,
+			),
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":%q,"is_error":true,"content":"/bin/sh: cache retry limit exceeded"}]}}`,
+				id, old, toolID,
+			),
+		})
+	}
+
+	// Same 20-of-30 spread as the identifier case above, but with two plain
+	// English words instead of an identifier.
+	for i := 0; i < 17; i++ {
+		id := fmt.Sprintf("plan-common-noise-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-common-noise", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"cache retry discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	for i := 0; i < 10; i++ {
+		id := fmt.Sprintf("plan-common-other-%d", i)
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "plan-common-other", id+".jsonl"), id, []string{
+			fmt.Sprintf(
+				`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":"unrelated color palette discussion number %d"}}`,
+				id, old, i,
+			),
+		})
+	}
+
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	steps := planSearchSteps("1. cache retry")
+	if len(steps) != 1 || len(steps[0]) != 2 {
+		t.Fatalf("steps = %v, want a single two-term step", steps)
+	}
+	matches := index.PlanFrictionMatches(
+		index.DefaultDir(),
+		steps,
+		func(index.SessionMeta) bool { return true },
+		4,
+	)
+	if len(matches) != 0 {
+		t.Fatalf("non-identifier common terms should still fail the floor, got %v", matches)
+	}
+}
+
+func samplePlanMatches(project string) []index.PlanCooccurrence {
+	base := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	sessions := []index.SessionMeta{
+		{ID: "wall-a", Harness: "claude", Project: project, Updated: base},
+		{ID: "wall-b", Harness: "codex", Project: project, Updated: base.Add(24 * time.Hour)},
+		{ID: "wall-c", Harness: "claude", Project: project, Updated: base.Add(48 * time.Hour)},
+	}
+	return []index.PlanCooccurrence{{
+		Wall: index.Friction{
+			Text:     "/bin/sh: timeout: command not found",
+			Sessions: sessions,
+			Last:     sessions[2].Updated,
+		},
+		Command:         `timeout 5 deploy_probe --config C:\work\repo\PLAN.md`,
+		CommandSessions: sessions[:2],
+	}}
+}
+
+func withPlanLookup(t *testing.T, result []index.PlanCooccurrence) {
+	t.Helper()
+	oldReady := planIndexReady
+	oldLookup := planFrictionLookup
+	planIndexReady = func(string) bool { return true }
+	planFrictionLookup = func(
+		_ string,
+		_ [][]string,
+		keep func(index.SessionMeta) bool,
+		limit int,
+	) []index.PlanCooccurrence {
+		var out []index.PlanCooccurrence
+		for _, match := range result {
+			var wall []index.SessionMeta
+			members := map[string]bool{}
+			for _, meta := range match.Wall.Sessions {
+				if keep(meta) {
+					wall = append(wall, meta)
+					members[planMetaKey(meta)] = true
+				}
+			}
+			if len(wall) < index.FrictionMinSessions {
+				continue
+			}
+			var commands []index.SessionMeta
+			for _, meta := range match.CommandSessions {
+				if keep(meta) && members[planMetaKey(meta)] {
+					commands = append(commands, meta)
+				}
+			}
+			if len(commands) == 0 {
+				continue
+			}
+			match.Wall.Sessions = wall
+			match.CommandSessions = commands
+			out = append(out, match)
+			if limit > 0 && len(out) == limit {
+				break
+			}
+		}
+		return out
+	}
+	t.Cleanup(func() {
+		planIndexReady = oldReady
+		planFrictionLookup = oldLookup
+	})
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -146,6 +146,12 @@ var commands = map[string]command{
 	"hook-antigravity": func(dir string, _ []string) error {
 		return runHookAntigravity(dir, os.Stdin, os.Stdout)
 	},
+	"hook-plan": func(dir string, _ []string) error {
+		return runHookPlan(dir, os.Stdin, os.Stdout)
+	},
+	"check": func(dir string, rest []string) error {
+		return runCheck(dir, rest, os.Stdin, os.Stdout)
+	},
 	"hook-context":    cmdHookContext,
 	"hook-precompact": func(dir string, _ []string) error { runHookPrecompact(dir); return nil },
 	"hook-refresh":    func(dir string, _ []string) error { runHookRefresh(dir); return nil },
@@ -2306,6 +2312,8 @@ Usage:
   deja handoff [--to <agent>] [id-prefix] [--exec]
   deja hook-prompt [--plain]  (UserPromptSubmit hook: relevance recall per prompt)
   deja hook-antigravity (Antigravity PreInvocation hook: inject on first turn)
+  deja hook-plan     (PreToolUse ExitPlanMode hook: factual plan/history co-occurrences)
+  deja check -       (read a plan from stdin and print factual co-occurrences)
   deja view [--no-open]  (browse your memory: sessions, recalls, notes — one local HTML)
   deja ctx <query|id-prefix>
   deja blame <path> [--all] [--json] [--project name] [--harness name] [--since 30d]

--- a/internal/index/plan.go
+++ b/internal/index/plan.go
@@ -1,0 +1,474 @@
+package index
+
+import (
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// PlanCooccurrence is one factual join between a recurring wall and a plan
+// step's informative terms. The wall side is the claim: a full census found
+// a matching command logged alongside the wall in only 1 of 19 carriers (74%
+// of carriers have zero command records at all), so requiring one would
+// reject nearly every real recurrence. Command and CommandSessions are a
+// strengthening when a matching command happens to exist, not a
+// precondition — Command is "" when none was found.
+type PlanCooccurrence struct {
+	Wall            Friction
+	Command         string
+	CommandSessions []SessionMeta
+}
+
+type planWallCluster struct {
+	hash  uint64
+	metas []SessionMeta
+}
+
+type planIndexedTerm struct {
+	text     string
+	sessions map[uint32]bool
+}
+
+// planIdentifierIDFFloor is the informativeness bar for an identifier-shaped
+// plan term — lower than dejaVuIDFFloor, but not zero. A census of 2,886 real
+// sessions found identifier-shaped false-positive anchors (cannot, directory,
+// branch, runner) topping out at idf 0.70, while true anchors (hermes 1.09,
+// hermes-agent 1.21) started at 1.09; this floor sits in the gap.
+const planIdentifierIDFFloor = 1.0
+
+// PlanFrictionMatches joins existing manifest wall hashes to a plan step's
+// informative terms — the wall text naming one of them is the finding; a
+// matching command record is looked up too but only strengthens it (see
+// PlanCooccurrence). keep is applied before any session is materialized, so
+// callers can enforce activation policy without denied text crossing the
+// boundary.
+//
+// The index is read as-is. This function never builds, repairs, or refreshes
+// it.
+func PlanFrictionMatches(dir string, steps [][]string, keep func(SessionMeta) bool, limit int) []PlanCooccurrence {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	if len(steps) == 0 {
+		return nil
+	}
+
+	unlock, locked, err := tryLockDir(dir)
+	if err != nil {
+		return nil
+	}
+	if locked {
+		defer unlock()
+	}
+
+	manifest, err := readManifestCached(dir)
+	if err != nil || len(manifest.Sessions) == 0 || !recordsIntact(dir, manifest) {
+		return nil
+	}
+
+	clusters := planWallClusters(manifest, keep)
+	if len(clusters) == 0 {
+		return nil
+	}
+
+	indexedSteps, candidates, needs := planIndexedSteps(dir, manifest, steps)
+	if len(indexedSteps) == 0 {
+		return nil
+	}
+
+	// The first cut is manifest and posting only: a wall survives when one of
+	// its carrier sessions has at least the plan step's informative-term
+	// floor. carriers records, per eligible cluster, which of its own metas
+	// were the ones that actually matched — not the whole cluster — so the
+	// session read below stays scoped to what earned it.
+	var eligible []planWallCluster
+	carriers := map[uint64][]SessionMeta{}
+	for _, cluster := range clusters {
+		var hit []SessionMeta
+		for _, meta := range cluster.metas {
+			for step := range indexedSteps {
+				if candidates[step][meta.Ord] {
+					hit = append(hit, meta)
+					break
+				}
+			}
+		}
+		if len(hit) > 0 {
+			eligible = append(eligible, cluster)
+			carriers[cluster.hash] = hit
+		}
+	}
+	if len(eligible) == 0 {
+		return nil
+	}
+
+	// Wall text recovery reads full sessions too, but only this cluster's
+	// own carriers and it stops at the first hit — cheaper than
+	// materializing every candidate session for a command search that most
+	// carriers will never satisfy. Doing it first lets the mandatory
+	// cooccurrence check (the wall text itself naming a plan term) prune the
+	// set before the command pass touches anything.
+	type wallHit struct {
+		cluster planWallCluster
+		text    string
+	}
+	var hits []wallHit
+	candidateMetas := map[string]SessionMeta{}
+	for _, cluster := range eligible {
+		wanted := map[uint64]string{cluster.hash: ""}
+		frictionTexts(dir, manifest, cluster.metas, wanted, cluster.hash)
+		text := wanted[cluster.hash]
+		if text == "" || !planWallSharesTerm(text, indexedSteps) {
+			continue
+		}
+		hits = append(hits, wallHit{cluster: cluster, text: text})
+		for _, meta := range carriers[cluster.hash] {
+			candidateMetas[meta.Harness+":"+meta.ID] = meta
+		}
+	}
+	if len(hits) == 0 {
+		return nil
+	}
+
+	metas := make([]SessionMeta, 0, len(candidateMetas))
+	for _, meta := range candidateMetas {
+		metas = append(metas, meta)
+	}
+	sort.Slice(metas, func(i, j int) bool {
+		return newestFirstMeta(metas[i], metas[j])
+	})
+
+	sessions, err := sessionsForMetas(dir, metas)
+	if err != nil {
+		return nil
+	}
+
+	// No hash-to-command index exists. Materialize only sessions carrying a
+	// wall that already cleared the cooccurrence check, then look for a
+	// stored command carrying the same step's informative terms. This is a
+	// strengthening pass: a step with no matching command simply leaves
+	// Command empty, it does not drop the finding (see PlanCooccurrence).
+	commands := map[string]map[int]string{}
+	for i, session := range sessions {
+		if i >= len(metas) {
+			break
+		}
+		meta := metas[i]
+		key := meta.Harness + ":" + meta.ID
+		for step, terms := range indexedSteps {
+			if !candidates[step][meta.Ord] {
+				continue
+			}
+			if command := planCommandForStep(session, terms, needs[step]); command != "" {
+				if commands[key] == nil {
+					commands[key] = map[int]string{}
+				}
+				commands[key][step] = command
+			}
+		}
+	}
+
+	var out []PlanCooccurrence
+	for _, hit := range hits {
+		command, commandSessions := planWallCommand(
+			hit.text, hit.cluster, indexedSteps, commands,
+		)
+
+		out = append(out, PlanCooccurrence{
+			Wall: Friction{
+				Text:     hit.text,
+				Sessions: hit.cluster.metas,
+				Last:     hit.cluster.metas[0].Updated,
+			},
+			Command:         command,
+			CommandSessions: commandSessions,
+		})
+		if limit > 0 && len(out) == limit {
+			break
+		}
+	}
+	return out
+}
+
+// planWallSharesTerm reports whether the wall's own text names one of the
+// plan's informative terms. This is the cooccurrence claim itself, so unlike
+// a command match it is never optional.
+func planWallSharesTerm(wallText string, steps [][]planIndexedTerm) bool {
+	for _, terms := range steps {
+		for _, term := range terms {
+			if planTextHasTerm(wallText, term.text) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func planWallClusters(manifest Manifest, keep func(SessionMeta) bool) []planWallCluster {
+	byHash := map[uint64][]SessionMeta{}
+	for _, meta := range manifest.Sessions {
+		if keep != nil && !keep(meta) {
+			continue
+		}
+		for _, hash := range meta.Hit {
+			byHash[hash] = append(byHash[hash], meta)
+		}
+	}
+
+	var clusters []planWallCluster
+	for hash, metas := range byHash {
+		if len(metas) < FrictionMinSessions {
+			continue
+		}
+		sort.Slice(metas, func(i, j int) bool {
+			return newestFirstMeta(metas[i], metas[j])
+		})
+		clusters = append(clusters, planWallCluster{hash: hash, metas: metas})
+	}
+	sort.Slice(clusters, func(i, j int) bool {
+		if len(clusters[i].metas) != len(clusters[j].metas) {
+			return len(clusters[i].metas) > len(clusters[j].metas)
+		}
+		left, right := clusters[i].metas[0], clusters[j].metas[0]
+		if !left.Updated.Equal(right.Updated) {
+			return left.Updated.After(right.Updated)
+		}
+		return clusters[i].hash < clusters[j].hash
+	})
+	return clusters
+}
+
+func planIndexedSteps(dir string, manifest Manifest, steps [][]string) ([][]planIndexedTerm, []map[uint32]bool, []int) {
+	var indexed [][]planIndexedTerm
+	var candidates []map[uint32]bool
+	var needs []int
+	totalDocs := float64(len(manifest.Sessions)) + 1
+
+	for _, step := range steps {
+		// A step naming an identifier is as specific on one word as an
+		// ordinary step is on two — cmd/deja's hook-prompt path already
+		// trusts a lone identifier hit, and this join follows the same call
+		// so a plan step doesn't need a stronger bar than a prompt does.
+		need := 2
+		if planHasIdentifierTerm(step) {
+			need = 1
+		}
+
+		seen := map[string]bool{}
+		var terms []planIndexedTerm
+		for _, raw := range step {
+			term := strings.ToLower(strings.TrimSpace(raw))
+			if term == "" || seen[term] {
+				continue
+			}
+			seen[term] = true
+
+			sessions := planTermSessions(dir, term)
+			if len(sessions) == 0 {
+				continue
+			}
+			// A wall's own vocabulary is repeated-work vocabulary, so it is
+			// common by construction — a census against the real corpus
+			// measured "hermes" at idf 1.10 and "pytest" at idf 1.23, both
+			// under the full floor, and every one of ~14 known-good plan
+			// recurrences was lost to it. An identifier is informative by
+			// shape (a name, not a sentence word), not by rarity, so it gets
+			// a lower bar — but not none: re-measured at 2,886 sessions,
+			// identifier-shaped false positives (cannot, directory, branch,
+			// runner) topped out at idf 0.70 while true anchors (hermes
+			// 1.09, hermes-agent 1.21) started at 1.09, so
+			// planIdentifierIDFFloor sits at the gap between them.
+			// Non-identifier terms still need the full floor.
+			floor := dejaVuIDFFloor
+			if planIsIdentifierTerm(term) {
+				floor = planIdentifierIDFFloor
+			}
+			idf := math.Log(totalDocs / float64(len(sessions)+1))
+			if idf < floor && len(sessions) > 2 {
+				continue
+			}
+			terms = append(terms, planIndexedTerm{
+				text:     term,
+				sessions: sessions,
+			})
+		}
+		if len(terms) < need {
+			continue
+		}
+
+		counts := map[uint32]int{}
+		for _, term := range terms {
+			for ord := range term.sessions {
+				counts[ord]++
+			}
+		}
+		matched := map[uint32]bool{}
+		for ord, count := range counts {
+			if count >= need {
+				matched[ord] = true
+			}
+		}
+		if len(matched) == 0 {
+			continue
+		}
+		indexed = append(indexed, terms)
+		candidates = append(candidates, matched)
+		needs = append(needs, need)
+	}
+	return indexed, candidates, needs
+}
+
+// planHasIdentifierTerm reports whether any term in a step is
+// identifier-shaped (see planIsIdentifierTerm). Used to size the step's need
+// (1 term vs. 2) at both the raw-term-selection layer (cmd/deja) and here.
+func planHasIdentifierTerm(terms []string) bool {
+	for _, t := range terms {
+		if planIsIdentifierTerm(t) {
+			return true
+		}
+	}
+	return false
+}
+
+// planIsIdentifierTerm mirrors cmd/deja's hasIdentifierTerm at the single-term
+// level: a term is identifier-shaped when it is long (>=6) or carries a
+// symbol/digit an English word wouldn't. Duplicated rather than imported
+// because cmd/deja depends on internal/index, not the other way around.
+func planIsIdentifierTerm(t string) bool {
+	if len(t) >= 6 {
+		return true
+	}
+	for _, r := range t {
+		if r == '_' || r == '.' || r == '/' || r == '-' || (r >= '0' && r <= '9') {
+			return true
+		}
+	}
+	return false
+}
+
+func planTermSessions(dir, term string) map[uint32]bool {
+	keys := queryKeys(term)
+	if len(keys) == 0 {
+		return nil
+	}
+
+	var intersection map[uint32]bool
+	for _, key := range keys {
+		postings, err := postingsFor(dir, key)
+		if err != nil || len(postings) == 0 {
+			return nil
+		}
+		current := map[uint32]bool{}
+		for _, posting := range postings {
+			current[posting.Sid] = true
+		}
+		if intersection == nil {
+			intersection = current
+			continue
+		}
+		for ord := range intersection {
+			if !current[ord] {
+				delete(intersection, ord)
+			}
+		}
+		if len(intersection) == 0 {
+			return nil
+		}
+	}
+	return intersection
+}
+
+func planCommandForStep(session model.Session, terms []planIndexedTerm, need int) string {
+	best := ""
+	bestMatches := 0
+	for _, message := range session.Messages {
+		if message.Role != roleCommand {
+			continue
+		}
+		command := strings.Join(strings.Fields(message.Text), " ")
+		if command == "" {
+			continue
+		}
+		matched := 0
+		for _, term := range terms {
+			if planTextHasTerm(command, term.text) {
+				matched++
+			}
+		}
+		if matched < need {
+			continue
+		}
+		if matched > bestMatches ||
+			(matched == bestMatches && (best == "" || len(command) < len(best))) ||
+			(matched == bestMatches && len(command) == len(best) && command < best) {
+			best = command
+			bestMatches = matched
+		}
+	}
+	return best
+}
+
+func planWallCommand(
+	wallText string,
+	cluster planWallCluster,
+	steps [][]planIndexedTerm,
+	commands map[string]map[int]string,
+) (string, []SessionMeta) {
+	groups := map[string]map[string]SessionMeta{}
+	for step, terms := range steps {
+		sharesTerm := false
+		for _, term := range terms {
+			if planTextHasTerm(wallText, term.text) {
+				sharesTerm = true
+				break
+			}
+		}
+		if !sharesTerm {
+			continue
+		}
+		for _, meta := range cluster.metas {
+			key := meta.Harness + ":" + meta.ID
+			command := commands[key][step]
+			if command == "" {
+				continue
+			}
+			if groups[command] == nil {
+				groups[command] = map[string]SessionMeta{}
+			}
+			groups[command][key] = meta
+		}
+	}
+
+	best := ""
+	bestCount := 0
+	for command, sessions := range groups {
+		if len(sessions) > bestCount ||
+			(len(sessions) == bestCount && (best == "" || command < best)) {
+			best = command
+			bestCount = len(sessions)
+		}
+	}
+	if best == "" {
+		return "", nil
+	}
+
+	selected := groups[best]
+	out := make([]SessionMeta, 0, len(selected))
+	for _, meta := range cluster.metas {
+		if _, ok := selected[meta.Harness+":"+meta.ID]; ok {
+			out = append(out, meta)
+		}
+	}
+	return best, out
+}
+
+func planTextHasTerm(text, term string) bool {
+	terms, phrases := query.QueryParts(term)
+	if len(terms) == 0 && len(phrases) == 0 {
+		return false
+	}
+	return query.MatchesParts(text, terms, phrases, nil)
+}

--- a/internal/index/plan.go
+++ b/internal/index/plan.go
@@ -10,12 +10,12 @@ import (
 )
 
 // PlanCooccurrence is one factual join between a recurring wall and a plan
-// step's informative terms. The wall side is the claim: a full census found
-// a matching command logged alongside the wall in only 1 of 19 carriers (74%
-// of carriers have zero command records at all), so requiring one would
-// reject nearly every real recurrence. Command and CommandSessions are a
-// strengthening when a matching command happens to exist, not a
-// precondition — Command is "" when none was found.
+// step's informative terms. The wall side is the claim: a census of one
+// personal index found a matching command logged alongside the wall for only
+// 1 of its 19 walls, and 84 of its 110 carrier sessions hold no command
+// record at all, so requiring one would reject nearly every real recurrence.
+// Command and CommandSessions are a strengthening when a matching command
+// happens to exist, not a precondition — Command is "" when none was found.
 type PlanCooccurrence struct {
 	Wall            Friction
 	Command         string

--- a/internal/index/plan_test.go
+++ b/internal/index/plan_test.go
@@ -1,0 +1,450 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// planWall is a friction line by isFriction's rules: it names something
+// specific, carries no quote or comment marker, and sits inside the length
+// window. Its identifier is the only term the plan and the wall share.
+const planWall = "ModuleNotFoundError: No module named pytest_asyncio"
+
+// planCorpus builds a store where term frequency is set deliberately, because
+// the two-tier floor is a claim about frequency and shape together:
+//
+//	pytest_asyncio  identifier, 20 of 59 sessions -> idf 1.05
+//	cache, queue    plain,      20 of 59 sessions -> idf 1.05
+//	stale, flush    plain,       4 of 59 sessions -> idf 2.48
+//
+// So the identifier and the plain pair at 20 differ only in shape, and the
+// plain pair at 4 shows a plain term still has a route through.
+//
+// The wall is in the first four sessions, which is FrictionMinSessions plus
+// one, and commands is how many of those also log a command record.
+func planCorpus(t *testing.T, commands int) string {
+	t.Helper()
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "plan-index")
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	var sessions []model.Session
+	for i := range 59 {
+		s := model.Session{
+			ID:      "s" + string(rune('A'+i/26)) + string(rune('a'+i%26)),
+			Harness: "claude",
+			Project: "p",
+			Updated: base.Add(time.Duration(i) * time.Hour),
+			Messages: []model.Message{
+				{Role: "user", Text: "session about unrelated frontend styling work"},
+			},
+		}
+		if i < 20 {
+			s.Messages = append(s.Messages, model.Message{
+				Role: "user", Text: "pytest_asyncio cache queue setup for the suite",
+			})
+		}
+		if i >= 20 {
+			// hydration never shares a session with stale, and purge_cache is
+			// an identifier that only these four hold — both are here so a
+			// term's reach can be checked against sessions that carry no wall.
+			s.Messages = append(s.Messages, model.Message{
+				Role: "user", Text: "hydration pass on the client",
+			})
+		}
+		if i >= 20 && i < 24 {
+			s.Messages = append(s.Messages, model.Message{
+				Role: "user", Text: "purge_cache wipe between the runs",
+			})
+		}
+		if i < 4 {
+			s.Messages = append(s.Messages,
+				model.Message{Role: "user", Text: "stale flush before the run"},
+				model.Message{Role: "tool-output", Text: planWall},
+			)
+		}
+		if i < commands {
+			s.Messages = append(s.Messages, model.Message{
+				Role: "command", Text: "pip install pytest_asyncio",
+			})
+		}
+		sessions = append(sessions, s)
+	}
+
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func planSteps(terms ...string) [][]string { return [][]string{terms} }
+
+func TestPlanFrictionMatchesReportsAWallSharingAPlanTerm(t *testing.T) {
+	dir := planCorpus(t, 0)
+	out := PlanFrictionMatches(dir, planSteps("pytest_asyncio"), nil, 0)
+	if len(out) != 1 {
+		t.Fatalf("findings = %d, want 1: %+v", len(out), out)
+	}
+	if out[0].Wall.Text != planWall {
+		t.Fatalf("wall text = %q", out[0].Wall.Text)
+	}
+	if len(out[0].Wall.Sessions) != 4 {
+		t.Fatalf("carrier sessions = %d, want 4", len(out[0].Wall.Sessions))
+	}
+	// No command record exists here, and the finding still stands. The command
+	// clause is a strengthening, not a precondition — 84 of 110 carrier
+	// sessions in the census that motivated this hold no command at all.
+	if out[0].Command != "" {
+		t.Fatalf("command invented from a store with none: %q", out[0].Command)
+	}
+}
+
+// The wall naming a plan term is the whole claim. A plan term that is in the
+// index but absent from the wall text has nothing to say about that wall.
+func TestPlanFrictionMatchesStaysSilentWhenTheWallNamesNothingInThePlan(t *testing.T) {
+	dir := planCorpus(t, 0)
+	// "stale flush" is in all four carrier sessions and clears the plain
+	// floor, so the step survives selection and the sessions are candidates.
+	// Only the wall text check stands between it and a finding.
+	if steps, _, _ := planIndexedSteps(dir, mustPlanManifest(t, dir), planSteps("stale", "flush")); len(steps) != 1 {
+		t.Fatalf("premise broken: step did not survive selection (%d steps)", len(steps))
+	}
+	if out := PlanFrictionMatches(dir, planSteps("stale", "flush"), nil, 0); out != nil {
+		t.Fatalf("reported a wall that names no plan term: %+v", out)
+	}
+}
+
+// keep runs before any session is materialized, so a denied project's text
+// must not reach the caller.
+func TestPlanFrictionMatchesRespectsTheActivationKeep(t *testing.T) {
+	dir := planCorpus(t, 0)
+	seen := 0
+	out := PlanFrictionMatches(dir, planSteps("pytest_asyncio"), func(SessionMeta) bool {
+		seen++
+		return false
+	}, 0)
+	if out != nil {
+		t.Fatalf("denied project crossed the boundary: %+v", out)
+	}
+	if seen == 0 {
+		t.Fatal("keep was never consulted")
+	}
+}
+
+// A plan is submitted at a moment when nothing may block on indexing, so a
+// missing index is a silent miss and never a build.
+func TestPlanFrictionMatchesNeverBuildsAnIndex(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "empty-index")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if out := PlanFrictionMatches(dir, planSteps("pytest_asyncio"), nil, 0); out != nil {
+		t.Fatalf("findings from an empty index: %+v", out)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("index directory was written to: %v", entries)
+	}
+}
+
+func TestPlanFrictionMatchesReportsACommandWhenOneWasLogged(t *testing.T) {
+	dir := planCorpus(t, 2)
+	// Two steps, and only the first one reaches the wall's carriers or is
+	// named by the wall text. The second must contribute nothing rather than
+	// borrow the first step's command.
+	steps := [][]string{{"pytest_asyncio"}, {"purge_cache"}}
+	out := PlanFrictionMatches(dir, steps, nil, 0)
+	if len(out) != 1 {
+		t.Fatalf("findings = %d, want 1", len(out))
+	}
+	if out[0].Command != "pip install pytest_asyncio" {
+		t.Fatalf("command = %q", out[0].Command)
+	}
+	if len(out[0].CommandSessions) != 2 {
+		t.Fatalf("command sessions = %d, want the 2 that logged it", len(out[0].CommandSessions))
+	}
+}
+
+// A plan term that reaches only sessions carrying no wall is not a finding:
+// the join is wall-to-plan, and half of it missing is silence.
+func TestPlanFrictionMatchesStaysSilentWhenNoWallCarrierMatches(t *testing.T) {
+	dir := planCorpus(t, 0)
+	// purge_cache is indexed and clears the floor, but the four sessions that
+	// hold it are not the four that hit the wall.
+	if steps, _, _ := planIndexedSteps(dir, mustPlanManifest(t, dir), planSteps("purge_cache")); len(steps) != 1 {
+		t.Fatalf("premise broken: purge_cache did not survive selection")
+	}
+	if out := PlanFrictionMatches(dir, planSteps("purge_cache"), nil, 0); out != nil {
+		t.Fatalf("wall reported for a term no carrier holds: %+v", out)
+	}
+}
+
+// A step's terms have to land on one session together, not merely exist.
+func TestPlanIndexedStepsNeedsTermsInTheSameSession(t *testing.T) {
+	dir := planCorpus(t, 0)
+	// Both clear the plain floor at 4 sessions each, and neither session set
+	// overlaps the other, so no session holds the two the step needs.
+	steps, _, _ := planIndexedSteps(dir, mustPlanManifest(t, dir), planSteps("stale", "wipe"))
+	if len(steps) != 0 {
+		t.Fatalf("step survived with its terms in disjoint sessions: %+v", steps)
+	}
+}
+
+func TestPlanFrictionMatchesIgnoresEmptyInput(t *testing.T) {
+	dir := planCorpus(t, 0)
+	if out := PlanFrictionMatches(dir, nil, nil, 0); out != nil {
+		t.Fatalf("no steps produced %+v", out)
+	}
+	if out := PlanFrictionMatches(dir, planSteps("", "   "), nil, 0); out != nil {
+		t.Fatalf("blank terms produced %+v", out)
+	}
+}
+
+// Wall texts for the ordering corpus. All five name the same identifier, so
+// which ones come back — and in what order — is decided by the clustering
+// alone.
+const (
+	wallFive     = planWall
+	wallLater    = "connection refused fetching pytest_asyncio from the mirror"
+	wallTieOne   = "ImportError: cannot find module pytest_asyncio in the venv"
+	wallTieTwo   = "fatal: pytest_asyncio plugin refused to load under the runner"
+	wallTooRare  = "permission denied while installing pytest_asyncio locally"
+	planWallSeen = 5
+)
+
+// planOrderCorpus spreads five walls over overlapping session sets so the
+// ordering rule is observable: more carriers first, then the newest carrier,
+// then the hash. wallTooRare is under FrictionMinSessions and must not appear
+// at all.
+//
+//	wallFive     sessions 0-4   5 carriers
+//	wallLater    sessions 3-5   3 carriers, newest is session 5
+//	wallTieOne   sessions 0-2   3 carriers, newest is session 2
+//	wallTieTwo   sessions 0-2   3 carriers, the same sessions as wallTieOne
+//	wallTooRare  sessions 0-1   2 carriers
+func planOrderCorpus(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "plan-order-index")
+	base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	walls := map[string][2]int{
+		wallFive: {0, 5}, wallLater: {3, 6},
+		wallTieOne: {0, 3}, wallTieTwo: {0, 3}, wallTooRare: {0, 2},
+	}
+
+	var sessions []model.Session
+	for i := range 59 {
+		s := model.Session{
+			ID:      "o" + string(rune('A'+i/26)) + string(rune('a'+i%26)),
+			Harness: "claude",
+			Project: "p",
+			Updated: base.Add(time.Duration(i) * time.Hour),
+			Messages: []model.Message{
+				{Role: "user", Text: "session about unrelated frontend styling work"},
+			},
+		}
+		if i < 20 {
+			s.Messages = append(s.Messages, model.Message{
+				Role: "user", Text: "pytest_asyncio setup for the suite",
+			})
+		}
+		// Sorted so the records land in a stable order run to run.
+		for _, text := range []string{wallFive, wallLater, wallTieOne, wallTieTwo, wallTooRare} {
+			span := walls[text]
+			if i >= span[0] && i < span[1] {
+				s.Messages = append(s.Messages, model.Message{Role: "tool-output", Text: text})
+			}
+		}
+		sessions = append(sessions, s)
+	}
+
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestPlanFrictionMatchesOrdersWallsAndDropsTheRareOne(t *testing.T) {
+	dir := planOrderCorpus(t)
+	out := PlanFrictionMatches(dir, planSteps("pytest_asyncio"), nil, 0)
+	if len(out) != 4 {
+		t.Fatalf("findings = %d, want 4 (wallTooRare excluded): %+v", len(out), out)
+	}
+	for _, hit := range out {
+		if hit.Wall.Text == wallTooRare {
+			t.Fatal("a wall in 2 sessions was reported as recurring")
+		}
+	}
+	if out[0].Wall.Text != wallFive || len(out[0].Wall.Sessions) != planWallSeen {
+		t.Fatalf("most-carried wall not first: %q with %d sessions",
+			out[0].Wall.Text, len(out[0].Wall.Sessions))
+	}
+	// Equal carrier counts, so the newer cluster wins.
+	if out[1].Wall.Text != wallLater {
+		t.Fatalf("newest of the three-carrier walls not second: %q", out[1].Wall.Text)
+	}
+	// wallTieOne and wallTieTwo share their carriers exactly, so only the hash
+	// separates them — the order is fixed, which one wins is not asserted.
+	rest := map[string]bool{out[2].Wall.Text: true, out[3].Wall.Text: true}
+	if !rest[wallTieOne] || !rest[wallTieTwo] {
+		t.Fatalf("tied walls missing: %q, %q", out[2].Wall.Text, out[3].Wall.Text)
+	}
+	again := PlanFrictionMatches(dir, planSteps("pytest_asyncio"), nil, 0)
+	if again[2].Wall.Text != out[2].Wall.Text {
+		t.Fatal("tie between identical clusters is not stable")
+	}
+}
+
+func TestPlanFrictionMatchesStopsAtTheLimit(t *testing.T) {
+	dir := planOrderCorpus(t)
+	out := PlanFrictionMatches(dir, planSteps("pytest_asyncio"), nil, 2)
+	if len(out) != 2 {
+		t.Fatalf("limit 2 returned %d", len(out))
+	}
+	// A limit keeps the front of the order, so it drops the weakest walls.
+	if out[0].Wall.Text != wallFive || out[1].Wall.Text != wallLater {
+		t.Fatalf("limit changed the order: %q, %q", out[0].Wall.Text, out[1].Wall.Text)
+	}
+}
+
+// An empty dir means the default index, which the hermetic env points at a
+// path that was never built.
+func TestPlanFrictionMatchesFallsBackToTheDefaultDir(t *testing.T) {
+	_ = hermeticIndexEnv(t)
+	if out := PlanFrictionMatches("", planSteps("pytest_asyncio"), nil, 0); out != nil {
+		t.Fatalf("findings from an unbuilt default index: %+v", out)
+	}
+}
+
+func TestPlanTermSessionsIntersectsEveryKey(t *testing.T) {
+	dir := planCorpus(t, 0)
+	queue := planTermSessions(dir, "queue")
+	if len(queue) == 0 {
+		t.Fatal("premise broken: queue is not in the index")
+	}
+	// styling is in every session, so the pair is bounded by the narrower key
+	// rather than the union of the two.
+	if both := planTermSessions(dir, "styling queue"); len(both) != len(queue) {
+		t.Fatalf("pair reached %d sessions, queue alone reaches %d", len(both), len(queue))
+	}
+	// hydration and stale are each indexed, and never in one session.
+	if got := planTermSessions(dir, "hydration stale"); len(got) != 0 {
+		t.Fatalf("terms that never co-occur intersected to %d sessions", len(got))
+	}
+	if got := planTermSessions(dir, "-"); got != nil {
+		t.Fatalf("a term with no searchable key reached %d sessions", len(got))
+	}
+}
+
+func mustPlanManifest(t *testing.T, dir string) Manifest {
+	t.Helper()
+	manifest, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+// The central claim of the two-tier floor: at one frequency, shape decides.
+// Wall vocabulary is repeated-work vocabulary and so is common by
+// construction, which is why the prompt floor at 2.0 excluded every one of
+// these terms.
+func TestPlanIndexedStepsGivesIdentifiersALowerFloor(t *testing.T) {
+	dir := planCorpus(t, 0)
+	manifest := mustPlanManifest(t, dir)
+
+	// Same 20 sessions, so the same idf. Only the shape differs.
+	identifier, _, needs := planIndexedSteps(dir, manifest, planSteps("pytest_asyncio"))
+	if len(identifier) != 1 || len(identifier[0]) != 1 || identifier[0][0].text != "pytest_asyncio" {
+		t.Fatalf("identifier term dropped: %+v", identifier)
+	}
+	if needs[0] != 1 {
+		t.Fatalf("identifier step need = %d, want 1", needs[0])
+	}
+	if plain, _, _ := planIndexedSteps(dir, manifest, planSteps("cache", "queue")); len(plain) != 0 {
+		t.Fatalf("plain terms at the same frequency survived: %+v", plain)
+	}
+
+	// And the plain floor is a floor, not a ban: rarer plain terms clear it.
+	rare, _, rareNeeds := planIndexedSteps(dir, manifest, planSteps("stale", "flush"))
+	if len(rare) != 1 || len(rare[0]) != 2 {
+		t.Fatalf("rare plain terms dropped: %+v", rare)
+	}
+	if rareNeeds[0] != 2 {
+		t.Fatalf("plain step need = %d, want 2", rareNeeds[0])
+	}
+}
+
+func TestPlanIndexedStepsSkipsTermsTheIndexNeverSaw(t *testing.T) {
+	dir := planCorpus(t, 0)
+	steps, _, _ := planIndexedSteps(dir, mustPlanManifest(t, dir), planSteps("zzz_unseen_identifier"))
+	if len(steps) != 0 {
+		t.Fatalf("term absent from the index survived: %+v", steps)
+	}
+}
+
+func TestPlanIsIdentifierTerm(t *testing.T) {
+	for _, term := range []string{"pytest", "hermes-agent", "v1.2", "a_b", "go/mod", "x9"} {
+		if !planIsIdentifierTerm(term) {
+			t.Errorf("%q not identifier-shaped", term)
+		}
+	}
+	for _, term := range []string{"cache", "queue", "stale", "the", ""} {
+		if planIsIdentifierTerm(term) {
+			t.Errorf("%q read as identifier-shaped", term)
+		}
+	}
+	if !planHasIdentifierTerm([]string{"the", "cache", "pytest_asyncio"}) {
+		t.Error("step with one identifier read as plain")
+	}
+	if planHasIdentifierTerm([]string{"the", "cache", "queue"}) {
+		t.Error("plain step read as carrying an identifier")
+	}
+}
+
+func TestPlanTextHasTerm(t *testing.T) {
+	if !planTextHasTerm(planWall, "pytest_asyncio") {
+		t.Error("wall does not match its own identifier")
+	}
+	if planTextHasTerm(planWall, "cache") {
+		t.Error("wall matched a term it does not contain")
+	}
+	if planTextHasTerm(planWall, "   ") {
+		t.Error("blank term matched")
+	}
+}
+
+func TestPlanCommandForStepPrefersTheStrongestThenShortest(t *testing.T) {
+	terms := []planIndexedTerm{{text: "pytest"}, {text: "asyncio"}}
+	session := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "pytest asyncio talk, not a command"},
+		{Role: "command", Text: "   \t  "},
+		{Role: "command", Text: "pytest -q"},
+		{Role: "command", Text: "  pip   install   pytest   asyncio  "},
+		{Role: "command", Text: "pip install pytest asyncio --upgrade"},
+	}}
+	// Two terms beat one, and among equals the shorter command wins. Fields
+	// collapsing is what makes the padded line the shorter of the two.
+	if got := planCommandForStep(session, terms, 2); got != "pip install pytest asyncio" {
+		t.Fatalf("command = %q", got)
+	}
+	// need is a floor: nothing clears 3 matches here.
+	if got := planCommandForStep(session, terms, 3); got != "" {
+		t.Fatalf("command %q cleared an impossible need", got)
+	}
+}

--- a/scripts/planbench/main.go
+++ b/scripts/planbench/main.go
@@ -1,0 +1,286 @@
+// Command planbench runs a directory of plans through `deja check -` and
+// reports how often the plan checker fires.
+//
+// It counts fires. It does not say whether a fire was right, and it cannot:
+// precision on this path is a human label — someone who was there, reading the
+// recalled wall against the plan in front of them — and both halves of that
+// judgment are local. The hand-labelled set behind the 6/30 reported on #532
+// came from private transcripts and will never ship, so the numbers in that
+// thread are not reproducible by anyone else. This produces the denominator on
+// a reader's own plans and a reader's own history, and leaves the verdict to
+// the reader.
+//
+// It drives the built binary rather than importing the matcher, which is the
+// one thing the other harnesses here do not do. `deja check -` is the only path
+// that composes what actually fires: step extraction, the index lookup, the
+// trust policy and the payload budget all live in package main beside it, and
+// calling index.PlanFrictionMatches directly would measure a component no user
+// runs — the same reason check exists at all (cmd/deja/check.go).
+//
+//	go build ./cmd/deja
+//	DEJA_INDEX_DIR=~/.cache/deja/index.db go run ./scripts/planbench -plans ./plans [-deja ./deja] [-dump]
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	plans := flag.String("plans", "", "directory of plan files, one plan per file")
+	bin := flag.String("deja", "deja", "deja binary to run — a build of this tree, not whatever is installed")
+	dump := flag.Bool("dump", false, "print each finding verbatim — recalled history text")
+	flag.Parse()
+
+	// No default: the only directory this tool could guess at is someone's own
+	// plans, and a harness that reads a private directory when run bare is a
+	// harness nobody can run bare.
+	if *plans == "" {
+		fmt.Fprintln(os.Stderr, "planbench needs -plans DIR")
+		os.Exit(1)
+	}
+	// Looked up once, before any plan runs: "executable file not found" is a
+	// setup error, and the same line repeated for every file in the directory
+	// buries the one plan that failed for its own reasons.
+	if _, err := exec.LookPath(*bin); err != nil {
+		fmt.Fprintln(os.Stderr, "deja:", err)
+		os.Exit(1)
+	}
+	if err := run(os.Stdout, os.Stderr, *bin, *plans, *dump); err != nil {
+		fmt.Fprintln(os.Stderr, "planbench:", err)
+		os.Exit(1)
+	}
+}
+
+// newCheckCmd is a seam: a test drives a stand-in for deja without building one.
+var newCheckCmd = func(bin string) *exec.Cmd {
+	return exec.Command(bin, "check", "-")
+}
+
+type planResult struct {
+	name     string
+	findings []string
+	// labels are the wall labels this plan cited, in the order the walls were
+	// first seen across the whole run.
+	labels []string
+}
+
+type wall struct {
+	label string
+	text  string
+	plans int
+}
+
+func run(out, errOut io.Writer, bin, dir string, dump bool) error {
+	names, err := planFiles(dir)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "plans %s · %d file%s\n\n", dir, len(names), plural(len(names)))
+
+	byWall := map[string]*wall{}
+	var order []*wall
+	var results []planResult
+	failed := 0
+	for _, name := range names {
+		findings, err := check(bin, filepath.Join(dir, name))
+		if err != nil {
+			fmt.Fprintf(errOut, "%s: %v\n", name, err)
+			failed++
+			continue
+		}
+		r := planResult{name: name, findings: findings}
+		for _, finding := range findings {
+			text := planWall(finding)
+			w := byWall[text]
+			if w == nil {
+				w = &wall{label: fmt.Sprintf("w%d", len(order)+1), text: text}
+				byWall[text] = w
+				order = append(order, w)
+			}
+			// planFindings emits a wall at most once per plan, so counting a
+			// plan per finding here needs no de-duplication of its own.
+			w.plans++
+			r.labels = append(r.labels, w.label)
+		}
+		results = append(results, r)
+	}
+
+	printResults(out, results, dump)
+
+	fired, findings := 0, 0
+	for _, r := range results {
+		if len(r.findings) > 0 {
+			fired++
+		}
+		findings += len(r.findings)
+	}
+	fmt.Fprintf(out, "\n%d plan%s · %d fired (%.1f%%) · %d finding%s · %d distinct wall%s\n",
+		len(results), plural(len(results)), fired, pct(fired, len(results)),
+		findings, plural(findings), len(order), plural(len(order)))
+	// The distinct-wall count is the number to read the finding count against.
+	// Twelve findings drawn from two walls is one recurring problem reported
+	// twelve times, not twelve independent hits, and the two shapes call for
+	// different judgments about whether the feature earns its place.
+	for _, w := range order {
+		fmt.Fprintf(out, "  %-4s cited by %d plan%s\n", w.label, w.plans, plural(w.plans))
+	}
+	if failed > 0 {
+		// A plan that fired nothing is a result — silence is the miss contract
+		// of the hook this measures, so it exits 0 and the tool stays usable in
+		// a loop. A plan that could not be run is not a result.
+		return fmt.Errorf("%d plan%s could not be run", failed, plural(failed))
+	}
+	return nil
+}
+
+func printResults(out io.Writer, results []planResult, dump bool) {
+	width := 12
+	for _, r := range results {
+		if n := len(r.name); n > width {
+			width = n
+		}
+	}
+	if width > 40 {
+		width = 40
+	}
+	for _, r := range results {
+		if len(r.findings) == 0 {
+			fmt.Fprintf(out, "  %-*s  silent\n", width, r.name)
+			continue
+		}
+		fmt.Fprintf(out, "  %-*s  fire · %d finding%s · %s\n",
+			width, r.name, len(r.findings), plural(len(r.findings)), strings.Join(r.labels, " "))
+		// Findings quote a stranger's history back at whoever is reading the
+		// table, which is fine on their own machine and not fine in a pasted
+		// result. Counts and labels by default, text on request — the rule
+		// corpusprobe follows for the same reason.
+		if !dump {
+			continue
+		}
+		for i, finding := range r.findings {
+			fmt.Fprintf(out, "  %-*s  %-4s %s\n", width, "", r.labels[i], finding)
+		}
+	}
+}
+
+// planFiles lists the plans to run. Every regular file counts: plans are
+// Markdown in practice, but nothing in the checker reads an extension, and a
+// harness that filtered on one would report a smaller denominator than the
+// directory holds. Dot files are skipped so a stray .DS_Store is not a plan.
+func planFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	if len(names) == 0 {
+		// Reporting 0/0 for a mistyped directory is the one failure this tool
+		// could hide from a loop that only reads the summary.
+		return nil, fmt.Errorf("no plan files in %s", dir)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// findingPrefix opens every line formatPlanFinding writes
+// (cmd/deja/hook_plan.go). It is the harness's one coupling to the finding
+// text, and it is deliberate: a line that does not start with it did not come
+// from the plan checker.
+const findingPrefix = "wall hit in "
+
+func check(bin, path string) ([]string, error) {
+	plan, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	cmd := newCheckCmd(bin)
+	cmd.Stdin = bytes.NewReader(plan)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return nil, fmt.Errorf("%w: %s", err, msg)
+		}
+		return nil, err
+	}
+	var findings []string
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, findingPrefix) {
+			// The first real run of this harness measured `deja search`. A deja
+			// older than the check subcommand does not fail on `deja check -`:
+			// an unknown first word falls through to search (cmd/deja/main.go),
+			// which ignores stdin, exits 0, and answers every plan with the
+			// same result lines — 47 findings for a one-step plan, and the same
+			// 47 for the next plan. Every finding starts with this prefix
+			// (formatPlanFinding), truncation takes the tail, so a line that
+			// does not is not a finding and the count is not a measurement.
+			//
+			// The line itself is not quoted here: it is whatever that other
+			// command decided to print out of a private history.
+			return nil, fmt.Errorf("printed a line that is not a finding — does %s have the check subcommand from this tree?", bin)
+		}
+		findings = append(findings, line)
+	}
+	return findings, nil
+}
+
+// planWall extracts the wall a finding cites, so the same wall recalled by
+// several plans collapses to one label. formatPlanFinding writes
+// `wall hit in N sessions[ since date]: "wall"` and appends the command clause
+// after a semicolon, so the wall is the first quoted string on the line.
+//
+// A finding trimmed to fit the payload budget can lose its closing quote. Then
+// the whole line is the key, and two truncated findings differing only past the
+// cut count as two walls — this overstates how many distinct walls fired rather
+// than collapsing walls that are not the same.
+func planWall(line string) string {
+	i := strings.Index(line, `"`)
+	if i < 0 {
+		return line
+	}
+	for j := i + 1; j < len(line); j++ {
+		switch line[j] {
+		case '\\':
+			j++
+		case '"':
+			if text, err := strconv.Unquote(line[i : j+1]); err == nil {
+				return text
+			}
+			return line
+		}
+	}
+	return line
+}
+
+func pct(a, b int) float64 {
+	if b == 0 {
+		return 0
+	}
+	return 100 * float64(a) / float64(b)
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/scripts/planbench/main_test.go
+++ b/scripts/planbench/main_test.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHelperDeja is not a test. It is the stand-in for the deja binary: it
+// reads a plan on stdin and prints one finding per line marked FIRE, which is
+// all planbench needs from it, and it exits on EXIT so the failure path can be
+// exercised without a broken install.
+func TestHelperDeja(t *testing.T) {
+	if os.Getenv("PLANBENCH_HELPER") != "1" {
+		return
+	}
+	// Before the test framework writes PASS to the stdout planbench is reading.
+	defer os.Exit(0)
+	plan, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		os.Exit(2)
+	}
+	for _, line := range strings.Split(string(plan), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "EXIT" {
+			fmt.Fprintln(os.Stderr, "deja: check failed")
+			os.Exit(1)
+		}
+		// A deja older than the check subcommand searches for the words
+		// instead, ignores stdin, and exits 0 with result lines.
+		if line == "OLD" {
+			fmt.Println("[claude · a-project · 2026-01-02 · 019fa282] some session title")
+			os.Exit(0)
+		}
+		if finding, ok := strings.CutPrefix(line, "FIRE "); ok {
+			fmt.Println(finding)
+		}
+	}
+}
+
+// useHelper points the harness at the stand-in above.
+func useHelper(t *testing.T) {
+	t.Helper()
+	original := newCheckCmd
+	newCheckCmd = func(string) *exec.Cmd {
+		cmd := exec.Command(os.Args[0], "-test.run=TestHelperDeja")
+		cmd.Env = append(os.Environ(), "PLANBENCH_HELPER=1")
+		return cmd
+	}
+	t.Cleanup(func() { newCheckCmd = original })
+}
+
+// unpad collapses the column padding so a test asserts on what a line says
+// rather than on how wide the longest file name happened to be.
+func unpad(out string) string {
+	lines := strings.Split(out, "\n")
+	for i, line := range lines {
+		lines[i] = strings.Join(strings.Fields(line), " ")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func writePlans(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+const (
+	migrationWall = `wall hit in 3 sessions since 2026-01-02: "the migration lock never released"`
+	timeoutWall   = `wall hit in 2 sessions since 2026-01-05: "the pool timed out"; past sessions also ran "make reset" (2 sessions)`
+)
+
+// The finding count alone reads as independent hits. Twelve findings drawn from
+// two walls is one problem reported twelve times, so the distinct-wall count is
+// the number that decides how to read the rest of the table — and it only works
+// if the same wall reached through different plans collapses to one label.
+func TestRunCountsDistinctWallsNotFindings(t *testing.T) {
+	useHelper(t)
+	dir := writePlans(t, map[string]string{
+		"a.md": "1. do the thing\nFIRE " + migrationWall + "\nFIRE " + timeoutWall + "\n",
+		"b.md": "1. do another thing\nFIRE " + migrationWall + "\n",
+		"c.md": "1. nothing recurs here\n",
+	})
+
+	var out, errOut bytes.Buffer
+	if err := run(&out, &errOut, "deja", dir, false); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := unpad(out.String())
+
+	for _, want := range []string{
+		"a.md fire · 2 findings · w1 w2",
+		"b.md fire · 1 finding · w1",
+		"c.md silent",
+		"3 plans · 2 fired (66.7%) · 3 findings · 2 distinct walls",
+		"w1 cited by 2 plans",
+		"w2 cited by 1 plan",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\n%s", want, got)
+		}
+	}
+	if errOut.Len() != 0 {
+		t.Errorf("stderr = %q, want empty", errOut.String())
+	}
+}
+
+// A finding quotes someone's history back at whoever reads the table, and the
+// table is the part that gets pasted into an issue. Text only on request.
+func TestRunPrintsHistoryTextOnlyWithDump(t *testing.T) {
+	useHelper(t)
+	dir := writePlans(t, map[string]string{
+		"a.md": "1. do the thing\nFIRE " + migrationWall + "\n",
+	})
+
+	var quiet, dumped, errOut bytes.Buffer
+	if err := run(&quiet, &errOut, "deja", dir, false); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.Contains(quiet.String(), "the migration lock never released") {
+		t.Errorf("recalled text printed without -dump\n%s", quiet.String())
+	}
+	if err := run(&dumped, &errOut, "deja", dir, true); err != nil {
+		t.Fatalf("run -dump: %v", err)
+	}
+	if !strings.Contains(dumped.String(), "the migration lock never released") {
+		t.Errorf("-dump printed no finding text\n%s", dumped.String())
+	}
+}
+
+// Silence is the miss contract of the hook this measures, so a run where
+// nothing fires has to exit 0 or the tool cannot be used in a loop. A plan that
+// could not be run is a different thing, and it must not take the rest of the
+// directory with it.
+func TestRunSeparatesSilenceFromFailure(t *testing.T) {
+	useHelper(t)
+	silent := writePlans(t, map[string]string{
+		"a.md": "1. nothing recurs here\n",
+		"b.md": "1. nor here\n",
+	})
+	var out, errOut bytes.Buffer
+	if err := run(&out, &errOut, "deja", silent, false); err != nil {
+		t.Fatalf("a silent run is a result, not an error: %v", err)
+	}
+	if !strings.Contains(out.String(), "2 plans · 0 fired (0.0%) · 0 findings · 0 distinct walls") {
+		t.Errorf("unexpected summary\n%s", out.String())
+	}
+
+	broken := writePlans(t, map[string]string{
+		"a.md": "1. nothing recurs here\n",
+		"b.md": "EXIT\n",
+		"c.md": "1. still measured\nFIRE " + migrationWall + "\n",
+	})
+	out.Reset()
+	errOut.Reset()
+	err := run(&out, &errOut, "deja", broken, false)
+	if err == nil {
+		t.Fatal("a plan that could not be run exited 0")
+	}
+	if !strings.Contains(err.Error(), "1 plan could not be run") {
+		t.Errorf("err = %v", err)
+	}
+	if !strings.Contains(errOut.String(), "b.md:") {
+		t.Errorf("the failing plan was not named: %q", errOut.String())
+	}
+	// The two plans either side of the failure still count.
+	if !strings.Contains(out.String(), "2 plans · 1 fired (50.0%) · 1 finding · 1 distinct wall") {
+		t.Errorf("a failed plan changed the denominator\n%s", out.String())
+	}
+}
+
+// The first real run of this harness measured `deja search`: an installed deja
+// with no check subcommand falls through to search, ignores the plan on stdin,
+// exits 0, and answers every plan with the same result lines. That reads as a
+// fire on every plan, and a one-step plan came back with 47 findings. A run
+// against the wrong binary has to fail, not report a rate.
+func TestRunRefusesOutputThatIsNotAFinding(t *testing.T) {
+	useHelper(t)
+	dir := writePlans(t, map[string]string{"a.md": "OLD\n"})
+
+	var out, errOut bytes.Buffer
+	err := run(&out, &errOut, "deja", dir, false)
+	if err == nil {
+		t.Fatal("search results were counted as findings")
+	}
+	if !strings.Contains(errOut.String(), "not a finding") {
+		t.Errorf("stderr = %q", errOut.String())
+	}
+	// Whatever that other command printed came out of a private history, and
+	// this table gets pasted into issues.
+	if strings.Contains(errOut.String()+out.String(), "019fa282") {
+		t.Errorf("the rejected line was echoed\n%s%s", errOut.String(), out.String())
+	}
+}
+
+// A mistyped -plans is the one failure a loop reading only the summary would
+// never see: 0/0 looks exactly like a directory where nothing fired.
+func TestPlanFilesRefusesADirectoryWithNoPlans(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".DS_Store"), []byte("junk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := planFiles(dir); err == nil {
+		t.Fatal("a directory holding no plan accepted")
+	}
+	if _, err := planFiles(filepath.Join(dir, "missing")); err == nil {
+		t.Fatal("a directory that does not exist accepted")
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "plan.txt"), []byte("1. step"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	names, err := planFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Extension-agnostic on purpose: nothing in the checker reads one.
+	if len(names) != 1 || names[0] != "plan.txt" {
+		t.Errorf("names = %v", names)
+	}
+}
+
+func TestPlanWallReadsTheWallOutOfAFinding(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "wall alone",
+			line: migrationWall,
+			want: "the migration lock never released",
+		},
+		{
+			// The command clause is a bonus on the same line, and grouping by
+			// it would split one wall across the plans that also recalled a
+			// command.
+			name: "command clause ignored",
+			line: timeoutWall,
+			want: "the pool timed out",
+		},
+		{
+			name: "quote inside the wall",
+			line: `wall hit in 2 sessions: "go test said \"FAIL\" again"`,
+			want: `go test said "FAIL" again`,
+		},
+		{
+			// Truncated by the payload budget: no closing quote to unquote.
+			name: "no closing quote",
+			line: `wall hit in 2 sessions: "the migration lock never rele…`,
+			want: `wall hit in 2 sessions: "the migration lock never rele…`,
+		},
+		{
+			name: "no quote at all",
+			line: "wall hit in 2 sessions",
+			want: "wall hit in 2 sessions",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := planWall(tt.line); got != tt.want {
+				t.Errorf("planWall(%q) = %q, want %q", tt.line, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds `deja check -` and `deja hook-plan` as explicit, off-by-default subcommands, plus `scripts/planbench` so the measurement can be repeated on someone else's plans. No install wiring, no hook registration: nothing here fires unless it is called by name.

This is the implementation from #532, opened at your request after the measurement came back short of the kill condition. The numbers are below and they are not overwhelming. I would rather you have the harness and decide than have my summary of it.

## What it does

`deja check -` reads a plan on stdin and prints one line per finding, or nothing. A finding states a co-occurrence and stops there:

```
wall hit in 23 sessions since 2026-07-20: "…: No module named pytest"
```

No contradiction claim, no "you already tried this". #541 is why. The judgement about whether the wall matters to the step is left to whoever reads it.

`deja hook-plan` is the same core behind a PreToolUse/ExitPlanMode shape. It shares one function with `check`, so the numbers below describe the hook path too.

Both honour the auto-activation policy and the existing `.hookseen` dedupe, and neither builds an index: a missing or stale one is a silent miss, because plan submission should not block on indexing.

## The measurement

30 real plans out of my own plan-mode history, against a personal index carrying 19 recurring walls, each hit in 3 or more sessions.

| gate | fires | precision (hand-labeled) |
|---|---|---|
| 2 informative terms, idf >= 2.0 (auto-recall's floor) | 0/30 | — |
| identifier-shaped terms exempt from the floor | 10/30 | ~0.69 |
| two-tier floor: identifier >= 1.0, plain >= 2.0 | 6/30 | 0.58–0.83 |

Only the last row reproduces at this branch. The first two came from earlier gates the code no longer contains.

Read 6/30 with the caveat attached: those six plans are three documents and their revisions, and all 12 findings carry **two** distinct wall strings. So the twelve findings are three documents against two walls, and that is the real size of the sample, not twelve independent judgements. `planbench` prints the distinct-wall count for exactly this reason.

## Two things the measurement taught me

**Wall vocabulary is common by construction.** Walls come from repeated work, so the terms that could anchor one are frequent in the corpus that produced them: the anchors that fired sit at idf 1.08 and 1.22, while ordinary words inside the same wall strings sit at 0.18–0.38. The informative floor built for prompts excludes every one of them. That is why row 1 is 0/30 rather than "a few misses".

The second floor at 1.0 sits in a measured gap (identifier-shaped false anchors topped out at 0.70, true ones started at 1.08), but I picked it on the same 30 plans the precision column reports, so read 0.83 as the optimistic in-sample end. The gap is not a law either: "preview" (1.26) and "denied" (1.85) are equally ordinary words that clear the same floor and simply did not appear in these plans.

**Requiring a command-role join leaves it silent.** 84 of the 110 wall-carrier sessions hold no command records at all, and at most 1 wall of 19 could ever join. So the join is an optional strengthening clause on a finding, never a precondition.

## The harness

```
DEJA_INDEX_DIR=~/.cache/deja/index.db go run ./scripts/planbench -plans ./plans
```

It runs each file in the directory through the built binary and prints fire/silent per plan, then totals: plans, fires, findings, and distinct walls cited. It counts; it does not judge. Precision is a human label, and the tool produces the denominator, not the verdict.

It refuses any output line that is not a finding. That guard exists because an older `deja` on PATH silently answered `check -` as a search (an unknown first word falls through) and reported 47 findings for a one-line plan. A precision harness that measures `deja search` and calls it a fire rate is worse than none.

Point it at a directory of plans only; every regular file counts as one, so a stray `results.tsv` inflates the denominator. Each file is listed, so it is visible, but the headline number moves.

## What I could not verify

`go test -race` does not run here: no C toolchain on this machine, and `-race` requires cgo. CI will be the first place it runs. Everything else in CONTRIBUTING passed: `gofmt -s`, `go vet ./...`, `go build ./cmd/deja`, and the package tests.

`scripts/planbench` ships with a test, which cuts against the note in ci.yml that harnesses under `scripts/` have none by design. I kept it because it pins the search-fallthrough guard above, and because `scripts/` is excluded from the coverage profile so it costs nothing there. If you would rather the directory stay uniform, deleting `main_test.go` loses nothing else.

## Kill condition

0.83 at best, in-sample, on a sample that is really three documents. I did not think that cleared the bar in #532, and I still do not. What changed is that you asked for the code and the harness anyway, so here they are, off by default and easy to delete if the numbers do not hold up on your plans.
