### PR TITLE
feat: point-of-action recall — carry the prior decision, wire hook-tool into PreToolUse

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -15,8 +15,10 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
@@ -46,6 +48,12 @@ const (
 	toolHookMaxBytes = 480
 	// toolHookDecisionBudget bounds the extracted decision inside that cap.
 	toolHookDecisionBudget = 200
+	// toolHookDecisionScan caps how many of the newest sessions the file line
+	// reads for a decision — this runs inside an action the agent waits on.
+	toolHookDecisionScan = 3
+	// toolHookMsgTail caps the messages scanned per session for the same reason:
+	// a decision states itself near the end, not buried in a long transcript.
+	toolHookMsgTail = 150
 	// toolHookMinFileSessions is when a file's history stops being noise. A
 	// file two sessions touched is ordinary work; five is a place with a past.
 	toolHookMinFileSessions = 5
@@ -246,25 +254,66 @@ func fileHookLine(dir, path string) string {
 
 // fileDecisionLine returns the single most relevant prior decision recorded
 // about this file, or "" if none can be extracted. It reads the newest in-scope
-// sessions (bounded, newest first) and takes the first one that yields a
-// conclusion — the same decision-carrying line the SessionStart digest surfaces,
-// but delivered at the moment the file is about to change.
+// sessions (bounded, newest first) and takes the first that yields a conclusion
+// and was not later taken back — the same decision-carrying line the SessionStart
+// digest surfaces, but delivered at the moment the file is about to change.
 func fileDecisionLine(dir string, metas []index.SessionMeta) string {
 	sort.Slice(metas, func(i, j int) bool { return metas[i].Updated.After(metas[j].Updated) })
-	const scan = 5
+	states := sources.PromotedLifecycles()
 	for i, meta := range metas {
-		if i >= scan {
+		if i >= toolHookDecisionScan {
 			break
 		}
 		s, ok, err := index.FindByIdentity(dir, meta.Harness, meta.ID)
-		if err != nil || !ok {
+		if err != nil || !ok || !decisionUsable(s, states) {
 			continue
 		}
+		// Bound the work inside a hook the agent is blocked on: a marathon
+		// session's whole history is not worth scanning for one line, and a
+		// decision states itself near the end anyway.
+		if len(s.Messages) > toolHookMsgTail {
+			s.Messages = s.Messages[len(s.Messages)-toolHookMsgTail:]
+		}
 		if cs := digest.Conclusions(s, toolHookDecisionBudget, 1); len(cs) > 0 {
-			return search.SafeText(strings.TrimSpace(cs[0]))
+			return trimTrailingFragment(search.SafeText(strings.TrimSpace(cs[0])))
 		}
 	}
 	return ""
+}
+
+// decisionUsable rejects a session whose decision should not be reused: one that
+// says in its own words it backed the approach out (GaveUp), and one a later
+// state marked rejected, superseded or stale. Surfacing either at the point of an
+// edit would push the agent to redo exactly what was undone.
+func decisionUsable(s model.Session, states map[string]sources.Lifecycle) bool {
+	if s.GaveUp {
+		return false
+	}
+	state := s.Lifecycle // a note that arrived by sync carries its own state
+	if lc, ok := states[s.Harness+":"+s.ID]; ok && lc.State != "" {
+		state = lc.State
+	}
+	switch state {
+	case "rejected", "superseded", "stale":
+		return false
+	}
+	return true
+}
+
+// trimTrailingFragment drops a half-word left by a byte-budget cut, so a decision
+// reads as "capped retries" rather than "capped retr". Only when the text was
+// actually cut (near the budget and not ending a sentence).
+func trimTrailingFragment(s string) string {
+	if len(s) < toolHookDecisionBudget-4 {
+		return s
+	}
+	if r := s[len(s)-1]; r == '.' || r == '!' || r == '?' {
+		return s
+	}
+	if i := strings.LastIndexAny(s, " \t"); i > 0 {
+		return strings.TrimRight(s[:i], " \t") + "…"
+	}
+	return s
 }
 
 // fileMetaInScope keeps a session only if it worked on this exact path (an

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -7,6 +7,7 @@ import (
 	"hash/fnv"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -29,16 +30,22 @@ import (
 // 1165-session store, 335 commands were run in three or more separate sessions
 // and 487 files were touched in five or more.
 //
-// The cost side is the reason this is deliberately thin. A prompt hook is paid
-// once per message; this is paid once per action, and there are an order of
-// magnitude more of those. So: a hard cap of one short line, no digest, no
-// snippets, and silence unless the history is a pattern rather than a
-// coincidence.
+// The cost side is the reason this stays lean. A prompt hook is paid once per
+// message; this is paid once per action, and there are an order of magnitude
+// more of those. So: at most one line carrying at most one prior decision, no
+// digest, no snippets, and silence unless the history is a pattern rather than a
+// coincidence. A measured A/B settled the payload: a line that only pointed at
+// `deja blame` changed nothing an agent did, while the same line carrying the
+// decision drove it to reuse the prior fix — so the file line names the decision
+// and keeps the pointer only as a fallback.
 
 const (
-	// toolHookMaxBytes is the whole payload. The line is a pointer, not an
-	// answer: an agent that wants the story calls recall.
-	toolHookMaxBytes = 300
+	// toolHookMaxBytes caps the whole payload. Wider than a bare pointer because
+	// the file line now carries one prior decision, which the measurement showed
+	// is what makes the difference; still one line, still per-action cheap.
+	toolHookMaxBytes = 480
+	// toolHookDecisionBudget bounds the extracted decision inside that cap.
+	toolHookDecisionBudget = 200
 	// toolHookMinFileSessions is when a file's history stops being noise. A
 	// file two sessions touched is ordinary work; five is a place with a past.
 	toolHookMinFileSessions = 5
@@ -108,8 +115,38 @@ func toolHookLine(dir string, input toolHookInput) string {
 		if path := strings.TrimSpace(input.ToolInput.FilePath); path != "" {
 			return fileHookLine(dir, path)
 		}
+	case "apply_patch":
+		// Codex and other OpenAI-style agents make every file edit through a
+		// single apply_patch tool: the patch text is in `command` and the path
+		// is in its header, not in file_path. Pull the targets out so the
+		// file-history line fires here too — without this the hook is blind to
+		// every edit those agents make.
+		for _, path := range applyPatchFiles(input.ToolInput.Command) {
+			if line := fileHookLine(dir, path); line != "" {
+				return line
+			}
+		}
 	}
 	return ""
+}
+
+// applyPatchFiles pulls the target paths out of an apply_patch body. Each file
+// section is headed by "*** Add File: p", "*** Update File: p" or "*** Delete
+// File: p", and a rename adds "*** Move to: p".
+func applyPatchFiles(patch string) []string {
+	var out []string
+	for _, line := range strings.Split(patch, "\n") {
+		line = strings.TrimSpace(line)
+		for _, pfx := range []string{"*** Update File: ", "*** Add File: ", "*** Delete File: ", "*** Move to: "} {
+			if strings.HasPrefix(line, pfx) {
+				if p := strings.TrimSpace(line[len(pfx):]); p != "" {
+					out = append(out, p)
+				}
+				break
+			}
+		}
+	}
+	return out
 }
 
 func commandHookLine(dir, cmd string) string {
@@ -173,6 +210,7 @@ func fileHookLine(dir, path string) string {
 	pol := policy.Load()
 	var sessions int
 	var last time.Time
+	var inScope []index.SessionMeta
 	for _, meta := range index.FileSessions(dir, path) {
 		if !pol.Allows(policy.ActivationAuto, meta.Project) {
 			continue
@@ -181,6 +219,7 @@ func fileHookLine(dir, path string) string {
 			continue
 		}
 		sessions++
+		inScope = append(inScope, meta)
 		if meta.Updated.After(last) {
 			last = meta.Updated
 		}
@@ -192,8 +231,40 @@ func fileHookLine(dir, path string) string {
 	if !last.IsZero() {
 		when = ", last " + last.Local().Format("2006-01-02")
 	}
-	return fmt.Sprintf("%s has been worked on in %s%s — `deja blame %s` has the history.",
-		search.SafeText(baseName(path)), toolSessionCount(sessions), when, search.SafeText(baseName(path)))
+	name := search.SafeText(baseName(path))
+	head := fmt.Sprintf("%s has been worked on in %s%s", name, toolSessionCount(sessions), when)
+	// The measured difference between a nudge that changes what an agent does
+	// and one it ignores is whether it carries the decision or only points at
+	// it: a line that said "deja blame X has the history" drove no reuse, while
+	// the same moment carrying the prior decision did. So surface the decision
+	// here, and fall back to the pointer only when none can be extracted.
+	if d := fileDecisionLine(dir, inScope); d != "" {
+		return head + " — prior decision: " + d
+	}
+	return fmt.Sprintf("%s — `deja blame %s` has the history.", head, name)
+}
+
+// fileDecisionLine returns the single most relevant prior decision recorded
+// about this file, or "" if none can be extracted. It reads the newest in-scope
+// sessions (bounded, newest first) and takes the first one that yields a
+// conclusion — the same decision-carrying line the SessionStart digest surfaces,
+// but delivered at the moment the file is about to change.
+func fileDecisionLine(dir string, metas []index.SessionMeta) string {
+	sort.Slice(metas, func(i, j int) bool { return metas[i].Updated.After(metas[j].Updated) })
+	const scan = 5
+	for i, meta := range metas {
+		if i >= scan {
+			break
+		}
+		s, ok, err := index.FindByIdentity(dir, meta.Harness, meta.ID)
+		if err != nil || !ok {
+			continue
+		}
+		if cs := digest.Conclusions(s, toolHookDecisionBudget, 1); len(cs) > 0 {
+			return search.SafeText(strings.TrimSpace(cs[0]))
+		}
+	}
+	return ""
 }
 
 // fileMetaInScope keeps a session only if it worked on this exact path (an

--- a/cmd/deja/hook_tool_test.go
+++ b/cmd/deja/hook_tool_test.go
@@ -167,6 +167,100 @@ func TestToolHookFileScopingIsLoadBearing(t *testing.T) {
 	}
 }
 
+// Codex and other OpenAI-style agents edit through a single apply_patch tool,
+// with the path inside the patch body rather than in file_path. The hook must
+// read that path so its file-history line fires on those agents' edits too,
+// not only on Claude's Edit/Write.
+func TestToolHookReadsTheFileFromAnApplyPatch(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for i := 0; i < 6; i++ {
+		id := "s" + string(rune('0'+i))
+		writeClaudeFixture(t, filepath.Join(root, "alpha", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"edit"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"/work/alpha/config.go","old_string":"a","new_string":"b"}}]}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", "/work/alpha")
+	patch := "*** Begin Patch\n*** Update File: /work/alpha/config.go\n@@\n+x\n*** End Patch\n"
+	payloadBytes, _ := json.Marshal(map[string]any{
+		"hook_event_name": "PreToolUse",
+		"tool_name":       "apply_patch",
+		"tool_input":      map[string]any{"command": patch},
+		"session_id":      "now",
+		"cwd":             "/work/alpha",
+	})
+	out := toolHookRun(t, string(payloadBytes))
+	if out == "" {
+		t.Fatal("apply_patch on a file with history produced no line")
+	}
+	var resp sessionStartHookResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(resp.HookSpecificOutput.AdditionalContext, "6 sessions") {
+		t.Errorf("apply_patch file history not surfaced:\n%s", resp.HookSpecificOutput.AdditionalContext)
+	}
+	if !strings.Contains(resp.HookSpecificOutput.AdditionalContext, "config.go") {
+		t.Errorf("the line does not name the file: %q", resp.HookSpecificOutput.AdditionalContext)
+	}
+	// A patch that only touches a file with no history stays silent.
+	noHist := "*** Begin Patch\n*** Add File: /work/alpha/brandnew.go\n@@\n+package p\n*** End Patch\n"
+	nb, _ := json.Marshal(map[string]any{
+		"hook_event_name": "PreToolUse", "tool_name": "apply_patch",
+		"tool_input": map[string]any{"command": noHist}, "session_id": "now2", "cwd": "/work/alpha",
+	})
+	if got := toolHookRun(t, string(nb)); got != "" {
+		t.Errorf("apply_patch on a file with no history spoke: %q", got)
+	}
+}
+
+// The file line carries the prior decision, not just a pointer to it: a
+// measured A/B showed a bare "deja blame has the history" changed nothing an
+// agent did, while the same moment carrying the decision drove reuse. When a
+// session that touched the file recorded a decision, it must appear in the line.
+func TestToolHookFileLineCarriesThePriorDecision(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	// Five plain edits so the file clears the history threshold.
+	for i := 0; i < 5; i++ {
+		id := "s" + string(rune('0'+i))
+		writeClaudeFixture(t, filepath.Join(root, "alpha", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"edit"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"/work/alpha/config.go","old_string":"a","new_string":"b"}}]}}`,
+		})
+	}
+	// The deciding session edits config.go and states the decision.
+	writeClaudeFixture(t, filepath.Join(root, "alpha", "decide.jsonl"), "decide", []string{
+		`{"type":"user","sessionId":"decide","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:05Z","message":{"role":"user","content":"settle config.go"}}`,
+		`{"type":"assistant","sessionId":"decide","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:06Z","message":{"role":"assistant","content":[{"type":"text","text":"Decision: config.go must load the ARENAGUARD sentinel before any read."},{"type":"tool_use","id":"td","name":"Edit","input":{"file_path":"/work/alpha/config.go","old_string":"x","new_string":"y"}}]}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", "/work/alpha")
+	out := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"/work/alpha/config.go"},"session_id":"now","cwd":"/work/alpha"}`)
+	if out == "" {
+		t.Fatal("no line for a file with history and a decision")
+	}
+	var resp sessionStartHookResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatal(err)
+	}
+	ctx := resp.HookSpecificOutput.AdditionalContext
+	if !strings.Contains(ctx, "prior decision:") {
+		t.Errorf("the line does not carry the decision:\n%s", ctx)
+	}
+	if !strings.Contains(ctx, "ARENAGUARD") {
+		t.Errorf("the decision content is missing:\n%s", ctx)
+	}
+}
+
 // The command line honours the trust policy: a command that ran only in a
 // withheld project stays silent, and the count excludes withheld sessions.
 func TestToolHookCommandHonoursTrustPolicy(t *testing.T) {

--- a/cmd/deja/hook_tool_test.go
+++ b/cmd/deja/hook_tool_test.go
@@ -261,6 +261,43 @@ func TestToolHookFileLineCarriesThePriorDecision(t *testing.T) {
 	}
 }
 
+// A decision the session itself took back must not be surfaced at the point of
+// an edit — that would push the agent to redo what was undone. When the only
+// session with a conclusion says it reverted, the line falls back to the pointer.
+func TestToolHookFileLineSkipsARevertedDecision(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for i := 0; i < 5; i++ {
+		id := "s" + string(rune('0'+i))
+		writeClaudeFixture(t, filepath.Join(root, "alpha", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"edit"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"/work/alpha/config.go","old_string":"a","new_string":"b"}}]}}`,
+		})
+	}
+	// The only session with a decision also says it reverted it.
+	writeClaudeFixture(t, filepath.Join(root, "alpha", "decide.jsonl"), "decide", []string{
+		`{"type":"user","sessionId":"decide","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:05Z","message":{"role":"user","content":"settle config.go"}}`,
+		`{"type":"assistant","sessionId":"decide","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:06Z","message":{"role":"assistant","content":[{"type":"text","text":"Decision: config.go should load the ARENAGUARD sentinel.\nBut we reverted it — it did not help and we backed it out."},{"type":"tool_use","id":"td","name":"Edit","input":{"file_path":"/work/alpha/config.go","old_string":"x","new_string":"y"}}]}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", "/work/alpha")
+	out := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"/work/alpha/config.go"},"session_id":"now","cwd":"/work/alpha"}`)
+	var resp sessionStartHookResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatal(err)
+	}
+	ctx := resp.HookSpecificOutput.AdditionalContext
+	if strings.Contains(ctx, "ARENAGUARD") {
+		t.Errorf("a reverted decision was surfaced at the edit:\n%s", ctx)
+	}
+	if !strings.Contains(ctx, "deja blame config.go") {
+		t.Errorf("with no usable decision it should fall back to the pointer:\n%s", ctx)
+	}
+}
+
 // The command line honours the trust policy: a command that ran only in a
 // withheld project stays silent, and the count excludes withheld sessions.
 func TestToolHookCommandHonoursTrustPolicy(t *testing.T) {

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -733,6 +733,10 @@ func installClaudeHook(exe string, uninstall bool) (installResult, error) {
 	nextRoot := updateClaudeSessionStartHook(root, exe, uninstall)
 	nextRoot = updateClaudeHook(nextRoot, "PreCompact", exe+" hook-precompact", "manual|auto", uninstall)
 	nextRoot = updateClaudeHook(nextRoot, "UserPromptSubmit", exe+" hook-prompt", "", uninstall)
+	// Recall at the moment of the action: before an edit or a command, hook-tool
+	// names the file's or command's prior decision. Scoped to the tools that
+	// change something so it never fires on a Read or a Glob.
+	nextRoot = updateClaudeHook(nextRoot, "PreToolUse", exe+" hook-tool", "Bash|Edit|Write|MultiEdit|NotebookEdit", uninstall)
 	next, err := json.MarshalIndent(nextRoot, "", "  ")
 	if err != nil {
 		return installResult{}, err
@@ -759,6 +763,8 @@ func hookStatusMessage(event string) string {
 		return "Searching past sessions…"
 	case "PreCompact":
 		return "Saving this session to memory…"
+	case "PreToolUse":
+		return "Checking what this touches…"
 	}
 	return ""
 }

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -33,7 +33,9 @@ func installCodexHooks(exe string, uninstall bool) (installResult, error) {
 	// the prior decision for the file or command about to change. Codex uses the
 	// same hooks.json shape as Claude Code, so both wire the same way.
 	updateCodexHook(root, "SessionStart", exe+" hook-context", "startup|resume", uninstall)
-	updateCodexHook(root, "PreToolUse", exe+" hook-tool", ".*", uninstall)
+	// Scoped to the tools that run a command or change a file (codex edits via
+	// apply_patch), so the hook does not spawn on every read.
+	updateCodexHook(root, "PreToolUse", exe+" hook-tool", "Bash|apply_patch", uninstall)
 	if hooks, _ := root["hooks"].(map[string]any); len(hooks) == 0 {
 		delete(root, "hooks")
 	}

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -29,46 +29,12 @@ func installCodexHooks(exe string, uninstall bool) (installResult, error) {
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, err
 	}
-	cmd := exe + " hook-context"
-	hooks, _ := root["hooks"].(map[string]any)
-	if hooks == nil {
-		hooks = map[string]any{}
-		root["hooks"] = hooks
-	}
-	entries, _ := hooks["SessionStart"].([]any)
-	var kept []any
-	found := false
-	for _, entryAny := range entries {
-		entry, _ := entryAny.(map[string]any)
-		if entry != nil && entryHasCommand(entry, cmd) {
-			if uninstall {
-				continue
-			}
-			// Take the entry over rather than leaving it as it was: an install
-			// from a new binary path, or from a version that gained a field,
-			// has to update ours in place or the change never reaches anyone
-			// who already had it.
-			found = true
-			adoptCodexHookEntry(entry, cmd)
-		}
-		kept = append(kept, entryAny)
-	}
-	if !uninstall && !found {
-		kept = append(kept, map[string]any{
-			"matcher": "startup|resume",
-			"hooks": []any{map[string]any{
-				"type": "command", "command": cmd, "timeout": 10,
-				// Codex surfaces statusMessage in its hook run summary.
-				"statusMessage": hookStatusMessage("SessionStart"),
-			}},
-		})
-	}
-	if len(kept) == 0 {
-		delete(hooks, "SessionStart")
-	} else {
-		hooks["SessionStart"] = kept
-	}
-	if len(hooks) == 0 {
+	// SessionStart carries the project digest; PreToolUse (hook-tool) carries
+	// the prior decision for the file or command about to change. Codex uses the
+	// same hooks.json shape as Claude Code, so both wire the same way.
+	updateCodexHook(root, "SessionStart", exe+" hook-context", "startup|resume", uninstall)
+	updateCodexHook(root, "PreToolUse", exe+" hook-tool", ".*", uninstall)
+	if hooks, _ := root["hooks"].(map[string]any); len(hooks) == 0 {
 		delete(root, "hooks")
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
@@ -80,9 +46,47 @@ func installCodexHooks(exe string, uninstall bool) (installResult, error) {
 	return installResult{Path: path, Action: a}, err
 }
 
+// updateCodexHook merges one deja hook for an event into codex's hooks.json,
+// idempotently: it adopts an entry we already own (so a move or an upgrade
+// updates in place) and adds one otherwise. Same shape as updateClaudeHook.
+func updateCodexHook(root map[string]any, event, cmd, matcher string, uninstall bool) {
+	hooks, _ := root["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+		root["hooks"] = hooks
+	}
+	entries, _ := hooks[event].([]any)
+	var kept []any
+	found := false
+	for _, entryAny := range entries {
+		entry, _ := entryAny.(map[string]any)
+		if entry != nil && entryHasCommand(entry, cmd) {
+			if uninstall {
+				continue
+			}
+			found = true
+			adoptCodexHookEntry(entry, cmd, event)
+		}
+		kept = append(kept, entryAny)
+	}
+	if !uninstall && !found {
+		h := map[string]any{"type": "command", "command": cmd, "timeout": 10}
+		// Codex surfaces statusMessage in its hook run summary.
+		if msg := hookStatusMessage(event); msg != "" {
+			h["statusMessage"] = msg
+		}
+		kept = append(kept, map[string]any{"matcher": matcher, "hooks": []any{h}})
+	}
+	if len(kept) == 0 {
+		delete(hooks, event)
+	} else {
+		hooks[event] = kept
+	}
+}
+
 // adoptCodexHookEntry rewrites the command and status message of an entry deja
 // already owns.
-func adoptCodexHookEntry(entry map[string]any, cmd string) {
+func adoptCodexHookEntry(entry map[string]any, cmd, event string) {
 	hs, _ := entry["hooks"].([]any)
 	for _, hAny := range hs {
 		h, _ := hAny.(map[string]any)
@@ -90,7 +94,7 @@ func adoptCodexHookEntry(entry map[string]any, cmd string) {
 			continue
 		}
 		h["command"] = cmd
-		if msg := hookStatusMessage("SessionStart"); msg != "" {
+		if msg := hookStatusMessage(event); msg != "" {
 			h["statusMessage"] = msg
 		}
 	}
@@ -316,7 +320,7 @@ func installSettingsHookRetiring(path, event, matcher string, timeout int, cmd s
 			// has to update ours in place or the change never reaches anyone
 			// who already had it.
 			found = true
-			adoptCodexHookEntry(entry, cmd)
+			adoptCodexHookEntry(entry, cmd, event)
 		}
 		kept = append(kept, entryAny)
 	}

--- a/cmd/deja/install_hooks_test.go
+++ b/cmd/deja/install_hooks_test.go
@@ -134,6 +134,76 @@ func TestCodexHookInstallAdoptsAnOlderEntry(t *testing.T) {
 	}
 }
 
+// Point-of-action recall is wired as a PreToolUse hook for both codex and
+// Claude, idempotently, and removed on uninstall.
+func TestPreToolUseWiresHookTool(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".claude"))
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	countHookTool := func(path, event string) int {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return 0
+		}
+		var root struct {
+			Hooks map[string][]struct {
+				Hooks []struct {
+					Command string `json:"command"`
+				} `json:"hooks"`
+			} `json:"hooks"`
+		}
+		if err := json.Unmarshal(b, &root); err != nil {
+			t.Fatalf("bad json in %s: %v", path, err)
+		}
+		n := 0
+		for _, g := range root.Hooks[event] {
+			for _, h := range g.Hooks {
+				if strings.Contains(h.Command, "deja") && strings.HasSuffix(h.Command, "hook-tool") {
+					n++
+				}
+			}
+		}
+		return n
+	}
+	codexPath := filepath.Join(home, ".codex", "hooks.json")
+	claudePath := filepath.Join(home, ".claude", "settings.json")
+
+	// Install twice: the PreToolUse hook-tool entry lands once, not twice.
+	for i := 0; i < 2; i++ {
+		if _, err := installCodexHooks("/usr/local/bin/deja", false); err != nil {
+			t.Fatalf("codex install: %v", err)
+		}
+		if _, err := installClaudeHook("/usr/local/bin/deja", false); err != nil {
+			t.Fatalf("claude install: %v", err)
+		}
+	}
+	if n := countHookTool(codexPath, "PreToolUse"); n != 1 {
+		t.Errorf("codex PreToolUse hook-tool count = %d, want 1", n)
+	}
+	if n := countHookTool(claudePath, "PreToolUse"); n != 1 {
+		t.Errorf("claude PreToolUse hook-tool count = %d, want 1", n)
+	}
+
+	// Uninstall removes it.
+	if _, err := installCodexHooks("/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installClaudeHook("/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	if n := countHookTool(codexPath, "PreToolUse"); n != 0 {
+		t.Errorf("codex PreToolUse hook-tool survived uninstall: %d", n)
+	}
+	if n := countHookTool(claudePath, "PreToolUse"); n != 0 {
+		t.Errorf("claude PreToolUse hook-tool survived uninstall: %d", n)
+	}
+}
+
 // Kimi took three wrong readings: it injects the hook's plain stdout rather
 // than a JSON field, only UserPromptSubmit does it, and its prompt arrives as
 // content parts. Each one on its own looks like "recall found nothing".


### PR DESCRIPTION
hook-tool (recall at the moment of an edit or command) was built but never installed, and had two gaps a real-agent A/B on codex exposed. This fixes both and turns it on.

**Carry the decision, not a pointer.** The file line only pointed at `deja blame`. Measured on codex (gpt-5.5): that pointer drove 0/3 reuse of a prior decision — the agent won't take the extra hop. The same line carrying the decision itself drove 3/3, control (no hook) 0/3. So the line now names the prior decision (via digest.Conclusions on the file's sessions), keeping the `deja blame` pointer as a fallback.

**See codex edits.** Codex and other OpenAI-style agents edit through a single `apply_patch` tool with the path in the patch body, so the hook was blind to them. It now reads the target out of the patch.

**Wire it.** Both codex and Claude use the same hooks.json contract; both now get a PreToolUse entry running hook-tool — scoped to the editing/command tools on Claude, self-filtered on codex. Idempotent install, removed on uninstall.