### PR TITLE
fix(packaging): re-pin windows manifests to 0.16.9

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,12 +1,12 @@
 {
     "architecture": {
         "64bit": {
-            "hash": "cf1f598e60ab602f4a0995fe3901ad1e61771a1cad0abb335ac67d1a54fa4db6",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.8/deja-vu_0.16.8_windows_amd64.zip"
+            "hash": "df4912f6cbc36d3e771272ac8194cd5ca8244fd9cdbbaf3155a22d3ee7ad7079",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.9/deja-vu_0.16.9_windows_amd64.zip"
         },
         "arm64": {
-            "hash": "b268cd128d44884f3006c002f36c11b16701830875c0f034970d0d6633c0e0cb",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.8/deja-vu_0.16.8_windows_arm64.zip"
+            "hash": "e83fed8d2d3a075454ed61d5761c537c6f805906142d0e80ed02945846ac988d",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.9/deja-vu_0.16.9_windows_arm64.zip"
         }
     },
     "autoupdate": {
@@ -24,5 +24,5 @@
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
-    "version": "0.16.8"
+    "version": "0.16.9"
 }

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.8
+PackageVersion: 0.16.9
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.8/deja-vu_0.16.8_windows_amd64.zip
-  InstallerSha256: CF1F598E60AB602F4A0995FE3901AD1E61771A1CAD0ABB335AC67D1A54FA4DB6
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.9/deja-vu_0.16.9_windows_amd64.zip
+  InstallerSha256: DF4912F6CBC36D3E771272AC8194CD5CA8244FD9CDBBAF3155A22D3EE7AD7079
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.8/deja-vu_0.16.8_windows_arm64.zip
-  InstallerSha256: B268CD128D44884F3006C002F36C11B16701830875C0F034970D0D6633C0E0CB
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.9/deja-vu_0.16.9_windows_arm64.zip
+  InstallerSha256: E83FED8D2D3A075454ED61D5761C537C6F805906142D0E80ED02945846AC988D
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.8
+PackageVersion: 0.16.9
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.8/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.9/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.8
+PackageVersion: 0.16.9
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
scoop and winget still pointed at 0.16.8, so the `windows manifests` CI check (pinmanifests -check) failed on every PR. Regenerated from the 0.16.9 checksums; -check passes.