### PR TITLE
docs+plugin: wire point-of-action, document hooks & ranking; fix latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ claude plugin marketplace add vshulcz/deja-vu
 claude plugin install deja-vu@deja-vu
 ```
 
-The plugin wires the same three hooks, the `/deja` command and the MCP server. It stands down on its own if `deja install` already wired them, so having both does not recall twice.
+The plugin wires the same hooks — session start, per-prompt, pre-compaction and the point-of-action PreToolUse — plus the `/deja` command and the MCP server. It stands down on its own if `deja install` already wired them, so having both does not recall twice.
 
 Codex, Cursor and Qwen read the same bundle from their own registries:
 
@@ -117,7 +117,7 @@ Claude Code, Codex, opencode, aider, Gemini CLI, Cursor, Antigravity, Grok Build
 | **Knows what held** | `deja promote <id> --state rejected --note "why"` — a decision you reverted comes back marked *tried and rejected*, with the reason and the date, on every hit for that session. Nothing is deleted: the agent sees what was decided **and** that it changed. Judged it wrong? `deja promote <id> --state accepted` takes the mark back — the latest mark wins, and the note keeps both |
 | **Sync** | `deja sync ssh laptop` — your memory follows you between machines, append-only, idempotent, no cloud in the middle |
 | **Handoff** | `deja handoff --to codex` — stuck in one agent? package the live context and continue in another: `codex "$(deja handoff --to codex)"`; fourteen harnesses can be started directly, the rest print the prompt to paste |
-| **Auto-recall** | `install --auto` adds a SessionStart hook: relevant memory lands in context before you ask — ranked by the files your repo is touching, ~120 ms on a 1000-session index; Claude Code also captures the current transcript before compaction |
+| **Auto-recall** | `install --auto` adds a SessionStart hook: relevant memory lands in context before you ask — ranked by the files your repo is touching, ~50 ms on a 1000-session index; Claude Code also captures the current transcript before compaction |
 | **At the point of an action** | before an agent edits a file or runs a command, deja names that file's or command's prior decision — the fix that held, the invocation that worked — from a `PreToolUse` hook, so it acts on what was settled instead of re-deciding it. `install --auto` wires it for codex and Claude |
 | **Project decisions up front** | the decisions you promoted *accepted* for a project are injected at session start, independent of the query, so the agent follows a settled choice — *we use pgx, not database/sql* — without anyone naming it |
 | **Indexes the work** | not just the talk about it: the files each turn opened, the commands that ran, and the exact spans an edit replaced — the part every summary throws away |

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -42,6 +42,19 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/deja.sh hook-tool",
+            "timeout": 10,
+            "statusMessage": "Checking what this touches\u2026"
+          }
+        ]
+      }
     ]
   },
   "mcpServers": {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,7 +131,25 @@ The MCP server calls the same index/search code as the CLI. It writes protocol r
 {"type":"command","command":"/abs/path/to/deja hook-context"}
 ```
 
-`deja hook-context` is intentionally hidden from normal help. It derives the current project from `CLAUDE_PROJECT_DIR` or `cwd` using the same Claude project-name logic as the parser, reads only an existing warm index (`manifest.gob`/`sessions.gob` must already exist), selects the most recent matching sessions by metadata project, and prints Claude's `SessionStart` response JSON with a compact markdown digest capped at 2KB. It never triggers a cold index build; missing index, empty results, corrupt data, or any other error produce no output and exit 0 so agent startup is not blocked.
+`deja hook-context` is intentionally hidden from normal help. It derives the current project from `CLAUDE_PROJECT_DIR` or `cwd` using the same Claude project-name logic as the parser, reads only an existing warm index (`manifest.gob`/`sessions.gob` must already exist), selects the most recent matching sessions by metadata project (ranked by the files the working tree is touching), leads them with the project's `accepted` promoted notes, and prints Claude's `SessionStart` response JSON with a compact markdown digest capped at 2KB. It never triggers a cold index build; missing index, empty results, corrupt data, or any other error produce no output and exit 0 so agent startup is not blocked.
+
+`--auto` wires three more hooks with the same fail-open contract, each a hidden subcommand that reads only a warm index and exits 0 on anything unexpected:
+
+- **`hook-prompt`** (`UserPromptSubmit`) searches the index for the prompt's content and injects a small digest, or the `you have been here` line on a déjà-vu match.
+- **`hook-tool`** (`PreToolUse`, matched to the editing/command tools) reads the tool payload — a `Bash` command or an `Edit`/`Write`/`apply_patch` target — and injects one line naming that file's or command's prior decision. Deliberately thin: it fires once per action, so it dedupes per agent session, stays silent unless the history is a pattern, and carries at most one decision.
+- **`hook-precompact`** (`PreCompact`, Claude Code) captures the current transcript into the index before compaction discards it.
+
+## Ranking
+
+Search intersects postings to find candidates, then scores each with BM25 over the query tokens and multiplies in a few bounded signals — each able to break a tie, none able to outrank plain relevance:
+
+- **decision** — a session that reached a conclusion is lifted, and the decision-carrying line (not the query-match line) is what recall shows.
+- **outcome** — a session whose own text reports it reverted an approach and settled nothing else is damped; one that reverted and then settled keeps the decision lift. A promoted `rejected`/`superseded`/`stale` lifecycle state travels with the session and is surfaced on every hit.
+- **worn (reuse)** — a session agents keep recalling is lifted on a `log2` curve capped at +50%, on the theory that what the machine keeps needing is worth surfacing; the cap keeps popularity below relevance.
+- **promoted note** — a curated note outranks the raw transcript it was distilled from.
+- **freshness** — recency decays the score gently so time is a hint, not a filter.
+
+`recall_context` and the hooks reuse the same scored order; the point-of-action decision line comes from the same conclusion extraction the digest uses.
 
 ## Add a new harness
 


### PR DESCRIPTION
Follow-ups to the 0.17.0 docs pass:

- **Plugin parity**: the Claude plugin now wires the PreToolUse point-of-action hook, matching what `deja install --auto` already does — it was the one hook the plugin path was missing.
- **Latency**: measured `deja hook-context` on a seeded 1000-session index at ~50 ms wall (git-taskfiles ~4 ms, load ~4 ms, names ~5 ms). Reconciles the README's stale ~120 ms to the site's ~50 ms.
- **Architecture guide**: documents all four auto-recall hooks and adds a Ranking section (decision, outcome/reverted, worn reuse, promoted, freshness) — the ranking strategy was undocumented.