### PR TITLE
fix(packaging): pin windows manifests to 0.17.0

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,12 +1,12 @@
 {
     "architecture": {
         "64bit": {
-            "hash": "df4912f6cbc36d3e771272ac8194cd5ca8244fd9cdbbaf3155a22d3ee7ad7079",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.9/deja-vu_0.16.9_windows_amd64.zip"
+            "hash": "9592dff87d29b612067274bae09cbebe42e10599bf4eee0d3714928af27f6f91",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.17.0/deja-vu_0.17.0_windows_amd64.zip"
         },
         "arm64": {
-            "hash": "e83fed8d2d3a075454ed61d5761c537c6f805906142d0e80ed02945846ac988d",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.16.9/deja-vu_0.16.9_windows_arm64.zip"
+            "hash": "c71761cae23ea83d7a36f69f49f151dbd682c0c1ba96f90fe86283141d5c6070",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.17.0/deja-vu_0.17.0_windows_arm64.zip"
         }
     },
     "autoupdate": {
@@ -24,5 +24,5 @@
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
-    "version": "0.16.9"
+    "version": "0.17.0"
 }

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.9
+PackageVersion: 0.17.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.9/deja-vu_0.16.9_windows_amd64.zip
-  InstallerSha256: DF4912F6CBC36D3E771272AC8194CD5CA8244FD9CDBBAF3155A22D3EE7AD7079
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.17.0/deja-vu_0.17.0_windows_amd64.zip
+  InstallerSha256: 9592DFF87D29B612067274BAE09CBEBE42E10599BF4EEE0D3714928AF27F6F91
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.16.9/deja-vu_0.16.9_windows_arm64.zip
-  InstallerSha256: E83FED8D2D3A075454ED61D5761C537C6F805906142D0E80ED02945846AC988D
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.17.0/deja-vu_0.17.0_windows_arm64.zip
+  InstallerSha256: C71761CAE23EA83D7A36F69F49F151DBD682C0C1BA96F90FE86283141D5C6070
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.9
+PackageVersion: 0.17.0
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.16.9/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.17.0/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.16.9
+PackageVersion: 0.17.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
The scoop and winget manifests still pointed at 0.16.9, so the "windows manifests" check went red on every PR after the 0.17.0 release. Regenerated from the release checksums; `pinmanifests -check` passes.