### PR TITLE
test(windows): let windows CI say which of these still fail

### DIFF
--- a/internal/index/import_before_index_test.go
+++ b/internal/index/import_before_index_test.go
@@ -17,7 +17,6 @@ import (
 // A local session and the imported records must both be reachable after a
 // plain import-then-index.
 func TestImportBeforeFirstIndexKeepsLocalSessions(t *testing.T) {
-	skipWindowsPortability(t)
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")
 	proj := filepath.Join(claudeRoot, "-tmp-local")

--- a/internal/index/scope_leak_test.go
+++ b/internal/index/scope_leak_test.go
@@ -50,7 +50,6 @@ func TestEnsureHonorsHarnessScope(t *testing.T) {
 }
 
 func TestDateTokensMakeSessionsFindableByMonth(t *testing.T) {
-	skipWindowsPortability(t)
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")
 	proj := filepath.Join(claudeRoot, "-tmp-app")

--- a/internal/index/shared_counts_test.go
+++ b/internal/index/shared_counts_test.go
@@ -9,7 +9,6 @@ import (
 // HarnessSharedCounts is what lets doctor tell a parse failure from an id
 // collision (#1101); it had no test of its own, and the package floor noticed.
 func TestHarnessSharedCounts(t *testing.T) {
-	skipWindowsPortability(t)
 	dir := filepath.Join(t.TempDir(), "index.db")
 	store := t.TempDir()
 	// Two transcripts writing one id: the manifest keeps a single row for them

--- a/internal/index/sync_boundary_test.go
+++ b/internal/index/sync_boundary_test.go
@@ -14,7 +14,6 @@ import (
 // watermark instant. Every rebuild of the manifest must carry it, or ordinary
 // ingest between two pushes silently turns it back into a resend.
 func TestBoundarySurvivesIncrementalIngest(t *testing.T) {
-	skipWindowsPortability(t)
 	const ts = "2026-01-02T03:04:05Z"
 	dir, tmp := syncPeerIndex(t, msgLine(ts, "only message"))
 	n, commit, err := ExportDeferred(dir, filepath.Join(tmp, "out1"), "laptop")
@@ -58,7 +57,6 @@ func TestBoundarySurvivesIncrementalIngest(t *testing.T) {
 // Watermarks are per source. A push that touches project B must not disturb
 // what project A has already delivered.
 func TestUnrelatedPushDoesNotWipeOtherBoundaries(t *testing.T) {
-	skipWindowsPortability(t)
 	const ts = "2026-01-02T03:04:05Z"
 	dir, tmp := syncPeerIndex(t, msgLine(ts, "project a message"))
 	if _, commit, err := ExportDeferred(dir, filepath.Join(tmp, "a1"), "laptop"); err != nil {
@@ -104,7 +102,6 @@ func TestUnrelatedPushDoesNotWipeOtherBoundaries(t *testing.T) {
 // what arrives next: the exclude list is a privacy control, not a filter on
 // new traffic.
 func TestExcludeAppliesToAlreadyImportedSessions(t *testing.T) {
-	skipWindowsPortability(t)
 	dir, tmp := syncPeerIndex(t, msgLine("2026-01-02T03:04:05Z", "nda project notes"))
 	batch := filepath.Join(tmp, "batch")
 	if _, err := Export(dir, batch); err != nil {

--- a/internal/index/sync_peer_test.go
+++ b/internal/index/sync_peer_test.go
@@ -44,7 +44,6 @@ func msgLine(ts, text string) string {
 // What one peer has already received says nothing about what another peer
 // has: a global watermark silently partitions history across machines.
 func TestExportWatermarksAreScopedPerPeer(t *testing.T) {
-	skipWindowsPortability(t)
 	dir, tmp := syncPeerIndex(t, msgLine("2026-01-02T03:04:05Z", "shared history"))
 	n, commit, err := ExportDeferred(dir, filepath.Join(tmp, "toLaptop"), "laptop")
 	if err != nil || n != 1 {
@@ -65,7 +64,6 @@ func TestExportWatermarksAreScopedPerPeer(t *testing.T) {
 // Harnesses that stamp every message of a session with one timestamp (aider,
 // Cursor) must not lose the messages appended after the first push.
 func TestExportKeepsMessagesSharingTheWatermarkTimestamp(t *testing.T) {
-	skipWindowsPortability(t)
 	const ts = "2026-01-02T03:04:05Z"
 	dir, tmp := syncPeerIndex(t, msgLine(ts, "first message"))
 	n, commit, err := ExportDeferred(dir, filepath.Join(tmp, "out1"), "peer")
@@ -143,7 +141,6 @@ func TestImportHonorsTombstonesAfterCacheWipe(t *testing.T) {
 // The exclude list keeps a project out of this machine's memory; a sync from
 // another machine must not put it back.
 func TestImportHonorsExcludeList(t *testing.T) {
-	skipWindowsPortability(t)
 	dir, tmp := syncPeerIndex(t, msgLine("2026-01-02T03:04:05Z", "nda project notes"))
 	batch := filepath.Join(tmp, "batch")
 	if _, err := Export(dir, batch); err != nil {

--- a/internal/index/sync_persist_test.go
+++ b/internal/index/sync_persist_test.go
@@ -37,7 +37,6 @@ func writeSyncBatch(t *testing.T, dir string, recs []SyncRecord) {
 // deja-sync-import path that the next update classified as a removed source,
 // purging every imported record.
 func TestImportedRecordsSurviveRebuildAndUpdate(t *testing.T) {
-	skipWindowsPortability(t)
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")
 	proj := filepath.Join(claudeRoot, "-tmp-local")

--- a/internal/index/tool_stream_test.go
+++ b/internal/index/tool_stream_test.go
@@ -229,7 +229,6 @@ func TestSpanInventorySkipsSpansWithNoPath(t *testing.T) {
 // empty slice on every session and no error — silence, which is how it cost a
 // wrong measurement before it was noticed (#633).
 func TestRecentCarriesTouched(t *testing.T) {
-	skipWindowsPortability(t)
 	tmp := t.TempDir()
 	proj := filepath.Join(tmp, "claude", "-tmp-touch")
 	if err := os.MkdirAll(proj, 0o755); err != nil {

--- a/internal/index/windows_portability_test.go
+++ b/internal/index/windows_portability_test.go
@@ -5,12 +5,11 @@ import (
 	"testing"
 )
 
-// skipWindowsPortability defers a test that bakes in unix path fixtures
-// (unix-style cwd, flat store layouts) and asserts unix-derived projects,
-// attribution or error wording. deja derives those from file paths with
-// filepath.Rel/Separator and a lexicographic path comparison, so they diverge
-// on windows. These pass on macOS and ubuntu; the windows portability of the
-// fixtures — and one unproven session-count doubling — is tracked in #1119.
+// skipWindowsPortability is kept as the single place a windows-only skip would
+// go, and is deliberately unused: the skips it held are removed, so windows CI
+// reports what actually fails rather than reporting nothing. See #1119.
+//
+//nolint:unused
 func skipWindowsPortability(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Working #1119, and using the windows machine we have.

Nine `internal/index` tests are skipped on windows. Eight are described as fixture portability; the ninth is not:

> **Unproven, needs a windows repro:** `TestHarnessSharedCounts` gets `session count = 2, want 1` — two files with the same content `sessionId` should collapse to one manifest key, and the id override is OS-independent in the code, yet windows doubles the count. Could be a real windows path-handling bug in the loader, or another fixture artefact. Do not dismiss without a windows run.

I read the path: the id starts as the filename base and is replaced by the `sessionId` in the content, which is the same on every OS, and the manifest key is `harness:id`. `attributeSession` compares `s.Path < held.Path`, which differs by separator but still yields one winner and one key. I cannot see where a second row comes from, and I cannot run windows to find out.

CI can. The skips are removed so `test / windows-latest` reports what actually fails instead of reporting nothing and calling it green.

**This PR is expected to go red**, and that is the point. I will read the failures, fix what is fixture and diagnose what is not, and land the result here — the final state of this branch will be green or precisely skipped with a reason per test, not a blanket.

Local runs are unchanged: `internal/index` passes on macOS as before.