### PR TITLE
fix(brief): the first screen named sessions the policy withholds

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -156,7 +156,24 @@ func runBrief(dir string, w io.Writer) error {
 
 	// Read the index as-is: the brief must never trigger a rebuild or let
 	// indexing narration tear through its layout.
-	if recent, err := index.RecentMatching(dir, 3, search.Options{}); err == nil && len(recent) > 0 {
+	// Filtered like every other browsing surface: `last`, search and the status
+	// line all refuse a session a rule withholds, and this screen named the
+	// project and the first line of it three times over (#1350, the shape #1026
+	// fixed on the status line). Asked for more than three so the block still
+	// fills when some are withheld.
+	//
+	// The search activation, while the asked-twice line below uses auto: the two
+	// serve different readers. This block is what the person is looking at, and
+	// browsing is what the search rule governs; that line is about what an agent
+	// would be handed, which is the auto rule's business.
+	recent, err := index.RecentMatching(dir, briefRecentLines*8, search.Options{})
+	if err == nil {
+		recent, _ = policyFilterSessionsCounted(policy.ActivationSearch, recent)
+		if len(recent) > briefRecentLines {
+			recent = recent[:briefRecentLines]
+		}
+	}
+	if err == nil && len(recent) > 0 {
 		label := "recent    "
 		for _, s := range recent {
 			title := s.Title
@@ -304,6 +321,9 @@ func trimBriefTitleTo(t string, max int) string {
 	}
 	return t
 }
+
+// briefRecentLines is how many recent sessions the brief names.
+const briefRecentLines = 3
 
 // briefTitleBudget is how much title fits after a prefix of prefixLen columns.
 //

--- a/cmd/deja/brief_recent_policy_test.go
+++ b/cmd/deja/brief_recent_policy_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The brief's recent block names a project and the first line of a session.
+// Search, `last`, blame and the status line all refuse a session a trust rule
+// withholds; this screen named three of them.
+func TestBriefRecentHonoursThePolicy(t *testing.T) {
+	dir := importedStore(t, 3)
+	writePolicy(t, `{"activations":{"search":{"local":true,"imported":false},"auto":{"local":true,"imported":false}}}`)
+
+	var buf bytes.Buffer
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if out := buf.String(); strings.Contains(out, "projx") || strings.Contains(out, "kafka") {
+		t.Errorf("the brief names a session the policy withholds:\n%s", out)
+	}
+}
+
+// With no rule in the way the block still fills: a fix that simply dropped it
+// would pass the test above.
+func TestBriefRecentStillNamesWhatIsAllowed(t *testing.T) {
+	dir := importedStore(t, 3)
+
+	var buf bytes.Buffer
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "recent") || !strings.Contains(out, "projx") {
+		t.Errorf("the brief stopped naming recent sessions:\n%s", out)
+	}
+	if n := strings.Count(out, "projx"); n != 3 {
+		t.Errorf("the brief names %d recent sessions, want 3:\n%s", n, out)
+	}
+}
+
+// A rule that withholds only some sessions leaves the block full rather than
+// short: the brief asks for more than it shows for exactly this reason.
+func TestBriefRecentFillsAroundWithheldSessions(t *testing.T) {
+	dir := importedStore(t, 3)
+	// A local session alongside the imported ones, newer than none of them:
+	// the block should fill with it rather than come back short.
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"the local scheduler question"},"timestamp":"2026-08-02T10:00:00Z","sessionId":"solo","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "solo.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The withheld one is the NEWEST, so a brief that asks for only as many as
+	// it shows comes back short.
+	writePolicy(t, `{"activations":{"search":{"local":false,"imported":true}}}`)
+
+	var buf bytes.Buffer
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "scheduler") {
+		t.Errorf("the brief names a withheld session:\n%s", out)
+	}
+	if n := strings.Count(out, "projx"); n != 3 {
+		t.Errorf("the brief names %d recent sessions, want the block filled with the 3 allowed:\n%s", n, out)
+	}
+}


### PR DESCRIPTION
The brief is the first screen someone sees, and its recent block named the
project and opening line of three sessions the trust policy withholds:

```
recent     [claude] imported:tmp/projx · Jan 1 0001 · the kafka consumer rebala…
           [claude] imported:tmp/projx · Jan 1 0001 · the kafka consumer rebala…
           [claude] imported:tmp/projx · Jan 1 0001 · the kafka consumer rebala…
```

Search, `last`, blame, ctx and the status line all refuse those. This is the
shape #1026 fixed on the status line, one screen over.

It now filters on the search activation, as the status line does. The block asks
for eight times what it shows so that withholding some of the newest sessions
leaves it full rather than short — a test covers exactly that, with the withheld
session the newest one, because an earlier version of it passed with a
three-session fetch by accident.

The review asked why this line uses the search activation while the asked-twice
line below uses auto. They serve different readers: this block is what the person
is looking at, and browsing is the search rule's business; that line is about
what an agent would be handed. The comment now says so, so the next reader does
not make them agree.

Closes #1350.
