### PR TITLE
fix(search): ctx and the prompt digest dated sessions in UTC, not the reader's zone

### DIFF
--- a/internal/search/ctx_date_test.go
+++ b/internal/search/ctx_date_test.go
@@ -1,0 +1,59 @@
+package search
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Every surface that prints a session's date prints the reader's — `deja show`,
+// `deja last`, recall, resources/list — because an agent quoting it must not
+// name a different day from the one on the user's screen. The ctx header
+// formatted in UTC instead, so a reader far enough from it saw ctx name one day
+// and everything else name the next for the same session. ctx is the briefing
+// written to be handed to another agent, which makes its header the date most
+// likely to be repeated back.
+func TestContextHeaderDatesInTheReadersZone(t *testing.T) {
+	// Fourteen hours ahead, so a late-UTC stamp lands on the next local day.
+	zone, err := time.LoadLocation("Pacific/Kiritimati")
+	if err != nil {
+		t.Skip("zone database unavailable")
+	}
+	prev := time.Local
+	time.Local = zone
+	t.Cleanup(func() { time.Local = prev })
+
+	updated := time.Date(2026, 6, 15, 20, 30, 0, 0, time.UTC)
+	utcDay := updated.Format("2006-01-02")
+	localDay := updated.In(zone).Format("2006-01-02")
+	if utcDay == localDay {
+		t.Fatalf("the fixture no longer straddles midnight (%s), so it cannot tell the two apart", utcDay)
+	}
+
+	s := model.Session{
+		Harness: "claude", Project: "work", ID: "lt1",
+		Updated:  updated,
+		Messages: []model.Message{{Role: "user", Text: "the zibbleflux deadlock", Time: updated}},
+	}
+	// The prompt-hook digest carries the same date on the surface an agent
+	// reads most often, so it is asserted here rather than left to drift.
+	if d := AutoRecallDigestFor([]model.Session{s}, 4000, nil); d != "" {
+		if strings.Contains(d, utcDay) && !strings.Contains(d, localDay) {
+			t.Errorf("the prompt digest names the UTC day %s, not the reader's %s\n%s", utcDay, localDay, d)
+		}
+	}
+
+	var b bytes.Buffer
+	PrintContext(&b, s, "zibbleflux")
+	head := strings.SplitN(b.String(), "\n", 2)[0]
+
+	if strings.Contains(head, utcDay) {
+		t.Errorf("the ctx header names the UTC day %s; the reader's screen says %s\n%s", utcDay, localDay, head)
+	}
+	if !strings.Contains(head, localDay) {
+		t.Errorf("the ctx header does not name the reader's day %s\n%s", localDay, head)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -308,7 +308,11 @@ func autoRecallSessionFor(s model.Session, now time.Time, provenance bool, terms
 	} else {
 		date := ""
 		if !s.Updated.IsZero() {
-			date = " · " + s.Updated.Format("2006-01-02")
+			// The reader's zone, like the provenance line above and the ctx
+			// header: this digest is injected on every prompt, so it is the
+			// date an agent is most likely to repeat back, and it must not
+			// name a different day from the one on the user's screen (#856).
+			date = " · " + s.Updated.Local().Format("2006-01-02")
 		}
 		fmt.Fprintf(&b, "- **%s** `%s`%s\n", digestLine(s.Project), digestLine(short(s.ID)), date)
 	}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1127,7 +1127,17 @@ func PrintContext(w io.Writer, s model.Session, query string) {
 	// `deja show`, `deja ctx` and the MCP context tools printed it raw (#1090).
 	fmt.Fprintf(w, "# deja context: %s · %s · %s", s.Harness, SafeLine(s.Project), SafeLine(s.ID))
 	if !s.Updated.IsZero() {
-		fmt.Fprintf(w, " · updated %s", s.Updated.Format("2006-01-02"))
+		// The reader's zone, as `deja last`, resources/list and the MCP recall
+		// listing already do. This header formatted the timestamp as it came —
+		// UTC for every source but aider — so a reader far enough from it saw
+		// ctx name one day and those surfaces name the next for one session.
+		// ctx is the briefing written to be handed to another agent, which
+		// makes its header a date that gets repeated back (#856).
+		//
+		// Not everything is local yet: `deja show` prints per-message stamps in
+		// the timestamp's own zone, and the superseded marker is minted in UTC
+		// because lifecycle.go compares against it. Those want their own change.
+		fmt.Fprintf(w, " · updated %s", s.Updated.Local().Format("2006-01-02"))
 	}
 	fmt.Fprintln(w)
 	qlow := strings.ToLower(query)


### PR DESCRIPTION
Night hunt, iteration 35, from the list of invariants this repo states in prose. `cmd/deja/mcp_resources.go:50` says it plainly: *an agent quoting this date to the user must not name a different day from the one on their screen* (#856). Two surfaces did not follow it.

Reproduced under `TZ=Pacific/Kiritimati` with a session stamped `2026-06-15T20:30Z` — fourteen hours ahead, so the local day is the next one:

```
deja last        2026-06-16
resources/list   2026-06-16
mcp recall       2026-06-16
deja ctx         2026-06-15   ← the briefing written to be handed to another agent
prompt digest    2026-06-15   ← injected on every prompt
```

Both are display-only. Nothing parses either back: `deja ctx` has no JSON form, the header is only ever prefix-matched in tests, and the digest is text for a model. Checked that no hash, bench measurement or sync payload reads them.

The prompt digest was not in the original diff — the review found it, and it is the more important half: it is the text an agent sees most often, so it is the date most likely to be repeated at the user.

Deliberately left alone, with the reason in the comment:

- `deja show` prints per-message stamps in the timestamp's own zone. Different fix, wider blast radius, and its own note to the reader (`main.go:439`) already claims something about zones that is not true — worth a change of its own rather than a rider on this one.
- The superseded marker is minted in UTC because `lifecycle.go:195` compares against that string. Making it local means changing both sides together.
- `blame`, `promote`, `view` and the stats page have the same split; none of them is a date an agent quotes.

Two mutations fail the test: restoring UTC in the ctx header, and restoring it in the digest. The fixture asserts it straddles midnight before asserting anything else, so it cannot pass by the two days being equal. It skips where the zone database is absent, as three existing tests in this repo already do for the Windows leg.
