### PR TITLE
refactor: the benchmark for the hook now runs the hook's own extraction

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/bench"
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/prompt"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
@@ -118,7 +119,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 		if chain.Negative {
 			continue
 		}
-		terms := promptSearchTerms(chain.Question)
+		terms := prompt.Terms(chain.Question)
 		fired, correct := promptBenchProbe(indexDir, chain.Project, chain.ID, terms)
 		arm := &report.Real
 		switch chain.Kind {
@@ -140,7 +141,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	// Negative questions are asked against every project in turn: firing
 	// anywhere is a false fire.
 	for _, q := range negativeQuestions() {
-		terms := promptSearchTerms(q)
+		terms := prompt.Terms(q)
 		negTerms = append(negTerms, len(terms))
 		report.Negative.Cases++
 		for _, chain := range corpus.Chains {

--- a/cmd/deja/hook_plan.go
+++ b/cmd/deja/hook_plan.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/prompt"
 )
 
 // planHookBudget is the complete framed payload budget. Findings receive the
@@ -272,7 +273,7 @@ func stripPlanCheckbox(s string) string {
 func planSearchSteps(plan string) [][]string {
 	var out [][]string
 	for _, step := range extractPlanSteps(plan) {
-		terms := promptSearchTerms(step)
+		terms := prompt.Terms(step)
 		if len(terms) > planTermLimit {
 			terms = terms[:planTermLimit]
 		}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -18,6 +17,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/redact"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/prompt"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
@@ -128,7 +128,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// this prompt also earns a recall, so it is decided before the gates that
 	// silence the recall path.
 	nudge := failureNudge(dir, string(input.Prompt))
-	terms := promptSearchTerms(string(input.Prompt))
+	terms := prompt.Terms(string(input.Prompt))
 	if !promptTermsWorthAsking(terms) {
 		return emitNudgeOnly(stdout, plain, nudge)
 	}
@@ -146,7 +146,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// Rank THIS project's sessions by how well they match the prompt terms
 	// (IDF-weighted), rather than reconstructing an AND query — natural
 	// prompts are full of filler that poisons an AND.
-	ranked, matched, strong, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, promptCandidates)
+	ranked, matched, strong, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, prompt.Candidates)
 	if err != nil || len(ranked) == 0 {
 		return emitNudgeOnly(stdout, plain, nudge)
 	}
@@ -265,104 +265,6 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	return nil
 }
 
-// promptSearchTerms extracts the informative tokens from a natural-language
-// prompt: stop words and short fragments dropped, capped so the query stays
-// specific.
-func promptSearchTerms(prompt string) []string {
-	fields := strings.FieldsFunc(strings.ToLower(prompt), func(r rune) bool {
-		wordy := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') ||
-			r == '-' || r == '_' || r == '.' || r == '/' || r >= 0x400
-		return !wordy
-	})
-	var out []string
-	seen := map[string]bool{}
-	add := func(f string) bool {
-		if seen[f] {
-			return false
-		}
-		seen[f] = true
-		out = append(out, f)
-		return len(out) == 6
-	}
-	for _, f := range fields {
-		if len(f) < 3 || search.IsStopWord(f) || seen[f] || !techTerm(f) {
-			continue
-		}
-		if add(f) {
-			return out
-		}
-	}
-	// CJK carries no spaces, so FieldsFunc hands back a whole phrase as one
-	// field, and techTerm rejects every rune above 127 — a Chinese, Japanese
-	// or Korean prompt therefore yields no terms at all and auto-recall can
-	// never fire for it. Fall back to the terms the relevance tier already
-	// ranks on: per-run bigrams with pure-grammar pairs dropped. A bigram is
-	// as specific as the identifiers techTerm looks for, and the caller still
-	// demands two of them overlap before claiming a déjà vu.
-	if hasCJKRune(prompt) {
-		for _, t := range index.RelevanceTerms(prompt) {
-			if !hasCJKRune(t) {
-				continue
-			}
-			if add(t) {
-				break
-			}
-		}
-	}
-	// Cyrillic hits the same wall for the same reason: techTerm rejects every
-	// rune above 127, so a Russian prompt without an ASCII identifier yields
-	// nothing and auto-recall stays silent. Unlike CJK it is space-separated,
-	// so the words are already there — they just need a length floor and the
-	// closed class removed, and the index matches their inflected forms.
-	for _, f := range fields {
-		if seen[f] || !cyrPromptTerm(f) {
-			continue
-		}
-		if add(f) {
-			break
-		}
-	}
-	return out
-}
-
-// cyrPromptTerm reports whether a field is a Cyrillic word specific enough to
-// search on. Short words carry no signal and the closed class is noise, so
-// both are dropped; what is left is roughly what techTerm keeps for ASCII.
-func cyrPromptTerm(f string) bool {
-	n := 0
-	for _, r := range f {
-		if r < 0x400 || r > 0x4ff {
-			return false
-		}
-		n++
-	}
-	return n >= 5 && !cyrPromptStop[f]
-}
-
-// The closed class plus the handful of verbs that open half of all questions.
-var cyrPromptStop = map[string]bool{
-	"который": true, "которая": true, "которые": true, "потому": true,
-	"чтобы": true, "нужно": true, "надо": true, "можно": true, "нельзя": true,
-	"когда": true, "почему": true, "зачем": true, "какой": true, "какая": true,
-	"какие": true, "этот": true, "эта": true, "это": true, "тот": true,
-	"такой": true, "также": true, "тоже": true, "очень": true, "просто": true,
-	"сейчас": true, "сделать": true, "делать": true, "сделай": true,
-	"работает": true, "работать": true, "показать": true, "посмотреть": true,
-	"давай": true, "было": true, "были": true, "будет": true, "быть": true,
-	"есть": true, "нет": true, "если": true, "или": true, "как": true,
-	"что": true, "где": true, "там": true, "тут": true, "уже": true, "ещё": true,
-}
-
-func hasCJKRune(s string) bool {
-	for _, r := range s {
-		if unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
-			unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r) {
-			return true
-		}
-	}
-	return false
-}
-
 // promptTermsWorthAsking is the gate before the index is touched. Two terms
 // were required, which silenced the sharpest prompt there is: "do we need
 // pgbouncer here" reduces to one term and never reached the store, while "add
@@ -393,51 +295,6 @@ func hasIdentifierTerm(terms []string) bool {
 		}
 	}
 	return false
-}
-
-// promptFiller is the short English filler a four-character floor lets
-// through. search.IsStopWord is deliberately not extended: it governs search
-// queries too, where "about" typed on purpose should still match.
-var promptFiller = map[string]bool{
-	"about": true, "again": true, "after": true, "before": true, "still": true,
-	"there": true, "their": true, "these": true, "those": true, "which": true,
-	"would": true, "could": true, "should": true, "thing": true, "things": true,
-	"really": true, "maybe": true, "into": true, "from": true, "with": true,
-	"that": true, "this": true, "what": true, "when": true, "were": true,
-	"have": true, "does": true, "just": true, "like": true, "make": true,
-	"made": true, "want": true, "need": true, "know": true, "tell": true,
-	"show": true, "look": true, "some": true, "more": true, "most": true,
-	"then": true, "than": true, "here": true, "your": true, "ours": true,
-	"going": true, "doing": true, "being": true, "used": true, "using": true,
-	"give": true, "take": true, "come": true, "seen": true, "said": true,
-}
-
-// techTerm keeps tokens that can actually identify past work: identifiers,
-// error codes, paths, or long plain-ASCII words. Ordinary prose — any
-// language — matches by theme, not by task, and theme matches are what made
-// déjà vu fire on every prompt.
-func techTerm(f string) bool {
-	if promptFiller[f] {
-		return false
-	}
-	long := 0
-	for _, r := range f {
-		if r == '_' || r == '.' || r == '/' || r == '-' || (r >= '0' && r <= '9') {
-			return true
-		}
-		if r > 127 {
-			return false
-		}
-		long++
-	}
-	// Seven was a proxy for "looks like an identifier" and the wrong one:
-	// etag, ttl, mutex, gzip, oauth and most of what people actually type is
-	// shorter. Measured on `deja bench prompt`, dropping to four takes real
-	// questions answered from 2/12 to 7/12 with precision unchanged at 1.00
-	// and no false fire on any negative control; three scores higher still
-	// but starts keeping words like "log" and "run", so four is where the
-	// evidence stops being comfortable.
-	return long >= 4
 }
 
 // citationLine pre-writes the narration so the agent copies structure instead
@@ -499,25 +356,6 @@ func citationLine(s model.Session, terms []string) string {
 	return fmt.Sprintf("\nIf it helped, say: \"deja-vu recalled: %s (%s%s, deja:%s) — reusing it.\"",
 		title, s.Harness, date, shortID(s.ID))
 }
-
-// promptCandidates is how many ranked sessions the hook asks for before
-// filtering, against the two it will ever inject.
-//
-// It was eight, sized against two exclusions — the session being written and
-// anything too fresh — and its comment said so. Three more arrived afterwards:
-// the trust policy withholds a project, a weak match is dropped, and a session
-// already injected in this conversation is skipped. Any of them can fill the
-// window, and when they do the answer sitting below is never looked at and the
-// hook says nothing at all.
-//
-// Already-injected is the one that makes this ordinary rather than contrived:
-// it accumulates as a conversation goes on, so the failure arrives after a
-// handful of prompts, on the sessions the user asks about most.
-//
-// The cost of a wider window is a longer list to walk, not a longer search: the
-// ranking already scored every session in the project, and this only takes more
-// of what it produced.
-const promptCandidates = 32
 
 // alreadyInjected returns the session ids this hook already injected into the
 // given agent session, so follow-up prompts do not repeat the same memory.

--- a/cmd/deja/hook_prompt_cjk_test.go
+++ b/cmd/deja/hook_prompt_cjk_test.go
@@ -1,9 +1,14 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/prompt"
+)
 
 // A CJK prompt is one field to FieldsFunc (no spaces) and techTerm rejects
-// every rune above 127, so promptSearchTerms returned nothing at all and
+// every rune above 127, so prompt.Terms returned nothing at all and
 // runHookPrompt bailed at the "fewer than two terms" guard: auto-recall could
 // never fire for a Chinese, Japanese or Korean user.
 func TestPromptSearchTermsCJK(t *testing.T) {
@@ -17,7 +22,7 @@ func TestPromptSearchTermsCJK(t *testing.T) {
 		{"полное совпадение по-русски", nil}, // Cyrillic path unchanged
 	}
 	for _, c := range cases {
-		got := promptSearchTerms(c.prompt)
+		got := prompt.Terms(c.prompt)
 		if c.wantAny == nil {
 			continue
 		}
@@ -43,7 +48,7 @@ func TestPromptSearchTermsCJK(t *testing.T) {
 // counterpart of a stop word, and RelevanceTerms already drops them, so the
 // hook inherits that filtering for free.
 func TestPromptSearchTermsCJKDropsGrammar(t *testing.T) {
-	got := promptSearchTerms("我为什么不用 postgres 的索引")
+	got := prompt.Terms("我为什么不用 postgres 的索引")
 	for _, junk := range []string{"什么", "在哪", "怎么"} {
 		for _, g := range got {
 			if g == junk {
@@ -64,9 +69,9 @@ func TestPromptSearchTermsCJKDropsGrammar(t *testing.T) {
 
 // An ASCII prompt must behave exactly as before: the CJK branch is skipped.
 func TestPromptSearchTermsASCIIUnchanged(t *testing.T) {
-	got := promptSearchTerms("fix the authentication middleware timeout")
+	got := prompt.Terms("fix the authentication middleware timeout")
 	for _, g := range got {
-		if hasCJKRune(g) {
+		if strings.ContainsFunc(g, func(r rune) bool { return r > 0x2E80 }) {
 			t.Errorf("ASCII prompt produced a CJK term: %v", got)
 		}
 	}

--- a/cmd/deja/hook_prompt_injected_test.go
+++ b/cmd/deja/hook_prompt_injected_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/vshulcz/deja-vu/internal/prompt"
 	"strings"
 	"testing"
 )
@@ -59,15 +60,15 @@ func TestSearchTermsComeFromTheUserNotTheLastRecall(t *testing.T) {
 	raw := "<hook_context>&lt;deja-recall&gt;\n  - User: have a look at internal/index/retrieval.go\n" +
 		"  - Assistant: the AND across query words is why plain questions come back empty\n" +
 		"&lt;/deja-recall&gt;</hook_context>\n\nHow often does the pgbouncer certificate rotate?"
-	var prompt hookPromptText
+	var typed hookPromptText
 	payload, err := json.Marshal(raw)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := prompt.UnmarshalJSON(payload); err != nil {
+	if err := typed.UnmarshalJSON(payload); err != nil {
 		t.Fatal(err)
 	}
-	terms := promptSearchTerms(string(prompt))
+	terms := prompt.Terms(string(typed))
 	if len(terms) == 0 {
 		t.Fatal("the user's own question produced no search terms")
 	}

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/vshulcz/deja-vu/internal/prompt"
 	"io"
 	"os"
 	"path/filepath"
@@ -81,7 +82,7 @@ func TestHookPromptSilentPaths(t *testing.T) {
 }
 
 func TestPromptSearchTerms(t *testing.T) {
-	got := promptSearchTerms("Why is the connection pool exhausted again in the gateway???")
+	got := prompt.Terms("Why is the connection pool exhausted again in the gateway???")
 	joined := strings.Join(got, " ")
 	if !strings.Contains(joined, "connection") || !strings.Contains(joined, "gateway") {
 		t.Fatalf("terms = %v", got)
@@ -95,18 +96,8 @@ func TestPromptSearchTerms(t *testing.T) {
 	if !strings.Contains(joined, "pool") {
 		t.Fatalf("short identifier dropped: %v", got)
 	}
-	if len(promptSearchTerms("a of to")) != 0 {
+	if len(prompt.Terms("a of to")) != 0 {
 		t.Fatal("stop words must not produce terms")
-	}
-	for term, want := range map[string]bool{
-		"auth.go": true, "e404": true, "npm_token": true, "singleflight": true,
-		// Four characters is the floor `deja bench prompt` settled on: "brew"
-		// is a real command name, and words this short are what people type.
-		"brew": true, "ttl": false, "пост": false, "готовь": false,
-	} {
-		if techTerm(term) != want {
-			t.Fatalf("techTerm(%q) = %v, want %v", term, !want, want)
-		}
 	}
 }
 
@@ -308,7 +299,7 @@ func TestDejaVuLineCooldown(t *testing.T) {
 // identifier used to yield no terms and auto-recall could never fire for it —
 // the same hole CJK had, in the language this project is written from.
 func TestPromptSearchTermsCyrillic(t *testing.T) {
-	got := promptSearchTerms("почему падает индексация кириллицы")
+	got := prompt.Terms("почему падает индексация кириллицы")
 	if len(got) < 2 {
 		t.Fatalf("Russian prompt yielded %v, recall cannot fire", got)
 	}
@@ -320,11 +311,11 @@ func TestPromptSearchTermsCyrillic(t *testing.T) {
 		}
 	}
 	// Short words carry no signal.
-	if terms := promptSearchTerms("а он там был"); len(terms) != 0 {
+	if terms := prompt.Terms("а он там был"); len(terms) != 0 {
 		t.Errorf("short Russian words became terms: %v", terms)
 	}
 	// A prompt mixing Russian prose with an identifier keeps both.
-	mixed := promptSearchTerms("почему падает openBucketDir на кириллице")
+	mixed := prompt.Terms("почему падает openBucketDir на кириллице")
 	var hasIdent, hasWord bool
 	for _, g := range mixed {
 		if g == "openbucketdir" {

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/prompt"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -219,7 +220,7 @@ func commandHookLine(dir, cmd string) string {
 // cheaper lookup, and this hook fires on a build or a deploy rather than on
 // every message — the prompt hook already pays a search per keystroke.
 func commandDecisionLine(dir, cmd string) string {
-	terms := promptSearchTerms(normalizedCommandText(cmd))
+	terms := prompt.Terms(normalizedCommandText(cmd))
 	if len(terms) == 0 {
 		return ""
 	}

--- a/cmd/deja/recall_gates_test.go
+++ b/cmd/deja/recall_gates_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/vshulcz/deja-vu/internal/prompt"
 	"strings"
 	"testing"
 
@@ -90,12 +91,12 @@ func TestSingleTermNeedsAnIdentifier(t *testing.T) {
 // The filler list exists because the four-character floor lets these through;
 // without it "what about that thing" reads as three search terms.
 func TestPromptFillerIsDropped(t *testing.T) {
-	got := promptSearchTerms("what about that thing we were going to make")
+	got := prompt.Terms("what about that thing we were going to make")
 	if len(got) > 0 {
 		t.Fatalf("pure filler produced terms: %v", got)
 	}
 	// And a real question still keeps its words.
-	if terms := promptSearchTerms("what about the etag reuse"); len(terms) == 0 {
+	if terms := prompt.Terms("what about the etag reuse"); len(terms) == 0 {
 		t.Fatal("filtering took the real terms with it")
 	}
 }

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1,0 +1,182 @@
+// Package prompt turns what a person typed into the terms auto-recall searches
+// on.
+//
+// It lives here rather than beside the hook because the benchmark that measures
+// the hook is a separate command and could not call it. It was reimplementing
+// the extraction instead — on relevance terms, with neither the identifier test
+// nor the six-term cap — so the numbers it reported for the auto-recall gate
+// were measured against a different rule from the one that runs.
+package prompt
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// relevanceTerms is the ranking's own tokenisation, used for the scripts that
+// carry no ASCII identifier to find.
+func relevanceTerms(q string) []string { return index.RelevanceTerms(q) }
+
+// promptSearchTerms extracts the informative tokens from a natural-language
+// prompt: stop words and short fragments dropped, capped so the query stays
+// specific.
+func Terms(prompt string) []string {
+	fields := strings.FieldsFunc(strings.ToLower(prompt), func(r rune) bool {
+		wordy := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') ||
+			r == '-' || r == '_' || r == '.' || r == '/' || r >= 0x400
+		return !wordy
+	})
+	var out []string
+	seen := map[string]bool{}
+	add := func(f string) bool {
+		if seen[f] {
+			return false
+		}
+		seen[f] = true
+		out = append(out, f)
+		return len(out) == 6
+	}
+	for _, f := range fields {
+		if len(f) < 3 || query.IsStopWord(f) || seen[f] || !techTerm(f) {
+			continue
+		}
+		if add(f) {
+			return out
+		}
+	}
+	// CJK carries no spaces, so FieldsFunc hands back a whole phrase as one
+	// field, and techTerm rejects every rune above 127 — a Chinese, Japanese
+	// or Korean prompt therefore yields no terms at all and auto-recall can
+	// never fire for it. Fall back to the terms the relevance tier already
+	// ranks on: per-run bigrams with pure-grammar pairs dropped. A bigram is
+	// as specific as the identifiers techTerm looks for, and the caller still
+	// demands two of them overlap before claiming a déjà vu.
+	if hasCJKRune(prompt) {
+		for _, t := range relevanceTerms(prompt) {
+			if !hasCJKRune(t) {
+				continue
+			}
+			if add(t) {
+				break
+			}
+		}
+	}
+	// Cyrillic hits the same wall for the same reason: techTerm rejects every
+	// rune above 127, so a Russian prompt without an ASCII identifier yields
+	// nothing and auto-recall stays silent. Unlike CJK it is space-separated,
+	// so the words are already there — they just need a length floor and the
+	// closed class removed, and the index matches their inflected forms.
+	for _, f := range fields {
+		if seen[f] || !cyrPromptTerm(f) {
+			continue
+		}
+		if add(f) {
+			break
+		}
+	}
+	return out
+}
+
+// cyrPromptTerm reports whether a field is a Cyrillic word specific enough to
+// search on. Short words carry no signal and the closed class is noise, so
+// both are dropped; what is left is roughly what techTerm keeps for ASCII.
+func cyrPromptTerm(f string) bool {
+	n := 0
+	for _, r := range f {
+		if r < 0x400 || r > 0x4ff {
+			return false
+		}
+		n++
+	}
+	return n >= 5 && !cyrPromptStop[f]
+}
+func hasCJKRune(s string) bool {
+	for _, r := range s {
+		if unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
+			unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r) {
+			return true
+		}
+	}
+	return false
+}
+
+// promptFiller is the short English filler a four-character floor lets
+// through. search.IsStopWord is deliberately not extended: it governs search
+// queries too, where "about" typed on purpose should still match.
+var promptFiller = map[string]bool{
+	"about": true, "again": true, "after": true, "before": true, "still": true,
+	"there": true, "their": true, "these": true, "those": true, "which": true,
+	"would": true, "could": true, "should": true, "thing": true, "things": true,
+	"really": true, "maybe": true, "into": true, "from": true, "with": true,
+	"that": true, "this": true, "what": true, "when": true, "were": true,
+	"have": true, "does": true, "just": true, "like": true, "make": true,
+	"made": true, "want": true, "need": true, "know": true, "tell": true,
+	"show": true, "look": true, "some": true, "more": true, "most": true,
+	"then": true, "than": true, "here": true, "your": true, "ours": true,
+	"going": true, "doing": true, "being": true, "used": true, "using": true,
+	"give": true, "take": true, "come": true, "seen": true, "said": true,
+}
+
+// techTerm keeps tokens that can actually identify past work: identifiers,
+// error codes, paths, or long plain-ASCII words. Ordinary prose — any
+// language — matches by theme, not by task, and theme matches are what made
+// déjà vu fire on every prompt.
+func techTerm(f string) bool {
+	if promptFiller[f] {
+		return false
+	}
+	long := 0
+	for _, r := range f {
+		if r == '_' || r == '.' || r == '/' || r == '-' || (r >= '0' && r <= '9') {
+			return true
+		}
+		if r > 127 {
+			return false
+		}
+		long++
+	}
+	// Seven was a proxy for "looks like an identifier" and the wrong one:
+	// etag, ttl, mutex, gzip, oauth and most of what people actually type is
+	// shorter. Measured on `deja bench prompt`, dropping to four takes real
+	// questions answered from 2/12 to 7/12 with precision unchanged at 1.00
+	// and no false fire on any negative control; three scores higher still
+	// but starts keeping words like "log" and "run", so four is where the
+	// evidence stops being comfortable.
+	return long >= 4
+}
+
+// The closed class plus the handful of verbs that open half of all questions.
+var cyrPromptStop = map[string]bool{
+	"который": true, "которая": true, "которые": true, "потому": true,
+	"чтобы": true, "нужно": true, "надо": true, "можно": true, "нельзя": true,
+	"когда": true, "почему": true, "зачем": true, "какой": true, "какая": true,
+	"какие": true, "этот": true, "эта": true, "это": true, "тот": true,
+	"такой": true, "также": true, "тоже": true, "очень": true, "просто": true,
+	"сейчас": true, "сделать": true, "делать": true, "сделай": true,
+	"работает": true, "работать": true, "показать": true, "посмотреть": true,
+	"давай": true, "было": true, "были": true, "будет": true, "быть": true,
+	"есть": true, "нет": true, "если": true, "или": true, "как": true,
+	"что": true, "где": true, "там": true, "тут": true, "уже": true, "ещё": true,
+}
+
+// Candidates is how many ranked sessions the hook asks for before
+// filtering, against the two it will ever inject.
+//
+// It was eight, sized against two exclusions — the session being written and
+// anything too fresh — and its comment said so. Three more arrived afterwards:
+// the trust policy withholds a project, a weak match is dropped, and a session
+// already injected in this conversation is skipped. Any of them can fill the
+// window, and when they do the answer sitting below is never looked at and the
+// hook says nothing at all.
+//
+// Already-injected is the one that makes this ordinary rather than contrived:
+// it accumulates as a conversation goes on, so the failure arrives after a
+// handful of prompts, on the sessions the user asks about most.
+//
+// The cost of a wider window is a longer list to walk, not a longer search: the
+// ranking already scored every session in the project, and this only takes more
+// of what it produced.
+const Candidates = 32

--- a/scripts/longmemeval/main.go
+++ b/scripts/longmemeval/main.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/prompt"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
@@ -524,8 +525,11 @@ func runHookPrecision(questions []lmeQuestion, limit int) {
 			cleanup()
 			fatal(err)
 		}
-		terms := index.RelevanceTerms(questions[i].Question)
-		_, matched, strong, err := index.ProjectRelevant(dir, nil, terms, 8)
+		// The hook's own extraction, not the ranking's. They differ by the
+		// identifier test and a six-term cap, so measuring the gate on
+		// relevance terms measured a rule that never runs.
+		terms := prompt.Terms(questions[i].Question)
+		_, matched, strong, err := index.ProjectRelevant(dir, nil, terms, prompt.Candidates)
 		if err != nil {
 			cleanup()
 			fatal(err)


### PR DESCRIPTION
Fifth item from the research pass, and it is the measuring-instrument kind.

`longmemeval -hook-precision` reports what the auto-recall gate would do, and it was **reproducing** the gate rather than calling it. The hook turns a prompt into terms with an identifier test, a three-character floor, a six-term cap and fallbacks for CJK and Cyrillic. The benchmark used `index.RelevanceTerms`, which has none of those. It also asked for eight candidates where the hook now asks for thirty-two (#1274).

Both the extraction and the candidate count live in `internal/prompt` now, and both callers use them. The code is moved, not rewritten: `cmd/deja` behaves exactly as before, and nothing in its tests changed except the two that reached into functions which no longer live there.

### What it was reporting

60 cross-paired prompts whose answer is never in the haystack, so every injection is a false fire:

```
before   39/60 = 65.0%   (one term 34, two or more 20)
after    37/60 = 61.7%   (one term 35, two or more 17)
```

It was overstating the false-fire rate and splitting it differently between the one-term and two-term cases. Neither number moved because the gate changed — the gate was never what was being measured.

### Attribution, checked rather than assumed

`deja bench prompt` reads 11/12 real questions answered at precision 1.00 with no false fire, against the 7/12 recorded in the code comments. That is **not** this change: measured on `origin/main` before it, the number is already 11/12. The candidate window in #1274 did it. Worth stating, because a refactor that arrives next to an improvement will otherwise be credited with it.