### PR TITLE
fix(sync): a bad import path came back as a raw syscall error on windows

### DIFF
--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -299,10 +299,16 @@ func Import(dir, inDir string) (int, error) {
 	// quiet zero.
 	fi, err := os.Stat(inDir)
 	if err != nil {
-		if os.IsNotExist(err) {
+		// Anything but a permission problem reads as "it is not there" to the
+		// person who typed it, and windows says a great deal more than that: a
+		// path holding control characters is an invalid name rather than a
+		// missing one, so IsNotExist is false and the raw syscall error went
+		// back — carrying the unsanitised path with it, which is the escape
+		// sequence this wording exists to defuse.
+		if !os.IsPermission(err) {
 			return 0, fmt.Errorf("no such directory: %s", search.SafeLine(inDir))
 		}
-		return 0, err
+		return 0, fmt.Errorf("cannot read %s: %s", search.SafeLine(inDir), search.SafeLine(err.Error()))
 	}
 	if !fi.IsDir() {
 		return 0, fmt.Errorf("%s is a file; sync import wants the directory a `sync export` wrote", inDir)

--- a/internal/index/sync_path_line_test.go
+++ b/internal/index/sync_path_line_test.go
@@ -8,8 +8,12 @@ import (
 // The import path comes from whatever the caller passed — a script, an agent
 // acting on a repo's instructions. Printed verbatim, a newline in it ended
 // deja's error line and started one that reads as deja's own output.
+//
+// This ran on unix only, and windows was where it mattered most: a path holding
+// control characters is an invalid name there rather than a missing one, so the
+// not-exist branch was skipped and the raw syscall error went back with the
+// path still in it.
 func TestSyncImportErrorKeepsThePathOnOneLine(t *testing.T) {
-	skipWindowsPortability(t)
 	bad := "/tmp/no\u001bXsuch\ndeja: store is clean\u202edir"
 	_, err := Import(t.TempDir(), bad)
 	if err == nil {


### PR DESCRIPTION
Found while working #1119 — one of the nine skipped tests turned out to be hiding a real defect rather than a fixture artefact.

`deja sync import` sanitises the path in its error, because that path comes from whatever the caller passed — a script, or an agent acting on a repository's instructions — and a newline in it ends deja's error line and starts one that reads as deja's own output.

That wording was reached **only** when `os.Stat` reported the directory missing. On windows a path holding control characters is an *invalid name*, not a missing one, so `os.IsNotExist` is false, the branch was skipped, and the raw error went back:

```
CreateFile /tmp/no<ESC>Xsuch
deja: store is clean<RLO>dir: The filename, directory name, or volume label syntax is incorrect.
```

The escape sequence the wording exists to defuse, printed verbatim, with the forged line intact.

Anything that is not a permission problem reads as "it is not there" to the person who typed it, so that is what it says. A permission error is now worded and sanitised too, rather than passed through.

The test for this was skipped on windows — the one platform where it could fail. It runs everywhere now.