### PR TITLE
docs(site): bare deja prints the brief on a terminal, not usage (#1105)

### DIFF
--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -85,7 +85,7 @@
 <tr><td><code>deja bench recall|context</code></td><td>Reproducible search-quality and context-readiness benchmarks.</td></tr>
 <tr><td><code>deja update</code></td><td>Update a standalone install (Homebrew/npm update via the package manager).</td></tr>
 </tbody></table>
-<div class="note">Run <code>deja</code> with no arguments for the usage summary, or any command with its flags. Everything is offline except <code>update</code>, <code>sync ssh</code> and the <code>doctor</code> version check.</div>
+<div class="note">Bare <code>deja</code> on a terminal prints the living brief; piped or redirected it prints the usage summary, which <code>deja --help</code> also shows, and any command takes <code>--help</code> for its flags. Everything is offline except <code>update</code>, <code>sync ssh</code> and the <code>doctor</code> version check.</div>
 
 </article>
 </div>


### PR DESCRIPTION
The commands reference closing note said bare `deja` prints the usage summary, contradicting the table row that (correctly) says it prints the living brief on a terminal. It prints usage only when piped or redirected. Closes #1105.