### PR TITLE
fix(index): an incremental update wrote credentials into the mined pairs

### DIFF
--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/redact"
 )
 
 // Fix pairs: the error a session hit, and the command that came next and made
@@ -289,18 +290,30 @@ func LooksLikeError(text string) bool {
 func mergeFixes(dir, tmp string, replacements []model.Session, replaced map[string]bool) {
 	carried := ReadFixes(dir)
 	kept := make([]FixPair, 0, len(carried))
+	dirty := false
 	for _, p := range carried {
 		// Whatever this update re-read, it re-mines below; keeping the old rows
 		// too would duplicate a session's pairs on every edit to its file.
-		if !replaced[p.Key] {
-			kept = append(kept, p)
+		if replaced[p.Key] {
+			continue
 		}
+		// An index built before this path scrubbed its sessions holds pairs with
+		// the credential still in them, and carrying is all that ever happens to
+		// a pair whose session is not re-read — so without this the leak outlives
+		// the fix for it, indefinitely, on the machine that already has it.
+		if e, counts := redact.Text(p.Error); len(counts) > 0 {
+			p.Error, dirty = e, true
+		}
+		if c, counts := redact.Text(p.Command); len(counts) > 0 {
+			p.Command, dirty = c, true
+		}
+		kept = append(kept, p)
 	}
 	var fresh []FixPair
 	for _, s := range replacements {
 		fresh = append(fresh, fixPairsIn(s.Messages, s.Harness+":"+s.ID, s.Project)...)
 	}
-	if len(fresh) == 0 && len(kept) == len(carried) {
+	if len(fresh) == 0 && len(kept) == len(carried) && !dirty {
 		return
 	}
 	seen := map[string]int{}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1698,6 +1698,14 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		skipRedactions[p] = true
 	}
 	carryRedactions(&m, old, skipRedactions)
+	// Scrub once, up front, the way both full builds do — everything below reads
+	// these sessions. Redacting per message inside the record loop instead left
+	// the sessions themselves raw, so whatever was mined from them afterwards
+	// was raw too: a credential in an error line reached fixes.gob whole while a
+	// rebuild of the same corpus produced a clean one. It also left
+	// metaForSession hashing unredacted text, so the friction signatures a
+	// session carried depended on which build path had touched it last.
+	preRedactSessions(&m, replacements)
 	buckets := bucketPostings{}
 	addRec := func(r Record) error {
 		if r.SourcePath == "" {
@@ -1826,7 +1834,8 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 			if seenMsgs.dup(key, msg.Role, msg.Time, msg.Text) {
 				continue
 			}
-			text := redactForIngest(&m, s.Path, msg.Text)
+			// Already redacted (and length-capped) by preRedactSessions above.
+			text := msg.Text
 			if err := addRec(Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time}); err != nil {
 				_ = rw.Close()
 				return err

--- a/internal/index/sidecar_redaction_test.go
+++ b/internal/index/sidecar_redaction_test.go
@@ -1,0 +1,118 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Both full-build paths scrub the sessions in place before mining anything from
+// them, because the record loop redacts into a local and leaves the sessions
+// holding the raw text. The incremental path had no such call, so a secret in
+// an error line or a command reached fixes.gob whole — while rebuilding the
+// same corpus from scratch produced a clean one. Which build path a machine
+// happened to take decided whether its credentials were written to disk.
+//
+// The assertion is on the bytes of the index, not on what a command prints: the
+// leak is the file, and every reader of it inherits the problem.
+func TestIncrementalUpdateRedactsWhatItMines(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, filepath.Join(tmp, "home"))
+	claude := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claude, "-work")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+
+	const secret = "sk-live-ZZTOPSECRET1234567890abcd"
+	plain := func(name, ts string) {
+		body := `{"type":"user","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"user","content":"ordinary work"}}
+{"type":"assistant","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"assistant","content":"nothing special"}}
+`
+		if err := os.WriteFile(filepath.Join(proj, name+".jsonl"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// An error carrying a credential, settled by a command carrying the same
+	// one — which is what makes it a pair worth mining.
+	leaky := func(name, ts string) {
+		body := `{"type":"user","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"user","content":"deploy is broken"}}
+{"type":"user","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"user","content":[{"type":"tool_result","content":[{"type":"text","text":"connection refused: db.internal:5432 for ` + secret + `"}]}]}}
+{"type":"assistant","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"kubectl create secret generic api --from-literal=token=` + secret + `"}}]}}
+{"type":"assistant","sessionId":"` + name + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"assistant","content":"recreated it and the deploy came back"}}
+`
+		if err := os.WriteFile(filepath.Join(proj, name+".jsonl"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dir := filepath.Join(tmp, "index.db")
+	plain("a", "2026-02-01T03:04:05Z")
+	plain("b", "2026-02-02T03:04:05Z")
+	plain("c", "2026-02-03T03:04:05Z")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if found := filesHolding(t, dir, secret); len(found) > 0 {
+		t.Fatalf("the full build already leaks into %v — this test can no longer tell the paths apart", found)
+	}
+
+	// The sessions holding it arrive afterwards: the incremental path.
+	leaky("d", "2026-03-01T03:04:05Z")
+	leaky("e", "2026-03-02T03:04:05Z")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Absence of the secret proves nothing if nothing was mined. Pin that the
+	// pair exists first, so this cannot pass by the fixture quietly stopping to
+	// qualify — the evidence rules in fixPairsIn are strict and have moved
+	// before.
+	if len(ReadFixes(dir)) == 0 {
+		t.Fatal("no pair was mined, so the assertion below would hold for the wrong reason")
+	}
+	if found := filesHolding(t, dir, secret); len(found) > 0 {
+		t.Errorf("an incremental update wrote the raw credential into %v", found)
+	}
+
+	// A machine that already ran the leaky build carries its poisoned file
+	// forward, and carrying is all that ever happens to a pair whose session is
+	// not re-read. Simulate that: put the credential back into the pair on disk
+	// and let one ordinary session trigger an update.
+	pairs := ReadFixes(dir)
+	pairs[0].Error = "connection refused: db.internal:5432 for " + secret
+	if err := writeGob(filepath.Join(dir, fixesFile), pairs); err != nil {
+		t.Fatal(err)
+	}
+	plain("f", "2026-04-01T03:04:05Z")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if found := filesHolding(t, dir, secret); len(found) > 0 {
+		t.Errorf("a credential carried in from an older index survived the update, in %v", found)
+	}
+}
+
+// filesHolding names the files under dir whose bytes contain want.
+func filesHolding(t *testing.T, dir, want string) []string {
+	t.Helper()
+	var out []string
+	err := filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return nil
+		}
+		if strings.Contains(string(b), want) {
+			out = append(out, filepath.Base(p))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}


### PR DESCRIPTION
Found by the night hunt, iteration 5. This is a regression I introduced in #1297 and it writes secrets to disk, so it should go in ahead of anything else queued.

Both full-build paths call `preRedactSessions` on the sessions before mining any sidecar from them. The incremental path never did: its record loop redacted each message into a local and left the sessions holding the raw text, and `mergeFixes` mines pairs from those sessions.

Reproduced on the same corpus, same binary:

```
full build                      → clean
incremental update              → fixes.gob holds sk-live-…
from-scratch rebuild            → clean
```

Which build path a machine happened to take decided whether its credentials were written to disk.

Fixed by scrubbing up front, where both full paths do it, rather than by adding a second scrub late. That placement also fixes two things the late one would not:

- `metaForSession` hashes `Asked`/`Hit` from the session text, so friction signatures differed between a session indexed incrementally and the same session rebuilt — an error that matched `deja error` yesterday could stop matching. Now both paths hash the same redacted text.
- The regex battery ran twice over every message on this path (once per message in the loop, once for the sidecars). Now once, as on the full paths.

Also scrubs pairs carried from an older index. Carrying is all that ever happens to a pair whose session is not re-read, so without it a machine that already ran the leaky build keeps the credential forever — the index version is unchanged, so nothing forces the rebuild that would clear it. Verified end to end: leaky binary leaves the secret in `fixes.gob`; after upgrading, one ordinary new session scrubs it.

The test asserts on the bytes of the index rather than on what a command prints, because the leak is the file and every reader inherits it. It pins that a pair is actually mined first, so absence of the secret cannot pass for the wrong reason. Removing the up-front scrub fails with `an incremental update wrote the raw credential into [commands.gob fixes.gob records.bin]`; removing the carried-pair scrub fails with `a credential carried in from an older index survived the update, in [fixes.gob]`.

Reviewer found all of this beyond the initial leak; the placement, the carried pairs and the vacuous assertion are its findings.