### PR TITLE
fix(index): an incremental update deleted the mined sidecars

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1844,7 +1844,32 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	if err := writeManifest(tmp, m); err != nil {
 		return err
 	}
+	carrySidecars(dir, tmp)
 	return swapIndexDir(dir, tmp)
+}
+
+// carrySidecars copies the mined sidecars from the live index into the
+// incremental build, because the swap replaces the whole directory and this
+// path does not mine them again — it deliberately never holds the whole corpus.
+//
+// Without this, one incremental update deleted all three. `fix` went silent
+// outright, since it has no other source; ranking lost its query expansion;
+// commands survived only because they have a fallback path. And an incremental
+// update is not a rare event — it is what a new session in any store triggers,
+// so the sidecars were being destroyed during ordinary use and only came back
+// on the next full rebuild.
+//
+// They are carried, not rebuilt: pairs mined from sessions that arrived in this
+// update are missing until a full build, which is the ordinary staleness of a
+// derived file and not the same thing as having none.
+func carrySidecars(dir, tmp string) {
+	for _, name := range []string{fixesFile, commandsFile, cooccurFile} {
+		b, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		_ = os.WriteFile(filepath.Join(tmp, name), b, 0o600)
+	}
 }
 
 func canAppendIncremental(changed map[string]FileState, old map[string]FileState) bool {

--- a/internal/index/sidecar_carry_test.go
+++ b/internal/index/sidecar_carry_test.go
@@ -1,0 +1,75 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// An incremental update replaces the whole index directory, and the path that
+// builds it never mines the sidecars — it deliberately never holds the whole
+// corpus. So the swap used to delete them: one new session anywhere, and `fix`
+// had nothing to answer with, ranking lost its query expansion, and neither
+// came back until the next full rebuild. Ordinary use, silently degraded.
+//
+// This asserts the files survive, not what is in them. What is in them is
+// allowed to be one update stale; being absent is not.
+func TestIncrementalUpdateKeepsTheMinedSidecars(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, filepath.Join(tmp, "home"))
+	claude := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claude, "-work")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+
+	// An error followed by a command, twice, which is the evidence a fix pair
+	// needs before deja will keep it.
+	session := func(name, ts string) {
+		body := `{"type":"user","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"user","content":"build broken"}}
+{"type":"user","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"user","content":[{"type":"tool_result","content":[{"type":"text","text":"undefined: renderInvoice in vendor/billing/api.go"}]}]}}
+{"type":"assistant","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go mod vendor && go build ./..."}}]}}
+{"type":"assistant","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"assistant","content":"vendoring fixed it"}}
+`
+		if err := os.WriteFile(filepath.Join(proj, name+".jsonl"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	session("a", "2026-01-02T03:04:05Z")
+	session("b", "2026-01-03T03:04:05Z")
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Whatever the full build mined is what the incremental one has to keep.
+	// cooccur needs more sessions than this fixture has and is carried by the
+	// same code; asserting on it here would only pin the fixture's size.
+	var want []string
+	for _, name := range []string{fixesFile, commandsFile, cooccurFile} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			want = append(want, name)
+		}
+	}
+	if len(want) < 2 {
+		t.Fatalf("full build mined only %v — the fixture no longer clears the bars this test needs", want)
+	}
+	if len(FixesFor(dir, "undefined: renderInvoice in vendor/billing/api.go", 3, nil)) == 0 {
+		t.Fatal("full build mined no fix pair; the fixture is not exercising what this test guards")
+	}
+
+	// One more session is all it takes: this is the incremental path.
+	session("c", "2026-01-04T03:04:05Z")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range want {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("an incremental update dropped %s", name)
+		}
+	}
+	if len(FixesFor(dir, "undefined: renderInvoice in vendor/billing/api.go", 3, nil)) == 0 {
+		t.Error("fix went silent after an incremental update")
+	}
+}


### PR DESCRIPTION
Closes #1295.

One `deja remember` — or any new session in any store — replaced the index directory with a build that never mined `fixes.gob`, `commands.gob` or `cooccur.gob`, so all three were gone until the next full rebuild. `fix` has no other source and answered nothing; ranking lost its query expansion; commands kept working off their fallback, which is why nothing looked broken.

Carries the three files into the incremental build before the swap. Carried rather than re-mined, because that path deliberately never holds the whole corpus — pairs from sessions that arrived in this update are missing until a full build, which is a derived file being one update stale rather than absent.

The test seeds an error settled twice, indexes, adds one session, and asserts the files and `fix` survive. Removing the carry makes it fail with `an incremental update dropped fixes.gob` and `fix went silent after an incremental update`.