### PR TITLE
feat(site): give the home page a rhythm and somewhere to land

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,25 @@ to local files, and deja turns those files into one memory layer all of them rea
 | **It survives compaction** | Measured over 43 compactions: the summary keeps 77% of the decisions and 0.2% of the commands you ran. deja hands back the other 99.8%. |
 | **Recall at the point of action** | Before an agent edits a file or runs a command, deja names that file's prior decision or that command's working invocation, from a `PreToolUse` hook. |
 | **It indexes the work, not just the talk** | The files each turn opened, the commands that ran with their exit status, and the exact spans an edit replaced. That is the part every summary throws away. |
+
+<details>
+<summary>Four more: rejected decisions, staleness, sync and handoff, redaction</summary>
+
+| | |
+| --- | --- |
 | **It knows what held** | `deja promote <id> --state rejected --note "why"` marks a decision you reverted. Every later hit for that session shows it was tried and rejected, with the reason. Nothing is deleted, and `--state accepted` takes the mark back. |
 | **It says when the ground moved** | A hit reports *4 files this session touched have changed since*, and says nothing when it cannot tell. It never claims anything is unchanged. |
 | **Sync and handoff** | `deja sync ssh laptop` moves memory between machines, append-only, no cloud in the middle. `deja handoff --to codex` packages the live context so you can continue in another agent. |
 | **Redaction** | Keys, tokens, JWTs and private key blocks are stripped at index time, so the cache is safe to keep. |
+
+</details>
+
+### Your own work, wrapped
+
+`deja stats --card` draws it in the terminal; give it a filename and it writes an
+SVG for a profile README.
+
+<p align="center"><img src="docs/assets/stats-card-demo.svg" width="760" alt="deja stats card: a year of agent sessions as a heatmap, the agents they came from, and the longest one"></p>
 
 The full feature reference lives in the [docs](https://vshulcz.github.io/deja-vu/).
 
@@ -319,6 +334,17 @@ battle-tested paths. Field reports welcome in [#9](https://github.com/vshulcz/de
 deja uninstall --all
 rm -rf ~/.cache/deja
 ```
+
+## Try it on your own history
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
+deja install --auto
+```
+
+Ten seconds to install, about ten to index. The next session your agent opens, it
+already knows what you solved in that project — including everything from before
+you installed this.
 
 ## Contributing
 

--- a/cmd/deja/readme_mcp_tools_test.go
+++ b/cmd/deja/readme_mcp_tools_test.go
@@ -27,6 +27,26 @@ func TestReadmeListsEveryMCPToolTheServerRegisters(t *testing.T) {
 		t.Fatalf("tools is %T", payload["tools"])
 	}
 
+	// Four places listed these, and every one of them had drifted to the two
+	// the server started with: the README, the bundle manifest, the
+	// architecture note, and the file an agent reads to install deja — which
+	// is the worst of them, since an agent that reads it learns that four of
+	// the six do not exist.
+	for _, doc := range []string{"README.md", "llms-install.md",
+		filepath.Join("docs", "ARCHITECTURE.md")} {
+		b, err := os.ReadFile(filepath.Join("..", "..", doc))
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(b)
+		for _, tool := range tools {
+			name, _ := tool["name"].(string)
+			if !strings.Contains(text, "`"+name+"`") {
+				t.Errorf("%s never mentions the %q tool", doc, name)
+			}
+		}
+	}
+
 	b, err := os.ReadFile(filepath.Join("..", "..", "README.md"))
 	if err != nil {
 		t.Fatal(err)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,10 @@ This document is for people changing `deja` internals.
 
 ## Source parsers
 
-Parsers live in `internal/sources` and return `[]model.Session`.
+Parsers live in `internal/sources` and return `[]model.Session`. The table is
+the seventeen the loader registers; `docs/registry/` describes each store's
+layout in detail, and `internal/sources/registry_test.go` checks that index
+against the loader list.
 
 | Source | Code | Input |
 | --- | --- | --- |
@@ -19,6 +22,12 @@ Parsers live in `internal/sources` and return `[]model.Session`.
 | Qwen Code | `qwen.go` | JSONL chats under `~/.qwen/projects/*/chats` |
 | pi | `pi.go` | JSONL transcripts under `~/.pi/agent/sessions` |
 | Copilot CLI | `copilot.go` | `events.jsonl` per session under `~/.copilot/session-state` |
+| Cline | `cline.go` | task JSON under the VS Code extension's storage, both store generations |
+| Roo Code | `roo.go` | task JSON under `rooveterinaryinc.roo-cline` in VS Code globalStorage |
+| Goose | `goose.go` | legacy JSONL sessions and the newer SQLite session store |
+| Kimi Code | `kimi.go` | per-agent `wire.jsonl` under `~/.kimi-code/sessions` |
+| OpenClaw | `openclaw.go` | append-only pi-format JSONL under `~/.openclaw/agents` |
+| Hermes | `hermes.go`, `hermes_pg.go` | SQLite state per profile, or Postgres when `DEJA_HERMES_PG_DSN` is set |
 | deja notes | `notes.go` | `deja remember` entries in `notes.jsonl` |
 
 File-based sources are parsed with a worker pool sized to `runtime.NumCPU()`. Results are collected by input file index and then appended in sorted path order, so parsing can be parallel while index writes stay deterministic.
@@ -107,7 +116,7 @@ The export watermark is per source path (falling back to session key for synthet
 
 `currentFiles` records path, size, and mtime for known stores.
 
-`EnsureForSearch` compares the current file set with `manifest.json`:
+`EnsureForSearch` compares the current file set with `manifest.gob`:
 
 - fresh manifest: do nothing;
 - version or scope mismatch: rebuild;
@@ -128,8 +137,15 @@ Supported methods:
 
 Tools:
 
-- `recall`: returns compact snippets for matching sessions.
-- `recall_context`: returns the markdown digest used by `deja ctx`.
+- `recall`: compact snippets for matching sessions.
+- `recall_context`: the markdown digest `deja ctx` prints.
+- `blame`: the sessions that discussed a file, and what was decided.
+- `fix`: what this machine ran after the same error last time.
+- `how`: the real invocation for a tool here, from what agents ran.
+- `remember`: stores one durable decision for later recall.
+
+Each carries an annotation naming what it is for, so an agent can choose between
+them without reading the descriptions in full.
 
 The MCP server calls the same index/search code as the CLI. It writes protocol responses to stdout and keeps logs/progress off stdout so agents receive valid JSON-RPC.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -229,6 +229,48 @@ footer .sp{flex:1}
   #vu{display:none}
 }
 
+
+/* ── chapters ────────────────────────────────────────────────────────────
+   A full-bleed panel behind a section, so the page reads as chapters rather
+   than as one long scroll of the same tone. */
+.band{position:relative;padding:80px 0;margin-bottom:104px}
+.band::before{content:"";position:absolute;inset:0 calc(50% - 50vw);
+  background:var(--panel);border-top:1px solid var(--line);border-bottom:1px solid var(--line);
+  z-index:-1}
+.band > :last-child{margin-bottom:0}
+
+/* ── two columns, so the page is not five left-aligned blocks ─────────── */
+.split{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:56px;align-items:start}
+.split .right{align-self:center}
+
+/* a number on the heading, where the section has one worth naming */
+h2 .fig{color:var(--amber);letter-spacing:0;margin-left:10px}
+
+/* ── the closing band ────────────────────────────────────────────────── */
+.closer{position:relative;padding:88px 0 96px;text-align:center;margin-top:104px}
+.closer::before{content:"";position:absolute;inset:0 calc(50% - 50vw);
+  background:var(--panel);border-top:1px solid var(--line);z-index:-1}
+.closer img{width:110px;height:110px;margin:0 auto 26px;display:block}
+.closer h2{font:700 clamp(26px,3.4vw,38px)/1.2 var(--sans);letter-spacing:-.022em;
+  color:var(--ink);text-transform:none;margin-bottom:14px}
+.closer p{color:var(--faint);font:13px var(--mono);margin-bottom:26px}
+.closer .cmdline{margin:0 auto}
+
+/* ── the footer ──────────────────────────────────────────────────────── */
+footer{border-top:1px solid var(--line);margin-top:0;padding:44px 0 64px;
+  display:grid;grid-template-columns:1.4fr 1fr 1fr 1fr;gap:32px;
+  font:12.5px/1.9 var(--mono);color:var(--faint)}
+footer .who{display:flex;flex-direction:column;gap:10px}
+footer .who img{width:34px;height:34px;border-radius:9px}
+footer .col b{display:block;color:var(--body);font-weight:400;text-transform:uppercase;
+  letter-spacing:.14em;font-size:10.5px;margin-bottom:8px;opacity:.75}
+footer a{display:block;color:var(--faint)}
+footer a:hover{color:var(--ph-hi)}
+@media(max-width:860px){
+  .split{grid-template-columns:minmax(0,1fr);gap:26px}
+  .band{padding:56px 0;margin-bottom:72px}
+  footer{grid-template-columns:1fr 1fr;gap:26px}
+}
 @media(max-width:620px){
   /* The header did not fit: the GitHub button ran off the right edge and the
      brand broke across two lines. Wrapping keeps every link reachable, which
@@ -306,13 +348,20 @@ footer .sp{flex:1}
 
 <section class="reveal">
   <h2>The difference</h2>
-  <p class="big">Every memory tool starts empty and records forward.
-    <em>deja starts full.</em></p>
-  <p class="note">The transcripts are the memory. There is no capture step to remember to
-    run and no stack to stand up — your agents have been writing this to disk all along.</p>
+  <div class="split">
+    <div>
+      <p class="big">Every memory tool starts empty and records forward.
+        <em>deja starts full.</em></p>
+    </div>
+    <div class="right">
+      <p class="note" style="margin:0">The transcripts are the memory. There is no capture
+        step to remember to run and no stack to stand up — your agents have been writing
+        this to disk all along.</p>
+    </div>
+  </div>
 </section>
 
-<section class="reveal" id="demo">
+<section class="reveal band" id="demo">
   <h2>Try it — a live search over a fake history</h2>
   <p class="big" style="margin-bottom:26px">Type what you half-remember.
     <em>Get the session where it was solved.</em></p>
@@ -336,7 +385,7 @@ footer .sp{flex:1}
 </section>
 
 <section class="reveal">
-  <h2>How it works</h2>
+  <h2>How it works <span class="fig">3 steps</span></h2>
   <div class="steps">
     <div class="step"><span class="n">01</span><h3>It reads what is already there</h3>
       <p>Every coding agent writes its sessions to disk. deja parses those stores in place —
@@ -351,9 +400,10 @@ footer .sp{flex:1}
 </section>
 
 <section class="reveal">
-  <h2>Works with</h2>
-  <p class="big">Solve it in Codex. <em>Claude remembers.</em></p>
-  <div class="agents">
+  <h2>Works with <span class="fig">17</span></h2>
+  <div class="split">
+    <div><p class="big" style="margin:0">Solve it in Codex. <em>Claude remembers.</em></p></div>
+    <div class="right"><div class="agents" style="margin:0">
     <span>Claude Code</span><span>Codex CLI</span><span>Cursor</span><span>opencode</span>
     <span>Gemini CLI</span><span>Cline</span><span>Copilot CLI</span><span>Roo Code</span>
     <span>aider</span><span>Goose</span><span>Qwen Code</span><span>Kimi Code</span>
@@ -363,7 +413,7 @@ footer .sp{flex:1}
 </section>
 
 
-<section class="reveal">
+<section class="reveal band">
   <h2>What a year of it looks like</h2>
   <p class="big" style="margin-bottom:26px">Your own work, <em>wrapped.</em></p>
   <div class="cardshot"><img src="assets/stats-card-demo.svg" alt="deja stats card: a year of agent sessions, the agents they came from, and the longest one" loading="lazy"></div>
@@ -372,19 +422,53 @@ footer .sp{flex:1}
 </section>
 
 <section class="reveal">
-  <h2>Private by construction</h2>
-  <p class="big">Nothing leaves your machine <em>unless you ask it to.</em></p>
-  <p class="note">Indexing and search are local. Keys, tokens and private key blocks are
-    stripped at index time, so the cache is safe to keep. No account, no telemetry —
-    even this page keeps what it remembers about you in your own browser.</p>
+  <h2>Private by construction <span class="fig">0 accounts</span></h2>
+  <div class="split">
+    <div><p class="big" style="margin:0">Nothing leaves your machine
+      <em>unless you ask it to.</em></p></div>
+    <div class="right">
+      <p class="note" style="margin:0">Indexing and search are local. Keys, tokens and
+        private key blocks are stripped at index time, so the cache is safe to keep.
+        No account, no telemetry — even this page keeps what it remembers about you in
+        your own browser.</p>
+    </div>
+  </div>
+</section>
+
+<section class="closer reveal">
+  <img src="assets/icon-live.svg" width="110" height="110" alt="">
+  <h2>Your history is already on this machine.</h2>
+  <p>ten seconds to install, about ten to index — then the next session already knows</p>
+  <div class="cmdline">
+    <span class="p">$</span>
+    <code id="i2">curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</code>
+    <button class="copy" data-copy="i2">copy</button>
+  </div>
 </section>
 
 <footer>
-  <span>MIT © vshulcz</span>
-  <span class="sp"></span>
-  <a href="guide/privacy.html">Privacy</a>
-  <a href="guide/commands.html">CLI</a>
-  <a href="https://github.com/vshulcz/deja-vu">GitHub</a>
+  <div class="who">
+    <img src="assets/icon.svg" alt="">
+    <span>deja-vu — memory for coding agents.<br>MIT © vshulcz</span>
+  </div>
+  <div class="col"><b>Guide</b>
+    <a href="guide/getting-started.html">Getting started</a>
+    <a href="guide/agents.html">Agents &amp; MCP</a>
+    <a href="guide/search.html">Search</a>
+    <a href="guide/commands.html">CLI reference</a>
+  </div>
+  <div class="col"><b>Reference</b>
+    <a href="guide/harnesses.html">Harnesses</a>
+    <a href="guide/benchmarks.html">Benchmarks</a>
+    <a href="guide/compare.html">How it compares</a>
+    <a href="guide/privacy.html">Privacy</a>
+  </div>
+  <div class="col"><b>Project</b>
+    <a href="https://github.com/vshulcz/deja-vu">GitHub</a>
+    <a href="https://github.com/vshulcz/deja-vu/releases">Releases</a>
+    <a href="https://www.npmjs.com/package/@vshulcz/deja-vu">npm</a>
+    <a href="https://github.com/vshulcz/deja-vu/issues">Issues</a>
+  </div>
 </footer>
 
 <div id="keys" aria-hidden="true">

--- a/llms-install.md
+++ b/llms-install.md
@@ -26,10 +26,14 @@ Claude Code, etc.) add:
 
 If `deja` is not on PATH, use the npx form: `"command": "npx", "args": ["-y", "@vshulcz/deja-vu", "mcp"]`.
 
-For Claude Code, Codex and opencode there is a one-command setup instead:
+For the seventeen harnesses deja knows — Claude Code, Codex, Cursor, opencode,
+Gemini CLI, Cline, Copilot CLI, Roo Code, aider, Goose, Qwen Code, Kimi Code,
+Antigravity, Grok Build, OpenClaw, pi and Hermes — there is a one-command setup
+instead:
 
 ```sh
-deja install --all    # MCP everywhere; add --auto for session-start auto-recall
+deja install --auto   # MCP recall everywhere it finds, plus session-start recall
+deja install --all    # the same without the session-start hook
 ```
 
 ## Verify
@@ -39,6 +43,13 @@ deja warmup           # builds the local index (~10s for a few GB of history)
 deja "test query"     # CLI search works
 ```
 
-The MCP tools are `recall` (dense results under ~4KB) and `recall_context`
-(markdown digest of the best-matching session). No API keys, no network
-access, no configuration required.
+The MCP tools:
+
+- `recall` — dense results under ~4KB for a query.
+- `recall_context` — markdown digest of the best-matching session.
+- `blame` — which sessions discussed a file, and what was decided.
+- `fix` — what this machine ran after the same error last time.
+- `how` — the real invocation for a tool here, with its real flags.
+- `remember` — store one durable decision for a later session to recall.
+
+No API keys, no network access, no configuration required.


### PR DESCRIPTION
The page had become tidy and monotonous: seven sections with the same shape — label, big line, paragraph — flush left with the right half empty five times over, one tone from top to bottom, and an ending that was a paragraph about privacy followed by three footer links.

- **A closing band.** A reader who has scrolled the whole page is the most convinced they will ever be, and there was nothing there to do. The cat, one sentence and the command, full width.
- **Chapters.** Two sections sit on a full-bleed panel, so the page reads as parts rather than as a length.
- **Alternation.** Three sections move their supporting text to the right, so the eye goes down in a zig-zag rather than a straight line.
- **Numbers.** After the proof band there was not another figure on the page: seventeen beside what it works with, three steps beside how, zero accounts beside privacy.
- **A footer** with the mark, the licence and three columns of links.

Not done, and deliberately: the architecture diagram. It was the one item of the six not picked.

Checked at 390 — nothing overflows — and the interaction driver passes unchanged: search, both easter eggs, konami, the sleeping and talking cat, the shortcuts card, the split headline and the exchange replay.