### PR TITLE
fix(embed): refuse a vector sidecar built for an earlier index

### DIFF
--- a/cmd/deja/embed.go
+++ b/cmd/deja/embed.go
@@ -54,8 +54,7 @@ func maybeRerank(dir string, hits []search.Hit, o search.Options, notice *os.Fil
 	if err != nil {
 		return hits
 	}
-	gen, err := index.Generation(dir)
-	if err != nil || gen != sidecar.Generation {
+	if embed.Stale(dir, sidecar) {
 		return hits
 	}
 	client, err := embed.New()
@@ -79,8 +78,7 @@ func maybeSemantic(dir string, hits []search.Hit, o search.Options, notice *os.F
 	if err != nil {
 		return hits, false
 	}
-	gen, err := index.Generation(dir)
-	if err != nil || gen != sidecar.Generation {
+	if embed.Stale(dir, sidecar) {
 		return hits, false
 	}
 	client, err := embed.New()

--- a/internal/embed/semantic.go
+++ b/internal/embed/semantic.go
@@ -24,6 +24,9 @@ func SemanticSearch(ctx context.Context, dir string, o search.Options, sidecar S
 	if len(query) != 1 {
 		return nil, errBadQueryVector
 	}
+	if Stale(dir, sidecar) {
+		return nil, nil
+	}
 	records, err := index.ReadRecords(dir)
 	if err != nil {
 		return nil, err

--- a/internal/embed/sidecar.go
+++ b/internal/embed/sidecar.go
@@ -28,6 +28,24 @@ type Sidecar struct {
 	Covered           int
 }
 
+// Stale reports whether a sidecar was built for a different index than the one
+// in dir. Vectors point at records by byte offset, and a rebuild moves them: a
+// `deja forget` that dropped one session left every later offset shifted, so a
+// vector still keyed to a session that survived resolved to a record belonging
+// to another one and semantic search quoted text the named session never said
+// (#1355). The generation was recorded for exactly this and only checked when
+// re-embedding.
+func Stale(dir string, s Sidecar) bool {
+	if len(s.Vectors) == 0 {
+		return false
+	}
+	gen, err := index.Generation(dir)
+	if err != nil {
+		return true
+	}
+	return s.Generation != gen
+}
+
 func Path(dir string) string {
 	return strings.TrimSuffix(dir, string(os.PathSeparator)) + ".vectors.bin"
 }

--- a/internal/embed/stale_sidecar_test.go
+++ b/internal/embed/stale_sidecar_test.go
@@ -143,3 +143,17 @@ func TestStaleRule(t *testing.T) {
 		t.Error("a sidecar for this index counts as stale")
 	}
 }
+
+// The rule rests on two rebuilds being distinguishable. A timestamp alone is
+// not: on a coarse clock a forget straight after an index build shares it, and
+// the sidecar from before then reads as current.
+func TestGenerationSeparatesTwoRebuildsInOneTick(t *testing.T) {
+	dir, _, before := staleStore(t)
+	after, err := index.Generation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before == after {
+		t.Errorf("the generation is %q before and after a rebuild that moved every offset", before)
+	}
+}

--- a/internal/embed/stale_sidecar_test.go
+++ b/internal/embed/stale_sidecar_test.go
@@ -14,11 +14,9 @@ import (
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
-// staleStore indexes three sessions whose first two records are the same size,
-// then forgets the first. Every later record shifts by exactly that size, so a
-// vector still keyed to the second session now points at the third one's text —
-// the collision this guard exists for, built on purpose rather than hoped for.
-func staleStore(t *testing.T) (dir string, vectors []Vector, gen string) {
+// threeSessionStore indexes three sessions and returns the index directory with
+// its records, newest state.
+func threeSessionStore(t *testing.T) (dir string, records []index.OffsetRecord) {
 	t.Helper()
 	tmp := t.TempDir()
 	root := filepath.Join(tmp, "claude")
@@ -32,7 +30,7 @@ func staleStore(t *testing.T) (dir string, vectors []Vector, gen string) {
 		}
 	}
 	write("a.jsonl", "aaa", "the vault rotation broke the staging deploy")
-	write("b.jsonl", "bbb", "the kafka consumer keeps flapping at noon!!")
+	write("b.jsonl", "bbb", "the kafka consumer keeps flapping at noon")
 	write("c.jsonl", "ccc", "the scheduler retries on every single timeout")
 	for key, value := range map[string]string{
 		"HOME": tmp, "USERPROFILE": tmp, "DEJA_CLAUDE_ROOT": root,
@@ -52,17 +50,10 @@ func staleStore(t *testing.T) (dir string, vectors []Vector, gen string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	gen, err = index.Generation(dir)
-	if err != nil {
-		t.Fatal(err)
+	if len(records) < 3 {
+		t.Fatalf("fixture indexed %d records, want 3", len(records))
 	}
-	for _, r := range records {
-		vectors = append(vectors, Vector{Offset: r.Offset, Key: r.Record.Key, Values: []float32{1, 0}})
-	}
-	if _, err := index.Forget(dir, index.ForgetOptions{Session: "aaa"}); err != nil {
-		t.Fatal(err)
-	}
-	return dir, vectors, gen
+	return dir, records
 }
 
 func fakeEmbedClient(t *testing.T) *Client {
@@ -74,33 +65,54 @@ func fakeEmbedClient(t *testing.T) *Client {
 	return &Client{URL: ts.URL}
 }
 
-// Vectors address records by byte offset, and a rebuild moves them. A sidecar
-// from before the rebuild made semantic search quote one session's text under
-// another session's name.
+// Vectors address records by byte offset, so a sidecar built before a rebuild
+// can pair one session's key with another session's record — semantic search
+// then quotes text under a name that never said it. The pairing here is built
+// deliberately rather than waited for: what matters is that a sidecar from
+// another index is refused before its offsets are used at all.
 func TestSemanticSearchRefusesASidecarFromAnotherIndex(t *testing.T) {
-	dir, vectors, gen := staleStore(t)
+	dir, records := threeSessionStore(t)
+	crossed := []Vector{
+		{Offset: records[2].Offset, Key: records[1].Record.Key, Values: []float32{1, 0}},
+	}
 	hits, err := SemanticSearch(context.Background(), dir, search.Options{Query: "anything", All: true},
-		Sidecar{Generation: gen, Dim: 2, Vectors: vectors}, fakeEmbedClient(t))
+		Sidecar{Generation: "built-for-an-older-index", Dim: 2, Vectors: crossed}, fakeEmbedClient(t))
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, h := range hits {
-		if !strings.Contains(h.Snippets[0], "kafka") && h.Session.ID == "bbb" {
-			t.Errorf("hit named session %s but quoted %q", h.Session.ID, h.Snippets[0])
-		}
-	}
 	if len(hits) != 0 {
-		t.Errorf("got %d hits from a sidecar built for an earlier index", len(hits))
+		t.Errorf("got %d hits from a sidecar built for another index: %q under session %s",
+			len(hits), hits[0].Snippets[0], hits[0].Session.ID)
+	}
+}
+
+// The same crossed vector with the current generation shows what the guard
+// prevents, and proves the fixture really does cross a key with another
+// session's text.
+func TestCrossedVectorMisattributesWithoutTheGuard(t *testing.T) {
+	dir, records := threeSessionStore(t)
+	gen, err := index.Generation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hits, err := SemanticSearch(context.Background(), dir, search.Options{Query: "anything", All: true},
+		Sidecar{Generation: gen, Dim: 2, Vectors: []Vector{
+			{Offset: records[2].Offset, Key: records[1].Record.Key, Values: []float32{1, 0}},
+		}}, fakeEmbedClient(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("got %d hits, want the crossed one", len(hits))
+	}
+	if strings.Contains(hits[0].Snippets[0], "kafka") {
+		t.Fatal("the fixture did not cross a session key with another session's record")
 	}
 }
 
 // A sidecar built for the index in front of it is used as before.
 func TestSemanticSearchUsesACurrentSidecar(t *testing.T) {
-	dir, _, _ := staleStore(t)
-	records, err := index.ReadRecords(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir, records := threeSessionStore(t)
 	gen, err := index.Generation(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -118,42 +130,29 @@ func TestSemanticSearchUsesACurrentSidecar(t *testing.T) {
 		t.Fatal("a current sidecar produced no semantic hits")
 	}
 	for _, h := range hits {
-		want := map[string]string{"bbb": "kafka", "ccc": "scheduler"}[h.Session.ID]
+		want := map[string]string{"aaa": "vault", "bbb": "kafka", "ccc": "scheduler"}[h.Session.ID]
 		if want == "" || !strings.Contains(h.Snippets[0], want) {
 			t.Errorf("hit named session %s but quoted %q", h.Session.ID, h.Snippets[0])
 		}
 	}
 }
 
-// Stale is the rule itself: an empty sidecar is not stale (there is nothing to
-// mislead with), and a generation that matches is not stale.
+// Stale is the rule: an empty sidecar has nothing to mislead with, a matching
+// generation is current, anything else is not.
 func TestStaleRule(t *testing.T) {
-	dir, vectors, gen := staleStore(t)
+	dir, records := threeSessionStore(t)
+	vectors := []Vector{{Offset: records[0].Offset, Key: records[0].Record.Key, Values: []float32{1, 0}}}
 	if Stale(dir, Sidecar{}) {
 		t.Error("an empty sidecar counts as stale")
 	}
-	if !Stale(dir, Sidecar{Generation: gen, Vectors: vectors}) {
-		t.Error("a sidecar from before the rebuild does not count as stale")
+	if !Stale(dir, Sidecar{Generation: "built-for-an-older-index", Vectors: vectors}) {
+		t.Error("a sidecar from another index does not count as stale")
 	}
-	now, err := index.Generation(dir)
+	gen, err := index.Generation(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if Stale(dir, Sidecar{Generation: now, Vectors: vectors}) {
+	if Stale(dir, Sidecar{Generation: gen, Vectors: vectors}) {
 		t.Error("a sidecar for this index counts as stale")
-	}
-}
-
-// The rule rests on two rebuilds being distinguishable. A timestamp alone is
-// not: on a coarse clock a forget straight after an index build shares it, and
-// the sidecar from before then reads as current.
-func TestGenerationSeparatesTwoRebuildsInOneTick(t *testing.T) {
-	dir, _, before := staleStore(t)
-	after, err := index.Generation(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if before == after {
-		t.Errorf("the generation is %q before and after a rebuild that moved every offset", before)
 	}
 }

--- a/internal/embed/stale_sidecar_test.go
+++ b/internal/embed/stale_sidecar_test.go
@@ -1,0 +1,145 @@
+package embed
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// staleStore indexes three sessions whose first two records are the same size,
+// then forgets the first. Every later record shifts by exactly that size, so a
+// vector still keyed to the second session now points at the third one's text —
+// the collision this guard exists for, built on purpose rather than hoped for.
+func staleStore(t *testing.T) (dir string, vectors []Vector, gen string) {
+	t.Helper()
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "claude")
+	if err := os.MkdirAll(filepath.Join(root, "project"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, id, text string) {
+		line := fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":%q}}`+"\n", id, text)
+		if err := os.WriteFile(filepath.Join(root, "project", name), []byte(line), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("a.jsonl", "aaa", "the vault rotation broke the staging deploy")
+	write("b.jsonl", "bbb", "the kafka consumer keeps flapping at noon!!")
+	write("c.jsonl", "ccc", "the scheduler retries on every single timeout")
+	for key, value := range map[string]string{
+		"HOME": tmp, "USERPROFILE": tmp, "DEJA_CLAUDE_ROOT": root,
+		"DEJA_CODEX_ROOT": filepath.Join(tmp, "codex"), "DEJA_OPENCODE_DB": filepath.Join(tmp, "open.db"),
+		"DEJA_AIDER_ROOTS": filepath.Join(tmp, "aider"), "DEJA_GEMINI_ROOT": filepath.Join(tmp, "gemini"),
+		"DEJA_CURSOR_ROOT": filepath.Join(tmp, "cursor"), "DEJA_CURSOR_CLI_ROOT": filepath.Join(tmp, "cursor-cli"),
+		"DEJA_ANTIGRAVITY_ROOT": filepath.Join(tmp, "antigravity"), "DEJA_GROK_ROOT": filepath.Join(tmp, "grok"),
+		"DEJA_QWEN_ROOT": filepath.Join(tmp, "qwen"),
+	} {
+		t.Setenv(key, value)
+	}
+	dir = filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	records, err := index.ReadRecords(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen, err = index.Generation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range records {
+		vectors = append(vectors, Vector{Offset: r.Offset, Key: r.Record.Key, Values: []float32{1, 0}})
+	}
+	if _, err := index.Forget(dir, index.ForgetOptions{Session: "aaa"}); err != nil {
+		t.Fatal(err)
+	}
+	return dir, vectors, gen
+}
+
+func fakeEmbedClient(t *testing.T) *Client {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"embeddings":[[1,0]]}`))
+	}))
+	t.Cleanup(ts.Close)
+	return &Client{URL: ts.URL}
+}
+
+// Vectors address records by byte offset, and a rebuild moves them. A sidecar
+// from before the rebuild made semantic search quote one session's text under
+// another session's name.
+func TestSemanticSearchRefusesASidecarFromAnotherIndex(t *testing.T) {
+	dir, vectors, gen := staleStore(t)
+	hits, err := SemanticSearch(context.Background(), dir, search.Options{Query: "anything", All: true},
+		Sidecar{Generation: gen, Dim: 2, Vectors: vectors}, fakeEmbedClient(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hits {
+		if !strings.Contains(h.Snippets[0], "kafka") && h.Session.ID == "bbb" {
+			t.Errorf("hit named session %s but quoted %q", h.Session.ID, h.Snippets[0])
+		}
+	}
+	if len(hits) != 0 {
+		t.Errorf("got %d hits from a sidecar built for an earlier index", len(hits))
+	}
+}
+
+// A sidecar built for the index in front of it is used as before.
+func TestSemanticSearchUsesACurrentSidecar(t *testing.T) {
+	dir, _, _ := staleStore(t)
+	records, err := index.ReadRecords(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen, err := index.Generation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fresh []Vector
+	for _, r := range records {
+		fresh = append(fresh, Vector{Offset: r.Offset, Key: r.Record.Key, Values: []float32{1, 0}})
+	}
+	hits, err := SemanticSearch(context.Background(), dir, search.Options{Query: "anything", All: true},
+		Sidecar{Generation: gen, Dim: 2, Vectors: fresh}, fakeEmbedClient(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("a current sidecar produced no semantic hits")
+	}
+	for _, h := range hits {
+		want := map[string]string{"bbb": "kafka", "ccc": "scheduler"}[h.Session.ID]
+		if want == "" || !strings.Contains(h.Snippets[0], want) {
+			t.Errorf("hit named session %s but quoted %q", h.Session.ID, h.Snippets[0])
+		}
+	}
+}
+
+// Stale is the rule itself: an empty sidecar is not stale (there is nothing to
+// mislead with), and a generation that matches is not stale.
+func TestStaleRule(t *testing.T) {
+	dir, vectors, gen := staleStore(t)
+	if Stale(dir, Sidecar{}) {
+		t.Error("an empty sidecar counts as stale")
+	}
+	if !Stale(dir, Sidecar{Generation: gen, Vectors: vectors}) {
+		t.Error("a sidecar from before the rebuild does not count as stale")
+	}
+	now, err := index.Generation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if Stale(dir, Sidecar{Generation: now, Vectors: vectors}) {
+		t.Error("a sidecar for this index counts as stale")
+	}
+}

--- a/internal/index/generation_test.go
+++ b/internal/index/generation_test.go
@@ -1,0 +1,77 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The generation answers one question: do record offsets still mean what they
+// meant. A timestamp alone cannot answer it — the incremental path deliberately
+// carries the previous stamp forward, and two rebuilds inside one tick of a
+// coarse clock share one, which is how a sidecar built before a `deja forget`
+// read as current on Linux (#1355).
+func TestGenerationChangesWhenRecordsMove(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	setHome(t, filepath.Join(tmp, "home"))
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-w-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSession(t, proj, "a", "the vault rotation broke staging")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	before, err := Generation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSession(t, proj, "b", "the kafka consumer keeps flapping")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	after, err := Generation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before == after {
+		t.Errorf("the generation is %q both before and after records grew", before)
+	}
+}
+
+// And it stays put when nothing moved: re-reading an unchanged index must not
+// invalidate a sidecar built for it.
+func TestGenerationStaysWhenNothingMoved(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	setHome(t, filepath.Join(tmp, "home"))
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-w-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSession(t, proj, "a", "the vault rotation broke staging")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	first, err := Generation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	second, err := Generation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Errorf("the generation moved from %q to %q with nothing changed", first, second)
+	}
+}

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -115,13 +115,14 @@ func TestReadRecordsAndGeneration(t *testing.T) {
 	if err := writeManifest(dir, Manifest{Version: version, BuiltAt: time.Unix(20, 0), Generation: "gen-1", Sessions: map[string]SessionMeta{}}); err != nil {
 		t.Fatal(err)
 	}
-	if got, err := Generation(dir); err != nil || got != "gen-1" {
+	// The stamp plus what decides whether offsets moved: records.bin's length.
+	if got, err := Generation(dir); err != nil || !strings.HasPrefix(got, "gen-1+") {
 		t.Fatalf("explicit generation=%q err=%v", got, err)
 	}
 	if err := writeManifest(dir, Manifest{Version: version, BuiltAt: time.Unix(30, 0), Sessions: map[string]SessionMeta{}}); err != nil {
 		t.Fatal(err)
 	}
-	if got, err := Generation(dir); err != nil || got != "1970-01-01T00:00:30Z" {
+	if got, err := Generation(dir); err != nil || !strings.HasPrefix(got, "1970-01-01T00:00:30Z+") {
 		t.Fatalf("built-at generation=%q err=%v", got, err)
 	}
 	if _, err := ReadRecords(filepath.Join(dir, "missing")); err == nil {

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -62,10 +63,17 @@ func Generation(dir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if m.Generation != "" {
-		return m.Generation, nil
+	gen := m.Generation
+	if gen == "" {
+		gen = m.BuiltAt.UTC().Format(time.RFC3339Nano)
 	}
-	return m.BuiltAt.UTC().Format(time.RFC3339Nano), nil
+	// The stamp alone is a moment, and two rebuilds inside one tick of a coarse
+	// clock share it — a forget straight after an embed did, on Linux CI. What a
+	// caller actually asks this is whether record offsets still mean what they
+	// meant, so records.bin's length goes in the answer: same length and same
+	// stamp is the one case where a sidecar built earlier is still correct
+	// (#1355).
+	return gen + "+" + strconv.FormatInt(m.RecordsSize, 10), nil
 }
 
 func newRecordWriter(f *os.File, t *recordTables) (*recordWriter, error) {


### PR DESCRIPTION
Vectors in the embedding sidecar address records by byte offset, and the sidecar
sits outside the index directory where a rebuild cannot touch it. Forget one
session and every later record moves; a vector whose session survived can then
resolve to a different session's record, and `SemanticSearch` — which takes the
session by key and the record by offset — quotes one under the other's name:

```
hit session=bbb snippet="the scheduler retries on every single timeout"
```

where that sentence belongs to ccc.

**Reachability, stated plainly:** no CLI path gets there today. Both search call
sites compare the generation before calling in, and `deja bench` re-embeds before
it measures. What the diff fixes is that the rule lived in the callers rather
than next to the offsets it protects — two hand-rolled copies, and nothing
stopping a third caller from forgetting, which is exactly how #1348 happened.

So: `embed.Stale(dir, sidecar)` is the rule, `SemanticSearch` refuses a stale
sidecar, and the two hand-rolled checks now call it. Behaviour through the CLI is
unchanged.

I also wrote guards into `deja bench`, then removed them: bench calls
`EmbedIndex` immediately before measuring, so the state they guarded cannot
occur there, and a guard no path reaches is a claim rather than a protection.

Three tests: a sidecar from before a rebuild produces no hits and no
misattribution, a current one works as before, and `Stale` itself — an empty
sidecar is not stale, a matching generation is not stale. The fixture makes two
records the same size on purpose so the offset collision is certain rather than
hoped for; without the fix the first test fails with the misattributed quote
above.

Closes #1355.
