### PR TITLE
fix(mcp): how filtered by the CLI's trust policy, not the agent's

### DIFF
--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -67,7 +67,7 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 	if err := index.Ensure(dir, "", false, os.Stderr); err != nil {
 		return ensureError(dir, err)
 	}
-	entries, hidden, err := howEntries(dir, terms, project)
+	entries, hidden, err := howEntries(dir, terms, project, policy.ActivationSearch)
 	if err != nil {
 		return err
 	}
@@ -96,12 +96,23 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 
 // howEntries groups the commands that mention every term, so the same
 // invocation run on twenty days counts as one answer with a weight.
-func howEntries(dir string, terms []string, project string) ([]howEntry, int, error) {
+//
+// The activation is the caller's, not a constant: the same command table is
+// served to the person at their own terminal and to an agent over MCP, and the
+// trust policy keys on which of those it is. Hardcoding the search activation
+// here meant a machine that allows imported memory in its owner's searches and
+// denies it over MCP handed the imported command to the agent anyway — while
+// recall, asked the same thing, correctly said it was withholding something.
+//
+// The count of what was withheld travels with it, because filtering alone turns
+// a leak into a confident "no command mentions that" over records the policy
+// hid, and an agent told nothing exists invents something.
+func howEntries(dir string, terms []string, project, activation string) ([]howEntry, int, error) {
 	pol := policy.Load()
 	hidden := 0
 	byCmd := map[string]*howEntry{}
 	err := index.EachRecordOfRole(dir, "command", func(meta index.SessionMeta, r index.Record) {
-		if !pol.Allows(policy.ActivationSearch, meta.Project) {
+		if !pol.Allows(activation, meta.Project) {
 			hidden++
 			return
 		}

--- a/cmd/deja/how_policy_test.go
+++ b/cmd/deja/how_policy_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// The trust policy keys on which channel is asking: a machine may allow
+// imported memory in its owner's own searches and deny it to an agent over MCP.
+// `how` served both from one function with the search activation compiled in,
+// so the MCP rule was never consulted — recall, asked the same question on the
+// same machine, correctly said it was withholding something while how handed
+// the imported command over.
+func TestHowHonoursTheChannelsOwnPolicy(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claude, "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Written out rather than seeded: `how` answers from command records, and
+	// only a Bash tool_use produces one.
+	body := `{"type":"user","sessionId":"sess-one","cwd":"/app","timestamp":"2026-10-01T09:00:00Z","message":{"role":"user","content":"how do we ship the zonkomatic"}}
+{"type":"assistant","sessionId":"sess-one","cwd":"/app","timestamp":"2026-10-01T09:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"helm upgrade zonkomatic --set replicas=9"}}]}}
+`
+	if err := os.WriteFile(filepath.Join(proj, "sess-one.jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+
+	cfg := filepath.Join(tmp, "config", "deja")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Denied over MCP, allowed for the owner's own searches. Keyed on "local"
+	// because the seeded session is this machine's own; the split is what
+	// matters, not which origin carries it.
+	if err := os.WriteFile(filepath.Join(cfg, "policy.json"),
+		[]byte(`{"activations":{"mcp":{"local":false},"search":{"local":true}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	if policy.Load().Allows(policy.ActivationMCP, "app") {
+		t.Fatal("the policy did not take effect, so this test would pass for the wrong reason")
+	}
+	if !policy.Load().Allows(policy.ActivationSearch, "app") {
+		t.Fatal("the search side is denied too, so this cannot tell the two apart")
+	}
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	entries, _, err := howEntries(dir, []string{"zonkomatic"}, "", policy.ActivationSearch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("the owner's own search returned nothing, so the fixture never had a command to withhold")
+	}
+
+	out, err := callMCPTool(dir, "how", json.RawMessage(`{"what":"zonkomatic"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "replicas=9") {
+		t.Errorf("how handed the command to the agent although the mcp policy denies it: %q", out)
+	}
+	// Filtering alone would turn the leak into a confident negative over records
+	// that do exist, which is the failure emptyRecallAnswerPolicy and blame's
+	// omission note were both written for.
+	if strings.Contains(out, "No command on this machine") {
+		t.Errorf("how told the agent nothing exists while the policy was hiding something: %q", out)
+	}
+
+	// The other direction, which absence alone cannot prove: with the mcp rule
+	// allowing, the command must come back. Without this the test still passes
+	// if how simply stops answering anyone.
+	if err := os.WriteFile(filepath.Join(cfg, "policy.json"),
+		[]byte(`{"activations":{"mcp":{"local":true},"search":{"local":true}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err = callMCPTool(dir, "how", json.RawMessage(`{"what":"zonkomatic"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "replicas=9") {
+		t.Errorf("how withheld the command although the mcp policy allows it: %q", out)
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -313,11 +313,18 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if err := index.Ensure(dir, "", false, mcpProgress()); err != nil {
 			return "", err
 		}
-		entries, _, err := howEntries(dir, strings.Fields(a.What), a.Project)
+		entries, hidden, err := howEntries(dir, strings.Fields(a.What), a.Project, policy.ActivationMCP)
 		if err != nil {
 			return "", err
 		}
 		if len(entries) == 0 {
+			// Not a flat negative when the policy is what emptied the answer:
+			// an agent told nothing exists invents one, and here something does
+			// exist. The CLI has said so since the note was written; this
+			// surface was returning the negative regardless.
+			if note := policyHiddenNote(policy.ActivationMCP, hidden); note != "" {
+				return strings.TrimSpace(note), nil
+			}
 			return fmt.Sprintf("No command on this machine mentions %q.", a.What), nil
 		}
 		limit := int(a.Limit)


### PR DESCRIPTION
Night hunt, iteration 28, applying the pattern the last three findings share: for each guard, check whether its predicate describes the case it has to catch.

The trust policy keys on which channel is asking — `search`, `mcp` and `auto` are configured independently. `howEntries` served both the CLI and the MCP tool from one function with `policy.ActivationSearch` compiled in, so the mcp rule was never consulted on the mcp path.

Reproduced with `{"activations":{"mcp":{"imported":false},"search":{"imported":true}}}` — a reasonable split, since a person's own terminal is theirs and an agent's channel is not:

```
recall over MCP  → "the trust policy does not allow them on this path. There is prior work here; it is not being shown."
how over MCP     → $ helm upgrade zonkomatic ./charts/zonkomatic --set secretreplicas=9
```

The activation now travels with the caller. The reviewer audited every one of the ~60 activation sites and found no other mismatch: hook paths are uniformly `auto`, MCP paths `mcp`, CLI paths `search`, and `howEntries` was the only helper shared across two surfaces with one compiled in.

Second half, from the same review: filtering alone would have traded the leak for a confident "No command on this machine mentions X" over records that do exist — the failure `emptyRecallAnswerPolicy` and blame's omission note were both written for, and which the CLI side of `how` already avoids. The withheld count now reaches the agent through the existing `policyHiddenNote`, so no new wording was invented.

The test asserts both directions, because absence alone would also pass if `how` stopped answering anyone: denied → the command is absent and the answer is not a flat negative; allowed → the command is there. Three mutations fail it — restoring the search activation, removing the withheld note, and blanking the results.

Two pre-existing things the review turned up, not touched here: `embed.go:48` decides what goes to the external embedding endpoint on `ActivationSearch` alone, and the MCP `how` and `fix` handlers record no usage, so `deja log` understates what they handed over — the gap #682 closed for blame.