### PR TITLE
test(mcp): pin the tools/list payload to a token budget

### DIFF
--- a/cmd/deja/mcp_tools_budget_test.go
+++ b/cmd/deja/mcp_tools_budget_test.go
@@ -2,48 +2,68 @@ package main
 
 import (
 	"encoding/json"
+	"sort"
 	"testing"
-
-	"github.com/vshulcz/deja-vu/internal/index"
 )
 
-// toolsListBudget is the ceiling on the whole tools/list payload, in bytes.
+// Every session that wires deja's MCP server pays for tools/list before the
+// agent does anything, whether or not it ever calls a tool. Six tools cost
+// about 1700 tokens today, and most of that is prose in the descriptions rather
+// than schema. The failure mode this pins is not one big commit — it is a tool
+// added here, three sentences of guidance appended there, each too small to
+// argue with, until the standing cost has doubled and nobody chose it.
 //
-// This is the one part of the MCP surface every session pays for whether or not
-// it uses deja: the host reads the list before the agent does anything. Nothing
-// was watching it, and it is the kind of cost that only ever grows — a sentence
-// added to a description looks free at the point of writing and is charged on
-// every request from then on, on every machine deja is wired into.
-//
-// The number is the payload as it stands with a little room, not an aspiration.
-// It is deliberately tight: hitting it is supposed to force the question of
-// whether the words belong in a description at all, rather than be raised a
-// little each time. Long-form guidance about when to call a tool and how to
-// report what it found is read once and belongs in the initialize handshake or
-// a resource; the description should carry what the tool does and what its
-// arguments mean.
-const toolsListBudget = 7200
+// So the budget is on the whole payload, not per tool. Reaching more of deja
+// from the agent is worth doing (#1174); paying for it linearly is not. If this
+// fails, the question to ask is whether the new capability has to be a tool at
+// all — `instructions` is read once, resources/list costs nothing here, and a
+// hook already fires at the point of action.
+const mcpToolsListCharBudget = 7200
 
-func TestToolsListStaysWithinItsTokenBudget(t *testing.T) {
-	resp, _, _ := handleMCP(index.DefaultDir(), rpcRequest{Method: "tools/list"})
-	payload, ok := resp.(map[string]any)
+func TestMCPToolsListStaysWithinItsTokenBudget(t *testing.T) {
+	hermeticEnv(t)
+
+	resp := driveMCP(t, `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	res, ok := resp[0]["result"].(map[string]any)
 	if !ok {
-		t.Fatalf("tools/list returned %T, not an object", resp)
+		t.Fatalf("tools/list returned no result: %#v", resp[0])
 	}
-	whole, err := json.Marshal(payload["tools"])
+	tools, ok := res["tools"].([]any)
+	if !ok {
+		t.Fatalf("tools/list returned no tools: %#v", res)
+	}
+
+	payload, err := json.Marshal(tools)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(whole) > toolsListBudget {
-		tools, _ := payload["tools"].([]map[string]any)
-		t.Errorf("tools/list is %d bytes, over the %d-byte budget by %d (~%d tokens a session, on every session)",
-			len(whole), toolsListBudget, len(whole)-toolsListBudget, (len(whole)-toolsListBudget)/4)
-		for _, tool := range tools {
-			one, err := json.Marshal(tool)
-			if err != nil {
-				continue
-			}
-			t.Logf("  %-16s %5d bytes  ~%4d tokens", tool["name"], len(one), len(one)/4)
+	if len(payload) <= mcpToolsListCharBudget {
+		return
+	}
+
+	// Say where it went. A bare "over budget" sends the next person to measure
+	// by hand, which is how the number got stale in the first place.
+	type sized struct {
+		name string
+		n    int
+		desc int
+	}
+	var each []sized
+	for _, ti := range tools {
+		tool, _ := ti.(map[string]any)
+		b, err := json.Marshal(tool)
+		if err != nil {
+			t.Fatal(err)
 		}
+		name, _ := tool["name"].(string)
+		desc, _ := tool["description"].(string)
+		each = append(each, sized{name, len(b), len(desc)})
+	}
+	sort.Slice(each, func(i, j int) bool { return each[i].n > each[j].n })
+
+	t.Errorf("tools/list is %d chars (~%d tokens) over a %d budget, paid every session by every wired agent",
+		len(payload), (len(payload)-mcpToolsListCharBudget)/4, mcpToolsListCharBudget)
+	for _, e := range each {
+		t.Logf("  %-16s %5d chars (~%4d tokens), description %d", e.name, e.n, e.n/4, e.desc)
 	}
 }


### PR DESCRIPTION
First piece of #1174. Measured on main: six tools, 6815 chars ≈ 1700 tokens, paid by every wired agent on every session before it does anything — and most of it is prose in descriptions, not schema.

The budget is on the whole payload rather than per tool, because the way this grows is a tool here and three sentences of guidance there, each too small to argue with. Failure prints the per-tool breakdown so the next person doesn't measure by hand.

Also checked the issue's second claim: my installed binary answers with four tools, but that's a stale local build — `how` and `fix` landed in bd66a64 and shipped in v0.17.0, so what shipped does match what main defines.