### PR TITLE
feat(search): satisfying the AND is worth places, not everything

### DIFF
--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -215,10 +215,39 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 // is describing a real cluster and needs no help.
 const thinAND = 10
 
+// strictPromotion is what satisfying the strict AND is worth, counted in places
+// on the relevance ranking.
+//
+// It used to be worth everything: the strict head was concatenated in front of
+// the ranked tail, so one session that happened to carry every query word led
+// an answer even when the ranking put it fortieth. That is the case this tail
+// exists for — a thin AND on a large store — so the head is usually one or two
+// incidental sessions.
+//
+// Worth nothing is no better: the AND is real evidence, and #1226 measured that
+// keeping strict matches first is why hit@1 is what it is.
+const strictPromotion = 10
+
+// fusedPlace is where a session sits once both tiers have had their say: its
+// place in the relevance ranking, moved up by strictPromotion if it also
+// satisfied the strict AND.
+//
+// The result is deliberately allowed to go negative. Clamping it at zero was
+// the first version, and it collapsed every promoted session onto the same
+// place, where the tie-break was posting order — so the strict head kept its
+// absolute lead and lost the ranking it did have. day0bench read that as hit@1
+// 21/40 -> 17/40.
+func fusedPlace(relevanceRank int, strict bool) int {
+	if strict {
+		return relevanceRank - strictPromotion
+	}
+	return relevanceRank
+}
+
 // withRelevanceTail keeps a thin AND result and hangs the relevance ranking
 // underneath it, so a question whose wording excluded the answer can still
-// reach it. The strict sessions stay in front: they are why hit@1 is what it
-// is, and relevance ranked alone scores worse at the first position.
+// reach it. Strict sessions keep a bounded lead rather than an absolute one —
+// see strictPromotion.
 //
 // Order is the contract here. RelevanceHits scores by arrival (len-rank), so
 // the merged order survives to the caller untouched; anything that re-sorts
@@ -258,16 +287,21 @@ func withRelevanceTail(dir string, m Manifest, o query.Options, res SearchResult
 	for i, r := range rel.Sessions {
 		relRank[r.Harness+":"+r.ID] = i
 	}
-	head := append([]model.Session(nil), ss...)
-	sort.SliceStable(head, func(i, j int) bool {
-		ri, oki := relRank[head[i].Harness+":"+head[i].ID]
-		rj, okj := relRank[head[j].Harness+":"+head[j].ID]
-		if oki != okj {
-			return oki
+	// Both lists, ordered by one rule. The strict head used to sit in front of
+	// everything whatever the ranking thought of it, which made a thin AND —
+	// often one incidental session — the whole top of the answer. Satisfying the
+	// AND is strong evidence and stays worth something definite: a fixed number
+	// of places, not an unconditional lead. A strict session the ranking scored
+	// badly can now be passed by a relevance session it scored well.
+	unranked := len(rel.Sessions)
+	place := func(s model.Session, strict bool) int {
+		r, ok := relRank[s.Harness+":"+s.ID]
+		if !ok {
+			r = unranked
 		}
-		return oki && ri < rj
-	})
-	merged := head
+		return fusedPlace(r, strict)
+	}
+	merged := append([]model.Session(nil), ss...)
 	added := 0
 	for _, r := range rel.Sessions {
 		if seen[r.Harness+":"+r.ID] {
@@ -276,6 +310,14 @@ func withRelevanceTail(dir string, m Manifest, o query.Options, res SearchResult
 		merged = append(merged, r)
 		added++
 	}
+	at := make(map[string]int, len(merged))
+	for _, s := range merged {
+		key := s.Harness + ":" + s.ID
+		at[key] = place(s, seen[key])
+	}
+	sort.SliceStable(merged, func(i, j int) bool {
+		return at[merged[i].Harness+":"+merged[i].ID] < at[merged[j].Harness+":"+merged[j].ID]
+	})
 	if added == 0 {
 		return res, nil
 	}

--- a/internal/index/tier_fusion_test.go
+++ b/internal/index/tier_fusion_test.go
@@ -1,0 +1,89 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// fusionIndex builds a store big enough for the relevance tail to engage — it
+// declines to rank a store no larger than its own window — holding one session
+// that satisfies the strict AND incidentally and one that actually answers.
+func fusionIndex(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "idx")
+	var sessions []model.Session
+	for i := 0; i < 80; i++ {
+		sessions = append(sessions, model.Session{
+			ID: fmt.Sprintf("filler%02d", i), Harness: "claude", Project: "p", Updated: time.Now(),
+			Messages: []model.Message{{Role: "user", Text: "notes about the weekly planning meeting"}},
+		})
+	}
+	// Carries every word of the question and answers none of it.
+	sessions = append(sessions, model.Session{
+		ID: "incidental", Harness: "claude", Project: "p", Updated: time.Now(),
+		Messages: []model.Message{{Role: "user", Text: "many people own a bicycle; how many own a car is another question"}},
+	})
+	// Answers it, and is missing two of the question's words.
+	sessions = append(sessions, model.Session{
+		ID: "answer", Harness: "claude", Project: "p", Updated: time.Now(),
+		Messages: []model.Message{{Role: "user", Text: "I keep three bicycles in the garage, the blue one is my commuter"}},
+	})
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// A thin strict result used to be concatenated in front of the whole ranked
+// tail, so one session that happened to carry every query word led the answer
+// however the ranking scored it — and a thin AND on a large store is exactly
+// the case this tail exists for, so that head is usually incidental.
+//
+// The lead is bounded now: worth a fixed number of places rather than all of
+// them. Pinned on the rule rather than on a staged result, because a strict
+// match that the ranking puts more than ten places down is not something a
+// synthetic corpus produces on demand — satisfying the AND is why they rank
+// high in the first place. What that rule is worth in practice is day0bench:
+// hit@5 28/40 -> 30/40, MRR .618 -> .622, longmemeval unmoved.
+func TestStrictEvidenceIsWorthPlacesNotEverything(t *testing.T) {
+	// Ranked far below something better: it gives way.
+	if got, want := fusedPlace(30, true), fusedPlace(15, false); got <= want {
+		t.Errorf("a strict match ranked 30th places at %d, ahead of a relevance match ranked 15th at %d", got, want)
+	}
+	// Ranked close behind: the AND is real evidence and still wins.
+	if got, want := fusedPlace(5, true), fusedPlace(0, false); got >= want {
+		t.Errorf("a strict match ranked 5th places at %d, behind a relevance match ranked first at %d", got, want)
+	}
+	// Two promoted sessions keep the order the ranking gave them. Clamping this
+	// at zero collapsed them together and cost day0bench four questions at
+	// rank 1.
+	if fusedPlace(2, true) >= fusedPlace(9, true) {
+		t.Error("promotion lost the ranking among the sessions it promoted")
+	}
+}
+
+// And the evidence a strict match carries is still worth something definite:
+// with nothing better ranked above it, it leads.
+func TestAStrictMatchStillLeadsWhenNothingOutranksIt(t *testing.T) {
+	dir := fusionIndex(t)
+	result, err := SearchDetailed(dir, search.Options{Query: "bicycle car question", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Sessions) == 0 {
+		t.Fatal("no results at all")
+	}
+	if got := result.Sessions[0].ID; got != "incidental" {
+		t.Errorf("the only session holding every word of this query ranked behind %q", got)
+	}
+}


### PR DESCRIPTION
First of the improvement ideas from the research pass, and the one it ranked highest. Measured one change at a time as agreed.

When a strict match comes back thin on a large store, the relevance ranking is hung underneath it (#1226). The strict head was **concatenated in front of that whole ranked tail**, so one session that happened to carry every word of the question led the answer however the ranking scored it. A thin AND on a large store is exactly the case this tail exists for, so that head is usually one incidental session.

Satisfying the AND is worth a fixed number of places on the relevance ranking now, not all of them. A strict session the ranking scored badly can be passed by a relevance session it scored well; one ranked just behind still leads.

```
day0bench, 1910 sessions
  hit@1    21/40   unchanged
  hit@5    28/40 -> 30/40
  MRR      .618  -> .622

longmemeval, 200    77.5 / 93.0 / 97.0, MRR .843    unmoved across the whole sweep
decisionbench       green
```

Ten was picked by measuring five, ten and fifteen: five costs a question at rank 1, fifteen gives one back at rank 5. A three-point sweep on forty questions, so a reasonable value rather than a tuned one — and longmemeval does not move at any of them, which is the part that matters for shipping it.

### The version that did not work

The first attempt clamped the promoted place at zero. That collapsed every strict session onto the same place, where the tie-break was posting order, so the head kept its absolute lead and lost the ranking it did have:

```
hit@1 21/40 -> 17/40      MRR .618 -> .557
```

Worth writing down because the symptom looked like the idea failing rather than the implementation.

### On the test

It pins the rule, not a staged result. A strict match that the ranking puts more than ten places down is not something a synthetic corpus produces on demand — satisfying the AND is why they rank high in the first place — and a fixture that passed by coincidence would be worse than none. What the rule is worth in practice is the day0bench line above. The integration test that remains checks the other half: a strict match with nothing better above it still leads.
