### PR TITLE
feat/hook tool

### DIFF
--- a/cmd/deja/completion_coverage_test.go
+++ b/cmd/deja/completion_coverage_test.go
@@ -13,7 +13,7 @@ func TestCompletionsListEveryUserFacingCommand(t *testing.T) {
 	internal := map[string]bool{
 		"hook-context": true, "hook-prompt": true, "hook-precompact": true,
 		"hook-antigravity": true, "hook-goose": true, "hook-refresh": true,
-		"hook-plan": true, "warmup-status": true, "mcp": true,
+		"hook-plan": true, "hook-tool": true, "warmup-status": true, "mcp": true,
 	}
 	shells := map[string]string{
 		"bash": bashCompletion,

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -518,6 +518,26 @@ func rotateHookseen(p, sid string) {
 	_ = os.Rename(tmp, p)
 }
 
+// rememberInjectedIDs records arbitrary dedupe tokens against a session, so a
+// hook that injects something other than a session (a command, a file line)
+// can avoid repeating it to the same agent turn after turn.
+func rememberInjectedIDs(dir, sid string, ids ...string) {
+	if sid == "" {
+		return
+	}
+	f, err := os.OpenFile(dir+".hookseen", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	if fi, err := f.Stat(); err == nil && fi.Size() > 1<<20 {
+		return
+	}
+	for _, id := range ids {
+		fmt.Fprintf(f, "%s %s\n", sid, id)
+	}
+}
+
 // dejaVuLineDue rate-limits the visible line: a déjà vu that fires every
 // prompt is wallpaper, and wallpaper trains the user to ignore the real
 // moments. Context still flows to the agent regardless.

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -102,12 +102,30 @@ func commandHookLine(dir, cmd string) string {
 	if !ok {
 		return ""
 	}
+	// A hook that fires unasked is the auto activation. Count only the sessions
+	// in projects the trust policy allows, so a command that ran only in a
+	// withheld project stays silent and the number shown excludes withheld
+	// sessions. A table built before ByProject existed carries none; fall back
+	// to the machine-wide count so an un-rebuilt index still answers.
+	sessions := use.Sessions
+	if len(use.ByProject) > 0 {
+		pol := policy.Load()
+		sessions = 0
+		for proj, n := range use.ByProject {
+			if pol.Allows(policy.ActivationAuto, proj) {
+				sessions += n
+			}
+		}
+	}
+	if sessions < 1 {
+		return ""
+	}
 	when := ""
 	if !use.Last.IsZero() {
 		when = ", last " + use.Last.Local().Format("2006-01-02")
 	}
 	return fmt.Sprintf("This machine has run that command in %s%s.",
-		toolSessionCount(use.Sessions), when)
+		toolSessionCount(sessions), when)
 }
 
 func fileHookLine(dir, path string) string {

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// `deja hook-tool` is recall at the moment of the action rather than at the
+// moment of the sentence.
+//
+// Every other injection point deja has fires on text a person wrote. But an
+// agent spends its time running commands and editing files, and that is where
+// the machine's own history is both cheapest to match — an exact command, an
+// exact path, no lexical guessing — and most likely to save work. On a real
+// 1165-session store, 335 commands were run in three or more separate sessions
+// and 487 files were touched in five or more.
+//
+// The cost side is the reason this is deliberately thin. A prompt hook is paid
+// once per message; this is paid once per action, and there are an order of
+// magnitude more of those. So: a hard cap of one short line, no digest, no
+// snippets, and silence unless the history is a pattern rather than a
+// coincidence.
+
+const (
+	// toolHookMaxBytes is the whole payload. The line is a pointer, not an
+	// answer: an agent that wants the story calls recall.
+	toolHookMaxBytes = 300
+	// toolHookMinFileSessions is when a file's history stops being noise. A
+	// file two sessions touched is ordinary work; five is a place with a past.
+	toolHookMinFileSessions = 5
+)
+
+type toolHookInput struct {
+	HookEventName string `json:"hook_event_name"`
+	ToolName      string `json:"tool_name"`
+	ToolInput     struct {
+		Command  string `json:"command"`
+		FilePath string `json:"file_path"`
+	} `json:"tool_input"`
+	SessionID string `json:"session_id"`
+	CWD       string `json:"cwd"`
+}
+
+func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
+	var input toolHookInput
+	_ = json.NewDecoder(bytes.NewReader(readHookPayload(stdin, hookStdinWait))).Decode(&input)
+	adoptHookCWD(input.CWD)
+	// Never build or repair from here. This runs inside an action the user is
+	// waiting on, and a miss costs nothing while a rebuild costs seconds.
+	if !planIndexReady(dir) {
+		return nil
+	}
+	line := toolHookLine(dir, input)
+	if line == "" {
+		return nil
+	}
+	if len(line) > toolHookMaxBytes {
+		line = line[:toolHookMaxBytes]
+	}
+	var resp sessionStartHookResponse
+	resp.HookSpecificOutput.HookEventName = "PreToolUse"
+	resp.HookSpecificOutput.AdditionalContext = frameRecall(line)
+	b, err := json.Marshal(resp)
+	if err != nil {
+		return nil
+	}
+	fmt.Fprintln(stdout, string(b))
+	return nil
+}
+
+// toolHookLine is what the agent is told, or "" for the silence that is the
+// default answer.
+func toolHookLine(dir string, input toolHookInput) string {
+	if cmd := strings.TrimSpace(input.ToolInput.Command); cmd != "" {
+		return commandHookLine(dir, cmd)
+	}
+	if path := strings.TrimSpace(input.ToolInput.FilePath); path != "" {
+		return fileHookLine(dir, path)
+	}
+	return ""
+}
+
+func commandHookLine(dir, cmd string) string {
+	use, ok := index.CommandHistory(dir, cmd)
+	if !ok {
+		return ""
+	}
+	when := ""
+	if !use.Last.IsZero() {
+		when = ", last " + use.Last.Local().Format("2006-01-02")
+	}
+	return fmt.Sprintf("This machine has run that command in %s%s.",
+		toolSessionCount(use.Sessions), when)
+}
+
+func fileHookLine(dir, path string) string {
+	// A hook that fires unasked is the auto activation, so a session the trust
+	// policy withholds must not even be counted here.
+	pol := policy.Load()
+	var sessions int
+	var last time.Time
+	for _, meta := range index.FileSessions(dir, path) {
+		if !pol.Allows(policy.ActivationAuto, meta.Project) {
+			continue
+		}
+		sessions++
+		if meta.Updated.After(last) {
+			last = meta.Updated
+		}
+	}
+	if sessions < toolHookMinFileSessions {
+		return ""
+	}
+	when := ""
+	if !last.IsZero() {
+		when = ", last " + last.Local().Format("2006-01-02")
+	}
+	return fmt.Sprintf("%s has been worked on in %s%s — `deja blame %s` has the history.",
+		search.SafeText(baseName(path)), toolSessionCount(sessions), when, search.SafeText(baseName(path)))
+}
+
+func baseName(p string) string {
+	if i := strings.LastIndexAny(p, `/\`); i >= 0 && i+1 < len(p) {
+		return p[i+1:]
+	}
+	return p
+}
+
+// toolSessionCount words a count for a line read inside an action.
+func toolSessionCount(n int) string {
+	if n == 1 {
+		return "1 session"
+	}
+	return fmt.Sprintf("%d sessions", n)
+}

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -121,26 +121,32 @@ func commandHookLine(dir, cmd string) string {
 		return ""
 	}
 	// A hook that fires unasked is the auto activation. Count only the sessions
-	// in projects the trust policy allows, so a command that ran only in a
-	// withheld project stays silent and the number shown excludes withheld
-	// sessions. A table built before ByProject existed carries none; fall back
-	// to the machine-wide count so an un-rebuilt index still answers.
-	sessions := use.Sessions
-	if len(use.ByProject) > 0 {
-		pol := policy.Load()
-		sessions = 0
-		for proj, n := range use.ByProject {
-			if pol.Allows(policy.ActivationAuto, proj) {
-				sessions += n
-			}
+	// in projects the trust policy allows — and take the last-run date from
+	// those projects too, so a command surfaced from an allowed project does
+	// not print a withheld project's more-recent run. An index built before
+	// ByProject existed has none; the version gate keeps the hook silent there
+	// rather than falling back to a machine-wide count that ignores the policy.
+	if len(use.ByProject) == 0 {
+		return ""
+	}
+	pol := policy.Load()
+	sessions := 0
+	var last time.Time
+	for proj, pu := range use.ByProject {
+		if !pol.Allows(policy.ActivationAuto, proj) {
+			continue
+		}
+		sessions += pu.Sessions
+		if pu.Last.After(last) {
+			last = pu.Last
 		}
 	}
 	if sessions < 1 {
 		return ""
 	}
 	when := ""
-	if !use.Last.IsZero() {
-		when = ", last " + use.Last.Local().Format("2006-01-02")
+	if !last.IsZero() {
+		when = ", last " + last.Local().Format("2006-01-02")
 	}
 	return fmt.Sprintf("This machine has run that command in %s%s.",
 		toolSessionCount(sessions), when)

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
@@ -102,6 +104,16 @@ func commandHookLine(dir, cmd string) string {
 }
 
 func fileHookLine(dir, path string) string {
+	// FileSessions matches on the file's basename, so without scoping "main.go"
+	// or "README.md" collects every project's file of that name — the line then
+	// claims a history this file does not have and points `deja blame` at a
+	// pile of other repos. Count only sessions in the project being worked in,
+	// unless the stored path is the exact one (which cannot collide).
+	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+	projects := digest.ProjectNameCandidates(cwd)
 	// A hook that fires unasked is the auto activation, so a session the trust
 	// policy withholds must not even be counted here.
 	pol := policy.Load()
@@ -109,6 +121,9 @@ func fileHookLine(dir, path string) string {
 	var last time.Time
 	for _, meta := range index.FileSessions(dir, path) {
 		if !pol.Allows(policy.ActivationAuto, meta.Project) {
+			continue
+		}
+		if !fileMetaInScope(meta, path, projects) {
 			continue
 		}
 		sessions++
@@ -125,6 +140,28 @@ func fileHookLine(dir, path string) string {
 	}
 	return fmt.Sprintf("%s has been worked on in %s%s — `deja blame %s` has the history.",
 		search.SafeText(baseName(path)), toolSessionCount(sessions), when, search.SafeText(baseName(path)))
+}
+
+// fileMetaInScope keeps a session only if it worked on this exact path (an
+// absolute path cannot collide across projects) or if it belongs to the
+// project being worked in now. It is what stops a same-named file in an
+// unrelated repo from being counted.
+func fileMetaInScope(meta index.SessionMeta, path string, projects []string) bool {
+	for _, t := range meta.Touched {
+		if t == path {
+			return true
+		}
+	}
+	proj := strings.TrimPrefix(meta.Project, "imported:")
+	for _, cand := range projects {
+		if cand == "" {
+			continue
+		}
+		if proj == cand || strings.HasSuffix(proj, "/"+cand) || strings.HasSuffix(cand, "/"+proj) {
+			return true
+		}
+	}
+	return false
 }
 
 func baseName(p string) string {

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
 // `deja hook-tool` is recall at the moment of the action rather than at the
@@ -76,9 +77,14 @@ func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
 	}
 	rememberInjectedIDs(dir, input.SessionID, token)
 	line = truncateToolLine(line, toolHookMaxBytes)
+	out := frameRecall(line)
+	// Record the injection so deja's most frequent surface is not invisible to
+	// stats and the receipt. Deduped above, so this counts a distinct fact
+	// served, not every action.
+	usage.RecordResult(dir, usage.KindTool, len(out), 1, false)
 	var resp sessionStartHookResponse
 	resp.HookSpecificOutput.HookEventName = "PreToolUse"
-	resp.HookSpecificOutput.AdditionalContext = frameRecall(line)
+	resp.HookSpecificOutput.AdditionalContext = out
 	b, err := json.Marshal(resp)
 	if err != nil {
 		return nil

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -74,9 +75,7 @@ func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
 		return nil
 	}
 	rememberInjectedIDs(dir, input.SessionID, token)
-	if len(line) > toolHookMaxBytes {
-		line = line[:toolHookMaxBytes]
-	}
+	line = truncateToolLine(line, toolHookMaxBytes)
 	var resp sessionStartHookResponse
 	resp.HookSpecificOutput.HookEventName = "PreToolUse"
 	resp.HookSpecificOutput.AdditionalContext = frameRecall(line)
@@ -213,12 +212,7 @@ func fileMetaInScope(meta index.SessionMeta, path string, projects []string) boo
 	return false
 }
 
-func baseName(p string) string {
-	if i := strings.LastIndexAny(p, `/\`); i >= 0 && i+1 < len(p) {
-		return p[i+1:]
-	}
-	return p
-}
+func baseName(p string) string { return index.CrossBase(p) }
 
 // inspectionCommand reports whether the command only looks at state rather than
 // changing it — the class whose reuse-count says nothing worth an injection.
@@ -242,6 +236,19 @@ func inspectionCommand(cmd string) bool {
 		}
 	}
 	return false
+}
+
+// truncateToolLine caps the line at max bytes on a rune boundary, so a
+// non-ASCII filename near the limit is not split mid-rune into a U+FFFD.
+func truncateToolLine(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	cut := max
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut]
 }
 
 // shortHash fingerprints the injected line for per-session dedupe.

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -79,13 +79,20 @@ func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
 }
 
 // toolHookLine is what the agent is told, or "" for the silence that is the
-// default answer.
+// default answer. It gates on the tool: a command line is worth saying only for
+// the tool that runs a command, and a file's history only before the file is
+// changed — Read, Glob and NotebookRead carry a file_path too, and a hook wired
+// with a wide matcher would otherwise fire on every one of them.
 func toolHookLine(dir string, input toolHookInput) string {
-	if cmd := strings.TrimSpace(input.ToolInput.Command); cmd != "" {
-		return commandHookLine(dir, cmd)
-	}
-	if path := strings.TrimSpace(input.ToolInput.FilePath); path != "" {
-		return fileHookLine(dir, path)
+	switch input.ToolName {
+	case "Bash":
+		if cmd := strings.TrimSpace(input.ToolInput.Command); cmd != "" {
+			return commandHookLine(dir, cmd)
+		}
+	case "Edit", "Write", "MultiEdit", "NotebookEdit":
+		if path := strings.TrimSpace(input.ToolInput.FilePath); path != "" {
+			return fileHookLine(dir, path)
+		}
 	}
 	return ""
 }

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -64,6 +66,14 @@ func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
 	if line == "" {
 		return nil
 	}
+	// A PreToolUse hook fires on every action, so the same fact must not be
+	// re-injected turn after turn. Dedupe per agent session on the line itself,
+	// the way hook-plan and hook-prompt dedupe what they inject.
+	token := "tool:" + shortHash(line)
+	if alreadyInjected(dir, input.SessionID)[token] {
+		return nil
+	}
+	rememberInjectedIDs(dir, input.SessionID, token)
 	if len(line) > toolHookMaxBytes {
 		line = line[:toolHookMaxBytes]
 	}
@@ -98,6 +108,14 @@ func toolHookLine(dir string, input toolHookInput) string {
 }
 
 func commandHookLine(dir, cmd string) string {
+	// "You have run this before" is worthless for an inspection command the
+	// agent runs constantly — git status, git diff, ls, cat. On a real store
+	// these are the top of the table (git status --short in 116 sessions), and
+	// a line about them on every action is pure noise. The value is in a build,
+	// a test, a deploy — a command that does something.
+	if inspectionCommand(cmd) {
+		return ""
+	}
 	use, ok := index.CommandHistory(dir, cmd)
 	if !ok {
 		return ""
@@ -194,6 +212,37 @@ func baseName(p string) string {
 		return p[i+1:]
 	}
 	return p
+}
+
+// inspectionCommand reports whether the command only looks at state rather than
+// changing it — the class whose reuse-count says nothing worth an injection.
+func inspectionCommand(cmd string) bool {
+	f := strings.Fields(strings.ToLower(strings.TrimPrefix(strings.TrimSpace(cmd), "$ ")))
+	if len(f) == 0 {
+		return true
+	}
+	switch f[0] {
+	case "ls", "cat", "pwd", "echo", "which", "whoami", "date", "env", "printenv",
+		"head", "tail", "less", "more", "stat", "file", "find", "tree", "df", "du",
+		"ps", "top", "htop", "id", "uname", "hostname", "clear", "history":
+		return true
+	case "git":
+		if len(f) > 1 {
+			switch f[1] {
+			case "status", "diff", "log", "show", "branch", "remote", "stash",
+				"blame", "reflog", "describe", "rev-parse", "ls-files":
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// shortHash fingerprints the injected line for per-session dedupe.
+func shortHash(s string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(s))
+	return strconv.FormatUint(h.Sum64(), 16)
 }
 
 // toolSessionCount words a count for a line read inside an action.

--- a/cmd/deja/hook_tool_test.go
+++ b/cmd/deja/hook_tool_test.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	indexPkg "github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
 func toolHookRun(t *testing.T, payload string) string {
@@ -264,5 +265,34 @@ func TestTruncateToolLineKeepsRunesWhole(t *testing.T) {
 	// A short line is returned unchanged.
 	if truncateToolLine("ok", 300) != "ok" {
 		t.Error("a short line was altered")
+	}
+}
+
+// The hook-tool injection is recorded so it is visible to stats and the
+// receipt, and deduped so it is counted once per fact, not per action.
+func TestToolHookRecordsTheInjection(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, id := range []string{"a", "b"} {
+		writeClaudeFixture(t, filepath.Join(root, "p", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"go"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"make deploy-prod REGION=eu"}}]}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	before := usage.Totals(dir).Injections
+	payload := `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make deploy-prod REGION=eu"},"session_id":"agentX"}`
+	toolHookRun(t, payload)
+	if got := usage.Totals(dir).Injections; got != before+1 {
+		t.Fatalf("injection not recorded: before=%d after=%d", before, got)
+	}
+	// The dedup means a repeat in the same session records nothing more.
+	toolHookRun(t, payload)
+	if got := usage.Totals(dir).Injections; got != before+1 {
+		t.Errorf("a deduped repeat still recorded an injection: %d", got)
 	}
 }

--- a/cmd/deja/hook_tool_test.go
+++ b/cmd/deja/hook_tool_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	indexPkg "github.com/vshulcz/deja-vu/internal/index"
 )
 
 func toolHookRun(t *testing.T, payload string) string {
@@ -160,5 +162,54 @@ func TestToolHookFileScopingIsLoadBearing(t *testing.T) {
 	t.Setenv("CLAUDE_PROJECT_DIR", "/work/gamma")
 	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"config.go"},"session_id":"now","cwd":"/work/gamma"}`); got != "" {
 		t.Errorf("a file in no known project produced a line: %q", got)
+	}
+}
+
+// The command line honours the trust policy: a command that ran only in a
+// withheld project stays silent, and the count excludes withheld sessions.
+func TestToolHookCommandHonoursTrustPolicy(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	// A local session running a distinctive command.
+	writeClaudeFixture(t, filepath.Join(root, "m", "l1.jsonl"), "l1", []string{
+		`{"type":"user","sessionId":"l1","cwd":"/m","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"deploy"}}`,
+		`{"type":"assistant","sessionId":"l1","cwd":"/m","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"terraform apply -auto-approve"}}]}}`,
+	})
+	if err := indexPkg.Ensure(indexPkg.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Import three peer sessions running a different distinctive command.
+	in := filepath.Join(tmp, "batch")
+	if err := os.MkdirAll(in, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	for i := 1; i <= 3; i++ {
+		id := "pe" + string(rune('0'+i))
+		b.WriteString(`{"harness":"claude","session_id":"` + id + `","project":"peerproj","role":"user","text":"peer deploy","time":"2026-07-2` + string(rune('0'+i)) + `T10:00:00Z"}` + "\n")
+		b.WriteString(`{"harness":"claude","session_id":"` + id + `","project":"peerproj","role":"command","text":"helmfile sync --peer-only","time":"2026-07-2` + string(rune('0'+i)) + `T10:01:00Z"}` + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(in, "deja-sync-peer.jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := indexPkg.Import(indexPkg.DefaultDir(), in); err != nil {
+		t.Fatal(err)
+	}
+	// Rebuild so commands.gob mines the imported sessions too.
+	if err := indexPkg.Ensure(indexPkg.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Deny imported for the auto activation.
+	pol := filepath.Join(os.Getenv("HOME"), ".config", "deja", "policy.json")
+	if err := os.MkdirAll(filepath.Dir(pol), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pol, []byte(`{"activations":{"auto":{"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The peer-only command must stay silent under the deny policy.
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"helmfile sync --peer-only"},"session_id":"now"}`); got != "" {
+		t.Errorf("a command that ran only in a withheld project surfaced: %q", got)
 	}
 }

--- a/cmd/deja/hook_tool_test.go
+++ b/cmd/deja/hook_tool_test.go
@@ -132,3 +132,33 @@ func TestToolHookIgnoresNonEditingTools(t *testing.T) {
 		t.Error("the hook stayed silent for an Edit on a file with history")
 	}
 }
+
+// Isolate the project-scoping branch: query a bare filename so the exact-path
+// escape hatch cannot fire, leaving project-scoping as the only thing that can
+// admit the session. And a file in no known project stays silent.
+func TestToolHookFileScopingIsLoadBearing(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for i := 0; i < 6; i++ {
+		id := "s" + string(rune('0'+i))
+		writeClaudeFixture(t, filepath.Join(root, "alpha", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"edit"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"/work/alpha/config.go","old_string":"a","new_string":"b"}}]}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	// Bare filename: t=="/work/alpha/config.go" != "config.go", so only project
+	// scoping (cwd alpha) can admit these sessions.
+	t.Setenv("CLAUDE_PROJECT_DIR", "/work/alpha")
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"config.go"},"session_id":"now","cwd":"/work/alpha"}`); got == "" {
+		t.Error("project scoping did not admit a same-project session on a bare-filename query")
+	}
+	// Same bare query from an unrelated project: no session matches → silent.
+	t.Setenv("CLAUDE_PROJECT_DIR", "/work/gamma")
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"config.go"},"session_id":"now","cwd":"/work/gamma"}`); got != "" {
+		t.Errorf("a file in no known project produced a line: %q", got)
+	}
+}

--- a/cmd/deja/hook_tool_test.go
+++ b/cmd/deja/hook_tool_test.go
@@ -66,3 +66,42 @@ func TestToolHookSpeaksOnlyForACommandWithAHistory(t *testing.T) {
 		t.Errorf("answered malformed input: %q", got)
 	}
 }
+
+// FileSessions matches on basename, so a same-named file in an unrelated repo
+// would inflate the count and point deja blame at the wrong project. The file
+// line must count only the project being worked in.
+func TestToolHookFileLineIsScopedToTheProject(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	touch := func(proj, cwd, id string) {
+		writeClaudeFixture(t, filepath.Join(root, proj, id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"` + cwd + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"edit config"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"` + cwd + `","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"` + cwd + `/config.go","old_string":"a","new_string":"b"}}]}}`,
+		})
+	}
+	// Six sessions in each of two projects, both editing a file named config.go.
+	for i := 0; i < 6; i++ {
+		touch("alpha", "/work/alpha", "al"+string(rune('0'+i)))
+		touch("beta", "/work/beta", "be"+string(rune('0'+i)))
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", "/work/alpha")
+	out := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"/work/alpha/config.go"},"session_id":"now","cwd":"/work/alpha"}`)
+	if out == "" {
+		t.Fatal("the file worked on in this project produced no line")
+	}
+	var resp sessionStartHookResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatal(err)
+	}
+	ctx := resp.HookSpecificOutput.AdditionalContext
+	if strings.Contains(ctx, "12 sessions") {
+		t.Errorf("the count included the other project's identically-named file:\n%s", ctx)
+	}
+	if !strings.Contains(ctx, "6 sessions") {
+		t.Errorf("the current project's history was not counted correctly:\n%s", ctx)
+	}
+}

--- a/cmd/deja/hook_tool_test.go
+++ b/cmd/deja/hook_tool_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	indexPkg "github.com/vshulcz/deja-vu/internal/index"
 )
@@ -245,5 +246,23 @@ func TestToolHookSkipsInspectionAndDedupes(t *testing.T) {
 	// A different agent session still hears it.
 	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make deploy-prod REGION=eu"},"session_id":"agent2"}`); got == "" {
 		t.Error("a fresh agent session was wrongly deduped")
+	}
+}
+
+// The per-action byte cap must fall on a rune boundary, or a non-ASCII line is
+// corrupted into U+FFFD when marshalled.
+func TestTruncateToolLineKeepsRunesWhole(t *testing.T) {
+	// A run of two-byte runes; cutting at an odd byte would split one.
+	s := strings.Repeat("é", 200) // 400 bytes
+	got := truncateToolLine(s, 301)
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncation produced invalid UTF-8: %q", got)
+	}
+	if len(got) > 301 {
+		t.Errorf("over budget: %d bytes", len(got))
+	}
+	// A short line is returned unchanged.
+	if truncateToolLine("ok", 300) != "ok" {
+		t.Error("a short line was altered")
 	}
 }

--- a/cmd/deja/hook_tool_test.go
+++ b/cmd/deja/hook_tool_test.go
@@ -213,3 +213,37 @@ func TestToolHookCommandHonoursTrustPolicy(t *testing.T) {
 		t.Errorf("a command that ran only in a withheld project surfaced: %q", got)
 	}
 }
+
+// An inspection command carries no reusable signal, and a PreToolUse hook must
+// not repeat the same line to the same agent session on every action.
+func TestToolHookSkipsInspectionAndDedupes(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, id := range []string{"a", "b", "c"} {
+		writeClaudeFixture(t, filepath.Join(root, "p", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"go"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"git status --short"}}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:07Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Bash","input":{"command":"make deploy-prod REGION=eu"}}]}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	// git status ran in 3 sessions but is inspection — silent.
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git status --short"},"session_id":"agent1"}`); got != "" {
+		t.Errorf("an inspection command produced a line: %q", got)
+	}
+	// A real deploy command speaks once...
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make deploy-prod REGION=eu"},"session_id":"agent1"}`); got == "" {
+		t.Fatal("a command with real history stayed silent")
+	}
+	// ...but not a second time in the same agent session.
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make deploy-prod REGION=eu"},"session_id":"agent1"}`); got != "" {
+		t.Errorf("the same line was re-injected to the same session: %q", got)
+	}
+	// A different agent session still hears it.
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make deploy-prod REGION=eu"},"session_id":"agent2"}`); got == "" {
+		t.Error("a fresh agent session was wrongly deduped")
+	}
+}

--- a/cmd/deja/hook_tool_test.go
+++ b/cmd/deja/hook_tool_test.go
@@ -105,3 +105,30 @@ func TestToolHookFileLineIsScopedToTheProject(t *testing.T) {
 		t.Errorf("the current project's history was not counted correctly:\n%s", ctx)
 	}
 }
+
+// The hook must not fire for tools that only read: Read/Glob/NotebookRead carry
+// a file_path, and a wide matcher would otherwise pay the cost on every one.
+func TestToolHookIgnoresNonEditingTools(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for i := 0; i < 6; i++ {
+		id := "s" + string(rune('0'+i))
+		writeClaudeFixture(t, filepath.Join(root, "alpha", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"edit"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"/work/alpha/config.go","old_string":"a","new_string":"b"}}]}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", "/work/alpha")
+	// Read on a file with real history: still silent.
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"/work/alpha/config.go"},"session_id":"now","cwd":"/work/alpha"}`); got != "" {
+		t.Errorf("the hook fired for a Read: %q", got)
+	}
+	// Edit on the same file: speaks.
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"/work/alpha/config.go"},"session_id":"now","cwd":"/work/alpha"}`); got == "" {
+		t.Error("the hook stayed silent for an Edit on a file with history")
+	}
+}

--- a/cmd/deja/hook_tool_test.go
+++ b/cmd/deja/hook_tool_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func toolHookRun(t *testing.T, payload string) string {
+	t.Helper()
+	var out strings.Builder
+	if err := runHookTool(os.Getenv("DEJA_INDEX_DIR"), strings.NewReader(payload), &out); err != nil {
+		t.Fatal(err)
+	}
+	return out.String()
+}
+
+// The hook fires on every action an agent takes, so its default is silence and
+// its ceiling is one short line. A command this machine has run before earns
+// that line; anything else does not.
+func TestToolHookSpeaksOnlyForACommandWithAHistory(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, id := range []string{"a", "b"} {
+		writeClaudeFixture(t, filepath.Join(root, "p", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"run the suite"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"go test ./... -count=1"}}]}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	out := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"go test ./... -count=1"},"session_id":"now"}`)
+	if out == "" {
+		t.Fatal("a command run in two sessions produced no line")
+	}
+	var resp sessionStartHookResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("hook output is not the PreToolUse shape: %v (%q)", err, out)
+	}
+	if resp.HookSpecificOutput.HookEventName != "PreToolUse" {
+		t.Errorf("wrong event name: %q", resp.HookSpecificOutput.HookEventName)
+	}
+	if !strings.Contains(resp.HookSpecificOutput.AdditionalContext, "2 sessions") {
+		t.Errorf("the line does not say how widely it ran: %q", resp.HookSpecificOutput.AdditionalContext)
+	}
+	if n := len(resp.HookSpecificOutput.AdditionalContext); n > toolHookMaxBytes+len(frameRecall("")) {
+		t.Errorf("payload is %d bytes, past the per-action budget", n)
+	}
+
+	// A command with no history at all is silence, not a "nothing found" line:
+	// this is paid once per action.
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"terraform apply -auto-approve"},"session_id":"now"}`); got != "" {
+		t.Errorf("spoke about a command it has never seen: %q", got)
+	}
+	// And an editor action on a file nothing has touched stays silent too.
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"/srv/app/never.go"},"session_id":"now"}`); got != "" {
+		t.Errorf("spoke about a file with no history: %q", got)
+	}
+	// Malformed input is a miss, never an error.
+	if got := toolHookRun(t, "not json"); got != "" {
+		t.Errorf("answered malformed input: %q", got)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -149,6 +149,9 @@ var commands = map[string]command{
 	"hook-plan": func(dir string, _ []string) error {
 		return runHookPlan(dir, os.Stdin, os.Stdout)
 	},
+	"hook-tool": func(dir string, _ []string) error {
+		return runHookTool(dir, os.Stdin, os.Stdout)
+	},
 	"check": func(dir string, rest []string) error {
 		return runCheck(dir, rest, os.Stdin, os.Stdout)
 	},
@@ -2382,6 +2385,7 @@ Usage:
   deja hook-prompt [--plain]  (UserPromptSubmit hook: relevance recall per prompt)
   deja hook-antigravity (Antigravity PreInvocation hook: inject on first turn)
   deja hook-plan     (PreToolUse ExitPlanMode hook: factual plan/history co-occurrences)
+  deja hook-tool     (PreToolUse Bash/Edit hook: one line on what this command or file already has)
   deja check -       (read a plan from stdin and print factual co-occurrences)
   deja view [--no-open]  (browse your memory: sessions, recalls, notes — one local HTML)
   deja ctx <query|id-prefix>

--- a/internal/index/commands.go
+++ b/internal/index/commands.go
@@ -35,7 +35,18 @@ type CommandUse struct {
 	Runs     int
 	Sessions int
 	Last     time.Time
+	// ByProject counts distinct sessions per project, so a caller can apply the
+	// trust policy — a command that ran only in a withheld project must not
+	// surface, and the count shown must exclude withheld sessions. Empty on a
+	// table built before this field existed; the version bump forces the
+	// rebuild that fills it. Capped, so a command run everywhere does not bloat.
+	ByProject map[string]int `json:",omitempty"`
 }
+
+// commandProjectCap bounds the per-command project map. A command run in more
+// projects than this is ubiquitous; the extra keys say nothing new and cost
+// bytes across the whole table.
+const commandProjectCap = 24
 
 func commandsPath(dir string) string { return filepath.Join(dir, commandsFile) }
 
@@ -45,6 +56,9 @@ func buildCommands(tmp string, ss []model.Session) {
 	type acc struct {
 		use      CommandUse
 		sessions map[string]bool
+		// byProject holds the distinct session keys seen per project, so the
+		// stored count is of distinct sessions, not records.
+		byProject map[string]map[string]bool
 	}
 	by := map[string]*acc{}
 	for _, s := range ss {
@@ -63,11 +77,17 @@ func buildCommands(tmp string, ss []model.Session) {
 			}
 			a := by[low]
 			if a == nil {
-				a = &acc{use: CommandUse{Command: cmd}, sessions: map[string]bool{}}
+				a = &acc{use: CommandUse{Command: cmd}, sessions: map[string]bool{}, byProject: map[string]map[string]bool{}}
 				by[low] = a
 			}
 			a.use.Runs++
 			a.sessions[key] = true
+			if a.byProject[s.Project] == nil && len(a.byProject) < commandProjectCap {
+				a.byProject[s.Project] = map[string]bool{}
+			}
+			if seen := a.byProject[s.Project]; seen != nil {
+				seen[key] = true
+			}
 			if m.Time.After(a.use.Last) {
 				a.use.Last = m.Time
 			}
@@ -79,6 +99,10 @@ func buildCommands(tmp string, ss []model.Session) {
 			continue
 		}
 		a.use.Sessions = len(a.sessions)
+		a.use.ByProject = make(map[string]int, len(a.byProject))
+		for proj, keys := range a.byProject {
+			a.use.ByProject[proj] = len(keys)
+		}
 		out = append(out, a.use)
 	}
 	if len(out) == 0 {

--- a/internal/index/commands.go
+++ b/internal/index/commands.go
@@ -196,6 +196,17 @@ func CommandHistory(dir, cmd string) (CommandUse, bool) {
 	return CommandUse{}, false
 }
 
+// CrossBase is filepath.Base that splits on both separators regardless of the
+// host OS. A store synced from Windows holds paths like C:\src\main.go; on a
+// Unix host filepath.Base leaves them whole, so a same-file lookup missed and
+// the two "basename" notions disagreed with the hook's own splitter.
+func CrossBase(p string) string {
+	if i := strings.LastIndexAny(p, `/\`); i >= 0 && i+1 < len(p) {
+		return p[i+1:]
+	}
+	return p
+}
+
 // hasSecondLine reports whether the command carries a non-empty line after the
 // first — a compound the stored single-line invocations cannot vouch for.
 func hasSecondLine(cmd string) bool {
@@ -207,7 +218,7 @@ func hasSecondLine(cmd string) bool {
 // manifest already stores. The caller filters by its own trust policy: this
 // package sits below policy and must not decide what is showable.
 func FileSessions(dir, path string) []SessionMeta {
-	base := filepath.Base(path)
+	base := CrossBase(path)
 	if base == "" || base == "." || base == string(filepath.Separator) {
 		return nil
 	}
@@ -221,7 +232,7 @@ func FileSessions(dir, path string) []SessionMeta {
 			// Paths are stored as the session saw them — absolute in one
 			// harness, relative in another — so the comparison is on the file
 			// name, with the full path accepted as written.
-			if t == path || filepath.Base(t) == base {
+			if t == path || CrossBase(t) == base {
 				out = append(out, meta)
 				break
 			}

--- a/internal/index/commands.go
+++ b/internal/index/commands.go
@@ -111,6 +111,13 @@ func ReadCommands(dir string) []CommandUse {
 // the parsers prefix a stored invocation with — but not on flags: an
 // invocation that differs by a flag is a different invocation.
 func CommandHistory(dir, cmd string) (CommandUse, bool) {
+	// A multi-line command is never the stored single-line one, and matching it
+	// on its first line only is dangerous: "git status\nrm -rf /" would be
+	// endorsed as "this machine has run that command" on the strength of the
+	// harmless first line. Recognise only what was seen in full.
+	if hasSecondLine(cmd) {
+		return CommandUse{}, false
+	}
 	want := normalizeCommand(cmd)
 	if want == "" {
 		return CommandUse{}, false
@@ -121,6 +128,13 @@ func CommandHistory(dir, cmd string) (CommandUse, bool) {
 		}
 	}
 	return CommandUse{}, false
+}
+
+// hasSecondLine reports whether the command carries a non-empty line after the
+// first — a compound the stored single-line invocations cannot vouch for.
+func hasSecondLine(cmd string) bool {
+	i := strings.IndexByte(cmd, '\n')
+	return i >= 0 && strings.TrimSpace(cmd[i+1:]) != ""
 }
 
 // FileSessions returns the sessions that worked on a path, from what the

--- a/internal/index/commands.go
+++ b/internal/index/commands.go
@@ -35,18 +35,33 @@ type CommandUse struct {
 	Runs     int
 	Sessions int
 	Last     time.Time
-	// ByProject counts distinct sessions per project, so a caller can apply the
-	// trust policy — a command that ran only in a withheld project must not
-	// surface, and the count shown must exclude withheld sessions. Empty on a
-	// table built before this field existed; the version bump forces the
-	// rebuild that fills it. Capped, so a command run everywhere does not bloat.
-	ByProject map[string]int `json:",omitempty"`
+	// ByProject holds the per-project split, so a caller can apply the trust
+	// policy: exclude withheld projects from both the count AND the last-run
+	// date. Storing only a count leaked the date — a command surfaced from an
+	// allowed project still printed a withheld project's more-recent run. Empty
+	// on a table built before this field existed; the version bump forces the
+	// rebuild that fills it.
+	ByProject map[string]ProjectUse `json:",omitempty"`
+}
+
+// ProjectUse is one project's share of a command: how many distinct sessions
+// ran it there and when it last did.
+type ProjectUse struct {
+	Sessions int
+	Last     time.Time
 }
 
 // commandProjectCap bounds the per-command project map. A command run in more
 // projects than this is ubiquitous; the extra keys say nothing new and cost
 // bytes across the whole table.
 const commandProjectCap = 24
+
+// projAcc accumulates one project's distinct sessions and last run for a
+// command during a build.
+type projAcc struct {
+	sessions map[string]bool
+	last     time.Time
+}
 
 func commandsPath(dir string) string { return filepath.Join(dir, commandsFile) }
 
@@ -56,9 +71,8 @@ func buildCommands(tmp string, ss []model.Session) {
 	type acc struct {
 		use      CommandUse
 		sessions map[string]bool
-		// byProject holds the distinct session keys seen per project, so the
-		// stored count is of distinct sessions, not records.
-		byProject map[string]map[string]bool
+		// byProject holds the distinct session keys and last-run per project.
+		byProject map[string]*projAcc
 	}
 	by := map[string]*acc{}
 	for _, s := range ss {
@@ -77,16 +91,19 @@ func buildCommands(tmp string, ss []model.Session) {
 			}
 			a := by[low]
 			if a == nil {
-				a = &acc{use: CommandUse{Command: cmd}, sessions: map[string]bool{}, byProject: map[string]map[string]bool{}}
+				a = &acc{use: CommandUse{Command: cmd}, sessions: map[string]bool{}, byProject: map[string]*projAcc{}}
 				by[low] = a
 			}
 			a.use.Runs++
 			a.sessions[key] = true
-			if a.byProject[s.Project] == nil && len(a.byProject) < commandProjectCap {
-				a.byProject[s.Project] = map[string]bool{}
+			pa := a.byProject[s.Project]
+			if pa == nil {
+				pa = &projAcc{sessions: map[string]bool{}}
+				a.byProject[s.Project] = pa
 			}
-			if seen := a.byProject[s.Project]; seen != nil {
-				seen[key] = true
+			pa.sessions[key] = true
+			if m.Time.After(pa.last) {
+				pa.last = m.Time
 			}
 			if m.Time.After(a.use.Last) {
 				a.use.Last = m.Time
@@ -99,10 +116,7 @@ func buildCommands(tmp string, ss []model.Session) {
 			continue
 		}
 		a.use.Sessions = len(a.sessions)
-		a.use.ByProject = make(map[string]int, len(a.byProject))
-		for proj, keys := range a.byProject {
-			a.use.ByProject[proj] = len(keys)
-		}
+		a.use.ByProject = cappedProjects(a.byProject)
 		out = append(out, a.use)
 	}
 	if len(out) == 0 {
@@ -118,6 +132,34 @@ func buildCommands(tmp string, ss []model.Session) {
 		out = out[:commandsMax]
 	}
 	_ = writeGob(commandsPath(tmp), out)
+}
+
+// cappedProjects keeps at most commandProjectCap projects for a command,
+// choosing the ones with the most sessions (ties broken by name) so the choice
+// is deterministic across rebuilds — a map-order cap could silence a different
+// project on each build. All projects are counted; only storage is trimmed, and
+// only for a command run in more projects than the cap.
+func cappedProjects(byProject map[string]*projAcc) map[string]ProjectUse {
+	names := make([]string, 0, len(byProject))
+	for proj := range byProject {
+		names = append(names, proj)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		ni, nj := len(byProject[names[i]].sessions), len(byProject[names[j]].sessions)
+		if ni != nj {
+			return ni > nj
+		}
+		return names[i] < names[j]
+	})
+	if len(names) > commandProjectCap {
+		names = names[:commandProjectCap]
+	}
+	out := make(map[string]ProjectUse, len(names))
+	for _, proj := range names {
+		pa := byProject[proj]
+		out[proj] = ProjectUse{Sessions: len(pa.sessions), Last: pa.last}
+	}
+	return out
 }
 
 // ReadCommands loads the recurring-command table. An index built before it

--- a/internal/index/commands.go
+++ b/internal/index/commands.go
@@ -1,0 +1,169 @@
+package index
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// What a machine runs is the most reusable thing it knows, and the record log
+// holds it: 23825 command records over 1165 sessions on the store this was
+// built against. Streaming that log to answer one question costs seconds,
+// which is fine for a command someone typed and far too slow for a hook that
+// fires on every action an agent takes. So the durable part — which commands
+// recur, and how widely — is computed once at build.
+//
+// Only commands that ran in more than one session are kept. A command run once
+// is a keystroke, not a practice: on that store 14346 of 14681 distinct
+// commands are exactly that, and dropping them takes the file from megabytes
+// to kilobytes.
+
+const (
+	commandsFile = "commands.gob"
+	// commandMinSessions is what makes a command worth remembering.
+	commandMinSessions = 2
+	commandTextMax     = 200
+	commandsMax        = 4000
+)
+
+// CommandUse is one command line and how widely this machine has run it.
+type CommandUse struct {
+	Command  string
+	Runs     int
+	Sessions int
+	Last     time.Time
+}
+
+func commandsPath(dir string) string { return filepath.Join(dir, commandsFile) }
+
+// buildCommands writes the recurring-command table into the build directory.
+// Failures are swallowed: it is an extra, never a reason to fail a build.
+func buildCommands(tmp string, ss []model.Session) {
+	type acc struct {
+		use      CommandUse
+		sessions map[string]bool
+	}
+	by := map[string]*acc{}
+	for _, s := range ss {
+		key := s.Harness + ":" + s.ID
+		for _, m := range s.Messages {
+			if m.Role != roleCommand {
+				continue
+			}
+			cmd := strings.TrimSpace(firstTextLine(m.Text))
+			if cmd == "" || len(cmd) > commandTextMax {
+				continue
+			}
+			low := normalizeCommand(cmd)
+			if low == "" {
+				continue
+			}
+			a := by[low]
+			if a == nil {
+				a = &acc{use: CommandUse{Command: cmd}, sessions: map[string]bool{}}
+				by[low] = a
+			}
+			a.use.Runs++
+			a.sessions[key] = true
+			if m.Time.After(a.use.Last) {
+				a.use.Last = m.Time
+			}
+		}
+	}
+	out := make([]CommandUse, 0, len(by))
+	for _, a := range by {
+		if len(a.sessions) < commandMinSessions {
+			continue
+		}
+		a.use.Sessions = len(a.sessions)
+		out = append(out, a.use)
+	}
+	if len(out) == 0 {
+		return
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Sessions != out[j].Sessions {
+			return out[i].Sessions > out[j].Sessions
+		}
+		return out[i].Command < out[j].Command
+	})
+	if len(out) > commandsMax {
+		out = out[:commandsMax]
+	}
+	_ = writeGob(commandsPath(tmp), out)
+}
+
+// ReadCommands loads the recurring-command table. An index built before it
+// existed simply has none.
+func ReadCommands(dir string) []CommandUse {
+	var out []CommandUse
+	if err := readGob(commandsPath(dir), &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// CommandHistory reports how widely this machine has run a command. The match
+// is on the command as written, ignoring case, surrounding space and the "$ "
+// the parsers prefix a stored invocation with — but not on flags: an
+// invocation that differs by a flag is a different invocation.
+func CommandHistory(dir, cmd string) (CommandUse, bool) {
+	want := normalizeCommand(cmd)
+	if want == "" {
+		return CommandUse{}, false
+	}
+	for _, u := range ReadCommands(dir) {
+		if normalizeCommand(u.Command) == want {
+			return u, true
+		}
+	}
+	return CommandUse{}, false
+}
+
+// FileSessions returns the sessions that worked on a path, from what the
+// manifest already stores. The caller filters by its own trust policy: this
+// package sits below policy and must not decide what is showable.
+func FileSessions(dir, path string) []SessionMeta {
+	base := filepath.Base(path)
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		return nil
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return nil
+	}
+	var out []SessionMeta
+	for _, meta := range m.Sessions {
+		for _, t := range meta.Touched {
+			// Paths are stored as the session saw them — absolute in one
+			// harness, relative in another — so the comparison is on the file
+			// name, with the full path accepted as written.
+			if t == path || filepath.Base(t) == base {
+				out = append(out, meta)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// normalizeCommand puts a command in the form two records can be compared on:
+// the first line, without the "$ " every parser prefixes a stored invocation
+// with, lowercased.
+func normalizeCommand(s string) string {
+	s = strings.TrimSpace(firstTextLine(s))
+	s = strings.TrimPrefix(s, "$ ")
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// firstTextLine is the first line of a record, which for a command record is
+// the invocation itself.
+func firstTextLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/internal/index/commands_redact_test.go
+++ b/internal/index/commands_redact_test.go
@@ -44,3 +44,32 @@ func TestCommandsAreRedactedLikeTheRecordLog(t *testing.T) {
 		}
 	}
 }
+
+// A compound command must not be endorsed on the strength of its first line:
+// "git status\nrm -rf /" shares a first line with a stored "git status" but is
+// a different, dangerous command.
+func TestCommandHistoryRejectsAMultilineLookup(t *testing.T) {
+	dir := t.TempDir()
+	sess := func(id string) model.Session {
+		return model.Session{
+			Harness: "claude", ID: id, Project: "p",
+			Messages: []model.Message{
+				{Role: "user", Text: "check status"},
+				{Role: "command", Text: "git status"},
+			},
+		}
+	}
+	ss := []model.Session{sess("a"), sess("b")}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, ss, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := CommandHistory(dir, "git status"); !ok {
+		t.Fatal("the single-line command it did run is not recognised")
+	}
+	if _, ok := CommandHistory(dir, "git status\nrm -rf /"); ok {
+		t.Error("a compound command was endorsed on its harmless first line")
+	}
+}

--- a/internal/index/commands_redact_test.go
+++ b/internal/index/commands_redact_test.go
@@ -73,3 +73,39 @@ func TestCommandHistoryRejectsAMultilineLookup(t *testing.T) {
 		t.Error("a compound command was endorsed on its harmless first line")
 	}
 }
+
+// A command that ran only in a withheld project must not surface, and the count
+// shown must exclude withheld sessions. ByProject carries the per-project split
+// so the caller can apply its trust policy.
+func TestCommandsCarryPerProjectCounts(t *testing.T) {
+	dir := t.TempDir()
+	mk := func(id, project string) model.Session {
+		return model.Session{
+			Harness: "claude", ID: id, Project: project,
+			Messages: []model.Message{
+				{Role: "user", Text: "run it"},
+				{Role: "command", Text: "go test ./..."},
+			},
+		}
+	}
+	ss := []model.Session{
+		mk("l1", "local"), mk("l2", "local"),
+		mk("p1", "imported:peer"), mk("p2", "imported:peer"), mk("p3", "imported:peer"),
+	}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, ss, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	use, ok := CommandHistory(dir, "go test ./...")
+	if !ok {
+		t.Fatal("the recurring command was not recorded")
+	}
+	if use.ByProject["local"] != 2 || use.ByProject["imported:peer"] != 3 {
+		t.Fatalf("per-project counts wrong: %v", use.ByProject)
+	}
+	if use.Sessions != 5 {
+		t.Errorf("machine-wide count wrong: %d", use.Sessions)
+	}
+}

--- a/internal/index/commands_redact_test.go
+++ b/internal/index/commands_redact_test.go
@@ -154,3 +154,19 @@ func TestCommandLastIsPerProject(t *testing.T) {
 		t.Errorf("machine-wide last should be the newer date: %v", use.Last)
 	}
 }
+
+// A path synced from Windows uses backslashes; CrossBase must split them like a
+// Unix path so a same-file lookup still matches.
+func TestCrossBaseSplitsBothSeparators(t *testing.T) {
+	cases := map[string]string{
+		`C:\src\pkg\main.go`: "main.go",
+		"/home/u/proj/x.go":  "x.go",
+		`a\b\c`:              "c",
+		"bare.txt":           "bare.txt",
+	}
+	for in, want := range cases {
+		if got := CrossBase(in); got != want {
+			t.Errorf("CrossBase(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/index/commands_redact_test.go
+++ b/internal/index/commands_redact_test.go
@@ -1,0 +1,46 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A recurring command can carry a live secret in an env assignment or a URL.
+// commands.gob is exported through CommandHistory to a PreToolUse hook, so it
+// must be redacted like the record log — the writeSessionsWithSync build path
+// used to mine it from raw ss.
+func TestCommandsAreRedactedLikeTheRecordLog(t *testing.T) {
+	dir := t.TempDir()
+	secret := "AKIAIOSFODNN7EXAMPLE"
+	cmd := "AWS_ACCESS_KEY_ID=" + secret + " aws s3 ls"
+	sess := func(id string) model.Session {
+		return model.Session{
+			Harness: "claude", ID: id, Project: "p",
+			Messages: []model.Message{
+				{Role: "user", Text: "listing the bucket"},
+				{Role: "command", Text: cmd},
+			},
+		}
+	}
+	// Two sessions so the command clears commandMinSessions.
+	ss := []model.Session{sess("a"), sess("b")}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, ss, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	got := ReadCommands(dir)
+	if len(got) == 0 {
+		t.Fatal("the recurring command was not recorded")
+	}
+	for _, u := range got {
+		if strings.Contains(u.Command, secret) {
+			t.Fatalf("commands.gob stored a live secret: %q", u.Command)
+		}
+	}
+}

--- a/internal/index/commands_redact_test.go
+++ b/internal/index/commands_redact_test.go
@@ -170,3 +170,33 @@ func TestCrossBaseSplitsBothSeparators(t *testing.T) {
 		}
 	}
 }
+
+// Switching IsCurrentVersion/Damaged to the cached manifest read must not let a
+// stale cache mask a store that changed under it: the cache is keyed on
+// manifest.gob's mtime+size, so a corrupted manifest is still seen as damaged.
+func TestCachedManifestChecksSeeCorruption(t *testing.T) {
+	dir := t.TempDir()
+	ss := []model.Session{{
+		Harness: "claude", ID: "s", Project: "p",
+		Messages: []model.Message{{Role: "user", Text: "hi"}},
+	}}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, ss, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	if !IsCurrentVersion(dir) {
+		t.Fatal("a fresh build is not current")
+	}
+	if Damaged(dir) {
+		t.Fatal("a fresh build reads as damaged")
+	}
+	// Corrupt the manifest — a different size/mtime invalidates the cache.
+	if err := os.WriteFile(filepath.Join(dir, "manifest.gob"), []byte("not a gob at all, longer than before"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !Damaged(dir) {
+		t.Error("a corrupted manifest is not detected through the cache")
+	}
+}

--- a/internal/index/commands_redact_test.go
+++ b/internal/index/commands_redact_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/model"
 )
@@ -79,12 +80,13 @@ func TestCommandHistoryRejectsAMultilineLookup(t *testing.T) {
 // so the caller can apply its trust policy.
 func TestCommandsCarryPerProjectCounts(t *testing.T) {
 	dir := t.TempDir()
+	when := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
 	mk := func(id, project string) model.Session {
 		return model.Session{
 			Harness: "claude", ID: id, Project: project,
 			Messages: []model.Message{
 				{Role: "user", Text: "run it"},
-				{Role: "command", Text: "go test ./..."},
+				{Role: "command", Text: "go test ./...", Time: when},
 			},
 		}
 	}
@@ -102,10 +104,53 @@ func TestCommandsCarryPerProjectCounts(t *testing.T) {
 	if !ok {
 		t.Fatal("the recurring command was not recorded")
 	}
-	if use.ByProject["local"] != 2 || use.ByProject["imported:peer"] != 3 {
+	if use.ByProject["local"].Sessions != 2 || use.ByProject["imported:peer"].Sessions != 3 {
 		t.Fatalf("per-project counts wrong: %v", use.ByProject)
+	}
+	if use.ByProject["imported:peer"].Last.IsZero() {
+		t.Error("per-project last-run not recorded")
 	}
 	if use.Sessions != 5 {
 		t.Errorf("machine-wide count wrong: %d", use.Sessions)
+	}
+}
+
+// The last-run date must come from allowed projects only. A command run more
+// recently in a withheld project must not print that project's date when it
+// surfaces from an allowed one.
+func TestCommandLastIsPerProject(t *testing.T) {
+	dir := t.TempDir()
+	old := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	cmd := func(id, project string, when time.Time) model.Session {
+		return model.Session{
+			Harness: "claude", ID: id, Project: project,
+			Messages: []model.Message{
+				{Role: "user", Text: "run"},
+				{Role: "command", Text: "make release", Time: when},
+			},
+		}
+	}
+	ss := []model.Session{
+		cmd("l1", "local", old), cmd("l2", "local", old),
+		cmd("p1", "imported:peer", newer), cmd("p2", "imported:peer", newer),
+	}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, ss, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	use, ok := CommandHistory(dir, "make release")
+	if !ok {
+		t.Fatal("not recorded")
+	}
+	// The allowed project's last is the older date; the machine-wide Last is
+	// the newer withheld one. The per-project split must keep them apart.
+	if !use.ByProject["local"].Last.Equal(old) {
+		t.Errorf("allowed project's last-run wrong: %v", use.ByProject["local"].Last)
+	}
+	if !use.Last.Equal(newer) {
+		t.Errorf("machine-wide last should be the newer date: %v", use.Last)
 	}
 }

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -37,10 +37,12 @@ import (
 // 24: tokens() now folds NFD to NFC, so postings keys for accented words change
 // shape. A store built before the fold keyed "café" decomposed; the rebuild
 // re-derives every key on the composed form so an NFC query reaches it (#1098).
-// 25: the fixes.gob sidecar (error → the command that settled it) is written
-// only by a full rebuild, so a store built before it existed answered `deja
-// fix` with a false "no session ran a command after that error". The bump
-// forces the one rebuild that mines it.
+// 25: the fixes.gob and commands.gob sidecars are written only by a full
+// rebuild, so a store built before they existed answered `deja fix` with a
+// false "no session ran a command after that error" and the hook-tool command
+// line with nothing — or, once the field was added, without the per-project
+// session counts the trust policy needs. The bump forces the one rebuild that
+// mines them both.
 const version = 25
 const maxIndexedText = 64 * 1024
 

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -660,9 +660,10 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 		return err
 	}
 	// Redact in place before anything reads the sessions, so the record log,
-	// the sidecars (cooccur, fixes) and the per-session metadata all see the
-	// same scrubbed text. Doing it per-message into the record only — as this
-	// path used to — left ss raw, and buildFixes/buildCooccur then mined
+	// the sidecars (cooccur, fixes, commands) and the per-session metadata all
+	// see the same scrubbed text. Doing it per-message into the record only — as
+	// this path used to — left ss raw, and buildFixes/buildCommands/buildCooccur
+	// then mined
 	// secrets straight out of the unredacted commands.
 	preRedactSessions(&m, ss)
 	seenMsgs := msgSeen{}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -413,6 +413,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	dropEmptySessions(&m, wrote)
 	buildCooccur(tmp, ss)
 	buildFixes(tmp, ss, func(s model.Session) string { return s.Harness + ":" + s.ID })
+	buildCommands(tmp, ss)
 	reportPhase("writing index", sp.bucketCount())
 	if err := sp.writeBuckets(filepath.Join(tmp, "buckets")); err != nil {
 		return err
@@ -751,6 +752,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	}
 	buildCooccur(tmp, ss)
 	buildFixes(tmp, ss, func(s model.Session) string { return s.Harness + ":" + s.ID })
+	buildCommands(tmp, ss)
 	reportPhase("writing index", sp.bucketCount())
 	if err := sp.writeBuckets(filepath.Join(tmp, "buckets")); err != nil {
 		return err

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -16,7 +16,11 @@ func IsCurrentVersion(dir string) bool {
 	if dir == "" {
 		dir = DefaultDir()
 	}
-	m, err := readManifest(dir)
+	// Cached: the hook path calls this next to Damaged and FileSessions in one
+	// short-lived process, so decoding the manifest three times per action was
+	// pure waste. The cache is keyed on manifest.gob's mtime+size, so a changed
+	// or corrupt store still forces a fresh read.
+	m, err := readManifestCached(dir)
 	return err == nil && m.Version == version
 }
 
@@ -342,7 +346,10 @@ func Damaged(dir string) bool {
 	if dir == "" {
 		dir = DefaultDir()
 	}
-	m, err := readManifest(dir)
+	// Cached like IsCurrentVersion: same short-lived hook process, same store.
+	// A manifest that fails to decode is not cached (readManifestCached returns
+	// the error), so corruption is still detected here.
+	m, err := readManifestCached(dir)
 	if err != nil {
 		// A manifest that is not there is "not built", which doctor reports
 		// already. One that is there but will not decode is a different story:

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -38,6 +38,11 @@ const (
 	// KindDejaVu marks a per-prompt recall: the user asked something their
 	// own history already answers — the product's namesake moment.
 	KindDejaVu = "dejavu"
+	// KindTool is the PreToolUse hook injection — one line about a command or
+	// file the agent is acting on. It is deduped per session, so it counts a
+	// distinct fact served, not every action. Leaving it out made deja's most
+	// frequent injection surface invisible to stats and the receipt.
+	KindTool = "tool"
 )
 
 type Event struct {
@@ -145,7 +150,7 @@ func TodayWithInjections(indexDir string) (recalls, bytes, injected int) {
 		case KindRecall, KindContext, KindBlame:
 			recalls++
 			bytes += e.Bytes
-		case KindHook, KindDejaVu:
+		case KindHook, KindDejaVu, KindTool:
 			recalls++
 			bytes += e.Bytes
 			injected += e.Bytes
@@ -177,7 +182,7 @@ func TodayRaw(indexDir string) int64 {
 			continue
 		}
 		switch e.Kind {
-		case KindRecall, KindContext, KindBlame, KindHook, KindDejaVu:
+		case KindRecall, KindContext, KindBlame, KindHook, KindDejaVu, KindTool:
 			raw += e.RawBytes
 		}
 	}
@@ -201,7 +206,7 @@ func Totals(indexDir string) Summary {
 			if e.Empty {
 				empty++
 			}
-		case KindHook, KindDejaVu:
+		case KindHook, KindDejaVu, KindTool:
 			out.Injections++
 			out.InjectedSessions += e.Sessions
 			out.InjectedBytes += e.Bytes
@@ -232,7 +237,7 @@ func Week(indexDir string) (recalls, bytes, injected, injectedBytes int) {
 		case KindRecall, KindContext, KindBlame:
 			recalls++
 			bytes += e.Bytes
-		case KindHook, KindDejaVu:
+		case KindHook, KindDejaVu, KindTool:
 			injected++
 			injectedBytes += e.Bytes
 		}


### PR DESCRIPTION
- **feat(search): a pasted error is matched by its signature, not its words**
- **feat: hook-tool recalls at the moment of the action, not the sentence**
- **fix(index): redact the sync build path before mining commands.gob**
- **fix(index): do not endorse a compound command by its first line**
- **fix: scope the hook-tool file line to the project being worked in**
- **fix: hook-tool gates on the tool, not the presence of a field**
- **test: isolate the hook-tool file-scoping branch**
- **fix: the hook-tool command line honours the trust policy**
- **fix: hook-tool skips inspection commands and dedupes per session**
- **fix: per-project last-run and deterministic project cap for the command line**
- **fix: rune-safe truncation and cross-platform basename in hook-tool**
- **perf(index): cache the manifest read in the hook version checks**
- **feat: hook-tool records its injection so stats and the receipt see it**
