### PR TITLE
fix(index): re-indexing one transcript no longer erases another sharing its id (#699)

### DIFF
--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -85,7 +85,7 @@
 <tr><td><code>deja bench recall|context</code></td><td>Reproducible search-quality and context-readiness benchmarks.</td></tr>
 <tr><td><code>deja update</code></td><td>Update a standalone install (Homebrew/npm update via the package manager).</td></tr>
 </tbody></table>
-<div class="note">Run <code>deja</code> with no arguments for the usage summary, or any command with its flags. Everything is offline except <code>update</code>, <code>sync ssh</code> and the <code>doctor</code> version check.</div>
+<div class="note">Bare <code>deja</code> on a terminal prints the living brief; piped or redirected it prints the usage summary, which <code>deja --help</code> also shows, and any command takes <code>--help</code> for its flags. Everything is offline except <code>update</code>, <code>sync ssh</code> and the <code>doctor</code> version check.</div>
 
 </article>
 </div>

--- a/internal/index/collision_test.go
+++ b/internal/index/collision_test.go
@@ -189,10 +189,22 @@ func TestReindexingOneHalfOfACollisionKeepsTheOther(t *testing.T) {
 	if len(metas) != 1 || metas[0].Project != "alpha" || metas[0].Title != "the alpha work on pool sizing" {
 		t.Fatalf("metas = %#v — alpha's row was lost or overwritten", metas)
 	}
-	// The records are a separate matter: they are keyed by harness:id too, so
-	// re-indexing beta drops alpha's text from the postings even though its
-	// row survives. Tracked in #699 — this test pins the row.
-	if _, err := Search(dir, search.Options{Query: "beta rewritten", All: true}); err != nil {
+	// #699 was the other half of the same collision: records are keyed by
+	// harness:id too, so re-indexing beta dropped alpha's text from the postings
+	// even though alpha's row survived — content loss until a full rebuild.
+	// Alpha was never re-read, so its content must still be there.
+	alpha, err := Search(dir, search.Options{Query: "pool sizing", All: true})
+	if err != nil {
 		t.Fatal(err)
+	}
+	if len(alpha) == 0 {
+		t.Fatal("re-indexing beta dropped alpha's content from the index (#699)")
+	}
+	beta, err := Search(dir, search.Options{Query: "beta rewritten", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(beta) == 0 {
+		t.Fatal("beta's rewritten content was not indexed")
 	}
 }

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1756,7 +1756,15 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		// Superseded sessions are handled by replaceKeys.
 		h := harnessForPath(r.SourcePath)
 		sharedStore := h == "opencode" || h == "cursor-db" || h == "goose-db"
-		if removed[r.SourcePath] || (changed[r.SourcePath].Path != "" && !sharedStore) || replaceKeys[r.Key] {
+		// replaceKeys is scoped to shared stores. A shared store is parsed since
+		// a watermark, so a superseded session's old record is not re-read and
+		// clause two never reaches it — replaceKeys is what drops it. For a
+		// per-file harness, a removed or changed file's old records are already
+		// dropped by the two clauses above, so applying replaceKeys there only
+		// hurts: two transcripts in different projects can share a filename-derived
+		// id, and dropping by key alone erased the sibling that was never re-read
+		// (#699). The record's own SourcePath decides its fate for those.
+		if removed[r.SourcePath] || (changed[r.SourcePath].Path != "" && !sharedStore) || (sharedStore && replaceKeys[r.Key]) {
 			return
 		}
 		recErr = addRec(r)


### PR DESCRIPTION
Two transcripts named `session-1.jsonl` in different projects share a filename-derived id (`claude:session-1`). Records are keyed by harness:id, so the incremental replacement pass — which drops every record under a replaced key before re-adding the changed file's — wiped the sibling's text too, even though that file was never re-read. The manifest row survived (#698), but the other conversation's content was gone from the index until a full rebuild.

`replaceKeys` is only needed for shared stores (opencode/cursor/goose), which are parsed since a watermark and so aren't re-emitted per session. For per-file harnesses, a removed or changed file's old records are already dropped by SourcePath, so applying replaceKeys there only erased siblings. Scoped it to shared stores. Strengthens the existing collision test to assert the untouched half's content survives (fails before the fix). Closes #699.