### PR TITLE
docs: the no-hook harness count was stale and had inverted

### DIFF
--- a/cmd/deja/logo.go
+++ b/cmd/deja/logo.go
@@ -128,8 +128,8 @@ func logoLinesArt(art, info []string) []string {
 		out = append(out, line)
 	}
 	// An info column taller than the mark keeps going underneath it rather
-	// than being cut off: sixteen harnesses plus a header already overflow,
-	// so the last stores were silently dropped from the greeting.
+	// than being cut off: the harness list plus a header outgrew the mark long
+	// ago, so the last stores were silently dropped from the greeting.
 	for j := len(art) - top; j < len(info); j++ {
 		if j < 0 {
 			continue

--- a/cmd/deja/mcp_instructions.go
+++ b/cmd/deja/mcp_instructions.go
@@ -19,9 +19,9 @@ func mcpInstructions(dir string) string {
 		b.WriteString(s.progress())
 		b.WriteString("); recall works now but covers more history as it finishes.")
 	} else if warmupJustRequested(dir) && index.HasManifest(dir) {
-		// Thirteen of the sixteen harnesses have no hook and read this and
-		// nothing else. A rebuild that has not reported yet left them with the
-		// ordinary instructions and an index this build cannot read (#879).
+		// A harness with no auto-recall wiring reads this and nothing else. A
+		// rebuild that has not reported yet left it with the ordinary
+		// instructions and an index this build cannot read (#879).
 		b.WriteString(" The index is being rebuilt right now; recall covers more history once it finishes.")
 	}
 	return b.String()

--- a/cmd/deja/warmup_status.go
+++ b/cmd/deja/warmup_status.go
@@ -203,10 +203,10 @@ func cmdWarmupStatus(dir string, _ []string) error {
 }
 
 // emptyRecallAnswer distinguishes "there is nothing" from "there is nothing
-// YET". Thirteen of the sixteen harnesses have no hook to speak through and
-// reach deja only over MCP, so a tool result is the one place they can learn
-// that the first index is still being built. Without this the agent reads a
-// confident negative and tells the user they have no history.
+// YET". A harness with no auto-recall wiring reaches deja over MCP and nothing
+// else, so a tool result is the one place it can learn that the first index is
+// still being built. Without this the agent reads a confident negative and
+// tells the user they have no history.
 func emptyRecallAnswer(dir, q string) string { return emptyRecallAnswerPolicy(dir, q, 0) }
 
 // emptyRecallAnswerPolicy adds the reason when a rule, not the query, is why

--- a/cmd/deja/warmup_status_test.go
+++ b/cmd/deja/warmup_status_test.go
@@ -153,9 +153,9 @@ func TestWarmupStatusCommandIsSilentWithoutABuild(t *testing.T) {
 	}
 }
 
-// Thirteen of the sixteen harnesses have no hook and reach deja only over
-// MCP. A recall during the first build must not answer with a confident
-// negative, or the agent tells the user they have no history at all.
+// A harness with no auto-recall wiring reaches deja only over MCP. A recall
+// during the first build must not answer with a confident negative, or the
+// agent tells the user they have no history at all.
 func TestMCPRecallDistinguishesEmptyFromStillBuilding(t *testing.T) {
 	tmp := hermeticEnv(t)
 	dir := filepath.Join(tmp, "index.db")


### PR DESCRIPTION
Four comments said "thirteen of the sixteen harnesses have no hook and reach deja only over MCP". That was true when most harnesses had no hook. From the registry today: 18 harnesses, 15 wire auto-recall, and the ones that don't are copilot, roo and zed — so it's two reaching deja over MCP alone, not thirteen.

The number was never why the code does what it does. What matters is the condition: a harness with no auto-recall wiring reads the MCP instructions and nothing else, so that string and the empty-recall answer have to carry the still-building notice. Comments now say that instead of a count that drifts every time a harness lands.