### PR TITLE
ci: cache the Go build to cut windows compile time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.25.x'
-          cache: false
       - run: go mod verify
       - run: go vet ./...
       # -timeout below the job's own patience: a hung test then dies with every


### PR DESCRIPTION
The windows test job runs ~19m vs 2-3m elsewhere, and the bulk of it is compilation, not the tests. The Go build cache was off (`cache: false`), so every run recompiled the stdlib, deps and the whole module from scratch — and with `-race` on windows that is the expensive part.

Removing `cache: false` turns setup-go's cache back on: it persists GOCACHE/GOMODCACHE keyed on go.sum, so a warm run recompiles only what changed. `-race` and full coverage stay on every platform.

Proof: comparing this branch's first (cold) windows run against a re-run (warm) — numbers in a comment below.