### PR TITLE
test(e2e): walk the path a user actually takes

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -58,4 +58,22 @@ HOME="$H" USERPROFILE="$H" $D install codex | grep -q "unchanged" || fail "insta
 grep -q 'model = "gpt"' "$H/.codex/config.toml" || fail "install clobbered config"
 HOME="$H" USERPROFILE="$H" $D uninstall codex | grep -q "updated" || fail "uninstall"
 
+# the per-prompt hook, from a directory named like the fixture's project so
+# auto-recall is in scope. This is the path that carries memory without anyone
+# asking, and nothing here exercised it: the MCP handshake above proves the
+# tool answers when called, not that anything calls it.
+WORK="$(mktemp -d)/project"
+mkdir -p "$WORK"
+( cd "$WORK" && printf '%s\n' '{"prompt":"the frobnicator parser bug again","session_id":"e2e-1"}' | $D hook-prompt ) \
+  | grep -q 'frobnicator' || fail "hook-prompt returned no recall for a prompt about indexed work"
+
+# --auto wires whatever it finds, and doctor agrees with it afterwards. The two
+# disagreeing is the failure a user cannot see: doctor is the command they run
+# when memory is not working.
+A="$(mktemp -d)"
+mkdir -p "$A/.claude"
+printf '{}\n' > "$A/.claude/settings.json"
+HOME="$A" USERPROFILE="$A" $D install --auto >/dev/null 2>&1 || fail "install --auto"
+HOME="$A" USERPROFILE="$A" $D doctor | grep -q "precompact   wired" || fail "doctor disagrees with install --auto"
+
 echo "e2e OK"


### PR DESCRIPTION
Seventh item from the research pass.

The smoke test built the real binary and exercised search, the warm second run, `ctx`, the JSON envelope, the MCP handshake, and installing one harness idempotently. Two things it never touched:

- **The per-prompt hook.** This is what carries memory when nobody asks for it. The MCP handshake proves the tool answers when it is called; it proves nothing about anything calling it.
- **`deja install --auto`** — the command the whole product depends on, and the one I had to add to `install.sh` earlier today because nothing named it.

Both are in now. The hook runs from a directory named like the fixture's project, so auto-recall is in scope, and its envelope has to carry the indexed content. `--auto` runs against a home with one agent in it, and `doctor` then has to agree with what it wrote — those two disagreeing is the failure a user cannot see, because doctor is what they run when memory is not working.

Checked in both directions: pointing the hook at a project that does not exist makes it fail with

```
e2e FAIL: hook-prompt returned no recall for a prompt about indexed work
```

### Not added

The brief's wiring line, from #1277. It only prints on a terminal, and a shell script is not one — the Go tests cover both directions of it instead.