### PR TITLE
fix(search): one date form per list, so the column reads vertically

### DIFF
--- a/internal/search/date_column_test.go
+++ b/internal/search/date_column_test.go
@@ -1,0 +1,50 @@
+package search
+
+import (
+	"testing"
+	"time"
+)
+
+// The age column is the one part of the screen meant to be read vertically.
+// Two sessions a day apart printed "6d ago" and "Jul 26" one row under the
+// other, because the relative form stops at a week — correct on each row and
+// unreadable as a column.
+func TestDateColumnHoldsOneFormForTheWholeList(t *testing.T) {
+	now := time.Now()
+	day := 24 * time.Hour
+
+	// Everything inside the week: the relative form, which is the warm one.
+	recent := []time.Time{now, now.Add(-2 * day), now.Add(-6 * day)}
+	fmtRecent := dateColumn(recent)
+	if got := fmtRecent(recent[0]); got != "today" {
+		t.Errorf("newest row = %q, want the relative form", got)
+	}
+	if got := fmtRecent(recent[2]); got != "6d ago" {
+		t.Errorf("oldest row = %q, want the relative form", got)
+	}
+
+	// One row past the week takes the whole column with it.
+	mixed := []time.Time{now, now.Add(-6 * day), now.Add(-8 * day)}
+	fmtMixed := dateColumn(mixed)
+	for i, when := range mixed {
+		got := fmtMixed(when)
+		if got == "today" || len(got) > 0 && got[len(got)-1] == 'o' {
+			t.Errorf("row %d = %q; one row aged out, so no row may be relative", i, got)
+		}
+	}
+	// And consecutive days now read as consecutive.
+	first, second := fmtMixed(mixed[1]), fmtMixed(mixed[2])
+	if first == second {
+		t.Errorf("two days rendered the same: %q", first)
+	}
+}
+
+// A zero time is a session with no date; it must not decide the column's form
+// for the rows that do have one.
+func TestDateColumnIgnoresUndatedRows(t *testing.T) {
+	now := time.Now()
+	col := dateColumn([]time.Time{{}, now, now.Add(-time.Hour)})
+	if got := col(now); got != "today" {
+		t.Errorf("column = %q, want the relative form; an undated row is not an old one", got)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -872,16 +872,24 @@ func Print(w io.Writer, hits []Hit, o Options) {
 		return
 	}
 	color := colorOK(w)
+	// One form for the whole column, decided before the first row is printed.
+	when := make([]time.Time, 0, len(hits))
 	for _, h := range hits {
-		d := "-"
-		if !h.Session.Updated.IsZero() {
-			d = relativeDate(h.Session.Updated)
-		}
-		// A day of notes is one session whose id *is* a date, minted in UTC.
-		// The reader's zone put a different day on the line than the id beside
-		// it, and only for deja's own buckets (#883).
+		t := h.Session.Updated
 		if day, ok := NoteBucketDay(h.Session); ok {
-			d = relativeDate(noteBucketNoon(day))
+			t = noteBucketNoon(day)
+		}
+		when = append(when, t)
+	}
+	dated := dateColumn(when)
+	for i, h := range hits {
+		d := "-"
+		if !when[i].IsZero() {
+			// A day of notes is one session whose id *is* a date, minted in
+			// UTC. The reader's zone put a different day on the line than the
+			// id beside it, and only for deja's own buckets (#883) — which is
+			// why the time was chosen above rather than here.
+			d = dated(when[i])
 		}
 		// project and id are transcript/peer free text printed to a terminal;
 		// an escape or bidi run in an imported project name would repaint the
@@ -1279,6 +1287,52 @@ func harnessTag(h string, color bool) string {
 		return cGreen + tag + cReset + cBold
 	}
 	return tag
+}
+
+// dateColumn picks one form for a whole column and returns a formatter that
+// holds to it.
+//
+// Both forms are correct, and mixing them is what makes the column unreadable:
+// two sessions a day apart printed "6d ago" and "Jul 26" one row under the
+// other, because the relative form stops at a week. A reader scanning down
+// cannot see they are consecutive without doing the arithmetic. So the rule is
+// per rendering rather than per row — if any row has aged out of the relative
+// form, every row is dated.
+func dateColumn(times []time.Time) func(time.Time) string {
+	for _, t := range times {
+		if t.IsZero() {
+			continue
+		}
+		if !isRelativeAge(t) {
+			return absoluteDate
+		}
+	}
+	return relativeDate
+}
+
+// isRelativeAge reports whether relativeDate would answer in the relative form.
+func isRelativeAge(t time.Time) bool {
+	return daysAgo(t) < 7
+}
+
+func daysAgo(t time.Time) int {
+	now := time.Now()
+	// In the reader's zone, not the timestamp's — see relativeDate.
+	t = t.In(now.Location())
+	y1, m1, d1 := now.Date()
+	y2, m2, d2 := t.Date()
+	today := time.Date(y1, m1, d1, 0, 0, 0, 0, now.Location())
+	day := time.Date(y2, m2, d2, 0, 0, 0, 0, now.Location())
+	return int(today.Sub(day).Hours() / 24)
+}
+
+func absoluteDate(t time.Time) string {
+	now := time.Now()
+	t = t.In(now.Location())
+	if t.Year() == now.Year() {
+		return t.Format("Jan 2")
+	}
+	return t.Format("Jan 2 2006")
 }
 
 func relativeDate(t time.Time) string {


### PR DESCRIPTION
Closes #852.

Both forms were right; mixing them is what made the column unreadable:

```
[claude] t5c/proj · 6d ago  · session 2
[claude] t5c/proj · Jul 26  · session 1
[claude] t5c/proj · Jul 25  · session 0
```

Rows one and two are consecutive days, rendered differently because the relative form stops at seven. Nobody scanning that column can see they are consecutive without doing arithmetic.

The form is now chosen once per rendering rather than per row: if any row has aged out of the relative form, every row is dated. A list where everything is recent — the common case for `recent` — still reads "today" and "2d ago".

An undated row does not decide the form for the rows that have one; that is its own test, because `IsZero` sorting as ancient is the easy way to get this wrong.