### PR TITLE
test(sweep): a rig that drives every installed harness against a recording endpoint

### DIFF
--- a/scripts/day0bench/main.go
+++ b/scripts/day0bench/main.go
@@ -34,6 +34,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/pprof"
+	"sort"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -131,6 +133,10 @@ func writeCodex(root, id string, ts time.Time, turns []turn) error {
 type runResult struct {
 	written, indexed int
 	build, first     time.Duration
+	// lat holds every query's wall time, so the report can show the typical
+	// query and the worst one rather than only the first, which is the one
+	// most distorted by a cold cache.
+	lat []time.Duration
 	// found counts the answer session appearing anywhere in the top depthK,
 	// which separates the two ways a query fails: ranked badly, or never
 	// retrieved at all. Only the second one is fixed by ranking work.
@@ -146,6 +152,7 @@ func main() {
 	limit := flag.Int("limit", 20, "questions to run")
 	control := flag.Bool("control", false, "write the corpus but read an empty store: must score zero")
 	ctxBin := flag.String("ctx", "", "path to a ctx binary to run over the same corpus, scored the same way")
+	cpuprofile := flag.String("cpuprofile", "", "write a CPU profile of the whole run here")
 	misses := flag.Bool("misses", false, "print the questions whose answer session never came back, for triage")
 	corpus := flag.Int("corpus", 0, "lay down history from this many questions while scoring -limit of them; holds the questions fixed so only the pile grows")
 	flag.Parse()
@@ -170,6 +177,19 @@ func main() {
 	all := qs
 	if *corpus > 0 && len(all) > *corpus {
 		all = all[:*corpus]
+	}
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "day0bench:", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			fmt.Fprintln(os.Stderr, "day0bench:", err)
+			os.Exit(1)
+		}
+		defer pprof.StopCPUProfile()
 	}
 	if *limit > 0 && len(qs) > *limit {
 		qs = qs[:*limit]
@@ -211,10 +231,27 @@ func report(name string, r runResult) {
 	if r.written > 0 {
 		reach = float64(r.indexed) / float64(r.written) * 100
 	}
-	fmt.Printf("%-8s reach %d/%d (%.1f%%)  build %s  first answer %s  hit@1 %d/%d  hit@5 %d/%d  found@%d %d/%d\n",
+	p50, p95 := percentiles(r.lat)
+	fmt.Printf("%-8s reach %d/%d (%.1f%%)  build %s  first %s  p50 %s  p95 %s  hit@1 %d/%d  hit@5 %d/%d  found@%d %d/%d\n",
 		name, r.indexed, r.written, reach,
 		r.build.Round(time.Millisecond), r.first.Round(time.Millisecond),
+		p50.Round(time.Microsecond), p95.Round(time.Microsecond),
 		r.hit1, r.n, r.hit5, r.n, depthK, r.found, r.n)
+}
+
+// percentiles reports the median and the tail of a query-latency sample. The
+// first query alone says more about a cold page cache than about the search.
+func percentiles(ds []time.Duration) (time.Duration, time.Duration) {
+	if len(ds) == 0 {
+		return 0, 0
+	}
+	s := append([]time.Duration(nil), ds...)
+	sort.Slice(s, func(i, j int) bool { return s[i] < s[j] })
+	at := func(q float64) time.Duration {
+		i := int(float64(len(s)-1) * q)
+		return s[i]
+	}
+	return at(0.5), at(0.95)
 }
 
 func run(w writer, all, qs []question, control bool, misses bool) (runResult, error) {
@@ -300,6 +337,7 @@ func run(w writer, all, qs []question, control bool, misses bool) (runResult, er
 		if i == 0 {
 			out.first = time.Since(t1)
 		}
+		out.lat = append(out.lat, time.Since(t1))
 		want := map[string]bool{}
 		for _, id := range q.AnswerSession {
 			want[id] = true

--- a/scripts/harnesssweep/main.go
+++ b/scripts/harnesssweep/main.go
@@ -1,0 +1,813 @@
+// Command harnesssweep runs each installed harness against a recording
+// endpoint and reports whether deja's memory reached the request.
+//
+// Everything else deja tests answers a narrower question. The install tests say
+// the files are written and parse; the benchmarks say the ranking is good. Only
+// this says whether a harness, given those files, actually carries the recall
+// into what it sends the model — which is the whole product. The bug that
+// prompted it was of exactly that shape: deja's opencode plugin appended its
+// recall as a second system block, and every turn against a strict endpoint
+// failed. Valid files, correct ranking, broken product.
+//
+// Each harness gets an empty home, its own index built from -corpus, and one
+// turn. The control arm runs the same harness with deja not installed, because
+// a harness that fails on its own proves nothing about deja.
+//
+//	go run ./scripts/mockmodel -port 18777 -log /tmp/reqs.jsonl &
+//	go run ./scripts/harnesssweep -corpus ~/.claude/projects -log /tmp/reqs.jsonl
+//
+// Harnesses that need an account are skipped rather than reported as broken:
+// a login wall is not a deja defect. Neither is a harness that runs no hooks
+// headless — codex and grok both do that, which is why they come back with no
+// recall here and are still correct in a terminal.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type harness struct {
+	name   string
+	target string // the deja install target
+	bin    string
+	args   func(prompt, base, model string) []string
+	// setup writes whatever the harness needs to reach the mock: a provider
+	// block, an endpoint, a model name. Without it most of them stop at a
+	// login prompt and the sweep learns nothing.
+	setup func(home, base, model string) error
+	// wrapped means deja ships a `deja <name>` front end for this harness.
+	// Those two invocations are different products: the wrapper refreshes the
+	// context and says so, while the bare binary reads whatever was left on
+	// disk in silence. A sweep that only ran one of them would describe the
+	// harness wrongly whichever it chose.
+	wrapped bool
+	// resume continues the session the first turn opened, for the harnesses
+	// that can do it without a terminal. One turn only ever tests the opening
+	// move; the promise is memory for every question, and the machinery that
+	// could break the second is real — deja suppresses recall it has already
+	// injected into a session, and the plugins cache per prompt.
+	resume func(prompt, base, model string) []string
+	// wrongProduct reports that the binary on PATH is not the product deja
+	// wires, and why. Two different tools ship as `grok`: xAI's Grok Build,
+	// which reads Claude-shaped hooks out of ~/.grok, and a community CLI of
+	// the same name that shares the directory and reads none. Running the
+	// second and reporting "no recall" blames deja for a harness it was never
+	// talking to.
+	wrongProduct func() string
+	// toolHook marks a harness deja wires a PreToolUse hook into. That hook
+	// speaks at the moment of an action rather than at the start of a session,
+	// and nothing exercised it until the mock learned to answer with a tool
+	// call — the sweep only ever asked questions, so no tool was ever used.
+	toolHook bool
+	// mcp marks a harness deja installs its MCP server into. Everything else
+	// here reads what deja pushed into the request; this is the other
+	// direction — whether the harness can reach back to deja and get an
+	// answer. It is the only channel some of them have for a follow-up.
+	mcp bool
+	// sessionScoped marks a harness with no way to recall against the prompt.
+	// aider has neither hooks nor an MCP client; its read-only files are the
+	// whole channel, and nothing tells deja what was typed. Recall that does
+	// not answer the question is the best such a harness can do, so reporting
+	// it as a defect would bury the harnesses where it is one.
+	sessionScoped bool
+}
+
+func harnesses() []harness {
+	return []harness{
+		{"claude", "claude-auto", "claude",
+			func(p, _, _ string) []string {
+				return []string{"-p", p, "--permission-mode", "bypassPermissions"}
+			}, nil, false,
+			func(p, _, _ string) []string {
+				return []string{"-p", p, "--continue", "--permission-mode", "bypassPermissions"}
+			}, nil, true, true, false},
+		{"opencode", "opencode-auto", "opencode",
+			func(p, _, _ string) []string { return []string{"run", p} }, setupOpencode, false,
+			func(p, _, _ string) []string { return []string{"run", "--continue", p} }, nil, false, true, false},
+		{"codex", "codex-auto", "codex",
+			func(p, _, _ string) []string { return []string{"exec", "--skip-git-repo-check", p} }, setupCodex, false, nil, nil, true, true, false},
+		{"goose", "goose-auto", "goose",
+			func(p, _, _ string) []string { return []string{"run", "-t", p} }, setupGoose, true,
+			// Bare goose has no working prompt channel: it discards hook stdout,
+			// and .goosehints is read once when the session opens. MOIM, which is
+			// re-read every turn, is env-only — so the wrapper arm below is where
+			// goose recalls for the question.
+			nil, nil, false, true, true},
+		{"qwen", "qwen-auto", "qwen",
+			func(p, _, _ string) []string { return []string{"-p", p, "-y"} }, nil, false, nil, nil, false, true, false},
+		{"grok", "grok-auto", "grok",
+			func(p, base, model string) []string {
+				return []string{"-p", p, "-u", base, "-k", "local", "-m", model}
+			}, nil, false, nil, grokIsTheOtherProduct, true, true, false},
+		{"aider", "aider", "aider",
+			func(p, base, model string) []string {
+				return []string{"--no-git", "--yes", "--openai-api-base", base,
+					"--openai-api-key", "local", "--model", "openai/" + model,
+					// Every arm gets an empty home, so every arm is a first run:
+					// without these aider opened its release notes in the
+					// browser once per arm, on the machine running the sweep.
+					"--no-analytics", "--no-browser", "--no-check-update",
+					"--no-show-release-notes", "--message", p}
+				// aider has no MCP client at all.
+			}, nil, true, nil, nil, false, false, true},
+		// Both of these were assumed to need an account and were left out for
+		// it. Neither does: cline takes any OpenAI-compatible base URL, and
+		// openclaw takes a provider block in its own config.
+		{"cline", "cline-auto", "cline",
+			func(p, _, _ string) []string { return []string{"--auto-approve", "true", p} },
+			setupCline, false, nil, nil, false, true, false},
+		{"openclaw", "openclaw-auto", "openclaw",
+			func(p, _, model string) []string {
+				return []string{"agent", "--local", "-m", p, "--model", "mock/" + model,
+					// Without a session key openclaw refuses to pick one and
+					// exits before reaching the model.
+					"--session-key", "harnesssweep"}
+			}, setupOpenClaw, false,
+			func(p, _, model string) []string {
+				// The same key is the same session.
+				return []string{"agent", "--local", "-m", p, "--model", "mock/" + model,
+					"--session-key", "harnesssweep"}
+			}, nil, false, true, false},
+		{"kimi", "kimi-auto", "kimi",
+			func(p, _, model string) []string {
+				// -p is already non-interactive; kimi refuses both --auto and
+				// --yolo alongside it.
+				return []string{"-p", p, "-m", "mock/" + model}
+			}, setupKimi, false,
+			func(p, _, model string) []string {
+				return []string{"-p", p, "-c", "-m", "mock/" + model}
+			}, nil, false, true, false},
+	}
+}
+
+// grokIsTheOtherProduct returns a reason to skip when the `grok` on PATH is
+// the community CLI rather than xAI's Grok Build. It has no hook system at
+// all — only MCP — so deja's hooks sit in ~/.grok unread, and a sweep that
+// does not say so reports a defect against the wrong program.
+func grokIsTheOtherProduct() string {
+	out, err := exec.Command("grok", "--help").CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	help := strings.ToLower(string(out))
+	if strings.Contains(help, "hook") {
+		return ""
+	}
+	if strings.Contains(help, "conversational ai cli") || strings.Contains(help, "--base-url") {
+		return "the `grok` on PATH is the community CLI, which has no hooks; " +
+			"deja wires xAI's Grok Build"
+	}
+	return ""
+}
+
+func setupKimi(home, base, model string) error {
+	dir := filepath.Join(home, ".kimi-code")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	// kimi's own `provider add` imports from a models.dev-shaped registry over
+	// HTTP, which a sweep would have to serve. The config it writes afterwards
+	// is this, and writing it directly needs no server.
+	body := fmt.Sprintf(`[providers.mock]
+type = "openai"
+api_key = "local"
+base_url = %q
+
+[models."mock/%s"]
+provider = "mock"
+model = %q
+max_context_size = 128000
+capabilities = [ "tool_use" ]
+display_name = "Mock Model"
+`, base, model, model)
+	path := filepath.Join(dir, "config.toml")
+	// Appended, never written over: kimi's hook lives in this same file, and
+	// deja has already installed it by the time setup runs. Replacing the file
+	// deleted that block, and the sweep then reported kimi as getting no
+	// recall — a defect in the sweep that reads exactly like one in deja.
+	old, _ := os.ReadFile(path)
+	if strings.Contains(string(old), "[providers.") {
+		return nil
+	}
+	next := string(old)
+	if next != "" && !strings.HasSuffix(next, "\n") {
+		next += "\n"
+	}
+	if next != "" {
+		next += "\n"
+	}
+	return os.WriteFile(path, []byte(next+body), 0o644)
+}
+
+func setupCline(home, base, model string) error {
+	// cline keeps provider credentials in its own store, written by its own
+	// command; there is no file to drop in.
+	cmd := exec.Command("cline", "auth", "-p", "openai", "-k", "local",
+		"-b", base, "-m", model)
+	cmd.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("cline auth: %v: %s", err, firstLine(string(out)))
+	}
+	return nil
+}
+
+func setupOpenClaw(home, base, model string) error {
+	dir := filepath.Join(home, ".openclaw")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "openclaw.json")
+	cfg := map[string]any{}
+	if b, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(b, &cfg)
+	}
+	// openai-completions, not the default: openclaw's openai provider speaks
+	// the responses API, which the recording endpoint does not serve.
+	cfg["models"] = map[string]any{"mode": "merge", "providers": map[string]any{
+		"mock": map[string]any{
+			"baseUrl": base, "apiKey": "local", "api": "openai-completions",
+			"models": []any{map[string]any{"id": model, "name": "mock"}},
+		},
+	}}
+	b, _ := json.MarshalIndent(cfg, "", "  ")
+	return os.WriteFile(path, b, 0o644)
+}
+
+func setupOpencode(home, base, model string) error {
+	dir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "opencode.json")
+	cfg := map[string]any{}
+	if b, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(b, &cfg)
+	}
+	cfg["$schema"] = "https://opencode.ai/config.json"
+	cfg["model"] = "local/" + model
+	cfg["provider"] = map[string]any{"local": map[string]any{
+		"npm": "@ai-sdk/openai-compatible", "name": "local",
+		"options": map[string]any{"baseURL": base, "apiKey": "local"},
+		"models":  map[string]any{model: map[string]any{"name": "mock"}},
+	}}
+	b, _ := json.MarshalIndent(cfg, "", "  ")
+	return os.WriteFile(path, b, 0o644)
+}
+
+func setupCodex(home, base, model string) error {
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "config.toml")
+	// Keep whatever deja wrote (its MCP block) and add only the provider.
+	var keep []string
+	if b, err := os.ReadFile(path); err == nil {
+		for _, line := range strings.Split(string(b), "\n") {
+			if !strings.HasPrefix(line, "model =") && !strings.HasPrefix(line, "model_provider =") &&
+				!strings.HasPrefix(line, "approval_policy") && !strings.HasPrefix(line, "sandbox_mode") &&
+				!strings.HasPrefix(line, "[model_providers.") {
+				keep = append(keep, line)
+			}
+		}
+	}
+	body := fmt.Sprintf("model = %q\nmodel_provider = \"mock\"\napproval_policy = \"never\"\n"+
+		"sandbox_mode = \"read-only\"\n\n[model_providers.mock]\nname = \"mock\"\nbase_url = %q\n"+
+		"wire_api = \"responses\"\nrequires_openai_auth = false\n\n%s\n",
+		model, base, strings.Join(keep, "\n"))
+	return os.WriteFile(path, []byte(body), 0o644)
+}
+
+func setupGoose(home, _, model string) error {
+	dir := filepath.Join(home, ".config", "goose")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "config.yaml")
+	body, _ := os.ReadFile(path)
+	if !strings.Contains(string(body), "GOOSE_PROVIDER") {
+		body = append([]byte(fmt.Sprintf("GOOSE_PROVIDER: openai\nGOOSE_MODEL: %s\n", model)), body...)
+	}
+	return os.WriteFile(path, body, 0o644)
+}
+
+type result struct {
+	ran      bool
+	requests int
+	recall   bool
+	// shown is whether the person running the harness was told any of this
+	// happened. Memory that works and says nothing is the complaint the
+	// product hears most, and it is invisible to every check that only reads
+	// the request: on a real sweep the recall reached four harnesses and only
+	// some of them mentioned it.
+	shown bool
+	// answered is whether what arrived is about the question. A harness can
+	// pass every other check and still be blind: cline's plugin got a rule,
+	// which is handed nothing, so it recalled whatever the session opened
+	// with; gemini's prompt hook was handed the request with the previous
+	// recall already inside it, so every search term came from deja's own
+	// output. Both showed "recall reached the model" here.
+	answered bool
+	// echoed is the answer anywhere in the request, not only inside a recall
+	// block. A tool result comes back as a tool result, in whatever shape the
+	// protocol uses, so the stricter check would call a working MCP round trip
+	// a failure.
+	echoed bool
+	// refused is the harness rejecting the call itself rather than deja
+	// answering badly. codex declares its MCP tools inside a namespace and
+	// routes none of the call shapes a mock can produce — reporting that as
+	// "the tool returned nothing useful" blames deja for a call that never
+	// reached it.
+	refused  bool
+	rejected bool
+	err      string
+	took     time.Duration
+	// second is the follow-up turn in the same session, when the harness can
+	// be resumed without a terminal. nil means it cannot.
+	second *result
+}
+
+func main() {
+	deja := flag.String("deja", "", "path to the deja binary (default: build one)")
+	corpus := flag.String("corpus", "", "a directory of Claude-format transcripts to index")
+	logPath := flag.String("log", "/tmp/harnesssweep.jsonl", "the mockmodel request log")
+	base := flag.String("base", "http://127.0.0.1:18777/v1", "the mockmodel endpoint")
+	model := flag.String("model", "mock-model", "the model name the mock answers to")
+	repo := flag.String("repo", ".", "run the harnesses from here; recall is project-scoped")
+	prompt := flag.String("prompt", "How often does the deploy token for the billing gateway rotate?",
+		"the question to ask")
+	answer := flag.String("answer", "rotates every",
+		"a phrase from the corpus that answers -prompt; the recall has to carry "+
+			"it, or the harness is getting memory that is not about the question")
+	prompt2 := flag.String("prompt2", "why does the rate limiter reject valid traffic?",
+		"a second, different question, asked in the same session")
+	answer2 := flag.String("answer2", "per-process, not per-cluster",
+		"a phrase from the corpus that answers -prompt2")
+	toolBase := flag.String("tool-base", "",
+		"a second mockmodel endpoint started with -tool-call; enables the tool arm")
+	toolLog := flag.String("tool-log", "", "the request log of that second endpoint")
+	toolPrompt := flag.String("tool-prompt", "Run `npm run build` and tell me what happens.",
+		"the question that leads to the tool call")
+	toolEvidence := flag.String("tool-evidence", "last time:",
+		"what deja's PreToolUse hook should contribute for that command")
+	mcpBase := flag.String("mcp-base", "",
+		"a mockmodel endpoint started with -tool-call recall; enables the MCP arm")
+	mcpLog := flag.String("mcp-log", "", "the request log of that endpoint")
+	only := flag.String("only", "", "comma-separated harness names")
+	flag.Parse()
+
+	if *corpus == "" {
+		fmt.Fprintln(os.Stderr, "harnesssweep: -corpus is required")
+		os.Exit(2)
+	}
+	exe := *deja
+	if exe == "" {
+		out, err := os.MkdirTemp("", "sweepbin")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "harnesssweep:", err)
+			os.Exit(1)
+		}
+		defer os.RemoveAll(out)
+		exe = filepath.Join(out, "deja")
+		build := exec.Command("go", "build", "-o", exe, "./cmd/deja")
+		build.Stderr = os.Stderr
+		if err := build.Run(); err != nil {
+			fmt.Fprintln(os.Stderr, "harnesssweep: build:", err)
+			os.Exit(1)
+		}
+	}
+	wanted := map[string]bool{}
+	for _, n := range strings.Split(*only, ",") {
+		if n = strings.TrimSpace(n); n != "" {
+			wanted[n] = true
+		}
+	}
+
+	for _, h := range harnesses() {
+		if len(wanted) > 0 && !wanted[h.name] {
+			continue
+		}
+		if _, err := exec.LookPath(h.bin); err != nil {
+			fmt.Printf("%-10s SKIP  %s is not installed\n", h.name, h.bin)
+			continue
+		}
+		if h.wrongProduct != nil {
+			if why := h.wrongProduct(); why != "" {
+				fmt.Printf("%-10s SKIP  %s\n", h.name, why)
+				continue
+			}
+		}
+		withDeja := run(h, exe, *corpus, *logPath, *base, *model, *repo, *prompt, *answer, *prompt2, *answer2, true, false)
+		control := run(h, exe, *corpus, *logPath, *base, *model, *repo, *prompt, *answer, "", "", false, false)
+		report(h.name, withDeja, control, *answer != "", h.sessionScoped)
+		if h.mcp && *mcpBase != "" && *mcpLog != "" {
+			m := run(h, exe, *corpus, *mcpLog, *mcpBase, *model, *repo,
+				"What did we settle about the billing gateway deploy token?",
+				*answer, "", "", true, false)
+			verdict := "MCP answered from inside the harness"
+			switch {
+			case m.requests < 2:
+				verdict = "the harness never called deja's MCP tool"
+			case m.refused:
+				verdict = "the harness would not route the call"
+			case !m.echoed:
+				verdict = "MCP TOOL RETURNED NOTHING USEFUL"
+			}
+			fmt.Printf("%-10s %-34s %-14s (mcp)\n", "", verdict, "")
+		}
+		if h.toolHook && *toolBase != "" && *toolLog != "" {
+			t := run(h, exe, *corpus, *toolLog, *toolBase, *model, *repo,
+				*toolPrompt, *toolEvidence, "", "", true, false)
+			verdict := "PreToolUse recall reached the model"
+			switch {
+			case t.requests < 2:
+				verdict = "no tool call happened: " + firstLine(t.err)
+			case !t.answered:
+				verdict = "PRETOOLUSE RECALL MISSING"
+			}
+			fmt.Printf("%-10s %-34s %-14s (tool)\n", "", verdict, "")
+		}
+		// Uninstalling has to leave the harness exactly as it was found. The
+		// failure this catches is not theoretical: grok's hooks survived
+		// `uninstall --all` and went on calling a binary the user had just
+		// removed, which is a harness that errors on every turn.
+		if left, ok := checkUninstall(h, exe, *corpus, *base, *model, *repo); !ok {
+			fmt.Printf("%-10s %-34s %-14s\n", "", "UNINSTALL LEFT FILES", strings.Join(left, " "))
+		}
+		for _, problem := range checkReinstall(h, exe, *corpus, *repo) {
+			fmt.Printf("%-10s %-34s %s\n", "", "REINSTALL", problem)
+		}
+		if h.wrapped {
+			w := run(h, exe, *corpus, *logPath, *base, *model, *repo, *prompt, *answer, "", "", true, true)
+			seen := "silent"
+			if w.shown {
+				seen = "receipt shown"
+			}
+			// The wrapper is where a harness can gain a channel the bare
+			// binary does not have: goose's MOIM file is re-read every turn
+			// and is env-only, so only `deja goose` gets recall for the
+			// question. Reporting only the receipt here hid that difference.
+			verdict := ""
+			switch {
+			case !w.recall:
+				verdict = "NO RECALL in the request"
+			case *answer != "" && !w.answered:
+				verdict = "session-scoped recall"
+			case *answer != "":
+				verdict = "recall answers the question"
+			}
+			fmt.Printf("%-10s %-34s %-14s (via `deja %s`)\n", "", verdict, seen, h.bin)
+		}
+	}
+}
+
+func run(h harness, exe, corpus, logPath, base, model, repo, prompt, answer, prompt2, answer2 string, install, wrapper bool) result {
+	var out result
+	home, err := os.MkdirTemp("", "sweep-"+h.name)
+	if err != nil {
+		return result{err: err.Error()}
+	}
+	defer os.RemoveAll(home)
+
+	env := append(os.Environ(),
+		"HOME="+home, "USERPROFILE="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+		"DEJA_CLAUDE_ROOT="+corpus,
+		// A fresh index per run: deja remembers what it injected into a
+		// session and rate-limits its own notice, so a shared one makes the
+		// second run disagree with the first for reasons of its own.
+		"DEJA_INDEX_DIR="+filepath.Join(home, "idx"),
+		"OPENAI_API_KEY=local", "OPENAI_BASE_URL="+base, "OPENAI_API_BASE="+base,
+		"OPENAI_MODEL="+model, "OPENAI_HOST="+strings.TrimSuffix(base, "/v1"),
+		"OPENAI_BASE_PATH=v1/chat/completions",
+		// Claude Code speaks the messages API, which the mock also serves, and
+		// it takes the endpoint from the environment. It is the harness deja
+		// is most used with and it was not in this sweep at all.
+		"ANTHROPIC_BASE_URL="+strings.TrimSuffix(base, "/v1"),
+		"ANTHROPIC_AUTH_TOKEN=local", "ANTHROPIC_API_KEY=local",
+		"ANTHROPIC_MODEL=claude-mock", "ANTHROPIC_SMALL_FAST_MODEL=claude-mock",
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
+		// Nothing in a sweep may open a browser on the machine running it.
+		// aider's flags were not enough — it still reached for one — and
+		// Python's webbrowser obeys BROWSER, so point it at a command that
+		// does nothing. The rest are the per-tool switches, set as env so they
+		// hold for any invocation, including the wrapper's.
+		"BROWSER=true", "AIDER_ANALYTICS=false", "AIDER_ANALYTICS_DISABLE=1",
+		"AIDER_CHECK_UPDATE=false", "AIDER_SHOW_RELEASE_NOTES=false",
+		"DO_NOT_TRACK=1")
+
+	deja := func(args ...string) {
+		cmd := exec.Command(exe, args...)
+		cmd.Env = env
+		// From the repo: recall is scoped to the project, so an install run
+		// from anywhere else finds nothing and writes an empty context.
+		cmd.Dir = repo
+		_ = cmd.Run()
+	}
+	deja("index")
+	if install {
+		deja("install", h.target, "--no-index")
+	}
+	if h.setup != nil {
+		if err := h.setup(home, base, model); err != nil {
+			return result{err: err.Error()}
+		}
+	}
+
+	// Read the log by offset rather than truncating it: the mock holds the
+	// file open, and truncating under it sends the next writes past the end.
+	start := int64(0)
+	if fi, err := os.Stat(logPath); err == nil {
+		start = fi.Size()
+	}
+	t0 := time.Now()
+	bin, args := h.bin, h.args(prompt, base, model)
+	if wrapper {
+		bin, args = exe, append([]string{h.bin}, args...)
+	}
+	cmd := exec.Command(bin, args...)
+	cmd.Env = env
+	cmd.Dir = repo
+	stdout, runErr := cmd.CombinedOutput()
+	out.took = time.Since(t0)
+	out.ran = runErr == nil
+	if runErr != nil {
+		out.err = firstLine(string(stdout))
+	}
+	out.rejected = strings.Contains(string(stdout), "System message must be at the beginning")
+	out.refused = strings.Contains(string(stdout), "unsupported call")
+	// The receipt as every host renders it: deja's own wording, whatever
+	// framing the harness wraps around it.
+	out.shown = strings.Contains(string(stdout), "deja recalled") ||
+		strings.Contains(string(stdout), "deja-vu recalled") ||
+		strings.Contains(string(stdout), "deja: recalled")
+
+	sent, n := readSince(logPath, start)
+	out.requests = n
+	out.recall = strings.Contains(sent, "deja-recall")
+	// The answer has to be inside the recall, not merely somewhere in the
+	// request: the prompt itself quotes the question, and a harness that
+	// echoes the corpus for other reasons would otherwise read as a pass.
+	out.answered = answer != "" && strings.Contains(recallBlocks(sent), answer)
+	out.echoed = answer != "" && strings.Contains(sent, answer)
+	out.second = secondTurn(h, env, logPath, base, model, repo, prompt2, answer2)
+	return out
+}
+
+// secondTurn continues the session the first turn opened and asks about
+// something else, in the home the first turn left behind — so whatever the
+// harness and deja wrote is still there.
+func secondTurn(h harness, env []string, logPath, base, model, repo, prompt, answer string) *result {
+	if h.resume == nil || prompt == "" {
+		return nil
+	}
+	var out result
+	start := int64(0)
+	if fi, err := os.Stat(logPath); err == nil {
+		start = fi.Size()
+	}
+	cmd := exec.Command(h.bin, h.resume(prompt, base, model)...)
+	cmd.Env = env
+	cmd.Dir = repo
+	stdout, runErr := cmd.CombinedOutput()
+	out.ran = runErr == nil
+	if runErr != nil {
+		out.err = firstLine(string(stdout))
+	}
+	sent, n := readSince(logPath, start)
+	out.requests = n
+	out.recall = strings.Contains(sent, "deja-recall")
+	out.answered = answer != "" && strings.Contains(recallBlocks(sent), answer)
+	return &out
+}
+
+// recallBlocks returns just what deja put in the request. The block is JSON
+// encoded by the time it reaches the log, so the closing tag is matched in both
+// spellings; an unterminated block is taken to run to the end, which is the
+// reading that cannot hide a missing answer.
+func recallBlocks(sent string) string {
+	var b strings.Builder
+	rest := sent
+	for {
+		i := strings.Index(rest, "deja-recall")
+		if i < 0 {
+			return b.String()
+		}
+		rest = rest[i+len("deja-recall"):]
+		end := len(rest)
+		for _, close := range []string{"/deja-recall", `</deja-recall`} {
+			if j := strings.Index(rest, close); j >= 0 && j < end {
+				end = j
+			}
+		}
+		b.WriteString(rest[:end])
+		rest = rest[end:]
+	}
+}
+
+// readSince returns what was appended to the log after offset, and how many
+// records that is. Reading the whole file and slicing is enough here: a sweep's
+// log is small, and the alternative is holding a handle on a file another
+// process is appending to.
+// checkUninstall installs, uninstalls, and reports any deja file still on disk.
+// Files are matched by content rather than by name: a harness config deja
+// edited in place keeps its own name, and what matters is whether deja's
+// command is still in it.
+// checkReinstall covers the two things that happen to an install after it is
+// made: it is run again, and the binary moves. Running it again must not leave
+// two of anything, and moving the binary must not leave a config calling the
+// old path — a hook pointing at a binary that is no longer there fails on
+// every turn, and the harness reports it as deja being broken.
+func checkReinstall(h harness, exe, corpus, repo string) []string {
+	home, err := os.MkdirTemp("", "sweep-reinstall-"+h.name)
+	if err != nil {
+		return nil
+	}
+	defer os.RemoveAll(home)
+
+	// A second binary at a different path, standing in for an upgrade that
+	// moved it: brew to go install, a version directory, a rename.
+	moved := filepath.Join(home, "moved-deja")
+	if b, err := os.ReadFile(exe); err == nil {
+		_ = os.WriteFile(moved, b, 0o755)
+	} else {
+		return nil
+	}
+
+	env := append(os.Environ(),
+		"HOME="+home, "USERPROFILE="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+		"DEJA_CLAUDE_ROOT="+corpus,
+		"DEJA_INDEX_DIR="+filepath.Join(home, "idx"))
+	install := func(bin string) {
+		cmd := exec.Command(bin, "install", h.target, "--no-index")
+		cmd.Env = env
+		cmd.Dir = repo
+		_ = cmd.Run()
+	}
+
+	install(exe)
+	first := snapshot(home)
+	install(exe)
+	again := snapshot(home)
+
+	var problems []string
+	for path, before := range first {
+		after, ok := again[path]
+		if !ok {
+			continue
+		}
+		if n, m := strings.Count(before, "hook-"), strings.Count(after, "hook-"); m > n {
+			problems = append(problems, fmt.Sprintf("%s gained a second wiring on reinstall (%d then %d)",
+				path, n, m))
+		}
+	}
+
+	install(moved)
+	for path, body := range snapshot(home) {
+		if strings.Contains(body, exe) {
+			problems = append(problems, path+" still calls the old binary path after it moved")
+		}
+	}
+	return problems
+}
+
+// snapshot reads every file under home except deja's own state and index.
+func snapshot(home string) map[string]string {
+	out := map[string]string{}
+	_ = filepath.WalkDir(home, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() ||
+			strings.HasPrefix(path, filepath.Join(home, "idx")) ||
+			strings.HasPrefix(path, filepath.Join(home, ".config", "deja")) ||
+			strings.HasSuffix(path, ".bak") {
+			return nil
+		}
+		if b, rerr := os.ReadFile(path); rerr == nil {
+			if rel, rerr := filepath.Rel(home, path); rerr == nil {
+				out[rel] = string(b)
+			}
+		}
+		return nil
+	})
+	return out
+}
+
+func checkUninstall(h harness, exe, corpus, base, model, repo string) ([]string, bool) {
+	home, err := os.MkdirTemp("", "sweep-uninstall-"+h.name)
+	if err != nil {
+		return nil, true
+	}
+	defer os.RemoveAll(home)
+	env := append(os.Environ(),
+		"HOME="+home, "USERPROFILE="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+		"DEJA_CLAUDE_ROOT="+corpus,
+		"DEJA_INDEX_DIR="+filepath.Join(home, "idx"))
+	deja := func(args ...string) {
+		cmd := exec.Command(exe, args...)
+		cmd.Env = env
+		cmd.Dir = repo
+		_ = cmd.Run()
+	}
+	deja("install", h.target, "--no-index")
+	deja("uninstall", h.target)
+
+	var left []string
+	_ = filepath.WalkDir(home, func(path string, d os.DirEntry, err error) error {
+		// deja's own state directory is not residue: uninstall clears the
+		// target list inside it and the file is deja's to keep.
+		if err != nil || d.IsDir() ||
+			strings.HasPrefix(path, filepath.Join(home, "idx")) ||
+			strings.HasPrefix(path, filepath.Join(home, ".config", "deja")) {
+			return nil
+		}
+		b, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil
+		}
+		// The binary's own path is what a stale hook would still be calling.
+		if strings.Contains(string(b), exe) || strings.Contains(string(b), "deja hook-") {
+			if rel, rerr := filepath.Rel(home, path); rerr == nil {
+				left = append(left, rel)
+			} else {
+				left = append(left, path)
+			}
+		}
+		return nil
+	})
+	return left, len(left) == 0
+}
+
+func readSince(path string, offset int64) (string, int) {
+	b, err := os.ReadFile(path)
+	if err != nil || int64(len(b)) <= offset {
+		return "", 0
+	}
+	body := strings.TrimSpace(string(b[offset:]))
+	if body == "" {
+		return "", 0
+	}
+	return body, strings.Count(body, "\n") + 1
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	if len(s) > 120 {
+		s = s[:120] + "…"
+	}
+	return s
+}
+
+func report(name string, withDeja, control result, wantAnswer, sessionScoped bool) {
+	// A harness that cannot complete a turn without deja cannot say anything
+	// about deja: an account wall, a missing model, a flag this sweep got
+	// wrong. Naming that separately keeps it out of the defect column.
+	if control.requests == 0 {
+		fmt.Printf("%-10s SKIP  the harness never reached the model on its own: %s\n", name, control.err)
+		return
+	}
+	verdict := "recall reached the model"
+	switch {
+	case withDeja.rejected:
+		verdict = "REJECTED the request deja produced"
+	case !withDeja.recall:
+		verdict = "NO RECALL in the request"
+	case wantAnswer && !withDeja.answered && sessionScoped:
+		verdict = "session-scoped recall (no prompt channel)"
+	case wantAnswer && !withDeja.answered:
+		verdict = "RECALL MISSED THE QUESTION"
+	}
+	seen := "silent"
+	if withDeja.shown {
+		seen = "receipt shown"
+	}
+	broke := ""
+	if control.ran && !withDeja.ran {
+		broke = "  · deja broke a turn that worked without it"
+	}
+	fmt.Printf("%-10s %-34s %-14s (%d request(s), %s)%s\n", name, verdict, seen,
+		withDeja.requests, withDeja.took.Round(time.Millisecond), broke)
+	if s := withDeja.second; s != nil {
+		follow := "recall answers the follow-up"
+		switch {
+		case !s.ran && s.requests == 0:
+			follow = "could not resume: " + s.err
+		case !s.recall:
+			follow = "NO RECALL on the follow-up"
+		case !s.answered:
+			follow = "FOLLOW-UP GOT THE FIRST QUESTION'S MEMORY"
+		}
+		fmt.Printf("%-10s %-34s %-14s (turn 2)\n", "", follow, "")
+	}
+}

--- a/scripts/mcpprobe/main.go
+++ b/scripts/mcpprobe/main.go
@@ -1,0 +1,208 @@
+// Command mcpprobe speaks MCP to deja and reports anything a client would
+// choke on.
+//
+// Eight harnesses reach deja through this server, so a malformed reply breaks
+// all of them at once — and it is the one surface the harness sweep cannot see,
+// because a client only calls a tool when its model decides to. This drives the
+// protocol directly: the handshake, the tool and resource listings, a real
+// recall, and the inputs a client sends when something has gone wrong.
+//
+//	go run ./scripts/mkcorpus -out /tmp/corpus
+//	deja index                       # with DEJA_CLAUDE_ROOT at /tmp/corpus/projects
+//	go run ./scripts/mcpprobe -deja ./deja -want "47 days"
+//
+// Exits non-zero if anything failed, so it can gate a release.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type rpc struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  any             `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+type client struct {
+	in   io.WriteCloser
+	out  *bufio.Reader
+	next int
+}
+
+func (c *client) send(method string, params any, notify bool) (rpc, error) {
+	msg := map[string]any{"jsonrpc": "2.0", "method": method}
+	if params != nil {
+		msg["params"] = params
+	}
+	if !notify {
+		c.next++
+		msg["id"] = c.next
+	}
+	b, _ := json.Marshal(msg)
+	if _, err := c.in.Write(append(b, '\n')); err != nil {
+		return rpc{}, err
+	}
+	if notify {
+		return rpc{}, nil
+	}
+	line, err := c.out.ReadString('\n')
+	if err != nil {
+		return rpc{}, fmt.Errorf("no reply to %s: %w", method, err)
+	}
+	var r rpc
+	if err := json.Unmarshal([]byte(line), &r); err != nil {
+		return rpc{}, fmt.Errorf("%s returned something that is not JSON-RPC: %s", method, strings.TrimSpace(line))
+	}
+	return r, nil
+}
+
+var failures []string
+
+func check(ok bool, what string) {
+	if ok {
+		fmt.Println("  ok   " + what)
+		return
+	}
+	fmt.Println("  BAD  " + what)
+	failures = append(failures, what)
+}
+
+func main() {
+	deja := flag.String("deja", "deja", "the deja binary to speak to")
+	want := flag.String("want", "", "a string the recall must contain (a fact only the corpus holds)")
+	query := flag.String("query", "deploy token rotate", "what to recall")
+	flag.Parse()
+
+	cmd := exec.Command(*deja, "mcp")
+	cmd.Stderr = os.Stderr
+	stdin, err := cmd.StdinPipe()
+	fatal(err)
+	stdout, err := cmd.StdoutPipe()
+	fatal(err)
+	fatal(cmd.Start())
+	c := &client{in: stdin, out: bufio.NewReader(stdout)}
+
+	init, err := c.send("initialize", map[string]any{
+		"protocolVersion": "2025-06-18",
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": "mcpprobe", "version": "1"},
+	}, false)
+	fatal(err)
+	var initResult struct {
+		ProtocolVersion string `json:"protocolVersion"`
+		ServerInfo      struct {
+			Name string `json:"name"`
+		} `json:"serverInfo"`
+		Capabilities map[string]any `json:"capabilities"`
+	}
+	_ = json.Unmarshal(init.Result, &initResult)
+	check(init.Error == nil, "initialize succeeds")
+	check(initResult.ServerInfo.Name != "", "the server names itself")
+	check(initResult.ProtocolVersion != "", "the server states a protocol version")
+
+	_, _ = c.send("notifications/initialized", map[string]any{}, true)
+
+	list, err := c.send("tools/list", map[string]any{}, false)
+	fatal(err)
+	var tools struct {
+		Tools []struct {
+			Name        string         `json:"name"`
+			Description string         `json:"description"`
+			InputSchema map[string]any `json:"inputSchema"`
+		} `json:"tools"`
+	}
+	_ = json.Unmarshal(list.Result, &tools)
+	check(len(tools.Tools) > 0, "tools/list returns tools")
+	for _, t := range tools.Tools {
+		// A tool with no description is a tool a model will not choose, and a
+		// schema that is not an object is one a client cannot render.
+		check(t.Description != "", t.Name+" describes itself")
+		check(t.InputSchema["type"] == "object", t.Name+" has an object input schema")
+	}
+
+	for _, t := range tools.Tools {
+		if !strings.Contains(t.Name, "recall") {
+			continue
+		}
+		r, err := c.send("tools/call", map[string]any{
+			"name": t.Name, "arguments": map[string]any{"query": *query},
+		}, false)
+		fatal(err)
+		body := string(r.Result)
+		check(r.Error == nil, t.Name+" answers")
+		check(strings.Contains(body, `"type":"text"`) || strings.Contains(body, `"type": "text"`),
+			t.Name+" returns a text block")
+		if *want != "" {
+			check(strings.Contains(body, *want), t.Name+" found what only the corpus holds")
+		}
+	}
+
+	// Everything a client does when something has gone wrong. A server that
+	// dies here takes the whole session with it.
+	unknown, err := c.send("tools/call", map[string]any{"name": "no_such_tool", "arguments": map[string]any{}}, false)
+	fatal(err)
+	check(unknown.Error != nil || strings.Contains(string(unknown.Result), "isError"),
+		"an unknown tool is an error, not a crash")
+
+	if len(tools.Tools) > 0 {
+		_, err = c.send("tools/call", map[string]any{"name": tools.Tools[0].Name, "arguments": map[string]any{}}, false)
+		check(err == nil, "missing arguments do not end the session")
+	}
+
+	if _, ok := initResult.Capabilities["resources"]; ok {
+		res, err := c.send("resources/list", map[string]any{}, false)
+		fatal(err)
+		check(res.Error == nil, "resources/list answers, since the server advertises resources")
+		var resources struct {
+			Resources []struct {
+				URI string `json:"uri"`
+			} `json:"resources"`
+		}
+		_ = json.Unmarshal(res.Result, &resources)
+		if len(resources.Resources) > 0 {
+			read, err := c.send("resources/read", map[string]any{"uri": resources.Resources[0].URI}, false)
+			fatal(err)
+			check(read.Error == nil, "a listed resource can be read")
+		}
+		// What a hostile or confused client sends.
+		for _, uri := range []string{"", "not-a-uri", "deja://session/../../etc/passwd", "deja://session/claude:nope"} {
+			bad, err := c.send("resources/read", map[string]any{"uri": uri}, false)
+			fatal(err)
+			check(bad.Error != nil, fmt.Sprintf("resources/read refuses %q", uri))
+		}
+	}
+
+	after, err := c.send("tools/list", map[string]any{}, false)
+	fatal(err)
+	check(after.Error == nil, "the server still answers after all of that")
+
+	_ = stdin.Close()
+	_ = cmd.Wait()
+
+	if len(failures) > 0 {
+		fmt.Fprintf(os.Stderr, "\n%d problem(s):\n  %s\n", len(failures), strings.Join(failures, "\n  "))
+		os.Exit(1)
+	}
+	fmt.Println("\nno problems")
+}
+
+func fatal(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mcpprobe:", err)
+		os.Exit(1)
+	}
+}

--- a/scripts/mkcorpus/main.go
+++ b/scripts/mkcorpus/main.go
@@ -1,0 +1,190 @@
+// Command mkcorpus writes a synthetic history to sweep a harness against.
+//
+// harnesssweep needs a store to recall from, and pointing it at a real one
+// makes the run unrepeatable and puts private transcripts in the way. This
+// writes transcripts in Claude Code's on-disk shape, holding the three things
+// deja indexes separately: what was said, the commands that were run, and the
+// files that were touched.
+//
+// The counts are chosen to clear the bars deja applies before it will speak,
+// which is easy to get wrong by hand. A command is remembered once it has
+// recurred in two sessions; a file is a place with a past at five. A corpus
+// under those bars produces a hook that says nothing, which reads exactly like
+// a hook that is broken — an afternoon was spent on that.
+//
+//	go run ./scripts/mkcorpus -out /tmp/corpus
+//	go run ./scripts/harnesssweep -corpus /tmp/corpus/projects ...
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// The one fact a sweep asks about, planted deep enough that the ranking has to
+// find it rather than stumble on it.
+//
+// The interval is a flag, not a constant, because an agent with tools reads
+// the repository: given permission to run commands, antigravity answered "47
+// days" from this file with no memory involved at all, in the arm that was
+// supposed to have none. A sweep that wants an answer only memory can give
+// passes -interval with a number this checkout does not contain.
+const answerQuestion = "how often does the deploy token for the billing gateway rotate?"
+
+func answerFact(days int) string {
+	return fmt.Sprintf("we settled it: the billing gateway deploy token rotates every %d days, "+
+		"pinned to the vault lease", days)
+}
+
+var chatter = [][2]string{
+	{"the login page flashes on reload", "a layout shift: the avatar image had no width attribute"},
+	{"nightly export is slow again", "it re-reads the whole ledger; it wants a cursor by updated_at"},
+	{"tests are flaky on the runner", "two of them share a temp directory and race on cleanup"},
+	{"the webhook signature check fails", "the body was read twice, so the second read hashed nothing"},
+	{"staging deploy hung", "the health check waited on a port the container never opened"},
+	{"search results feel stale", "the index only refreshes on write; reads never trigger it"},
+	{"rate limiter rejects valid traffic", "the window is per-process, not per-cluster"},
+	{"migration locked the table", "it rewrote the whole table; add the column nullable first"},
+}
+
+var commands = [][3]string{
+	{"npm run build", "Error: Cannot find module 'esbuild'", "the lockfile was stale; `npm ci` fixed it"},
+	{"go test ./...", "--- FAIL: TestRetryBudget", "the budget counts attempts, not elapsed time"},
+	{"docker compose up -d", "Error: port is already allocated", "the old stack was still running; compose down first"},
+}
+
+var files = [][2]string{
+	{"internal/index/retrieval.go", "the AND across query words is why plain questions come back empty"},
+	{"cmd/deja/install.go", "install writes through a symlink, so dotfiles repos keep their file"},
+}
+
+type writer struct {
+	dir   string
+	clock time.Time
+	n     int
+}
+
+func (w *writer) session(id string, turns []turn) error {
+	path := filepath.Join(w.dir, id+".jsonl")
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for i, t := range turns {
+		var content any = t.text
+		if t.role == "assistant" {
+			blocks := []any{map[string]any{"type": "text", "text": t.text}}
+			if t.tool != nil {
+				blocks = append(blocks, t.tool)
+			}
+			content = blocks
+		}
+		if t.result != "" {
+			content = []any{map[string]any{
+				"type": "tool_result", "tool_use_id": t.toolID, "content": t.result}}
+		}
+		if err := enc.Encode(map[string]any{
+			"type":      t.role,
+			"sessionId": id,
+			"timestamp": w.clock.Add(time.Duration(i) * time.Minute).UTC().Format(time.RFC3339),
+			"message":   map[string]any{"role": t.role, "content": content},
+		}); err != nil {
+			return err
+		}
+	}
+	w.clock = w.clock.Add(12 * time.Hour)
+	w.n++
+	return nil
+}
+
+type turn struct {
+	role, text string
+	tool       map[string]any
+	toolID     string
+	result     string
+}
+
+func say(role, text string) turn { return turn{role: role, text: text} }
+
+func main() {
+	out := flag.String("out", "", "where to write the corpus")
+	project := flag.String("project", "-Users-you-code-deja-vu",
+		"the transcript directory name, which is the project deja records")
+	interval := flag.Int("interval", 47,
+		"the rotation interval the planted fact states; pass a number this "+
+			"checkout does not contain so an agent with tools cannot grep it")
+	flag.Parse()
+	if *out == "" {
+		fmt.Fprintln(os.Stderr, "mkcorpus: -out is required")
+		os.Exit(2)
+	}
+	dir := filepath.Join(*out, "projects", *project)
+	if err := os.RemoveAll(*out); err != nil {
+		fmt.Fprintln(os.Stderr, "mkcorpus:", err)
+		os.Exit(1)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, "mkcorpus:", err)
+		os.Exit(1)
+	}
+	w := &writer{dir: dir, clock: time.Now().AddDate(0, 0, -60)}
+	fail := func(err error) {
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "mkcorpus:", err)
+			os.Exit(1)
+		}
+	}
+
+	// Plain conversation, with the answer buried early so it has to be ranked
+	// rather than found by recency.
+	for i, c := range chatter {
+		turns := []turn{say("user", c[0]), say("assistant", c[1])}
+		if i == 1 {
+			turns = append([]turn{say("user", answerQuestion), say("assistant", answerFact(*interval))}, turns...)
+		}
+		fail(w.session(fmt.Sprintf("chat-%02d", i), turns))
+	}
+
+	// Commands, twice each: once is not yet a habit deja will mention.
+	for i, c := range commands {
+		for rep := range 2 {
+			id := fmt.Sprintf("cmd-%02d-%d", i, rep)
+			toolID := fmt.Sprintf("t%d%d", i, rep)
+			fail(w.session(id, []turn{
+				say("user", "let's try "+c[0]),
+				{role: "assistant", text: "running " + c[0], toolID: toolID,
+					tool: map[string]any{"type": "tool_use", "id": toolID, "name": "Bash",
+						"input": map[string]any{"command": c[0]}}},
+				{role: "user", toolID: toolID, result: c[1]},
+				say("assistant", c[2]),
+			}))
+		}
+	}
+
+	// Files, six sessions each: five is where deja calls a file a place with a
+	// past rather than ordinary work.
+	for i, f := range files {
+		for rep := range 6 {
+			id := fmt.Sprintf("file-%02d-%d", i, rep)
+			toolID := fmt.Sprintf("e%d%d", i, rep)
+			fail(w.session(id, []turn{
+				say("user", "have a look at "+f[0]),
+				{role: "assistant", text: "reading it", toolID: toolID,
+					tool: map[string]any{"type": "tool_use", "id": toolID, "name": "Edit",
+						"input": map[string]any{"file_path": "/Users/you/code/deja-vu/" + f[0],
+							"old_string": "before", "new_string": "after"}}},
+				{role: "user", toolID: toolID, result: "edited"},
+				say("assistant", f[1]),
+			}))
+		}
+	}
+
+	fmt.Printf("%d sessions in %s\n", w.n, dir)
+	fmt.Printf("ask it: %q — the answer is only in there\n", answerQuestion)
+}

--- a/scripts/mockmodel/main.go
+++ b/scripts/mockmodel/main.go
@@ -1,0 +1,646 @@
+// Command mockmodel stands in for a model so a harness can be driven end to
+// end, and records what it was actually sent.
+//
+// Checking that deja writes the right files says nothing about what a harness
+// does with them. Checking against a real model says little either: the answer
+// is the model's, the latency is the network's, and a laptop model falls over
+// under the load. This serves the three wire protocols the harnesses speak,
+// answers instantly with a fixed string, and writes every request it received
+// to a log — so a sweep can ask the only question that matters, which is
+// whether the memory reached the request.
+//
+// It also enforces the rule that a strict endpoint enforces: a system message
+// may not follow a user message. That is not pedantry. deja's opencode plugin
+// appended its recall as a second system block, and every turn against such an
+// endpoint failed with "System message must be at the beginning" — found by
+// driving the real interface, invisible to every other kind of test.
+//
+//	go run ./scripts/mockmodel -port 18777 -log /tmp/requests.jsonl
+//
+// Then point a harness at http://127.0.0.1:18777/v1 and read the log.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const model = "mock-model"
+
+type message struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+type request struct {
+	Model        string          `json:"model"`
+	Stream       bool            `json:"stream"`
+	Messages     []message       `json:"messages"`
+	Input        json.RawMessage `json:"input"`
+	Instructions string          `json:"instructions"`
+	System       json.RawMessage `json:"system"`
+	// Tools is what the harness says it can do. Every harness names its shell
+	// tool differently — Bash, shell, run_commands — so a mock configured with
+	// one fixed name calls something two of them do not have, and the whole
+	// PreToolUse path silently goes untested. Reading the name out of the
+	// request removes that per-harness knowledge.
+	Tools json.RawMessage `json:"tools"`
+}
+
+// toolNames lists every tool the request declared, in the order given.
+func toolNames(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var tools []struct {
+		Name     string `json:"name"`
+		Function struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	if json.Unmarshal(raw, &tools) != nil {
+		return nil
+	}
+	var out []string
+	for _, t := range tools {
+		if t.Name != "" {
+			out = append(out, t.Name)
+		} else if t.Function.Name != "" {
+			out = append(out, t.Function.Name)
+		}
+	}
+	return out
+}
+
+// declaredTool is one entry of the request's tools array, in whichever shape
+// the wire protocol uses: {type,function:{name,parameters}} on chat
+// completions, {type,name,parameters} on responses, {name,input_schema} on
+// messages.
+type declaredTool struct {
+	Type        string          `json:"type"`
+	Name        string          `json:"name"`
+	Parameters  json.RawMessage `json:"parameters"`
+	InputSchema json.RawMessage `json:"input_schema"`
+	Function    struct {
+		Name       string          `json:"name"`
+		Parameters json.RawMessage `json:"parameters"`
+	} `json:"function"`
+	// Tools is the namespace form: codex declares an MCP server as one entry
+	// of type "namespace" holding the server's tools, rather than one flat
+	// entry per tool. Calling the namespace itself does nothing, which is
+	// what made codex the only harness whose MCP arm came back empty.
+	Tools []declaredTool `json:"tools"`
+}
+
+func (d declaredTool) name() string {
+	if d.Name != "" {
+		return d.Name
+	}
+	return d.Function.Name
+}
+
+func (d declaredTool) schema() json.RawMessage {
+	switch {
+	case len(d.Parameters) > 0:
+		return d.Parameters
+	case len(d.InputSchema) > 0:
+		return d.InputSchema
+	default:
+		return d.Function.Parameters
+	}
+}
+
+// shellTool picks the tool that runs a command and builds the arguments its own
+// schema asks for. Both halves have to come from the request: harnesses differ
+// on the name (Bash, bash, exec_command) and on the shape — codex takes a
+// string under "cmd", Claude takes one under "command", and another takes an
+// argv array. Hardcoding either meant the call was rejected on arrival and the
+// PreToolUse hook never ran, which reads like a harness that ignores tools.
+func shellTool(raw json.RawMessage, command string) (string, string) {
+	if len(raw) == 0 {
+		return "", ""
+	}
+	var tools []declaredTool
+	if json.Unmarshal(raw, &tools) != nil {
+		return "", ""
+	}
+	// Longest first so "run_commands" is not matched by "run".
+	wanted := []string{"run_commands", "execute_command", "run_terminal_cmd",
+		"exec_command", "local_shell", "bash", "shell", "terminal", "exec"}
+	best, bestRank := declaredTool{}, len(wanted)
+	for _, t := range tools {
+		name := strings.ToLower(t.name())
+		if name == "" {
+			continue
+		}
+		for rank, w := range wanted {
+			if name == w && rank < bestRank {
+				best, bestRank = t, rank
+			}
+		}
+	}
+	if bestRank == len(wanted) {
+		return "", ""
+	}
+	return best.name(), commandArguments(best.schema(), command)
+}
+
+// recallTool picks deja's own recall tool out of what the harness declared.
+// The prefix is the harness's: deja__recall in one, mcp__deja__recall in
+// another, a single mcp__deja entry in a third.
+func recallTool(raw json.RawMessage, query string) (string, string) {
+	if len(raw) == 0 {
+		return "", ""
+	}
+	var tools []declaredTool
+	if json.Unmarshal(raw, &tools) != nil {
+		return "", ""
+	}
+	var fallback declaredTool
+	for _, t := range tools {
+		name := strings.ToLower(t.name())
+		if !strings.Contains(name, "deja") {
+			continue
+		}
+		if t.Type == "namespace" || len(t.Tools) > 0 {
+			if inner, args := recallInNamespace(t, query); inner != "" {
+				return inner, args
+			}
+			continue
+		}
+		if strings.Contains(name, "recall") && !strings.Contains(name, "context") {
+			return t.name(), queryArguments(t.schema(), query)
+		}
+		if fallback.name() == "" {
+			fallback = t
+		}
+	}
+	if fallback.name() == "" {
+		return "", ""
+	}
+	return fallback.name(), queryArguments(fallback.schema(), query)
+}
+
+// recallInNamespace returns the name of the recall tool inside a namespace
+// entry. The namespace declares no parameters of its own and its tools carry
+// plain names, so the call goes to the plain name; both qualified forms —
+// namespace.tool and namespace__tool — are rejected by codex's router.
+func recallInNamespace(ns declaredTool, query string) (string, string) {
+	var first declaredTool
+	for _, t := range ns.Tools {
+		name := strings.ToLower(t.name())
+		if strings.Contains(name, "recall") && !strings.Contains(name, "context") {
+			return t.name(), queryArguments(t.schema(), query)
+		}
+		if first.name() == "" {
+			first = t
+		}
+	}
+	if first.name() == "" {
+		return "", ""
+	}
+	return first.name(), queryArguments(first.schema(), query)
+}
+
+// queryArguments renders the search text under whichever property the tool's
+// schema names for it.
+func queryArguments(schema json.RawMessage, query string) string {
+	var doc struct {
+		Properties map[string]struct {
+			Type string `json:"type"`
+		} `json:"properties"`
+		Required []string `json:"required"`
+	}
+	_ = json.Unmarshal(schema, &doc)
+	for _, key := range []string{"query", "q", "search", "terms", "text", "prompt"} {
+		if _, ok := doc.Properties[key]; ok {
+			return `{"` + key + `":` + strconv.Quote(query) + `}`
+		}
+	}
+	// A required property this mock does not know about would make the call
+	// fail on arrival; naming the commonest one keeps the failure legible.
+	return `{"query":` + strconv.Quote(query) + `}`
+}
+
+// commandArguments renders the command under the property the schema names for
+// it, as the type the schema asks for.
+func commandArguments(schema json.RawMessage, command string) string {
+	var doc struct {
+		Properties map[string]struct {
+			Type string `json:"type"`
+		} `json:"properties"`
+	}
+	_ = json.Unmarshal(schema, &doc)
+	for _, key := range []string{"command", "cmd", "commands", "script"} {
+		prop, ok := doc.Properties[key]
+		if !ok {
+			continue
+		}
+		if prop.Type == "array" {
+			argv, _ := json.Marshal([]string{"/bin/sh", "-c", command})
+			return `{"` + key + `":` + string(argv) + `}`
+		}
+		return `{"` + key + `":` + strconv.Quote(command) + `}`
+	}
+	// No property this mock recognises: fall back to the commonest spelling
+	// rather than sending nothing, so the failure is visible in the harness's
+	// own error instead of as silence.
+	return `{"command":` + strconv.Quote(command) + `}`
+}
+
+type server struct {
+	reply string
+	// toolCall makes the first answer a call to the harness's shell tool
+	// instead of text. Nothing else exercises what a harness does around a
+	// tool — its PreToolUse hooks, its approval flow — and a mock that only
+	// ever talks leaves that whole path untested.
+	toolCall string
+	// toolArg is the command the call asks for. It matters: deja's PreToolUse
+	// hook speaks only about commands the history has seen, so a fixed `echo`
+	// made every run look like a hook that produces nothing.
+	toolArg string
+	mu      sync.Mutex
+	logw    *os.File
+}
+
+// resolveTool returns the tool this request should be answered with: the one
+// named on the command line, or — with "auto" — whatever this harness calls
+// its shell.
+func (s *server) resolveTool(req request) (string, string) {
+	if s.toolCall == "" {
+		return "", ""
+	}
+	// Once per conversation, not once per process: a sweep points every
+	// harness at one mock, and a process-wide flag meant the first harness
+	// took the only tool call and every later one silently got prose — which
+	// reads exactly like a harness that refuses to use tools.
+	if alreadyCalled(req) {
+		return "", ""
+	}
+	switch s.toolCall {
+	case "auto":
+		return shellTool(req.Tools, s.toolArg)
+	case "recall":
+		// The MCP path end to end: whether the server deja installs is
+		// actually reachable from inside the harness and answers. Every other
+		// check reads what deja put in the request; this one makes the harness
+		// come back to deja for it.
+		return recallTool(req.Tools, s.toolArg)
+	}
+	return s.toolCall, commandArguments(nil, s.toolArg)
+}
+
+// alreadyCalled reports whether this conversation already carries the result of
+// a call, in any of the three protocols' spellings. Asking again would loop.
+func alreadyCalled(req request) bool {
+	var b strings.Builder
+	for _, m := range req.Messages {
+		// Chat completions send the result as its own message, whose only
+		// marks are the role and a tool_call_id this struct does not keep.
+		// Matching on the body alone missed it, and the mock then asked for
+		// the same call again on every turn.
+		if m.Role == "tool" {
+			return true
+		}
+		b.WriteString(m.Role)
+		b.Write(m.Content)
+	}
+	b.Write(req.Input)
+	body := b.String()
+	for _, marker := range []string{"tool_result", "function_call_output",
+		"call_mock", "toolu_mock", "fc_mock"} {
+		if strings.Contains(body, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *server) record(path string, msgs []message) {
+	s.recordWith(path, msgs, nil)
+}
+
+// recordWith also stores the tool names the request declared. Without them a
+// run that produced no tool call is unreadable: it looks the same whether the
+// harness offered nothing, offered something under a name the mock did not
+// recognise, or refused the call.
+func (s *server) recordWith(path string, msgs []message, tools []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.logw == nil {
+		return
+	}
+	rec := struct {
+		Path     string    `json:"path"`
+		At       time.Time `json:"at"`
+		Messages []message `json:"messages"`
+		Tools    []string  `json:"tools,omitempty"`
+	}{path, time.Now().UTC(), msgs, tools}
+	if b, err := json.Marshal(rec); err == nil {
+		fmt.Fprintln(s.logw, string(b))
+	}
+}
+
+func writeJSON(w http.ResponseWriter, code int, body any) {
+	b, _ := json.Marshal(body)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", fmt.Sprint(len(b)))
+	w.WriteHeader(code)
+	_, _ = w.Write(b)
+}
+
+// sse writes one server-sent event and flushes: a harness reading a stream
+// receives nothing until the writer flushes, and several of them only stream.
+func sse(w http.ResponseWriter, event string, data any) {
+	b, _ := json.Marshal(data)
+	if event != "" {
+		fmt.Fprintf(w, "event: %s\n", event)
+	}
+	fmt.Fprintf(w, "data: %s\n\n", b)
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (s *server) models(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"object": "list",
+		"data":   []any{map[string]any{"id": model, "object": "model", "created": time.Now().Unix()}},
+	})
+}
+
+// systemAfterUser is the rule a strict endpoint enforces and the one deja
+// tripped on. Reporting it as a 400 rather than accepting it is the whole
+// point: a mock that is more forgiving than production tests nothing.
+func systemAfterUser(msgs []message) bool {
+	for i, m := range msgs {
+		if m.Role == "system" && i > 0 && msgs[i-1].Role != "system" {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *server) chat(w http.ResponseWriter, r *http.Request, req request) {
+	s.recordWith(r.URL.Path, req.Messages, toolNames(req.Tools))
+	tool, toolArgs := s.resolveTool(req)
+	if systemAfterUser(req.Messages) {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"error": map[string]any{"message": "System message must be at the beginning."},
+		})
+		return
+	}
+	// One call, on the first turn only, the same rule the responses path
+	// follows: the harness sends the result back, and asking again loops.
+	// Without this the whole PreToolUse surface — deja's hook-tool, which
+	// several harnesses wire — went untested against every harness that
+	// speaks chat completions rather than responses.
+	if tool != "" {
+		call := map[string]any{"id": "call_mock", "type": "function",
+			"function": map[string]any{"name": tool,
+				"arguments": toolArgs}}
+		if !req.Stream {
+			writeJSON(w, http.StatusOK, map[string]any{
+				"id": "mock", "object": "chat.completion", "created": time.Now().Unix(), "model": model,
+				"choices": []any{map[string]any{"index": 0, "finish_reason": "tool_calls",
+					"message": map[string]any{"role": "assistant", "content": nil,
+						"tool_calls": []any{call}}}},
+				"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+			})
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		streamed := map[string]any{"index": 0, "id": "call_mock", "type": "function",
+			"function": map[string]any{"name": tool,
+				"arguments": toolArgs}}
+		for _, chunk := range []map[string]any{
+			{"delta": map[string]any{"role": "assistant", "tool_calls": []any{streamed}}},
+			{"delta": map[string]any{}, "finish_reason": "tool_calls"},
+		} {
+			body := map[string]any{"id": "mock", "object": "chat.completion.chunk",
+				"created": time.Now().Unix(), "model": model}
+			choice := map[string]any{"index": 0, "delta": chunk["delta"]}
+			choice["finish_reason"] = chunk["finish_reason"]
+			body["choices"] = []any{choice}
+			sse(w, "", body)
+		}
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		return
+	}
+	if !req.Stream {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"id": "mock", "object": "chat.completion", "created": time.Now().Unix(), "model": model,
+			"choices": []any{map[string]any{"index": 0, "finish_reason": "stop",
+				"message": map[string]any{"role": "assistant", "content": s.reply}}},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+		})
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	base := map[string]any{"id": "mock", "object": "chat.completion.chunk",
+		"created": time.Now().Unix(), "model": model}
+	for _, delta := range []any{
+		map[string]any{"role": "assistant"},
+		map[string]any{"content": s.reply},
+		map[string]any{},
+	} {
+		chunk := map[string]any{}
+		for k, v := range base {
+			chunk[k] = v
+		}
+		finish := any(nil)
+		if len(delta.(map[string]any)) == 0 {
+			finish = "stop"
+		}
+		chunk["choices"] = []any{map[string]any{"index": 0, "delta": delta, "finish_reason": finish}}
+		sse(w, "", chunk)
+	}
+	// The terminator is a literal, not a JSON string: quoting it made a real
+	// harness fail with `Type validation failed: Value: "[DONE]"`.
+	fmt.Fprint(w, "data: [DONE]\n\n")
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (s *server) responses(w http.ResponseWriter, r *http.Request, req request) {
+	tool, toolArgs := s.resolveTool(req)
+	s.recordWith(r.URL.Path, []message{
+		{Role: "instructions", Content: json.RawMessage(strconv.Quote(req.Instructions))},
+		{Role: "input", Content: req.Input},
+	}, toolNames(req.Tools))
+	output := []any{map[string]any{"id": "msg_mock", "type": "message", "role": "assistant",
+		"status":  "completed",
+		"content": []any{map[string]any{"type": "output_text", "text": s.reply, "annotations": []any{}}}}}
+	// One call per conversation: the harness sends the result back, and asking
+	// again would loop. resolveTool decides that from the request.
+	if tool != "" {
+		output = []any{map[string]any{
+			"id": "fc_mock", "type": "function_call", "status": "completed",
+			"name": tool, "call_id": "call_mock",
+			"arguments": toolArgs,
+		}}
+	}
+	body := map[string]any{
+		"id": "resp_mock", "object": "response", "created_at": time.Now().Unix(),
+		"status": "completed", "model": model,
+		"output": output,
+		"usage":  map[string]any{"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+	}
+	if !req.Stream {
+		writeJSON(w, http.StatusOK, body)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	inProgress := map[string]any{}
+	for k, v := range body {
+		inProgress[k] = v
+	}
+	inProgress["status"] = "in_progress"
+	inProgress["output"] = []any{}
+	sse(w, "response.created", map[string]any{"type": "response.created", "response": inProgress})
+	// A streamed function call is its own event sequence. Streaming text
+	// deltas and then completing with a function_call in the output is a
+	// response no client can reconcile: codex took it as a disconnected
+	// stream and gave up before running anything.
+	if item, ok := output[0].(map[string]any); ok && item["type"] == "function_call" {
+		sse(w, "response.output_item.added", map[string]any{
+			"type": "response.output_item.added", "output_index": 0, "item": item})
+		sse(w, "response.function_call_arguments.delta", map[string]any{
+			"type": "response.function_call_arguments.delta", "item_id": "fc_mock",
+			"output_index": 0, "delta": item["arguments"]})
+		sse(w, "response.function_call_arguments.done", map[string]any{
+			"type": "response.function_call_arguments.done", "item_id": "fc_mock",
+			"output_index": 0, "arguments": item["arguments"]})
+		sse(w, "response.output_item.done", map[string]any{
+			"type": "response.output_item.done", "output_index": 0, "item": item})
+		sse(w, "response.completed", map[string]any{"type": "response.completed", "response": body})
+		return
+	}
+	sse(w, "response.output_text.delta", map[string]any{
+		"type": "response.output_text.delta", "item_id": "msg_mock",
+		"output_index": 0, "content_index": 0, "delta": s.reply})
+	sse(w, "response.completed", map[string]any{"type": "response.completed", "response": body})
+}
+
+func (s *server) messages(w http.ResponseWriter, r *http.Request, req request) {
+	msgs := req.Messages
+	if len(req.System) > 0 {
+		msgs = append([]message{{Role: "system", Content: req.System}}, msgs...)
+	}
+	s.recordWith(r.URL.Path, msgs, toolNames(req.Tools))
+	body := map[string]any{
+		"id": "msg_mock", "type": "message", "role": "assistant", "model": model,
+		"content":     []any{map[string]any{"type": "text", "text": s.reply}},
+		"stop_reason": "end_turn", "stop_sequence": nil,
+		"usage": map[string]any{"input_tokens": 1, "output_tokens": 1},
+	}
+	// The tool call, on the first turn only, as on the other two paths. This
+	// is what puts deja's PreToolUse hook under test: it is wired for Claude,
+	// codex and grok, and of those only Claude runs hooks headless.
+	if tool, args := s.resolveTool(req); tool != "" {
+		var input map[string]any
+		_ = json.Unmarshal([]byte(args), &input)
+		body["content"] = []any{map[string]any{
+			"type": "tool_use", "id": "toolu_mock", "name": tool,
+			"input": input,
+		}}
+		body["stop_reason"] = "tool_use"
+	}
+	if !req.Stream {
+		writeJSON(w, http.StatusOK, body)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	start := map[string]any{}
+	for k, v := range body {
+		start[k] = v
+	}
+	start["content"] = []any{}
+	sse(w, "message_start", map[string]any{"type": "message_start", "message": start})
+	if block, ok := body["content"].([]any); ok && len(block) > 0 {
+		if first, ok := block[0].(map[string]any); ok && first["type"] == "tool_use" {
+			sse(w, "content_block_start", map[string]any{"type": "content_block_start",
+				"index": 0, "content_block": map[string]any{"type": "tool_use",
+					"id": first["id"], "name": first["name"], "input": map[string]any{}}})
+			raw, _ := json.Marshal(first["input"])
+			sse(w, "content_block_delta", map[string]any{"type": "content_block_delta",
+				"index": 0, "delta": map[string]any{"type": "input_json_delta",
+					"partial_json": string(raw)}})
+			sse(w, "content_block_stop", map[string]any{"type": "content_block_stop", "index": 0})
+			sse(w, "message_delta", map[string]any{"type": "message_delta",
+				"delta": map[string]any{"stop_reason": "tool_use", "stop_sequence": nil},
+				"usage": map[string]any{"output_tokens": 1}})
+			sse(w, "message_stop", map[string]any{"type": "message_stop"})
+			return
+		}
+	}
+	sse(w, "content_block_start", map[string]any{"type": "content_block_start", "index": 0,
+		"content_block": map[string]any{"type": "text", "text": ""}})
+	sse(w, "content_block_delta", map[string]any{"type": "content_block_delta", "index": 0,
+		"delta": map[string]any{"type": "text_delta", "text": s.reply}})
+	sse(w, "content_block_stop", map[string]any{"type": "content_block_stop", "index": 0})
+	sse(w, "message_delta", map[string]any{"type": "message_delta",
+		"delta": map[string]any{"stop_reason": "end_turn", "stop_sequence": nil},
+		"usage": map[string]any{"output_tokens": 1}})
+	sse(w, "message_stop", map[string]any{"type": "message_stop"})
+}
+
+func (s *server) post(w http.ResponseWriter, r *http.Request) {
+	var req request
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	path := strings.TrimSuffix(r.URL.Path, "/")
+	switch {
+	case strings.HasSuffix(path, "/responses"):
+		s.responses(w, r, req)
+	case strings.HasSuffix(path, "/messages"):
+		s.messages(w, r, req)
+	default:
+		s.chat(w, r, req)
+	}
+}
+
+func main() {
+	port := flag.Int("port", 18777, "port to listen on")
+	logPath := flag.String("log", "", "write every request here as JSON lines")
+	reply := flag.String("reply", "47", "what the model answers")
+	toolCall := flag.String("tool-call", "", "answer the first turn by calling this tool (e.g. shell)")
+	toolArg := flag.String("tool-arg", "echo mockmodel probe",
+		"the command -tool-call asks for; use one the corpus has run to exercise the PreToolUse hook")
+	flag.Parse()
+
+	s := &server{reply: *reply, toolCall: *toolCall, toolArg: *toolArg}
+	if *logPath != "" {
+		f, err := os.Create(*logPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		s.logw = f
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			s.models(w, r)
+			return
+		}
+		s.post(w, r)
+	})
+	addr := fmt.Sprintf("127.0.0.1:%d", *port)
+	fmt.Printf("mockmodel on http://%s/v1 (log %q)\n", addr, *logPath)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}

--- a/scripts/mockmodel/main_test.go
+++ b/scripts/mockmodel/main_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func post(t *testing.T, s *server, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	w := httptest.NewRecorder()
+	s.post(w, r)
+	return w
+}
+
+// The stream terminator is a literal. Marshalling it like every other event
+// wrote `data: "[DONE]"`, and a real harness stopped on it with
+// `Type validation failed: Value: "[DONE]"` — the mock's own bug, found by
+// pointing an actual client at it.
+func TestChatStreamEndsWithALiteralDone(t *testing.T) {
+	s := &server{reply: "47"}
+	w := post(t, s, "/v1/chat/completions", `{"stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+	body := w.Body.String()
+	if !strings.Contains(body, "data: [DONE]") {
+		t.Fatalf("no terminator in the stream:\n%s", body)
+	}
+	if strings.Contains(body, `data: "[DONE]"`) {
+		t.Fatalf("the terminator is quoted:\n%s", body)
+	}
+	if !strings.Contains(body, `"content":"47"`) {
+		t.Fatalf("the reply never arrived:\n%s", body)
+	}
+}
+
+// Being stricter than a permissive endpoint is the point: this is the rule
+// deja's opencode plugin broke, and a mock that accepted it would have proved
+// the bug absent.
+func TestSystemAfterUserIsRejected(t *testing.T) {
+	s := &server{reply: "47"}
+	w := post(t, s, "/v1/chat/completions",
+		`{"messages":[{"role":"user","content":"hi"},{"role":"system","content":"late"}]}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "System message must be at the beginning") {
+		t.Fatalf("wrong error: %s", w.Body.String())
+	}
+
+	// System first is the shape deja was fixed to produce.
+	ok := post(t, s, "/v1/chat/completions",
+		`{"messages":[{"role":"system","content":"recall"},{"role":"user","content":"hi"}]}`)
+	if ok.Code != http.StatusOK {
+		t.Fatalf("system-first was rejected: %d %s", ok.Code, ok.Body.String())
+	}
+}
+
+// Each protocol has to answer in its own shape, or the harness that speaks it
+// cannot be swept at all — codex speaks only the responses API, Claude Code
+// only the Anthropic one.
+func TestEveryProtocolAnswers(t *testing.T) {
+	s := &server{reply: "47"}
+	for _, tc := range []struct{ path, body, want string }{
+		{"/v1/chat/completions", `{"messages":[{"role":"user","content":"hi"}]}`, "chat.completion"},
+		{"/v1/responses", `{"input":"hi"}`, "output_text"},
+		{"/v1/messages", `{"messages":[{"role":"user","content":"hi"}],"system":"recall"}`, "end_turn"},
+	} {
+		w := post(t, s, tc.path, tc.body)
+		if w.Code != http.StatusOK {
+			t.Errorf("%s: status %d", tc.path, w.Code)
+			continue
+		}
+		if !strings.Contains(w.Body.String(), tc.want) {
+			t.Errorf("%s: answer does not look like its protocol:\n%s", tc.path, w.Body.String())
+		}
+		var v any
+		if err := json.Unmarshal(w.Body.Bytes(), &v); err != nil {
+			t.Errorf("%s: invalid JSON: %v", tc.path, err)
+		}
+	}
+}

--- a/scripts/mockmodel/tools_test.go
+++ b/scripts/mockmodel/tools_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Every harness names its shell tool differently and declares a different
+// argument shape for it. A mock that hardcodes either calls something the
+// harness does not have, or calls it wrongly — and the run then looks like a
+// harness that ignores tools, which is what it looked like for two of three.
+func TestShellToolComesFromWhatTheHarnessDeclared(t *testing.T) {
+	for _, tc := range []struct {
+		name, tools, wantName, wantArgs string
+	}{
+		{
+			name:     "chat completions, string argument",
+			tools:    `[{"type":"function","function":{"name":"bash","parameters":{"type":"object","properties":{"command":{"type":"string"}}}}}]`,
+			wantName: "bash",
+			wantArgs: `{"command":"npm run build"}`,
+		},
+		{
+			name:     "responses, a different property name",
+			tools:    `[{"type":"function","name":"exec_command","parameters":{"type":"object","properties":{"cmd":{"type":"string"}}}}]`,
+			wantName: "exec_command",
+			wantArgs: `{"cmd":"npm run build"}`,
+		},
+		{
+			name:     "an argv array rather than a string",
+			tools:    `[{"type":"function","name":"shell","parameters":{"type":"object","properties":{"command":{"type":"array"}}}}]`,
+			wantName: "shell",
+			wantArgs: `{"command":["/bin/sh","-c","npm run build"]}`,
+		},
+		{
+			name:     "messages, input_schema",
+			tools:    `[{"name":"Bash","input_schema":{"type":"object","properties":{"command":{"type":"string"}}}}]`,
+			wantName: "Bash",
+			wantArgs: `{"command":"npm run build"}`,
+		},
+		{
+			name:  "nothing that runs a command",
+			tools: `[{"name":"read_file"},{"name":"web_search"}]`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			name, args := shellTool(json.RawMessage(tc.tools), "npm run build")
+			if name != tc.wantName {
+				t.Fatalf("tool = %q, want %q", name, tc.wantName)
+			}
+			if name != "" && args != tc.wantArgs {
+				t.Fatalf("arguments = %s, want %s", args, tc.wantArgs)
+			}
+		})
+	}
+}
+
+// deja's MCP tools carry the harness's own prefix, so the recall tool cannot be
+// named on the command line either.
+func TestRecallToolIsFoundUnderAnyPrefix(t *testing.T) {
+	for _, tools := range []string{
+		`[{"name":"deja__recall","input_schema":{"type":"object","properties":{"query":{"type":"string"}}}}]`,
+		`[{"type":"function","function":{"name":"mcp__deja__recall","parameters":{"type":"object","properties":{"query":{"type":"string"}}}}}]`,
+	} {
+		name, args := recallTool(json.RawMessage(tools), "billing gateway")
+		if !strings.Contains(name, "recall") {
+			t.Errorf("no recall tool found in %s", tools)
+		}
+		if !strings.Contains(args, "billing gateway") {
+			t.Errorf("the query did not reach the arguments: %s", args)
+		}
+	}
+	// A harness that exposes deja under one entry rather than one per tool.
+	name, _ := recallTool(json.RawMessage(`[{"name":"mcp__deja"}]`), "x")
+	if name != "mcp__deja" {
+		t.Errorf("the single-entry form was not used: %q", name)
+	}
+	if name, _ := recallTool(json.RawMessage(`[{"name":"read_file"}]`), "x"); name != "" {
+		t.Errorf("a harness without deja's tools returned %q", name)
+	}
+}
+
+// One tool call per conversation, decided from the request. A flag on the
+// server meant the first harness in a sweep took the only call and every later
+// one silently got prose instead.
+func TestToolCallHappensOncePerConversation(t *testing.T) {
+	s := &server{reply: "47", toolCall: "auto", toolArg: "npm run build"}
+	tools := `"tools":[{"type":"function","function":{"name":"bash","parameters":{"type":"object","properties":{"command":{"type":"string"}}}}}]`
+
+	first := post(t, s, "/v1/chat/completions",
+		`{`+tools+`,"messages":[{"role":"user","content":"build it"}]}`)
+	if !strings.Contains(first.Body.String(), "tool_calls") {
+		t.Fatalf("no tool call on the opening turn:\n%s", first.Body.String())
+	}
+	// The same conversation, now carrying the result.
+	second := post(t, s, "/v1/chat/completions",
+		`{`+tools+`,"messages":[{"role":"user","content":"build it"},`+
+			`{"role":"assistant","content":null},`+
+			`{"role":"tool","tool_call_id":"call_mock","content":"ok"}]}`)
+	if strings.Contains(second.Body.String(), "tool_calls") {
+		t.Errorf("asked for the same call again, which loops the harness:\n%s",
+			second.Body.String())
+	}
+	// A different conversation still gets one.
+	third := post(t, s, "/v1/chat/completions",
+		`{`+tools+`,"messages":[{"role":"user","content":"build it again"}]}`)
+	if !strings.Contains(third.Body.String(), "tool_calls") {
+		t.Errorf("a fresh conversation got no tool call:\n%s", third.Body.String())
+	}
+}


### PR DESCRIPTION
Nothing here changes deja. It is the rig that drives the harnesses, split out of #1217 so the product changes can be read on their own.

Everything else deja tests answers a narrower question than the one that matters. The install tests say the files are written and parse; the benchmarks say the ranking is good. Neither says whether a harness, given those files, carries the recall into what it sends the model — which is the whole product.

**`scripts/mockmodel`** stands in for a model. It serves the three wire protocols the harnesses speak, answers instantly, and logs every request it received. It also enforces one rule a real endpoint enforces and a permissive mock would not: a system message may not follow a user message. That rule is why it exists — deja's opencode plugin appended its recall as a second system block and every turn against a strict endpoint failed, which no other kind of test could see.

It can answer with a tool call rather than prose, and that is what puts deja's PreToolUse hook under test for the first time. The tool's name and argument shape come from the request rather than from a flag: harnesses disagree on both — `Bash` taking `command` as a string, `exec_command` taking `cmd`, another taking an argv array, and codex declaring its MCP server as one namespace entry holding its tools. Every one of those was a run that looked like a harness ignoring tools until the mock read the declaration instead of guessing.

**`scripts/harnesssweep`** installs deja into an empty home per harness, drives one turn, and reports what arrived. Three things it learned to separate, each after reporting a defect that was not one:

- recall that *arrives* versus recall that *answers the question asked*. A harness can pass every other check and still be handed memory chosen before the user typed anything.
- a harness with no prompt-time channel at all (aider has neither hooks nor an MCP client) versus one where deja simply is not using the channel that exists.
- the binary on PATH not being the product deja wires. Two different tools ship as `grok`; the community CLI shares `~/.grok` and reads no hooks.

**`scripts/mkcorpus`** generates the corpus a sweep needs. The planted interval is a flag rather than a constant because an agent with tools reads the repository: given permission to run commands, one harness answered "47 days" out of this file with no memory involved, in the arm that was supposed to have none.

**`scripts/mcpprobe`** exercises the MCP server directly, and `day0bench` gains a reproducible context column.

No product code is touched, so there is nothing here to regress. The findings this rig produced are in the PRs that follow.
