### PR TITLE
perf(index): count co-occurring pairs a shard at a time

### DIFF
--- a/internal/index/cooccur.go
+++ b/internal/index/cooccur.go
@@ -21,6 +21,10 @@ const (
 	cooccurNeighbors   = 6  // kept per token
 	cooccurMinPair     = 3  // sessions two tokens must share
 	cooccurMaxSessions = 20000
+	// cooccurShards is how many passes the pair count is split into. Eight holds
+	// an eighth of the pairs at a time for eight walks of the capped id lists,
+	// which are two orders of magnitude cheaper than the map they feed.
+	cooccurShards = 8
 )
 
 func cooccurPath(dir string) string { return filepath.Join(dir, cooccurFile) }
@@ -79,19 +83,18 @@ func buildCooccur(tmp string, ss []model.Session) {
 	}
 	band := func(v uint32) bool { return df[v] >= cooccurMinDF && df[v] <= maxDF }
 
-	// One packed key per unordered pair, canonical by id. The neighbour pass
-	// below expands it back to both sides, so which side is canonical never
-	// reaches the output.
-	pairs := map[uint64]int{}
-	kept := make([]uint32, 0, cooccurTokensPerSn)
+	// The tokens each session contributes pairs from: rarest first, capped, so a
+	// ubiquitous session cannot explode the map. Computed once and kept — at
+	// most cooccurTokensPerSn ids per session — while the full token sets go, so
+	// the pair passes below walk something small.
+	keptPerSession := make([][]uint32, 0, len(ss))
 	for _, list := range perSession {
-		kept = kept[:0]
+		kept := make([]uint32, 0, cooccurTokensPerSn)
 		for _, v := range list {
 			if band(v) {
 				kept = append(kept, v)
 			}
 		}
-		// rarest first, capped: ubiquitous sessions must not explode the map
 		sort.Slice(kept, func(i, j int) bool {
 			if df[kept[i]] == df[kept[j]] {
 				return toks[kept[i]] < toks[kept[j]]
@@ -101,31 +104,52 @@ func buildCooccur(tmp string, ss []model.Session) {
 		if len(kept) > cooccurTokensPerSn {
 			kept = kept[:cooccurTokensPerSn]
 		}
-		for i := 0; i < len(kept); i++ {
-			for j := i + 1; j < len(kept); j++ {
-				a, b := kept[i], kept[j]
-				if a > b {
-					a, b = b, a
-				}
-				pairs[uint64(a)<<32|uint64(b)]++
-			}
-		}
+		keptPerSession = append(keptPerSession, kept)
 	}
+	perSession = nil
+
 	type nc struct {
 		t string
 		c int
 	}
-	// Each canonical pair (a,b) is a neighbor of both a and b, so one pass over
-	// the half-map rebuilds the full candidate lists. Filtering at threshold
-	// here keeps the transient cand map to the pairs that can actually survive.
 	cand := map[string][]nc{}
-	for key, c := range pairs {
-		if c < cooccurMinPair {
-			continue
+	// One packed key per unordered pair, canonical by id, counted a shard at a
+	// time. Holding every pair at once was the larger half of a build's peak
+	// footprint on a store of a few thousand sessions (#1137): the map is one
+	// entry per distinct pair of co-occurring tokens, which grows far faster
+	// than the corpus does. A shard costs one more walk of the capped id lists,
+	// which is cheap, and the counts are exact either way — each pair lands in
+	// exactly one shard.
+	//
+	// Each canonical pair (a,b) is a neighbour of both a and b, so expanding it
+	// to both sides here rebuilds the same candidate lists the single-map
+	// version produced; the final sort is by count then token, so the order
+	// shards are visited in cannot reach the output.
+	for shard := uint64(0); shard < cooccurShards; shard++ {
+		pairs := map[uint64]int{}
+		for _, kept := range keptPerSession {
+			for i := 0; i < len(kept); i++ {
+				for j := i + 1; j < len(kept); j++ {
+					a, b := kept[i], kept[j]
+					if a > b {
+						a, b = b, a
+					}
+					key := uint64(a)<<32 | uint64(b)
+					if key%cooccurShards != shard {
+						continue
+					}
+					pairs[key]++
+				}
+			}
 		}
-		a, b := toks[uint32(key>>32)], toks[uint32(key)]
-		cand[a] = append(cand[a], nc{b, c})
-		cand[b] = append(cand[b], nc{a, c})
+		for key, c := range pairs {
+			if c < cooccurMinPair {
+				continue
+			}
+			a, b := toks[uint32(key>>32)], toks[uint32(key)]
+			cand[a] = append(cand[a], nc{b, c})
+			cand[b] = append(cand[b], nc{a, c})
+		}
 	}
 	neighbors := map[string][]string{}
 	for tok, list := range cand {

--- a/internal/index/cooccur_shard_test.go
+++ b/internal/index/cooccur_shard_test.go
@@ -1,0 +1,166 @@
+package index
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// referenceCooccur is the neighbour map computed the obvious way: every pair of
+// every session's kept tokens in one map, no sharding. Slow and memory-hungry by
+// design — it exists to say what the answer is.
+func referenceCooccur(ss []model.Session) map[string][]string {
+	if len(ss) < cooccurMinDF || len(ss) > cooccurMaxSessions {
+		return nil
+	}
+	df := map[string]int{}
+	perSession := make([][]string, 0, len(ss))
+	for _, s := range ss {
+		seen := map[string]bool{}
+		for _, m := range s.Messages {
+			for _, tok := range tokens(m.Text) {
+				if len(tok) < 4 || query.IsStopWord(tok) || seen[tok] {
+					continue
+				}
+				seen[tok] = true
+			}
+		}
+		list := make([]string, 0, len(seen))
+		for t := range seen {
+			list = append(list, t)
+			df[t]++
+		}
+		perSession = append(perSession, list)
+	}
+	maxDF := len(ss) / 4
+	if maxDF < 8 {
+		maxDF = 8
+	}
+	type pair struct{ a, b string }
+	pairs := map[pair]int{}
+	for _, list := range perSession {
+		var kept []string
+		for _, t := range list {
+			if df[t] >= cooccurMinDF && df[t] <= maxDF {
+				kept = append(kept, t)
+			}
+		}
+		sort.Slice(kept, func(i, j int) bool {
+			if df[kept[i]] == df[kept[j]] {
+				return kept[i] < kept[j]
+			}
+			return df[kept[i]] < df[kept[j]]
+		})
+		if len(kept) > cooccurTokensPerSn {
+			kept = kept[:cooccurTokensPerSn]
+		}
+		for i := 0; i < len(kept); i++ {
+			for j := i + 1; j < len(kept); j++ {
+				a, b := kept[i], kept[j]
+				if a > b {
+					a, b = b, a
+				}
+				pairs[pair{a, b}]++
+			}
+		}
+	}
+	type nc struct {
+		t string
+		c int
+	}
+	cand := map[string][]nc{}
+	for p, c := range pairs {
+		if c < cooccurMinPair {
+			continue
+		}
+		cand[p.a] = append(cand[p.a], nc{p.b, c})
+		cand[p.b] = append(cand[p.b], nc{p.a, c})
+	}
+	out := map[string][]string{}
+	for tok, list := range cand {
+		sort.Slice(list, func(i, j int) bool {
+			if list[i].c == list[j].c {
+				return list[i].t < list[j].t
+			}
+			return list[i].c > list[j].c
+		})
+		if len(list) > cooccurNeighbors {
+			list = list[:cooccurNeighbors]
+		}
+		names := make([]string, len(list))
+		for i, e := range list {
+			names[i] = e.t
+		}
+		out[tok] = names
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// shardTestCorpus draws each session's tokens from a vocabulary far larger than
+// any one session, so pairs land on both sides of cooccurMinPair rather than all
+// surviving or all being dropped. Measured on 300 sessions: 13903 pairs seen
+// once, 19302 twice (both dropped), 18074 exactly at the threshold of three, and
+// 23475 above it.
+func shardTestCorpus(sessions int) []model.Session {
+	ss := make([]model.Session, 0, sessions)
+	for i := 0; i < sessions; i++ {
+		var b strings.Builder
+		x := uint32(i*2654435761 + 999)
+		for j := 0; j < 40; j++ {
+			x = x*1664525 + 1013904223
+			fmt.Fprintf(&b, "token%05d ", x%400)
+		}
+		ss = append(ss, model.Session{
+			Harness: "claude", ID: fmt.Sprintf("s%04d", i), Project: "app",
+			Messages: []model.Message{{Role: "user", Text: b.String()}},
+		})
+	}
+	return ss
+}
+
+// Counting the pairs a shard at a time is an accounting change, not a change of
+// answer: each pair lands in exactly one shard, and the neighbour lists are
+// sorted by count then token, so which shard was walked first cannot show
+// through (#1137).
+func TestShardedCooccurMatchesTheObviousComputation(t *testing.T) {
+	ss := shardTestCorpus(300)
+	want := referenceCooccur(ss)
+	if len(want) == 0 {
+		t.Fatal("the corpus produced no neighbours, so the test compares nothing")
+	}
+	dir := t.TempDir()
+	buildCooccur(dir, ss)
+	got := readCooccur(dir)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sharded build differs from the obvious one: %d tokens vs %d", len(got), len(want))
+		for tok, list := range want {
+			if !reflect.DeepEqual(got[tok], list) {
+				t.Errorf("  %q: got %v, want %v", tok, got[tok], list)
+				break
+			}
+		}
+	}
+}
+
+// Every shard count must give the same answer, which is what makes the constant
+// free to tune.
+func TestCooccurAnswerDoesNotDependOnShardCount(t *testing.T) {
+	if cooccurShards < 2 {
+		t.Fatal("sharding is off, so this proves nothing")
+	}
+	ss := shardTestCorpus(300)
+	dir := t.TempDir()
+	buildCooccur(dir, ss)
+	got := readCooccur(dir)
+	if want := referenceCooccur(ss); !reflect.DeepEqual(got, want) {
+		t.Errorf("shard count %d changes the answer", cooccurShards)
+	}
+}


### PR DESCRIPTION
`buildCooccur` held every session's distinct token set and a map of every
co-occurring pair at once. The pair map is the expensive half: it has one entry
per distinct pair of tokens that ever met, which grows far faster than the corpus
does.

Measured on an 8000-session store whose pairs are as sparse as a real one's:

| | peak heap | time |
|---|---|---|
| before | 408 MB | 1.72 s |
| after | 116 MB | 1.54 s |

Two changes. Each session's capped token list is computed once and the full
token sets are dropped, so the pair passes walk at most 64 ids per session. And
the pairs are counted a shard at a time — key modulo eight — so an eighth of them
is live at once. The extra walks are cheap next to the map operations they
replace, which is why the time did not move.

The answer is unchanged, and that is the part worth checking rather than
asserting: the test computes the neighbour map the obvious way — one map, no
shards, written independently — and compares. Each pair lands in exactly one
shard, and the neighbour lists are sorted by count then token, so the order
shards are visited in cannot show through.

The review asked whether the test corpus actually exercises the
three-sessions-minimum threshold. Measured rather than assumed: of its pairs,
13903 are seen once and 19302 twice (both dropped), 18074 sit exactly at the
threshold, and 23475 above it. That is recorded next to the fixture so nobody
has to work it out again.

Closes #1137.
