### PR TITLE
fix(stats): the card was printing a line out of the reader's own history

### DIFF
--- a/cmd/deja/statscard.go
+++ b/cmd/deja/statscard.go
@@ -74,13 +74,16 @@ func renderStatsCard(r stats.Report) string {
 
 	renderAgents(&b, r, 470, 120)
 
-	if title := strings.TrimSpace(r.Longest.Title); title != "" && r.Longest.Messages > 0 {
-		// The whole line stays in the left band. Anchoring the message count to
-		// the card's right edge put it through the agents block, which occupies
-		// that half of this row.
-		cardText(&b, pad, 442, 11, "700", "THE LONGEST ONE", "#55626a", "letter-spacing=\"1.5\"")
-		cardText(&b, pad+150, 442, 12, "400",
-			clipTitle(title, 24)+"  ·  "+formatStatNumber(r.Longest.Messages)+" messages", "#8b989a")
+	// Counts only, no content: see longestLine in statscard_term.go and #1180.
+	if r.Longest.Messages > 0 {
+		cardText(&b, pad, 472, 11, "700", "THE LONGEST SESSION", "#55626a", "letter-spacing=\"1.5\"")
+		cardText(&b, pad+170, 472, 12, "400",
+			formatStatNumber(r.Longest.Messages)+" messages", "#8b989a")
+	}
+	if n := r.RepeatQuestions; n > 0 {
+		cardText(&b, w-pad, 472, 12, "400",
+			formatStatNumber(n)+" questions asked more than once", "#8b989a",
+			"text-anchor=\"end\"")
 	}
 
 	foot := "$ deja stats --card"
@@ -93,24 +96,6 @@ func renderStatsCard(r stats.Report) string {
 	fmt.Fprintf(&b, `<rect width="%d" height="%d" fill="url(#scan)"/>`+"\n", w, h)
 	b.WriteString("</svg>\n")
 	return b.String()
-}
-
-// clipTitle keeps a session title inside its column. Runes, not bytes: this is
-// the one string on the card that came from a user, so it is the one that is
-// not ASCII.
-func clipTitle(title string, max int) string {
-	runes := []rune(title)
-	if len(runes) <= max {
-		return title
-	}
-	cut := max - 1
-	for i := cut; i > 0; i-- {
-		if runes[i] == ' ' {
-			cut = i
-			break
-		}
-	}
-	return string(runes[:cut]) + "…"
 }
 
 // renderAgents draws where the history came from. The bar sits in a track, so a

--- a/cmd/deja/statscard_privacy_test.go
+++ b/cmd/deja/statscard_privacy_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/stats"
+)
+
+// The card exists to be published: it prints an embed snippet and invites the
+// reader to paste it into a README. What makes that safe is that it carries
+// counts and nothing else — no project name, no path, no sentence out of the
+// reader's own history.
+//
+// That property is easy to trade away for a card that feels more personal, and
+// it was traded away once: the longest session's title was printed on both
+// cards for a day. This is the test that would have caught it.
+func TestNeitherCardPrintsContentFromTheHistory(t *testing.T) {
+	const (
+		title   = "продолжай DDD-рефактор для платёжного шлюза"
+		project = "acme-payments-internal"
+	)
+	r := stats.Report{
+		TotalSessions:   1225,
+		TotalMessages:   139970,
+		RepeatQuestions: 18,
+		WeekRecalls:     70,
+		Longest: stats.SessionStat{
+			Title: title, Project: project, Harness: "claude", Messages: 31868,
+		},
+		TopProjects: []stats.ProjectStats{{Project: project, Sessions: 400}},
+		Harnesses:   []stats.HarnessStats{{Harness: "claude", Sessions: 62}},
+	}
+	r.DateRange.Start, r.DateRange.End = "2026-04-18", "2026-08-15"
+	r.Heatmap.Max = 8
+	r.Heatmap.Weeks = make([][7]int, 53)
+	for w := 40; w < 53; w++ {
+		r.Heatmap.Weeks[w][0] = 3
+	}
+
+	for name, out := range map[string]string{
+		"the terminal card": strings.Join(statsCardLines(r), "\n"),
+		"the SVG card":      renderStatsCard(r),
+	} {
+		for _, secret := range []string{title, project} {
+			if strings.Contains(out, secret) {
+				t.Errorf("%s prints %q, which came out of the reader's own history", name, secret)
+			}
+		}
+		// the counts derived from those sessions are fine, and are the point
+		if !strings.Contains(out, "31,868") {
+			t.Errorf("%s dropped the longest session's size along with its title", name)
+		}
+		if !strings.Contains(out, "18") {
+			t.Errorf("%s does not show how many questions were asked more than once", name)
+		}
+	}
+}

--- a/cmd/deja/statscard_term.go
+++ b/cmd/deja/statscard_term.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/mark"
-	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/stats"
 )
 
@@ -132,10 +131,9 @@ func statsCardLines(r stats.Report) []string {
 		add(sectionRule("WHERE IT CAME FROM"))
 		add(agents...)
 	}
-	if line := longestLine(r); line != "" {
+	if lines := longestLine(r); len(lines) > 0 {
 		add("")
-		add(paint(cardFaint, "THE LONGEST ONE"))
-		add(line)
+		add(lines...)
 	}
 	return frame(body, footer())
 }
@@ -435,40 +433,29 @@ func agentBlock(r stats.Report) []string {
 // has no report.
 var dateSpanText string
 
-// longestLine is the one piece of the card that is not a count: the title of
-// the longest session, which is a sentence someone wrote on this machine. It is
-// what makes the card theirs rather than a shape two people with the same
-// totals would both get.
-//
-// The title comes from the index, so it is already redacted; SafeLine is what
-// stops a control character in it from moving the cursor out of the card.
-func longestLine(r stats.Report) string {
-	title := strings.TrimSpace(r.Longest.Title)
-	if title == "" || r.Longest.Messages == 0 {
-		return ""
+// longestLine is the longest session, by its size alone. It carried the title
+// too, until #1180 pointed out what the card is for: it prints an embed snippet
+// and invites you to paste it somewhere public, and what makes that safe is
+// that it holds counts and nothing else — no project, no path, no content. A
+// title is content, and it came out of the reader's own history.
+func longestLine(r stats.Report) []string {
+	if r.Longest.Messages == 0 {
+		return nil
 	}
-	count := formatStatNumber(r.Longest.Messages) + " messages"
-	room := cardInner - len(count) - 2
-	title = search.SafeLine(title)
-	// Runes, not bytes. This is the one string on the card that comes from a
-	// user, so it is the one that is not ASCII, and cutting a multi-byte
-	// character in half prints a replacement box in the middle of their own
-	// words.
-	if runes := []rune(title); len(runes) > room {
-		cut := room - 1
-		for i := cut; i > 0; i-- {
-			if runes[i] == ' ' {
-				cut = i
-				break
-			}
-		}
-		title = string(runes[:cut]) + "…"
+	left := "the longest session ran " + formatStatNumber(r.Longest.Messages) + " messages"
+	if r.RepeatQuestions <= 0 {
+		return []string{paint(cardDim, left)}
 	}
-	gap := cardInner - visibleLen(title) - visibleLen(count)
-	if gap < 1 {
-		gap = 1
+	// The number that is evidence rather than volume: a question asked twice is
+	// the reader having re-solved something.
+	right := formatStatNumber(r.RepeatQuestions) + " questions asked more than once"
+	if gap := cardInner - visibleLen(left) - visibleLen(right); gap >= 2 {
+		return []string{paint(cardDim, left) + strings.Repeat(" ", gap) + paint(cardBright, right)}
 	}
-	return paint(cardDim, title) + strings.Repeat(" ", gap) + paint(cardFaint, count)
+	// Together they are wider than the card, and a line that does not fit walks
+	// the border down the page. Two lines rather than one string with a newline
+	// in it: the frame pads what it is given, so an embedded break escapes it.
+	return []string{paint(cardDim, left), paint(cardBright, right)}
 }
 
 // footer is what makes a screenshot say where it came from. Dim enough not to

--- a/cmd/deja/statscard_term_test.go
+++ b/cmd/deja/statscard_term_test.go
@@ -23,6 +23,9 @@ func sampleReport() stats.Report {
 	r.DateRange.Start = "2026-04-18"
 	r.DateRange.End = "2026-08-15"
 	r.WeekRecalls = 70
+	// Twice now a line has overflowed the border because the sample lacked the
+	// field that makes it long. This is the third such field.
+	r.RepeatQuestions = 21
 	// A Cyrillic title is the case that broke the width maths: 22 printed
 	// columns and 40 bytes. Without one here the border test measured only
 	// ASCII and passed while the shipped card came out short.


### PR DESCRIPTION
The card exists to be published: it prints an embed snippet and invites you to paste it into a README. What makes that safe is that it carries counts and nothing else — no project, no path, no content. #1180 says so explicitly, and calls that the reason the card is shareable at all.

I put the longest session's **title** on both cards yesterday to make them personal. It did, by printing a sentence out of someone's own work onto a thing they are being encouraged to post in public. Titles carry project names — the one on my own machine names a client. The count stays; the words go.

In its place is the figure #1180 calls the interesting one, and which `deja stats` already computes for the terminal report: **how many questions were asked more than once**. That is evidence the reader personally re-solved something, which is the problem deja claims to fix, and it says more than a message count does.

A test now fails if either card prints a title or a project it was handed — the test that would have caught this a day ago.

Two smaller things on the way: the new pair overflowed the border when both halves were long, and the sample report did not show it *for the third time* because it lacked the field that makes the line long. It stacks when it will not fit, and the sample carries the field now. `clipTitle` went with the title it clipped.

This does not close #1180 — the other half of that issue is history that predates the install, which needs a first-build timestamp the manifest does not keep.