### PR TITLE
fix(search): the first excerpt showed repetition, not the answer

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -171,6 +171,9 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 	type snipCand struct {
 		text   string
 		weight int
+		// window is how tightly the query's words meet in this message; 0 means
+		// they never do.
+		window int
 	}
 	snipCands := make([]snipCand, 0, 16)
 	df := make([]int, len(qtoks))
@@ -210,6 +213,11 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 			}
 			low := strings.ToLower(m.Text)
 			c := 0
+			// windowText and windowToks are the pair proximity is measured on: the
+			// surface text and the query's own words, except where the match came from
+			// folding — measuring the unfolded pair there finds nothing and reports a
+			// genuine match as words that never meet.
+			windowText, windowToks := low, qtoks
 			if re != nil {
 				c = len(re.FindAllStringIndex(m.Text, -1))
 			} else {
@@ -223,6 +231,9 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 					foldedLow := cjkfold.String(low)
 					c = countIn(cjkfold.String(m.Text), foldedLow, qtoksFolded,
 						phrasesFolded, qlowFolded, o.FuzzyVariants)
+					if c > 0 {
+						windowText, windowToks = foldedLow, qtoksFolded
+					}
 				}
 			}
 			if c > 0 {
@@ -234,8 +245,9 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 				// strongest few become the excerpts after the scan. Taking the
 				// first three showed wherever a word happened to appear early
 				// rather than the passage that carries the answer.
-				snipCands = append(snipCands, snipCand{text: m.Text, weight: c})
-				if w := tokenWindow(low, qtoks); w > 0 && (doc.minWindow == 0 || w < doc.minWindow) {
+				w := tokenWindow(windowText, windowToks)
+				snipCands = append(snipCands, snipCand{text: m.Text, weight: c, window: w})
+				if w > 0 && (doc.minWindow == 0 || w < doc.minWindow) {
 					doc.minWindow = w
 				}
 			}
@@ -248,8 +260,23 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 				}
 			}
 		}
-		// Strongest matches first, original order among equals, top three shown.
-		sort.SliceStable(snipCands, func(i, j int) bool { return snipCands[i].weight > snipCands[j].weight })
+		// The passage that answers a question is where its words come together, so
+		// a message that says them together outranks one that repeats a single word:
+		// a search for "what did my dad give me" led with six "gift"s and put the
+		// line naming the dad second (#1325). The relevance tier already picks its
+		// excerpt this way; the exact tier ranked on the raw count alone. Count
+		// still decides between passages that are equally tight, and among equals
+		// the order they were said in stands. Top three shown.
+		sort.SliceStable(snipCands, func(i, j int) bool {
+			a, b := snipCands[i], snipCands[j]
+			if (a.window > 0) != (b.window > 0) {
+				return a.window > 0
+			}
+			if a.window > 0 && a.window != b.window {
+				return a.window < b.window
+			}
+			return a.weight > b.weight
+		})
 		for i := 0; i < len(snipCands) && i < 3; i++ {
 			doc.hit.Snippets = append(doc.hit.Snippets, snippet(snipCands[i].text, o.Query, re))
 		}

--- a/internal/search/snippet_meet_modes_test.go
+++ b/internal/search/snippet_meet_modes_test.go
@@ -1,0 +1,56 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Ranking excerpts by how tightly the query's words meet only makes sense when
+// the query is words. A regex is not: QueryParts splits `dad|gift` into two
+// words a message can hold together without the pattern matching them that way,
+// so the excerpt must still be chosen by how often the pattern actually hit.
+func TestRegexSnippetsStillRankByMatchCount(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", Project: "p", ID: "s1",
+		Messages: []model.Message{
+			{Role: "user", Text: "dad gift"},
+			{Role: "user", Text: "gift, gift and one more gift"},
+		},
+	}
+	hits, err := Run([]model.Session{s}, Options{Query: "dad|gift", Regex: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || len(hits[0].Snippets) == 0 {
+		t.Fatal("no snippet, so the test measured nothing")
+	}
+	if !strings.Contains(hits[0].Snippets[0], "one more gift") {
+		t.Errorf("first snippet is %q, not the passage the pattern hit most", hits[0].Snippets[0])
+	}
+}
+
+// A match found by folding scripts is a real match. Measuring how its words meet
+// against the unfolded text finds nothing, which would rank a genuine hit behind
+// passages the query never met in at all.
+func TestFoldedMatchIsNotRankedAsWordsThatNeverMeet(t *testing.T) {
+	scattered := strings.Repeat("連接池", 6) + strings.Repeat("其他內容", 200) + "修復"
+	s := model.Session{
+		Harness: "claude", Project: "p", ID: "s1",
+		Messages: []model.Message{
+			{Role: "user", Text: scattered},
+			{Role: "user", Text: "修復連接池洩漏的辦法"},
+		},
+	}
+	hits, err := Run([]model.Session{s}, Options{Query: "修复 连接池"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || len(hits[0].Snippets) == 0 {
+		t.Fatal("a Simplified query did not reach Traditional text")
+	}
+	if !strings.Contains(hits[0].Snippets[0], "修復連接池洩漏") {
+		t.Errorf("first snippet is %q, not the passage where the folded words meet", hits[0].Snippets[0])
+	}
+}

--- a/internal/search/snippet_meet_test.go
+++ b/internal/search/snippet_meet_test.go
@@ -1,0 +1,54 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The first snippet is the line a reader — or an agent with one line of budget —
+// actually reads. A message repeating one query word beat the message that said
+// both words together, so the excerpt showed noise and the answer came second.
+func TestSnippetLeadsWithThePassageWhereWordsMeet(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", Project: "p", ID: "s1",
+		Messages: []model.Message{
+			{Role: "user", Text: strings.Repeat("gift ", 6) + strings.Repeat("filler ", 300) + "dad"},
+			{Role: "user", Text: "the gift my dad gave me for the trip"},
+		},
+	}
+	hits, err := Run([]model.Session{s}, Options{Query: "dad gift"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || len(hits[0].Snippets) == 0 {
+		t.Fatal("no snippet, so the test measured nothing")
+	}
+	if !strings.Contains(hits[0].Snippets[0], "my dad gave me") {
+		t.Errorf("first snippet is %q, not the passage where the words meet", hits[0].Snippets[0])
+	}
+}
+
+// Among passages that are equally tight, the one carrying more of the query
+// still leads — otherwise a fix could pass the test above by ranking on
+// tightness alone and losing the signal count was there for.
+func TestSnippetStillPrefersTheDenserOfTwoTightPassages(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", Project: "p", ID: "s1",
+		Messages: []model.Message{
+			{Role: "user", Text: "dad gift"},
+			{Role: "user", Text: "dad gift, and another dad gift"},
+		},
+	}
+	hits, err := Run([]model.Session{s}, Options{Query: "dad gift"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || len(hits[0].Snippets) == 0 {
+		t.Fatal("no snippet, so the test measured nothing")
+	}
+	if !strings.Contains(hits[0].Snippets[0], "another dad gift") {
+		t.Errorf("first snippet is %q, not the passage carrying more of the query", hits[0].Snippets[0])
+	}
+}


### PR DESCRIPTION
The first excerpt under a hit is what a reader stops at, and what an agent with
one line of budget gets. The exact tier picked it by match count alone, so a
message repeating one query word six times led, and the line that answered the
query came second:

```
gift gift gift gift gift gift filler filler filler filler filler filler …
the gift my dad gave me for the trip
```

The relevance tier already picks its excerpt where the query's words meet, and
says why in its own comment. That never reached the exact tier — the tier most
searches land in — even though the proximity figure is computed one line above,
for `doc.minWindow`, and then dropped.

Candidates now carry that window and sort on it: passages where the words meet
first, tighter first among those, and count still decides between passages that
are equally tight, so the signal it was there for is not lost.

One thing the review turned up on the way: a match found by folding scripts was
being measured against the unfolded text, where the query's words are not
present at all. A genuine cross-script hit would have been ranked as words that
never meet. Proximity is now measured on whichever pair actually matched.

Four tests: the answer must beat the repetition, the denser of two equally tight
passages must still lead, regex excerpts must still rank by how often the pattern
hit, and a folded match must not be demoted.

Closes #1325.
