### PR TITLE
fix(search): show the message that earned the rank, not the wordiest one

### DIFF
--- a/internal/index/relevance_roles_test.go
+++ b/internal/index/relevance_roles_test.go
@@ -1,0 +1,112 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// rolesIndex lays down one session whose speech and whose work records say
+// different things, so a result can be traced to which of the two carried it.
+func rolesIndex(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "idx")
+	sessions := []model.Session{{
+		ID: "a", Harness: "claude", Project: "p", Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: "the deploy pipeline kept timing out on the staging cluster"},
+			{Role: "assistant", Text: "raised the readiness probe budget and it settled"},
+			{Role: roleCommand, Text: "kubectl rollout restart deployment/frobnicator"},
+			{Role: roleFiles, Text: "charts/frobnicator/values.yaml"},
+		},
+	}}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The relevance tier never scans records, so it served every record of every
+// session it ranked. Exact search hides file lists and commands on purpose — a
+// path is a note of what a turn touched, not something said — and the two paths
+// disagreed about the same session.
+func TestRelevanceDoesNotServeWorkRecords(t *testing.T) {
+	dir := rolesIndex(t)
+	m, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := relevanceSearch(dir, m, query.Options{Query: "frobnicator values rollout", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range result.Sessions {
+		for _, msg := range s.Messages {
+			if msg.Role == roleCommand || msg.Role == roleFiles {
+				t.Errorf("relevance served a %s record: %q", msg.Role, msg.Text)
+			}
+		}
+	}
+}
+
+// And with an explicit role, the other side of the conversation is not an
+// answer to it.
+func TestRelevanceHonoursTheRequestedRole(t *testing.T) {
+	dir := rolesIndex(t)
+	m, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := relevanceSearch(dir, m, query.Options{
+		Query: "readiness probe budget settled", Role: "user", All: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range result.Sessions {
+		for _, msg := range s.Messages {
+			if msg.Role != "user" {
+				t.Errorf("--role=user returned a %s message: %q", msg.Role, msg.Text)
+			}
+		}
+	}
+}
+
+// The same rule reaches the auto-recall path, which loads sessions the same way
+// and had the same hole: a hook that pastes a file list into the model's
+// context is pasting the wrong thing.
+func TestProjectRelevantDoesNotServeWorkRecords(t *testing.T) {
+	dir := rolesIndex(t)
+	ss, _, _, err := ProjectRelevant(dir, []string{"p"}, []string{"frobnicator", "values", "rollout"}, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range ss {
+		for _, msg := range s.Messages {
+			if msg.Role == roleCommand || msg.Role == roleFiles {
+				t.Errorf("auto-recall served a %s record: %q", msg.Role, msg.Text)
+			}
+		}
+	}
+}
+
+// Nothing above should have cost the ordinary answer.
+func TestSpeechStillComesBack(t *testing.T) {
+	dir := rolesIndex(t)
+	result, err := SearchDetailed(dir, search.Options{Query: "deploy pipeline timing out", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Sessions) == 0 {
+		t.Fatal("the session that answers this in plain speech did not come back")
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -420,7 +420,7 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 		if len(weak) > relevanceWindow {
 			weak = weak[:relevanceWindow]
 		}
-		ss, err := sessionsForMetas(dir, weak)
+		ss, err := sessionsServable(dir, weak, o)
 		if err != nil {
 			return SearchResult{}, err
 		}
@@ -432,7 +432,7 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 		weak = weak[:relevanceWindow-len(keep)]
 	}
 	keep = append(keep, weak...)
-	ss, err := sessionsForMetas(dir, keep)
+	ss, err := sessionsServable(dir, keep, o)
 	if err != nil {
 		return SearchResult{}, err
 	}
@@ -508,7 +508,7 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 	if len(metas) == 0 {
 		return nil, nil, nil, nil
 	}
-	out, err := sessionsForMetas(dir, metas)
+	out, err := sessionsServable(dir, metas, query.Options{})
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1004,6 +1004,59 @@ func RecentProject(dir, project string, n int) ([]model.Session, error) {
 	return sessionsForMetas(dir, metas)
 }
 
+// recordServable says whether a record may be served for a query.
+//
+// Both retrieval paths have to ask this and only one of them did. Exact search
+// asked it per record while scanning; the relevance tier never scans, so it
+// served every record of every session it ranked — a --role=user recall could
+// come back holding assistant text, and an ordinary one could be carried by a
+// file list or a command that exact search hides on purpose.
+//
+// Work records are why the question is not simply o.Role. A file list is a
+// record of what a turn touched, not something said; an invocation is an
+// action, not an answer; a replaced span is the file's old contents. All three
+// are indexed and searchable, and served only when asked for by name.
+func recordServable(role string, o query.Options) bool {
+	if o.Role != "" && !roleMatches(role, o.Role) {
+		return false
+	}
+	for _, work := range []string{roleFiles, roleCommand, roleEdit} {
+		if role == work && o.Role != work {
+			return false
+		}
+	}
+	return true
+}
+
+// sessionsServable loads the sessions and keeps only the records this query is
+// allowed to be served, dropping any session left holding nothing.
+//
+// A session that emptied here was ranked entirely on records the caller is not
+// allowed to see — a file list, a command, or, under --role, the other side of
+// the conversation. Returning it with no messages would be worse than dropping
+// it: the count would say a match exists and the result would show nothing.
+func sessionsServable(dir string, metas []SessionMeta, o query.Options) ([]model.Session, error) {
+	all, err := sessionsForMetas(dir, metas)
+	if err != nil {
+		return nil, err
+	}
+	out := all[:0]
+	for _, s := range all {
+		kept := s.Messages[:0]
+		for _, m := range s.Messages {
+			if recordServable(m.Role, o) {
+				kept = append(kept, m)
+			}
+		}
+		if len(kept) == 0 {
+			continue
+		}
+		s.Messages = kept
+		out = append(out, s)
+	}
+	return out, nil
+}
+
 // sessionsForMetas loads full sessions for the given metas in ONE pass over
 // records.bin. The per-session variant re-scanned the whole log for every
 // session, which turned a session-start hook into hundreds of milliseconds.
@@ -1423,24 +1476,7 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		if o.Since > 0 && meta.Updated.Before(time.Now().Add(-o.Since)) {
 			return
 		}
-		if o.Role != "" && !roleMatches(r.Role, o.Role) {
-			return
-		}
-		// A file list is a record of what a turn touched, not something said.
-		// Left in ordinary ranking it lifts a session because a path happened
-		// to contain the words of a question, so it is indexed and searchable
-		// but served only when asked for by role.
-		if r.Role == roleFiles && o.Role != roleFiles {
-			return
-		}
-		// Same rule for commands: an invocation is an action, not an answer.
-		if r.Role == roleCommand && o.Role != roleCommand {
-			return
-		}
-		// A replaced span is the file's old contents, not a statement about
-		// anything. It is stored so `deja restore` can find it and served only
-		// when asked for by role.
-		if r.Role == roleEdit && o.Role != roleEdit {
+		if !recordServable(r.Role, o) {
 			return
 		}
 		s := by[r.Key]

--- a/internal/search/relevance_snippet_test.go
+++ b/internal/search/relevance_snippet_test.go
@@ -1,0 +1,60 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The relevance ranker scores a session by the idf mass of its best single
+// message: the passage where the rare words of the question are is what makes
+// the session an answer. It then throws that away, and the snippet is chosen by
+// a different rule — how many distinct query terms a message contains, each
+// counted the same.
+//
+// The two disagree exactly when one rare word carries the session. "How many
+// bikes do I own?" ranks on many, bikes, own; a message saying "many people own
+// one" holds two of them and the message saying "three bikes" holds one, so the
+// session is ranked on the second and shown as the first.
+//
+// That is the whole of what an agent reads before deciding whether to use a
+// result, which is why it is worth its own test rather than an aggregate.
+func TestTheSnippetComesFromTheMessageThatEarnedTheRank(t *testing.T) {
+	// The filler words have to be common across the returned set for this to be
+	// the real situation; a term is only worth little because everything has it.
+	var sessions []model.Session
+	for i := 0; i < 6; i++ {
+		sessions = append(sessions, model.Session{
+			ID: string(rune('a' + i)), Harness: "claude", Project: "p",
+			Messages: []model.Message{
+				{Role: "user", Text: "there are many ways to own one of these"},
+			},
+		})
+	}
+	answer := model.Session{
+		ID: "answer", Harness: "claude", Project: "p",
+		Messages: []model.Message{
+			{Role: "user", Text: "how many of these do people own, generally speaking"},
+			{Role: "user", Text: "I keep three bikes in the garage and ride the blue one"},
+		},
+	}
+	sessions = append(sessions, answer)
+
+	hits := RelevanceHits(sessions, []string{"many", "bikes", "own"})
+	var got *Hit
+	for i := range hits {
+		if hits[i].Session.ID == "answer" {
+			got = &hits[i]
+		}
+	}
+	if got == nil {
+		t.Fatal("the session holding the rare word is not in the hits at all")
+	}
+	if len(got.Snippets) == 0 {
+		t.Fatal("no snippet at all for the session that answers the question")
+	}
+	if !strings.Contains(strings.ToLower(got.Snippets[0]), "bikes") {
+		t.Errorf("the first snippet is the filler message, not the one that earned the rank:\n  %s", got.Snippets[0])
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1431,11 +1431,62 @@ func ErrorHits(ss []model.Session) []Hit {
 	return hits
 }
 
+// sessionHolds says whether a term appears anywhere in a session, stopping at
+// the first message that has it. Joining a session's text into one string to
+// ask this is quadratic in the number of messages, and these are transcripts.
+func sessionHolds(s model.Session, t string) bool {
+	folded := ""
+	for _, m := range s.Messages {
+		low := strings.ToLower(m.Text)
+		if strings.Contains(low, t) {
+			return true
+		}
+		if ft := cjkfold.String(t); ft != t || cjkfold.HasCJK(t) {
+			if folded = cjkfold.String(low); strings.Contains(folded, ft) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// termWeights says what each query term is worth for picking an excerpt, from
+// how much of the answer set holds it.
+//
+// The index knows the real idf and this layer does not, but it does not need
+// to: the question here is only which of two messages in one session to show,
+// and a term carried by every session that came back cannot be what separates
+// them. A word in one result of fifty is what names that result; a word in all
+// fifty is the shape of the question.
+//
+// Bounded below so a term the whole set shares still counts for something — it
+// is weak evidence, not none — and so a message holding two common words can
+// still beat one holding a single common word.
+func termWeights(ss []model.Session, terms []string) map[string]float64 {
+	if len(ss) == 0 {
+		return nil
+	}
+	df := make(map[string]int, len(terms))
+	for _, s := range ss {
+		for _, t := range terms {
+			if sessionHolds(s, t) {
+				df[t]++
+			}
+		}
+	}
+	out := make(map[string]float64, len(terms))
+	for _, t := range terms {
+		out[t] = 0.2 + math.Log(float64(len(ss)+1)/float64(df[t]+1))
+	}
+	return out
+}
+
 // RelevanceHits wraps relevance-ranked sessions as hits WITHOUT re-scoring:
 // the index already ordered them by IDF overlap, and exact-match BM25 (which
 // just failed) must not reshuffle the ranking. Count and snippets come from
 // term occurrences so output still shows why each session surfaced.
 func RelevanceHits(ss []model.Session, terms []string) []Hit {
+	weight := termWeights(ss, terms)
 	hits := make([]Hit, 0, len(ss))
 	for rank, s := range ss {
 		hit := Hit{Session: s, Tier: TierRelevance}
@@ -1443,45 +1494,57 @@ func RelevanceHits(ss []model.Session, terms []string) []Hit {
 		// message that contains any one of them. The passage that answers a
 		// question is where its words come together — a session about a gift
 		// from a sister used to be shown for "what did my dad give me" because
-		// "gift" matched first. Score each message by distinct terms hit; the
-		// best two become the excerpts an agent reads to decide.
+		// "gift" matched first.
+		//
+		// Terms are worth what they distinguish, not one each. The ranker picks
+		// a session by the idf mass of its best message and then discards which
+		// message that was; counting terms equally here picked a different one
+		// whenever a single rare word carried the session. "How many bikes do I
+		// own?" ranked a session on "three bikes" and displayed "many people own
+		// one", which is the passage an agent reads before deciding whether the
+		// result is worth anything.
 		type msgScore struct {
-			idx, distinct int
-			center        string
+			idx      int
+			distinct int
+			weighted float64
+			center   string
 		}
 		best := make([]msgScore, 0, 8)
 		for mi, m := range s.Messages {
 			low := strings.ToLower(m.Text)
 			var foldedLow string
 			distinct := 0
+			weighted := 0.0
 			center := ""
+			// The rarest term a message holds is what names it, so it is what
+			// the excerpt gets centred on.
+			heaviest := 0.0
 			for _, t := range terms {
-				if strings.Contains(low, t) {
-					distinct++
-					if center == "" {
-						center = t
+				found := strings.Contains(low, t)
+				if !found {
+					if ft := cjkfold.String(t); ft != t || cjkfold.HasCJK(t) {
+						if foldedLow == "" {
+							foldedLow = cjkfold.String(low)
+						}
+						found = strings.Contains(foldedLow, ft)
 					}
+				}
+				if !found {
 					continue
 				}
-				if ft := cjkfold.String(t); ft != t || cjkfold.HasCJK(t) {
-					if foldedLow == "" {
-						foldedLow = cjkfold.String(low)
-					}
-					if strings.Contains(foldedLow, ft) {
-						distinct++
-						if center == "" {
-							center = t
-						}
-					}
+				distinct++
+				weighted += weight[t]
+				if center == "" || weight[t] > heaviest {
+					center, heaviest = t, weight[t]
 				}
 			}
 			if distinct > 0 {
 				hit.Count++
-				best = append(best, msgScore{mi, distinct, center})
+				best = append(best, msgScore{mi, distinct, weighted, center})
 			}
 		}
-		// Most distinct terms first; a stable sort keeps message order among ties.
-		sort.SliceStable(best, func(i, j int) bool { return best[i].distinct > best[j].distinct })
+		// Heaviest first; a stable sort keeps message order among ties.
+		sort.SliceStable(best, func(i, j int) bool { return best[i].weighted > best[j].weighted })
 		for i := 0; i < len(best) && i < 2; i++ {
 			hit.Snippets = append(hit.Snippets, snippet(s.Messages[best[i].idx].Text, best[i].center, nil))
 		}


### PR DESCRIPTION
Second correctness finding from the research pass. Stacked on #1263.

The test was written first and run against the old code, so the defect is on record rather than argued:

```
--- FAIL: TestTheSnippetComesFromTheMessageThatEarnedTheRank
    the first snippet is the filler message, not the one that earned the rank:
      how many of these do people own, generally speaking
```

The session was ranked on *"I keep three bikes in the garage"*. It was displayed as the sentence above.

The ranker scores a session by the idf mass of its best single message — the passage where the rare words of the question are is what makes the session an answer — and then throws away which message that was. Snippets came from a second rule: how many distinct query terms a message holds, counted one each. `many` + `own` beats `bikes`, every time, and that excerpt is the whole of what an agent reads before deciding whether to use a result.

Terms are worth what they distinguish now. The weight comes from how much of the answer set holds each one — this layer has no idf and does not need it: a term carried by every session that came back cannot be what separates them. It is bounded below, so a common word stays weak evidence rather than none, and two of them still beat one.

### Numbers

```
day0bench      hit@1 21/40  hit@5 28/40  found@50 40/40  mrr 0.618   unchanged
longmemeval    hit@1 77.5%  hit@5 93.0%  hit@20 97.0%   MRR 0.843    unchanged
decisionbench  green
searchbench    overall median 33.7ms  p90 200ms          unchanged
```

Unchanged is right: this moves what is displayed, not what is ranked.

One thing worth noting from writing it. The first version asked whether a session holds a term by joining its messages into one string, which is quadratic in the number of messages — on transcripts. It stops at the first message that has the term instead.
