### PR TITLE
fix(mcp): the server took the blocking index lock it had just avoided

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -517,6 +517,25 @@ func recallText(dir, q, harness string, limit, budget int) (string, error) {
 	return text, err
 }
 
+// wholeSessionForMCP reads one session for a caller that must not wait.
+//
+// `findByPrefix` is the CLI helper and opens with a blocking `index.Ensure` —
+// right for a command someone typed, wrong here. Every caller below has already
+// been through `EnsureForSearchStale`, which deliberately refuses to wait: it
+// serves the snapshot on disk and hands the rebuild to a detached warmup,
+// because rebuilding inline blows the client's tool timeout. Calling the
+// blocking version afterwards undid exactly that — and if the lock happened to
+// be free it would run the whole rebuild on the server's thread rather than
+// merely wait for it.
+//
+// By identity rather than by prefix, too: `FindByPrefix` matches the id across
+// every harness and answers with the newest match, so the "full story" printed
+// for a hit could be a different session that shares its id — a real case, not
+// a theoretical one (#719). The hit knows its own harness; use it.
+func wholeSessionForMCP(dir string, s model.Session) (model.Session, bool, error) {
+	return index.FindByIdentity(dir, s.Harness, s.ID)
+}
+
 func recallTextResult(dir, q, harness string, limit, offset, budget int) (string, int, int64, []string, error) {
 	if limit <= 0 {
 		limit = 5
@@ -664,7 +683,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 				// whole session for the best hit alone, the same upgrade
 				// recall_context makes for the same reason (#1011).
 				whole := h.Session
-				if full, ok, ferr := findByPrefix(dir, whole.ID); ferr == nil && ok {
+				if full, ok, ferr := wholeSessionForMCP(dir, whole); ferr == nil && ok {
 					whole = full
 				}
 				if cs := digest.Conclusions(whole, left, 3); len(cs) > 0 {
@@ -774,7 +793,7 @@ func recallContextResult(dir, q, harness string) (string, int, int64, []string, 
 	// an answer worded nothing like the question (the decision itself) never
 	// reached the agent, the same gap CLI ctx closed (#1011).
 	whole := hits[0].Session
-	if full, ok, ferr := findByPrefix(dir, whole.ID); ferr == nil && ok {
+	if full, ok, ferr := wholeSessionForMCP(dir, whole); ferr == nil && ok {
 		whole = full
 	}
 	var b bytes.Buffer

--- a/cmd/deja/mcp_no_block_test.go
+++ b/cmd/deja/mcp_no_block_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Everything the MCP server answers from opens with EnsureForSearchStale, which
+// refuses to wait: it serves the snapshot on disk and hands the rebuild to a
+// detached warmup, because rebuilding inline blows the client's tool timeout.
+// Then, to print what a session concluded, it read the whole best hit through
+// findByPrefix — the CLI helper, which opens with a blocking index.Ensure. The
+// careful part was undone a few hundred lines below it, and if the lock was
+// free the server would run the rebuild on its own thread rather than wait for
+// it. Found by instrumenting LockWaitNotice and reading the stack:
+//
+//	index.lockDir → index.Ensure → main.findByPrefix → main.recallTextResult
+//
+// Asserted on the source because the behavioural version needs a second process
+// holding the lock at the right instant, which is racy in a unit suite. Every
+// file the server answers from is scanned, not just mcp.go: the first version
+// of this guard read one of the two and would have missed the same call in
+// resources/read.
+func TestNothingTheMCPServerServesUsesTheBlockingLookup(t *testing.T) {
+	// Guard the guard: a rename must retire or retarget this, not leave it
+	// green against a name nobody uses.
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(src), "func findByPrefix(") {
+		t.Fatal("findByPrefix is gone from main.go — retire or retarget this test")
+	}
+
+	files, err := filepath.Glob("mcp*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanned := 0
+	for _, name := range files {
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		scanned++
+		for i, line := range strings.Split(string(b), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			// No trailing paren: findByPrefixHarness calls findByPrefix and
+			// blocks exactly the same way, and a bare name would match an
+			// alias taken as a value.
+			if strings.Contains(line, "findByPrefix") {
+				t.Errorf("%s:%d reaches findByPrefix, which blocks on the index lock; "+
+					"this path serves a client that cannot wait", name, i+1)
+			}
+		}
+	}
+	if scanned < 2 {
+		t.Fatalf("scanned %d files; the server is spread over more than that, so this is reading the wrong directory", scanned)
+	}
+}

--- a/cmd/deja/mcp_resources.go
+++ b/cmd/deja/mcp_resources.go
@@ -74,7 +74,7 @@ func mcpResourceRead(dir, uri string) (any, int, string) {
 	if i := strings.IndexByte(ref, ':'); i >= 0 {
 		id = ref[i+1:]
 	}
-	s, found, err := findByPrefix(dir, id)
+	s, found, err := index.FindByPrefix(dir, id)
 	if err != nil {
 		return nil, -32603, err.Error()
 	}


### PR DESCRIPTION
Night hunt, iteration 14, from the loose end left by iteration 13 — a lock-wait notice appeared on a path designed never to wait, and reading the code twice did not find it. Instrumenting `LockWaitNotice` did, first try:

```
index.lockDir → index.Ensure → main.findByPrefix → main.recallTextResult
```

`recallTextResult` opens with `EnsureForSearchStale`, which refuses to wait: it serves the snapshot on disk and hands the rebuild to a detached warmup, because rebuilding inline blows the client's tool timeout. Then, to print what the best session concluded, it read that session through `findByPrefix` — the CLI helper, which opens with a blocking `index.Ensure`. So the careful part was undone a few hundred lines below it. Waiting is the good case: if the lock happened to be free, the server ran the whole rebuild on the thread answering the client.

Three call sites, not one — `recall`, `recall_context`, and `resources/read`. The reviewer found the third; my first guard read only `mcp.go` and could not see it.

Also resolves by identity rather than by bare id. `FindByPrefix` matches the id across every harness and answers with the newest match, so the "full story" printed for a hit could be a different session sharing its id — the case #719 already documents. The hit knows its own harness, and `attachAnswers` in the same file was already doing it this way.

The guard is on the source, because the behavioural version needs a second process holding the lock at the right instant. It scans every `mcp*.go`, refuses to pass if it scanned fewer than two, checks that `findByPrefix` still exists before trusting a green result, and matches the bare name so `findByPrefixHarness` — which calls it and blocks identically — cannot slip through. All three ways of reintroducing the bug fail it.

Left for #1306, which the same review turned up: `resources/list`, `fix` and `how` still call the blocking `index.Ensure` and can rebuild inline, and two of them skip the "deja is indexing" guard so a cold index answers with a raw errno.
