### PR TITLE
fix(search): a long message hid the phrase that answered the query

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -614,8 +614,9 @@ func freshnessDecay(updated, now time.Time) float64 {
 }
 
 // windowOccurrenceCap bounds how many places of one token are weighed when
-// measuring how close the query's words come together, and windowScanLimit
-// bounds how many are looked at to choose them. Without either, a long
+// measuring how close the query's words come together; windowScanLimit bounds
+// how many are walked to choose them, and windowSegments how many are sampled
+// when even the rarest query word runs past that. Without either, a long
 // transcript message full of a common word makes this quadratic.
 //
 // The places kept are spread across the whole text rather than taken from the
@@ -626,6 +627,10 @@ func freshnessDecay(updated, now time.Time) float64 {
 const (
 	windowOccurrenceCap = 32
 	windowScanLimit     = 4096
+	// windowSegments is how many equal slices of a message get one sampled
+	// place each. Twice the cap, so spread still has more places than it keeps
+	// and can choose them.
+	windowSegments = windowOccurrenceCap * 2
 )
 
 // spread picks at most cap of the places, evenly across them, always keeping
@@ -682,22 +687,74 @@ func tokenWindow(low string, qtoks []string) int {
 
 	type occurrence struct{ at, tok int }
 	var occs []occurrence
-	var at []int
+
+	// Anchor on the rarest token. Sampling each token's places independently
+	// cannot find a tight cluster it did not happen to sample: a message that
+	// repeats one query word thousands of times and says the phrase once, in the
+	// middle, was measured against whichever repetition the sampling kept —
+	// hundreds of characters from the phrase (#1318). Anchoring instead asks the
+	// question that proximity actually is: for this place of the rare word,
+	// where is the nearest place of every other one?
+	anchor := -1
+	var at, buf []int
 	for ti, tok := range qtoks {
-		at = at[:0]
-		for i := 0; i < len(low) && len(at) < windowScanLimit; {
+		buf = buf[:0]
+		for i := 0; i < len(low) && len(buf) < windowScanLimit; {
 			j := strings.Index(low[i:], tok)
 			if j < 0 {
 				break
 			}
-			at = append(at, i+j)
+			buf = append(buf, i+j)
 			i += j + 1
 		}
-		if len(at) == 0 {
+		if len(buf) == 0 {
 			return 0
 		}
-		for _, p := range spread(at, windowOccurrenceCap) {
-			occs = append(occs, occurrence{p, ti})
+		// Counting the places is the same walk as finding them, and the walk is
+		// already capped, so the rarest token costs nothing extra to identify.
+		if anchor < 0 || len(buf) < len(at) {
+			anchor = ti
+			at = append(at[:0], buf...)
+		}
+	}
+	atok := qtoks[anchor]
+	if len(at) == windowScanLimit {
+		// The rare token is itself everywhere, so every place has a neighbour
+		// close by and which places are looked at stops mattering. Take one per
+		// segment of the text, which costs one pass instead of tens of thousands
+		// of searches, and keep the last — the tightest cluster is as often at
+		// the very end as anywhere.
+		at = at[:0]
+		for i, seg := 0, 0; i < len(low) && seg < windowSegments; {
+			j := strings.Index(low[i:], atok)
+			if j < 0 {
+				break
+			}
+			p := i + j
+			at = append(at, p)
+			seg = p*windowSegments/len(low) + 1
+			if next := len(low) * seg / windowSegments; next > p {
+				i = next
+			} else {
+				i = p + 1
+			}
+		}
+		if last := strings.LastIndex(low, atok); len(at) > 0 && last > at[len(at)-1] {
+			at = append(at, last)
+		}
+	}
+	for _, p := range spread(at, windowOccurrenceCap) {
+		occs = append(occs, occurrence{p, anchor})
+		for ti, tok := range qtoks {
+			if ti == anchor {
+				continue
+			}
+			if l := strings.LastIndex(low[:min(p+len(tok), len(low))], tok); l >= 0 {
+				occs = append(occs, occurrence{l, ti})
+			}
+			if r := strings.Index(low[p:], tok); r >= 0 {
+				occs = append(occs, occurrence{p + r, ti})
+			}
 		}
 	}
 	sort.Slice(occs, func(a, b int) bool { return occs[a].at < occs[b].at })

--- a/internal/search/window_brute_force_test.go
+++ b/internal/search/window_brute_force_test.go
@@ -1,0 +1,84 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// bruteWindow is the definition tokenWindow implements, computed the slow way:
+// the tightest span over every combination of one place per token.
+func bruteWindow(low string, toks []string) int {
+	places := make([][]int, len(toks))
+	for ti, tok := range toks {
+		for i := 0; i < len(low); {
+			j := strings.Index(low[i:], tok)
+			if j < 0 {
+				break
+			}
+			places[ti] = append(places[ti], i+j)
+			i += j + 1
+		}
+		if len(places[ti]) == 0 {
+			return 0
+		}
+	}
+	best := -1
+	var walk func(ti, lo, hi int)
+	walk = func(ti, lo, hi int) {
+		if ti == len(toks) {
+			if span := hi - lo; best < 0 || span < best {
+				best = span
+			}
+			return
+		}
+		for _, p := range places[ti] {
+			nlo, nhi := lo, hi
+			if p < nlo || ti == 0 {
+				nlo = p
+			}
+			if end := p + len(toks[ti]); end > nhi || ti == 0 {
+				nhi = end
+			}
+			walk(ti+1, nlo, nhi)
+		}
+	}
+	walk(0, 0, 0)
+	if best < 0 {
+		return 0
+	}
+	return best
+}
+
+// Anchoring on the rarest token and taking its nearest neighbours on each side
+// has to give the same answer as trying every combination — including with more
+// than two tokens, and with tokens of different lengths, where which token is
+// the anchor changes what the neighbour search sees.
+func TestTokenWindowMatchesBruteForce(t *testing.T) {
+	// Every case puts the tokens' first occurrences further apart than
+	// proximityNear, so tokenWindow does the real work instead of returning its
+	// cheap first-occurrence bound.
+	far := strings.Repeat("gap ", 100)
+	cases := []struct {
+		text string
+		toks []string
+	}{
+		{"alpha " + far + "beta alpha", []string{"alpha", "beta"}},
+		{strings.Repeat("alpha ", 60) + "beta " + strings.Repeat("alpha ", 30), []string{"alpha", "beta"}},
+		{"beta " + strings.Repeat("alpha ", 60) + "beta", []string{"alpha", "beta"}},
+		{"aa " + far + strings.Repeat("bbbbbbbb aa ", 20) + "cccccccccccc", []string{"aa", "bbbbbbbb", "cccccccccccc"}},
+		{"cccccccccccc " + far + strings.Repeat("bbbbbbbb aa ", 20), []string{"aa", "bbbbbbbb", "cccccccccccc"}},
+		{"one " + far + strings.Repeat("one ", 25) + "two three " + strings.Repeat("one ", 25) + "two", []string{"one", "two", "three"}},
+		{strings.Repeat("x ", 200) + "needle x haystack", []string{"needle", "haystack"}},
+	}
+	for _, c := range cases {
+		want := bruteWindow(c.text, c.toks)
+		got := tokenWindow(c.text, c.toks)
+		if got == 0 || want == 0 {
+			t.Errorf("toks %v: got %d, brute force %d", c.toks, got, want)
+			continue
+		}
+		if got != want {
+			t.Errorf("toks %v: window %d, tightest is %d", c.toks, got, want)
+		}
+	}
+}

--- a/internal/search/window_scan_limit_test.go
+++ b/internal/search/window_scan_limit_test.go
@@ -1,0 +1,56 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// denseAround builds a message that repeats one query word before and after the
+// phrase that answers the question, so the phrase sits wherever the caller puts
+// it inside a text far longer than any occurrence cap.
+func denseAround(before, after int) string {
+	var b strings.Builder
+	for i := 0; i < before; i++ {
+		b.WriteString("alpha ")
+	}
+	b.WriteString("alpha beta")
+	for i := 0; i < after; i++ {
+		b.WriteString(" alpha")
+	}
+	return b.String()
+}
+
+// The phrase is at the very end, past thousands of repetitions. Sampling places
+// across the text can still land just short of the final one, so the last place
+// is always kept.
+func TestTokenWindowSeesPhraseAtTheEnd(t *testing.T) {
+	got := tokenWindow(denseAround(6097, 0), []string{"alpha", "beta"})
+	if got == 0 {
+		t.Fatal("tokenWindow found nothing, so the probe measured nothing")
+	}
+	if want := len("alpha beta"); got != want {
+		t.Errorf("window %d, want %d: the phrase at the end was not measured", got, want)
+	}
+}
+
+// The phrase sits in the middle, past the point where enumerating occurrences
+// from the front used to stop. Taking the first N places measured this message
+// against a repetition thousands of characters from the phrase.
+func TestTokenWindowSeesPhraseInTheMiddle(t *testing.T) {
+	got := tokenWindow(denseAround(6000, 6000), []string{"alpha", "beta"})
+	if got == 0 {
+		t.Fatal("tokenWindow found nothing, so the probe measured nothing")
+	}
+	if want := len("alpha beta"); got != want {
+		t.Errorf("window %d, want %d: the phrase in the middle was not measured", got, want)
+	}
+}
+
+// The phrase at the start has always worked, and must keep working — otherwise
+// a fix could pass the tests above by only ever looking at the tail.
+func TestTokenWindowStillSeesPhraseAtTheStart(t *testing.T) {
+	got := tokenWindow("alpha beta "+strings.Repeat("alpha ", 6000), []string{"alpha", "beta"})
+	if want := len("alpha beta"); got != want {
+		t.Errorf("window %d, want %d: the phrase at the start was not measured", got, want)
+	}
+}

--- a/internal/search/window_scan_limit_test.go
+++ b/internal/search/window_scan_limit_test.go
@@ -46,6 +46,24 @@ func TestTokenWindowSeesPhraseInTheMiddle(t *testing.T) {
 	}
 }
 
+// Both query words run past the cap, so there is no rare token to anchor on and
+// places get sampled across the text instead. Every place then has a neighbour
+// close by, and the window must still come out as that neighbour rather than as
+// the distance to whichever place the sampling kept.
+func TestTokenWindowWhenEveryQueryWordIsEverywhere(t *testing.T) {
+	// Both words appear five thousand times, always a few words apart, and the
+	// one place they sit together is at the very end. The lone leading "alpha"
+	// puts the first occurrences far enough apart that the cheap
+	// first-occurrence bound cannot answer, so the sampling runs.
+	low := "alpha " + strings.Repeat("gap ", 100) +
+		strings.Repeat("alpha gap gap gap gap beta gap gap gap gap ", 5000) +
+		"alpha beta"
+	got := tokenWindow(low, []string{"alpha", "beta"})
+	if want := len("alpha beta"); got != want {
+		t.Errorf("window %d, want %d: the pair at the end was outside the sampled places", got, want)
+	}
+}
+
 // The phrase at the start has always worked, and must keep working — otherwise
 // a fix could pass the tests above by only ever looking at the tail.
 func TestTokenWindowStillSeesPhraseAtTheStart(t *testing.T) {


### PR DESCRIPTION
Proximity is the signal that the query's words belong to one thought, and it was
blind in exactly the messages where it matters most.

`tokenWindow` enumerated the first 4096 places of each query token and kept 32
spread across those. In a message that repeats one query word past the cap and
only then says the phrase that answers the question, the phrase was never among
the sampled places: the window came out as the distance to whichever repetition
the scan reached. Measured on a message with 6097 repetitions and the phrase at
the end, the window was 12016 characters instead of 10 — the boost went to noise.
The comment above the constants already promised places "spread across the whole
text rather than taken from the front", which stopped being true past the cap.

Now the rarest query token is the anchor, and for each of its places the nearest
occurrence of every other token on each side is weighed. That is the question
proximity actually asks, and it makes the answer exact rather than sampled: a new
test cross-checks it against brute force over every combination, including three
tokens of different lengths.

Cost is unchanged — 0.11-0.15 ms on a 360KB message against 0.10-0.18 ms before,
because identifying the rarest token is the same capped walk that already
happened. When even the rarest token runs past the cap, places are sampled one
per segment of the text; every place then has a neighbour close by, so which ones
are looked at stops mattering.

Closes #1318.
