### PR TITLE
fix(stats): replace an extension the card cannot honour instead of appending

### DIFF
--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -68,7 +68,11 @@ func runStats(dir string, args []string) error {
 			card = true
 			cardPath = "deja-stats.svg"
 			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-				cardPath = cardFileName(args[i+1])
+				var note string
+				cardPath, note = cardFileName(args[i+1])
+				if note != "" {
+					fmt.Fprint(os.Stderr, note)
+				}
 				i++
 			}
 		case "--harness", "--project", "--since", "--role":
@@ -398,9 +402,18 @@ func statHarnessTag(h string, color bool) string {
 // writing it into card.png produced a file GitHub serves as a PNG and every
 // browser refuses — while the command cheerfully printed the markdown to embed
 // it. A name that already says svg is left alone.
-func cardFileName(path string) string {
-	if strings.EqualFold(filepath.Ext(path), ".svg") {
-		return path
+func cardFileName(path string) (string, string) {
+	ext := filepath.Ext(path)
+	if strings.EqualFold(ext, ".svg") {
+		return path, ""
 	}
-	return path + ".svg"
+	// Appending kept the wrong extension in the name: card.png became
+	// card.png.svg, an SVG named after a format it is not, and a script that
+	// went on to upload card.png found nothing there (#1056). Replace it, and
+	// say so once — silence is what made the first version confusing.
+	if ext != "" {
+		out := strings.TrimSuffix(path, ext) + ".svg"
+		return out, fmt.Sprintf("deja: the card is an SVG, so it goes to %s rather than %s\n", filepath.Base(out), filepath.Base(path))
+	}
+	return path + ".svg", ""
 }

--- a/cmd/deja/stats_test.go
+++ b/cmd/deja/stats_test.go
@@ -12,16 +12,24 @@ import (
 // markdown to embed it — a broken image for anyone who followed the hint.
 
 func TestCardFileNameKeepsTheFormatHonest(t *testing.T) {
+	// An extension deja cannot honour is replaced, not appended: card.png used
+	// to become card.png.svg, an SVG named after a format it is not (#1056).
 	for in, want := range map[string]string{
 		"deja-stats.svg": "deja-stats.svg",
 		"CARD.SVG":       "CARD.SVG",
-		"card.png":       "card.png.svg",
-		"card.txt":       "card.txt.svg",
+		"card.png":       "card.svg",
+		"card.txt":       "card.svg",
 		"card":           "card.svg",
 		"dir/card":       "dir/card.svg",
+		"dir/card.jpeg":  "dir/card.svg",
 	} {
-		if got := cardFileName(in); got != want {
+		got, note := cardFileName(in)
+		if got != want {
 			t.Fatalf("cardFileName(%q) = %q, want %q", in, got, want)
+		}
+		// The replacement is stated once; a name deja could keep says nothing.
+		if wantNote := filepath.Ext(in) != "" && !strings.EqualFold(filepath.Ext(in), ".svg"); wantNote != (note != "") {
+			t.Errorf("cardFileName(%q) note = %q, want a note: %v", in, note, wantNote)
 		}
 	}
 }


### PR DESCRIPTION
When the stats card path carries an extension the card writer can't honour, deja appended its own instead of replacing it, producing a double-extension filename. Replace it and emit a one-line note. `cardFileName` now returns the path and that note. Rebased out of an old audit branch; the rest of that branch was already in main.