### PR TITLE
feat: widen the recall snippet window for more context

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1052,11 +1052,11 @@ func snippet(s, q string, re *regexp.Regexp) string {
 			idx = utf8.RuneCountInString(s[:b])
 		}
 	}
-	start := idx - 70
+	start := idx - 100
 	if start < 0 {
 		start = 0
 	}
-	end := start + 180
+	end := start + 300
 	if end > len(r) {
 		end = len(r)
 	}


### PR DESCRIPTION
The snippet window was 180 chars around the match, which often cut off the clause that answered. Widened to ~300 with more lead-in. Display-only: ranking and recall unchanged (LongMemEval TOTAL hit@1 stays 84.2%, answer-budget test still green). On the agent-choice probe (top-5-but-not-rank-1 cases) the agent picked the right session 5/6 vs 4/6 before, because the answering clause now fits in the excerpt. Progression across the two snippet PRs: 2/6 → 4/6 → 5/6.