### PR TITLE
fix(search): project scoping matched only one separator, and windows uses the other

### DIFF
--- a/internal/index/project_scope_test.go
+++ b/internal/index/project_scope_test.go
@@ -16,6 +16,11 @@ func TestProjectScopeMatchesSegmentsNotSubstrings(t *testing.T) {
 		{"scratchpad/demo", "demo"},
 		{"imported:deja-vu", "deja-vu"},
 		{"imported:goprojects/deja-vu", "deja-vu"},
+		// windows builds the same name with its own separator. Matching only
+		// "/" made every scoped ranking there return nothing, which the CI leg
+		// only reports when a pull request asks for it.
+		{`goprojects\deja-vu`, "deja-vu"},
+		{`imported:goprojects\deja-vu`, "deja-vu"},
 	}
 	for _, c := range joined {
 		if !projectInScope(c.project, c.want) {
@@ -28,6 +33,7 @@ func TestProjectScopeMatchesSegmentsNotSubstrings(t *testing.T) {
 		{"deja-push", "deja"},
 		{"deja-vu", "deja"},
 		{"goprojects/d3fvxl-redirect", "d3fvxl"},
+		{`goprojects\d3fvxl-redirect`, "d3fvxl"},
 		{"shulcz/coding", "shulcz"},
 		{"pin-manifests", "-"},
 		{"telegram-mtproxy-forwarder", "-"},

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -673,7 +673,15 @@ func projectInScope(project, want string) bool {
 		// project under the same name.
 		p = rest
 	}
-	return p == w || strings.HasSuffix(p, "/"+w)
+	if p == w {
+		return true
+	}
+	// Both separators, because a project name is built from a path and windows
+	// builds it with backslashes. Matching only "/" made every scoped ranking on
+	// windows return nothing — the substring rule this replaced happened not to
+	// care which separator it was, and taking the loose rule out took the
+	// platform's separator with it.
+	return strings.HasSuffix(p, "/"+w) || strings.HasSuffix(p, `\`+w)
 }
 
 // relevantMetasCounts additionally reports how many terms of ANY frequency


### PR DESCRIPTION
main has been red since #1276. My regression.

That change replaced substring project matching with whole path segments, and compared against `/` alone. A project name is built from a path, and windows builds it with backslashes — so on windows every scoped ranking matched nothing. `ProjectRelevant` returns empty, and four tests fail:

```
atomicity_test.go:251   ranking = [], want s1 first (rare term dominates filler)
atomicity_test.go:293   full-address session missing: got=0 matched=[]
cyrillic_test.go:213    relevance tier returned nothing for a Russian prompt
locked_read_test.go:63  the read returned nothing while a rebuild held the lock
```

All four are the same failure wearing different hats: auto-recall returns nothing on windows.

The substring rule this replaced happened not to care which separator it was. Taking the loose rule out took the platform separator with it — the sort of thing a tightening does quietly.

Both separators now, pinned in `TestProjectScopeMatchesSegmentsNotSubstrings` with windows-shaped names. Without the fix that test fails twice.

### How this got through

The windows leg is opt-in per pull request: it runs on every push to main, on the weekly canary, on demand, and on a PR labelled `windows`. #1276 was not labelled, so its PR reported `test / windows-latest` **green while running nothing** — the leg skips from the inside so it stays a required check. The failure then landed on main, where the leg does run.

That is working as designed and it cost a day. Worth considering whether a change under `internal/index` or `internal/sources` should carry the label automatically.