### PR TITLE
ci: stop reinstalling shellcheck, cap the job at 10 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,11 +273,17 @@ jobs:
   scripts:
     name: shellcheck + actionlint
     runs-on: ubuntu-latest
+    # Without this the job's ceiling is six hours. Installing shellcheck through
+    # apt hung twice in a row on 2026-08-18 and each hang blocked every merge
+    # until someone cancelled the run by hand.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: shellcheck
         run: |
-          sudo apt-get update -q && sudo apt-get install -y -q shellcheck
+          # Preinstalled on the ubuntu runner image; installing it again bought
+          # nothing and was the step that hung.
+          shellcheck --version
           shellcheck install.sh scripts/e2e.sh
       - name: actionlint
         run: |


### PR DESCRIPTION
The `shellcheck + actionlint` job hung twice in a row tonight, both times on
`sudo apt-get update && sudo apt-get install -y shellcheck`, and each hang blocked
merging until the run was cancelled by hand — 29 minutes the first time. The job
had no `timeout-minutes`, so its real ceiling was six hours.

shellcheck already ships on the ubuntu runner image, so the install bought
nothing. The step now calls `shellcheck --version` first: if a future image ever
drops it, this fails in seconds with a clear message instead of silently skipping
the lint.

The 10-minute cap is the other half — the step that hangs next time should fail,
not sit there.

Both linters run clean locally against this change.

Nine other jobs in this file also have no `timeout-minutes`. Left alone here
since only this one has actually hung; say the word and they get the same cap.
