### PR TITLE
feat(search): --session narrows a search to one session

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -44,7 +44,7 @@ _deja_completion() {
     local install_targets="%INSTALL_TARGETS% --all --auto"
 
     if (( COMP_CWORD == 1 )); then
-        COMPREPLY=( $(compgen -W "$commands --version -version --json --re --all --no-embed --harness --project --since --role --rebuild" -- "$cur") )
+        COMPREPLY=( $(compgen -W "$commands --version -version --json --re --all --no-embed --harness --project --since --role --session --rebuild" -- "$cur") )
         return
     fi
 
@@ -132,7 +132,7 @@ _deja_completion() {
             if [[ "$prev" == "--harness" ]]; then
                 COMPREPLY=( $(compgen -W "$harnesses" -- "$cur") )
             else
-                COMPREPLY=( $(compgen -W "--json --re --all --no-embed --harness --project --since --role --rebuild" -- "$cur") )
+                COMPREPLY=( $(compgen -W "--json --re --all --no-embed --harness --project --since --role --session --rebuild" -- "$cur") )
             fi
             ;;
     esac
@@ -250,7 +250,7 @@ _deja() {
     check|ctx|embed|hook-precompact|hook-prompt|mcp|share|show|sources|statusline|update|version|warmup)
       ;;
     *)
-      _arguments '--json[print JSON]' '--re[interpret query as a regular expression]' '--all[include all results]' '--no-embed[skip semantic reranking]' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(user assistant tool)' '--rebuild[force a full rebuild]'
+      _arguments '--json[print JSON]' '--re[interpret query as a regular expression]' '--all[include all results]' '--no-embed[skip semantic reranking]' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(user assistant tool)' '--session=[only one session]:id:' '--rebuild[force a full rebuild]'
       ;;
   esac
 }
@@ -271,6 +271,7 @@ complete -c deja -n '__deja_needs_command' -l harness -r -a 'claude codex openco
 complete -c deja -n '__deja_needs_command' -l project -r
 complete -c deja -n '__deja_needs_command' -l since -r
 complete -c deja -n '__deja_needs_command' -l role -r -a 'user assistant tool'
+complete -c deja -n '__deja_needs_command' -l session -r
 complete -c deja -n '__deja_needs_command' -l rebuild
 
 complete -c deja -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish'

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1263,6 +1263,9 @@ func activeFilters(o search.Options, sinceRaw string) string {
 	if o.Role != "" {
 		parts = append(parts, fmt.Sprintf("role %q", o.Role))
 	}
+	if o.Session != "" {
+		parts = append(parts, fmt.Sprintf("session %q", o.Session))
+	}
 	// The same predicate filterRecentSources uses. parseDur accepts a negative
 	// duration, and a negative Since filters nothing — naming it would report a
 	// filter that was never applied and hide the empty-store advice, which is
@@ -1562,7 +1565,7 @@ func parseSearch(args []string) (search.Options, error) {
 			o.All = true
 		case "--no-embed":
 			o.NoEmbed = true
-		case "--harness", "--project", "--since", "--role", "--limit":
+		case "--harness", "--project", "--since", "--role", "--limit", "--session":
 			if i+1 >= len(args) {
 				return o, fmt.Errorf("%s needs value", a)
 			}
@@ -1575,6 +1578,8 @@ func parseSearch(args []string) (search.Options, error) {
 				o.Project = v
 			case "--role":
 				o.Role = v
+			case "--session":
+				o.Session = v
 			case "--limit":
 				n, err := strconv.Atoi(v)
 				if err != nil || n < 1 || n > 100 {
@@ -1614,7 +1619,7 @@ func parseSearch(args []string) (search.Options, error) {
 // searchFlags is every flag the bare search form accepts, for the typo check.
 var searchFlags = []string{
 	"--json", "--re", "--all", "--no-embed", "--rebuild",
-	"--harness", "--project", "--since", "--role", "--limit",
+	"--harness", "--project", "--since", "--role", "--limit", "--session",
 }
 
 // nearestSearchFlag names the flag a token was probably meant to be. It stays
@@ -2440,6 +2445,7 @@ Search flags (the bare "deja [flags] <query>" form above):
   --since <duration>            only sessions newer than e.g. 30d, 12h
   --role <name>                 only match turns from one role: user, assistant,
                                 tool (tool output), files, command, edit
+  --session <id>                only one session, by the id a hit prints
   --limit <1-100>               max sessions to return (default 15)
   --all                         return every match, no cap
   --re                          treat the query as a regular expression
@@ -2455,6 +2461,7 @@ Examples:
   deja last 20 --harness codex
   deja last --project api-gateway
   deja last --since 7d --role user
+  deja --session 01a00feb --role tool "go build"   (what ran inside one session)
   deja --re "timeout|deadline exceeded"
   deja ctx "schema migration rollback" > deja-context.md
   deja install --all

--- a/cmd/deja/search_session_e2e_test.go
+++ b/cmd/deja/search_session_e2e_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The two-step loop #1321 asks for: find the session by what was said, then
+// search inside it for what was done. Without --session the second step meant
+// turning the id back into a file path and grepping it by hand.
+func TestSearchInsideOneSession(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, id, user, tool string) {
+		lines := `{"type":"user","message":{"role":"user","content":"` + user + `"},"timestamp":"2026-08-02T10:00:00Z","sessionId":"` + id + `","cwd":"/proj"}` + "\n" +
+			`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"` + tool + `"}]},"timestamp":"2026-08-02T10:01:00Z","sessionId":"` + id + `","cwd":"/proj"}` + "\n"
+		if err := os.WriteFile(filepath.Join(store, name), []byte(lines), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("a.jsonl", "aaa11111", "why does the build fail", "go build ./... undefined parseThing")
+	write("b.jsonl", "bbb22222", "why does the build fail here too", "go build ./... undefined otherThing")
+	if err := index.Ensure(os.Getenv("DEJA_INDEX_DIR"), "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := captureRun(t, "search", "--role", "tool", "--all", "go build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(all, "parseThing") || !strings.Contains(all, "otherThing") {
+		t.Fatalf("the fixture does not put work in both sessions:\n%s", all)
+	}
+
+	one, err := captureRun(t, "search", "--session", "aaa1", "--role", "tool", "--all", "go build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(one, "parseThing") {
+		t.Errorf("searching inside the session lost its own work:\n%s", one)
+	}
+	if strings.Contains(one, "otherThing") {
+		t.Errorf("searching inside one session answered from another:\n%s", one)
+	}
+}
+
+// A search that comes back empty because of a filter has to name the filter:
+// "no matches" alone reads as "you have no such memory" (#686, #715, #727).
+func TestEmptySearchNamesTheSessionFilter(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"the build fails on staging"},"timestamp":"2026-08-02T10:00:00Z","sessionId":"aaa11111","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "a.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(os.Getenv("DEJA_INDEX_DIR"), "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The advice goes to stderr, where every other "why is this empty" line goes.
+	out, err := captureRunStderr(t, "search", "--session", "zzz99999", "build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `session "zzz99999"`) {
+		t.Errorf("an empty result does not say a session filter was applied:\n%s", out)
+	}
+}

--- a/cmd/deja/search_session_flag_test.go
+++ b/cmd/deja/search_session_flag_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The flag has to reach the search options, carry its value, and behave like
+// its neighbours when it is mistyped or left empty.
+func TestSearchSessionFlagParses(t *testing.T) {
+	o, err := parseSearch([]string{"--session", "01a00feb", "--role", "tool", "build"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.Session != "01a00feb" {
+		t.Errorf("session = %q", o.Session)
+	}
+	if o.Role != "tool" || o.Query != "build" {
+		t.Errorf("the rest of the line was lost: %#v", o)
+	}
+}
+
+func TestSearchSessionFlagNeedsAValue(t *testing.T) {
+	if _, err := parseSearch([]string{"--session"}); err == nil {
+		t.Error("a flag with no value was accepted")
+	}
+}
+
+// A near miss names the flag rather than being swallowed into the query, as it
+// does for every other search flag (#755).
+func TestSearchSessionFlagTypoIsNamed(t *testing.T) {
+	_, err := parseSearch([]string{"--sesion", "abc", "build"})
+	if err == nil || !strings.Contains(err.Error(), "--session") {
+		t.Errorf("typo error = %v", err)
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -43,8 +43,12 @@ type Options struct {
 	Query                  string
 	Regex                  bool
 	Harness, Project, Role string
-	Since                  time.Duration
-	Limit                  int
+	// Session narrows a search to one session, by the id prefix a hit prints.
+	// Finding the session by what was said and then searching inside it — for a
+	// command, a file, an error — took reopening the transcript by hand (#1321).
+	Session string
+	Since   time.Duration
+	Limit   int
 	// Total and Capped travel from RunDetailed to Print so the JSON envelope
 	// can report how many sessions matched before the cap, not merely how many
 	// survived it. Counting the survivors measures the cap.

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -186,6 +186,12 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 		if o.Project != "" && !strings.Contains(strings.ToLower(s.Project), strings.ToLower(o.Project)) {
 			continue
 		}
+		// By the id prefix a hit prints, and by the id a session was synced
+		// under, so "find the session, then search inside it" can use the id
+		// from the first step whichever machine it came from (#1321, #1316).
+		if o.Session != "" && !strings.HasPrefix(s.ID, o.Session) && !strings.HasPrefix(s.OrigID, o.Session) {
+			continue
+		}
 		if !cut.IsZero() && s.Updated.Before(cut) {
 			continue
 		}

--- a/internal/search/session_scope_test.go
+++ b/internal/search/session_scope_test.go
@@ -1,0 +1,85 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func twoSessionsWithWork(now time.Time) []model.Session {
+	return []model.Session{
+		{
+			Harness: "grok", Project: "app", ID: "01a00feb", Updated: now,
+			Messages: []model.Message{
+				{Role: "user", Text: "why does the build fail"},
+				{Role: "tool-output", Text: "go build ./... : undefined parseThing"},
+			},
+		},
+		{
+			Harness: "grok", Project: "app", ID: "77bb2211", Updated: now,
+			Messages: []model.Message{
+				{Role: "user", Text: "why does the build fail here too"},
+				{Role: "tool-output", Text: "go build ./... : undefined otherThing"},
+			},
+		},
+	}
+}
+
+// Finding a session by what was said and then searching inside it for what was
+// done is the second step deja had no way to take: the id had to be turned back
+// into a file path and grepped by hand (#1321).
+func TestSearchNarrowsToOneSession(t *testing.T) {
+	ss := twoSessionsWithWork(time.Now())
+	hits, err := Run(ss, Options{Query: "build", All: true, Role: "tool", Session: "01a00"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("got %d hits, want only the named session: %#v", len(hits), hits)
+	}
+	if hits[0].Session.ID != "01a00feb" {
+		t.Errorf("hit is session %s", hits[0].Session.ID)
+	}
+}
+
+// Without the flag both sessions answer, so the test above is measuring the
+// flag rather than a fixture that only had one match.
+func TestSearchWithoutSessionSeesBoth(t *testing.T) {
+	ss := twoSessionsWithWork(time.Now())
+	hits, err := Run(ss, Options{Query: "build", All: true, Role: "tool"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("got %d hits, want both: %#v", len(hits), hits)
+	}
+}
+
+// An id that names nothing answers with nothing rather than falling back to the
+// whole store.
+func TestSearchWithAnUnknownSessionFindsNothing(t *testing.T) {
+	ss := twoSessionsWithWork(time.Now())
+	hits, err := Run(ss, Options{Query: "build", All: true, Session: "nosuchid"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 0 {
+		t.Errorf("got %d hits for an id that names no session", len(hits))
+	}
+}
+
+// The id a session was synced under resolves too, the way show and ctx take it
+// (#1316).
+func TestSearchNarrowsByTheIdASessionCameWith(t *testing.T) {
+	ss := twoSessionsWithWork(time.Now())
+	ss[0].ID = "imported-9f3c"
+	ss[0].OrigID = "01a00feb"
+	hits, err := Run(ss, Options{Query: "build", All: true, Session: "01a00"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 || hits[0].Session.ID != "imported-9f3c" {
+		t.Errorf("got %d hits: %#v", len(hits), hits)
+	}
+}


### PR DESCRIPTION
Second of the three things #1321 asks for. The first step — find a session by
what was said — worked; the second — search inside it for what was done — meant
turning the id back into a file path and grepping the JSONL by hand.

```
deja --session 01a00feb --role tool "go build"
```

`--session` takes the id prefix a hit prints, and also the id a session was
synced under, so the id from step one works whichever machine it came from
(#1316). It sits with the other narrowing flags in parsing, filtering, help,
examples, the typo suggestion and all three shell completions.

An empty result names it, like every other filter: `"build" matched nothing under
session "zzz99999"` rather than a bare miss that reads as "you have no such
memory".

One thing left as it is, and worth a second opinion: a prefix that names several
sessions narrows to all of them silently. `forget` refuses an ambiguous prefix
because it is about to delete; here the flag is a filter and each hit prints the
session it came from, so I left it quiet rather than adding a warning nobody
asked for. Say the word if it should warn.

Also unchanged: `deja last` has its own flag block and did not get `--session` —
last is "what happened recently", where narrowing to one session has no meaning.

Seven tests: the flag narrows, the same query without it sees both sessions, an
unknown id finds nothing rather than falling back to the store, a synced id
resolves, the flag parses and rejects a missing value, a typo names it, and the
empty result explains itself.

Refs #1321.
