### PR TITLE
fix(blame): quote what was said about the file, not the first mention

### DIFF
--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -89,6 +89,16 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 		}
 		hit := BlameHit{Session: session, Title: sessionTitle(session), Tier: TierExact}
 		specificity := 0.0
+		// Quote the messages that say the most about the file, not the first two
+		// to name it. A session that mentions a file in passing and discusses it
+		// properly further down was quoted on the passing line, which is the
+		// evidence a reader judges the hit by (#1329).
+		type mention struct {
+			text  string
+			count int
+			level float64
+		}
+		var mentions []mention
 		for _, message := range session.Messages {
 			count, level := mentionScore(message.Text, base, forms)
 			if count == 0 {
@@ -98,9 +108,19 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 			if level > specificity {
 				specificity = level
 			}
-			if len(hit.Snippets) < 2 {
-				hit.Snippets = append(hit.Snippets, snippet(message.Text, target.Base, nil))
+			mentions = append(mentions, mention{message.Text, count, level})
+		}
+		// A path-shaped mention outranks a bare filename however often the bare
+		// name is repeated; among equally specific ones, the message that keeps
+		// returning to the file wins; among equals, the order they were said in.
+		sort.SliceStable(mentions, func(i, j int) bool {
+			if mentions[i].level != mentions[j].level {
+				return mentions[i].level > mentions[j].level
 			}
+			return mentions[i].count > mentions[j].count
+		})
+		for i := 0; i < len(mentions) && i < 2; i++ {
+			hit.Snippets = append(hit.Snippets, snippet(mentions[i].text, target.Base, nil))
 		}
 		if hit.Count == 0 {
 			continue

--- a/internal/search/blame_quote_test.go
+++ b/internal/search/blame_quote_test.go
@@ -1,0 +1,48 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The quotes under a blame hit are the evidence a reader judges it by, so they
+// have to be the messages that say something about the file. Taking the first
+// two mentions led with whichever line named it earliest.
+func TestBlameQuotesTheMessageThatExplainsTheFile(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", Project: "p", ID: "s1",
+		Messages: []model.Message{
+			{Role: "user", Text: "also worth a look at auth.go some day"},
+			{Role: "assistant", Text: "in internal/auth/auth.go we moved the token check out of auth.go because auth.go ran it twice"},
+		},
+	}
+	hits := Blame([]model.Session{s}, BlameTarget{Base: "auth.go", FullPath: "internal/auth/auth.go"}, BlameOptions{})
+	if len(hits) == 0 || len(hits[0].Snippets) == 0 {
+		t.Fatal("no blame hit, so the test measured nothing")
+	}
+	if !strings.Contains(hits[0].Snippets[0], "moved the token check") {
+		t.Errorf("first quote is %q, not the message that explains the file", hits[0].Snippets[0])
+	}
+}
+
+// A message naming the file by path is more specific evidence than one repeating
+// the bare name, however often it repeats it — otherwise a fix could rank on the
+// count alone and quote whichever line says "auth.go" the most.
+func TestBlamePrefersThePathOverTheRepeatedBareName(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", Project: "p", ID: "s1",
+		Messages: []model.Message{
+			{Role: "user", Text: "auth.go auth.go auth.go auth.go, anyway"},
+			{Role: "assistant", Text: "the change is in internal/auth/auth.go"},
+		},
+	}
+	hits := Blame([]model.Session{s}, BlameTarget{Base: "auth.go", FullPath: "internal/auth/auth.go"}, BlameOptions{})
+	if len(hits) == 0 || len(hits[0].Snippets) == 0 {
+		t.Fatal("no blame hit, so the test measured nothing")
+	}
+	if !strings.Contains(hits[0].Snippets[0], "internal/auth/auth.go") {
+		t.Errorf("first quote is %q, not the one naming the path", hits[0].Snippets[0])
+	}
+}


### PR DESCRIPTION
The two quotes under a blame hit are what a reader judges it by, and they were
the first two messages that named the file. A session that mentions a file in
passing and then explains what was done to it led with the passing line:

```
also worth a look at auth.go some day
```

instead of

```
in internal/auth/auth.go we moved the token check out of auth.go …
```

Mentions are now ranked by how specifically they name the file — a path beats a
bare filename however often the bare name repeats — then by how often. Both
figures already came out of `mentionScore` and were being thrown away. `Count`
and the session's `specificity` are computed exactly as before, so ranking
between hits is unchanged; only which messages get quoted moves.

Fifth place with this same cause, after #1318, #1322, #1326 and #1328.

Closes #1329.
