### PR TITLE
feat(roo): move guidance out of the always-on rules file into a skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Cursor, opencode, Gemini CLI, Qwen Code and Kimi Code get deja's guidance as a skill rather than a block of text that sits in context all session. Cursor had nothing at all before — it has no user-level instructions file — and the old blocks in `AGENTS.md`, `GEMINI.md` and `QWEN.md` are removed on the next install, leaving everything else in that file alone.
+- Cursor, opencode, Gemini CLI, Qwen Code, Kimi Code and Roo Code get deja's guidance as a skill rather than a block of text that sits in context all session. Cursor had nothing at all before — it has no user-level instructions file — and the old blocks in `AGENTS.md`, `GEMINI.md` and `QWEN.md`, and Roo's always-on rules file, are removed on the next install, leaving everything else in that file alone.
 
 ## [0.17.0] - 2026-08-11
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ limits, trust assumptions, and release verification.
 | pi | `${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
 | OpenClaw | `${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl`<br>`${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl` | ✅ | ✅ | — | — | — | paste | — |
 | Copilot CLI | `${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl` | ✅ | ✕ | ✅ | ? | ✅ | ✅ | — |
-| Roo Code | `<vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json`<br>`${DEJA_ROO_ROOTS}/tasks/*/api_conversation_history.json`<br>`~/.vscode-mock/global-storage/tasks/*/api_conversation_history.json` | ✅ | ? | — | — | — | paste | — |
+| Roo Code | `<vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json`<br>`${DEJA_ROO_ROOTS}/tasks/*/api_conversation_history.json`<br>`~/.vscode-mock/global-storage/tasks/*/api_conversation_history.json` | ✅ | ? | ✅ | — | — | paste | — |
 
 ✅ works &middot; — possible, not built yet &middot; ✕ the harness has no such mechanism &middot; ⚠ blocked by an upstream bug &middot; ? not investigated
 

--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -49,7 +49,9 @@ func autoWirings() []autoWiring {
 		{"cline", func() string { return filepath.Join(sources.ClinePluginsDir(), "deja", "index.js") }, "hook-context"},
 		{"goose", func() string { return gooseHookPath() }, "hook-goose"},
 		{"aider", func() string { return aiderContextPath() }, ""},
-		{"roo", func() string { return rooRulesPath() }, ""},
+		// Roo's guidance moved out of the always-on rules file into a skill;
+		// checking the old path reported a correctly wired machine as missing.
+		{"roo", func() string { return guidancePath("roo") }, ""},
 	}
 }
 

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -97,9 +97,9 @@ func guidancePath(harness string) string {
 		// whether or not anyone asks about past work.
 		return filepath.Join(opencodeConfigHome(), "opencode", "skills", "deja-history", "SKILL.md")
 	case "roo":
-		// Global rules are read verbatim into the system prompt for every
-		// mode and every task, which is the only always-on channel Roo has.
-		return rooRulesPath()
+		// Roo scans ~/.roo/skills; the rules file it used before is read
+		// verbatim into the system prompt for every mode and every task.
+		return filepath.Join(homeDir(), ".roo", "skills", "deja-history", "SKILL.md")
 	default:
 		return ""
 	}
@@ -141,49 +141,61 @@ When recalled history genuinely helps, say so to the user in one short line: "de
 	return guidanceStart + "\n" + guidanceBody + "\n" + guidanceEnd + "\n"
 }
 
-// retiredGuidancePath is where a previous version of deja wrote guidance for a
+// retiredGuidancePaths are where previous versions of deja wrote guidance for a
 // harness that has since moved. Install strips deja's block from it, because a
 // harness that reads both would otherwise carry the old copy in every session
 // forever — the file belongs to the user and nothing else would ever clean it.
-func retiredGuidancePath(harness string) string {
+func retiredGuidancePaths(harness string) []string {
 	switch harness {
 	case "opencode":
-		return filepath.Join(opencodeConfigHome(), "opencode", "AGENTS.md")
+		return []string{filepath.Join(opencodeConfigHome(), "opencode", "AGENTS.md")}
 	case "gemini":
-		return filepath.Join(sources.GeminiHome(), "GEMINI.md")
+		return []string{filepath.Join(sources.GeminiHome(), "GEMINI.md")}
 	case "qwen":
-		return filepath.Join(sources.QwenConfigDir(), "QWEN.md")
+		return []string{filepath.Join(sources.QwenConfigDir(), "QWEN.md")}
 	case "kimi":
-		return filepath.Join(sources.KimiConfigDir(), "AGENTS.md")
+		return []string{filepath.Join(sources.KimiConfigDir(), "AGENTS.md")}
+	case "roo":
+		return []string{rooRulesPath()}
 	}
-	return ""
+	return nil
 }
 
 // dropRetiredGuidance removes deja's marked block from a file it no longer
 // writes, leaving every other line in it alone.
 func dropRetiredGuidance(harness string) error {
-	path := retiredGuidancePath(harness)
-	if path == "" {
-		return nil
-	}
-	old, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
+	for _, path := range retiredGuidancePaths(harness) {
+		old, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
 		}
-		return err
+		// A whole file deja owned, such as roo's own rules file, has no markers
+		// in it and is simply removed.
+		if start, end := guidanceMarkerLines(string(old)); start < 0 || end < 0 {
+			if strings.Contains(string(old), "deja") && filepath.Base(path) == "deja.md" {
+				if err := os.Remove(path); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		next := updateGuidanceBlock(string(old), true)
+		// A file that held nothing but our block was ours to begin with, so
+		// leaving it behind empty would be litter rather than someone's content.
+		if strings.TrimSpace(next) == "" {
+			if err := os.Remove(path); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := writeIfChanged(path, old, []byte(next)); err != nil {
+			return err
+		}
 	}
-	if start, end := guidanceMarkerLines(string(old)); start < 0 || end < 0 {
-		return nil
-	}
-	next := updateGuidanceBlock(string(old), true)
-	// A file that held nothing but our block was ours to begin with, so leaving
-	// an empty AGENTS.md behind would be litter rather than someone's content.
-	if strings.TrimSpace(next) == "" {
-		return os.Remove(path)
-	}
-	_, err = writeIfChanged(path, old, []byte(next))
-	return err
+	return nil
 }
 
 func installGuidance(harness string, uninstall bool) (installResult, error) {
@@ -297,7 +309,7 @@ func guidanceHarness(harness string) string {
 // user, and deja only ever appends a marked block there.
 func guidanceOwnsWholeFile(harness string) bool {
 	switch harness {
-	case "claude-code", "claude", "antigravity", "copilot", "pi", "cursor", "opencode", "gemini", "qwen", "kimi":
+	case "claude-code", "claude", "antigravity", "copilot", "pi", "cursor", "opencode", "gemini", "qwen", "kimi", "roo":
 		return true
 	}
 	return false

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -172,14 +172,10 @@ func dropRetiredGuidance(harness string) error {
 			}
 			return err
 		}
-		// A whole file deja owned, such as roo's own rules file, has no markers
-		// in it and is simply removed.
+		// No markers means the file is not ours, whatever its name. Roo's old
+		// rules file carried them like every other block, so stripping it
+		// empties the file and the branch below removes it.
 		if start, end := guidanceMarkerLines(string(old)); start < 0 || end < 0 {
-			if strings.Contains(string(old), "deja") && filepath.Base(path) == "deja.md" {
-				if err := os.Remove(path); err != nil {
-					return err
-				}
-			}
 			continue
 		}
 		next := updateGuidanceBlock(string(old), true)

--- a/cmd/deja/guidance_migrate_test.go
+++ b/cmd/deja/guidance_migrate_test.go
@@ -16,7 +16,7 @@ func TestOpencodeGuidanceMigratesOffAgentsFile(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	agents := retiredGuidancePath("opencode")
+	agents := retiredGuidancePaths("opencode")[0]
 	if err := os.MkdirAll(filepath.Dir(agents), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/guidance_test.go
+++ b/cmd/deja/guidance_test.go
@@ -24,8 +24,8 @@ func TestGuidanceTargetsAreUserLevelAndRespectXDG(t *testing.T) {
 	}
 	// The AGENTS.md block an older deja wrote is stripped on install, so it
 	// does not sit in every session beside the skill that replaced it.
-	if got := retiredGuidancePath("opencode"); got != filepath.Join(xdg, "opencode", "AGENTS.md") {
-		t.Fatalf("opencode retired path = %q", got)
+	if got := retiredGuidancePaths("opencode"); len(got) != 1 || got[0] != filepath.Join(xdg, "opencode", "AGENTS.md") {
+		t.Fatalf("opencode retired paths = %q", got)
 	}
 	// Inside the plugin: antigravity ingests skills/ from a directory marked by
 	// plugin.json, and `agy plugin validate` confirms it there. Beside the

--- a/cmd/deja/install_roo.go
+++ b/cmd/deja/install_roo.go
@@ -54,9 +54,10 @@ func installRoo(exe string, uninstall bool) (installResult, error) {
 	return last, nil
 }
 
-// rooRulesPath is the global rules directory: <home>/.roo/rules, read for
-// every mode. Mode-specific directories (rules-code, rules-ask, …) sit beside
-// it and would each need their own copy.
+// rooRulesPath is where deja used to write guidance: the global rules
+// directory <home>/.roo/rules, read verbatim into the system prompt for every
+// mode and every task. Guidance is a skill now and install removes this file;
+// the path survives so it can be cleaned up on machines that still have it.
 func rooRulesPath() string {
 	return filepath.Join(homeDir(), ".roo", "rules", "deja.md")
 }

--- a/cmd/deja/install_roo_test.go
+++ b/cmd/deja/install_roo_test.go
@@ -75,32 +75,45 @@ func TestInstallRooSkipsHostsWithoutStorage(t *testing.T) {
 
 // Roo has no hook that could refresh a digest, so what goes into the global
 // rules is guidance — text that stays true — not recalled sessions.
-func TestRooGuidanceGoesToGlobalRules(t *testing.T) {
+// Roo reads ~/.roo/skills, which costs its frontmatter until something looks
+// relevant. The rules file it used before is read verbatim into the system
+// prompt for every mode and every task, so install takes that one away.
+func TestRooGuidanceIsASkillAndDropsTheRulesFile(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	rules := rooRulesPath()
+	if err := os.MkdirAll(filepath.Dir(rules), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rules, []byte(guidanceStart+"\nold\n"+guidanceEnd+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := installGuidance("roo", false); err != nil {
 		t.Fatalf("guidance: %v", err)
 	}
-	p := filepath.Join(home, ".roo", "rules", "deja.md")
+	p := filepath.Join(home, ".roo", "skills", "deja-history", "SKILL.md")
 	b, err := os.ReadFile(p)
 	if err != nil {
-		t.Fatalf("rules file missing: %v", err)
+		t.Fatalf("skill missing: %v", err)
 	}
-	if !strings.Contains(string(b), guidanceStart) {
-		t.Fatalf("no deja block:\n%s", b)
+	if !strings.Contains(string(b), "name: deja-history") {
+		t.Fatalf("no skill frontmatter:\n%s", b)
 	}
 	// Mode-specific directories sit beside this one; writing into one of them
 	// would make recall advice appear in Code mode and vanish in Ask mode.
-	if strings.Contains(p, "rules-") {
+	if strings.Contains(p, "skills-") {
 		t.Fatalf("guidance landed in a mode-specific directory: %s", p)
+	}
+	if _, err := os.Stat(rules); !os.IsNotExist(err) {
+		left, _ := os.ReadFile(rules)
+		t.Fatalf("always-on rules file survived: %q err=%v", left, err)
 	}
 	if _, err := installGuidance("roo", true); err != nil {
 		t.Fatalf("uninstall: %v", err)
 	}
-	b, _ = os.ReadFile(p)
-	if strings.Contains(string(b), guidanceStart) {
-		t.Fatalf("uninstall left the block:\n%s", b)
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		t.Fatal("uninstall left the skill")
 	}
 }
 

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -73,7 +73,7 @@
 <tr><td>pi</td><td><code>${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
 <tr><td>OpenClaw</td><td><code>${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl</code><br><code>${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl</code></td><td>✅</td><td>✅</td><td>—</td><td>—</td><td>—</td><td>paste</td><td>—</td></tr>
 <tr><td>Copilot CLI</td><td><code>${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl</code></td><td>✅</td><td>✕</td><td>✅</td><td>?</td><td>✅</td><td>✅</td><td>—</td></tr>
-<tr><td>Roo Code</td><td><code><vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json</code><br><code>${DEJA_ROO_ROOTS}/tasks/*/api_conversation_history.json</code><br><code>~/.vscode-mock/global-storage/tasks/*/api_conversation_history.json</code></td><td>✅</td><td>?</td><td>—</td><td>—</td><td>—</td><td>paste</td><td>—</td></tr>
+<tr><td>Roo Code</td><td><code><vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json</code><br><code>${DEJA_ROO_ROOTS}/tasks/*/api_conversation_history.json</code><br><code>~/.vscode-mock/global-storage/tasks/*/api_conversation_history.json</code></td><td>✅</td><td>?</td><td>✅</td><td>—</td><td>—</td><td>paste</td><td>—</td></tr>
 </table>
 <p>✅ works &middot; — possible, not built yet &middot; ✕ the harness has no such mechanism &middot; ⚠ blocked by an upstream bug &middot; ? not investigated</p>
 <ul>

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -283,14 +283,14 @@
      "state": "unknown",
      "why": "not investigated yet"
     },
-    "skill": {
-     "state": "todo",
-     "why": "loads skills from ~/.grok/skills/ and also reads Claude Code skills and plugins with no extra setup",
-     "source": "https://docs.x.ai/build/features/skills-plugins-marketplaces"
-    },
     "command": {
      "state": "unknown",
      "why": "not investigated yet"
+    },
+    "skill": {
+     "state": "todo",
+     "why": "Grok Build reads ~/.grok/skills, but deja writes guidance to both GROK.md and AGENTS.md because three grok CLIs share that directory; which of them read skills is not established",
+     "source": "https://docs.x.ai/build/features/skills-plugins-marketplaces"
     }
    }
   },
@@ -529,7 +529,7 @@
    "capabilities": {
     "mcp": true,
     "auto": false,
-    "skill": false,
+    "skill": true,
     "command": false,
     "resume": false,
     "handoff": "paste",
@@ -539,11 +539,6 @@
     "auto": {
      "state": "unknown",
      "why": "not investigated yet"
-    },
-    "skill": {
-     "state": "todo",
-     "why": "parses SKILL.md frontmatter and loads the body when a request matches",
-     "source": "https://roocodeinc.github.io/Roo-Code/features/skills/"
     },
     "command": {
      "state": "todo",


### PR DESCRIPTION
Roo's guidance lived in `~/.roo/rules/deja.md`, which the docs describe as read verbatim into the system prompt for every mode and every task — the most expensive channel of any harness here. Roo also scans `~/.roo/skills/` ([docs](https://roocodeinc.github.io/Roo-Code/features/skills/)), so it gets the skill and the rules file is removed on install.

```
$ deja install roo --no-index
roo: guidance created ~/.roo/skills/deja-history/SKILL.md

skill: True   old rules file gone: True   user's own rule kept: True
```

`retiredGuidancePath` becomes `retiredGuidancePaths` and returns a list, because retiring is not always one file — and it now handles a whole file deja owned, like this one, in addition to a marked block inside someone else's.

**Grok was in this branch and came back out.** Its skills directory is documented (`~/.grok/skills/`), so it looked like the same change. But deja writes grok's block to *both* `GROK.md` and `AGENTS.md`, and the comment on that code says why: three grok CLIs share the directory, the one that reads `GROK.md` is not the one being maintained, and grok-dev reads `AGENTS.md`. I confirmed Grok Build reads skills. I have nothing on the other two. Moving it would have silently taken memory away from whichever of them does not, so it stays `todo` with that reason recorded in the registry rather than being half-verified and shipped.

The dedicated test for the old behaviour is rewritten rather than dropped: it now asserts the skill is written, the always-on rules file is gone, and — kept from the original — that nothing lands in a mode-specific directory, which would make recall advice appear in Code mode and vanish in Ask mode.

Ten of seventeen harnesses have a skill.

Part of #1192.
