### PR TITLE
feat(search): rank the whole question and its rare part, and take the better

### DIFF
--- a/internal/index/focus_fusion_test.go
+++ b/internal/index/focus_fusion_test.go
@@ -1,0 +1,73 @@
+package index
+
+import "testing"
+
+// A question asked in plain speech carries words that are filler to a reader
+// and content to the index. "How many bikes do I own" ranks on many, bikes and
+// own; the session that answers it holds only the rare one, and sessions about
+// how many people own things hold two. Scored on the whole query the answer
+// loses to them.
+//
+// Scoring only the rare words instead was measured and rejected: day0bench
+// gained .003 and longmemeval lost 1.5 points of hit@1 and 3 of hit@20. The
+// view is not wrong, it is only right sometimes, so it is kept beside the other
+// one and each session takes its better place at a price.
+func TestAFocusedWinTakesABetterPlaceButPaysForIt(t *testing.T) {
+	// Ranked last on the whole query, first on the rare part of it.
+	ranked := make([]relevanceScored, 12)
+	for i := range ranked {
+		ranked[i] = relevanceScored{meta: SessionMeta{ID: string(rune('a' + i))}, score: float64(12 - i)}
+	}
+	ranked[11].focus = 100
+
+	out := fuseFocus(ranked)
+	at := -1
+	for i, r := range out {
+		if r.meta.ID == ranked[11].meta.ID {
+			at = i
+			break
+		}
+	}
+	if at < 0 {
+		t.Fatal("the session disappeared from the ranking")
+	}
+	// Its price puts it level with the session already holding that place, and a
+	// tie goes to the view that ranked the whole query — so it lands just behind.
+	if at != focusPrice+1 {
+		t.Errorf("a session first on the focused view sits at %d, want %d: paid its price and no more", at, focusPrice+1)
+	}
+}
+
+// The price is what stops the focused view from being the ranking. A session
+// the whole query already ranks first must not be displaced by one that merely
+// carries a rare word.
+func TestTheFocusedViewCannotTakeTheFront(t *testing.T) {
+	ranked := make([]relevanceScored, 6)
+	for i := range ranked {
+		ranked[i] = relevanceScored{meta: SessionMeta{ID: string(rune('a' + i))}, score: float64(6 - i)}
+	}
+	ranked[5].focus = 100
+
+	out := fuseFocus(ranked)
+	if out[0].meta.ID != "a" {
+		t.Errorf("the front of the ranking changed hands to %q", out[0].meta.ID)
+	}
+}
+
+// And a ranking where the two views agree comes back exactly as it was: this
+// reorders only where they disagree.
+func TestAgreementLeavesTheOrderAlone(t *testing.T) {
+	ranked := make([]relevanceScored, 8)
+	for i := range ranked {
+		ranked[i] = relevanceScored{
+			meta:  SessionMeta{ID: string(rune('a' + i))},
+			score: float64(8 - i),
+			focus: float64(8 - i),
+		}
+	}
+	for i, r := range fuseFocus(ranked) {
+		if r.meta.ID != ranked[i].meta.ID {
+			t.Fatalf("agreeing views still reordered the ranking at %d: %q, want %q", i, r.meta.ID, ranked[i].meta.ID)
+		}
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -562,6 +562,67 @@ func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n in
 	return metas, informative, strong, err
 }
 
+// relevanceScored is one session's standing after the ranking pass: its score
+// over the whole query, and its score over only the words that distinguish.
+type relevanceScored struct {
+	meta    SessionMeta
+	score   float64
+	matched int
+	any     int
+	strong  int
+	focus   float64
+}
+
+// focusPrice is what a session pays for being convincing only on the rare part
+// of the query rather than on all of it. Counted in places, like the strict
+// promotion above: a session the focused view puts first and the whole-query
+// view puts thirtieth ends up fourth, not first.
+const focusPrice = 3
+
+// fuseFocus reorders a ranking by the better of two views of the same query.
+//
+// A question asked in plain speech carries words that are filler to a reader
+// and content to the index: "how many bikes do I own" ranks on many, bikes and
+// own, and the session that answers it holds only the rare one while sessions
+// about how many people own things hold two of them. Scored on the whole query
+// the answer loses. Scored on the rare part alone it wins — and that view is
+// wrong on other queries, where the common words are the question.
+//
+// So both are kept and each session takes its better place, the focused one at
+// a price. Ordering by the fused place rather than by a blended score keeps the
+// two views from having to be on the same scale, which they are not.
+func fuseFocus(ranked []relevanceScored) []relevanceScored {
+	if len(ranked) < 2 {
+		return ranked
+	}
+	order := make([]int, len(ranked))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(a, b int) bool { return ranked[order[a]].focus > ranked[order[b]].focus })
+	byFocus := make([]int, len(ranked))
+	for place, idx := range order {
+		byFocus[idx] = place
+	}
+	// The place travels with the row. Sorting the rows while indexing a
+	// parallel slice by the comparator's arguments reads the place of whatever
+	// has been swapped into that position, not of the row being compared.
+	type placed struct {
+		row   relevanceScored
+		place int
+	}
+	rows := make([]placed, len(ranked))
+	for i, r := range ranked {
+		rows[i] = placed{r, min(i, byFocus[i]+focusPrice)}
+	}
+	sort.SliceStable(rows, func(a, b int) bool { return rows[a].place < rows[b].place })
+	out := make([]relevanceScored, len(rows))
+	for i, r := range rows {
+		out[i] = r.row
+	}
+	return out
+}
+
 // relevantMetasCounts additionally reports how many terms of ANY frequency
 // each session matched — the noise gate for full-index relevance search,
 // where demanding two rare terms also rejects real answers that pair one
@@ -608,6 +669,14 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 	defer br.close()
 	totalDocs := float64(len(m.Sessions)) + 1
 	score := map[uint32]float64{}
+	// focus is the same scoring restricted to the words that distinguish. A
+	// question asked in plain speech carries filler that is a content word to
+	// the index — "how many bikes do I own" ranks on many, bikes and own — and
+	// the session that answers it often holds only the rare one. Scored on the
+	// whole query it loses to sessions carrying more of the filler; scored on
+	// the rare part alone it wins. Neither view is right on its own, so both are
+	// kept and the better place of the two is used, at a price.
+	focus := map[uint32]float64{}
 	matchedTerms := map[uint32]int{}
 	strongTerms := map[uint32]int{}
 	anyTerms := map[uint32]int{}
@@ -789,7 +858,11 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			// Saturated term frequency: repeated mentions add confidence
 			// with quickly diminishing returns, so a marathon session cannot
 			// bury a focused one through sheer repetition.
-			score[ord] += idf * (1 + 0.25*math.Log2(float64(tf[ord])))
+			weighted := idf * (1 + 0.25*math.Log2(float64(tf[ord])))
+			score[ord] += weighted
+			if informative {
+				focus[ord] += weighted
+			}
 			anyTerms[ord]++
 			if informative {
 				matchedTerms[ord]++
@@ -799,14 +872,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			}
 		}
 	}
-	type scored struct {
-		meta    SessionMeta
-		score   float64
-		matched int
-		any     int
-		strong  int
-	}
-	ranked := make([]scored, 0, len(score))
+	ranked := make([]relevanceScored, 0, len(score))
 	for ord, sc := range score {
 		if sc <= 0 {
 			continue
@@ -838,7 +904,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		if matchedTerms[ord] > 1 {
 			sc *= 1 + 0.15*float64(matchedTerms[ord]-1)
 		}
-		ranked = append(ranked, scored{inProject[ord], sc, matchedTerms[ord], anyTerms[ord], strongTerms[ord]})
+		ranked = append(ranked, relevanceScored{inProject[ord], sc, matchedTerms[ord], anyTerms[ord], strongTerms[ord], focus[ord]})
 	}
 	if len(ranked) == 0 {
 		return nil, nil, nil, termsKnown, 0, nil, readErr
@@ -854,6 +920,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		// what the user sees first.
 		return ranked[i].meta.ID < ranked[j].meta.ID
 	})
+	ranked = fuseFocus(ranked)
 	// Counted here, one line above the truncation, because this is the last
 	// moment the pool exists.
 	matchedTotal := len(ranked)


### PR DESCRIPTION
Second improvement idea from the research pass, measured on its own after #1265.

A question asked in plain speech carries words that are filler to a reader and content to the index. "How many bikes do I own" ranks on `many`, `bikes`, `own`; the session that answers it holds only the rare one, and sessions about how many people own things hold two. Scored on the whole query the answer loses to them.

Scoring only the informative words *instead* was measured and rejected earlier in #1216: day0bench gained .003 of MRR while longmemeval lost 1.5 points of hit@1 and 3 of hit@20. That view is not wrong — it is right sometimes.

So both are scored in the same pass, reading no extra postings, and each session takes the better of its two places, the focused one at a price of three:

- first on the focused view, thirtieth on the whole query → lands fourth
- already first on the whole query → keeps the front
- the two views agree → the ranking comes back untouched

```
day0bench, 1910 sessions
  hit@1    21/40   unchanged
  hit@5    30/40 -> 31/40
  MRR      .622  -> .627

longmemeval, 200
  hit@1    77.5   unchanged
  hit@5    93.0   unchanged
  hit@10   96.0 -> 95.5     one question of two hundred
  hit@20   97.0   unchanged
  MRR      .843   unchanged

decisionbench  green
searchbench    p90 202ms, unmoved
```

Three was picked against two and five: two scores a hair better on day0 and identically on longmemeval, three is the same trade with less of the focused view in it.

### What this is not

The research suggested recognising question frames — "how many X do I own", "what type of X" — and building a focused query from them. This does the same job without them, because English phrase rules would be fitting the benchmark's wording rather than the problem. deja is used in every language its harnesses are.

### Bug found while writing it

The first version kept places in a slice parallel to the rows and indexed it by the sort comparator's arguments. Those are positions in the slice being sorted, so it read the place of whatever had been swapped into that position rather than of the row being compared. The place travels with the row now.
