### PR TITLE
fix(view): name the redaction floor when the page holds a masked secret (#857)

### DIFF
--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/query"
+	"github.com/vshulcz/deja-vu/internal/redact"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/stats"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -102,6 +103,16 @@ func runView(dir string, args []string) error {
 		return err
 	}
 	fmt.Fprintf(os.Stdout, "deja: view written to %s\n", path)
+	// The page is a self-contained file whose whole purpose is to be looked at
+	// and passed around, so it carries the same redaction floor the other
+	// outbound paths (share, sync export, promote --to) print — but only when it
+	// actually holds masked content, so local browsing stays quiet (#857).
+	// Redaction happens at index time, so the markers are already in the page.
+	if body, rerr := os.ReadFile(path); rerr == nil {
+		if masked := strings.Count(string(body), redact.Marker); masked > 0 {
+			fmt.Fprintf(os.Stderr, "deja: %d secret%s masked in this page. pattern redaction is a floor — review before sharing; rotate anything that leaked.\n", masked, pluralS(masked))
+		}
+	}
 	if openBrowser {
 		openInBrowser(path)
 	}

--- a/cmd/deja/view_test.go
+++ b/cmd/deja/view_test.go
@@ -29,6 +29,42 @@ func viewFixtureIndex(t *testing.T) string {
 	return dir
 }
 
+// The view page is a self-contained file made to be passed around, so it must
+// carry the same redaction floor the other outbound paths print when it holds a
+// masked secret — and stay quiet when it does not, so local browsing is silent
+// (#857).
+func TestViewNamesTheRedactionFloorWhenThePageHoldsAMaskedSecret(t *testing.T) {
+	hermeticEnv(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	ts := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-app", "sec.jsonl"), "sec", []string{
+		`{"type":"user","sessionId":"sec","timestamp":"` + ts + `","message":{"role":"user","content":"the key was AKIAABCDABCDABCDABCD in the config"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "v.html")
+	stderr, err := captureRunStderr(t, "view", "--no-open", "--out", out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr, "pattern redaction is a floor") {
+		t.Fatalf("view did not name the redaction floor for a page carrying a masked secret:\n%s", stderr)
+	}
+}
+
+func TestViewStaysQuietWhenNothingIsMasked(t *testing.T) {
+	viewFixtureIndex(t)
+	out := filepath.Join(t.TempDir(), "v.html")
+	stderr, err := captureRunStderr(t, "view", "--no-open", "--out", out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stderr, "pattern redaction is a floor") {
+		t.Fatalf("view printed the floor on a page with no masked content:\n%s", stderr)
+	}
+}
+
 func TestViewGeneratesSelfContainedHTML(t *testing.T) {
 	dir := viewFixtureIndex(t)
 	out := filepath.Join(t.TempDir(), "view.html")


### PR DESCRIPTION
deja view writes a self-contained page whose purpose is to be looked at and passed around, but it was the only outbound path that said nothing about the redaction floor that share, sync export and promote --to all print. It now prints the same review-before-sharing line — but only when the page actually carries a masked marker, so local browsing stays quiet. Closes #857.