### PR TITLE
feat(hook): surface a project's accepted decisions at session start

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -757,6 +757,14 @@ func hookDigestResult(dir string) (string, int, int64, []string, int) {
 		}
 	}
 	mark("environment")
+	// The project's standing decisions lead the block: they are the user's own
+	// settled choices, and an agent should read them before the session digest,
+	// not after. Query-independent, so a convention surfaces even when nothing
+	// in the task names it — the gap plain recall cannot close.
+	if conv := projectConventions(names, 6, 800); conv != "" {
+		text = conv + "\n" + text
+	}
+	mark("conventions")
 	// The candidates that never made it into the digest were never served:
 	// counting their transcripts here inflated the distillation ratio deja
 	// prints about itself (1 session distilled, 3 sessions' bytes claimed).

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -676,6 +676,16 @@ func hookDigestResult(dir string) (string, int, int64, []string, int) {
 	mark("names+worktrees")
 	pol := policy.Load()
 	mark("policy")
+	// The standing decisions are scoped by the same trust policy as the session
+	// digest: a project the policy withholds from auto-activation must not leak
+	// its decisions here either.
+	var allowedNames []string
+	for _, n := range names {
+		if pol.Allows(policy.ActivationAuto, n) {
+			allowedNames = append(allowedNames, n)
+		}
+	}
+	conventions := projectConventions(allowedNames, 6, 800)
 	var ss []model.Session
 	seen := map[string]bool{}
 	lookupNames := names
@@ -713,6 +723,13 @@ func hookDigestResult(dir string) (string, int, int64, []string, int) {
 	}
 	mark("load-sessions")
 	if len(ss) == 0 {
+		// A project can have settled decisions and no recent session left to
+		// show them (the transcript was forgotten, or aged past the window).
+		// The standing decisions still apply, so serve them alone rather than
+		// going out empty.
+		if conventions != "" {
+			return conventions, 0, 0, nil, withheld
+		}
 		// withheld travels even with nothing to show: it is the only thing
 		// that separates "the rule hid all of it" from "no history here".
 		return "", 0, 0, nil, withheld
@@ -761,8 +778,8 @@ func hookDigestResult(dir string) (string, int, int64, []string, int) {
 	// settled choices, and an agent should read them before the session digest,
 	// not after. Query-independent, so a convention surfaces even when nothing
 	// in the task names it — the gap plain recall cannot close.
-	if conv := projectConventions(names, 6, 800); conv != "" {
-		text = conv + "\n" + text
+	if conventions != "" {
+		text = conventions + "\n" + text
 	}
 	mark("conventions")
 	// The candidates that never made it into the digest were never served:

--- a/cmd/deja/hook_conventions.go
+++ b/cmd/deja/hook_conventions.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// projectConventions returns a compact, query-independent block of the
+// decisions a user promoted and still accepts in this project.
+//
+// Recall surfaces a promoted note only when the query happens to match its
+// text, so a standing decision — "we use pgx, not database/sql" — stays silent
+// on every task that does not name it, which is most of them. The agent then
+// re-decides something the user already settled. This block states those
+// decisions up front, before the agent makes a choice, so it follows them
+// without anyone having to mention them.
+//
+// Only accepted notes for the current project, newest first, capped by count
+// and bytes. rejected/superseded/stale states are left out: LoadPromotedNotes
+// keeps the latest state per source, so a decision that was later reversed
+// carries a non-accepted state and never reaches here.
+func projectConventions(names []string, maxNotes, budget int) string {
+	if len(names) == 0 || maxNotes <= 0 || budget <= 0 {
+		return ""
+	}
+	want := map[string]bool{}
+	for _, n := range names {
+		want[n] = true
+	}
+	var picked []sources.PromotedNote
+	for _, n := range sources.LoadPromotedNotes() {
+		if n.State != "accepted" || !want[n.Project] {
+			continue
+		}
+		picked = append(picked, n)
+	}
+	if len(picked) == 0 {
+		return ""
+	}
+	// Newest first: a later decision outranks an older one on the same topic.
+	sort.Slice(picked, func(i, j int) bool { return picked[i].At.After(picked[j].At) })
+
+	var b strings.Builder
+	b.WriteString("standing decisions in this project (promoted and still accepted — follow them unless the user overrides):\n")
+	head := b.Len()
+	shown := 0
+	for _, note := range picked {
+		if shown >= maxNotes {
+			break
+		}
+		line := conventionLine(note)
+		if line == "" {
+			continue
+		}
+		row := "  · " + search.SafeLine(line) + "\n"
+		if b.Len()+len(row) > budget {
+			break
+		}
+		b.WriteString(row)
+		shown++
+	}
+	if b.Len() == head {
+		return ""
+	}
+	return b.String()
+}
+
+// conventionLine is the one line to show for a promoted note: its title, or the
+// first sentence of its body when it has no title. Kept short — the block is a
+// reminder of what was decided, not the reasoning, which recall_context carries.
+func conventionLine(n sources.PromotedNote) string {
+	if t := strings.TrimSpace(n.Title); t != "" {
+		return t
+	}
+	text := strings.TrimSpace(strings.ReplaceAll(n.Text, "\n", " "))
+	if text == "" {
+		return ""
+	}
+	for i, r := range text {
+		if (r == '.' || r == '!' || r == '?') && (i+1 >= len(text) || text[i+1] == ' ') {
+			return strings.TrimSpace(text[:i+1])
+		}
+	}
+	const cap = 200
+	if len(text) > cap {
+		return strings.TrimSpace(text[:cap])
+	}
+	return text
+}

--- a/cmd/deja/hook_conventions_test.go
+++ b/cmd/deja/hook_conventions_test.go
@@ -107,3 +107,27 @@ func TestSessionStartSurfacesADecisionTheDigestDropped(t *testing.T) {
 		t.Fatalf("the decision was already in the digest; the block proves nothing here:\n%s", text)
 	}
 }
+
+// Standing decisions are scoped by the same trust policy as the session digest:
+// a project whose origin the policy withholds from auto-activation must not have
+// its decisions injected either.
+func TestStandingDecisionsRespectTheTrustPolicy(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("CLAUDE_PROJECT_DIR", "/proj")
+
+	seedDecision(t, "proj", "decision", "we standardised on pgx pgxpolicymarker")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "promote", "decision"); err != nil {
+		t.Fatal(err)
+	}
+	// Deny local memory for auto-activation.
+	writePolicyFile(t, `{"activations":{"auto":{"local":false}}}`)
+
+	text, _, _, _, _ := hookDigestResult(dir)
+	if strings.Contains(text, "pgxpolicymarker") {
+		t.Fatalf("a policy-denied project's decision was injected into the hook:\n%s", text)
+	}
+}

--- a/cmd/deja/hook_conventions_test.go
+++ b/cmd/deja/hook_conventions_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+func seedDecision(t *testing.T, project, id, text string) {
+	t.Helper()
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-"+project)
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"` + text + `"},"timestamp":"2026-07-12T10:00:00Z","sessionId":"` + id + `","cwd":"/` + project + `"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// projectConventions returns only the accepted notes for the named project, and
+// excludes rejected notes and other projects' decisions.
+func TestProjectConventionsFiltersToAcceptedAndProject(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+
+	seedDecision(t, "proj", "keep", "we chose pgx over database/sql keepmarker")
+	seedDecision(t, "proj", "gone", "we tried the ORM but dropped it gonemarker")
+	seedDecision(t, "other", "elsewhere", "unrelated project decision othermarker")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "promote", "keep"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "promote", "gone", "--state", "rejected", "--note", "backed out"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "promote", "elsewhere"); err != nil {
+		t.Fatal(err)
+	}
+
+	out := projectConventions([]string{"proj"}, 6, 800)
+	if !strings.Contains(out, "keepmarker") {
+		t.Fatalf("accepted decision for the project was not surfaced:\n%s", out)
+	}
+	if strings.Contains(out, "gonemarker") {
+		t.Fatalf("a rejected decision leaked into the standing block:\n%s", out)
+	}
+	if strings.Contains(out, "othermarker") {
+		t.Fatalf("another project's decision leaked in:\n%s", out)
+	}
+	// A project with nothing accepted gets no block at all.
+	if s := projectConventions([]string{"other"}, 6, 800); strings.Contains(s, "keepmarker") {
+		t.Fatalf("proj decision leaked into other's block:\n%s", s)
+	}
+}
+
+// The standing-decisions block surfaces a settled decision that the reactive
+// session digest drops. Without a task signal the digest loads only the few
+// newest sessions per project, so an older decision falls outside it — yet it is
+// exactly the kind an agent must not re-litigate. The convention block carries
+// it regardless of how many newer sessions buried it.
+func TestSessionStartSurfacesADecisionTheDigestDropped(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("CLAUDE_PROJECT_DIR", "/proj")
+
+	// The decision is the oldest; three newer sessions push it out of the
+	// recency-limited digest window.
+	seedDecision(t, "proj", "decision", "we standardised on pgx not database/sql pgxdecisionmarker")
+	for _, s := range []struct{ id, text string }{
+		{"newer1", "tweak the landing page copy newer1marker"},
+		{"newer2", "bump the linter version newer2marker"},
+		{"newer3", "rename a test helper newer3marker"},
+	} {
+		store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+		rec := `{"type":"user","message":{"role":"user","content":"` + s.text + `"},"timestamp":"2026-07-20T10:00:00Z","sessionId":"` + s.id + `","cwd":"/proj"}` + "\n"
+		if err := os.WriteFile(filepath.Join(store, s.id+".jsonl"), []byte(rec), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "promote", "decision"); err != nil {
+		t.Fatal(err)
+	}
+
+	text, _, _, _, _ := hookDigestResult(dir)
+	if !strings.Contains(text, "standing decisions in this project") {
+		t.Fatalf("no standing-decisions block was injected:\n%s", text)
+	}
+	marker := "pgxdecisionmarker"
+	idx := strings.Index(text, "standing decisions in this project")
+	convBlock := text[idx:]
+	rest := text[:idx]
+	if !strings.Contains(convBlock, marker) {
+		t.Fatalf("the decision was not in the standing block:\n%s", text)
+	}
+	// The proof that this closes a real gap: the reactive digest did not carry
+	// the decision on its own — only the convention block did.
+	if strings.Contains(rest, marker) {
+		t.Fatalf("the decision was already in the digest; the block proves nothing here:\n%s", text)
+	}
+}


### PR DESCRIPTION
Promoted notes only surface through recall when the query lexically matches their text. A standing decision — "we standardised on pgx, not database/sql" — then stays silent on every task that doesn't name it, and the agent re-decides something the user already settled.

SessionStart now injects the accepted decisions for the current project up front: query-independent, recency-independent, only `accepted` state, only this project, capped at 6 notes / 800 bytes. rejected/superseded/stale never appear.

Test proves the gap it closes: without a task signal the digest loads only the newest few sessions per project, so an older decision falls outside it — the new block carries it anyway, and the test asserts the decision is present only in the standing block, not in the reactive digest.