### PR TITLE
fix(digest): share and the handover tail said nothing when they cut

### DIFF
--- a/internal/digest/cut_marker_test.go
+++ b/internal/digest/cut_marker_test.go
@@ -1,0 +1,106 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func longSession() model.Session {
+	long := "we moved the scheduler into its own process " +
+		strings.Repeat("after weighing the options ", 30) + "and then reverted that."
+	return model.Session{
+		Harness: "claude", Project: "app", ID: "s1",
+		Messages: []model.Message{
+			{Role: "user", Text: "what did we settle on for the scheduler?"},
+			{Role: "assistant", Text: long},
+		},
+	}
+}
+
+// A block that stops mid-sentence reads as a finished thought, and the end of a
+// message is where a session says it reverted something. Both surfaces that hand
+// a session on — `deja share` and the handover tail — cut to fit and said
+// nothing about it.
+func TestTruncatedBlocksSayTheyWereCut(t *testing.T) {
+	s := longSession()
+	for _, tc := range []struct {
+		name string
+		out  string
+	}{
+		{"share", Share(s, 400)},
+		{"tail", tailSection(s, 300)},
+	} {
+		got := strings.TrimSpace(tc.out)
+		if !strings.HasSuffix(got, "…") {
+			t.Errorf("%s ends on an unmarked cut: %q", tc.name, got[max(0, len(got)-50):])
+		}
+	}
+}
+
+// The marker comes out of the budget rather than being added to it: these blocks
+// are sized to fit somewhere.
+func TestTruncatedBlocksStayWithinBudget(t *testing.T) {
+	s := longSession()
+	for _, budget := range []int{120, 300, 400, 900} {
+		if n := len(Share(s, budget)); n > budget {
+			t.Errorf("share at budget %d produced %d bytes", budget, n)
+		}
+		if n := len(tailSection(s, budget)); n > budget {
+			t.Errorf("tail at budget %d produced %d bytes", budget, n)
+		}
+	}
+}
+
+// A session that fits is left alone — no marker, nothing dropped. Otherwise a
+// fix could pass the tests above by marking everything.
+func TestBlocksThatFitAreUnmarked(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", Project: "app", ID: "s1",
+		Messages: []model.Message{
+			{Role: "user", Text: "what did we settle on for the scheduler?"},
+			{Role: "assistant", Text: "we moved it into its own process."},
+		},
+	}
+	got := Share(s, 4000)
+	if strings.Contains(got, "…") {
+		t.Errorf("a session that fits was marked as cut: %q", got)
+	}
+	if !strings.Contains(got, "we moved it into its own process.") {
+		t.Errorf("a session that fits lost its content: %q", got)
+	}
+}
+
+// A marker in the middle of a block is worse than none: it says the passage it
+// follows was cut and lets the next one read as continuous. Once a chunk is cut,
+// the block ends.
+func TestNothingFollowsAMarkedCut(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", Project: "app", ID: "s1",
+		Messages: []model.Message{
+			{Role: "user", Text: "what did we settle on for the scheduler?"},
+			{Role: "assistant", Text: "we moved the scheduler out " + strings.Repeat("after weighing the options ", 30) + strings.Repeat(" ", 60) + "and then reverted that."},
+			{Role: "assistant", Text: "the retry budget stays where it is for now."},
+		},
+	}
+	// Sweep the budget: whether the cut lands in a run of spaces, mid-word or on
+	// a rune boundary changes how much room is left after it.
+	for budget := 150; budget <= 900; budget++ {
+		for _, tc := range []struct {
+			name string
+			out  string
+		}{
+			{"share", Share(s, budget)},
+			{"tail", tailSection(s, budget)},
+		} {
+			i := strings.Index(tc.out, "…")
+			if i < 0 {
+				continue
+			}
+			if rest := strings.TrimSpace(tc.out[i+len("…"):]); rest != "" {
+				t.Fatalf("%s at budget %d continues after a marked cut with %q", tc.name, budget, rest)
+			}
+		}
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -46,10 +46,17 @@ func Share(s model.Session, budget int) string {
 				continue
 			}
 			chunk := fmt.Sprintf("%s\n\n", text)
-			if b.Len()+len(chunk) > budget {
-				chunk = UTF8SafeCut(chunk, budget-b.Len())
+			cut := b.Len()+len(chunk) > budget
+			if cut {
+				chunk = cutMarked(chunk, budget-b.Len())
 			}
 			b.WriteString(chunk)
+			// A marker says the passage before it was cut. Anything written
+			// after it reads as continuing text and makes the marker a lie, and
+			// trimming can leave enough room for another message to fit.
+			if cut {
+				break
+			}
 		}
 	}
 	var users, assistants []model.Message
@@ -200,6 +207,29 @@ func looksLikeDataDump(t string) bool {
 		}
 	}
 	return longestRun > 200
+}
+
+// cutMarker is how this package says a passage was cut. It ends the block, so
+// it carries the paragraph break with it.
+const cutMarker = "…\n\n"
+
+// cutMarked trims a passage to n bytes and says that it was cut. A block handed
+// to a person or an agent that simply stops reads as a finished thought, and the
+// end of a message is where a session says it changed its mind — the same defect
+// #1336 fixed for conclusions. The marker is paid for out of the budget rather
+// than added to it.
+func cutMarked(s string, n int) string {
+	if n <= len(cutMarker) {
+		return ""
+	}
+	t := strings.TrimRight(UTF8SafeCut(s, n-len(cutMarker)), " \t\n")
+	if t == "" {
+		return ""
+	}
+	if strings.HasSuffix(t, "…") {
+		return t + "\n\n"
+	}
+	return t + cutMarker
 }
 
 func UTF8SafeCut(s string, n int) string {
@@ -397,11 +427,13 @@ func tailSection(s model.Session, budget int) string {
 	for i := len(picked) - 1; i >= 0; i-- {
 		m := picked[i]
 		chunk := fmt.Sprintf("**%s:** %s\n\n", m.Role, MessageText(m.Text))
-		if b.Len()+len(chunk) > budget {
-			chunk = UTF8SafeCut(chunk, budget-b.Len())
+		cut := b.Len()+len(chunk) > budget
+		if cut {
+			chunk = cutMarked(chunk, budget-b.Len())
 		}
 		b.WriteString(chunk)
-		if b.Len() >= budget {
+		// Same reason as in Share: nothing follows a marked cut.
+		if cut || b.Len() >= budget {
 			break
 		}
 	}


### PR DESCRIPTION
Same shape as #1336, two more places: `deja share` and the handover tail both
fill a byte budget and cut the last message mid-sentence with nothing marking it.

```
… after weighing the options after weig
```

The message ended "and then reverted that". The reader gets a decision that
reads as standing.

Both now go through `cutMarked`, which appends the ellipsis this package already
uses for truncation elsewhere and takes the marker out of the budget rather than
adding it — these blocks are sized to fit somewhere.

The review raised a second thing worth having: a marker with text after it stops
meaning "this passage was cut". Sweeping 750 budgets on both surfaces did not
produce it, but at the helper level a marked cut can leave 61 bytes unspent, so
the property was holding by luck of what the trim removed. The block now ends at
a cut, which makes it hold by construction; the sweep stays as a test either way.

Four tests: the cut is marked, the budget is still respected across a range of
sizes, a session that fits is left unmarked, and nothing follows a marker.

Closes #1338.
