### PR TITLE
docs: let the hero make one claim, and say the same thing everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <p align="center"><img src="assets/logo.svg" width="340" alt="deja-vu"></p>
 
-<p align="center"><strong>Your agents already solved this. deja finds it.</strong><br>Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk &mdash; months of history from before you installed it &mdash; searches 3.5&nbsp;GB in ~1.5&nbsp;ms, and serves it back to any agent over MCP. It ranks by what actually held, not just what matched, and before your agent edits a file or runs a command it names the decision already reached there. Moves with you between machines over SSH. One zero-dependency binary, fully local.</p>
+<p align="center"><strong>Your agents already solved this. deja finds it.</strong><br>Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk &mdash; months of history from before you installed it &mdash; and serves them back to any agent over MCP.</p>
+
+<p align="center">Then it keeps working: it ranks by what actually held rather than what merely matched, and before your agent edits a file or runs a command it names the decision already reached there. One zero-dependency binary, fully local, no model.</p>
 
 <p align="center"><strong>84.9% hit@1</strong> on LongMemEval-S retrieval &mdash; no LLM, no embeddings, no API key. <a href="https://vshulcz.github.io/deja-vu/guide/benchmarks.html">Harness in-repo, run it yourself.</a></p>
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center"><strong>Your agents already solved this. deja finds it.</strong><br>Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk &mdash; months of history from before you installed it &mdash; and serves them back to any agent over MCP.</p>
 
-<p align="center">Then it keeps working: it ranks by what actually held rather than what merely matched, and before your agent edits a file or runs a command it names the decision already reached there. One zero-dependency binary, fully local, no model.</p>
+<p align="center">Then it keeps working: it ranks by what actually held rather than what merely matched, and once its hooks are wired it names the decision already reached on a file before your agent edits it. One zero-dependency binary, fully local.</p>
 
 <p align="center"><strong>84.9% hit@1</strong> on LongMemEval-S retrieval &mdash; no LLM, no embeddings, no API key. <a href="https://vshulcz.github.io/deja-vu/guide/benchmarks.html">Harness in-repo, run it yourself.</a></p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>deja — search your Claude Code, Codex and Cursor history</title>
-<meta name="description" content="Persistent memory for coding agents, built from the session history they already wrote — including everything from before you installed it. Search Claude Code, Codex, opencode, Cursor, Gemini CLI and twelve more, and have it recalled automatically over MCP. One zero-dependency binary, fully local, no model.">
+<meta name="description" content="Persistent memory for coding agents, built from the history they already wrote — including everything from before you installed it. Claude Code, Codex and 15 more.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="deja-vu — search every session your coding agents ever wrote">
-<meta property="og:description" content="Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk, including everything from before you installed it, and serves them back over MCP. One binary, fully local, no model.">
+<meta property="og:description" content="Memory tools start empty and record forward. deja starts full: it indexes the coding-agent sessions already on your disk, from before you installed it.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -315,7 +315,7 @@ footer .spacer{flex:1}
 ╚═════╝ ╚══════╝ ╚════╝ ╚═╝  ╚═╝        ╚═══╝   ╚═════╝</pre>
     <h1 class="tagline">your agents already solved this. <span class="f2">deja finds it.</span></h1>
     <p class="tagline" style="margin-top:8px;font-size:clamp(.85rem,2vw,1.05rem)"><span class="f2">84.9% hit@1</span> on LongMemEval-S retrieval — no LLM, no embeddings, no API key. <a href="guide/benchmarks.html" style="color:inherit">measured, in-repo →</a></p>
-    <p class="sub">Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk &mdash; months of history from before you installed it &mdash; and serves them back to any agent over MCP. It ranks by what actually held rather than what merely matched, and before your agent edits a file or runs a command it names the decision already reached there. One zero-dependency binary, fully local, no model.</p>
+    <p class="sub">Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk &mdash; months of history from before you installed it &mdash; and serves them back to any agent over MCP. It ranks by what actually held rather than what merely matched, and once its hooks are wired it names the decision already reached on a file before your agent edits it. One zero-dependency binary, fully local.</p>
     <div class="heroline">
       <span class="p">$</span>
       <code id="cmd">curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</code>

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="deja-vu — search every session your coding agents ever wrote">
-<meta property="og:description" content="Your agents already solved this. deja finds it. One local index across seventeen coding agents, served back to them via MCP.">
+<meta property="og:description" content="Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk, including everything from before you installed it, and serves them back over MCP. One binary, fully local, no model.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -315,7 +315,7 @@ footer .spacer{flex:1}
 ╚═════╝ ╚══════╝ ╚════╝ ╚═╝  ╚═╝        ╚═══╝   ╚═════╝</pre>
     <h1 class="tagline">your agents already solved this. <span class="f2">deja finds it.</span></h1>
     <p class="tagline" style="margin-top:8px;font-size:clamp(.85rem,2vw,1.05rem)"><span class="f2">84.9% hit@1</span> on LongMemEval-S retrieval — no LLM, no embeddings, no API key. <a href="guide/benchmarks.html" style="color:inherit">measured, in-repo →</a></p>
-    <p class="sub">Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk, searches gigabytes in ~1&nbsp;ms, serves memory back over MCP, and moves with you between machines over SSH. One zero-dependency binary, fully local.</p>
+    <p class="sub">Memory tools start empty and record forward. deja starts full: it indexes the sessions your coding agents already wrote to disk &mdash; months of history from before you installed it &mdash; and serves them back to any agent over MCP. It ranks by what actually held rather than what merely matched, and before your agent edits a file or runs a command it names the decision already reached there. One zero-dependency binary, fully local, no model.</p>
     <div class="heroline">
       <span class="p">$</span>
       <code id="cmd">curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</code>


### PR DESCRIPTION
The hero was making seven claims at once, so the one that matters — memory tools start empty, deja starts full — got buried. Speed and SSH move out (speed already sits in the benchmark block below it); outcome ranking and point-of-action stay, since those are the parts no neighbouring tool does.

Site hero and `og:description` now say the same thing as the README instead of three variants.

Closes #1183
