### PR TITLE
fix: sanitize the project and id in the context header

### DIFF
--- a/internal/search/context_header_safe_test.go
+++ b/internal/search/context_header_safe_test.go
@@ -1,0 +1,32 @@
+package search
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// PrintContext heads its output with the session's project and id — transcript
+// text a harness wrote. The body is SafeText'd; the header must be too, or
+// `deja show`, `deja ctx` and the MCP context tools print an escape or a bidi
+// run straight to a terminal or the agent (#1090).
+func TestPrintContextSanitisesTheHeader(t *testing.T) {
+	var b bytes.Buffer
+	s := model.Session{Harness: "claude", Project: "proj\x1b[31m", ID: "id\u202eevil"}
+	PrintContext(&b, s, "")
+	header := strings.SplitN(b.String(), "\n", 2)[0]
+	for _, r := range header {
+		if unicode.IsControl(r) {
+			t.Fatalf("context header carried a control rune %U: %q", r, header)
+		}
+	}
+	if strings.ContainsRune(header, '\u202e') {
+		t.Fatalf("context header carried a bidi override: %q", header)
+	}
+	if !strings.Contains(header, "proj") {
+		t.Fatalf("header lost the project text: %q", header)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -959,7 +959,11 @@ func isWorkRecord(role string) bool {
 }
 
 func PrintContext(w io.Writer, s model.Session, query string) {
-	fmt.Fprintf(w, "# deja context: %s · %s · %s", s.Harness, s.Project, s.ID)
+	// Project and id are transcript text a harness wrote, and this is one line:
+	// an escape byte in either recolours the header and a carriage return
+	// rewinds it. The body below is already SafeText'd; the header was not, so
+	// `deja show`, `deja ctx` and the MCP context tools printed it raw (#1090).
+	fmt.Fprintf(w, "# deja context: %s · %s · %s", s.Harness, SafeLine(s.Project), SafeLine(s.ID))
 	if !s.Updated.IsZero() {
 		fmt.Fprintf(w, " · updated %s", s.Updated.Format("2006-01-02"))
 	}


### PR DESCRIPTION
The context body is already SafeText'd, but the header line that show, ctx and the MCP context tools print carried the session project and id raw — an escape or bidi run in either reached the terminal or the agent. This finishes the escape-stripping across search, show and last.

Closes #1090