### PR TITLE
feat: say what makes memory arrive, at the two moments it is missed

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -78,6 +78,16 @@ func runBrief(dir string, w io.Writer) error {
 		bold, reset, version, bold, ov.Sessions, reset, pluralS(ov.Sessions),
 		bold, ov.Harnesses, reset, pluralS(ov.Harnesses))
 
+	// An index and no agent reading it is the state a fresh install lands in,
+	// and nothing said so: install.sh drops a binary, `deja` builds the memory
+	// and reports it, and the part that makes any of it arrive on its own is a
+	// second command nobody has been told about. It sits directly under the
+	// header because that is the only line a first-time reader is certain to
+	// read.
+	if nothingWired() {
+		fmt.Fprintf(w, "wire       %sno agent is wired to this yet%s — `deja install --auto`\n", bold, reset)
+	}
+
 	recalls, bytes, _ := usage.TodayWithInjections(dir)
 	weekRecalls, _, _, _ := usage.Week(dir)
 	dejaVu := usage.DejaVuWeek(dir)

--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -63,6 +63,22 @@ func autoWirings() []autoWiring {
 	}
 }
 
+// nothingWired reports whether no harness on this machine has an auto-recall
+// file. It is a stat per harness and no index read, which is what the brief can
+// afford — that screen has to feel instant.
+//
+// Auto-recall alone is the question worth asking here. An MCP server is a tool
+// the agent may call; these files are what make memory arrive without anyone
+// asking, which is the thing someone thinks they installed.
+func nothingWired() bool {
+	for _, a := range autoWirings() {
+		if _, err := os.Stat(a.path()); err == nil {
+			return false
+		}
+	}
+	return true
+}
+
 // doctorAutoRecall prints one line per harness. "stale" is the interesting
 // state: the file is there, so an install looks done, but nothing in it calls
 // deja any more — which is exactly how a silently dead integration looks.

--- a/cmd/deja/first_run_wiring_test.go
+++ b/cmd/deja/first_run_wiring_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A fresh install lands with an index and no agent reading it. install.sh drops
+// a binary, a bare `deja` builds the memory and reports it, and the command
+// that makes any of it arrive on its own — `deja install --auto` — was named
+// nowhere in that path: not by the installer, and not by the screen the reader
+// is looking at.
+//
+// Someone who stops there has installed a search tool by accident. They have to
+// remember to run deja by hand, which is the one thing this is built not to
+// need.
+func TestTheBriefSaysWhenNoAgentIsWired(t *testing.T) {
+	tmp := hermeticEnv(t)
+	proj := filepath.Join(tmp, "claude", "project")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"wire-1","cwd":"/w","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"the retry loop drops the last attempt"}}`
+	if err := os.WriteFile(filepath.Join(proj, "s.jsonl"), []byte(line+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := runBrief(index.DefaultDir(), &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "install --auto") {
+		t.Errorf("history was found and no agent is wired, and the screen never says so:\n%s", got)
+	}
+}
+
+// And it goes quiet once something is wired: a line that is always there is
+// not a prompt, it is furniture.
+func TestTheBriefStopsSayingItOnceWired(t *testing.T) {
+	tmp := hermeticEnv(t)
+	proj := filepath.Join(tmp, "claude", "project")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"wire-2","cwd":"/w","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"the retry loop drops the last attempt"}}`
+	if err := os.WriteFile(filepath.Join(proj, "s.jsonl"), []byte(line+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// One wiring file is enough: the question is whether anything reads this.
+	wired := autoWirings()[0].path()
+	if err := os.MkdirAll(filepath.Dir(wired), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wired, []byte("hook-context\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := runBrief(index.DefaultDir(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "no agent is wired") {
+		t.Errorf("a wired machine is still being told to wire itself:\n%s", out.String())
+	}
+}

--- a/install.sh
+++ b/install.sh
@@ -114,3 +114,9 @@ case ":$PATH:" in
     fi
     ;;
 esac
+
+# What actually makes memory arrive. Everything above this line puts a binary on
+# the disk; nothing has been wired into an agent yet, and a reader who stops
+# here has installed a search tool by accident.
+printf '\nnext: %s install --auto\n' "$dest_dir/$bin"
+printf '      wires deja into every coding agent found on this machine\n'


### PR DESCRIPTION
Fourth item from the research pass, and the one that costs a new user the most.

A fresh install lands with an index and **no agent reading it**, and nothing in that path says so:

- `install.sh` drops a binary and talks about PATH.
- A bare `deja` builds the memory and reports how much of it there is.
- `deja install --auto` — the command that makes any of it arrive on its own — is named in neither. It appears once, in the examples at the bottom of forty lines of help.

Someone who stops there has installed a search tool by accident. They have to remember to run deja by hand, which is the one thing this is built not to need.

```
next: ~/.local/bin/deja install --auto
      wires deja into every coding agent found on this machine
```

and, while nothing is wired:

```
deja-vu 0.17.2 · 1244 sessions across 14 agents
wire       no agent is wired to this yet — `deja install --auto`
today      3 sessions · 12 recalls served (41 KB)
```

It goes quiet once something is wired. A line that is always there is furniture, not a prompt — there is a test for each direction.

The check is a stat per harness and no index read, which is what that screen can afford; it has to feel instant. It asks only about auto-recall: an MCP server is a tool the agent *may* call, and these files are what make memory arrive without anyone asking, which is what someone thinks they installed.