### PR TITLE
fix(search): the excerpt slid off the match in text that lowercases shorter

### DIFF
--- a/internal/search/lowercase_premise_test.go
+++ b/internal/search/lowercase_premise_test.go
@@ -1,0 +1,37 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// snippet finds a match in the lowercased text and cuts the original, carrying
+// the position across as a rune index. That is only sound because lowercasing in
+// Go maps one rune to one rune — it is the simple case mapping, not Unicode's
+// full one, so nothing expands the way "ﬁ" or a Turkish İ would under a locale
+// aware mapping. The premise is cheap to check and would break silently, so it
+// is checked.
+func TestToLowerKeepsRuneCount(t *testing.T) {
+	bad := 0
+	for r := rune(0); r <= 0x10FFFF; r++ {
+		if r >= 0xD800 && r <= 0xDFFF {
+			continue
+		}
+		s := string(r)
+		if n := utf8.RuneCountInString(strings.ToLower(s)); n != 1 {
+			if bad < 10 {
+				t.Errorf("U+%04X lowercases to %d runes", r, n)
+			}
+			bad++
+		}
+	}
+	t.Logf("runes whose lowercase is not one rune: %d", bad)
+
+	// Invalid UTF-8 too: bytes that are not runes at all.
+	for _, s := range []string{"\xff\xfe", "a\x80b", "\xed\xa0\x80"} {
+		if utf8.RuneCountInString(strings.ToLower(s)) != utf8.RuneCountInString(s) {
+			t.Errorf("invalid input %q changed rune count under ToLower", s)
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1391,7 +1391,13 @@ func snippet(s, q string, re *regexp.Regexp) string {
 			}
 		}
 		if b > 0 {
-			idx = utf8.RuneCountInString(s[:b])
+			// Count runes in the lowercased string, which is where b came from.
+			// Lowercasing maps rune to rune, so the count carries over to s —
+			// the byte offsets do not: "İ" is two bytes and lowercases to one,
+			// so a Turkish message put the excerpt a rune earlier for every
+			// capital İ before the match, and enough of them moved the window
+			// off the match entirely (#1331).
+			idx = utf8.RuneCountInString(low[:b])
 		}
 	}
 	start := idx - 100

--- a/internal/search/snippet_lowercase_test.go
+++ b/internal/search/snippet_lowercase_test.go
@@ -1,0 +1,26 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// The excerpt is positioned by searching the lowercased text and then cutting
+// the original. Lowercasing maps rune to rune but not byte to byte — "İ" is two
+// bytes and lowercases to one — so a message with enough capital İ before the
+// match had its window slide backwards until the match fell outside it.
+func TestSnippetSurvivesLowercasingThatChangesByteLength(t *testing.T) {
+	text := strings.Repeat("İ ", 400) + "the needle is here"
+	if got := Snippet(text, "needle"); !strings.Contains(got, "needle") {
+		t.Errorf("excerpt does not contain the match it was cut around: %q", got[:min(60, len(got))])
+	}
+}
+
+// The ordinary case must keep working: no length-changing runes, match in the
+// middle, excerpt centred on it.
+func TestSnippetStillCentresOnPlainText(t *testing.T) {
+	text := strings.Repeat("filler ", 200) + "the needle is here" + strings.Repeat(" filler", 200)
+	if got := Snippet(text, "needle"); !strings.Contains(got, "the needle is here") {
+		t.Errorf("excerpt %q lost the match", got)
+	}
+}


### PR DESCRIPTION
The match is found in the lowercased text and the excerpt is cut from the
original, so the position has to cross between them. It crossed as
`utf8.RuneCountInString(s[:b])` — counting runes in the original using an offset
into the lowercased string.

Lowercasing maps rune to rune but not byte to byte: "İ" is two bytes and
lowercases to one. Every such rune before the match moved the window a rune
earlier, and enough of them moved it off the match completely:

```go
text := strings.Repeat("İ ", 400) + "the needle is here"
Snippet(text, "needle")   // excerpt contains no "needle"
```

Counting in the string the offset came from fixes it. That is only sound if
lowercasing preserves rune counts, which Go's simple case mapping does — the
review raised İ, ẞ and the ligatures as counterexamples, so rather than argue it,
there is now a test that walks every code point plus some invalid UTF-8 and
checks the count never changes. It found none, and it will say so if a future Go
switches to full case mappings.

Closes #1331.
