### PR TITLE
fix(search): the relevance tier served records exact search hides

### DIFF
--- a/internal/index/relevance_roles_test.go
+++ b/internal/index/relevance_roles_test.go
@@ -1,0 +1,112 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// rolesIndex lays down one session whose speech and whose work records say
+// different things, so a result can be traced to which of the two carried it.
+func rolesIndex(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "idx")
+	sessions := []model.Session{{
+		ID: "a", Harness: "claude", Project: "p", Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: "the deploy pipeline kept timing out on the staging cluster"},
+			{Role: "assistant", Text: "raised the readiness probe budget and it settled"},
+			{Role: roleCommand, Text: "kubectl rollout restart deployment/frobnicator"},
+			{Role: roleFiles, Text: "charts/frobnicator/values.yaml"},
+		},
+	}}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The relevance tier never scans records, so it served every record of every
+// session it ranked. Exact search hides file lists and commands on purpose — a
+// path is a note of what a turn touched, not something said — and the two paths
+// disagreed about the same session.
+func TestRelevanceDoesNotServeWorkRecords(t *testing.T) {
+	dir := rolesIndex(t)
+	m, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := relevanceSearch(dir, m, query.Options{Query: "frobnicator values rollout", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range result.Sessions {
+		for _, msg := range s.Messages {
+			if msg.Role == roleCommand || msg.Role == roleFiles {
+				t.Errorf("relevance served a %s record: %q", msg.Role, msg.Text)
+			}
+		}
+	}
+}
+
+// And with an explicit role, the other side of the conversation is not an
+// answer to it.
+func TestRelevanceHonoursTheRequestedRole(t *testing.T) {
+	dir := rolesIndex(t)
+	m, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := relevanceSearch(dir, m, query.Options{
+		Query: "readiness probe budget settled", Role: "user", All: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range result.Sessions {
+		for _, msg := range s.Messages {
+			if msg.Role != "user" {
+				t.Errorf("--role=user returned a %s message: %q", msg.Role, msg.Text)
+			}
+		}
+	}
+}
+
+// The same rule reaches the auto-recall path, which loads sessions the same way
+// and had the same hole: a hook that pastes a file list into the model's
+// context is pasting the wrong thing.
+func TestProjectRelevantDoesNotServeWorkRecords(t *testing.T) {
+	dir := rolesIndex(t)
+	ss, _, _, err := ProjectRelevant(dir, []string{"p"}, []string{"frobnicator", "values", "rollout"}, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range ss {
+		for _, msg := range s.Messages {
+			if msg.Role == roleCommand || msg.Role == roleFiles {
+				t.Errorf("auto-recall served a %s record: %q", msg.Role, msg.Text)
+			}
+		}
+	}
+}
+
+// Nothing above should have cost the ordinary answer.
+func TestSpeechStillComesBack(t *testing.T) {
+	dir := rolesIndex(t)
+	result, err := SearchDetailed(dir, search.Options{Query: "deploy pipeline timing out", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Sessions) == 0 {
+		t.Fatal("the session that answers this in plain speech did not come back")
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -420,7 +420,7 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 		if len(weak) > relevanceWindow {
 			weak = weak[:relevanceWindow]
 		}
-		ss, err := sessionsForMetas(dir, weak)
+		ss, err := sessionsServable(dir, weak, o)
 		if err != nil {
 			return SearchResult{}, err
 		}
@@ -432,7 +432,7 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 		weak = weak[:relevanceWindow-len(keep)]
 	}
 	keep = append(keep, weak...)
-	ss, err := sessionsForMetas(dir, keep)
+	ss, err := sessionsServable(dir, keep, o)
 	if err != nil {
 		return SearchResult{}, err
 	}
@@ -508,7 +508,7 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 	if len(metas) == 0 {
 		return nil, nil, nil, nil
 	}
-	out, err := sessionsForMetas(dir, metas)
+	out, err := sessionsServable(dir, metas, query.Options{})
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1004,6 +1004,59 @@ func RecentProject(dir, project string, n int) ([]model.Session, error) {
 	return sessionsForMetas(dir, metas)
 }
 
+// recordServable says whether a record may be served for a query.
+//
+// Both retrieval paths have to ask this and only one of them did. Exact search
+// asked it per record while scanning; the relevance tier never scans, so it
+// served every record of every session it ranked — a --role=user recall could
+// come back holding assistant text, and an ordinary one could be carried by a
+// file list or a command that exact search hides on purpose.
+//
+// Work records are why the question is not simply o.Role. A file list is a
+// record of what a turn touched, not something said; an invocation is an
+// action, not an answer; a replaced span is the file's old contents. All three
+// are indexed and searchable, and served only when asked for by name.
+func recordServable(role string, o query.Options) bool {
+	if o.Role != "" && !roleMatches(role, o.Role) {
+		return false
+	}
+	for _, work := range []string{roleFiles, roleCommand, roleEdit} {
+		if role == work && o.Role != work {
+			return false
+		}
+	}
+	return true
+}
+
+// sessionsServable loads the sessions and keeps only the records this query is
+// allowed to be served, dropping any session left holding nothing.
+//
+// A session that emptied here was ranked entirely on records the caller is not
+// allowed to see — a file list, a command, or, under --role, the other side of
+// the conversation. Returning it with no messages would be worse than dropping
+// it: the count would say a match exists and the result would show nothing.
+func sessionsServable(dir string, metas []SessionMeta, o query.Options) ([]model.Session, error) {
+	all, err := sessionsForMetas(dir, metas)
+	if err != nil {
+		return nil, err
+	}
+	out := all[:0]
+	for _, s := range all {
+		kept := s.Messages[:0]
+		for _, m := range s.Messages {
+			if recordServable(m.Role, o) {
+				kept = append(kept, m)
+			}
+		}
+		if len(kept) == 0 {
+			continue
+		}
+		s.Messages = kept
+		out = append(out, s)
+	}
+	return out, nil
+}
+
 // sessionsForMetas loads full sessions for the given metas in ONE pass over
 // records.bin. The per-session variant re-scanned the whole log for every
 // session, which turned a session-start hook into hundreds of milliseconds.
@@ -1423,24 +1476,7 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		if o.Since > 0 && meta.Updated.Before(time.Now().Add(-o.Since)) {
 			return
 		}
-		if o.Role != "" && !roleMatches(r.Role, o.Role) {
-			return
-		}
-		// A file list is a record of what a turn touched, not something said.
-		// Left in ordinary ranking it lifts a session because a path happened
-		// to contain the words of a question, so it is indexed and searchable
-		// but served only when asked for by role.
-		if r.Role == roleFiles && o.Role != roleFiles {
-			return
-		}
-		// Same rule for commands: an invocation is an action, not an answer.
-		if r.Role == roleCommand && o.Role != roleCommand {
-			return
-		}
-		// A replaced span is the file's old contents, not a statement about
-		// anything. It is stored so `deja restore` can find it and served only
-		// when asked for by role.
-		if r.Role == roleEdit && o.Role != roleEdit {
+		if !recordServable(r.Role, o) {
 			return
 		}
 		s := by[r.Key]


### PR DESCRIPTION
First of the correctness findings from the deep research pass on search. No ranking change; this is about what the two retrieval paths are allowed to serve, where they disagreed.

Exact search asks, per record, whether it may be served. It drops the other side of the conversation under `--role`, and it always drops file lists, commands and replaced spans — a path is a note of what a turn touched rather than something said, so those are indexed and searchable but served only when asked for by name (`retrieval.go:1426-1443`).

The relevance tier never scans records. It ranks metas and then loads every record of every session it picked, so it asked none of that.

Consequences, all reachable today:

- `deja recall --role=user` can come back holding assistant text.
- An ordinary recall can be carried by a command or a file list that the same query, answered by the exact tier, hides.
- `ProjectRelevant` — the auto-recall path — loads sessions the same way, so a hook could paste a file list into the model's context.

The rule is one function now (`recordServable`) and both paths ask it. A session left holding nothing after filtering is dropped rather than returned empty: it was ranked entirely on records this caller may not see, and a result that claims a match and shows nothing is worse than no result at all.

### Numbers

```
day0bench      hit@1 21/40  hit@5 28/40  found@50 40/40  mrr 0.618   unchanged
longmemeval    hit@1 77.5%  hit@5 93.0%  hit@20 97.0%   MRR 0.843    unchanged
decisionbench  green
```

Unchanged is the expected result and the reason this needed its own tests: those corpora are transcripts, with no tool records in them at all, so the defect is invisible there. The new tests carry one session whose speech and whose work records say different things — they fail seven ways without the fix.

Known and deliberately not addressed here: postings from work records still contribute to the *score*, because a posting carries only a broad tool bit and not a role. That is a second stage — materialised rescoring or a richer posting tag — and it is a bigger change than this one.
