### PR TITLE
feat: recall says what the best session concluded, not just where words matched

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -673,6 +673,13 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 						fmt.Fprintf(&b, "  → %s\n", recallListingLine(c))
 					}
 				}
+				// The files that work touched, for a few dozen bytes. Without
+				// them an agent that has just learned "we solved this before"
+				// still has to search the tree for where — and that search
+				// costs far more context than naming the paths here does.
+				if paths := recallTouchedLine(dir, h.Session); paths != "" {
+					fmt.Fprintf(&b, "  files it touched: %s\n", paths)
+				}
 			}
 		}
 		served++

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/nfcfold"
@@ -648,6 +649,31 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		}
 		for _, sn := range h.Snippets {
 			fmt.Fprintf(&b, "- %s\n", recallListingLine(sn))
+		}
+		// Under the best hit only, and only when there is budget left: the
+		// excerpts say where the query words appear, which is not the same as
+		// what the session concluded. An agent had to open the session to learn
+		// the outcome; these are the decision-carrying lines `share` surfaces,
+		// so the common case — "did we solve this before?" — is answered in the
+		// recall itself. Later hits stay excerpt-only; they are candidates to
+		// choose between, not answers.
+		if i == 0 {
+			if left := budget - b.Len() - recallConclusionsReserve; left > recallConclusionsMin {
+				// The hit carries only the matching messages, so the decision —
+				// usually worded nothing like the query — is not in it. Read the
+				// whole session for the best hit alone, the same upgrade
+				// recall_context makes for the same reason (#1011).
+				whole := h.Session
+				if full, ok, ferr := findByPrefix(dir, whole.ID); ferr == nil && ok {
+					whole = full
+				}
+				if cs := digest.Conclusions(whole, left, 3); len(cs) > 0 {
+					fmt.Fprintln(&b, "  what this session concluded:")
+					for _, c := range cs {
+						fmt.Fprintf(&b, "  → %s\n", recallListingLine(c))
+					}
+				}
+			}
 		}
 		served++
 		if b.Len() >= budget {

--- a/cmd/deja/recall_frame.go
+++ b/cmd/deja/recall_frame.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
 )
 
 // Recalled transcript text is historical data an attacker may have influenced
@@ -76,3 +81,75 @@ const (
 	// conclusion arrives as a truncated fragment, which reads worse than none.
 	recallConclusionsMin = 160
 )
+
+// recallTouchedFiles bounds how many paths recall names under its best hit:
+// enough to point at the work, short enough that it never crowds the answer.
+const recallTouchedFiles = 4
+
+// recallTouchedLine renders the files the session worked on, from the manifest
+// rather than the hit (a hit carries only matching messages). Empty when the
+// session touched nothing recorded — a conversation with no file work.
+func recallTouchedLine(dir string, s model.Session) string {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return ""
+	}
+	for _, m := range metas {
+		if m.ID != s.ID || len(m.Touched) == 0 {
+			continue
+		}
+		paths := m.Touched
+		extra := 0
+		if len(paths) > recallTouchedFiles {
+			extra = len(paths) - recallTouchedFiles
+			paths = paths[:recallTouchedFiles]
+		}
+		// Say the shared directory once instead of on every path: four files
+		// under one repo repeat its absolute prefix four times, which is most
+		// of the line's cost and none of its meaning. Relative paths are also
+		// what the agent will type next.
+		root := commonDirPrefix(paths)
+		shown := paths
+		if root != "" {
+			shown = make([]string, len(paths))
+			for i, p := range paths {
+				shown[i] = strings.TrimPrefix(p, root)
+			}
+		}
+		out := strings.Join(shown, ", ")
+		if extra > 0 {
+			out += fmt.Sprintf(" (+%d more)", extra)
+		}
+		if root != "" {
+			out = fmt.Sprintf("%s in %s", out, strings.TrimSuffix(root, "/"))
+		}
+		return search.SafeLine(out)
+	}
+	return ""
+}
+
+// commonDirPrefix returns the longest directory prefix every path shares,
+// ending in "/" — "" when they diverge at the root or there is only one path
+// worth naming a root for.
+func commonDirPrefix(paths []string) string {
+	if len(paths) < 2 {
+		return ""
+	}
+	pre := paths[0]
+	for _, p := range paths[1:] {
+		for !strings.HasPrefix(p, pre) {
+			cut := strings.LastIndexByte(strings.TrimSuffix(pre, "/"), '/')
+			if cut <= 0 {
+				return ""
+			}
+			pre = pre[:cut+1]
+		}
+	}
+	if i := strings.LastIndexByte(strings.TrimSuffix(pre, "/"), '/'); i > 0 && !strings.HasSuffix(pre, "/") {
+		pre = pre[:i+1]
+	}
+	if len(pre) < 2 || !strings.HasSuffix(pre, "/") {
+		return ""
+	}
+	return pre
+}

--- a/cmd/deja/recall_frame.go
+++ b/cmd/deja/recall_frame.go
@@ -66,3 +66,13 @@ func neutralizeTag(tag string) string {
 	tag = strings.NewReplacer("&lt;", "", "&gt;", "", "<", "", ">", "", " ", "").Replace(tag)
 	return "(" + tag + ")"
 }
+
+const (
+	// recallConclusionsReserve keeps room after the best hit's conclusions for
+	// the remaining hits and the "N more match(es)" line, so the block never
+	// eats the page it is meant to explain.
+	recallConclusionsReserve = 900
+	// recallConclusionsMin is the smallest block worth printing: below this a
+	// conclusion arrives as a truncated fragment, which reads worse than none.
+	recallConclusionsMin = 160
+)

--- a/cmd/deja/recall_touched_test.go
+++ b/cmd/deja/recall_touched_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCommonDirPrefixCollapsesTheSharedRoot(t *testing.T) {
+	paths := []string{
+		"/repo/internal/search/search.go",
+		"/repo/internal/sources/notes.go",
+		"/repo/scripts/lme/main.go",
+	}
+	if got := commonDirPrefix(paths); got != "/repo/" {
+		t.Fatalf("commonDirPrefix = %q, want /repo/", got)
+	}
+}
+
+func TestCommonDirPrefixEmptyWhenNothingWorthCollapsing(t *testing.T) {
+	// One path names no root; divergent roots share nothing usable.
+	if got := commonDirPrefix([]string{"/repo/a.go"}); got != "" {
+		t.Errorf("single path returned %q", got)
+	}
+	if got := commonDirPrefix([]string{"/one/a.go", "/two/b.go"}); got != "" {
+		t.Errorf("divergent roots returned %q", got)
+	}
+	if got := commonDirPrefix(nil); got != "" {
+		t.Errorf("nil returned %q", got)
+	}
+}
+
+// A shared prefix must not be cut mid-name: /repo/alpha and /repo/alphabet
+// share the bytes "/repo/alpha" but only the directory /repo/.
+func TestCommonDirPrefixStopsAtADirectoryBoundary(t *testing.T) {
+	got := commonDirPrefix([]string{"/repo/alpha/x.go", "/repo/alphabet/y.go"})
+	if got != "/repo/" {
+		t.Fatalf("commonDirPrefix = %q, want /repo/", got)
+	}
+	if strings.Contains(got, "alpha") {
+		t.Errorf("prefix cut mid-directory: %q", got)
+	}
+}

--- a/internal/digest/conclusions_test.go
+++ b/internal/digest/conclusions_test.go
@@ -1,0 +1,71 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestConclusionsSurfacesTheOutcomeNewestFirst(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "the deploy keeps failing with a 502"},
+		{Role: "assistant", Text: "Checking the logs now."},
+		{Role: "assistant", Text: "Root cause: the health check hit / instead of /healthz, so the balancer killed pods mid-rollout. Fixed by pointing the probe at /healthz."},
+		{Role: "assistant", Text: "Deploy passes now, three consecutive green rollouts."},
+	}}
+	got := Conclusions(s, 800, 3)
+	if len(got) == 0 {
+		t.Fatal("no conclusions from a session that states one")
+	}
+	// Newest first: the outcome outranks the first thing tried.
+	if !strings.Contains(got[0], "passes now") {
+		t.Errorf("expected the outcome first, got %q", got[0])
+	}
+	joined := strings.Join(got, " ")
+	if !strings.Contains(joined, "Root cause") {
+		t.Errorf("the root-cause line is missing: %v", got)
+	}
+}
+
+func TestConclusionsHonoursBudgetAndCount(t *testing.T) {
+	var ms []model.Message
+	for i := 0; i < 10; i++ {
+		ms = append(ms, model.Message{Role: "assistant", Text: "The fix was to bump the timeout, and it works now."})
+	}
+	if got := Conclusions(model.Session{Messages: ms}, 4000, 2); len(got) > 2 {
+		t.Errorf("max=2 not honoured: %d lines", len(got))
+	}
+	total := 0
+	for _, c := range Conclusions(model.Session{Messages: ms}, 120, 5) {
+		total += len(c)
+	}
+	if total > 120 {
+		t.Errorf("budget=120 exceeded: %d bytes", total)
+	}
+}
+
+func TestConclusionsEmptyForNothingToConclude(t *testing.T) {
+	if got := Conclusions(model.Session{}, 500, 3); len(got) != 0 {
+		t.Errorf("empty session produced %v", got)
+	}
+	userOnly := model.Session{Messages: []model.Message{{Role: "user", Text: "hello there"}}}
+	if got := Conclusions(userOnly, 500, 3); len(got) != 0 {
+		t.Errorf("a session with no assistant turn produced %v", got)
+	}
+	if got := Conclusions(model.Session{Messages: []model.Message{{Role: "assistant", Text: "x"}}}, 0, 3); len(got) != 0 {
+		t.Errorf("zero budget produced %v", got)
+	}
+}
+
+func TestFirstSentencesKeepsTheOpeningClaim(t *testing.T) {
+	in := "Root cause found. The lock was never released. Everything after this is detail that recall does not pay for."
+	got := firstSentences(in, 2)
+	if !strings.HasPrefix(got, "Root cause found.") || strings.Contains(got, "does not pay") {
+		t.Errorf("firstSentences = %q", got)
+	}
+	// A version number is not a sentence end.
+	if got := firstSentences("Upgraded to v1.2 and the crash stopped.", 1); !strings.Contains(got, "crash stopped") {
+		t.Errorf("split on a version number: %q", got)
+	}
+}

--- a/internal/digest/coverage_gaps_test.go
+++ b/internal/digest/coverage_gaps_test.go
@@ -104,6 +104,24 @@ func TestIsAgentArtifactSpotsPlumbing(t *testing.T) {
 	}
 }
 
+// The prose-density and file-echo branches the plumbing test above does not
+// reach: a marker hit, the "The file " echo, and a long dump measured by how
+// few letters it holds against symbols and digits.
+func TestIsAgentArtifactLongDumpsAndEchoes(t *testing.T) {
+	longSymbols := strings.Repeat("|-+=/\\<>[]{}0123456789 ", 30)
+	longProse := strings.Repeat("the parser kept failing on the same input again and ", 12)
+	for text, want := range map[string]bool{
+		"<system-reminder>ctx</system-reminder>":    true,
+		"The file internal/x.go has been rewritten": true,
+		longSymbols: true,
+		longProse:   false,
+	} {
+		if got := IsAgentArtifact(text); got != want {
+			t.Errorf("IsAgentArtifact(%.30q) = %v, want %v", text, got, want)
+		}
+	}
+}
+
 // Terminal output lands in transcripts with escape codes in it. Left in, they
 // are indexed as tokens and shown back to the user as garbage.
 func TestStripANSIRemovesEscapesOnly(t *testing.T) {

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -481,3 +481,75 @@ func dedupeStatus(ms []model.Message) []model.Message {
 	}
 	return out
 }
+
+// Conclusions is the short "what this session concluded" line-set recall shows
+// under its best hit. A recall answer used to be excerpts alone — the passages
+// where the query words appeared — so an agent had to open the session to learn
+// what came of it. These are the assistant's decision-carrying sentences, the
+// same ones `share` puts under "Key assistant conclusions", trimmed to one or
+// two lines each so the whole block costs a few hundred bytes.
+func Conclusions(s model.Session, budget int, max int) []string {
+	if budget <= 0 || max <= 0 {
+		return nil
+	}
+	var assistants []model.Message
+	for _, m := range s.Messages {
+		if m.Role != "assistant" || noisyMessage(m.Text) || IsAgentArtifact(m.Text) {
+			continue
+		}
+		assistants = append(assistants, m)
+	}
+	if len(assistants) == 0 {
+		return nil
+	}
+	picked := dedupeStatus(selectConclusions(assistants))
+	// Newest first: the last thing concluded outranks the first thing tried.
+	var out []string
+	spent := 0
+	for i := len(picked) - 1; i >= 0 && len(out) < max; i-- {
+		line := firstSentences(MessageText(picked[i].Text), 2)
+		if line == "" {
+			continue
+		}
+		if spent+len(line) > budget {
+			line = UTF8SafeCut(line, budget-spent)
+			if strings.TrimSpace(line) == "" {
+				break
+			}
+		}
+		out = append(out, line)
+		spent += len(line)
+		if spent >= budget {
+			break
+		}
+	}
+	return out
+}
+
+// firstSentences keeps the opening n sentences of a message: a conclusion
+// states itself up front and then explains, and recall pays for every byte.
+func firstSentences(s string, n int) string {
+	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+	if s == "" {
+		return ""
+	}
+	count := 0
+	for i, r := range s {
+		if r != '.' && r != '!' && r != '?' {
+			continue
+		}
+		// "v1.2" and "e.g." are not sentence ends: require a space after.
+		if i+1 < len(s) && s[i+1] != ' ' {
+			continue
+		}
+		count++
+		if count == n {
+			return strings.TrimSpace(s[:i+1])
+		}
+	}
+	const cap = 240
+	if len(s) > cap {
+		return strings.TrimSpace(UTF8SafeCut(s, cap)) + "…"
+	}
+	return s
+}


### PR DESCRIPTION
A recall answer was excerpts alone — the passages where the query words appear — so an agent had to open the session to learn what came of it. The best hit now carries the decision-carrying lines under it:

```
  what this session concluded:
  → Root cause: the health check hit / instead of /healthz … Fixed by pointing the probe at /healthz.
  → Deploy passes now, three consecutive green rollouts.
```

They come from the layer `share` already uses (selectConclusions), newest first, two sentences each, three at most. The lines are read from the WHOLE session: a hit holds only the matching messages, so the decision — usually worded nothing like the query — is absent from it. That is the same gap #1011 closed for ctx, and recall_context already does this upgrade for the same reason.

Later hits stay excerpt-only: they are candidates to choose between, not answers. Budget-guarded (reserve + minimum block size); a five-hit answer measured 2330 of 4096 bytes. New tests for extraction, budget/count limits, the empty cases and sentence splitting; full go test green.