### PR TITLE
fix(suggest): the first-run phrase came from withheld sessions

### DIFF
--- a/cmd/deja/suggest.go
+++ b/cmd/deja/suggest.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/query"
 )
 
@@ -22,11 +23,23 @@ import (
 // actually wrote (#625).
 func suggestFirstQuery(dir string) string {
 	ss, err := index.SearchWithRecovery(dir, query.Options{All: true, Role: "user"}, nil)
-	if err != nil || len(ss) < 3 {
+	if err != nil {
 		return ""
 	}
-	// Document frequency over what was typed across the whole store; candidate
-	// phrases only from the recent part of it.
+	// "Your own three-week-old problem" has to be yours. On a machine whose
+	// history arrived by sync, an unfiltered pick printed a phrase out of a
+	// peer's session on the first screen — while search, the recent block and
+	// the status line all refuse those sessions (#1352, the shape #1026 and
+	// #1350 fixed elsewhere). Browsing gate, as on those surfaces.
+	ss, _ = policyFilterSessionsCounted(policy.ActivationSearch, ss)
+	if len(ss) < 3 {
+		return ""
+	}
+	// Document frequency over what was typed in the sessions above — the ones a
+	// rule lets this reader see — and candidate phrases only from the recent
+	// part of them. Counting frequency over the whole store instead would let
+	// how often a word appears in withheld sessions decide which of the
+	// reader's own phrases gets shown.
 	df := map[string]int{}
 	for _, s := range ss {
 		seen := map[string]bool{}

--- a/cmd/deja/suggest_policy_test.go
+++ b/cmd/deja/suggest_policy_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// recentImportedStore is importedStore with dates and topics a suggestion can
+// actually be made from: the phrase picker looks at the last two months only,
+// and takes a phrase whose two words each recur across sessions.
+func recentImportedStore(t *testing.T, n int) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	topics := []string{
+		"kafka consumer rebalance keeps flapping",
+		"vault rotation broke staging deploy",
+		"scheduler retries twice every timeout",
+		"cache eviction wiped session store",
+	}
+	var batch []byte
+	for i := 0; i < n; i++ {
+		b, err := json.Marshal(index.SyncRecord{
+			Harness: "claude", SessionID: "peer" + string(rune('1'+i)), Project: "tmp/projx",
+			Role: "user", Text: topics[i%len(topics)], Time: now.AddDate(0, 0, -i-1),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		batch = append(append(batch, b...), '\n')
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), batch, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The suggestion after a first index is "a phrase from your own history",
+// printed to argue that the memory is worth having. On a machine whose history
+// arrived by sync, it was lifting that phrase out of sessions the trust policy
+// withholds from every other surface.
+func TestSuggestHonoursThePolicy(t *testing.T) {
+	dir := recentImportedStore(t, 8)
+	if got := suggestFirstQuery(dir); got == "" {
+		t.Fatal("no suggestion without a policy, so the test measures nothing")
+	}
+	writePolicy(t, `{"activations":{"search":{"local":true,"imported":false},"auto":{"local":true,"imported":false}}}`)
+	if got := suggestFirstQuery(dir); got != "" {
+		t.Errorf("suggested %q, a phrase from sessions the policy withholds", got)
+	}
+}
+
+// A rule that allows the sessions leaves the suggestion in place: the screen
+// is there to show someone their own history back.
+func TestSuggestStillSpeaksWhenAllowed(t *testing.T) {
+	dir := recentImportedStore(t, 8)
+	writePolicy(t, `{"activations":{"search":{"local":true,"imported":true}}}`)
+	if got := suggestFirstQuery(dir); got == "" {
+		t.Error("no suggestion though the policy allows these sessions")
+	}
+}


### PR DESCRIPTION
Third surface with the shape #1026 fixed on the status line and #1350 fixed on
the brief's recent block — and this one is the line meant to be the argument for
the tool.

After a first index build deja prints a phrase from the reader's own recent
history. It was reading every user turn out of the index unfiltered, so on a
machine whose history arrived by sync with a local-only rule:

```go
suggestFirstQuery(dir)   // "kafka consumer"
```

— a phrase out of a peer's session, presented as the reader's own, while search,
the recent block and the status line all refuse those sessions.

Filtered on the search activation before the phrase is chosen. Document
frequency is counted over the same filtered sessions rather than the whole
store: leaving it global would let how often a word appears in withheld sessions
decide which of the reader's own phrases gets shown. The comment above it said
"across the whole store" and now says what the code does — the review caught
that.

Two tests: with a withholding rule there is no suggestion, and with a rule that
allows the same sessions there still is. The first asserts a suggestion exists
before the policy is applied, so it cannot pass by the fixture simply never
producing one.

Closes #1352.
