### PR TITLE
fix(install): stop replacing a skill someone has edited

### DIFF
--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -274,7 +274,34 @@ func writeSharedSkill(harness string, uninstall bool) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	_, err = writeIfChanged(path, old, []byte(skillFile(skillBody)))
+	return writeSkillOfOurs(path, old, []byte(skillFile(skillBody)))
+}
+
+// writeGuidanceFile writes guidance, refusing to replace a skill someone has
+// edited. A block inside the user's own AGENTS.md is edited surgically and is
+// not at risk; a SKILL.md is a whole file deja owns and replaces.
+func writeGuidanceFile(path string, old, next []byte) (string, error) {
+	if !strings.HasSuffix(path, "SKILL.md") {
+		return writeIfChanged(path, old, next)
+	}
+	if !forceGuidance && skillWasEdited(path, old) {
+		fmt.Printf("skill: kept your edited %s — `deja install --force` to take deja's version\n", shortHome(path))
+		return "kept", nil
+	}
+	action, err := writeIfChanged(path, old, next)
+	if err != nil {
+		return action, err
+	}
+	rememberSkill(path, next)
+	return action, nil
+}
+
+// writeSkillOfOurs writes a skill unless the copy on disk is not the one deja
+// left there. An edited skill is kept and reported rather than blocking the
+// install: the person who tuned the wording keeps it, the rest of the install
+// still happens, and --force is how to ask for deja's version back.
+func writeSkillOfOurs(path string, old, next []byte) error {
+	_, err := writeGuidanceFile(path, old, next)
 	return err
 }
 
@@ -331,9 +358,12 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 	} else {
 		next = []byte(updateGuidanceBlock(string(old), uninstall))
 	}
-	a, err := writeIfChanged(path, old, next)
+	a, err := writeGuidanceFile(path, old, next)
 	if err != nil {
 		return installResult{}, err
+	}
+	if a == "kept" {
+		return installResult{Path: path, Action: a}, nil
 	}
 	// grok is three CLIs sharing one directory: the one that still reads
 	// GROK.md is not the one being maintained, and grok-dev reads AGENTS.md

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -35,6 +35,12 @@ func runInstall(dir string, args []string, uninstall bool) error {
 			noIndex = true
 			continue
 		}
+		// Take deja's version of a skill back, over one that has been edited.
+		// Without it an edited skill is kept and named rather than replaced.
+		if arg == "--force" {
+			forceGuidance = true
+			continue
+		}
 		targetArgs = append(targetArgs, arg)
 	}
 	verb := "install"
@@ -47,7 +53,7 @@ func runInstall(dir string, args []string, uninstall bool) error {
 	if len(targetArgs) > 1 {
 		for _, a := range targetArgs {
 			if strings.HasPrefix(a, "--") && a != "--all" && a != "--auto" {
-				return fmt.Errorf("%s: unknown flag %q — it takes a target plus --no-guidance or --no-index", verb, a)
+				return fmt.Errorf("%s: unknown flag %q — it takes a target plus --no-guidance, --no-index or --force", verb, a)
 			}
 		}
 	}
@@ -683,6 +689,10 @@ func backupOnce(path string) (bool, error) {
 // exist, is an empty config it then creates (#676). The flag is process-wide
 // because the command is: one run, one direction.
 var removingWiring bool
+
+// forceGuidance is set by `deja install --force`: replace a skill deja can see
+// has been edited since it wrote it.
+var forceGuidance bool
 
 // mentionsDeja reports whether a config snapshot carries deja's own wiring.
 // The markers are what every generator writes: the subcommands the hooks call,

--- a/cmd/deja/install_cline.go
+++ b/cmd/deja/install_cline.go
@@ -53,7 +53,7 @@ func installClineAuto(exe string, uninstall bool) (installResult, error) {
 		return installResult{}, err
 	}
 	oldSkill, _ := os.ReadFile(filepath.Join(skill, "SKILL.md"))
-	if _, err := writeIfChanged(filepath.Join(skill, "SKILL.md"), oldSkill, []byte(skillFile(skillBody))); err != nil {
+	if _, err := writeGuidanceFile(filepath.Join(skill, "SKILL.md"), oldSkill, []byte(skillFile(skillBody))); err != nil {
 		return installResult{}, err
 	}
 	return installResult{Path: path, Action: a}, nil

--- a/cmd/deja/skill_marks.go
+++ b/cmd/deja/skill_marks.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Install writes skills into directories that belong to the user, and it used
+// to replace one whenever its contents differed from what deja generates. That
+// is right for a stale copy an older deja wrote and wrong for a file someone
+// edited, and nothing on disk told the two apart: a person who tuned the
+// wording of their skill lost it on the next install, silently.
+//
+// What deja wrote is recorded here, beside its own state rather than beside the
+// skill. A marker file in a skills directory is a file the harness may try to
+// parse, and the point of this is to stop leaving things in the user's
+// directories that they did not ask for.
+func skillMarksPath() string { return index.DefaultDir() + ".skills" }
+
+func skillMarks() map[string]string {
+	out := map[string]string{}
+	b, err := os.ReadFile(skillMarksPath())
+	if err != nil {
+		return out
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if sum, path, ok := strings.Cut(strings.TrimSpace(line), " "); ok {
+			out[path] = sum
+		}
+	}
+	return out
+}
+
+func rememberSkill(path string, content []byte) {
+	marks := skillMarks()
+	marks[path] = contentMark(content)
+	paths := make([]string, 0, len(marks))
+	for p := range marks {
+		paths = append(paths, p)
+	}
+	// Sorted so rewriting the file is a no-op when nothing changed, rather than
+	// a fresh permutation of the same lines.
+	sort.Strings(paths)
+	var b strings.Builder
+	for _, p := range paths {
+		b.WriteString(marks[p])
+		b.WriteByte(' ')
+		b.WriteString(p)
+		b.WriteByte('\n')
+	}
+	_ = os.WriteFile(skillMarksPath(), []byte(b.String()), 0o600)
+}
+
+func contentMark(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// skillWasEdited reports whether the file on disk is something other than what
+// deja last wrote there.
+//
+// A file with no mark is treated as deja's. That is the state every existing
+// install is in, and calling all of them edited would refuse to update a skill
+// on every machine that has one — the protection starts from the next write.
+func skillWasEdited(path string, old []byte) bool {
+	if len(old) == 0 {
+		return false
+	}
+	mark, ok := skillMarks()[path]
+	if !ok {
+		return false
+	}
+	return mark != contentMark(old)
+}

--- a/cmd/deja/skill_marks_test.go
+++ b/cmd/deja/skill_marks_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Install writes skills into directories that belong to the user, and replaced
+// one whenever its contents differed from what deja generates. That is right
+// for a stale copy an older deja wrote and wrong for a file someone edited, and
+// nothing on disk told them apart: a person who tuned the wording of their
+// skill lost it on the next install, silently, with no way to notice except
+// reading the file again.
+func TestAnEditedSkillIsKept(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(t.TempDir(), "skills", "deja-history", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ours := []byte("---\nname: deja-history\n---\n\nask deja first.\n")
+	if _, err := writeGuidanceFile(path, nil, ours); err != nil {
+		t.Fatal(err)
+	}
+
+	edited := []byte("---\nname: deja-history\n---\n\nask deja first, and always in Russian.\n")
+	if err := os.WriteFile(path, edited, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	next := []byte("---\nname: deja-history\n---\n\nask deja first, then blame.\n")
+	action, err := writeGuidanceFile(path, edited, next)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if action != "kept" {
+		t.Errorf("an edited skill reported %q, not kept", action)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "always in Russian") {
+		t.Errorf("the user's own wording was overwritten:\n%s", got)
+	}
+}
+
+// A copy deja wrote is still refreshed, or an improvement to the skill never
+// reaches anyone who left it alone.
+func TestAStaleSkillOfOursIsRefreshed(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(t.TempDir(), "skills", "deja-history", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ours := []byte("old wording\n")
+	if _, err := writeGuidanceFile(path, nil, ours); err != nil {
+		t.Fatal(err)
+	}
+	next := []byte("new wording\n")
+	if _, err := writeGuidanceFile(path, ours, next); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "new wording\n" {
+		t.Errorf("a skill deja wrote was not refreshed: %q", got)
+	}
+}
+
+// And --force is how someone asks for deja's version back.
+func TestForceTakesTheSkillBack(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(t.TempDir(), "skills", "deja-history", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeGuidanceFile(path, nil, []byte("ours\n")); err != nil {
+		t.Fatal(err)
+	}
+	edited := []byte("mine\n")
+	if err := os.WriteFile(path, edited, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	forceGuidance = true
+	defer func() { forceGuidance = false }()
+	if _, err := writeGuidanceFile(path, edited, []byte("ours again\n")); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "ours again\n" {
+		t.Errorf("--force did not take the skill back: %q", got)
+	}
+}
+
+// A block inside the user's own AGENTS.md is edited surgically and was never at
+// risk, so it must not start being refused.
+func TestABlockInSomeoneElsesFileIsStillWritten(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(t.TempDir(), "AGENTS.md")
+	if err := os.WriteFile(path, []byte("their notes\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeGuidanceFile(path, []byte("their notes\n"), []byte("their notes\nand deja's block\n")); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), "deja's block") {
+		t.Errorf("a guidance block was refused as if it were a skill: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #1212.

Install writes skills into directories that belong to the user, and replaced one whenever its contents differed from what deja generates. Right for a stale copy an older deja wrote; wrong for a file someone edited — and nothing on disk told the two apart. A person who tuned the wording of their skill lost it on the next install, **silently**, with no way to notice except reading the file again.

What deja writes is recorded now. The marker lives beside deja's own state rather than beside the skill: a stray file in a skills directory is a file the harness may try to parse, and not leaving things in the user's directories is the whole point of the issue.

### The decision the issue left open

It asked whether a modified file should block the install or be left with a note. **Left and named**: blocking means one edited skill stops the wiring of thirteen other harnesses, and deja installs on every upgrade.

```
skill: kept your edited ~/.agents/skills/deja-history/SKILL.md — `deja install --force` to take deja's version
```

A copy deja wrote is refreshed exactly as before, or an improvement to the skill would never reach anyone who left theirs alone.

### A file with no marker counts as deja's

That is the state every existing install is in. Calling them all edited would refuse to update a skill on every machine that already has one, which is a worse failure than the one being fixed. The protection starts from the next write.

### Not in scope

Command files have the same shape and are not covered here — the issue mentions them, and they deserve the same treatment once this one has been in use. Guidance blocks inside someone's own `AGENTS.md` are untouched: those are edited surgically and were never at risk. There is a test that they do not start being refused.