### PR TITLE
fix(index): an id a session was synced under resolved to nothing

### DIFF
--- a/internal/index/find_orig_id_test.go
+++ b/internal/index/find_orig_id_test.go
@@ -1,0 +1,108 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Import rewrites a session's id, and OrigID keeps the one it had on the machine
+// it came from (#1049). Nothing looked at it, so a reader who saw an id on one
+// machine and typed it on another was told no session matches — about a session
+// deja holds and prints that very id for under `--json`. resume even has a
+// sentence written for the case ("synced from another machine — resume it
+// there") that could never fire, because the lookup never resolved the id.
+//
+// Done as a real round trip rather than a hand-staged manifest: the id is only
+// rewritten by import, so staging the row by hand would assert against my own
+// idea of what import does.
+func TestFindByPrefixResolvesTheIdTheSessionCameWith(t *testing.T) {
+	const origID = "faraway1"
+	line := `{"type":"user","sessionId":"` + origID + `","cwd":"/w","timestamp":"2026-09-01T09:00:00Z","message":{"role":"user","content":"the thrumbleknot migration"}}` + "\n"
+
+	// Machine A: index it, export it.
+	dirA, tmpA := syncPeerIndex(t, line)
+	box := filepath.Join(tmpA, "box")
+	if _, err := Export(dirA, box); err != nil {
+		t.Fatal(err)
+	}
+
+	// Machine B: its own session, then A's import on top.
+	tmpB := t.TempDir()
+	setHome(t, filepath.Join(tmpB, "home"))
+	claudeB := filepath.Join(tmpB, "claude", "-tmp-b")
+	if err := os.MkdirAll(claudeB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	local := `{"type":"user","sessionId":"local1","cwd":"/w","timestamp":"2026-09-02T09:00:00Z","message":{"role":"user","content":"the local parser work"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(claudeB, "local.jsonl"), []byte(local), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmpB, "claude"))
+	dirB := filepath.Join(tmpB, "index.db")
+	if err := Ensure(dirB, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(dirB, box); err != nil {
+		t.Fatal(err)
+	}
+
+	// The precondition everything below rests on: import really did rename it.
+	m, err := readManifest(dirB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	renamed := false
+	for _, meta := range m.Sessions {
+		if meta.OrigID == origID && meta.ID != origID {
+			renamed = true
+		}
+	}
+	if !renamed {
+		t.Fatal("import did not rewrite the id, so there is nothing here for this test to resolve")
+	}
+
+	got, ok, err := FindByPrefix(dirB, origID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("the id the session came with resolves to nothing")
+	}
+	if got.OrigID != origID {
+		t.Errorf("resolved to %q (orig %q), want the session imported as %q", got.ID, got.OrigID, origID)
+	}
+
+	// The count has to agree with what the resolver just did, or the reader is
+	// told the selector matches nothing and then watches it open a session
+	// (#853, with the sign flipped).
+	if n := PrefixMatches(dirB, origID); n == 0 {
+		t.Errorf("the resolver opened a session for %q while the count says none match", origID)
+	}
+
+	// A local id still wins: the fallback runs only when nothing else matched.
+	got, ok, err = FindByPrefix(dirB, "local1")
+	if err != nil || !ok {
+		t.Fatalf("the local id stopped resolving: ok=%v err=%v", ok, err)
+	}
+	if got.ID != "local1" {
+		t.Errorf("a local id resolved to %q", got.ID)
+	}
+
+	// And an exact match on the imported id beats a local id that merely
+	// contains it: typing the whole thing should not hand over something else.
+	near := `{"type":"user","sessionId":"zz-` + origID + `-zz","cwd":"/w","timestamp":"2026-09-03T09:00:00Z","message":{"role":"user","content":"a local session whose id contains the other one"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(claudeB, "near.jsonl"), []byte(near), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dirB, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err = FindByPrefix(dirB, origID)
+	if err != nil || !ok {
+		t.Fatalf("the imported id stopped resolving once a local id contained it: ok=%v err=%v", ok, err)
+	}
+	if got.OrigID != origID {
+		t.Errorf("typing %q in full opened %q instead of the session imported under it", origID, got.ID)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1334,6 +1334,18 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 			matches = append(matches, meta)
 		}
 	}
+	// The id the session came with, before the loose pass: import rewrites the
+	// id and OrigID keeps the old one (#1049), and a reader who typed that id in
+	// full should not be handed a local session that merely contains it as a
+	// substring. Nothing consulted OrigID at all, so `show`/`resume`/`ctx` said
+	// no session matches about a session deja holds and prints that id for.
+	if len(matches) == 0 {
+		for _, meta := range m.Sessions {
+			if meta.OrigID != "" && strings.HasPrefix(meta.OrigID, p) {
+				matches = append(matches, meta)
+			}
+		}
+	}
 	if len(matches) == 0 {
 		for _, meta := range m.Sessions {
 			if idLooselyMatches(meta.ID, p) {
@@ -1341,6 +1353,12 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 			}
 		}
 	}
+	// The id the session had on the machine it came from. Import rewrites the
+	// id, and OrigID is kept precisely so that fact is not lost (#1049) — but
+	// nothing looked at it, so someone who read an id on one machine and typed
+	// it on another was told no session matches, about a session deja holds and
+	// prints that very id for under `--json`. After the local forms, so a local
+	// id always wins over an imported one that happens to collide.
 	// Last: the `harness:id` shape deja prints in `forget --list` and in
 	// promote's receipts, which every reading command refused (#921).
 	if len(matches) == 0 {
@@ -1375,8 +1393,16 @@ func PrefixMatches(dir, p string) int {
 	if err != nil {
 		return 0
 	}
+	// Counted the same way FindByPrefix resolves, including the id a session was
+	// imported under: #853 requires the count and the resolver to agree, and a
+	// selector that opens a session while the count says zero is that failure
+	// with the sign flipped.
 	n := 0
 	for _, meta := range m.Sessions {
+		if meta.OrigID != "" && strings.HasPrefix(meta.OrigID, p) {
+			n++
+			continue
+		}
 		if strings.HasPrefix(meta.ID, p) {
 			n++
 		}
@@ -1436,6 +1462,10 @@ func PrefixHarnesses(dir, id string) []string {
 	}
 	var out []string
 	for _, meta := range m.Sessions {
+		if meta.OrigID == id {
+			out = append(out, meta.Harness)
+			continue
+		}
 		if meta.ID == id {
 			out = append(out, meta.Harness)
 		}


### PR DESCRIPTION
Night hunt, iteration 40. Sync rewrites a session's id on import and keeps the old one in `OrigID`, deliberately — #1049 added it because rebuilding the row from scratch "dropped what only the import knew … the id it had on the machine it came from". Nothing then looked at it.

So the id a user reads on one machine does not work on the other:

```
deja show faraway1      deja: no session matches "faraway1"
deja resume faraway1    deja: no session matches "faraway1"
deja ctx faraway1       deja: no session matches "faraway1"
deja last --json        {"id": "imported-bfce745b3871", "orig_id": "faraway1"}
```

The last line is the same command telling the reader that id belongs to a session it holds.

`resume` turns out to have had the right answer written for it all along — `session imported-…ce745b3871 was synced from another machine — resume it there` — which could never fire, because the lookup never resolved the id. Same shape as #1309: the sentence exists, the predicate excludes the case.

The fallback runs after the exact-id pass and before the loose substring pass, so a local id still wins outright, and typing an imported id in full is not beaten by a local id that merely contains it.

`PrefixMatches` and `PrefixHarnesses` learned the same form. That is not tidiness: their own comment (#853) says the count and the resolver have to agree, "or a reader is told an id matches nothing and then watches it open" — resolving without counting is that failure with the sign flipped, and it would have silently swallowed the cross-harness case where two peers each had `s1`.

Left alone deliberately: `Forget`, `Unforget` and `FindByIdentity` still match the local id only. Destructive and exact-identity selectors are strict on purpose (#855), so `deja forget --session <original-id>` still reports nothing while `show` now works. Worth revisiting, but widening a destructive selector is not a change to make in the same breath as fixing a read.

Three mutations fail the test: dropping the fallback from the resolver, dropping it from the count, and — via the added case — a local session whose id contains the imported one. The fixture does a real export/import round trip and asserts import actually renamed the session before testing anything else, since staging that row by hand would only assert my own idea of what import does.
