### PR TITLE
fix(site): the phone layout, which I had never actually looked at

### DIFF
--- a/docs/assets/guide.js
+++ b/docs/assets/guide.js
@@ -102,6 +102,29 @@
     nav.parentNode.insertBefore(hint,nav.nextSibling);
   })();
 
+
+  /* ── the sidebar folds on a phone ───────────────────────────────────────
+     Eleven links and a cat above the article means scrolling past the whole
+     guide to reach the page you opened. */
+  (function(){
+    var side=document.querySelector('.doc aside');
+    if(!side||!matchMedia('(max-width:860px)').matches)return;
+
+    var here=side.querySelector('a[aria-current]');
+    var box=document.createElement('details');
+    box.className='sidefold';
+    var head=document.createElement('summary');
+    head.innerHTML='<span>Guide</span><b>'+(here?here.textContent.trim():'contents')+'</b>';
+    box.appendChild(head);
+    while(side.firstChild)box.appendChild(side.firstChild);
+    side.appendChild(box);
+
+    /* opening it should not leave the reader somewhere else when it closes */
+    box.addEventListener('toggle',function(){
+      if(!box.open)side.scrollIntoView({block:'nearest'});
+    });
+  })();
+
   /* new page behaviour goes above this line, inside this closure */
 
   /* ── a hairline that fills as you read ─────────────────────────────── */

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -82,7 +82,9 @@ footer a:hover{color:var(--ph-hi)}
   border-left:2px solid transparent}
 .doc aside a:hover{color:var(--ink);background:var(--panel)}
 .doc aside a[aria-current]{color:var(--ph-hi);border-left-color:var(--ph);background:var(--panel)}
-.doc article{min-width:0;max-width:74ch}
+/* long words break rather than push the column: on a 360px phone an italic
+   phrase was hanging nine pixels off the edge */
+.doc article{min-width:0;max-width:74ch;overflow-wrap:break-word}
 
 /* The prompt before the title stays: it is a terminal tool, and the mark of one
    costs a heading nothing. The ## before every h2 did not — at one per section
@@ -232,3 +234,27 @@ h2:hover .hlink{opacity:1}
 .searchhint:hover{border-color:var(--ph-dim);color:var(--ink)}
 .searchhint kbd{border:1px solid var(--line);border-radius:4px;padding:0 5px;color:var(--ph-hi)}
 @media(max-width:700px){.searchhint span{display:none}}
+
+@media(max-width:620px){
+  /* The header did not fit: the GitHub button ran off the right edge and the
+     brand broke across two lines. Wrapping keeps every link reachable, which
+     matters more on a phone than keeping the row to one line. */
+  nav{flex-wrap:wrap;row-gap:6px;padding:12px 20px}
+  nav .spacer{display:none}
+  nav .brand{white-space:nowrap;width:100%}
+  nav .lnk{padding:6px 8px}
+}
+
+@media(max-width:860px){
+  .sidefold{border:1px solid var(--line);border-radius:10px;background:var(--panel);
+    margin-bottom:8px}
+  .sidefold summary{display:flex;align-items:baseline;gap:10px;cursor:pointer;
+    padding:12px 14px;font:12px var(--mono);color:var(--faint);list-style:none}
+  .sidefold summary::-webkit-details-marker{display:none}
+  .sidefold summary::after{content:"▾";margin-left:auto;color:var(--ph-dim)}
+  .sidefold[open] summary::after{content:"▴"}
+  .sidefold summary b{color:var(--ph-hi);font-weight:400}
+  .sidefold > a,.sidefold > .grp{margin-left:6px;margin-right:6px}
+  .sidefold > a:last-of-type{margin-bottom:10px}
+  .doc aside a.sidecat{margin-top:14px}
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,7 +60,7 @@ nav .lnk:hover{color:var(--ink);background:var(--panel)}
 nav .cta{color:var(--bg);background:var(--coat);padding:8px 14px;border-radius:7px;font-weight:600}
 nav .cta:hover{background:var(--coat-hi);color:var(--bg)}
 
-header{padding:72px 0 96px;display:grid;grid-template-columns:1fr 290px;gap:56px;align-items:center}
+header{padding:72px 0 96px;display:grid;grid-template-columns:minmax(0,1fr) 290px;gap:56px;align-items:center}
 h1{font:700 clamp(36px,5.1vw,58px)/1.06 var(--sans);letter-spacing:-.028em;color:var(--ink);margin-bottom:22px}
 h1 em{font-style:normal;color:var(--amber)}
 .lede{font-size:19px;line-height:1.55;max-width:40ch;margin-bottom:32px}
@@ -73,7 +73,10 @@ h1 em{font-style:normal;color:var(--amber)}
 .cmdline{display:flex;align-items:center;gap:10px;background:var(--panel);
   border:1px solid var(--line);border-radius:10px;padding:13px 15px;font:13.5px var(--mono);max-width:560px}
 .cmdline .p{color:var(--amber)}
-.cmdline code{color:var(--ink);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+/* min-width:0 or the flex item refuses to shrink below the width of the
+   command, which on a phone pushed the whole hero column to 560px and cut
+   the headline, the lede and everything under them off the screen */
+.cmdline code{color:var(--ink);flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .cmdline button{background:none;border:1px solid var(--line);color:var(--faint);
   border-radius:6px;padding:5px 10px;font:11px var(--mono);cursor:pointer}
 .cmdline button:hover{color:var(--ink);border-color:var(--coat-dim)}
@@ -225,8 +228,18 @@ footer .sp{flex:1}
   .js .reveal{opacity:1;transform:none;transition:none}
   #vu{display:none}
 }
+
+@media(max-width:620px){
+  /* The header did not fit: the GitHub button ran off the right edge and the
+     brand broke across two lines. Wrapping keeps every link reachable, which
+     matters more on a phone than keeping the row to one line. */
+  nav{flex-wrap:wrap;row-gap:6px;padding:12px 20px}
+  nav .sp,nav .spacer{display:none}
+  nav .brand{white-space:nowrap;width:100%}
+  nav .lnk{padding:6px 8px}
+}
 @media(max-width:860px){
-  header{grid-template-columns:1fr;gap:32px}
+  header{grid-template-columns:minmax(0,1fr);gap:32px}
   .catwrap{order:-1;justify-self:start}
   .catwrap img{width:150px;height:150px}
   .proof,.steps{grid-template-columns:1fr}


### PR DESCRIPTION
Three faults on a phone.

**The install command could not shrink.** A flex item does not go below its content unless told to, and that content is an unbreakable URL — so the hero column was pinned at 560px and the headline, the lede and everything under them ran off the side. `min-width:0`, and the grid columns are `minmax(0,1fr)` so they can be squeezed at all.

**The header did not fit.** The GitHub button hung off the right edge and the brand broke across two lines. It wraps below 620px; every link stays reachable, which matters more on a phone than keeping one row.

**The guide stacked its whole sidebar above the article**, so reaching the first word of a page meant scrolling past eleven links and the cat. It folds below 860px with the current page named on the fold.

Why none of it was caught: **headless Chrome will not make its window narrower than 500px**, so every phone screenshot I took was a 390-wide crop of a 500-wide layout. That makes a page look cut whether or not anything is wrong, and hides anything that only breaks below 500 — I had been reading artefacts as either fine or broken with no way to tell which.

Rendering the page inside an iframe gives it a real viewport at whatever width it is handed, and the probe reports which elements stick out past it by name. Checked at 360, 390 and 768; the desktop drivers still pass unchanged.