### PR TITLE
feat/error signature tier

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -572,7 +572,10 @@ func cmdCtx(dir string, rest []string) error {
 		o.FuzzyVariants = result.Variants
 	}
 	var hits []search.Hit
-	if result.Tier == search.TierRelevance {
+	if result.Tier == search.TierError {
+		fmt.Fprintln(os.Stderr, "deja: matched by error signature; showing the sessions that hit it")
+		hits = search.ErrorHits(ss)
+	} else if result.Tier == search.TierRelevance {
 		fmt.Fprintln(os.Stderr, "deja: no exact match; showing sessions ranked by relevance to the whole query")
 		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(o.Query))
 	} else if hits, err = search.Run(ss, o); err != nil {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -811,7 +811,8 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 		o.FuzzyVariants = result.Variants
 	}
 	var hits []search.Hit
-	if result.Tier == search.TierError {
+	switch result.Tier {
+	case search.TierError:
 		// A pasted error IS a match; ErrorHits keeps the ranking and the error
 		// neighbourhood the tier found. Re-scoring it as an ordinary run would
 		// zero it out — the word ladder already failed, which is why this tier
@@ -822,7 +823,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 		if o.Total < len(hits) {
 			o.Total = len(hits)
 		}
-	} else if result.Tier == search.TierRelevance {
+	case search.TierRelevance:
 		fmt.Fprintln(os.Stderr, "deja: no exact match; showing sessions ranked by relevance to the whole query")
 		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(o.Query))
 		// This tier ranks and truncates inside retrieval, so counting the
@@ -837,7 +838,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 		if o.Total < len(hits) {
 			o.Total = len(hits)
 		}
-	} else {
+	default:
 		// RunDetailed rather than Run: the JSON envelope reports how many
 		// sessions matched before the cap, and that is not recoverable from a
 		// list the cap has already trimmed.

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -811,7 +811,18 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 		o.FuzzyVariants = result.Variants
 	}
 	var hits []search.Hit
-	if result.Tier == search.TierRelevance {
+	if result.Tier == search.TierError {
+		// A pasted error IS a match; ErrorHits keeps the ranking and the error
+		// neighbourhood the tier found. Re-scoring it as an ordinary run would
+		// zero it out — the word ladder already failed, which is why this tier
+		// fired at all.
+		fmt.Fprintln(os.Stderr, "deja: matched by error signature; showing the sessions that hit it")
+		hits = search.ErrorHits(ss)
+		o.Total, o.Capped = result.Total, result.Capped
+		if o.Total < len(hits) {
+			o.Total = len(hits)
+		}
+	} else if result.Tier == search.TierRelevance {
 		fmt.Fprintln(os.Stderr, "deja: no exact match; showing sessions ranked by relevance to the whole query")
 		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(o.Query))
 		// This tier ranks and truncates inside retrieval, so counting the

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -464,7 +464,9 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		o.FuzzyVariants = result.Variants
 	}
 	var hits []search.Hit
-	if result.Tier == search.TierRelevance {
+	if result.Tier == search.TierError {
+		hits = search.ErrorHits(ss)
+	} else if result.Tier == search.TierRelevance {
 		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(q))
 	} else if hits, err = search.Run(ss, o); err != nil {
 		return "", 0, 0, nil, err
@@ -514,6 +516,8 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		fmt.Fprintf(&b, "No exact match; using word forms: %s\n", strings.Join(fuzzySummary(result.Variants), ", "))
 	} else if result.Fuzzy {
 		fmt.Fprintf(&b, "No exact match; using close spellings: %s\n", strings.Join(fuzzySummary(result.Variants), ", "))
+	} else if result.Tier == search.TierError {
+		fmt.Fprintln(&b, "No exact match; these sessions hit the same error (matched by signature).")
 	} else if result.Tier == search.TierRelevance {
 		fmt.Fprintln(&b, "No exact match; sessions ranked by relevance to the whole query.")
 	}
@@ -617,7 +621,9 @@ func recallContextResult(dir, q, harness string) (string, int, int64, []string, 
 		o.FuzzyVariants = result.Variants
 	}
 	var hits []search.Hit
-	if result.Tier == search.TierRelevance {
+	if result.Tier == search.TierError {
+		hits = search.ErrorHits(ss)
+	} else if result.Tier == search.TierRelevance {
 		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(q))
 	} else if hits, err = search.Run(ss, o); err != nil {
 		return "", 0, 0, nil, err

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -24,10 +24,12 @@ could not tell which it had without inspecting the value. It now always returns
 the envelope, and the envelope answers the two questions a caller cannot answer
 from a list of hits:
 
-- `tier` — which tier answered: `exact`, `close`, `stemmed`, `semantic`, or
-  `relevance`. **`relevance` means nothing matched** and these are the nearest
-  sessions deja could find. Counting those as hits overstates recall, and this
-  used to be readable only as a sentence on stderr.
+- `tier` — which tier answered: `exact`, `close`, `stemmed`, `semantic`,
+  `error`, or `relevance`. **`relevance` means nothing matched** and these are
+  the nearest sessions deja could find. Counting those as hits overstates
+  recall, and this used to be readable only as a sentence on stderr. **`error`
+  IS a match** — the query was a pasted error and these sessions hit that exact
+  error (matched by signature, not by words); count them as hits.
 - `total` and `capped` — how many sessions matched, and whether a cap hid some.
 - `policy_withheld` — how many matching sessions this machine's trust policy
   kept out of the answer. Omitted when none were. Present on `search --json`,

--- a/internal/index/errorsearch.go
+++ b/internal/index/errorsearch.go
@@ -30,22 +30,41 @@ func errorSigSearch(dir string, m Manifest, o query.Options) (SearchResult, erro
 	if len(sigs) == 0 {
 		return SearchResult{}, nil
 	}
-	var metas []SessionMeta
+	type scored struct {
+		meta SessionMeta
+		hits int
+	}
+	var cand []scored
 	for _, meta := range m.Sessions {
 		if !sessionMetaMatches(meta, o) {
 			continue
 		}
+		hits := 0
 		for _, h := range meta.Hit {
 			if sigs[h] {
-				metas = append(metas, meta)
-				break
+				hits++
 			}
 		}
+		if hits > 0 {
+			cand = append(cand, scored{meta, hits})
+		}
 	}
-	if len(metas) == 0 {
+	if len(cand) == 0 {
 		return SearchResult{}, nil
 	}
-	sort.SliceStable(metas, func(i, j int) bool { return newestFirstMeta(metas[i], metas[j]) })
+	// Rank by how much of the paste a session hit, not by recency alone. A long
+	// trace carries several error lines; the session that tripped over more of
+	// them is the closer match, and newest-first only decided ties before this.
+	sort.SliceStable(cand, func(i, j int) bool {
+		if cand[i].hits != cand[j].hits {
+			return cand[i].hits > cand[j].hits
+		}
+		return newestFirstMeta(cand[i].meta, cand[j].meta)
+	})
+	metas := make([]SessionMeta, len(cand))
+	for i := range cand {
+		metas[i] = cand[i].meta
+	}
 	total := len(metas)
 	if len(metas) > relevanceWindow {
 		metas = metas[:relevanceWindow]
@@ -69,7 +88,11 @@ func errorSigSearch(dir string, m Manifest, o query.Options) (SearchResult, erro
 	if len(kept) == 0 {
 		return SearchResult{}, nil
 	}
-	return SearchResult{Sessions: kept, Tier: query.TierRelevance, Total: total}, nil
+	// relevanceResult sets Total and Capped together, so a store with more than
+	// the window's worth of sessions on one error says "showing N of M" instead
+	// of reporting the window as the whole (the #497 shape).
+	res := relevanceResult(kept, total)
+	return res, nil
 }
 
 // querySigs hashes every line of the query that names something specific that

--- a/internal/index/errorsearch.go
+++ b/internal/index/errorsearch.go
@@ -88,11 +88,17 @@ func errorSigSearch(dir string, m Manifest, o query.Options) (SearchResult, erro
 	if len(kept) == 0 {
 		return SearchResult{}, nil
 	}
-	// relevanceResult sets Total and Capped together, so a store with more than
-	// the window's worth of sessions on one error says "showing N of M" instead
-	// of reporting the window as the whole (the #497 shape).
-	res := relevanceResult(kept, total)
-	return res, nil
+	// Capped is about the window, not the neighbourhood filter. relevanceResult
+	// would set Capped = total > len(kept), but kept also shrinks when
+	// aroundErrorLines drops a session whose stored Hit hash no longer appears
+	// in its records — that is not the window hiding a retrievable session, so
+	// it must not read as "showing N of M". Cap only when the window trimmed.
+	return SearchResult{
+		Sessions: kept,
+		Tier:     query.TierRelevance,
+		Total:    total,
+		Capped:   total > relevanceWindow,
+	}, nil
 }
 
 // querySigs hashes every line of the query that names something specific that

--- a/internal/index/errorsearch.go
+++ b/internal/index/errorsearch.go
@@ -1,0 +1,119 @@
+package index
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// Searching a pasted error is the commonest thing anyone does with a memory
+// tool — "why is this broken" is 22.4% of user turns on a real 1165-session
+// store — and it is the case the lexical ladder is worst at. A stack trace is
+// not a question: it carries paths, line numbers, goroutine ids and a hash or
+// two, so an AND over its words matches nothing, and the relevance tier then
+// ranks by whichever of those words happen to be rare.
+//
+// The store already fingerprints errors: every session carries the hashes of
+// the specific lines it tripped over (SessionMeta.Hit, built for `deja
+// friction`). Matching on that hash finds the sessions that hit this error
+// even when not one word of the paste appears in them the same way.
+//
+// This runs after the exact/stem/fuzzy rungs and before relevance, so it never
+// takes a case the exact tier could answer.
+func errorSigSearch(dir string, m Manifest, o query.Options) (SearchResult, error) {
+	if o.Regex || strings.Contains(o.Query, "\"") {
+		return SearchResult{}, nil
+	}
+	sigs := querySigs(o.Query)
+	if len(sigs) == 0 {
+		return SearchResult{}, nil
+	}
+	var metas []SessionMeta
+	for _, meta := range m.Sessions {
+		if !sessionMetaMatches(meta, o) {
+			continue
+		}
+		for _, h := range meta.Hit {
+			if sigs[h] {
+				metas = append(metas, meta)
+				break
+			}
+		}
+	}
+	if len(metas) == 0 {
+		return SearchResult{}, nil
+	}
+	sort.SliceStable(metas, func(i, j int) bool { return newestFirstMeta(metas[i], metas[j]) })
+	total := len(metas)
+	if len(metas) > relevanceWindow {
+		metas = metas[:relevanceWindow]
+	}
+	ss, err := sessionsForMetas(dir, metas)
+	if err != nil {
+		return SearchResult{}, err
+	}
+	// The sessions come back whole, and what the caller needs is the part that
+	// hit this error: keep the records carrying the signature plus the two
+	// around each, the same neighbourhood rule the prompt hook uses.
+	for i := range ss {
+		ss[i].Messages = aroundErrorLines(ss[i].Messages, sigs)
+	}
+	kept := ss[:0]
+	for _, s := range ss {
+		if len(s.Messages) > 0 {
+			kept = append(kept, s)
+		}
+	}
+	if len(kept) == 0 {
+		return SearchResult{}, nil
+	}
+	return SearchResult{Sessions: kept, Tier: query.TierRelevance, Total: total}, nil
+}
+
+// querySigs hashes every line of the query that names something specific that
+// went wrong. A paste usually carries one; a long trace can carry several.
+func querySigs(q string) map[uint64]bool {
+	out := map[uint64]bool{}
+	for _, raw := range strings.Split(q, "\n") {
+		if line, ok := FrictionLine(raw); ok {
+			out[frictionHash(line)] = true
+		}
+	}
+	return out
+}
+
+// aroundErrorLines narrows a session to the messages that carry one of the
+// signatures, with two either side so the fix that followed is visible.
+func aroundErrorLines(ms []model.Message, sigs map[uint64]bool) []model.Message {
+	const window = 2
+	keep := map[int]bool{}
+	for i, m := range ms {
+		hit := false
+		for _, raw := range strings.Split(m.Text, "\n") {
+			if line, ok := FrictionLine(raw); ok && sigs[frictionHash(line)] {
+				hit = true
+				break
+			}
+		}
+		if !hit {
+			continue
+		}
+		for j := i - window; j <= i+window; j++ {
+			if j >= 0 && j < len(ms) {
+				keep[j] = true
+			}
+		}
+	}
+	if len(keep) == 0 {
+		return nil
+	}
+	out := make([]model.Message, 0, len(keep))
+	for i, m := range ms {
+		if keep[i] {
+			out = append(out, m)
+		}
+	}
+	return out
+}

--- a/internal/index/errorsearch.go
+++ b/internal/index/errorsearch.go
@@ -95,7 +95,7 @@ func errorSigSearch(dir string, m Manifest, o query.Options) (SearchResult, erro
 	// it must not read as "showing N of M". Cap only when the window trimmed.
 	return SearchResult{
 		Sessions: kept,
-		Tier:     query.TierRelevance,
+		Tier:     query.TierError,
 		Total:    total,
 		Capped:   total > relevanceWindow,
 	}, nil

--- a/internal/index/errorsearch_test.go
+++ b/internal/index/errorsearch_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/query"
@@ -113,5 +114,48 @@ func TestOrdinaryQuestionIsNotTreatedAsAnError(t *testing.T) {
 	}
 	if len(res.Sessions) != 0 {
 		t.Errorf("a question with no error line was answered by the error tier: %+v", res.Sessions)
+	}
+}
+
+// A long trace carries several error lines; the session that hit more of them
+// is the closer match, ahead of a fresher session that hit only one. And the
+// result reports Total/Capped honestly when more than the window matched.
+func TestErrorTierRanksByHowMuchOfThePasteMatched(t *testing.T) {
+	now := time.Now()
+	// "broad" hits two of the pasted error lines; "narrow" is newer but hits one.
+	broad := model.Session{
+		Harness: "claude", ID: "broad", Project: "p", Updated: now.Add(-time.Hour),
+		Messages: []model.Message{
+			{Role: "tool-output", Text: "panic: runtime error: invalid memory address"},
+			{Role: "tool-output", Text: "psql: connection refused on port 5432"},
+			{Role: "command", Text: "restarted postgres and added a nil guard"},
+		},
+	}
+	narrow := model.Session{
+		Harness: "claude", ID: "narrow", Project: "p", Updated: now,
+		Messages: []model.Message{
+			{Role: "tool-output", Text: "psql: connection refused on port 5432"},
+			{Role: "command", Text: "brew services start postgresql"},
+		},
+	}
+	dir := t.TempDir()
+	writeTestStore(t, dir, broad, narrow)
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paste := "panic: runtime error: invalid memory address\n...\npsql: connection refused on port 5432\n"
+	res, err := errorSigSearch(dir, m, mkOptions(paste))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sessions) < 2 {
+		t.Fatalf("both sessions should match, got %d", len(res.Sessions))
+	}
+	if res.Sessions[0].ID != "broad" {
+		t.Errorf("the session that hit more of the paste is not first: %q", res.Sessions[0].ID)
+	}
+	if res.Tier != query.TierRelevance {
+		t.Errorf("wrong tier %q", res.Tier)
 	}
 }

--- a/internal/index/errorsearch_test.go
+++ b/internal/index/errorsearch_test.go
@@ -155,7 +155,7 @@ func TestErrorTierRanksByHowMuchOfThePasteMatched(t *testing.T) {
 	if res.Sessions[0].ID != "broad" {
 		t.Errorf("the session that hit more of the paste is not first: %q", res.Sessions[0].ID)
 	}
-	if res.Tier != query.TierRelevance {
+	if res.Tier != query.TierError {
 		t.Errorf("wrong tier %q", res.Tier)
 	}
 }

--- a/internal/index/errorsearch_test.go
+++ b/internal/index/errorsearch_test.go
@@ -159,3 +159,57 @@ func TestErrorTierRanksByHowMuchOfThePasteMatched(t *testing.T) {
 		t.Errorf("wrong tier %q", res.Tier)
 	}
 }
+
+// Total/Capped must be honest: a pool bigger than the window says "showing N of
+// M" (Capped true, Total = full count); a small pool is not capped even when the
+// neighbourhood filter dropped a session (that is not the window hiding one).
+func TestErrorTierTotalAndCapped(t *testing.T) {
+	dir := t.TempDir()
+	// 60 sessions all hitting the same error line — more than relevanceWindow.
+	ss := make([]model.Session, 0, 60)
+	for i := 0; i < 60; i++ {
+		id := "s" + string(rune('A'+i/26)) + string(rune('a'+i%26))
+		ss = append(ss, model.Session{
+			Harness: "claude", ID: id, Project: "p",
+			Messages: []model.Message{
+				{Role: "tool-output", Text: "psql: connection refused on port 5432"},
+			},
+		})
+	}
+	writeTestStore(t, dir, ss...)
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := errorSigSearch(dir, m, mkOptions("psql: connection refused on port 5432"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Total != 60 {
+		t.Errorf("Total = %d, want 60 (the full match count, not the window)", res.Total)
+	}
+	if !res.Capped {
+		t.Error("a match pool larger than the window must report Capped")
+	}
+	if len(res.Sessions) > relevanceWindow {
+		t.Errorf("served %d sessions, past the window of %d", len(res.Sessions), relevanceWindow)
+	}
+
+	// A small pool is not capped.
+	dir2 := t.TempDir()
+	writeTestStore(t, dir2, model.Session{
+		Harness: "claude", ID: "one", Project: "p",
+		Messages: []model.Message{{Role: "tool-output", Text: "psql: connection refused on port 5432"}},
+	})
+	m2, err := readManifest(dir2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res2, err := errorSigSearch(dir2, m2, mkOptions("psql: connection refused on port 5432"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res2.Capped {
+		t.Errorf("a single-session match reported Capped: total=%d served=%d", res2.Total, len(res2.Sessions))
+	}
+}

--- a/internal/index/errorsearch_test.go
+++ b/internal/index/errorsearch_test.go
@@ -1,0 +1,117 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// writeTestStore builds a real index directory from sessions given in memory.
+func writeTestStore(t *testing.T, dir string, ss ...model.Session) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, ss, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mkOptions(q string) query.Options { return query.Options{Query: q, All: true} }
+
+// A pasted error carries paths, line numbers and goroutine ids, so an AND over
+// its words matches nothing and the word ladder falls through to ranking by
+// whichever token happens to be rare. The session that hit that exact error is
+// already fingerprinted; match on the fingerprint.
+func TestPastedErrorFindsTheSessionThatHitIt(t *testing.T) {
+	dir := t.TempDir()
+	hit := model.Session{
+		Harness: "claude", ID: "hit", Project: "p",
+		Messages: []model.Message{
+			{Role: "user", Text: "starting the worker"},
+			{Role: "tool-output", Text: "worker.py:41: ModuleNotFoundError: No module named 'aiokafka'"},
+			{Role: "command", Text: "uv pip install aiokafka"},
+		},
+	}
+	other := model.Session{
+		Harness: "claude", ID: "other", Project: "p",
+		Messages: []model.Message{
+			{Role: "user", Text: "unrelated work on the parser"},
+			{Role: "assistant", Text: "renamed the token stream"},
+		},
+	}
+	writeTestStore(t, dir, hit, other)
+
+	// The paste is not the stored line: different file, different line number,
+	// a traceback around it. Only the error itself is shared.
+	paste := "Traceback (most recent call last):\n" +
+		"  File \"/srv/app/main.py\", line 7, in <module>\n" +
+		"ModuleNotFoundError: No module named 'aiokafka'\n"
+	res, err := SearchDetailed(dir, mkOptions(paste))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sessions) == 0 {
+		t.Fatal("the pasted error found nothing")
+	}
+	if res.Sessions[0].ID != "hit" {
+		t.Errorf("wrong session first: %q", res.Sessions[0].ID)
+	}
+}
+
+// The tier serves the neighbourhood of the error rather than the error line
+// alone: what a reader needs is the command that came after it.
+func TestErrorTierCarriesWhatFollowedTheError(t *testing.T) {
+	dir := t.TempDir()
+	writeTestStore(t, dir, model.Session{
+		Harness: "claude", ID: "hit", Project: "p",
+		Messages: []model.Message{
+			{Role: "user", Text: "starting the worker"},
+			{Role: "tool-output", Text: "worker.py:41: ModuleNotFoundError: No module named 'aiokafka'"},
+			{Role: "command", Text: "uv pip install aiokafka"},
+		},
+	})
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := errorSigSearch(dir, m, mkOptions("ModuleNotFoundError: No module named 'aiokafka'"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(res.Sessions))
+	}
+	var text string
+	for _, msg := range res.Sessions[0].Messages {
+		text += msg.Text + "\n"
+	}
+	if !strings.Contains(text, "uv pip install aiokafka") {
+		t.Errorf("the recovery is not in the result:\n%s", text)
+	}
+}
+
+// An ordinary question must not be routed through the error tier: it has no
+// error line, so the tier stays silent and the word ladder keeps the case.
+func TestOrdinaryQuestionIsNotTreatedAsAnError(t *testing.T) {
+	dir := t.TempDir()
+	writeTestStore(t, dir, model.Session{
+		Harness: "claude", ID: "s", Project: "p",
+		Messages: []model.Message{{Role: "tool-output", Text: "worker.py:41: ModuleNotFoundError: No module named 'aiokafka'"}},
+	})
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := errorSigSearch(dir, m, mkOptions("how do we deploy the worker"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sessions) != 0 {
+		t.Errorf("a question with no error line was answered by the error tier: %+v", res.Sessions)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -157,6 +157,14 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 			} else if result.Fuzzy {
 				return result, nil
 			}
+			// A pasted error that matched no postings is the case the word
+			// ladder cannot win: its identifiers are line numbers and hashes.
+			// The friction hashes the store already keeps answer it exactly.
+			if result, ferr := errorSigSearch(dir, m, o); ferr != nil {
+				return SearchResult{}, fmt.Errorf("error signature: %w", ferr)
+			} else if len(result.Sessions) > 0 {
+				return result, nil
+			}
 			return relevanceSearch(dir, m, o)
 		}
 		ss, err := scanRecords(dir, m, o, nil)
@@ -180,6 +188,14 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 		}
 		if result, ferr := cooccurSearch(dir, m, o); ferr != nil {
 			return SearchResult{}, fmt.Errorf("cooccur postings: %w", ferr)
+		} else if len(result.Sessions) > 0 {
+			return result, nil
+		}
+		// A pasted error that matched no postings is the case the word
+		// ladder cannot win: its identifiers are line numbers and hashes.
+		// The friction hashes the store already keeps answer it exactly.
+		if result, ferr := errorSigSearch(dir, m, o); ferr != nil {
+			return SearchResult{}, fmt.Errorf("error signature: %w", ferr)
 		} else if len(result.Sessions) > 0 {
 			return result, nil
 		}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -80,6 +80,11 @@ const (
 	// exact ladder finds nothing — natural-language questions rarely survive
 	// an AND over every word.
 	TierRelevance = "relevance"
+	// TierError answers a pasted error by matching it against stored friction
+	// signatures. Unlike relevance, it IS a match — the sessions returned hit
+	// the exact error — so it is shown with the error neighbourhood as the
+	// snippet, not re-scored against the paste's words.
+	TierError = "error"
 )
 
 // QueryParts separates ordinary terms from quoted phrases without changing

--- a/internal/search/relevance_hits_test.go
+++ b/internal/search/relevance_hits_test.go
@@ -126,3 +126,30 @@ func TestSnippetCentresOnTheMatch(t *testing.T) {
 		t.Fatal("snippet for an absent term is empty")
 	}
 }
+
+// The error tier renders the neighbourhood it found as the snippet, without
+// re-scoring against the paste's words — a trace whose only shared token is a
+// goroutine id would otherwise show "0 matches" over the very session that hit
+// the error.
+func TestErrorHitsSnippetTheNeighbourhood(t *testing.T) {
+	ss := []model.Session{{
+		ID: "hit", Messages: []model.Message{
+			{Role: "tool-output", Text: "panic: runtime error: invalid memory address"},
+			{Role: "command", Text: "added a nil guard in worker.go"},
+		},
+	}}
+	hits := ErrorHits(ss)
+	if len(hits) != 1 {
+		t.Fatalf("hits = %d", len(hits))
+	}
+	if hits[0].Tier != TierError {
+		t.Errorf("tier = %q", hits[0].Tier)
+	}
+	if hits[0].Count == 0 || len(hits[0].Snippets) == 0 {
+		t.Fatalf("the neighbourhood was not snippeted: count=%d snips=%d", hits[0].Count, len(hits[0].Snippets))
+	}
+	joined := strings.Join(hits[0].Snippets, " ")
+	if !strings.Contains(joined, "nil guard") {
+		t.Errorf("the recovery is not in the snippet: %q", joined)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -39,6 +39,7 @@ const (
 	TierClose    = query.TierClose
 	TierSemantic = query.TierSemantic
 	TierStemmed  = "stemmed"
+	TierError    = query.TierError
 )
 
 func QueryParts(q string) (terms []string, phrases []string) { return query.QueryParts(q) }
@@ -1269,6 +1270,29 @@ func contextText(s string, matched bool) string {
 
 // TierRelevance mirrors query.TierRelevance for callers of this package.
 const TierRelevance = query.TierRelevance
+
+// ErrorHits renders the error-signature tier. The sessions arrive already
+// ranked and already narrowed to the neighbourhood of the pasted error, so
+// each becomes one hit whose snippets are those messages — re-scoring them
+// against the paste's words (as the relevance tier would) throws away the
+// passage the tier found and can render a real match as "0 matches".
+func ErrorHits(ss []model.Session) []Hit {
+	hits := make([]Hit, 0, len(ss))
+	for rank, s := range ss {
+		hit := Hit{Session: s, Tier: TierError, Count: len(s.Messages), Score: float64(len(ss) - rank)}
+		for _, m := range s.Messages {
+			if strings.TrimSpace(m.Text) == "" {
+				continue
+			}
+			hit.Snippets = append(hit.Snippets, snippet(m.Text, "", nil))
+			if len(hit.Snippets) == 2 {
+				break
+			}
+		}
+		hits = append(hits, hit)
+	}
+	return hits
+}
 
 // RelevanceHits wraps relevance-ranked sessions as hits WITHOUT re-scoring:
 // the index already ordered them by IDF overlap, and exact-match BM25 (which

--- a/scripts/longmemeval/main.go
+++ b/scripts/longmemeval/main.go
@@ -270,7 +270,9 @@ func runQuestion(q lmeQuestion) (int, questionDetail, time.Duration, error) {
 	// Exactly the CLI/MCP code path: search.Run for exact/stem/fuzzy tiers,
 	// order-preserving RelevanceHits when the ladder degraded to relevance.
 	var hits []search.Hit
-	if result.Tier == search.TierRelevance {
+	if result.Tier == search.TierError {
+		hits = search.ErrorHits(result.Sessions)
+	} else if result.Tier == search.TierRelevance {
 		hits = search.RelevanceHits(result.Sessions, index.RelevanceTerms(q.Question))
 	} else if hits, err = search.Run(result.Sessions, o); err != nil {
 		return 0, questionDetail{}, 0, err


### PR DESCRIPTION
- **feat(search): a pasted error is matched by its signature, not its words**
- **fix(search): rank the error tier by match count and report Total honestly**
- **fix(search): the error tier caps on the window, not the neighbourhood filter**
- **fix(search): the error tier renders the error neighbourhood, not 0 matches**
- **fix(search): cmdSearch renders the error tier too, not just ctx**
