### PR TITLE
fix(files): a path synced from Windows was never trimmed

### DIFF
--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -381,12 +381,16 @@ var repoCheck sync.Map
 // and "b7/repo/internal/y.go", which read as relative paths starting in
 // different places rather than as one tree with its head removed (#727).
 func trimPath(p string) string {
-	parts := strings.Split(filepath.Clean(p), string(filepath.Separator))
-	// Clean leaves an empty first element for an absolute path. Dropping it is
-	// not a truncation, so it must not draw an ellipsis.
-	if len(parts) > 0 && parts[0] == "" {
-		parts = parts[1:]
-	}
+	// Both separators, for the reason CrossBase gives: a store synced from
+	// Windows holds paths like C:\src\app\x.go, and on a Unix host those
+	// split into one segment, so the head is never removed and a long path
+	// runs past the column it is printed in while its Unix twin is trimmed.
+	parts := strings.FieldsFunc(filepath.Clean(p), func(r rune) bool {
+		return r == '/' || r == '\\'
+	})
+	// FieldsFunc drops the empty leading field an absolute path produces, which
+	// is what the old explicit trim did: losing the root is not a truncation and
+	// must not draw an ellipsis.
 	if len(parts) > 4 {
 		return "…/" + strings.Join(parts[len(parts)-4:], "/")
 	}

--- a/cmd/deja/files_trim_synced_test.go
+++ b/cmd/deja/files_trim_synced_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A synced index holds paths as the machine that wrote them spelled them, so a
+// Windows transcript puts `C:\src\app\x.go` in front of a Unix reader. Splitting
+// on filepath.Separator alone made such a path a single segment, so its head was
+// never removed: the Unix twin of the same file trimmed to four segments and the
+// Windows one printed whole, past the 56-wide column it shares. CrossBase
+// (commands.go) was written for the same reason on the same kind of path.
+func TestTrimPathTrimsAWindowsOriginPathToo(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`C:\src\app\internal\deep\handler.go`, "…/app/internal/deep/handler.go"},
+		{`C:\a\b\c.go`, "C:/a/b/c.go"},
+		// Mixed, which a path that crossed a sync can be.
+		{`C:\src/app\internal/deep\x.go`, "…/app/internal/deep/x.go"},
+		// And the Unix behaviour is untouched.
+		{"/a/b/c/d.go", "a/b/c/d.go"},
+		{"/a/b/c/d/e.go", "…/b/c/d/e.go"},
+		{"retry.go", "retry.go"},
+	}
+	for _, c := range cases {
+		if got := trimPath(c.in); got != c.want {
+			t.Errorf("trimPath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+	// The column is 56 wide; a real Windows checkout path is longer than that
+	// untrimmed, which is the whole point.
+	long := `C:\Users\someone\source\repos\Company\Project\src\Services\PaymentHandler.cs`
+	if got := trimPath(long); len(got) > 56 || !strings.HasPrefix(got, "…/") {
+		t.Errorf("a long windows path came back as %q (%d chars)", got, len(got))
+	}
+}


### PR DESCRIPTION
Night hunt, iteration 38. `trimPath` split on `filepath.Separator` alone, so a path a Windows machine wrote — which a synced index holds verbatim, as #1289 established — was a single segment and never had its head removed:

```
before   C:\Users\someone\source\repos\Company\Project\src\Services\PaymentHandler.cs
after    …/src/Services/PaymentHandler.cs
```

It is printed in a 56-wide column beside its Unix twin, which does get trimmed, so one synced project's files ran past the column while the local ones lined up.

The codebase already recognises this exact problem one file over: `CrossBase` (`cmd/deja/commands.go`) is `filepath.Base` that splits on both separators, written because "a store synced from Windows holds paths like `C:\src\main.go`; on a Unix host `filepath.Base` leaves them whole". `trimPath` is the same case, unfixed.

`strings.FieldsFunc` also drops the empty leading field an absolute path produces, which is what the explicit trim below it was doing — the existing `TestTrimPathMarksTheCut` still passes unchanged, including its boundary cases (`/a/b/c/d.go` keeps its head, `/a/b/c/d/e.go` gets the ellipsis).

One thing worth passing on from writing the test: the file was first called `files_trim_windows_test.go`, and `_windows` before `_test.go` is a **GOOS constraint** — Go silently excluded it, `go test -list` did not show it, and it would have compiled on no machine anyone runs this on. Renamed to `files_trim_synced_test.go`. A test named after the platform it is about is a test that never runs.
