### PR TITLE
fix(hook): the per-prompt recall stopped looking before it found anything

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -145,9 +145,8 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	}
 	// Rank THIS project's sessions by how well they match the prompt terms
 	// (IDF-weighted), rather than reconstructing an AND query — natural
-	// prompts are full of filler that poisons an AND. n=8 to leave room after
-	// excluding the current/too-fresh sessions.
-	ranked, matched, strong, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, 8)
+	// prompts are full of filler that poisons an AND.
+	ranked, matched, strong, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, promptCandidates)
 	if err != nil || len(ranked) == 0 {
 		return emitNudgeOnly(stdout, plain, nudge)
 	}
@@ -500,6 +499,25 @@ func citationLine(s model.Session, terms []string) string {
 	return fmt.Sprintf("\nIf it helped, say: \"deja-vu recalled: %s (%s%s, deja:%s) — reusing it.\"",
 		title, s.Harness, date, shortID(s.ID))
 }
+
+// promptCandidates is how many ranked sessions the hook asks for before
+// filtering, against the two it will ever inject.
+//
+// It was eight, sized against two exclusions — the session being written and
+// anything too fresh — and its comment said so. Three more arrived afterwards:
+// the trust policy withholds a project, a weak match is dropped, and a session
+// already injected in this conversation is skipped. Any of them can fill the
+// window, and when they do the answer sitting below is never looked at and the
+// hook says nothing at all.
+//
+// Already-injected is the one that makes this ordinary rather than contrived:
+// it accumulates as a conversation goes on, so the failure arrives after a
+// handful of prompts, on the sessions the user asks about most.
+//
+// The cost of a wider window is a longer list to walk, not a longer search: the
+// ranking already scored every session in the project, and this only takes more
+// of what it produced.
+const promptCandidates = 32
 
 // alreadyInjected returns the session ids this hook already injected into the
 // given agent session, so follow-up prompts do not repeat the same memory.

--- a/cmd/deja/hook_prompt_window_test.go
+++ b/cmd/deja/hook_prompt_window_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The per-prompt hook asks the ranking for a fixed number of candidates and
+// then filters them: the trust policy can withhold one, a weak match is
+// dropped, a marathon session can narrow to nothing, the session being written
+// is never recalled to itself, and anything already injected this conversation
+// is skipped. Only two survivors are ever used.
+//
+// The window was sized against two of those — its comment said "to leave room
+// after excluding the current/too-fresh sessions" — and three more arrived
+// afterwards. When the filtered ones fill it, the answer below them is never
+// looked at and the hook says nothing at all, on a machine where it is
+// installed and reported healthy.
+//
+// Staged on the weak-match filter, which needs no state and is always on: nine
+// sessions carry the question's ordinary words and outrank the one session
+// carrying its rare one, exactly the way a plainly worded question ranks.
+func TestTheHookLooksPastTheCandidatesItWillNotUse(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	write := func(id, text string) {
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"` + old +
+				`","message":{"role":"user","content":"` + text + `"}}`,
+		})
+	}
+	// Enough history for the shared term to still count as rare.
+	for i := 0; i < 200; i++ {
+		write(fmt.Sprintf("noise%03d", i), "notes on the weekly planning meeting and the roadmap")
+	}
+	// Ten sessions that all answer the question, so the ranking has no reason to
+	// prefer one of them and every one clears the bar to be injected.
+	shown := make([]string, 0, 9)
+	for i := 0; i < 10; i++ {
+		id := fmt.Sprintf("probe%02d", i)
+		write(id, "the hydrostat_probe reported a stale pressure reading again")
+		if i < 9 {
+			shown = append(shown, id)
+		}
+	}
+
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	// Nine have already been shown in this conversation, which is the ordinary
+	// state by the fourth or fifth prompt rather than a contrived one.
+	var seen strings.Builder
+	for _, id := range shown {
+		fmt.Fprintf(&seen, "agent-1 %s\n", id)
+	}
+	if err := os.WriteFile(index.DefaultDir()+".hookseen", []byte(seen.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	in := strings.NewReader(`{"prompt":"stale pressure reading from the hydrostat_probe again","session_id":"agent-1"}`)
+	if err := runHookPrompt(index.DefaultDir(), in, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Len() == 0 {
+		t.Fatal("the candidates the hook cannot use filled its window and the one it could was never looked at: " +
+			"nothing was recalled")
+	}
+	var resp struct {
+		HookSpecificOutput struct {
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("hook output is not the expected envelope: %v\n%s", err, out.String())
+	}
+	if !strings.Contains(resp.HookSpecificOutput.AdditionalContext, "hydrostat_probe") {
+		t.Errorf("the session that answers the question was reached but not recalled:\n%s",
+			resp.HookSpecificOutput.AdditionalContext)
+	}
+}


### PR DESCRIPTION
First item from the second research pass, and the only one of its eight that turned out to be a live silent failure.

The per-prompt hook asks the ranking for a fixed number of candidates and then filters them:

- the trust policy withholds a project
- a weak match is dropped
- a marathon session can narrow to nothing
- the session being written is never recalled to itself
- anything already injected in this conversation is skipped

Two survivors are used. The window was **eight**, and its own comment said why: *"to leave room after excluding the current/too-fresh sessions"*. Three of those five filters arrived after that line was written.

When the filtered ones fill the window, the answer below is never looked at and the hook returns **nothing at all** — on a machine where it is installed and `deja doctor` reports it healthy.

Already-injected is what makes this ordinary rather than contrived: it accumulates as a conversation goes on, so it arrives after a handful of prompts, on exactly the sessions being asked about repeatedly.

Thirty-two now. The cap of two injections is unchanged, and nothing extra is searched — the ranking has already scored every session in the project, and this takes more of what it produced.

### Two stagings that did not reproduce it

Worth recording, because it changes what the finding means.

The first fixture made ten identical sessions and marked nine seen. It produced an empty hook output — but for the wrong reason: ten identical sessions make the rare word common, so the tenth failed the strength gate and would never have been injected at any window size.

The second staged the weak-match filter: nine sessions carrying the question's ordinary words, one carrying its rare one. That passes at a window of eight, because the rare-term answer now rises into the top eight on its own — the ranking work in #1261 and #1266 did that. The window was hiding less than it used to, and still hid this.

The staging that does reproduce it is the plainest one: nine sessions already shown, a tenth as good sitting below them. Empty output at eight, recalled at thirty-two.
