### PR TITLE
fix(registry): the MCP registry description was six characters too long

### DIFF
--- a/cmd/deja/manifest_description_test.go
+++ b/cmd/deja/manifest_description_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// registryDescriptionLimit is what the MCP registry accepts. Over it, publishing
+// fails with a 422 after the release has already been tagged and built — the
+// registry job runs on the merge, so nothing before it can catch this.
+//
+// It did: 0.17.2 went out with a description of 106 characters, added when the
+// harness count was written into it, and the registry rejected it. The mcpb
+// manifest was sitting on exactly 100 at the same time, which is not a margin.
+const registryDescriptionLimit = 100
+
+func TestManifestDescriptionsFitTheRegistry(t *testing.T) {
+	for _, path := range []string{
+		filepath.Join("..", "..", "server.json"),
+		filepath.Join("..", "..", "packaging", "mcpb", "manifest.json"),
+	} {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var manifest struct {
+			Description string `json:"description"`
+		}
+		if err := json.Unmarshal(b, &manifest); err != nil {
+			t.Fatalf("%s: %v", path, err)
+		}
+		if manifest.Description == "" {
+			t.Errorf("%s has no description", path)
+			continue
+		}
+		if n := len(manifest.Description); n > registryDescriptionLimit {
+			t.Errorf("%s description is %d characters, over the registry's %d:\n  %q",
+				path, n, registryDescriptionLimit, manifest.Description)
+		}
+	}
+}

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Recall your own past coding sessions, across every AI tool you use.",
   "author": {
     "name": "vshulcz",

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "name": "deja-vu",
   "display_name": "deja-vu",
   "version": "0.0.0",
-  "description": "Local searchable memory over the session histories of seventeen coding agents, served back over MCP.",
+  "description": "Local searchable memory over the session histories of seventeen coding agents.",
   "long_description": "deja indexes the session transcripts your coding agents already write to disk — Claude Code, Codex, Cursor, opencode, aider, cline, roo, goose and others — and serves them back over MCP. It starts full rather than empty: history from before you installed it is searchable immediately. Retrieval is lexical, with no LLM, no embedding model and no API key. Secrets are redacted before anything is indexed. Nothing leaves the machine.",
   "author": {
     "name": "vshulcz",

--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,12 +1,12 @@
 {
     "architecture": {
         "64bit": {
-            "hash": "c9090dd1b8b58b612b8782690808d3fdd75f618115d7c84930776130b16a2f0b",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.17.1/deja-vu_0.17.1_windows_amd64.zip"
+            "hash": "2141eaa52d619f36545838765cba8acee4064adbac1b6ccba2bec1910e9ac69a",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.17.2/deja-vu_0.17.2_windows_amd64.zip"
         },
         "arm64": {
-            "hash": "14ae131fa54e1c3180f005f4f444a00fe42ecefc4014977e396306d27ad90d47",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.17.1/deja-vu_0.17.1_windows_arm64.zip"
+            "hash": "e1b6e9621f437c1f746edcadfe711c6a85f096c9c69b3ec930c8046b3f803c40",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.17.2/deja-vu_0.17.2_windows_arm64.zip"
         }
     },
     "autoupdate": {
@@ -24,5 +24,5 @@
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
-    "version": "0.17.1"
+    "version": "0.17.2"
 }

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.17.1
+PackageVersion: 0.17.2
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.17.1/deja-vu_0.17.1_windows_amd64.zip
-  InstallerSha256: C9090DD1B8B58B612B8782690808D3FDD75F618115D7C84930776130B16A2F0B
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.17.2/deja-vu_0.17.2_windows_amd64.zip
+  InstallerSha256: 2141EAA52D619F36545838765CBA8ACEE4064ADBAC1B6CCBA2BEC1910E9AC69A
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.17.1/deja-vu_0.17.1_windows_arm64.zip
-  InstallerSha256: 14AE131FA54E1C3180F005F4F444A00FE42ECEFC4014977E396306D27AD90D47
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.17.2/deja-vu_0.17.2_windows_arm64.zip
+  InstallerSha256: E1B6E9621F437C1F746EDCADFE711C6A85F096C9C69B3EC930C8046B3F803C40
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.17.1
+PackageVersion: 0.17.2
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.17.1/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.17.2/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.17.1
+PackageVersion: 0.17.2
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.vshulcz/deja-vu",
-  "description": "Local searchable memory over the session histories of seventeen coding agents, served back via MCP recall.",
+  "description": "Local searchable memory over the session histories of seventeen coding agents.",
   "repository": {
     "url": "https://github.com/vshulcz/deja-vu",
     "source": "github"


### PR DESCRIPTION
Publishing 0.17.2 failed with a 422:

```
expected length <= 100
value: "Local searchable memory over the session histories of seventeen coding agents, served back via MCP recall."
```

106 characters, gained when the harness count was written into it. The mcpb manifest was on exactly 100 at the same time, which is not a margin.

Both are 78 now — dropping "served back via MCP recall" costs nothing on a registry of MCP servers.

There is a test, because nothing before the merge could have caught this. The registry job runs on the merge, so the first report of an over-long description is a failed publish after the release is tagged and built.