### PR TITLE
test(index): isolate the notes store from the developer's real one

### DIFF
--- a/internal/index/grok_test.go
+++ b/internal/index/grok_test.go
@@ -22,6 +22,20 @@ func TestMain(m *testing.M) {
 		// developer who has it set would otherwise have the suite write into
 		// their real ~/.config/deja.
 		"XDG_CONFIG_HOME": filepath.Join(root, "config"),
+		// Notes resolve via XDG_DATA_HOME, then APPDATA on Windows, then
+		// DEJA_NOTES_FILE — none of which HOME can reach. Without these the
+		// suite appended fixture notes to the developer's real store and then
+		// failed reading them back as leaked `deja` sessions (#1141). cmd/deja's
+		// TestMain already blanks the same keys; this closes the drift.
+		"XDG_DATA_HOME":           "",
+		"APPDATA":                 filepath.Join(root, "AppData", "Roaming"),
+		"DEJA_NOTES_FILE":         "",
+		"DEJA_SOURCE_INSTANCE":    "",
+		"CLAUDE_CONFIG_DIR":       "",
+		"CODEX_HOME":              "",
+		"GEMINI_CLI_HOME":         "",
+		"CURSOR_CONFIG_DIR":       "",
+		"AIDER_CHAT_HISTORY_FILE": "",
 		// A developer with DEJA_INDEX_DIR exported reads their own index
 		// here, and the suite went red on their machine only.
 		"DEJA_INDEX_DIR":        "",

--- a/internal/index/notes_isolation_test.go
+++ b/internal/index/notes_isolation_test.go
@@ -1,0 +1,25 @@
+package index
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The suite writes and reads promoted notes, and sources.NotesFile() resolves
+// through XDG_DATA_HOME and APPDATA before it ever reaches HOME. When TestMain
+// left those pointing at the developer's real profile, the suite appended
+// fixtures to their store and then failed reading them back as leaked `deja`
+// sessions (#1141). This pins the store under the temp root so that drift
+// fails here, naming the real path, instead of eleven arithmetic tests.
+func TestNotesFileStaysUnderTheTestRoot(t *testing.T) {
+	nf := sources.NotesFile()
+	home := os.Getenv("HOME")
+	appdata := os.Getenv("APPDATA")
+	if (home != "" && strings.HasPrefix(nf, home)) || (appdata != "" && strings.HasPrefix(nf, appdata)) {
+		return
+	}
+	t.Fatalf("notes store resolved outside the test root: %q — TestMain is leaking to the developer's real store (HOME=%q APPDATA=%q); blank XDG_DATA_HOME/DEJA_NOTES_FILE and point APPDATA at the temp root (#1141)", nf, home, appdata)
+}

--- a/internal/index/notes_isolation_test.go
+++ b/internal/index/notes_isolation_test.go
@@ -18,7 +18,13 @@ func TestNotesFileStaysUnderTheTestRoot(t *testing.T) {
 	nf := sources.NotesFile()
 	home := os.Getenv("HOME")
 	appdata := os.Getenv("APPDATA")
-	if (home != "" && strings.HasPrefix(nf, home)) || (appdata != "" && strings.HasPrefix(nf, appdata)) {
+	// Anchor to HOME alone. TestMain points HOME at the temp root on every
+	// platform and every notes path lands under it — root\AppData\Roaming on
+	// Windows, root/.local/share elsewhere. Accepting an APPDATA prefix would
+	// read the drift back from the very environment the guard exists to catch:
+	// drop the APPDATA redirect (the exact shape of #1141) and NotesFile falls
+	// back to the real profile, yet an APPDATA-prefix check would still pass.
+	if home != "" && strings.HasPrefix(nf, home) {
 		return
 	}
 	t.Fatalf("notes store resolved outside the test root: %q — TestMain is leaking to the developer's real store (HOME=%q APPDATA=%q); blank XDG_DATA_HOME/DEJA_NOTES_FILE and point APPDATA at the temp root (#1141)", nf, home, appdata)


### PR DESCRIPTION
Thanks @Sora-bluesky for the diagnosis — it was exactly right.

internal/index's TestMain neutralized HOME/XDG_CONFIG_HOME and the DEJA_*_ROOT set, but not XDG_DATA_HOME, APPDATA or DEJA_NOTES_FILE — the three paths sources.NotesFile() resolves through before HOME. So the suite appended promoted-note fixtures to the developer's real store and then failed eleven tests reading them back as leaked `deja` sessions.

Blanks the same keys cmd/deja's TestMain already does (closing the drift) and adds a regression test that pins NotesFile() under the temp root, so this fails loudly instead of quietly the next time the maps drift apart. Confirmed with your repro: `XDG_DATA_HOME=/tmp/xdg go test ./internal/index/` now passes and leaves the notes file untouched.

Closes #1141