### PR TITLE
fix(index): hook-tool never saw a command that became a habit after the last full build

### DIFF
--- a/internal/index/commands.go
+++ b/internal/index/commands.go
@@ -134,6 +134,107 @@ func buildCommands(tmp string, ss []model.Session) {
 	_ = writeGob(commandsPath(tmp), out)
 }
 
+// buildCommandsFromIndex rebuilds the table from the records an index already
+// holds, rather than from sessions in memory.
+//
+// The incremental path has only the sessions this update touched, and these
+// counters are aggregates — how many distinct sessions ran a command, in which
+// projects, last when. A subset cannot be merged into an aggregate: for a
+// session being re-read there is no way to subtract what it contributed before.
+// So carrying the table forward was the only option, and it meant hook-tool
+// stayed silent about every command that became a habit after the last full
+// build — which is every habit, since a new session is a new file and that is
+// the path this runs on.
+//
+// Reading it back out of the records is exact, because by this point the
+// records in tmp are the whole corpus: the ones carried over plus the ones this
+// update wrote. It is the same source `deja how` already answers from.
+func buildCommandsFromIndex(tmp string) {
+	type acc struct {
+		use       CommandUse
+		sessions  map[string]bool
+		byProject map[string]*projAcc
+	}
+	by := map[string]*acc{}
+	// Identity is harness:id and nothing guarantees it is unique: two transcripts
+	// named session-1.jsonl in different projects share one manifest row, and the
+	// row carries the winner's project. A full build files each conversation's
+	// commands under its own project, because it reads the session rather than
+	// the row — and the trust policy, --project and the exclude patterns all key
+	// on that. Recomputing from records here would file the loser's commands
+	// under the winner's project, which is the leak ByProject exists to prevent.
+	// A record whose source path is not the row's path is exactly that case;
+	// leave the carried table alone rather than publish a wrong attribution.
+	collided := false
+	err := EachRecordOfRole(tmp, roleCommand, func(meta SessionMeta, r Record) {
+		if collided {
+			return
+		}
+		if r.SourcePath != "" && meta.Path != "" && r.SourcePath != meta.Path {
+			collided = true
+			return
+		}
+		cmd := strings.TrimSpace(firstTextLine(r.Text))
+		if cmd == "" || len(cmd) > commandTextMax {
+			return
+		}
+		low := normalizeCommand(cmd)
+		if low == "" {
+			return
+		}
+		a := by[low]
+		if a == nil {
+			a = &acc{use: CommandUse{Command: cmd}, sessions: map[string]bool{}, byProject: map[string]*projAcc{}}
+			by[low] = a
+		}
+		a.use.Runs++
+		a.sessions[r.Key] = true
+		pa := a.byProject[meta.Project]
+		if pa == nil {
+			pa = &projAcc{sessions: map[string]bool{}}
+			a.byProject[meta.Project] = pa
+		}
+		pa.sessions[r.Key] = true
+		if r.Time.After(pa.last) {
+			pa.last = r.Time
+		}
+		if r.Time.After(a.use.Last) {
+			a.use.Last = r.Time
+		}
+	})
+	if err != nil || collided {
+		// An extra, never a reason to fail an update: the carried table stays.
+		return
+	}
+	out := make([]CommandUse, 0, len(by))
+	for _, a := range by {
+		if len(a.sessions) < commandMinSessions {
+			continue
+		}
+		a.use.Sessions = len(a.sessions)
+		a.use.ByProject = cappedProjects(a.byProject)
+		out = append(out, a.use)
+	}
+	if len(out) == 0 {
+		return
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Sessions != out[j].Sessions {
+			return out[i].Sessions > out[j].Sessions
+		}
+		return out[i].Command < out[j].Command
+	})
+	if len(out) > commandsMax {
+		out = out[:commandsMax]
+	}
+	// Atomic, unlike the full build's write: there the file does not exist yet,
+	// here a good carried table is already sitting in tmp. A truncating write
+	// that fails partway would ship an undecodable file, and ReadCommands
+	// answers nothing at all for that — hook-tool would go silent until the
+	// next full rebuild, which is worse than the staleness this replaces.
+	_ = writeGobAtomic(commandsPath(tmp), out)
+}
+
 // cappedProjects keeps at most commandProjectCap projects for a command,
 // choosing the ones with the most sessions (ties broken by name) so the choice
 // is deterministic across rebuilds — a map-order cap could silence a different

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1845,9 +1845,10 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		return err
 	}
 	carrySidecars(dir, tmp)
-	// After carrying, not instead of it: mergeFixes writes only when it has
-	// something to say, and the carried file is what a quiet update leaves.
+	// After carrying, not instead of it: both of these write only when they
+	// have something to say, and the carried file is what a quiet update leaves.
 	mergeFixes(dir, tmp, replacements, replaceKeys)
+	buildCommandsFromIndex(tmp)
 	return swapIndexDir(dir, tmp)
 }
 

--- a/internal/index/sidecar_carry_test.go
+++ b/internal/index/sidecar_carry_test.go
@@ -100,4 +100,18 @@ func TestIncrementalUpdateKeepsTheMinedSidecars(t *testing.T) {
 	if len(FixesFor(dir, "undefined: renderInvoice in vendor/billing/api.go", 3, nil)) == 0 {
 		t.Error("mining the new sessions dropped the carried pairs")
 	}
+
+	// The command table has the same shape of problem and needed a different
+	// answer. Its counters are aggregates — distinct sessions, per project —
+	// and a subset cannot be merged into one, so it is recomputed from the
+	// records the index already holds. hook-tool is its only reader, and it
+	// stayed silent about every command that became a habit after the last full
+	// build, which is every habit: the sessions that make one arrive through
+	// this path. Both new sessions above ran the same command.
+	use, ok := CommandHistory(dir, "docker compose restart flimbardb")
+	if !ok {
+		t.Error("a command that became a habit after the full build is missing from the table")
+	} else if use.Sessions != 2 {
+		t.Errorf("command counted in %d sessions, want 2", use.Sessions)
+	}
 }


### PR DESCRIPTION
Found by the night hunt, iteration 2. Same family as #1296/#1297, different answer.

`commands.gob` is carried across an incremental update and never recomputed. `canAppendIncremental` returns false for a new file, so every new session takes the rewrite path — and new sessions are what make a command recur. `CommandHistory` is read only by `hook-tool`, on every agent action, so the effect is that point-of-action recall stays silent about every habit formed since the last full build.

Reproduced:

```
1. known command, after full build          → "has run that command in 2 sessions"
2. new habit, after an incremental update   → silence
3. same, after a from-scratch rebuild       → "has run that command in 2 sessions"
```

The counters are aggregates — distinct sessions, per project, last run — so a subset cannot be merged into them the way fix pairs can: for a session being re-read there is no way to subtract what it contributed before. Recomputed from the command records already written into the build instead, which is exact because by that point they are the whole corpus, and is the same source `deja how` answers from.

Cost measured on a 2000-session store, one new session each time: 0.13–0.14s before, 0.13–0.15s after — within noise.

Two findings from the reviewer, both fixed here:

- Project attribution came from the manifest row rather than the session, which differs when two transcripts share an id (#698). The row carries the winner's project, so the loser's commands would be filed under it — and the trust policy, `--project` and the exclude patterns all key on that, which is the leak `ByProject` exists to prevent. A record whose source path is not the row's path is exactly that case; the rebuild now bails and leaves the carried table alone.
- The write was `writeGob` (truncate in place) over a good carried file. A failed encode would ship an undecodable table, and `ReadCommands` answers nothing at all for that — silent hook until the next full rebuild, worse than the staleness being fixed. Now `writeGobAtomic`.

The test asserts the habit is in the table with the right session count; removing the rebuild fails it with `a command that became a habit after the full build is missing from the table`.