### PR TITLE
perf(index): cut the CJK bigram build overhead without changing the index

### DIFF
--- a/internal/index/cjkindex.go
+++ b/internal/index/cjkindex.go
@@ -1,0 +1,167 @@
+package index
+
+import (
+	"hash/fnv"
+	"unicode/utf8"
+
+	"github.com/vshulcz/deja-vu/internal/cjkfold"
+)
+
+// hexBuckets fixes every shard name in a lookup table. bucket relies on these
+// exact names for on-disk compatibility while avoiding formatter work in the
+// build path addressed by #492.
+var hexBuckets = [256]string{
+	"x00", "x01", "x02", "x03", "x04", "x05", "x06", "x07",
+	"x08", "x09", "x0a", "x0b", "x0c", "x0d", "x0e", "x0f",
+	"x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17",
+	"x18", "x19", "x1a", "x1b", "x1c", "x1d", "x1e", "x1f",
+	"x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27",
+	"x28", "x29", "x2a", "x2b", "x2c", "x2d", "x2e", "x2f",
+	"x30", "x31", "x32", "x33", "x34", "x35", "x36", "x37",
+	"x38", "x39", "x3a", "x3b", "x3c", "x3d", "x3e", "x3f",
+	"x40", "x41", "x42", "x43", "x44", "x45", "x46", "x47",
+	"x48", "x49", "x4a", "x4b", "x4c", "x4d", "x4e", "x4f",
+	"x50", "x51", "x52", "x53", "x54", "x55", "x56", "x57",
+	"x58", "x59", "x5a", "x5b", "x5c", "x5d", "x5e", "x5f",
+	"x60", "x61", "x62", "x63", "x64", "x65", "x66", "x67",
+	"x68", "x69", "x6a", "x6b", "x6c", "x6d", "x6e", "x6f",
+	"x70", "x71", "x72", "x73", "x74", "x75", "x76", "x77",
+	"x78", "x79", "x7a", "x7b", "x7c", "x7d", "x7e", "x7f",
+	"x80", "x81", "x82", "x83", "x84", "x85", "x86", "x87",
+	"x88", "x89", "x8a", "x8b", "x8c", "x8d", "x8e", "x8f",
+	"x90", "x91", "x92", "x93", "x94", "x95", "x96", "x97",
+	"x98", "x99", "x9a", "x9b", "x9c", "x9d", "x9e", "x9f",
+	"xa0", "xa1", "xa2", "xa3", "xa4", "xa5", "xa6", "xa7",
+	"xa8", "xa9", "xaa", "xab", "xac", "xad", "xae", "xaf",
+	"xb0", "xb1", "xb2", "xb3", "xb4", "xb5", "xb6", "xb7",
+	"xb8", "xb9", "xba", "xbb", "xbc", "xbd", "xbe", "xbf",
+	"xc0", "xc1", "xc2", "xc3", "xc4", "xc5", "xc6", "xc7",
+	"xc8", "xc9", "xca", "xcb", "xcc", "xcd", "xce", "xcf",
+	"xd0", "xd1", "xd2", "xd3", "xd4", "xd5", "xd6", "xd7",
+	"xd8", "xd9", "xda", "xdb", "xdc", "xdd", "xde", "xdf",
+	"xe0", "xe1", "xe2", "xe3", "xe4", "xe5", "xe6", "xe7",
+	"xe8", "xe9", "xea", "xeb", "xec", "xed", "xee", "xef",
+	"xf0", "xf1", "xf2", "xf3", "xf4", "xf5", "xf6", "xf7",
+	"xf8", "xf9", "xfa", "xfb", "xfc", "xfd", "xfe", "xff",
+}
+
+// bucket shards a token by its opening runes. The first three runes are decoded
+// without materializing the whole token, but #492 preserves the legacy byte
+// contract for invalid UTF-8 by returning to the []rune conversion whenever
+// decoding observes an invalid byte in that prefix.
+func bucket(tok string) string {
+	var first, second rune
+	end := 0
+	count := 0
+	for count < 3 && end < len(tok) {
+		r, size := utf8.DecodeRuneInString(tok[end:])
+		if r == utf8.RuneError && size == 1 {
+			return bucketInvalidUTF8(tok)
+		}
+		switch count {
+		case 0:
+			first = r
+		case 1:
+			second = r
+		}
+		end += size
+		count++
+	}
+
+	if count >= 2 && isShardASCII(first) && isShardASCII(second) {
+		return safe(tok[:2])
+	}
+
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(tok[:end]))
+	return hexBuckets[h.Sum32()%256]
+}
+
+// bucketInvalidUTF8 reproduces the legacy conversion before hashing. []rune
+// replaces invalid bytes with U+FFFD, and converting the prefix back to a
+// string re-encodes those replacements; skipping either step would move
+// existing query terms to different buckets.
+func bucketInvalidUTF8(tok string) string {
+	runes := []rune(tok)
+	if len(runes) >= 2 && isShardASCII(runes[0]) && isShardASCII(runes[1]) {
+		return safe(string(runes[:2]))
+	}
+	if len(runes) > 3 {
+		runes = runes[:3]
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(string(runes)))
+	return hexBuckets[h.Sum32()%256]
+}
+
+// cjkIndexKeys emits folded posting keys directly from CJK runs. It keeps the
+// query-side bigram path independent and deduplicates folded pairs because the
+// index callers already treat repeated posting keys as one key. The packed
+// representation widens each rune before shifting so supplementary-plane
+// values cannot overflow (#492).
+func cjkIndexKeys(s string, emit func(tok string)) {
+	// A CJK rune is never a single UTF-8 byte, so this guard preserves the
+	// cjkBigrams fast path without decoding an ASCII-only message.
+	ascii := true
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			ascii = false
+			break
+		}
+	}
+	if ascii {
+		return
+	}
+
+	seen := map[uint64]struct{}{}
+	emitFolded := func(r1, r2 rune) {
+		key := (uint64(r1) << 21) | uint64(r2)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+
+		n := 1 + utf8.RuneLen(r2)
+		if r1 != 0 {
+			n += utf8.RuneLen(r1)
+		}
+		tok := make([]byte, n)
+		tok[0] = 't'
+		pos := 1
+		if r1 != 0 {
+			pos += utf8.EncodeRune(tok[pos:], r1)
+		}
+		utf8.EncodeRune(tok[pos:], r2)
+		emit(string(tok))
+	}
+
+	var previous rune
+	runLength := 0
+	flush := func() {
+		if runLength == 1 {
+			// Zero is only the packed-key marker for a unigram. It is never
+			// written into the emitted token.
+			emitFolded(0, previous)
+		}
+		runLength = 0
+	}
+
+	for _, r := range s {
+		if !isCJK(r) {
+			flush()
+			continue
+		}
+
+		r = cjkfold.Rune(r)
+		if runLength == 0 {
+			previous = r
+			runLength = 1
+			continue
+		}
+
+		emitFolded(previous, r)
+		previous = r
+		runLength = 2
+	}
+	flush()
+}

--- a/internal/index/cjkindex_diff_test.go
+++ b/internal/index/cjkindex_diff_test.go
@@ -161,6 +161,28 @@ func TestCJKIndexKeysFoldCollision492(t *testing.T) {
 	}
 }
 
+// The byte-identical buckets/ check testifies for ingestion only. The query
+// side still depends on cjkBigrams emitting unfolded bigrams — the
+// function-word filter must see the runes the user typed — and that has no
+// index artifact to diff, so this pins it directly: Traditional-script input
+// through expandCJKTokens keeps its script, before and after the ingestion
+// emitter split (#492).
+func TestExpandCJKTokensKeepsScript492(t *testing.T) {
+	got := expandCJKTokens([]string{"韓國簽證"})
+	want := []string{"韓國", "國簽", "簽證"}
+	if len(got) != len(want) {
+		t.Fatalf("expandCJKTokens(韓國簽證) = %q, want %q", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Fatalf("expandCJKTokens(韓國簽證)[%d] = %q, want %q (folded or reordered)", i, got[i], w)
+		}
+	}
+	if f := cjkfold.String("韓國"); f == "韓國" {
+		t.Fatalf("fixture lost its point: %q does not fold", "韓國")
+	}
+}
+
 // The benchmarks pit the new emitter and shard function against the legacy
 // copies above inside one binary, so the comparison is immune to the
 // binary-layout variance that dominates whole-build wall clocks on small

--- a/internal/index/cjkindex_diff_test.go
+++ b/internal/index/cjkindex_diff_test.go
@@ -1,0 +1,256 @@
+package index
+
+import (
+	"fmt"
+	"hash/fnv"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/cjkfold"
+)
+
+func legacyBucket(tok string) string {
+	runes := []rune(tok)
+	if len(runes) >= 2 && isShardASCII(runes[0]) && isShardASCII(runes[1]) {
+		return safe(string(runes[:2]))
+	}
+	if len(runes) > 3 {
+		runes = runes[:3]
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(string(runes)))
+	return fmt.Sprintf("x%02x", h.Sum32()%256)
+}
+
+func legacyCJKKeys(s string) []string {
+	var out []string
+	for _, bg := range cjkBigrams(s) {
+		out = append(out, "t"+cjkfold.String(bg))
+	}
+	return out
+}
+
+func collectCJKIndexKeys492(s string) []string {
+	var out []string
+	cjkIndexKeys(s, func(tok string) {
+		out = append(out, tok)
+	})
+	return out
+}
+
+func assertSameKeySet492(t *testing.T, input string, got, want []string) {
+	t.Helper()
+
+	gotSet := make(map[string]struct{}, len(got))
+	for _, key := range got {
+		gotSet[key] = struct{}{}
+	}
+	wantSet := make(map[string]struct{}, len(want))
+	for _, key := range want {
+		wantSet[key] = struct{}{}
+	}
+
+	if len(gotSet) != len(wantSet) {
+		t.Fatalf("input %q: key-set size differs: got %d (%q), want %d (%q)",
+			input, len(gotSet), got, len(wantSet), want)
+	}
+	for key := range wantSet {
+		if _, ok := gotSet[key]; !ok {
+			t.Fatalf("input %q: missing key %q: got %q, want %q",
+				input, key, got, want)
+		}
+	}
+}
+
+func countKey492(keys []string, want string) int {
+	n := 0
+	for _, key := range keys {
+		if key == want {
+			n++
+		}
+	}
+	return n
+}
+
+func TestBucketDifferential492(t *testing.T) {
+	cases := []struct {
+		name string
+		tok  string
+	}{
+		{name: "empty", tok: ""},
+		{name: "one ASCII rune", tok: "t"},
+		{name: "two ASCII runes", tok: "ta"},
+		{name: "three ASCII runes", tok: "tag"},
+		{name: "second rune non-ASCII", tok: "t界"},
+		{name: "CJK followed by Latin", tok: "界tag"},
+		{name: "supplementary Han", tok: "t𠀾"},
+		{name: "ASCII punctuation", tok: "t-"},
+		{name: "ASCII uppercase and punctuation", tok: "T!"},
+		{name: "invalid prefix", tok: "t\xff\xfe"},
+		{name: "truncated multibyte prefix", tok: "t\xe8\xa8"},
+		{name: "lone continuation byte", tok: "\x80"},
+		{name: "lone continuation bytes", tok: "\x80\xbf"},
+		{name: "valid RuneError query term", tok: "t\ufffdquery"},
+		{name: "RuneError followed by invalid byte", tok: "t\ufffd\xffquery"},
+		{name: "invalid third rune after ASCII shard", tok: "ta\xff"},
+		{name: "invalid byte after hashed prefix", tok: "t界\xff"},
+		{name: "invalid byte beyond hashed prefix", tok: "t界語\xff"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bucket(tc.tok)
+			want := legacyBucket(tc.tok)
+			if got != want {
+				t.Fatalf("bucket(%q) = %q, legacyBucket = %q; bytes: % x",
+					tc.tok, got, want, []byte(tc.tok))
+			}
+		})
+	}
+}
+
+func TestCJKIndexKeysDifferential492(t *testing.T) {
+	longRun := strings.Repeat("漢字仮名", 24)
+	if len(longRun) <= 64 {
+		t.Fatalf("long-run fixture is only %d bytes", len(longRun))
+	}
+
+	cases := []struct {
+		name string
+		text string
+	}{
+		{name: "ASCII guard", text: "plain ASCII text only"},
+		{name: "fold collision", text: "關係 关系"},
+		{name: "single-rune runs", text: "茶 A 山"},
+		{name: "two-rune run", text: "装订"},
+		{name: "supplementary-plane Han", text: "𠀾界𠀀"},
+		{name: "kana only", text: "ひらがなカタカナ"},
+		{name: "Hangul only", text: "한글만사용"},
+		{name: "mixed CJK and Latin boundaries", text: "abc装订def 관계 xyz"},
+		{name: "long CJK run across tokenizer byte boundary", text: longRun},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectCJKIndexKeys492(tc.text)
+			want := legacyCJKKeys(tc.text)
+			assertSameKeySet492(t, tc.text, got, want)
+		})
+	}
+}
+
+func TestCJKIndexKeysFoldCollision492(t *testing.T) {
+	traditional := "關係"
+	simplified := "关系"
+	if cjkfold.String(traditional) != cjkfold.String(simplified) {
+		t.Fatalf("fixture does not fold to one key: %q -> %q, %q -> %q",
+			traditional, cjkfold.String(traditional),
+			simplified, cjkfold.String(simplified))
+	}
+
+	input := traditional + " " + simplified
+	got := collectCJKIndexKeys492(input)
+	want := legacyCJKKeys(input)
+	assertSameKeySet492(t, input, got, want)
+
+	collisionKey := "t" + cjkfold.String(traditional)
+	if n := countKey492(want, collisionKey); n != 2 {
+		t.Fatalf("legacy fixture should emit collision key twice, got %d in %q", n, want)
+	}
+	if n := countKey492(got, collisionKey); n != 1 {
+		t.Fatalf("new emitter should deduplicate collision key, got %d in %q", n, got)
+	}
+}
+
+// The benchmarks pit the new emitter and shard function against the legacy
+// copies above inside one binary, so the comparison is immune to the
+// binary-layout variance that dominates whole-build wall clocks on small
+// corpora (#492).
+
+var benchJAText = strings.Repeat("昨日のビルドで漢字の索引が遅くなった原因を調べた。設定を確認し、キャッシュを削除した。", 4)
+
+func BenchmarkCJKKeysLegacy(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		keys := legacyCJKKeys(benchJAText)
+		if len(keys) == 0 {
+			b.Fatal("no keys")
+		}
+	}
+}
+
+func BenchmarkCJKKeysNew(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		n := 0
+		cjkIndexKeys(benchJAText, func(string) { n++ })
+		if n == 0 {
+			b.Fatal("no keys")
+		}
+	}
+}
+
+var benchBucketToks = []string{"tconfig", "t設定", "t漢字", "tjanuary", "tcache", "t索引", "t2026-01", "tビル"}
+
+func BenchmarkBucketLegacy(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tok := range benchBucketToks {
+			if legacyBucket(tok) == "" {
+				b.Fatal("empty bucket")
+			}
+		}
+	}
+}
+
+func BenchmarkBucketNew(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tok := range benchBucketToks {
+			if bucket(tok) == "" {
+				b.Fatal("empty bucket")
+			}
+		}
+	}
+}
+
+func TestCJKIndexDifferentialGenerative492(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+
+	t.Run("bucket random bytes", func(t *testing.T) {
+		for i := 0; i < 1000; i++ {
+			b := make([]byte, rng.Intn(32))
+			for j := range b {
+				b[j] = byte(rng.Intn(256))
+			}
+			if len(b) > 0 && i%5 == 0 {
+				b[0] = 0xff
+			}
+
+			tok := string(b)
+			got := bucket(tok)
+			want := legacyBucket(tok)
+			if got != want {
+				t.Fatalf("case %d: bucket bytes % x = %q, legacyBucket = %q",
+					i, b, got, want)
+			}
+		}
+	})
+
+	t.Run("CJK and ASCII mixes", func(t *testing.T) {
+		alphabet := []rune{
+			'关', '關', '系', '係', '装', '訂', '計', '数',
+			'漢', '字', '𠀾', '𠀀', '界',
+			'あ', 'い', 'う', 'カ', 'ナ',
+			'한', '글', '만',
+			'a', 'Z', '0', '_', '-', ' ', '.', '/', '\n',
+		}
+		for i := 0; i < 300; i++ {
+			var text strings.Builder
+			n := rng.Intn(80)
+			for j := 0; j < n; j++ {
+				text.WriteRune(alphabet[rng.Intn(len(alphabet))])
+			}
+
+			input := text.String()
+			got := collectCJKIndexKeys492(input)
+			want := legacyCJKKeys(input)
+			assertSameKeySet492(t, input, got, want)
+		}
+	})
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -2387,12 +2387,15 @@ func indexKeys(s string) []string {
 	for _, part := range identifierParts(s) {
 		out = append(out, "t"+part)
 	}
-	for _, bg := range cjkBigrams(s) {
-		// Fold Traditional to Simplified so the same word written either way
-		// lands on one key and a query in one script reaches content in the
-		// other. Folding only the key keeps the stored text untouched.
-		out = append(out, "t"+cjkfold.String(bg))
-	}
+	// Bigram keys fold Traditional to Simplified so the same word written
+	// either way lands on one key and a query in one script reaches content in
+	// the other. Folding only the key keeps the stored text untouched. The
+	// emitter folds runs in place and dedupes folded pairs — cheaper than
+	// folding each emitted bigram, and every caller collapses repeated keys
+	// anyway (#492).
+	cjkIndexKeys(s, func(tok string) {
+		out = append(out, tok)
+	})
 	return out
 }
 
@@ -2538,19 +2541,6 @@ func recordMatchesQueryVariants(r Record, o query.Options, variants map[string][
 // and Greek token in the corpus landed in the single bucket "t_". Each lookup
 // then had to scan the whole non-ASCII vocabulary. Sharding by runes keeps
 // ASCII bucket names exactly as they were and spreads the rest over 256.
-func bucket(tok string) string {
-	runes := []rune(tok)
-	if len(runes) >= 2 && isShardASCII(runes[0]) && isShardASCII(runes[1]) {
-		return safe(string(runes[:2]))
-	}
-	if len(runes) > 3 {
-		runes = runes[:3]
-	}
-	h := fnv.New32a()
-	_, _ = h.Write([]byte(string(runes)))
-	return fmt.Sprintf("x%02x", h.Sum32()%256)
-}
-
 // isShardASCII reports whether a rune is one byte wide, so slicing it cannot
 // split a multi-byte sequence.
 func isShardASCII(r rune) bool { return r < 128 }

--- a/tools/bench492/README.md
+++ b/tools/bench492/README.md
@@ -1,0 +1,30 @@
+# bench492 — CJK bigram build-cost harness
+
+The measurement rig behind the numbers in #492: a deterministic corpus
+generator and an interleaved A/B runner for full builds. Everything runs
+against isolated `DEJA_INDEX_DIR` / `DEJA_CLAUDE_ROOT` paths and a fake HOME,
+so a real store on the machine is neither read nor touched.
+
+```
+python gen_corpus.py --out /tmp/bench --sessions 5000 --projects 50
+go build -o deja-a ./cmd/deja        # baseline commit
+go build -o deja-b ./cmd/deja        # comparison commit (or a stubbed build)
+python run_bench.py --out-root /tmp/bench --head-bin ./deja-a --stub-bin ./deja-b --rounds 7
+```
+
+`results.csv` holds one row per (round, arm, binary); `results-summary.txt`
+reports min/median per cell. Interleaving keeps a machine-wide slowdown from
+landing on one cell; read the min column first, contention only ever adds.
+
+Two lessons from using it, so the next measurement does not relearn them:
+
+- Wall-clock deltas between two *different binaries* carry binary-layout
+  noise — around ±15% of a small corpus's build time on the machine this was
+  built on, measured by comparing two builds of identical source. Effects
+  well above that (the bigram on/off arms) are safe to read; single-digit
+  percentages are not. For those, put both implementations in one test
+  binary and benchmark them side by side; `allocs/op` is immune entirely.
+- To measure against a real store instead of the generated one, point
+  `--out-root` at a directory whose `store-<arm>/claude-root` is a copy of
+  (or junction to) the real transcripts. Keep `DEJA_INDEX_DIR` isolation —
+  the runner never writes into a live index either way.

--- a/tools/bench492/gen_corpus.py
+++ b/tools/bench492/gen_corpus.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Deterministic corpus generator for upstream issue #492 (CJK bigram build
+cost re-measurement).
+
+Produces two arms of "claude" harness JSONL transcripts, laid out exactly as
+internal/sources/claude.go expects them under DEJA_CLAUDE_ROOT:
+
+    <out>/store-ja/claude-root/<project>/<session>.jsonl
+    <out>/store-en/claude-root/<project>/<session>.jsonl
+
+Shape learned from fixtures/registry/claude-code/session.jsonl and
+fixtures/synthetic/claude/project/session.jsonl, and cross-checked
+against the parser in internal/sources/claude_decode.go:
+
+    {"type": "user"|"assistant",
+     "sessionId": "<session id>",
+     "timestamp": "<RFC3339>",
+     "message": {"role": "user"|"assistant",
+                 "content": [{"type": "text", "text": "<body>"}]}}
+
+Only `type` in {"user", "assistant"} lines are counted by the parser
+(claude_decode.go:56-58), sessionId overrides the filename-derived id
+(claude_decode.go:59-61), timestamp accepts RFC3339 or epoch via
+claudeTime/parseTimeAny, and message.content is read by claudeTextKind
+(claude_decode.go:154-206) as either a plain string or a list of blocks with
+a "text" field. Project directory names are NOT expected to be dash-encoded
+absolute paths here on purpose: resolveEncodedPath (claude.go:195-239) only
+recurses into filesystem probing when the base name starts with "-", and a
+plain name like "proj0007" short-circuits that path immediately
+(claude.go:201-204), keeping this benchmark's timing free of unrelated
+os.Stat noise from project-name decoding.
+
+Determinism: every byte written here is a function of --seed and --sessions.
+No wall-clock read; timestamps are offsets from a fixed 2026-01-01T00:00:00Z
+base.
+"""
+import argparse
+import json
+import os
+import random
+import shutil
+import sys
+from datetime import datetime, timedelta, timezone
+
+BASE_TIME = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+# Message-count-per-session distribution (user/assistant alternating pairs).
+# Weighted so the mean is 3.2 messages/session -> 5000 sessions ~= 16000
+# messages, matching the harness's "5000 sessions / ~16000 messages" target.
+SESSION_MSG_CHOICES = [2, 4, 6]
+SESSION_MSG_WEIGHTS = [0.55, 0.30, 0.15]
+
+MSG_CHAR_MIN = 200
+MSG_CHAR_MAX = 600
+
+# --- Japanese vocabulary -----------------------------------------------
+# Deliberately mixes kanji compounds, hiragana verb/particle chains and
+# katakana loanwords so generated CJK runs look like real dev-chat text:
+# unicode.Han + Hiragana + Katakana runs broken only at ASCII punctuation
+# ("。" "、" are not in those unicode categories either, which matches how
+# real Japanese sentences already break bigram runs at sentence boundaries).
+JA_NOUNS = [
+    "実装", "設計", "検証", "性能", "計測", "処理", "速度", "品質", "機能", "修正",
+    "変更", "確認", "対応", "問題", "原因", "分析", "結果", "状況", "環境", "構成",
+    "仕様", "手順", "手法", "方針", "指標", "閾値", "上限", "下限", "範囲", "条件",
+    "権限", "設定", "初期化", "終了", "監視", "記録", "履歴", "履歴管理", "統計",
+    "文字列", "分割", "統合", "並列", "直列", "同期", "非同期", "排他", "競合",
+    "再現", "回帰", "検出", "抽出", "解析", "推定", "予測", "分布", "偏差", "誤差",
+    "利用者", "開発者", "運用者", "保守", "移行", "互換", "後方互換", "前方互換",
+    "索引", "辞書", "語彙", "頻度", "重複", "断片", "連結", "分節", "境界", "走査",
+    "実行時間", "待機時間", "応答時間", "処理時間", "経過時間", "計測結果", "測定値",
+]
+JA_VERB_PHRASES = [
+    "確認します", "確認しました", "実行します", "実行しました", "検証します", "検証しました",
+    "対応します", "対応しました", "修正します", "修正しました", "計測します", "計測しました",
+    "分析します", "分析しました", "調査します", "調査しました", "反映します", "反映しました",
+    "更新します", "更新しました", "削除します", "削除しました", "追加します", "追加しました",
+    "統合します", "統合しました", "分割します", "分割しました", "同期します", "同期しました",
+    "再現できました", "再現できませんでした", "解消しました", "改善しました", "悪化しました",
+]
+JA_KATAKANA = [
+    "システム", "データ", "インデックス", "パフォーマンス", "テスト", "ユーザー", "サーバー",
+    "ファイル", "プロセス", "キャッシュ", "メモリ", "スレッド", "ビルド", "デバッグ", "ログ",
+    "クエリ", "トークン", "バイグラム", "パイプライン", "バッファ", "ストリーム", "レイテンシ",
+    "スループット", "ベンチマーク", "リグレッション", "コミット", "ブランチ", "リポジトリ",
+]
+JA_PARTICLES = ["を", "に", "は", "が", "で", "と", "の", "から", "まで", "より", "へ"]
+JA_CONNECTORS = ["また、", "さらに、", "一方、", "そのため、", "したがって、", "次に、", "最後に、", "なお、"]
+
+
+def build_ja_sentence(rng: random.Random) -> str:
+    parts = []
+    if rng.random() < 0.35:
+        parts.append(rng.choice(JA_CONNECTORS))
+    n_clauses = rng.randint(1, 3)
+    for i in range(n_clauses):
+        noun = rng.choice(JA_NOUNS) if rng.random() < 0.6 else rng.choice(JA_KATAKANA)
+        particle = rng.choice(JA_PARTICLES)
+        parts.append(noun + particle)
+    parts.append(rng.choice(JA_VERB_PHRASES))
+    return "".join(parts) + "。"
+
+
+def build_ja_message(rng: random.Random) -> str:
+    # Accumulate whole sentences until the target is reached; the joined
+    # string may overshoot the target by up to one sentence's length, which
+    # is fine for a "200-600 chars, roughly" corpus and keeps every sentence
+    # (and therefore every CJK run) intact rather than truncated mid-run.
+    target = rng.randint(MSG_CHAR_MIN, MSG_CHAR_MAX)
+    out = []
+    total = 0
+    while total < target:
+        s = build_ja_sentence(rng)
+        out.append(s)
+        total += len(s)
+    return "".join(out)
+
+
+# --- English vocabulary (control arm) -----------------------------------
+EN_NOUNS = [
+    "implementation", "design", "verification", "performance", "measurement",
+    "processing", "speed", "quality", "feature", "fix", "change", "confirmation",
+    "response", "issue", "cause", "analysis", "result", "status", "environment",
+    "configuration", "specification", "procedure", "method", "policy", "metric",
+    "threshold", "upper bound", "lower bound", "range", "condition", "permission",
+    "setting", "initialization", "shutdown", "monitoring", "record", "history",
+    "statistics", "string", "split", "merge", "parallelism", "serialization",
+    "synchronization", "contention", "reproduction", "regression", "detection",
+    "extraction", "estimation", "prediction", "distribution", "deviation", "error",
+    "user", "developer", "operator", "maintenance", "migration", "compatibility",
+    "index", "dictionary", "vocabulary", "frequency", "duplication", "fragment",
+    "concatenation", "segment", "boundary", "scan", "runtime", "latency", "elapsed time",
+]
+EN_VERB_PHRASES = [
+    "will confirm this", "confirmed this", "will run this", "ran this",
+    "will verify this", "verified this", "will address this", "addressed this",
+    "will fix this", "fixed this", "will measure this", "measured this",
+    "will analyze this", "analyzed this", "will investigate this", "investigated this",
+    "will apply this", "applied this", "will update this", "updated this",
+    "will remove this", "removed this", "will add this", "added this",
+    "will merge this", "merged this", "will split this", "split this",
+    "was reproducible", "was not reproducible", "was resolved", "improved", "regressed",
+]
+EN_CONNECTORS = ["Also,", "Furthermore,", "On the other hand,", "Therefore,", "Next,", "Finally,", "Note that,"]
+
+
+def build_en_sentence(rng: random.Random) -> str:
+    parts = []
+    if rng.random() < 0.35:
+        parts.append(rng.choice(EN_CONNECTORS))
+    n_clauses = rng.randint(1, 3)
+    clause_words = []
+    for i in range(n_clauses):
+        clause_words.append("the " + rng.choice(EN_NOUNS))
+    parts.append(" and ".join(clause_words))
+    parts.append(rng.choice(EN_VERB_PHRASES))
+    return " ".join(parts) + "."
+
+
+def build_en_message(rng: random.Random) -> str:
+    target = rng.randint(MSG_CHAR_MIN, MSG_CHAR_MAX)
+    out = []
+    total = 0
+    while total < target:
+        s = build_en_sentence(rng)
+        out.append(s)
+        total += len(s) + 1
+    return " ".join(out)
+
+
+def session_message_count(rng: random.Random) -> int:
+    return rng.choices(SESSION_MSG_CHOICES, weights=SESSION_MSG_WEIGHTS, k=1)[0]
+
+
+def gen_arm(out_root: str, arm: str, sessions: int, projects: int, seed: int, build_message):
+    rng = random.Random(seed)
+    claude_root = os.path.join(out_root, f"store-{arm}", "claude-root")
+    if os.path.isdir(claude_root):
+        shutil.rmtree(claude_root)
+    os.makedirs(claude_root, exist_ok=True)
+
+    total_messages = 0
+    t = BASE_TIME
+    for i in range(sessions):
+        project = f"proj{(i % projects):04d}"
+        proj_dir = os.path.join(claude_root, project)
+        os.makedirs(proj_dir, exist_ok=True)
+        session_id = f"{arm}-session-{i:05d}"
+        n_msgs = session_message_count(rng)
+        t = t + timedelta(seconds=37)
+        lines = []
+        for m in range(n_msgs):
+            role = "user" if m % 2 == 0 else "assistant"
+            body = build_message(rng)
+            t = t + timedelta(seconds=rng.randint(3, 45))
+            line = {
+                "type": role,
+                "sessionId": session_id,
+                "cwd": f"C:\\fakehome\\projects\\{project}",
+                "timestamp": t.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "message": {
+                    "role": role,
+                    "content": [{"type": "text", "text": body}],
+                },
+            }
+            lines.append(json.dumps(line, ensure_ascii=False))
+        total_messages += n_msgs
+        path = os.path.join(proj_dir, f"{session_id}.jsonl")
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            f.write("\n".join(lines) + "\n")
+    return total_messages
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--sessions", type=int, default=5000, help="sessions per arm")
+    ap.add_argument("--projects", type=int, default=50, help="distinct project dirs per arm")
+    ap.add_argument("--seed", type=int, default=492, help="base seed (ja uses seed, en uses seed+1)")
+    ap.add_argument("--out", default=os.path.dirname(os.path.abspath(__file__)), help="output root (bench492)")
+    args = ap.parse_args()
+
+    ja_total = gen_arm(args.out, "ja", args.sessions, args.projects, args.seed, build_ja_message)
+    en_total = gen_arm(args.out, "en", args.sessions, args.projects, args.seed + 1, build_en_message)
+
+    print(f"ja: {args.sessions} sessions, {ja_total} messages -> {os.path.join(args.out, 'store-ja', 'claude-root')}")
+    print(f"en: {args.sessions} sessions, {en_total} messages -> {os.path.join(args.out, 'store-en', 'claude-root')}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/bench492/run_bench.py
+++ b/tools/bench492/run_bench.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Runner for the #492 CJK bigram build-cost re-measurement.
+
+Matrix: arm {ja, en} x binary {head, stub}, interleaved one round at a time
+(h-ja, s-ja, h-en, s-en, repeat) so a machine-wide slowdown mid-run does not
+land entirely on one cell. Each cell measurement:
+
+  1. delete the index dir for that (arm, bin) cell
+  2. run `<bin> index --rebuild` with the cell's env (isolated store,
+     isolated index dir, isolated fake HOME so no other harness on this
+     machine's real ~/.claude or ~/.codex gets touched or picked up)
+  3. record wall time (time.perf_counter) and the rebuilt index dir's total
+     size in bytes
+
+Output: results.csv (round,arm,bin,seconds,index_bytes) and
+results-summary.txt (min/median per arm x bin cell).
+
+This script only measures; it does not build binaries or generate the corpus (gen_corpus.py does that).
+"""
+import argparse
+import csv
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def dir_size(path: str) -> int:
+    if not os.path.exists(path):
+        return 0
+    if os.path.isfile(path):
+        return os.path.getsize(path)
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            fp = os.path.join(root, name)
+            try:
+                total += os.path.getsize(fp)
+            except OSError:
+                pass
+    return total
+
+
+def cell_env(fakehome: str, index_dir: str, claude_root: str) -> dict:
+    env = dict(os.environ)
+    for k in ("HOME", "USERPROFILE", "APPDATA", "LOCALAPPDATA", "CODEX_HOME"):
+        env[k] = fakehome
+    env["DEJA_INDEX_DIR"] = index_dir
+    env["DEJA_CLAUDE_ROOT"] = claude_root
+    env["GOMAXPROCS"] = "2"
+    # Keep this benchmark to the claude source only — no other harness
+    # should be discoverable under the fake HOME anyway, but DEJA_SOURCE
+    # scoping (if the binary reads it) is one more belt for the same buckle.
+    return env
+
+
+def run_cell(binary: str, arm: str, bin_label: str, out_root: str, fakehome: str, log_dir: str, round_no: int):
+    index_dir = os.path.join(out_root, f"idx-{arm}-{bin_label}")
+    claude_root = os.path.join(out_root, f"store-{arm}", "claude-root")
+    if not os.path.isdir(claude_root):
+        raise SystemExit(f"run_bench: missing corpus dir {claude_root} — run gen_corpus.py first")
+
+    if os.path.isdir(index_dir):
+        shutil.rmtree(index_dir)
+    elif os.path.exists(index_dir):
+        os.remove(index_dir)
+
+    env = cell_env(fakehome, index_dir, claude_root)
+    log_path = os.path.join(log_dir, f"round{round_no:03d}-{bin_label}-{arm}.log")
+
+    t0 = time.perf_counter()
+    with open(log_path, "w", encoding="utf-8") as logf:
+        proc = subprocess.run(
+            [binary, "index", "--rebuild"],
+            env=env,
+            stdout=logf,
+            stderr=subprocess.STDOUT,
+        )
+    elapsed = time.perf_counter() - t0
+
+    if proc.returncode != 0:
+        raise SystemExit(
+            f"run_bench: {binary} index --rebuild failed (rc={proc.returncode}) for {bin_label}/{arm} "
+            f"round {round_no} — see {log_path}"
+        )
+
+    size = dir_size(index_dir)
+    return elapsed, size
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rounds", type=int, default=7)
+    ap.add_argument("--out-root", default=HERE)
+    ap.add_argument("--head-bin", required=True, help="baseline deja binary")
+    ap.add_argument("--stub-bin", required=True, help="comparison deja binary (stubbed or optimized)")
+    ap.add_argument("--arms", default="ja,en")
+    args = ap.parse_args()
+
+    out_root = os.path.abspath(args.out_root)
+    head_bin = os.path.abspath(args.head_bin)
+    stub_bin = os.path.abspath(args.stub_bin)
+    arms = args.arms.split(",")
+
+    for b in (head_bin, stub_bin):
+        if not os.path.isfile(b):
+            raise SystemExit(f"run_bench: binary not found: {b}")
+
+    fakehome = os.path.join(out_root, "fakehome")
+    os.makedirs(fakehome, exist_ok=True)
+    log_dir = os.path.join(out_root, "logs")
+    os.makedirs(log_dir, exist_ok=True)
+
+    binaries = [("head", head_bin), ("stub", stub_bin)]
+
+    rows = []  # (round, arm, bin, seconds, index_bytes)
+    csv_path = os.path.join(out_root, "results.csv")
+    with open(csv_path, "w", newline="", encoding="utf-8") as csvf:
+        writer = csv.writer(csvf)
+        writer.writerow(["round", "arm", "bin", "seconds", "index_bytes"])
+        for round_no in range(1, args.rounds + 1):
+            for bin_label, binpath in binaries:
+                for arm in arms:
+                    elapsed, size = run_cell(binpath, arm, bin_label, out_root, fakehome, log_dir, round_no)
+                    print(f"round {round_no} {bin_label:4s} {arm:2s}  {elapsed:8.3f}s  {size:>12} bytes", flush=True)
+                    rows.append((round_no, arm, bin_label, elapsed, size))
+                    writer.writerow([round_no, arm, bin_label, f"{elapsed:.6f}", size])
+                    csvf.flush()
+
+    summary_path = os.path.join(out_root, "results-summary.txt")
+    with open(summary_path, "w", encoding="utf-8") as sf:
+        sf.write(f"rounds={args.rounds} arms={arms}\n\n")
+        groups = {}
+        for round_no, arm, bin_label, elapsed, size in rows:
+            groups.setdefault((arm, bin_label), []).append((elapsed, size))
+        for arm in arms:
+            for bin_label, _ in binaries:
+                key = (arm, bin_label)
+                vals = groups.get(key, [])
+                if not vals:
+                    continue
+                secs = [v[0] for v in vals]
+                sizes = [v[1] for v in vals]
+                sf.write(
+                    f"{arm:2s} {bin_label:4s}  n={len(vals)}  "
+                    f"time min={min(secs):.3f}s median={statistics.median(secs):.3f}s max={max(secs):.3f}s  "
+                    f"size min={min(sizes)} median={statistics.median(sizes):.0f} max={max(sizes)}\n"
+                )
+        sf.write("\nbigram cost (head - stub), by median:\n")
+        for arm in arms:
+            h = groups.get((arm, "head"))
+            s = groups.get((arm, "stub"))
+            if not h or not s:
+                continue
+            h_t = statistics.median(v[0] for v in h)
+            s_t = statistics.median(v[0] for v in s)
+            h_sz = statistics.median(v[1] for v in h)
+            s_sz = statistics.median(v[1] for v in s)
+            sf.write(
+                f"  {arm:2s}: time {h_t:.3f}s - {s_t:.3f}s = {h_t - s_t:+.3f}s   "
+                f"size {h_sz:.0f} - {s_sz:.0f} = {h_sz - s_sz:+.0f} bytes\n"
+            )
+
+    print(f"wrote {csv_path}")
+    print(f"wrote {summary_path}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The pass 1 rewrite sketched in [#492](https://github.com/vshulcz/deja-vu/issues/492#issuecomment-5260556062): same keys, same bucket names, byte-identical `buckets/`, less work producing them.

Two changes, both index-side only:

- `cjkIndexKeys` replaces the build-path use of `cjkBigrams`. It folds each CJK run once through `cjkfold.Rune` while walking it, dedupes folded pairs in one `map[uint64]struct{}` keyed on the rune pair, and builds each emitted key with a single allocation. The legacy path folded every emitted bigram separately and deduped the same keys twice, once on pre-fold strings inside `cjkBigrams` and again in `eachIndexKey`. The query side (`cjkBigrams`, `expandCJKTokens`) is untouched — its dedupe is what keeps a phrase query's AND slots useful, and the function-word filter still sees the runes the user typed.
- `bucket` decodes at most three leading runes in place instead of materializing `[]rune` of the whole token, and reads shard names from a 256-entry table instead of `fmt.Sprintf`. Query terms can carry bytes no tokenizer produced, so the moment decoding hits an invalid byte in that prefix the function returns to a verbatim copy of the legacy `[]rune` conversion — U+FFFD replacement and all — keeping every existing term in the bucket it is in today.

## Equivalence, verified

- `buckets/` is byte-identical old-vs-new (`diff -r`) on three corpora: the all-Japanese and English arms from the #492 measurement, plus a mixed store of both. `records.bin` hashes equal; `manifest.gob` matches in size (its bytes carry timestamps).
- `cjkindex_diff_test.go` pins the boundary classes against verbatim legacy copies: invalid UTF-8 prefixes, 1/2/3-rune ASCII edges, fold-collision pairs (關係/关系), single-rune runs, supplementary-plane Han, kana and Hangul, a run crossing the tokenizer's 64-byte flush, and seeded generative sweeps over random bytes and script mixes.
- The query side is the leg a byte-identical index cannot testify for, as the review on the issue pointed out: `cjkBigrams` stays shared and unfolded (the function-word filter must see the runes the user typed), so `TestExpandCJKTokensKeepsScript492` pushes Traditional input through `expandCJKTokens` and asserts the bigrams keep their script — a future fold inside the shared function now fails a query-side test, not just `TestCJKFoldUnit`.
- Full suite passes. The dedupe-scope change is observable only as fewer duplicate strings in `indexKeys`' return value; every caller either dedupes (`eachIndexKey`, both incremental paths) or converges through `encodePostings`' offset dedupe (`sync.go` import path), which the fold-collision test locks in.

## What it buys

Same-binary benchmarks (new implementation against the legacy copies in the same test binary, i7-14700K):

| | legacy | new | |
|---|---|---|---|
| key emission, one Japanese message | 11.4 µs, 214 allocs | 5.7 µs, 44 allocs | 2.0× |
| `bucket`, 8 mixed tokens | 510 ns, 8 allocs | 96 ns, 0 allocs | 5.3× |

One honest caveat on end-to-end numbers, in the spirit of this thread's cold-cache retraction: on this corpus's English arm (3.2 s builds), binary layout alone moved whole-build wall clock by about 15% between two builds of identical old code (default flags against `-trimpath`), interleaved in one window — more than this change's whole expected effect — and `-trimpath` builds of the old and new code land in the same band. So I am not quoting a wall-clock delta from this rig; the per-stage profile in the issue comment says where the removed work was (0.30 s dedupe maps + 0.22 s per-bigram folds + 0.28 s Sprintf out of a 2.7 s bigram delta), and the allocation counts above are layout-immune. A corpus at the scale of the original report should see it above the noise.

How much the dedupe savings buy on real text also depends on the corpus's bigram repetition rate, and a deterministic generator's repetition is not obviously that of real conversation — the offer on the issue to re-run this against a real-Chinese store answers that directly, so the harness rides along: `tools/bench492/` holds the corpus generator and the interleaved runner, both confined to isolated index and store paths. Drop that commit if `tools/` is not where you want it living.
