### PR TITLE
fix(index): a rewritten records file kept the old generation

### DIFF
--- a/internal/embed/reuse_test.go
+++ b/internal/embed/reuse_test.go
@@ -1,0 +1,162 @@
+package embed
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// countingClient answers every embed request and records how many texts it was
+// asked to embed.
+func countingClient(t *testing.T, embedded *atomic.Int64) *Client {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Input []string `json:"input"`
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		n := len(body.Input)
+		embedded.Add(int64(n))
+		out := make([][]float32, n)
+		for i := range out {
+			out[i] = []float32{1, 0}
+		}
+		payload, _ := json.Marshal(map[string]any{"embeddings": out})
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(ts.Close)
+	return &Client{URL: ts.URL, Model: "test"}
+}
+
+func embedStore(t *testing.T) (dir string, addSession func(id string)) {
+	t.Helper()
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "claude")
+	if err := os.MkdirAll(filepath.Join(root, "project"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(id string) {
+		line := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"session ` + id + ` about the scheduler"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(root, "project", id+".jsonl"), []byte(line), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, id := range []string{"a", "b", "c", "d", "e"} {
+		write(id)
+	}
+	for key, value := range map[string]string{
+		"HOME": tmp, "USERPROFILE": tmp, "DEJA_CLAUDE_ROOT": root,
+		"DEJA_CODEX_ROOT": filepath.Join(tmp, "codex"), "DEJA_OPENCODE_DB": filepath.Join(tmp, "open.db"),
+		"DEJA_AIDER_ROOTS": filepath.Join(tmp, "aider"), "DEJA_GEMINI_ROOT": filepath.Join(tmp, "gemini"),
+		"DEJA_CURSOR_ROOT": filepath.Join(tmp, "cursor"), "DEJA_CURSOR_CLI_ROOT": filepath.Join(tmp, "cursor-cli"),
+		"DEJA_ANTIGRAVITY_ROOT": filepath.Join(tmp, "antigravity"), "DEJA_GROK_ROOT": filepath.Join(tmp, "grok"),
+		"DEJA_QWEN_ROOT": filepath.Join(tmp, "qwen"),
+	} {
+		t.Setenv(key, value)
+	}
+	dir = filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Growing a session already in the index is the common event and the only
+	// one that appends in place; a brand-new session rebuilds records.bin, where
+	// no offset can be trusted afterwards.
+	return dir, func(id string) {
+		f, err := os.OpenFile(filepath.Join(root, "project", "a.jsonl"), os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		line := `{"type":"user","sessionId":"a","timestamp":"2026-01-02T00:00:00Z","message":{"role":"user","content":"and then ` + id + ` happened to the scheduler"}}` + "\n"
+		if _, err := f.WriteString(line); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := index.Ensure(dir, "", false, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// Embedding costs a network call per record. A session that grows is appended
+// to records.bin in place, so every vector already paid for still points at the
+// record it was made from — only the new message needs embedding.
+func TestEmbedIndexOnlyEmbedsWhatIsNew(t *testing.T) {
+	var embedded atomic.Int64
+	client := countingClient(t, &embedded)
+	dir, addSession := embedStore(t)
+	if _, err := EmbedIndex(dir, client, nil); err != nil {
+		t.Fatal(err)
+	}
+	if first := embedded.Load(); first != 5 {
+		t.Fatalf("first build embedded %d records, want 5 — the fixture is wrong", first)
+	}
+	addSession("f") // one more message in a session already indexed
+	embedded.Store(0)
+	if _, err := EmbedIndex(dir, client, nil); err != nil {
+		t.Fatal(err)
+	}
+	if again := embedded.Load(); again != 1 {
+		t.Errorf("one more message re-embedded %d records, want 1", again)
+	}
+}
+
+// The layout rule underneath it, stated directly: a stamp that changed is a
+// rebuild and invalidates every offset; the same stamp with a file that only
+// grew is an append and invalidates nothing; a file that shrank moved records.
+func TestSameLayout(t *testing.T) {
+	for name, tc := range map[string]struct {
+		was, now string
+		want     bool
+	}{
+		"identical":         {"2026-01-01T00:00:00Z+100", "2026-01-01T00:00:00Z+100", true},
+		"appended":          {"2026-01-01T00:00:00Z+100", "2026-01-01T00:00:00Z+180", true},
+		"shrank":            {"2026-01-01T00:00:00Z+180", "2026-01-01T00:00:00Z+100", false},
+		"rebuilt":           {"2026-01-01T00:00:00Z+100", "2026-01-01T00:00:09Z+100", false},
+		"no size at all":    {"2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z+100", false},
+		"empty":             {"", "2026-01-01T00:00:00Z+100", false},
+		"no stamp":          {"+100", "+180", false},
+		"size not a number": {"2026-01-01T00:00:00Z+abc", "2026-01-01T00:00:00Z+180", false},
+		"negative size":     {"2026-01-01T00:00:00Z+-5", "2026-01-01T00:00:00Z+180", false},
+	} {
+		if got := sameLayout(tc.was, tc.now); got != tc.want {
+			t.Errorf("%s: sameLayout(%q, %q) = %v", name, tc.was, tc.now, got)
+		}
+	}
+}
+
+// The other side of the rule, end to end: a new session rebuilds records.bin,
+// so no offset survives and every vector has to be made again. Cheap would be
+// wrong here.
+func TestEmbedIndexRebuildsEverythingAfterANewSession(t *testing.T) {
+	var embedded atomic.Int64
+	client := countingClient(t, &embedded)
+	dir, _ := embedStore(t)
+	if _, err := EmbedIndex(dir, client, nil); err != nil {
+		t.Fatal(err)
+	}
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	line := `{"type":"user","sessionId":"z","timestamp":"2026-01-03T00:00:00Z","message":{"role":"user","content":"a brand new session about the scheduler"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "project", "z.jsonl"), []byte(line), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	embedded.Store(0)
+	if _, err := EmbedIndex(dir, client, nil); err != nil {
+		t.Fatal(err)
+	}
+	if again := embedded.Load(); again != 6 {
+		t.Errorf("a rebuild re-embedded %d records, want all 6 — offsets moved", again)
+	}
+}

--- a/internal/embed/sidecar.go
+++ b/internal/embed/sidecar.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -43,7 +44,41 @@ func Stale(dir string, s Sidecar) bool {
 	if err != nil {
 		return true
 	}
-	return s.Generation != gen
+	return !sameLayout(s.Generation, gen)
+}
+
+// sameLayout reports whether two generations describe an index where the
+// offsets a vector holds still point at the same records.
+//
+// A generation is the build's stamp and the size records.bin had then. The
+// stamp alone cannot answer this — the incremental path carries it forward on
+// purpose, and two rebuilds inside one tick of a coarse clock share one — but
+// the size alone is too strict: appending a session grows the file without
+// moving a single existing record, and treating that as a new index threw away
+// every vector and re-embedded the whole store on each `deja index` (#1357).
+// So: same stamp and a file that only grew is the same layout.
+func sameLayout(was, now string) bool {
+	if was == now {
+		return true
+	}
+	wasStamp, wasSize, ok := splitGeneration(was)
+	nowStamp, nowSize, ok2 := splitGeneration(now)
+	if !ok || !ok2 || wasStamp != nowStamp {
+		return false
+	}
+	return nowSize >= wasSize
+}
+
+func splitGeneration(gen string) (stamp string, size int64, ok bool) {
+	i := strings.LastIndexByte(gen, '+')
+	if i < 0 {
+		return "", 0, false
+	}
+	n, err := strconv.ParseInt(gen[i+1:], 10, 64)
+	if err != nil || i == 0 || n < 0 {
+		return "", 0, false
+	}
+	return gen[:i], n, true
 }
 
 func Path(dir string) string {
@@ -73,7 +108,7 @@ func EmbedIndex(dir string, client *Client, keep func(index.Record) bool) (Sidec
 		return Sidecar{}, err
 	}
 	old, _ := Read(dir)
-	if old.Model != client.Model || old.Generation != gen || old.Dim == 0 {
+	if old.Model != client.Model || !sameLayout(old.Generation, gen) || old.Dim == 0 {
 		old = Sidecar{}
 	}
 	seen := make(map[int64]bool, len(old.Vectors))

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1777,7 +1777,14 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		_ = rf.Close()
 		return err
 	}
-	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: old.Generation, Scope: scope,
+	// A new generation, not the old one: this path opens records.bin with
+	// O_TRUNC and writes every surviving record again, so an offset from before
+	// it means nothing afterwards. Carrying the stamp forward told anything
+	// keyed on it — the embedding sidecar — that the file it measured was still
+	// there (#1357). Only appendIncremental, which appends in place, may keep a
+	// generation.
+	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(),
+		Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
 		ExportWatermarks: old.ExportWatermarks, ExportBoundary: old.ExportBoundary, ImportedRecords: old.ImportedRecords}
 	skipRedactions := map[string]bool{}
 	for p := range changed {


### PR DESCRIPTION
Measuring what #1355 cost turned up a hole older than it.

**The cost.** Putting records.bin's size into the generation meant every append
changed it, so `EmbedIndex` stopped recognising its own sidecar: one more
message in a session re-embedded all six records instead of one. On a real store
that is a paid API call per record on every `deja index`.

**The hole.** `updateIndex` — the incremental path — opens records.bin with
`O_TRUNC`, writes every surviving record again, and carried the *previous*
generation forward. So before #1355, a sidecar built before an incremental
re-index looked current while every offset in it could have moved: the exact
hazard #1355 was opened for, on the path I had not looked at. My own
`sameLayout` would have reopened it.

So the generation now says what it means. A rewritten file gets a new stamp,
because nothing in it can be addressed the old way. Only `appendIncremental`,
which appends in place, keeps the old one, and `sameLayout` reads that as: same
stamp with a file that only grew is the same layout, everything else is not.

The net effect on cost is the honest one — a growing session re-embeds one
record, a new session re-embeds the store, because in that case the offsets
really did move.

Three tests: the append path embeds only the new message, a new session embeds
everything, and `sameLayout` itself across identical, appended, shrunk, rebuilt
and malformed generations. The review asked for the malformed cases and for a
stamp-less generation to be rejected; both are in there.

Closes #1357.
