### PR TITLE
feat(copilot): turn tool calls and results into work records

### DIFF
--- a/internal/sources/copilot.go
+++ b/internal/sources/copilot.go
@@ -34,6 +34,18 @@ func ParseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 	return parseCopilotFileFromOffset(path, offset)
 }
 
+// copilotDialect is Copilot's tool vocabulary, read off events.jsonl its own
+// CLI wrote. Names are lowercase where Claude's are capitalised, the file key
+// is `path`, and the replaced span is `old_str` rather than `old_string` —
+// reading the wrong one loses the only record of what stopped existing.
+var copilotDialect = toolDialect{
+	pathKey:   "path",
+	pathTools: map[string]bool{"edit": true, "read": true, "write": true, "create": true},
+	shellTool: "bash",
+	editTools: map[string]bool{"edit": true},
+	oldKey:    "old_str",
+}
+
 func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, error) {
 	s := model.Session{
 		Harness: "copilot",
@@ -70,6 +82,55 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 			if txt, _ := data["content"].(string); txt != "" {
 				s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
 			}
+		case "tool.execution_start":
+			// The call carries the work: which file, what it replaced, what
+			// command ran. Copilot files these outside the message stream, so
+			// the assistant turns that do nothing but call tools were being
+			// stored as empty and the work was reachable from nothing.
+			if data == nil {
+				return
+			}
+			name, _ := data["toolName"].(string)
+			args, _ := data["arguments"].(map[string]any)
+			if name == "" || args == nil {
+				return
+			}
+			part := []any{map[string]any{"type": "tool_use", "name": name, "input": args}}
+			var records []model.Message
+			if IndexToolPaths() {
+				if p := toolPathsIn(part, copilotDialect); p != "" {
+					records = append(records, model.Message{Role: RoleFiles, Text: p, Time: t})
+				}
+			}
+			if IndexEdits() {
+				for _, span := range editSpansIn(part, copilotDialect) {
+					records = append(records, model.Message{Role: RoleEdit, Text: span, Time: t})
+				}
+			}
+			if IndexCommands() {
+				for _, cmd := range commandsIn(part, copilotDialect) {
+					records = append(records, model.Message{Role: RoleCommand, Text: cmd, Time: t})
+				}
+			}
+			if len(records) == 0 {
+				return
+			}
+			s.Touch(t)
+			s.Messages = append(s.Messages, records...)
+		case "tool.execution_complete":
+			// Kept whether or not the call succeeded: the error a command hit
+			// is exactly what a later search reaches for, and copilot's own
+			// failure text was unreachable before this.
+			if !IndexToolOutput() || data == nil {
+				return
+			}
+			result, _ := data["result"].(map[string]any)
+			out, _ := result["content"].(string)
+			if out = strings.TrimSpace(out); out == "" {
+				return
+			}
+			s.Touch(t)
+			s.Messages = append(s.Messages, model.Message{Role: RoleToolOutput, Text: out, Time: t})
 		}
 	})
 	if len(s.Messages) == 0 {

--- a/internal/sources/copilot_work_test.go
+++ b/internal/sources/copilot_work_test.go
@@ -1,0 +1,84 @@
+package sources
+
+import (
+	"strings"
+	"testing"
+)
+
+// One session that works: it speaks, edits a file, runs a command that fails,
+// reads a file, and closes. Shapes are the ones the Copilot CLI writes —
+// lowercase tool names, `path` rather than `file_path`, `old_str` rather than
+// `old_string`, and results under `result.content`.
+func copilotWorkLines() []string {
+	return []string{
+		`{"type":"session.start","data":{"sessionId":"s1","startTime":"2026-07-20T05:13:54.687Z","context":{"cwd":"/Users/x/coding/gateway"}},"timestamp":"2026-07-20T05:13:54.707Z"}`,
+		`{"type":"user.message","data":{"content":"the build is broken"},"timestamp":"2026-07-20T05:13:58.653Z"}`,
+		`{"type":"assistant.message","data":{"content":"looking at it"},"timestamp":"2026-07-20T05:14:00.973Z"}`,
+		`{"type":"tool.execution_start","data":{"toolName":"edit","arguments":{"path":"/Users/x/coding/gateway/main.go","old_str":"println(\"hello\")","new_str":"println(\"goodbye\")"}},"timestamp":"2026-07-20T05:14:01.100Z"}`,
+		`{"type":"tool.execution_complete","data":{"success":true,"result":{"content":"1 replacement"}},"timestamp":"2026-07-20T05:14:01.200Z"}`,
+		`{"type":"tool.execution_start","data":{"toolName":"bash","arguments":{"command":"go vet ./..."}},"timestamp":"2026-07-20T05:14:02.100Z"}`,
+		`{"type":"tool.execution_complete","data":{"success":false,"result":{"content":"pattern ./...: directory prefix . does not contain main module"}},"timestamp":"2026-07-20T05:14:02.900Z"}`,
+		`{"type":"tool.execution_start","data":{"toolName":"read","arguments":{"path":"/Users/x/coding/gateway/go.mod"}},"timestamp":"2026-07-20T05:14:03.100Z"}`,
+		`{"type":"tool.execution_start","data":{"toolName":"todo","arguments":{"items":[]}},"timestamp":"2026-07-20T05:14:03.500Z"}`,
+		`{"type":"session.shutdown","data":{},"timestamp":"2026-07-20T05:14:04.029Z"}`,
+	}
+}
+
+func TestParseCopilotEmitsWorkRecords(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DEJA_COPILOT_ROOT", root)
+	p := writeCopilotFixture(t, root, "s1", copilotWorkLines())
+	ss, err := ParseCopilotFile(p)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v %d", err, len(ss))
+	}
+	byRole := map[string][]string{}
+	for _, m := range ss[0].Messages {
+		byRole[m.Role] = append(byRole[m.Role], m.Text)
+	}
+
+	if got := byRole[RoleCommand]; len(got) != 1 || got[0] != "$ go vet ./..." {
+		t.Errorf("commands = %q, want the vet run alone — todo carries none", got)
+	}
+	wantFiles := []string{"/Users/x/coding/gateway/main.go", "/Users/x/coding/gateway/go.mod"}
+	if got := byRole[RoleFiles]; strings.Join(got, ",") != strings.Join(wantFiles, ",") {
+		t.Errorf("files = %q, want the edit and the read in order", got)
+	}
+	// old_str, not old_string: reading the wrong key stores the path with no
+	// span, which is the record silently losing what it is for.
+	if got := byRole[RoleEdit]; len(got) != 1 ||
+		got[0] != "/Users/x/coding/gateway/main.go\nprintln(\"hello\")" ||
+		strings.Contains(strings.Join(got, ""), "goodbye") {
+		t.Errorf("edit = %q, want only the bytes that stopped existing", got)
+	}
+	// The failure is the point: it is what a later search reaches for.
+	wantOut := []string{"1 replacement", "pattern ./...: directory prefix . does not contain main module"}
+	if got := byRole[RoleToolOutput]; strings.Join(got, "|") != strings.Join(wantOut, "|") {
+		t.Errorf("tool output = %q, want both results including the error", got)
+	}
+}
+
+// With the switches off the stream is what it was before tool events were
+// read, so nobody's existing index changes shape under them.
+func TestParseCopilotWorkRecordsSwitchOff(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DEJA_COPILOT_ROOT", root)
+	t.Setenv("DEJA_INDEX_COMMANDS", "0")
+	t.Setenv("DEJA_INDEX_PATHS", "0")
+	t.Setenv("DEJA_INDEX_EDITS", "0")
+	t.Setenv("DEJA_INDEX_TOOL_OUTPUT", "0")
+	p := writeCopilotFixture(t, root, "s1", copilotWorkLines())
+	ss, err := ParseCopilotFile(p)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, m := range ss[0].Messages {
+		switch m.Role {
+		case RoleCommand, RoleFiles, RoleEdit, RoleToolOutput:
+			t.Fatalf("record %q survived its switch", m.Role)
+		}
+	}
+	if len(ss[0].Messages) != 2 {
+		t.Fatalf("want the two spoken turns back, got %d", len(ss[0].Messages))
+	}
+}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -361,6 +361,19 @@ type toolDialect struct {
 	// with a path and an old_string, which is how the Claude decoder has always
 	// read MultiEdit's sub-edits.
 	editTools map[string]bool
+	// oldKey names the argument holding the text an edit replaced. Copilot
+	// calls it old_str where Claude calls it old_string, and reading the wrong
+	// one loses the only record of what stopped existing. Empty means
+	// old_string.
+	oldKey string
+}
+
+// oldSpanKey is oldKey with its default applied.
+func (d toolDialect) oldSpanKey() string {
+	if d.oldKey == "" {
+		return "old_string"
+	}
+	return d.oldKey
 }
 
 var claudeDialect = toolDialect{
@@ -430,7 +443,7 @@ func editSpansIn(v any, d toolDialect) []string {
 		if path == "" {
 			continue
 		}
-		old, _ := in["old_string"].(string)
+		old, _ := in[d.oldSpanKey()].(string)
 		spans := []string{old}
 		if edits, ok := in["edits"].([]any); ok {
 			for _, e := range edits {
@@ -438,7 +451,7 @@ func editSpansIn(v any, d toolDialect) []string {
 				if !ok {
 					continue
 				}
-				o, _ := em["old_string"].(string)
+				o, _ := em[d.oldSpanKey()].(string)
 				spans = append(spans, o)
 			}
 		}


### PR DESCRIPTION
Part of #655 — copilot, which that issue ranks first for having the richest shape.

Copilot records its work as `tool.execution_start` / `tool.execution_complete` events outside the message stream, and the parser read past them. So a session that edited two files and ran three commands answered nothing:

```
deja "directory prefix" --harness copilot   → no matches    (the error it hit)
deja "go mod init"      --harness copilot   → no matches    (the command it ran)
```

Both now land, through the same `toolDialect` machinery the other parsers use rather than a second copy of the extraction.

One addition to the shared type: `oldKey`. Copilot names the replaced span `old_str` where Claude names it `old_string`, and `editSpansIn` hardcoded the latter — reading the wrong key stores the path with no span, which is the edit record silently losing the thing it exists for. Defaults to `old_string`, so the other three dialects are untouched.

Failed results are kept on purpose: the error a command hit is what a later search reaches for.

Tests cover the vocabulary, the ordering, and — the one that makes the rest safe to take — that with every `DEJA_INDEX_*` switch off the stream is exactly the two spoken turns it was before.