### PR TITLE
fix: trim surrounding space from a search query

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1541,8 +1541,11 @@ func parseSearch(args []string) (search.Options, error) {
 		}
 	}
 	// Match the NFC canonicalisation ingest applies to stored text, so a query
-	// typed in either normalisation reaches the same records (#1098).
-	o.Query = nfcfold.Compose(strings.Join(q, " "))
+	// typed in either normalisation reaches the same records (#1098). Trim
+	// surrounding space: a leading space left the exact-match tier hunting for
+	// " token" and an exact-only term (an error code, a coined name) missed,
+	// while a real word was rescued by its word-forms and hid the gap.
+	o.Query = nfcfold.Compose(strings.TrimSpace(strings.Join(q, " ")))
 	if o.Query == "" {
 		return o, fmt.Errorf("query required")
 	}

--- a/cmd/deja/search_flag_typo_test.go
+++ b/cmd/deja/search_flag_typo_test.go
@@ -46,3 +46,18 @@ func TestParseSearchRejectsAMisspelledFlag(t *testing.T) {
 		t.Errorf("limit = %d query = %q err = %v", o.Limit, o.Query, err)
 	}
 }
+
+func TestParseSearchTrimsSurroundingSpace(t *testing.T) {
+	// A leading space left the exact-match tier hunting for " token", so an
+	// exact-only term (an error code, a coined name) missed on a pasted query.
+	for _, in := range []string{" WHITEWORD", "WHITEWORD ", "  WHITEWORD  "} {
+		o, err := parseSearch([]string{in})
+		if err != nil || o.Query != "WHITEWORD" {
+			t.Errorf("parseSearch(%q): query = %q err = %v", in, o.Query, err)
+		}
+	}
+	// Space-only is empty once trimmed, so it is rejected rather than searched.
+	if _, err := parseSearch([]string{"   "}); err == nil {
+		t.Errorf("space-only query should be rejected")
+	}
+}


### PR DESCRIPTION
A leading space made the exact-match tier hunt for `" token"`, so an exact-only term — an error code, a coined name, an identifier — missed when the query was pasted with a stray space, while a real word was rescued by its word-forms and hid it.

`deja " WHITEWORD"` returned nothing; `deja "WHITEWORD"` matched. Trailing space already worked, so it was leading-space-only and only on exact-only terms. Fix trims the query before the match tiers; whitespace-only now returns "query required" instead of a no-op search.

Test `TestParseSearchTrimsSurroundingSpace` covers it; reverting the trim fails it.