### PR TITLE
fix(doctor): reported embedding coverage search would not use

### DIFF
--- a/cmd/deja/doctor_embed_stale_test.go
+++ b/cmd/deja/doctor_embed_stale_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/embed"
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// doctor is where someone goes when semantic results stop coming. Vectors
+// address records by offset, so search refuses a sidecar built for an earlier
+// index — and doctor was still reporting its coverage, which reads as "the
+// embeddings are there" on the one screen meant to say otherwise.
+func TestDoctorReportsNoCoverageForASidecarSearchRefuses(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"the scheduler retries twice"},"timestamp":"2026-08-02T10:00:00Z","sessionId":"aaa","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "a.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := os.Getenv("DEJA_INDEX_DIR")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Input []string `json:"input"`
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		out := make([][]float32, len(body.Input))
+		for i := range out {
+			out[i] = []float32{1, 0}
+		}
+		payload, _ := json.Marshal(map[string]any{"embeddings": out})
+		_, _ = w.Write(payload)
+	}))
+	defer ts.Close()
+	if _, err := embed.EmbedIndex(dir, &embed.Client{URL: ts.URL, Model: "test"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	before := collectDoctorEmbed(dir)
+	if before == nil || before.Coverage == 0 {
+		t.Fatal("no coverage before a rebuild, so the test measures nothing")
+	}
+
+	// A second session rebuilds records.bin, so no offset in the sidecar means
+	// what it did and search refuses it.
+	line2 := `{"type":"user","message":{"role":"user","content":"the cache eviction wiped sessions"},"timestamp":"2026-08-03T10:00:00Z","sessionId":"bbb","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "b.jsonl"), []byte(line2), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	s, err := embed.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !embed.Stale(dir, s) {
+		t.Fatal("the rebuild left the sidecar usable, so the test measures nothing")
+	}
+	if r := collectDoctorEmbed(dir); r != nil && r.Coverage > 0 {
+		t.Errorf("doctor reports %.1f%% coverage from a sidecar search will not use", r.Coverage)
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -224,6 +224,14 @@ func collectDoctorEmbed(dir string) *doctorEmbedReport {
 		return r
 	}
 	r.Model, r.Dim = s.Model, s.Dim
+	// Coverage the search will not use is not coverage. Vectors address records
+	// by offset, so search refuses a sidecar built for an earlier index (#1355)
+	// — and doctor is the screen someone opens to find out why semantic results
+	// stopped, which is the worst place to report 50% of a file nothing reads
+	// (#1359).
+	if embed.Stale(dir, s) {
+		return r
+	}
 	if records, err := index.ReadRecords(dir); err == nil && len(records) > 0 {
 		r.Coverage = float64(s.Covered) / float64(len(records)) * 100
 	}


### PR DESCRIPTION
Vectors address records by byte offset, so search refuses a sidecar built for an
earlier index (#1355). doctor went on reporting that sidecar's coverage:

```
after a rebuild: search sees the sidecar as stale=true
after a rebuild: doctor says coverage=50.0%
```

doctor is the screen someone opens when semantic results stop coming, which
makes it the worst place to report half a file nothing reads. It now reports the
model and dimension it found, and no coverage.

Two guards in the test so it cannot pass by measuring nothing: coverage must be
non-zero before the rebuild, and the sidecar must actually be stale after it.

Closes #1359.
