### PR TITLE
fix(redact): a filesystem path is not a secret whatever its case

### DIFF
--- a/internal/redact/path_not_secret_test.go
+++ b/internal/redact/path_not_secret_test.go
@@ -1,0 +1,52 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+// A scratch path is not a credential. The uppercase-only exemption was standing
+// in for "looks like base64", and a macOS agent directory defeats it: the
+// `-Users-<name>` segment supplies the case mix and a uuid directory supplies
+// the entropy. When the record was nothing but that path — the output of a
+// `pwd` — the whole message became `[redacted:entropy]`.
+func TestAPathIsNotRedactedAsASecret(t *testing.T) {
+	for _, path := range []string{
+		"/private/tmp/claude-501/-Users-shulcz/9f0aa059-0c09-41f3-96a5-755b7b560be5/scratchpad/codexprobe",
+		"/Users/Alice/Library/Application Support/Code/User/globalStorage",
+		"~/Projects/Acme-Gateway/internal/db/pool.go",
+		"./build/Release-iphoneos/App.app/Contents/MacOS/App",
+	} {
+		t.Run(strings.Split(path, "/")[1], func(t *testing.T) {
+			got, _ := Text(path)
+			if strings.Contains(got, "[redacted") {
+				t.Fatalf("path was redacted:\n  in:  %s\n  out: %s", path, got)
+			}
+		})
+	}
+}
+
+// The exemption must not become a way to smuggle a secret past the scan: a
+// blob is not rooted, and anything carrying '=' or ':' is an assignment, a
+// scheme or base64 padding rather than a bare path.
+func TestThePathExemptionDoesNotCoverBlobs(t *testing.T) {
+	for name, tok := range map[string]string{
+		"base64 with slashes":  "dGhpcy9pcy9hL2Jsb2IvY29udGVudA==",
+		"rooted assignment":    "/etc/key=aB3dEf9hIjKlMnOpQrStUvWxYz012345",
+		"url with credentials": "https://user:aB3dEf9hIjKlMnOpQrStUvWx@example.com/path",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if looksLikePath(tok) {
+				t.Fatalf("%q was treated as a path", tok)
+			}
+		})
+	}
+	// And the shape the exemption is for still qualifies.
+	if !looksLikePath("/Users/Bob/src/app/main.go") {
+		t.Error("a plain rooted path was not recognised")
+	}
+	// One separator is a token like /tmp, not a path worth exempting.
+	if looksLikePath("/AbCdEfGh0123456789") {
+		t.Error("a single-segment token was treated as a path")
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -340,6 +340,24 @@ func isHexish(s string) bool {
 	return true
 }
 
+// looksLikePath reports whether a token is a filesystem path rather than
+// something that merely contains slashes. Rooted, more than one separator, and
+// carrying none of the punctuation a credential or a URL brings with it — a
+// base64 blob has no leading slash, and `https://…` and `key:value` both fail
+// on the characters they are named for.
+func looksLikePath(tok string) bool {
+	if !strings.HasPrefix(tok, "/") && !strings.HasPrefix(tok, "~/") &&
+		!strings.HasPrefix(tok, "./") && !strings.HasPrefix(tok, "../") {
+		return false
+	}
+	if strings.Count(tok, "/") < 2 {
+		return false
+	}
+	// '=' is base64 padding and the assignment a secret arrives in; ':' is a
+	// scheme or a key. Either one means this is not a bare path.
+	return !strings.ContainsAny(tok, "=:")
+}
+
 func entropyCandidate(tok string) bool {
 	if len(tok) > 256 || isHexish(tok) || charClasses(tok) < 3 {
 		return false
@@ -347,6 +365,17 @@ func entropyCandidate(tok string) bool {
 	// Lowercase-only path segments sneak into the charset via '/' and '-';
 	// real secrets with slashes (base64) mix cases.
 	if strings.Contains(tok, "/") && strings.ToLower(tok) == tok {
+		return false
+	}
+	// A filesystem path is not a blob whatever its case. The lowercase rule
+	// above was standing in for "looks like base64", and a macOS scratch
+	// directory defeats it twice over: `-Users-<name>` supplies the uppercase
+	// and a uuid directory supplies the entropy, so `/private/tmp/…/<uuid>/…`
+	// scored as a secret. When the record was nothing but that path — the
+	// output of a `pwd` — the whole message became `[redacted:entropy]`, which
+	// destroys the content rather than masking it, and says a key was removed
+	// when none was there.
+	if looksLikePath(tok) {
 		return false
 	}
 	return shannonBits(tok) >= entropyMinBits


### PR DESCRIPTION
Closes #653.

`entropyCandidate` exempted slash-containing tokens only when entirely lowercase. A macOS agent directory defeats that twice: `-Users-<name>` supplies the case mix, a uuid directory supplies the entropy. So this scored as a secret:

```
/private/tmp/claude-501/-Users-shulcz/<uuid>/scratchpad/codexprobe
```

And when the record was nothing but that path — the output of a `pwd` — the whole message became `[redacted:entropy]`. Not a masked secret: destroyed content, labelled as a key that was never there. It is the shape of every agent scratch directory on macOS.

The uppercase rule was standing in for "looks like base64", so the exemption now says what it means: rooted, more than one separator, and none of the punctuation a credential or URL brings — `=` is base64 padding and the assignment a secret arrives in, `:` is a scheme or a key.

Tested both ways round, because an exemption is also a hole: base64 with slashes, a rooted `=` assignment and a URL with credentials must all still be caught, and a single-segment token like `/AbCdEf…` is not a path.