### PR TITLE
fix(docs): the harness count said seventeen in five of the seven places it appears

### DIFF
--- a/cmd/deja/readme_harness_count_test.go
+++ b/cmd/deja/readme_harness_count_test.go
@@ -49,9 +49,19 @@ func TestReadmeSpellsTheHarnessCountTheRegistryHas(t *testing.T) {
 	// re-reads when the main one changes — it was still leading with the
 	// previous tagline months later, on a page that gets five hundred installs
 	// a week. Third-party write-ups were quoting a count from before July.
-	// Four files spell the count and only two were checked, so when Zed made it
-	// eighteen the other two stayed on seventeen.
-	for _, name := range []string{"README.md", "npm/README.md", "llms-install.md", "docs/ARCHITECTURE.md"} {
+	// Seven files spell the count and only two were checked, so when Zed made it
+	// eighteen the other five stayed on seventeen — including the two manifest
+	// descriptions, which is the line the MCP registry shows next to the name,
+	// and the harnesses page, which says it in the lede and in three meta tags.
+	for _, name := range []string{
+		"README.md",
+		"npm/README.md",
+		"llms-install.md",
+		"docs/ARCHITECTURE.md",
+		"server.json",
+		"packaging/mcpb/manifest.json",
+		"docs/guide/harnesses.html",
+	} {
 		b, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
 		if err != nil {
 			t.Fatalf("%s: %v", name, err)

--- a/cmd/deja/readme_harness_count_test.go
+++ b/cmd/deja/readme_harness_count_test.go
@@ -49,24 +49,26 @@ func TestReadmeSpellsTheHarnessCountTheRegistryHas(t *testing.T) {
 	// re-reads when the main one changes — it was still leading with the
 	// previous tagline months later, on a page that gets five hundred installs
 	// a week. Third-party write-ups were quoting a count from before July.
-	for _, name := range []string{"README.md", "npm/README.md"} {
+	// Four files spell the count and only two were checked, so when Zed made it
+	// eighteen the other two stayed on seventeen.
+	for _, name := range []string{"README.md", "npm/README.md", "llms-install.md", "docs/ARCHITECTURE.md"} {
 		b, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
 		if err != nil {
 			t.Fatalf("%s: %v", name, err)
 		}
 		text := strings.ToLower(string(b))
 
+		// The word, not a phrase around it. These four documents each have their
+		// own voice — "eighteen coding agents", "the eighteen harnesses deja
+		// installs into", "the eighteen the loader registers" — and pinning one
+		// phrasing meant the other two were never checked at all.
 		for _, stale := range words {
-			if stale == want {
-				continue
-			}
-			if strings.Contains(text, stale+" coding agents") ||
-				strings.Contains(text, stale+" harnesses") {
-				t.Errorf("%s counts %q harnesses; the registry has %d (%s)", name, stale, n, want)
+			if stale != want && strings.Contains(text, stale) {
+				t.Errorf("%s still counts %q; the registry has %d (%s)", name, stale, n, want)
 			}
 		}
-		if !strings.Contains(text, want+" coding agents") {
-			t.Errorf("%s does not say %q coding agents; the registry has %d", name, want, n)
+		if !strings.Contains(text, want) {
+			t.Errorf("%s never says %q; the registry has %d harnesses", name, want, n)
 		}
 	}
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,7 +5,7 @@ This document is for people changing `deja` internals.
 ## Source parsers
 
 Parsers live in `internal/sources` and return `[]model.Session`. The table is
-the seventeen the loader registers; `docs/registry/` describes each store's
+the eighteen the loader registers; `docs/registry/` describes each store's
 layout in detail, and `internal/sources/registry_test.go` checks that index
 against the loader list.
 

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -5,11 +5,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Claude Code, Codex, Cursor and 14 more agents — deja-vu</title>
-<meta name="description" content="The seventeen coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta name="description" content="The eighteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Claude Code, Codex, Cursor and 14 more agents — deja-vu">
-<meta property="og:description" content="The seventeen coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta property="og:description" content="The eighteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/harnesses.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -26,12 +26,12 @@
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
 <meta name="twitter:title" content="Claude Code, Codex, Cursor and 14 more agents — deja-vu">
-<meta name="twitter:description" content="The seventeen coding agents deja indexes today, where each stores its history, and how to add a new one.">
+<meta name="twitter:description" content="The eighteen coding agents deja indexes today, where each stores its history, and how to add a new one.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
 <link rel="apple-touch-icon" href="../assets/icon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Harnesses","description":"The seventeen coding agents deja indexes today, where each stores its history, and how to add a new one.","url":"https://vshulcz.github.io/deja-vu/guide/harnesses.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Harnesses","description":"The eighteen coding agents deja indexes today, where each stores its history, and how to add a new one.","url":"https://vshulcz.github.io/deja-vu/guide/harnesses.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Harnesses","item":"https://vshulcz.github.io/deja-vu/guide/harnesses.html"}]}</script>
 </head>
 <body>
@@ -54,8 +54,8 @@
 <article>
 
 <h1>Harnesses</h1>
-<p class="pagelede">the seventeen it reads, and what each one supports<span class="mins" data-mins></span></p>
-<p>deja indexes seventeen coding-agent histories into one retroactive index. A fix found in one agent is recalled inside another.</p>
+<p class="pagelede">the eighteen it reads, and what each one supports<span class="mins" data-mins></span></p>
+<p>deja indexes eighteen coding-agent histories into one retroactive index. A fix found in one agent is recalled inside another.</p>
 <!-- matrix:start -->
 <table>
 <tr><th>Harness</th><th>Store</th><th>MCP recall</th><th>Auto-recall</th><th>Skill</th><th>Command</th><th>Resume</th><th>Handoff</th><th>Needs</th></tr>

--- a/llms-install.md
+++ b/llms-install.md
@@ -26,7 +26,7 @@ Claude Code, etc.) add:
 
 If `deja` is not on PATH, use the npx form: `"command": "npx", "args": ["-y", "@vshulcz/deja-vu", "mcp"]`.
 
-For the seventeen harnesses deja installs into — Claude Code, Codex, Cursor, opencode,
+For the eighteen harnesses deja installs into — Claude Code, Codex, Cursor, opencode,
 Gemini CLI, Cline, Copilot CLI, Roo Code, aider, Goose, Qwen Code, Kimi Code,
 Antigravity, Grok Build, OpenClaw, pi and Hermes — there is a one-command setup
 instead:

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "name": "deja-vu",
   "display_name": "deja-vu",
   "version": "0.0.0",
-  "description": "Local searchable memory over the session histories of seventeen coding agents.",
+  "description": "Local searchable memory over the session histories of eighteen coding agents.",
   "long_description": "deja indexes the session transcripts your coding agents already write to disk — Claude Code, Codex, Cursor, opencode, aider, cline, roo, goose and others — and serves them back over MCP. It starts full rather than empty: history from before you installed it is searchable immediately. Retrieval is lexical, with no LLM, no embedding model and no API key. Secrets are redacted before anything is indexed. Nothing leaves the machine.",
   "author": {
     "name": "vshulcz",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.vshulcz/deja-vu",
-  "description": "Local searchable memory over the session histories of seventeen coding agents.",
+  "description": "Local searchable memory over the session histories of eighteen coding agents.",
   "repository": {
     "url": "https://github.com/vshulcz/deja-vu",
     "source": "github"


### PR DESCRIPTION
Zed made it eighteen. Five files still said seventeen, including `server.json` — the description the MCP registry shows next to the name — and `docs/guide/harnesses.html`, which says it in the lede and in three meta tags.

The guard read only the two READMEs and matched the literal phrase "eighteen coding agents", which the other files don't use. It now looks for the count word itself and rejects any other one across all seven; I checked each file fails when reverted.