### PR TITLE
test: read the usage text instead of piping stdout

### DIFF
--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -1117,27 +1117,20 @@ func TestInstallHonorsUpstreamHomes(t *testing.T) {
 // its absence from --help led at least one user to conclude it did not exist.
 // This test pins each documented flag to the parser that implements it.
 func TestUsageDocumentsSearchFlags(t *testing.T) {
-	var b bytes.Buffer
-	old := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	os.Stdout = w
-	printUsage()
-	if err := w.Close(); err != nil {
-		t.Fatalf("close: %v", err)
-	}
-	os.Stdout = old
-	if _, err := b.ReadFrom(r); err != nil {
-		t.Fatalf("read: %v", err)
-	}
-	got := b.String()
+	// usageText rather than printUsage through a pipe. The text is what is under
+	// test, and swapping os.Stdout for a pipe hung on windows until the suite's
+	// twelve-minute alarm fired, taking every later test in the package with it
+	// (#1119).
+	got := usageText()
 
-	for _, flag := range []string{
-		"--harness", "--project", "--since", "--role",
-		"--limit", "--all", "--re", "--json", "--no-embed",
-	} {
+	// Every flag parseSearch accepts, read from the list the parser itself uses,
+	// so a flag added without a line in the help is caught here rather than by
+	// the person who cannot find it.
+	for _, flag := range searchFlags {
+		if flag == "--rebuild" {
+			// Documented with the commands that take it, not in the search block.
+			continue
+		}
 		if !strings.Contains(got, flag) {
 			t.Errorf("printUsage does not document %s, but parseSearch accepts it", flag)
 		}
@@ -1160,6 +1153,8 @@ func flagArgsFor(flag string) []string {
 		return []string{"--role", "user", "q"}
 	case "--limit":
 		return []string{"--limit", "15", "q"}
+	case "--session":
+		return []string{"--session", "01a00feb", "q"}
 	default:
 		return []string{flag, "q"}
 	}


### PR DESCRIPTION
Windows CI on main is red: `cmd/deja` hits the twelve-minute alarm, and the
dump names the test that was still running after 9m42s.

```
panic: test timed out after 12m0s
	running tests:
		TestUsageDocumentsSearchFlags (9m42s)
```

The test swapped `os.Stdout` for a pipe, called `printUsage()`, and read the pipe
afterwards. `printUsage` only formats a 4 KB string — there is nothing in it to
take nine minutes — so what hung is the plumbing around it, and it hung only on
windows. Since the alarm kills the whole binary, every later test in the package
went unvalidated with it, which is the state #1119 describes.

`usageText()` returns that same string, so the test reads it directly and the
pipe is gone.

Two things came free. The flag list is now `searchFlags` — the list the parser
itself uses — so a flag added without a line in the help fails here rather than
in someone's terminal; and that immediately caught `--session`, which I added
this morning and had not documented in that test's table.

I cannot reproduce the hang on macOS, so this PR carries the `windows` label to
run the full windows suite before it merges rather than after.

Refs #1119.
