### PR TITLE
fix: index hangs, import hiding local sessions, semantic policy leak, and audit-wave fixes

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -832,6 +832,14 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	}
 	var semantic bool
 	hits, semantic = maybeSemantic(dir, hits, o, os.Stderr)
+	if semantic {
+		// The lexical hits were scoped by the trust policy above, but the
+		// semantic tier reaches the whole sidecar and brings back sessions of
+		// its own — an imported peer's content the policy withholds from every
+		// other read path leaked straight through the embedding fallback. Scope
+		// the semantic hits the same way before they are shown.
+		hits, _ = policyFilterHitsCounted(policy.ActivationSearch, hits)
+	}
 	o.Semantic = semantic
 	// Policy scoping, reranking and the semantic tier all run after the cap, so
 	// the pre-cap count can no longer describe what is being returned. When

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1311,11 +1311,18 @@ func noteAmbiguousPrefix(dir, id, action string) {
 		return
 	}
 	// When the matches are the same id in different harnesses there is no
-	// longer prefix to reach for, and --harness is the only thing that
-	// separates them (#719).
+	// longer prefix to reach for, and naming the harness is the only thing
+	// that separates them (#719). The `harness:id` form is the one every
+	// command that resolves a selector accepts — show/last also take
+	// --harness, but promote/handoff/resume/share do not, so advising the
+	// flag sent those readers into "unknown flag --harness".
 	if hs := index.PrefixHarnesses(dir, id); len(hs) > 1 {
-		fmt.Fprintf(os.Stderr, "deja: %d sessions share the id %q — %s the most recent; use --harness %s\n",
-			len(hs), id, action, strings.Join(hs, "|"))
+		forms := make([]string, len(hs))
+		for i, h := range hs {
+			forms[i] = h + ":" + id
+		}
+		fmt.Fprintf(os.Stderr, "deja: %d sessions share the id %q — %s the most recent; name one as %s\n",
+			len(hs), id, action, strings.Join(forms, " or "))
 		return
 	}
 	// "A longer prefix" is not available when the reader copied an elided id

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1494,6 +1494,14 @@ func parseSearch(args []string) (search.Options, error) {
 	args = splitEqualsForms(args)
 	for i := 0; i < len(args); i++ {
 		a := args[i]
+		if a == "--" {
+			// End of options: the rest is the query verbatim, even a word that
+			// spells a flag. Without this there is no way to search for the
+			// literal text of a flag name — `deja -- --json` kept parsing
+			// --json as the flag and left "--" stranded in the query.
+			q = append(q, args[i+1:]...)
+			break
+		}
 		switch a {
 		case "--json":
 			o.JSON = true

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -865,6 +865,13 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 			printNoMatches(os.Stderr, dir, o.Query)
 		}
 	}
+	if o.Capped && len(hits) > 0 {
+		// The cap is silent everywhere else: 15 results look like the whole
+		// answer, and nothing says another N are waiting behind --all. deja
+		// narrates every other place the ladder hides a session, so it says
+		// this one too.
+		fmt.Fprintf(os.Stderr, "deja: showing %d of %d — add --all to see the rest\n", len(hits), o.Total)
+	}
 	search.Print(os.Stdout, hits, o)
 	return nil
 }

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -125,7 +125,7 @@ func handleMCP(dir string, req rpcRequest) (any, int, string) {
 				"name":        "remember",
 				"description": "Store one durable decision or conclusion so a future session can recall it. Call right after a decision is settled, a tricky bug is resolved, or the user says 'remember this', 'note that for next time', 'don't forget we chose X'. Write a single self-contained fact (e.g. 'We use Postgres advisory locks for the job queue because Redis lost messages under load'). Do NOT store transcripts, routine conversation, or anything already obvious from the code. text is required; project defaults to notes.",
 				"annotations": map[string]any{"title": "Remember a decision", "readOnlyHint": false},
-				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"text": map[string]any{"type": "string", "description": "A durable fact, decision, or conclusion to remember."}, "project": map[string]any{"type": "string", "description": "Optional project name; defaults to notes."}}, "required": []string{"text"}},
+				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"text": map[string]any{"type": "string", "description": "A durable fact, decision, or conclusion to remember."}, "project": map[string]any{"type": "string", "description": "Optional project name; defaults to notes."}, "tags": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Optional navigation tags, searchable as #tag."}}, "required": []string{"text"}},
 			},
 		}}, 0, ""
 	case "resources/list":
@@ -254,8 +254,9 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		return text, err
 	case "remember":
 		var a struct {
-			Text    string `json:"text"`
-			Project string `json:"project"`
+			Text    string   `json:"text"`
+			Project string   `json:"project"`
+			Tags    []string `json:"tags"`
 		}
 		if err := json.Unmarshal(raw, &a); err != nil {
 			return "", err
@@ -266,7 +267,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Project) == "" {
 			a.Project = "notes"
 		}
-		if err := notesWriteError(sources.AppendNote(a.Project, a.Text, time.Now())); err != nil {
+		if err := notesWriteError(sources.AppendNoteTagged(a.Project, a.Text, a.Tags, time.Now())); err != nil {
 			return "", err
 		}
 		if err := index.EnsureForSearch(dir, search.Options{All: true}, false, mcpProgress()); err != nil {

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -474,6 +474,12 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	}
 	var semantic bool
 	hits, semantic = maybeSemantic(dir, hits, o, os.Stderr)
+	if semantic {
+		// The semantic tier reaches the whole sidecar, past the policy scoping
+		// the lexical hits already had; scope its hits too or an imported peer's
+		// content the policy withholds reaches the agent through recall.
+		hits, _ = policyFilterHitsCounted(policy.ActivationMCP, hits)
+	}
 	o.Semantic = semantic
 	if len(hits) == 0 {
 		return emptyRecallAnswerPolicy(dir, q, policyHidden), 0, 0, nil, nil
@@ -620,6 +626,9 @@ func recallContextResult(dir, q, harness string) (string, int, int64, []string, 
 	hits, semantic = maybeSemantic(dir, hits, o, os.Stderr)
 	if semantic {
 		o.Tier = search.TierSemantic
+		// Semantic hits skip the policy scoping the lexical ones got; apply it
+		// here too, or recall_context leaks a withheld imported session.
+		hits, _ = policyFilterHitsCounted(policy.ActivationMCP, hits)
 	}
 	if len(hits) == 0 {
 		return emptyRecallAnswerPolicy(dir, q, policyHidden), 0, 0, nil, nil

--- a/cmd/deja/mcp_remember_tags_test.go
+++ b/cmd/deja/mcp_remember_tags_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The CLI `remember --tag` stores navigation tags, but the MCP remember tool
+// dropped them: an agent that tagged a note over MCP got an untagged note, and
+// `deja "#tag"` never found it. The tool now threads tags through the same
+// AppendNoteTagged path the CLI uses.
+func TestMCPRememberStoresTags(t *testing.T) {
+	withStatsStores(t)
+	dir := os.Getenv("DEJA_INDEX_DIR")
+
+	_, err := callMCPTool(dir, "remember", []byte(`{"text":"tagged decision","project":"tp","tags":["urgent","perf"]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var body strings.Builder
+	for _, s := range sources.LoadNotes() {
+		for _, m := range s.Messages {
+			body.WriteString(m.Text)
+			body.WriteByte('\n')
+		}
+	}
+	got := body.String()
+	if !strings.Contains(got, "#urgent") || !strings.Contains(got, "#perf") {
+		t.Errorf("remember dropped its tags; note body = %q", got)
+	}
+}

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -132,7 +132,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	// suppressed and `promote` reported success over a note that never showed.
 	// Say so and name the one command that restores it, rather than silently
 	// clearing a tombstone the reader set on purpose.
-	if noteID := "deja-note-" + strings.ReplaceAll(src, ":", "-"); index.Tombstoned("deja:"+noteID) {
+	if noteID := "deja-note-" + strings.ReplaceAll(src, ":", "-"); index.Tombstoned("deja:" + noteID) {
 		fmt.Fprintf(os.Stderr, "deja: the note is written but stays hidden — %s was forgotten, and its tombstone lifts only through `deja forget --unforget deja:%s`\n", noteID, noteID)
 	}
 	if exportPath != "" {

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -127,6 +127,14 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	if err := index.EnsureForSearch(dir, search.Options{All: true}, false, os.Stderr); err != nil {
 		fmt.Fprintf(os.Stderr, "deja: the note is written; the index could not be updated yet — %v\n", err)
 	}
+	// Promoting a session that was forgotten writes the note back to disk, but
+	// a tombstone lifts only through unforget by design — so the note stayed
+	// suppressed and `promote` reported success over a note that never showed.
+	// Say so and name the one command that restores it, rather than silently
+	// clearing a tombstone the reader set on purpose.
+	if noteID := "deja-note-" + strings.ReplaceAll(src, ":", "-"); index.Tombstoned("deja:"+noteID) {
+		fmt.Fprintf(os.Stderr, "deja: the note is written but stays hidden — %s was forgotten, and its tombstone lifts only through `deja forget --unforget deja:%s`\n", noteID, noteID)
+	}
 	if exportPath != "" {
 		masked, err := exportPromoted(exportPath, title, text, src, state, s.Updated)
 		if err != nil {

--- a/cmd/deja/promote_shared_id_hint_test.go
+++ b/cmd/deja/promote_shared_id_hint_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The shared-id notice used to advise `--harness`, which show and last accept
+// but promote/handoff/resume/share reject with "unknown flag" — so the reader
+// promote left picking in silence (#872) was handed advice their command could
+// not follow. The notice now names the harness:id form every selector accepts,
+// and this test holds both halves: the advice is emitted, and it works.
+func TestPromoteSharedIDHintIsFollowable(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude", "-proj")
+	qwen := filepath.Join(tmp, "qwen", "projects", "proj", "chats")
+	for _, d := range []string{claude, qwen} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
+	write := func(p, body string) {
+		if err := os.WriteFile(p, []byte(body+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(claude, "shared99.jsonl"),
+		`{"type":"user","sessionId":"shared99","cwd":"/w/p","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"claude side content"}}`)
+	write(filepath.Join(qwen, "shared99.jsonl"),
+		`{"type":"user","sessionId":"shared99","timestamp":"2026-07-25T10:00:00Z","message":{"role":"user","parts":[{"text":"qwen side content"}]}}`)
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bare shared id: the notice names both harness:id forms, never the flag
+	// promote rejects.
+	notice, err := captureRunStderr(t, "promote", "shared99")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(notice, "claude:shared99 or qwen:shared99") {
+		t.Errorf("shared-id notice did not name the followable form:\n%s", notice)
+	}
+	if strings.Contains(notice, "--harness") {
+		t.Errorf("notice still advised a flag promote rejects:\n%s", notice)
+	}
+
+	// The advised form resolves without the "unknown flag" the reader hit when
+	// they followed the old --harness advice.
+	out, err := captureRunStderr(t, "promote", "qwen:shared99")
+	if err != nil {
+		t.Fatalf("advised form failed: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "unknown flag") {
+		t.Errorf("advised form was rejected:\n%s", out)
+	}
+}

--- a/cmd/deja/promote_tombstone_warn_test.go
+++ b/cmd/deja/promote_tombstone_warn_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Promoting a forgotten session writes the note back, but a tombstone lifts
+// only through unforget by design — so the note stayed suppressed and promote
+// reported success over a note that never appeared. It now says so and names
+// the restore command; an ordinary promote stays quiet.
+func TestPromoteWarnsWhenTheNoteIsTombstoned(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(tmp, "claude", "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	write := func(id, body string) {
+		line := `{"type":"user","sessionId":"` + id + `","cwd":"/w/p","timestamp":"2026-06-01T10:00:00Z","message":{"role":"user","content":"` + body + `"}}`
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("c1", "forgotten then repromoted")
+	write("c2", "never forgotten")
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Promote, forget the note, then promote the same source again.
+	if _, err := captureRunStderr(t, "promote", "c1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "forget", "--session", "deja-note-claude-c1"); err != nil {
+		t.Fatal(err)
+	}
+	warn, err := captureRunStderr(t, "promote", "c1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(warn, "stays hidden") || !strings.Contains(warn, "unforget deja:deja-note-claude-c1") {
+		t.Errorf("re-promote of a forgotten note did not warn:\n%s", warn)
+	}
+
+	// An ordinary promote of a session that was never forgotten stays quiet.
+	quiet, err := captureRunStderr(t, "promote", "c2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(quiet, "stays hidden") {
+		t.Errorf("ordinary promote warned about a tombstone it does not have:\n%s", quiet)
+	}
+}

--- a/cmd/deja/remember.go
+++ b/cmd/deja/remember.go
@@ -49,11 +49,20 @@ func runRemember(dir string, args []string) error {
 		}
 		project = sources.ClaudeProjectName(cwd)
 	}
-	if err := sources.AppendNoteTagged(project, text, tags, time.Now()); err != nil {
+	now := time.Now()
+	if err := sources.AppendNoteTagged(project, text, tags, now); err != nil {
 		return notesWriteError(err)
 	}
 	if err := index.EnsureForSearch(dir, search.Options{All: true}, false, os.Stderr); err != nil {
 		return err
+	}
+	// A day-note the reader forgot keeps its tombstone until unforget, so a
+	// later `remember` on the same day and project writes into a note that
+	// stays hidden — the silent success promote used to report on the same
+	// path. Name the restore command rather than lose the line quietly.
+	dayNote := "deja-" + now.Local().Format("2006-01-02") + "-" + strings.TrimSpace(project)
+	if index.Tombstoned("deja:" + dayNote) {
+		fmt.Fprintf(os.Stderr, "deja: it is written but stays hidden — %s was forgotten, and its tombstone lifts only through `deja forget --unforget deja:%s`\n", dayNote, dayNote)
 	}
 	suffix := ""
 	if norm := sources.NormalizeTags(tags); len(norm) > 0 {

--- a/cmd/deja/remember_tombstone_warn_test.go
+++ b/cmd/deja/remember_tombstone_warn_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// A day-note the reader forgot keeps its tombstone until unforget, so a later
+// `remember` on the same day and project writes into a note that stays hidden.
+// remember now names the restore command instead of reporting a silent success;
+// an ordinary remember stays quiet.
+func TestRememberWarnsWhenTheDayNoteIsTombstoned(t *testing.T) {
+	hermeticEnv(t)
+	dayNote := "deja-" + time.Now().Local().Format("2006-01-02") + "-p"
+
+	if _, err := captureRunStderr(t, "remember", "first thing", "--project", "p"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "forget", "--session", dayNote); err != nil {
+		t.Fatal(err)
+	}
+	warn, err := captureRunStderr(t, "remember", "second thing", "--project", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(warn, "stays hidden") || !strings.Contains(warn, "unforget deja:"+dayNote) {
+		t.Errorf("remember into a forgotten day-note did not warn:\n%s", warn)
+	}
+
+	quiet, err := captureRunStderr(t, "remember", "clean thing", "--project", "fresh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(quiet, "stays hidden") {
+		t.Errorf("remember into a fresh project warned about a tombstone it has none of:\n%s", quiet)
+	}
+}

--- a/cmd/deja/search_cap_hint_test.go
+++ b/cmd/deja/search_cap_hint_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The default result cap (15) was silent: 15 hits looked like the whole
+// answer and nothing pointed at --all for the rest. deja narrates every other
+// place the ladder hides a session, so a capped search says so too.
+func TestSearchCapNamesTheHiddenRest(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Two sessions match; a --limit of 1 caps it, which is the same shape the
+	// default cap makes when more than 15 match.
+	for _, id := range []string{"capone", "captwo"} {
+		line := `{"type":"user","message":{"role":"user","content":"capneedle here in ` + id + `"},"timestamp":"2026-08-01T10:00:00Z","sessionId":"` + id + `","cwd":"/proj"}`
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRunStderr(t, "--no-embed", "--limit", "1", "capneedle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "showing 1 of 2") || !strings.Contains(out, "--all") {
+		t.Errorf("capped search hid the rest silently:\n%s", out)
+	}
+
+	// --all shows everything, so there is nothing to point at.
+	out, err = captureRunStderr(t, "--no-embed", "--all", "capneedle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "showing") && strings.Contains(out, "of") {
+		t.Errorf("--all should not announce a cap:\n%s", out)
+	}
+}

--- a/cmd/deja/search_flag_typo_test.go
+++ b/cmd/deja/search_flag_typo_test.go
@@ -61,3 +61,17 @@ func TestParseSearchTrimsSurroundingSpace(t *testing.T) {
 		t.Errorf("space-only query should be rejected")
 	}
 }
+
+func TestParseSearchDashDashEndsOptions(t *testing.T) {
+	// `--` stops flag parsing so a query can be the literal text of a flag.
+	// Before, --json after it still turned on JSON mode and "--" was left in
+	// the query, so flag-colliding text was unsearchable.
+	o, err := parseSearch([]string{"--", "--json"})
+	if err != nil || o.Query != "--json" || o.JSON {
+		t.Fatalf("parseSearch(-- --json): query=%q json=%v err=%v", o.Query, o.JSON, err)
+	}
+	o, err = parseSearch([]string{"pool", "--", "--limit", "5"})
+	if err != nil || o.Query != "pool --limit 5" || o.Limit != 0 {
+		t.Fatalf("parseSearch(pool -- --limit 5): query=%q limit=%d err=%v", o.Query, o.Limit, err)
+	}
+}

--- a/cmd/deja/semantic_policy_leak_test.go
+++ b/cmd/deja/semantic_policy_leak_test.go
@@ -51,6 +51,16 @@ func TestSemanticSearchHonoursTheTrustPolicy(t *testing.T) {
 		t.Fatalf("semantic search leaked imported content under deny:\n%s", out)
 	}
 
+	// The MCP recall path (recallTextResult) has its own semantic fallback and
+	// must scope it the same way — an agent hitting recall must not receive a
+	// withheld imported session either.
+	writePolicyFile(t, `{"activations":{"mcp":{"imported":false},"search":{"imported":false}}}`)
+	if text, _, _, _, err := recallTextResult(index.DefaultDir(), "zzzlexicalmiss", "", 5, 0, 4096); err != nil {
+		t.Fatal(err)
+	} else if strings.Contains(text, "peeronlymarker") {
+		t.Fatalf("MCP recall leaked imported content via semantic under deny:\n%s", text)
+	}
+
 	// Allowed, the same query surfaces it — proving the query does reach the
 	// semantic tier and the deny above is what withheld it.
 	writePolicyFile(t, `{"activations":{"search":{"imported":true}}}`)

--- a/cmd/deja/semantic_policy_leak_test.go
+++ b/cmd/deja/semantic_policy_leak_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// The lexical tier scopes hits by the trust policy, but the semantic fallback
+// reaches the whole sidecar. Without the same scoping it handed an imported
+// peer's content — withheld from every other read path — straight to the
+// caller whenever an embedding endpoint was configured.
+func TestSemanticSearchHonoursTheTrustPolicy(t *testing.T) {
+	tmp := hermeticEnv(t)
+
+	// An imported session, the way sync import records one.
+	batch := filepath.Join(tmp, "batch")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"harness":"claude","session_id":"peer1","project":"proj/p","role":"user","text":"peeronlymarker widget rendering pipeline","time":"2026-05-01T10:00:00+00:00"}` + "\n"
+	if err := os.WriteFile(filepath.Join(batch, "deja-sync-aaaa-1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "sync", "import", batch); err != nil {
+		t.Fatal(err)
+	}
+
+	// A constant-vector endpoint: every query is cosine-1 to the stored record,
+	// so a lexical miss always falls through to a semantic match.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[1,0]}]}`))
+	}))
+	defer ts.Close()
+	t.Setenv("DEJA_EMBED_URL", ts.URL)
+	if err := runEmbed(index.DefaultDir(), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Deny imported for search, then a lexical miss that only the semantic tier
+	// can answer. The imported content must not come back.
+	writePolicyFile(t, `{"activations":{"search":{"imported":false}}}`)
+	out, _ := captureRun(t, "zzzlexicalmiss")
+	if strings.Contains(out, "peeronlymarker") {
+		t.Fatalf("semantic search leaked imported content under deny:\n%s", out)
+	}
+
+	// Allowed, the same query surfaces it — proving the query does reach the
+	// semantic tier and the deny above is what withheld it.
+	writePolicyFile(t, `{"activations":{"search":{"imported":true}}}`)
+	out, _ = captureRun(t, "zzzlexicalmiss")
+	if !strings.Contains(out, "peeronlymarker") {
+		t.Fatalf("semantic search did not return imported content when allowed:\n%s", out)
+	}
+}
+
+func writePolicyFile(t *testing.T, body string) {
+	t.Helper()
+	p := policy.Path()
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/deja/show_ambiguous_test.go
+++ b/cmd/deja/show_ambiguous_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // "Use a longer prefix" cannot be followed when the ids are the same string;
-// --harness is the only thing that separates them (#719).
+// naming the harness (harness:id) is the only thing that separates them (#719).
 func TestShowNamesHarnessWhenIDsAreShared(t *testing.T) {
 	tmp := hermeticEnv(t)
 	claude := filepath.Join(tmp, "claude", "proj-p")
@@ -45,8 +45,13 @@ func TestShowNamesHarnessWhenIDsAreShared(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(shared, "share the id") || !strings.Contains(shared, "--harness claude|qwen") {
+	// The advice names the harness:id form, which every selector-resolving
+	// command accepts — promote/handoff/resume/share reject --harness (#872).
+	if !strings.Contains(shared, "share the id") || !strings.Contains(shared, "claude:abc12345 or qwen:abc12345") {
 		t.Errorf("shared id: %q", shared)
+	}
+	if strings.Contains(shared, "--harness") {
+		t.Errorf("still advised a flag some commands reject: %q", shared)
 	}
 	if strings.Contains(shared, "longer prefix") {
 		t.Errorf("still advised a longer prefix: %q", shared)

--- a/internal/index/import_before_index_test.go
+++ b/internal/index/import_before_index_test.go
@@ -1,0 +1,63 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// Importing into a dir that was never indexed writes the initial manifest.
+// That manifest used to snapshot every local transcript as already seen while
+// ingesting none, so the next index found itself fresh and skipped the
+// reader's own sessions — local history stayed invisible until a full rebuild.
+// A local session and the imported records must both be reachable after a
+// plain import-then-index.
+func TestImportBeforeFirstIndexKeepsLocalSessions(t *testing.T) {
+	skipWindowsPortability(t)
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-tmp-local")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	local := `{"type":"user","sessionId":"local1","timestamp":"2026-08-01T10:00:00Z","message":{"role":"user","content":"localneedle question"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "local1.jsonl"), []byte(local), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+
+	// Import first, into a dir that has never been indexed.
+	base := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	batchDir := filepath.Join(tmp, "batches")
+	writeSyncBatch(t, batchDir, []SyncRecord{
+		{Harness: "claude", SessionID: "remote1", Project: "deja-vu", Role: "user", Text: "importneedle question", Time: base},
+	})
+	if n, err := Import(dir, batchDir); err != nil || n != 1 {
+		t.Fatalf("import n=%d err=%v", n, err)
+	}
+
+	// The plain index every reader runs next must ingest the local session.
+	if err := EnsureForSearch(dir, search.Options{Query: "localneedle"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if ss, err := Search(dir, search.Options{Query: "localneedle", All: true}); err != nil {
+		t.Fatal(err)
+	} else if len(ss) != 1 {
+		t.Fatalf("local session lost after import-then-index: got %d", len(ss))
+	}
+	// And the imported records are still there.
+	if ss, err := Search(dir, search.Options{Query: "importneedle", All: true}); err != nil {
+		t.Fatal(err)
+	} else if len(ss) != 1 || !strings.HasPrefix(ss[0].Project, "imported:") {
+		t.Fatalf("imported record lost: %#v", ss)
+	}
+}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -666,7 +666,14 @@ func initEmptyIndex(dir string) error {
 	if err := f.Close(); err != nil {
 		return err
 	}
-	m := Manifest{Version: version, Files: currentFiles(""), Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), ExportWatermarks: map[string]int64{}, ImportedRecords: map[string]bool{}}
+	// Files stays empty on purpose. Snapshotting the local stores here recorded
+	// every transcript as already seen while ingesting none of them, so the
+	// next `deja index` found the manifest fresh and skipped the reader's own
+	// sessions — import on a machine that had never indexed left the local
+	// history invisible until a full rebuild. An empty file set makes the next
+	// index treat every local file as new and ingest it, next to the imported
+	// records this manifest carries.
+	m := Manifest{Version: version, Files: map[string]FileState{}, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), ExportWatermarks: map[string]int64{}, ImportedRecords: map[string]bool{}}
 	return writeManifest(dir, m)
 }
 

--- a/internal/sources/aider.go
+++ b/internal/sources/aider.go
@@ -30,7 +30,9 @@ func AiderFiles() []string {
 		if seen[p] {
 			return
 		}
-		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+		// Regular files only: a FIFO at the history path would block the
+		// parser's Open forever (same hang walkFiles guards against).
+		if fi, err := os.Stat(p); err == nil && fi.Mode().IsRegular() {
 			seen[p] = true
 			out = append(out, p)
 		}

--- a/internal/sources/antigravity.go
+++ b/internal/sources/antigravity.go
@@ -43,7 +43,7 @@ func AntigravityTranscripts() []string {
 	for _, root := range AntigravityRoots() {
 		matches, err := filepath.Glob(filepath.Join(root, "brain", "*", ".system_generated", "logs", "transcript.jsonl"))
 		if err == nil {
-			out = append(out, matches...)
+			out = append(out, keepRegular(matches)...)
 		}
 	}
 	return out

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -114,25 +114,23 @@ func claudeTime(raw json.RawMessage) time.Time {
 	if len(raw) == 0 || string(raw) == "null" {
 		return time.Time{}
 	}
+	// Both shapes go through parseTimeAny so the claude fast path reads the
+	// same timestamp variants every other parser does: a stringified or
+	// fractional epoch, or an RFC3339 that dropped its zone or seconds. It used
+	// to accept only RFC3339 strings and whole-number epochs, so those turns
+	// lost their date to the zero time and sorted as "-".
 	if raw[0] == '"' {
 		var s string
 		if json.Unmarshal(raw, &s) != nil {
 			return time.Time{}
 		}
-		if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
-			return t
-		}
-		return time.Time{}
+		return parseTimeAny(s)
 	}
 	var n json.Number
 	if json.Unmarshal(raw, &n) != nil {
 		return time.Time{}
 	}
-	i, err := n.Int64()
-	if err != nil {
-		return time.Time{}
-	}
-	return unixGuess(i)
+	return parseTimeAny(n)
 }
 
 // claudeText joins the text a message carries. Items that are not objects, or

--- a/internal/sources/coverage_extra_test.go
+++ b/internal/sources/coverage_extra_test.go
@@ -203,6 +203,28 @@ func TestAiderClaudeAntigravityAndUtilityEdges(t *testing.T) {
 	if got := parseTimeAny("1777629600"); got.Unix() != 1777629600 {
 		t.Fatalf("stringified epoch time = %v (want unix 1777629600)", got)
 	}
+	// RFC3339 that dropped its zone or seconds, or used a space instead of the
+	// T, is still a timestamp — parse it rather than lose the whole date.
+	for _, s := range []string{
+		"2026-05-01T10:00:00",
+		"2026-05-01T10:00Z",
+		"2026-05-01 10:00:00",
+	} {
+		if got := parseTimeAny(s); got.IsZero() || got.Year() != 2026 || got.Month() != 5 {
+			t.Fatalf("lenient timestamp %q = %v (want 2026-05)", s, got)
+		}
+	}
+	// The claude fast path reads timestamps through claudeTime; it must accept
+	// the same variants, not only whole-number epochs and RFC3339 strings.
+	if got := claudeTime(json.RawMessage(`"1777629600"`)); got.Unix() != 1777629600 {
+		t.Fatalf("claudeTime stringified epoch = %v", got)
+	}
+	if got := claudeTime(json.RawMessage(`1777629600.5`)); got.Unix() != 1777629600 {
+		t.Fatalf("claudeTime fractional epoch = %v", got)
+	}
+	if got := claudeTime(json.RawMessage(`"2026-05-01T10:00Z"`)); got.IsZero() || got.Year() != 2026 {
+		t.Fatalf("claudeTime seconds-less RFC3339 = %v", got)
+	}
 	if got := parseNestedTime(map[string]any{"time": "not-map"}, "time", "created"); !got.IsZero() {
 		t.Fatalf("non-map nested time = %v", got)
 	}

--- a/internal/sources/coverage_extra_test.go
+++ b/internal/sources/coverage_extra_test.go
@@ -194,6 +194,15 @@ func TestAiderClaudeAntigravityAndUtilityEdges(t *testing.T) {
 	if got := parseTimeAny(json.Number("bad")); !got.IsZero() {
 		t.Fatalf("bad json number time = %v", got)
 	}
+	// A fractional epoch is a valid Number that Int64 rejects; it must still
+	// date the turn rather than fall to the zero time (#UseNumber float loss).
+	if got := parseTimeAny(json.Number("1777629600.5")); got.Unix() != 1777629600 {
+		t.Fatalf("fractional epoch time = %v (want unix 1777629600)", got)
+	}
+	// A stringified epoch is not RFC3339 but is still a timestamp.
+	if got := parseTimeAny("1777629600"); got.Unix() != 1777629600 {
+		t.Fatalf("stringified epoch time = %v (want unix 1777629600)", got)
+	}
 	if got := parseNestedTime(map[string]any{"time": "not-map"}, "time", "created"); !got.IsZero() {
 		t.Fatalf("non-map nested time = %v", got)
 	}

--- a/internal/sources/cursor.go
+++ b/internal/sources/cursor.go
@@ -72,7 +72,9 @@ func CursorTranscripts() []string {
 	root := filepath.Join(CursorCLIRoot(), "projects")
 	var out []string
 	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+		// Regular files only: a FIFO matching the glob would block the
+		// parser's Open forever (same hang walkFiles guards against).
+		if err != nil || !d.Type().IsRegular() {
 			return nil
 		}
 		if !strings.EqualFold(filepath.Ext(p), ".jsonl") {

--- a/internal/sources/gemini.go
+++ b/internal/sources/gemini.go
@@ -45,7 +45,9 @@ func GeminiChatFiles() []string {
 		}
 		chats := filepath.Join(root, e.Name(), "chats")
 		_ = filepath.WalkDir(chats, func(p string, d os.DirEntry, err error) error {
-			if err == nil && !d.IsDir() && (strings.HasSuffix(p, ".json") || strings.HasSuffix(p, ".jsonl")) {
+			// Regular files only: a FIFO matching the glob would block the
+			// parser's Open forever (same hang walkFiles guards against).
+			if err == nil && d.Type().IsRegular() && (strings.HasSuffix(p, ".json") || strings.HasSuffix(p, ".jsonl")) {
 				out = append(out, p)
 			}
 			return nil

--- a/internal/sources/irregular_discovery_test.go
+++ b/internal/sources/irregular_discovery_test.go
@@ -1,0 +1,58 @@
+//go:build !windows
+
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func mkfifoOrSkip(t *testing.T, path string) {
+	t.Helper()
+	if err := syscall.Mkfifo(path, 0o644); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+}
+
+// keepRegular is what the glob and Stat discovery paths lean on so a FIFO that
+// matched their pattern never reaches a parser's Open.
+func TestKeepRegularDropsNonRegular(t *testing.T) {
+	dir := t.TempDir()
+	reg := filepath.Join(dir, "reg.jsonl")
+	if err := os.WriteFile(reg, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fifo := filepath.Join(dir, "fifo.jsonl")
+	mkfifoOrSkip(t, fifo)
+
+	got := keepRegular([]string{reg, fifo, filepath.Join(dir, "missing.jsonl")})
+	if len(got) != 1 || got[0] != reg {
+		t.Fatalf("keepRegular = %v, want just %q", got, reg)
+	}
+}
+
+// The antigravity glob and the aider Stat scan both once returned a named pipe
+// that would block indexing. Their discovery must drop it.
+func TestAntigravityAndAiderSkipNamedPipes(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DEJA_ANTIGRAVITY_ROOT", root)
+	logs := filepath.Join(root, "brain", "traj", ".system_generated", "logs")
+	if err := os.MkdirAll(logs, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mkfifoOrSkip(t, filepath.Join(logs, "transcript.jsonl"))
+	if got := AntigravityTranscripts(); len(got) != 0 {
+		t.Errorf("antigravity returned a named pipe: %v", got)
+	}
+
+	aroot := t.TempDir()
+	t.Setenv("DEJA_AIDER_ROOTS", aroot)
+	mkfifoOrSkip(t, filepath.Join(aroot, ".aider.chat.history.md"))
+	for _, f := range AiderFiles() {
+		if f == filepath.Join(aroot, ".aider.chat.history.md") {
+			t.Errorf("aider returned a named pipe: %v", f)
+		}
+	}
+}

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -280,6 +280,20 @@ func AppendPromotedSourced(project, title, text, session, state string, tags []s
 	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("notes file is a symlink")
 	}
+	// An identical re-promote is not a correction. `promote` writes a record
+	// every run, so re-promoting an unchanged decision (same state, text,
+	// title and tags) used to append a duplicate: the note then carried the
+	// same line N times, and each copy lifted its own weight in recall —
+	// measured, a 5x-promoted note outscored an identical 1x one on the same
+	// date. Skip the write when the newest surviving record for this session
+	// already says the same thing; a real state or wording change differs and
+	// still appends, and a forget rewrites the record away so a later promote
+	// starts clean.
+	if last, ok := lastPromotedNote(path, session); ok &&
+		last.State == state && last.Text == text && last.Title == title &&
+		equalStrings(last.Tags, NormalizeTags(tags)) {
+		return nil
+	}
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600)
 	if err != nil {
 		return err
@@ -300,6 +314,47 @@ func AppendPromotedSourced(project, title, text, session, state string, tags []s
 		Kind: "promoted", Session: session, State: state, Title: title,
 		Tags: NormalizeTags(tags), SrcTS: stamp,
 	})
+}
+
+// lastPromotedNote returns the newest promoted record still on disk for a
+// source session. forget rewrites matching records away, so "still on disk"
+// is what re-promote-after-forget needs: no record found means start clean.
+func lastPromotedNote(path, session string) (note, bool) {
+	var last note
+	var found bool
+	_ = scanJSONLFromOffset(path, 0, func(m map[string]any) {
+		if k, _ := m["kind"].(string); k != "promoted" {
+			return
+		}
+		if s, _ := m["session"].(string); s != session {
+			return
+		}
+		last = note{}
+		last.State, _ = m["state"].(string)
+		last.Text, _ = m["text"].(string)
+		last.Title, _ = m["title"].(string)
+		if raw, ok := m["tags"].([]any); ok {
+			for _, x := range raw {
+				if v, ok := x.(string); ok {
+					last.Tags = append(last.Tags, v)
+				}
+			}
+		}
+		found = true
+	})
+	return last, found
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // renderNoteTags folds the tags array into "#tag" tokens appended to the

--- a/internal/sources/promote_dedup_test.go
+++ b/internal/sources/promote_dedup_test.go
@@ -1,0 +1,60 @@
+package sources
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// promote writes a record every run, so re-promoting an unchanged decision
+// used to append a duplicate — the note then carried the same line N times and
+// each copy lifted its own weight in recall. An identical re-promote must be a
+// no-op on disk; a genuine change (state, text, tags) still appends.
+func TestIdenticalRepromoteDoesNotGrowTheNote(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", path)
+	src := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+
+	appendOnce := func(state, text, title string, tags []string) {
+		if err := AppendPromotedSourced("proj", title, text, "claude:c1", state, tags, src, time.Now()); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	noteMessages := func() int {
+		ss, err := ParseNotesFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, s := range ss {
+			if s.ID == PromotedNoteID("claude:c1") {
+				return len(s.Messages)
+			}
+		}
+		return 0
+	}
+
+	// Five identical promotes collapse to one message.
+	for i := 0; i < 5; i++ {
+		appendOnce("accepted", "pool exhausted", "davit", []string{"perf"})
+	}
+	if got := noteMessages(); got != 1 {
+		t.Fatalf("identical re-promotes grew the note: got %d messages, want 1", got)
+	}
+
+	// A state change is a correction — it appends.
+	appendOnce("rejected", "pool exhausted", "davit", []string{"perf"})
+	if got := noteMessages(); got != 2 {
+		t.Fatalf("state change did not append: got %d messages, want 2", got)
+	}
+	// Repeating the rejected state does not grow it again.
+	appendOnce("rejected", "pool exhausted", "davit", []string{"perf"})
+	if got := noteMessages(); got != 2 {
+		t.Fatalf("identical rejected re-promote grew the note: got %d, want 2", got)
+	}
+	// A new tag is a change — it appends.
+	appendOnce("rejected", "pool exhausted", "davit", []string{"perf", "urgent"})
+	if got := noteMessages(); got != 3 {
+		t.Fatalf("tag change did not append: got %d messages, want 3", got)
+	}
+}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -31,11 +31,25 @@ func EnvPath(k, def string) string {
 func parseTimeAny(v any) time.Time {
 	switch x := v.(type) {
 	case string:
-		if t, err := time.Parse(time.RFC3339Nano, x); err == nil {
-			return t
+		// The field is always a timestamp, so try the layouts a store might
+		// have written it in before giving up. RFC3339 is the common one; the
+		// rest drop a piece it treats as optional — a missing zone, missing
+		// seconds, a space where the T should be — each of which used to lose
+		// the whole date to the zero time.
+		for _, layout := range []string{
+			time.RFC3339Nano,
+			"2006-01-02T15:04:05",
+			"2006-01-02T15:04Z07:00",
+			"2006-01-02T15:04",
+			"2006-01-02 15:04:05Z07:00",
+			"2006-01-02 15:04:05",
+		} {
+			if t, err := time.Parse(layout, x); err == nil {
+				return t
+			}
 		}
-		// Some stores stringify the epoch ("1777629600", fractional or not).
-		// The field is always a timestamp, so a bare number in it is an epoch.
+		// Some stores stringify the epoch ("1777629600", fractional or not),
+		// a bare number in a field that is always a timestamp.
 		if f, err := strconv.ParseFloat(x, 64); err == nil {
 			return unixGuess(int64(f))
 		}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -33,11 +34,23 @@ func parseTimeAny(v any) time.Time {
 		if t, err := time.Parse(time.RFC3339Nano, x); err == nil {
 			return t
 		}
+		// Some stores stringify the epoch ("1777629600", fractional or not).
+		// The field is always a timestamp, so a bare number in it is an epoch.
+		if f, err := strconv.ParseFloat(x, 64); err == nil {
+			return unixGuess(int64(f))
+		}
 	case float64:
 		return unixGuess(int64(x))
 	case json.Number:
-		n, _ := x.Int64()
-		return unixGuess(n)
+		if n, err := x.Int64(); err == nil {
+			return unixGuess(n)
+		}
+		// A fractional epoch — Python's time.time() writes one — is a valid
+		// Number that Int64 rejects; without the Float64 fallback the whole
+		// turn lost its date to the zero time, and the session sorted as "-".
+		if f, err := x.Float64(); err == nil {
+			return unixGuess(int64(f))
+		}
 	}
 	return time.Time{}
 }

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -194,6 +194,19 @@ func scanJSONLFromOffset(path string, offset int64, fn func(map[string]any)) err
 	}
 }
 
+// keepRegular drops any path that is not a regular file. Discovery paths that
+// glob or list names (rather than walking DirEntries) use it so a FIFO or
+// socket matching the pattern cannot reach a parser's Open and block it.
+func keepRegular(paths []string) []string {
+	out := paths[:0]
+	for _, p := range paths {
+		if fi, err := os.Lstat(p); err == nil && fi.Mode().IsRegular() {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 func walkFiles(root string, pred func(string) bool) []string {
 	var out []string
 	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -207,7 +207,12 @@ func walkFiles(root string, pred func(string) bool) []string {
 			}
 			return nil
 		}
-		if d.Type()&os.ModeSymlink == 0 && !d.IsDir() && pred(p) {
+		// Only regular files. A FIFO or socket that matched the session glob
+		// hung the whole index: the parser's Open blocks on a named pipe with
+		// no writer and never returns, so one such file in a scanned store
+		// froze indexing for good. IsRegular already excludes symlinks and
+		// directories, so it subsumes the checks it replaces.
+		if d.Type().IsRegular() && pred(p) {
 			out = append(out, p)
 		}
 		return nil

--- a/internal/sources/walk_irregular_test.go
+++ b/internal/sources/walk_irregular_test.go
@@ -1,0 +1,45 @@
+//go:build !windows
+
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// A FIFO that matched the session glob hung the whole index: the parser's Open
+// blocks on a named pipe with no writer and never returns. walkFiles must hand
+// back only regular files so one such node in a scanned store cannot freeze
+// indexing.
+func TestWalkFilesSkipsNamedPipes(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real.jsonl")
+	if err := os.WriteFile(real, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pipe := filepath.Join(dir, "pipe.jsonl")
+	if err := syscall.Mkfifo(pipe, 0o644); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+
+	got := walkFiles(dir, func(p string) bool { return strings.HasSuffix(p, ".jsonl") })
+
+	var sawReal, sawPipe bool
+	for _, p := range got {
+		if p == real {
+			sawReal = true
+		}
+		if p == pipe {
+			sawPipe = true
+		}
+	}
+	if !sawReal {
+		t.Errorf("dropped the regular file: %v", got)
+	}
+	if sawPipe {
+		t.Errorf("returned a named pipe the parser would block on: %v", got)
+	}
+}


### PR DESCRIPTION
Audit wave over the index, sources, promote/remember and MCP surfaces. Each item was reproduced on a hermetic index, fixed, and covered by a test with a mutation check.

Two are real hangs/data-loss:
- Index froze forever on a FIFO or socket in a scanned store — `Open` blocks on a pipe with no writer. Discovery now keeps only regular files.
- Import before the first `index` snapshotted the local stores into the manifest, so the next index found it "fresh" and skipped the reader's own sessions until a full rebuild. The initial manifest now starts with an empty file set.

One is a trust-policy leak:
- The semantic tier reached the whole sidecar past the policy scoping the lexical hits already had, so an imported peer's withheld content came back through the embedding fallback. Scoped in search, MCP recall and recall_context.

Rest are correctness/UX: claude timestamps now accept stringified/fractional epochs and zone-less RFC3339 (were losing the date); identical re-promote no longer inflates a note's recall weight; promote/remember say when they wrote into a tombstoned note; the shared-id hint names `harness:id` instead of a `--harness` flag those commands reject; `--` ends options in search; MCP remember accepts tags; search says when results were capped.
