### PR TITLE
test: measure the two things #1216 and #1174 turn on

### DIFF
--- a/cmd/deja/mcp_tools_budget_test.go
+++ b/cmd/deja/mcp_tools_budget_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// toolsListBudget is the ceiling on the whole tools/list payload, in bytes.
+//
+// This is the one part of the MCP surface every session pays for whether or not
+// it uses deja: the host reads the list before the agent does anything. Nothing
+// was watching it, and it is the kind of cost that only ever grows — a sentence
+// added to a description looks free at the point of writing and is charged on
+// every request from then on, on every machine deja is wired into.
+//
+// The number is the payload as it stands with a little room, not an aspiration.
+// It is deliberately tight: hitting it is supposed to force the question of
+// whether the words belong in a description at all, rather than be raised a
+// little each time. Long-form guidance about when to call a tool and how to
+// report what it found is read once and belongs in the initialize handshake or
+// a resource; the description should carry what the tool does and what its
+// arguments mean.
+const toolsListBudget = 7200
+
+func TestToolsListStaysWithinItsTokenBudget(t *testing.T) {
+	resp, _, _ := handleMCP(index.DefaultDir(), rpcRequest{Method: "tools/list"})
+	payload, ok := resp.(map[string]any)
+	if !ok {
+		t.Fatalf("tools/list returned %T, not an object", resp)
+	}
+	whole, err := json.Marshal(payload["tools"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(whole) > toolsListBudget {
+		tools, _ := payload["tools"].([]map[string]any)
+		t.Errorf("tools/list is %d bytes, over the %d-byte budget by %d (~%d tokens a session, on every session)",
+			len(whole), toolsListBudget, len(whole)-toolsListBudget, (len(whole)-toolsListBudget)/4)
+		for _, tool := range tools {
+			one, err := json.Marshal(tool)
+			if err != nil {
+				continue
+			}
+			t.Logf("  %-16s %5d bytes  ~%4d tokens", tool["name"], len(one), len(one)/4)
+		}
+	}
+}

--- a/scripts/day0bench/main.go
+++ b/scripts/day0bench/main.go
@@ -141,6 +141,28 @@ type runResult struct {
 	// which separates the two ways a query fails: ranked badly, or never
 	// retrieved at all. Only the second one is fixed by ranking work.
 	hit1, hit5, found, n int
+	// ranks is where the answer actually landed, one per question that found it
+	// at all, counting from one.
+	//
+	// The three counters above are thresholds, and thresholds go quiet exactly
+	// when the work turns to ranking: once every answer is inside the window,
+	// found stops moving and hit@1 only reports the top of the pile. A change
+	// that lifts eight answers from rank 30 to rank 7 shows up in none of them.
+	ranks []int
+}
+
+// mrr is the mean reciprocal rank: one over where the answer landed, averaged
+// over every question, counting a question that never found it as zero. It
+// moves whenever anything moves, which is what the threshold counters cannot do.
+func (r runResult) mrr() float64 {
+	if r.n == 0 {
+		return 0
+	}
+	var sum float64
+	for _, rank := range r.ranks {
+		sum += 1 / float64(rank)
+	}
+	return sum / float64(r.n)
 }
 
 // depthK bounds both sides' result list, so found means the same thing in
@@ -154,6 +176,7 @@ func main() {
 	ctxBin := flag.String("ctx", "", "path to a ctx binary to run over the same corpus, scored the same way")
 	cpuprofile := flag.String("cpuprofile", "", "write a CPU profile of the whole run here")
 	misses := flag.Bool("misses", false, "print the questions whose answer session never came back, for triage")
+	ranks := flag.Bool("ranks", false, "print where each answer landed, for triage of ranking rather than retrieval")
 	corpus := flag.Int("corpus", 0, "lay down history from this many questions while scoring -limit of them; holds the questions fixed so only the pile grows")
 	flag.Parse()
 	if *data == "" {
@@ -199,7 +222,7 @@ func main() {
 	}
 
 	for _, w := range writers() {
-		r, err := run(w, all, qs, *control, *misses)
+		r, err := run(w, all, qs, *control, *misses, *ranks)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "day0bench %s: %v\n", w.harness, err)
 			os.Exit(1)
@@ -232,11 +255,11 @@ func report(name string, r runResult) {
 		reach = float64(r.indexed) / float64(r.written) * 100
 	}
 	p50, p95 := percentiles(r.lat)
-	fmt.Printf("%-8s reach %d/%d (%.1f%%)  build %s  first %s  p50 %s  p95 %s  hit@1 %d/%d  hit@5 %d/%d  found@%d %d/%d\n",
+	fmt.Printf("%-8s reach %d/%d (%.1f%%)  build %s  first %s  p50 %s  p95 %s  hit@1 %d/%d  hit@5 %d/%d  found@%d %d/%d  mrr %.3f\n",
 		name, r.indexed, r.written, reach,
 		r.build.Round(time.Millisecond), r.first.Round(time.Millisecond),
 		p50.Round(time.Microsecond), p95.Round(time.Microsecond),
-		r.hit1, r.n, r.hit5, r.n, depthK, r.found, r.n)
+		r.hit1, r.n, r.hit5, r.n, depthK, r.found, r.n, r.mrr())
 }
 
 // percentiles reports the median and the tail of a query-latency sample. The
@@ -254,7 +277,7 @@ func percentiles(ds []time.Duration) (time.Duration, time.Duration) {
 	return at(0.5), at(0.95)
 }
 
-func run(w writer, all, qs []question, control bool, misses bool) (runResult, error) {
+func run(w writer, all, qs []question, control, misses, ranks bool) (runResult, error) {
 	var out runResult
 	tmp, err := os.MkdirTemp("", "day0")
 	if err != nil {
@@ -358,8 +381,12 @@ func run(w writer, all, qs []question, control bool, misses bool) (runResult, er
 				out.hit5++
 			}
 			out.found++
+			out.ranks = append(out.ranks, rank+1)
 			hit = true
 			break
+		}
+		if hit && ranks {
+			fmt.Printf("  rank %2d  %s: %s\n", out.ranks[len(out.ranks)-1], q.ID, q.Question)
 		}
 		// A question whose answer session never came back at all is a retrieval
 		// miss, not a ranking one, and no amount of reordering reaches it.


### PR DESCRIPTION
Groundwork for #1216 and #1174. No behaviour change — both are instruments, and the first one changed what #1216 is about.

### #1216 is no longer a retrieval problem

`found@50` on the 1910-session corpus is **40/40**. #1226 took it from 28 to 34 and it has since reached every question. The ceiling the issue was written against is gone, and `-misses` now prints nothing.

What is left is where the answers sit, and day0bench could not say. It reported three thresholds, which is the right instrument while answers are falling out of the window and the wrong one once they are all inside it: `found@50` is pinned, `hit@1` only describes the top of the pile, and a change that lifts eight answers from rank 30 to rank 7 shows up in neither.

It reports the rank now — `-ranks` per question, MRR in the summary.

```
hit@1 21/40   hit@5 28/40   found@50 40/40   mrr 0.616
```

Twenty-one at rank 1, seven more inside five, twelve spread from 6 to 46:

```
rank 46  how many bikes do I own
rank 43  what was my previous occupation
rank 27  what degree did I graduate with
rank 21  what type of rice is my favorite
rank 16  where did I complete my Bachelor's
rank 15  how long is my daily commute
rank 15  what certification did I complete
rank 13  where do I take yoga classes
rank 11  how much is the painting worth
rank  8  what time do I stop checking work emails
rank  7  what type of cocktail did I try
rank  6  what did I buy for my sister's birthday
```

These are the same questions the issue listed as recoverable by one rare term, which is the shape of the remaining work: they are retrieved, and something above them outranks them.

### #1174 gets a budget

`tools/list` is 6815 bytes, ~1700 tokens, and it is the one part of the MCP surface every session pays for whether or not deja is used — the host reads it before the agent does anything. Nothing was watching it. A sentence added to a description looks free where it is written and is charged on every request from then on, on every machine deja is wired into.

The ceiling is the payload as it stands with a little room, so raising it is a decision rather than something that happens a line at a time. On failure it prints the per-tool breakdown, since the answer is usually one tool.

Also checked, and it is fine: the issue asks whether what ships matches what main defines. `fix` and `how` arrived in #1154, which is in v0.17.0 and v0.17.1. The four-tool binary in the issue was a stale local dev build.
