### PR TITLE
fix(search): rank by how long the session is, not how much of it matched

### DIFF
--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -140,6 +140,7 @@ when empty:
 | `agent_title` | `title` came from the assistant because the session has no user turn |
 | `touched` | the few files this session worked on most |
 | `gave_up` | the session's own text reports something being tried and backed out |
+| `words` | length of the whole session in words, as the index counted it; ranking normalises by it |
 | `orig_id` | id this session had on the machine it was imported from |
 | `lifecycle` | state of an imported promoted note: `accepted`, `rejected`, `superseded` or `stale` |
 | `lifecycle_note` | the note left with that state |

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -150,6 +150,12 @@ type SessionMeta struct {
 	// the user's judgement and stay theirs. Additive: an older manifest
 	// decodes with it false and hits print as they did before.
 	GaveUp bool `json:",omitempty"`
+	// Words is the whole session's length in words. Ranking reads back only
+	// the records that matched, so BM25 normalised by the size of the match
+	// rather than by the size of the session. Additive: a manifest written
+	// before it existed decodes with it zero and ranking falls back to what it
+	// can see.
+	Words int `json:",omitempty"`
 	// Hit holds hashes of the specific errors this session tripped over, so
 	// the first screen can name a wall the machine keeps running into without
 	// reading a single session. Same trade as Asked: the text is recovered

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1034,7 +1034,7 @@ func metaForSession(s model.Session) SessionMeta {
 	// rebuild reloads imported sessions out of the index itself, and rebuilding
 	// the row from scratch dropped what only the import knew — the note's state
 	// and the id it had on the machine it came from (#1049).
-	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, AgentTitle: agentTitle, Started: s.Started, Updated: s.Updated, Touched: topTouchedFiles(s.Messages), Asked: askedHashes(s.Messages), Hit: frictionHashes(s.Messages), GaveUp: gaveUp(s.Messages),
+	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, AgentTitle: agentTitle, Started: s.Started, Updated: s.Updated, Touched: topTouchedFiles(s.Messages), Asked: askedHashes(s.Messages), Hit: frictionHashes(s.Messages), GaveUp: gaveUp(s.Messages), Words: sessionWords(s.Messages),
 		OrigID: s.OrigID, Lifecycle: s.Lifecycle, LifecycleNote: s.LifecycleNote, LifecycleAt: s.LifecycleAt}
 }
 
@@ -1265,6 +1265,24 @@ func nextSessionOrd(sessions map[string]SessionMeta) uint32 {
 	return maxOrd + 1
 }
 
+// sessionWords counts the words of a whole session, which is the document
+// length BM25 is supposed to normalise by. Runs of letters, digits and the
+// characters identifiers are made of, matching how the ranking side counts.
+func sessionWords(ms []model.Message) int {
+	n := 0
+	for _, m := range ms {
+		inWord := false
+		for _, r := range m.Text {
+			word := unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-'
+			if word && !inWord {
+				n++
+			}
+			inWord = word
+		}
+	}
+	return n
+}
+
 // sessionFromMeta is the one place a manifest entry becomes a session. It
 // carries Touched, which retrieval used to copy by hand in a second, nearly
 // identical constructor — so a caller reading it off `Recent` got an empty
@@ -1279,6 +1297,7 @@ func sessionFromMeta(meta SessionMeta) model.Session {
 		ID: meta.ID, Harness: meta.Harness, Project: meta.Project, Path: meta.Path,
 		Title: meta.Title, AgentTitle: meta.AgentTitle, Started: meta.Started, Updated: meta.Updated, Touched: meta.Touched,
 		GaveUp: meta.GaveUp,
+		Words:  meta.Words,
 		OrigID: meta.OrigID, Lifecycle: meta.Lifecycle, LifecycleNote: meta.LifecycleNote, LifecycleAt: meta.LifecycleAt,
 	}
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -25,6 +25,13 @@ type Session struct {
 	// tried and backed out. Parsers do not set it; the index fills it from
 	// what it read, and it is false for a store indexed before it existed.
 	GaveUp bool `json:"gave_up,omitempty"`
+	// Words is how long the whole session is, in words. Search sees only the
+	// messages that matched a query, so it had no way to tell a short session
+	// that is about the query from a marathon that mentions it once — the two
+	// look the same size from inside a result. Parsers do not set it; the index
+	// fills it from what it counted at build time, and it is zero for a store
+	// indexed before it existed.
+	Words int `json:"words,omitempty"`
 	// Touched lists the few files this session worked on most. Parsers do not
 	// set it; the index fills it from what it stored, so a caller holding a
 	// search result can ask a cheap question about those files without reading

--- a/internal/search/marathon_length_test.go
+++ b/internal/search/marathon_length_test.go
@@ -1,0 +1,76 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Ranking never sees a whole session — the index reads back the records that
+// matched the query. Normalising BM25 by that made a marathon look small: it
+// mentions "webhook" in two short lines out of a day's work, and those two
+// lines were the entire document as far as the ranker could tell. Measured on a
+// real store, one active session held first place on five of ten unrelated
+// queries. The index counts the session at build time so the ranker can
+// normalise by its real size.
+func TestMarathonDoesNotOutrankTheSessionAboutTheQuery(t *testing.T) {
+	now := time.Now()
+	marathon := model.Session{
+		ID: "marathon", Harness: "claude", Project: "work", Updated: now,
+		// Two passing mentions, exactly what the index would hand back.
+		Messages: []model.Message{
+			{Role: "user", Text: "and the webhook thing too", Time: now},
+			{Role: "assistant", Text: "noted the webhook, back to the parser", Time: now},
+		},
+		Words: 40000,
+	}
+	about := model.Session{
+		ID: "about", Harness: "claude", Project: "work", Updated: now.Add(-time.Hour),
+		Messages: []model.Message{
+			{Role: "user", Text: "the webhook retries three times and then drops the event", Time: now},
+			{Role: "assistant", Text: "capped webhook retries at three, the fourth attempt is dropped on purpose", Time: now},
+		},
+		Words: 400,
+	}
+	hits, err := Run([]model.Session{marathon, about}, Options{Query: "webhook"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("no hits")
+	}
+	if hits[0].Session.ID != "about" {
+		t.Errorf("the marathon that mentions the word outranks the session about it: %q first", hits[0].Session.ID)
+	}
+}
+
+// A store indexed before the count existed reports zero words, and ranking has
+// to keep working on what it can see rather than treating every session as
+// weightless.
+func TestRankingSurvivesASessionCountedByAnOlderIndex(t *testing.T) {
+	now := time.Now()
+	long := model.Session{
+		ID: "long", Harness: "claude", Updated: now,
+		Messages: []model.Message{
+			{Role: "assistant", Text: strings.Repeat("filler ", 400) + "webhook", Time: now},
+		},
+	}
+	short := model.Session{
+		ID: "short", Harness: "claude", Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: "webhook retries capped at three", Time: now},
+		},
+	}
+	hits, err := Run([]model.Session{long, short}, Options{Query: "webhook"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("no hits")
+	}
+	if hits[0].Session.ID != "short" {
+		t.Errorf("without a stored word count, the padded session wins: %q first", hits[0].Session.ID)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -246,6 +246,22 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 		for i := 0; i < len(snipCands) && i < 3; i++ {
 			doc.hit.Snippets = append(doc.hit.Snippets, snippet(snipCands[i].text, o.Query, re))
 		}
+		// The index hands ranking the records that matched, not the session, so
+		// doc.length measures the size of the match. Normalising by that told
+		// BM25 that a marathon mentioning a word in three short lines is a
+		// three-line document — measured on a real store, one active session
+		// took first place on five of ten unrelated queries. When the index
+		// counted the session, normalise by the session.
+		// Not the session length outright: normalising by it alone punishes a
+		// long session that really is about the query, and cost one answer on
+		// LongMemEval (84.2% → 84.0% hit@1). The geometric mean of the two
+		// lengths keeps that question and still demotes the marathon —
+		// LongMemEval unchanged at 84.2% / 0.887 MRR, and a session that
+		// mentions the query twice inside a day's work no longer outranks the
+		// session about it.
+		if doc.hit.Session.Words > 0 {
+			doc.length = int(math.Sqrt(float64(doc.length) * float64(doc.hit.Session.Words)))
+		}
 		corpusDocuments++
 		corpusLength += doc.length
 		for i, n := range doc.termCount {


### PR DESCRIPTION
The index hands ranking only the matching records, so BM25 normalised by the
size of the match — a marathon that mentions a word twice looked like a
two-line document. LongMemEval unchanged at 84.2% hit@1 / 0.887 MRR.
