### PR TITLE
ci: stop instrumenting coverage on the platforms that never read it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,14 @@ jobs:
       # to 12m as the suite grew — cmd/deja under -race on the windows runner
       # runs ~6m of real, non-hung work, and 12m keeps a wide margin below the
       # job's 30m so a true hang still dies with a stack.
+      # Coverage instrumentation is only read on Linux, where the floor runs.
+      # Windows paid for -covermode=atomic on top of -race and threw the
+      # profile away: the test step alone was 1726s of the job's 30m cap.
       - run: go test -race -timeout 12m -coverprofile=coverage.out -covermode=atomic ./...
+        if: runner.os == 'Linux'
+        shell: bash
+      - run: go test -race -timeout 12m ./...
+        if: runner.os != 'Linux'
         shell: bash
       - run: go build ./cmd/deja
       - name: Benchmark lexical recall floor


### PR DESCRIPTION
The Windows job has been cancelled at its 30-minute cap three times today, on PRs that changed documentation and registry JSON. Each one cost half an hour and a manual re-run, which is how a flake teaches people to stop reading red.

It is not spread across the job. From a green run's step timings:

```
1s     Set up job
5s     checkout
17s    setup-go
14s    go vet
1726s  go test -race -coverprofile=coverage.out -covermode=atomic ./...
2s     go build
```

Everything except the test step is 40 seconds. The test step is 28.8 minutes against a 30-minute ceiling — which is why a docs-only PR can tip over it.

Part of that is coverage the platform never uses. `-coverprofile` and `-covermode=atomic` were passed on all three runners, but the Coverage floor step is `if: runner.os == 'Linux'` — so Windows and macOS were paying for atomic counter instrumentation, on top of `-race`, and discarding the profile. This splits the step: Linux keeps coverage because it reads it, the others run the same tests without it.

What this does not claim: that it is the whole 28.8 minutes. `-race` on the Windows runner is expensive on its own, and the existing comment in the workflow already says the suite runs about four times slower there. This removes the part that is provably wasted; the remaining gap is worth measuring separately, with the job's own timings rather than a guess.

Closes #1179 only if the ceiling stops being hit. Worth watching the next few Windows runs before calling it fixed — I would rather reopen it than close it early.
