### PR TITLE
fix(search): length normalisation did nothing for Chinese sessions

### DIFF
--- a/internal/search/cjk_length_test.go
+++ b/internal/search/cjk_length_test.go
@@ -1,0 +1,89 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func twoSessions(t *testing.T, aside, answer, askedIn, query string) []Hit {
+	t.Helper()
+	now := time.Now()
+	mk := func(id, user, assistant string) model.Session {
+		return model.Session{
+			Harness: "claude", Project: "app", ID: id, Updated: now,
+			Messages: []model.Message{{Role: "user", Text: user}, {Role: "assistant", Text: assistant}},
+		}
+	}
+	hits, err := Run([]model.Session{
+		mk("aside", askedIn, aside),
+		mk("answer", askedIn, answer),
+	}, Options{Query: query})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hits
+}
+
+// BM25 normalises by document length so that a long session mentioning a term
+// once does not outrank a short one that is about it. Length was counted in
+// whitespace-separated words, and Chinese, Japanese and Korean write none, so a
+// four-thousand-character aside counted as one word and the normalisation had
+// nothing to work with.
+func TestLongCJKAsideDoesNotCrowdTheAnswer(t *testing.T) {
+	filler := strings.Repeat("这里有很多与问题无关的背景说明和讨论内容", 200)
+	hits := twoSessions(t,
+		filler+"顺便提一下调度器"+filler,
+		"我们把调度器移到了单独的进程",
+		"我们来聊聊别的事情", "调度器")
+	if len(hits) != 2 {
+		t.Fatalf("got %d hits, want both", len(hits))
+	}
+	if hits[0].Session.ID != "answer" {
+		t.Fatalf("top hit is %s, not the session about it", hits[0].Session.ID)
+	}
+	// The margin is the point, not just the order: before, the aside scored
+	// within a third of the answer.
+	if ratio := hits[0].Score / hits[1].Score; ratio < 2 {
+		t.Errorf("answer scores only %.2fx the passing mention", ratio)
+	}
+}
+
+// The same shape in English must be unchanged — the fix adds to the count for
+// scripts without spaces and must not touch the ones with them.
+func TestLongASCIIAsideStillLosesByTheSameMargin(t *testing.T) {
+	filler := strings.Repeat("here is a lot of unrelated background discussion and content ", 200)
+	hits := twoSessions(t,
+		filler+"by the way the scheduler"+filler,
+		"we moved the scheduler to its own process",
+		"lets talk about something else", "scheduler")
+	if len(hits) != 2 {
+		t.Fatalf("got %d hits, want both", len(hits))
+	}
+	if hits[0].Session.ID != "answer" {
+		t.Fatalf("top hit is %s, not the session about it", hits[0].Session.ID)
+	}
+	if ratio := hits[0].Score / hits[1].Score; ratio < 4 {
+		t.Errorf("answer scores only %.2fx the passing mention, which is worse than it was", ratio)
+	}
+}
+
+// Length is words for scripts that write them and characters for the ones that
+// do not. Counting characters everywhere would quietly re-scale every English
+// document too.
+func TestDocumentLengthUnitPerScript(t *testing.T) {
+	counts, userCounts := make([]int, 1), make([]int, 1)
+	if got := countDocumentWords("we moved the scheduler to its own process", nil, nil, counts, userCounts, false); got != 8 {
+		t.Errorf("English length = %d, want its 8 words", got)
+	}
+	// 我们把调度器移到了单独的进程 is 14 characters and no spaces.
+	if got := countDocumentWords("我们把调度器移到了单独的进程", nil, nil, counts, userCounts, false); got != 14 {
+		t.Errorf("Chinese length = %d, want its 14 characters", got)
+	}
+	// A run with both in it is one word plus three characters, not three.
+	if got := countDocumentWords("scheduler調度器", nil, nil, counts, userCounts, false); got != 4 {
+		t.Errorf("mixed-run length = %d, want 4: the English half counts too", got)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -970,6 +970,11 @@ func titleBoost(titleHits, queryTokenCount int) float64 {
 func countDocumentWords(s string, terms []string, variants map[string][]string, counts, userCounts []int, user bool) int {
 	length := 0
 	start := -1
+	// cjk counts the characters of a run written in a script without spaces, and
+	// other counts the rest of that run, so a mixed run like "scheduler調度器"
+	// contributes both. Counted here rather than in a second pass over the word:
+	// this runs over every message of every candidate on every search.
+	cjk, other := 0, 0
 	for i := 0; i <= len(s); {
 		isWord := false
 		size := 0
@@ -977,12 +982,34 @@ func countDocumentWords(s string, terms []string, variants map[string][]string, 
 			r, n := utf8.DecodeRuneInString(s[i:])
 			size = n
 			isWord = unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-'
+			if isWord {
+				if cjkfold.IsCJK(r) {
+					cjk++
+				} else {
+					other++
+				}
+			}
 		}
 		if isWord && start < 0 {
 			start = i
 		} else if !isWord && start >= 0 {
 			word := s[start:i]
-			length++
+			// Length feeds BM25's normalisation, the part that stops a long
+			// document mentioning a term once from outranking a short one about
+			// it. Chinese, Japanese and Korean put no spaces between words, so a
+			// four-thousand-character aside was one word long and normalisation
+			// had nothing to work with: measured on the same content, a passing
+			// mention was separated from the answer by 6.2x in English and 1.3x
+			// in Chinese (#1344). Their characters are the words.
+			if cjk > 0 {
+				length += cjk
+				if other > 0 {
+					length++
+				}
+			} else {
+				length++
+			}
+			cjk, other = 0, 0
 			for j, term := range terms {
 				matched := word == term
 				if !matched {


### PR DESCRIPTION
Third place with the cause behind #1340 and #1342, and the one that shows up as
ranking rather than as something missing.

BM25 normalises by document length, which is what keeps a long session that
mentions a term once from outranking a short one about it. Length was one per run
of letters and digits, and these scripts write no separators, so a
four-thousand-character aside was one word long. Measured on the same content:

| | answer | passing mention | separation |
|---|---|---|---|
| English | 0.8000 | 0.1297 | 6.2x |
| Chinese | 0.2370 | 0.1823 | 1.3x |
| Chinese, after | 0.3993 | 0.1296 | 3.1x |

It does not reach the English figure — term frequency for these scripts comes
from substring counting rather than the word list — but the normalisation starts
doing its job, and the English numbers do not move.

The characters are counted in the same pass that finds word boundaries rather
than in a second walk of each word, since this runs over every message of every
candidate on every search. A run can also hold both scripts, `scheduler調度器`,
and the review caught that counting only its CJK characters dropped the English
word from the length entirely — it now contributes both, with a test.

Three tests: the long Chinese aside must lose by at least 2x, the English case
must still win by at least 4x, and the unit itself is pinned — words for scripts
that write them, characters for the ones that do not, both for a mixed run.
Counting characters everywhere passes the first two and fails the third.

Closes #1344.
