### PR TITLE
fix(sources): report the files deja reads, not the tree around them

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1830,6 +1830,67 @@ func durationError(s string) error {
 	return fmt.Errorf("%q is not a duration deja understands — try 30d, 12h, or 90m", s)
 }
 
+// presentFiles is one path if it exists, nothing otherwise: a store deja names
+// but does not have should weigh nothing rather than the directory around it.
+func presentFiles(paths ...string) []string {
+	var out []string
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func cursorReadFiles() []string {
+	return append(sources.CursorTranscripts(), sources.CursorDBs()...)
+}
+
+// filesSize sums what the parser would open, counting each path once: cursor
+// and hermes list a file under more than one discovery rule.
+func filesSize(paths []string) int64 {
+	seen := map[string]bool{}
+	var total int64
+	for _, p := range paths {
+		if p == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			total += fi.Size()
+		}
+	}
+	return total
+}
+
+// commonDir is the deepest directory holding every path, which is the answer to
+// "where is my history" — the configured root can be a parent of it, or, when a
+// harness keeps its store somewhere else entirely, not contain it at all.
+func commonDir(paths []string) string {
+	dir := ""
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		d := filepath.Dir(p)
+		if dir == "" {
+			dir = d
+			continue
+		}
+		for dir != d && !strings.HasPrefix(d+string(filepath.Separator), dir+string(filepath.Separator)) {
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				return dir
+			}
+			dir = parent
+		}
+	}
+	return dir
+}
+
 func printSources(dir string) {
 	redactions := map[string]int{}
 	if red, err := index.Redactions(dir); err == nil {
@@ -1840,35 +1901,48 @@ func printSources(dir string) {
 	if antigravityLocation == "" {
 		antigravityLocation = filepath.Join(sources.Home(), ".gemini", "antigravity*")
 	}
+	// files names what the parser opens. The screen answers "where is my history
+	// and how much of it is there", and roots are where deja looks rather than
+	// what it reads: a codex root reported 108 MB of plugins, caches and sqlite
+	// WALs around 1.3 MB of transcripts, and hermes named a directory holding
+	// one crash log while the store it reads sat elsewhere (#654).
 	items := []struct {
 		name, location string
 		roots          []string
+		files          func() []string
 		load           func() []model.Session
 	}{
-		{"claude", sources.ClaudeRoot(), []string{sources.ClaudeRoot()}, sources.LoadClaude},
-		{"codex", sources.CodexRoot(), []string{sources.CodexRoot()}, sources.LoadCodex},
-		{"gemini", sources.GeminiRoot(), []string{filepath.Join(sources.GeminiRoot(), "tmp")}, sources.LoadGemini},
-		{"cursor", strings.Join([]string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, string(os.PathListSeparator)), []string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, sources.LoadCursor},
-		{"antigravity", antigravityLocation, antigravityRoots, sources.LoadAntigravity},
-		{"grok", sources.GrokRoot(), []string{sources.GrokRoot()}, sources.LoadGrok},
-		{"qwen", filepath.Join(sources.QwenRoot(), "projects"), []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.LoadQwen},
-		{"kimi", filepath.Join(sources.KimiRoot(), "sessions"), []string{filepath.Join(sources.KimiRoot(), "sessions")}, sources.LoadKimi},
-		{"goose", filepath.Join(sources.GooseRoot(), "sessions"), []string{filepath.Join(sources.GooseRoot(), "sessions")}, sources.LoadGoose},
-		{"hermes", sources.HermesProfilesRoot(), []string{sources.HermesProfilesRoot()}, sources.LoadHermes},
-		{"copilot", sources.CopilotRoot(), []string{sources.CopilotRoot()}, sources.LoadCopilot},
-		{"cline", sources.ClineSessionsDir(), append([]string{sources.ClineSessionsDir()}, sources.ClineLegacyRoots()...), sources.LoadCline},
-		{"roo", strings.Join(sources.RooRoots(), string(os.PathListSeparator)), sources.RooRoots(), sources.LoadRoo},
-		{"pi", sources.PiRoot(), []string{sources.PiRoot()}, sources.LoadPi},
-		{"openclaw", sources.OpenClawRoot(), []string{sources.OpenClawRoot()}, sources.LoadOpenClaw},
-		{"zed", sources.ZedDB(), []string{sources.ZedDB()}, sources.LoadZed},
-		{"deja", sources.NotesFile(), []string{sources.NotesFile()}, sources.LoadNotes},
+		{"claude", sources.ClaudeRoot(), []string{sources.ClaudeRoot()}, sources.ClaudeFiles, sources.LoadClaude},
+		{"codex", sources.CodexRoot(), []string{sources.CodexRoot()}, sources.CodexFiles, sources.LoadCodex},
+		{"gemini", sources.GeminiRoot(), []string{filepath.Join(sources.GeminiRoot(), "tmp")}, sources.GeminiChatFiles, sources.LoadGemini},
+		{"cursor", strings.Join([]string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, string(os.PathListSeparator)), []string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, cursorReadFiles, sources.LoadCursor},
+		{"antigravity", antigravityLocation, antigravityRoots, sources.AntigravityTranscripts, sources.LoadAntigravity},
+		{"grok", sources.GrokRoot(), []string{sources.GrokRoot()}, sources.GrokSessionFiles, sources.LoadGrok},
+		{"qwen", filepath.Join(sources.QwenRoot(), "projects"), []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.QwenSessionFiles, sources.LoadQwen},
+		{"kimi", filepath.Join(sources.KimiRoot(), "sessions"), []string{filepath.Join(sources.KimiRoot(), "sessions")}, sources.KimiSessionFiles, sources.LoadKimi},
+		{"goose", filepath.Join(sources.GooseRoot(), "sessions"), []string{filepath.Join(sources.GooseRoot(), "sessions")}, sources.GooseSessionFiles, sources.LoadGoose},
+		{"hermes", sources.HermesProfilesRoot(), []string{sources.HermesProfilesRoot()}, sources.HermesSessionFiles, sources.LoadHermes},
+		{"copilot", sources.CopilotRoot(), []string{sources.CopilotRoot()}, sources.CopilotSessionFiles, sources.LoadCopilot},
+		{"cline", sources.ClineSessionsDir(), append([]string{sources.ClineSessionsDir()}, sources.ClineLegacyRoots()...), sources.ClineSessionFiles, sources.LoadCline},
+		{"roo", strings.Join(sources.RooRoots(), string(os.PathListSeparator)), sources.RooRoots(), sources.RooTaskFiles, sources.LoadRoo},
+		{"pi", sources.PiRoot(), []string{sources.PiRoot()}, sources.PiSessionFiles, sources.LoadPi},
+		{"openclaw", sources.OpenClawRoot(), []string{sources.OpenClawRoot()}, sources.OpenClawSessionFiles, sources.LoadOpenClaw},
+		{"zed", sources.ZedDB(), []string{sources.ZedDB()}, func() []string { return presentFiles(sources.ZedDB()) }, sources.LoadZed},
+		{"deja", sources.NotesFile(), []string{sources.NotesFile()}, func() []string { return presentFiles(sources.NotesFile()) }, sources.LoadNotes},
 	}
 	for _, it := range items {
-		var size int64
 		redacted := 0
 		for _, root := range it.roots {
-			size += pathSize(root)
 			redacted += redactionsUnder(redactions, root)
+		}
+		// Only paths that are files on this machine: a discovery rule can name
+		// something that is not one — hermes returns a token for a Postgres
+		// store — and neither a size nor a directory can be read off that.
+		read := presentFiles(it.files()...)
+		size := filesSize(read)
+		location := it.location
+		if where := commonDir(read); where != "" {
+			location = where
 		}
 		raw := it.load()
 		ss := sources.FilterSessions(raw)
@@ -1903,7 +1977,7 @@ func printSources(dir string) {
 		if excluded > 0 {
 			note += fmt.Sprintf("\texcluded-sessions=%d", excluded)
 		}
-		fmt.Printf("%s\t%s\tsessions=%d messages=%d size=%s redacted=%d%s\n", it.name, it.location, sources.CountSessions(ss), msg, humanBytes(size), redacted, note)
+		fmt.Printf("%s\t%s\tsessions=%d messages=%d size=%s redacted=%d%s\n", it.name, location, sources.CountSessions(ss), msg, humanBytes(size), redacted, note)
 	}
 	aiderFiles := sources.AiderFiles()
 	var aiderSize int64

--- a/cmd/deja/sources_size_test.go
+++ b/cmd/deja/sources_size_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func sourcesLine(t *testing.T, harness string) string {
+	t.Helper()
+	out, err := captureRun(t, "sources")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, harness+"\t") {
+			return line
+		}
+	}
+	t.Fatalf("no %s line in:\n%s", harness, out)
+	return ""
+}
+
+// `deja sources` answers "where is my history and how much of it is there". It
+// summed the tree it looks in rather than the files it opens, so a codex store
+// reported 108 MB of plugins, caches and sqlite WALs around 1.3 MB of
+// transcripts (#654).
+func TestSourcesSizeCountsOnlyWhatItReads(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "codex")
+	if err := os.MkdirAll(filepath.Join(root, "sessions", "2026", "08"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "plugins"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CODEX_ROOT", root)
+	rollout := `{"type":"session_meta","payload":{"id":"sess-1","cwd":"/work/app"}}` + "\n" +
+		`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"why does the build fail"}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "sessions", "2026", "08", "rollout-sess-1.jsonl"), []byte(rollout), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "plugins", "blob.bin"), make([]byte, 10<<20), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	line := sourcesLine(t, "codex")
+	if strings.Contains(line, "MB") {
+		t.Errorf("the size counts files deja never opens: %s", line)
+	}
+	if !strings.Contains(line, "sessions=1") {
+		t.Errorf("the transcript stopped being read: %s", line)
+	}
+	if !strings.Contains(line, filepath.Join("sessions", "2026", "08")) {
+		t.Errorf("the path does not name where the transcripts are: %s", line)
+	}
+}
+
+// A harness with nothing on this machine still names somewhere to look, rather
+// than an empty column: the empty-machine advice sends people here.
+func TestSourcesNamesARootWhenNothingIsRead(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "empty-codex")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CODEX_ROOT", root)
+	line := sourcesLine(t, "codex")
+	if !strings.Contains(line, root) {
+		t.Errorf("an empty store names no path: %s", line)
+	}
+	if !strings.Contains(line, "size=0 B") {
+		t.Errorf("an empty store reports a size: %s", line)
+	}
+}
+
+// A discovery rule can name something that is not a file on this machine:
+// hermes returns a token for a Postgres store. Reading a directory off that
+// gave "." as the store's location.
+func TestSourcesIgnoresAStoreThatIsNotAFile(t *testing.T) {
+	tmp := hermeticEnv(t)
+	profiles := filepath.Join(tmp, "hermes", "profiles")
+	if err := os.MkdirAll(profiles, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_HERMES_ROOT", filepath.Join(tmp, "hermes"))
+	t.Setenv("DEJA_HERMES_PG_DSN", "postgres://user:pw@localhost:5432/hermes")
+	line := sourcesLine(t, "hermes")
+	if strings.Contains(line, "\t.\t") || strings.Contains(line, "hermes-pg:") {
+		t.Errorf("the location is not a place on disk: %s", line)
+	}
+	if !strings.Contains(line, "size=0 B") {
+		t.Errorf("a store deja cannot weigh reports a size: %s", line)
+	}
+}


### PR DESCRIPTION
`deja sources` answers "where is my history and how much of it is there", and it
summed the directory it looks in rather than the files it opens:

```
codex  ~/.codex  sessions=1 messages=1 size=10.0 MB
```

on a store whose transcript is 203 bytes and whose remaining 10 MB is a blob deja
never opens. The reported path had the same problem — a parent of the read path,
or, for hermes, a directory that does not contain the store at all.

Each harness now reports what its own parser walks: the discovery function the
loader itself uses, summed file by file, with the deepest directory holding them
as the location. A harness with nothing on this machine still names its root, so
the empty-machine advice keeps pointing somewhere.

The review caught a case I had broken: `HermesSessionFiles` returns a token
(`hermes-pg:<hash>`) when the store is Postgres, and taking a directory off that
gave `.` as the location. Only paths that are files on this machine are used now,
which is also the honest answer for a store that is not on disk: no size, and the
configured root as the place to look.

Redactions and the permission check still work from the roots — those questions
are about the tree, not about the files.

Three tests: the size counts only what is read, an empty store still names a
path, and a store that is not a file does not become `.`.

Closes #654.
