### PR TITLE
ci: let govulncheck use the newest Go patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,14 @@ jobs:
         with:
           go-version: '1.25.x'
           cache: false
+          # Without this, setup-go stops at whatever Go the runner image
+          # already carries, because it satisfies 1.25.x — and that is a
+          # patch or two behind. Every standard-library advisory then fails
+          # this job on a fix that is already released: five of them, all
+          # fixed in 1.25.13, against an image carrying 1.25.12. The other
+          # jobs keep the cached toolchain; this is the one that has to be
+          # on the newest patch to mean anything.
+          check-latest: true
       - run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
       - run: govulncheck ./...
 


### PR DESCRIPTION
`govulncheck` has been failing on every open PR with five standard-library advisories, all of them already fixed in Go 1.25.13. The job pins `go-version: '1.25.x'`, which should have picked it up — but `setup-go` defaults to `check-latest: false`, so it stops at whatever the runner image carries as soon as that satisfies the spec:

```
check-latest: false
Found in cache @ /opt/hostedtoolcache/go/1.25.12/x64
go version go1.25.12 linux/amd64
```

1.25.13 is in the setup-go manifest; the job simply never looked. Rerunning does not help, which is why this looked like a database change rather than a toolchain one.

Only the vulnerability job gets `check-latest`. The rest keep the cached toolchain — they do not care which patch they are on, and downloading Go on every run for them buys nothing.
