### PR TITLE
fix(search): name the user's pattern in an invalid --re error

### DIFF
--- a/internal/search/regex_error_test.go
+++ b/internal/search/regex_error_test.go
@@ -1,0 +1,24 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// An invalid --re pattern must report the pattern the user typed, not deja's
+// case-insensitive prefix. Compiling "(?i)"+query echoed `(?i)(` back at someone
+// who wrote `(`, which reads like their own text and hides the real mistake.
+func TestRegexErrorNamesTheUserPattern(t *testing.T) {
+	_, err := Run([]model.Session{}, Options{Query: "(", Regex: true})
+	if err == nil {
+		t.Fatal("an invalid regex must be reported, not swallowed")
+	}
+	if strings.Contains(err.Error(), "(?i)") {
+		t.Fatalf("the error leaks deja's injected (?i) prefix: %v", err)
+	}
+	if !strings.Contains(err.Error(), "`(`") && !strings.Contains(err.Error(), ": (") {
+		t.Fatalf("the error does not name the user's pattern: %v", err)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -151,6 +151,13 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 		var err error
 		re, err = regexp.Compile("(?i)" + o.Query)
 		if err != nil {
+			// The (?i) prefix is deja's, not the user's. Reporting the compile
+			// error verbatim echoes `(?i)(` back at someone who typed `(`, so
+			// re-compile their pattern alone for a message that names what they
+			// actually wrote.
+			if _, uerr := regexp.Compile(o.Query); uerr != nil {
+				return nil, uerr
+			}
 			return nil, err
 		}
 	}


### PR DESCRIPTION
An invalid `--re` regex reported deja's injected `(?i)` prefix — someone who typed `(` saw `error parsing regexp: missing closing ): (?i)(`. Re-compile the bare pattern on failure so the message names what they actually wrote. RE2 already rules out catastrophic backtracking; this is purely the error text.