### PR TITLE
fix(codex): doctor called a working hook untrusted, and an unrunnable one wired

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -212,26 +212,33 @@ func doctorCodexHook(w io.Writer) {
 		fmt.Fprintf(w, "  %-12s missing      %s\n", "codex-hook", hooksPath)
 		return
 	}
-	cfg, err := os.ReadFile(filepath.Join(sources.CodexHome(), "config.toml"))
-	status := "wired"
-	if err == nil {
-		if i := strings.Index(string(cfg), "hooks.json:session_start"); i >= 0 {
-			rest := string(cfg[i:])
-			off, on := strings.Index(rest, "enabled = false"), strings.Index(rest, "enabled = true")
-			if off >= 0 && (on == -1 || on > off) {
-				status = "disabled"
-			} else if !codexHookTrusted(hooksPath, rest) {
-				// Codex pins the hook file's hash when the user trusts it.
-				// Any reinstall that rewrites hooks.json invalidates that,
-				// and the hook stops running while enabled stays true — so
-				// this is the state that looks healthiest and works least.
-				status = "untrusted"
-			}
+	cfgPath := filepath.Join(sources.CodexHome(), "config.toml")
+	cfg, err := os.ReadFile(cfgPath)
+	if err != nil {
+		// Codex's trust store is its config. Without it there is nothing to
+		// read, and guessing either way is worse than saying so.
+		fmt.Fprintf(w, "  %-12s %-11s %s  (cannot read %s, so whether codex trusts the hook is unknown)\n",
+			"codex-hook", "wired", hooksPath, cfgPath)
+		return
+	}
+	// Untrusted until the config says otherwise. An entry that codex has never
+	// been shown is the state where it silently runs nothing: measured on codex
+	// 0.142.4, a home with hooks.json and no trust entry produced no hook at
+	// all under `codex exec`, and the same run with
+	// --dangerously-bypass-hook-trust ran it. That state used to read "wired".
+	status := "untrusted"
+	if section := codexHookTrustSection(string(cfg)); section != "" {
+		off, on := strings.Index(section, "enabled = false"), strings.Index(section, "enabled = true")
+		switch {
+		case off >= 0 && (on == -1 || on > off):
+			status = "disabled"
+		case strings.Contains(section, "trusted_hash = \"sha256:"):
+			status = "wired"
 		}
 	}
 	line := fmt.Sprintf("  %-12s %-11s %s", "codex-hook", status, hooksPath)
 	if status == "untrusted" {
-		line += "  (codex will not run it until you review it — press t in codex, or run /hooks)"
+		line += "  (codex has not been shown it — open codex once and approve it, or run /hooks; until then `codex exec` runs no hook at all)"
 	}
 	if status == "disabled" {
 		line += "  (codex trusts but disabled it — re-enable in codex settings or hooks.state)"

--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -101,24 +99,46 @@ func yamlHasKey(path, key string) bool {
 	return false
 }
 
-// codexHookTrusted compares the hook file against the hash codex recorded
-// when the user last trusted it. A mismatch means codex is holding the hook
-// for review, however enabled it looks in the config.
-func codexHookTrusted(hooksPath, stateSection string) bool {
-	i := strings.Index(stateSection, "trusted_hash = \"sha256:")
-	if i < 0 {
-		return true // no pin recorded: nothing to contradict
-	}
-	rest := stateSection[i+len("trusted_hash = \"sha256:"):]
-	end := strings.IndexByte(rest, '"')
-	if end < 0 {
-		return true
-	}
-	want := rest[:end]
-	b, err := os.ReadFile(hooksPath)
+// codexHasSeenItsHook reports whether codex has recorded any opinion about the
+// session-start hook. Until it has, codex runs nothing — and in `codex exec`
+// there is no interface in which to approve it, which is how scripted runs end
+// up with no memory while every file on disk looks correctly installed.
+func codexHasSeenItsHook() bool {
+	cfg, err := os.ReadFile(filepath.Join(sources.CodexHome(), "config.toml"))
 	if err != nil {
-		return true
+		return true // nothing to read: do not raise an alarm we cannot support
 	}
-	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:]) == want
+	return codexHookTrustSection(string(cfg)) != ""
+}
+
+// codexHookTrustSection returns the block of codex's config that records what
+// it thinks of our session-start hook, or "" when there is none.
+//
+// Codex keys its trust store per hook rather than per file —
+// `[hooks.state."<path>/hooks.json:session_start:0:0"]` — and the block ends at
+// the next table header. Reading to the end of the file instead, which is what
+// this did, lets an `enabled = false` belonging to some unrelated table decide
+// what deja reports about ours.
+//
+// It deliberately does not check the recorded hash. deja cannot reproduce it:
+// on codex 0.142.4 the pin for a hook whose command is one line long is not the
+// sha256 of the hook file, of the command, of the handler object in any
+// serialisation, or of any combination of the two with the matcher, the event
+// or the key — checked. Comparing the file's own sha256 against it, which is
+// what this did, therefore called every working install untrusted. Presence of
+// a pin is what deja can honestly read: it means codex has been shown this hook
+// and kept an opinion about it.
+func codexHookTrustSection(cfg string) string {
+	i := strings.Index(cfg, "hooks.json:session_start")
+	if i < 0 {
+		return ""
+	}
+	rest := cfg[i:]
+	// Past the key's own line, so the header we stop at is the next one.
+	if nl := strings.IndexByte(rest, '\n'); nl >= 0 {
+		if end := strings.Index(rest[nl:], "\n["); end >= 0 {
+			return rest[:nl+end]
+		}
+	}
+	return rest
 }

--- a/cmd/deja/doctor_auto_test.go
+++ b/cmd/deja/doctor_auto_test.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"os"
 	"path/filepath"
 	"strings"
@@ -102,29 +100,33 @@ func TestCompletionListsEveryInstallTarget(t *testing.T) {
 	}
 }
 
-// Codex pins the hook file's hash when the user trusts it, and any reinstall
-// that rewrites hooks.json invalidates the pin. The hook then stops running
-// while `enabled = true` stays in the config — the state that looks healthiest
-// and works least, and the one doctor used to call "wired".
-func TestCodexHookTrustDetectsARewrittenFile(t *testing.T) {
-	dir := t.TempDir()
-	hooks := filepath.Join(dir, "hooks.json")
-	if err := os.WriteFile(hooks, []byte(`{"hooks":{"session_start":[]}}`), 0o644); err != nil {
-		t.Fatal(err)
+// Codex gates hooks behind a trust store of its own, keyed per hook in
+// config.toml. Measured on codex 0.142.4: a home whose hooks.json is perfectly
+// wired but which codex has never been shown runs no hook at all under
+// `codex exec` — no marker — while the same run with
+// --dangerously-bypass-hook-trust runs it. That is the state that looks
+// healthiest and works least, and deja used to call it "wired".
+//
+// The pin itself is not checkable from here. Codex's trusted_hash is not the
+// sha256 of the hook file, and deja comparing the two called every working
+// install untrusted — on the machine this was written on, doctor said untrusted
+// while codex was demonstrably delivering deja's recall to the model.
+func TestCodexHookTrustSectionStopsAtTheNextTable(t *testing.T) {
+	cfg := `[hooks.state."/h/hooks.json:session_start:0:0"]
+trusted_hash = "sha256:abc"
+
+[projects."/some/other"]
+enabled = false
+`
+	got := codexHookTrustSection(cfg)
+	if !strings.Contains(got, "trusted_hash") {
+		t.Fatalf("the hook's own pin is missing from its section: %q", got)
 	}
-	sum := sha256.Sum256([]byte(`{"hooks":{"session_start":[]}}`))
-	matching := "\ntrusted_hash = \"sha256:" + hex.EncodeToString(sum[:]) + "\"\nenabled = true\n"
-	if !codexHookTrusted(hooks, matching) {
-		t.Fatal("an untouched hook file is reported untrusted")
+	if strings.Contains(got, "enabled = false") {
+		t.Errorf("the section ran on into an unrelated table, whose enabled flag would decide our status: %q", got)
 	}
-	stale := "\ntrusted_hash = \"sha256:0000000000000000000000000000000000000000000000000000000000000000\"\nenabled = true\n"
-	if codexHookTrusted(hooks, stale) {
-		t.Fatal("a rewritten hook file is reported trusted")
-	}
-	// A config with no pin at all is a codex that never asked; saying
-	// "untrusted" there would be a false alarm on every fresh install.
-	if !codexHookTrusted(hooks, "\nenabled = true\n") {
-		t.Fatal("absence of a pin reported as untrusted")
+	if codexHookTrustSection("[projects.\"/x\"]\nenabled = true\n") != "" {
+		t.Error("a config that never mentions the hook reported a section for it")
 	}
 }
 

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -559,6 +559,33 @@ func TestDoctorCodexHookStates(t *testing.T) {
 	if !strings.Contains(out.String(), "codex-hook   disabled") || !strings.Contains(out.String(), "re-enable") {
 		t.Fatalf("disabled state wrong:\n%s", out.String())
 	}
+
+	// A config codex has written but which says nothing about our hook. That is
+	// a fresh install, and it is the state where codex silently runs nothing:
+	// measured on 0.142.4, `codex exec` produced no hook here, and the same run
+	// with --dangerously-bypass-hook-trust produced it. deja used to call this
+	// "wired", which is the report that leaves someone believing memory is on.
+	if err := os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte("model = \"gpt-5\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	doctorHooks(&out)
+	if !strings.Contains(out.String(), "codex-hook   untrusted") {
+		t.Fatalf("a hook codex has never been shown must not read as wired:\n%s", out.String())
+	}
+
+	// And once codex has recorded an opinion, it is wired. deja cannot check the
+	// pin — its value is not the hook file's sha256 — and comparing the two
+	// reported every working install as untrusted.
+	if err := os.WriteFile(filepath.Join(codexHome, "config.toml"),
+		[]byte("[hooks.state.\"/x/hooks.json:session_start:0:0\"]\ntrusted_hash = \"sha256:aa\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	doctorHooks(&out)
+	if !strings.Contains(out.String(), "codex-hook   wired") {
+		t.Fatalf("a trusted hook must read as wired:\n%s", out.String())
+	}
 }
 
 func TestHookContextDoesNotBlockOnSilentStdin(t *testing.T) {

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -610,7 +610,15 @@ func installCodexAuto(exe string, uninstall bool) (installResult, error) {
 	if _, err := installCodex(exe, uninstall); err != nil {
 		return installResult{}, err
 	}
-	return installCodexHooks(exe, uninstall)
+	res, err := installCodexHooks(exe, uninstall)
+	// Writing the file is not the same as codex agreeing to run it. Said here
+	// because this is the moment someone is watching, and because the state it
+	// warns about is invisible: everything on disk looks right and no memory
+	// arrives.
+	if err == nil && !uninstall && !codexHasSeenItsHook() {
+		fmt.Println("codex: open codex once and approve the hook (/hooks) — until then it runs nothing, `codex exec` included")
+	}
+	return res, err
 }
 
 func installOpencodeAuto(exe string, uninstall bool) (installResult, error) {


### PR DESCRIPTION
Closes #1218 and #1219, which turn out to be one thing, and it is not what either says.

## Codex gates hooks behind a trust store

Measured on codex 0.142.4, a sandbox `CODEX_HOME` with a marker hook and nothing else:

```
codex exec "say hi"                                    no marker
codex exec --dangerously-bypass-hook-trust "say hi"    marker
```

So `codex exec` runs hooks perfectly well. It does not run **untrusted** ones, and in exec there is no interface in which to approve them. #1218 read that as "exec runs no hooks".

## The output is not discarded either

#1219 says the hook's output goes nowhere. Standing a recorder in for the model and reading what codex actually sends:

```json
{"type":"message","role":"developer","content":[{"type":"input_text",
  "text":"ZZMARKERZZ the deploy key lives in vault at secret/ci/deploy"}]}
```

`hookSpecificOutput.additionalContext` arrives as a developer message immediately before the user's. Repeated against the real home with the real hook, no bypass flag: `deja-recall` is in the request.

## What was actually broken was deja's report

Both readings of codex's trust store were backwards.

**A working hook read "untrusted".** deja compared the sha256 of `hooks.json` against the recorded pin, and that is not what the pin is — codex keys trust per hook, not per file. Its value is not the hash of the file, the command, the handler object in any serialisation, or any of those combined with the matcher, the event or the key; all checked. On the machine this was written on, `deja doctor` said `codex-hook untrusted` while codex was delivering recall to the model on every turn. deja cannot verify that pin and no longer pretends to.

**The state that actually breaks read "wired".** A config with no entry for the hook never entered the branch at all, so it fell through to `wired`. That is a fresh install — the state where codex silently runs nothing, and the one someone automating with `codex exec` is most likely to be in.

```
codex-hook   untrusted  ~/.codex/hooks.json  (codex has not been shown it — open codex once
                                              and approve it, or run /hooks; until then
                                              `codex exec` runs no hook at all)
```

Install says the same at the moment someone is watching.

**And the section it read ran to the end of the file**, so an `enabled = false` belonging to an unrelated table could decide what deja reported about ours. It stops at the next table header.

## Note on the replaced test

`TestCodexHookTrustDetectsARewrittenFile` asserted the file-hash theory, including that a missing pin should read as trusted — "saying untrusted there would be a false alarm on every fresh install". A fresh install is exactly the case where codex runs nothing, so that was the wrong way round too. It is replaced by tests for the section boundary and for both doctor states.
