### PR TITLE
feat(assets): give the cat a cat's timing

### DIFF
--- a/assets/logo-dark.svg
+++ b/assets/logo-dark.svg
@@ -3,27 +3,38 @@
      sprite is the source, and the terminal banner draws from the same grid.
      Coat, accent and features are the three colours xterm-256 holds exactly,
      so vector and terminal agree. -->
-  <path fill="#8787af" d="M60 19h6v6h-6ZM138 19h6v6h-6ZM54 25h18v6h-18ZM132 25h18v6h-18ZM54 31h24v6h-24ZM126 31h24v6h-24ZM54 37h30v6h-30ZM120 37h30v6h-30ZM54 43h96v6h-96ZM48 49h108v6h-108ZM48 55h108v6h-108ZM48 61h108v6h-108ZM48 67h108v6h-108ZM48 73h108v6h-108ZM48 79h108v6h-108ZM48 85h48v6h-48ZM108 85h48v6h-48ZM48 91h108v6h-108ZM54 97h96v6h-96ZM60 103h84v6h-84ZM66 109h72v6h-72ZM66 115h72v6h-72ZM66 121h72v6h-72ZM66 127h72v6h-72ZM60 133h84v6h-84ZM60 139h84v6h-84ZM66 145h24v6h-24ZM114 145h24v6h-24Z"/>
+  <path fill="#8787af" d="M54 43h96v6h-96ZM48 49h108v6h-108ZM48 55h108v6h-108ZM48 61h108v6h-108ZM48 67h108v6h-108ZM48 73h108v6h-108ZM48 79h108v6h-108ZM48 85h48v6h-48ZM108 85h48v6h-48ZM48 91h108v6h-108ZM54 97h96v6h-96ZM60 103h84v6h-84ZM66 109h72v6h-72ZM66 115h72v6h-72ZM66 121h72v6h-72ZM66 127h72v6h-72ZM60 133h84v6h-84ZM60 139h84v6h-84ZM66 145h24v6h-24ZM114 145h24v6h-24Z"/>
   <path fill="#ff8700" d="M96 85h12v6h-12Z"/>
   <g class="t0"><path fill="#8787af" d="M150 103h12v6h-12ZM150 109h12v6h-12ZM150 115h12v6h-12ZM150 121h12v6h-12ZM150 127h12v6h-12ZM144 133h12v6h-12ZM144 139h12v6h-12Z"/></g>
   <g class="t1"><path fill="#8787af" d="M156 103h12v6h-12ZM150 109h12v6h-12ZM150 115h12v6h-12ZM150 121h12v6h-12ZM150 127h12v6h-12ZM144 133h12v6h-12ZM144 139h12v6h-12Z"/></g>
   <g class="t2"><path fill="#8787af" d="M162 103h12v6h-12ZM156 109h12v6h-12ZM150 115h12v6h-12ZM150 121h12v6h-12ZM150 127h12v6h-12ZM144 133h12v6h-12ZM144 139h12v6h-12Z"/></g>
   <g class="eyes-open"><path fill="#1c1c1c" d="M66 61h12v6h-12ZM126 61h12v6h-12ZM66 67h12v6h-12ZM126 67h12v6h-12ZM66 73h12v6h-12ZM126 73h12v6h-12Z"/></g>
   <g class="eyes-shut"><path fill="#1c1c1c" d="M60 73h24v6h-24ZM120 73h24v6h-24Z"/></g>
+  <g class="ear-up"><path fill="#8787af" d="M60 19h6v6h-6ZM138 19h6v6h-6ZM54 25h18v6h-18ZM132 25h18v6h-18ZM54 31h24v6h-24ZM126 31h24v6h-24ZM54 37h30v6h-30ZM120 37h30v6h-30Z"/></g>
+  <g class="ear-flick"><path fill="#8787af" d="M60 19h6v6h-6ZM54 25h18v6h-18ZM54 31h24v6h-24ZM132 31h18v6h-18ZM54 37h30v6h-30ZM120 37h30v6h-30Z"/></g>
   <style>
-    .t1, .t2, .eyes-shut { opacity: 0 }
+    .t1, .t2, .eyes-shut, .ear-flick { opacity: 0 }
     @media (prefers-reduced-motion: no-preference) {
-      .t0 { animation: dv-t0 1.15s steps(1, end) infinite }
-      .t1 { animation: dv-t1 1.15s steps(1, end) infinite }
-      .t2 { animation: dv-t2 1.15s steps(1, end) infinite }
-      .eyes-open { animation: dv-open 6.5s steps(1, end) infinite }
-      .eyes-shut { animation: dv-shut 6.5s steps(1, end) infinite }
+      .t0  { animation: dv-t0 4.7s steps(1, end) infinite }
+      .t1  { animation: dv-t1 4.7s steps(1, end) infinite }
+      .t2  { animation: dv-t2 4.7s steps(1, end) infinite }
+      .eyes-open { animation: dv-open 7.3s steps(1, end) infinite }
+      .eyes-shut { animation: dv-shut 7.3s steps(1, end) infinite }
+      .ear-up { animation: dv-ear-up 11.3s steps(1, end) infinite }
+      .ear-flick { animation: dv-ear 11.3s steps(1, end) infinite }
     }
-    @keyframes dv-t0 { 0%, 24.9% { opacity: 1 } 25%, 100% { opacity: 0 } }
-    @keyframes dv-t1 { 0%, 24.9% { opacity: 0 } 25%, 49.9% { opacity: 1 } 50%, 74.9% { opacity: 0 } 75%, 100% { opacity: 1 } }
-    @keyframes dv-t2 { 0%, 49.9% { opacity: 0 } 50%, 74.9% { opacity: 1 } 75%, 100% { opacity: 0 } }
-    @keyframes dv-open { 0%, 92% { opacity: 1 } 93%, 97% { opacity: 0 } 98%, 100% { opacity: 1 } }
-    @keyframes dv-shut { 0%, 92% { opacity: 0 } 93%, 97% { opacity: 1 } 98%, 100% { opacity: 0 } }
+    /* The tail rests for four fifths of its cycle, then sweeps out and back:
+       up, mid, out, mid, and still again. */
+    @keyframes dv-t0 { 0%, 79.9% { opacity: 1 } 80%, 96.9% { opacity: 0 } 97%, 100% { opacity: 1 } }
+    @keyframes dv-t1 { 0%, 79.9% { opacity: 0 } 80%, 84.9% { opacity: 1 } 85%, 91.9% { opacity: 0 } 92%, 96.9% { opacity: 1 } 97%, 100% { opacity: 0 } }
+    @keyframes dv-t2 { 0%, 84.9% { opacity: 0 } 85%, 91.9% { opacity: 1 } 92%, 100% { opacity: 0 } }
+    /* Two blinks, not one: a quick one, then a slower one a beat later, which
+       is what a cat does and what a metronome does not. */
+    @keyframes dv-open { 0%, 87.9% { opacity: 1 } 88%, 90.4% { opacity: 0 } 90.5%, 95.9% { opacity: 1 } 96%, 99.4% { opacity: 0 } 99.5%, 100% { opacity: 1 } }
+    @keyframes dv-shut { 0%, 87.9% { opacity: 0 } 88%, 90.4% { opacity: 1 } 90.5%, 95.9% { opacity: 0 } 96%, 99.4% { opacity: 1 } 99.5%, 100% { opacity: 0 } }
+    /* One flick, and it is over before you are sure you saw it. */
+    @keyframes dv-ear { 0%, 96.9% { opacity: 0 } 97%, 99.4% { opacity: 1 } 99.5%, 100% { opacity: 0 } }
+    @keyframes dv-ear-up { 0%, 96.9% { opacity: 1 } 97%, 99.4% { opacity: 0 } 99.5%, 100% { opacity: 1 } }
   </style>
   <g font-family="SF Mono, JetBrains Mono, Fira Code, Menlo, monospace">
     <text x="208" y="105" font-size="72" font-weight="700" fill="#e8e6f0">deja-vu</text>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -3,27 +3,38 @@
      sprite is the source, and the terminal banner draws from the same grid.
      Coat, accent and features are the three colours xterm-256 holds exactly,
      so vector and terminal agree. -->
-  <path fill="#8787af" d="M60 19h6v6h-6ZM138 19h6v6h-6ZM54 25h18v6h-18ZM132 25h18v6h-18ZM54 31h24v6h-24ZM126 31h24v6h-24ZM54 37h30v6h-30ZM120 37h30v6h-30ZM54 43h96v6h-96ZM48 49h108v6h-108ZM48 55h108v6h-108ZM48 61h108v6h-108ZM48 67h108v6h-108ZM48 73h108v6h-108ZM48 79h108v6h-108ZM48 85h48v6h-48ZM108 85h48v6h-48ZM48 91h108v6h-108ZM54 97h96v6h-96ZM60 103h84v6h-84ZM66 109h72v6h-72ZM66 115h72v6h-72ZM66 121h72v6h-72ZM66 127h72v6h-72ZM60 133h84v6h-84ZM60 139h84v6h-84ZM66 145h24v6h-24ZM114 145h24v6h-24Z"/>
+  <path fill="#8787af" d="M54 43h96v6h-96ZM48 49h108v6h-108ZM48 55h108v6h-108ZM48 61h108v6h-108ZM48 67h108v6h-108ZM48 73h108v6h-108ZM48 79h108v6h-108ZM48 85h48v6h-48ZM108 85h48v6h-48ZM48 91h108v6h-108ZM54 97h96v6h-96ZM60 103h84v6h-84ZM66 109h72v6h-72ZM66 115h72v6h-72ZM66 121h72v6h-72ZM66 127h72v6h-72ZM60 133h84v6h-84ZM60 139h84v6h-84ZM66 145h24v6h-24ZM114 145h24v6h-24Z"/>
   <path fill="#ff8700" d="M96 85h12v6h-12Z"/>
   <g class="t0"><path fill="#8787af" d="M150 103h12v6h-12ZM150 109h12v6h-12ZM150 115h12v6h-12ZM150 121h12v6h-12ZM150 127h12v6h-12ZM144 133h12v6h-12ZM144 139h12v6h-12Z"/></g>
   <g class="t1"><path fill="#8787af" d="M156 103h12v6h-12ZM150 109h12v6h-12ZM150 115h12v6h-12ZM150 121h12v6h-12ZM150 127h12v6h-12ZM144 133h12v6h-12ZM144 139h12v6h-12Z"/></g>
   <g class="t2"><path fill="#8787af" d="M162 103h12v6h-12ZM156 109h12v6h-12ZM150 115h12v6h-12ZM150 121h12v6h-12ZM150 127h12v6h-12ZM144 133h12v6h-12ZM144 139h12v6h-12Z"/></g>
   <g class="eyes-open"><path fill="#1c1c1c" d="M66 61h12v6h-12ZM126 61h12v6h-12ZM66 67h12v6h-12ZM126 67h12v6h-12ZM66 73h12v6h-12ZM126 73h12v6h-12Z"/></g>
   <g class="eyes-shut"><path fill="#1c1c1c" d="M60 73h24v6h-24ZM120 73h24v6h-24Z"/></g>
+  <g class="ear-up"><path fill="#8787af" d="M60 19h6v6h-6ZM138 19h6v6h-6ZM54 25h18v6h-18ZM132 25h18v6h-18ZM54 31h24v6h-24ZM126 31h24v6h-24ZM54 37h30v6h-30ZM120 37h30v6h-30Z"/></g>
+  <g class="ear-flick"><path fill="#8787af" d="M60 19h6v6h-6ZM54 25h18v6h-18ZM54 31h24v6h-24ZM132 31h18v6h-18ZM54 37h30v6h-30ZM120 37h30v6h-30Z"/></g>
   <style>
-    .t1, .t2, .eyes-shut { opacity: 0 }
+    .t1, .t2, .eyes-shut, .ear-flick { opacity: 0 }
     @media (prefers-reduced-motion: no-preference) {
-      .t0 { animation: dv-t0 1.15s steps(1, end) infinite }
-      .t1 { animation: dv-t1 1.15s steps(1, end) infinite }
-      .t2 { animation: dv-t2 1.15s steps(1, end) infinite }
-      .eyes-open { animation: dv-open 6.5s steps(1, end) infinite }
-      .eyes-shut { animation: dv-shut 6.5s steps(1, end) infinite }
+      .t0  { animation: dv-t0 4.7s steps(1, end) infinite }
+      .t1  { animation: dv-t1 4.7s steps(1, end) infinite }
+      .t2  { animation: dv-t2 4.7s steps(1, end) infinite }
+      .eyes-open { animation: dv-open 7.3s steps(1, end) infinite }
+      .eyes-shut { animation: dv-shut 7.3s steps(1, end) infinite }
+      .ear-up { animation: dv-ear-up 11.3s steps(1, end) infinite }
+      .ear-flick { animation: dv-ear 11.3s steps(1, end) infinite }
     }
-    @keyframes dv-t0 { 0%, 24.9% { opacity: 1 } 25%, 100% { opacity: 0 } }
-    @keyframes dv-t1 { 0%, 24.9% { opacity: 0 } 25%, 49.9% { opacity: 1 } 50%, 74.9% { opacity: 0 } 75%, 100% { opacity: 1 } }
-    @keyframes dv-t2 { 0%, 49.9% { opacity: 0 } 50%, 74.9% { opacity: 1 } 75%, 100% { opacity: 0 } }
-    @keyframes dv-open { 0%, 92% { opacity: 1 } 93%, 97% { opacity: 0 } 98%, 100% { opacity: 1 } }
-    @keyframes dv-shut { 0%, 92% { opacity: 0 } 93%, 97% { opacity: 1 } 98%, 100% { opacity: 0 } }
+    /* The tail rests for four fifths of its cycle, then sweeps out and back:
+       up, mid, out, mid, and still again. */
+    @keyframes dv-t0 { 0%, 79.9% { opacity: 1 } 80%, 96.9% { opacity: 0 } 97%, 100% { opacity: 1 } }
+    @keyframes dv-t1 { 0%, 79.9% { opacity: 0 } 80%, 84.9% { opacity: 1 } 85%, 91.9% { opacity: 0 } 92%, 96.9% { opacity: 1 } 97%, 100% { opacity: 0 } }
+    @keyframes dv-t2 { 0%, 84.9% { opacity: 0 } 85%, 91.9% { opacity: 1 } 92%, 100% { opacity: 0 } }
+    /* Two blinks, not one: a quick one, then a slower one a beat later, which
+       is what a cat does and what a metronome does not. */
+    @keyframes dv-open { 0%, 87.9% { opacity: 1 } 88%, 90.4% { opacity: 0 } 90.5%, 95.9% { opacity: 1 } 96%, 99.4% { opacity: 0 } 99.5%, 100% { opacity: 1 } }
+    @keyframes dv-shut { 0%, 87.9% { opacity: 0 } 88%, 90.4% { opacity: 1 } 90.5%, 95.9% { opacity: 0 } 96%, 99.4% { opacity: 1 } 99.5%, 100% { opacity: 0 } }
+    /* One flick, and it is over before you are sure you saw it. */
+    @keyframes dv-ear { 0%, 96.9% { opacity: 0 } 97%, 99.4% { opacity: 1 } 99.5%, 100% { opacity: 0 } }
+    @keyframes dv-ear-up { 0%, 96.9% { opacity: 1 } 97%, 99.4% { opacity: 0 } 99.5%, 100% { opacity: 1 } }
   </style>
   <g font-family="SF Mono, JetBrains Mono, Fira Code, Menlo, monospace">
     <text x="208" y="105" font-size="72" font-weight="700" fill="#1d1b2e">deja-vu</text>

--- a/docs/assets/icon-live.svg
+++ b/docs/assets/icon-live.svg
@@ -4,26 +4,37 @@
      sprite is the source, and the terminal banner draws from the same grid.
      Coat, accent and features are the three colours xterm-256 holds exactly,
      so vector and terminal agree. -->
-  <path fill="#8787af" d="M104 68h12v12h-12ZM260 68h12v12h-12ZM92 80h36v12h-36ZM248 80h36v12h-36ZM92 92h48v12h-48ZM236 92h48v12h-48ZM92 104h60v12h-60ZM224 104h60v12h-60ZM92 116h192v12h-192ZM80 128h216v12h-216ZM80 140h216v12h-216ZM80 152h216v12h-216ZM80 164h216v12h-216ZM80 176h216v12h-216ZM80 188h216v12h-216ZM80 200h96v12h-96ZM200 200h96v12h-96ZM80 212h216v12h-216ZM92 224h192v12h-192ZM104 236h168v12h-168ZM116 248h144v12h-144ZM116 260h144v12h-144ZM116 272h144v12h-144ZM116 284h144v12h-144ZM104 296h168v12h-168ZM104 308h168v12h-168ZM116 320h48v12h-48ZM212 320h48v12h-48Z"/>
+  <path fill="#8787af" d="M92 116h192v12h-192ZM80 128h216v12h-216ZM80 140h216v12h-216ZM80 152h216v12h-216ZM80 164h216v12h-216ZM80 176h216v12h-216ZM80 188h216v12h-216ZM80 200h96v12h-96ZM200 200h96v12h-96ZM80 212h216v12h-216ZM92 224h192v12h-192ZM104 236h168v12h-168ZM116 248h144v12h-144ZM116 260h144v12h-144ZM116 272h144v12h-144ZM116 284h144v12h-144ZM104 296h168v12h-168ZM104 308h168v12h-168ZM116 320h48v12h-48ZM212 320h48v12h-48Z"/>
   <path fill="#ff8700" d="M176 200h24v12h-24Z"/>
   <g class="t0"><path fill="#8787af" d="M284 236h24v12h-24ZM284 248h24v12h-24ZM284 260h24v12h-24ZM284 272h24v12h-24ZM284 284h24v12h-24ZM272 296h24v12h-24ZM272 308h24v12h-24Z"/></g>
   <g class="t1"><path fill="#8787af" d="M296 236h24v12h-24ZM284 248h24v12h-24ZM284 260h24v12h-24ZM284 272h24v12h-24ZM284 284h24v12h-24ZM272 296h24v12h-24ZM272 308h24v12h-24Z"/></g>
   <g class="t2"><path fill="#8787af" d="M308 236h24v12h-24ZM296 248h24v12h-24ZM284 260h24v12h-24ZM284 272h24v12h-24ZM284 284h24v12h-24ZM272 296h24v12h-24ZM272 308h24v12h-24Z"/></g>
   <g class="eyes-open"><path fill="#1c1c1c" d="M116 152h24v12h-24ZM236 152h24v12h-24ZM116 164h24v12h-24ZM236 164h24v12h-24ZM116 176h24v12h-24ZM236 176h24v12h-24Z"/></g>
   <g class="eyes-shut"><path fill="#1c1c1c" d="M104 176h48v12h-48ZM224 176h48v12h-48Z"/></g>
+  <g class="ear-up"><path fill="#8787af" d="M104 68h12v12h-12ZM260 68h12v12h-12ZM92 80h36v12h-36ZM248 80h36v12h-36ZM92 92h48v12h-48ZM236 92h48v12h-48ZM92 104h60v12h-60ZM224 104h60v12h-60Z"/></g>
+  <g class="ear-flick"><path fill="#8787af" d="M104 68h12v12h-12ZM92 80h36v12h-36ZM92 92h48v12h-48ZM248 92h36v12h-36ZM92 104h60v12h-60ZM224 104h60v12h-60Z"/></g>
   <style>
-    .t1, .t2, .eyes-shut { opacity: 0 }
+    .t1, .t2, .eyes-shut, .ear-flick { opacity: 0 }
     @media (prefers-reduced-motion: no-preference) {
-      .t0 { animation: dv-t0 1.15s steps(1, end) infinite }
-      .t1 { animation: dv-t1 1.15s steps(1, end) infinite }
-      .t2 { animation: dv-t2 1.15s steps(1, end) infinite }
-      .eyes-open { animation: dv-open 6.5s steps(1, end) infinite }
-      .eyes-shut { animation: dv-shut 6.5s steps(1, end) infinite }
+      .t0  { animation: dv-t0 4.7s steps(1, end) infinite }
+      .t1  { animation: dv-t1 4.7s steps(1, end) infinite }
+      .t2  { animation: dv-t2 4.7s steps(1, end) infinite }
+      .eyes-open { animation: dv-open 7.3s steps(1, end) infinite }
+      .eyes-shut { animation: dv-shut 7.3s steps(1, end) infinite }
+      .ear-up { animation: dv-ear-up 11.3s steps(1, end) infinite }
+      .ear-flick { animation: dv-ear 11.3s steps(1, end) infinite }
     }
-    @keyframes dv-t0 { 0%, 24.9% { opacity: 1 } 25%, 100% { opacity: 0 } }
-    @keyframes dv-t1 { 0%, 24.9% { opacity: 0 } 25%, 49.9% { opacity: 1 } 50%, 74.9% { opacity: 0 } 75%, 100% { opacity: 1 } }
-    @keyframes dv-t2 { 0%, 49.9% { opacity: 0 } 50%, 74.9% { opacity: 1 } 75%, 100% { opacity: 0 } }
-    @keyframes dv-open { 0%, 92% { opacity: 1 } 93%, 97% { opacity: 0 } 98%, 100% { opacity: 1 } }
-    @keyframes dv-shut { 0%, 92% { opacity: 0 } 93%, 97% { opacity: 1 } 98%, 100% { opacity: 0 } }
+    /* The tail rests for four fifths of its cycle, then sweeps out and back:
+       up, mid, out, mid, and still again. */
+    @keyframes dv-t0 { 0%, 79.9% { opacity: 1 } 80%, 96.9% { opacity: 0 } 97%, 100% { opacity: 1 } }
+    @keyframes dv-t1 { 0%, 79.9% { opacity: 0 } 80%, 84.9% { opacity: 1 } 85%, 91.9% { opacity: 0 } 92%, 96.9% { opacity: 1 } 97%, 100% { opacity: 0 } }
+    @keyframes dv-t2 { 0%, 84.9% { opacity: 0 } 85%, 91.9% { opacity: 1 } 92%, 100% { opacity: 0 } }
+    /* Two blinks, not one: a quick one, then a slower one a beat later, which
+       is what a cat does and what a metronome does not. */
+    @keyframes dv-open { 0%, 87.9% { opacity: 1 } 88%, 90.4% { opacity: 0 } 90.5%, 95.9% { opacity: 1 } 96%, 99.4% { opacity: 0 } 99.5%, 100% { opacity: 1 } }
+    @keyframes dv-shut { 0%, 87.9% { opacity: 0 } 88%, 90.4% { opacity: 1 } 90.5%, 95.9% { opacity: 0 } 96%, 99.4% { opacity: 1 } 99.5%, 100% { opacity: 0 } }
+    /* One flick, and it is over before you are sure you saw it. */
+    @keyframes dv-ear { 0%, 96.9% { opacity: 0 } 97%, 99.4% { opacity: 1 } 99.5%, 100% { opacity: 0 } }
+    @keyframes dv-ear-up { 0%, 96.9% { opacity: 1 } 97%, 99.4% { opacity: 0 } 99.5%, 100% { opacity: 1 } }
   </style>
 </svg>

--- a/docs/assets/logo-dark.svg
+++ b/docs/assets/logo-dark.svg
@@ -3,27 +3,38 @@
      sprite is the source, and the terminal banner draws from the same grid.
      Coat, accent and features are the three colours xterm-256 holds exactly,
      so vector and terminal agree. -->
-  <path fill="#8787af" d="M60 19h6v6h-6ZM138 19h6v6h-6ZM54 25h18v6h-18ZM132 25h18v6h-18ZM54 31h24v6h-24ZM126 31h24v6h-24ZM54 37h30v6h-30ZM120 37h30v6h-30ZM54 43h96v6h-96ZM48 49h108v6h-108ZM48 55h108v6h-108ZM48 61h108v6h-108ZM48 67h108v6h-108ZM48 73h108v6h-108ZM48 79h108v6h-108ZM48 85h48v6h-48ZM108 85h48v6h-48ZM48 91h108v6h-108ZM54 97h96v6h-96ZM60 103h84v6h-84ZM66 109h72v6h-72ZM66 115h72v6h-72ZM66 121h72v6h-72ZM66 127h72v6h-72ZM60 133h84v6h-84ZM60 139h84v6h-84ZM66 145h24v6h-24ZM114 145h24v6h-24Z"/>
+  <path fill="#8787af" d="M54 43h96v6h-96ZM48 49h108v6h-108ZM48 55h108v6h-108ZM48 61h108v6h-108ZM48 67h108v6h-108ZM48 73h108v6h-108ZM48 79h108v6h-108ZM48 85h48v6h-48ZM108 85h48v6h-48ZM48 91h108v6h-108ZM54 97h96v6h-96ZM60 103h84v6h-84ZM66 109h72v6h-72ZM66 115h72v6h-72ZM66 121h72v6h-72ZM66 127h72v6h-72ZM60 133h84v6h-84ZM60 139h84v6h-84ZM66 145h24v6h-24ZM114 145h24v6h-24Z"/>
   <path fill="#ff8700" d="M96 85h12v6h-12Z"/>
   <g class="t0"><path fill="#8787af" d="M150 103h12v6h-12ZM150 109h12v6h-12ZM150 115h12v6h-12ZM150 121h12v6h-12ZM150 127h12v6h-12ZM144 133h12v6h-12ZM144 139h12v6h-12Z"/></g>
   <g class="t1"><path fill="#8787af" d="M156 103h12v6h-12ZM150 109h12v6h-12ZM150 115h12v6h-12ZM150 121h12v6h-12ZM150 127h12v6h-12ZM144 133h12v6h-12ZM144 139h12v6h-12Z"/></g>
   <g class="t2"><path fill="#8787af" d="M162 103h12v6h-12ZM156 109h12v6h-12ZM150 115h12v6h-12ZM150 121h12v6h-12ZM150 127h12v6h-12ZM144 133h12v6h-12ZM144 139h12v6h-12Z"/></g>
   <g class="eyes-open"><path fill="#1c1c1c" d="M66 61h12v6h-12ZM126 61h12v6h-12ZM66 67h12v6h-12ZM126 67h12v6h-12ZM66 73h12v6h-12ZM126 73h12v6h-12Z"/></g>
   <g class="eyes-shut"><path fill="#1c1c1c" d="M60 73h24v6h-24ZM120 73h24v6h-24Z"/></g>
+  <g class="ear-up"><path fill="#8787af" d="M60 19h6v6h-6ZM138 19h6v6h-6ZM54 25h18v6h-18ZM132 25h18v6h-18ZM54 31h24v6h-24ZM126 31h24v6h-24ZM54 37h30v6h-30ZM120 37h30v6h-30Z"/></g>
+  <g class="ear-flick"><path fill="#8787af" d="M60 19h6v6h-6ZM54 25h18v6h-18ZM54 31h24v6h-24ZM132 31h18v6h-18ZM54 37h30v6h-30ZM120 37h30v6h-30Z"/></g>
   <style>
-    .t1, .t2, .eyes-shut { opacity: 0 }
+    .t1, .t2, .eyes-shut, .ear-flick { opacity: 0 }
     @media (prefers-reduced-motion: no-preference) {
-      .t0 { animation: dv-t0 1.15s steps(1, end) infinite }
-      .t1 { animation: dv-t1 1.15s steps(1, end) infinite }
-      .t2 { animation: dv-t2 1.15s steps(1, end) infinite }
-      .eyes-open { animation: dv-open 6.5s steps(1, end) infinite }
-      .eyes-shut { animation: dv-shut 6.5s steps(1, end) infinite }
+      .t0  { animation: dv-t0 4.7s steps(1, end) infinite }
+      .t1  { animation: dv-t1 4.7s steps(1, end) infinite }
+      .t2  { animation: dv-t2 4.7s steps(1, end) infinite }
+      .eyes-open { animation: dv-open 7.3s steps(1, end) infinite }
+      .eyes-shut { animation: dv-shut 7.3s steps(1, end) infinite }
+      .ear-up { animation: dv-ear-up 11.3s steps(1, end) infinite }
+      .ear-flick { animation: dv-ear 11.3s steps(1, end) infinite }
     }
-    @keyframes dv-t0 { 0%, 24.9% { opacity: 1 } 25%, 100% { opacity: 0 } }
-    @keyframes dv-t1 { 0%, 24.9% { opacity: 0 } 25%, 49.9% { opacity: 1 } 50%, 74.9% { opacity: 0 } 75%, 100% { opacity: 1 } }
-    @keyframes dv-t2 { 0%, 49.9% { opacity: 0 } 50%, 74.9% { opacity: 1 } 75%, 100% { opacity: 0 } }
-    @keyframes dv-open { 0%, 92% { opacity: 1 } 93%, 97% { opacity: 0 } 98%, 100% { opacity: 1 } }
-    @keyframes dv-shut { 0%, 92% { opacity: 0 } 93%, 97% { opacity: 1 } 98%, 100% { opacity: 0 } }
+    /* The tail rests for four fifths of its cycle, then sweeps out and back:
+       up, mid, out, mid, and still again. */
+    @keyframes dv-t0 { 0%, 79.9% { opacity: 1 } 80%, 96.9% { opacity: 0 } 97%, 100% { opacity: 1 } }
+    @keyframes dv-t1 { 0%, 79.9% { opacity: 0 } 80%, 84.9% { opacity: 1 } 85%, 91.9% { opacity: 0 } 92%, 96.9% { opacity: 1 } 97%, 100% { opacity: 0 } }
+    @keyframes dv-t2 { 0%, 84.9% { opacity: 0 } 85%, 91.9% { opacity: 1 } 92%, 100% { opacity: 0 } }
+    /* Two blinks, not one: a quick one, then a slower one a beat later, which
+       is what a cat does and what a metronome does not. */
+    @keyframes dv-open { 0%, 87.9% { opacity: 1 } 88%, 90.4% { opacity: 0 } 90.5%, 95.9% { opacity: 1 } 96%, 99.4% { opacity: 0 } 99.5%, 100% { opacity: 1 } }
+    @keyframes dv-shut { 0%, 87.9% { opacity: 0 } 88%, 90.4% { opacity: 1 } 90.5%, 95.9% { opacity: 0 } 96%, 99.4% { opacity: 1 } 99.5%, 100% { opacity: 0 } }
+    /* One flick, and it is over before you are sure you saw it. */
+    @keyframes dv-ear { 0%, 96.9% { opacity: 0 } 97%, 99.4% { opacity: 1 } 99.5%, 100% { opacity: 0 } }
+    @keyframes dv-ear-up { 0%, 96.9% { opacity: 1 } 97%, 99.4% { opacity: 0 } 99.5%, 100% { opacity: 1 } }
   </style>
   <g font-family="SF Mono, JetBrains Mono, Fira Code, Menlo, monospace">
     <text x="208" y="105" font-size="72" font-weight="700" fill="#e8e6f0">deja-vu</text>

--- a/scripts/genlogo/main.go
+++ b/scripts/genlogo/main.go
@@ -50,6 +50,16 @@ func movingTail() map[mark.Cell]bool {
 			out[c] = true
 		}
 	}
+	// The ears too. Every cell either pose paints comes out of the still layer,
+	// so each pose can be drawn as its own group. Filling the dropped ones with
+	// the background colour instead worked on the dark icon and put a black
+	// notch on the light logo, where the background is neither dark nor there.
+	for c := range earCells(mark.Ears["up"]) {
+		out[c] = true
+	}
+	for c := range earCells(mark.Ears["flick"]) {
+		out[c] = true
+	}
 	return out
 }
 
@@ -80,23 +90,77 @@ func alive(x0, y0, size int) string {
 		mark.Hex[mark.Feature], mark.CellsD(mark.Eyes["tall"], x0, y0, size))
 	fmt.Fprintf(&b, "  <g class=\"eyes-shut\"><path fill=\"%s\" d=\"%s\"/></g>\n",
 		mark.Hex[mark.Feature], mark.CellsD(mark.Eyes["closed"], x0, y0, size))
+
+	// Both ear poses, each as its own group, swapped by the flick.
+	for _, ear := range []struct {
+		class, pose string
+	}{{"ear-up", "up"}, {"ear-flick", "flick"}} {
+		fmt.Fprintf(&b, "  <g class=\"%s\"><path fill=\"%s\" d=\"%s\"/></g>\n",
+			ear.class, mark.Hex[mark.Coat],
+			mark.CellsD(sortCells(cellList(earCells(mark.Ears[ear.pose]))), x0, y0, size))
+	}
+
 	b.WriteString(`  <style>
-    .t1, .t2, .eyes-shut { opacity: 0 }
+    .t1, .t2, .eyes-shut, .ear-flick { opacity: 0 }
     @media (prefers-reduced-motion: no-preference) {
-      .t0 { animation: dv-t0 1.15s steps(1, end) infinite }
-      .t1 { animation: dv-t1 1.15s steps(1, end) infinite }
-      .t2 { animation: dv-t2 1.15s steps(1, end) infinite }
-      .eyes-open { animation: dv-open 6.5s steps(1, end) infinite }
-      .eyes-shut { animation: dv-shut 6.5s steps(1, end) infinite }
+      .t0  { animation: dv-t0 4.7s steps(1, end) infinite }
+      .t1  { animation: dv-t1 4.7s steps(1, end) infinite }
+      .t2  { animation: dv-t2 4.7s steps(1, end) infinite }
+      .eyes-open { animation: dv-open 7.3s steps(1, end) infinite }
+      .eyes-shut { animation: dv-shut 7.3s steps(1, end) infinite }
+      .ear-up { animation: dv-ear-up 11.3s steps(1, end) infinite }
+      .ear-flick { animation: dv-ear 11.3s steps(1, end) infinite }
     }
-    @keyframes dv-t0 { 0%, 24.9% { opacity: 1 } 25%, 100% { opacity: 0 } }
-    @keyframes dv-t1 { 0%, 24.9% { opacity: 0 } 25%, 49.9% { opacity: 1 } 50%, 74.9% { opacity: 0 } 75%, 100% { opacity: 1 } }
-    @keyframes dv-t2 { 0%, 49.9% { opacity: 0 } 50%, 74.9% { opacity: 1 } 75%, 100% { opacity: 0 } }
-    @keyframes dv-open { 0%, 92% { opacity: 1 } 93%, 97% { opacity: 0 } 98%, 100% { opacity: 1 } }
-    @keyframes dv-shut { 0%, 92% { opacity: 0 } 93%, 97% { opacity: 1 } 98%, 100% { opacity: 0 } }
+    /* The tail rests for four fifths of its cycle, then sweeps out and back:
+       up, mid, out, mid, and still again. */
+    @keyframes dv-t0 { 0%, 79.9% { opacity: 1 } 80%, 96.9% { opacity: 0 } 97%, 100% { opacity: 1 } }
+    @keyframes dv-t1 { 0%, 79.9% { opacity: 0 } 80%, 84.9% { opacity: 1 } 85%, 91.9% { opacity: 0 } 92%, 96.9% { opacity: 1 } 97%, 100% { opacity: 0 } }
+    @keyframes dv-t2 { 0%, 84.9% { opacity: 0 } 85%, 91.9% { opacity: 1 } 92%, 100% { opacity: 0 } }
+    /* Two blinks, not one: a quick one, then a slower one a beat later, which
+       is what a cat does and what a metronome does not. */
+    @keyframes dv-open { 0%, 87.9% { opacity: 1 } 88%, 90.4% { opacity: 0 } 90.5%, 95.9% { opacity: 1 } 96%, 99.4% { opacity: 0 } 99.5%, 100% { opacity: 1 } }
+    @keyframes dv-shut { 0%, 87.9% { opacity: 0 } 88%, 90.4% { opacity: 1 } 90.5%, 95.9% { opacity: 0 } 96%, 99.4% { opacity: 1 } 99.5%, 100% { opacity: 0 } }
+    /* One flick, and it is over before you are sure you saw it. */
+    @keyframes dv-ear { 0%, 96.9% { opacity: 0 } 97%, 99.4% { opacity: 1 } 99.5%, 100% { opacity: 0 } }
+    @keyframes dv-ear-up { 0%, 96.9% { opacity: 1 } 97%, 99.4% { opacity: 0 } 99.5%, 100% { opacity: 1 } }
   </style>
 `)
 	return b.String()
+}
+
+// earCells turns an ear pose's rows into the set of cells it paints.
+func earCells(rows []string) map[mark.Cell]bool {
+	out := map[mark.Cell]bool{}
+	src := rows
+	if src == nil {
+		src = mark.Body[:4]
+	}
+	for r, row := range src {
+		for c, ch := range row {
+			if ch == '#' {
+				out[mark.Cell{Row: r, Col: c}] = true
+			}
+		}
+	}
+	return out
+}
+
+func cellList(set map[mark.Cell]bool) []mark.Cell {
+	out := make([]mark.Cell, 0, len(set))
+	for c := range set {
+		out = append(out, c)
+	}
+	return out
+}
+
+func sortCells(in []mark.Cell) []mark.Cell {
+	sort.Slice(in, func(i, j int) bool {
+		if in[i].Row != in[j].Row {
+			return in[i].Row < in[j].Row
+		}
+		return in[i].Col < in[j].Col
+	})
+	return in
 }
 
 func logo(ink string, animate bool) string {


### PR DESCRIPTION
The tail swept a fixed 1.15s loop, which is a metronome. A cube can be endearing by being quick and bouncy; a cat is endearing for the opposite reason — long stillness, one precise movement, then stillness again, and never on the beat. Ours moved constantly and predictably, which reads as a mechanism rather than as an animal.

Three motions now, each mostly at rest, on cycle lengths that share no factor:

- the **tail** sweeps out and back over a fifth of 4.7s
- the **eyes** blink twice inside 7.3s — a quick one, then a slower one a beat later, which is what a cat does and a metronome does not
- an **ear flicks** once in 11.3s

The phases drift apart, so the combination does not visibly repeat. Measured by freezing the animation at 48 phases across twelve seconds: five distinct frames, **at rest in 79% of them**, movements falling in irregular clusters:

```
................112.......3..3....2112......4...
```

The ear poses have been in the sprite since the beginning and nothing had ever drawn them.

Two faults of mine on the way. The flick was first drawn as the cells it adds plus the cells it drops filled with the dark background — invisible on the icon, and **a black notch on the light logo**, where the background is neither dark nor there. Both poses are their own group now, the way the tail already was. And the first flick lasted a tenth of a second, quick enough that no reader would ever catch it.

A third was in the probe rather than the page: after renaming the ear classes I did not update the script that freezes them, so the ears ran live, were sampled at rest, and the measurement reported that the flick had stopped working.
