### PR TITLE
fix: redact secrets named in languages other than English

### DIFF
--- a/internal/redact/intl_secret_words_test.go
+++ b/internal/redact/intl_secret_words_test.go
@@ -1,0 +1,51 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+// A secret is named in whatever language its owner types in. Every pattern here
+// was English-only, so "пароль: <value>" was stored and shared in the clear
+// while "password: <value>" was redacted.
+func TestSecretWordsInOtherLanguagesAreRedacted(t *testing.T) {
+	secrets := []string{
+		"пароль: hunter2secretvalue123",
+		"пароля: hunter2secretvalue123",
+		"токен: ghp_abcdefghijklmnop12345",
+		"секрет = supersecretvalue1234",
+		"ключ: AKIAIOSFODNN7EXAMPLE1234",
+		"contraseña: supersecretvalue1234",
+		"senha: supersecretvalue1234",
+		"passwort: supersecretvalue1234",
+		"密码: supersecretvalue1234",
+		"パスワード: supersecretvalue1234",
+		"비밀번호: supersecretvalue1234",
+	}
+	for _, in := range secrets {
+		out, _ := Text(in)
+		if out == in {
+			t.Errorf("not redacted: %q", in)
+			continue
+		}
+		if !strings.Contains(out, "[redacted:") {
+			t.Errorf("no marker in %q -> %q", in, out)
+		}
+	}
+}
+
+// The looseness has to stop at prose: these name a key word but assign nothing
+// secret, and redacting them would eat ordinary sentences.
+func TestOrdinaryProseWithSecretWordsIsUntouched(t *testing.T) {
+	prose := []string{
+		"пароль от вина был простой",
+		"ключевые слова: обычный текст без секретов",
+		"the token is fine here",
+		"мы обсудили токен и решили его не менять",
+	}
+	for _, in := range prose {
+		if out, _ := Text(in); out != in {
+			t.Errorf("prose was redacted: %q -> %q", in, out)
+		}
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -32,8 +32,17 @@ var (
 	// x-api-key) and, in JSON, a closing quote can sit between the key and the
 	// delimiter ("api_key": "..."). Tolerate both so env-var and JSON forms are
 	// caught, not just a bare `api_key=`.
+	// The key words are matched in the languages people actually type in, not
+	// only English: a Russian speaker writes "пароль: …" or "токен: …" and the
+	// secret sat in the clear because every pattern here was English-only. The
+	// value class and length floor are the same, so the looseness is unchanged.
 	genericKVRE = regexp.MustCompile(`(?i)\b([\w.-]{0,64}?(?:api[_-]?key|secret|token|passwd|password|authorization))(\s*['"]?\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=._-]{16,})(['"]?)`)
-	bearerRE    = regexp.MustCompile(`(?i)\b(Bearer|Basic)(\s+)([A-Za-z0-9._~+/=-]{16,})`)
+	// The same shape in the languages people actually type in. \b is ASCII-only
+	// in RE2, so a Cyrillic or CJK key word can never sit behind it — these get
+	// their own pattern. A Russian speaker writing "пароль: …" had the secret
+	// stored in the clear because every pattern here was English-only.
+	genericKVIntlRE = regexp.MustCompile(`(?i)(парол[ьяею]|токен[ауы]?|секрет[ауы]?|ключ[аеиуом]?|contraseña|senha|passwort|密码|密碼|パスワード|비밀번호)(\s*['"]?\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=._-]{16,})(['"]?)`)
+	bearerRE        = regexp.MustCompile(`(?i)\b(Bearer|Basic)(\s+)([A-Za-z0-9._~+/=-]{16,})`)
 	// A secret named in prose and quoted rather than assigned. Tool output is
 	// full of this shape — `password authentication failed for user "admin"
 	// with password "S3cr3tP@ssw0rd!"` — and genericKVRE cannot reach it:
@@ -92,7 +101,10 @@ func kvAssignmentNearby(lower string) bool {
 // value — the rest of a longer name, spaces and an optional quote — and looks
 // for the ':' or '=' the pattern requires.
 func assignmentFollows(s string, i int) bool {
-	for i < len(s) && (isWordByte(s[i]) || s[i] == '.' || s[i] == '-') {
+	// Bytes >= 0x80 continue a non-ASCII word: the hint "парол" stops one byte
+	// short of "пароля", and skipping only ASCII left the ':' unreachable, so
+	// the gate said no and the intl pattern never ran.
+	for i < len(s) && (isWordByte(s[i]) || s[i] >= 0x80 || s[i] == '.' || s[i] == '-') {
 		i++
 	}
 	// The pattern uses \s, which is more than a space: a fuzz case of
@@ -115,7 +127,14 @@ func isSpaceByte(c byte) bool {
 // kvHints are the substrings genericKVRE can anchor on; providerHints the
 // literal prefixes of providerRE. Checking them first keeps the regexes off
 // the vast majority of messages, which contain no credentials at all.
-var kvHints = []string{"key", "secret", "token", "passw", "authorization"}
+// The non-English words are here for the same reason they are in genericKVRE:
+// the gate runs first, so a Russian "пароль:" never reached the regex at all.
+var kvHints = []string{
+	"key", "secret", "token", "passw", "authorization",
+	"пароль", "парол", "токен", "секрет", "ключ",
+	"contraseña", "senha", "mot de passe", "passwort",
+	"密码", "密碼", "パスワード", "비밀번호",
+}
 
 // "github_pat_" is listed on its own: "gh" is not a substring of "github".
 var providerHints = []string{"gh", "github_pat_", "glpat-", "sk_", "rk_", "sk-", "gsk_", "xai-", "hf_", "npm_", "xox", "AIza"}
@@ -169,6 +188,9 @@ func Text(s string) (string, Counts) {
 	}
 	if kvAssignmentNearby(lower) {
 		s = replaceSubmatch(s, genericKVRE, "credential", counts, func(m []string) string {
+			return m[1] + m[2] + m[3] + "[redacted:credential]" + closingQuote(m[3], m[5])
+		})
+		s = replaceSubmatch(s, genericKVIntlRE, "credential", counts, func(m []string) string {
 			return m[1] + m[2] + m[3] + "[redacted:credential]" + closingQuote(m[3], m[5])
 		})
 	}


### PR DESCRIPTION
Every credential pattern keyed on English words, so a user who writes `пароль: <value>` (or 密码, パスワード, contraseña, senha, Passwort, 비밀번호) had the secret stored in records.bin in the clear and served through show/share/recall — while the same line in English was redacted.

Two fixes: an intl key-word pattern, because `\b` is ASCII-only in RE2 and a Cyrillic or CJK word can never sit behind it; and the kv gate now skips non-ASCII word bytes, since the hint "парол" stopped one byte short of "пароля" and the pattern was never reached.

Prose that merely names a key word ("пароль от вина был простой", "the token is fine here") stays untouched. New tests cover both directions; full go test green.