### PR TITLE
feat(brief): read the terminal width instead of assuming 80

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -327,12 +327,12 @@ const briefRecentLines = 3
 
 // briefTitleBudget is how much title fits after a prefix of prefixLen columns.
 //
-// briefWidth is the target, not a measurement: reading the real terminal size
-// means a per-OS TIOCGWINSZ, and this module has no dependencies and builds for
-// Windows. 80 is the width that is wrong least often, COLUMNS is honoured for
-// the readers who export it, and the 44 cap keeps a wide terminal looking as it
-// always has. The floor stops a deep project path from cutting titles to
-// nothing — a line that overflows by a little beats one that says nothing.
+// The width is the terminal's when it can be read, COLUMNS when the reader
+// exports it, and 80 otherwise — a 60-column split pane wrapped every line of
+// the first screen a new user sees, and 80 was a guess that is wrong there
+// (#604). The 44 cap keeps a wide terminal looking as it always has, and the
+// floor stops a deep project path from cutting titles to nothing: a line that
+// overflows by a little beats one that says nothing.
 func briefTitleBudget(prefixLen int) int {
 	room := briefWidth() - prefixLen - 1 // the ellipsis
 	if room > briefTitleMax {
@@ -345,7 +345,12 @@ func briefTitleBudget(prefixLen int) int {
 }
 
 func briefWidth() int {
+	// COLUMNS first: a reader who exports it is overriding the terminal on
+	// purpose, and scripts set it to pin the layout.
 	if n, err := strconv.Atoi(os.Getenv("COLUMNS")); err == nil && n >= 20 && n <= 400 {
+		return n
+	}
+	if n, ok := terminalWidth(); ok && n >= 20 && n <= 400 {
 		return n
 	}
 	return 80

--- a/cmd/deja/width_test.go
+++ b/cmd/deja/width_test.go
@@ -28,7 +28,9 @@ func TestBriefWidthPrefersColumns(t *testing.T) {
 func TestBriefWidthFallsBackTo80(t *testing.T) {
 	for _, v := range []string{"", "wide", "0", "5", "100000"} {
 		if v == "" {
-			os.Unsetenv("COLUMNS")
+			if err := os.Unsetenv("COLUMNS"); err != nil {
+				t.Fatal(err)
+			}
 		} else {
 			t.Setenv("COLUMNS", v)
 		}

--- a/cmd/deja/width_test.go
+++ b/cmd/deja/width_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// Reading the terminal is best-effort: under `go test` stdout is a pipe, so the
+// answer must be "no" rather than a made-up number. Every caller falls back when
+// it hears no.
+func TestTerminalWidthSaysNoWhenThereIsNoTerminal(t *testing.T) {
+	if n, ok := terminalWidth(); ok {
+		t.Errorf("a pipe reported a width of %d columns", n)
+	}
+}
+
+// COLUMNS is an override, not a hint: a reader who exports it, or a script that
+// pins the layout, decides.
+func TestBriefWidthPrefersColumns(t *testing.T) {
+	t.Setenv("COLUMNS", "60")
+	if got := briefWidth(); got != 60 {
+		t.Errorf("briefWidth = %d with COLUMNS=60", got)
+	}
+}
+
+// Nonsense in COLUMNS is ignored rather than obeyed, and with no terminal to ask
+// the answer is the old default.
+func TestBriefWidthFallsBackTo80(t *testing.T) {
+	for _, v := range []string{"", "wide", "0", "5", "100000"} {
+		if v == "" {
+			os.Unsetenv("COLUMNS")
+		} else {
+			t.Setenv("COLUMNS", v)
+		}
+		if got := briefWidth(); got != 80 {
+			t.Errorf("COLUMNS=%q: briefWidth = %d, want the 80-column default", v, got)
+		}
+	}
+}

--- a/cmd/deja/width_unix.go
+++ b/cmd/deja/width_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// terminalWidth asks the terminal how wide it is, in columns.
+//
+// The brief and every other column-aligned screen used to assume 80 unless the
+// reader exported COLUMNS, so a 60-column split pane — what an editor gives
+// you — wrapped mid-word on the first screen a new user sees (#604). This is the
+// ioctl every terminal program uses for it; the module has no dependencies, so
+// it is spelled out here the way lock_unix.go spells out file locking.
+//
+// Not a terminal, or an ioctl that fails, reports false and the caller keeps its
+// old answer.
+func terminalWidth() (int, bool) {
+	var ws struct {
+		rows, cols, xpixel, ypixel uint16
+	}
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, os.Stdout.Fd(),
+		uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&ws)))
+	if errno != 0 || ws.cols == 0 {
+		return 0, false
+	}
+	return int(ws.cols), true
+}

--- a/cmd/deja/width_windows.go
+++ b/cmd/deja/width_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// terminalWidth asks the console how wide it is, in columns. The unix side does
+// this with TIOCGWINSZ; here it is GetConsoleScreenBufferInfo, called through
+// kernel32 directly because this module has no dependencies (#604).
+//
+// Anything other than a console — a pipe, a file, a redirect — reports false and
+// the caller keeps its old answer.
+func terminalWidth() (int, bool) {
+	var info struct {
+		size              struct{ x, y int16 }
+		cursor            struct{ x, y int16 }
+		attributes        uint16
+		left, top         int16
+		right, bottom     int16
+		maximumWindowSize struct{ x, y int16 }
+	}
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	proc := kernel32.NewProc("GetConsoleScreenBufferInfo")
+	ret, _, _ := proc.Call(os.Stdout.Fd(), uintptr(unsafe.Pointer(&info)))
+	if ret == 0 {
+		return 0, false
+	}
+	// The window, not the buffer: a console's scrollback buffer is often wider
+	// than the window showing it, and text is wrapped to the window.
+	width := int(info.right) - int(info.left) + 1
+	if width <= 0 {
+		return 0, false
+	}
+	return width, true
+}


### PR DESCRIPTION
Nothing in deja read the terminal size, so the first screen was laid out for 80
columns and a 60-column split pane wrapped every line of it. `COLUMNS` was
honoured, which helps the readers who export it and nobody else.

`terminalWidth()` asks the terminal: `TIOCGWINSZ` on unix,
`GetConsoleScreenBufferInfo` on windows, each in its own file the way
`lock_unix.go` and `lock_windows.go` are, and spelled out with the standard
library because this module has no dependencies. Anything that is not a terminal
— a pipe, a file, CI — reports no, and the caller keeps the answer it had.

`COLUMNS` still wins where it is set: a reader or a script exporting it is
overriding the terminal on purpose.

Measured on a store whose project name is long enough to matter, brief lines
through a pty:

| columns | longest line before | after |
|---|---|---|
| 40 | 84 | 66 |
| 60 | 84 | 66 |
| 100 | 84 | 94 |

The last row is the other half of the same fix: a wide terminal was being padded
to 80 and is now used.

**What this does not fix, stated with the numbers:** at 40 and 60 columns the
brief still overflows — five and four lines respectively. Titles now shrink to
their floor, but the *prefix* they follow (label, harness, project, date) is not
budgeted, and a long project name spends the line before the title starts. #604
says the fix should budget every column-aligned line; this PR adds the missing
primitive and wires it into the one screen that already had a budget. The prefix,
search hits, `files` and `restore` still need theirs.

Refs #604.
