### PR TITLE
fix(index): incremental updates never learned a new fix pair

### DIFF
--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -270,6 +270,70 @@ func LooksLikeError(text string) bool {
 	return false
 }
 
+// mergeFixes updates the carried pairs with what the sessions in this
+// incremental update contain.
+//
+// Carrying alone was not enough. A new session is a new file, and a new file
+// never takes the append path, so every session a user starts goes through the
+// incremental rebuild — which is exactly where new pairs come from. Carrying
+// them meant `fix` answered only what the last full build had mined, and on a
+// machine whose stores are append-only that build happens when the index
+// version changes and not otherwise.
+//
+// The pairs already carried keep their place unconditionally: they earned it
+// against the whole corpus, and re-judging them here — where most of that
+// corpus is not in hand — would drop the ones whose evidence was a repeat in a
+// session this update did not touch. Fresh candidates are judged the way a full
+// build judges them, counting a match against a carried pair as the repeat it
+// is.
+func mergeFixes(dir, tmp string, replacements []model.Session, replaced map[string]bool) {
+	carried := ReadFixes(dir)
+	kept := make([]FixPair, 0, len(carried))
+	for _, p := range carried {
+		// Whatever this update re-read, it re-mines below; keeping the old rows
+		// too would duplicate a session's pairs on every edit to its file.
+		if !replaced[p.Key] {
+			kept = append(kept, p)
+		}
+	}
+	var fresh []FixPair
+	for _, s := range replacements {
+		fresh = append(fresh, fixPairsIn(s.Messages, s.Harness+":"+s.ID, s.Project)...)
+	}
+	if len(fresh) == 0 && len(kept) == len(carried) {
+		return
+	}
+	seen := map[string]int{}
+	for _, p := range kept {
+		seen[fixKey(p)]++
+	}
+	repeats := map[string]int{}
+	for _, p := range fresh {
+		repeats[fixKey(p)]++
+	}
+	for _, p := range fresh {
+		k := fixKey(p)
+		if sharesTerm(p.Error, p.Command) || repeats[k]+seen[k] >= 2 {
+			kept = append(kept, p)
+		}
+	}
+	sort.SliceStable(kept, func(i, j int) bool { return kept[i].When.After(kept[j].When) })
+	written := map[string]bool{}
+	out := kept[:0]
+	for _, p := range kept {
+		k := fixKey(p)
+		if written[k] {
+			continue
+		}
+		written[k] = true
+		out = append(out, p)
+		if len(out) >= fixesMax {
+			break
+		}
+	}
+	_ = writeGob(fixesPath(tmp), out)
+}
+
 // ReadFixes loads the mined pairs. An index built before they existed simply
 // has none.
 func ReadFixes(dir string) []FixPair {

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1845,6 +1845,9 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		return err
 	}
 	carrySidecars(dir, tmp)
+	// After carrying, not instead of it: mergeFixes writes only when it has
+	// something to say, and the carried file is what a quiet update leaves.
+	mergeFixes(dir, tmp, replacements, replaceKeys)
 	return swapIndexDir(dir, tmp)
 }
 

--- a/internal/index/sidecar_carry_test.go
+++ b/internal/index/sidecar_carry_test.go
@@ -72,4 +72,32 @@ func TestIncrementalUpdateKeepsTheMinedSidecars(t *testing.T) {
 	if len(FixesFor(dir, "undefined: renderInvoice in vendor/billing/api.go", 3, nil)) == 0 {
 		t.Error("fix went silent after an incremental update")
 	}
+
+	// Keeping the old pairs is half of it. A new session is a new file, and a
+	// new file never takes the append path, so sessions arriving after the
+	// first build are the only source of new pairs and all of them come
+	// through here. Carrying alone left fix frozen at whatever the full build
+	// had seen — which this assertion, and not the one above, is what catches.
+	settled := func(name, ts string) {
+		body := `{"type":"user","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"user","content":"migration broke"}}
+{"type":"user","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"user","content":[{"type":"tool_result","content":[{"type":"text","text":"connection refused: flimbardb:5432"}]}]}}
+{"type":"assistant","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"docker compose restart flimbardb"}}]}}
+{"type":"assistant","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"assistant","content":"restarting it cleared the migration"}}
+`
+		if err := os.WriteFile(filepath.Join(proj, name+".jsonl"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	settled("d", "2026-02-01T03:04:05Z")
+	settled("e", "2026-02-02T03:04:05Z")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(FixesFor(dir, "connection refused: flimbardb:5432", 3, nil)) == 0 {
+		t.Error("a pair from a session that arrived after the full build was never mined")
+	}
+	// And the old one is still there: learning must not cost what was carried.
+	if len(FixesFor(dir, "undefined: renderInvoice in vendor/billing/api.go", 3, nil)) == 0 {
+		t.Error("mining the new sessions dropped the carried pairs")
+	}
 }


### PR DESCRIPTION
Follow-up to #1296, which was half the fix.

Carrying the sidecars stopped them being deleted, but nothing re-mined them. And `canAppendIncremental` requires the file to already be in the index, so a **new session — a new file — always takes the rebuild path**. That path is where every new pair comes from, and it was only carrying. `fix` answered whatever the last full build had seen and nothing since; on a machine whose stores are append-only that build happens when the index version changes and not otherwise.

Measured before this change: a second error settled twice, added after the first build, is found by a from-scratch build and never by an incremental one.

Mines the sessions in the update and merges them with the carried pairs. Carried pairs keep their place unconditionally — they earned it against the whole corpus, and re-judging them here, where most of that corpus is not in hand, would drop the ones whose evidence was a repeat in a session this update did not touch. Fresh candidates get the same rule a full build applies, counting a match against a carried pair as the repeat it is. Pairs for a session this update re-read are dropped before re-mining, so editing a session's file does not duplicate its pairs.

`commands` and `cooccur` stay carried-only: both are aggregates over the whole corpus (per-session counts, document frequencies) and merging a subset into them would double-count.

The test in #1296 passed with pure carrying — it asserted the files survived and the old pair still answered, both true and both beside the point. It now also adds a session with its own settled error and asserts that pair is found, and that the carried one survives the mining. Removing `mergeFixes` fails with `a pair from a session that arrived after the full build was never mined`; removing `carrySidecars` fails with `an incremental update dropped commands.gob`.