### PR TITLE
test(windows): a test's HOME never reached windows, so the whole suite shared one home

### DIFF
--- a/internal/index/asked_test.go
+++ b/internal/index/asked_test.go
@@ -108,7 +108,7 @@ func askedFixture(t *testing.T, sessions map[string][]string, when map[string]st
 			t.Fatal(err)
 		}
 	}
-	t.Setenv("HOME", tmp)
+	setHome(t, tmp)
 	t.Setenv("USERPROFILE", tmp)
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/collision_test.go
+++ b/internal/index/collision_test.go
@@ -14,7 +14,7 @@ import (
 // every build (#698).
 func TestSessionsSharingAnIDAreAttributedTheSameWayEveryBuild(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -73,7 +73,7 @@ func TestSessionsSharingAnIDAreAttributedTheSameWayEveryBuild(t *testing.T) {
 
 func TestReportCollisionsIsZeroWithoutOne(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -98,7 +98,7 @@ func TestReportCollisionsIsZeroWithoutOne(t *testing.T) {
 // won a shared id depended on that order (#698).
 func TestIncrementalPassAttributesCollisionsTheSameWay(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -153,7 +153,7 @@ func TestIncrementalPassAttributesCollisionsTheSameWay(t *testing.T) {
 // was how the first attempt at #698 deleted a session.
 func TestReindexingOneHalfOfACollisionKeepsTheOther(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/cooccur_tier_test.go
+++ b/internal/index/cooccur_tier_test.go
@@ -15,7 +15,7 @@ import (
 // answers "the thing next to the thing you remember".
 func TestCooccurTierSubstitutesANeighbouringTerm(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	claude := filepath.Join(home, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", claude)

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -21,7 +21,7 @@ import (
 func hermeticIndexEnv(t *testing.T) string {
 	t.Helper()
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "default-index"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))

--- a/internal/index/damaged_manifest_test.go
+++ b/internal/index/damaged_manifest_test.go
@@ -11,7 +11,7 @@ import (
 // store away and rebuilds it.
 func TestDamagedUnreadableManifest(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/damaged_test.go
+++ b/internal/index/damaged_test.go
@@ -11,7 +11,7 @@ import (
 // that could not return a single result (#735).
 func TestDamaged(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/dedup_test.go
+++ b/internal/index/dedup_test.go
@@ -32,7 +32,7 @@ func TestDuplicateFormatSessionsDoNotDuplicateMessages(t *testing.T) {
 	if err := os.WriteFile(jsonl, []byte(head), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_GEMINI_ROOT", gem)
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "nc"))

--- a/internal/index/deepverify_test.go
+++ b/internal/index/deepverify_test.go
@@ -12,7 +12,7 @@ import (
 func deepFixture(t *testing.T) (dir, src string) {
 	t.Helper()
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	claudeRoot := filepath.Join(tmp, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	dir = filepath.Join(tmp, "index.db")

--- a/internal/index/empty_buckets_test.go
+++ b/internal/index/empty_buckets_test.go
@@ -20,7 +20,7 @@ func TestAnEmptyBucketDirectoryCountsAsDamage(t *testing.T) {
 	}
 	// Every root the build consults, or another package's store leaks in and
 	// this index is not the one the test wrote.
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/empty_sessions_test.go
+++ b/internal/index/empty_sessions_test.go
@@ -12,7 +12,7 @@ import (
 // records (1159 against 1157 on my store) (#868).
 func TestSessionsWithNothingToIndexAreNotCounted(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	root := filepath.Join(home, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", root)

--- a/internal/index/find_many_test.go
+++ b/internal/index/find_many_test.go
@@ -11,7 +11,7 @@ import (
 // the single one walked the whole record log per session (#1069).
 func TestFindManyByIdentity(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	setHome(t, tmp)
 	t.Setenv("USERPROFILE", tmp)
 	idx := filepath.Join(tmp, "index.db")
 	t.Setenv("DEJA_INDEX_DIR", idx)

--- a/internal/index/find_substring_test.go
+++ b/internal/index/find_substring_test.go
@@ -10,7 +10,7 @@ import (
 // search is a head and a tail rather than a prefix (#707).
 func TestFindByPrefixFallsBackToASubstring(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/forget_promoted_count_test.go
+++ b/internal/index/forget_promoted_count_test.go
@@ -12,7 +12,7 @@ import (
 // notes a promoted note names something the reader may never have done (#957).
 func TestForgetCountsPromotedNotesApartFromDayBuckets(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -54,7 +54,7 @@ func TestForgetCountsPromotedNotesApartFromDayBuckets(t *testing.T) {
 // action share one selector (#961).
 func TestTombstoneMatchesCountsWhatUnforgetWouldLift(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))

--- a/internal/index/friction_test.go
+++ b/internal/index/friction_test.go
@@ -126,7 +126,7 @@ func frictionStore(t *testing.T, sessions int) string {
 	tmp := t.TempDir()
 	claude := filepath.Join(tmp, "claude")
 	writeFrictionSessions(t, claude, sessions)
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claude)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/fuzzy_known_test.go
+++ b/internal/index/fuzzy_known_test.go
@@ -17,7 +17,7 @@ import (
 func TestFuzzyWidensRareWordsAndLeavesCommonOnesAlone(t *testing.T) {
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	dir := filepath.Join(tmp, "index.db")
 	t.Setenv("DEJA_INDEX_DIR", dir)

--- a/internal/index/graceful_test.go
+++ b/internal/index/graceful_test.go
@@ -33,7 +33,7 @@ func TestUnreadableSourceSkippedNotFatal(t *testing.T) {
 	if err := os.WriteFile(bad, []byte(line("b1", "badneedle original")), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/grok_test.go
+++ b/internal/index/grok_test.go
@@ -63,7 +63,7 @@ func TestMain(m *testing.M) {
 
 func TestGrokIndexGrowthRenameAndRewind(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	setHome(t, tmp)
 	t.Setenv("USERPROFILE", tmp)
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/heal_test.go
+++ b/internal/index/heal_test.go
@@ -21,7 +21,7 @@ func TestSearchRecoversFromCorruptBucket(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(proj, "h1.jsonl"), []byte(data), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/import_before_index_test.go
+++ b/internal/index/import_before_index_test.go
@@ -17,7 +17,6 @@ import (
 // A local session and the imported records must both be reachable after a
 // plain import-then-index.
 func TestImportBeforeFirstIndexKeepsLocalSessions(t *testing.T) {
-	skipWindowsPortability(t)
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")
 	proj := filepath.Join(claudeRoot, "-tmp-local")
@@ -28,7 +27,7 @@ func TestImportBeforeFirstIndexKeepsLocalSessions(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(proj, "local1.jsonl"), []byte(local), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/import_forgotten_test.go
+++ b/internal/index/import_forgotten_test.go
@@ -14,7 +14,7 @@ import (
 // under a new one while `forget --list` still called it forgotten (#968).
 func TestImportLeavesOutSessionsThisMachineForgot(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))

--- a/internal/index/import_redaction_test.go
+++ b/internal/index/import_redaction_test.go
@@ -13,7 +13,7 @@ import (
 // way local ingest does, and rolls the count back with a refused file.
 func TestImportCountsItsRedactions(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	in := filepath.Join(home, "export")
 	if err := os.MkdirAll(in, 0o755); err != nil {
@@ -62,7 +62,7 @@ func TestImportCountsItsRedactions(t *testing.T) {
 // before the break does not inflate the total for records that never landed.
 func TestImportRedactionRollsBackWithARefusedFile(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	in := filepath.Join(home, "export")
 	if err := os.MkdirAll(in, 0o755); err != nil {

--- a/internal/index/import_secret_absent_test.go
+++ b/internal/index/import_secret_absent_test.go
@@ -15,7 +15,7 @@ import (
 // file of the index: records, manifest title, or postings.
 func TestImportLeavesNoRawSecretOnDisk(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	in := filepath.Join(home, "export")
 	if err := os.MkdirAll(in, 0o755); err != nil {

--- a/internal/index/imported_note_rebuild_test.go
+++ b/internal/index/imported_note_rebuild_test.go
@@ -46,7 +46,7 @@ func importedNoteMeta(t *testing.T, dir string) SessionMeta {
 // (#1049).
 func TestImportedNoteStateSurvivesRebuild(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
@@ -78,7 +78,7 @@ func TestImportedNoteStateSurvivesRebuild(t *testing.T) {
 // is in the note text, and a rebuild re-derives it (#1049).
 func TestImportedNoteStateDerivedFromTextWhenRowHasNone(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))

--- a/internal/index/imported_note_state_test.go
+++ b/internal/index/imported_note_state_test.go
@@ -13,7 +13,7 @@ import (
 // correction last (#975).
 func TestImportedNoteKeepsItsStateAndOrder(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -25,7 +25,7 @@ func TestIndexIngestSkipAndSearch(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(data), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "no-codex"))
@@ -174,7 +174,7 @@ func TestSyncExportImportSearchIdempotent(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(proj, "sync1.jsonl"), []byte(data), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -241,7 +241,7 @@ func TestSyncExportImportSearchIdempotent(t *testing.T) {
 
 func TestSyncImportBadJSONAndEmptyExport(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -290,7 +290,7 @@ func TestMultiWordSearchUsesAllPostingsAndDoesNotFullScan(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "no-codex"))
@@ -367,7 +367,7 @@ func TestIncrementalOnlyReingestsChangedFile(t *testing.T) {
 	if err := os.WriteFile(s2, []byte(`{"type":"user","sessionId":"s2","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"beta stable"}}`+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "no-codex"))
@@ -439,7 +439,7 @@ func TestIncrementalAppendOneFileBenchmarkStyle(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "no-codex"))
@@ -497,7 +497,7 @@ func TestIncrementalAppendOneFileBenchmarkStyle(t *testing.T) {
 
 func TestIndexRecentFindRecordsAndBranches(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	setHome(t, tmp)
 	t.Setenv("USERPROFILE", tmp)
 	idx := filepath.Join(tmp, "custom-index")
 	t.Setenv("DEJA_INDEX_DIR", idx)
@@ -586,7 +586,7 @@ func TestIndexRecentFindRecordsAndBranches(t *testing.T) {
 func TestSetOpencodeLastUpdated(t *testing.T) {
 	tmp := t.TempDir()
 	db := filepath.Join(tmp, "opencode.db")
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_OPENCODE_DB", db)
 	files := map[string]FileState{db: {Path: db}}
@@ -599,7 +599,7 @@ func TestSetOpencodeLastUpdated(t *testing.T) {
 
 func TestIndexHelperBranchCoverage(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	setHome(t, tmp)
 	t.Setenv("USERPROFILE", tmp)
 	t.Setenv("DEJA_INDEX_DIR", "")
 	if !strings.Contains(DefaultDir(), filepath.Join(".cache", "deja", "index.db")) {
@@ -794,7 +794,7 @@ func TestCurrentFilesSkipsSymlinks(t *testing.T) {
 	if err := os.Symlink(outside, link); err != nil {
 		t.Skipf("symlink unavailable: %v", err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "no-codex"))
@@ -815,7 +815,7 @@ func TestOldJSONManifestRebuildsTransparently(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(`{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"old manifest rebuild needle"}}`+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "no-codex"))
@@ -876,7 +876,7 @@ func TestRedactsSecretsAtIngest(t *testing.T) {
 	if err := os.WriteFile(p, []byte(data), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "no-codex"))

--- a/internal/index/ingest_safety_test.go
+++ b/internal/index/ingest_safety_test.go
@@ -41,7 +41,7 @@ func TestTornTailLineIndexedOnce(t *testing.T) {
 	writeClaudeLine(t, file, "t1", "first tornneedle message", false)
 	// torn second line: writer got interrupted mid-json
 	writeClaudeLine(t, file, "t1", "second tornneedle message", true)
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -104,7 +104,7 @@ func TestSubagentTranscriptsSkipped(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(sub, "a1.jsonl"), []byte(agent), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/integration_test.go
+++ b/internal/index/integration_test.go
@@ -17,7 +17,7 @@ import (
 func allHarnessEnv(t *testing.T) (root, dir string) {
 	t.Helper()
 	root = t.TempDir()
-	t.Setenv("HOME", filepath.Join(root, "home"))
+	setHome(t, filepath.Join(root, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(root, "home"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(root, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(root, "codex"))

--- a/internal/index/manifest_cache_test.go
+++ b/internal/index/manifest_cache_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestManifestCacheInvalidatesOnReindex(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	claudeRoot := filepath.Join(tmp, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	dir := filepath.Join(tmp, "index.db")

--- a/internal/index/note_dedupe_test.go
+++ b/internal/index/note_dedupe_test.go
@@ -14,7 +14,7 @@ import (
 // arrived under a new bucket and every peer grew a second copy (#977).
 func TestANoteDoesNotArriveTwiceUnderTwoBucketIds(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))

--- a/internal/index/note_state_title_test.go
+++ b/internal/index/note_state_title_test.go
@@ -18,7 +18,7 @@ import (
 // (#R11).
 func TestPromotedNoteTitleTracksTheCorrection(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
 	dir := filepath.Join(tmp, "index.db")
 	when := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)

--- a/internal/index/ord_churn_test.go
+++ b/internal/index/ord_churn_test.go
@@ -27,7 +27,7 @@ func TestReplacedSessionStaysSearchable(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(proj, "ord2.jsonl"), []byte(s2), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/partial_buckets_test.go
+++ b/internal/index/partial_buckets_test.go
@@ -14,7 +14,7 @@ import (
 // interrupted sync leaves exactly this — some files, not none.
 func TestOneMissingBucketFileCountsAsDamage(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	claude := filepath.Join(home, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", claude)
@@ -58,7 +58,7 @@ func TestOneMissingBucketFileCountsAsDamage(t *testing.T) {
 // not send every store built by an older deja into a rebuild loop.
 func TestAnUncountedManifestIsNotDamaged(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	claude := filepath.Join(home, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", claude)

--- a/internal/index/prefix_harnesses_test.go
+++ b/internal/index/prefix_harnesses_test.go
@@ -11,7 +11,7 @@ import (
 // prefix" cannot be followed — the ids are the same string (#719).
 func TestPrefixHarnesses(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))

--- a/internal/index/privacy_test.go
+++ b/internal/index/privacy_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestForgetTombstoneLifecycle(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(home, "index"))
@@ -105,7 +105,7 @@ func TestPrivacyHelpers(t *testing.T) {
 
 func TestTombstonePersistenceAndForgetNoop(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
 	if err := writeTombstones(map[string]bool{"z:last": true, "a:first": true}); err != nil {
@@ -200,7 +200,7 @@ func TestRebuildHonorsTombstonedLoadedSession(t *testing.T) {
 
 func TestUnforgetDoesNotOverMatchHarness(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
 	if err := writeTombstones(map[string]bool{"claude:abc": true, "codex:abc": true, "cursor:xyz": true}); err != nil {
@@ -232,7 +232,7 @@ func TestUnforgetDoesNotOverMatchHarness(t *testing.T) {
 // The command printed nothing at all, so "restored one session" and "that
 // prefix matched nothing" looked the same to the person running it (#672).
 func TestUnforgetReportsHowManyItLifted(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("XDG_CONFIG_HOME", "")
 	if err := writeTombstones(map[string]bool{"claude:a1": true, "claude:a2": true, "cursor:b1": true}); err != nil {

--- a/internal/index/qwen_test.go
+++ b/internal/index/qwen_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestQwenChangedAndAppendedFiles(t *testing.T) {
 	root := t.TempDir()
-	t.Setenv("HOME", filepath.Join(root, "home"))
+	setHome(t, filepath.Join(root, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(root, "qwen"))
 	path := filepath.Join(root, "qwen", "projects", "-tmp-index", "chats", "session.jsonl")

--- a/internal/index/readonly_test.go
+++ b/internal/index/readonly_test.go
@@ -22,7 +22,7 @@ func TestReadOnlyIndexStillAnswers(t *testing.T) {
 		t.Skip("root ignores the permission bits this test relies on")
 	}
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	claude := filepath.Join(home, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", claude)
@@ -70,7 +70,7 @@ func TestReadOnlyIndexStillAnswers(t *testing.T) {
 // still has to surface, or a broken index reads as an empty one.
 func TestLockFailuresOtherThanPermissionStillSurface(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	// A path whose parent is a file, not a directory: MkdirAll fails with
 	// something that is not a permission problem.
 	blocker := filepath.Join(home, "blocker")

--- a/internal/index/recent_order_test.go
+++ b/internal/index/recent_order_test.go
@@ -47,7 +47,7 @@ func TestNewestFirstMetaIsATotalOrder(t *testing.T) {
 // reordered itself on every run: six calls to `deja last`, six answers (#713).
 func TestRecentIsStableWhenTimestampsTie(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/relevance_tail_test.go
+++ b/internal/index/relevance_tail_test.go
@@ -49,7 +49,7 @@ func seedStore(t *testing.T, filler int) string {
 	t.Helper()
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	dir := filepath.Join(tmp, "index.db")
 	t.Setenv("DEJA_INDEX_DIR", dir)

--- a/internal/index/relevance_test.go
+++ b/internal/index/relevance_test.go
@@ -12,7 +12,7 @@ import (
 func TestLadderFallsBackToRelevance(t *testing.T) {
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	dir := filepath.Join(tmp, "index.db")
 	t.Setenv("DEJA_INDEX_DIR", dir)
@@ -114,7 +114,7 @@ func relevancePoolFixture(t *testing.T, n int) string {
 	t.Helper()
 	tmp := t.TempDir()
 	home := filepath.Join(tmp, "home")
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	claudeRoot := filepath.Join(tmp, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)

--- a/internal/index/renamed_path_test.go
+++ b/internal/index/renamed_path_test.go
@@ -14,7 +14,7 @@ import (
 // take a second conversation with it (#1086).
 func TestARenamedTranscriptIsNotASecondCopyOfItself(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	claude := filepath.Join(home, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", claude)
@@ -55,7 +55,7 @@ func TestARenamedTranscriptIsNotASecondCopyOfItself(t *testing.T) {
 // even when some unrelated file went away in the same pass.
 func TestTwoLiveTranscriptsSharingAnIdStillCollide(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	claude := filepath.Join(home, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", claude)

--- a/internal/index/scope_leak_test.go
+++ b/internal/index/scope_leak_test.go
@@ -50,7 +50,6 @@ func TestEnsureHonorsHarnessScope(t *testing.T) {
 }
 
 func TestDateTokensMakeSessionsFindableByMonth(t *testing.T) {
-	skipWindowsPortability(t)
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")
 	proj := filepath.Join(claudeRoot, "-tmp-app")

--- a/internal/index/selfrecall_test.go
+++ b/internal/index/selfrecall_test.go
@@ -58,7 +58,7 @@ func TestStripSelfRecallKeepsWhatTheUserWrote(t *testing.T) {
 // The whole point: what deja injects must not come back as what deja knows.
 func TestIndexDoesNotSwallowItsOwnRecall(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	claude := filepath.Join(home, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", claude)

--- a/internal/index/shared_counts_test.go
+++ b/internal/index/shared_counts_test.go
@@ -9,7 +9,6 @@ import (
 // HarnessSharedCounts is what lets doctor tell a parse failure from an id
 // collision (#1101); it had no test of its own, and the package floor noticed.
 func TestHarnessSharedCounts(t *testing.T) {
-	skipWindowsPortability(t)
 	dir := filepath.Join(t.TempDir(), "index.db")
 	store := t.TempDir()
 	// Two transcripts writing one id: the manifest keeps a single row for them

--- a/internal/index/stale_path_test.go
+++ b/internal/index/stale_path_test.go
@@ -15,7 +15,7 @@ import (
 // start on a full rebuild or serves an index that is missing the answer.
 func TestEnsureForSearchStaleDecidesWhatToServe(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	claude := filepath.Join(home, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", claude)
@@ -64,7 +64,7 @@ func TestEnsureForSearchStaleDecidesWhatToServe(t *testing.T) {
 // serves an index holding text the transcript no longer has.
 func TestEnsureForSearchStaleRefusesToAppendOntoARewind(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	claude := filepath.Join(home, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", claude)
@@ -93,7 +93,7 @@ func TestEnsureForSearchStaleRefusesToAppendOntoARewind(t *testing.T) {
 // a session must never be listed twice when two names both match it.
 func TestRecentProjectsRanksAndDeduplicates(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	claude := filepath.Join(home, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", claude)

--- a/internal/index/sync_boundary_test.go
+++ b/internal/index/sync_boundary_test.go
@@ -14,7 +14,6 @@ import (
 // watermark instant. Every rebuild of the manifest must carry it, or ordinary
 // ingest between two pushes silently turns it back into a resend.
 func TestBoundarySurvivesIncrementalIngest(t *testing.T) {
-	skipWindowsPortability(t)
 	const ts = "2026-01-02T03:04:05Z"
 	dir, tmp := syncPeerIndex(t, msgLine(ts, "only message"))
 	n, commit, err := ExportDeferred(dir, filepath.Join(tmp, "out1"), "laptop")
@@ -58,7 +57,6 @@ func TestBoundarySurvivesIncrementalIngest(t *testing.T) {
 // Watermarks are per source. A push that touches project B must not disturb
 // what project A has already delivered.
 func TestUnrelatedPushDoesNotWipeOtherBoundaries(t *testing.T) {
-	skipWindowsPortability(t)
 	const ts = "2026-01-02T03:04:05Z"
 	dir, tmp := syncPeerIndex(t, msgLine(ts, "project a message"))
 	if _, commit, err := ExportDeferred(dir, filepath.Join(tmp, "a1"), "laptop"); err != nil {
@@ -104,7 +102,6 @@ func TestUnrelatedPushDoesNotWipeOtherBoundaries(t *testing.T) {
 // what arrives next: the exclude list is a privacy control, not a filter on
 // new traffic.
 func TestExcludeAppliesToAlreadyImportedSessions(t *testing.T) {
-	skipWindowsPortability(t)
 	dir, tmp := syncPeerIndex(t, msgLine("2026-01-02T03:04:05Z", "nda project notes"))
 	batch := filepath.Join(tmp, "batch")
 	if _, err := Export(dir, batch); err != nil {

--- a/internal/index/sync_partial_test.go
+++ b/internal/index/sync_partial_test.go
@@ -15,7 +15,7 @@ import (
 // (#891).
 func TestImportKeepsGoingPastAFileItCannotRead(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	in := filepath.Join(home, "export")
 	if err := os.MkdirAll(in, 0o755); err != nil {
@@ -79,7 +79,7 @@ func TestImportKeepsGoingPastAFileItCannotRead(t *testing.T) {
 // every counter (#896).
 func TestImportDropsRecordsWithNothingInThem(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	in := filepath.Join(home, "export")
 	if err := os.MkdirAll(in, 0o755); err != nil {
@@ -135,7 +135,7 @@ func TestImportDropsRecordsWithNothingInThem(t *testing.T) {
 // brought nothing and they were lost for good (#897).
 func TestRetryAfterAFixedFileBringsExactlyWhatWasMissing(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setHome(t, home)
 	t.Setenv("USERPROFILE", home)
 	in := filepath.Join(home, "export")
 	if err := os.MkdirAll(in, 0o755); err != nil {

--- a/internal/index/sync_peer_test.go
+++ b/internal/index/sync_peer_test.go
@@ -44,7 +44,6 @@ func msgLine(ts, text string) string {
 // What one peer has already received says nothing about what another peer
 // has: a global watermark silently partitions history across machines.
 func TestExportWatermarksAreScopedPerPeer(t *testing.T) {
-	skipWindowsPortability(t)
 	dir, tmp := syncPeerIndex(t, msgLine("2026-01-02T03:04:05Z", "shared history"))
 	n, commit, err := ExportDeferred(dir, filepath.Join(tmp, "toLaptop"), "laptop")
 	if err != nil || n != 1 {
@@ -65,7 +64,6 @@ func TestExportWatermarksAreScopedPerPeer(t *testing.T) {
 // Harnesses that stamp every message of a session with one timestamp (aider,
 // Cursor) must not lose the messages appended after the first push.
 func TestExportKeepsMessagesSharingTheWatermarkTimestamp(t *testing.T) {
-	skipWindowsPortability(t)
 	const ts = "2026-01-02T03:04:05Z"
 	dir, tmp := syncPeerIndex(t, msgLine(ts, "first message"))
 	n, commit, err := ExportDeferred(dir, filepath.Join(tmp, "out1"), "peer")
@@ -143,7 +141,6 @@ func TestImportHonorsTombstonesAfterCacheWipe(t *testing.T) {
 // The exclude list keeps a project out of this machine's memory; a sync from
 // another machine must not put it back.
 func TestImportHonorsExcludeList(t *testing.T) {
-	skipWindowsPortability(t)
 	dir, tmp := syncPeerIndex(t, msgLine("2026-01-02T03:04:05Z", "nda project notes"))
 	batch := filepath.Join(tmp, "batch")
 	if _, err := Export(dir, batch); err != nil {

--- a/internal/index/sync_persist_test.go
+++ b/internal/index/sync_persist_test.go
@@ -37,7 +37,6 @@ func writeSyncBatch(t *testing.T, dir string, recs []SyncRecord) {
 // deja-sync-import path that the next update classified as a removed source,
 // purging every imported record.
 func TestImportedRecordsSurviveRebuildAndUpdate(t *testing.T) {
-	skipWindowsPortability(t)
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")
 	proj := filepath.Join(claudeRoot, "-tmp-local")
@@ -48,7 +47,7 @@ func TestImportedRecordsSurviveRebuildAndUpdate(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(proj, "local1.jsonl"), []byte(local), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -169,7 +168,7 @@ func TestImportedRecordsSurviveRebuildAndUpdate(t *testing.T) {
 // survive import, and re-import must stay a no-op.
 func TestImportKeepsSameTimestampMessages(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -198,7 +197,7 @@ func TestImportKeepsSameTimestampMessages(t *testing.T) {
 // conversation arrived (#670).
 func TestImportGivesSessionsATitle(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -255,7 +254,7 @@ func TestImportGivesSessionsATitle(t *testing.T) {
 // a typo for a directory that is right there with records in it (#678).
 func TestImportRejectsAPathThatIsNotADirectoryOfRecords(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/sync_unknown_field_test.go
+++ b/internal/index/sync_unknown_field_test.go
@@ -13,7 +13,7 @@ import (
 // into "nothing was imported from 1 file".
 func TestImportIgnoresUnknownRecordFields(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))

--- a/internal/index/testhome_test.go
+++ b/internal/index/testhome_test.go
@@ -1,0 +1,56 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setHome points a test's home at dir the way every platform reads it.
+//
+// t.Setenv("HOME", …) alone is a no-op on windows: sources.Home() goes through
+// os.UserHomeDir(), which reads USERPROFILE there, and the notes file goes
+// through os.UserConfigDir(), which reads APPDATA. TestMain sets both once for
+// the whole package, so on windows a test that thought it had its own home was
+// reading and writing the package's — one test's note showed up as a leaked
+// `deja` session in the next test's index, which is what a dozen tests in here
+// were skipped for.
+//
+// The unix behaviour is unchanged: HOME still decides, and the extra keys are
+// only read on windows.
+func setHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	t.Setenv("APPDATA", filepath.Join(dir, "AppData", "Roaming"))
+	t.Setenv("LOCALAPPDATA", filepath.Join(dir, "AppData", "Local"))
+}
+
+// The next test written in here will be copied from the one above it, and the
+// line being copied used to be t.Setenv("HOME", …). That reads as isolation on
+// the machine it was written on and provides none on windows, which is a thing
+// nobody discovers until a test that looks unrelated starts failing there.
+func TestTestsInThisPackageSetHomeThroughTheHelper(t *testing.T) {
+	names, err := filepath.Glob(filepath.Join(".", "*_test.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) < 2 {
+		t.Fatalf("globbed %d test files; the guard is reading the wrong directory", len(names))
+	}
+	for _, name := range names {
+		if name == filepath.Join(".", "testhome_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i, line := range strings.Split(string(b), "\n") {
+			if strings.Contains(line, `t.Setenv("HOME"`) {
+				t.Errorf("%s:%d sets HOME directly; use setHome, which windows also reads", name, i+1)
+			}
+		}
+	}
+}

--- a/internal/index/tool_stream_test.go
+++ b/internal/index/tool_stream_test.go
@@ -21,7 +21,7 @@ func TestEachToolOutputStreamsOnlyToolRecords(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -79,7 +79,7 @@ func TestRecordsForKeyMatchesAFullScan(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -145,7 +145,7 @@ func TestSpanInventoryCountsWhatRestoreCanHandBack(t *testing.T) {
 			edit("s2", "/w/pool.go", "another old pool")), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -206,7 +206,7 @@ func TestSpanInventorySkipsSpansWithNoPath(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(proj, "b1.jsonl"), []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
@@ -229,7 +229,6 @@ func TestSpanInventorySkipsSpansWithNoPath(t *testing.T) {
 // empty slice on every session and no error — silence, which is how it cost a
 // wrong measurement before it was noticed (#633).
 func TestRecentCarriesTouched(t *testing.T) {
-	skipWindowsPortability(t)
 	tmp := t.TempDir()
 	proj := filepath.Join(tmp, "claude", "-tmp-touch")
 	if err := os.MkdirAll(proj, 0o755); err != nil {
@@ -240,7 +239,7 @@ func TestRecentCarriesTouched(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(proj, "t1.jsonl"), []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setHome(t, t.TempDir())
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/index/windows_portability_test.go
+++ b/internal/index/windows_portability_test.go
@@ -5,12 +5,11 @@ import (
 	"testing"
 )
 
-// skipWindowsPortability defers a test that bakes in unix path fixtures
-// (unix-style cwd, flat store layouts) and asserts unix-derived projects,
-// attribution or error wording. deja derives those from file paths with
-// filepath.Rel/Separator and a lexicographic path comparison, so they diverge
-// on windows. These pass on macOS and ubuntu; the windows portability of the
-// fixtures — and one unproven session-count doubling — is tracked in #1119.
+// skipWindowsPortability is kept as the single place a windows-only skip would
+// go, and is deliberately unused: the skips it held are removed, so windows CI
+// reports what actually fails rather than reporting nothing. See #1119.
+//
+//nolint:unused
 func skipWindowsPortability(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Windows CI on #1286 came back with ten failures in `internal/index`, all the same shape: a note written by one test showing up as a leaked `deja` session in another test's index, from a path under the package's shared temp dir.

`t.Setenv("HOME", …)` is what 82 tests in there use for isolation, and on windows it isolates nothing — `sources.Home()` goes through `os.UserHomeDir()`, which reads USERPROFILE, and the notes file goes through `os.UserConfigDir()`, which reads APPDATA. TestMain sets both once for the package, so every test that thought it had its own home was reading and writing the same one. Unix never noticed because HOME is the only key that matters there.

`setHome` points all four at the same dir, and a guard fails if a direct `t.Setenv("HOME"` comes back — that line is what the next test in here will be copied from. The `skipWindowsPortability` calls from #1286 are gone with it, so the windows leg now actually runs these.

Needs the `windows` label to prove itself; that leg skips from the inside without it.

Supersedes #1286. Part of #1119.