### PR TITLE
feat(search): hand the ranking's own term weights down to the excerpt

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -585,7 +585,7 @@ func cmdCtx(dir string, rest []string) error {
 		hits = search.ErrorHits(ss)
 	} else if result.Tier == search.TierRelevance {
 		fmt.Fprintln(os.Stderr, "deja: no exact match; showing sessions ranked by relevance to the whole query")
-		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(o.Query))
+		hits = search.RelevanceHitsWeighted(ss, index.RelevanceMatchTerms(o.Query), result.TermIDF)
 	} else if hits, err = search.Run(ss, o); err != nil {
 		return err
 	}
@@ -833,7 +833,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 		}
 	case search.TierRelevance:
 		fmt.Fprintln(os.Stderr, "deja: no exact match; showing sessions ranked by relevance to the whole query")
-		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(o.Query))
+		hits = search.RelevanceHitsWeighted(ss, index.RelevanceMatchTerms(o.Query), result.TermIDF)
 		// This tier ranks and truncates inside retrieval, so counting the
 		// sessions it handed back measures its window, not the match: every
 		// query deeper than the window reported the window's own size and

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -551,7 +551,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	if result.Tier == search.TierError {
 		hits = search.ErrorHits(ss)
 	} else if result.Tier == search.TierRelevance {
-		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(q))
+		hits = search.RelevanceHitsWeighted(ss, index.RelevanceMatchTerms(q), result.TermIDF)
 	} else if hits, err = search.Run(ss, o); err != nil {
 		return "", 0, 0, nil, err
 	}
@@ -749,7 +749,7 @@ func recallContextResult(dir, q, harness string) (string, int, int64, []string, 
 	if result.Tier == search.TierError {
 		hits = search.ErrorHits(ss)
 	} else if result.Tier == search.TierRelevance {
-		hits = search.RelevanceHits(ss, index.RelevanceMatchTerms(q))
+		hits = search.RelevanceHitsWeighted(ss, index.RelevanceMatchTerms(q), result.TermIDF)
 	} else if hits, err = search.Run(ss, o); err != nil {
 		return "", 0, 0, nil, err
 	}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -292,6 +292,12 @@ type SearchResult struct {
 	// figure of its own and the caller's count stands.
 	Total  int
 	Capped bool
+	// TermIDF is what the relevance ranking judged each query term to be worth.
+	// It travels with the answer so the caller choosing which message to show
+	// can weigh the words the same way the ranking weighed the session. Without
+	// it that choice was made by counting terms, one each, and the two disagreed
+	// exactly when one rare word carried the session. Empty on every other tier.
+	TermIDF map[string]float64 `json:",omitempty"`
 }
 
 func DefaultDir() string {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -138,7 +138,7 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 							// which is still the only thing that withheld
 							// anything here.
 							tail := len(merged) - len(rel.Sessions)
-							return relevanceResult(merged, rel.Total+tail), nil
+							return relevanceResult(merged, rel.Total+tail, rel.TermIDF), nil
 						}
 					}
 				}
@@ -327,7 +327,7 @@ func withRelevanceTail(dir string, m Manifest, o query.Options, res SearchResult
 	// a term the ranking derives rather than reads, a date from a relative
 	// word, which the AND never had to match; the floor keeps the total from
 	// claiming fewer sessions than were handed back.
-	out := relevanceResult(merged, max(rel.Total, len(merged)))
+	out := relevanceResult(merged, max(rel.Total, len(merged)), rel.TermIDF)
 	// Keep the word-form annotations the ladder earned: the caller still tells
 	// the user it fell back to stems or close spellings, even though the order
 	// is now this tier's to keep.
@@ -416,9 +416,11 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 	if len(terms) < 2 {
 		return SearchResult{}, nil
 	}
-	metas, _, anyMatched, termsKnown, matched, strong, rerr := relevantMetasCounts(dir, m, nil, terms, relevanceWindow, func(meta SessionMeta) bool {
+	rank, rerr := relevantMetasCounts(dir, m, nil, terms, relevanceWindow, func(meta SessionMeta) bool {
 		return sessionMetaMatches(meta, o)
 	})
+	metas, anyMatched, strong := rank.metas, rank.any, rank.strong
+	termsKnown, matched := rank.termsKnown, rank.total
 	if rerr != nil {
 		// A corrupt or unreadable bucket: surface it so the recovery path
 		// rebuilds, rather than serving a silently short-ranked answer.
@@ -466,7 +468,7 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 		if err != nil {
 			return SearchResult{}, err
 		}
-		return relevanceResult(ss, matched), nil
+		return relevanceResult(ss, matched, rank.idf), nil
 	}
 	// Single-term sessions ride BEHIND every strong candidate: they widen
 	// deep recall without letting a lucky word outrank a real match.
@@ -478,7 +480,7 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 	if err != nil {
 		return SearchResult{}, err
 	}
-	return relevanceResult(ss, matched), nil
+	return relevanceResult(ss, matched, rank.idf), nil
 }
 
 // relevanceResult labels a relevance answer with the pool it was drawn from:
@@ -486,12 +488,13 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 // trimmed it, so capped can say plainly whether the caller is holding all of
 // them. Reporting len(ss) as the total was the bug in #497 — the window is
 // exactly the thing the number was supposed to see past.
-func relevanceResult(ss []model.Session, matched int) SearchResult {
+func relevanceResult(ss []model.Session, matched int, idf map[string]float64) SearchResult {
 	return SearchResult{
 		Sessions: ss,
 		Tier:     query.TierRelevance,
 		Total:    matched,
 		Capped:   matched > len(ss),
+		TermIDF:  idf,
 	}
 }
 
@@ -558,8 +561,27 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 }
 
 func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n int) ([]SessionMeta, []int, []int, error) {
-	metas, informative, _, _, _, strong, err := relevantMetasCounts(dir, m, projects, terms, n, nil)
-	return metas, informative, strong, err
+	rank, err := relevantMetasCounts(dir, m, projects, terms, n, nil)
+	return rank.metas, rank.informative, rank.strong, err
+}
+
+// relevanceRanking is what one ranking pass produced. It was seven return
+// values and a naked error, which is how the idf it computes came to be thrown
+// away at both call sites — there was nowhere to put it that did not make the
+// signature worse.
+type relevanceRanking struct {
+	metas []SessionMeta
+	// informative, any and strong count, per session, the query terms it holds
+	// that clear the idf floor, that it holds at all, and that are rare enough
+	// to identify something on their own.
+	informative, any, strong []int
+	// termsKnown is how many of the query's terms the corpus contains at all,
+	// and total how many sessions the ranking scored before n truncated it.
+	termsKnown, total int
+	// idf is what each query term was worth, so a caller choosing which message
+	// to show can weigh it the same way the ranking weighed the session rather
+	// than approximating it.
+	idf map[string]float64
 }
 
 // relevanceScored is one session's standing after the ranking pass: its score
@@ -638,7 +660,7 @@ func fuseFocus(ranked []relevanceScored) []relevanceScored {
 // Returns, in order: the ranked metas, their informative-term counts, their
 // any-frequency term counts, how many query terms the corpus knows at all,
 // and that pre-truncation total.
-func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int, keep func(SessionMeta) bool) ([]SessionMeta, []int, []int, int, int, []int, error) {
+func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int, keep func(SessionMeta) bool) (relevanceRanking, error) {
 	// A real bucket read error (a corrupt or unreadable postings file) must not
 	// pass as "the term is absent": that silently drops the term from the
 	// ranking. Remember the first one and hand it back so the caller triggers
@@ -663,11 +685,12 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		}
 	}
 	if len(inProject) == 0 {
-		return nil, nil, nil, 0, 0, nil, readErr
+		return relevanceRanking{}, readErr
 	}
 	br := newBucketReader(dir)
 	defer br.close()
 	totalDocs := float64(len(m.Sessions)) + 1
+	idfOf := map[string]float64{}
 	score := map[uint32]float64{}
 	// focus is the same scoring restricted to the words that distinguish. A
 	// question asked in plain speech carries filler that is a content word to
@@ -826,6 +849,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			termsKnown++
 		}
 		idf := math.Log(totalDocs / float64(minDF+1))
+		idfOf[term] = idf
 		if idf <= 0 {
 			// In a tiny corpus every ratio collapses to zero; a term living
 			// in only a couple of sessions still identifies them.
@@ -907,7 +931,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		ranked = append(ranked, relevanceScored{inProject[ord], sc, matchedTerms[ord], anyTerms[ord], strongTerms[ord], focus[ord]})
 	}
 	if len(ranked) == 0 {
-		return nil, nil, nil, termsKnown, 0, nil, readErr
+		return relevanceRanking{termsKnown: termsKnown}, readErr
 	}
 	sort.Slice(ranked, func(i, j int) bool {
 		if ranked[i].score != ranked[j].score {
@@ -937,7 +961,15 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		anyMatched = append(anyMatched, r.any)
 		strong = append(strong, r.strong)
 	}
-	return metas, matched, anyMatched, termsKnown, matchedTotal, strong, readErr
+	return relevanceRanking{
+		metas:       metas,
+		informative: matched,
+		any:         anyMatched,
+		strong:      strong,
+		termsKnown:  termsKnown,
+		total:       matchedTotal,
+		idf:         idfOf,
+	}, readErr
 }
 
 // FirstMatch tries candidate queries in order under ONE lock and manifest

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1486,7 +1486,22 @@ func termWeights(ss []model.Session, terms []string) map[string]float64 {
 // just failed) must not reshuffle the ranking. Count and snippets come from
 // term occurrences so output still shows why each session surfaced.
 func RelevanceHits(ss []model.Session, terms []string) []Hit {
-	weight := termWeights(ss, terms)
+	return RelevanceHitsWeighted(ss, terms, nil)
+}
+
+// RelevanceHitsWeighted is RelevanceHits told what the ranking judged each term
+// to be worth.
+//
+// The ranking picks a session by the idf mass of its best single message and
+// then discards which message that was, so the excerpt has to work out the same
+// answer again. Given the ranking's own weights it works out the same one;
+// given nothing it estimates them from how much of the answer set holds each
+// term, which is close but is an estimate.
+func RelevanceHitsWeighted(ss []model.Session, terms []string, idf map[string]float64) []Hit {
+	weight := idf
+	if weight == nil {
+		weight = termWeights(ss, terms)
+	}
 	hits := make([]Hit, 0, len(ss))
 	for rank, s := range ss {
 		hit := Hit{Session: s, Tier: TierRelevance}

--- a/internal/search/weighted_snippet_test.go
+++ b/internal/search/weighted_snippet_test.go
@@ -1,0 +1,63 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Estimating a term's worth from the answer set has one blind spot, and it is
+// not a corner: the answer set was selected for the rare term, so inside it the
+// rare term is everywhere. "How many bikes do I own" returns sessions about
+// bikes — every one of them holds `bikes` and one of them happens to hold
+// `many`, so by the set's own arithmetic `many` is the rarer word and the
+// excerpt centres on it.
+//
+// The ranking already knows what the words are worth against the whole corpus.
+// Handing that down is what this checks.
+func TestTheRankingsOwnWeightsBeatEstimatingThemFromTheAnswerSet(t *testing.T) {
+	var ss []model.Session
+	for i := 0; i < 4; i++ {
+		ss = append(ss, model.Session{
+			ID: string(rune('a' + i)), Harness: "claude", Project: "p",
+			Messages: []model.Message{{Role: "user", Text: "a review of touring bikes for long rides"}},
+		})
+	}
+	ss = append(ss, model.Session{
+		ID: "answer", Harness: "claude", Project: "p",
+		Messages: []model.Message{
+			{Role: "user", Text: "how many of these are there, generally speaking"},
+			{Role: "user", Text: "I keep three bikes in the garage"},
+		},
+	})
+	terms := []string{"many", "bikes"}
+
+	// What the corpus says: bikes is rare in nineteen hundred sessions, many is
+	// not. Within these five, the arithmetic is the other way round.
+	corpus := map[string]float64{"many": 0.4, "bikes": 4.5}
+
+	estimated := snippetFor(t, RelevanceHits(ss, terms), "answer")
+	exact := snippetFor(t, RelevanceHitsWeighted(ss, terms, corpus), "answer")
+
+	if strings.Contains(strings.ToLower(estimated), "bikes") {
+		t.Skip("the estimate happened to agree here; this test is about the case where it cannot")
+	}
+	if !strings.Contains(strings.ToLower(exact), "bikes") {
+		t.Errorf("with the ranking's own weights the excerpt is still the filler message:\n  %s", exact)
+	}
+}
+
+func snippetFor(t *testing.T, hits []Hit, id string) string {
+	t.Helper()
+	for _, h := range hits {
+		if h.Session.ID == id {
+			if len(h.Snippets) == 0 {
+				t.Fatalf("no snippet for %q", id)
+			}
+			return h.Snippets[0]
+		}
+	}
+	t.Fatalf("%q is not in the hits", id)
+	return ""
+}


### PR DESCRIPTION
P4 from the research pass, and it finishes what #1264 started.

#1264 made the excerpt follow the rare word by estimating what each term is worth from how much of the answer set holds it. That estimate has one blind spot, and it is not a corner case: **the answer set was selected for the rare term, so inside it the rare term is everywhere.** A question about bikes returns sessions about bikes, one of which happens to also say "many" — by the set's own arithmetic "many" is then the rarer word, and the excerpt centres on it.

`TestTheRankingsOwnWeightsBeatEstimatingThemFromTheAnswerSet` is that case, and it is not hypothetical: the estimate picks the filler message there, and the ranking's real weights pick the one that earned the rank.

The ranking already computes what every query term is worth against the whole corpus and threw it away. It travels with the answer now, and the excerpt weighs the words the same way the session was weighed. The estimate stays as the fallback for callers with no ranking to hand.

### Also here

The ranking pass returned seven values and an error. That shape is why the idf was discarded at both call sites in the first place — there was nowhere to put it that did not make the signature worse. It returns one struct now.

### Numbers

```
day0bench      hit@1 21/40  hit@5 31/40  found@50 40/40  mrr 0.627   unchanged
longmemeval    77.5 / 93.0 / 95.5 / 97.0,  MRR 0.843                 unchanged
decisionbench  green
```

**No benchmark can show this**, and that is worth saying plainly. All four score which sessions come back and in what order, and this changes neither. It changes the sentence an agent reads before deciding whether a result is worth anything — which the research pass tied to `-agent-cases` selection, and which needs a model in the loop to score rather than a rank.
