### PR TITLE
feat/hits say when something was reverted

### DIFF
--- a/cmd/deja/giveup_surface_test.go
+++ b/cmd/deja/giveup_surface_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A session that ended in a dead end used to arrive looking exactly like one
+// that ended in an answer: the state that says otherwise is set by hand, and on
+// a real store of 1160 sessions nothing carried it. The transcript says it in
+// words, so the hit says it too — end to end, through indexing and search.
+func TestSearchSaysWhenASessionBackedSomethingOut(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "p", "dead-end.jsonl"), "dead-end", []string{
+		`{"type":"user","sessionId":"dead-end","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"cap the webhook retries at three"}}`,
+		`{"type":"assistant","sessionId":"dead-end","timestamp":"2026-01-02T03:05:05Z","message":{"role":"assistant","content":[{"type":"text","text":"capped them, then reverted the cap because the queue backed up"}]}}`,
+	})
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "p", "held.jsonl"), "held", []string{
+		`{"type":"user","sessionId":"held","timestamp":"2026-01-03T03:04:05Z","message":{"role":"user","content":"what happened with the webhook queue"}}`,
+		`{"type":"assistant","sessionId":"held","timestamp":"2026-01-03T03:05:05Z","message":{"role":"assistant","content":[{"type":"text","text":"the webhook queue drains fine since the batch size went up"}]}}`,
+	})
+	out, err := captureRun(t, "webhook")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "reports backing something out") {
+		t.Errorf("the session that reverted its own change is served without a word about it:\n%s", out)
+	}
+	// And the session that reached an answer is not labelled with someone
+	// else's dead end.
+	if strings.Count(out, "reports backing something out") != 1 {
+		t.Errorf("the marker landed on more than the session that earned it:\n%s", out)
+	}
+}

--- a/cmd/deja/giveup_surface_test.go
+++ b/cmd/deja/giveup_surface_test.go
@@ -26,12 +26,12 @@ func TestSearchSaysWhenASessionBackedSomethingOut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, "reports backing something out") {
+	if !strings.Contains(out, "mentions backing an approach out") {
 		t.Errorf("the session that reverted its own change is served without a word about it:\n%s", out)
 	}
 	// And the session that reached an answer is not labelled with someone
 	// else's dead end.
-	if strings.Count(out, "reports backing something out") != 1 {
+	if strings.Count(out, "mentions backing an approach out") != 1 {
 		t.Errorf("the marker landed on more than the session that earned it:\n%s", out)
 	}
 }

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -544,13 +544,14 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		if line := lifecycleLine(h); line != "" {
 			fmt.Fprintf(&b, "%s\n", line)
 		}
-		// A session that says it backed something out is the one result an
-		// agent must not follow to the letter, and nothing said so: the
-		// lifecycle states carry that meaning but are set by hand, and on a
-		// real store of 1160 sessions not one carried "rejected". The
-		// transcript said it in words instead.
+		// A session that says it backed an approach out carries a signal the
+		// lifecycle states would carry if anyone set them by hand — on a real
+		// 1160-session store not one did. The wording tells the agent an
+		// approach inside was abandoned, not that the whole session is a dead
+		// end: the tried-then-fixed session is the most useful one, and the
+		// excerpts show which path was dropped.
 		if h.Session.GaveUp && h.Lifecycle == "" {
-			fmt.Fprintln(&b, "[this session reports backing something out — read the excerpts before reusing it]")
+			fmt.Fprintln(&b, "[this session abandoned one approach partway — check the excerpts for which, the rest may still hold]")
 		}
 		if h.Superseded != "" {
 			fmt.Fprintf(&b, "[earlier attempt — a newer session in this project covers the same ground, updated %s]\n", h.Superseded)

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -544,6 +544,14 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		if line := lifecycleLine(h); line != "" {
 			fmt.Fprintf(&b, "%s\n", line)
 		}
+		// A session that says it backed something out is the one result an
+		// agent must not follow to the letter, and nothing said so: the
+		// lifecycle states carry that meaning but are set by hand, and on a
+		// real store of 1160 sessions not one carried "rejected". The
+		// transcript said it in words instead.
+		if h.Session.GaveUp && h.Lifecycle == "" {
+			fmt.Fprintln(&b, "[this session reports backing something out — read the excerpts before reusing it]")
+		}
 		if h.Superseded != "" {
 			fmt.Fprintf(&b, "[earlier attempt — a newer session in this project covers the same ground, updated %s]\n", h.Superseded)
 		}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -137,6 +137,7 @@ when empty:
 | `title` | first user turn, elided to terminal width |
 | `agent_title` | `title` came from the assistant because the session has no user turn |
 | `touched` | the few files this session worked on most |
+| `gave_up` | the session's own text reports something being tried and backed out |
 | `orig_id` | id this session had on the machine it was imported from |
 | `lifecycle` | state of an imported promoted note: `accepted`, `rejected`, `superseded` or `stale` |
 | `lifecycle_note` | the note left with that state |

--- a/internal/index/blame_import_touched_test.go
+++ b/internal/index/blame_import_touched_test.go
@@ -63,3 +63,64 @@ func TestImportPopulatesTouchedForBlame(t *testing.T) {
 		t.Fatalf("imported session Touched=%v does not include /repo/auth.go — blame cannot attribute the peer's edit", found.Touched)
 	}
 }
+
+// A reversal reported in an earlier import batch must survive a later batch
+// that does not repeat it: import is incremental, so GaveUp unions with the
+// row like Touched/Asked/Hit do, rather than being cleared by a quiet batch.
+func TestImportGaveUpSurvivesALaterBatch(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	shared := filepath.Join(tmp, "shared")
+	if err := os.MkdirAll(shared, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(shared, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gaveUpOf := func() bool {
+		metas, err := AllMeta(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range metas {
+			if metas[i].OrigID == "peer2" || metas[i].Project == "imported:svc2" {
+				return metas[i].GaveUp
+			}
+		}
+		t.Fatal("imported session not found")
+		return false
+	}
+
+	t0 := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	write("deja-sync-a.jsonl",
+		`{"harness":"claude","session_id":"peer2","project":"svc2","role":"assistant","text":"reverted the retry cap, it made the queue worse","time":"`+t0+`"}`+"\n")
+	if _, err := Import(dir, shared); err != nil {
+		t.Fatal(err)
+	}
+	if !gaveUpOf() {
+		t.Fatal("the reversal reported in the first batch was not marked")
+	}
+
+	// A later batch with more of the same session but no reversal line.
+	t1 := time.Date(2026, 7, 20, 11, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	if err := os.Remove(filepath.Join(shared, "deja-sync-a.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+	write("deja-sync-b.jsonl",
+		`{"harness":"claude","session_id":"peer2","project":"svc2","role":"assistant","text":"added a metric for the queue depth","time":"`+t1+`"}`+"\n")
+	if _, err := Import(dir, shared); err != nil {
+		t.Fatal(err)
+	}
+	if !gaveUpOf() {
+		t.Error("a later quiet batch cleared the reversal mark from an earlier one")
+	}
+}

--- a/internal/index/giveup.go
+++ b/internal/index/giveup.go
@@ -88,6 +88,7 @@ func GiveUpLine(l string) (string, bool) {
 		}
 	}
 	low := strings.ToLower(l)
+	lineIsQuestion := strings.HasSuffix(strings.TrimSpace(low), "?")
 	for _, p := range giveUpPhrases {
 		i := strings.Index(low, p)
 		if i < 0 {
@@ -95,9 +96,10 @@ func GiveUpLine(l string) (string, bool) {
 		}
 		// A reflexive Russian verb is a thing rolling by itself, not someone
 		// rolling a change back: "откатил" is a substring of "откатился" ("the
-		// ball rolled under the couch"). The "-ся"/"-сь" suffix is the tell.
-		rest := low[i+len(p):]
-		if strings.HasPrefix(rest, "ся") || strings.HasPrefix(rest, "сь") {
+		// ball rolled under the couch"). The reflexive particle "-ся"/"-сь"
+		// comes after the gender/number vowel — откатил·ся, откатил·а·сь,
+		// откатил·о·сь, откатил·и·сь — so check for it with the vowel optional.
+		if reflexiveSuffix(low[i+len(p):]) {
 			continue
 		}
 		clause := reversalClause(low, i, len(p))
@@ -107,7 +109,7 @@ func GiveUpLine(l string) (string, bool) {
 		// reverting tomorrow"), and a bare question ("should we have reverted
 		// this?") all describe a reversal that was considered, refused, or is
 		// still ahead — not one that was done.
-		if clauseNegatesOrDefers(clause, p) {
+		if clauseNegatesOrDefers(clause, p, lineIsQuestion) {
 			continue
 		}
 		return l, true
@@ -137,37 +139,53 @@ func reversalClause(low string, phraseAt, phraseLen int) string {
 	return low[start:end]
 }
 
-// clauseNegatesOrDefers reports whether the clause holding the reversal phrase
-// says the reversal did not happen: a negator anywhere in the clause, a
-// conditional/future frame, or the clause being the interrogative one (it and
-// the "?" that ends the line are the same clause).
-func clauseNegatesOrDefers(clause, phrase string) bool {
-	for _, neg := range []string{
-		"not ", "n't ", "never ", "without ", "avoid ",
-		"не ", "нельзя ", "без ",
-	} {
-		if strings.Contains(clause, neg) && strings.Index(clause, neg) < strings.Index(clause, phrase) {
+// reflexiveSuffix reports whether the text right after a Russian reversal verb
+// is a reflexive particle — with the gender/number vowel that precedes it in
+// the past tense optional: ся, сь, ась, ось, ись, ялись, and so on.
+func reflexiveSuffix(rest string) bool {
+	for _, s := range []string{"ся", "сь", "ась", "ось", "ись", "лся", "лась", "лось", "лись"} {
+		if strings.HasPrefix(rest, s) {
 			return true
 		}
 	}
-	for _, defer_ := range []string{
+	return false
+}
+
+// clauseNegatesOrDefers reports whether the clause holding the reversal phrase
+// says the reversal did not happen: a negator or a conditional/future modal
+// that governs the phrase (both must sit BEFORE it — "if we roll it back", not
+// "reverted it since it would break"), or the clause being interrogative.
+func clauseNegatesOrDefers(clause, phrase string, lineIsQuestion bool) bool {
+	pi := strings.Index(clause, phrase)
+	// A negator or modal only governs the reversal when it comes before it. A
+	// modal after the phrase belongs to a different verb — "reverted it since
+	// it would corrupt state" is a report, not a hypothetical.
+	for _, w := range []string{
+		"not ", "n't ", "never ", "without ", "avoid ",
 		"if ", "would ", "could ", "should ", "might ", "planning to ",
-		"going to ", "i'll ", "we'll ", "will ", "если ", "надо ли ", "стоит ли ",
+		"going to ", "i'll ", "we'll ", "will ",
+		"не ", "нельзя ", "без ", "если ", "надо ли ", "стоит ли ",
 	} {
-		if strings.Contains(clause, defer_) {
+		if j := strings.Index(clause, w); j >= 0 && j < pi {
 			return true
 		}
 	}
 	// The clause itself is the question — "did we roll it back, or is it still
-	// live?" — even when the "?" lands in a later clause. An interrogative lead
-	// is the tell; a declarative report ("откатили, но не помогло") has none.
+	// live?" — even when the "?" lands in a later clause. Strong question words
+	// only ever lead a question; the copulas (is/was/are/were) also lead a
+	// passive report ("was rolled back after review"), so those reject only
+	// when the line actually ends in "?".
 	c := strings.TrimSpace(clause)
-	for _, q := range []string{
-		"did ", "do ", "does ", "is ", "are ", "was ", "were ", "can ",
-		"why ", "what ", "how ", "when ", "whether ",
-	} {
+	for _, q := range []string{"did ", "do ", "does ", "why ", "what ", "how ", "when ", "whether ", "can "} {
 		if strings.HasPrefix(c, q) {
 			return true
+		}
+	}
+	if lineIsQuestion {
+		for _, q := range []string{"is ", "are ", "was ", "were "} {
+			if strings.HasPrefix(c, q) {
+				return true
+			}
 		}
 	}
 	return strings.HasSuffix(c, "?")

--- a/internal/index/giveup.go
+++ b/internal/index/giveup.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/model"
 )
@@ -48,29 +49,67 @@ var giveUpPhrases = []string{
 // GiveUpLine reports whether a line says an approach was tried and dropped.
 func GiveUpLine(l string) (string, bool) {
 	l = strings.TrimSpace(l)
-	if len(l) < giveUpLineMin || len(l) > giveUpLineMax {
+	// Length in runes, not bytes: a byte budget gives Cyrillic half the room,
+	// so a Russian report of a rollback was rejected as too long at 150 bytes
+	// (75 characters) and the 12-byte floor was only six Cyrillic characters.
+	if n := utf8.RuneCountInString(l); n < giveUpLineMin || n > giveUpLineMax {
 		return l, false
 	}
-	// Source, not speech: a string literal, a comment or a diff line that
-	// contains the words is code about reverting, not a report of one.
-	for _, source := range []string{"\"", "$(", "=~", "print(", "//", "#", "/*"} {
-		if strings.HasPrefix(l, source) || strings.Contains(l, source) {
+	// Source, not speech: a line that IS code — a comment, a string literal, a
+	// diff line — is talking about reverting, not reporting it. But the marker
+	// only ever runs on user/assistant prose, and real prose carries quotes,
+	// issue refs and URLs ("reverted the change from #1143", "rolled back after
+	// reading github.com/x/y//issues"). So reject a line that BEGINS like code,
+	// not any line that merely contains a quote or a slash somewhere.
+	for _, prefix := range []string{"//", "#", "/*", "*", "--", "-- ", ">", "|"} {
+		if strings.HasPrefix(l, prefix) {
+			return l, false
+		}
+	}
+	// A function call with a string argument is code, wherever it sits:
+	// `log.Printf("reverted %s", name)`. `("` is the call-with-string shape and
+	// does not appear in prose, whereas a bare quote (`reverted the "fast path"`)
+	// does — so this rejects the code without rejecting the report.
+	for _, code := range []string{"(\"", "('", "=~", "println", "printf(", "system("} {
+		if strings.Contains(l, code) {
 			return l, false
 		}
 	}
 	low := strings.ToLower(l)
-	// A question is not a report. "should we revert this?" is the moment
-	// before the decision, and marking it would put the label on the session
-	// that considered reverting rather than the one that did.
-	if strings.HasSuffix(low, "?") {
-		return l, false
-	}
+	// A pure question is the moment before the decision, not the decision:
+	// "should we revert this?" must not mark the session that only considered
+	// it. But a report that ends with a follow-up question is still a report —
+	// "откатили, но не помогло, что дальше?" — so only reject a line that is
+	// nothing but a question: it ends in "?" and no reversal phrase precedes.
+	isQuestion := strings.HasSuffix(strings.TrimSpace(low), "?")
 	for _, p := range giveUpPhrases {
 		if strings.Contains(low, p) {
+			if isQuestion && phraseInQuestionClause(low, p) {
+				return l, false
+			}
 			return l, true
 		}
 	}
 	return l, false
+}
+
+// phraseInQuestionClause reports whether the reversal phrase shares the final
+// interrogative clause with the trailing "?" — "should we have reverted this?"
+// — rather than sitting in a statement before it — "откатили, но не помогло,
+// что дальше?". The test is whether any sentence boundary separates the phrase
+// from the question mark: none means the phrase is part of the question.
+func phraseInQuestionClause(low, phrase string) bool {
+	i := strings.Index(low, phrase)
+	if i < 0 {
+		return true
+	}
+	tail := low[i+len(phrase):]
+	for _, sep := range []string{". ", "! ", "? ", "— ", " - ", ", ", "; "} {
+		if strings.Contains(tail, sep) {
+			return false
+		}
+	}
+	return true
 }
 
 // gaveUpFromRecords is gaveUp for the import path, which holds a session as

--- a/internal/index/giveup.go
+++ b/internal/index/giveup.go
@@ -1,0 +1,101 @@
+package index
+
+import (
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A rejected approach is the most expensive thing a store can forget: the next
+// session re-implements it, tests it, watches it fail and reverts it again —
+// call it ten thousand tokens. deja already models the state (`promote --state
+// rejected`), and on a real store of 1160 sessions the count of sessions
+// carrying it is zero, because it is set by hand and nobody sets it by hand.
+//
+// The evidence is there in the transcripts regardless: on that same store, 557
+// records across 33 sessions say in so many words that something was reverted,
+// did not work, or was given up on. This detects those statements at ingest so
+// a hit can carry the fact. It says nothing about which approach was dropped —
+// that is what the excerpts are for — and it is not a lifecycle state: a state
+// is the user's own judgement, and this is only what the transcript reports.
+const (
+	giveUpLineMin = 12
+	giveUpLineMax = 300
+)
+
+// giveUpPhrases are the ways people say they backed something out. Kept
+// narrow: "failed" and "broken" describe the world, not a decision about it,
+// and matching them would mark most sessions in any store.
+var giveUpPhrases = []string{
+	// English.
+	"reverted", "rolled back", "rolling back", "backed out", "back it out",
+	"gave up on", "giving up on", "abandoned that", "abandoned this",
+	"dropped that approach", "scrap that", "did not work", "didn't work",
+	"does not work", "doesn't work", "that approach failed", "undid the",
+	// Russian.
+	"откатил", "откатили", "откатываю", "вернул как было", "вернули как было",
+	"не сработал", "не заработал", "не помогло", "не получилось",
+	"отказались от", "отбросил", "отменил изменен",
+}
+
+// GiveUpLine reports whether a line says an approach was tried and dropped.
+func GiveUpLine(l string) (string, bool) {
+	l = strings.TrimSpace(l)
+	if len(l) < giveUpLineMin || len(l) > giveUpLineMax {
+		return l, false
+	}
+	// Source, not speech: a string literal, a comment or a diff line that
+	// contains the words is code about reverting, not a report of one.
+	for _, source := range []string{"\"", "$(", "=~", "print(", "//", "#", "/*"} {
+		if strings.HasPrefix(l, source) || strings.Contains(l, source) {
+			return l, false
+		}
+	}
+	low := strings.ToLower(l)
+	// A question is not a report. "should we revert this?" is the moment
+	// before the decision, and marking it would put the label on the session
+	// that considered reverting rather than the one that did.
+	if strings.HasSuffix(low, "?") {
+		return l, false
+	}
+	for _, p := range giveUpPhrases {
+		if strings.Contains(low, p) {
+			return l, true
+		}
+	}
+	return l, false
+}
+
+// gaveUpFromRecords is gaveUp for the import path, which holds a session as
+// records rather than as messages.
+func gaveUpFromRecords(recs []Record) bool {
+	for _, r := range recs {
+		if r.Role != "user" && r.Role != "assistant" {
+			continue
+		}
+		for _, line := range strings.Split(r.Text, "\n") {
+			if _, ok := GiveUpLine(line); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// gaveUp reports whether a session says, somewhere in what was actually said,
+// that something was tried and dropped. Only speech counts: tool output is
+// full of the word "reverted" from git itself, and a command someone ran is
+// not a statement about how it went.
+func gaveUp(ms []model.Message) bool {
+	for _, m := range ms {
+		if m.Role != "user" && m.Role != "assistant" {
+			continue
+		}
+		for _, line := range strings.Split(m.Text, "\n") {
+			if _, ok := GiveUpLine(line); ok {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/index/giveup.go
+++ b/internal/index/giveup.go
@@ -55,13 +55,23 @@ func GiveUpLine(l string) (string, bool) {
 	if n := utf8.RuneCountInString(l); n < giveUpLineMin || n > giveUpLineMax {
 		return l, false
 	}
+	// An assistant states a reversal inside a bulleted or quoted summary as
+	// often as in a sentence ("* reverted the caching layer, it broke
+	// ordering"). Strip a leading list or quote marker so the report inside is
+	// still read, before the code-shape checks below.
+	for _, bullet := range []string{"* ", "> ", "- ", "+ "} {
+		if strings.HasPrefix(l, bullet) {
+			l = strings.TrimSpace(l[len(bullet):])
+			break
+		}
+	}
 	// Source, not speech: a line that IS code — a comment, a string literal, a
 	// diff line — is talking about reverting, not reporting it. But the marker
 	// only ever runs on user/assistant prose, and real prose carries quotes,
 	// issue refs and URLs ("reverted the change from #1143", "rolled back after
 	// reading github.com/x/y//issues"). So reject a line that BEGINS like code,
 	// not any line that merely contains a quote or a slash somewhere.
-	for _, prefix := range []string{"//", "#", "/*", "*", "--", "-- ", ">", "|"} {
+	for _, prefix := range []string{"//", "#", "/*", "--", "-- ", "|"} {
 		if strings.HasPrefix(l, prefix) {
 			return l, false
 		}
@@ -76,40 +86,89 @@ func GiveUpLine(l string) (string, bool) {
 		}
 	}
 	low := strings.ToLower(l)
-	// A pure question is the moment before the decision, not the decision:
-	// "should we revert this?" must not mark the session that only considered
-	// it. But a report that ends with a follow-up question is still a report —
-	// "откатили, но не помогло, что дальше?" — so only reject a line that is
-	// nothing but a question: it ends in "?" and no reversal phrase precedes.
-	isQuestion := strings.HasSuffix(strings.TrimSpace(low), "?")
 	for _, p := range giveUpPhrases {
-		if strings.Contains(low, p) {
-			if isQuestion && phraseInQuestionClause(low, p) {
-				return l, false
-			}
-			return l, true
+		i := strings.Index(low, p)
+		if i < 0 {
+			continue
 		}
+		// A reflexive Russian verb is a thing rolling by itself, not someone
+		// rolling a change back: "откатил" is a substring of "откатился" ("the
+		// ball rolled under the couch"). The "-ся"/"-сь" suffix is the tell.
+		rest := low[i+len(p):]
+		if strings.HasPrefix(rest, "ся") || strings.HasPrefix(rest, "сь") {
+			continue
+		}
+		clause := reversalClause(low, i, len(p))
+		// A reversal that did not happen is not a report. Negation ("we
+		// haven't reverted", "never gave up on", "не откатывать"), a
+		// conditional or future ("if it fails we roll it back", "I'll be
+		// reverting tomorrow"), and a bare question ("should we have reverted
+		// this?") all describe a reversal that was considered, refused, or is
+		// still ahead — not one that was done.
+		if clauseNegatesOrDefers(clause, p) {
+			continue
+		}
+		return l, true
 	}
 	return l, false
 }
 
-// phraseInQuestionClause reports whether the reversal phrase shares the final
-// interrogative clause with the trailing "?" — "should we have reverted this?"
-// — rather than sitting in a statement before it — "откатили, но не помогло,
-// что дальше?". The test is whether any sentence boundary separates the phrase
-// from the question mark: none means the phrase is part of the question.
-func phraseInQuestionClause(low, phrase string) bool {
-	i := strings.Index(low, phrase)
-	if i < 0 {
-		return true
-	}
-	tail := low[i+len(phrase):]
-	for _, sep := range []string{". ", "! ", "? ", "— ", " - ", ", ", "; "} {
-		if strings.Contains(tail, sep) {
-			return false
+// reversalClause returns the sentence the phrase sits in, lowercased: from the
+// separator before it to the separator after. The verdict — did this reversal
+// happen — is a property of the clause, not the whole line, so a report in one
+// sentence is not overruled by a question in the next.
+func reversalClause(low string, phraseAt, phraseLen int) string {
+	seps := []string{". ", "! ", "? ", "; ", "— ", " - ", ", "}
+	start := 0
+	for _, sep := range seps {
+		if j := strings.LastIndex(low[:phraseAt], sep); j >= 0 && j+len(sep) > start {
+			start = j + len(sep)
 		}
 	}
-	return true
+	end := len(low)
+	after := phraseAt + phraseLen
+	for _, sep := range seps {
+		if j := strings.Index(low[after:], sep); j >= 0 && after+j < end {
+			end = after + j
+		}
+	}
+	return low[start:end]
+}
+
+// clauseNegatesOrDefers reports whether the clause holding the reversal phrase
+// says the reversal did not happen: a negator anywhere in the clause, a
+// conditional/future frame, or the clause being the interrogative one (it and
+// the "?" that ends the line are the same clause).
+func clauseNegatesOrDefers(clause, phrase string) bool {
+	for _, neg := range []string{
+		"not ", "n't ", "never ", "without ", "avoid ",
+		"не ", "нельзя ", "без ",
+	} {
+		if strings.Contains(clause, neg) && strings.Index(clause, neg) < strings.Index(clause, phrase) {
+			return true
+		}
+	}
+	for _, defer_ := range []string{
+		"if ", "would ", "could ", "should ", "might ", "planning to ",
+		"going to ", "i'll ", "we'll ", "will ", "если ", "надо ли ", "стоит ли ",
+	} {
+		if strings.Contains(clause, defer_) {
+			return true
+		}
+	}
+	// The clause itself is the question — "did we roll it back, or is it still
+	// live?" — even when the "?" lands in a later clause. An interrogative lead
+	// is the tell; a declarative report ("откатили, но не помогло") has none.
+	c := strings.TrimSpace(clause)
+	for _, q := range []string{
+		"did ", "do ", "does ", "is ", "are ", "was ", "were ", "can ",
+		"why ", "what ", "how ", "when ", "whether ",
+	} {
+		if strings.HasPrefix(c, q) {
+			return true
+		}
+	}
+	return strings.HasSuffix(c, "?")
 }
 
 // gaveUpFromRecords is gaveUp for the import path, which holds a session as

--- a/internal/index/giveup.go
+++ b/internal/index/giveup.go
@@ -88,7 +88,6 @@ func GiveUpLine(l string) (string, bool) {
 		}
 	}
 	low := strings.ToLower(l)
-	lineIsQuestion := strings.HasSuffix(strings.TrimSpace(low), "?")
 	for _, p := range giveUpPhrases {
 		i := strings.Index(low, p)
 		if i < 0 {
@@ -109,7 +108,7 @@ func GiveUpLine(l string) (string, bool) {
 		// reverting tomorrow"), and a bare question ("should we have reverted
 		// this?") all describe a reversal that was considered, refused, or is
 		// still ahead — not one that was done.
-		if clauseNegatesOrDefers(clause, p, lineIsQuestion) {
+		if clauseNegatesOrDefers(clause, p) {
 			continue
 		}
 		return l, true
@@ -155,7 +154,7 @@ func reflexiveSuffix(rest string) bool {
 // says the reversal did not happen: a negator or a conditional/future modal
 // that governs the phrase (both must sit BEFORE it — "if we roll it back", not
 // "reverted it since it would break"), or the clause being interrogative.
-func clauseNegatesOrDefers(clause, phrase string, lineIsQuestion bool) bool {
+func clauseNegatesOrDefers(clause, phrase string) bool {
 	pi := strings.Index(clause, phrase)
 	// A negator or modal only governs the reversal when it comes before it. A
 	// modal after the phrase belongs to a different verb — "reverted it since
@@ -172,20 +171,20 @@ func clauseNegatesOrDefers(clause, phrase string, lineIsQuestion bool) bool {
 	}
 	// The clause itself is the question — "did we roll it back, or is it still
 	// live?" — even when the "?" lands in a later clause. Strong question words
-	// only ever lead a question; the copulas (is/was/are/were) also lead a
-	// passive report ("was rolled back after review"), so those reject only
-	// when the line actually ends in "?".
+	// only ever lead a question.
 	c := strings.TrimSpace(clause)
 	for _, q := range []string{"did ", "do ", "does ", "why ", "what ", "how ", "when ", "whether ", "can "} {
 		if strings.HasPrefix(c, q) {
 			return true
 		}
 	}
-	if lineIsQuestion {
-		for _, q := range []string{"is ", "are ", "was ", "were "} {
-			if strings.HasPrefix(c, q) {
-				return true
-			}
+	// A copula (is/was/are/were) leads both a passive report ("was rolled back
+	// after review") and a question ("was that rolled back"). The tell is what
+	// follows it: a passive report puts the reversal phrase straight after the
+	// copula, a question inserts a subject ("that", "this", "those") first.
+	for _, cop := range []string{"is ", "are ", "was ", "were "} {
+		if strings.HasPrefix(c, cop) && !strings.HasPrefix(c, cop+phrase) {
+			return true
 		}
 	}
 	return strings.HasSuffix(c, "?")

--- a/internal/index/giveup.go
+++ b/internal/index/giveup.go
@@ -58,8 +58,10 @@ func GiveUpLine(l string) (string, bool) {
 	// An assistant states a reversal inside a bulleted or quoted summary as
 	// often as in a sentence ("* reverted the caching layer, it broke
 	// ordering"). Strip a leading list or quote marker so the report inside is
-	// still read, before the code-shape checks below.
-	for _, bullet := range []string{"* ", "> ", "- ", "+ "} {
+	// still read. Only "* " and "> ", which are unambiguous — "- " and "+ " are
+	// also diff markers, and a removed line "- reverted the old code" is not a
+	// report of anyone reverting anything.
+	for _, bullet := range []string{"* ", "> "} {
 		if strings.HasPrefix(l, bullet) {
 			l = strings.TrimSpace(l[len(bullet):])
 			break
@@ -71,7 +73,7 @@ func GiveUpLine(l string) (string, bool) {
 	// issue refs and URLs ("reverted the change from #1143", "rolled back after
 	// reading github.com/x/y//issues"). So reject a line that BEGINS like code,
 	// not any line that merely contains a quote or a slash somewhere.
-	for _, prefix := range []string{"//", "#", "/*", "--", "-- ", "|"} {
+	for _, prefix := range []string{"//", "#", "/*", "--", "- ", "+ ", "|"} {
 		if strings.HasPrefix(l, prefix) {
 			return l, false
 		}

--- a/internal/index/giveup.go
+++ b/internal/index/giveup.go
@@ -12,30 +12,37 @@ import (
 // rejected`), and on a real store of 1160 sessions the count of sessions
 // carrying it is zero, because it is set by hand and nobody sets it by hand.
 //
-// The evidence is there in the transcripts regardless: on that same store, 557
-// records across 33 sessions say in so many words that something was reverted,
-// did not work, or was given up on. This detects those statements at ingest so
-// a hit can carry the fact. It says nothing about which approach was dropped —
-// that is what the excerpts are for — and it is not a lifecycle state: a state
-// is the user's own judgement, and this is only what the transcript reports.
+// The evidence is there in the transcripts regardless: people say in so many
+// words that they reverted, rolled back, or gave up on an approach. This
+// detects that class of statement at ingest — a reversal, not a description of
+// failure — so a hit can carry the fact. On a real 1165-session store it marks
+// about 2% of sessions. It says nothing about which approach was dropped — that
+// is what the excerpts are for — and it is not a lifecycle state: a state is
+// the user's own judgement, and this is only what the transcript reports.
 const (
 	giveUpLineMin = 12
 	giveUpLineMax = 300
 )
 
-// giveUpPhrases are the ways people say they backed something out. Kept
-// narrow: "failed" and "broken" describe the world, not a decision about it,
-// and matching them would mark most sessions in any store.
+// giveUpPhrases are the ways people say they backed something out. Kept to
+// reports of a reversal — the decision to undo — and deliberately not to
+// descriptions of failure. "didn't work", "does not work", "failed", "broken"
+// are how nearly every debugging session opens ("the retry doesn't work when
+// the queue is full") and how an assistant hedges ("if that doesn't work, we
+// can add an index"); matching them marked half of ordinary sessions as dead
+// ends. A reversal is a narrower, verifiable event: something was in, and was
+// taken back out.
 var giveUpPhrases = []string{
-	// English.
-	"reverted", "rolled back", "rolling back", "backed out", "back it out",
-	"gave up on", "giving up on", "abandoned that", "abandoned this",
-	"dropped that approach", "scrap that", "did not work", "didn't work",
-	"does not work", "doesn't work", "that approach failed", "undid the",
-	// Russian.
-	"откатил", "откатили", "откатываю", "вернул как было", "вернули как было",
-	"не сработал", "не заработал", "не помогло", "не получилось",
-	"отказались от", "отбросил", "отменил изменен",
+	// English — reversals only.
+	"reverted", "rolled back", "rolling back", "roll it back",
+	"backed out", "back it out", "gave up on", "giving up on",
+	"abandoned that", "abandoned this", "abandoned the",
+	"dropped that approach", "dropped this approach", "scrap that",
+	"undid the", "undo the change", "reverting the",
+	// Russian — reversals only.
+	"откатил", "откатили", "откатываю", "откатывать",
+	"вернул как было", "вернули как было", "вернул обратно", "вернули обратно",
+	"отказались от", "отказался от", "отбросил", "отменил изменен",
 }
 
 // GiveUpLine reports whether a line says an approach was tried and dropped.

--- a/internal/index/giveup_test.go
+++ b/internal/index/giveup_test.go
@@ -105,6 +105,8 @@ func TestGiveUpLineRejectsUnrealisedReversals(t *testing.T) {
 		"should we have reverted, or patched forward?",
 		// Reflexive Russian verb, not a reversal action.
 		"мяч откатился под диван и застрял там надолго",
+		// A diff removed-line is not a report of a reversal.
+		"- reverted the old migration helper",
 	}
 	for _, l := range notReports {
 		if _, ok := GiveUpLine(l); ok {

--- a/internal/index/giveup_test.go
+++ b/internal/index/giveup_test.go
@@ -110,6 +110,10 @@ func TestGiveUpLineRejectsUnrealisedReversals(t *testing.T) {
 		"камни откатились вниз по склону после дождя",
 		// A diff removed-line is not a report of a reversal.
 		"- reverted the old migration helper",
+		// A copula question without a "?" is still a question, not a report.
+		"was that rolled back",
+		"is that reverted yet",
+		"were those changes reverted",
 	}
 	for _, l := range notReports {
 		if _, ok := GiveUpLine(l); ok {

--- a/internal/index/giveup_test.go
+++ b/internal/index/giveup_test.go
@@ -103,8 +103,11 @@ func TestGiveUpLineRejectsUnrealisedReversals(t *testing.T) {
 		// Question with an internal separator.
 		"did we roll it back, or is it still live?",
 		"should we have reverted, or patched forward?",
-		// Reflexive Russian verb, not a reversal action.
+		// Reflexive Russian verb (all genders/numbers), not a reversal action.
 		"мяч откатился под диван и застрял там надолго",
+		"деталь откатилась назад и упала со стола",
+		"колесо откатилось в сторону от станка",
+		"камни откатились вниз по склону после дождя",
 		// A diff removed-line is not a report of a reversal.
 		"- reverted the old migration helper",
 	}
@@ -121,6 +124,11 @@ func TestGiveUpLineRejectsUnrealisedReversals(t *testing.T) {
 		"we backed out the migration and went with the view instead",
 		"* reverted the caching layer, it broke ordering",
 		"> rolled back the migration after the DBA complained",
+		// A modal AFTER the phrase belongs to another verb — still a report.
+		"reverted it since it would corrupt state otherwise",
+		"reverted the index because a full scan could deadlock",
+		// Subject-elided passive report is not a question.
+		"was rolled back after review, all good now",
 	}
 	for _, l := range reports {
 		if _, ok := GiveUpLine(l); !ok {

--- a/internal/index/giveup_test.go
+++ b/internal/index/giveup_test.go
@@ -59,3 +59,30 @@ func TestGaveUpReadsSpeechAndNotToolOutput(t *testing.T) {
 		t.Error("the assistant saying it reverted the change is not detected")
 	}
 }
+
+// P0-9/10/11: real prose reports carry quotes, issue refs and URLs, and can end
+// in a follow-up question; a byte budget must not halve the room for Cyrillic.
+func TestGiveUpLineDetectsRealProseReports(t *testing.T) {
+	reports := []string{
+		"reverted the change from #1143 and shipped the view instead",
+		"rolled back after reading github.com/foo/bar//issues/3, it deadlocked",
+		`reverted the "fast path" change because it broke ordering`,
+		"откатили, но не помогло, что дальше?", // report + question
+		"откатили миграцию пула соединений на постгресе, потому что она держала лок на всю таблицу и всё вставало намертво", // long Cyrillic
+	}
+	for _, l := range reports {
+		if _, ok := GiveUpLine(l); !ok {
+			t.Errorf("a real report was rejected: %q", l)
+		}
+	}
+	notReports := []string{
+		"should we revert this change?",       // pure question
+		`log.Printf("reverted %s", name)`,     // code with string arg
+		"// reverted in the previous release", // comment
+	}
+	for _, l := range notReports {
+		if _, ok := GiveUpLine(l); ok {
+			t.Errorf("a non-report was accepted: %q", l)
+		}
+	}
+}

--- a/internal/index/giveup_test.go
+++ b/internal/index/giveup_test.go
@@ -86,3 +86,43 @@ func TestGiveUpLineDetectsRealProseReports(t *testing.T) {
 		}
 	}
 }
+
+// Precision review: a reversal that did not happen — negated, conditional,
+// future, or the reflexive Russian verb — must not mark the session.
+func TestGiveUpLineRejectsUnrealisedReversals(t *testing.T) {
+	notReports := []string{
+		// Negation.
+		"we haven't reverted the migration yet",
+		"we never gave up on the retry approach",
+		"не отказались от идеи с пулом соединений",
+		"он сказал не откатывать это ни в коем случае",
+		// Conditional / future.
+		"if this fails we just roll it back, no big deal",
+		"we could roll it back but we won't do that now",
+		"I'll be reverting the config change tomorrow",
+		// Question with an internal separator.
+		"did we roll it back, or is it still live?",
+		"should we have reverted, or patched forward?",
+		// Reflexive Russian verb, not a reversal action.
+		"мяч откатился под диван и застрял там надолго",
+	}
+	for _, l := range notReports {
+		if _, ok := GiveUpLine(l); ok {
+			t.Errorf("an unrealised or non-reversal was marked: %q", l)
+		}
+	}
+	// And genuine reports still pass, including a report that ends in a
+	// separate follow-up question.
+	reports := []string{
+		"reverted the retry cap, it made the queue worse",
+		"откатили, но не помогло, что дальше?",
+		"we backed out the migration and went with the view instead",
+		"* reverted the caching layer, it broke ordering",
+		"> rolled back the migration after the DBA complained",
+	}
+	for _, l := range reports {
+		if _, ok := GiveUpLine(l); !ok {
+			t.Errorf("a genuine report was dropped: %q", l)
+		}
+	}
+}

--- a/internal/index/giveup_test.go
+++ b/internal/index/giveup_test.go
@@ -1,0 +1,54 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestGiveUpLineKeepsReportsAndDropsEverythingElse(t *testing.T) {
+	reports := []string{
+		"reverted the retry cap, it made the queue worse",
+		"откатили пул соединений, стало хуже",
+		"we backed out the migration and went with the view instead",
+		"the sidecar approach did not work, dropping it",
+	}
+	for _, l := range reports {
+		if _, ok := GiveUpLine(l); !ok {
+			t.Errorf("a report of backing something out is not detected: %q", l)
+		}
+	}
+	notReports := []string{
+		// A question is the moment before the decision, not the decision.
+		"should we have reverted the retry cap?",
+		// Source that talks about reverting is code, not a report.
+		`log.Printf("reverted %s", name)`,
+		"// reverted in the previous release",
+		// Too short to say anything, and too long to be a statement.
+		"reverted",
+		// Ordinary failure talk describes the world, not a decision about it.
+		"the build failed on the arm runner again",
+	}
+	for _, l := range notReports {
+		if _, ok := GiveUpLine(l); ok {
+			t.Errorf("this is not a report of backing something out: %q", l)
+		}
+	}
+}
+
+// Tool output is full of the word: git prints it, deja prints it, and a diff
+// carries whatever the file said. Only what someone actually said counts.
+func TestGaveUpReadsSpeechAndNotToolOutput(t *testing.T) {
+	fromOutput := []model.Message{
+		{Role: "tool-output", Text: "HEAD is now at 8f2c19a Revert \"cap retries\"\nreverted 1 commit"},
+	}
+	if gaveUp(fromOutput) {
+		t.Error("git's own output marks the session as a dead end")
+	}
+	fromSpeech := []model.Message{
+		{Role: "assistant", Text: "capped the retries\nreverted that, it made the queue worse"},
+	}
+	if !gaveUp(fromSpeech) {
+		t.Error("the assistant saying it reverted the change is not detected")
+	}
+}

--- a/internal/index/giveup_test.go
+++ b/internal/index/giveup_test.go
@@ -11,7 +11,8 @@ func TestGiveUpLineKeepsReportsAndDropsEverythingElse(t *testing.T) {
 		"reverted the retry cap, it made the queue worse",
 		"откатили пул соединений, стало хуже",
 		"we backed out the migration and went with the view instead",
-		"the sidecar approach did not work, dropping it",
+		"abandoned the sidecar approach and went back to the cron job",
+		"gave up on the websocket path, polling it is",
 	}
 	for _, l := range reports {
 		if _, ok := GiveUpLine(l); !ok {
@@ -26,7 +27,13 @@ func TestGiveUpLineKeepsReportsAndDropsEverythingElse(t *testing.T) {
 		"// reverted in the previous release",
 		// Too short to say anything, and too long to be a statement.
 		"reverted",
-		// Ordinary failure talk describes the world, not a decision about it.
+		// Ordinary failure talk describes the world, not a decision about it —
+		// this is how nearly every debugging session opens, and it must not
+		// mark the session as a dead end.
+		"the webhook retry doesn't work when the queue is full",
+		"if that does not work, we can add an index on created_at",
+		"the sidecar approach did not work, still digging",
+		"не сработал ретрай при переполнении очереди, смотрю почему",
 		"the build failed on the arm runner again",
 	}
 	for _, l := range notReports {

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -145,6 +145,11 @@ type SessionMeta struct {
 	Lifecycle     string `json:",omitempty"`
 	LifecycleNote string `json:",omitempty"`
 	LifecycleAt   string `json:",omitempty"`
+	// GaveUp marks a session whose own text reports that something was tried
+	// and backed out. It is evidence, not a lifecycle state — the states are
+	// the user's judgement and stay theirs. Additive: an older manifest
+	// decodes with it false and hits print as they did before.
+	GaveUp bool `json:",omitempty"`
 	// Hit holds hashes of the specific errors this session tripped over, so
 	// the first screen can name a wall the machine keeps running into without
 	// reading a single session. Same trade as Asked: the text is recovered

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1023,7 +1023,7 @@ func metaForSession(s model.Session) SessionMeta {
 	// rebuild reloads imported sessions out of the index itself, and rebuilding
 	// the row from scratch dropped what only the import knew — the note's state
 	// and the id it had on the machine it came from (#1049).
-	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, AgentTitle: agentTitle, Started: s.Started, Updated: s.Updated, Touched: topTouchedFiles(s.Messages), Asked: askedHashes(s.Messages), Hit: frictionHashes(s.Messages),
+	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, AgentTitle: agentTitle, Started: s.Started, Updated: s.Updated, Touched: topTouchedFiles(s.Messages), Asked: askedHashes(s.Messages), Hit: frictionHashes(s.Messages), GaveUp: gaveUp(s.Messages),
 		OrigID: s.OrigID, Lifecycle: s.Lifecycle, LifecycleNote: s.LifecycleNote, LifecycleAt: s.LifecycleAt}
 }
 
@@ -1267,6 +1267,7 @@ func sessionFromMeta(meta SessionMeta) model.Session {
 	return model.Session{
 		ID: meta.ID, Harness: meta.Harness, Project: meta.Project, Path: meta.Path,
 		Title: meta.Title, AgentTitle: meta.AgentTitle, Started: meta.Started, Updated: meta.Updated, Touched: meta.Touched,
+		GaveUp: meta.GaveUp,
 		OrigID: meta.OrigID, Lifecycle: meta.Lifecycle, LifecycleNote: meta.LifecycleNote, LifecycleAt: meta.LifecycleAt,
 	}
 }

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -858,6 +858,11 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 		if hh := hitFromRecords(recsByKey[key]); len(hh) > 0 {
 			meta.Hit = hh
 		}
+		// And whether the session reports backing something out, so a peer's
+		// dead end arrives marked instead of reading like a live answer.
+		if gaveUpFromRecords(recsByKey[key]) {
+			meta.GaveUp = true
+		}
 		old := m.Sessions[key]
 		if old.ID != "" {
 			meta.Ord = old.Ord

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -860,9 +860,7 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 		}
 		// And whether the session reports backing something out, so a peer's
 		// dead end arrives marked instead of reading like a live answer.
-		if gaveUpFromRecords(recsByKey[key]) {
-			meta.GaveUp = true
-		}
+		batchGaveUp := gaveUpFromRecords(recsByKey[key])
 		old := m.Sessions[key]
 		if old.ID != "" {
 			meta.Ord = old.Ord
@@ -880,7 +878,12 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 			meta.Touched = mergeCappedStrings(old.Touched, meta.Touched, touchedFileCap)
 			meta.Asked = mergeCappedU64(old.Asked, meta.Asked, askedQuestionCap)
 			meta.Hit = mergeCappedU64(old.Hit, meta.Hit, frictionSessionCap)
+			// Same reason: a reversal reported in an earlier batch is not in
+			// this one, so OR with what the row already carried rather than
+			// letting a later batch clear the mark.
+			meta.GaveUp = old.GaveUp || batchGaveUp
 		} else {
+			meta.GaveUp = batchGaveUp
 			meta.Ord = nextOrd
 			nextOrd++
 		}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -21,6 +21,10 @@ type Session struct {
 	Updated  time.Time `json:"updated"`
 	Messages []Message `json:"messages,omitempty"`
 	Source   *Source   `json:"source,omitempty"`
+	// GaveUp marks a session that says, in its own words, that something was
+	// tried and backed out. Parsers do not set it; the index fills it from
+	// what it read, and it is false for a store indexed before it existed.
+	GaveUp bool `json:"gave_up,omitempty"`
 	// Touched lists the few files this session worked on most. Parsers do not
 	// set it; the index fills it from what it stored, so a caller holding a
 	// search result can ask a cheap question about those files without reading

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -844,6 +844,17 @@ func Print(w io.Writer, hits []Hit, o Options) {
 			}
 			fmt.Fprintln(w, note)
 		}
+		// Nobody sets the rejected state by hand, so the sessions that ended in
+		// a dead end look exactly like the ones that ended in an answer. When
+		// the transcript itself says something was backed out, say so — as
+		// evidence from the session, not as a state someone recorded.
+		if h.Session.GaveUp && h.Lifecycle == "" {
+			note := "  reports backing something out — read before reusing"
+			if color {
+				note = cDim + note + cReset
+			}
+			fmt.Fprintln(w, note)
+		}
 		if h.Moved != "" {
 			note := h.Moved
 			if color {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -847,9 +847,12 @@ func Print(w io.Writer, hits []Hit, o Options) {
 		// Nobody sets the rejected state by hand, so the sessions that ended in
 		// a dead end look exactly like the ones that ended in an answer. When
 		// the transcript itself says something was backed out, say so — as
-		// evidence from the session, not as a state someone recorded.
+		// evidence from the session, not as a state someone recorded. The
+		// wording is deliberately mild: a session that tried one thing, dropped
+		// it and found another is the most useful kind, so this flags an
+		// abandoned approach inside it, not the whole session as a dead end.
 		if h.Session.GaveUp && h.Lifecycle == "" {
-			note := "  reports backing something out — read before reusing"
+			note := "  mentions backing an approach out — one path here was abandoned"
 			if color {
 				note = cDim + note + cReset
 			}


### PR DESCRIPTION
- **feat: a hit says when the session backed something out**
- **fix(index): the revert marker fires on a reversal, not on 'doesn't work'**
- **fix(index): count runes, keep prose reports, allow a trailing question**
- **fix(index): imported GaveUp unions like Touched, not cleared by a quiet batch**
- **fix(index): the revert marker ignores reversals that did not happen**
- **fix(index): a diff removed-line is not a revert report**
- **fix(index): handle every reflexive form, modal-after-phrase, passive report**
- **fix: soften the revert marker — an approach was dropped, not the whole session**
- **fix(index): tell a passive report from a copula question by word order**
