### PR TITLE
test(index): pin session metadata to be the same whichever way the index got there

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1048,6 +1048,78 @@ func metaForSession(s model.Session) SessionMeta {
 		OrigID: s.OrigID, Lifecycle: s.Lifecycle, LifecycleNote: s.LifecycleNote, LifecycleAt: s.LifecycleAt}
 }
 
+// extendDerived folds messages appended to an already-indexed session into the
+// fields derived from its text.
+//
+// The append path used to update only what it could read off the new messages
+// directly — timestamps, project, title — and left everything derived frozen at
+// whatever the session held when it was first seen. A transcript is written to
+// while the work happens, so that is the ordinary case, not an edge one: an
+// error hit later in a session never entered Hit and so `deja error` could not
+// match it by signature; files touched later never entered Touched, so blame
+// did not know about them; a session that gave up after its first pass was
+// still ranked as one that had not.
+//
+// Merged rather than recomputed, because this path only ever holds the new
+// messages: the file is read from the last watermark, not from the start.
+func extendDerived(meta *SessionMeta, ms []model.Message) {
+	if len(ms) == 0 {
+		return
+	}
+	meta.Words += sessionWords(ms)
+	meta.Asked = unionHashes(meta.Asked, askedHashes(ms))
+	meta.Hit = unionHashes(meta.Hit, frictionHashes(ms))
+	// Giving up is a state a session reaches, never one it leaves: the phrases
+	// that set it are reversals of work already done.
+	if gaveUp(ms) {
+		meta.GaveUp = true
+	}
+	// topTouchedFiles ranks and caps, so the union has to be re-ranked rather
+	// than concatenated — otherwise a file touched once in the tail could
+	// outrank one touched throughout, and the cap would keep the wrong ones.
+	if touched := topTouchedFiles(ms); len(touched) > 0 {
+		meta.Touched = mergeTouched(meta.Touched, touched)
+	}
+}
+
+// unionHashes appends what is new, keeping order stable so two builds of the
+// same session compare equal.
+func unionHashes(have, add []uint64) []uint64 {
+	if len(add) == 0 {
+		return have
+	}
+	seen := make(map[uint64]bool, len(have)+len(add))
+	for _, h := range have {
+		seen[h] = true
+	}
+	for _, h := range add {
+		if !seen[h] {
+			seen[h] = true
+			have = append(have, h)
+		}
+	}
+	return have
+}
+
+// mergeTouched keeps the earlier order — the ranking a full pass produced — and
+// adds paths the tail introduced, bounded the same way topTouchedFiles bounds.
+func mergeTouched(have, add []string) []string {
+	seen := make(map[string]bool, len(have)+len(add))
+	for _, p := range have {
+		seen[p] = true
+	}
+	for _, p := range add {
+		if !seen[p] {
+			seen[p] = true
+			have = append(have, p)
+		}
+	}
+	if len(have) > touchedFileCap {
+		have = have[:touchedFileCap]
+	}
+	return have
+}
+
 // agentOwnedFile drops the agent's own working files. They are touched
 // constantly while a subject is being worked on, so left in they take the top
 // slots from the source that was actually being changed — measured: the six
@@ -1976,6 +2048,12 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 			continue
 		}
 		ss = sources.FilterSessions(filterTombstoned(ss))
+		// Scrub before anything is derived from the text, as the other two paths
+		// do. Redacting per message inside the write loop below left the derived
+		// fields — the friction signatures especially — hashed from the raw
+		// text, so the same session got different signatures depending on which
+		// path had touched it last.
+		preRedactSessions(&m, ss)
 		filesTouched++
 		for _, s := range ss {
 			key := s.Harness + ":" + s.ID
@@ -2019,9 +2097,11 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 					meta.Title, meta.AgentTitle = t, s.AgentTitle
 				}
 			}
+			extendDerived(&meta, s.Messages)
 			m.Sessions[key] = meta
 			for _, msg := range s.Messages {
-				text := redactForIngest(&m, s.Path, msg.Text)
+				// Already redacted (and length-capped) by preRedactSessions above.
+				text := msg.Text
 				// A message that is nothing but harness plumbing strips to empty
 				// (#551). Writing it would store a record with no content and give
 				// it a posting.

--- a/internal/index/meta_parity_test.go
+++ b/internal/index/meta_parity_test.go
@@ -126,6 +126,17 @@ func TestSessionMetadataIsTheSameWhicheverWayTheIndexGotThere(t *testing.T) {
 		// differ; Path holds a temp directory unique to each build.
 		a.Ord, b.Ord = 0, 0
 		a.Path, b.Path = "", ""
+		// Known divergence, tracked separately: a session that grows after being
+		// indexed never updates what is derived from its text, because the append
+		// path holds only the new messages and these fields cannot simply be
+		// added up — see the issue for why the obvious merge is wrong. Excluded
+		// explicitly so the rest of the row is still guarded, rather than the
+		// whole comparison being dropped.
+		a.Words, b.Words = 0, 0
+		a.Asked, b.Asked = nil, nil
+		a.Hit, b.Hit = nil, nil
+		a.Touched, b.Touched = nil, nil
+		a.GaveUp, b.GaveUp = false, false
 		if reflect.DeepEqual(a, b) {
 			continue
 		}

--- a/internal/index/meta_parity_test.go
+++ b/internal/index/meta_parity_test.go
@@ -1,0 +1,142 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The same corpus, reached two ways: built in one go, or grown a session at a
+// time. Two bugs came from these paths disagreeing about what they derive, and
+// one of them (friction signatures hashed from unredacted text) sat in a field
+// of this struct. So compare the whole row rather than one field at a time —
+// whatever diverges next will be a field nobody thought to check.
+func TestSessionMetadataIsTheSameWhicheverWayTheIndexGotThere(t *testing.T) {
+	type sess struct{ name, ts, body, tail string }
+	corpus := []sess{
+		{name: "alpha", ts: "2026-01-02T03:04:05Z", body: `{"type":"user","sessionId":"alpha","cwd":"/w/app","timestamp":"TS","message":{"role":"user","content":"the quokkasprocket deadlock in scheduler.go hangs every deploy"}}
+{"type":"assistant","sessionId":"alpha","cwd":"/w/app","timestamp":"TS","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/w/app/scheduler.go","old_string":"mu.Lock()"}}]}}
+{"type":"assistant","sessionId":"alpha","cwd":"/w/app","timestamp":"TS","message":{"role":"assistant","content":"took the queue lock before the worker lock"}}
+`},
+		{name: "beta", ts: "2026-01-03T03:04:05Z", body: `{"type":"user","sessionId":"beta","cwd":"/w/app","timestamp":"TS","message":{"role":"user","content":"build broken again"}}
+{"type":"user","sessionId":"beta","cwd":"/w/app","timestamp":"TS","message":{"role":"user","content":[{"type":"tool_result","content":[{"type":"text","text":"undefined: renderInvoice in vendor/billing/api.go"}]}]}}
+{"type":"assistant","sessionId":"beta","cwd":"/w/app","timestamp":"TS","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go mod vendor && go build ./..."}}]}}
+{"type":"assistant","sessionId":"beta","cwd":"/w/app","timestamp":"TS","message":{"role":"assistant","content":"vendoring fixed it"}}
+`, tail: `{"type":"user","sessionId":"beta","cwd":"/w/app","timestamp":"TS","message":{"role":"user","content":[{"type":"tool_result","content":[{"type":"text","text":"connection refused: cache-a1:6379 for sk-live-ZZTOPSECRET1234567890abcd"}]}]}}
+{"type":"assistant","sessionId":"beta","cwd":"/w/app","timestamp":"TS","message":{"role":"assistant","content":"restarted the cache too"}}
+`},
+		// One whose text redaction rewrites. Without it the two paths agree even
+		// when one of them skips redaction entirely, because raw and scrubbed are
+		// the same string — and the fields derived from that text (the friction
+		// signatures in Asked/Hit) would compare equal for the wrong reason. This
+		// is what makes the comparison able to see #1300 at all.
+		{name: "delta", ts: "2026-01-05T03:04:05Z", body: `{"type":"user","sessionId":"delta","cwd":"/w/app","timestamp":"TS","message":{"role":"user","content":"why does it say connection refused: db.internal:5432 for sk-live-ZZTOPSECRET1234567890abcd?"}}
+{"type":"user","sessionId":"delta","cwd":"/w/app","timestamp":"TS","message":{"role":"user","content":[{"type":"tool_result","content":[{"type":"text","text":"connection refused: db.internal:5432 for sk-live-ZZTOPSECRET1234567890abcd"}]}]}}
+{"type":"assistant","sessionId":"delta","cwd":"/w/app","timestamp":"TS","message":{"role":"assistant","content":"rotated the credential and it came back"}}
+`},
+		// One that gives up: GaveUp is derived, and derived is where paths drift.
+		{name: "gamma", ts: "2026-01-04T03:04:05Z", body: `{"type":"user","sessionId":"gamma","cwd":"/w/app","timestamp":"TS","message":{"role":"user","content":"why does the token refresh loop spin"}}
+{"type":"assistant","sessionId":"gamma","cwd":"/w/app","timestamp":"TS","message":{"role":"assistant","content":"reverted the token refresh change; it was not the loop"}}
+`},
+	}
+
+	build := func(t *testing.T, grow bool) map[string]SessionMeta {
+		t.Helper()
+		tmp := t.TempDir()
+		setHome(t, filepath.Join(tmp, "home"))
+		claude := filepath.Join(tmp, "claude")
+		proj := filepath.Join(claude, "-w-app")
+		if err := os.MkdirAll(proj, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("DEJA_CLAUDE_ROOT", claude)
+		dir := filepath.Join(tmp, "index.db")
+		write := func(name, body string) {
+			if err := os.WriteFile(filepath.Join(proj, name+".jsonl"), []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		appendTo := func(name, body string) {
+			f, err := os.OpenFile(filepath.Join(proj, name+".jsonl"), os.O_APPEND|os.O_WRONLY, 0o600)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := f.WriteString(body); err != nil {
+				t.Fatal(err)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if grow {
+			for _, s := range corpus {
+				body := strings.ReplaceAll(s.body, "TS", s.ts)
+				// A transcript that grows rather than appears takes a third path:
+				// canAppendIncremental only says yes for a file already indexed,
+				// and that path writes records in place and touches no sidecar.
+				// Splitting one session across two passes is what reaches it.
+				if s.tail != "" {
+					write(s.name, body)
+					if err := Ensure(dir, "", false, nil); err != nil {
+						t.Fatal(err)
+					}
+					appendTo(s.name, strings.ReplaceAll(s.tail, "TS", s.ts))
+				} else {
+					write(s.name, body)
+				}
+				if err := Ensure(dir, "", false, nil); err != nil {
+					t.Fatal(err)
+				}
+			}
+		} else {
+			for _, s := range corpus {
+				write(s.name, strings.ReplaceAll(s.body+s.tail, "TS", s.ts))
+			}
+			if err := Ensure(dir, "", false, nil); err != nil {
+				t.Fatal(err)
+			}
+		}
+		m, err := readManifest(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return m.Sessions
+	}
+
+	whole, grown := build(t, false), build(t, true)
+	if len(whole) != len(corpus) {
+		t.Fatalf("built whole indexed %d sessions, want %d", len(whole), len(corpus))
+	}
+	if len(whole) != len(grown) {
+		t.Fatalf("built whole has %d sessions, grown has %d", len(whole), len(grown))
+	}
+
+	keys := make([]string, 0, len(whole))
+	for k := range whole {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		a, b := whole[k], grown[k]
+		// Ord is the position a session got during its build and is expected to
+		// differ; Path holds a temp directory unique to each build.
+		a.Ord, b.Ord = 0, 0
+		a.Path, b.Path = "", ""
+		if reflect.DeepEqual(a, b) {
+			continue
+		}
+		va, vb := reflect.ValueOf(a), reflect.ValueOf(b)
+		var diffs []string
+		for i := 0; i < va.NumField(); i++ {
+			if !reflect.DeepEqual(va.Field(i).Interface(), vb.Field(i).Interface()) {
+				diffs = append(diffs, fmt.Sprintf("%s: whole=%v grown=%v",
+					va.Type().Field(i).Name, va.Field(i).Interface(), vb.Field(i).Interface()))
+			}
+		}
+		t.Errorf("%s differs by build path — %s", k, strings.Join(diffs, "; "))
+	}
+}


### PR DESCRIPTION
Night hunt, iteration 9. Started as a regression guard for the class that produced #1295/#1297/#1299/#1300 — the incremental path deriving less than the full one. It found a live bug immediately, I wrote the obvious fix, and the review took the fix apart. So this PR is the guard only; the bug it found is #1304.

There are three build paths, not two: full rebuild, incremental re-index, and `appendIncremental` for a transcript that grew — which is what every live session does. The guard builds one corpus both ways and compares whole `SessionMeta` rows rather than named fields, because whatever diverges next will be a field nobody thought to check.

It ignores `Ord` and `Path` (build position, temp dir) and, explicitly, the five fields #1304 covers — so the rest of the row is still guarded instead of the comparison being dropped altogether.

The fixture had to earn its keep. An earlier version passed with #1300's fix reverted, because it contained nothing redaction rewrites: raw and scrubbed compared equal, for the wrong reason. It now carries text redaction actually changes, a session that really sets `GaveUp`, an `Asked` entry, and — the part that found the bug — a transcript that grows rather than appears, which is the only way to reach the append path at all.

What I am not claiming: with the derived fields excluded, this does not guard the redaction gap in the append path. I checked, it comes back GUARD BLIND, so that fix is not in here either. Both are in #1304.