### PR TITLE
docs: name pages for what people search, and correct the compare table

### DIFF
--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Agents & MCP — deja-vu docs</title>
+<title>Persistent memory for coding agents over MCP — deja-vu docs</title>
 <meta name="description" content="How deja gives your coding agents a searchable memory over MCP: recall, recall_context, blame, remember, and session-start auto-recall.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/agents.html">
 <meta property="og:type" content="article">

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Persistent memory for coding agents over MCP — deja-vu docs</title>
+<title>Persistent memory for coding agents over MCP — deja-vu</title>
 <meta name="description" content="How deja gives your coding agents a searchable memory over MCP: recall, recall_context, blame, remember, and session-start auto-recall.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/agents.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Agents & MCP — deja-vu docs">
+<meta property="og:title" content="Persistent memory for coding agents over MCP — deja-vu">
 <meta property="og:description" content="How deja gives your coding agents a searchable memory over MCP: recall, recall_context, blame, remember, and session-start auto-recall.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/agents.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -24,7 +24,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Agents &amp; MCP — deja-vu docs">
+<meta name="twitter:title" content="Persistent memory for coding agents over MCP — deja-vu">
 <meta name="twitter:description" content="How deja gives your coding agents a searchable memory over MCP: recall, recall_context, blame, remember, and session-start auto-recall.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>How deja compares — Mem0, Letta, memU, Memori, claude-mem &amp; others</title>
+<title>How deja compares — coding-agent memory systems</title>
 <meta name="description" content="An honest feature-by-feature comparison of deja-vu with Mem0, Letta, memU, Memori, claude-mem and agentmemory: capture model, storage fidelity, infrastructure, retrieval, benchmarks.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/compare.html">
 <meta property="og:type" content="article">

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -77,7 +77,7 @@
 <tr><td>Stored as</td><td class="us">verbatim, redacted</td><td>LLM facts</td><td>memory blocks</td><td>markdown</td><td>SQL rows</td><td>LLM summaries</td><td>events + vectors</td></tr>
 <tr><td>Needs LLM/embedding key</td><td class="us y">no</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>model or API</td></tr>
 <tr><td>Background process</td><td class="us y">none</td><td>server / cloud</td><td>server + Postgres</td><td>server / cloud</td><td class="y">none</td><td>worker</td><td>daemon, ports</td></tr>
-<tr><td>Coding agents</td><td class="us">16 native parsers (Claude Code, Codex, opencode, Cursor, Goose, OpenClaw…)</td><td>via SDK/MCP</td><td>own runtime</td><td>adapters</td><td>frameworks</td><td>Claude Code</td><td>via hooks</td></tr>
+<tr><td>Coding agents</td><td class="us">17 native parsers (Claude Code, Codex, opencode, Cursor, Goose, OpenClaw…)</td><td>via SDK/MCP</td><td>own runtime</td><td>adapters</td><td>frameworks</td><td>Claude Code, opencode, Antigravity, OpenClaw</td><td>via hooks</td></tr>
 <tr><td>Cross-machine sync</td><td class="us y">✓ SSH, no cloud</td><td>cloud</td><td>server-side</td><td>cloud / self-host</td><td>your DB</td><td class="n">—</td><td class="n">—</td></tr>
 <tr><td>Recall provenance</td><td class="us y">✓ log + receipts</td><td class="n">—</td><td>partial</td><td class="n">—</td><td>queryable rows</td><td>viewer</td><td>dashboard</td></tr>
 <tr><td>Retrieval</td><td class="us">tiered lexical, optional embeddings</td><td>vector + graph</td><td>agent + vector</td><td>embeddings</td><td>SQL + vector</td><td>vector</td><td>hybrid RRF</td></tr>
@@ -117,7 +117,7 @@
 <p><b>Mem0 / Memori</b> — you are building an application and want to give <em>your users</em> memory through an API. deja has no SDK; it is not for app-embedded memory.</p>
 <p><b>Letta</b> — you want a full agent runtime with self-editing memory and you're happy living inside it. deja is the opposite bet: memory only, bring whatever agent you already use.</p>
 <p><b>memU</b> — you want curated, distilled knowledge files and don't mind the agent doing the distilling. deja keeps the verbatim record and searches it instead.</p>
-<p><b>claude-mem</b> — you only use Claude Code and prefer compressed summaries over raw history. deja covers 17 agents and keeps recall lossless.</p>
+<p><b>claude-mem</b> — you prefer compressed summaries over raw history. It installs into Claude Code, opencode, Antigravity and OpenClaw gateways; deja parses 17 agents and keeps recall lossless.</p>
 <p><b>MemPalace</b> — the closest overlap by far, and the honest comparison is narrow: it also reads Claude Code sessions off disk and also keeps them verbatim. It brings a local embedding model and a vector store; deja is one binary with neither, parses 17 harnesses rather than three, and adds the things built around a code history specifically — <code>deja blame</code>, SSH sync, sanitized digests. If you want semantic paraphrase matching and don't mind a Python install with a 300&nbsp;MB model, theirs is the better fit.</p>
 <p><b>cognee / Graphiti</b> — you want a knowledge graph with entities, relationships and time-valid facts to reason over, and you accept a database and an LLM key as the price. deja does not build a graph; it searches what was said.</p>
 <p><b>Hindsight</b> — you want an agent to accumulate curated beliefs about the world over time, through an API you call. deja never writes memories of its own: it indexes the record your agents already produced.</p>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Harnesses — deja-vu docs</title>
+<title>Supported coding agents: Claude Code, Codex, Cursor and 14 more — deja-vu docs</title>
 <meta name="description" content="The seventeen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:type" content="article">

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Supported coding agents: Claude Code, Codex, Cursor and 14 more — deja-vu docs</title>
+<title>Claude Code, Codex, Cursor and 14 more agents — deja-vu</title>
 <meta name="description" content="The seventeen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Harnesses — deja-vu docs">
+<meta property="og:title" content="Claude Code, Codex, Cursor and 14 more agents — deja-vu">
 <meta property="og:description" content="The seventeen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -24,7 +24,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Harnesses — deja-vu docs">
+<meta name="twitter:title" content="Claude Code, Codex, Cursor and 14 more agents — deja-vu">
 <meta name="twitter:description" content="The seventeen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Search your Claude Code and Codex session history — deja-vu docs</title>
+<title>Search your Claude Code and Codex history — deja-vu</title>
 <meta name="description" content="deja search syntax: exact and phrase queries, natural language with stop-word handling, fuzzy typo tolerance, confidence tiers, and optional local semantic recall.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/search.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Search — deja-vu docs">
+<meta property="og:title" content="Search your Claude Code and Codex history — deja-vu">
 <meta property="og:description" content="deja search syntax: exact and phrase queries, natural language with stop-word handling, fuzzy typo tolerance, confidence tiers, and optional local semantic recall.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/search.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -24,7 +24,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Search — deja-vu docs">
+<meta name="twitter:title" content="Search your Claude Code and Codex history — deja-vu">
 <meta name="twitter:description" content="deja search syntax: exact and phrase queries, natural language with stop-word handling, fuzzy typo tolerance, confidence tiers, and optional local semantic recall.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Search — deja-vu docs</title>
+<title>Search your Claude Code and Codex session history — deja-vu docs</title>
 <meta name="description" content="deja search syntax: exact and phrase queries, natural language with stop-word handling, fuzzy typo tolerance, confidence tiers, and optional local semantic recall.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/search.html">
 <meta property="og:type" content="article">

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,8 +4,8 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>deja-vu — your agents already solved this. deja finds it.</title>
-<meta name="description" content="A memory layer for coding agents: search, MCP recall, auto-context, secret redaction, stats, share and sync over the session histories Claude Code, Codex, opencode, Cursor, Gemini CLI, aider, Antigravity, Grok Build, Qwen Code, Kimi Code, Cline, Roo Code, OpenClaw, Goose, Hermes, pi and Copilot CLI already write. One zero-dependency binary, fully local.">
+<title>deja — search the Claude Code, Codex and Cursor history already on your disk</title>
+<meta name="description" content="Persistent memory for coding agents, built from the session history they already wrote — including everything from before you installed it. Search Claude Code, Codex, opencode, Cursor, Gemini CLI and twelve more, and have it recalled automatically over MCP. One zero-dependency binary, fully local, no model.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="deja-vu — search every session your coding agents ever wrote">

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>deja — search the Claude Code, Codex and Cursor history already on your disk</title>
+<title>deja — search your Claude Code, Codex and Cursor history</title>
 <meta name="description" content="Persistent memory for coding agents, built from the session history they already wrote — including everything from before you installed it. Search Claude Code, Codex, opencode, Cursor, Gemini CLI and twelve more, and have it recalled automatically over MCP. One zero-dependency binary, fully local, no model.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <meta property="og:type" content="website">


### PR DESCRIPTION
Docs pages were all titled "<Thing> — deja-vu docs", which nobody searches for. Titles now say what the page is in the words people actually type — search claude code history, persistent memory for coding agents — with the project name second. No keyword stuffing; the landing page just says Claude Code in its title now, which it did not before.

Also fixes two stale claims on the compare page: it said 16 native parsers where registry.json has 17, and described claude-mem as Claude Code only when their README documents opencode, Antigravity and OpenClaw too.

Closes #1176, Closes #1177
