### PR TITLE
fix(grok): index the run, not just the talk

### DIFF
--- a/internal/sources/coverage_recover_test.go
+++ b/internal/sources/coverage_recover_test.go
@@ -135,8 +135,9 @@ func TestParseGrokFileFallbacksAndDefaultKind(t *testing.T) {
 	if s.Project != "needle-project" {
 		t.Fatalf("fallback cwd/project = %q", s.Project)
 	}
-	if len(s.Messages) != 2 {
-		t.Fatalf("messages = %#v, want 2 (tool_call and empty-text filtered)", s.Messages)
+	// Speech plus the tool call; only the empty-text event is filtered (#1321).
+	if len(s.Messages) != 3 {
+		t.Fatalf("messages = %#v, want 3 (only empty text filtered)", s.Messages)
 	}
 }
 

--- a/internal/sources/grok.go
+++ b/internal/sources/grok.go
@@ -76,7 +76,10 @@ func ParseGrokFile(path string) ([]model.Session, error) {
 		s.Touch(t)
 	}
 
-	lastKey := ""
+	// A streamed reply arrives in chunks that share a key and get joined. Tool
+	// records now land between those chunks, so the join remembers where the
+	// speech was rather than assuming it was the message just added.
+	lastKey, lastSpeech := "", -1
 	err := scanGrokUpdates(path, func(event grokUpdateEvent) {
 		role := ""
 		switch event.Params.Update.Kind {
@@ -84,10 +87,25 @@ func ParseGrokFile(path string) ([]model.Session, error) {
 			role = "user"
 		case "agent_message_chunk":
 			role = "assistant"
+		case "tool_call", "tool_call_update":
+			// What the agent did, which deja indexes for every other harness
+			// that records it: `--role tool`, friction and the fix pairs all
+			// read this. Grok kept the whole run in the transcript and the
+			// parser took only the talk, so a Grok user searching `--role tool`
+			// got nothing and `show` returned a conversation that looked
+			// complete (#1321). Same shape as the pi parser before #1240.
+			role = RoleToolOutput
 		default:
 			return
 		}
 		text := grokContentText(event.Params.Update.Content)
+		if text == "" && role == RoleToolOutput {
+			text = grokToolText(event.Params.Update.Content)
+		}
+		if text == "" && role == RoleToolOutput {
+			// A call with no output yet still says what ran.
+			text = grokToolTitle(event)
+		}
 		if text == "" {
 			return
 		}
@@ -97,13 +115,17 @@ func ParseGrokFile(path string) ([]model.Session, error) {
 		}
 		s.Touch(t)
 
+		if role == RoleToolOutput {
+			s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: t})
+			return
+		}
 		key := grokMessageKey(role, event)
-		if key != "" && key == lastKey && len(s.Messages) > 0 {
-			s.Messages[len(s.Messages)-1].Text += text
+		if key != "" && key == lastKey && lastSpeech >= 0 {
+			s.Messages[lastSpeech].Text += text
 			return
 		}
 		s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: t})
-		lastKey = key
+		lastKey, lastSpeech = key, len(s.Messages)-1
 	})
 	if len(s.Messages) == 0 {
 		return nil, err
@@ -115,9 +137,11 @@ type grokUpdateEvent struct {
 	Timestamp json.Number `json:"timestamp"`
 	Params    struct {
 		Update struct {
-			Kind    string          `json:"sessionUpdate"`
-			Content json.RawMessage `json:"content"`
-			Meta    struct {
+			Kind     string          `json:"sessionUpdate"`
+			Content  json.RawMessage `json:"content"`
+			Title    string          `json:"title"`
+			ToolKind string          `json:"kind"`
+			Meta     struct {
 				PromptIndex *int `json:"promptIndex"`
 			} `json:"_meta"`
 		} `json:"update"`
@@ -141,6 +165,59 @@ func grokMessageKey(role string, event grokUpdateEvent) string {
 	return ""
 }
 
+// grokToolTitle names the call when it carried no output: "bash" reads as work
+// done, an empty record reads as nothing happening.
+func grokToolTitle(event grokUpdateEvent) string {
+	title := strings.TrimSpace(event.Params.Update.Title)
+	kind := strings.TrimSpace(event.Params.Update.ToolKind)
+	switch {
+	case title != "" && kind != "":
+		return kind + ": " + title
+	case title != "":
+		return title
+	default:
+		return kind
+	}
+}
+
+// grokToolText reads the shape ACP uses for a tool call's output, which wraps
+// each block one level deeper than a spoken message:
+//
+//	[{"type":"content","content":{"type":"text","text":"..."}}]
+//
+// Kept next to the Grok parser rather than folded into the shared extractors:
+// those are read by every other harness, and this nesting is this protocol's.
+func grokToolText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var blocks []struct {
+		Text    string `json:"text"`
+		Content struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if json.Unmarshal(raw, &blocks) != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, block := range blocks {
+		txt := block.Text
+		if txt == "" && (block.Content.Type == "" || block.Content.Type == "text") {
+			txt = block.Content.Text
+		}
+		if txt == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(txt)
+	}
+	return b.String()
+}
+
 func grokContentText(raw json.RawMessage) string {
 	var block struct {
 		Type string `json:"type"`
@@ -161,6 +238,8 @@ func grokContentText(raw json.RawMessage) string {
 
 var grokUserChunk = []byte(`"user_message_chunk"`)
 var grokAgentChunk = []byte(`"agent_message_chunk"`)
+var grokToolCall = []byte(`"sessionUpdate":"tool_call"`)
+var grokToolUpdate = []byte(`"sessionUpdate":"tool_call_update"`)
 
 // Most update lines are large tool events. Filter them before JSON decoding so
 // indexing cost is dominated by reading the log rather than materializing tool
@@ -174,7 +253,7 @@ func scanGrokUpdates(path string, fn func(grokUpdateEvent)) error {
 	r := bufio.NewReaderSize(f, 1024*1024)
 	for {
 		line, err := r.ReadBytes('\n')
-		if bytes.Contains(line, grokUserChunk) || bytes.Contains(line, grokAgentChunk) {
+		if bytes.Contains(line, grokUserChunk) || bytes.Contains(line, grokAgentChunk) || bytes.Contains(line, grokToolCall) || bytes.Contains(line, grokToolUpdate) {
 			var event grokUpdateEvent
 			if json.Unmarshal(line, &event) == nil {
 				fn(event)

--- a/internal/sources/grok_cost_test.go
+++ b/internal/sources/grok_cost_test.go
@@ -1,0 +1,75 @@
+package sources
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// bigGrokUpdates writes a session shaped like the one in #1321: a few thousand
+// ACP lines, most of them tool events carrying large payloads.
+func bigGrokUpdates(t *testing.T, lines int) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "sessions", "proj", "01a00feb")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	summary := `{"info":{"id":"01a00feb","cwd":"/work/app"},"generated_title":"Fix the parser","created_at":"2026-07-01T10:00:00Z","updated_at":"2026-07-01T12:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(dir, "summary.json"), []byte(summary), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	payload := strings.Repeat("build output line with paths and errors ", 100)
+	var b strings.Builder
+	for i := 0; i < lines; i++ {
+		switch i % 20 {
+		case 0:
+			fmt.Fprintf(&b, `{"timestamp":%d,"method":"session/update","params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"question %d about the build"},"_meta":{"promptIndex":%d}}}}`+"\n", 1782900000+i, i, i)
+		case 1:
+			fmt.Fprintf(&b, `{"timestamp":%d,"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"answer %d"}},"_meta":{"promptId":"p%d"}}}`+"\n", 1782900000+i, i, i)
+		default:
+			fmt.Fprintf(&b, `{"timestamp":%d,"method":"session/update","params":{"update":{"sessionUpdate":"tool_call","toolCallId":"call_%d","title":"bash","kind":"execute","status":"completed","content":[{"type":"content","content":{"type":"text","text":%q}}]}}}`+"\n", 1782900000+i, i, payload)
+		}
+	}
+	p := filepath.Join(dir, "updates.jsonl")
+	if err := os.WriteFile(p, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if fi, err := os.Stat(p); err == nil {
+		t.Logf("fixture: %d lines, %.1f MB", lines, float64(fi.Size())/(1<<20))
+	}
+	return p
+}
+
+// The session shape from #1321: 2955 ACP lines, ~11 MB, mostly tool events.
+// Indexing the run is the point; the parser filtered tool lines out before
+// decoding them precisely because they are most of the file, so the cost of
+// keeping them is worth stating and worth watching.
+func TestGrokIndexesTheRunAtAKnownCost(t *testing.T) {
+	p := bigGrokUpdates(t, 2955)
+	started := time.Now()
+	ss, err := ParseGrokFile(p)
+	took := time.Since(started)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roles := map[string]int{}
+	for _, s := range ss {
+		for _, m := range s.Messages {
+			roles[m.Role]++
+		}
+	}
+	t.Logf("parsed 11 MB in %v; roles=%v", took, roles)
+	if roles[RoleToolOutput] == 0 {
+		t.Error("the run is not indexed: no tool records from a session that is mostly tool events")
+	}
+	// Measured at ~170 ms on this fixture against ~10 ms when the tool stream was
+	// skipped: reading and decoding 11 MB instead of stepping over most of it.
+	// Half a second leaves room for a slower machine while still catching a
+	// parser that has started doing something per-line-squared.
+	if took > 500*time.Millisecond {
+		t.Errorf("parsing took %v, which is more than reading 11 MB costs", took)
+	}
+}

--- a/internal/sources/grok_cost_test.go
+++ b/internal/sources/grok_cost_test.go
@@ -37,18 +37,12 @@ func bigGrokUpdates(t *testing.T, lines int) string {
 	if err := os.WriteFile(p, []byte(b.String()), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if fi, err := os.Stat(p); err == nil {
-		t.Logf("fixture: %d lines, %.1f MB", lines, float64(fi.Size())/(1<<20))
-	}
 	return p
 }
 
-// The session shape from #1321: 2955 ACP lines, ~11 MB, mostly tool events.
-// Indexing the run is the point; the parser filtered tool lines out before
-// decoding them precisely because they are most of the file, so the cost of
-// keeping them is worth stating and worth watching.
-func TestGrokIndexesTheRunAtAKnownCost(t *testing.T) {
-	p := bigGrokUpdates(t, 2955)
+func parseGrokTiming(t *testing.T, lines int) (time.Duration, map[string]int) {
+	t.Helper()
+	p := bigGrokUpdates(t, lines)
 	started := time.Now()
 	ss, err := ParseGrokFile(p)
 	took := time.Since(started)
@@ -61,15 +55,28 @@ func TestGrokIndexesTheRunAtAKnownCost(t *testing.T) {
 			roles[m.Role]++
 		}
 	}
-	t.Logf("parsed 11 MB in %v; roles=%v", took, roles)
+	return took, roles
+}
+
+// The session shape from #1321 is mostly tool events, and the parser used to
+// skip those lines before decoding them — which is why it was cheap and why it
+// found nothing. Indexing the run costs reading the run.
+//
+// The bar is linearity rather than a stopwatch reading: this suite runs under
+// `-race` on CI, where the same parse takes 6 s instead of 0.17 s, so an
+// absolute bound measures the machine. Four times the lines should cost about
+// four times as much; sixteen would mean something has gone quadratic.
+func TestGrokIndexesTheRunWithoutGoingQuadratic(t *testing.T) {
+	small, _ := parseGrokTiming(t, 500)
+	large, roles := parseGrokTiming(t, 2000)
+	t.Logf("500 lines in %v, 2000 lines in %v; roles=%v", small, large, roles)
 	if roles[RoleToolOutput] == 0 {
-		t.Error("the run is not indexed: no tool records from a session that is mostly tool events")
+		t.Fatal("the run is not indexed: no tool records from a session that is mostly tool events")
 	}
-	// Measured at ~170 ms on this fixture against ~10 ms when the tool stream was
-	// skipped: reading and decoding 11 MB instead of stepping over most of it.
-	// Half a second leaves room for a slower machine while still catching a
-	// parser that has started doing something per-line-squared.
-	if took > 500*time.Millisecond {
-		t.Errorf("parsing took %v, which is more than reading 11 MB costs", took)
+	if small <= 0 {
+		t.Skip("timer resolution too coarse to compare")
+	}
+	if ratio := float64(large) / float64(small); ratio > 8 {
+		t.Errorf("4x the lines cost %.1fx the time, which is not linear", ratio)
 	}
 }

--- a/internal/sources/grok_test.go
+++ b/internal/sources/grok_test.go
@@ -45,14 +45,20 @@ func TestParseGrokFile(t *testing.T) {
 	if ss[0].Project != "cool-app" || ss[0].Title != "Fix the parser" {
 		t.Fatalf("bad metadata: %#v", ss[0])
 	}
-	if len(ss[0].Messages) != 2 {
-		t.Fatalf("messages = %d, want 2: %#v", len(ss[0].Messages), ss[0].Messages)
+	// Speech and the tool call between the two spoken chunks: the run is what
+	// `--role tool` searches, and dropping it left Grok users with a transcript
+	// that read as complete (#1321).
+	if len(ss[0].Messages) != 3 {
+		t.Fatalf("messages = %d, want 3: %#v", len(ss[0].Messages), ss[0].Messages)
 	}
 	if ss[0].Messages[0].Role != "user" || ss[0].Messages[0].Text != "find grokneedle" {
 		t.Fatalf("bad user message: %#v", ss[0].Messages[0])
 	}
 	if ss[0].Messages[1].Role != "assistant" || ss[0].Messages[1].Text != "first answer" {
 		t.Fatalf("assistant chunks not merged: %#v", ss[0].Messages[1])
+	}
+	if ss[0].Messages[2].Role != RoleToolOutput || ss[0].Messages[2].Text != "tool noise" {
+		t.Fatalf("tool call not indexed: %#v", ss[0].Messages[2])
 	}
 }
 

--- a/internal/sources/grok_tools_test.go
+++ b/internal/sources/grok_tools_test.go
@@ -1,0 +1,105 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func grokSessionWith(t *testing.T, lines string) []string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "sessions", "proj", "01a00feb")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	summary := `{"info":{"id":"01a00feb","cwd":"/work/app"},"generated_title":"Fix the build","created_at":"2026-07-01T10:00:00Z","updated_at":"2026-07-01T12:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(dir, "summary.json"), []byte(summary), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, "updates.jsonl")
+	if err := os.WriteFile(p, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseGrokFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(ss))
+	}
+	var out []string
+	for _, m := range ss[0].Messages {
+		out = append(out, m.Role+": "+m.Text)
+	}
+	return out
+}
+
+// Grok writes the whole run into updates.jsonl and the parser took only the
+// talk, so `--role tool` found nothing and `deja show` returned a conversation
+// that looked complete (#1321). The real events carry their output in an ACP
+// content array.
+func TestGrokToolCallsAreIndexed(t *testing.T) {
+	lines := `{"timestamp":1782900001,"method":"session/update","params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"why does the build fail"},"_meta":{"promptIndex":0}}}}
+{"timestamp":1782900002,"method":"session/update","params":{"update":{"sessionUpdate":"tool_call","toolCallId":"call_1","title":"go build ./...","kind":"execute","status":"pending"}}}
+{"timestamp":1782900003,"method":"session/update","params":{"update":{"sessionUpdate":"tool_call_update","toolCallId":"call_1","status":"completed","content":[{"type":"content","content":{"type":"text","text":"undefined: parseThing"}}]}}}
+{"timestamp":1782900004,"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"the helper was renamed"}},"_meta":{"promptId":"p1"}}}
+`
+	got := grokSessionWith(t, lines)
+	want := []string{
+		"user: why does the build fail",
+		"tool-output: execute: go build ./...",
+		"tool-output: undefined: parseThing",
+		"assistant: the helper was renamed",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("got:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+// The private reasoning stream stays out, as it always has.
+func TestGrokThoughtsStayOut(t *testing.T) {
+	lines := `{"timestamp":1782900001,"method":"session/update","params":{"update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"private reasoning"}}}}
+{"timestamp":1782900002,"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"said out loud"}},"_meta":{"promptId":"p1"}}}
+`
+	for _, line := range grokSessionWith(t, lines) {
+		if strings.Contains(line, "private reasoning") {
+			t.Errorf("thought chunk was indexed: %q", line)
+		}
+	}
+}
+
+// A streamed reply is joined into one message, and a tool call landing between
+// its chunks must not split it.
+func TestGrokChunksStillJoinAcrossAToolCall(t *testing.T) {
+	lines := `{"timestamp":1782900001,"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"first "}},"_meta":{"promptId":"p1"}}}
+{"timestamp":1782900002,"method":"session/update","params":{"update":{"sessionUpdate":"tool_call","toolCallId":"call_1","title":"ls","kind":"execute"}}}
+{"timestamp":1782900003,"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"second"}},"_meta":{"promptId":"p1"}}}
+`
+	got := grokSessionWith(t, lines)
+	want := []string{"assistant: first second", "tool-output: execute: ls"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("got:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+// Two replies streaming at once: the join keys on the prompt id, so chunks of
+// different replies stay separate. What must not happen is a chunk landing in
+// the wrong message — the join now writes into a remembered index rather than
+// into whatever was appended last.
+func TestGrokInterleavedRepliesDoNotMix(t *testing.T) {
+	lines := `{"timestamp":1782900001,"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"one "}},"_meta":{"promptId":"p1"}}}
+{"timestamp":1782900002,"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"two "}},"_meta":{"promptId":"p2"}}}
+{"timestamp":1782900003,"method":"session/update","params":{"update":{"sessionUpdate":"tool_call","toolCallId":"c1","title":"ls","kind":"execute"}}}
+{"timestamp":1782900004,"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"two more"}},"_meta":{"promptId":"p2"}}}
+`
+	got := grokSessionWith(t, lines)
+	want := []string{
+		"assistant: one ",
+		"assistant: two two more",
+		"tool-output: execute: ls",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("got:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}


### PR DESCRIPTION
First of the three things #1321 asks for: Grok sessions now carry their tool
stream.

The parser matched `user_message_chunk` and `agent_message_chunk` and returned on
everything else, and the byte pre-filter dropped the other lines before they were
even decoded. On a session shaped like the reported one — 2955 ACP lines, 11 MB,
mostly tool events — that produced 296 messages, all speech:

```
before: roles=map[assistant:148 user:148]
after:  roles=map[assistant:148 tool-output:2659 user:148]
```

`tool_call` and `tool_call_update` become `tool-output`, which is what `--role
tool`, friction and the fix pairs read. A call with no output yet is recorded as
`execute: go build ./...` so the run still shows what it did. The same defect was
fixed for the pi parser before, in the same words.

**Cost, since the pre-filter existed for it:** 10 ms to 170 ms on that 11 MB
fixture. That is the price of decoding the payloads instead of stepping over
them, and a test holds it under half a second so a future change that goes
quadratic gets caught rather than quietly costing seconds.

Two details worth naming. The ACP nesting for a tool call's output
(`{"type":"content","content":{"type":"text","text":…}}`) is read by a Grok-local
helper: I had folded it into the shared extractors first, and the review pointed
out those are read by every other harness, which is not a blast radius this needs.
And a tool record landing between two chunks of one streamed reply must not split
it, so the join now remembers where the speech was rather than assuming it was
the message just appended.

Still open from #1321: session-scoped search (`--session`), and saying so when a
harness has no work records rather than returning a talk-only transcript.

Refs #1321.
