### PR TITLE
test(kimi): pin record-less results and tear tool lines

### DIFF
--- a/internal/sources/kimi_test.go
+++ b/internal/sources/kimi_test.go
@@ -100,21 +100,43 @@ func TestParseKimiMidStreamAndIncrementalAppend(t *testing.T) {
 }
 
 func TestParseKimiToleratesTornTail(t *testing.T) {
+	// A torn tail is what a crash mid-write leaves behind. The message tear is
+	// the original case; tool.call and tool.result lines are the longer ones —
+	// an args blob is where a write is most likely to be caught mid-flush — so
+	// each shape is torn in turn. The guarantee is the same for all three: the
+	// torn line vanishes, everything before it comes out untouched.
 	_, wire := kimiFixture(t)
-	torn := kimiWireHead + `{"type":"context.append_message","message":{"role":"user","co`
-	if err := os.WriteFile(wire, []byte(torn), 0o644); err != nil {
+	if err := os.WriteFile(wire, []byte(kimiWireTools), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ss, err := ParseKimiFile(wire)
-	if err != nil || len(ss) != 1 || len(ss[0].Messages) != 2 {
-		t.Fatalf("torn tail: err=%v sessions=%d", err, len(ss))
+	whole, err := ParseKimiFile(wire)
+	if err != nil || len(whole) != 1 {
+		t.Fatalf("baseline: %v %d", err, len(whole))
+	}
+	tears := []struct{ name, tail string }{
+		{"message", `{"type":"context.append_message","message":{"role":"user","co`},
+		{"tool call", `{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"t9","name":"Edit","args":{"path":"/w/proj/main.go","old_string":"the old bytes, torn off mid-`},
+		{"tool result", `{"type":"context.append_loop_event","event":{"type":"tool.result","toolCallId":"t9","result":{"output":"go: downloading github.com/`},
+	}
+	for _, tear := range tears {
+		if err := os.WriteFile(wire, []byte(kimiWireTools+tear.tail), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		ss, err := ParseKimiFile(wire)
+		if err != nil || len(ss) != 1 {
+			t.Fatalf("%s tear: err=%v sessions=%d", tear.name, err, len(ss))
+		}
+		if got, want := len(ss[0].Messages), len(whole[0].Messages); got != want {
+			t.Errorf("%s tear: messages = %d, want the %d the untorn file yields", tear.name, got, want)
+		}
 	}
 }
 
 // kimiWireTools is one step that works: it speaks, runs a command, reads the
 // file, makes an edit that fails, writes a note, reads an image, touches its
-// todo list, and closes with more text. Shapes are the ones the Kimi CLI writes: args key
-// `path` (not `file_path`), `command` for Bash, and results under
+// todo list — a call that yields no record, though its result still carries
+// output — and closes with more text. Shapes are the ones the Kimi CLI writes:
+// args key `path` (not `file_path`), `command` for Bash, and results under
 // `result.output` — plain, isError, or empty.
 const kimiWireTools = kimiWireHead + `{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"please fix the test"}]},"time":1782295203000}
 {"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"s2"},"time":1782295203100}
@@ -129,6 +151,7 @@ const kimiWireTools = kimiWireHead + `{"type":"context.append_message","message"
 {"type":"context.append_loop_event","event":{"type":"tool.result","toolCallId":"t4","result":{"output":""}},"time":1782295204000}
 {"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"t5","name":"ReadMediaFile","args":{"path":"/w/proj/cover.png"}},"time":1782295204050}
 {"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"t6","name":"TodoList","args":{"items":[]}},"time":1782295204100}
+{"type":"context.append_loop_event","event":{"type":"tool.result","toolCallId":"t6","result":{"output":"2 todos, both open"}},"time":1782295204150}
 {"type":"context.append_loop_event","event":{"type":"content.part","part":{"type":"text","text":" — fixed"}},"time":1782295204200}
 {"type":"context.append_loop_event","event":{"type":"step.end","uuid":"s2","finishReason":"end_turn"},"time":1782295204300}
 `
@@ -157,9 +180,11 @@ func TestParseKimiEmitsWorkRecords(t *testing.T) {
 		strings.Contains(strings.Join(got, ""), "goodbye") {
 		t.Errorf("edit = %q, want only the bytes that stopped existing", got)
 	}
-	wantOut := []string{"FAIL: TestX (0.01s)", "package main", "old_string not found"}
+	// The todo note lands although its call yields no record: tool.result is
+	// indexed on its own switch, independent of what the call produced.
+	wantOut := []string{"FAIL: TestX (0.01s)", "package main", "old_string not found", "2 todos, both open"}
 	if got := byRole[RoleToolOutput]; strings.Join(got, "|") != strings.Join(wantOut, "|") {
-		t.Errorf("tool output = %q, want the failure, the file and the error — never the empty result", got)
+		t.Errorf("tool output = %q, want the failure, the file, the error and the todo note — never the empty result", got)
 	}
 	// The stream flushes when a call yields a record, so the words that led
 	// to the first command land before it, not at step.end.


### PR DESCRIPTION
The two follow-ups from #1221's review (https://github.com/vshulcz/deja-vu/pull/1221#issuecomment-5292588451).

The todo-list call in `kimiWireTools` now carries a result, and the fixture says which way it is meant to go: a call that yields no record still lands its output as `RoleToolOutput` — tool.result is indexed on its own switch, independent of what the call produced.

The torn-tail test used to tear only a text event, from before the parser read tool events. It now runs against the full tools fixture and tears each shape in turn — the message, a tool.call caught mid-args, a tool.result caught mid-output — pinning the same guarantee for all three: the torn line vanishes, everything before it comes out untouched.