### PR TITLE
fix(cjk): repeat questions, superseded and related notes were off in CJK

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -391,6 +391,14 @@ func markEarlierAttempts(hits []Hit) {
 					set[w] = true
 				}
 			}
+			// Overlap is what marks one session as an earlier pass over another's
+			// problem. Chinese, Japanese and Korean write no separator between
+			// words, so a whole excerpt was one token and two sessions about the
+			// same thing overlapped in nothing (#1348) — the index reads those
+			// scripts as bigrams and so does this.
+			for _, b := range cjkfold.Bigrams(sn) {
+				set[b] = true
+			}
 		}
 		sets[i] = set
 	}

--- a/internal/search/superseded_scripts_test.go
+++ b/internal/search/superseded_scripts_test.go
@@ -1,0 +1,62 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A hit is marked as an earlier pass over the same problem when it overlaps
+// heavily with a newer session in the same project. Overlap was measured in
+// whitespace-separated words, and Chinese, Japanese and Korean write none, so
+// two sessions about the same thing shared nothing and the marker never fired.
+func TestSupersededMarkerWorksInCJK(t *testing.T) {
+	now := time.Now()
+	body := "我们把调度器移到了单独的进程并且把重试次数限制为三次这样任务就不会重复执行了"
+	older := model.Session{
+		Harness: "claude", Project: "app", ID: "older", Updated: now.AddDate(0, 0, -30),
+		Messages: []model.Message{{Role: "assistant", Text: body}},
+	}
+	newer := model.Session{
+		Harness: "claude", Project: "app", ID: "newer", Updated: now,
+		Messages: []model.Message{{Role: "assistant", Text: body + "后来又调整了一次"}},
+	}
+	hits, err := Run([]model.Session{older, newer}, Options{Query: "调度器"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	marked := false
+	for _, h := range hits {
+		if h.Session.ID == "older" && h.Superseded != "" {
+			marked = true
+		}
+	}
+	if !marked {
+		t.Error("the older Chinese session was not marked as an earlier pass")
+	}
+}
+
+// Two sessions about different things must not be marked, or the label means
+// nothing.
+func TestSupersededMarkerSkipsUnrelatedCJK(t *testing.T) {
+	now := time.Now()
+	older := model.Session{
+		Harness: "claude", Project: "app", ID: "older", Updated: now.AddDate(0, 0, -30),
+		Messages: []model.Message{{Role: "assistant", Text: "我们把调度器移到了单独的进程" + strings.Repeat("并且写了很多说明", 4)}},
+	}
+	newer := model.Session{
+		Harness: "claude", Project: "app", ID: "newer", Updated: now,
+		Messages: []model.Message{{Role: "assistant", Text: "调度器的日志格式换成了结构化输出" + strings.Repeat("完全不同的内容在这里", 4)}},
+	}
+	hits, err := Run([]model.Session{older, newer}, Options{Query: "调度器"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hits {
+		if h.Session.ID == "older" && h.Superseded != "" {
+			t.Error("an unrelated older session was marked as an earlier pass")
+		}
+	}
+}

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vshulcz/deja-vu/internal/cjkfold"
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
@@ -497,6 +498,12 @@ func noteWordSet(s string) map[string]bool {
 		if len(w) >= 5 {
 			out[w] = true
 		}
+	}
+	// Two notes are related when they share words. Chinese, Japanese and Korean
+	// write no separator between them, so a whole note was one word and no two
+	// such notes could ever share the three the bar asks for (#1348).
+	for _, b := range cjkfold.Bigrams(s) {
+		out[b] = true
 	}
 	return out
 }

--- a/internal/sources/notes_related_scripts_test.go
+++ b/internal/sources/notes_related_scripts_test.go
@@ -1,0 +1,39 @@
+package sources
+
+import "testing"
+
+// Two notes are related when they share words. Chinese, Japanese and Korean
+// write no separator between them, so a whole note was one word and no two such
+// notes could share the three the bar asks for.
+func TestNoteWordSetSeesCJKWords(t *testing.T) {
+	a := noteWordSet("调度器移到了单独的进程并且限制了重试次数")
+	b := noteWordSet("调度器移到了单独的进程后来又调整了一次")
+	shared := 0
+	for w := range a {
+		if b[w] {
+			shared++
+		}
+	}
+	if shared < 3 {
+		t.Errorf("two notes about the same thing share %d words, which is under the bar for relating them", shared)
+	}
+}
+
+// Notes about different things must not become related, or the bar means
+// nothing.
+func TestNoteWordSetKeepsUnrelatedCJKApart(t *testing.T) {
+	// Not a trivially distant pair: both are ordinary sentences carrying the
+	// grammatical characters every Chinese sentence carries — 的, 了, 我们 — so
+	// the bar has to survive shared function words, not just shared topics.
+	a := noteWordSet("我们把调度器移到了单独的进程")
+	b := noteWordSet("我们把日志的格式换成了结构化输出")
+	shared := 0
+	for w := range a {
+		if b[w] {
+			shared++
+		}
+	}
+	if shared >= 3 {
+		t.Errorf("two unrelated notes share %d words", shared)
+	}
+}

--- a/internal/stats/repeat_questions_scripts_test.go
+++ b/internal/stats/repeat_questions_scripts_test.go
@@ -1,0 +1,40 @@
+package stats
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func askedTwice(q string) []model.Session {
+	return []model.Session{
+		{Harness: "claude", Project: "app", ID: "a", Messages: []model.Message{{Role: "user", Text: q}}},
+		{Harness: "claude", Project: "app", ID: "b", Messages: []model.Message{{Role: "user", Text: q}}},
+	}
+}
+
+// The repeat-questions figure counts questions asked in more than one session.
+// It required four whitespace-separated words, and Chinese, Japanese and Korean
+// write none, so the figure read zero for anyone working in them.
+func TestRepeatQuestionsCountsCJK(t *testing.T) {
+	english := RepeatQuestions(askedTwice("why does the scheduler run tasks twice?"))
+	if english != 1 {
+		t.Fatalf("English repeat questions = %d, want 1 — the probe measured nothing", english)
+	}
+	if got := RepeatQuestions(askedTwice("调度器为什么会重复执行任务？")); got != english {
+		t.Errorf("the same question counts %d times in English and %d in Chinese", english, got)
+	}
+}
+
+// Short acknowledgements repeat in every session and are not questions, in any
+// script.
+func TestRepeatQuestionsIgnoresShortAcknowledgements(t *testing.T) {
+	for name, q := range map[string]string{
+		"english": "ok?",
+		"chinese": "好吗？",
+	} {
+		if got := RepeatQuestions(askedTwice(q)); got != 0 {
+			t.Errorf("%s: %q counted as a repeated question %d times", name, q, got)
+		}
+	}
+}

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/vshulcz/deja-vu/internal/cjkfold"
 	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/redact"
@@ -429,8 +430,15 @@ func RepeatQuestions(ss []model.Session) int {
 			}
 			stem := questionStemFor(m.Text)
 			// Short acknowledgements ("ok", "continue") repeat across every
-			// session; only substantial messages count as questions.
-			if stem == "" || len(strings.Fields(stem)) < 4 || seen[stem] {
+			// session; only substantial messages count as questions. Chinese,
+			// Japanese and Korean write no separator between words, so such a
+			// question is one field however much it asks and this figure read
+			// zero for anyone working in them (#1348) — their characters are the
+			// words, as the index counts them for the same purpose.
+			if stem == "" || seen[stem] {
+				continue
+			}
+			if len(strings.Fields(stem)) < 4 && cjkfold.CountCJK(stem) < 4 {
 				continue
 			}
 			seen[stem] = true


### PR DESCRIPTION
The last three whitespace word counts, after #1340, #1342, #1344 and #1346.
Three separate features, each off rather than degraded for anyone working in
Chinese, Japanese or Korean:

- `deja stats` repeat questions read zero, because the stem needed four
  whitespace words. This was a second copy of the bar #1346 fixed in the index;
  the fix there did not reach here.
- The superseded marker never fired: it decides a hit is an earlier pass over a
  newer session's problem by excerpt overlap, and two Chinese sessions about the
  same thing overlapped in nothing.
- No two notes in those scripts could ever share the three words that relate
  them, since a whole note was one word.

The first counts characters, matching what the index now does. The other two add
the bigrams the index already reads those scripts as.

The bars on the last two are a raw shared count and an overlap ratio, so adding
bigrams could have made unrelated texts look alike — the grammatical characters
every Chinese sentence carries form bigrams too. Both "must stay apart" tests use
ordinary sentences sharing 我们, 的 and 了 rather than trivially distant ones, and
each of the three fixes has a mutation that its own test catches.

Closes #1348.
