### PR TITLE
fix(search): hang the relevance ranking under a thin AND

### DIFF
--- a/internal/index/cooccur.go
+++ b/internal/index/cooccur.go
@@ -31,22 +31,45 @@ func buildCooccur(tmp string, ss []model.Session) {
 	if len(ss) < cooccurMinDF || len(ss) > cooccurMaxSessions {
 		return
 	}
-	df := map[string]int{}
-	perSession := make([][]string, 0, len(ss))
+	// Tokens become dense ids once, so the pair pass hashes integers instead
+	// of strings. That inner loop runs for every pair of every session's kept
+	// tokens — thousands of sessions times up to 64 tokens each — and string
+	// hashing there was most of what a cold build spent on this map.
+	ids := map[string]uint32{}
+	var toks []string
+	id := func(t string) uint32 {
+		if v, ok := ids[t]; ok {
+			return v
+		}
+		v := uint32(len(toks))
+		ids[t] = v
+		toks = append(toks, t)
+		return v
+	}
+	var df []int
+	perSession := make([][]uint32, 0, len(ss))
+	seen := map[uint32]bool{}
 	for _, s := range ss {
-		seen := map[string]bool{}
+		clear(seen)
 		for _, m := range s.Messages {
 			for _, tok := range tokens(m.Text) {
-				if len(tok) < 4 || query.IsStopWord(tok) || seen[tok] {
+				if len(tok) < 4 || query.IsStopWord(tok) {
 					continue
 				}
-				seen[tok] = true
+				v := id(tok)
+				if seen[v] {
+					continue
+				}
+				seen[v] = true
 			}
 		}
-		list := make([]string, 0, len(seen))
-		for tok := range seen {
-			list = append(list, tok)
-			df[tok]++
+		list := make([]uint32, 0, len(seen))
+		for v := range seen {
+			list = append(list, v)
+			for len(df) <= int(v) {
+				df = append(df, 0)
+			}
+			df[v]++
 		}
 		perSession = append(perSession, list)
 	}
@@ -54,20 +77,24 @@ func buildCooccur(tmp string, ss []model.Session) {
 	if maxDF < 8 {
 		maxDF = 8
 	}
-	band := func(tok string) bool { return df[tok] >= cooccurMinDF && df[tok] <= maxDF }
+	band := func(v uint32) bool { return df[v] >= cooccurMinDF && df[v] <= maxDF }
 
-	pairs := map[string]map[string]int{}
+	// One packed key per unordered pair, canonical by id. The neighbour pass
+	// below expands it back to both sides, so which side is canonical never
+	// reaches the output.
+	pairs := map[uint64]int{}
+	kept := make([]uint32, 0, cooccurTokensPerSn)
 	for _, list := range perSession {
-		kept := make([]string, 0, len(list))
-		for _, tok := range list {
-			if band(tok) {
-				kept = append(kept, tok)
+		kept = kept[:0]
+		for _, v := range list {
+			if band(v) {
+				kept = append(kept, v)
 			}
 		}
 		// rarest first, capped: ubiquitous sessions must not explode the map
 		sort.Slice(kept, func(i, j int) bool {
 			if df[kept[i]] == df[kept[j]] {
-				return kept[i] < kept[j]
+				return toks[kept[i]] < toks[kept[j]]
 			}
 			return df[kept[i]] < df[kept[j]]
 		})
@@ -76,18 +103,11 @@ func buildCooccur(tmp string, ss []model.Session) {
 		}
 		for i := 0; i < len(kept); i++ {
 			for j := i + 1; j < len(kept); j++ {
-				// Store each unordered pair once, in canonical order. The map
-				// used to hold both a→b and b→a, doubling the largest structure
-				// of the build; the neighbor pass below expands it back to both
-				// sides (#1137).
 				a, b := kept[i], kept[j]
 				if a > b {
 					a, b = b, a
 				}
-				if pairs[a] == nil {
-					pairs[a] = map[string]int{}
-				}
-				pairs[a][b]++
+				pairs[uint64(a)<<32|uint64(b)]++
 			}
 		}
 	}
@@ -99,14 +119,13 @@ func buildCooccur(tmp string, ss []model.Session) {
 	// the half-map rebuilds the full candidate lists. Filtering at threshold
 	// here keeps the transient cand map to the pairs that can actually survive.
 	cand := map[string][]nc{}
-	for a, ns := range pairs {
-		for b, c := range ns {
-			if c < cooccurMinPair {
-				continue
-			}
-			cand[a] = append(cand[a], nc{b, c})
-			cand[b] = append(cand[b], nc{a, c})
+	for key, c := range pairs {
+		if c < cooccurMinPair {
+			continue
 		}
+		a, b := toks[uint32(key>>32)], toks[uint32(key)]
+		cand[a] = append(cand[a], nc{b, c})
+		cand[b] = append(cand[b], nc{a, c})
 	}
 	neighbors := map[string][]string{}
 	for tok, list := range cand {

--- a/internal/index/fuzzy_known_test.go
+++ b/internal/index/fuzzy_known_test.go
@@ -1,0 +1,73 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A word the corpus is full of gains nothing from its neighbours: it is not a
+// typo, and widening it only adds postings that discriminate nothing. This is
+// what keeps an ordinary question off the candidate walk. A rare word is still
+// widened even when spelled correctly, because there a near-neighbour is
+// usually the same thing said differently — measured: narrowing those too cost
+// longmemeval hit@5 2.5 points.
+func TestFuzzyWidensRareWordsAndLeavesCommonOnesAlone(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-w-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// "deploy" lands well past the common bar; "rice" and "ice" stay rare and
+	// one edit apart. The bar counts postings, which are per message, so one
+	// busy session carries it — a file per posting made this the slowest test
+	// in the package on Windows.
+	var busy strings.Builder
+	for i := range commonTokenPostings + 20 {
+		fmt.Fprintf(&busy, "we deploy the service again, run %d\n", i)
+	}
+	writeMessages(t, proj, "common", busy.String())
+	writeSession(t, proj, "rice", "jasmine rice is the one I keep buying")
+	writeSession(t, proj, "ice", "the ice machine in the hotel was broken")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	_, variants, err := fuzzyPostings(dir, []string{"deploy"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := variants["deploy"]; len(v) != 1 || v[0] != "deploy" {
+		t.Fatalf("a word the corpus is full of was widened to %v", v)
+	}
+
+	_, variants, err = fuzzyPostings(dir, []string{"rice"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(variants["rice"]) < 2 {
+		t.Fatalf("a rare word lost its neighbours: %v", variants["rice"])
+	}
+
+	// A real typo still has to reach the word behind it.
+	_, variants, err = fuzzyPostings(dir, []string{"rcie"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, v := range variants["rcie"] {
+		if v == "rice" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("typo no longer reaches the word it meant: %v", variants["rcie"])
+	}
+}

--- a/internal/index/locked_read_test.go
+++ b/internal/index/locked_read_test.go
@@ -1,0 +1,66 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A rebuild holds the index lock, and rebuilds happen on their own schedule —
+// after an upgrade, in the background, on the first run of a new format. The
+// read paths a hook uses take that lock without blocking on purpose, because
+// waiting would stall the agent for the whole rebuild. Nothing checked either
+// half of that: not that the read still answers, and not that it returns at
+// all rather than waiting.
+func TestReadsAnswerWhileTheIndexLockIsHeld(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z",` +
+		`"message":{"role":"user","content":"the quetzalcoatl migration"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hold it the way a rebuild does.
+	unlock, ok, err := tryLockDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("could not take the lock this test is about")
+	}
+	defer unlock()
+
+	done := make(chan struct{})
+	var got int
+	go func() {
+		defer close(done)
+		sessions, _, _, rerr := ProjectRelevant(dir, []string{"app"},
+			[]string{"quetzalcoatl"}, 2)
+		if rerr != nil {
+			t.Errorf("read under the lock: %v", rerr)
+		}
+		got = len(sessions)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the read waited on the lock; a hook doing this stalls the agent " +
+			"for the length of a rebuild")
+	}
+	if got == 0 {
+		t.Error("the read returned nothing while a rebuild held the lock, so " +
+			"recall goes silent for the length of every rebuild")
+	}
+}

--- a/internal/index/relevance_tail_test.go
+++ b/internal/index/relevance_tail_test.go
@@ -1,0 +1,171 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// seedFiller writes n sessions of unrelated chatter, so the store is bigger
+// than the window the relevance tail is drawn from. Below that size the tail
+// stays off by design and none of this applies.
+func seedFiller(t *testing.T, proj string, n int) {
+	t.Helper()
+	for i := range n {
+		sid := fmt.Sprintf("filler-%d", i)
+		line := `{"type":"user","sessionId":"` + sid + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"routine standup chatter number ` + fmt.Sprint(i) + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func writeSession(t *testing.T, proj, sid, text string) {
+	t.Helper()
+	line := `{"type":"user","sessionId":"` + sid + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeMessages puts one session on disk carrying a message per line, for the
+// tests that need many postings rather than many sessions.
+func writeMessages(t *testing.T, proj, sid, body string) {
+	t.Helper()
+	var b strings.Builder
+	for _, line := range strings.Split(strings.TrimSpace(body), "\n") {
+		b.WriteString(`{"type":"user","sessionId":"` + sid + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + line + `"}}` + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedStore(t *testing.T, filler int) string {
+	t.Helper()
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-w-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The session that answers the question, worded the way people actually
+	// write: it never says "own", so an AND over the question's words cannot
+	// reach it. It does carry two of them, which is the bar relevance sets —
+	// one lucky word is noise.
+	writeSession(t, proj, "answer", "not that many bikes really, both of mine live in the hallway")
+	// An incidental session that does satisfy the AND, on a completely
+	// different subject. This is what a strict match lands on.
+	writeSession(t, proj, "incidental", "many courier bikes own their routes downtown")
+	seedFiller(t, proj, filler)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestThinANDGetsRelevanceTailBeneathIt(t *testing.T) {
+	dir := seedStore(t, relevanceWindow+10)
+
+	r, err := SearchWithRecoveryDetailed(dir, query.Options{Query: "how many bikes do I own", All: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Sessions) < 2 {
+		t.Fatalf("tail did not run: %d session(s), tier %q", len(r.Sessions), r.Tier)
+	}
+	// The strict match keeps the first position. Relevance ranked alone scores
+	// worse there, so the tail must never push it down.
+	if r.Sessions[0].ID != "incidental" {
+		t.Fatalf("strict hit lost the top spot to %q", r.Sessions[0].ID)
+	}
+	found := false
+	for _, s := range r.Sessions {
+		if s.ID == "answer" {
+			found = true
+		}
+	}
+	if !found {
+		ids := make([]string, 0, len(r.Sessions))
+		for _, s := range r.Sessions {
+			ids = append(ids, s.ID)
+		}
+		t.Fatalf("the answer the AND excluded is still unreachable: %v", ids)
+	}
+	// Order is the contract: RelevanceHits scores by arrival, so the merged
+	// list has to be labelled as the tier that preserves it.
+	if r.Tier != query.TierRelevance {
+		t.Fatalf("tier = %q, want relevance so the merged order survives", r.Tier)
+	}
+	// The strict hit is inside the pool the ranking scored, so counting it
+	// again would tell the caller there is more behind the window than there
+	// is. The total may never be smaller than what was handed back either.
+	if r.Total < len(r.Sessions) {
+		t.Fatalf("total %d is under the %d sessions returned", r.Total, len(r.Sessions))
+	}
+	if r.Total > len(r.Sessions) != r.Capped {
+		t.Fatalf("capped=%v disagrees with total %d over %d sessions", r.Capped, r.Total, len(r.Sessions))
+	}
+}
+
+func TestWordFormFallbackKeepsItsAnnotationUnderTheTail(t *testing.T) {
+	dir := seedStore(t, relevanceWindow+10)
+
+	// "biked" has no postings of its own; the ladder reaches the corpus
+	// through the stem fold, and that fallback is worth telling the user
+	// about even once relevance owns the order.
+	r, err := SearchWithRecoveryDetailed(dir, query.Options{Query: "how many biked hallway", All: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Sessions) == 0 {
+		t.Skip("no word-form fallback for this corpus")
+	}
+	if r.Stemmed && len(r.Variants) == 0 {
+		t.Fatal("the stemmed notice survived but the word forms behind it did not")
+	}
+}
+
+func TestSmallStoreKeepsItsStrictAnswerAlone(t *testing.T) {
+	dir := seedStore(t, 3)
+
+	r, err := SearchWithRecoveryDetailed(dir, query.Options{Query: "how many bikes do I own", All: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Few results out of few sessions is an answer, not a symptom. Ranking a
+	// store smaller than the window returns most of it, which would attach the
+	// rest of the history to a precise query.
+	for _, s := range r.Sessions {
+		if s.ID != "incidental" {
+			t.Fatalf("small store got a tail: %q came back too", s.ID)
+		}
+	}
+}
+
+func TestWideANDIsLeftAlone(t *testing.T) {
+	dir := seedStore(t, relevanceWindow+10)
+
+	// A query the filler sessions all satisfy: the intersection is describing
+	// a real cluster, so nothing should be appended to it.
+	r, err := SearchWithRecoveryDetailed(dir, query.Options{Query: "routine standup chatter", All: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Sessions) < thinAND {
+		t.Fatalf("expected a wide AND, got %d sessions", len(r.Sessions))
+	}
+	for _, s := range r.Sessions {
+		if s.ID == "answer" {
+			t.Fatal("a wide AND was widened further by the tail")
+		}
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -150,12 +150,12 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 			if result, ferr := stemSearch(dir, m, o); ferr != nil {
 				return SearchResult{}, fmt.Errorf("stem postings: %w", ferr)
 			} else if result.Stemmed {
-				return result, nil
+				return withRelevanceTail(dir, m, o, result)
 			}
 			if result, ferr := fuzzySearch(dir, m, o); ferr != nil {
 				return SearchResult{}, fmt.Errorf("fuzzy postings: %w", ferr)
 			} else if result.Fuzzy {
-				return result, nil
+				return withRelevanceTail(dir, m, o, result)
 			}
 			// A pasted error that matched no postings is the case the word
 			// ladder cannot win: its identifiers are line numbers and hashes.
@@ -179,17 +179,17 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 		if result, ferr := stemSearch(dir, m, o); ferr != nil {
 			return SearchResult{}, fmt.Errorf("stem postings: %w", ferr)
 		} else if result.Stemmed {
-			return result, nil
+			return withRelevanceTail(dir, m, o, result)
 		}
 		if result, ferr := fuzzySearch(dir, m, o); ferr != nil {
 			return SearchResult{}, fmt.Errorf("fuzzy postings: %w", ferr)
 		} else if result.Fuzzy {
-			return result, nil
+			return withRelevanceTail(dir, m, o, result)
 		}
 		if result, ferr := cooccurSearch(dir, m, o); ferr != nil {
 			return SearchResult{}, fmt.Errorf("cooccur postings: %w", ferr)
 		} else if len(result.Sessions) > 0 {
-			return result, nil
+			return withRelevanceTail(dir, m, o, result)
 		}
 		// A pasted error that matched no postings is the case the word
 		// ladder cannot win: its identifiers are line numbers and hashes.
@@ -201,7 +201,96 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 		}
 		return relevanceSearch(dir, m, o)
 	}
-	return SearchResult{Sessions: ss, Tier: fallbackTier, Variants: fallbackVariants}, err
+	if err != nil {
+		return SearchResult{}, err
+	}
+	return withRelevanceTail(dir, m, o, SearchResult{Sessions: ss, Tier: fallbackTier, Variants: fallbackVariants})
+}
+
+// thinAND is how few sessions an AND has to return before its own strictness
+// becomes the suspect. A question asked in plain words requires every content
+// word to be present, so on a large history it lands on a handful of sessions
+// or on nothing — measured over a 1910-session corpus, the queries whose answer
+// never came back returned between one and eight. Above that the intersection
+// is describing a real cluster and needs no help.
+const thinAND = 10
+
+// withRelevanceTail keeps a thin AND result and hangs the relevance ranking
+// underneath it, so a question whose wording excluded the answer can still
+// reach it. The strict sessions stay in front: they are why hit@1 is what it
+// is, and relevance ranked alone scores worse at the first position.
+//
+// Order is the contract here. RelevanceHits scores by arrival (len-rank), so
+// the merged order survives to the caller untouched; anything that re-sorts
+// this by exact-match scoring would undo the point.
+func withRelevanceTail(dir string, m Manifest, o query.Options, res SearchResult) (SearchResult, error) {
+	ss := res.Sessions
+	if len(ss) == 0 || len(ss) >= thinAND {
+		return res, nil
+	}
+	// A store smaller than the window the tail is drawn from has nothing to
+	// rank: relevance would hand back most of it, which is a dump rather than
+	// a ranking, and a precise query would come back with the rest of the
+	// store attached. Few results out of few sessions is an answer, not a
+	// symptom; the case this exists for is a handful out of thousands.
+	if len(m.Sessions) <= relevanceWindow {
+		return res, nil
+	}
+	// relevanceSearch declines quoted phrases, regex, and queries with fewer
+	// than two informative words, which is exactly the set that wants its
+	// strict answer left alone.
+	rel, err := relevanceSearch(dir, m, o)
+	if err != nil || len(rel.Sessions) == 0 {
+		// A tail is an improvement, not a requirement: if ranking the whole
+		// store fails, the strict answer is still a correct answer.
+		return res, nil
+	}
+	seen := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		seen[s.Harness+":"+s.ID] = true
+	}
+	// The head arrives in posting order, not in any ranking: the tier that
+	// produced it expected the caller to rank it, and the caller cannot once
+	// this is labelled relevance. Order it by where the same sessions sit in
+	// the relevance pool, which is a real ranking over the same query, and
+	// leave anything the pool never scored at the back of the head.
+	relRank := make(map[string]int, len(rel.Sessions))
+	for i, r := range rel.Sessions {
+		relRank[r.Harness+":"+r.ID] = i
+	}
+	head := append([]model.Session(nil), ss...)
+	sort.SliceStable(head, func(i, j int) bool {
+		ri, oki := relRank[head[i].Harness+":"+head[i].ID]
+		rj, okj := relRank[head[j].Harness+":"+head[j].ID]
+		if oki != okj {
+			return oki
+		}
+		return oki && ri < rj
+	})
+	merged := head
+	added := 0
+	for _, r := range rel.Sessions {
+		if seen[r.Harness+":"+r.ID] {
+			continue
+		}
+		merged = append(merged, r)
+		added++
+	}
+	if added == 0 {
+		return res, nil
+	}
+	// A session that satisfies the AND carries every query key, so it is
+	// already inside the pool relevance scored, and adding the strict count on
+	// top would count it twice — that pool size is the total. The exception is
+	// a term the ranking derives rather than reads, a date from a relative
+	// word, which the AND never had to match; the floor keeps the total from
+	// claiming fewer sessions than were handed back.
+	out := relevanceResult(merged, max(rel.Total, len(merged)))
+	// Keep the word-form annotations the ladder earned: the caller still tells
+	// the user it fell back to stems or close spellings, even though the order
+	// is now this tier's to keep.
+	out.Stemmed, out.Fuzzy, out.Variants = res.Stemmed, res.Fuzzy, res.Variants
+	return out, nil
 }
 
 // RelevanceTerms extracts the rankable tokens of a natural-language query:
@@ -1731,6 +1820,12 @@ func intersectSubstringPostingsDetailed(dir string, bare []string) ([]posting, m
 	return out, variants, nil
 }
 
+// commonTokenPostings is where a word stops being worth widening. Below it a
+// near-neighbour is usually the same thing spelled differently and is worth
+// the candidate walk; at or above it the word is ordinary vocabulary the
+// corpus is full of, and its neighbours only cost time.
+const commonTokenPostings = 200
+
 func fuzzyPostings(dir string, terms, phrases []string) ([]posting, map[string][]string, error) {
 	if !hasFuzzyToken(terms) {
 		return nil, nil, nil
@@ -1742,7 +1837,22 @@ func fuzzyPostings(dir string, terms, phrases []string) ([]posting, map[string][
 	perToken := make([]map[int64]posting, len(terms))
 	variants := map[string][]string{}
 	for i, term := range terms {
-		matches := closeTokens(term, idx)
+		// A term the corpus spells exactly is not a typo, and this tier exists
+		// for typos. One bucket read settles it; the candidate walk behind
+		// closeTokens compares the term against every token of a similar
+		// length and was running for words like "rice" and "favorite" that
+		// the index already holds verbatim.
+		// A word the corpus already uses everywhere gains nothing from its
+		// neighbours: it is not a typo, and widening it only adds postings
+		// that discriminate nothing. A rare word is still worth widening even
+		// when it is spelled correctly, because a near-neighbour of a rare
+		// word is usually the same thing said differently.
+		var matches []string
+		if exact, eerr := postingsFor(dir, "t"+term); eerr == nil && len(exact) >= commonTokenPostings {
+			matches = []string{term}
+		} else {
+			matches = closeTokens(term, idx)
+		}
 		if len(matches) == 0 {
 			return nil, nil, nil
 		}

--- a/internal/redact/providergate_test.go
+++ b/internal/redact/providergate_test.go
@@ -1,0 +1,66 @@
+package redact
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// The provider gate decides whether the provider-token matcher runs at all, so
+// a wrong skip leaves a live credential in the index. This proves it is a
+// necessary condition rather than a heuristic: whenever the regex matches, the
+// gate must have passed.
+func TestProviderGateNeverHidesAMatch(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260813))
+	// Fragments that land on and around every alternative in the pattern,
+	// including the prefixes the gate was tightened to, near-misses of them,
+	// and values just under and just over the length each one requires.
+	parts := []string{
+		"ghp_", "gho_", "ghs_", "ghu_", "ghr_", "ghx_", "gh", "github_pat_",
+		"glpat-", "sk_live_", "sk_test_", "rk_live_", "sk-", "gsk_", "xai-",
+		"hf_", "npm_", "xoxb-", "xoxp-", "AIza",
+		"abcdefghijklmnopqrst", "abcdefghijklmnopqrstuvwxyz0123456789",
+		"0123456789012345", "short", " ", "\n", "\t", ".", "-", "_",
+		"through", "thought", "enough", "right", "highlight",
+	}
+	for range 20000 {
+		var b strings.Builder
+		for n := rng.Intn(8); n >= 0; n-- {
+			b.WriteString(parts[rng.Intn(len(parts))])
+		}
+		s := b.String()
+		if providerRE.FindStringIndex(s) != nil && !containsAnyFold(s, providerHints) {
+			t.Fatalf("gate skipped a real match: %q", s)
+		}
+	}
+}
+
+// And it has to skip what it exists for. "gh" alone is inside ordinary English,
+// which put the regex on nearly every message of a chat history.
+func TestProviderGateSkipsOrdinaryEnglish(t *testing.T) {
+	for _, s := range []string{
+		"I thought the through-line was right there",
+		"enough light to highlight the neighbourhood",
+		"we might have brought the wrong one tonight",
+		"the daughter laughed at the tough dough",
+	} {
+		if containsAnyFold(s, providerHints) {
+			t.Errorf("gate let ordinary English through: %q", s)
+		}
+	}
+}
+
+// The tokens themselves still have to be redacted end to end.
+func TestProviderTokensStillRedacted(t *testing.T) {
+	for _, s := range []string{
+		"ghp_" + strings.Repeat("a", 30),
+		"github_pat_" + strings.Repeat("b", 30),
+		"sk-" + strings.Repeat("c", 30),
+		"AIza" + strings.Repeat("d", 32),
+	} {
+		out, _ := Text("here it is: " + s)
+		if strings.Contains(out, s) {
+			t.Errorf("token survived redaction: %q", out)
+		}
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -136,8 +136,18 @@ var kvHints = []string{
 	"密码", "密碼", "パスワード", "비밀번호",
 }
 
-// "github_pat_" is listed on its own: "gh" is not a substring of "github".
-var providerHints = []string{"gh", "github_pat_", "glpat-", "sk_", "rk_", "sk-", "gsk_", "xai-", "hf_", "npm_", "xox", "AIza"}
+// Each hint is a literal the regex cannot match without, so skipping on a
+// negative cannot change what is redacted. They have to be as long as the
+// literal prefix actually is: "gh" alone is inside "through", "right" and
+// "enough", so it let ordinary English through the gate and put the provider
+// regex on nearly every message in a chat history — a third of index build
+// time spent proving that "thought" is not a GitHub token. The regex wants
+// gh[opsur]_, so the hints spell that out. "github_pat_" is separate because
+// "gh" is not a substring of "github".
+var providerHints = []string{
+	"ghp_", "gho_", "ghs_", "ghu_", "ghr_", "github_pat_",
+	"glpat-", "sk_", "rk_", "sk-", "gsk_", "xai-", "hf_", "npm_", "xox", "AIza",
+}
 
 func containsAnyFold(s string, hints []string) bool {
 	for _, h := range hints {

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -269,6 +270,12 @@ func trimJSONSpace(b []byte) []byte {
 	return b
 }
 
+// jsonlReaders keeps the megabyte read buffer alive between files. A history
+// is thousands of transcripts, and allocating the buffer per file made the
+// buffer itself half of everything a cold index build allocated — 3.7 GB of
+// churn over 3745 sessions, for one buffer's worth of actual working memory.
+var jsonlReaders = sync.Pool{New: func() any { return bufio.NewReaderSize(nil, 1024*1024) }}
+
 // scanJSONLBytes hands each line to the caller without copying it or building a
 // decoder for it. The slice is only valid for the duration of the call.
 func scanJSONLBytes(path string, offset int64, fn func([]byte)) error {
@@ -282,7 +289,11 @@ func scanJSONLBytes(path string, offset int64, fn func([]byte)) error {
 			return err
 		}
 	}
-	r := bufio.NewReaderSize(f, 1024*1024)
+	r := jsonlReaders.Get().(*bufio.Reader)
+	// Reset before returning it as well as after taking it: a pooled reader
+	// must not keep the last file open through its reference.
+	defer func() { r.Reset(nil); jsonlReaders.Put(r) }()
+	r.Reset(f)
 	for {
 		line, err := r.ReadBytes('\n')
 		if trimmed := trimJSONSpace(line); len(trimmed) > 0 {


### PR DESCRIPTION
The retrieval half of #1216, split out of #1217.

A question asked in plain words requires every content word to be present, so on a large history it lands on a handful of sessions — often one, and often the wrong one. The answer is in the index and reachable, but the question's own wording excludes it before ranking gets a say.

When an AND comes back thin (under 10 sessions) on a store bigger than the relevance window, the relevance ranking is now hung underneath it. The strict sessions keep the front: they are why hit@1 is what it is, and relevance ranked alone scores worse at the first position. `RelevanceHits` scores by arrival, so the merged order survives to the caller — which is why the result is labelled as that tier.

On day0bench over a 1910-session corpus:

```
before   hit@1 21/40   hit@5 25/40   found@50 28/40
after    hit@1 21/40   hit@5 27/40   found@50 34/40
```

At 3745 sessions the same change takes found@50 from 44/80 to 68/80. longmemeval is unchanged at 90.0% / 95.0%, and decisionbench stays green.

Two gates keep it from firing where it would only add noise. A wide AND is describing a real cluster and is left alone. And a store smaller than the window has nothing to rank — relevance would hand back most of it, so a precise query on a small history would come back with the rest of the history attached; few results out of few sessions is an answer, not a symptom.

The same tail is hung under the stemmed and fuzzy fallbacks, which had the same shape, and a word the corpus is full of no longer widens into fuzzy matching: a term with 200+ postings is not a typo, and widening it cost time to find worse.

Three performance changes ride along, none of them behavioural:

- the provider gate in `redact` matched every word containing `gh`, so it ran the expensive path on ordinary prose. Anchored to the real prefixes (`ghp_`, `gho_`, `github_pat_`, …), redaction went 1.56s → 0.61s on the same store.
- the transcript reader allocated a 1MB buffer per file; pooled, allocations across a full build drop 7.1GB → 3.1GB.
- the co-occurrence pass hashed strings for every pair; interning the tokens first takes peak RSS 619MB → 387MB.

p95 search latency 90ms → 73ms.

One test with no product change: `TestReadsAnswerWhileTheIndexLockIsHeld`. The read paths a hook uses take the index lock non-blocking on purpose, because waiting stalls the agent for the length of a rebuild. Nothing checked either half of that — that the read returns rather than waits, and that it still answers. It does both; this pins it.
