### PR TITLE
fix(recall): Chinese sessions were skipped as having nothing to say

### DIFF
--- a/internal/cjkfold/bigrams_test.go
+++ b/internal/cjkfold/bigrams_test.go
@@ -1,0 +1,30 @@
+package cjkfold
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBigrams(t *testing.T) {
+	// Overlapping pairs inside a run, so a query for any adjacent pair reaches
+	// the text that contains it.
+	if got, want := Bigrams("装订计数"), []string{"装订", "订计", "计数"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Bigrams = %q, want %q", got, want)
+	}
+	// A run of one keeps its character: there is no pair to make.
+	if got, want := Bigrams("我 them"), []string{"我"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Bigrams = %q, want %q", got, want)
+	}
+	// Runs never cross a non-CJK boundary, and repeats are emitted once.
+	if got, want := Bigrams("装订 and 装订"), []string{"装订"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Bigrams = %q, want %q", got, want)
+	}
+	// ASCII-only text decodes nothing.
+	if got := Bigrams("nothing to see here"); got != nil {
+		t.Errorf("Bigrams = %q on ASCII, want none", got)
+	}
+	// Mixed scripts: each run is its own.
+	if got, want := Bigrams("ログ and 日志"), []string{"ログ", "日志"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Bigrams = %q, want %q", got, want)
+	}
+}

--- a/internal/cjkfold/fold.go
+++ b/internal/cjkfold/fold.go
@@ -17,6 +17,7 @@ package cjkfold
 import (
 	"sync"
 	"unicode"
+	"unicode/utf8"
 )
 
 // foldTrad and foldSimp are parallel rune sequences: foldTrad[i] folds to
@@ -94,4 +95,60 @@ func CountCJK(s string) int {
 		}
 	}
 	return n
+}
+
+// Bigrams emits the bigram set for every CJK run in s.
+//
+// Bigrams keep the script they were written in. Folding happens where postings
+// keys are built (indexKeys and queryKeys), not here, so the query-time
+// function-word filter still sees the runes the user actually typed: 係 folds
+// to 系, which is a content character in 系統 and 關係, so a filter applied
+// after folding could not tell the two apart.
+func Bigrams(s string) []string {
+	// The index hands this the whole message body, so a transcript with no CJK in
+	// it would otherwise decode every rune and run all four unicode.Is searches
+	// to build nothing. A CJK rune is never a single UTF-8 byte, so one byte scan
+	// answers the question before any decoding starts.
+	ascii := true
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			ascii = false
+			break
+		}
+	}
+	if ascii {
+		return nil
+	}
+
+	var out []string
+	seen := map[string]bool{}
+	var run []rune
+	flush := func() {
+		switch {
+		case len(run) == 1:
+			t := string(run)
+			if !seen[t] {
+				seen[t] = true
+				out = append(out, t)
+			}
+		case len(run) >= 2:
+			for i := 0; i+1 < len(run); i++ {
+				t := string(run[i : i+2])
+				if !seen[t] {
+					seen[t] = true
+					out = append(out, t)
+				}
+			}
+		}
+		run = run[:0]
+	}
+	for _, r := range s {
+		if IsCJK(r) {
+			run = append(run, r)
+			continue
+		}
+		flush()
+	}
+	flush()
+	return out
 }

--- a/internal/index/cjk.go
+++ b/internal/index/cjk.go
@@ -1,8 +1,7 @@
 package index
 
 import (
-	"unicode"
-	"unicode/utf8"
+	"github.com/vshulcz/deja-vu/internal/cjkfold"
 )
 
 // CJK text carries no spaces, so the base tokenizer collapses whole phrases
@@ -12,67 +11,6 @@ import (
 // A single-rune run keeps its unigram. Runs never cross a non-CJK boundary,
 // so ASCII and Cyrillic paths are untouched, and bigrams are ordinary tokens
 // downstream — postings, ranking and the ladder apply unchanged.
-
-func isCJK(r rune) bool {
-	return unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
-		unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r)
-}
-
-// cjkBigrams emits the bigram set for every CJK run in s.
-//
-// Bigrams keep the script they were written in. Folding happens where postings
-// keys are built (indexKeys and queryKeys), not here, so the query-time
-// function-word filter still sees the runes the user actually typed: 係 folds
-// to 系, which is a content character in 系統 and 關係, so a filter applied
-// after folding could not tell the two apart.
-func cjkBigrams(s string) []string {
-	// indexKeys hands this the whole message body, so a transcript with no CJK in
-	// it would otherwise decode every rune and run all four unicode.Is searches
-	// to build nothing. A CJK rune is never a single UTF-8 byte, so one byte scan
-	// answers the question before any decoding starts.
-	ascii := true
-	for i := 0; i < len(s); i++ {
-		if s[i] >= utf8.RuneSelf {
-			ascii = false
-			break
-		}
-	}
-	if ascii {
-		return nil
-	}
-
-	var out []string
-	seen := map[string]bool{}
-	var run []rune
-	flush := func() {
-		switch {
-		case len(run) == 1:
-			t := string(run)
-			if !seen[t] {
-				seen[t] = true
-				out = append(out, t)
-			}
-		case len(run) >= 2:
-			for i := 0; i+1 < len(run); i++ {
-				t := string(run[i : i+2])
-				if !seen[t] {
-					seen[t] = true
-					out = append(out, t)
-				}
-			}
-		}
-		run = run[:0]
-	}
-	for _, r := range s {
-		if isCJK(r) {
-			run = append(run, r)
-			continue
-		}
-		flush()
-	}
-	flush()
-	return out
-}
 
 // expandCJKTokens maps each token to itself plus, for every CJK run of 2+
 // runes inside it, that run's bigram set — the query-side mirror of the index
@@ -87,7 +25,7 @@ func expandCJKTokens(toks []string) []string {
 		hasCJK := false
 		allCJK := true
 		for _, r := range runes {
-			if isCJK(r) {
+			if cjkfold.IsCJK(r) {
 				hasCJK = true
 			} else {
 				allCJK = false
@@ -104,15 +42,15 @@ func expandCJKTokens(toks []string) []string {
 		}
 		i := 0
 		for i < len(runes) {
-			if !isCJK(runes[i]) {
+			if !cjkfold.IsCJK(runes[i]) {
 				i++
 				continue
 			}
 			j := i
-			for j < len(runes) && isCJK(runes[j]) {
+			for j < len(runes) && cjkfold.IsCJK(runes[j]) {
 				j++
 			}
-			out = append(out, cjkBigrams(string(runes[i:j]))...)
+			out = append(out, cjkfold.Bigrams(string(runes[i:j]))...)
 			i = j
 		}
 	}
@@ -169,7 +107,7 @@ func cjkFunctionBigram(tok string) bool {
 		return false
 	}
 	for _, r := range runes {
-		if !isCJK(r) || !cjkFunctionRunes[r] {
+		if !cjkfold.IsCJK(r) || !cjkFunctionRunes[r] {
 			return false
 		}
 	}

--- a/internal/index/cjk_ascii_test.go
+++ b/internal/index/cjk_ascii_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"github.com/vshulcz/deja-vu/internal/cjkfold"
 	"strings"
 	"testing"
 )
@@ -37,13 +38,13 @@ func TestCJKBigramsOnlyFiresOnCJK(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := cjkBigrams(tc.in)
+			got := cjkfold.Bigrams(tc.in)
 			if len(got) != len(tc.want) {
-				t.Fatalf("cjkBigrams(%q) = %q, want %q", tc.in, got, tc.want)
+				t.Fatalf("cjkfold.Bigrams(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 			for i := range got {
 				if got[i] != tc.want[i] {
-					t.Fatalf("cjkBigrams(%q) = %q, want %q", tc.in, got, tc.want)
+					t.Fatalf("cjkfold.Bigrams(%q) = %q, want %q", tc.in, got, tc.want)
 				}
 			}
 		})
@@ -56,7 +57,7 @@ func TestCJKBigramsOnlyFiresOnCJK(t *testing.T) {
 // what changed is the work done to arrive at it.
 func TestCJKBigramsDoesNotAllocateOnNonCJK(t *testing.T) {
 	body := strings.Repeat("the ingest worker leaks goroutines after a reload. ", 200)
-	if allocs := testing.AllocsPerRun(50, func() { cjkBigrams(body) }); allocs != 0 {
+	if allocs := testing.AllocsPerRun(50, func() { cjkfold.Bigrams(body) }); allocs != 0 {
 		t.Errorf("cjkBigrams on a %d-byte ASCII body made %v allocations, want 0", len(body), allocs)
 	}
 }
@@ -66,7 +67,7 @@ func BenchmarkCJKBigramsASCII(b *testing.B) {
 	b.SetBytes(int64(len(body)))
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		cjkBigrams(body)
+		cjkfold.Bigrams(body)
 	}
 }
 
@@ -75,6 +76,6 @@ func BenchmarkCJKBigramsCJK(b *testing.B) {
 	b.SetBytes(int64(len(body)))
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		cjkBigrams(body)
+		cjkfold.Bigrams(body)
 	}
 }

--- a/internal/index/cjk_fold_test.go
+++ b/internal/index/cjk_fold_test.go
@@ -87,7 +87,7 @@ func TestCJKFoldUnit(t *testing.T) {
 	}
 	// Bigrams keep the script they were written in — the function-word filter
 	// depends on that, because 係 folds to 系 which is content in 系統.
-	if got := cjkBigrams("韓國簽證"); got[0] != "韓國" {
+	if got := cjkfold.Bigrams("韓國簽證"); got[0] != "韓國" {
 		t.Errorf("bigrams should stay unfolded, got %v", got)
 	}
 	// The keys built from them are what must agree across scripts.

--- a/internal/index/cjk_test.go
+++ b/internal/index/cjk_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"github.com/vshulcz/deja-vu/internal/cjkfold"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,7 +78,7 @@ func TestCJKBigramSearch(t *testing.T) {
 }
 
 func TestCJKBigramsUnit(t *testing.T) {
-	got := cjkBigrams("装订计数")
+	got := cjkfold.Bigrams("装订计数")
 	want := []string{"装订", "订计", "计数"}
 	if len(got) != len(want) {
 		t.Fatalf("bigrams = %v", got)
@@ -87,10 +88,10 @@ func TestCJKBigramsUnit(t *testing.T) {
 			t.Fatalf("bigrams = %v, want %v", got, want)
 		}
 	}
-	if got := cjkBigrams("茶"); len(got) != 1 || got[0] != "茶" {
+	if got := cjkfold.Bigrams("茶"); len(got) != 1 || got[0] != "茶" {
 		t.Fatalf("unigram run = %v", got)
 	}
-	if got := cjkBigrams("plain ascii"); len(got) != 0 {
+	if got := cjkfold.Bigrams("plain ascii"); len(got) != 0 {
 		t.Fatalf("ascii leaked = %v", got)
 	}
 }

--- a/internal/index/cjkindex.go
+++ b/internal/index/cjkindex.go
@@ -147,7 +147,7 @@ func cjkIndexKeys(s string, emit func(tok string)) {
 	}
 
 	for _, r := range s {
-		if !isCJK(r) {
+		if !cjkfold.IsCJK(r) {
 			flush()
 			continue
 		}

--- a/internal/index/cjkindex_diff_test.go
+++ b/internal/index/cjkindex_diff_test.go
@@ -25,7 +25,7 @@ func legacyBucket(tok string) string {
 
 func legacyCJKKeys(s string) []string {
 	var out []string
-	for _, bg := range cjkBigrams(s) {
+	for _, bg := range cjkfold.Bigrams(s) {
 		out = append(out, "t"+cjkfold.String(bg))
 	}
 	return out

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -355,7 +355,7 @@ func RelevanceTerms(q string) []string {
 	seen := map[string]bool{}
 	var out []string
 	for _, f := range fields {
-		if len([]rune(f)) < 2 || (len(f) < 3 && !isCJK([]rune(f)[0])) || search.IsStopWord(f) || seen[f] {
+		if len([]rune(f)) < 2 || (len(f) < 3 && !cjkfold.IsCJK([]rune(f)[0])) || search.IsStopWord(f) || seen[f] {
 			continue
 		}
 		if cjkFunctionBigram(f) {

--- a/internal/search/cjk_relevance_test.go
+++ b/internal/search/cjk_relevance_test.go
@@ -1,0 +1,71 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func cjkSession(now time.Time) model.Session {
+	return model.Session{
+		Harness: "claude", Project: "app", ID: "s1", Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: "调度器为什么会重复执行任务"},
+			{Role: "assistant", Text: "我们把调度器移到了单独的进程并且把重试次数限制为三次"},
+		},
+	}
+}
+
+// Safe-mode auto-recall skips sessions with too little to say, counted in
+// distinct words. Chinese, Japanese and Korean put no separator between words,
+// so a whole answer counted as one or two and every such session was judged
+// empty and skipped.
+func TestCJKSessionReachesAutoRecall(t *testing.T) {
+	now := time.Now()
+	got := BuildAutoRecall([]model.Session{cjkSession(now)}, AutoRecallOptions{
+		Mode: RecallSafe, Now: now, ProjectNames: []string{"app"},
+	})
+	if got.Sessions == 0 {
+		t.Error("a Chinese session never reaches auto-recall")
+	}
+}
+
+// The bar still has to mean something: a session that really says nothing is
+// still skipped, in any script.
+func TestEmptySessionIsStillSkipped(t *testing.T) {
+	now := time.Now()
+	s := model.Session{
+		Harness: "claude", Project: "app", ID: "s2", Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: "好"},
+			{Role: "assistant", Text: "好"},
+		},
+	}
+	if got := BuildAutoRecall([]model.Session{s}, AutoRecallOptions{
+		Mode: RecallSafe, Now: now, ProjectNames: []string{"app"},
+	}); got.Sessions != 0 {
+		t.Errorf("a session saying nothing was recalled: %q", got.Text)
+	}
+}
+
+// Two different Chinese sessions must not read as duplicates of each other:
+// the same word set decides that, and counting whole sentences as single words
+// made every pair look either identical or unrelated.
+func TestTwoCJKSessionsAreNotNearDuplicates(t *testing.T) {
+	now := time.Now()
+	a := cjkSession(now)
+	b := model.Session{
+		Harness: "claude", Project: "app", ID: "s3", Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: "缓存为什么会失效"},
+			{Role: "assistant", Text: "我们把缓存的过期时间改成了一个小时并且加了监控"},
+		},
+	}
+	got := BuildAutoRecall([]model.Session{a, b}, AutoRecallOptions{
+		Mode: RecallSafe, Now: now, ProjectNames: []string{"app"},
+	})
+	if got.Sessions != 2 {
+		t.Errorf("got %d sessions, want both: %q", got.Sessions, got.Text)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -8,6 +8,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/vshulcz/deja-vu/internal/cjkfold"
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/model"
 )
@@ -192,6 +193,14 @@ func wordSet(s string) map[string]bool {
 		if utf8.RuneCountInString(word) >= 3 {
 			set[word] = true
 		}
+	}
+	// Chinese, Japanese and Korean put no separator between words, so the split
+	// above returns whole sentences: a session written in them counted two or
+	// three "words" and fell under the bar auto-recall sets for having anything
+	// to say (#1342). The index already reads those scripts as overlapping
+	// bigrams; this counts them the same way.
+	for _, b := range cjkfold.Bigrams(s) {
+		set[b] = true
 	}
 	return set
 }


### PR DESCRIPTION
Same cause as #1340, one layer up. Safe-mode auto-recall skips a session with too
little to say, measured in distinct words, and those scripts write no separators
between words:

```go
relevanceWords(chineseSession)   // 2, where the English equivalent scores 16
```

Two is under the bar, so the session is never offered at session start. Whether
it survives comes down to punctuation — a 。 between two clauses buys a third
"word" — which is why this is intermittent rather than total and invisible in
fixtures.

The index has read these scripts as overlapping bigrams since #337; the recall
heuristics predate that. `wordSet` now counts the same bigrams. To let
`internal/search` call the emitter — `internal/index` imports search, so the
dependency cannot run the other way — `cjkBigrams` and `isCJK` moved to
`internal/cjkfold`, which already owned the script knowledge, and index calls the
shared ones. Nothing about what gets indexed changes; the tests that covered the
emitter moved with it.

Three tests: a Chinese session reaches auto-recall, a session that really says
nothing is still skipped, and two different Chinese sessions are not taken for
duplicates of each other.

One thing the tests do not pin: bigrams over per-character counting. Both pass
these tests, and at the 0.8 duplicate threshold I could not build a case that
separates them. Bigrams are what the index uses, and having one notion of a word
in these scripts is the reason to prefer them — not evidence.

Closes #1342.
