### PR TITLE
fix(index): the one sidecar write that overwrites a good file was not atomic

### DIFF
--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -344,7 +344,11 @@ func mergeFixes(dir, tmp string, replacements []model.Session, replaced map[stri
 			break
 		}
 	}
-	_ = writeGob(fixesPath(tmp), out)
+	// Atomic, unlike the full build's write a few functions up: there the file
+	// cannot exist yet, here carrySidecars has just put a good one in place. A
+	// truncating write that failed partway would leave it undecodable, and that
+	// reads as no pairs at all — silence until the next full rebuild.
+	_ = writeGobAtomic(fixesPath(tmp), out)
 }
 
 // ReadFixes loads the mined pairs. An index built before they existed simply

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -344,10 +344,12 @@ func mergeFixes(dir, tmp string, replacements []model.Session, replaced map[stri
 			break
 		}
 	}
-	// Atomic, unlike the full build's write a few functions up: there the file
-	// cannot exist yet, here carrySidecars has just put a good one in place. A
-	// truncating write that failed partway would leave it undecodable, and that
-	// reads as no pairs at all — silence until the next full rebuild.
+	// Atomic, unlike buildFixes above: that one writes into a directory made
+	// moments earlier, where the file cannot exist. This one runs after
+	// carrySidecars has copied the live table into the build directory, and the
+	// swap ships whatever is there. A truncating write that failed partway would
+	// ship an undecodable file, which ReadFixes reports as no pairs at all —
+	// silence until the next full rebuild.
 	_ = writeGobAtomic(fixesPath(tmp), out)
 }
 

--- a/internal/index/gob_write_test.go
+++ b/internal/index/gob_write_test.go
@@ -1,0 +1,53 @@
+package index
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// writeGob opens with O_TRUNC and only then encodes, so a failed encode leaves
+// the file it was overwriting destroyed — emptied, in the case below, where the
+// encoder refuses the value before writing a byte.
+//
+// That is harmless where the file cannot already exist: the full builds write
+// each sidecar into a directory they just created. It is not harmless where a
+// good file has just been carried in and is being rewritten, because a reader
+// treats an undecodable sidecar as having no content at all — one failed write
+// silences the feature until the next full rebuild.
+//
+// A channel is what makes the encoder refuse. A struct with a channel field
+// does not: gob quietly skips fields it cannot handle, which is worth knowing
+// before writing a test that relies on one.
+func TestAFailedGobWriteKeepsOrLosesWhatWasThere(t *testing.T) {
+	dir := t.TempDir()
+	const good = "the file that was already there"
+	fail := make(chan int)
+
+	t.Run("writeGob loses it", func(t *testing.T) {
+		p := filepath.Join(dir, "plain.gob")
+		if err := writeGob(p, good); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeGob(p, fail); err == nil {
+			t.Fatal("the encode was expected to fail; this test no longer proves anything")
+		}
+		var back string
+		if err := readGob(p, &back); err == nil && back == good {
+			t.Skip("writeGob no longer truncates before encoding — the hazard is gone")
+		}
+	})
+
+	t.Run("writeGobAtomic keeps it", func(t *testing.T) {
+		p := filepath.Join(dir, "atomic.gob")
+		if err := writeGobAtomic(p, good); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeGobAtomic(p, fail); err == nil {
+			t.Fatal("the encode was expected to fail; this test no longer proves anything")
+		}
+		var back string
+		if err := readGob(p, &back); err != nil || back != good {
+			t.Errorf("a failed atomic write lost the previous content: %q, %v", back, err)
+		}
+	})
+}

--- a/internal/index/gob_write_test.go
+++ b/internal/index/gob_write_test.go
@@ -31,9 +31,12 @@ func TestAFailedGobWriteKeepsOrLosesWhatWasThere(t *testing.T) {
 		if err := writeGob(p, fail); err == nil {
 			t.Fatal("the encode was expected to fail; this test no longer proves anything")
 		}
+		// Asserted, not skipped: the loss is the hazard this documents, and if
+		// writeGob ever stops truncating first, whoever changes it should be the
+		// one to retire this — not have it quietly pass.
 		var back string
 		if err := readGob(p, &back); err == nil && back == good {
-			t.Skip("writeGob no longer truncates before encoding — the hazard is gone")
+			t.Error("writeGob preserved the previous content; the reason for the atomic call site is gone and this test should go with it")
 		}
 	})
 


### PR DESCRIPTION
Night hunt, iteration 8. Audited every `writeGob` call after #1299 turned up one of these.

Four sites. Three are full builds writing into a directory they just created, where the file cannot exist yet — safe. The fourth is `mergeFixes`, which runs after `carrySidecars` has put a good `fixes.gob` in place and then overwrites it.

`writeGob` opens with `O_TRUNC` and encodes afterwards, so a write that fails partway leaves the previous file destroyed. `ReadFixes` treats an undecodable file as no pairs at all, so one failed write silences `fix` until the next full rebuild — and on an append-only store that is when the index version changes and not otherwise.

The test is the comparison, and it is worth having on its own: the same failing encode against both writers, asserting the previous content is gone from one and intact in the other. It also records something that cost time to find out — gob quietly **skips** struct fields it cannot handle, so a struct with a channel field encodes fine and proves nothing; only a bare channel makes the encoder refuse.

Being honest about what is and is not guarded: the call-site change itself has no test that would fail without it, because that needs a write to fail at that exact point and there is no fault injection here. What the test pins is that the two writers really do differ in the way the change assumes.