### PR TITLE
feat(search): rank a backed-out session below one that held

### DIFF
--- a/internal/search/outcome_rank_test.go
+++ b/internal/search/outcome_rank_test.go
@@ -1,0 +1,137 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A session whose own text reports the approach was backed out is a dead end,
+// not the answer — and it is usually the louder one, because it repeated the
+// terms while flailing. Term frequency alone hands the agent that reverted
+// attempt first, which invites redoing what already failed. GaveUp must demote
+// it below a quieter session that held. decisionbench measures the lift on a
+// corpus (25% -> 100% held-first); this pins the behaviour in CI.
+func TestGaveUpSessionRanksBelowOneThatHeld(t *testing.T) {
+	day := time.Now().Add(-24 * time.Hour)
+	msg := func(role, text string) model.Message { return model.Message{Role: role, Text: text, Time: day} }
+
+	held := model.Session{
+		ID: "held", Harness: "claude", Project: "p", Updated: day,
+		Messages: []model.Message{
+			msg("user", "retry budget failing"),
+			msg("assistant", "We capped retries at 3 with jitter; the pool stopped saturating."),
+		},
+	}
+	// The reverted attempt is the louder match — it repeats the terms — and is
+	// equally recent, so on the text alone it wins.
+	reverted := model.Session{
+		ID: "reverted", Harness: "claude", Project: "p", Updated: day, GaveUp: true,
+		Messages: []model.Message{
+			msg("user", "retry budget retry budget again"),
+			msg("user", "retry budget still"),
+			msg("assistant", "We tried capping retries at 3 but reverted it — it did not help and we backed it out."),
+		},
+	}
+
+	hits, err := Run([]model.Session{reverted, held}, Options{Query: "retry budget", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || hits[0].Session.ID != "held" {
+		top := "—"
+		if len(hits) > 0 {
+			top = hits[0].Session.ID
+		}
+		t.Fatalf("a backed-out session outranked the one that held: top=%s", top)
+	}
+	// It is demoted, not hidden: the reverted attempt still appears, second.
+	if len(hits) != 2 {
+		t.Fatalf("the reverted session was dropped, not demoted: got %d hits", len(hits))
+	}
+}
+
+// GaveUp is a session-level flag: one line reporting a reversal marks the whole
+// session, even when a later line lands the real fix ("reverted the pool cap;
+// the fix was pgx"). Such a session reached a conclusion, so it must keep the
+// decision boost and take no give-up penalty — otherwise the outcome signal
+// buries the very answer it should surface, below a louder session that only
+// talked about the topic.
+func TestRevertedThenSolvedKeepsTheDecision(t *testing.T) {
+	day := time.Now().Add(-24 * time.Hour)
+	msg := func(role, text string) model.Message { return model.Message{Role: role, Text: text, Time: day} }
+
+	// Louder on the query terms and decides nothing — on term frequency alone it
+	// wins, and if the solved session were wrongly penalised it would stay on top.
+	plain := model.Session{
+		ID: "plain", Harness: "claude", Project: "p", Updated: day,
+		Messages: []model.Message{
+			msg("user", "connection pool connection pool question"),
+			msg("assistant", "Some background on the connection pool and connection pool sizing."),
+		},
+	}
+	// Reverted one attempt, landed another. GaveUp is true, but it decided
+	// something, so it must outrank the quiet-topic session above.
+	solved := model.Session{
+		ID: "solved", Harness: "claude", Project: "p", Updated: day, GaveUp: true,
+		Messages: []model.Message{
+			msg("user", "connection pool saturating"),
+			msg("assistant", "We reverted the connection pool cap; the fix was switching to pgx pooling."),
+		},
+	}
+
+	hits, err := Run([]model.Session{plain, solved}, Options{Query: "connection pool", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || hits[0].Session.ID != "solved" {
+		top := "—"
+		if len(hits) > 0 {
+			top = hits[0].Session.ID
+		}
+		t.Fatalf("a reverted-then-solved session was buried by a quiet-topic one: top=%s", top)
+	}
+}
+
+// The give-up penalty reads the transcript; a lifecycle state is a later human
+// judgement about the same session. Only "accepted" overrides the penalty — a
+// person vouched for the outcome. "rejected" agrees the session was a dead end,
+// so a rejected give-up must stay demoted even when it is the louder match;
+// otherwise marking a session rejected would rank it higher, not lower.
+func TestLifecycleGatesTheGiveUpPenalty(t *testing.T) {
+	day := time.Now().Add(-24 * time.Hour)
+	msg := func(role, text string) model.Message { return model.Message{Role: role, Text: text, Time: day} }
+
+	// The same reverted, undecided transcript recorded twice, differing only in
+	// the lifecycle state a person later attached. Identical text means identical
+	// term frequency, so the ONLY thing that can separate them is the give-up
+	// penalty: the accepted copy waives it (score S), the rejected copy takes it
+	// (0.5·S), so accepted must rank strictly first. Before the fix both states
+	// skipped the penalty, leaving them tied — the id "aaa-rejected" then sorted
+	// ahead and this failed, which is the behaviour it pins.
+	body := []model.Message{
+		msg("user", "cache stampede cache stampede"),
+		msg("assistant", "We tried a mutex but reverted it — it did not help and we backed it out."),
+	}
+	accepted := model.Session{
+		ID: "zzz-accepted", Harness: "claude", Project: "p", Updated: day,
+		GaveUp: true, Lifecycle: "accepted", Messages: body,
+	}
+	rejected := model.Session{
+		ID: "aaa-rejected", Harness: "claude", Project: "p", Updated: day,
+		GaveUp: true, Lifecycle: "rejected", Messages: body,
+	}
+
+	hits, err := Run([]model.Session{rejected, accepted}, Options{Query: "cache stampede", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 2 || hits[0].Session.ID != "zzz-accepted" {
+		top := "—"
+		if len(hits) > 0 {
+			top = hits[0].Session.ID
+		}
+		t.Fatalf("a rejected give-up was not ranked below the accepted copy of the same session: top=%s", top)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -487,7 +487,13 @@ func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLengt
 		// answered says them once and then explains. Measured on a corpus built
 		// for exactly that shape, the deciding session was ranked last of four
 		// in every case before this.
-		if decidesSomething(doc.hit.Session) {
+		//
+		// A session can both back out one attempt and land another ("reverted
+		// the pool cap; the fix was switching to pgx"). That still reached a
+		// conclusion, so it earns the boost — the give-up penalty below is what
+		// stays clear of it.
+		decided := decidesSomething(doc.hit.Session)
+		if decided {
 			score *= decisionBoost
 		}
 		// A pasted log outranks a human answer on term frequency alone: it
@@ -495,6 +501,24 @@ func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLengt
 		// this existed, the paste won every question of that shape.
 		if looksPasted(doc.hit.Session) {
 			score *= pastePenalty
+		}
+		// A session whose own text says the approach was backed out and reached
+		// no other conclusion is the dead end, not the answer: handed to an
+		// agent first, it invites repeating what already failed — and the
+		// louder it flailed, the higher term frequency ranks it. Demote it
+		// below a session that held, without hiding it (the marker still
+		// explains it was reverted). Only when it decided nothing else: a
+		// session that reverted one thing and settled another keeps the boost
+		// above. Skipped only when a person accepted the session afterwards —
+		// that is a fresher judgement that overrides the transcript. The other
+		// lifecycle states do not rescue it: rejected and stale agree it was a
+		// dead end, and superseded means a better record exists, so the give-up
+		// penalty still applies. Read the state off the session, not the hit: a
+		// hit's Lifecycle is attached by the CLI after ranking, so it is empty
+		// here, while a promoted session that arrived by sync carries its state
+		// on the session itself.
+		if doc.hit.Session.GaveUp && !decided && doc.hit.Session.Lifecycle != "accepted" {
+			score *= gaveUpPenalty
 		}
 		score *= freshnessDecay(doc.hit.Session.Updated, now)
 		doc.hit.Score = score
@@ -682,6 +706,12 @@ func decidesSomething(s model.Session) bool {
 // trace someone diagnosed, a config that turned out to be wrong — so this
 // lowers them behind real discussion rather than hiding them.
 const pastePenalty = 0.5
+
+// gaveUpPenalty damps a session whose own text reports the approach was backed
+// out. Same magnitude as pastePenalty and for the same reason: it lowers the
+// dead end behind a conclusion that held, but does not hide it — "we tried this
+// and reverted" is worth reading, second, so an agent learns what not to redo.
+const gaveUpPenalty = 0.5
 
 // pasteMinLines is the length below which repetition means nothing. Three
 // identical short lines are a list; fourteen are a log.

--- a/scripts/decisionbench/main.go
+++ b/scripts/decisionbench/main.go
@@ -174,6 +174,54 @@ func main() {
 		len(probes), hit1, 100*float64(hit1)/float64(len(probes)), hit3, 100*float64(hit3)/float64(len(probes)))
 	report("noise     ", sessions, noise, *verbose)
 	reportUsage(sessions, *verbose)
+	reportOutcome(*verbose)
+}
+
+// reportOutcome asks whether a conclusion that held outranks one the transcript
+// later backed out of. Both sessions decide the same thing in the same words;
+// one carries GaveUp because its own text reports the reversal. deja marks
+// GaveUp on a printed result but does not rank by it, so an agent is handed the
+// abandoned answer as readily as the one that worked. This measures that gap —
+// the first honest number for outcome-aware ranking.
+func reportOutcome(verbose bool) {
+	base := time.Date(2026, 2, 1, 3, 4, 5, 0, time.UTC)
+	var corpus []model.Session
+	var probes []probe
+	topics := []struct{ id, terms, held, reverted string }{
+		{"retry", "retry budget backoff", "We capped retries at 3 with jitter; the pool stopped saturating.", "We tried capping retries at 3 but reverted it — it did not help and we backed it out."},
+		{"cache", "cache stampede lock", "We added a per-key lock on the cache fill; stampedes stopped.", "We tried a per-key lock on the cache fill but gave up — it deadlocked, reverted."},
+		{"index", "search index rebuild", "We rebuilt the index incrementally; the memory spike is gone.", "We tried an incremental rebuild, abandoned it — it corrupted the index, backed out."},
+		{"schema", "schema migration lock", "We ran the migration in batches; no more lock timeouts.", "We tried a batched migration but reverted — it left half-migrated rows, gave up."},
+	}
+	for i, t := range topics {
+		day := base.AddDate(0, 0, -i*3)
+		// The trap: the session that backed out is the LOUDER one — it repeats
+		// the terms while flailing — and both are equally recent. On the text
+		// alone the abandoned answer wins, which is the dead end handed to the
+		// agent. Only knowing the outcome demotes it below the quieter one that
+		// held.
+		held := session(t.id+"-held", day, []string{t.terms + " failing", t.held})
+		rev := session(t.id+"-reverted", day, []string{
+			t.terms + " " + t.terms + " again", t.terms + " still", t.reverted,
+		})
+		rev.GaveUp = true
+		corpus = append(corpus, held, rev)
+		probes = append(probes, probe{query: t.terms, decision: t.id + "-held"})
+	}
+	first := 0
+	for _, p := range probes {
+		hits, _ := search.Run(corpus, search.Options{Query: p.query, All: true})
+		if len(hits) > 0 && hits[0].Session.ID == p.decision {
+			first++
+		} else if verbose {
+			top := "—"
+			if len(hits) > 0 {
+				top = hits[0].Session.ID
+			}
+			fmt.Printf("  miss  %-30q want=%s top=%s\n", p.query, p.decision, top)
+		}
+	}
+	fmt.Printf("outcome    %d · held ranked first %d (%.0f%%)\n", len(probes), first, 100*float64(first)/float64(len(probes)))
 }
 
 // corpus builds, for each question, one deciding session and several louder


### PR DESCRIPTION
`GaveUp` was only a display note, so a session whose transcript says it reverted an approach ranked like one that worked — often higher, because it repeated the terms while flailing. An agent handed that first just redoes what already failed.

Now a give-up that reached no other conclusion takes a 0.5 penalty (same size as the paste penalty), so the session that held ranks first. Two guards keep it honest:
- a session that reverted one attempt but settled another still counts as deciding something, so it keeps the decision boost and takes no penalty;
- a session a person marked `accepted` is never demoted for a stray reverted line — that judgement overrides the transcript. `rejected`/`stale`/`superseded` don't rescue it.

It's demoted, not hidden — the note still explains a path was backed out.

Measured: decisionbench held-first 25% → 100%, other axes unchanged. longmemeval evidence-recall flat to +0.8pt (54.2→55.0 hit@1), single-session-user +3.5, temporal +1.4 — no regression.