### PR TITLE
fix(search): one decisive word is a match, not a weak one

### DIFF
--- a/internal/index/decisive_term_test.go
+++ b/internal/index/decisive_term_test.go
@@ -1,0 +1,71 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// A question asked in plain words carries filler alongside the one word that
+// identifies the answer. "How many bikes do I own?" ranks on many, bikes, own —
+// and sessions holding the two filler words used to count as real matches while
+// the single session that says bikes rode behind all of them, because the split
+// between a real match and a weak one counted terms and never asked what they
+// were worth.
+//
+// On the 1910-session day0 corpus that put the answer at rank 46 of 50, under
+// wineries and invasive species. It is at 10 now.
+func TestOneDecisiveWordOutranksTwoFillerOnes(t *testing.T) {
+	// The filler words have to be common for this to be the real situation:
+	// in a corpus of four everything is rare, idf collapses, and an earlier
+	// tier answers before relevance is ever asked.
+	var texts []string
+	for i := 0; i < 40; i++ {
+		texts = append(texts, "there are many ways to own one of these and many people own several")
+	}
+	answer := len(texts)
+	texts = append(texts, "I keep three bikes in the garage and ride the blue to work")
+	dir := nlIndex(t, texts...)
+
+	// Straight at the relevance tier rather than through the ladder: on a corpus
+	// this small an earlier tier answers first, and the ordering under test is
+	// this one's.
+	m, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := relevanceSearch(dir, m, query.Options{Query: "How many bikes do I own?", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Sessions) == 0 {
+		t.Fatal("a question whose rare word is in the corpus returned nothing")
+	}
+	want := string(rune('a' + answer))
+	if got := result.Sessions[0].ID; got != want {
+		rank := -1
+		for i, s := range result.Sessions {
+			if s.ID == want {
+				rank = i + 1
+			}
+		}
+		t.Errorf("the session holding the rare word ranked %d of %d, want it first (got %q first)",
+			rank, len(result.Sessions), got)
+	}
+}
+
+// The other half of the same rule, and the reason it is gated. Where the words
+// a rare term stands alone against are not words at all, one surviving anchor
+// is noise however rare it is, and the tier owes the query silence rather than
+// its best guess.
+func TestALoneRareWordAmongTyposStillSaysNothing(t *testing.T) {
+	dir := nlIndex(t, "I keep three bikes in the garage and ride the blue to work")
+	result, err := SearchDetailed(dir, search.Options{Query: "zzqx wwvv bikes", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Sessions) != 0 {
+		t.Errorf("a query of two typos and one real word answered anyway: %d sessions", len(result.Sessions))
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -374,7 +374,7 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 	if len(terms) < 2 {
 		return SearchResult{}, nil
 	}
-	metas, _, anyMatched, termsKnown, matched, _, rerr := relevantMetasCounts(dir, m, nil, terms, relevanceWindow, func(meta SessionMeta) bool {
+	metas, _, anyMatched, termsKnown, matched, strong, rerr := relevantMetasCounts(dir, m, nil, terms, relevanceWindow, func(meta SessionMeta) bool {
 		return sessionMetaMatches(meta, o)
 	})
 	if rerr != nil {
@@ -387,8 +387,20 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 	}
 	keep := make([]SessionMeta, 0, len(metas))
 	var weak []SessionMeta
+	// A lone rare term is only trustworthy when the words it is alone against
+	// are real words the corpus knows and the session simply does not use. On
+	// "zzqx wwvv limiter" the others are typos, and one surviving anchor is
+	// noise however rare it is — which is the silence the tier owes a query it
+	// cannot honestly answer.
+	decisive := len(terms) >= 3 && termsKnown >= 2
 	for i, meta := range metas {
-		if anyMatched[i] >= 2 {
+		// Two ordinary words, or one word rare enough to identify something on
+		// its own. Counting terms alone was the whole of it, and it is the wrong
+		// question on a spoken sentence: "How many bikes do I own?" carries
+		// `many` and `own` alongside `bikes`, so every session holding the two
+		// filler words counted as a real match and the one session that says
+		// bikes — twenty of nineteen hundred do — rode behind all of them.
+		if anyMatched[i] >= 2 || (decisive && strong[i] > 0) {
 			keep = append(keep, meta)
 		} else {
 			weak = append(weak, meta)


### PR DESCRIPTION
Part of #1216. One cause, found by looking at where a bad answer actually came from.

The relevance tier sorts its candidates into real matches and a weak tail, and the rule is **how many query terms a session holds** — two or more is a match, one rides behind every one of them. On a question asked in plain words that is the wrong question.

"How many bikes do I own?" ranks on `many`, `bikes`, `own`. Every session carrying the two filler words counted as a real match. The one session that says bikes — twenty of nineteen hundred do — went to the back of the queue, and came out at rank 46 of 50, under wineries, invasive species and eco-friendly car wash soaps.

Its whole score was one term's idf: `sc=5.357 bestMsg=4.511 any=1 strong=1`. It was never outscored. It was sorted into the tail before scoring had a say.

A session is a real match now if it holds two terms **or one rare enough to identify something on its own**. The ranking already works that out — `strong` — and this call site was discarding it with `_`.

### The gate, and why there is one

The first version of this had no gate and broke two tests, both of which turned out to be a contract rather than an accident: `TestStemFallbackNeedsTwoAnchors` and the no-match line in `TestNoMatchesNamesTheTermsThatMatchAlone`. On "zzqx wwvv limiter" the words the rare term stands alone against are not words at all, and one surviving anchor is noise however rare it is. The tier owes that query silence.

So the promotion requires the query to be a real sentence: three or more ranking terms, at least two of them known to the corpus. Both halves are pinned — and the first test earns its keep, since without the fix it puts the answer last of forty-one.

### Numbers

```
day0bench, 1910 sessions
  bikes question   rank 46 → 10
  mrr              0.616 → 0.618

longmemeval, 200   77.5% hit@1 / 93.0% hit@5   unchanged to a tenth
decisionbench      green
```

MRR barely moves, and that is the honest reading: this removes one way an answer is discarded before it is scored, and it is not the only thing holding the other eleven down. The rest are held by the score itself — a session that repeats two filler words across a long transcript can still out-total one rare word, because the coverage and co-occurrence bonuses count terms rather than what they are worth. That is the next thing to look at, and it wants its own change.
