### PR TITLE
fix(recall): the session-start block opened with "let me look at that"

### DIFF
--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -8,6 +8,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
@@ -239,6 +240,16 @@ func autoRecallSessionFor(s model.Session, now time.Time, provenance bool, terms
 	matched := false
 	if len(terms) > 0 {
 		problem, conclusions = matchedLines(s, terms)
+		matched = len(conclusions) > 0
+	} else {
+		// No question yet — this is the block handed over at session start.
+		// Nothing can be matched, and walking the transcript from the top takes
+		// the first two things the agent said, which are "let me look" and "I
+		// have found the file". What the session decided is at the end of it.
+		//
+		// digest.Conclusions already picks the decision-carrying lines, newest
+		// first, and is what `deja share` prints under the same heading.
+		conclusions = digest.Conclusions(s, 400, 2)
 		matched = len(conclusions) > 0
 	}
 	for _, m := range s.Messages {

--- a/internal/search/session_start_test.go
+++ b/internal/search/session_start_test.go
@@ -1,0 +1,58 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// At session start there is no question yet, so there is nothing to match and
+// the digest walks the session from the top: the first user line becomes the
+// problem and the first two assistant lines become the conclusions.
+//
+// The first two assistant lines of a real session are "let me look" and "I have
+// found the file". What the session decided is at the end. So the block an
+// agent is handed before it does anything opens with the least useful sentences
+// in the transcript, and the decision it exists to carry is not in it.
+func TestSessionStartQuotesWhatWasConcludedNotWhatWasSaidFirst(t *testing.T) {
+	s := model.Session{
+		ID: "a", Harness: "claude", Project: "p", Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: "the export job times out on the nightly run"},
+			{Role: "assistant", Text: "Let me take a look at the job configuration."},
+			{Role: "assistant", Text: "I have found the scheduler file, reading it now."},
+			{Role: "user", Text: "any idea yet?"},
+			{Role: "assistant", Text: "We decided to move the export off the shared pool: it now runs on its own worker with a 30 minute budget, and the timeouts stopped."},
+		},
+	}
+	got := AutoRecallDigest([]model.Session{s}, 2000)
+	if got == "" {
+		t.Fatal("no digest at all for a session with a decision in it")
+	}
+	if !strings.Contains(got, "own worker") {
+		t.Errorf("the decision this session reached is not in the block an agent is handed:\n%s", got)
+	}
+	if strings.Contains(got, "take a look") {
+		t.Errorf("the block opens with the agent saying it will look at something:\n%s", got)
+	}
+}
+
+// And when the caller does have terms — the per-prompt hook — the lines that
+// carry those words are still what gets quoted. Two different questions, two
+// different answers.
+func TestAPromptStillQuotesTheLinesThatMatchIt(t *testing.T) {
+	s := model.Session{
+		ID: "b", Harness: "claude", Project: "p", Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: "the export job times out on the nightly run"},
+			{Role: "assistant", Text: "The scheduler holds a lock on the manifest table while it runs."},
+			{Role: "assistant", Text: "We decided to move the export off the shared pool onto its own worker."},
+		},
+	}
+	got := AutoRecallDigestFor([]model.Session{s}, 2000, []string{"manifest", "lock"})
+	if !strings.Contains(got, "manifest") {
+		t.Errorf("a question about the manifest lock was answered with something else:\n%s", got)
+	}
+}


### PR DESCRIPTION
Sixth item from the research pass.

At session start there is no question yet, so nothing can be matched, and the digest walked each session from the top: the first user line became the problem and the **first two assistant lines** became the conclusions.

The first two assistant lines of a real session are the agent saying it will look at something and that it has found the file. What the session decided is at the end of it. So the block an agent is handed *before it does anything* opened with the least useful sentences in the transcript, and the decision it exists to carry was not in it.

The test fails on the old code with both halves of that:

```
the decision this session reached is not in the block an agent is handed
the block opens with the agent saying it will look at something
```

It uses `digest.Conclusions` for the query-independent case now — the decision-carrying lines, newest first, which is what `deja share` already prints under its own heading. Nothing new was written; the selector was there and this path was not using it.

The per-prompt path is untouched. When there *is* a question, the lines carrying its words are still what gets quoted, and there is a test holding each side so the two cannot drift into each other.

```
deja bench context   294 tokens · coverage 1.00 · negatives 0    identical before and after
decisionbench        green
```

Same budget and the same facts, different sentences — which is the whole of what this changes.