### PR TITLE
fix(index): a question in Chinese never counted as asked before

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -17,6 +17,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/vshulcz/deja-vu/internal/cjkfold"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/nfcfold"
 	"github.com/vshulcz/deja-vu/internal/query"
@@ -1278,7 +1279,12 @@ func questionStem(text string) string {
 		}
 	}
 	fields := strings.Fields(b.String())
-	if len(fields) < 5 {
+	if len(fields) < 5 && cjkfold.CountCJK(text) < 5 {
+		// Chinese, Japanese and Korean write no separator between words, so a
+		// question in those scripts is a single field however much it asks, and
+		// the five-word bar dropped every one of them: a person could ask the
+		// same thing weekly and deja never noticed (#1346). Their characters are
+		// the words.
 		return ""
 	}
 	return strings.Join(fields, " ")

--- a/internal/index/question_stem_scripts_test.go
+++ b/internal/index/question_stem_scripts_test.go
@@ -1,0 +1,47 @@
+package index
+
+import "testing"
+
+// deja notices when someone asks the same thing again, by folding a question to
+// a stem and matching stems. A stem needs five words, and Chinese, Japanese and
+// Korean write no separator between them, so a question in those scripts was one
+// word however much it asked and never got a stem at all.
+func TestQuestionStemAcrossScripts(t *testing.T) {
+	for name, q := range map[string]string{
+		"english": "why does the scheduler run tasks twice",
+		"chinese": "调度器为什么会重复执行任务",
+		"korean":  "스케줄러가작업을두번실행하는이유는무엇입니까",
+		"russian": "почему планировщик выполняет задачи дважды",
+	} {
+		if questionStem(q) == "" {
+			t.Errorf("%s: no stem, so asking this twice is never noticed", name)
+		}
+		if _, ok := askedHashOf(q + "？"); !ok {
+			t.Errorf("%s: not tracked as an asking at all", name)
+		}
+	}
+}
+
+// The bar still has to keep trivia out: "ok" and "继续" repeat in every session
+// and mean nothing.
+func TestShortAskingsStillHaveNoStem(t *testing.T) {
+	for name, q := range map[string]string{
+		"english short": "why not",
+		"chinese short": "为什么",
+		"russian short": "а почему",
+	} {
+		if got := questionStem(q); got != "" {
+			t.Errorf("%s: got stem %q, want none", name, got)
+		}
+	}
+}
+
+// The same question asked twice folds to the same stem, which is the whole
+// point of having one.
+func TestSameChineseQuestionFoldsTogether(t *testing.T) {
+	a, ok1 := askedHashOf("调度器为什么会重复执行任务？")
+	b, ok2 := askedHashOf("调度器为什么会重复执行任务？")
+	if !ok1 || !ok2 || a != b {
+		t.Errorf("the same question hashed to %d and %d (ok %v, %v)", a, b, ok1, ok2)
+	}
+}


### PR DESCRIPTION
Fourth place with the cause behind #1340, #1342 and #1344, and the one where the
feature is simply off rather than degraded.

A user turn is folded to a stem, the stem is hashed into `SessionMeta.Asked`, and
matching hashes are what "you asked this before" reads. The stem needs five
words, and Chinese, Japanese and Korean write no separator between them:

```go
questionStem("调度器为什么会重复执行任务")   // ""
askedHashOf("调度器为什么会重复执行任务？")  // _, false
```

Someone can ask the same thing weekly in Chinese and deja will not notice once.

Their characters are the words, so five of them is the same bar. The stem for
such a question is the question itself, which means two askings match when they
are written the same way and not when they differ by a character — narrower than
for English, and still the difference between the feature working and not
existing.

Three tests: questions in four scripts get a stem and register as askings, short
ones in each still do not, and the same Chinese question asked twice folds to the
same hash.

Two limits worth stating rather than hiding: an unpunctuated Chinese question
still never reaches the stem, because the gate before it recognises a question by
"？" or by an English or Russian opening word; and Korean does write spaces, so
it could already reach the bar the long way.

Closes #1346.
