### PR TITLE
fix(doctor): two rows under "Hooks" were not hooks

### DIFF
--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -17,6 +17,13 @@ type autoWiring struct {
 	name   string
 	path   func() string
 	marker string
+	// kind is what the file actually is, when it is not a hook. Every row in
+	// this table used to read "wired" under a heading that says Hooks, and two
+	// of them are not hooks: aider's is a context file that only a wrapper
+	// command refreshes, and roo's is guidance that asks the agent to call
+	// recall rather than handing it anything. Reporting all three the same way
+	// tells someone their memory arrives on its own when it does not.
+	kind string
 }
 
 // autoWirings is the single list doctor and the coverage test both read.
@@ -27,30 +34,32 @@ func autoWirings() []autoWiring {
 	return []autoWiring{
 		{"opencode", func() string {
 			return filepath.Join(opencodeConfigHome(), "opencode", "plugins", "deja.js")
-		}, "hook-context"},
-		{"cursor", func() string { return filepath.Join(sources.CursorCLIHome(), "hooks.json") }, "hook-context"},
+		}, "hook-context", ""},
+		{"cursor", func() string { return filepath.Join(sources.CursorCLIHome(), "hooks.json") }, "hook-context", ""},
 		{"gemini", func() string {
 			return filepath.Join(sources.GeminiHome(), "extensions", "deja", "hooks", "hooks.json")
-		}, "hook-context"},
-		{"qwen", func() string { return filepath.Join(sources.QwenConfigDir(), "settings.json") }, "hook-prompt"},
-		{"kimi", func() string { return filepath.Join(sources.KimiConfigDir(), "config.toml") }, "hook-prompt"},
+		}, "hook-context", ""},
+		{"qwen", func() string { return filepath.Join(sources.QwenConfigDir(), "settings.json") }, "hook-prompt", ""},
+		{"kimi", func() string { return filepath.Join(sources.KimiConfigDir(), "config.toml") }, "hook-prompt", ""},
 		{"antigravity", func() string {
 			return filepath.Join(antigravityConfigHome(), "plugins", "deja", "hooks.json")
-		}, "hook-antigravity"},
-		{"pi", func() string { return filepath.Join(sources.PiConfigDir(), "extensions", "deja.ts") }, "hook-context"},
+		}, "hook-antigravity", ""},
+		{"pi", func() string { return filepath.Join(sources.PiConfigDir(), "extensions", "deja.ts") }, "hook-context", ""},
 		{"hermes", func() string {
 			return filepath.Join(sources.HermesHome(), "plugins", "deja", "__init__.py")
-		}, "hook-context"},
+		}, "hook-context", ""},
 		{"openclaw", func() string {
 			return filepath.Join(sources.OpenClawStateDir(), "hooks", openclawHookName, "handler.js")
-		}, "hook-context"},
-		{"cline", func() string { return filepath.Join(sources.ClinePluginsDir(), "deja", "index.js") }, "hook-context"},
-		{"goose", func() string { return gooseHookPath() }, "hook-goose"},
-		{"grok", func() string { return grokHooksPath() }, "hook-context"},
-		{"aider", func() string { return aiderContextPath() }, ""},
+		}, "hook-context", ""},
+		{"cline", func() string { return filepath.Join(sources.ClinePluginsDir(), "deja", "index.js") }, "hook-context", ""},
+		{"goose", func() string { return gooseHookPath() }, "hook-goose", ""},
+		{"grok", func() string { return grokHooksPath() }, "hook-context", ""},
+		{"aider", func() string { return aiderContextPath() }, "",
+			"context file — refreshed by `deja aider`, not by aider itself"},
 		// Roo's guidance moved out of the always-on rules file into a skill;
 		// checking the old path reported a correctly wired machine as missing.
-		{"roo", func() string { return guidancePath("roo") }, ""},
+		{"roo", func() string { return guidancePath("roo") }, "",
+			"guidance — the agent is told to call recall, not handed it"},
 	}
 }
 
@@ -61,13 +70,17 @@ func doctorAutoRecall(w io.Writer) {
 	for _, a := range autoWirings() {
 		path := a.path()
 		b, err := os.ReadFile(path)
+		note := ""
+		if a.kind != "" {
+			note = "  (" + a.kind + ")"
+		}
 		switch {
 		case err != nil:
-			fmt.Fprintf(w, "  %-12s %-11s %s\n", a.name, "missing", path)
+			fmt.Fprintf(w, "  %-12s %-11s %s%s\n", a.name, "missing", path, note)
 		case a.marker != "" && !strings.Contains(string(b), a.marker):
 			fmt.Fprintf(w, "  %-12s %-11s %s  (no %s call — reinstall)\n", a.name, "stale", path, a.marker)
 		default:
-			fmt.Fprintf(w, "  %-12s %-11s %s\n", a.name, "wired", path)
+			fmt.Fprintf(w, "  %-12s %-11s %s%s\n", a.name, "wired", path, note)
 		}
 	}
 }

--- a/cmd/deja/doctor_kind_test.go
+++ b/cmd/deja/doctor_kind_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// The table is headed "Hooks" and every row read "wired", including two that
+// are not hooks. aider's file is a context file that only `deja aider`
+// refreshes — bare aider reads whatever was written last. roo's is guidance:
+// the agent is asked to call recall, and hands itself nothing if it does not.
+//
+// Someone reading a row that says wired concludes memory arrives on its own.
+// For those two it does not, and the whole point of this command is to be the
+// thing a person trusts when memory is not working.
+func TestTheHooksTableSaysWhichRowsAreNotHooks(t *testing.T) {
+	var out bytes.Buffer
+	doctorAutoRecall(&out)
+	got := out.String()
+
+	for _, want := range []struct{ name, says string }{
+		{"aider", "context file"},
+		{"roo", "guidance"},
+	} {
+		line := ""
+		for _, l := range strings.Split(got, "\n") {
+			if strings.Contains(l, want.name+" ") {
+				line = l
+			}
+		}
+		if line == "" {
+			t.Errorf("%s has no row at all", want.name)
+			continue
+		}
+		if !strings.Contains(line, want.says) {
+			t.Errorf("%s reads as a hook like any other:\n  %s", want.name, line)
+		}
+	}
+
+	// And a real hook carries no such note, or the distinction says nothing.
+	for _, l := range strings.Split(got, "\n") {
+		if strings.Contains(l, "opencode ") &&
+			(strings.Contains(l, "context file") || strings.Contains(l, "guidance")) {
+			t.Errorf("a real hook was annotated as something else:\n  %s", l)
+		}
+	}
+}


### PR DESCRIPTION
Second item from the research pass.

Every row of that table read \`wired\` and meant three different things. Twelve are hooks: they fire on their own and what they produce reaches the model. Two are not.

- **aider** — a context file that only \`deja aider\` refreshes. Bare aider reads whatever was written last.
- **roo** — guidance. The agent is asked to call recall; if it does not, nothing arrives.

Someone reading `wired` under a heading that says Hooks concludes memory arrives on its own. For those two it does not — and this is the command people run when memory is *not* working, which is exactly when a confident wrong answer costs the most.

```
aider   wired    ~/.config/deja/aider-context.md  (context file — refreshed by `deja aider`, not by aider itself)
roo     missing  ~/.agents/skills/deja-history/SKILL.md  (guidance — the agent is told to call recall, not handed it)
```

The other rows are unchanged: a distinction everything carries says nothing, and the test checks that a real hook stays unannotated.

### One claim from the research that did not survive checking

It reported that doctor shows Copilot as automatically wired. It does not — Copilot is not in this table at all. It has MCP and guidance and no hook, and it is reported under those. Left alone.