### PR TITLE
fix(search): measure the tightest window, not the span between first mentions

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -613,13 +613,56 @@ func freshnessDecay(updated, now time.Time) float64 {
 	return 1 / (1 + age)
 }
 
-// tokenWindow returns the tightest character span of a message that contains
-// every query token at least once (first occurrences — an approximation that
-// costs nothing extra at scan time). 0 when some token is missing.
+// windowOccurrenceCap bounds how many places of one token are weighed when
+// measuring how close the query's words come together, and windowScanLimit
+// bounds how many are looked at to choose them. Without either, a long
+// transcript message full of a common word makes this quadratic.
+//
+// The places kept are spread across the whole text rather than taken from the
+// front. Taking the first N was the first version, and it moved the defect
+// rather than removing it: a message repeating one query word sixty times
+// before the phrase that actually answers the question was still measured
+// against the sixtieth repetition instead of the phrase.
+const (
+	windowOccurrenceCap = 32
+	windowScanLimit     = 4096
+)
+
+// spread picks at most cap of the places, evenly across them, always keeping
+// the first and the last — the tightest cluster is as often at the end of a
+// message as at the start.
+func spread(at []int, cap int) []int {
+	if len(at) <= cap {
+		return at
+	}
+	out := make([]int, 0, cap)
+	step := float64(len(at)-1) / float64(cap-1)
+	for i := 0; i < cap; i++ {
+		out = append(out, at[int(float64(i)*step+0.5)])
+	}
+	return out
+}
+
+// tokenWindow is the tightest character span in this text that contains every
+// query token.
+//
+// It used to measure between the FIRST place each token appears, which is not a
+// window at all: a message that mentions "connection" in its opening line and
+// then discusses "connection pool exhausted" as one phrase four paragraphs down
+// was scored on the four paragraphs. Proximity is the signal that the words
+// belong to one thought, and first-occurrence spacing is nearly the opposite of
+// measuring it.
 func tokenWindow(low string, qtoks []string) int {
 	if len(qtoks) < 2 {
 		return 0
 	}
+	// The span between first occurrences is an upper bound on the real window —
+	// it is one way of picking one place per token, and the real answer is the
+	// best of all of them. When that bound already reads as one thought, the
+	// exact figure cannot change the verdict, only sharpen a boost that is
+	// nearly at its ceiling. Enumerating occurrences costs about a fifth of
+	// search latency, so it is spent only where the cheap answer says the words
+	// are scattered, which is the case it gets wrong.
 	first, last := -1, -1
 	for _, tok := range qtoks {
 		i := strings.Index(low, tok)
@@ -633,18 +676,71 @@ func tokenWindow(low string, qtoks []string) int {
 			last = end
 		}
 	}
-	return last - first
+	if cheap := last - first; cheap <= proximityNear {
+		return cheap
+	}
+
+	type occurrence struct{ at, tok int }
+	var occs []occurrence
+	var at []int
+	for ti, tok := range qtoks {
+		at = at[:0]
+		for i := 0; i < len(low) && len(at) < windowScanLimit; {
+			j := strings.Index(low[i:], tok)
+			if j < 0 {
+				break
+			}
+			at = append(at, i+j)
+			i += j + 1
+		}
+		if len(at) == 0 {
+			return 0
+		}
+		for _, p := range spread(at, windowOccurrenceCap) {
+			occs = append(occs, occurrence{p, ti})
+		}
+	}
+	sort.Slice(occs, func(a, b int) bool { return occs[a].at < occs[b].at })
+
+	// Slide a window along the occurrences, shrinking it from the left for as
+	// long as it still holds every token.
+	seen := make([]int, len(qtoks))
+	have, best, left := 0, -1, 0
+	for right := range occs {
+		if seen[occs[right].tok] == 0 {
+			have++
+		}
+		seen[occs[right].tok]++
+		for have == len(qtoks) {
+			span := occs[right].at + len(qtoks[occs[right].tok]) - occs[left].at
+			if best < 0 || span < best {
+				best = span
+			}
+			seen[occs[left].tok]--
+			if seen[occs[left].tok] == 0 {
+				have--
+			}
+			left++
+		}
+	}
+	if best < 0 {
+		return 0
+	}
+	return best
 }
 
+// proximityNear is the width at which a window stops reading as one thought.
+const proximityNear = 200
+
 // proximityBoost rewards documents where the query terms sit together: a
-// window under ~200 chars reads as one thought, a spread across kilobytes is
-// coincidence. Bounded at +35%.
+// window under proximityNear chars reads as one thought, a spread across
+// kilobytes is coincidence. Bounded at +35%.
 func proximityBoost(window, queryTokenCount int) float64 {
 	if window <= 0 || queryTokenCount < 2 {
 		return 1
 	}
 	span := float64(window)
-	boost := 1 + 0.35*(200/(200+span))
+	boost := 1 + 0.35*(proximityNear/(proximityNear+span))
 	return boost
 }
 

--- a/internal/search/token_window_test.go
+++ b/internal/search/token_window_test.go
@@ -1,0 +1,46 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// Proximity is the signal that the query's words belong to one thought.
+// Measuring between the FIRST place each word appears is close to the opposite
+// of measuring that: a message that says "connection" in its opening line and
+// then discusses "connection pool exhausted" as a phrase four paragraphs down
+// was scored on the four paragraphs.
+func TestTheWindowIsTheTightestOneNotTheFirstOne(t *testing.T) {
+	text := strings.ToLower(
+		"connection issues have been on my mind all week. " +
+			strings.Repeat("unrelated discussion of scheduling and travel plans. ", 20) +
+			"the connection pool exhausted under load")
+	got := tokenWindow(text, []string{"connection", "pool", "exhausted"})
+	// "connection pool exhausted" is 25 characters; anything near that is the
+	// phrase, anything near a thousand is the whole message.
+	if got > 40 {
+		t.Errorf("window is %d characters: measured across the message rather than across the phrase", got)
+	}
+}
+
+// A token that is genuinely absent still means no window at all, and one token
+// has no window to speak of.
+func TestAMissingTokenHasNoWindow(t *testing.T) {
+	if got := tokenWindow("the connection pool exhausted", []string{"connection", "kafka"}); got != 0 {
+		t.Errorf("a query token absent from the text produced a window of %d", got)
+	}
+	if got := tokenWindow("the connection pool exhausted", []string{"connection"}); got != 0 {
+		t.Errorf("a single token produced a window of %d", got)
+	}
+}
+
+// The tightest cluster can be anywhere, including behind a long run of one of
+// the words — the case the occurrence cap has to survive.
+func TestTheCapDoesNotHideTheTightestCluster(t *testing.T) {
+	text := strings.ToLower(
+		strings.Repeat("pool ", windowOccurrenceCap*2) + "connection pool exhausted")
+	got := tokenWindow(text, []string{"connection", "pool", "exhausted"})
+	if got > 40 {
+		t.Errorf("window is %d characters: the cap stopped before the cluster", got)
+	}
+}


### PR DESCRIPTION
P5 from the research pass.

Proximity is the signal that the query's words belong to one thought, and it feeds a boost worth up to 35%. It was measured **between the first place each word appears**, which is close to the opposite of measuring that: a message mentioning "connection" in its opening line and then discussing "connection pool exhausted" as a phrase four paragraphs down was scored on the four paragraphs.

It is the real minimum covering window now.

### Paying for it only where it matters

Enumerating occurrences costs about a fifth of search latency. The span between first occurrences is an **upper bound** on the true window — it is one way of picking one place per token, and the answer is the best of all of them — so where that bound already reads as one thought, the exact figure can only sharpen a boost already near its ceiling. Below that width the cheap answer stands.

```
searchbench median   33.6 / 37.0 / 36.6 ms   against 33.5-35.2 before
```

Inside run-to-run variance. Unguarded it was 39.8.

### The first version was wrong in an instructive way

It kept the first 32 occurrences of each token. That moves the defect rather than removing it: a message repeating one query word sixty times before the phrase that answers the question is still measured against the sixtieth repetition. The places weighed are spread across the text now, first and last always kept. `TestTheCapDoesNotHideTheTightestCluster` failed on the first version and passes on this one.

### Numbers

```
day0bench      hit@1 21/40  hit@5 31/40  found@50 40/40  mrr .627   unchanged
longmemeval    77.5 / 93.0 / 95.5 / 97.0,  MRR .843                 unchanged
decisionbench  green
```

The research pass expected up to one question on day0 and two on longmemeval. Neither appeared. This ships as a correctness fix — the number feeding the boost was not the number it was documented to be — and not as a ranking gain. If that is not worth a change on its own, this is the one to drop.
