### PR TITLE
fix(index): touched files stopped meaning worked-on-most after a batch

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1103,21 +1103,32 @@ func unionHashes(have, add []uint64) []uint64 {
 
 // mergeTouched keeps the earlier order — the ranking a full pass produced — and
 // adds paths the tail introduced, bounded the same way topTouchedFiles bounds.
+// mergeTouched fuses two ranked lists of touched paths. Both sides come out of
+// rankTouched, where position is the ranking and nothing else carries it, so the
+// merge takes one from each side in turn. Appending the new list after the old
+// one and cutting at the cap ignored the ranking it was handed: six paths from
+// an earlier batch filled the list and the file this batch worked on hardest
+// never appeared, though Touched is the files a session worked on most (#1333).
 func mergeTouched(have, add []string) []string {
 	seen := make(map[string]bool, len(have)+len(add))
-	for _, p := range have {
+	out := make([]string, 0, touchedFileCap)
+	keep := func(p string) bool {
+		if p == "" || seen[p] {
+			return true
+		}
 		seen[p] = true
+		out = append(out, p)
+		return len(out) < touchedFileCap
 	}
-	for _, p := range add {
-		if !seen[p] {
-			seen[p] = true
-			have = append(have, p)
+	for i := 0; i < len(have) || i < len(add); i++ {
+		if i < len(have) && !keep(have[i]) {
+			return out
+		}
+		if i < len(add) && !keep(add[i]) {
+			return out
 		}
 	}
-	if len(have) > touchedFileCap {
-		have = have[:touchedFileCap]
-	}
-	return have
+	return out
 }
 
 // agentOwnedFile drops the agent's own working files. They are touched

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -766,29 +766,8 @@ func fileEndsWithNewline(f *os.File) bool {
 	return buf[0] == '\n'
 }
 
-// mergeCappedStrings unions a and b, keeping a's order first and dropping
-// duplicates, then caps the result. Used to carry an imported session's earlier
-// Touched files across a re-import instead of overwriting them.
-func mergeCappedStrings(a, b []string, limit int) []string {
-	if len(b) == 0 {
-		return a
-	}
-	seen := make(map[string]bool, len(a)+len(b))
-	out := make([]string, 0, len(a)+len(b))
-	for _, s := range append(append([]string(nil), a...), b...) {
-		if s == "" || seen[s] {
-			continue
-		}
-		seen[s] = true
-		out = append(out, s)
-		if len(out) >= limit {
-			break
-		}
-	}
-	return out
-}
-
-// mergeCappedU64 is mergeCappedStrings for the hash lists (Asked, Hit).
+// mergeCappedU64 unions two hash lists, keeping the first list's order and
+// dropping whatever does not fit under the cap.
 func mergeCappedU64(a, b []uint64, limit int) []uint64 {
 	if len(b) == 0 {
 		return a
@@ -881,9 +860,14 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 			// A re-import carries only the records new since last time; the ones
 			// behind the earlier Touched/Asked/Hit are in the ledger and skipped,
 			// so recomputing from this batch alone would drop them. Union with what
-			// the session already had — earlier entries first — so a file a peer
-			// edited in an earlier batch stays blamable (#1024 follow-up).
-			meta.Touched = mergeCappedStrings(old.Touched, meta.Touched, touchedFileCap)
+			// the session already had, so a file a peer edited in an earlier batch
+			// stays blamable (#1024 follow-up). Both sides are ranked lists, so the
+			// union is by rank: taking the older list first and cutting the newer
+			// off at the cap kept six earlier paths over the file this batch worked
+			// on hardest (#1333). Six slots mean some earlier path does lose its
+			// place — to a path the session worked on more, which is what the field
+			// holds.
+			meta.Touched = mergeTouched(old.Touched, meta.Touched)
 			meta.Asked = mergeCappedU64(old.Asked, meta.Asked, askedQuestionCap)
 			meta.Hit = mergeCappedU64(old.Hit, meta.Hit, frictionSessionCap)
 			// Same reason: a reversal reported in an earlier batch is not in

--- a/internal/index/touched_merge_test.go
+++ b/internal/index/touched_merge_test.go
@@ -1,0 +1,46 @@
+package index
+
+import (
+	"slices"
+	"testing"
+)
+
+// SessionMeta.Touched is the files a session worked on most, and a session gets
+// updated in batches — a re-index of a growing transcript, a sync from another
+// machine. Filling the list from the older batch and cutting the newer one off
+// threw away the ranking both sides were handed.
+func TestTouchedMergeKeepsTheTopOfBothBatches(t *testing.T) {
+	have := []string{"a.go", "b.go", "c.go", "d.go", "e.go", "f.go"}
+	add := rankTouched(map[string]int{"hot.go": 40, "cold.go": 1})
+	got := mergeTouched(slices.Clone(have), add)
+	if !slices.Contains(got, "hot.go") {
+		t.Errorf("merged %v: the file this batch worked on hardest is missing", got)
+	}
+	if got[0] != "a.go" {
+		t.Errorf("merged %v: the file the session worked on hardest before is no longer first", got)
+	}
+	if len(got) > touchedFileCap {
+		t.Errorf("merged %v: over the cap of %d", got, touchedFileCap)
+	}
+}
+
+// Nothing may be listed twice, and a batch that adds nothing new must leave the
+// list alone — otherwise re-indexing an unchanged session would churn it.
+func TestTouchedMergeIsStableAndDeduplicates(t *testing.T) {
+	have := []string{"a.go", "b.go", "c.go"}
+	got := mergeTouched(slices.Clone(have), []string{"b.go", "a.go"})
+	if !slices.Equal(got, have) {
+		t.Errorf("merged %v, want %v unchanged", got, have)
+	}
+}
+
+// The empty cases the callers actually hit: a session with no earlier list, and
+// a batch that touched nothing.
+func TestTouchedMergeHandlesEmptySides(t *testing.T) {
+	if got := mergeTouched(nil, []string{"a.go", "b.go"}); !slices.Equal(got, []string{"a.go", "b.go"}) {
+		t.Errorf("merged %v from an empty session", got)
+	}
+	if got := mergeTouched([]string{"a.go"}, nil); !slices.Equal(got, []string{"a.go"}) {
+		t.Errorf("merged %v from an empty batch", got)
+	}
+}


### PR DESCRIPTION
`Touched` holds the six files a session worked on most, and `rankTouched`
produces it by recurrence. Sessions get updated in batches, though, and both
merge paths appended the new batch after the old list and cut at the cap:

```go
have := []string{"a.go", "b.go", "c.go", "d.go", "e.go", "f.go"}
add := rankTouched(map[string]int{"hot.go": 40, "cold.go": 1})
mergeTouched(have, add)   // [a.go b.go c.go d.go e.go f.go]
```

Once the list is full, nothing a session does later can enter it. The field stops
meaning "worked on most" and starts meaning "first six ever seen" — and the
comment two lines above the call already said it must not: *"the union has to be
re-ranked rather than concatenated — otherwise a file touched once in the tail
could outrank one touched throughout, and the cap would keep the wrong ones."*

Both sides are ranked lists whose ranking lives in the position alone, so the
union is now taken by rank — one from each side in turn. Not the exact answer:
that needs per-path counts the manifest does not carry. It does keep the top of
both batches rather than only the top of the older one.

The sync path had its own copy of the concatenating merge; it calls the same
helper now, and `mergeCappedStrings` had no other caller. Six slots do mean an
earlier path can lose its place — to a path the session worked on more, which is
what the field is for; the sync comment says so rather than still claiming
earlier entries always win.

Closes #1333.
