### PR TITLE
feat(search): make the reuse boost reach past dead ties

### DIFF
--- a/internal/search/ranking_test.go
+++ b/internal/search/ranking_test.go
@@ -77,7 +77,7 @@ func TestWornBoostBreaksTiesButIsCapped(t *testing.T) {
 	if hits[0].Session.ID != "worn" || hits[0].Reused != 4 {
 		t.Fatalf("worn tie-break missing: %+v", hits[0])
 	}
-	if wornBoost(1000) != 1.2 {
+	if wornBoost(1000) != 1.5 {
 		t.Fatalf("worn boost uncapped: %f", wornBoost(1000))
 	}
 	// A clearly better match must beat a worn weak one: relevance > popularity.
@@ -89,5 +89,27 @@ func TestWornBoostBreaksTiesButIsCapped(t *testing.T) {
 	}
 	if hits2[0].Session.ID != "strong" {
 		t.Fatalf("popularity outranked relevance: %+v", hits2)
+	}
+}
+
+// Reuse must reach past a dead tie: a recurring answer the user keeps pulling
+// back should surface even when a louder session repeats the query terms a
+// couple more times. At the old 0.05/1.2 shape it did not — a single extra term
+// buried the reused answer, so the signal was nearly inert. This pins the reach.
+func TestWornBoostRescuesAnOutmatchedRecurringAnswer(t *testing.T) {
+	// The answer names the topic and says it was settled; the distractor repeats
+	// the terms twice more and was never reused — louder on the text alone.
+	answer := rankSession("answer", "", "retry budget issue; we resolved retry budget before and it held")
+	distractor := rankSession("distractor", "", "retry budget retry budget retry budget keeps failing; raw logs about retry budget")
+	hits, err := Run([]model.Session{distractor, answer}, Options{Query: "retry budget", All: true, RecallWorn: map[string]int{"answer": 6}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || hits[0].Session.ID != "answer" {
+		top := "—"
+		if len(hits) > 0 {
+			top = hits[0].Session.ID
+		}
+		t.Fatalf("reuse did not rescue an out-matched recurring answer: top=%s", top)
 	}
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -747,12 +747,17 @@ func looksPasted(s model.Session) bool {
 // relevance. Kept modest: a note about X must not bury a transcript about Y.
 const promotedNoteBoost = 1.25
 
-// wornBoost rewards sessions agents keep recalling — capped hard at +20% so
-// popularity can never outrank relevance, only break near-ties.
+// wornBoost rewards sessions agents keep recalling. The shape is set by
+// measurement (scripts/reusebench, internal/search reuse tests): at the old
+// 0.05 slope / 1.2 cap the boost rescued a reused answer only when a louder
+// session tied it exactly — a single extra term of noise buried it, so the
+// signal was nearly inert. A 0.10 slope and 1.5 cap let reuse surface an answer
+// out-matched by a couple of terms, while a heavily-reused near-miss still loses
+// to a strong match: relevance stays dominant, reuse breaks more than dead ties.
 func wornBoost(n int) float64 {
-	boost := 1 + 0.05*math.Log2(float64(1+n))
-	if boost > 1.2 {
-		return 1.2
+	boost := 1 + 0.10*math.Log2(float64(1+n))
+	if boost > 1.5 {
+		return 1.5
 	}
 	return boost
 }

--- a/scripts/decisionbench/main.go
+++ b/scripts/decisionbench/main.go
@@ -30,7 +30,7 @@ import (
 // question equally well on the text; one of them is the one agents keep pulling
 // back. That is the only signal deja has about what actually helped someone,
 // as opposed to what reads like an answer — and until now nothing measured
-// whether the 1.2× ceiling on it does anything at all.
+// whether the 1.5× ceiling on it does anything at all.
 func reportUsage(sessions []model.Session, verbose bool) {
 	// Two equally-worded sessions per topic, one of them worn.
 	var corpus []model.Session

--- a/scripts/reusebench/main.go
+++ b/scripts/reusebench/main.go
@@ -1,0 +1,83 @@
+// Command reusebench asks how far the reuse signal reaches. deja boosts a
+// session agents keep pulling back (wornBoost, capped +20%), on the theory that
+// what the user reused before is what they need again. decisionbench proves the
+// boost breaks a tie and respects the relevance ceiling; this asks the question
+// in between: when the answer the user keeps reusing is worded more quietly than
+// a louder session that only looks like an answer, does the reuse history still
+// surface it — and at what text gap does the +20% cap run out?
+//
+// Each topic pits a recurring answer (reused, worded once) against a distractor
+// that repeats the query terms `extra` more times and was never reused. The
+// sweep over `extra` is the reach curve: with the boost off vs on, how often the
+// reused answer still ranks first as the distractor gets louder.
+//
+//	go run ./scripts/reusebench
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func session(id string, when time.Time, texts []string) model.Session {
+	s := model.Session{ID: id, Harness: "claude", Project: "app", Started: when, Updated: when}
+	for i, t := range texts {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		s.Messages = append(s.Messages, model.Message{Role: role, Text: t, Time: when.Add(time.Duration(i) * time.Minute)})
+	}
+	return s
+}
+
+func pct(a, n int) string { return fmt.Sprintf("%3.0f%%", 100*float64(a)/float64(n)) }
+
+func main() {
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	topics := []string{
+		"retry budget", "cache stampede", "leader election", "schema drift",
+		"token refresh", "index rebuild", "connection pool", "memory leak",
+	}
+	const reuse = 6
+
+	fmt.Println("reusebench · does reuse-history rescue a recurring answer a louder session would bury?")
+	fmt.Printf("%-12s %-9s %-9s %-7s\n", "distractor", "worn-off", "worn-on", "lift")
+	for _, extra := range []int{0, 1, 2, 3, 4} {
+		off, on, n := 0, 0, 0
+		for i, t := range topics {
+			day := base.AddDate(0, 0, -i)
+			ans := "answer-" + fmt.Sprint(i)
+			dis := "distractor-" + fmt.Sprint(i)
+
+			// The answer states the topic and that it was settled — quiet, one
+			// mention of the terms per turn.
+			answer := session(ans, day, []string{t + " issue", "we resolved " + t + " before and it held"})
+
+			// The distractor repeats the query terms `extra` more times and was
+			// never reused: it looks more like an answer on the text alone.
+			loud := t
+			for k := 0; k < extra; k++ {
+				loud += " " + t
+			}
+			distractor := session(dis, day, []string{loud + " keeps failing", "raw logs about " + t})
+
+			corpus := []model.Session{answer, distractor}
+			worn := map[string]int{ans: reuse}
+
+			hb, _ := search.Run(corpus, search.Options{Query: t, All: true})
+			if len(hb) > 0 && hb[0].Session.ID == ans {
+				off++
+			}
+			hw, _ := search.Run(corpus, search.Options{Query: t, All: true, RecallWorn: worn})
+			if len(hw) > 0 && hw[0].Session.ID == ans {
+				on++
+			}
+			n++
+		}
+		fmt.Printf("+%-11d %-9s %-9s %+d\n", extra, pct(off, n), pct(on, n), on-off)
+	}
+}


### PR DESCRIPTION
deja boosts sessions agents keep recalling (wornBoost), but measured, the boost was nearly inert: at 0.05 slope / 1.2 cap it rescued a recurring answer only when a louder session tied it *exactly* — one extra term of noise buried it. New scripts/reusebench shows the reach: at the old shape a distractor repeating the query terms even once won 8/8; the reused answer never surfaced.

0.10 slope / 1.5 cap lets reuse surface an answer out-matched by a couple of terms (reusebench: 0→100% at +1 and +2), while still stopping at +3 so relevance dominates. Guards intact: decisionbench relevance-still-wins 3/3, longmemeval unchanged (it never sets the worn signal), search tests green. A new ranking test pins the reach and fails at the old shape.