### PR TITLE
docs: the README listed four MCP tools; the server serves six

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,18 +171,20 @@ Full reference: [commands](https://vshulcz.github.io/deja-vu/guide/commands.html
 
 ### MCP tools
 
-The server exposes `recall`, `recall_context`, `blame` and `remember`. `deja install` wires
-them in, so this is only needed to configure an agent by hand.
+The server exposes `recall`, `recall_context`, `blame`, `fix`, `how` and `remember`.
+`deja install` wires them in, so this is only needed to configure an agent by hand.
 
 <details>
 <summary>Arguments and return shapes</summary>
 
 | Tool | Arguments | Returns |
 | --- | --- | --- |
-| `recall` | `query`, `harness?`, `limit?` | Dense matching snippets, capped at 4KB. |
+| `recall` | `query`, `harness?`, `limit?`, `offset?` | Dense matching snippets, capped at 4KB. |
 | `recall_context` | `query`, `harness?` | Markdown digest of the best-matching session. |
-| `blame` | `path`, `harness?`, `project?`, `since?`, `limit?` | Sessions that discussed a file. |
-| `remember` | `text`, `project?` | Stores a durable decision for later recall. |
+| `blame` | `path`, `harness?`, `project?`, `since?`, `limit?`, `all?` | Sessions that discussed a file. |
+| `fix` | `error`, `project?`, `limit?` | What this machine ran after that same error before. |
+| `how` | `what`, `project?`, `limit?` | The real invocation, from what agents ran here. |
+| `remember` | `text`, `project?`, `tags?` | Stores a durable decision for later recall. |
 
 </details>
 

--- a/cmd/deja/readme_mcp_tools_test.go
+++ b/cmd/deja/readme_mcp_tools_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The README listed four MCP tools while the server has served six since fix and
+// how were added. Nothing compared the two, so the page quietly undersold the
+// product — Glama's own listing of this server had the right six.
+//
+// This reads the tools the server actually registers and requires each one to
+// appear in the README, both in the sentence and in the argument table.
+func TestReadmeListsEveryMCPToolTheServerRegisters(t *testing.T) {
+	resp, code, msg := handleMCP(t.TempDir(), rpcRequest{Method: "tools/list"})
+	if code != 0 {
+		t.Fatalf("tools/list: %d %s", code, msg)
+	}
+	payload, ok := resp.(map[string]any)
+	if !ok {
+		t.Fatalf("tools/list returned %T", resp)
+	}
+	tools, ok := payload["tools"].([]map[string]any)
+	if !ok {
+		t.Fatalf("tools is %T", payload["tools"])
+	}
+
+	b, err := os.ReadFile(filepath.Join("..", "..", "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	readme := string(b)
+
+	for _, tool := range tools {
+		name, _ := tool["name"].(string)
+		if name == "" {
+			t.Fatalf("a tool has no name: %v", tool)
+		}
+		if !strings.Contains(readme, "`"+name+"`") {
+			t.Errorf("README never mentions the %q tool", name)
+		}
+		if !strings.Contains(readme, "| `"+name+"` |") {
+			t.Errorf("README's MCP table has no row for %q", name)
+		}
+
+		schema, _ := tool["inputSchema"].(map[string]any)
+		props, _ := schema["properties"].(map[string]any)
+		row := tableRow(readme, name)
+		for arg := range props {
+			// the table marks optional arguments with a trailing "?" inside the
+			// code span, so both spellings count as naming it
+			if !strings.Contains(row, "`"+arg+"`") && !strings.Contains(row, "`"+arg+"?`") {
+				t.Errorf("README's %q row does not name the %q argument: %s", name, arg, row)
+			}
+		}
+	}
+}
+
+// tableRow returns the README table row for a tool, or "" when there is none.
+func tableRow(readme, tool string) string {
+	head := "| `" + tool + "` |"
+	i := strings.Index(readme, head)
+	if i < 0 {
+		return ""
+	}
+	rest := readme[i:]
+	if j := strings.IndexByte(rest, '\n'); j >= 0 {
+		return rest[:j]
+	}
+	return rest
+}


### PR DESCRIPTION
`fix` and `how` have been registered since they shipped and never reached the README, so the MCP section undersold the server by two tools. Glama's listing of this repo had the right six all along — that is how it turned up.

The argument table was short too, and each of these came from the server's own `inputSchema` rather than from reading handlers: `recall` takes `offset`, `blame` takes `all`, `fix` and `how` take `limit`, `remember` takes `tags`.

A test now drives `tools/list` and requires every tool and every argument name to appear in the table, so the next tool added cannot land unmentioned. It caught all five gaps above before I wrote a line of the fix.