### PR TITLE
test: cover untested leaves — query, cjkfold, model, stats, sources

### DIFF
--- a/internal/cjkfold/fold_test.go
+++ b/internal/cjkfold/fold_test.go
@@ -1,0 +1,76 @@
+package cjkfold
+
+import "testing"
+
+// The two generated tables are parallel: foldTrad[i] folds to foldSimp[i].
+// Rune() silently skips any Traditional entry past the end of foldSimp, so an
+// unequal length would drop mappings without any error. Guard the invariant.
+func TestFoldTablesAligned(t *testing.T) {
+	trad := []rune(foldTrad)
+	simp := []rune(foldSimp)
+	if len(trad) != len(simp) {
+		t.Fatalf("foldTrad has %d runes, foldSimp has %d — tables misaligned", len(trad), len(simp))
+	}
+}
+
+func TestRuneFolds(t *testing.T) {
+	pairs := map[rune]rune{
+		'國': '国', '學': '学', '車': '车', '馬': '马',
+		'龍': '龙', '離': '离', '書': '书', '讀': '读',
+		'語': '语', '漢': '汉',
+	}
+	for trad, want := range pairs {
+		if got := Rune(trad); got != want {
+			t.Errorf("Rune(%q) = %q, want %q", trad, got, want)
+		}
+	}
+}
+
+func TestRuneLeavesOthers(t *testing.T) {
+	// Already-simplified, Latin, Cyrillic, Hiragana and Katakana runes fold to
+	// themselves.
+	for _, r := range []rune{'国', 'a', 'я', 'あ', 'ア', '5', '国'} {
+		if got := Rune(r); got != r {
+			t.Errorf("Rune(%q) = %q, want unchanged", r, got)
+		}
+	}
+}
+
+func TestString(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"讀書", "读书"},
+		{"漢語", "汉语"},
+		{"hello", "hello"},
+		{"смысл", "смысл"},
+		{"mix 車 and text", "mix 车 and text"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := String(c.in); got != c.want {
+			t.Errorf("String(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestStringUnchangedReturnsInput(t *testing.T) {
+	// Nothing to fold: the same string comes back.
+	in := "only latin and 国 already simplified"
+	if got := String(in); got != in {
+		t.Errorf("String(%q) = %q, want unchanged", in, got)
+	}
+}
+
+func TestHasCJK(t *testing.T) {
+	yes := []string{"漢", "書と本", "アイス", "한국어", "mixed 語 here"}
+	for _, s := range yes {
+		if !HasCJK(s) {
+			t.Errorf("HasCJK(%q) = false, want true", s)
+		}
+	}
+	no := []string{"", "hello world", "смысл", "12345", "a.b,c"}
+	for _, s := range no {
+		if HasCJK(s) {
+			t.Errorf("HasCJK(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSessionSetSource(t *testing.T) {
@@ -23,5 +24,42 @@ func TestUnsetSourceIsOmittedInsteadOfEmittedEmpty(t *testing.T) {
 	b, err := json.Marshal(Session{ID: "x", Harness: "claude"})
 	if err != nil || strings.Contains(string(b), `"source"`) {
 		t.Fatalf("session JSON = %s, err = %v", b, err)
+	}
+}
+
+func TestTouchSetsAndWidensWindow(t *testing.T) {
+	base := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+
+	var s Session
+	s.Touch(base)
+	if !s.Started.Equal(base) || !s.Updated.Equal(base) {
+		t.Fatalf("first touch: started=%v updated=%v", s.Started, s.Updated)
+	}
+
+	earlier := base.Add(-time.Hour)
+	s.Touch(earlier)
+	if !s.Started.Equal(earlier) || !s.Updated.Equal(base) {
+		t.Fatalf("earlier touch moved started only: started=%v updated=%v", s.Started, s.Updated)
+	}
+
+	later := base.Add(time.Hour)
+	s.Touch(later)
+	if !s.Started.Equal(earlier) || !s.Updated.Equal(later) {
+		t.Fatalf("later touch moved updated only: started=%v updated=%v", s.Started, s.Updated)
+	}
+
+	// A time already inside the window changes nothing.
+	s.Touch(base)
+	if !s.Started.Equal(earlier) || !s.Updated.Equal(later) {
+		t.Fatalf("inside-window touch changed the window: started=%v updated=%v", s.Started, s.Updated)
+	}
+}
+
+func TestTouchIgnoresZero(t *testing.T) {
+	s := Session{Started: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	before := s.Started
+	s.Touch(time.Time{})
+	if !s.Started.Equal(before) || !s.Updated.IsZero() {
+		t.Fatalf("zero touch changed state: started=%v updated=%v", s.Started, s.Updated)
 	}
 }

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -19,7 +19,7 @@ func TestTokens(t *testing.T) {
 	}{
 		{"Hello, WORLD hello", []string{"hello", "world"}},
 		{"  spaced   out  ", []string{"spaced", "out"}},
-		{"a I x", nil},                       // every token is a single rune, all dropped
+		{"a I x", nil}, // every token is a single rune, all dropped
 		{"(rate) [limit].", []string{"rate", "limit"}},
 		{"", nil},
 		{"Dup dup DUP", []string{"dup"}}, // lowercase + dedupe

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -1,0 +1,149 @@
+package query
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func sortedCopy(s []string) []string {
+	out := append([]string(nil), s...)
+	sort.Strings(out)
+	return out
+}
+
+func TestTokens(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"Hello, WORLD hello", []string{"hello", "world"}},
+		{"  spaced   out  ", []string{"spaced", "out"}},
+		{"a I x", nil},                       // every token is a single rune, all dropped
+		{"(rate) [limit].", []string{"rate", "limit"}},
+		{"", nil},
+		{"Dup dup DUP", []string{"dup"}}, // lowercase + dedupe
+	}
+	for _, c := range cases {
+		got := Tokens(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("Tokens(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTokensDropsShortAndDedupes(t *testing.T) {
+	got := Tokens("go go a to")
+	// "a" is one rune -> dropped; "go" deduped; "to" kept (2 runes).
+	if !reflect.DeepEqual(got, []string{"go", "to"}) {
+		t.Fatalf("Tokens = %v", got)
+	}
+}
+
+func TestQueryPartsStripsStopWords(t *testing.T) {
+	terms, phrases := QueryParts("the quick brown fox")
+	if len(phrases) != 0 {
+		t.Fatalf("phrases = %v, want none", phrases)
+	}
+	want := []string{"brown", "fox", "quick"}
+	if !reflect.DeepEqual(sortedCopy(terms), want) {
+		t.Fatalf("terms = %v, want %v", terms, want)
+	}
+}
+
+func TestQueryPartsAllStopWordsKept(t *testing.T) {
+	// When every term is a stop word, withoutStopWords keeps them rather than
+	// returning nothing to search for.
+	terms, _ := QueryParts("the and of")
+	if len(terms) == 0 {
+		t.Fatal("all-stopword query returned no terms")
+	}
+}
+
+func TestQueryPartsPhrase(t *testing.T) {
+	terms, phrases := QueryParts(`find "rate limit" bug`)
+	if !reflect.DeepEqual(phrases, []string{"rate limit"}) {
+		t.Fatalf("phrases = %v", phrases)
+	}
+	// The phrase's own words also join the term set.
+	for _, w := range []string{"find", "bug", "rate", "limit"} {
+		if !contains(terms, w) {
+			t.Fatalf("terms %v missing %q", terms, w)
+		}
+	}
+}
+
+func TestQueryPartsEmptyPhraseIgnored(t *testing.T) {
+	// A quote pair with no letter or digit is not a phrase.
+	_, phrases := QueryParts(`alpha "   " beta`)
+	if len(phrases) != 0 {
+		t.Fatalf("phrases = %v, want none", phrases)
+	}
+}
+
+func TestQueryPartsUnterminatedQuote(t *testing.T) {
+	// An unfinished quote falls back to plain tokenisation, no phrases.
+	terms, phrases := QueryParts(`foo "bar`)
+	if len(phrases) != 0 {
+		t.Fatalf("phrases = %v, want none", phrases)
+	}
+	if !contains(terms, "foo") || !contains(terms, "bar") {
+		t.Fatalf("terms = %v, want foo and bar", terms)
+	}
+}
+
+func TestMatchesQuery(t *testing.T) {
+	if !MatchesQuery("The rate limiter fired again", "rate limiter") {
+		t.Error("expected match on both terms")
+	}
+	if MatchesQuery("only the rate here", "rate limiter") {
+		t.Error("missing term should not match")
+	}
+	if MatchesQuery("anything", "") {
+		t.Error("empty query should match nothing")
+	}
+}
+
+func TestMatchesPartsPhrase(t *testing.T) {
+	if !MatchesParts("hit the rate limit today", nil, []string{"rate limit"}, nil) {
+		t.Error("phrase present should match")
+	}
+	if MatchesParts("rate then limit", nil, []string{"rate limit"}, nil) {
+		t.Error("split phrase should not match")
+	}
+}
+
+func TestMatchesPartsVariants(t *testing.T) {
+	variants := map[string][]string{"colour": {"color"}}
+	if !MatchesParts("the color is red", []string{"colour"}, nil, variants) {
+		t.Error("variant should satisfy the term")
+	}
+}
+
+func TestMatchesPartsEmptyIsFalse(t *testing.T) {
+	if MatchesParts("some text", nil, nil, nil) {
+		t.Error("no terms and no phrases should not match")
+	}
+}
+
+func TestIsStopWord(t *testing.T) {
+	for _, w := range []string{"the", "and", "что", "делай"} {
+		if !IsStopWord(w) {
+			t.Errorf("%q should be a stop word", w)
+		}
+	}
+	for _, w := range []string{"rate", "limiter", "deja"} {
+		if IsStopWord(w) {
+			t.Errorf("%q should not be a stop word", w)
+		}
+	}
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sources/claude_decode_coverage_test.go
+++ b/internal/sources/claude_decode_coverage_test.go
@@ -1,0 +1,58 @@
+package sources
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestClaudeTextKind(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		wantText string
+		wantTool bool
+	}{
+		{"plain string", `"hello there"`, "hello there", false},
+		{"text part", `[{"type":"text","text":"hi"}]`, "hi", false},
+		{"tool result string", `[{"type":"tool_result","content":"the output"}]`, "the output", true},
+		{"tool result mcp blocks", `[{"type":"tool_result","content":[{"type":"text","text":"mcp out"},{"type":"image"}]}]`, "mcp out", true},
+		{"mixed counts as speech", `[{"type":"text","text":"do it"},{"type":"tool_result","content":"result"}]`, "do it\nresult", false},
+		{"empty", ``, "", false},
+		{"scalar non-string", `123`, "", false},
+		{"malformed array", `[{bad}]`, "", false},
+	}
+	for _, c := range cases {
+		gotText, gotTool := claudeTextKind(json.RawMessage(c.raw))
+		if gotText != c.wantText || gotTool != c.wantTool {
+			t.Errorf("%s: claudeTextKind(%s) = (%q, %v), want (%q, %v)", c.name, c.raw, gotText, gotTool, c.wantText, c.wantTool)
+		}
+	}
+}
+
+func TestClaudeTextReturnsJustText(t *testing.T) {
+	if got := claudeText(json.RawMessage(`[{"type":"tool_result","content":"x"}]`)); got != "x" {
+		t.Fatalf("claudeText = %q, want x", got)
+	}
+}
+
+func TestHarnessRegistryHelpers(t *testing.T) {
+	names := HarnessNames()
+	if len(names) == 0 {
+		t.Fatal("HarnessNames returned nothing")
+	}
+	found := false
+	for _, n := range names {
+		if n == "claude" {
+			found = true
+		}
+		if !IsKnownHarness(n) {
+			t.Errorf("HarnessNames listed %q but IsKnownHarness says no", n)
+		}
+	}
+	if !found {
+		t.Errorf("claude not among harnesses: %v", names)
+	}
+	if IsKnownHarness("definitely-not-a-harness") {
+		t.Error("IsKnownHarness accepted an unknown name")
+	}
+}

--- a/internal/sources/notes_lifecycle_coverage_test.go
+++ b/internal/sources/notes_lifecycle_coverage_test.go
@@ -1,0 +1,97 @@
+package sources
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A promoted note borrows its source session's opening line as a title. forget
+// strips that title (#666); unforget restores it (#969); forgetting the note
+// itself drops the line. Exercise the whole round trip.
+func TestPromotedNoteTitleRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", path)
+
+	src := "claude:sess1"
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	if err := AppendPromotedSourced("proj", "Borrowed Title", "the decision text", src, "accepted", nil, time.Time{}, now); err != nil {
+		t.Fatal(err)
+	}
+
+	titleOf := func() (string, bool) {
+		ss, err := ParseNotesFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, s := range ss {
+			if s.ID == PromotedNoteID(src) {
+				return s.Title, true
+			}
+		}
+		return "", false
+	}
+
+	if title, ok := titleOf(); !ok || !strings.Contains(title, "Borrowed Title") {
+		t.Fatalf("after promote, title = %q (present=%v)", title, ok)
+	}
+
+	// forget strips the borrowed title.
+	n, err := ForgetPromotedTitles(func(s string) bool { return s == src })
+	if err != nil || n != 1 {
+		t.Fatalf("ForgetPromotedTitles = %d, %v", n, err)
+	}
+	if title, ok := titleOf(); !ok || strings.Contains(title, "Borrowed Title") {
+		t.Fatalf("title survived forget: %q", title)
+	}
+
+	// unforget restores it from the source session.
+	n, err = RestorePromotedTitles(func(s string) string {
+		if s == src {
+			return "Restored Title"
+		}
+		return ""
+	})
+	if err != nil || n != 1 {
+		t.Fatalf("RestorePromotedTitles = %d, %v", n, err)
+	}
+	if title, ok := titleOf(); !ok || !strings.Contains(title, "Restored Title") {
+		t.Fatalf("title not restored: %q", title)
+	}
+
+	// forgetting the note itself removes the line entirely.
+	n, err = ForgetPromotedNotes(func(id string) bool { return id == PromotedNoteID(src) })
+	if err != nil || n != 1 {
+		t.Fatalf("ForgetPromotedNotes = %d, %v", n, err)
+	}
+	if title, ok := titleOf(); ok {
+		t.Fatalf("note survived ForgetPromotedNotes: %q", title)
+	}
+}
+
+func TestPromotedNoteHelpersNoMatchChangeNothing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", path)
+	if err := AppendPromotedSourced("proj", "Title", "text", "claude:keep", "accepted", nil, time.Time{}, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	for _, got := range []int{
+		mustCount(t, func() (int, error) { return ForgetPromotedTitles(func(string) bool { return false }) }),
+		mustCount(t, func() (int, error) { return ForgetPromotedNotes(func(string) bool { return false }) }),
+		mustCount(t, func() (int, error) { return RestorePromotedTitles(func(string) string { return "" }) }),
+	} {
+		if got != 0 {
+			t.Errorf("a no-match rewrite changed %d lines, want 0", got)
+		}
+	}
+}
+
+func mustCount(t *testing.T, f func() (int, error)) int {
+	t.Helper()
+	n, err := f()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return n
+}

--- a/internal/stats/filter_coverage_test.go
+++ b/internal/stats/filter_coverage_test.go
@@ -90,8 +90,8 @@ func TestTrimRunes(t *testing.T) {
 		n    int
 		want string
 	}{
-		{"short", 10, "short"},   // fits
-		{"exactly", 7, "exactly"},// exact length
+		{"short", 10, "short"},    // fits
+		{"exactly", 7, "exactly"}, // exact length
 		{"truncate me", 5, "trun…"},
 		{"x", 1, "x"},
 		{"multibyte ✓ é ж", 5, "mult…"},

--- a/internal/stats/filter_coverage_test.go
+++ b/internal/stats/filter_coverage_test.go
@@ -1,0 +1,104 @@
+package stats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func TestFilterNoCriteriaReturnsInput(t *testing.T) {
+	ss := []model.Session{{Harness: "claude"}, {Harness: "codex"}}
+	got := Filter(ss, search.Options{})
+	if len(got) != 2 {
+		t.Fatalf("no-criteria filter dropped sessions: %d", len(got))
+	}
+}
+
+func TestFilterByHarnessAndProject(t *testing.T) {
+	ss := []model.Session{
+		{Harness: "claude", Project: "Agent-Fabric"},
+		{Harness: "codex", Project: "agent-fabric"},
+		{Harness: "claude", Project: "other"},
+	}
+	got := Filter(ss, search.Options{Harness: "claude"})
+	if len(got) != 2 {
+		t.Fatalf("harness filter = %d, want 2", len(got))
+	}
+	// Project match is case-insensitive substring.
+	got = Filter(ss, search.Options{Project: "fabric"})
+	if len(got) != 2 {
+		t.Fatalf("project filter = %d, want 2", len(got))
+	}
+}
+
+func TestFilterBySince(t *testing.T) {
+	now := time.Now()
+	ss := []model.Session{
+		{Harness: "a", Updated: now.Add(-time.Hour)},
+		{Harness: "b", Updated: now.Add(-48 * time.Hour)},
+	}
+	got := Filter(ss, search.Options{Since: 24 * time.Hour})
+	if len(got) != 1 || got[0].Harness != "a" {
+		t.Fatalf("since filter = %+v, want only the recent one", got)
+	}
+}
+
+func TestFilterByRoleKeepsOnlyMatchingMessages(t *testing.T) {
+	ss := []model.Session{
+		{Harness: "a", Messages: []model.Message{
+			{Role: "user", Text: "q"},
+			{Role: "assistant", Text: "a"},
+			{Role: "user", Text: "q2"},
+		}},
+		{Harness: "b", Messages: []model.Message{
+			{Role: "assistant", Text: "only assistant"},
+		}},
+	}
+	got := Filter(ss, search.Options{Role: "user"})
+	if len(got) != 1 {
+		t.Fatalf("role filter kept %d sessions, want 1 (the one with user turns)", len(got))
+	}
+	if len(got[0].Messages) != 2 {
+		t.Fatalf("role filter kept %d messages, want 2 user turns", len(got[0].Messages))
+	}
+	// The original session must not be mutated.
+	if len(ss[0].Messages) != 3 {
+		t.Fatalf("Filter mutated the caller's session: %d messages", len(ss[0].Messages))
+	}
+}
+
+func TestScaledBar(t *testing.T) {
+	cases := []struct{ n, maxN, width, want int }{
+		{0, 10, 20, 0},   // no value, no bar
+		{5, 0, 20, 0},    // no scale, guarded
+		{10, 10, 20, 20}, // full
+		{5, 10, 20, 10},  // half
+		{1, 1000, 20, 1}, // tiny but non-zero rounds up to one cell
+	}
+	for _, c := range cases {
+		if got := ScaledBar(c.n, c.maxN, c.width); got != c.want {
+			t.Errorf("ScaledBar(%d,%d,%d) = %d, want %d", c.n, c.maxN, c.width, got, c.want)
+		}
+	}
+}
+
+func TestTrimRunes(t *testing.T) {
+	cases := []struct {
+		s    string
+		n    int
+		want string
+	}{
+		{"short", 10, "short"},   // fits
+		{"exactly", 7, "exactly"},// exact length
+		{"truncate me", 5, "trun…"},
+		{"x", 1, "x"},
+		{"multibyte ✓ é ж", 5, "mult…"},
+	}
+	for _, c := range cases {
+		if got := TrimRunes(c.s, c.n); got != c.want {
+			t.Errorf("TrimRunes(%q,%d) = %q, want %q", c.s, c.n, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Test-only, no production changes. Adds coverage to packages that had gaps: internal/query (0→100%), internal/cjkfold (0→100%, plus a guard that the two generated fold tables stay equal length), internal/model Touch (40→100%), internal/stats Filter/ScaledBar/TrimRunes, and the Claude content decoder plus promoted-note title round-trip in internal/sources.