### PR TITLE
feat: size the unprompted recall to how strong the match is

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -166,7 +166,7 @@ func promptBenchProbe(dir, project, chainID string, terms []string) (fired, corr
 	if !promptTermsWorthAsking(terms) {
 		return false, false
 	}
-	ranked, matched, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil {
 		return false, false
 	}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -184,12 +184,22 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// "You have been here" on the strength of one word teaches the user to
 	// ignore the line. The recall itself still goes in.
 	showLine := confident && dejaVuLineDue(dir)
-	digest := search.AutoRecallDigest(ss, promptHookBudget-recallFrameOverhead)
-	if strings.TrimSpace(digest) == "" {
-		return nil
+	// The payload is sized to the claim. Two informative terms is a real match
+	// and earns the digest; a single rare term is a hint, and a hint that costs
+	// a full digest on every message is most of what deja spends. The pointer
+	// keeps it discoverable — the agent learns there is history here and can
+	// ask for it — for 134 bytes against the 0.5-1.3 KB a real digest measures.
+	var body string
+	if confident {
+		body = search.AutoRecallDigest(ss, promptHookBudget-recallFrameOverhead)
+		if strings.TrimSpace(body) == "" {
+			return nil
+		}
+		body = promptHookLead + rejectedWarning + body + citationLine(ss[0])
+	} else {
+		body = weakRecallPointer(ss, terms) + rejectedWarning
 	}
-	lead := promptHookLead + rejectedWarning
-	out := frameRecall(lead + digest + citationLine(ss[0]))
+	out := frameRecall(body)
 	usage.RecordDigestTerms(dir, usage.KindDejaVu, out, len(ss), rawSize(ss), terms, sessionIDs(ss)...)
 	if plain {
 		fmt.Fprintln(stdout, out)
@@ -692,3 +702,29 @@ func sessionIDs(ss []model.Session) []string {
 }
 
 const promptHookLead = "deja found prior sessions matching this request. If one genuinely helps, use it and tell the user in one short line what deja-vu recalled; otherwise ignore silently.\n"
+
+// weakRecallPointer is what an unconfident match injects instead of a digest:
+// one line saying history exists and how to reach it. A single rare term is a
+// hint, not an answer, and this hook runs on every message — spending a full
+// digest on a hint is where most of deja's unprompted context cost went.
+// Naming the topic and the date is what makes the pointer worth following.
+func weakRecallPointer(ss []model.Session, terms []string) string {
+	if len(ss) == 0 {
+		return ""
+	}
+	s := ss[0]
+	topic := dejaVuTopic(s)
+	if topic == "" {
+		topic = strings.Join(terms, " ")
+	}
+	when := "earlier"
+	if !s.Updated.IsZero() {
+		when = search.RelativeDate(s.Updated)
+	}
+	more := ""
+	if len(ss) > 1 {
+		more = fmt.Sprintf(" (+%d more)", len(ss)-1)
+	}
+	return fmt.Sprintf("deja: this project has history on %q from %s%s — call recall with a specific token if it matters here.\n",
+		search.SafeLine(topic), when, more)
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -117,7 +117,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// (IDF-weighted), rather than reconstructing an AND query — natural
 	// prompts are full of filler that poisons an AND. n=8 to leave room after
 	// excluding the current/too-fresh sessions.
-	ranked, matched, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, 8)
+	ranked, matched, strong, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, 8)
 	if err != nil || len(ranked) == 0 {
 		return nil
 	}
@@ -132,11 +132,15 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		if !pol.Allows(policy.ActivationAuto, s.Project) {
 			continue
 		}
-		// matched counts only informative terms — ones rare enough in this
-		// corpus to identify something. One of those is a weak claim but a
-		// fair answer to a question that was actually asked, so it is served
-		// without the déjà vu line; two or more earn the announcement.
-		if matched[i] < 1 || (matched[i] < 2 && !hasIdentifierTerm(terms)) {
+		// matched counts informative terms; strong counts the rare ones — a
+		// term that identifies something on its own rather than merely beating
+		// the corpus average. Two informative terms earn the announcement. A
+		// single term is a weak claim, so it only injects when that term is
+		// strong: "pgbouncer" answers a question, "problem" does not, and this
+		// hook pays its cost on every message the user sends. Measured on
+		// cross-paired prompts whose answer is absent, the old bar injected on
+		// 94% of them; half of those rested on one ordinary word.
+		if matched[i] < 1 || (matched[i] < 2 && strong[i] < 1) {
 			continue
 		}
 		if matched[i] >= 2 {

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -673,6 +673,13 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 						fmt.Fprintf(&b, "  → %s\n", recallListingLine(c))
 					}
 				}
+				// The files that work touched, for a few dozen bytes. Without
+				// them an agent that has just learned "we solved this before"
+				// still has to search the tree for where — and that search
+				// costs far more context than naming the paths here does.
+				if paths := recallTouchedLine(dir, h.Session); paths != "" {
+					fmt.Fprintf(&b, "  files it touched: %s\n", paths)
+				}
 			}
 		}
 		served++

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/nfcfold"
@@ -648,6 +649,31 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		}
 		for _, sn := range h.Snippets {
 			fmt.Fprintf(&b, "- %s\n", recallListingLine(sn))
+		}
+		// Under the best hit only, and only when there is budget left: the
+		// excerpts say where the query words appear, which is not the same as
+		// what the session concluded. An agent had to open the session to learn
+		// the outcome; these are the decision-carrying lines `share` surfaces,
+		// so the common case — "did we solve this before?" — is answered in the
+		// recall itself. Later hits stay excerpt-only; they are candidates to
+		// choose between, not answers.
+		if i == 0 {
+			if left := budget - b.Len() - recallConclusionsReserve; left > recallConclusionsMin {
+				// The hit carries only the matching messages, so the decision —
+				// usually worded nothing like the query — is not in it. Read the
+				// whole session for the best hit alone, the same upgrade
+				// recall_context makes for the same reason (#1011).
+				whole := h.Session
+				if full, ok, ferr := findByPrefix(dir, whole.ID); ferr == nil && ok {
+					whole = full
+				}
+				if cs := digest.Conclusions(whole, left, 3); len(cs) > 0 {
+					fmt.Fprintln(&b, "  what this session concluded:")
+					for _, c := range cs {
+						fmt.Fprintf(&b, "  → %s\n", recallListingLine(c))
+					}
+				}
+			}
 		}
 		served++
 		if b.Len() >= budget {

--- a/cmd/deja/recall_frame.go
+++ b/cmd/deja/recall_frame.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
 )
 
 // Recalled transcript text is historical data an attacker may have influenced
@@ -76,3 +81,75 @@ const (
 	// conclusion arrives as a truncated fragment, which reads worse than none.
 	recallConclusionsMin = 160
 )
+
+// recallTouchedFiles bounds how many paths recall names under its best hit:
+// enough to point at the work, short enough that it never crowds the answer.
+const recallTouchedFiles = 4
+
+// recallTouchedLine renders the files the session worked on, from the manifest
+// rather than the hit (a hit carries only matching messages). Empty when the
+// session touched nothing recorded — a conversation with no file work.
+func recallTouchedLine(dir string, s model.Session) string {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return ""
+	}
+	for _, m := range metas {
+		if m.ID != s.ID || len(m.Touched) == 0 {
+			continue
+		}
+		paths := m.Touched
+		extra := 0
+		if len(paths) > recallTouchedFiles {
+			extra = len(paths) - recallTouchedFiles
+			paths = paths[:recallTouchedFiles]
+		}
+		// Say the shared directory once instead of on every path: four files
+		// under one repo repeat its absolute prefix four times, which is most
+		// of the line's cost and none of its meaning. Relative paths are also
+		// what the agent will type next.
+		root := commonDirPrefix(paths)
+		shown := paths
+		if root != "" {
+			shown = make([]string, len(paths))
+			for i, p := range paths {
+				shown[i] = strings.TrimPrefix(p, root)
+			}
+		}
+		out := strings.Join(shown, ", ")
+		if extra > 0 {
+			out += fmt.Sprintf(" (+%d more)", extra)
+		}
+		if root != "" {
+			out = fmt.Sprintf("%s in %s", out, strings.TrimSuffix(root, "/"))
+		}
+		return search.SafeLine(out)
+	}
+	return ""
+}
+
+// commonDirPrefix returns the longest directory prefix every path shares,
+// ending in "/" — "" when they diverge at the root or there is only one path
+// worth naming a root for.
+func commonDirPrefix(paths []string) string {
+	if len(paths) < 2 {
+		return ""
+	}
+	pre := paths[0]
+	for _, p := range paths[1:] {
+		for !strings.HasPrefix(p, pre) {
+			cut := strings.LastIndexByte(strings.TrimSuffix(pre, "/"), '/')
+			if cut <= 0 {
+				return ""
+			}
+			pre = pre[:cut+1]
+		}
+	}
+	if i := strings.LastIndexByte(strings.TrimSuffix(pre, "/"), '/'); i > 0 && !strings.HasSuffix(pre, "/") {
+		pre = pre[:i+1]
+	}
+	if len(pre) < 2 || !strings.HasSuffix(pre, "/") {
+		return ""
+	}
+	return pre
+}

--- a/cmd/deja/recall_frame.go
+++ b/cmd/deja/recall_frame.go
@@ -66,3 +66,13 @@ func neutralizeTag(tag string) string {
 	tag = strings.NewReplacer("&lt;", "", "&gt;", "", "<", "", ">", "", " ", "").Replace(tag)
 	return "(" + tag + ")"
 }
+
+const (
+	// recallConclusionsReserve keeps room after the best hit's conclusions for
+	// the remaining hits and the "N more match(es)" line, so the block never
+	// eats the page it is meant to explain.
+	recallConclusionsReserve = 900
+	// recallConclusionsMin is the smallest block worth printing: below this a
+	// conclusion arrives as a truncated fragment, which reads worse than none.
+	recallConclusionsMin = 160
+)

--- a/cmd/deja/recall_touched_test.go
+++ b/cmd/deja/recall_touched_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCommonDirPrefixCollapsesTheSharedRoot(t *testing.T) {
+	paths := []string{
+		"/repo/internal/search/search.go",
+		"/repo/internal/sources/notes.go",
+		"/repo/scripts/lme/main.go",
+	}
+	if got := commonDirPrefix(paths); got != "/repo/" {
+		t.Fatalf("commonDirPrefix = %q, want /repo/", got)
+	}
+}
+
+func TestCommonDirPrefixEmptyWhenNothingWorthCollapsing(t *testing.T) {
+	// One path names no root; divergent roots share nothing usable.
+	if got := commonDirPrefix([]string{"/repo/a.go"}); got != "" {
+		t.Errorf("single path returned %q", got)
+	}
+	if got := commonDirPrefix([]string{"/one/a.go", "/two/b.go"}); got != "" {
+		t.Errorf("divergent roots returned %q", got)
+	}
+	if got := commonDirPrefix(nil); got != "" {
+		t.Errorf("nil returned %q", got)
+	}
+}
+
+// A shared prefix must not be cut mid-name: /repo/alpha and /repo/alphabet
+// share the bytes "/repo/alpha" but only the directory /repo/.
+func TestCommonDirPrefixStopsAtADirectoryBoundary(t *testing.T) {
+	got := commonDirPrefix([]string{"/repo/alpha/x.go", "/repo/alphabet/y.go"})
+	if got != "/repo/" {
+		t.Fatalf("commonDirPrefix = %q, want /repo/", got)
+	}
+	if strings.Contains(got, "alpha") {
+		t.Errorf("prefix cut mid-directory: %q", got)
+	}
+}

--- a/internal/digest/conclusions_test.go
+++ b/internal/digest/conclusions_test.go
@@ -1,0 +1,71 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestConclusionsSurfacesTheOutcomeNewestFirst(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "the deploy keeps failing with a 502"},
+		{Role: "assistant", Text: "Checking the logs now."},
+		{Role: "assistant", Text: "Root cause: the health check hit / instead of /healthz, so the balancer killed pods mid-rollout. Fixed by pointing the probe at /healthz."},
+		{Role: "assistant", Text: "Deploy passes now, three consecutive green rollouts."},
+	}}
+	got := Conclusions(s, 800, 3)
+	if len(got) == 0 {
+		t.Fatal("no conclusions from a session that states one")
+	}
+	// Newest first: the outcome outranks the first thing tried.
+	if !strings.Contains(got[0], "passes now") {
+		t.Errorf("expected the outcome first, got %q", got[0])
+	}
+	joined := strings.Join(got, " ")
+	if !strings.Contains(joined, "Root cause") {
+		t.Errorf("the root-cause line is missing: %v", got)
+	}
+}
+
+func TestConclusionsHonoursBudgetAndCount(t *testing.T) {
+	var ms []model.Message
+	for i := 0; i < 10; i++ {
+		ms = append(ms, model.Message{Role: "assistant", Text: "The fix was to bump the timeout, and it works now."})
+	}
+	if got := Conclusions(model.Session{Messages: ms}, 4000, 2); len(got) > 2 {
+		t.Errorf("max=2 not honoured: %d lines", len(got))
+	}
+	total := 0
+	for _, c := range Conclusions(model.Session{Messages: ms}, 120, 5) {
+		total += len(c)
+	}
+	if total > 120 {
+		t.Errorf("budget=120 exceeded: %d bytes", total)
+	}
+}
+
+func TestConclusionsEmptyForNothingToConclude(t *testing.T) {
+	if got := Conclusions(model.Session{}, 500, 3); len(got) != 0 {
+		t.Errorf("empty session produced %v", got)
+	}
+	userOnly := model.Session{Messages: []model.Message{{Role: "user", Text: "hello there"}}}
+	if got := Conclusions(userOnly, 500, 3); len(got) != 0 {
+		t.Errorf("a session with no assistant turn produced %v", got)
+	}
+	if got := Conclusions(model.Session{Messages: []model.Message{{Role: "assistant", Text: "x"}}}, 0, 3); len(got) != 0 {
+		t.Errorf("zero budget produced %v", got)
+	}
+}
+
+func TestFirstSentencesKeepsTheOpeningClaim(t *testing.T) {
+	in := "Root cause found. The lock was never released. Everything after this is detail that recall does not pay for."
+	got := firstSentences(in, 2)
+	if !strings.HasPrefix(got, "Root cause found.") || strings.Contains(got, "does not pay") {
+		t.Errorf("firstSentences = %q", got)
+	}
+	// A version number is not a sentence end.
+	if got := firstSentences("Upgraded to v1.2 and the crash stopped.", 1); !strings.Contains(got, "crash stopped") {
+		t.Errorf("split on a version number: %q", got)
+	}
+}

--- a/internal/digest/coverage_gaps_test.go
+++ b/internal/digest/coverage_gaps_test.go
@@ -104,6 +104,24 @@ func TestIsAgentArtifactSpotsPlumbing(t *testing.T) {
 	}
 }
 
+// The prose-density and file-echo branches the plumbing test above does not
+// reach: a marker hit, the "The file " echo, and a long dump measured by how
+// few letters it holds against symbols and digits.
+func TestIsAgentArtifactLongDumpsAndEchoes(t *testing.T) {
+	longSymbols := strings.Repeat("|-+=/\\<>[]{}0123456789 ", 30)
+	longProse := strings.Repeat("the parser kept failing on the same input again and ", 12)
+	for text, want := range map[string]bool{
+		"<system-reminder>ctx</system-reminder>":    true,
+		"The file internal/x.go has been rewritten": true,
+		longSymbols: true,
+		longProse:   false,
+	} {
+		if got := IsAgentArtifact(text); got != want {
+			t.Errorf("IsAgentArtifact(%.30q) = %v, want %v", text, got, want)
+		}
+	}
+}
+
 // Terminal output lands in transcripts with escape codes in it. Left in, they
 // are indexed as tokens and shown back to the user as garbage.
 func TestStripANSIRemovesEscapesOnly(t *testing.T) {

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -481,3 +481,75 @@ func dedupeStatus(ms []model.Message) []model.Message {
 	}
 	return out
 }
+
+// Conclusions is the short "what this session concluded" line-set recall shows
+// under its best hit. A recall answer used to be excerpts alone — the passages
+// where the query words appeared — so an agent had to open the session to learn
+// what came of it. These are the assistant's decision-carrying sentences, the
+// same ones `share` puts under "Key assistant conclusions", trimmed to one or
+// two lines each so the whole block costs a few hundred bytes.
+func Conclusions(s model.Session, budget int, max int) []string {
+	if budget <= 0 || max <= 0 {
+		return nil
+	}
+	var assistants []model.Message
+	for _, m := range s.Messages {
+		if m.Role != "assistant" || noisyMessage(m.Text) || IsAgentArtifact(m.Text) {
+			continue
+		}
+		assistants = append(assistants, m)
+	}
+	if len(assistants) == 0 {
+		return nil
+	}
+	picked := dedupeStatus(selectConclusions(assistants))
+	// Newest first: the last thing concluded outranks the first thing tried.
+	var out []string
+	spent := 0
+	for i := len(picked) - 1; i >= 0 && len(out) < max; i-- {
+		line := firstSentences(MessageText(picked[i].Text), 2)
+		if line == "" {
+			continue
+		}
+		if spent+len(line) > budget {
+			line = UTF8SafeCut(line, budget-spent)
+			if strings.TrimSpace(line) == "" {
+				break
+			}
+		}
+		out = append(out, line)
+		spent += len(line)
+		if spent >= budget {
+			break
+		}
+	}
+	return out
+}
+
+// firstSentences keeps the opening n sentences of a message: a conclusion
+// states itself up front and then explains, and recall pays for every byte.
+func firstSentences(s string, n int) string {
+	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+	if s == "" {
+		return ""
+	}
+	count := 0
+	for i, r := range s {
+		if r != '.' && r != '!' && r != '?' {
+			continue
+		}
+		// "v1.2" and "e.g." are not sentence ends: require a space after.
+		if i+1 < len(s) && s[i+1] != ' ' {
+			continue
+		}
+		count++
+		if count == n {
+			return strings.TrimSpace(s[:i+1])
+		}
+	}
+	const cap = 240
+	if len(s) > cap {
+		return strings.TrimSpace(UTF8SafeCut(s, cap)) + "…"
+	}
+	return s
+}

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -243,7 +243,7 @@ func TestProjectRelevantRanksByIDFNotFiller(t *testing.T) {
 		t.Fatal(err)
 	}
 	// A prompt full of filler plus the one rare term must rank s1 first.
-	got, _, err := ProjectRelevant(dir, []string{"app"}, []string{"need", "the", "quetzalcoatl"}, 2)
+	got, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"need", "the", "quetzalcoatl"}, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +274,7 @@ func TestProjectRelevantDottedTermNeedsAllSubTokens(t *testing.T) {
 	if err := Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	got, matched, err := ProjectRelevant(dir, []string{"app"}, []string{"203.0.113.51"}, 4)
+	got, matched, _, err := ProjectRelevant(dir, []string{"app"}, []string{"203.0.113.51"}, 4)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/cyrillic_test.go
+++ b/internal/index/cyrillic_test.go
@@ -205,7 +205,7 @@ func TestRussianRelevanceFoldsInflections(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Nominative singular in the prompt, instrumental plural in the session.
-	got, matched, err := ProjectRelevant(dir, []string{"app"}, []string{"миграция", "репликация"}, 3)
+	got, matched, _, err := ProjectRelevant(dir, []string{"app"}, []string{"миграция", "репликация"}, 3)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/lock_nonblocking_test.go
+++ b/internal/index/lock_nonblocking_test.go
@@ -24,7 +24,7 @@ func TestReadsDoNotBlockWhileTheIndexIsLocked(t *testing.T) {
 	go func() {
 		defer close(done)
 		_, _, _ = FindByPrefix(dir, "nothing")
-		_, _, _ = ProjectRelevant(dir, []string{"p"}, []string{"term"}, 3)
+		_, _, _, _ = ProjectRelevant(dir, []string{"p"}, []string{"term"}, 3)
 		_, _ = RecentProject(dir, "p", 3)
 		_, _, _ = FirstMatch(dir, []string{"term"}, 3)
 	}()

--- a/internal/index/relevance_bench_test.go
+++ b/internal/index/relevance_bench_test.go
@@ -50,7 +50,7 @@ func BenchmarkRussianRelevance(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if _, _, err := ProjectRelevant(dir, []string{"app"}, terms, 10); err != nil {
+		if _, _, _, err := ProjectRelevant(dir, []string{"app"}, terms, 10); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -285,7 +285,7 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 	if len(terms) < 2 {
 		return SearchResult{}, nil
 	}
-	metas, _, anyMatched, termsKnown, matched, rerr := relevantMetasCounts(dir, m, nil, terms, relevanceWindow, func(meta SessionMeta) bool {
+	metas, _, anyMatched, termsKnown, matched, _, rerr := relevantMetasCounts(dir, m, nil, terms, relevanceWindow, func(meta SessionMeta) bool {
 		return sessionMetaMatches(meta, o)
 	})
 	if rerr != nil {
@@ -359,6 +359,16 @@ func relevanceResult(ss []model.Session, matched int) SearchResult {
 // are informative regardless — small corpora never reach the ratio bar.
 const dejaVuIDFFloor = 2.0
 
+// dejaVuStrongIDFFloor is the bar for a term rare enough to justify an
+// UNPROMPTED recall on its own. The ordinary floor admits words that merely
+// beat the average — in a corpus of a few thousand sessions that includes
+// "session", "problem", "думать" — and the auto-recall hook fires on every
+// message, so one such word was enough to inject on nearly any prompt.
+// Measured on cross-paired prompts (the answer never present), the hook would
+// have injected on 94% of them; requiring a strong term for the single-match
+// case removes the half that rests on one ordinary word.
+const dejaVuStrongIDFFloor = 3.0
+
 // ProjectRelevant ranks the current project's sessions by how well they match
 // the prompt terms — without reconstructing an AND query, which poisons on
 // filler words. Each session scores the IDF-weighted sum of prompt terms it
@@ -369,7 +379,7 @@ const dejaVuIDFFloor = 2.0
 // the prompt terms. matched reports, per returned session, how many distinct
 // INFORMATIVE terms hit (idf >= dejaVuIDFFloor) — callers gate on it so
 // generic words cannot manufacture a confident "you have been here".
-func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Session, []int, error) {
+func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Session, []int, []int, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -378,35 +388,35 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 	// rebuild — which every user hits on an index-format upgrade.
 	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if ok {
 		defer unlock()
 	}
 	m, err := readManifestCached(dir)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	metas, matched, rerr := relevantMetasMatched(dir, m, projects, terms, n)
+	metas, matched, strong, rerr := relevantMetasMatched(dir, m, projects, terms, n)
 	if rerr != nil {
 		// A corrupt or unreadable bucket. The hook never rebuilds, so surface
 		// it rather than inject a silently short-ranked déjà vu; the caller
 		// stays quiet on an error.
-		return nil, nil, rerr
+		return nil, nil, nil, rerr
 	}
 	if len(metas) == 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 	out, err := sessionsForMetas(dir, metas)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return out, matched, nil
+	return out, matched, strong, nil
 }
 
-func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n int) ([]SessionMeta, []int, error) {
-	metas, informative, _, _, _, err := relevantMetasCounts(dir, m, projects, terms, n, nil)
-	return metas, informative, err
+func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n int) ([]SessionMeta, []int, []int, error) {
+	metas, informative, _, _, _, strong, err := relevantMetasCounts(dir, m, projects, terms, n, nil)
+	return metas, informative, strong, err
 }
 
 // relevantMetasCounts additionally reports how many terms of ANY frequency
@@ -424,7 +434,7 @@ func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n in
 // Returns, in order: the ranked metas, their informative-term counts, their
 // any-frequency term counts, how many query terms the corpus knows at all,
 // and that pre-truncation total.
-func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int, keep func(SessionMeta) bool) ([]SessionMeta, []int, []int, int, int, error) {
+func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int, keep func(SessionMeta) bool) ([]SessionMeta, []int, []int, int, int, []int, error) {
 	// A real bucket read error (a corrupt or unreadable postings file) must not
 	// pass as "the term is absent": that silently drops the term from the
 	// ranking. Remember the first one and hand it back so the caller triggers
@@ -449,13 +459,14 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		}
 	}
 	if len(inProject) == 0 {
-		return nil, nil, nil, 0, 0, nil
+		return nil, nil, nil, 0, 0, nil, readErr
 	}
 	br := newBucketReader(dir)
 	defer br.close()
 	totalDocs := float64(len(m.Sessions)) + 1
 	score := map[uint32]float64{}
 	matchedTerms := map[uint32]int{}
+	strongTerms := map[uint32]int{}
 	anyTerms := map[uint32]int{}
 	// perMessage tracks how many distinct terms hit each message (record
 	// offset) of a session: co-occurrence inside one message is a far
@@ -612,6 +623,9 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			idf = 0.1
 		}
 		informative := idf >= dejaVuIDFFloor || minDF <= 2
+		// Rare enough to identify something on its own: either well past the
+		// ordinary bar, or living in a single session of the whole corpus.
+		strong := idf >= dejaVuStrongIDFFloor || minDF <= 1
 		for ord := range hit {
 			mm := perMessage[ord]
 			if mm == nil {
@@ -637,6 +651,9 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			if informative {
 				matchedTerms[ord]++
 			}
+			if strong {
+				strongTerms[ord]++
+			}
 		}
 	}
 	type scored struct {
@@ -644,6 +661,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		score   float64
 		matched int
 		any     int
+		strong  int
 	}
 	ranked := make([]scored, 0, len(score))
 	for ord, sc := range score {
@@ -677,10 +695,10 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		if matchedTerms[ord] > 1 {
 			sc *= 1 + 0.15*float64(matchedTerms[ord]-1)
 		}
-		ranked = append(ranked, scored{inProject[ord], sc, matchedTerms[ord], anyTerms[ord]})
+		ranked = append(ranked, scored{inProject[ord], sc, matchedTerms[ord], anyTerms[ord], strongTerms[ord]})
 	}
 	if len(ranked) == 0 {
-		return nil, nil, nil, termsKnown, 0, readErr
+		return nil, nil, nil, termsKnown, 0, nil, readErr
 	}
 	sort.Slice(ranked, func(i, j int) bool {
 		if ranked[i].score != ranked[j].score {
@@ -702,12 +720,14 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 	metas := make([]SessionMeta, 0, len(ranked))
 	matched := make([]int, 0, len(ranked))
 	anyMatched := make([]int, 0, len(ranked))
+	strong := make([]int, 0, len(ranked))
 	for _, r := range ranked {
 		metas = append(metas, r.meta)
 		matched = append(matched, r.matched)
 		anyMatched = append(anyMatched, r.any)
+		strong = append(strong, r.strong)
 	}
-	return metas, matched, anyMatched, termsKnown, matchedTotal, readErr
+	return metas, matched, anyMatched, termsKnown, matchedTotal, strong, readErr
 }
 
 // loadSessionRecords materializes one session's transcript from the index.

--- a/scripts/longmemeval/main.go
+++ b/scripts/longmemeval/main.go
@@ -50,6 +50,7 @@ func main() {
 	skipAbs := flag.Bool("skip-abs", false, "skip abstention (_abs) questions, matching cleaned-dataset runs")
 	verbose := flag.Bool("v", false, "log per-question results")
 	dumpMisses := flag.String("dump-misses", "", "write a JSONL miss report (rank!=1) to this path")
+	hookPrecision := flag.Int("hook-precision", 0, "measure the auto-recall hook gate on N cross-paired prompts (0 = off)")
 	precision := flag.Bool("precision", false, "measure false-positive recalls: pair each question's prompt with another question's haystack (no answer present) and report how often anything surfaces")
 	agentCases := flag.Int("agent-cases", 0, "dump N cases where the answer is in top-5 but not rank-1, for an agent-choice A/B")
 	flag.Parse()
@@ -80,6 +81,10 @@ func main() {
 			}
 		}
 		questions = kept
+	}
+	if *hookPrecision > 0 {
+		runHookPrecision(questions, *hookPrecision)
+		return
 	}
 	if *precision {
 		runPrecision(questions)
@@ -449,4 +454,106 @@ func runAgentCases(questions []lmeQuestion, n int) {
 			return
 		}
 	}
+}
+
+// buildHaystackIndex writes a question's haystack as Claude transcripts and
+// indexes it, returning the index dir. Shared by the search and hook probes so
+// both measure the same ingestion the CLI runs.
+func buildHaystackIndex(q lmeQuestion) (string, func(), error) {
+	tmp, err := os.MkdirTemp("", "lmehook")
+	if err != nil {
+		return "", func() {}, err
+	}
+	cleanup := func() { _ = os.RemoveAll(tmp) }
+	proj := filepath.Join(tmp, "claude", "-work-lme")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		return "", cleanup, err
+	}
+	for si, turns := range q.HaystackSessions {
+		id := q.HaystackSessionID[si]
+		ts := parseLMEDate(q.HaystackDates[si])
+		f, err := os.Create(filepath.Join(proj, id+".jsonl"))
+		if err != nil {
+			return "", cleanup, err
+		}
+		enc := json.NewEncoder(f)
+		for ti, turn := range turns {
+			var content any = turn.Content
+			if turn.Role == "assistant" {
+				content = []any{map[string]any{"type": "text", "text": turn.Content}}
+			}
+			if err := enc.Encode(map[string]any{
+				"type": turn.Role, "sessionId": id,
+				"timestamp": ts.Add(time.Duration(ti) * time.Minute).UTC().Format(time.RFC3339),
+				"message":   map[string]any{"role": turn.Role, "content": content},
+			}); err != nil {
+				_ = f.Close()
+				return "", cleanup, err
+			}
+		}
+		if err := f.Close(); err != nil {
+			return "", cleanup, err
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	_ = os.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	_ = os.Setenv("DEJA_INDEX_DIR", dir)
+	if err := index.Ensure(dir, "claude", true, nil); err != nil {
+		return "", cleanup, err
+	}
+	return dir, cleanup, nil
+}
+
+// runHookPrecision measures the UNPROMPTED path: the auto-recall hook fires on
+// every user message, so its false-positive rate is paid on every message.
+// Each prompt is paired with another question's haystack — the answer is never
+// present — and the probe reports how often the hook's gate would still inject.
+// It replicates the gate rather than calling the hook: ProjectRelevant with the
+// prompt's terms, then the matched-count bar the hook applies.
+func runHookPrecision(questions []lmeQuestion, limit int) {
+	if limit > 0 && limit < len(questions) {
+		questions = questions[:limit]
+	}
+	n := len(questions)
+	var wouldInject, oneTerm, twoPlus int
+	start := time.Now()
+	for i := range questions {
+		j := (i + 1) % n
+		dir, cleanup, err := buildHaystackIndex(questions[j])
+		if err != nil {
+			cleanup()
+			fatal(err)
+		}
+		terms := index.RelevanceTerms(questions[i].Question)
+		_, matched, strong, err := index.ProjectRelevant(dir, nil, terms, 8)
+		if err != nil {
+			cleanup()
+			fatal(err)
+		}
+		best, bestStrong := 0, 0
+		for k, m := range matched {
+			if m > best {
+				best = m
+			}
+			if k < len(strong) && strong[k] > bestStrong {
+				bestStrong = strong[k]
+			}
+		}
+		switch {
+		case best >= 2:
+			twoPlus++
+			wouldInject++
+		case best == 1:
+			oneTerm++
+			if bestStrong >= 1 {
+				wouldInject++ // a rare term still earns a single-match inject
+			}
+		}
+		cleanup()
+	}
+	fmt.Printf("auto-recall HOOK precision (prompt_i × haystack_{i+1}, answer never present)\n")
+	fmt.Printf("pairs: %d · wall: %s\n\n", n, time.Since(start).Round(time.Second))
+	fmt.Printf("would inject (current gate) %4d / %d = %.1f%%\n", wouldInject, n, 100*float64(wouldInject)/float64(n))
+	fmt.Printf("  on ONE informative term %4d / %d = %.1f%%   (the bar a rarity test would raise)\n", oneTerm, n, 100*float64(oneTerm)/float64(n))
+	fmt.Printf("  on TWO or more          %4d / %d = %.1f%%   (would still inject)\n", twoPlus, n, 100*float64(twoPlus)/float64(n))
 }


### PR DESCRIPTION
A single ordinary word no longer triggers an unprompted recall, and the payload is sized to the claim: two informative terms earn the digest, one rare term gets a pointer instead.

Measured on the hook path: false injections 94.0% → 75.3%. The stricter variant (53.3%) is deliberately not taken — it breaks recall in small stores where idf collapses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GDwiNjSPHAGkB6VRsNs7V