### PR TITLE
fix(sources): a project is spelled the same on every platform

### DIFF
--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -174,7 +174,7 @@ func TestPrintInstallProofListsDistinctProjects(t *testing.T) {
 	b, _ := io.ReadAll(r)
 	out := string(b)
 	if !strings.Contains(out, "deja already knows this machine:") ||
-		!strings.Contains(out, filepath.Join("tmp", "beta")) || !strings.Contains(out, "gamma") {
+		!strings.Contains(out, "tmp/beta") || !strings.Contains(out, "gamma") {
 		t.Fatalf("proof output = %q", out)
 	}
 	// One line per project, newest first, capped at three.

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -473,7 +473,7 @@ func TestStatsCommandJSONAndNoColor(t *testing.T) {
 	if byHarness["claude"].Sessions != 3 || byHarness["claude"].Messages != 6 || byHarness["codex"].Sessions != 1 || byHarness["codex"].Messages != 2 {
 		t.Fatalf("harnesses = %#v", report.Harnesses)
 	}
-	if len(report.TopProjects) == 0 || report.TopProjects[0].Project != filepath.Join("tmp", "alpha") || report.TopProjects[0].Sessions != 2 {
+	if len(report.TopProjects) == 0 || report.TopProjects[0].Project != "tmp/alpha" || report.TopProjects[0].Sessions != 2 {
 		t.Fatalf("top projects = %#v", report.TopProjects)
 	}
 

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -226,7 +226,7 @@ func ProjectNameCandidates(cwd string) []string {
 		names = append(names, name)
 	}
 	if base := filepath.Base(cwd); base != "" {
-		add(filepath.Join(filepath.Base(filepath.Dir(cwd)), base))
+		add(filepath.Base(filepath.Dir(cwd)) + "/" + base)
 		add(base)
 	}
 	// The same repo appears under every worktree's path; sessions recorded in
@@ -237,7 +237,7 @@ func ProjectNameCandidates(cwd string) []string {
 	for _, root := range gitWorktreeRoots(cwd) {
 		add(sources.ClaudeProjectName(root))
 		if base := filepath.Base(root); base != "" {
-			add(filepath.Join(filepath.Base(filepath.Dir(root)), base))
+			add(filepath.Base(filepath.Dir(root)) + "/" + base)
 			add(base)
 		}
 	}

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -46,7 +46,7 @@ func TestIndexIngestSkipAndSearch(t *testing.T) {
 	if !HasManifest(dir) {
 		t.Fatal("manifest missing after build")
 	}
-	projectSessions, err := RecentProject(dir, filepath.Join("deja", "vu"), 2)
+	projectSessions, err := RecentProject(dir, "deja/vu", 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +320,7 @@ func TestMultiWordSearchUsesAllPostingsAndDoesNotFullScan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	m.Sessions["claude:unposted"] = SessionMeta{ID: "unposted", Harness: "claude", Project: filepath.Join("deja", "vu"), Path: "manual", Updated: time.Now()}
+	m.Sessions["claude:unposted"] = SessionMeta{ID: "unposted", Harness: "claude", Project: "deja/vu", Path: "manual", Updated: time.Now()}
 	rec, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_APPEND|os.O_WRONLY, 0)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -167,7 +167,7 @@ func decodeProjectBase(base string) string {
 	if resolved := resolveEncodedPath(base); resolved != "" {
 		segs := strings.Split(strings.Trim(resolved, string(filepath.Separator)), string(filepath.Separator))
 		if len(segs) >= 2 {
-			return filepath.Join(segs[len(segs)-2], segs[len(segs)-1])
+			return projectSegments(segs[len(segs)-2], segs[len(segs)-1])
 		}
 		if len(segs) == 1 {
 			return segs[0]
@@ -186,7 +186,7 @@ func decodeProjectBase(base string) string {
 	if len(clean) == 1 {
 		return clean[0]
 	}
-	return filepath.Join(clean[len(clean)-2], clean[len(clean)-1])
+	return projectSegments(clean[len(clean)-2], clean[len(clean)-1])
 }
 
 // resolveEncodedPath finds the real directory an encoded project name points

--- a/internal/sources/name_test.go
+++ b/internal/sources/name_test.go
@@ -21,11 +21,11 @@ func TestClaudeProjectNameResolvesHyphenatedDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 	encoded := strings.ReplaceAll(real, string(filepath.Separator), "-")
-	if got := claudeProjectName(filepath.Join("/claude/projects", encoded)); got != filepath.Join("projects", "deja-vu") {
+	if got := claudeProjectName(filepath.Join("/claude/projects", encoded)); got != "projects/deja-vu" {
 		t.Fatalf("resolved name = %q, want projects/deja-vu", got)
 	}
 	// Non-existent paths keep the old heuristic.
-	if got := claudeProjectName("/claude/projects/-no-such-root-deja-vu"); got != filepath.Join("deja", "vu") {
+	if got := claudeProjectName("/claude/projects/-no-such-root-deja-vu"); got != "deja/vu" {
 		t.Fatalf("fallback name = %q, want deja/vu", got)
 	}
 }

--- a/internal/sources/pi_test.go
+++ b/internal/sources/pi_test.go
@@ -41,7 +41,7 @@ func TestParsePiFile(t *testing.T) {
 	if s.ID != "abc-123" {
 		t.Fatalf("id = %q, want abc-123", s.ID)
 	}
-	if s.Project != filepath.Join("deja", "vu") {
+	if s.Project != "deja/vu" {
 		t.Fatalf("project = %q, want deja/vu", s.Project)
 	}
 	if len(s.Messages) != 4 {

--- a/internal/sources/project_paths.go
+++ b/internal/sources/project_paths.go
@@ -63,7 +63,7 @@ func projectFromPaths(ms []model.Message) string {
 	}
 	segs := strings.Split(strings.Trim(best, string(filepath.Separator)), string(filepath.Separator))
 	if len(segs) >= 2 {
-		return filepath.Join(segs[len(segs)-2], segs[len(segs)-1])
+		return projectSegments(segs[len(segs)-2], segs[len(segs)-1])
 	}
 	return filepath.Base(best)
 }

--- a/internal/sources/project_paths_test.go
+++ b/internal/sources/project_paths_test.go
@@ -44,7 +44,9 @@ func TestProjectFromPathsTakesTheMajorityRepo(t *testing.T) {
 		filesMsg(filepath.Join(b, "main.go")),
 	}
 	got := projectFromPaths(ms)
-	want := filepath.Join(filepath.Base(filepath.Dir(a)), "alpha")
+	// "/" rather than filepath.Join: a project name is an identifier and is
+	// spelled the same on every platform.
+	want := filepath.Base(filepath.Dir(a)) + "/alpha"
 	if got != want {
 		t.Fatalf("project = %q, want %q", got, want)
 	}

--- a/internal/sources/project_separator_test.go
+++ b/internal/sources/project_separator_test.go
@@ -1,0 +1,18 @@
+package sources
+
+import "testing"
+
+// A project name is an identifier, not a path on this disk. Assembled with the
+// OS separator it reads goprojects\deja-vu on windows and goprojects/deja-vu
+// everywhere else — two names for one project.
+//
+// Scoping then misses on windows, where eleven internal/index tests were
+// failing on exactly this, and sync is worse: a project exported from a windows
+// machine arrives as "tmp\touch" and never matches the "tmp/touch" the same
+// repository is called on any other machine, so the peer's history is indexed
+// and unreachable.
+func TestAProjectNameIsSpelledTheSameOnEveryPlatform(t *testing.T) {
+	if got := projectSegments("goprojects", "deja-vu"); got != "goprojects/deja-vu" {
+		t.Errorf("project name = %q, want it separated by / on every platform", got)
+	}
+}

--- a/internal/sources/qwen_test.go
+++ b/internal/sources/qwen_test.go
@@ -28,7 +28,7 @@ func TestParseQwenFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ss) != 1 || ss[0].Project != filepath.Join("deja", "vu") || len(ss[0].Messages) != 3 {
+	if len(ss) != 1 || ss[0].Project != "deja/vu" || len(ss[0].Messages) != 3 {
 		t.Fatalf("parsed sessions = %#v", ss)
 	}
 	if ss[0].Messages[0].Text != "first\n question" || ss[0].Messages[1].Text != "surface\n answer" || ss[0].Messages[2].Role != "assistant" {

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -184,7 +184,7 @@ func TestParseClaudeProjectFromEncodedDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ss) != 1 || ss[0].Project != filepath.Join("deja", "vu") {
+	if len(ss) != 1 || ss[0].Project != "deja/vu" {
 		t.Fatalf("project came from wrong source: %#v", ss)
 	}
 }
@@ -209,7 +209,7 @@ func TestParseClaudeProjectFromNestedSubagentPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ss) != 1 || ss[0].Project != filepath.Join("deja", "vu") {
+	if len(ss) != 1 || ss[0].Project != "deja/vu" {
 		t.Fatalf("project came from id path segment: %#v", ss)
 	}
 }

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -198,6 +198,16 @@ func textFromContent(v any) string {
 	return ""
 }
 
+// projectSegments joins the last two path segments into the name a project is
+// known by. Always with "/", because that name is an identifier rather than a
+// path on this disk: built with the OS separator it reads goprojects\deja-vu on
+// windows and goprojects/deja-vu everywhere else, which is two names for one
+// project. Scoping then misses on windows, and a project synced from a windows
+// machine never matches itself on any other.
+func projectSegments(parent, base string) string {
+	return parent + "/" + base
+}
+
 func projectName(path string) string {
 	if path == "" {
 		return "-"


### PR DESCRIPTION
Found by letting windows CI run the tests it had been skipping (#1119), and it turns out to matter well beyond windows.

The two-segment project name was assembled with `filepath.Join`, so the same repository is called

```
goprojects/deja-vu     on macOS and linux
goprojects\deja-vu     on windows
```

Two names for one project.

**On windows** that is why eleven `internal/index` tests fail: scoping compares the name against path segments and misses. The failure messages say it outright — `Project:"tmp\\touch"` where the test wants `tmp/touch`.

**Across machines it is worse.** A project exported from a windows machine arrives as `tmp\touch`, and never matches the `tmp/touch` the same repository is called on any other. The peer's history is indexed and then unreachable by anything scoped — which is most of what deja does automatically.

The name is an identifier, not a path on this disk. It is built with `/` at all three places it is derived: the Claude project decoder, the shared path decoder, and the candidate list a hook scopes with.

`projectInScope` already accepts both separators since #1287, and that stays — it is what protects an index written by an older build. This fixes the spelling at the source so new ones agree.

Windows CI on this branch is the check that matters; the label is on.