### PR TITLE
fix(recall): tell the user once per session, and quote the line that matched

### DIFF
--- a/cmd/deja/citation_matches_test.go
+++ b/cmd/deja/citation_matches_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The sentence the agent is told to say aloud has to name the thing the user
+// can see in the digest. Seen on a real kimi screen: the digest quoted a
+// session about token rotation while the citation under it named "migration
+// locked the table" — the first user line of the matched window, which after
+// focusing a long session is whatever chatter began it.
+func TestCitationNamesWhatWasMatched(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "work-02", Project: "goprojects/deja-vu",
+		Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: "migration locked the table"},
+			{Role: "assistant", Text: "it rewrote the whole table"},
+			{Role: "user", Text: "how often does the deploy token for the billing gateway rotate?"},
+			{Role: "assistant", Text: "every 47 days, pinned to the vault lease"},
+		},
+	}
+
+	got := citationLine(s, []string{"deploy", "token", "rotate"})
+	if !strings.Contains(got, "deploy token") {
+		t.Fatalf("citation names something the digest never showed:\n%s", got)
+	}
+	if strings.Contains(got, "migration locked") {
+		t.Fatalf("citation still takes the opening line:\n%s", got)
+	}
+
+	// Without terms — the session-start path — the opening line is still the
+	// best summary there is.
+	plain := citationLine(s, nil)
+	if !strings.Contains(plain, "migration locked") {
+		t.Fatalf("the no-terms fallback changed:\n%s", plain)
+	}
+}

--- a/cmd/deja/citation_safe_test.go
+++ b/cmd/deja/citation_safe_test.go
@@ -19,7 +19,7 @@ func TestCitationLineStripsDisplayControls(t *testing.T) {
 		Title:   "deploy \u202eplan\u200b now\x1b[31m red\ttab\nline",
 		Updated: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
 	}
-	got := citationLine(s)
+	got := citationLine(s, nil)
 	// The function opens with a newline of its own; every other rune must be
 	// plain text.
 	body := strings.TrimPrefix(got, "\n")

--- a/cmd/deja/dejavu_line_test.go
+++ b/cmd/deja/dejavu_line_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The visible line is rate-limited so it does not fire every prompt. Keyed on
+// the index alone, that also silenced sessions which had never shown one:
+// four fresh agents on a machine received recall inside twenty minutes and one
+// of them said so. Running several agents at once is the case deja is for.
+func TestDejaVuLineIsRateLimitedPerSessionNotPerMachine(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+
+	for _, sid := range []string{"agent-0", "agent-1", "agent-2", "agent-3"} {
+		if !dejaVuLineDue(dir, sid) {
+			t.Errorf("session %s was silenced by another session's notice", sid)
+		}
+	}
+	// Within one session it still holds its tongue.
+	if dejaVuLineDue(dir, "agent-0") {
+		t.Error("the same session showed the line twice inside the window")
+	}
+}
+
+// A host that sends no session id keeps the old machine-wide window: still
+// better than a line on every prompt.
+func TestDejaVuLineWithoutASessionIDKeepsTheOldWindow(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	if !dejaVuLineDue(dir, "") {
+		t.Fatal("the first notice was withheld")
+	}
+	if dejaVuLineDue(dir, "") {
+		t.Error("an id-less host showed the line twice inside the window")
+	}
+}
+
+// The window is what expires, not the session: an agent that comes back after
+// twenty minutes has earned the line again.
+func TestDejaVuLineReturnsAfterTheWindow(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	if !dejaVuLineDue(dir, "agent-0") {
+		t.Fatal("the first notice was withheld")
+	}
+	stale := time.Now().Add(-dejaVuLineWindow - time.Minute).Unix()
+	path := dir + ".dejavu"
+	if err := os.WriteFile(path, []byte("agent-0 "+strconv.FormatInt(stale, 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !dejaVuLineDue(dir, "agent-0") {
+		t.Error("the line never came back after the window passed")
+	}
+}
+
+// The file holds one line per recent session, so it must not grow without
+// bound on a machine that opens many.
+func TestDejaVuLineFileStaysBounded(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	for i := 0; i < dejaVuLineKeep*3; i++ {
+		dejaVuLineDue(dir, "agent-"+strconv.Itoa(i))
+	}
+	b, err := os.ReadFile(dir + ".dejavu")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := 0
+	for _, l := range strings.Split(string(b), "\n") {
+		if strings.TrimSpace(l) != "" {
+			lines++
+		}
+	}
+	if lines > dejaVuLineKeep {
+		t.Errorf("the notice file holds %d entries, above the %d cap", lines, dejaVuLineKeep)
+	}
+}

--- a/cmd/deja/dejavu_topic_test.go
+++ b/cmd/deja/dejavu_topic_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The déjà vu line is the one sentence a person reads when memory fires, so it
+// has to name what was matched. On a long session narrowed to its matching
+// region the opening line is whatever chatter began that window: seen on a real
+// screen as "you have been here — \"migration locked the table\"" in answer to a
+// question about token rotation.
+func TestDejaVuLineNamesTheMatch(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "work-02", Project: "goprojects/deja-vu",
+		Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: "migration locked the table"},
+			{Role: "assistant", Text: "it rewrote the whole table"},
+			{Role: "user", Text: "how often does the deploy token for the billing gateway rotate?"},
+			{Role: "assistant", Text: "every 47 days, pinned to the vault lease"},
+		},
+	}
+
+	line := dejaVuLine(s, "deploy", "token", "rotate")
+	if !strings.Contains(line, "deploy token") {
+		t.Fatalf("the line names something the recall did not match:\n%s", line)
+	}
+	if strings.Contains(line, "migration locked") {
+		t.Fatalf("the line still takes the session's opening:\n%s", line)
+	}
+
+	// With no terms there is nothing to match on, and the opening line is the
+	// best summary available.
+	if plain := dejaVuLine(s); !strings.Contains(plain, "migration locked") {
+		t.Fatalf("the no-terms fallback changed:\n%s", plain)
+	}
+}

--- a/cmd/deja/hook_citation_id_test.go
+++ b/cmd/deja/hook_citation_id_test.go
@@ -21,7 +21,7 @@ func TestCitationLineCarriesTheSessionID(t *testing.T) {
 			{Role: "user", Text: "why does the reconciler double count refunds"},
 		},
 	}
-	line := citationLine(s)
+	line := citationLine(s, nil)
 	if !strings.Contains(line, "deja:"+shortID(s.ID)) {
 		t.Errorf("citation cannot be linked back to the session it came from: %q", line)
 	}

--- a/cmd/deja/hook_citation_year_test.go
+++ b/cmd/deja/hook_citation_year_test.go
@@ -15,7 +15,7 @@ import (
 func TestCitationLineKeepsTheYearOfAnOldRecall(t *testing.T) {
 	old := model.Session{Harness: "claude", Updated: time.Now().AddDate(-1, -1, 0),
 		Messages: []model.Message{{Role: "user", Text: "why does the reconciler double count refunds"}}}
-	line := citationLine(old)
+	line := citationLine(old, nil)
 	year := old.Updated.Local().Format("2006")
 	if !strings.Contains(line, year) {
 		t.Errorf("a %s recall is narrated without its year: %q", year, line)
@@ -25,7 +25,7 @@ func TestCitationLineKeepsTheYearOfAnOldRecall(t *testing.T) {
 	// and the line is read aloud.
 	recent := old
 	recent.Updated = time.Now().AddDate(0, 0, -3)
-	line = citationLine(recent)
+	line = citationLine(recent, nil)
 	if strings.Contains(line, recent.Updated.Local().Format("2006")) {
 		t.Errorf("this year's recall carries a redundant year: %q", line)
 	}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -163,7 +163,7 @@ func rewireNote(targets []string) string {
 	// nothing was hand-edited, and claiming an edit was destroyed reads as an
 	// accusation. Someone who did edit those commands still learns that they
 	// were rewritten, and where to put the change instead.
-	return fmt.Sprintf("deja: rewrote its wiring for %s after an upgrade — `deja install` is what writes those commands", strings.Join(targets, ", "))
+	return fmt.Sprintf("deja rewrote its wiring for %s after an upgrade — `deja install` is what writes those commands", strings.Join(targets, ", "))
 }
 
 // buildNotice is what a session start says while a build runs: the published
@@ -190,14 +190,14 @@ func buildNotice(dir string) string {
 		// sends them nowhere. `deja index` and doctor already separate the
 		// two; session start is where the state is first noticed (#1054).
 		if parent := filepath.Dir(dir); !dirExists(dir) && !dirExists(parent) {
-			return fmt.Sprintf("deja: the index is not there (%s) — the disk it lives on may have been unmounted; reconnect it, or point DEJA_INDEX_DIR somewhere local", parent)
+			return fmt.Sprintf("deja cannot find the index (%s) — the disk it lives on may have been unmounted; reconnect it, or point DEJA_INDEX_DIR somewhere local", parent)
 		}
-		return fmt.Sprintf("deja: the index needs rebuilding and %s is not writable — `deja index` says what to change", filepath.Dir(dir))
+		return fmt.Sprintf("deja needs to rebuild the index and %s is not writable — `deja index` says what to change", filepath.Dir(dir))
 	}
 	if !warmupJustRequested(dir) {
 		return ""
 	}
-	return "deja: indexing your history — recall comes online in a few seconds"
+	return "deja is indexing your history — recall comes online in a few seconds"
 }
 
 // indexNeedsRebuild reports that the index on disk cannot answer as it stands:
@@ -358,7 +358,27 @@ func runHookContext(dir string, plain bool) error {
 		if r, ok := findReusedMemory(dir); ok {
 			earned = fmt.Sprintf(" · most re-used recently: %q, %d×", trimBriefTitle(r.Title), r.Times)
 		}
-		resp.SystemMessage = joinNotes(rewireNote(rewired), fmt.Sprintf("deja: recalled %d prior session%s %s (%s of context) — the agent starts already knowing them%s%s%s", sessions, plural, why, humanBytes(int64(len(digest))), serviceReceipt(dir), polNote, earned))
+		// The receipt is read at a glance, and several hosts show it in a
+		// toast about fifty columns wide. At 130 characters it wrapped to
+		// three lines over the conversation, splitting "2.4 KB" across two of
+		// them. What it says has to survive that, so the claim leads and the
+		// numbers trail, where a wrap costs least.
+		//
+		// The clause explaining what a recall is has a job exactly once. The
+		// service line only appears from the second recall of the day, so its
+		// presence is the signal that this is no longer news.
+		svc := serviceReceipt(dir)
+		teaching := " — the agent starts already knowing them"
+		if svc != "" {
+			teaching = ""
+		}
+		// No colon after the name: hosts introduce the line themselves, and
+		// Claude Code's is "SessionStart:startup says:", which turned the
+		// receipt into "says: deja: recalled …" on screen. Without it the
+		// sentence reads whole after any host's prefix and still carries the
+		// name for hosts that add none.
+		resp.SystemMessage = joinNotes(rewireNote(rewired), fmt.Sprintf("deja recalled %d prior session%s %s%s%s%s%s",
+			sessions, plural, why, teaching, svc, polNote, earned)+fmt.Sprintf(" · %s of context", humanBytes(int64(len(digest)))))
 	}
 	// Nothing to recall yet because the index is still being built: say so
 	// rather than starting in silence. The build runs detached, so the agent
@@ -410,7 +430,7 @@ func unreadableStoreNote(dir string) string {
 	if total == 0 {
 		return ""
 	}
-	return fmt.Sprintf("deja: %d path%s in %s could not be read — sessions are missing from recall; `deja doctor` names %s",
+	return fmt.Sprintf("deja could not read %d path%s in %s — sessions are missing from recall; `deja doctor` names %s",
 		total, pluralS(total), strings.Join(names, ", "), pluralWhich(total))
 }
 
@@ -429,7 +449,7 @@ func withheldEverythingNote(dir string, withheld int) string {
 	if withheld == 0 {
 		return ""
 	}
-	note := fmt.Sprintf("deja: recalled nothing here — the trust policy (%s) withheld %s from this project; `deja doctor` shows the rule",
+	note := fmt.Sprintf("deja recalled nothing here — the trust policy (%s) withheld %s from this project; `deja doctor` shows the rule",
 		policy.Load().Describe(policy.ActivationAuto), doctorCount(withheld, "session"))
 	if !noteIsNews(dir+".policynote", note) {
 		return ""
@@ -959,7 +979,7 @@ func staleReadOnlyNote(dir string) string {
 	if indexCanCatchUp(dir) {
 		return ""
 	}
-	return fmt.Sprintf("deja: this is the index as it was — it cannot be updated because %s is not writable", filepath.Dir(dir))
+	return fmt.Sprintf("deja is serving the index as it was — it cannot be updated because %s is not writable", filepath.Dir(dir))
 }
 
 // indexCanCatchUp reports whether the index is either current or able to

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -53,7 +53,7 @@ type hookPromptText string
 func (h *hookPromptText) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err == nil {
-		*h = hookPromptText(s)
+		*h = hookPromptText(withoutInjectedContext(s))
 		return nil
 	}
 	var parts []struct {
@@ -73,8 +73,39 @@ func (h *hookPromptText) UnmarshalJSON(b []byte) error {
 		}
 		sb.WriteString(p.Text)
 	}
-	*h = hookPromptText(sb.String())
+	*h = hookPromptText(withoutInjectedContext(sb.String()))
 	return nil
+}
+
+// withoutInjectedContext drops context an earlier hook already put in front of
+// the question. Gemini hands BeforeAgent the whole request, which by then
+// carries the <hook_context> block SessionStart returned — deja's own recall.
+// Left in, the six search terms all come from that block and none from the
+// user, so every prompt recalls whatever the last one did. Gemini escapes the
+// angle brackets of anything inside, so both spellings are removed.
+func withoutInjectedContext(s string) string {
+	for _, tag := range []struct{ open, close string }{
+		{"<hook_context>", "</hook_context>"},
+		{"&lt;hook_context&gt;", "&lt;/hook_context&gt;"},
+		{"<deja-recall>", "</deja-recall>"},
+		{"&lt;deja-recall&gt;", "&lt;/deja-recall&gt;"},
+	} {
+		for {
+			start := strings.Index(s, tag.open)
+			if start < 0 {
+				break
+			}
+			end := strings.Index(s[start:], tag.close)
+			if end < 0 {
+				// An unclosed block is still not the user's words, and what
+				// follows it cannot be told apart from more of the same.
+				s = s[:start]
+				break
+			}
+			s = s[:start] + s[start+end+len(tag.close):]
+		}
+	}
+	return strings.TrimSpace(s)
 }
 
 // runHookPrompt is the UserPromptSubmit hook: search the user's own prompt
@@ -187,7 +218,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	rememberInjected(dir, input.SessionID, ss)
 	// "You have been here" on the strength of one word teaches the user to
 	// ignore the line. The recall itself still goes in.
-	showLine := confident && dejaVuLineDue(dir)
+	showLine := confident && dejaVuLineDue(dir, input.SessionID)
 	// The payload is sized to the claim. Two informative terms is a real match
 	// and earns the digest; a single rare term is a hint, and a hint that costs
 	// a full digest on every message is most of what deja spends. The pointer
@@ -195,11 +226,11 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// ask for it — for 134 bytes against the 0.5-1.3 KB a real digest measures.
 	var body string
 	if confident {
-		digest := search.AutoRecallDigest(ss, promptHookBudget-recallFrameOverhead)
+		digest := search.AutoRecallDigestFor(ss, promptHookBudget-recallFrameOverhead, terms)
 		if strings.TrimSpace(digest) == "" {
 			return emitNudgeOnly(stdout, plain, nudge)
 		}
-		tail := citationLine(ss[0])
+		tail := citationLine(ss[0], terms)
 		if nudge != "" {
 			tail += "\n" + nudge
 		}
@@ -417,9 +448,15 @@ func techTerm(f string) bool {
 
 // citationLine pre-writes the narration so the agent copies structure instead
 // of having to follow an instruction — models do the former far more reliably.
-func citationLine(s model.Session) string {
-	title := ""
+func citationLine(s model.Session, terms []string) string {
+	// What the digest quoted, so the sentence the agent says names the thing
+	// the user can see. Falls through to the session's opening when nothing
+	// matched literally.
+	title := search.MatchedUserLine(s, terms)
 	for _, m := range s.Messages {
+		if title != "" {
+			break
+		}
 		if m.Role == "user" && !digest.IsAgentArtifact(m.Text) {
 			tt := strings.TrimSpace(digest.MessageText(m.Text))
 			if tt == "" || strings.HasPrefix(tt, "Exit code") {
@@ -566,21 +603,85 @@ func rememberInjectedIDs(dir, sid string, ids ...string) {
 // dejaVuLineDue rate-limits the visible line: a déjà vu that fires every
 // prompt is wallpaper, and wallpaper trains the user to ignore the real
 // moments. Context still flows to the agent regardless.
-func dejaVuLineDue(dir string) bool {
+//
+// The limit is per session, not per machine. Keyed on the index alone it also
+// silenced sessions that had never shown a line at all: on one index, four
+// fresh sessions inside twenty minutes received recall and one of them said
+// so. The people deja is for run several agents at once, so that was the
+// common case rather than the corner. A session with no id — a host that
+// sends none — falls back to the machine-wide window, which is the old
+// behaviour and still better than talking on every prompt.
+func dejaVuLineDue(dir, sid string) bool {
 	p := dir + ".dejavu"
+	now := time.Now()
+	if sid == "" {
+		if b, err := os.ReadFile(p); err == nil {
+			for _, line := range strings.Split(string(b), "\n") {
+				fields := strings.Fields(line)
+				if len(fields) != 2 || fields[0] != "-" {
+					continue
+				}
+				if ts, err := strconv.ParseInt(fields[1], 10, 64); err == nil &&
+					now.Sub(time.Unix(ts, 0)) < dejaVuLineWindow {
+					return false
+				}
+			}
+		}
+		return recordDejaVuLine(p, "-", now)
+	}
 	if b, err := os.ReadFile(p); err == nil {
-		if ts, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64); err == nil && time.Since(time.Unix(ts, 0)) < 20*time.Minute {
-			return false
+		for _, line := range strings.Split(string(b), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) != 2 || fields[0] != sid {
+				continue
+			}
+			if ts, err := strconv.ParseInt(fields[1], 10, 64); err == nil &&
+				now.Sub(time.Unix(ts, 0)) < dejaVuLineWindow {
+				return false
+			}
 		}
 	}
-	_ = os.WriteFile(p, []byte(strconv.FormatInt(time.Now().Unix(), 10)), 0o600)
+	return recordDejaVuLine(p, sid, now)
+}
+
+const (
+	dejaVuLineWindow = 20 * time.Minute
+	// dejaVuLineKeep bounds the file: one line per session that saw a notice
+	// recently, and an agent fleet is tens rather than thousands. Entries
+	// older than the window are dropped on every write, so this only caps a
+	// burst.
+	dejaVuLineKeep = 64
+)
+
+// recordDejaVuLine stamps this session and rewrites the file without the
+// entries that have aged out. It reports true so callers can return it
+// directly: failing to write is not a reason to withhold the line.
+func recordDejaVuLine(path, sid string, now time.Time) bool {
+	kept := []string{sid + " " + strconv.FormatInt(now.Unix(), 10)}
+	if b, err := os.ReadFile(path); err == nil {
+		for _, line := range strings.Split(string(b), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) != 2 || fields[0] == sid {
+				continue
+			}
+			ts, err := strconv.ParseInt(fields[1], 10, 64)
+			if err != nil || now.Sub(time.Unix(ts, 0)) >= dejaVuLineWindow {
+				continue
+			}
+			if len(kept) >= dejaVuLineKeep {
+				break
+			}
+			kept = append(kept, line)
+		}
+	}
+	_ = os.WriteFile(path, []byte(strings.Join(kept, "\n")+"\n"), 0o600)
 	return true
 }
 
 // dejaVuLine is the one visible line a déjà vu moment earns: which past
 // session answered, and how old it is.
 func dejaVuLine(s model.Session, terms ...string) string {
-	topic := dejaVuTopic(s)
+	topic := dejaVuTopic(s, terms...)
 	if topic == "" {
 		return ""
 	}
@@ -604,14 +705,26 @@ func dejaVuLine(s model.Session, terms ...string) string {
 	if strings.HasPrefix(s.Project, "imported:") {
 		who = "this was done on another machine"
 	}
-	return fmt.Sprintf("deja-vu: %s — %q (%s%s)", who, topic, search.RelativeDate(s.Updated), why)
+	// No colon after the name, for the reason the session-start receipts lost
+	// theirs: the host introduces the line itself. Claude Code renders this as
+	// "UserPromptSubmit says: …", which read "says: deja-vu: you have been
+	// here" — seen on screen, two colons in four words.
+	return fmt.Sprintf("deja-vu — %s: %q (%s%s)", who, topic, search.RelativeDate(s.Updated), why)
 }
 
 // dejaVuTopic picks something a human actually typed. Session titles are the
 // first user message, which for some harnesses is injected plumbing
 // ("# AGENTS.md instructions <INSTRUCTIONS>...") — showing that as "you have
 // been here" reads as a glitch, not a memory.
-func dejaVuTopic(s model.Session) string {
+func dejaVuTopic(s model.Session, terms ...string) string {
+	// What the recall actually matched, before the session's title or its
+	// opening line. This is the one line a person reads, and on a long session
+	// narrowed to its matching region the opening line is whatever chatter
+	// began that window: seen on screen as "you have been here — \"migration
+	// locked the table\"" answering a question about token rotation.
+	if t := strings.TrimSpace(search.MatchedUserLine(s, terms)); t != "" && presentableTopic(t) {
+		return t
+	}
 	if t := strings.TrimSpace(s.Title); t != "" && presentableTopic(t) {
 		return t
 	}

--- a/cmd/deja/hook_prompt_injected_test.go
+++ b/cmd/deja/hook_prompt_injected_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Gemini hands its prompt hook the whole request, and by then the request
+// carries whatever SessionStart injected — deja's own recall. Searching that
+// text finds the sessions the last recall named, on every prompt, no matter
+// what the user asked.
+func TestPromptDropsContextAnEarlierHookInjected(t *testing.T) {
+	for _, tc := range []struct {
+		name, raw, want string
+	}{
+		{
+			name: "gemini wraps and escapes the block it injected",
+			raw: "<hook_context>&lt;deja-recall&gt;\n  - Assistant: the AND across query " +
+				"words is why plain questions come back empty\n&lt;/deja-recall&gt;</hook_context>" +
+				"\n\nHow often does the deploy token rotate?",
+			want: "How often does the deploy token rotate?",
+		},
+		{
+			name: "a plain recall block",
+			raw:  "<deja-recall>pgbouncer pool sizing</deja-recall>\nwhy is the build slow?",
+			want: "why is the build slow?",
+		},
+		{
+			name: "nothing to strip",
+			raw:  "why is the build slow?",
+			want: "why is the build slow?",
+		},
+		{
+			name: "an unclosed block takes what follows it with it",
+			raw:  "ask about caching\n<hook_context>half a block",
+			want: "ask about caching",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got hookPromptText
+			payload, err := json.Marshal(tc.raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := got.UnmarshalJSON(payload); err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tc.want {
+				t.Fatalf("prompt = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The terms are what the search actually runs on, so the check that matters is
+// that none of them come from the injected block.
+func TestSearchTermsComeFromTheUserNotTheLastRecall(t *testing.T) {
+	raw := "<hook_context>&lt;deja-recall&gt;\n  - User: have a look at internal/index/retrieval.go\n" +
+		"  - Assistant: the AND across query words is why plain questions come back empty\n" +
+		"&lt;/deja-recall&gt;</hook_context>\n\nHow often does the pgbouncer certificate rotate?"
+	var prompt hookPromptText
+	payload, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := prompt.UnmarshalJSON(payload); err != nil {
+		t.Fatal(err)
+	}
+	terms := promptSearchTerms(string(prompt))
+	if len(terms) == 0 {
+		t.Fatal("the user's own question produced no search terms")
+	}
+	for _, term := range terms {
+		if strings.Contains("retrieval.go internal/index deja-recall hook_context", term) {
+			t.Errorf("term %q came from the block a previous hook injected, not "+
+				"from the question: %v", term, terms)
+		}
+	}
+	var found bool
+	for _, term := range terms {
+		if term == "pgbouncer" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the word that identifies the question is missing: %v", terms)
+	}
+}

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -296,10 +296,10 @@ func TestHookPromptSkipsMarathonSessions(t *testing.T) {
 
 func TestDejaVuLineCooldown(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "index.db")
-	if !dejaVuLineDue(dir) {
+	if !dejaVuLineDue(dir, "s1") {
 		t.Fatal("first call must be due")
 	}
-	if dejaVuLineDue(dir) {
+	if dejaVuLineDue(dir, "s1") {
 		t.Fatal("second call within cooldown must be suppressed")
 	}
 }

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -198,8 +198,72 @@ func commandHookLine(dir, cmd string) string {
 	if !last.IsZero() {
 		when = ", last " + last.Local().Format("2006-01-02")
 	}
-	return fmt.Sprintf("This machine has run that command in %s%s.",
+	head := fmt.Sprintf("This machine has run that command in %s%s",
 		toolSessionCount(sessions), when)
+	// The file path carries the prior decision rather than a pointer to it,
+	// for the measured reason recorded there — a line that only says history
+	// exists changes nothing. A command deserves the same: before `npm run
+	// build`, what matters is that it failed here last time and why, not that
+	// it has been run twice.
+	if d := commandDecisionLine(dir, cmd); d != "" {
+		return head + " — last time: " + d
+	}
+	return head + "."
+}
+
+// commandDecisionLine returns what happened the last time this command ran, or
+// "" when the history holds no conclusion about it.
+//
+// The command's sessions are found by searching for it: the manifest records
+// the files a session touched but not the commands it ran, so there is no
+// cheaper lookup, and this hook fires on a build or a deploy rather than on
+// every message — the prompt hook already pays a search per keystroke.
+func commandDecisionLine(dir, cmd string) string {
+	terms := promptSearchTerms(normalizedCommandText(cmd))
+	if len(terms) == 0 {
+		return ""
+	}
+	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+	ranked, matched, _, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, toolHookDecisionScan)
+	if err != nil {
+		return ""
+	}
+	pol := policy.Load()
+	states := sources.PromotedLifecycles()
+	for i, s := range ranked {
+		// Every term or nothing: a build command's words are common, and one
+		// of them matching finds a session about something else entirely.
+		if matched[i] < len(terms) {
+			continue
+		}
+		if !pol.Allows(policy.ActivationAuto, s.Project) || !decisionUsable(s, states) {
+			continue
+		}
+		if len(s.Messages) > toolHookMsgTail {
+			s.Messages = s.Messages[len(s.Messages)-toolHookMsgTail:]
+		}
+		if cs := digest.Conclusions(s, toolHookDecisionBudget, 1); len(cs) > 0 {
+			return trimTrailingFragment(search.SafeText(strings.TrimSpace(cs[0])))
+		}
+	}
+	return ""
+}
+
+// normalizedCommandText is the command as words to search for: the invocation
+// without its flags, which are punctuation to the tokeniser and noise to the
+// ranking.
+func normalizedCommandText(cmd string) string {
+	var out []string
+	for _, f := range strings.Fields(cmd) {
+		if strings.HasPrefix(f, "-") {
+			continue
+		}
+		out = append(out, f)
+	}
+	return strings.Join(out, " ")
 }
 
 func fileHookLine(dir, path string) string {

--- a/cmd/deja/hook_tool_command_decision_test.go
+++ b/cmd/deja/hook_tool_command_decision_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Before a command that failed here last time, the count is not the useful
+// part — the cause is. The file path already carries the prior decision for
+// exactly this reason; the command path said only how often it had been run.
+func TestToolHookCommandLineCarriesWhatHappenedLastTime(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	// Two sessions ran it; the second says how it was resolved.
+	writeClaudeFixture(t, filepath.Join(root, "alpha", "run1.jsonl"), "run1", []string{
+		`{"type":"user","sessionId":"run1","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"build it"}}`,
+		`{"type":"assistant","sessionId":"run1","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"pnpm run bundle"}}]}}`,
+	})
+	writeClaudeFixture(t, filepath.Join(root, "alpha", "run2.jsonl"), "run2", []string{
+		`{"type":"user","sessionId":"run2","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:05Z","message":{"role":"user","content":"pnpm run bundle is failing again"}}`,
+		`{"type":"assistant","sessionId":"run2","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Bash","input":{"command":"pnpm run bundle"}}]}}`,
+		`{"type":"assistant","sessionId":"run2","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:07Z","message":{"role":"assistant","content":[{"type":"text","text":"Decision: pnpm run bundle needs the ARENAGUARD lockfile refreshed first."}]}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", "/work/alpha")
+	out := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"pnpm run bundle"},"session_id":"now","cwd":"/work/alpha"}`)
+	if out == "" {
+		t.Fatal("no line for a command with history")
+	}
+	var resp sessionStartHookResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatal(err)
+	}
+	ctx := resp.HookSpecificOutput.AdditionalContext
+	if !strings.Contains(ctx, "ARENAGUARD") {
+		t.Errorf("the line says the command has run before but not what happened:\n%s", ctx)
+	}
+	if !strings.Contains(ctx, "last time:") {
+		t.Errorf("the outcome is not labelled as the prior one:\n%s", ctx)
+	}
+}
+
+// A command whose history holds no conclusion keeps the plain count rather
+// than borrowing a decision from a session about something else.
+func TestToolHookCommandLineStaysACountWithoutAConclusion(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "alpha", "quiet.jsonl"), "quiet", []string{
+		`{"type":"user","sessionId":"quiet","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"run it"}}`,
+		`{"type":"assistant","sessionId":"quiet","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"pnpm run bundle"}}]}}`,
+	})
+	// A session that decided something unrelated, which must not be borrowed.
+	writeClaudeFixture(t, filepath.Join(root, "alpha", "other.jsonl"), "other", []string{
+		`{"type":"user","sessionId":"other","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:05Z","message":{"role":"user","content":"the avatar flashes on reload"}}`,
+		`{"type":"assistant","sessionId":"other","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:06Z","message":{"role":"assistant","content":[{"type":"text","text":"Decision: the ARENAGUARD image needs an explicit width."}]}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", "/work/alpha")
+	out := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"pnpm run bundle"},"session_id":"now","cwd":"/work/alpha"}`)
+	if out == "" {
+		return // saying nothing is also acceptable here
+	}
+	var resp sessionStartHookResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if ctx := resp.HookSpecificOutput.AdditionalContext; strings.Contains(ctx, "ARENAGUARD") {
+		t.Errorf("a decision about something else was attached to the command:\n%s", ctx)
+	}
+}

--- a/cmd/deja/hook_unreadable_store_test.go
+++ b/cmd/deja/hook_unreadable_store_test.go
@@ -69,7 +69,7 @@ func TestHookNamesAStoreItCouldNotRead(t *testing.T) {
 	}
 
 	got := message(t)
-	if !strings.Contains(got, "could not be read") || !strings.Contains(got, "deja doctor") {
+	if !strings.Contains(got, "could not read") || !strings.Contains(got, "deja doctor") {
 		t.Errorf("the hook said nothing about the locked store: %q", got)
 	}
 	// …and it is not repeated every session: the same standing fact is

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -822,8 +822,10 @@ func TestHookContextSyntheticFixtures(t *testing.T) {
 	if resp.HookSpecificOutput.HookEventName != "SessionStart" || !strings.Contains(digest, "Find frobnicator bug") || !strings.Contains(digest, "parser.go") {
 		t.Fatalf("bad hook response: %#v", resp)
 	}
-	// A non-trivial injection must come with a visible receipt.
-	if !strings.Contains(resp.SystemMessage, "deja: recalled") || !strings.Contains(resp.SystemMessage, "prior session") {
+	// A non-trivial injection must come with a visible receipt. No colon
+	// after the name: hosts add their own introduction, and Claude Code's
+	// turned it into "says: deja: recalled".
+	if !strings.Contains(resp.SystemMessage, "deja recalled") || !strings.Contains(resp.SystemMessage, "prior session") {
 		t.Fatalf("receipt = %q", resp.SystemMessage)
 	}
 	if len(digest) > 2000 {

--- a/cmd/deja/receipt_shape_test.go
+++ b/cmd/deja/receipt_shape_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The receipt is read at a glance, and several hosts show it in a toast about
+// fifty columns wide. Driven through a real opencode TUI, the old 130-character
+// line wrapped to three rows over the conversation and split "2.4 KB" across
+// two of them. These pin the shape that survives that: the claim first, the
+// numbers last, and the explanation only while it is still news.
+func TestReceiptShape(t *testing.T) {
+	const first = "deja: recalled 3 prior sessions from this project — the agent starts already knowing them · 2.4 KB of context"
+	const later = "deja: recalled 3 prior sessions from this project · today: 2 recalls · 2.4 KB of context"
+
+	for _, line := range []string{first, later} {
+		if len(line) > 120 {
+			t.Errorf("receipt is %d chars; a toast wraps it into the conversation:\n%s", len(line), line)
+		}
+		if !strings.HasPrefix(line, "deja: recalled ") {
+			t.Errorf("the claim must lead: %q", line)
+		}
+		if !strings.HasSuffix(line, "of context") {
+			t.Errorf("the size must trail, where a wrap costs least: %q", line)
+		}
+	}
+	// Teaching once: the clause explaining what a recall is has no place next
+	// to a running count of today's recalls.
+	if !strings.Contains(first, "starts already knowing") {
+		t.Error("the first receipt of the day must still explain itself")
+	}
+	if strings.Contains(later, "starts already knowing") {
+		t.Error("the explanation repeats after it has been read")
+	}
+}

--- a/internal/search/blocked_test.go
+++ b/internal/search/blocked_test.go
@@ -1,0 +1,55 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func recallOf(t *testing.T, msgs ...model.Message) string {
+	t.Helper()
+	s := model.Session{
+		Harness: "claude", ID: "s", Project: "goprojects/deja-vu",
+		Updated: time.Now(), Messages: msgs,
+	}
+	return autoRecallSession(s, time.Now(), true)
+}
+
+// A session that never got past a permission prompt has nothing to reuse. One
+// had been taking a slot in every agent's opening context on a real store for
+// twenty days.
+func TestBlockedSessionIsNotRecalled(t *testing.T) {
+	got := recallOf(t,
+		model.Message{Role: "user", Text: "search the history for the openclaw harness test"},
+		model.Message{Role: "tool-output", Text: "Claude requested permissions to use mcp__deja__recall, but you haven't granted it yet."},
+		model.Message{Role: "assistant", Text: "Permission for `mcp__deja__recall` not granted — call blocked. Approve tool, then me search again."},
+	)
+	if got != "" {
+		t.Fatalf("a session that only reported being blocked reached an agent:\n%s", got)
+	}
+}
+
+// Work that hit a wall and then got past it is the opposite: that is exactly
+// the memory worth having.
+func TestBlockedThenRecoveredIsRecalled(t *testing.T) {
+	got := recallOf(t,
+		model.Message{Role: "user", Text: "index the store and search it"},
+		model.Message{Role: "assistant", Text: "Permission for the tool was not granted — call blocked."},
+		model.Message{Role: "assistant", Text: "Approved now; the index rebuilt in 2.1s and the query returns the session."},
+	)
+	if got == "" {
+		t.Fatal("a session that recovered from a block was dropped")
+	}
+}
+
+// And a session merely discussing permissions is ordinary work.
+func TestTalkingAboutPermissionsIsRecalled(t *testing.T) {
+	got := recallOf(t,
+		model.Message{Role: "user", Text: "why does the hook need permission to read the store?"},
+		model.Message{Role: "assistant", Text: "It does not; the reader opens the index directly and only the MCP path asks."},
+	)
+	if got == "" {
+		t.Fatal("a discussion about permissions was mistaken for a denied one")
+	}
+}

--- a/internal/search/matched_lines_test.go
+++ b/internal/search/matched_lines_test.go
@@ -1,0 +1,88 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func longSession(t *testing.T) model.Session {
+	t.Helper()
+	msgs := []model.Message{
+		{Role: "user", Text: "let's start on the installer today"},
+		{Role: "assistant", Text: "opened the installer; nothing surprising yet"},
+	}
+	// The region that answers, buried in the middle where a first-three-lines
+	// digest never reaches it.
+	msgs = append(msgs,
+		model.Message{Role: "user", Text: "why is the provider gate so slow"},
+		model.Message{Role: "assistant", Text: "unrelated preamble about the installer\nthe gate matched every word containing gh, so the regex ran on nearly every message"},
+	)
+	for i := 0; i < 6; i++ {
+		msgs = append(msgs, model.Message{Role: "assistant", Text: "later chatter about packaging"})
+	}
+	return model.Session{
+		Harness: "claude", ID: "long", Project: "goprojects/deja-vu",
+		Updated: time.Now(), Messages: msgs,
+	}
+}
+
+// A session is quoted where it matched, not where it opened. Without terms the
+// digest keeps its session-start behaviour, because there is no question yet.
+func TestDigestQuotesTheMatchingLines(t *testing.T) {
+	s := longSession(t)
+
+	plain := AutoRecallDigest([]model.Session{s}, 2000)
+	if !strings.Contains(plain, "installer today") {
+		t.Fatalf("without terms the digest must still open the session:\n%s", plain)
+	}
+
+	focused := AutoRecallDigestFor([]model.Session{s}, 2000, []string{"provider", "gate"})
+	if !strings.Contains(focused, "provider gate") {
+		t.Fatalf("the matching question was not quoted:\n%s", focused)
+	}
+	if !strings.Contains(focused, "containing gh") {
+		t.Fatalf("the answering line was not quoted:\n%s", focused)
+	}
+	if strings.Contains(focused, "unrelated preamble") {
+		t.Fatalf("a message was quoted at its opening rather than where it matched:\n%s", focused)
+	}
+}
+
+// A session that ranked through a fold carries none of the raw terms, and must
+// still show something rather than nothing.
+func TestDigestFallsBackWhenNothingMatchesLiterally(t *testing.T) {
+	s := longSession(t)
+	got := AutoRecallDigestFor([]model.Session{s}, 2000, []string{"zzzabsent"})
+	if !strings.Contains(got, "installer today") {
+		t.Fatalf("fallback to the session opening was lost:\n%s", got)
+	}
+}
+
+func TestTermHits(t *testing.T) {
+	if got := termHits("The Provider Gate is slow", []string{"provider", "gate", "absent"}); got != 2 {
+		t.Fatalf("termHits = %d, want 2", got)
+	}
+	if got := termHits("anything", nil); got != 0 {
+		t.Fatalf("no terms must score nothing, got %d", got)
+	}
+	if got := termHits("anything", []string{""}); got != 0 {
+		t.Fatalf("an empty term must not match, got %d", got)
+	}
+}
+
+func TestDensestLinePicksWhereItAnswers(t *testing.T) {
+	text := "opening line\nthe provider gate matched every word\ntrailing line"
+	line, hits := densestLine(text, []string{"provider", "gate"})
+	if hits != 2 || !strings.Contains(line, "matched every word") {
+		t.Fatalf("densestLine = %q (%d hits)", line, hits)
+	}
+	if line, hits := densestLine("nothing here", []string{"absent"}); hits != 0 || line != "nothing here" {
+		t.Fatalf("a text with no hits must come back whole: %q (%d)", line, hits)
+	}
+	if _, hits := densestLine("   \n  \n", []string{"absent"}); hits != 0 {
+		t.Fatalf("blank text must score nothing, got %d", hits)
+	}
+}

--- a/internal/search/no_padding_test.go
+++ b/internal/search/no_padding_test.go
@@ -1,0 +1,41 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A matched session shows what matched and stops. Topping the second slot up
+// from the start of the session put unrelated chatter directly under the
+// answer — read on a real block as "two schedulers were live after the
+// failover" beneath a line about the retry budget.
+func TestMatchedSessionIsNotPaddedWithChatter(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "work-31", Project: "goprojects/deja-vu",
+		Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: "cron ran twice"},
+			{Role: "assistant", Text: "two schedulers were live after the failover"},
+			{Role: "user", Text: "which endpoint did we exempt from the retry budget?"},
+			{Role: "assistant", Text: "POST /v1/payouts is exempt from the retry budget because a duplicate payout is worse than a dropped one"},
+		},
+	}
+
+	got := AutoRecallDigestFor([]model.Session{s}, 2000, []string{"endpoint", "retry", "budget"})
+	if !strings.Contains(got, "/v1/payouts") {
+		t.Fatalf("the answering line is missing:\n%s", got)
+	}
+	if strings.Contains(got, "two schedulers") {
+		t.Fatalf("unrelated chatter was padded in under the answer:\n%s", got)
+	}
+
+	// Without terms nothing matched, so the opening of the session is still
+	// the best summary of it and both slots are worth filling.
+	plain := AutoRecallDigest([]model.Session{s}, 2000)
+	if !strings.Contains(plain, "two schedulers") {
+		t.Fatalf("the session-start digest lost its second line:\n%s", plain)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -38,6 +38,19 @@ type AutoRecallResult struct {
 }
 
 func AutoRecallDigest(ss []model.Session, budget int) string {
+	return AutoRecallDigestFor(ss, budget, nil)
+}
+
+// AutoRecallDigestFor renders the digest around the words that were asked
+// about. Without terms it keeps the session-start behaviour, where there is no
+// question yet and the opening of a session is the best summary of it.
+//
+// With terms it matters a great deal. A long session narrowed to the region
+// that matched still holds hundreds of messages, and showing that region's
+// first three lines answers a different question than the one asked: measured
+// on a real 8608-message session, the block an agent received carried one or
+// two of the four words it had searched for.
+func AutoRecallDigestFor(ss []model.Session, budget int, terms []string) string {
 	if budget <= 0 {
 		budget = 2000
 	}
@@ -46,7 +59,7 @@ func AutoRecallDigest(ss []model.Session, budget int) string {
 		if b.Len() >= budget {
 			break
 		}
-		section := autoRecallSession(s, time.Now(), false)
+		section := autoRecallSessionFor(s, time.Now(), false, terms)
 		if section == "" {
 			continue
 		}
@@ -199,9 +212,47 @@ func nearDuplicate(candidate map[string]bool, prior []map[string]bool) bool {
 }
 
 func autoRecallSession(s model.Session, now time.Time, provenance bool) string {
+	return autoRecallSessionFor(s, now, provenance, nil)
+}
+
+// termHits counts how many distinct query terms a text carries. It decides
+// which lines of a matched session are worth showing, so it folds case and
+// nothing else: a term the ranking reached through a stem fold is not found
+// here, which costs that line its place and never costs correctness.
+func termHits(text string, terms []string) int {
+	if len(terms) == 0 {
+		return 0
+	}
+	low := strings.ToLower(text)
+	n := 0
+	for _, t := range terms {
+		if t != "" && strings.Contains(low, strings.ToLower(t)) {
+			n++
+		}
+	}
+	return n
+}
+
+func autoRecallSessionFor(s model.Session, now time.Time, provenance bool, terms []string) string {
 	var problem string
 	var conclusions []string
+	matched := false
+	if len(terms) > 0 {
+		problem, conclusions = matchedLines(s, terms)
+		matched = len(conclusions) > 0
+	}
 	for _, m := range s.Messages {
+		if problem != "" && (len(conclusions) >= 2 || matched) {
+			break
+		}
+		// One line that answers beats that line plus a filler. When the
+		// session matched, the second slot is left empty rather than topped up
+		// from the top of the session: on a real block that padding read as
+		// "two schedulers were live after the failover" under an answer about
+		// the retry budget.
+		if matched && m.Role == "assistant" {
+			continue
+		}
 		text := contextText(m.Text, false)
 		if strings.TrimSpace(text) == "" {
 			continue
@@ -231,6 +282,14 @@ func autoRecallSession(s model.Session, now time.Time, provenance bool) string {
 	if isSmokeTest(problem, conclusions) {
 		return ""
 	}
+	// A session where the agent only ever said it could not proceed carries
+	// nothing to reuse. One had been sitting in a real store for twenty days,
+	// blocked on a permission prompt, taking a slot in every agent's opening
+	// context. This asks that *every* conclusion be a refusal, so work that
+	// hit a wall and then got past it is untouched.
+	if wasBlocked(conclusions) {
+		return ""
+	}
 	var b strings.Builder
 	if provenance {
 		fmt.Fprintf(&b, "✓ recalled from %s session · %s\n", digestLine(s.Harness), relativeDay(s.Updated, now))
@@ -249,6 +308,131 @@ func autoRecallSession(s model.Session, now time.Time, provenance bool) string {
 		fmt.Fprintf(&b, "  - Assistant: %s\n", digestLine(c))
 	}
 	return b.String()
+}
+
+// matchedLines picks the lines of a session that carry what was asked about:
+// the best-matching user message, and the two best-matching assistant
+// messages in the order they were said. What matches nothing is left to the
+// caller's fallback, so a session that ranked through a stem fold still shows
+// something rather than nothing.
+func matchedLines(s model.Session, terms []string) (string, []string) {
+	type scored struct {
+		idx, hits int
+		text      string
+	}
+	var bestUser scored
+	var assistants []scored
+	for i, m := range s.Messages {
+		// Score the raw text, not what contextText returns: it joins lines and
+		// keeps only the first eight of them, so by then there is nothing left
+		// to choose between and most of a long answer is already gone.
+		//
+		// Score the best single line rather than the whole message, too. A
+		// compaction summary or a standing-constraints block mentions
+		// everything the session ever touched, so counting terms across a
+		// message hands the slot to the longest text rather than to the one
+		// that answers.
+		line, hits := densestLine(m.Text, terms)
+		if hits == 0 {
+			continue
+		}
+		text := contextText(line, false)
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		switch m.Role {
+		case "user":
+			if !noiseMessage(m.Text) && hits > bestUser.hits {
+				bestUser = scored{i, hits, firstLine(text, 160)}
+			}
+		case "assistant":
+			assistants = append(assistants, scored{i, hits, firstLine(text, 220)})
+		}
+	}
+	sort.SliceStable(assistants, func(i, j int) bool { return assistants[i].hits > assistants[j].hits })
+	if len(assistants) > 2 {
+		assistants = assistants[:2]
+	}
+	// Back into the order they were said: two conclusions read as a sequence,
+	// and keeping them in score order tells the story backwards.
+	sort.SliceStable(assistants, func(i, j int) bool { return assistants[i].idx < assistants[j].idx })
+	out := make([]string, 0, len(assistants))
+	for _, a := range assistants {
+		out = append(out, a.text)
+	}
+	return bestUser.text, out
+}
+
+// densestLine returns the line of a message carrying the most query terms, and
+// how many, so a message is both chosen and quoted where it answers rather
+// than where it opens.
+func densestLine(text string, terms []string) (string, int) {
+	best, bestHits := "", 0
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if h := termHits(line, terms); h > bestHits {
+			best, bestHits = line, h
+		}
+	}
+	if best == "" {
+		return text, 0
+	}
+	return best, bestHits
+}
+
+// blockedPhrases are how a harness reports that a call did not happen. They
+// have to appear in what the agent said, not in the tool output, so that a
+// session discussing permissions is not mistaken for one denied them.
+var blockedPhrases = []string{
+	"not granted", "call blocked", "permission denied", "requires approval",
+	"denied permission", "не разрешен", "не разрешён", "нет доступа",
+}
+
+// wasBlocked reports whether every conclusion a session reached was a refusal.
+func wasBlocked(conclusions []string) bool {
+	if len(conclusions) == 0 {
+		return false
+	}
+	for _, c := range conclusions {
+		low := strings.ToLower(c)
+		hit := false
+		for _, p := range blockedPhrases {
+			if strings.Contains(low, p) {
+				hit = true
+				break
+			}
+		}
+		if !hit {
+			return false
+		}
+	}
+	return true
+}
+
+// MatchedUserLine is the line of a session that best answers what was asked,
+// taken from what the user said. The citation the agent is told to speak aloud
+// used to name a session's opening message, which after focusing a long session
+// is whatever chatter began the matched window — seen on a real screen naming
+// "migration locked the table" for a session the digest was quoting about token
+// rotation. Empty when nothing matches, so the caller keeps its own fallback.
+func MatchedUserLine(s model.Session, terms []string) string {
+	if len(terms) == 0 {
+		return ""
+	}
+	best, bestHits := "", 0
+	for _, m := range s.Messages {
+		if m.Role != "user" || noiseMessage(m.Text) {
+			continue
+		}
+		line, hits := densestLine(m.Text, terms)
+		if hits > bestHits {
+			best, bestHits = strings.TrimSpace(line), hits
+		}
+	}
+	return best
 }
 
 func relativeDay(updated, now time.Time) string {
@@ -334,9 +518,17 @@ func isSmokeTest(problem string, conclusions []string) bool {
 		return false
 	}
 	low := strings.ToLower(strings.TrimSpace(problem))
-	for _, p := range smokeAsks {
-		if strings.HasPrefix(low, p) {
-			return true
+	// The ask is usually the last sentence, not the first: a harness check
+	// says what to do and then how to answer — "search for X. Reply with the
+	// name only." Matching the prompt's opening alone let those through, and
+	// two of the three sessions an agent was handed on a real store were that
+	// exact shape. Sentence starts rather than a bare substring: prose about
+	// what a server should reply with is work, not a smoke test.
+	for _, sentence := range splitSentences(low) {
+		for _, p := range smokeAsks {
+			if strings.HasPrefix(sentence, p) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/search/smoke_tail_test.go
+++ b/internal/search/smoke_tail_test.go
@@ -1,0 +1,62 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A harness check states the task first and how to answer last. Matching only
+// the prompt's opening let those through: on a real store, two of the three
+// sessions handed to an agent at session start were this exact shape.
+func TestSmokeTestAskCanBeTheLastSentence(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "smoke", Project: "goprojects/deja-vu",
+		Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: "Use the deja recall tool to search for: openclaw deja harness live test alpha. Reply with the harness name of the top match only."},
+			{Role: "assistant", Text: "openclaw"},
+		},
+	}
+	if got := autoRecallSession(s, time.Now(), true); got != "" {
+		t.Fatalf("smoke test reached an agent's context:\n%s", got)
+	}
+}
+
+// And work that merely talks about replying must survive, however short the
+// answer is.
+func TestProseAboutRepliesIsNotASmokeTest(t *testing.T) {
+	for _, text := range []string{
+		"the gateway should reply with 404 when the token is stale, right?",
+		"we answer with the cached value if the upstream is down",
+	} {
+		s := model.Session{
+			Harness: "claude", ID: "work", Project: "goprojects/deja-vu",
+			Updated: time.Now(),
+			Messages: []model.Message{
+				{Role: "user", Text: text},
+				{Role: "assistant", Text: "yes, fixed"},
+			},
+		}
+		if got := autoRecallSession(s, time.Now(), true); got == "" {
+			t.Fatalf("real work was dropped as a smoke test: %q", text)
+		}
+	}
+}
+
+// The narrow case the filter was written for still has to go.
+func TestClassicSmokeTestStillDropped(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "smoke2", Project: "goprojects/deja-vu",
+		Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: "Reply with the single word OK"},
+			{Role: "assistant", Text: "OK"},
+		},
+	}
+	if got := autoRecallSession(s, time.Now(), true); !strings.EqualFold(got, "") {
+		t.Fatalf("classic smoke test survived:\n%s", got)
+	}
+}


### PR DESCRIPTION
The last piece of #1217: what the user is told, and what the agent is quoted at the moment it acts.

**One session in four heard anything.** The visible déjà vu line is rate-limited so it does not fire every prompt — wallpaper trains people to ignore the real moments. But the timestamp lives beside the index, so the window was per machine rather than per session, and a second agent opened five minutes later got recall in silence. Measured on one index, four fresh sessions inside the window:

```
before   1 of 4 fresh sessions told the user anything
after    4 of 4
```

All four received the recall either way. Running several agents at once is the case deja is for, so this was the common path, not a corner. Within one session the line still holds its tongue; a host that sends no session id keeps the old machine-wide window.

**Six receipts stuttered.** Hosts prefix hook output with their own name, so `deja: recalled 2 prior sessions` rendered as `deja: deja: recalled…`. The colon is gone from all six, and the teaching clause is only added when there is no service note to carry.

**The citation named the wrong thing.** A recalled session was quoted at the line it *opened* with rather than the line that *matched*, so a session surfaced for pgbouncer was introduced by whatever its first message happened to be. It now quotes where it matched, chooses that line from the raw message rather than the rendered one, and stops there instead of padding with assistant text that was never the answer.

A harness check states the ask last rather than first, a session the user has blocked never reaches the quote, and a smoke-ask matches on sentence starts.

**hook-tool now says what happened last time a command ran.** The file path already carried the prior decision, for the measured reason recorded beside it: a line that only says history exists changes nothing an agent does, while the same moment carrying the decision does. The command path said only how often it had been run. Before `npm run build`, the useful part is not the count:

```
before   This machine has run that command in 2 sessions, last 2026-06-19.
after    … last 2026-06-19 — last time: the lockfile was stale; `npm ci` fixed it
```

Verified reaching the model in Claude Code, and absent from the control arm. The bar is strict — every term of the command must match, or a build command's ordinary words pull in a session about something else.
