### PR TITLE
fix(search): a project is its path segments, not any name containing it

### DIFF
--- a/internal/index/project_scope_test.go
+++ b/internal/index/project_scope_test.go
@@ -1,0 +1,44 @@
+package index
+
+import "testing"
+
+// Automatic project scoping decides whose history recall ranks against. It was
+// any substring, and the names on a real machine show what that joins: the same
+// repository is recorded as "deja-vu" by some harnesses and "goprojects/deja-vu"
+// by others, so several forms have to match — but "deja" is not "deja-push",
+// and a project that parsed as "-" is not every hyphenated directory on the
+// disk.
+func TestProjectScopeMatchesSegmentsNotSubstrings(t *testing.T) {
+	joined := []struct{ project, want string }{
+		{"deja-vu", "deja-vu"},
+		{"goprojects/deja-vu", "deja-vu"},
+		{"Users/shulcz", "shulcz"},
+		{"scratchpad/demo", "demo"},
+		{"imported:deja-vu", "deja-vu"},
+		{"imported:goprojects/deja-vu", "deja-vu"},
+	}
+	for _, c := range joined {
+		if !projectInScope(c.project, c.want) {
+			t.Errorf("%q should be in scope for %q and is not", c.project, c.want)
+		}
+	}
+
+	// All six of these are joined by a substring rule, and all six are wrong.
+	separate := []struct{ project, want string }{
+		{"deja-push", "deja"},
+		{"deja-vu", "deja"},
+		{"goprojects/d3fvxl-redirect", "d3fvxl"},
+		{"shulcz/coding", "shulcz"},
+		{"pin-manifests", "-"},
+		{"telegram-mtproxy-forwarder", "-"},
+	}
+	for _, c := range separate {
+		if projectInScope(c.project, c.want) {
+			t.Errorf("%q is a different project from %q and was pulled into its scope", c.project, c.want)
+		}
+	}
+
+	if projectInScope("anything", "") {
+		t.Error("an empty project name matched something")
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -645,6 +645,37 @@ func fuseFocus(ranked []relevanceScored) []relevanceScored {
 	return out
 }
 
+// projectInScope says whether a session belongs to the project a caller is
+// working in, given one of the name forms that project is known by.
+//
+// Harnesses record the same project under different forms — on the machine this
+// was written on, the same repository appears as "deja-vu" in 69 sessions and
+// "goprojects/deja-vu" in 25 — so the caller supplies several and any of them
+// matching is the project. What decides is whole path segments.
+//
+// It used to be any substring, which joined 41 pairs of names on that machine
+// and was wrong about a third of them: "deja" pulled in both deja-push and
+// deja-vu, two different repositories, and a session whose project had parsed
+// as "-" matched every hyphenated project on the disk — deja-vu, pin-manifests,
+// mpc-autoscaler, telegram-mtproxy-forwarder. Recall in one project then ranks
+// against another's history, which is the one thing project scoping exists to
+// prevent.
+//
+// The explicit --project filter is left as a substring on purpose: that one is
+// documented as a substring and is the user asking, not deja guessing.
+func projectInScope(project, want string) bool {
+	if want == "" {
+		return false
+	}
+	p, w := strings.ToLower(project), strings.ToLower(want)
+	if rest, ok := strings.CutPrefix(p, "imported:"); ok {
+		// A synced session carries the peer's prefix and is otherwise the same
+		// project under the same name.
+		p = rest
+	}
+	return p == w || strings.HasSuffix(p, "/"+w)
+}
+
 // relevantMetasCounts additionally reports how many terms of ANY frequency
 // each session matched — the noise gate for full-index relevance search,
 // where demanding two rare terms also rejects real answers that pair one
@@ -675,10 +706,8 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			inProject[meta.Ord] = meta
 			continue
 		}
-		lp := strings.ToLower(meta.Project)
 		for _, want := range projects {
-			w := strings.ToLower(want)
-			if w != "" && (lp == w || strings.Contains(lp, w)) {
+			if projectInScope(meta.Project, want) {
 				inProject[meta.Ord] = meta
 				break
 			}


### PR DESCRIPTION
Third item from the research pass. Settled by looking at real project names rather than by reasoning about the rule.

Automatic project scoping decides whose history recall ranks against, and it matched **any substring**. Counted over the project names in a 1244-session index on this machine, that joins 41 pairs — and about a third of them are different projects:

```
deja      ->  deja-push, deja-vu
d3fvxl    ->  goprojects/d3fvxl-redirect
shulcz    ->  shulcz/coding
-         ->  deja-vu, pin-manifests, mpc-autoscaler,
              telegram-mtproxy-forwarder, work-demo
```

The last is the shape of the defect: a session whose project parsed as `-` is scoped against **every hyphenated directory on the disk**. Recall in one project then ranks against another's history, which is the one thing project scoping exists to prevent.

Whole path segments now.

### Why substring was there, and why it still works

Harnesses record the same project under different forms. In this index the same repository is `deja-vu` in 69 sessions and `goprojects/deja-vu` in 25; `shulcz` and `Users/shulcz`; `demo` and `work/demo`. The caller supplies several name forms and any of them matching is the project — that is unchanged, and every legitimate pair on this machine survives:

```
deja-vu             <- goprojects/deja-vu     kept
shulcz              <- Users/shulcz           kept
demo                <- work/demo              kept
RoutePilot          <- goprojects/routepilot  kept
```

One pair only matches through a shorter form: `openclaw/workspace` does not match `.openclaw/workspace` by segment, but `workspace` does, and the candidate list contains both. Checked before changing it, because that is exactly how this kind of tightening loses someone's sessions quietly.

### Left alone

The explicit `--project` filter stays a substring. It is documented as one, and it is the user asking rather than deja guessing.

`day0bench` and `decisionbench` are unchanged — their corpora are a single project, so nothing there can show this either way. The evidence is the name distribution above.
