### PR TITLE
feat(kimi): turn tool calls and results into work records

### DIFF
--- a/internal/sources/kimi.go
+++ b/internal/sources/kimi.go
@@ -19,8 +19,9 @@ import (
 // wire.jsonl is the append-only main-agent transcript. User turns arrive as
 // context.append_message records; streamed assistant turns never do — they
 // have to be reconstructed from step.begin → content.part → step.end loop
-// events. Only the main agent is indexed; sub-agents, tool payloads and
-// think-parts are skipped by design (issue #248).
+// events. Tool calls and their results arrive as loop events too (tool.call,
+// tool.result) and become work records (#655). Only the main agent is indexed;
+// sub-agents and think-parts are skipped by design (issue #248).
 
 // KimiConfigDir is the native Kimi Code home. DEJA_KIMI_ROOT intentionally
 // does not affect it because that variable only relocates reads.
@@ -42,6 +43,19 @@ func ParseKimiFile(path string) ([]model.Session, error) {
 
 func ParseKimiFileFromOffset(path string, offset int64) ([]model.Session, error) {
 	return parseKimiFileFromOffset(path, offset)
+}
+
+// kimiDialect is Kimi Code's tool vocabulary, read off wire.jsonl transcripts
+// its own CLI had just written. The names mirror Claude Code's — Kimi Code is
+// built in that shape — but the file key is `path` where Claude's is
+// `file_path`, and only Edit carries a replaced span; there is no MultiEdit.
+// ReadMediaFile is Kimi's own path tool. The shell tool's argument key is
+// `command`, which is what commandsIn already reads.
+var kimiDialect = toolDialect{
+	pathKey:   "path",
+	pathTools: map[string]bool{"Read": true, "Edit": true, "Write": true, "ReadMediaFile": true},
+	shellTool: "Bash",
+	editTools: map[string]bool{"Edit": true},
 }
 
 // kimiState is the slice of state.json deja cares about.
@@ -130,6 +144,59 @@ func parseKimiFileFromOffset(path string, offset int64) ([]model.Session, error)
 				pending.WriteString(text)
 			case "step.end":
 				flush()
+			case "tool.call":
+				// A call sits between the text parts of its step, so the
+				// pending stream is flushed before the record to keep the
+				// words that led to the call ahead of it. The flush happens
+				// only when the call yields a record: with every DEJA_INDEX_*
+				// switch off, the messages come out exactly as they did
+				// before tool events were read.
+				name, _ := e["name"].(string)
+				args, _ := e["args"].(map[string]any)
+				if name == "" || args == nil {
+					return
+				}
+				part := []any{map[string]any{"type": "tool_use", "name": name, "input": args}}
+				t := parseTimeAny(m["time"])
+				var records []model.Message
+				if IndexToolPaths() {
+					if p := toolPathsIn(part, kimiDialect); p != "" {
+						records = append(records, model.Message{Role: RoleFiles, Text: p, Time: t})
+					}
+				}
+				if IndexEdits() {
+					for _, span := range editSpansIn(part, kimiDialect) {
+						records = append(records, model.Message{Role: RoleEdit, Text: span, Time: t})
+					}
+				}
+				if IndexCommands() {
+					for _, cmd := range commandsIn(part, kimiDialect) {
+						records = append(records, model.Message{Role: RoleCommand, Text: cmd, Time: t})
+					}
+				}
+				if len(records) == 0 {
+					return
+				}
+				flush()
+				s.Touch(t)
+				s.Messages = append(s.Messages, records...)
+			case "tool.result":
+				// Every observed result shape carries its text under
+				// `output` — plain, with a note, truncated, or flagged
+				// isError. The error ones are kept on purpose: the error a
+				// command hit is exactly what a later search reaches for.
+				if !IndexToolOutput() {
+					return
+				}
+				r, _ := e["result"].(map[string]any)
+				out, _ := r["output"].(string)
+				if out = strings.TrimSpace(out); out == "" {
+					return
+				}
+				t := parseTimeAny(m["time"])
+				flush()
+				s.Touch(t)
+				s.Messages = append(s.Messages, model.Message{Role: RoleToolOutput, Text: out, Time: t})
 			}
 		}
 	})

--- a/internal/sources/kimi_test.go
+++ b/internal/sources/kimi_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -107,6 +108,97 @@ func TestParseKimiToleratesTornTail(t *testing.T) {
 	ss, err := ParseKimiFile(wire)
 	if err != nil || len(ss) != 1 || len(ss[0].Messages) != 2 {
 		t.Fatalf("torn tail: err=%v sessions=%d", err, len(ss))
+	}
+}
+
+// kimiWireTools is one step that works: it speaks, runs a command, reads the
+// file, makes an edit that fails, writes a note, reads an image, touches its
+// todo list, and closes with more text. Shapes are the ones the Kimi CLI writes: args key
+// `path` (not `file_path`), `command` for Bash, and results under
+// `result.output` — plain, isError, or empty.
+const kimiWireTools = kimiWireHead + `{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"please fix the test"}]},"time":1782295203000}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s2"},"time":1782295203100}
+{"type":"context.append_loop_event","event":{"type":"content.part","part":{"type":"text","text":"looking at the failing test"}},"time":1782295203200}
+{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"t1","name":"Bash","args":{"command":"go test ./...","timeout":60}},"time":1782295203300}
+{"type":"context.append_loop_event","event":{"type":"tool.result","toolCallId":"t1","result":{"output":"FAIL: TestX (0.01s)"}},"time":1782295203400}
+{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"t2","name":"Read","args":{"path":"/w/proj/main.go"}},"time":1782295203500}
+{"type":"context.append_loop_event","event":{"type":"tool.result","toolCallId":"t2","result":{"output":"package main"}},"time":1782295203600}
+{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"t3","name":"Edit","args":{"path":"/w/proj/main.go","old_string":"println(\"hello\")","new_string":"println(\"goodbye\")"}},"time":1782295203700}
+{"type":"context.append_loop_event","event":{"type":"tool.result","toolCallId":"t3","result":{"isError":true,"output":"old_string not found"}},"time":1782295203800}
+{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"t4","name":"Write","args":{"path":"/w/proj/notes.txt","content":"alpha"}},"time":1782295203900}
+{"type":"context.append_loop_event","event":{"type":"tool.result","toolCallId":"t4","result":{"output":""}},"time":1782295204000}
+{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"t5","name":"ReadMediaFile","args":{"path":"/w/proj/cover.png"}},"time":1782295204050}
+{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"t6","name":"TodoList","args":{"items":[]}},"time":1782295204100}
+{"type":"context.append_loop_event","event":{"type":"content.part","part":{"type":"text","text":" — fixed"}},"time":1782295204200}
+{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"s2","finishReason":"end_turn"},"time":1782295204300}
+`
+
+func TestParseKimiEmitsWorkRecords(t *testing.T) {
+	_, wire := kimiFixture(t)
+	if err := os.WriteFile(wire, []byte(kimiWireTools), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseKimiFile(wire)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v %d", err, len(ss))
+	}
+	byRole := map[string][]string{}
+	for _, m := range ss[0].Messages {
+		byRole[m.Role] = append(byRole[m.Role], m.Text)
+	}
+	if got := byRole[RoleCommand]; len(got) != 1 || got[0] != "$ go test ./..." {
+		t.Errorf("commands = %q, want the test run alone — TodoList and friends carry no command", got)
+	}
+	wantFiles := []string{"/w/proj/main.go", "/w/proj/main.go", "/w/proj/notes.txt", "/w/proj/cover.png"}
+	if got := byRole[RoleFiles]; strings.Join(got, ",") != strings.Join(wantFiles, ",") {
+		t.Errorf("files = %q, want the read, the edit, the write and the media read in order", got)
+	}
+	if got := byRole[RoleEdit]; len(got) != 1 || got[0] != "/w/proj/main.go\nprintln(\"hello\")" ||
+		strings.Contains(strings.Join(got, ""), "goodbye") {
+		t.Errorf("edit = %q, want only the bytes that stopped existing", got)
+	}
+	wantOut := []string{"FAIL: TestX (0.01s)", "package main", "old_string not found"}
+	if got := byRole[RoleToolOutput]; strings.Join(got, "|") != strings.Join(wantOut, "|") {
+		t.Errorf("tool output = %q, want the failure, the file and the error — never the empty result", got)
+	}
+	// The stream flushes when a call yields a record, so the words that led
+	// to the first command land before it, not at step.end.
+	var order []string
+	for _, m := range ss[0].Messages {
+		if m.Role == "assistant" || m.Role == RoleCommand {
+			order = append(order, m.Text)
+		}
+	}
+	want := []string{"answer one, joined", "looking at the failing test", "$ go test ./...", "— fixed"}
+	if strings.Join(order, "|") != strings.Join(want, "|") {
+		t.Errorf("order = %q, want the speech ahead of the command it led to", order)
+	}
+}
+
+func TestParseKimiToolRecordSwitchesOff(t *testing.T) {
+	_, wire := kimiFixture(t)
+	t.Setenv("DEJA_INDEX_COMMANDS", "0")
+	t.Setenv("DEJA_INDEX_PATHS", "0")
+	t.Setenv("DEJA_INDEX_EDITS", "0")
+	t.Setenv("DEJA_INDEX_TOOL_OUTPUT", "0")
+	if err := os.WriteFile(wire, []byte(kimiWireTools), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseKimiFile(wire)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v", err)
+	}
+	// With every switch off, no record-driven flush fires either: the step's
+	// text comes out as the single message it always was.
+	last := ss[0].Messages[len(ss[0].Messages)-1]
+	if last.Role != "assistant" || last.Text != "looking at the failing test — fixed" {
+		t.Fatalf("switched off, want the untouched stream back: %+v", ss[0].Messages)
+	}
+	for _, m := range ss[0].Messages {
+		switch m.Role {
+		case RoleCommand, RoleFiles, RoleEdit, RoleToolOutput:
+			t.Fatalf("record %q survived its switch", m.Role)
+		}
 	}
 }
 


### PR DESCRIPTION
The Kimi quarter of #655: wire.jsonl carries every call as a `context.append_loop_event` — `tool.call` with a name and args, `tool.result` with the output — and the parser read past both, so `deja files`, `deja restore` and command search were silent on every Kimi session.

Both event kinds now become the records the other harnesses emit, through the shared dialect helpers with Kimi's vocabulary:

- The tool names mirror Claude Code's — Kimi Code is built in that shape — but the file key is `path` where Claude's is `file_path` (the key Cursor uses too), only `Edit` carries a replaced span (`old_string`; there is no MultiEdit), and `ReadMediaFile` is Kimi's own path tool. The shell tool is `Bash` with its command under `command`, which is what `commandsIn` already reads.
- Read off wire transcripts the Kimi CLI had just written, per this issue's rule of checking rather than assuming: on the store here (71 main-agent wires), all 822 Bash calls carry `command`, all 99 Edits carry `path` + `old_string` + `new_string`, and every one of 1,616 results keeps its text under `result.output` — plain, with a note, truncated, or flagged `isError`. The error ones are kept on purpose: the error a command hit is exactly what a later search reaches for.
- The pending assistant stream flushes only when a call yields a record, so the words that led to a command stay ahead of it — and with every `DEJA_INDEX_*` switch off, the messages come out exactly as they did before tool events were read (`TestParseKimiToolRecordSwitchesOff` pins that).

## Measured on a real store

71 main-agent wires / 67 sessions; old and new binaries built from the same tree, same corpus, isolated index paths:

| query | old | new |
|---|---|---|
| a container name it ran in Bash | 2 sessions | 5 |
| a project directory in command paths | 1 | 3 |
| a file it edited | 1 | 9 |
| a conversation word, as control | 19 | 31 |

The control moves too because tool output mentions it; nothing the old index matched went away — for all four queries the old result set is a subset of the new one. `deja files <topic>` goes from "22 sessions mention it, none of them recorded a file near it" to a ranked file list. The index grows 2.5 → 8.9 MB on this store, nearly all of it tool-output text — the price the supported harnesses already pay.
