### PR TITLE
feat: credit for a recall names the session that earned it

### DIFF
--- a/cmd/deja/hook_citation_id_test.go
+++ b/cmd/deja/hook_citation_id_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Credit said aloud is the only signal that a recall helped, and it was only
+// linkable back to its session by title text — two sessions that open with the
+// same question are common, so the credit landed on whichever one matched
+// lexically. The citation carries the session id so the link is a fact.
+func TestCitationLineCarriesTheSessionID(t *testing.T) {
+	s := model.Session{
+		ID:      "8f2c19ab77d40e6b5c31",
+		Harness: "claude",
+		Updated: time.Now().AddDate(0, 0, -2),
+		Messages: []model.Message{
+			{Role: "user", Text: "why does the reconciler double count refunds"},
+		},
+	}
+	line := citationLine(s)
+	if !strings.Contains(line, "deja:"+shortID(s.ID)) {
+		t.Errorf("citation cannot be linked back to the session it came from: %q", line)
+	}
+	// The full id is not printed: the line is read aloud to the user, and a
+	// twelve-character prefix already selects one session everywhere else.
+	if strings.Contains(line, s.ID) {
+		t.Errorf("citation spends the whole id on a line meant to be spoken: %q", line)
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -428,7 +428,13 @@ func citationLine(s model.Session) string {
 		}
 		date = ", " + s.Updated.Local().Format(layout)
 	}
-	return fmt.Sprintf("\nIf it helped, say: \"deja-vu recalled: %s (%s%s) — reusing it.\"", title, s.Harness, date)
+	// The citation carries the session id because it is the only place a recall
+	// that actually helped becomes an observable fact: the agent's reply is
+	// indexed like any other message, so `deja:<id>` in it links the credit back
+	// to the session that earned it. Matching on title text instead was lexical
+	// and unreliable — two sessions opening with the same question are common.
+	return fmt.Sprintf("\nIf it helped, say: \"deja-vu recalled: %s (%s%s, deja:%s) — reusing it.\"",
+		title, s.Harness, date, shortID(s.ID))
 }
 
 // alreadyInjected returns the session ids this hook already injected into the


### PR DESCRIPTION
The spoken citation now carries deja:<short id>, so credit said aloud links
back to one session instead of being matched by title text.
