### PR TITLE
fix: re-import keeps a session's earlier touched files

### DIFF
--- a/internal/index/import_merge_touched_test.go
+++ b/internal/index/import_merge_touched_test.go
@@ -1,0 +1,79 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A peer's session grows and is re-exported: the second sync batch carries only
+// the new records (the old ones are already in the import ledger and skipped).
+// The imported meta was rebuilt from just that batch and overwrote Touched, so a
+// file the peer edited in the first batch stopped being blamable after the
+// second import. The merge must keep the earlier files, not replace them.
+func TestReimportKeepsEarlierTouchedFiles(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	shared := filepath.Join(tmp, "shared")
+	if err := os.MkdirAll(shared, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t1 := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	batch1 := `{"harness":"claude","session_id":"peer1","project":"svc","role":"user","text":"working on auth","time":"` + t1 + `"}` + "\n" +
+		`{"harness":"claude","session_id":"peer1","project":"svc","role":"files","text":"/repo/auth.go","time":"` + t1 + `"}` + "\n"
+	if err := os.WriteFile(filepath.Join(shared, "deja-sync-a.jsonl"), []byte(batch1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(dir, shared); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second batch: the same session, later, touching a different file.
+	t2 := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	batch2 := `{"harness":"claude","session_id":"peer1","project":"svc","role":"user","text":"now the database layer","time":"` + t2 + `"}` + "\n" +
+		`{"harness":"claude","session_id":"peer1","project":"svc","role":"files","text":"/repo/db.go","time":"` + t2 + `"}` + "\n"
+	if err := os.WriteFile(filepath.Join(shared, "deja-sync-b.jsonl"), []byte(batch2), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(dir, shared); err != nil {
+		t.Fatal(err)
+	}
+
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found *SessionMeta
+	for i := range metas {
+		if metas[i].OrigID == "peer1" {
+			found = &metas[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("imported session not found in %d metas", len(metas))
+	}
+	has := func(p string) bool {
+		for _, x := range found.Touched {
+			if x == p {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("/repo/db.go") {
+		t.Errorf("Touched=%v missing the new file /repo/db.go", found.Touched)
+	}
+	if !has("/repo/auth.go") {
+		t.Errorf("Touched=%v dropped /repo/auth.go from the first import — blame can no longer attribute it", found.Touched)
+	}
+}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -758,6 +758,48 @@ func fileEndsWithNewline(f *os.File) bool {
 	return buf[0] == '\n'
 }
 
+// mergeCappedStrings unions a and b, keeping a's order first and dropping
+// duplicates, then caps the result. Used to carry an imported session's earlier
+// Touched files across a re-import instead of overwriting them.
+func mergeCappedStrings(a, b []string, limit int) []string {
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[string]bool, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, s := range append(append([]string(nil), a...), b...) {
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+// mergeCappedU64 is mergeCappedStrings for the hash lists (Asked, Hit).
+func mergeCappedU64(a, b []uint64, limit int) []uint64 {
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[uint64]bool, len(a)+len(b))
+	out := make([]uint64, 0, len(a)+len(b))
+	for _, v := range append(append([]uint64(nil), a...), b...) {
+		if seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
 func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Record, metas map[string]SessionMeta) error {
 	rf, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
@@ -825,6 +867,14 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 			if old.Updated.After(meta.Updated) {
 				meta.Updated = old.Updated
 			}
+			// A re-import carries only the records new since last time; the ones
+			// behind the earlier Touched/Asked/Hit are in the ledger and skipped,
+			// so recomputing from this batch alone would drop them. Union with what
+			// the session already had — earlier entries first — so a file a peer
+			// edited in an earlier batch stays blamable (#1024 follow-up).
+			meta.Touched = mergeCappedStrings(old.Touched, meta.Touched, touchedFileCap)
+			meta.Asked = mergeCappedU64(old.Asked, meta.Asked, askedQuestionCap)
+			meta.Hit = mergeCappedU64(old.Hit, meta.Hit, frictionSessionCap)
 		} else {
 			meta.Ord = nextOrd
 			nextOrd++


### PR DESCRIPTION
A second sync batch carries only the records new since last time, so rebuilding Touched/Asked/Hit from it alone overwrote what earlier batches set — a peer's file stopped being blamable once its session grew. Unions the new values with the existing ones, capped. Repro test included.