### PR TITLE
docs: bring README, site and roadmap up to v0.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="assets/logo.svg" width="340" alt="deja-vu"></p>
 
-<p align="center"><strong>Your agents already solved this. deja finds it.</strong><br>Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk &mdash; months of history from before you installed it &mdash; searches 3.5&nbsp;GB in ~1.5&nbsp;ms, serves it back to any agent over MCP, and moves with you between machines over SSH. One zero-dependency binary, fully local.</p>
+<p align="center"><strong>Your agents already solved this. deja finds it.</strong><br>Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk &mdash; months of history from before you installed it &mdash; searches 3.5&nbsp;GB in ~1.5&nbsp;ms, and serves it back to any agent over MCP. It ranks by what actually held, not just what matched, and before your agent edits a file or runs a command it names the decision already reached there. Moves with you between machines over SSH. One zero-dependency binary, fully local.</p>
 
 <p align="center"><strong>84.9% hit@1</strong> on LongMemEval-S retrieval &mdash; no LLM, no embeddings, no API key. <a href="https://vshulcz.github.io/deja-vu/guide/benchmarks.html">Harness in-repo, run it yourself.</a></p>
 
@@ -108,7 +108,7 @@ That's it. Next session, ask your agent:
 
 ## What it is
 
-Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Roo Code, OpenClaw, Goose, pi and Copilot CLI write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
+Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Roo Code, OpenClaw, Goose, Hermes, pi and Copilot CLI write every conversation to local files — gigabytes of debugged problems and design decisions you can't search. deja is a zero-dependency binary that turns those histories into a memory layer:
 
 | Feature | What it does |
 | --- | --- |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,42 +1,54 @@
 # Roadmap
 
-This roadmap records direction, not release commitments. Linked issues contain
-the current scope and are the place to discuss design changes.
+Direction, not release commitments. What ships moves into the changelog; what is
+here is where the work is going. Linked issues carry the current scope and are
+the place to discuss design.
 
 ## Now
 
-- Add ingest-time project exclusions so selected histories never enter the
-  index ([#8](https://github.com/vshulcz/deja-vu/issues/8)).
-- Add `deja forget` for deleting sessions, projects, or age ranges from records
-  and postings ([#45](https://github.com/vshulcz/deja-vu/issues/45)).
-- Validate path discovery, terminal output, install configuration, and locking
-  on real Windows installations ([#9](https://github.com/vshulcz/deja-vu/issues/9)).
-- Maintain the security model, signed checksums, provenance, release SBOMs, and
-  structured parser-format reports as release and harness formats change.
+- **Windows correctness.** Several `internal/index` tests use Unix-shaped path
+  fixtures that only pass off Windows by accident, and the exclude-on-rebuild
+  path reads paths differently under Windows semantics — so a real privacy
+  control is unverified there ([#1119](https://github.com/vshulcz/deja-vu/issues/1119)).
+  Close the gap between "green on Linux and macOS" and "correct on Windows," on
+  real installations ([#9](https://github.com/vshulcz/deja-vu/issues/9)).
+- **Keep the claims measured.** Every ranking signal — outcome, reuse, decision,
+  point-of-action — has an in-repo benchmark, and a change ships with the
+  before/after. Extend the agent-in-the-loop A/B beyond the point-of-action hook
+  to the rest of the recall path.
+- Maintain the security model, signed checksums, provenance and release SBOMs as
+  release and harness formats change.
 
 ## Next
 
-- Add project and harness filters to `deja last`
-  ([#10](https://github.com/vshulcz/deja-vu/issues/10)).
-- Derive canonical project identity from a repository remote when available so
-  same-named repositories and worktrees do not collide
-  ([#44](https://github.com/vshulcz/deja-vu/issues/44)).
-- Improve share selection around decisions in tool-heavy sessions without
-  exposing raw tool dumps ([#22](https://github.com/vshulcz/deja-vu/issues/22)).
+- **Deepen curation past a single boost.** Reuse is a global signal today: a
+  session pulled for one query is lifted for every query. A per-query signal —
+  recording what a recall was for, not only that it happened — would let reuse be
+  both stronger and precise without lifting an off-topic session.
+- **Point-of-action beyond codex and Claude.** Carry the file's or command's
+  prior decision into other harnesses as their hook contracts allow.
+- Derive canonical project identity from a repository remote so same-named repos
+  and worktrees do not collide ([#44](https://github.com/vshulcz/deja-vu/issues/44)).
 
 ## Later
 
-- Add a typo-tolerant fallback only when exact and substring search return no
-  results, while keeping the normal search path unchanged
-  ([#11](https://github.com/vshulcz/deja-vu/issues/11)).
-- Expose recent sessions as an MCP resource and add bounded recall pagination
+- Expose recent sessions as an MCP resource alongside bounded recall pagination
   ([#12](https://github.com/vshulcz/deja-vu/issues/12)).
+- Mature the optional semantic tier (`deja embed`): still off by default and
+  external to the binary, it should degrade and recover as cleanly as the lexical
+  ladder does.
 
 ## Not planned
 
-- **Capture daemons:** deja indexes histories already written by each harness;
-  a recorder would add a persistent process and a second source of truth.
-- **Cloud sync by default:** implicit upload conflicts with local-only indexing;
-  sync remains an explicit export or SSH operation.
-- **Embeddings in the base binary:** model files and vector runtimes would break
-  the zero-runtime-dependency distribution and increase index cost.
+- **Capture daemons.** deja indexes the histories each harness already writes; a
+  recorder would add a persistent process and a second source of truth.
+- **Cloud sync by default.** Implicit upload conflicts with local-only indexing;
+  sync stays an explicit export or an SSH operation you run.
+- **Embeddings in the base binary.** Model files and vector runtimes would break
+  the zero-runtime-dependency distribution and inflate index cost. The semantic
+  tier stays opt-in and external.
+- **Enforcing recalled conclusions.** deja stays at the evidence layer. Curation
+  — promote, lifecycle states, standing project decisions — makes a decision
+  durable and surfaces when it was reverted or superseded, but the agent decides.
+  deja does not gate behaviour on a past conclusion, and does not claim an old
+  conclusion is still true; it shows what was decided and what changed.

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -59,10 +59,19 @@
 <tr><td><code>recall</code></td><td>Search past sessions across every agent and return dense matches under ~4&nbsp;KB. Fires on phrases like "didn't we fix this before".</td></tr>
 <tr><td><code>recall_context</code></td><td>Return a full markdown digest of the single best-matching session — the problem, decision and outcome.</td></tr>
 <tr><td><code>blame</code></td><td>Given a file path, the prior sessions that discussed it, most specific first. git blame for the conversations behind the code.</td></tr>
+<tr><td><code>fix</code></td><td>Given a failing error, the command this machine ran after that same error before, when it did not come back. Matched on the error itself, not its words — evidence, not a guaranteed fix.</td></tr>
+<tr><td><code>how</code></td><td>How this machine actually runs a thing — the real command with the real flags, from what agents ran before. Call before inventing a build, test or deploy invocation that a guess would get wrong on this setup.</td></tr>
 <tr><td><code>remember</code></td><td>Store a durable decision so a future session can recall it. Redacted and indexed like any other source.</td></tr>
 </tbody></table>
 <h2>Auto-recall</h2>
-<p><code>deja install --auto</code> adds a SessionStart hook (Claude Code, Codex, an opencode plugin). Relevant project memory is injected before you ask — read-only, capped at 2&nbsp;KB, framed as untrusted historical data so it never acts as an instruction. It also fires right after a context compaction, re-anchoring the model in what it just lost.</p>
+<p><code>deja install --auto</code> wires recall into the moments an agent works, not only when it thinks to ask. Where a harness supports each hook, memory arrives on its own at four points:</p>
+<ul>
+<li><b>At session start</b> — relevant project memory before you type, ranked by the files your repo is touching, and led by the decisions you promoted <em>accepted</em> for this project, so the agent follows what was settled instead of re-deciding it. Read-only, capped at 2&nbsp;KB, framed as untrusted historical data so it never acts as an instruction.</li>
+<li><b>On each prompt</b> — deja searches your history for what the prompt is actually about, and when it matches work already answered says so out loud: <code>deja-vu: you have been here</code>.</li>
+<li><b>Before an edit or a command</b> — a PreToolUse hook names that exact file's or command's prior decision, the fix that held or the invocation that worked, so the agent acts on what was settled rather than re-deriving it. Wired for codex and Claude.</li>
+<li><b>Before a context compaction</b> (Claude Code) — the transcript is captured into the index first, and the next session start re-anchors the model in what it just lost.</li>
+</ul>
+<p>Session-start auto-recall is wired across every harness that exposes a start hook — Claude Code, Codex, Cursor, Gemini CLI, opencode, Qwen, Kimi, Cline, Antigravity, OpenClaw, Goose and Hermes among them; the <a href="harnesses.html">harness matrix</a> is the source of truth. Where only MCP is available, recall is still one tool call away.</p>
 <p>The same injection carries what this machine keeps failing on: an error that hit three or more separate sessions — a binary that is not installed, a Python module that was never added — counted from the transcripts themselves. Agents rediscover those one failed command at a time, so the block says the count and what to do instead. It is served once per session, appears at session start where a hook is wired and on the first <code>recall</code> where only MCP is, and stays silent until something has failed in three separate sessions.</p>
 <h2>Windows</h2>
 <div class="note">On Windows, stdio MCP clients spawn through <code>cmd /c deja mcp</code>. <code>deja install</code> writes that form automatically.</div>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -70,7 +70,7 @@ deja "have we dealt with jwt refresh rotation before"</pre>
 <h2>Wire it into your agents</h2>
 <pre>deja install --all      # MCP recall for every agent found on this machine
 deja install --auto     # same, plus session-start auto-recall where supported</pre>
-<p>Four harnesses can pull deja straight from their own plugin registry instead — same wiring, no local step:</p>
+<p>Six harnesses can pull deja straight from their own plugin registry instead — same wiring, no local step:</p>
 <pre>claude plugin marketplace add vshulcz/deja-vu &amp;&amp; claude plugin install deja-vu@deja-vu
 codex  plugin marketplace add vshulcz/deja-vu &amp;&amp; codex plugin add deja-vu@deja-vu
 cursor-agent plugin marketplace add https://github.com/vshulcz/deja-vu

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -67,6 +67,7 @@
 <li><b>Stop-word handling</b> — natural phrasing like "have we dealt with jwt refresh rotation" drops filler words so the content tokens drive the search.</li>
 <li><b>Word forms</b> — <code>rotation</code> ↔ <code>rotated</code> via suffix folding.</li>
 <li><b>Typos</b> — close spellings within edit distance.</li>
+<li><b>Error signature</b> — paste a failing stack trace and deja matches the sessions that hit the same error by its <em>signature</em>, not its words, and can name the command that cleared it last time (<code>deja fix</code>, MCP <code>fix</code>).</li>
 <li><b>Semantic</b> — if a vector sidecar exists, a rephrased query with no shared words still matches.</li>
 </ul>
 <p>Each result carries a tier — <code>exact</code>, <code>close</code> (with the variant), or <code>semantic</code> (with the cosine) — in the CLI, JSON and MCP output.</p>
@@ -81,6 +82,14 @@ deja "ran out of db connections"   # matches "connection pool exhausted"</pre>
 <p>Every message also carries its month and year in the postings, and a query with no exact match reads them: <code>deja "what did we do in may"</code> meets May's sessions structurally, and relative phrases resolve against the moment you ask — <code>a week ago</code>, <code>last month</code>, <code>10 days ago</code>. They rank the fallback, they never filter, and a query whose words already match something is answered on those words alone — so for a hard cutoff, or to narrow a query that does match, use <code>--since</code>.</p>
 <h2>Earlier attempts</h2>
 <p>When an old session and a newer one from the same project match the same ground, the older hit is labeled an earlier attempt with the newer session's date — in CLI output, MCP digests, and as an additive <code>superseded</code> field in <code>--json</code>. History stays; the direction the project moved is visible.</p>
+<h2>What ranks first</h2>
+<p>Lexical overlap decides who is a candidate; what settled something decides who wins. Above the raw term match, deja weighs a few signals — none of them able to outrank plain relevance, only to break the ties it leaves:</p>
+<ul>
+<li><b>The session that concluded, not the one that kept asking.</b> A session that reached a decision outranks one that only discussed the topic, and recall surfaces the decision-carrying line, not just where the words appeared.</li>
+<li><b>What held over what was backed out.</b> A session whose own text says it reverted an approach and settled nothing else ranks below one that held — the dead end is still there, marked, but it is not the first thing an agent sees. A session that reverted one thing and settled another keeps its place.</li>
+<li><b>A recorded judgement over a raw guess.</b> A note you promoted outranks the transcript it came from, and a lifecycle state travels with the session on every hit: <em>tried and rejected</em>, <em>replaced by a later decision</em>, <em>marked stale</em>, with the reason and the date. Nothing is deleted — the agent sees what was decided and that it changed.</li>
+<li><b>What gets reused.</b> A session agents keep pulling back is lifted a little, on the theory that what the machine keeps needing is worth surfacing — bounded, so popularity never buries a stronger match.</li>
+</ul>
 </article>
 </div>
 <footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>deja-vu — your agents already solved this. deja finds it.</title>
-<meta name="description" content="A memory layer for coding agents: search, MCP recall, auto-context, secret redaction, stats, share and sync over the session histories Claude Code, Codex, opencode, Cursor, Gemini CLI, aider, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Roo Code, OpenClaw, Goose, pi and Copilot CLI already write. One zero-dependency binary, fully local.">
+<meta name="description" content="A memory layer for coding agents: search, MCP recall, auto-context, secret redaction, stats, share and sync over the session histories Claude Code, Codex, opencode, Cursor, Gemini CLI, aider, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Roo Code, OpenClaw, Goose, Hermes, pi and Copilot CLI already write. One zero-dependency binary, fully local.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="deja-vu — search every session your coding agents ever wrote">
@@ -365,7 +365,7 @@ footer .spacer{flex:1}
       <tr><td class="n">~1.5 ms</td><td class="c">median warm search over gigabytes of history; ~14 ms on the most common word</td></tr>
       <tr><td class="n">~50 ms</td><td class="c">session-start hook on a 1000-session index — memory lands before you type</td></tr>
       <tr><td class="n">84.9%</td><td class="c">hit@1 on LongMemEval-S session retrieval (94.3% hit@5) — no LLM, no embeddings, harness in-repo</td></tr>
-      <tr><td class="n">16</td><td class="c">coding agents indexed into one retroactive memory</td></tr>
+      <tr><td class="n">17</td><td class="c">coding agents indexed into one retroactive memory</td></tr>
     </table>
     <p class="foot"><a href="guide/benchmarks.html">how it's measured →</a></p>
   </div>


### PR DESCRIPTION
The docs still read like the July retrieval tool. This reframes deja as what it now is — a measured memory layer that ranks by what held and surfaces the decision at the point of an action — and fills the coverage gaps a code-grounded external review and a docs audit both flagged.

- **README/site framing**: recall now ranks by outcome and reuse, and names a file's or command's prior decision before the agent acts, not only on search.
- **Agents guide**: the four auto-recall hooks (session start, per-prompt, point-of-action PreToolUse, pre-compaction), the `fix` and `how` MCP tools, and broad harness support — the old text named one hook and three harnesses.
- **Search guide**: the error-signature tier, and a "what ranks first" section covering decision-carrying sessions, held-over-reverted, promoted notes / lifecycle states, and the bounded reuse boost.
- **Roadmap**: shipped items (forget, exclusions, fuzzy, last filters) moved out; real next work in (Windows correctness #1119, per-query reuse, point-of-action beyond codex/Claude); a "not planned" line on enforcing recalled conclusions.
- Fixes: harness list gains Hermes (17), the site's outlier "16", getting-started's "Four"→"Six" plugin registries.

Two follow-ups I did not touch here: the session-start latency figure differs between README (~120 ms) and the site (~50 ms) and needs a fresh measurement to reconcile; and the claude-plugin wires three hooks while `deja install` now wires four (point-of-action), which is a code gap, not a docs one.