### PR TITLE
feat(zed): index the built-in agent's threads (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Zed's built-in agent is the eighteenth harness deja indexes. Its threads are one SQLite store under Zed's *data* directory — `~/Library/Application Support/Zed/threads/threads.db` on macOS, not the `~/.config/zed` that holds only settings — and every thread body inside it is a zstd frame, so reading them needs the `zstd` CLI beside `sqlite3`. With either tool missing, `deja sources` says which one rather than reporting an empty history. Both thread document generations parse, because Zed rewrites a thread in the current shape only when that thread is next saved, so a store mixes them indefinitely. (#183)
+
 
 ## [0.17.2] - 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Install also writes user-level guidance for the harnesses it detects: Claude Cod
 
 ## What you get
 
-**Solve it in Codex. Claude remembers.** Seventeen coding agents write every conversation
+**Solve it in Codex. Claude remembers.** Eighteen coding agents write every conversation
 to local files, and deja turns those files into one memory layer all of them read.
 
 | | |
@@ -206,7 +206,7 @@ The server exposes `recall`, `recall_context`, `blame`, `fix`, `how` and `rememb
 ## Supported harnesses
 
 <!-- matrix:start -->
-Claude Code &middot; Cline &middot; Codex CLI &middot; opencode &middot; aider &middot; Gemini CLI &middot; Cursor &middot; Antigravity &middot; Grok Build &middot; Hermes &middot; Goose &middot; Qwen Code &middot; Kimi Code &middot; pi &middot; OpenClaw &middot; Copilot CLI &middot; Roo Code.
+Claude Code &middot; Cline &middot; Codex CLI &middot; opencode &middot; aider &middot; Gemini CLI &middot; Cursor &middot; Antigravity &middot; Grok Build &middot; Hermes &middot; Goose &middot; Qwen Code &middot; Kimi Code &middot; pi &middot; OpenClaw &middot; Copilot CLI &middot; Roo Code &middot; Zed.
 
 <details>
 <summary>What each one supports</summary>
@@ -230,6 +230,7 @@ Claude Code &middot; Cline &middot; Codex CLI &middot; opencode &middot; aider &
 | OpenClaw | ✅ | ✅ | ✅ | ✅ | — | paste | — |
 | Copilot CLI | ✅ | ✕ | ✅ | ✅ | ✅ | ✅ | — |
 | Roo Code | ✅ | ⚠ | ✅ | ✅ | ✕ | paste | — |
+| Zed | — | ✕ | — | — | ✕ | paste | sqlite3 + zstd |
 
 ✅ works &middot; — possible, not built yet &middot; ✕ the harness has no such mechanism &middot; ⚠ blocked by an upstream bug &middot; ? not investigated
 

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -54,6 +54,13 @@ func hermeticEnv(t *testing.T) string {
 	t.Setenv("DEJA_GROK_ROOT", filepath.Join(tmp, "grok"))
 	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
 	t.Setenv("DEJA_COPILOT_ROOT", filepath.Join(tmp, "copilot"))
+	// Zed resolves its store through the platform data directory, which on
+	// macOS sits under the home directory but on Linux follows XDG_DATA_HOME.
+	// Both are pinned so a contributor's own threads never reach a golden.
+	t.Setenv("DEJA_ZED_ROOT", filepath.Join(tmp, "zed"))
+	t.Setenv("DEJA_ZED_DB", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("FLATPAK_XDG_DATA_HOME", "")
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 	t.Setenv("CODEX_HOME", "")
 	t.Setenv("GEMINI_CLI_HOME", "")

--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -259,7 +259,9 @@ var handoffAlias = map[string]string{"agy": "antigravity"}
 
 // handoffPasteOnly mirrors the registry's `handoff: paste` entries; the
 // capability drift test keeps the two in sync.
-var handoffPasteOnly = map[string]bool{"openclaw": true, "hermes": true, "roo": true}
+// Zed is paste-only for the same reason Roo is: the agent lives in the editor,
+// so there is no CLI invocation to hand a prompt to.
+var handoffPasteOnly = map[string]bool{"openclaw": true, "hermes": true, "roo": true, "zed": true}
 
 func handoffTargets() []string {
 	return []string{"claude", "codex", "opencode", "cursor", "copilot", "gemini", "qwen", "antigravity", "aider", "pi", "grok", "cline", "goose", "kimi"}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1855,6 +1855,7 @@ func printSources(dir string) {
 		{"roo", strings.Join(sources.RooRoots(), string(os.PathListSeparator)), sources.RooRoots(), sources.LoadRoo},
 		{"pi", sources.PiRoot(), []string{sources.PiRoot()}, sources.LoadPi},
 		{"openclaw", sources.OpenClawRoot(), []string{sources.OpenClawRoot()}, sources.LoadOpenClaw},
+		{"zed", sources.ZedDB(), []string{sources.ZedDB()}, sources.LoadZed},
 		{"deja", sources.NotesFile(), []string{sources.NotesFile()}, sources.LoadNotes},
 	}
 	for _, it := range items {
@@ -1882,6 +1883,14 @@ func printSources(dir string) {
 		}
 		if it.name == "cursor" && len(sources.CursorDBs()) > 0 && !sources.SQLite3Available() {
 			note = "\t(sqlite3 CLI not found — Cursor IDE sessions unavailable)"
+		}
+		// Zed needs zstd as well as sqlite3: sqlite3 alone opens the store and
+		// reads nothing out of it, since every thread body is a compressed
+		// frame. SkipReason already words which of the two is missing.
+		if it.name == "zed" {
+			if reason := sources.SkipReason("zed"); reason != "" {
+				note = "\t(" + reason + " — Zed threads unavailable)"
+			}
 		}
 		if n := len(sources.ExclusionPatterns()); n > 0 {
 			note += fmt.Sprintf("\texcluded-patterns=%d", n)

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -76,6 +76,7 @@
 <tr><td>OpenClaw</td><td><code>${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl</code><br><code>${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td><td>paste</td><td>—</td></tr>
 <tr><td>Copilot CLI</td><td><code>${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl</code></td><td>✅</td><td>✕</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
 <tr><td>Roo Code</td><td><code><vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json</code><br><code>${DEJA_ROO_ROOTS}/tasks/*/api_conversation_history.json</code><br><code>~/.vscode-mock/global-storage/tasks/*/api_conversation_history.json</code></td><td>✅</td><td>⚠</td><td>✅</td><td>✅</td><td>✕</td><td>paste</td><td>—</td></tr>
+<tr><td>Zed</td><td><code>~/Library/Application Support/Zed/threads/threads.db</code><br><code>${XDG_DATA_HOME}/zed/threads/threads.db</code><br><code>%LOCALAPPDATA%/Zed/threads/threads.db</code><br><code>${DEJA_ZED_ROOT}/threads/threads.db</code><br><code>${DEJA_ZED_DB}</code></td><td>—</td><td>✕</td><td>—</td><td>—</td><td>✕</td><td>paste</td><td>sqlite3 + zstd</td></tr>
 </table>
 <p>✅ works &middot; — possible, not built yet &middot; ✕ the harness has no such mechanism &middot; ⚠ blocked by an upstream bug &middot; ? not investigated</p>
 <ul>
@@ -83,6 +84,7 @@
 <li>aider <code>command</code> — the slash command set is built in; adding custom commands is an open feature request upstream, not something a third party can wire today (https://github.com/Aider-AI/aider/issues/894)</li>
 <li>Copilot CLI <code>auto</code> — Copilot runs the hooks but drops their context, so recall there is MCP plus the skill</li>
 <li>Roo Code <code>auto</code> — Roo&#39;s hooks are in flight upstream, not shipped: PR #10785 implements a Claude Code-style hooks system, #11128 is Hooks beta and #11663 Hooks phase 1, all still open, and no release names lifecycle hooks. A user&#39;s bug report about PreToolUse coverage (#10834) shows they work on a branch build. Becomes work the day one of those merges (https://github.com/RooCodeInc/Roo-Code/pull/10785)</li>
+<li>Zed <code>auto</code> — Zed&#39;s agent exposes no lifecycle hook: nothing in the editor runs a command before a prompt is sent, so there is no point at which recall could be injected. Becomes work the day Zed ships one (no hook API in Zed 0.61)</li>
 </ul><!-- matrix:end -->
 <p>Each format is documented in the <a href="../registry/README.md">session format registry</a>, with synthetic fixtures and a conformance test that catches upstream drift.</p>
 <h2>Adding a harness</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -400,7 +400,7 @@ footer a:hover{color:var(--ph-hi)}
 </section>
 
 <section class="reveal">
-  <h2>Works with <span class="fig">17</span></h2>
+  <h2>Works with <span class="fig">18</span></h2>
   <div class="split">
     <div><p class="big" style="margin:0">Solve it in Codex. <em>Claude remembers.</em></p></div>
     <div class="right"><div class="agents" style="margin:0">
@@ -408,7 +408,7 @@ footer a:hover{color:var(--ph-hi)}
     <span>Gemini CLI</span><span>Cline</span><span>Copilot CLI</span><span>Roo Code</span>
     <span>aider</span><span>Goose</span><span>Qwen Code</span><span>Kimi Code</span>
     <span>Antigravity</span><span>Grok Build</span><span>OpenClaw</span><span>pi</span>
-    <span>Hermes</span><span class="more">one memory, all of them</span>
+    <span>Hermes</span><span>Zed</span><span class="more">one memory, all of them</span>
   </div>
 </section>
 

--- a/docs/registry/README.md
+++ b/docs/registry/README.md
@@ -25,6 +25,7 @@ This registry records observed on-disk session formats for the harnesses that de
 | [Copilot CLI](copilot.md) | session event JSONL |
 | [Roo Code](roo.md) | task JSON in VS Code globalStorage |
 | [Hermes](hermes.md) | SQLite state store |
+| [Zed](zed.md) | SQLite thread store, zstd-compressed bodies |
 
 ## Reporting drift
 

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -484,6 +484,56 @@
      "source": "no CLI ships with the extension"
     }
    }
+  },
+  {
+   "id": "zed",
+   "store_paths": [
+    "~/Library/Application Support/Zed/threads/threads.db",
+    "${XDG_DATA_HOME}/zed/threads/threads.db",
+    "%LOCALAPPDATA%/Zed/threads/threads.db",
+    "${DEJA_ZED_ROOT}/threads/threads.db",
+    "${DEJA_ZED_DB}"
+   ],
+   "format_kind": "sqlite",
+   "fixture_paths": [
+    "fixtures/registry/zed/zed.sql"
+   ],
+   "parser_source": "internal/sources/zed.go",
+   "last_verified": "2026-08-17",
+   "display_name": "Zed",
+   "capabilities": {
+    "mcp": false,
+    "auto": false,
+    "skill": false,
+    "command": false,
+    "resume": false,
+    "handoff": "paste",
+    "prereq": "sqlite3 + zstd"
+   },
+   "gaps": {
+    "mcp": {
+     "state": "todo",
+     "why": "Zed runs MCP servers — it keeps a context server registry and reads them from settings — but deja has no install target that writes that wiring, so nothing here claims it works yet"
+    },
+    "auto": {
+     "state": "impossible",
+     "why": "Zed's agent exposes no lifecycle hook: nothing in the editor runs a command before a prompt is sent, so there is no point at which recall could be injected. Becomes work the day Zed ships one",
+     "source": "no hook API in Zed 0.61"
+    },
+    "skill": {
+     "state": "todo",
+     "why": "Zed reads rules files, so guidance has somewhere to live, but deja neither owns nor writes one for it yet"
+    },
+    "command": {
+     "state": "todo",
+     "why": "Follows the skill gap: deja writes no file for Zed, so there is nothing for a command to be defined in"
+    },
+    "resume": {
+     "state": "impossible",
+     "why": "The agent lives in the editor and no zed CLI flag reopens a thread by id, so there is nothing for deja to print. Reopening a thread is a thing the editor does, not a command",
+     "source": "no resume flag in the zed CLI"
+    }
+   }
   }
  ]
 }

--- a/docs/registry/zed.md
+++ b/docs/registry/zed.md
@@ -1,0 +1,72 @@
+# Zed session format
+
+## Store and files
+
+Zed's built-in agent keeps every thread in one SQLite database under Zed's **data** directory, following its own `paths::data_dir()`:
+
+| Platform | Store |
+| --- | --- |
+| macOS | `~/Library/Application Support/Zed/threads/threads.db` |
+| Linux, FreeBSD | `${XDG_DATA_HOME:-~/.local/share}/zed/threads/threads.db` |
+| Windows | `%LOCALAPPDATA%\Zed\threads\threads.db` |
+
+`~/.config/zed` is the *config* directory. It exists on every platform and holds `settings.json`, keymaps and prompts — it holds no threads, so a reader that looks there finds nothing on a machine with years of history.
+
+A Flatpak install overrides the Linux root with `FLATPAK_XDG_DATA_HOME`. `DEJA_ZED_ROOT` relocates the root and `DEJA_ZED_DB` points at a store directly; the second is how the fixture is read without a Zed install.
+
+Reading this store needs the `sqlite3` CLI, like opencode's and Cursor's, **and** the `zstd` CLI, which no other harness needs. Thread bodies are compressed; sqlite3 alone opens the store and reads nothing out of it. With either tool missing, `deja sources` and `deja doctor` say which one rather than reporting an empty history.
+
+## Records
+
+One row is one thread, and one thread is one session. The table Zed ends up with is:
+
+```sql
+CREATE TABLE threads (
+    id TEXT PRIMARY KEY,
+    summary TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    data_type TEXT NOT NULL,
+    data BLOB NOT NULL,
+    parent_id TEXT,
+    folder_paths TEXT,
+    folder_paths_order TEXT,
+    created_at TEXT
+);
+```
+
+Only the first five columns are in the `CREATE TABLE`. The rest arrive as `ALTER TABLE` statements Zed runs at startup, so a store an older Zed wrote and a newer one has never opened has only the original five.
+
+`data_type` is `zstd` for everything Zed writes today and `json` for rows written before compression landed. Either way the payload is one thread document, and the document is flattened — Zed serialises `SerializedThread { #[serde(flatten)] thread, version }`, so `version` sits beside the thread's own fields rather than wrapping them.
+
+Current documents are version `0.3.0` and hold Rust's externally tagged `Message` enum:
+
+```json
+{"version":"0.3.0","title":"read the zed thread store","updated_at":"2026-07-19T09:00:02Z",
+ "messages":[{"User":{"id":"u1","content":[{"Text":"where does zed keep its agent threads?"}]}},
+             {"Agent":{"content":[{"Text":"in threads.db under the data dir"}],"tool_results":{}}},
+             "Resume"]}
+```
+
+A document written by the previous agent generation names the title `summary` and carries internally tagged segments instead:
+
+```json
+{"version":"0.2.0","summary":"legacy zed thread","updated_at":"2026-07-19T08:00:02Z",
+ "messages":[{"id":1,"role":"user","segments":[{"type":"text","text":"does the old shape still load?"}]}]}
+```
+
+Both matter. Zed rewrites a thread in the current shape only when that thread is next saved, so a store mixes generations indefinitely.
+
+`User` maps to `user` and `Agent` to `assistant`; a legacy document's `role` is already lowercase (`user`, `assistant`, `system`), and `system` is dropped as harness-authored. `Text` blocks are indexed and joined with newlines, and a `Mention`'s inlined `content` is indexed because that is the text Zed put in front of the model. Thinking, redacted thinking, tool calls, tool results, images and the `Resume` control marker are skipped.
+
+`folder_paths` is a serialized `PathList`: the workspace roots newline-joined in lexicographic order, with `folder_paths_order` holding comma-joined display indices. The first path names the project.
+
+## Known quirks and drift
+
+- Thread documents carry no per-message timestamp in either generation. Every message inherits the thread's start, as aider's do; message order comes from the array.
+- `updated_at` and `created_at` are Rust `to_rfc3339` output, so they end in `+00:00` rather than `Z`. They are not lexicographically comparable with a Go `RFC3339Nano` watermark — `.` sorts below `Z`, so comparing them as text drops a row that is newer by a fraction of a second. The incremental filter normalises both sides with `strftime` first, and keeps a row whose timestamp SQLite cannot parse rather than assuming it was already seen.
+- `created_at` is set from `updated_at` when a thread is first written, so a fresh thread's window is a point, not a range. On a store predating the column the window collapses onto `updated_at`.
+- A thread body that will not decode — a truncated frame, an unknown `data_type`, a document that is not a thread — costs that thread only. One unreadable row must not cost a user every other thread they have.
+- `parent_id` marks a subagent thread. Those rows are indexed like any other today; nothing filters them.
+- The compressed fixture row is a real zstd frame, so its bytes are opaque in review. The SQL states the plaintext it decompresses to and a test pins the two together.
+
+**Last verified:** 2026-08-17

--- a/fixtures/registry/zed/zed.sql
+++ b/fixtures/registry/zed/zed.sql
@@ -1,0 +1,52 @@
+-- Zed keeps every agent thread in one SQLite store. This fixture carries both
+-- storage encodings a live store mixes, because deja indexes history written
+-- before it was installed and Zed rewrites a thread's encoding only on save.
+--
+-- Row 1 (data_type 'json') is a pre-compression thread in the agent-1 shape:
+-- `summary` rather than `title`, and messages as {role, segments}.
+-- Row 2 (data_type 'zstd') is what Zed writes today: a zstd frame holding the
+-- flattened SerializedThread of version 0.3.0, whose messages are Rust's
+-- externally tagged Message enum.
+--
+-- The blob is opaque on purpose — it is a real frame, not a stand-in. It
+-- decompresses to exactly:
+--
+-- {"version":"0.3.0","title":"read the zed thread store","updated_at":"2026-07-19T09:00:02Z","messages":[{"User":{"id":"registry-user-1","content":[{"Text":"where does zed keep its agent threads?"}]}},{"Agent":{"content":[{"Thinking":{"text":"reasoning is not indexed","signature":null}},{"Text":"in threads.db under the data dir"}],"tool_results":{},"reasoning_details":null}},"Resume"]}
+--
+-- TestRegistryFixtureBlobMatchesItsDocumentedPlaintext pins that, so the two
+-- cannot drift apart. Regenerate with:
+--
+--   printf '%s' '<the json above>' | zstd -q -3 -c | od -An -v -tx1 | tr -d ' \n'
+create table threads (
+    id text primary key,
+    summary text not null,
+    updated_at text not null,
+    data_type text not null,
+    data blob not null,
+    parent_id text,
+    folder_paths text,
+    folder_paths_order text,
+    created_at text
+);
+insert into threads (id, summary, updated_at, data_type, data, folder_paths, folder_paths_order, created_at)
+values (
+    'registry-zed-legacy',
+    'legacy zed thread',
+    '2026-07-19T08:00:02+00:00',
+    'json',
+    '{"version":"0.2.0","summary":"legacy zed thread","updated_at":"2026-07-19T08:00:02Z","messages":[{"id":1,"role":"user","segments":[{"type":"text","text":"does the pre-compression thread shape still load?"}]},{"id":2,"role":"assistant","segments":[{"type":"thinking","text":"reasoning is not indexed"},{"type":"text","text":"agent-1 threads still parse"}]}]}',
+    '/workspace/registry-demo',
+    '0',
+    '2026-07-19T08:00:00+00:00'
+);
+insert into threads (id, summary, updated_at, data_type, data, folder_paths, folder_paths_order, created_at)
+values (
+    'registry-zed-modern',
+    'read the zed thread store',
+    '2026-07-19T09:00:02+00:00',
+    'zstd',
+    x'28b52ffd6483003d080086913522508b9a03e868169bd8439416496a1b321994fb4d86cc1a41dfdb85974f23d38c60022b002c002a008b8432a014018552787999a37d5993344efe73ab7f407f2c6aeccfcb6716d7c90a1180505e4e87face6027aea1bf3f1a26676c7ed32d3839a1bc6ba338bc555c1ada597ed7033b09cbfa85a93ee26404855a4aad8562042c175427b74fde12d1ba448a68494ca7ec6f974448e2c3592eb0939ea7f1984037bf30a48b48f243f401004fc38f347a032b836cdf1ce97196759946ff1c8c73ebd478fcb021b6acbdb76c90424324324c93cb7fcd0611005d142e1ceb3ab61d3a1e3ecc0569214a1646ec04a6c13272983779a70826280b313abd1ebad04ca6d82f284f7c2af5cc',
+    '/workspace/registry-demo',
+    '0',
+    '2026-07-19T09:00:00+00:00'
+);

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -33,6 +33,13 @@ func hermeticIndexEnv(t *testing.T) string {
 	t.Setenv("DEJA_CURSOR_CLI_ROOT", filepath.Join(tmp, "cursor-cli"))
 	t.Setenv("DEJA_ANTIGRAVITY_ROOT", filepath.Join(tmp, "antigravity"))
 	t.Setenv("DEJA_INCLUDE_SUBAGENTS", "")
+	// Zed resolves its store through the platform data directory, so both the
+	// XDG roots and the deja override are pinned. Without this an index run
+	// reads the contributor's own threads.
+	t.Setenv("DEJA_ZED_ROOT", filepath.Join(tmp, "zed"))
+	t.Setenv("DEJA_ZED_DB", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("FLATPAK_XDG_DATA_HOME", "")
 	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
 	return tmp
 }

--- a/internal/index/zed_test.go
+++ b/internal/index/zed_test.go
@@ -1,0 +1,133 @@
+package index
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// zedThreadRow builds one row the way Zed writes it: the thread document
+// compressed into a zstd frame, addressed by a hex blob literal.
+func zedThreadRow(t *testing.T, id, title, updated, text string) string {
+	t.Helper()
+	body := `{"version":"0.3.0","title":"` + title + `","updated_at":"` + updated + `","messages":[` +
+		`{"User":{"id":"u-` + id + `","content":[{"Text":"` + text + `"}]}},` +
+		`{"Agent":{"content":[{"Text":"reply to ` + id + `"}],"tool_results":{}}}]}`
+	cmd := exec.Command("zstd", "-q", "-3", "-c")
+	cmd.Stdin = strings.NewReader(body)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("compress thread: %v", err)
+	}
+	return "insert or replace into threads (id,summary,updated_at,data_type,data,folder_paths,created_at) values ('" +
+		id + "','" + title + "','" + updated + "','zstd',x'" + hex.EncodeToString(out.Bytes()) +
+		"','/w/app','" + updated + "');"
+}
+
+// A zed thread untouched since the watermark must survive an incremental pass
+// triggered by a change to the shared threads.db — the failure every db-backed
+// harness here is one mistake away from, since the whole store is one file.
+func TestZedIncrementalKeepsUntouchedThreads(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not available")
+	}
+	if _, err := exec.LookPath("zstd"); err != nil {
+		t.Skip("zstd not available")
+	}
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "index")
+	db := filepath.Join(tmp, "zed", "threads", "threads.db")
+	if err := os.MkdirAll(filepath.Dir(db), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	schema := `create table if not exists threads (
+    id text primary key, summary text not null, updated_at text not null,
+    data_type text not null, data blob not null, parent_id text,
+    folder_paths text, folder_paths_order text, created_at text);`
+	run := func(sql string) {
+		t.Helper()
+		cmd := exec.Command("sqlite3", db)
+		cmd.Stdin = strings.NewReader(sql)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("seed: %v: %s", err, out)
+		}
+	}
+
+	run(schema + zedThreadRow(t, "zed-old", "old thread", "2026-07-19T10:00:00+00:00", "oldzedfact about the retry budget"))
+	if err := Ensure(dir, "", false, os.Stderr); err != nil {
+		t.Fatal(err)
+	}
+	if hits, _ := Search(dir, search.Options{Query: "oldzedfact", All: true}); len(hits) == 0 {
+		t.Fatal("old zed thread not indexed on first pass")
+	}
+
+	run(zedThreadRow(t, "zed-new", "new thread", "2026-07-19T11:00:00+00:00", "newzedfact about the cache key"))
+	future := time.Now().Add(time.Hour)
+	_ = os.Chtimes(db, future, future)
+	if err := Ensure(dir, "", false, os.Stderr); err != nil {
+		t.Fatal(err)
+	}
+	if hits, _ := Search(dir, search.Options{Query: "newzedfact", All: true}); len(hits) == 0 {
+		t.Fatal("new zed thread not indexed on incremental pass")
+	}
+	if hits, _ := Search(dir, search.Options{Query: "oldzedfact", All: true}); len(hits) == 0 {
+		t.Fatal("REGRESSION: untouched zed thread vanished after incremental pass")
+	}
+}
+
+// Discovery has to find the store through Zed's own path logic, and the hit has
+// to carry the harness name so `--harness zed` and the search tag work.
+func TestZedStoreIsDiscoveredAndTagged(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not available")
+	}
+	if _, err := exec.LookPath("zstd"); err != nil {
+		t.Skip("zstd not available")
+	}
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "index")
+	db := filepath.Join(tmp, "zed", "threads", "threads.db")
+	if err := os.MkdirAll(filepath.Dir(db), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	schema := `create table threads (
+    id text primary key, summary text not null, updated_at text not null,
+    data_type text not null, data blob not null, parent_id text,
+    folder_paths text, folder_paths_order text, created_at text);`
+	cmd := exec.Command("sqlite3", db)
+	cmd.Stdin = strings.NewReader(schema + zedThreadRow(t, "zed-tagged", "tagged", "2026-07-19T12:00:00+00:00", "zedtaggedfact about the parser"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("seed: %v: %s", err, out)
+	}
+	if err := Ensure(dir, "", false, os.Stderr); err != nil {
+		t.Fatal(err)
+	}
+	hits, err := Search(dir, search.Options{Query: "zedtaggedfact", All: true})
+	if err != nil || len(hits) == 0 {
+		t.Fatalf("hits = %#v, err = %v", hits, err)
+	}
+	if hits[0].Harness != "zed" {
+		t.Fatalf("harness = %q, want zed", hits[0].Harness)
+	}
+	if hits[0].Project != "app" {
+		t.Fatalf("project = %q, want the folder_paths basename", hits[0].Project)
+	}
+	// Filtering by harness must reach it, and must not reach it under another
+	// name — a tag that matches everything is not a tag.
+	tagged, err := Search(dir, search.Options{Query: "zedtaggedfact", All: true, Harness: "zed"})
+	if err != nil || len(tagged) == 0 {
+		t.Fatalf("--harness zed found nothing: %#v, err = %v", tagged, err)
+	}
+	other, err := Search(dir, search.Options{Query: "zedtaggedfact", All: true, Harness: "claude"})
+	if err != nil || len(other) != 0 {
+		t.Fatalf("--harness claude reached a zed thread: %#v, err = %v", other, err)
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -324,6 +324,17 @@ func Registry() []Harness {
 			}},
 		},
 		{
+			// Zed's agent writes no session files: one SQLite store under its
+			// data dir, whose thread bodies are zstd frames rather than JSON.
+			Name: "zed", Load: LoadZed, Files: func() []string { return []string{ZedDB()} },
+			Kinds: []FileKind{{
+				Name:      "zed",
+				Match:     func(p string) bool { return p == ZedDB() },
+				Parse:     dbParse(ParseZedDB, ParseZedDBSince),
+				ParseFrom: dbParseFrom(ParseZedDB, ParseZedDBSince),
+			}},
+		},
+		{
 			Name: "deja", Load: LoadNotes, Files: func() []string { return []string{NotesFile()} },
 			Kinds: []FileKind{{
 				Name:      "deja",

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -43,6 +43,7 @@ func TestFormatRegistryConformance(t *testing.T) {
 		"DEJA_OPENCLAW_ROOT", "OPENCLAW_STATE_DIR",
 		"DEJA_INCLUDE_SUBAGENTS", "DEJA_OPENCODE_DB", "GEMINI_CLI_HOME",
 		"GROK_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+		"DEJA_ZED_ROOT", "DEJA_ZED_DB", "FLATPAK_XDG_DATA_HOME",
 		"DEJA_NOTES_FILE",
 	} {
 		t.Setenv(key, "")
@@ -195,6 +196,27 @@ func parseRegistryFixture(t *testing.T, id, path string) []model.Session {
 			t.Fatalf("create sqlite fixture: %v: %s", runErr, out)
 		}
 		sessions, err = ParseHermesDB(db)
+	case "zed":
+		if !SQLite3Available() {
+			t.Skip("sqlite3 not installed")
+		}
+		sql, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		db := filepath.Join(t.TempDir(), "threads.db")
+		// On stdin rather than as an argument: this fixture documents its
+		// opaque blob in a leading `--` comment, and the sqlite3 CLI reads a
+		// leading `--` as an option.
+		build := exec.Command("sqlite3", db)
+		build.Stdin = strings.NewReader(string(sql))
+		if out, runErr := build.CombinedOutput(); runErr != nil {
+			t.Fatalf("create sqlite fixture: %v: %s", runErr, out)
+		}
+		// Without zstd the fixture's compressed thread is skipped and its
+		// uncompressed one still parses, which is the degradation the harness
+		// is documented to have rather than a reason to skip the row.
+		sessions, err = ParseZedDB(db)
 	case "qwen":
 		sessions, err = ParseQwenFile(path)
 	case "pi":

--- a/internal/sources/skip.go
+++ b/internal/sources/skip.go
@@ -1,13 +1,20 @@
 package sources
 
-// SkipReason says why a harness deja can see on disk produced nothing. Today
-// that is only a missing sqlite3 CLI: five stores are read through it, and an
+// SkipReason says why a harness deja can see on disk produced nothing. That is
+// a missing external tool: six stores are read through the sqlite3 CLI, and an
 // index run that names every harness it read while staying silent about the
 // one it could not made an empty deja look like an empty history (#794).
+//
+// Zed needs a second tool. Its store is SQLite like the others, but every
+// thread body inside it is a zstd frame, so sqlite3 alone opens the store and
+// reads nothing out of it — the failure this exists to stop, one layer down.
 //
 // It returns "" when there is nothing to explain — including on a machine that
 // never used the harness, where a note about a tool would be noise.
 func SkipReason(harness string) string {
+	if harness == "zed" {
+		return zedSkipReason()
+	}
 	if SQLite3Available() {
 		return ""
 	}
@@ -28,4 +35,20 @@ func SkipReason(harness string) string {
 		return ""
 	}
 	return "sqlite3 CLI not found"
+}
+
+func zedSkipReason() string {
+	if !fileExists(ZedDB()) {
+		return ""
+	}
+	sqlite, zstd := SQLite3Available(), ZstdAvailable()
+	switch {
+	case !sqlite && !zstd:
+		return "sqlite3 and zstd CLIs not found"
+	case !sqlite:
+		return "sqlite3 CLI not found"
+	case !zstd:
+		return "zstd CLI not found"
+	}
+	return ""
 }

--- a/internal/sources/zed.go
+++ b/internal/sources/zed.go
@@ -249,7 +249,7 @@ func zedSession(db string, r zedRow) (model.Session, bool) {
 	s := model.Session{
 		ID:      r.ID,
 		Harness: "zed",
-		Project: projectName(zedFolder(r.Folders)),
+		Project: projectName(zedProject(r.Folders, th)),
 		Path:    db,
 		Title:   title,
 		Started: started,
@@ -320,6 +320,17 @@ type zedThread struct {
 	Summary   string            `json:"summary"`
 	UpdatedAt string            `json:"updated_at"`
 	Messages  []json.RawMessage `json:"messages"`
+	// Snapshot is where the thread was opened. The folder_paths column is the
+	// first place to look and is not always there: it arrives by ALTER TABLE,
+	// so a store an older Zed wrote and a newer one never opened has only the
+	// original five columns. Every thread document carries the path anyway.
+	Snapshot zedSnapshot `json:"initial_project_snapshot"`
+}
+
+type zedSnapshot struct {
+	Worktrees []struct {
+		Path string `json:"worktree_path"`
+	} `json:"worktree_snapshots"`
 }
 
 // zedMessage reads one message in either of the two shapes a live store mixes.
@@ -426,6 +437,27 @@ func zedLegacyMessage(m map[string]json.RawMessage) (role, text string) {
 		b.WriteString(seg.Text)
 	}
 	return role, b.String()
+}
+
+// zedProject is where a thread belongs: the folder_paths column when the store
+// has it, and the path the thread document recorded when it does not.
+//
+// This matters more than a missing label. A session with no project is
+// invisible to auto-recall, which ranks within the project the user is working
+// in — so on a store without that column, every Zed thread was indexed and
+// then unreachable by the thing that recalls without being asked. Measured on a
+// real store: thirty threads, thirty of them in project "-", and every one of
+// them carrying its own worktree path in the document.
+func zedProject(folders string, th zedThread) string {
+	if p := zedFolder(folders); p != "" {
+		return p
+	}
+	for _, w := range th.Snapshot.Worktrees {
+		if p := strings.TrimSpace(w.Path); p != "" {
+			return p
+		}
+	}
+	return ""
 }
 
 // zedFolder picks the project directory out of a serialized PathList. Zed

--- a/internal/sources/zed.go
+++ b/internal/sources/zed.go
@@ -1,0 +1,456 @@
+package sources
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Zed's built-in agent keeps every thread in one SQLite store, and unlike the
+// other db-backed harnesses the thread body is not JSON in a text column: it
+// is a zstd frame in a BLOB. Two things follow from that, and both are easy to
+// get wrong.
+//
+// The store lives under Zed's *data* directory, not its config directory.
+// ~/.config/zed exists on every platform and holds settings, keymaps and
+// prompts — it holds no threads at all. On macOS the threads are under
+// ~/Library/Application Support/Zed; ZedRoot mirrors Zed's own paths::data_dir.
+//
+// Reading a body needs a zstd decoder. deja has no runtime Go dependencies and
+// the standard library has no zstd, so the frame goes through the `zstd` CLI,
+// gated by ZstdAvailable the way the five sqlite3-backed stores are gated by
+// SQLite3Available. Without it a Zed store is reported as skipped rather than
+// as empty (see SkipReason).
+//
+// Verified against Zed 0.61 (crates/agent/src/db.rs, crates/agent/src/thread.rs,
+// crates/paths/src/paths.rs at 968a13d2).
+
+// ZedRoot is Zed's data directory, following paths::data_dir() upstream.
+// DEJA_ZED_ROOT relocates it for tests and for a relocated install.
+func ZedRoot() string {
+	if p := os.Getenv("DEJA_ZED_ROOT"); p != "" {
+		return p
+	}
+	return zedDataDir(runtime.GOOS)
+}
+
+// zedDataDir takes the platform as an argument rather than reading runtime.GOOS
+// so all three layouts stay reachable from a test on any machine. A Linux-only
+// CI job would otherwise never execute the macOS and Windows branches, which
+// are the two a contributor is least able to check by hand.
+func zedDataDir(goos string) string {
+	switch goos {
+	case "darwin":
+		return filepath.Join(Home(), "Library", "Application Support", "Zed")
+	case "windows":
+		if p := os.Getenv("LOCALAPPDATA"); p != "" {
+			return filepath.Join(p, "Zed")
+		}
+		return filepath.Join(Home(), "AppData", "Local", "Zed")
+	default:
+		// Linux and FreeBSD go through dirs::data_local_dir(), which is
+		// XDG_DATA_HOME when set. A Flatpak install overrides it outright.
+		if p := os.Getenv("FLATPAK_XDG_DATA_HOME"); p != "" {
+			return filepath.Join(p, "zed")
+		}
+		if p := os.Getenv("XDG_DATA_HOME"); p != "" {
+			return filepath.Join(p, "zed")
+		}
+		return filepath.Join(Home(), ".local", "share", "zed")
+	}
+}
+
+// ZedDB is the single thread store. DEJA_ZED_DB points at one directly, which
+// is how the conformance fixture is read without a Zed install.
+func ZedDB() string {
+	return EnvPath("DEJA_ZED_DB", filepath.Join(ZedRoot(), "threads", "threads.db"))
+}
+
+// ZstdAvailable reports whether the zstd CLI the zed parser shells out to is
+// on PATH. Zed compresses every thread it writes, so without this the store is
+// readable but its contents are not.
+func ZstdAvailable() bool {
+	_, err := exec.LookPath("zstd")
+	return err == nil
+}
+
+func LoadZed() []model.Session {
+	ss, err := ParseZedDBSince(ZedDB(), time.Time{})
+	if err != nil {
+		return nil
+	}
+	return ss
+}
+
+func ParseZedDB(db string) ([]model.Session, error) {
+	return ParseZedDBSince(db, time.Time{})
+}
+
+// zedCols keeps one row shape across both schema generations. parent_id,
+// folder_paths, folder_paths_order and created_at were added by ALTER TABLE
+// statements Zed runs at startup, so a store written by an older Zed that a
+// newer one has never opened still has only the original five columns.
+const (
+	zedFullCols = `id,summary,updated_at,created_at,folder_paths,data_type,hex(data) as data`
+	zedBaseCols = `id,summary,updated_at,null as created_at,null as folder_paths,data_type,hex(data) as data`
+)
+
+type zedRow struct {
+	ID        string `json:"id"`
+	Summary   string `json:"summary"`
+	UpdatedAt string `json:"updated_at"`
+	CreatedAt string `json:"created_at"`
+	Folders   string `json:"folder_paths"`
+	DataType  string `json:"data_type"`
+	Data      string `json:"data"`
+}
+
+// ParseZedDBSince reads threads updated after t. Every thread is one session:
+// Zed has no notion of a session spanning threads, and the thread id is the
+// stable identifier its own UI resumes by.
+func ParseZedDBSince(db string, t time.Time) ([]model.Session, error) {
+	// The sqlite3 CLI creates a missing database on open — never let it.
+	if fi, err := os.Stat(db); err != nil || fi.Size() == 0 {
+		return nil, nil
+	}
+	where := zedSinceWhere(t)
+	rows, err := zedRows(db, zedFullCols, where)
+	if err != nil {
+		// Retry against the original schema rather than reporting a whole
+		// harness as broken because two columns are missing.
+		var baseErr error
+		rows, baseErr = zedRows(db, zedBaseCols, where)
+		if baseErr != nil {
+			return nil, err
+		}
+	}
+	out := make([]model.Session, 0, len(rows))
+	for _, r := range rows {
+		s, ok := zedSession(db, r)
+		if !ok {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// zedSinceWhere filters on updated_at without comparing it as text. The column
+// is Rust's to_rfc3339 output and carries a "+00:00" offset, while a Go
+// watermark formatted with RFC3339Nano ends in "Z" and has its trailing
+// fractional zeros stripped. Comparing those as strings is wrong in both
+// directions: '.' sorts below 'Z', so a row a fraction of a second *newer*
+// than a whole-second watermark compares as older and would be dropped from
+// every incremental run. strftime normalises both sides to the same UTC shape
+// first. A timestamp SQLite cannot parse yields NULL and is kept, because a
+// row deja cannot place is a row to re-read, not one to discard.
+func zedSinceWhere(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	const norm = `strftime('%Y-%m-%dT%H:%M:%f',updated_at)`
+	w := sqlEscape(t.UTC().Format("2006-01-02T15:04:05.000"))
+	return " where " + norm + " is null or " + norm + " > '" + w + "'"
+}
+
+func zedRows(db, cols, where string) ([]zedRow, error) {
+	q := "select " + cols + " from threads" + where + " order by updated_at"
+	cmd := exec.Command("sqlite3", "-readonly", "-json", db, ".timeout 5000", q)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	dec := json.NewDecoder(stdout)
+	tok, err := dec.Token()
+	if err != nil {
+		waitErr := cmd.Wait()
+		if err == io.EOF {
+			// Empty stdout means either a query that matched nothing or one
+			// sqlite3 refused to run. Reporting the second as "no sessions"
+			// makes a harness disappear from recall while doctor still calls
+			// the store healthy.
+			if waitErr != nil {
+				return nil, fmt.Errorf("zed: query failed, the store schema may have changed: %w", waitErr)
+			}
+			return nil, nil
+		}
+		return nil, err
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '[' {
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("zed: bad sqlite json")
+	}
+	var rows []zedRow
+	for dec.More() {
+		var r zedRow
+		if err := dec.Decode(&r); err != nil {
+			_ = cmd.Wait()
+			return nil, err
+		}
+		rows = append(rows, r)
+	}
+	if _, err := dec.Token(); err != nil && err != io.EOF {
+		_ = cmd.Wait()
+		return nil, err
+	}
+	if err := cmd.Wait(); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// zedSession turns one row into a session, or reports false when the row
+// carries nothing worth indexing. A body that will not decode is skipped
+// rather than failing the store: one unreadable thread should not cost a user
+// every other thread they have.
+func zedSession(db string, r zedRow) (model.Session, bool) {
+	if r.ID == "" {
+		return model.Session{}, false
+	}
+	doc, err := zedBody(r.DataType, r.Data)
+	if err != nil {
+		return model.Session{}, false
+	}
+	var th zedThread
+	if err := json.Unmarshal(doc, &th); err != nil {
+		return model.Session{}, false
+	}
+	updated := zedTime(r.UpdatedAt)
+	if updated.IsZero() {
+		updated = zedTime(th.UpdatedAt)
+	}
+	// created_at is set from updated_at when Zed first writes a thread, so on a
+	// store predating the column the window collapses to a point rather than
+	// starting at the epoch.
+	started := zedTime(r.CreatedAt)
+	if started.IsZero() {
+		started = updated
+	}
+	title := th.Title
+	if title == "" {
+		title = th.Summary // legacy agent-1 threads name the field differently
+	}
+	if title == "" {
+		title = r.Summary
+	}
+	s := model.Session{
+		ID:      r.ID,
+		Harness: "zed",
+		Project: projectName(zedFolder(r.Folders)),
+		Path:    db,
+		Title:   title,
+		Started: started,
+		Updated: updated,
+	}
+	// Zed stores no per-message timestamp in either thread format, so every
+	// message inherits the thread's start the way aider's do. Order is carried
+	// by the array itself, which is what recall actually reads.
+	for _, raw := range th.Messages {
+		role, text := zedMessage(raw)
+		if text == "" || HarnessAuthored(role) {
+			continue
+		}
+		s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: started})
+	}
+	if len(s.Messages) == 0 {
+		return model.Session{}, false
+	}
+	return s, true
+}
+
+// zedBody undoes the storage encoding. data_type is "zstd" for everything Zed
+// writes today and "json" for rows written before compression landed; an
+// unknown value is an error rather than a guess, because feeding a compressed
+// frame to the JSON parser would report a corrupt thread instead of a format
+// deja does not know yet.
+func zedBody(dataType, hexData string) ([]byte, error) {
+	raw, err := hex.DecodeString(hexData)
+	if err != nil {
+		return nil, err
+	}
+	switch dataType {
+	case "json", "":
+		return raw, nil
+	case "zstd":
+		return zstdDecode(raw)
+	default:
+		return nil, fmt.Errorf("zed: unknown data_type %q", dataType)
+	}
+}
+
+// zstdDecode shells out per frame. Concatenating every frame into one `zstd -d`
+// would cost one process instead of N, but a single corrupt frame would then
+// take the whole store with it, and a store deja can half-read is worth more
+// than one it refuses. Incremental runs decompress only the threads that moved.
+func zstdDecode(frame []byte) ([]byte, error) {
+	if len(frame) == 0 {
+		return nil, fmt.Errorf("zed: empty thread body")
+	}
+	cmd := exec.Command("zstd", "-d", "-c", "-q")
+	cmd.Stdin = bytes.NewReader(frame)
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("zed: zstd -d: %w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	return out.Bytes(), nil
+}
+
+// zedThread is the flattened thread document. Zed serialises
+// SerializedThread{#[serde(flatten)] thread, version}, so the version sits
+// beside the thread's own fields rather than wrapping them. `title` is the
+// current name for what agent-1 threads called `summary`.
+type zedThread struct {
+	Version   string            `json:"version"`
+	Title     string            `json:"title"`
+	Summary   string            `json:"summary"`
+	UpdatedAt string            `json:"updated_at"`
+	Messages  []json.RawMessage `json:"messages"`
+}
+
+// zedMessage reads one message in either of the two shapes a live store mixes.
+//
+// Current threads (version 0.3.0) hold Rust's externally tagged Message enum:
+// {"User":{...}}, {"Agent":{...}} or the bare string "Resume". Threads written
+// by agent-1 and not re-saved since hold {"role":"user","segments":[...]}.
+// Both matter to deja specifically, whose pitch is the history from before it
+// was installed: Zed rewrites a thread in the new shape only when that thread
+// is next saved.
+//
+// Only user and assistant text is indexed. Thinking, tool payloads, images and
+// mentions' inlined file bodies are skipped by design, as they are for cline.
+func zedMessage(raw json.RawMessage) (role, text string) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == `"Resume"` {
+		// A resume marker is a control record, not something anyone said.
+		return "", ""
+	}
+	var tagged map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &tagged); err != nil {
+		return "", ""
+	}
+	if body, ok := tagged["User"]; ok {
+		return "user", zedContentText(body, "Text", "Mention")
+	}
+	if body, ok := tagged["Agent"]; ok {
+		return "assistant", zedContentText(body, "Text")
+	}
+	return zedLegacyMessage(tagged)
+}
+
+// zedContentText joins the wanted variants of a content block array. A Text
+// block is a bare string under its tag; a Mention is an object whose `content`
+// is the text Zed inlined for the model, which is the only part of it a reader
+// can index.
+func zedContentText(body json.RawMessage, keep ...string) string {
+	var msg struct {
+		Content []map[string]json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(body, &msg); err != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, block := range msg.Content {
+		for _, tag := range keep {
+			raw, ok := block[tag]
+			if !ok {
+				continue
+			}
+			var part string
+			if err := json.Unmarshal(raw, &part); err != nil {
+				// Mention is a struct, not a string.
+				var m struct {
+					Content string `json:"content"`
+				}
+				if err := json.Unmarshal(raw, &m); err != nil {
+					continue
+				}
+				part = m.Content
+			}
+			if part == "" {
+				continue
+			}
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(part)
+		}
+	}
+	return b.String()
+}
+
+// zedLegacyMessage reads an agent-1 message. Segments are internally tagged
+// ({"type":"text","text":...}), and only text segments are indexed; a thinking
+// segment carries the same tag shape and is dropped here.
+func zedLegacyMessage(m map[string]json.RawMessage) (role, text string) {
+	rawRole, ok := m["role"]
+	if !ok {
+		return "", ""
+	}
+	if err := json.Unmarshal(rawRole, &role); err != nil {
+		return "", ""
+	}
+	rawSegments, ok := m["segments"]
+	if !ok {
+		return "", ""
+	}
+	var segments []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(rawSegments, &segments); err != nil {
+		return "", ""
+	}
+	var b strings.Builder
+	for _, seg := range segments {
+		if seg.Type != "text" || seg.Text == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(seg.Text)
+	}
+	return role, b.String()
+}
+
+// zedFolder picks the project directory out of a serialized PathList. Zed
+// writes the paths newline-joined in lexicographic order with a separate
+// comma-joined index for display order; deja wants one project name, so the
+// first path wins and multi-root threads are named after it.
+func zedFolder(folders string) string {
+	for _, p := range strings.Split(folders, "\n") {
+		if p = strings.TrimSpace(p); p != "" {
+			return p
+		}
+	}
+	return ""
+}
+
+// zedTime accepts the offset form Rust's to_rfc3339 writes as well as the
+// plain forms a hand-edited or migrated row can hold.
+func zedTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
+}

--- a/internal/sources/zed_test.go
+++ b/internal/sources/zed_test.go
@@ -1,0 +1,605 @@
+package sources
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// zedHome isolates a test from a real Zed install. Both the store location and
+// the home it is derived from are pinned, so a contributor with threads on disk
+// runs the same test as CI.
+func zedHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("FLATPAK_XDG_DATA_HOME", "")
+	t.Setenv("DEJA_ZED_ROOT", filepath.Join(home, "zed"))
+	t.Setenv("DEJA_ZED_DB", "")
+	return home
+}
+
+func zedTestDB(t *testing.T, sql string) string {
+	t.Helper()
+	if !SQLite3Available() {
+		t.Skip("sqlite3 not installed")
+	}
+	db := filepath.Join(t.TempDir(), "threads.db")
+	// The script goes in on stdin, not as an argument: the fixture opens with a
+	// `--` comment and the sqlite3 CLI reads a leading `--` as an option.
+	cmd := exec.Command("sqlite3", db)
+	cmd.Stdin = strings.NewReader(sql)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create sqlite fixture: %v: %s", err, out)
+	}
+	return db
+}
+
+// zedZstdHex compresses a thread body the way Zed does, so a test row is a real
+// frame rather than a recorded one.
+func zedZstdHex(t *testing.T, plain string) string {
+	t.Helper()
+	if !ZstdAvailable() {
+		t.Skip("zstd not installed")
+	}
+	cmd := exec.Command("zstd", "-q", "-3", "-c")
+	cmd.Stdin = strings.NewReader(plain)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("compress fixture body: %v", err)
+	}
+	return hex.EncodeToString(out.Bytes())
+}
+
+const zedSchema = `create table threads (
+    id text primary key,
+    summary text not null,
+    updated_at text not null,
+    data_type text not null,
+    data blob not null,
+    parent_id text,
+    folder_paths text,
+    folder_paths_order text,
+    created_at text
+);`
+
+// zedSchemaOriginal is the table as Zed first created it, before the ALTER TABLE
+// statements that added parent_id, the folder columns and created_at.
+const zedSchemaOriginal = `create table threads (
+    id text primary key,
+    summary text not null,
+    updated_at text not null,
+    data_type text not null,
+    data blob not null
+);`
+
+const zedModernBody = `{"version":"0.3.0","title":"modern thread","updated_at":"2026-07-19T09:00:02Z","messages":[{"User":{"id":"u1","content":[{"Text":"first question"}]}},{"Agent":{"content":[{"Text":"first answer"}],"tool_results":{},"reasoning_details":null}}]}`
+
+func TestParseZedDBReadsBothStorageEncodings(t *testing.T) {
+	zedHome(t)
+	sql, err := os.ReadFile(filepath.Join("..", "..", "fixtures", "registry", "zed", "zed.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := zedTestDB(t, string(sql))
+	if !ZstdAvailable() {
+		t.Skip("zstd not installed")
+	}
+	sessions, err := ParseZedDB(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("sessions = %d, want 2: %#v", len(sessions), sessions)
+	}
+	// Ordered by updated_at, so the pre-compression thread comes first.
+	want := []struct {
+		id, title string
+		texts     []string
+	}{
+		{"registry-zed-legacy", "legacy zed thread", []string{"does the pre-compression thread shape still load?", "agent-1 threads still parse"}},
+		{"registry-zed-modern", "read the zed thread store", []string{"where does zed keep its agent threads?", "in threads.db under the data dir"}},
+	}
+	for i, w := range want {
+		got := sessions[i]
+		if got.ID != w.id || got.Title != w.title {
+			t.Fatalf("session %d = %q/%q, want %q/%q", i, got.ID, got.Title, w.id, w.title)
+		}
+		if got.Harness != "zed" || got.Project != "registry-demo" || got.Path != db {
+			t.Fatalf("session %d identity = %#v", i, got)
+		}
+		if got.Started.IsZero() || got.Updated.IsZero() || !got.Started.Before(got.Updated) {
+			t.Fatalf("session %d window = %v..%v", i, got.Started, got.Updated)
+		}
+		if len(got.Messages) != len(w.texts) {
+			t.Fatalf("session %d messages = %#v", i, got.Messages)
+		}
+		for j, text := range w.texts {
+			role := "user"
+			if j%2 == 1 {
+				role = "assistant"
+			}
+			if got.Messages[j].Role != role || got.Messages[j].Text != text {
+				t.Fatalf("session %d message %d = %#v, want %s/%q", i, j, got.Messages[j], role, text)
+			}
+			if !got.Messages[j].Time.Equal(got.Started) {
+				t.Fatalf("session %d message %d time = %v, want the thread start %v", i, j, got.Messages[j].Time, got.Started)
+			}
+		}
+	}
+}
+
+// A thread whose body will not decode costs that thread, not the store. The
+// opposite — returning an error — would drop every other thread a user has
+// because one row is truncated.
+func TestParseZedDBSkipsUnreadableThreadWithoutLosingTheStore(t *testing.T) {
+	zedHome(t)
+	good := zedZstdHex(t, zedModernBody)
+	sql := zedSchema + `
+insert into threads (id,summary,updated_at,data_type,data,folder_paths,created_at) values
+ ('broken-frame','truncated','2026-07-19T09:00:00+00:00','zstd',x'28b52ffd00',  '/w/p','2026-07-19T09:00:00+00:00'),
+ ('unknown-type','future encoding','2026-07-19T09:00:01+00:00','brotli',x'00',   '/w/p','2026-07-19T09:00:01+00:00'),
+ ('not-json','json but not a thread','2026-07-19T09:00:02+00:00','json','not json at all','/w/p','2026-07-19T09:00:02+00:00'),
+ ('no-messages','empty thread','2026-07-19T09:00:03+00:00','json','{"version":"0.3.0","title":"t","messages":[]}','/w/p','2026-07-19T09:00:03+00:00'),
+ ('ok','fine','2026-07-19T09:00:04+00:00','zstd',x'` + good + `','/w/p','2026-07-19T09:00:04+00:00');`
+	sessions, err := ParseZedDB(zedTestDB(t, sql))
+	if err != nil {
+		t.Fatalf("one unreadable row must not fail the store: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "ok" {
+		t.Fatalf("sessions = %#v, want only the readable thread", sessions)
+	}
+}
+
+// The regression this guards is silent: comparing Zed's "+00:00" timestamps
+// against a Go watermark as text drops rows that are newer by a fraction of a
+// second, because '.' sorts below 'Z'. An incremental index would then never
+// see them again.
+func TestParseZedDBSinceKeepsARowNewerByAFractionOfASecond(t *testing.T) {
+	zedHome(t)
+	body := zedZstdHex(t, zedModernBody)
+	sql := zedSchema + `
+insert into threads (id,summary,updated_at,data_type,data,folder_paths,created_at) values
+ ('older','older','2026-07-19T08:59:59.900+00:00','zstd',x'` + body + `','/w/p','2026-07-19T08:59:00+00:00'),
+ ('fraction-newer','fraction newer','2026-07-19T09:00:00.500+00:00','zstd',x'` + body + `','/w/p','2026-07-19T09:00:00+00:00'),
+ ('clearly-newer','clearly newer','2026-07-19T09:00:05+00:00','zstd',x'` + body + `','/w/p','2026-07-19T09:00:05+00:00');`
+	db := zedTestDB(t, sql)
+
+	watermark := time.Date(2026, 7, 19, 9, 0, 0, 0, time.UTC)
+	sessions, err := ParseZedDBSince(db, watermark)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ids []string
+	for _, s := range sessions {
+		ids = append(ids, s.ID)
+	}
+	if strings.Join(ids, ",") != "fraction-newer,clearly-newer" {
+		t.Fatalf("since %v returned %v, want the two newer rows", watermark, ids)
+	}
+
+	// A zero watermark is a full read, not a filter.
+	all, err := ParseZedDBSince(db, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("zero watermark returned %d sessions, want 3", len(all))
+	}
+}
+
+// A timestamp SQLite cannot parse must be re-read rather than dropped: a row
+// deja cannot place is not a row it has already seen.
+func TestParseZedDBSinceKeepsRowsWithAnUnparseableTimestamp(t *testing.T) {
+	zedHome(t)
+	body := zedZstdHex(t, zedModernBody)
+	sql := zedSchema + `
+insert into threads (id,summary,updated_at,data_type,data,folder_paths,created_at) values
+ ('no-timestamp','unparseable','not a timestamp','zstd',x'` + body + `','/w/p','2026-07-19T09:00:00+00:00');`
+	sessions, err := ParseZedDBSince(zedTestDB(t, sql), time.Date(2026, 7, 19, 9, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "no-timestamp" {
+		t.Fatalf("sessions = %#v, want the unplaceable row kept", sessions)
+	}
+	// updated_at is unusable, so the thread document's own field carries the window.
+	if got := sessions[0].Updated.Format(time.RFC3339); got != "2026-07-19T09:00:02Z" {
+		t.Fatalf("updated = %s, want the value from the thread body", got)
+	}
+}
+
+// Zed adds parent_id, the folder columns and created_at with ALTER TABLE at
+// startup, so a store an older Zed wrote and a newer one never opened has only
+// the original five columns.
+func TestParseZedDBFallsBackToTheOriginalSchema(t *testing.T) {
+	zedHome(t)
+	body := zedZstdHex(t, zedModernBody)
+	sql := zedSchemaOriginal + `
+insert into threads (id,summary,updated_at,data_type,data) values
+ ('pre-alter','pre alter','2026-07-19T09:00:02+00:00','zstd',x'` + body + `');`
+	sessions, err := ParseZedDB(zedTestDB(t, sql))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %#v, want one", sessions)
+	}
+	got := sessions[0]
+	if got.ID != "pre-alter" || len(got.Messages) != 2 {
+		t.Fatalf("session = %#v", got)
+	}
+	// With no folder column there is no project path, and with no created_at the
+	// window collapses onto updated_at rather than starting at the epoch.
+	if got.Project != "-" {
+		t.Fatalf("project = %q, want the unknown-project marker", got.Project)
+	}
+	if !got.Started.Equal(got.Updated) || got.Started.IsZero() {
+		t.Fatalf("window = %v..%v, want a single instant", got.Started, got.Updated)
+	}
+}
+
+func TestParseZedDBOnAMissingOrEmptyStoreReturnsNothing(t *testing.T) {
+	zedHome(t)
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty.db")
+	if err := os.WriteFile(empty, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{filepath.Join(dir, "absent.db"), empty} {
+		sessions, err := ParseZedDB(path)
+		if err != nil || sessions != nil {
+			t.Fatalf("%s: sessions = %#v, err = %v", filepath.Base(path), sessions, err)
+		}
+		// The sqlite3 CLI creates a database it is asked to open; nothing here may.
+		if path != empty {
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Fatalf("%s was created by the parser", path)
+			}
+		}
+	}
+	// LoadZed goes through the same guard and reports nothing rather than failing.
+	t.Setenv("DEJA_ZED_DB", filepath.Join(dir, "absent.db"))
+	if got := LoadZed(); got != nil {
+		t.Fatalf("LoadZed = %#v, want nil", got)
+	}
+}
+
+func TestZedMessageIgnoresControlRecordsAndNonTextBlocks(t *testing.T) {
+	cases := []struct {
+		name, raw, role, text string
+	}{
+		{"user text", `{"User":{"id":"u","content":[{"Text":"hello"}]}}`, "user", "hello"},
+		{"user text joined", `{"User":{"id":"u","content":[{"Text":"one"},{"Text":"two"}]}}`, "user", "one\ntwo"},
+		{"mention keeps the inlined content", `{"User":{"id":"u","content":[{"Mention":{"uri":"file:///a.go","content":"package a"}}]}}`, "user", "package a"},
+		{"image is skipped", `{"User":{"id":"u","content":[{"Image":{"source":"..."}},{"Text":"look"}]}}`, "user", "look"},
+		{"agent text", `{"Agent":{"content":[{"Text":"answer"}],"tool_results":{}}}`, "assistant", "answer"},
+		{"thinking is skipped", `{"Agent":{"content":[{"Thinking":{"text":"private","signature":null}},{"Text":"answer"}],"tool_results":{}}}`, "assistant", "answer"},
+		{"redacted thinking is skipped", `{"Agent":{"content":[{"RedactedThinking":"opaque"},{"Text":"answer"}],"tool_results":{}}}`, "assistant", "answer"},
+		{"tool use is skipped", `{"Agent":{"content":[{"ToolUse":{"name":"grep","input":{}}}],"tool_results":{}}}`, "assistant", ""},
+		{"resume marker is not speech", `"Resume"`, "", ""},
+		{"legacy text segments", `{"id":1,"role":"assistant","segments":[{"type":"text","text":"old"}]}`, "assistant", "old"},
+		{"legacy thinking segment is skipped", `{"id":1,"role":"assistant","segments":[{"type":"thinking","text":"private"},{"type":"text","text":"old"}]}`, "assistant", "old"},
+		{"legacy system role is still reported", `{"id":1,"role":"system","segments":[{"type":"text","text":"preamble"}]}`, "system", "preamble"},
+		{"content is not an array", `{"User":{"id":"u","content":"nope"}}`, "user", ""},
+		{"mention without content", `{"User":{"id":"u","content":[{"Mention":{"uri":"file:///a.go"}}]}}`, "user", ""},
+		{"legacy role is not a string", `{"role":42,"segments":[{"type":"text","text":"x"}]}`, "", ""},
+		{"legacy without segments", `{"role":"user"}`, "", ""},
+		{"legacy segments are not an array", `{"role":"user","segments":"nope"}`, "", ""},
+		{"legacy empty segments", `{"role":"user","segments":[]}`, "user", ""},
+		{"unknown shape", `{"Something":{"content":[]}}`, "", ""},
+		{"not an object", `42`, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			role, text := zedMessage([]byte(tc.raw))
+			if role != tc.role || text != tc.text {
+				t.Fatalf("zedMessage = %q/%q, want %q/%q", role, text, tc.role, tc.text)
+			}
+		})
+	}
+}
+
+// A system-role message is reported by zedMessage and dropped by the session
+// builder, which is where every harness's authored-preamble rule lives.
+func TestParseZedDBDropsHarnessAuthoredRoles(t *testing.T) {
+	zedHome(t)
+	body := `{"version":"0.2.0","summary":"s","updated_at":"2026-07-19T09:00:02Z","messages":[` +
+		`{"id":1,"role":"system","segments":[{"type":"text","text":"preamble"}]},` +
+		`{"id":2,"role":"user","segments":[{"type":"text","text":"real turn"}]}]}`
+	sql := zedSchema + `
+insert into threads (id,summary,updated_at,data_type,data,folder_paths,created_at) values
+ ('roles','roles','2026-07-19T09:00:02+00:00','json','` + body + `','/w/p','2026-07-19T09:00:00+00:00');`
+	sessions, err := ParseZedDB(zedTestDB(t, sql))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || len(sessions[0].Messages) != 1 || sessions[0].Messages[0].Text != "real turn" {
+		t.Fatalf("sessions = %#v, want only the user turn", sessions)
+	}
+}
+
+func TestZedFolderTakesTheFirstPath(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"/a/one", "/a/one"},
+		{"/a/one\n/b/two", "/a/one"},
+		{"\n\n/b/two", "/b/two"},
+		{"   \n", ""},
+	}
+	for _, tc := range cases {
+		if got := zedFolder(tc.in); got != tc.want {
+			t.Fatalf("zedFolder(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestZedTimeAcceptsTheFormsAStoreHolds(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"2026-07-19T09:00:02+00:00", "2026-07-19T09:00:02Z"},
+		{"2026-07-19T09:00:02.5Z", "2026-07-19T09:00:02Z"},
+		{"2026-07-19 09:00:02", "2026-07-19T09:00:02Z"},
+		{"not a time", ""},
+	}
+	for _, tc := range cases {
+		got := zedTime(tc.in)
+		if tc.want == "" {
+			if !got.IsZero() {
+				t.Fatalf("zedTime(%q) = %v, want zero", tc.in, got)
+			}
+			continue
+		}
+		if got.Format(time.RFC3339) != tc.want {
+			t.Fatalf("zedTime(%q) = %v, want %s", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestZedRootFollowsZedsDataDirAndItsOverride(t *testing.T) {
+	home := zedHome(t)
+	// The override wins everywhere, which is what the fixtures and the doctor
+	// store check rely on.
+	if got := ZedRoot(); got != filepath.Join(home, "zed") {
+		t.Fatalf("DEJA_ZED_ROOT ignored: %q", got)
+	}
+	if got := ZedDB(); got != filepath.Join(home, "zed", "threads", "threads.db") {
+		t.Fatalf("ZedDB = %q", got)
+	}
+	t.Setenv("DEJA_ZED_DB", filepath.Join(home, "elsewhere.db"))
+	if got := ZedDB(); got != filepath.Join(home, "elsewhere.db") {
+		t.Fatalf("DEJA_ZED_DB ignored: %q", got)
+	}
+
+	// Without the override the default is Zed's own data dir, which is not the
+	// config dir this parser was first reported against.
+	t.Setenv("DEJA_ZED_ROOT", "")
+	got := ZedRoot()
+	var want string
+	switch runtime.GOOS {
+	case "darwin":
+		want = filepath.Join(home, "Library", "Application Support", "Zed")
+	case "windows":
+		want = filepath.Join(home, "AppData", "Local", "Zed")
+	default:
+		want = filepath.Join(home, ".local", "share", "zed")
+	}
+	if got != want {
+		t.Fatalf("ZedRoot = %q, want %q", got, want)
+	}
+	if strings.Contains(got, filepath.Join(".config", "zed")) {
+		t.Fatalf("ZedRoot points at the config dir: %q", got)
+	}
+}
+
+// Every platform layout is asserted on every platform. The macOS and Windows
+// paths are the two a contributor is least able to check by hand, and a
+// Linux-only CI job would never reach them through runtime.GOOS.
+func TestZedDataDirCoversEveryPlatformLayout(t *testing.T) {
+	home := zedHome(t)
+	t.Run("darwin", func(t *testing.T) {
+		want := filepath.Join(home, "Library", "Application Support", "Zed")
+		if got := zedDataDir("darwin"); got != want {
+			t.Fatalf("zedDataDir(darwin) = %q, want %q", got, want)
+		}
+	})
+	t.Run("windows local app data", func(t *testing.T) {
+		want := filepath.Join(home, "AppData", "Local", "Zed")
+		if got := zedDataDir("windows"); got != want {
+			t.Fatalf("zedDataDir(windows) = %q, want %q", got, want)
+		}
+	})
+	t.Run("windows without LOCALAPPDATA", func(t *testing.T) {
+		t.Setenv("LOCALAPPDATA", "")
+		want := filepath.Join(home, "AppData", "Local", "Zed")
+		if got := zedDataDir("windows"); got != want {
+			t.Fatalf("zedDataDir(windows) = %q, want %q", got, want)
+		}
+	})
+	for _, goos := range []string{"linux", "freebsd"} {
+		t.Run(goos, func(t *testing.T) {
+			want := filepath.Join(home, ".local", "share", "zed")
+			if got := zedDataDir(goos); got != want {
+				t.Fatalf("zedDataDir(%s) = %q, want %q", goos, got, want)
+			}
+		})
+	}
+	t.Run("XDG_DATA_HOME", func(t *testing.T) {
+		t.Setenv("XDG_DATA_HOME", filepath.Join(home, "xdg"))
+		if got := zedDataDir("linux"); got != filepath.Join(home, "xdg", "zed") {
+			t.Fatalf("XDG_DATA_HOME ignored: %q", got)
+		}
+		t.Setenv("FLATPAK_XDG_DATA_HOME", filepath.Join(home, "flatpak"))
+		if got := zedDataDir("linux"); got != filepath.Join(home, "flatpak", "zed") {
+			t.Fatalf("FLATPAK_XDG_DATA_HOME must win: %q", got)
+		}
+	})
+}
+
+// A store whose table is gone is not a store with no threads. Both projections
+// fail, and the error has to say the schema may have moved — reporting it as an
+// empty harness is what makes a whole history disappear while doctor stays green.
+func TestParseZedDBReportsAStoreItCannotQuery(t *testing.T) {
+	zedHome(t)
+	db := zedTestDB(t, `create table not_threads (id text);`)
+	_, err := ParseZedDB(db)
+	if err == nil {
+		t.Fatal("a store with no threads table must be an error, not an empty read")
+	}
+	if !strings.Contains(err.Error(), "schema") {
+		t.Fatalf("error = %v, want it to name the schema", err)
+	}
+	// LoadZed swallows the error by contract — it is the cold-load path — but it
+	// must not panic or invent sessions.
+	t.Setenv("DEJA_ZED_DB", db)
+	if got := LoadZed(); got != nil {
+		t.Fatalf("LoadZed = %#v, want nil", got)
+	}
+}
+
+// The store is read through a tool deja does not ship, so the shapes it can
+// hand back are not all valid JSON arrays of rows. A stub on PATH is the only
+// way to reach those branches; nothing else can make the real sqlite3 lie.
+func TestParseZedDBSurvivesASqlite3ThatDoesNotAnswerInRows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub is a shell script")
+	}
+	zedHome(t)
+	real := zedTestDB(t, zedSchema)
+	const oneRow = `[{"id":"x","summary":"s","updated_at":"","data_type":"json","data":""}`
+	cases := []struct {
+		name, stdout string
+		exit         int
+		wantErr      bool
+	}{
+		{name: "not json at all", stdout: "not json\n", wantErr: true},
+		{name: "a json object rather than an array", stdout: `{"id":"x"}`, wantErr: true},
+		{name: "an array that stops mid-row", stdout: `[{"id":"x",`, wantErr: true},
+		// A truncated array that still exits 0 is read as the rows it did
+		// deliver: the exit status is what says the query was cut short, and a
+		// real sqlite3 that dies mid-stream returns one. Asserting an error
+		// here would be asserting something the tool cannot tell us.
+		{name: "a truncated array that exited cleanly", stdout: oneRow, wantErr: false},
+		{name: "a truncated array whose sqlite3 failed", stdout: oneRow, exit: 1, wantErr: true},
+		{name: "no output and a failed exit", stdout: "", exit: 1, wantErr: true},
+		{name: "no output and a clean exit", stdout: "", exit: 0, wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bin := t.TempDir()
+			script := fmt.Sprintf("#!/bin/sh\nprintf '%%s' %s\nexit %d\n", shellQuote(tc.stdout), tc.exit)
+			if err := os.WriteFile(filepath.Join(bin, "sqlite3"), []byte(script), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", bin)
+			sessions, err := ParseZedDB(real)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			// Nothing here decodes to a thread, so no case may invent a session.
+			if len(sessions) != 0 {
+				t.Fatalf("sessions = %#v, want none", sessions)
+			}
+		})
+	}
+}
+
+func shellQuote(s string) string { return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'" }
+
+// A thread document with no title of its own falls back to the row's summary
+// column, which is the copy Zed keeps outside the compressed body.
+func TestParseZedDBFallsBackToTheRowSummaryForATitle(t *testing.T) {
+	zedHome(t)
+	body := `{"version":"0.3.0","updated_at":"2026-07-19T09:00:02Z","messages":[` +
+		`{"User":{"id":"u","content":[{"Text":"untitled turn"}]}}]}`
+	sql := zedSchema + `
+insert into threads (id,summary,updated_at,data_type,data,folder_paths,created_at) values
+ ('untitled','the row summary','2026-07-19T09:00:02+00:00','json','` + body + `','/w/p','2026-07-19T09:00:00+00:00');`
+	sessions, err := ParseZedDB(zedTestDB(t, sql))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].Title != "the row summary" {
+		t.Fatalf("sessions = %#v, want the row's summary as the title", sessions)
+	}
+}
+
+func TestZedBodyRejectsWhatItCannotDecode(t *testing.T) {
+	if _, err := zedBody("json", "zz"); err == nil {
+		t.Fatal("non-hex data must be an error")
+	}
+	if _, err := zedBody("brotli", "00"); err == nil {
+		t.Fatal("an unknown data_type must be an error rather than a guess")
+	}
+	body, err := zedBody("", hex.EncodeToString([]byte(`{"title":"t"}`)))
+	if err != nil || string(body) != `{"title":"t"}` {
+		t.Fatalf("empty data_type = %q, %v; want the bytes unchanged", body, err)
+	}
+	if _, err := zstdDecode(nil); err == nil {
+		t.Fatal("an empty frame must be an error")
+	}
+}
+
+// The registry fixture's zstd row is a real frame, so its bytes are opaque in
+// review. The SQL states the plaintext it decompresses to; this keeps the two
+// from drifting apart, which is the failure a hex literal invites.
+func TestRegistryFixtureZstdBlobMatchesItsDocumentedPlaintext(t *testing.T) {
+	if !ZstdAvailable() {
+		t.Skip("zstd not installed")
+	}
+	b, err := os.ReadFile(filepath.Join("..", "..", "fixtures", "registry", "zed", "zed.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql := string(b)
+
+	var documented string
+	for _, line := range strings.Split(sql, "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "-- {"); ok {
+			documented = "{" + rest
+			break
+		}
+	}
+	if documented == "" {
+		t.Fatal("the fixture no longer documents the blob's plaintext")
+	}
+
+	start := strings.Index(sql, "x'")
+	if start < 0 {
+		t.Fatal("no blob literal in the fixture")
+	}
+	end := strings.Index(sql[start+2:], "'")
+	if end < 0 {
+		t.Fatal("unterminated blob literal in the fixture")
+	}
+	got, err := zedBody("zstd", sql[start+2:start+2+end])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(got)) != strings.TrimSpace(documented) {
+		t.Fatalf("blob decompresses to\n%s\nbut the fixture documents\n%s", got, documented)
+	}
+}
+
+func TestZstdAvailableReportsThePath(t *testing.T) {
+	// The gate is a PATH lookup, so an empty PATH is the one case that must
+	// report false on every machine, installed or not.
+	t.Setenv("PATH", "")
+	if ZstdAvailable() {
+		t.Fatal("ZstdAvailable must be false with an empty PATH")
+	}
+	if SQLite3Available() {
+		t.Fatal("SQLite3Available must be false with an empty PATH")
+	}
+}

--- a/internal/sources/zed_test.go
+++ b/internal/sources/zed_test.go
@@ -240,13 +240,44 @@ insert into threads (id,summary,updated_at,data_type,data) values
 	if got.ID != "pre-alter" || len(got.Messages) != 2 {
 		t.Fatalf("session = %#v", got)
 	}
-	// With no folder column there is no project path, and with no created_at the
+	// No folder column and no snapshot in the document either, which is the only
+	// case left with nothing to name the project by. With no created_at the
 	// window collapses onto updated_at rather than starting at the epoch.
 	if got.Project != "-" {
 		t.Fatalf("project = %q, want the unknown-project marker", got.Project)
 	}
 	if !got.Started.Equal(got.Updated) || got.Started.IsZero() {
 		t.Fatalf("window = %v..%v, want a single instant", got.Started, got.Updated)
+	}
+}
+
+// A real thread carries the path it was opened in, whatever the schema. The
+// folder_paths column arrives by ALTER TABLE, so a store an older Zed wrote and
+// a newer one never opened has only the original five columns — and on such a
+// store every thread was landing in the unknown-project marker.
+//
+// That is worse than a missing label: a session with no project is invisible to
+// auto-recall, which ranks within the project the user is working in. Measured
+// on a real 30-thread store, all thirty were "-", and all thirty carried their
+// own worktree path in the document.
+func TestParseZedDBTakesTheProjectFromTheDocumentWhenTheColumnIsGone(t *testing.T) {
+	zedHome(t)
+	const withSnapshot = `{"version":"0.3.0","title":"snapshot thread","updated_at":"2026-07-19T09:00:02Z",` +
+		`"initial_project_snapshot":{"worktree_snapshots":[{"worktree_path":"/Users/x/code/marketplace-price-tracker"}]},` +
+		`"messages":[{"User":{"id":"u1","content":[{"Text":"first question"}]}}]}`
+	body := zedZstdHex(t, withSnapshot)
+	sql := zedSchemaOriginal + `
+insert into threads (id,summary,updated_at,data_type,data) values
+ ('snap','snap','2026-07-19T09:00:02+00:00','zstd',x'` + body + `');`
+	sessions, err := ParseZedDB(zedTestDB(t, sql))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %#v, want one", sessions)
+	}
+	if got := sessions[0].Project; got != "marketplace-price-tracker" {
+		t.Errorf("project = %q, want it read off the document's worktree path", got)
 	}
 }
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -26,7 +26,7 @@ Claude Code, etc.) add:
 
 If `deja` is not on PATH, use the npx form: `"command": "npx", "args": ["-y", "@vshulcz/deja-vu", "mcp"]`.
 
-For the seventeen harnesses deja knows — Claude Code, Codex, Cursor, opencode,
+For the seventeen harnesses deja installs into — Claude Code, Codex, Cursor, opencode,
 Gemini CLI, Cline, Copilot CLI, Roo Code, aider, Goose, Qwen Code, Kimi Code,
 Antigravity, Grok Build, OpenClaw, pi and Hermes — there is a one-command setup
 instead:

--- a/npm/README.md
+++ b/npm/README.md
@@ -11,9 +11,10 @@ Every memory tool starts empty and records forward. **deja starts full.** It
 indexes the sessions your coding agents already wrote to disk — months of
 history from before you installed it — and serves them back over MCP.
 
-Seventeen coding agents write every conversation to local files: Claude Code,
+Eighteen coding agents write every conversation to local files: Claude Code,
 Codex, Cursor, opencode, Gemini CLI, Cline, Copilot CLI, Roo Code, aider,
-Goose, Qwen Code, Kimi Code, Antigravity, Grok Build, OpenClaw, pi and Hermes.
+Goose, Qwen Code, Kimi Code, Antigravity, Grok Build, OpenClaw, pi, Hermes and
+Zed.
 deja turns those files into one memory layer that all of them can read.
 
 One Go binary. No LLM, no embeddings, no API key, nothing leaves the machine.


### PR DESCRIPTION
Closes #183.

## The on-disk shape, confirmed

The issue asked for this to be checked on a real install and the version noted, so before the code:

**The store is not under `~/.config/zed`.** That directory exists on every platform and holds `settings.json`, keymaps and prompts — no threads. The threads are under Zed's **data** directory, per its own `paths::data_dir()`:

| Platform | Store |
| --- | --- |
| macOS | `~/Library/Application Support/Zed/threads/threads.db` |
| Linux, FreeBSD | `${XDG_DATA_HOME:-~/.local/share}/zed/threads/threads.db` |
| Windows | `%LOCALAPPDATA%\Zed\threads\threads.db` |

It is SQLite, so `opencode.go`/`cursor.go` were the right templates to point at — with one thing the issue could not have known:

```sql
CREATE TABLE threads (
    id TEXT PRIMARY KEY, summary TEXT NOT NULL, updated_at TEXT NOT NULL,
    data_type TEXT NOT NULL, data BLOB NOT NULL,
    parent_id TEXT, folder_paths TEXT, folder_paths_order TEXT, created_at TEXT
);
```

`data` is **zstd-compressed**, not JSON in a text column. `data_type` is `zstd` for everything Zed writes today and `json` only for rows predating compression.

Read off a real install (schema and paths) and Zed 0.61 at `968a13d2` (`crates/agent/src/db.rs`, `crates/agent/src/thread.rs`, `crates/paths/src/paths.rs`).

## The decision this forces, and the one I'd like checked

deja has no runtime Go dependencies and the standard library has no zstd. So the frame goes through the **`zstd` CLI**, gated by `ZstdAvailable()` exactly as five stores are gated by `SQLite3Available()`. `SkipReason("zed")` names whichever of the two is missing, so `deja sources` says

```
zed	/…/threads/threads.db	sessions=0 …	(zstd CLI not found — Zed threads unavailable)
```

rather than reporting an empty history — the #794 failure, one layer down, since `sqlite3` alone opens this store and reads nothing out of it.

**This is the part worth a maintainer's opinion:** zed is the first harness needing a second external tool. The alternatives I rejected were handling only `data_type='json'` (indexes almost nothing — Zed always compresses now) and vendoring a zstd decoder (against the no-dependencies rule). If you'd rather not take a second CLI dependency, say so and I'll rework it.

Decompression is per frame, not one batched `zstd -d` over concatenated frames. That costs a process per changed thread and buys isolation: one corrupt frame loses its own thread instead of the store. Incremental runs only decompress what moved.

## Two thread document generations

Both parse, and both had to. Zed serialises `SerializedThread { #[serde(flatten)] thread, version }`, so `version` sits beside the thread's fields rather than wrapping them. Current documents are `0.3.0` and hold Rust's externally tagged `Message` enum (`{"User":…}`, `{"Agent":…}`, `"Resume"`); agent-1 documents name the title `summary` and carry internally tagged `{"role":…,"segments":[…]}`.

Zed rewrites a thread in the current shape only when that thread is **next saved**, so a live store mixes generations indefinitely — and history from before deja was installed is the whole pitch, so dropping the old shape would quietly drop the oldest threads.

Indexing follows cline's line: user and assistant text only. Thinking, redacted thinking, tool calls, tool results, images and the `Resume` marker are skipped. A `Mention`'s inlined `content` is kept, because that is the text Zed put in front of the model.

## One bug this would have shipped with

`updated_at` is Rust `to_rfc3339` output, so it ends in `+00:00`; a Go watermark formatted with `RFC3339Nano` ends in `Z` and drops trailing fractional zeros. Comparing them as text is wrong in a direction that never surfaces: `.` sorts below `Z`, so a row newer than a whole-second watermark by half a second compares as *older* and an incremental pass would never look at it again. The filter normalises both sides with `strftime` first, and keeps a row whose timestamp SQLite cannot parse rather than assuming it was already seen. `TestParseZedDBSinceKeepsARowNewerByAFractionOfASecond` fails against the naive version.

## What is wired

- `internal/sources/zed.go` — parser, `DEJA_ZED_ROOT` and `DEJA_ZED_DB`, both schema generations (the later columns arrive by `ALTER TABLE` at startup, so a store an older Zed wrote and a newer one never opened has only the original five; there is a fallback projection).
- `internal/sources/registry.go` — harness entry, `dbParse`/`dbParseFrom` like opencode's, which is all discovery, load and incremental indexing needed.
- `internal/sources/skip.go` — the two-tool gate.
- `cmd/deja/main.go` — `deja sources` row and its missing-tool note. `cmd/deja/handoff.go` — paste-only, for Roo's reason: the agent lives in the editor, there is no CLI to hand a prompt to.
- `docs/registry/zed.md`, `registry.json`, the registry index, the generated matrix (`go run ./scripts/genmatrix`), and the harness count in `README.md`, `npm/README.md`, `docs/index.html`. `llms-install.md` said "the seventeen harnesses deja knows" about a one-command-setup list; since zed has no install target it is now "the seventeen harnesses deja installs into" rather than gaining a row it cannot honour.
- Hermetic env lists in `internal/sources/registry_test.go`, `cmd/deja/coverage_extra_test.go` and `internal/index/coverage_extra_test.go` — `DEJA_ZED_*` plus `XDG_DATA_HOME`/`FLATPAK_XDG_DATA_HOME`, without which an index run reads the contributor's own threads.

No MCP install target, so `mcp`/`auto`/`skill`/`command` are false with gap entries. Zed does run MCP servers and does read rules files, so `mcp` and `skill` are `todo`, not dead ends; `auto` is a fact about the harness — no lifecycle hook exists to inject recall into.

## Fixture

`fixtures/registry/zed/zed.sql` carries both encodings: the `json` row is readable SQL, the `zstd` row is a real frame as a hex blob. That blob is the one thing here that is opaque in review, which the registry README's "stored as SQL so changes remain reviewable" is right to want. So the SQL states the exact plaintext it decompresses to and `TestRegistryFixtureZstdBlobMatchesItsDocumentedPlaintext` pins the two together — the comment cannot drift from the bytes.

The conformance case builds the fixture on **stdin** rather than as an argument: the file opens with a `--` comment and the sqlite3 CLI reads a leading `--` as an option.

## Checks

```
go test ./... -race -count=1     all packages pass except one noted below
go vet ./...                     clean
gofmt -s                         clean
```

Per-package coverage against the CI floors, measured the way CONTRIBUTING asks:

| package | before | after | floor |
| --- | --- | --- | --- |
| `internal/sources` | 89.8% | 89.9% | 87% |
| `internal/index` | 90.6% | 90.6% | 90% |
| `cmd/deja` | 89.4% | 89.4% | 88% |

`zed.go` is 87.5–100% per function; the 87.5% is `zedRows`, whose remaining branches are sqlite3 subprocess failures, and `TestParseZedDBSurvivesASqlite3ThatDoesNotAnswerInRows` reaches most of them with a stub on PATH. Note the issue asked for 95% on the touched packages, which is above every floor those packages actually stand at — I held the floors and did not lower one; say the word if 95% is the real bar and I'll push `internal/sources` up.

`zedDataDir` takes the platform as an argument instead of reading `runtime.GOOS`, so the macOS and Windows layouts are asserted on every machine rather than only where CI happens to run.

Two things to be straight about:

- **`TestOpenClawPluginRecallsForThePrompt` fails for me, and it also fails on unmodified `main`** — `install_openclaw_plugin_test.go:154: driving the plugin: signal: killed`, the node subprocess dying on a loaded machine. Not from this change; I did not touch it.
- **I could not verify against a populated store.** My install has `threads.db` with the schema above and zero rows, so the schema, the paths and the compression are read off a real install, while the two document shapes come from Zed's source at the commit named above. Every fixture is synthetic, per CONTRIBUTING, and no real session data is in this PR. If you want a round-trip against a real thread before merging, that is a fair thing to ask for.
