### PR TITLE
feat(bench): measure the first minute after installing onto existing history

### DIFF
--- a/scripts/day0bench/ctx.go
+++ b/scripts/day0bench/ctx.go
@@ -35,7 +35,7 @@ var indexedSources = regexp.MustCompile(`indexed_sources:\s*([\d,]+)`)
 // runCtx mirrors run() for an external binary: same corpus, same questions,
 // same scoring. The control writes nothing, which is the day-0 state of a tool
 // that only records forward.
-func runCtx(bin string, qs []question, control bool) (runResult, error) {
+func runCtx(bin string, all, qs []question, control bool) (runResult, error) {
 	var out runResult
 	tmp, err := os.MkdirTemp("", "day0ctx")
 	if err != nil {
@@ -56,7 +56,7 @@ func runCtx(bin string, qs []question, control bool) (runResult, error) {
 	// and turns — so this is the same corpus either row was scored on.
 	projects := filepath.Join(home, ".claude", "projects")
 	seen := map[string]bool{}
-	for _, q := range qs {
+	for _, q := range all {
 		for i, turns := range q.Sessions {
 			id := q.SessionIDs[i]
 			if seen[id] {

--- a/scripts/day0bench/ctx.go
+++ b/scripts/day0bench/ctx.go
@@ -106,7 +106,7 @@ func runCtx(bin string, qs []question, control bool) (runResult, error) {
 
 	for i, q := range qs {
 		t1 := time.Now()
-		raw, err := ctx(true, "search", q.Question, "--limit", "5", "--json")
+		raw, err := ctx(true, "search", q.Question, "--limit", strconv.Itoa(depthK), "--json")
 		if err != nil {
 			return out, fmt.Errorf("ctx search: %w", err)
 		}
@@ -139,6 +139,7 @@ func runCtx(bin string, qs []question, control bool) (runResult, error) {
 			if rank < 5 {
 				out.hit5++
 			}
+			out.found++
 			break
 		}
 	}

--- a/scripts/day0bench/ctx.go
+++ b/scripts/day0bench/ctx.go
@@ -51,6 +51,9 @@ func runCtx(bin string, qs []question, control bool) (runResult, error) {
 		return out, err
 	}
 
+	// Only the Claude shape is laid down for ctx. The harness rows above differ
+	// in on-disk format, not in content — every one carries the same sessions
+	// and turns — so this is the same corpus either row was scored on.
 	projects := filepath.Join(home, ".claude", "projects")
 	seen := map[string]bool{}
 	for _, q := range qs {
@@ -72,9 +75,11 @@ func runCtx(bin string, qs []question, control bool) (runResult, error) {
 
 	ctx := func(quiet bool, args ...string) (string, error) {
 		cmd := exec.Command(bin, args...)
-		// A sandboxed HOME is the whole isolation here: ctx discovers history
-		// under it and keeps its index there too, so nothing touches the real one.
-		cmd.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+		// The environment is built from nothing rather than inherited: ctx reads
+		// CTX_DATA_ROOT, and a machine that has it set would answer these
+		// questions out of the real index instead of the corpus under test,
+		// which would look like a very good score and mean nothing.
+		cmd.Env = []string{"HOME=" + home, "USERPROFILE=" + home, "PATH=" + os.Getenv("PATH")}
 		if quiet {
 			cmd.Env = append(cmd.Env, "CTX_QUIET=1")
 		}

--- a/scripts/day0bench/ctx.go
+++ b/scripts/day0bench/ctx.go
@@ -1,0 +1,141 @@
+package main
+
+// The point of a day-0 number is that somebody else can get it too, so the
+// neighbouring column runs here rather than being quoted from a blog post.
+// Pass -ctx with a path to a ctx binary and it indexes the same corpus, in the
+// same sandbox home, answers the same questions, and is scored by the same
+// rule: the rank of the first returned session whose source file is one of the
+// question's answer sessions.
+//
+// ctx is asked for session-level results, which is what it returns by default
+// and what deja ranks, so neither side is being scored on the other's unit.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type ctxResults struct {
+	Results []struct {
+		Citations []struct {
+			SourcePath string `json:"source_path"`
+		} `json:"citations"`
+	} `json:"results"`
+}
+
+var indexedSources = regexp.MustCompile(`indexed_sources:\s*([\d,]+)`)
+
+// runCtx mirrors run() for an external binary: same corpus, same questions,
+// same scoring. The control writes nothing, which is the day-0 state of a tool
+// that only records forward.
+func runCtx(bin string, qs []question, control bool) (runResult, error) {
+	var out runResult
+	tmp, err := os.MkdirTemp("", "day0ctx")
+	if err != nil {
+		return out, err
+	}
+	defer os.RemoveAll(tmp)
+	// On macOS the temp dir sits under /var, a symlink to /private/var. ctx
+	// resolves the history it finds to real paths, which then no longer sit
+	// under an unresolved HOME, and it indexes nothing at all. Hand it the
+	// resolved path so the corpus is discoverable rather than silently empty.
+	home, err := filepath.EvalSymlinks(tmp)
+	if err != nil {
+		return out, err
+	}
+
+	projects := filepath.Join(home, ".claude", "projects")
+	seen := map[string]bool{}
+	for _, q := range qs {
+		for i, turns := range q.Sessions {
+			id := q.SessionIDs[i]
+			if seen[id] {
+				continue
+			}
+			seen[id] = true
+			out.written++
+			if control {
+				continue
+			}
+			if err := writeClaude(projects, id, parseDate(q.Dates[i]), turns); err != nil {
+				return out, err
+			}
+		}
+	}
+
+	ctx := func(quiet bool, args ...string) (string, error) {
+		cmd := exec.Command(bin, args...)
+		// A sandboxed HOME is the whole isolation here: ctx discovers history
+		// under it and keeps its index there too, so nothing touches the real one.
+		cmd.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+		if quiet {
+			cmd.Env = append(cmd.Env, "CTX_QUIET=1")
+		}
+		b, err := cmd.Output()
+		return string(b), err
+	}
+
+	t0 := time.Now()
+	if _, err := ctx(true, "setup"); err != nil {
+		return out, fmt.Errorf("ctx setup: %w", err)
+	}
+	out.build = time.Since(t0)
+
+	// CTX_QUIET silences status entirely, so this one call opts out of it.
+	status, err := ctx(false, "status")
+	if err != nil {
+		return out, fmt.Errorf("ctx status: %w", err)
+	}
+	if m := indexedSources.FindStringSubmatch(status); m != nil {
+		if n, err := strconv.Atoi(strings.ReplaceAll(m[1], ",", "")); err == nil {
+			out.indexed = n
+		}
+	}
+
+	for i, q := range qs {
+		t1 := time.Now()
+		raw, err := ctx(true, "search", q.Question, "--limit", "5", "--json")
+		if err != nil {
+			return out, fmt.Errorf("ctx search: %w", err)
+		}
+		if i == 0 {
+			out.first = time.Since(t1)
+		}
+		var res ctxResults
+		if err := json.Unmarshal([]byte(raw), &res); err != nil {
+			return out, fmt.Errorf("ctx search output: %w", err)
+		}
+		want := map[string]bool{}
+		for _, id := range q.AnswerSession {
+			want[id] = true
+		}
+		out.n++
+		for rank, r := range res.Results {
+			hit := false
+			for _, c := range r.Citations {
+				if want[strings.TrimSuffix(filepath.Base(c.SourcePath), ".jsonl")] {
+					hit = true
+					break
+				}
+			}
+			if !hit {
+				continue
+			}
+			if rank == 0 {
+				out.hit1++
+			}
+			if rank < 5 {
+				out.hit5++
+			}
+			break
+		}
+	}
+	return out, nil
+}

--- a/scripts/day0bench/main.go
+++ b/scripts/day0bench/main.go
@@ -146,6 +146,7 @@ func main() {
 	limit := flag.Int("limit", 20, "questions to run")
 	control := flag.Bool("control", false, "write the corpus but read an empty store: must score zero")
 	ctxBin := flag.String("ctx", "", "path to a ctx binary to run over the same corpus, scored the same way")
+	misses := flag.Bool("misses", false, "print the questions whose answer session never came back, for triage")
 	flag.Parse()
 	if *data == "" {
 		fmt.Fprintln(os.Stderr, "day0bench: -data is required")
@@ -166,7 +167,7 @@ func main() {
 	}
 
 	for _, w := range writers() {
-		r, err := run(w, qs, *control)
+		r, err := run(w, qs, *control, *misses)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "day0bench %s: %v\n", w.harness, err)
 			os.Exit(1)
@@ -204,7 +205,7 @@ func report(name string, r runResult) {
 		r.hit1, r.n, r.hit5, r.n, depthK, r.found, r.n)
 }
 
-func run(w writer, qs []question, control bool) (runResult, error) {
+func run(w writer, qs []question, control bool, misses bool) (runResult, error) {
 	var out runResult
 	tmp, err := os.MkdirTemp("", "day0")
 	if err != nil {
@@ -292,6 +293,7 @@ func run(w writer, qs []question, control bool) (runResult, error) {
 			want[id] = true
 		}
 		out.n++
+		hit := false
 		if len(hits) > depthK {
 			hits = hits[:depthK]
 		}
@@ -306,7 +308,13 @@ func run(w writer, qs []question, control bool) (runResult, error) {
 				out.hit5++
 			}
 			out.found++
+			hit = true
 			break
+		}
+		// A question whose answer session never came back at all is a retrieval
+		// miss, not a ranking one, and no amount of reordering reaches it.
+		if !hit && misses {
+			fmt.Printf("  miss %s: %s\n", q.ID, q.Question)
 		}
 	}
 	return out, nil

--- a/scripts/day0bench/main.go
+++ b/scripts/day0bench/main.go
@@ -147,6 +147,7 @@ func main() {
 	control := flag.Bool("control", false, "write the corpus but read an empty store: must score zero")
 	ctxBin := flag.String("ctx", "", "path to a ctx binary to run over the same corpus, scored the same way")
 	misses := flag.Bool("misses", false, "print the questions whose answer session never came back, for triage")
+	corpus := flag.Int("corpus", 0, "lay down history from this many questions while scoring -limit of them; holds the questions fixed so only the pile grows")
 	flag.Parse()
 	if *data == "" {
 		fmt.Fprintln(os.Stderr, "day0bench: -data is required")
@@ -162,12 +163,23 @@ func main() {
 		fmt.Fprintln(os.Stderr, "day0bench:", err)
 		os.Exit(1)
 	}
+	// The corpus and the scored set are separate knobs. Growing -limit alone
+	// grows the pile and swaps in different questions at the same time, so a
+	// drop could be either one; holding the questions still and moving -corpus
+	// asks only whether more history makes the same question harder.
+	all := qs
+	if *corpus > 0 && len(all) > *corpus {
+		all = all[:*corpus]
+	}
 	if *limit > 0 && len(qs) > *limit {
 		qs = qs[:*limit]
 	}
+	if *corpus <= 0 {
+		all = qs
+	}
 
 	for _, w := range writers() {
-		r, err := run(w, qs, *control, *misses)
+		r, err := run(w, all, qs, *control, *misses)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "day0bench %s: %v\n", w.harness, err)
 			os.Exit(1)
@@ -175,7 +187,7 @@ func main() {
 		report(w.harness, r)
 	}
 	if *ctxBin != "" {
-		r, err := runCtx(*ctxBin, qs, *control)
+		r, err := runCtx(*ctxBin, all, qs, *control)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "day0bench ctx:", err)
 			os.Exit(1)
@@ -205,7 +217,7 @@ func report(name string, r runResult) {
 		r.hit1, r.n, r.hit5, r.n, depthK, r.found, r.n)
 }
 
-func run(w writer, qs []question, control bool, misses bool) (runResult, error) {
+func run(w writer, all, qs []question, control bool, misses bool) (runResult, error) {
 	var out runResult
 	tmp, err := os.MkdirTemp("", "day0")
 	if err != nil {
@@ -220,7 +232,7 @@ func run(w writer, qs []question, control bool, misses bool) (runResult, error) 
 	// One shared corpus for every question, laid down once: this is a machine
 	// with months of history, not one haystack per query.
 	seen := map[string]bool{}
-	for _, q := range qs {
+	for _, q := range all {
 		for i, turns := range q.Sessions {
 			id := q.SessionIDs[i]
 			if seen[id] {

--- a/scripts/day0bench/main.go
+++ b/scripts/day0bench/main.go
@@ -1,0 +1,287 @@
+// Command day0bench measures the first minute after installing on a machine
+// that already has coding-agent history.
+//
+// Every other benchmark in this repo starts with a warm index over a corpus
+// that is already there, and answers "how well does deja rank what it holds".
+// This one answers the question deja is built around: the history predates the
+// install, so what does a cold machine give you before any work is done.
+//
+// What it reports, per run:
+//
+//   - reach: sessions written to disk versus sessions the parsers actually
+//     ingested, per harness. A parser that silently skips is the failure this
+//     is most likely to expose, and it is invisible to a warm-index benchmark.
+//   - build: wall time to go from no index to a queryable one.
+//   - first answer: wall time of the first query after that build.
+//   - hit@1 / hit@5 over questions whose answers exist only in that history.
+//
+// The control is the part that makes the rest mean anything: with -control the
+// corpus is written and deja is pointed at an empty store, which is what a
+// memory that only records forward would see on day zero. It must score zero.
+// If it does not, the questions are answerable from something other than the
+// history and every number here is inflated.
+//
+//	go run ./scripts/day0bench -data longmemeval_s_cleaned.json [-limit N] [-control]
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+type question struct {
+	ID            string   `json:"question_id"`
+	Question      string   `json:"question"`
+	AnswerSession []string `json:"answer_session_ids"`
+	Sessions      [][]turn `json:"haystack_sessions"`
+	SessionIDs    []string `json:"haystack_session_ids"`
+	Dates         []string `json:"haystack_dates"`
+	QuestionDate  string   `json:"question_date"`
+}
+
+type turn struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// writer lays a session down in one harness's real on-disk shape. Only formats
+// that are plain files are here: opencode and cursor keep sessions in SQLite,
+// and a synthetic database would test the fixture rather than the parser.
+type writer struct {
+	harness string
+	env     string // the DEJA_*_ROOT that points deja at this corpus
+	write   func(root, id string, ts time.Time, turns []turn) error
+}
+
+func writers() []writer {
+	return []writer{
+		{"claude", "DEJA_CLAUDE_ROOT", writeClaude},
+		{"codex", "DEJA_CODEX_ROOT", writeCodex},
+	}
+}
+
+func writeClaude(root, id string, ts time.Time, turns []turn) error {
+	proj := filepath.Join(root, "-work-day0")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		return err
+	}
+	f, err := os.Create(filepath.Join(proj, id+".jsonl"))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for i, t := range turns {
+		// Assistant content is a list of typed blocks on disk; writing it as a
+		// string makes the parser drop the turn.
+		var content any = t.Content
+		if t.Role == "assistant" {
+			content = []any{map[string]any{"type": "text", "text": t.Content}}
+		}
+		if err := enc.Encode(map[string]any{
+			"type":      t.Role,
+			"sessionId": id,
+			"timestamp": ts.Add(time.Duration(i) * time.Minute).UTC().Format(time.RFC3339),
+			"message":   map[string]any{"role": t.Role, "content": content},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeCodex(root, id string, ts time.Time, turns []turn) error {
+	dir := filepath.Join(root, "sessions", ts.UTC().Format("2006/01/02"))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	f, err := os.Create(filepath.Join(dir, "rollout-"+id+".jsonl"))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for i, t := range turns {
+		if err := enc.Encode(map[string]any{
+			"timestamp": ts.Add(time.Duration(i) * time.Minute).UTC().Format(time.RFC3339),
+			"type":      "response_item",
+			"payload": map[string]any{
+				"type":    "message",
+				"role":    t.Role,
+				"content": []any{map[string]any{"type": "input_text", "text": t.Content}},
+			},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type runResult struct {
+	written, indexed int
+	build, first     time.Duration
+	hit1, hit5, n    int
+}
+
+func main() {
+	data := flag.String("data", "", "LongMemEval-shaped corpus to lay down as history")
+	limit := flag.Int("limit", 20, "questions to run")
+	control := flag.Bool("control", false, "write the corpus but read an empty store: must score zero")
+	flag.Parse()
+	if *data == "" {
+		fmt.Fprintln(os.Stderr, "day0bench: -data is required")
+		os.Exit(2)
+	}
+	raw, err := os.ReadFile(*data)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "day0bench:", err)
+		os.Exit(1)
+	}
+	var qs []question
+	if err := json.Unmarshal(raw, &qs); err != nil {
+		fmt.Fprintln(os.Stderr, "day0bench:", err)
+		os.Exit(1)
+	}
+	if *limit > 0 && len(qs) > *limit {
+		qs = qs[:*limit]
+	}
+
+	for _, w := range writers() {
+		r, err := run(w, qs, *control)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "day0bench %s: %v\n", w.harness, err)
+			os.Exit(1)
+		}
+		reach := 0.0
+		if r.written > 0 {
+			reach = float64(r.indexed) / float64(r.written) * 100
+		}
+		fmt.Printf("%-8s reach %d/%d (%.1f%%)  build %s  first answer %s  hit@1 %d/%d  hit@5 %d/%d\n",
+			w.harness, r.indexed, r.written, reach,
+			r.build.Round(time.Millisecond), r.first.Round(time.Millisecond),
+			r.hit1, r.n, r.hit5, r.n)
+	}
+	if *control {
+		fmt.Println("\ncontrol: every hit above should be 0 — a memory that starts empty knows none of this")
+	}
+}
+
+func run(w writer, qs []question, control bool) (runResult, error) {
+	var out runResult
+	tmp, err := os.MkdirTemp("", "day0")
+	if err != nil {
+		return out, err
+	}
+	defer os.RemoveAll(tmp)
+	root := filepath.Join(tmp, w.harness)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return out, err
+	}
+
+	// One shared corpus for every question, laid down once: this is a machine
+	// with months of history, not one haystack per query.
+	seen := map[string]bool{}
+	for _, q := range qs {
+		for i, turns := range q.Sessions {
+			id := q.SessionIDs[i]
+			if seen[id] {
+				continue
+			}
+			seen[id] = true
+			if err := w.write(root, id, parseDate(q.Dates[i]), turns); err != nil {
+				return out, err
+			}
+			out.written++
+		}
+	}
+
+	dir := filepath.Join(tmp, "index.db")
+	// The control points deja at a directory with no history in it, which is
+	// what a forward-only memory sees on a machine it was just installed on.
+	readRoot := root
+	if control {
+		readRoot = filepath.Join(tmp, "empty")
+		if err := os.MkdirAll(readRoot, 0o755); err != nil {
+			return out, err
+		}
+	}
+	_ = os.Setenv(w.env, readRoot)
+	_ = os.Setenv("DEJA_INDEX_DIR", dir)
+
+	t0 := time.Now()
+	if err := index.Ensure(dir, w.harness, true, nil); err != nil {
+		return out, err
+	}
+	out.build = time.Since(t0)
+
+	if out.indexed, err = index.SessionCount(dir); err != nil {
+		return out, err
+	}
+
+	for i, q := range qs {
+		o := search.Options{Query: q.Question, All: true}
+		if t, err := time.Parse("2006/01/02 (Mon) 15:04", q.QuestionDate); err == nil {
+			o.Now = t
+		}
+		t1 := time.Now()
+		result, err := index.SearchWithRecoveryDetailed(dir, o, nil)
+		if err != nil {
+			return out, err
+		}
+		o.Tier = result.Tier
+		if result.Stemmed {
+			o.Stemmed = true
+			o.FuzzyVariants = result.Variants
+		} else if result.Fuzzy {
+			o.FuzzyVariants = result.Variants
+		}
+		var hits []search.Hit
+		switch {
+		case result.Tier == search.TierError:
+			hits = search.ErrorHits(result.Sessions)
+		case result.Tier == search.TierRelevance:
+			hits = search.RelevanceHits(result.Sessions, index.RelevanceTerms(q.Question))
+		default:
+			if hits, err = search.Run(result.Sessions, o); err != nil {
+				return out, err
+			}
+		}
+		if i == 0 {
+			out.first = time.Since(t1)
+		}
+		want := map[string]bool{}
+		for _, id := range q.AnswerSession {
+			want[id] = true
+		}
+		out.n++
+		for rank, h := range hits {
+			if !want[h.Session.ID] {
+				continue
+			}
+			if rank == 0 {
+				out.hit1++
+			}
+			if rank < 5 {
+				out.hit5++
+			}
+			break
+		}
+	}
+	return out, nil
+}
+
+func parseDate(s string) time.Time {
+	for _, layout := range []string{"2006/01/02 (Mon) 15:04", "2006/01/02", time.RFC3339} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t
+		}
+	}
+	return time.Now().AddDate(0, -3, 0)
+}

--- a/scripts/day0bench/main.go
+++ b/scripts/day0bench/main.go
@@ -131,8 +131,15 @@ func writeCodex(root, id string, ts time.Time, turns []turn) error {
 type runResult struct {
 	written, indexed int
 	build, first     time.Duration
-	hit1, hit5, n    int
+	// found counts the answer session appearing anywhere in the top depthK,
+	// which separates the two ways a query fails: ranked badly, or never
+	// retrieved at all. Only the second one is fixed by ranking work.
+	hit1, hit5, found, n int
 }
+
+// depthK bounds both sides' result list, so found means the same thing in
+// every row.
+const depthK = 50
 
 func main() {
 	data := flag.String("data", "", "LongMemEval-shaped corpus to lay down as history")
@@ -191,10 +198,10 @@ func report(name string, r runResult) {
 	if r.written > 0 {
 		reach = float64(r.indexed) / float64(r.written) * 100
 	}
-	fmt.Printf("%-8s reach %d/%d (%.1f%%)  build %s  first answer %s  hit@1 %d/%d  hit@5 %d/%d\n",
+	fmt.Printf("%-8s reach %d/%d (%.1f%%)  build %s  first answer %s  hit@1 %d/%d  hit@5 %d/%d  found@%d %d/%d\n",
 		name, r.indexed, r.written, reach,
 		r.build.Round(time.Millisecond), r.first.Round(time.Millisecond),
-		r.hit1, r.n, r.hit5, r.n)
+		r.hit1, r.n, r.hit5, r.n, depthK, r.found, r.n)
 }
 
 func run(w writer, qs []question, control bool) (runResult, error) {
@@ -285,6 +292,9 @@ func run(w writer, qs []question, control bool) (runResult, error) {
 			want[id] = true
 		}
 		out.n++
+		if len(hits) > depthK {
+			hits = hits[:depthK]
+		}
 		for rank, h := range hits {
 			if !want[h.Session.ID] {
 				continue
@@ -295,6 +305,7 @@ func run(w writer, qs []question, control bool) (runResult, error) {
 			if rank < 5 {
 				out.hit5++
 			}
+			out.found++
 			break
 		}
 	}

--- a/scripts/day0bench/main.go
+++ b/scripts/day0bench/main.go
@@ -21,7 +21,11 @@
 // If it does not, the questions are answerable from something other than the
 // history and every number here is inflated.
 //
-//	go run ./scripts/day0bench -data longmemeval_s_cleaned.json [-limit N] [-control]
+// Pass -ctx with a path to a ctx binary and it runs over the same corpus and
+// is scored by the same rule, so the neighbouring column is a run anyone can
+// repeat rather than a number quoted from somewhere.
+//
+//	go run ./scripts/day0bench -data longmemeval_s_cleaned.json [-limit N] [-control] [-ctx PATH]
 package main
 
 import (
@@ -134,6 +138,7 @@ func main() {
 	data := flag.String("data", "", "LongMemEval-shaped corpus to lay down as history")
 	limit := flag.Int("limit", 20, "questions to run")
 	control := flag.Bool("control", false, "write the corpus but read an empty store: must score zero")
+	ctxBin := flag.String("ctx", "", "path to a ctx binary to run over the same corpus, scored the same way")
 	flag.Parse()
 	if *data == "" {
 		fmt.Fprintln(os.Stderr, "day0bench: -data is required")
@@ -159,18 +164,32 @@ func main() {
 			fmt.Fprintf(os.Stderr, "day0bench %s: %v\n", w.harness, err)
 			os.Exit(1)
 		}
-		reach := 0.0
-		if r.written > 0 {
-			reach = float64(r.indexed) / float64(r.written) * 100
+		report(w.harness, r)
+	}
+	if *ctxBin != "" {
+		r, err := runCtx(*ctxBin, qs, *control)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "day0bench ctx:", err)
+			os.Exit(1)
 		}
-		fmt.Printf("%-8s reach %d/%d (%.1f%%)  build %s  first answer %s  hit@1 %d/%d  hit@5 %d/%d\n",
-			w.harness, r.indexed, r.written, reach,
-			r.build.Round(time.Millisecond), r.first.Round(time.Millisecond),
-			r.hit1, r.n, r.hit5, r.n)
+		report("ctx", r)
 	}
 	if *control {
 		fmt.Println("\ncontrol: every hit above should be 0 — a memory that starts empty knows none of this")
 	}
+}
+
+// report prints one row. Both sides go through it so the columns cannot drift
+// apart into two different definitions of the same word.
+func report(name string, r runResult) {
+	reach := 0.0
+	if r.written > 0 {
+		reach = float64(r.indexed) / float64(r.written) * 100
+	}
+	fmt.Printf("%-8s reach %d/%d (%.1f%%)  build %s  first answer %s  hit@1 %d/%d  hit@5 %d/%d\n",
+		name, r.indexed, r.written, reach,
+		r.build.Round(time.Millisecond), r.first.Round(time.Millisecond),
+		r.hit1, r.n, r.hit5, r.n)
 }
 
 func run(w writer, qs []question, control bool) (runResult, error) {
@@ -243,10 +262,10 @@ func run(w writer, qs []question, control bool) (runResult, error) {
 			o.FuzzyVariants = result.Variants
 		}
 		var hits []search.Hit
-		switch {
-		case result.Tier == search.TierError:
+		switch result.Tier {
+		case search.TierError:
 			hits = search.ErrorHits(result.Sessions)
-		case result.Tier == search.TierRelevance:
+		case search.TierRelevance:
 			hits = search.RelevanceHits(result.Sessions, index.RelevanceTerms(q.Question))
 		default:
 			if hits, err = search.Run(result.Sessions, o); err != nil {

--- a/scripts/day0bench/main.go
+++ b/scripts/day0bench/main.go
@@ -173,6 +173,11 @@ func main() {
 			os.Exit(1)
 		}
 		report("ctx", r)
+		// Said plainly here because the number is easy to misread: deja is timed
+		// in-process and ctx is timed as a subprocess, so its first answer
+		// carries process start and a freshness check that deja's does not.
+		// That is the wait a person at a terminal gets, not engine speed.
+		fmt.Println("\nnote: ctx is timed as a subprocess, deja in-process — first-answer times are not engine-to-engine")
 	}
 	if *control {
 		fmt.Println("\ncontrol: every hit above should be 0 — a memory that starts empty knows none of this")


### PR DESCRIPTION
Every benchmark in this repo starts with a warm index over a corpus that is already there, and answers "how well does deja rank what it holds". None answers the question the product is built around: the history predates the install, so what does a cold machine give you before any work is done.

```
$ go run ./scripts/day0bench -data longmemeval_s_cleaned.json -limit 40
claude   reach 1910/1910 (100.0%)  build 3.477s  first answer 3ms  hit@1 21/40  hit@5 25/40
codex    reach 1910/1910 (100.0%)  build 3.407s  first answer 3ms  hit@1 21/40  hit@5 25/40
```

Four numbers, and the first is the one no warm benchmark can produce:

- **reach** — sessions written to disk versus sessions the parsers actually ingested. A parser that silently skips is the failure #1175 predicted this would expose, and it is invisible once the index exists. Both formats ingest everything here.
- **build** — no index to a queryable one. This is the install-day wait, the thing a person actually experiences.
- **first answer** — the query right after that build, cold caches.
- **hit@1 / hit@5** — over questions whose answers exist only in that history.

**The control is what makes the rest mean anything.** `-control` lays the same corpus down and points deja at an empty store — what a memory that only records forward sees on the day it is installed:

```
$ go run ./scripts/day0bench -data … -limit 12 -control
claude   reach 0/590 (0.0%)  build 14ms  first answer 0s  hit@1 0/12  hit@5 0/12
codex    reach 0/590 (0.0%)  build 11ms  first answer 0s  hit@1 0/12  hit@5 0/12
```

Zero, as it has to be. Anything else would mean the questions are answerable from the repo, the filenames or general knowledge, and every number above would be inflated.

Two formats to start — Claude Code and Codex, both plain JSONL laid down in their real on-disk shapes and read by the production ingestion path, not a fixture loader. opencode and Cursor keep sessions in SQLite; a synthetic database would test the fixture rather than the parser, so they are deliberately absent rather than faked.

What this is not yet: a comparison. #1175 asks for a table anyone can reproduce across tools, and that needs each of them installed and driven the same way. This lays the track and states deja's own numbers on it; the neighbouring columns are the next step, and they belong in a run somebody else can repeat rather than in a claim.

Part of #1175.
