### PR TITLE
chore: drop smithery.yaml

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,7 +1,0 @@
-startCommand:
-  type: stdio
-  configSchema:
-    type: object
-    properties: {}
-  commandFunction: |-
-    (config) => ({ command: "npx", args: ["-y", "@vshulcz/deja-vu", "mcp"] })


### PR DESCRIPTION
The registry cannot take this server, so the descriptor described a listing that was never going to exist.

Nothing reads it: the two `smithery` mentions left in `scripts/mcpb` are comments citing smithery-ai/cli#787, which is about MCPB bundle validation and has nothing to do with this file.