### PR TITLE
fix(digest): a session written in Chinese, Japanese or Korean digested to nothing

### DIFF
--- a/internal/cjkfold/count_test.go
+++ b/internal/cjkfold/count_test.go
@@ -1,0 +1,24 @@
+package cjkfold
+
+import "testing"
+
+func TestIsCJKAndCountCJK(t *testing.T) {
+	for _, r := range []rune{'漢', 'ひ', 'カ', '한'} {
+		if !IsCJK(r) {
+			t.Errorf("%q is one of the scripts this package folds", r)
+		}
+	}
+	for _, r := range []rune{'a', 'Я', '1', ' ', '。'} {
+		if IsCJK(r) {
+			t.Errorf("%q is not Han, kana or Hangul", r)
+		}
+	}
+	// The count is what a caller needs to tell prose in these scripts from a
+	// dump that merely contains some of it.
+	if got := CountCJK("路径 is /tmp/数据库"); got != 5 {
+		t.Errorf("CountCJK = %d, want 5", got)
+	}
+	if got := CountCJK("plain ascii only"); got != 0 {
+		t.Errorf("CountCJK = %d on ASCII, want 0", got)
+	}
+}

--- a/internal/cjkfold/fold.go
+++ b/internal/cjkfold/fold.go
@@ -65,14 +65,33 @@ func String(s string) string {
 	return string(runes)
 }
 
+// IsCJK reports whether r is a Han, Hiragana, Katakana or Hangul rune — the
+// scripts this package folds, and the ones written without spaces between words.
+func IsCJK(r rune) bool {
+	return unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
+		unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r)
+}
+
 // HasCJK reports whether s contains any Han, Hiragana, Katakana or Hangul
 // rune, i.e. whether folding could make any difference to it.
 func HasCJK(s string) bool {
 	for _, r := range s {
-		if unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
-			unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r) {
+		if IsCJK(r) {
 			return true
 		}
 	}
 	return false
+}
+
+// CountCJK is HasCJK by the number: how many of s's runes are written in those
+// scripts. A caller deciding whether a line is prose in one of them needs the
+// share, not the presence — a JSON blob with Chinese values has both.
+func CountCJK(s string) int {
+	n := 0
+	for _, r := range s {
+		if IsCJK(r) {
+			n++
+		}
+	}
+	return n
 }

--- a/internal/digest/cjk_prose_test.go
+++ b/internal/digest/cjk_prose_test.go
@@ -1,0 +1,54 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The prose gate keeps pasted JSON and CLI walls out of digests by counting
+// whitespace-separated words. Chinese, Japanese and Korean are written without
+// spaces, so a whole paragraph counts as one word and every answer over 80 bytes
+// in those scripts was thrown away as a dump.
+func TestCJKAnswersAreProse(t *testing.T) {
+	for name, line := range map[string]string{
+		"chinese":  "我们把调度器移到了单独的进程" + strings.Repeat("在权衡了各种选择之后", 12) + "然后又撤销了。",
+		"japanese": "スケジューラを別のプロセスに移動しました" + strings.Repeat("いくつかの選択肢を検討した結果", 8) + "その後元に戻しました。",
+		"korean":   "스케줄러를 별도의 프로세스로 옮겼습니다" + strings.Repeat("여러 선택지를 검토한 끝에", 8) + "그 후 되돌렸습니다.",
+	} {
+		if !looksLikeProse(line) {
+			t.Errorf("%s: an answer written in this script reads as a pasted dump", name)
+		}
+	}
+}
+
+// A session written in Chinese must produce the conclusions an English one of
+// the same shape does.
+func TestConclusionsSurviveInCJK(t *testing.T) {
+	cjk := model.Session{Messages: []model.Message{
+		{Role: "assistant", Text: "我们把重试次数限制为三次" + strings.Repeat("在权衡了各种选择之后", 12) + "并且保持不变。"},
+		{Role: "assistant", Text: "我们把调度器移到了单独的进程" + strings.Repeat("在权衡了各种选择之后", 12) + "然后又撤销了。"},
+	}}
+	if got := Conclusions(cjk, 4000, 2); len(got) != 2 {
+		t.Errorf("got %d conclusions from a Chinese session, want 2: %q", len(got), got)
+	}
+}
+
+// The gate still has to do its job: a pasted listing is not prose, in any
+// script.
+func TestPastedDumpsAreStillNotProse(t *testing.T) {
+	for name, line := range map[string]string{
+		"json":    `{"path":"/tmp/a","size":12,"mode":420,"mtime":1699999999,"hash":"deadbeefdeadbeefdeadbeef","owner":"root"}`,
+		"listing": "drwxr-xr-x 5 root root 4096 Jan 1 00:00 /usr/lib/x86_64-linux-gnu/libfoo.so.1.2.3.4.5.6.7.8.9",
+		// The case the CJK allowance opens: structured output whose values are
+		// Chinese. The characters are there; the line is still a dump.
+		"cjk json": `{"路径":"/tmp/数据库/主表","模式":420,"大小":12,"哈希":"deadbeefdeadbeef","拥有者":"root","时间":1699999999}`,
+	} {
+		// The two gates MessageText applies together: a dump has to be caught
+		// by one of them.
+		if looksLikeProse(line) && !noiseLine(line) {
+			t.Errorf("%s: a pasted dump got through both gates", name)
+		}
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/vshulcz/deja-vu/internal/cjkfold"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/redact"
 	"github.com/vshulcz/deja-vu/internal/sources"
@@ -112,7 +113,7 @@ func looksLikeProse(line string) bool {
 	if len(line) < 80 {
 		return true
 	}
-	letters, total, wordish := 0, 0, 0
+	letters, total, wordish, spaceless := 0, 0, 0, 0
 	for _, f := range strings.Fields(line) {
 		hasLetter := false
 		for _, r := range f {
@@ -129,11 +130,23 @@ func looksLikeProse(line string) bool {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r >= 0x80 {
 			letters++
 		}
+		if cjkfold.IsCJK(r) {
+			spaceless++
+		}
 	}
 	if total == 0 {
 		return false
 	}
-	// enough real words, and letters are a real share of the characters
+	// enough real words, and letters are a real share of the characters.
+	// Chinese, Japanese and Korean prose is written without spaces, so Fields
+	// sees one long token and the word count reads a paragraph of it as a
+	// pasted dump: every assistant answer over 80 bytes in those scripts was
+	// dropped from digests, and a session written in them recalled nothing
+	// (#1340). Their characters are the words — but a share of the line, not a
+	// handful of them, or a JSON blob with Chinese values reads as a sentence.
+	if spaceless >= 8 && spaceless*100/total >= 50 {
+		return true
+	}
 	return wordish >= 4 && letters*100/total >= 45
 }
 


### PR DESCRIPTION
A session written in Chinese, Japanese or Korean produced no conclusions at all:

```go
Conclusions(cjk, 4000, 2)   // []
```

`looksLikeProse` keeps pasted dumps out of digests by requiring four or more
whitespace-separated words, and those scripts are written without spaces. Any
line over 80 bytes in them counted as one word and was dropped, taking `deja
share`, the handover block and recall's conclusions with it. Short lines slipped
under the 80-byte exemption, which is why small fixtures show nothing wrong.

Their characters are the words, so the gate now counts them — but as a share of
the line rather than a count, because a JSON blob with Chinese values has plenty
of CJK runes and is still a dump. That case is one of the tests; without the
share condition it reads as someone's sentence.

The rune predicate moved into `cjkfold` next to `HasCJK` rather than being
open-coded here, per review, and `CountCJK` is what the gate calls.

Four tests: answers in all three scripts read as prose, a Chinese session keeps
its conclusions, ASCII dumps are still caught, and so is a dump whose values are
Chinese.

Closes #1340.
