### PR TITLE
fix: embed and promote honour the trust policy

### DIFF
--- a/cmd/deja/bench.go
+++ b/cmd/deja/bench.go
@@ -73,7 +73,7 @@ func runBenchRecall(jsonOutput bool, seed int64) error {
 	}
 	report := benchReport{CorpusHash: corpus.Hash, Sessions: len(corpus.Sessions), Queries: len(corpus.Queries), Lexical: lexical, HybridStatus: "endpoint unavailable, skipped"}
 	if client, probeErr := embed.New(); probeErr == nil {
-		if _, embedErr := embed.EmbedIndex(indexDir, client); embedErr == nil {
+		if _, embedErr := embed.EmbedIndex(indexDir, client, nil); embedErr == nil {
 			var hybrid benchMetric
 			hybrid, err = measureRecall(indexDir, corpus.Queries, client)
 			if err != nil {

--- a/cmd/deja/embed.go
+++ b/cmd/deja/embed.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/embed"
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
@@ -21,8 +22,31 @@ func runEmbed(dir string, args []string) error {
 	if err != nil {
 		return err
 	}
-	_, err = embed.EmbedIndex(dir, client)
+	_, err = embed.EmbedIndex(dir, client, embedPolicyKeep(dir))
 	return err
+}
+
+// embedPolicyKeep skips records the trust policy withholds from search, so
+// embed does not ship a peer's imported content to the external endpoint under
+// a deny that every read path already honours. A record whose session is not in
+// the manifest is kept: unknown origin should not silently drop from search.
+func embedPolicyKeep(dir string) func(index.Record) bool {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return nil
+	}
+	project := make(map[string]string, len(metas))
+	for _, m := range metas {
+		project[m.Harness+":"+m.ID] = m.Project
+	}
+	pol := policy.Load()
+	return func(r index.Record) bool {
+		p, ok := project[r.Key]
+		if !ok {
+			return true
+		}
+		return pol.Allows(policy.ActivationSearch, p)
+	}
 }
 
 func maybeRerank(dir string, hits []search.Hit, o search.Options, notice *os.File) []search.Hit {

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -77,6 +77,13 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	if !ok {
 		return fmt.Errorf("no session matches %q%s", prefix, movedBucketHint(dir, prefix))
 	}
+	// A session the trust policy hides must not be promotable: `--to` wrote its
+	// content to a file and the note it built repeated the wall, both under a
+	// deny that share and handoff already honour on the same id. Gate here so
+	// the whole command refuses, the way share does.
+	if err := denyPolicyHidden(prefix, s, os.Stderr); err != nil {
+		return err
+	}
 	src := s.Harness + ":" + s.ID
 	if s.Harness == "deja" {
 		// A correction on a promoted note is what `promote` tells you to write,

--- a/cmd/deja/show_policy_test.go
+++ b/cmd/deja/show_policy_test.go
@@ -83,6 +83,15 @@ func TestDirectAccessHonoursTrustPolicy(t *testing.T) {
 			t.Errorf("%s leaked imported content under deny-imported:\n%s", args[0], out)
 		}
 	}
+	// promote --to wrote the imported content to a file the reader named, the
+	// one leak the others do not have; the whole command must refuse first.
+	exp := filepath.Join(t.TempDir(), "promoted.md")
+	if out, _ := captureRun(t, "promote", impID, "--to", exp); strings.Contains(out, "IMPORTEDMARKER") {
+		t.Errorf("promote leaked imported content under deny-imported:\n%s", out)
+	}
+	if b, err := os.ReadFile(exp); err == nil && strings.Contains(string(b), "IMPORTEDMARKER") {
+		t.Errorf("promote --to wrote imported content to the export file:\n%s", string(b))
+	}
 	// The local session stays reachable — the rule is about origin, not access.
 	if out, _ := captureRun(t, "show", "locz"); !strings.Contains(out, "LOCALMARKER") {
 		t.Errorf("show over-blocked a local session under deny-imported:\n%s", out)

--- a/internal/embed/embed_keep_test.go
+++ b/internal/embed/embed_keep_test.go
@@ -1,0 +1,69 @@
+package embed
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// keep is how embed keeps content the trust policy withholds off the wire to an
+// external endpoint. A dropped record must never reach the client at all.
+func TestEmbedIndexKeepFiltersRecords(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "claude", "-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"s","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"KEEPME semantic needle"}}` + "\n" +
+		`{"type":"user","sessionId":"s","timestamp":"2026-01-01T00:00:01Z","message":{"role":"user","content":"DROPME imported secret"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "s.jsonl"), []byte(rec), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input []string `json:"input"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		got = append(got, req.Input...)
+		out := make([][]float64, len(req.Input))
+		for i := range out {
+			out[i] = []float64{1}
+		}
+		b, _ := json.Marshal(map[string]any{"embeddings": out})
+		_, _ = w.Write(b)
+	}))
+	defer ts.Close()
+
+	keep := func(r index.Record) bool { return !strings.Contains(r.Text, "DROPME") }
+	if _, err := EmbedIndex(dir, &Client{URL: ts.URL, Model: "m"}, keep); err != nil {
+		t.Fatal(err)
+	}
+	for _, in := range got {
+		if strings.Contains(in, "DROPME") {
+			t.Errorf("a dropped record reached the endpoint: %q", in)
+		}
+	}
+	kept := false
+	for _, in := range got {
+		if strings.Contains(in, "KEEPME") {
+			kept = true
+		}
+	}
+	if !kept {
+		t.Errorf("the kept record never reached the endpoint: %v", got)
+	}
+}

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -186,22 +186,22 @@ func TestEmbedIndexRoundTripAndWatermark(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
-	s, err := EmbedIndex(dir, &Client{URL: ts.URL, Model: "m"})
+	s, err := EmbedIndex(dir, &Client{URL: ts.URL, Model: "m"}, nil)
 	if err != nil || calls != 1 || s.Covered != 1 || len(s.Vectors) != 1 {
 		t.Fatalf("first embed sidecar=%+v calls=%d err=%v", s, calls, err)
 	}
-	if _, err = EmbedIndex(dir, &Client{URL: ts.URL, Model: "m"}); err != nil || calls != 1 {
+	if _, err = EmbedIndex(dir, &Client{URL: ts.URL, Model: "m"}, nil); err != nil || calls != 1 {
 		t.Fatalf("watermark did not reuse vector calls=%d err=%v", calls, err)
 	}
 	if err := write(dir, Sidecar{Model: "m", Generation: s.Generation, Dim: 2}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := EmbedIndex(dir, &Client{URL: ts.URL, Model: "m"}); err == nil || !strings.Contains(err.Error(), "dimension changed") {
+	if _, err := EmbedIndex(dir, &Client{URL: ts.URL, Model: "m"}, nil); err == nil || !strings.Contains(err.Error(), "dimension changed") {
 		t.Fatalf("dimension change err=%v", err)
 	}
 	bad := httptest.NewServer(http.NotFoundHandler())
 	defer bad.Close()
-	if _, err := EmbedIndex(dir, &Client{URL: bad.URL, Model: "other"}); err == nil {
+	if _, err := EmbedIndex(dir, &Client{URL: bad.URL, Model: "other"}, nil); err == nil {
 		t.Fatal("embedding endpoint error was ignored")
 	}
 	if err := write(filepath.Join(tmp, "no", "missing"), Sidecar{}); err == nil {

--- a/internal/embed/sidecar.go
+++ b/internal/embed/sidecar.go
@@ -32,10 +32,23 @@ func Path(dir string) string {
 	return strings.TrimSuffix(dir, string(os.PathSeparator)) + ".vectors.bin"
 }
 
-func EmbedIndex(dir string, client *Client) (Sidecar, error) {
+// EmbedIndex embeds the index's records through client and writes the sidecar.
+// keep decides which records are sent: it is how the caller keeps content the
+// trust policy withholds off the wire to an external endpoint. A nil keep
+// embeds every record.
+func EmbedIndex(dir string, client *Client, keep func(index.Record) bool) (Sidecar, error) {
 	recs, err := index.ReadRecords(dir)
 	if err != nil {
 		return Sidecar{}, fmt.Errorf("read index records: %w", err)
+	}
+	if keep != nil {
+		kept := recs[:0:0]
+		for _, r := range recs {
+			if keep(r.Record) {
+				kept = append(kept, r)
+			}
+		}
+		recs = kept
 	}
 	gen, err := index.Generation(dir)
 	if err != nil {

--- a/internal/embed/sidecar_size_doc_test.go
+++ b/internal/embed/sidecar_size_doc_test.go
@@ -95,7 +95,7 @@ func TestReadmeSidecarSizeMatchesWhatEmbedWrites(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	if _, err := EmbedIndex(dir, &Client{URL: ts.URL, Model: "test", HTTP: ts.Client()}); err != nil {
+	if _, err := EmbedIndex(dir, &Client{URL: ts.URL, Model: "test", HTTP: ts.Client()}, nil); err != nil {
 		t.Fatal(err)
 	}
 	info, err := os.Stat(Path(dir))


### PR DESCRIPTION
Two egress paths shipped a hidden peer's imported content out under a deny that every read path (search, recall, files, blame, view, last, show, share, handoff, MCP) already honours.

**promote** `<imported-id> --to <file>` wrote the imported content to a file and built a note from it — while `share` and `handoff` refuse the same id. Fix gates the lookup with `denyPolicyHidden`, exactly as share does.

**embed** sent every indexed record to the external `DEJA_EMBED_URL`, imported included. Query-time semantic search already filters imported hits, but the build shipped the content off the machine regardless. Fix filters records the search policy withholds before they leave; a nil predicate (bench, the embed package tests) still embeds everything.

Both measured against a mock endpoint / an export file: imported content no longer leaves under deny; local still does. Tests cover both and fail when the gate is reverted.