### PR TITLE
fix: notes append starts a fresh line when the file has no trailing newline

### DIFF
--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -88,7 +88,7 @@ func AppendNoteTagged(project, text string, tags []string, now time.Time) error 
 	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("notes file is a symlink")
 	}
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0o600)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,34 @@ func AppendNoteTagged(project, text string, tags []string, now time.Time) error 
 	if now.IsZero() {
 		now = time.Now()
 	}
+	if err := padTrailingNewline(f); err != nil {
+		return err
+	}
 	return json.NewEncoder(f).Encode(note{TS: now.UTC().Format(time.RFC3339Nano), Project: project, Text: text, Tags: NormalizeTags(tags)})
+}
+
+// padTrailingNewline writes a newline into the append handle f when the file's
+// existing content does not end with one. notes.jsonl is documented as a
+// hand-editable file, so an editor that drops the final newline is a real
+// input: without this, the next record is glued onto the last line and the
+// reader — which decodes only the first JSON value per line — silently drops
+// it. It reads the last byte through f's own descriptor (fstat + pread), so
+// there is no second path lookup to race against the symlink guard above.
+// Best effort: a stat or read error leaves the append untouched.
+func padTrailingNewline(f *os.File) error {
+	info, err := f.Stat()
+	if err != nil || info.Size() == 0 {
+		return nil
+	}
+	last := make([]byte, 1)
+	if _, err := f.ReadAt(last, info.Size()-1); err != nil {
+		return nil
+	}
+	if last[0] == '\n' {
+		return nil
+	}
+	_, err = f.Write([]byte{'\n'})
+	return err
 }
 
 func LoadNotes() []model.Session {
@@ -294,7 +321,7 @@ func AppendPromotedSourced(project, title, text, session, state string, tags []s
 		equalStrings(last.Tags, NormalizeTags(tags)) {
 		return nil
 	}
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0o600)
 	if err != nil {
 		return err
 	}
@@ -308,6 +335,9 @@ func AppendPromotedSourced(project, title, text, session, state string, tags []s
 	stamp := ""
 	if !srcTS.IsZero() {
 		stamp = srcTS.UTC().Format(time.RFC3339Nano)
+	}
+	if err := padTrailingNewline(f); err != nil {
+		return err
 	}
 	return json.NewEncoder(f).Encode(note{
 		TS: now.UTC().Format(time.RFC3339Nano), Project: project, Text: text,

--- a/internal/sources/notes_append_newline_test.go
+++ b/internal/sources/notes_append_newline_test.go
@@ -1,0 +1,49 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// notes.jsonl is documented as a hand-editable file. An editor that drops the
+// final newline leaves the last record without one; the next `deja note` then
+// appended its JSON glued onto that line, and the reader — which decodes only
+// the first value per line — silently dropped the new note. The append must
+// start a fresh line first.
+func TestAppendNoteStartsAFreshLineWhenFileLacksTrailingNewline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", path)
+
+	// A pre-existing record with NO trailing newline, as a hand-edit can leave.
+	first := `{"ts":"2026-01-01T00:00:00Z","project":"proj","text":"first note"}`
+	if err := os.WriteFile(path, []byte(first), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AppendNote("proj", "second note", time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ParseNotesFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var texts []string
+	for _, s := range got {
+		for _, m := range s.Messages {
+			texts = append(texts, m.Text)
+		}
+	}
+	joined := ""
+	for _, x := range texts {
+		joined += x + "|"
+	}
+	if !contains(texts, "first note") {
+		t.Errorf("first note lost: %q", joined)
+	}
+	if !contains(texts, "second note") {
+		t.Errorf("second note lost — glued onto the previous line: %q", joined)
+	}
+}


### PR DESCRIPTION
If notes.jsonl lost its final newline (a hand-edit), the next `deja note`/`promote` glued its JSON onto the last line and the reader — which decodes one value per line — dropped it silently. Pads a newline first, reading the last byte through the same fd so the symlink guard above still holds. Repro test included.