### PR TITLE
fix: say when a role search found nothing because the store records none of that kind

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -897,6 +897,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 			fmt.Fprint(os.Stderr, note)
 		case activeFilters(o, sinceRaw) != "":
 			fmt.Fprintf(os.Stderr, "deja: %q matched nothing under %s\n", o.Query, activeFilters(o, sinceRaw))
+			fmt.Fprint(os.Stderr, emptyRoleNote(dir, o.Role))
 			fmt.Fprint(os.Stderr, olderThanWindow(dir, o.Since))
 		default:
 			printNoMatches(os.Stderr, dir, o.Query)
@@ -1247,6 +1248,28 @@ func checkRole(role string) error {
 		}
 	}
 	return fmt.Errorf("%q is not a role deja knows — one of: %s", role, strings.Join(knownRoles, ", "))
+}
+
+// emptyRoleNote says when a role found nothing because the store holds none of
+// that kind, rather than because the query missed.
+//
+// deja advertises that it indexes the work and not only the talk, and a harness
+// that records no tool calls gives a transcript that looks complete: `--role
+// tool` came back the same way a bad query does, and the reader had no way to
+// tell "not found" from "not recorded" (#1321). Only asked when a role-filtered
+// search already returned nothing.
+func emptyRoleNote(dir, role string) string {
+	if role == "" {
+		return ""
+	}
+	stored := role
+	if role == "tool" {
+		stored = sources.RoleToolOutput
+	}
+	if index.HasRecordOfRole(dir, stored) {
+		return ""
+	}
+	return fmt.Sprintf("deja: this index holds no %s records at all — the harnesses it read do not write them, or wrote none yet\n", role)
 }
 
 // activeFilters names the filters a caller set, so an empty result can say

--- a/cmd/deja/role_absent_test.go
+++ b/cmd/deja/role_absent_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// storeWith writes one session and indexes it. withWork adds a tool result, so
+// the same fixture can be a store that records the work and one that does not.
+func storeWith(t *testing.T, withWork bool) {
+	t.Helper()
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lines := `{"type":"user","message":{"role":"user","content":"why does the build fail on staging"},"timestamp":"2026-08-02T10:00:00Z","sessionId":"aaa","cwd":"/proj"}` + "\n"
+	if withWork {
+		lines += `{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"go build ./... : undefined parseThing"}]},"timestamp":"2026-08-02T10:01:00Z","sessionId":"aaa","cwd":"/proj"}` + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(store, "a.jsonl"), []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(os.Getenv("DEJA_INDEX_DIR"), "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// deja says it indexes the work and not only the talk. On a store whose harness
+// records no tool calls, `--role tool` answered exactly the way a bad query
+// does, so a transcript that was missing half of what happened looked complete
+// (#1321).
+func TestRoleSearchSaysWhenTheStoreHoldsNoneOfThatKind(t *testing.T) {
+	storeWith(t, false)
+	out, err := captureRunStderr(t, "search", "--role", "tool", "build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "no tool records") {
+		t.Errorf("an empty role search does not say the kind is absent:\n%s", out)
+	}
+}
+
+// When the store does hold them, the line must not appear: a query that simply
+// missed is a different answer, and saying both would teach the reader to
+// ignore it.
+func TestRoleSearchStaysQuietWhenTheKindExists(t *testing.T) {
+	storeWith(t, true)
+	out, err := captureRunStderr(t, "search", "--role", "tool", "nosuchtermanywhere")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "no tool records") {
+		t.Errorf("the note fired on a store that has tool records:\n%s", out)
+	}
+}
+
+// And it stays out of a search that found something.
+func TestRoleSearchWithHitsSaysNothingExtra(t *testing.T) {
+	storeWith(t, true)
+	out, err := captureRunStderr(t, "search", "--role", "tool", "parseThing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "no tool records") {
+		t.Errorf("the note fired on a search that matched:\n%s", out)
+	}
+}

--- a/internal/index/has_role_test.go
+++ b/internal/index/has_role_test.go
@@ -1,0 +1,64 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func roleStore(t *testing.T, withTool bool) string {
+	t.Helper()
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	setHome(t, filepath.Join(tmp, "home"))
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	proj := filepath.Join(claudeRoot, "-w-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lines := `{"type":"user","sessionId":"a","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"why does the build fail"}}` + "\n"
+	if withTool {
+		lines += `{"type":"user","sessionId":"a","timestamp":"2026-01-02T03:04:06Z","message":{"role":"user","content":[{"type":"tool_result","content":"go build ./... failed"}]}}` + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(proj, "a.jsonl"), []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The question behind "this index holds no tool records at all": absent means
+// absent, present means present, and an index that cannot be read says nothing
+// rather than claiming absence.
+func TestHasRecordOfRole(t *testing.T) {
+	if dir := roleStore(t, true); !HasRecordOfRole(dir, roleToolOutput) {
+		t.Error("a store with a tool result reports none")
+	}
+	if dir := roleStore(t, false); HasRecordOfRole(dir, roleToolOutput) {
+		t.Error("a talk-only store reports tool records")
+	}
+	if !HasRecordOfRole(filepath.Join(t.TempDir(), "no-index"), roleToolOutput) {
+		t.Error("an unreadable index claimed the role is absent")
+	}
+}
+
+// It stops at the first match rather than reading the whole log: the caller
+// asks on every empty role search, and most stores that have the records have
+// them near the front.
+func TestHasRecordOfRoleStopsEarly(t *testing.T) {
+	dir := roleStore(t, true)
+	started := time.Now()
+	for i := 0; i < 50; i++ {
+		if !HasRecordOfRole(dir, roleToolOutput) {
+			t.Fatal("lost the record it just found")
+		}
+	}
+	if took := time.Since(started); took > 5*time.Second {
+		t.Errorf("fifty existence checks took %v", took)
+	}
+}

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -187,6 +187,30 @@ const readAheadSize = 8 * 1024
 
 var readAheadPool = sync.Pool{New: func() any { b := make([]byte, readAheadSize); return &b }}
 
+// eachRecordUntil is eachRecord with a stop: fn returns false when it has seen
+// enough, which is how an existence question avoids reading a log it has already
+// answered.
+func eachRecordUntil(path string, t *recordTables, fn func(Record) bool) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	r := bufio.NewReaderSize(f, 1024*1024)
+	for {
+		rec, err := readRecord(r, t)
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if !fn(rec) {
+			return nil
+		}
+	}
+}
+
 func eachRecord(path string, t *recordTables, fn func(Record)) error {
 	f, err := os.Open(path)
 	if err != nil {
@@ -977,6 +1001,35 @@ func decodeRecordIn(b []byte, rel int, t *recordTables) (Record, bool) {
 // by the manifest, is the same data in a single scan.
 func EachToolOutput(dir string, fn func(SessionMeta, Record)) error {
 	return EachRecordOfRole(dir, roleToolOutput, fn)
+}
+
+// HasRecordOfRole reports whether the store holds any record of one role.
+//
+// An empty result under `--role tool` reads as "your query missed" when the
+// truth can be "nothing here records that": a harness that writes only the talk
+// gives a transcript that looks complete, and the reader has no way to tell the
+// two apart (#1321). Called only when a role-filtered search came back empty, so
+// it walks the records once on a path that has already returned nothing.
+func HasRecordOfRole(dir, role string) bool {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return true // unknown is not the same as absent; say nothing extra
+	}
+	found := false
+	// Stops at the first one. The note this feeds only prints when the answer is
+	// no, and that case has to read the whole log either way — but the case that
+	// prints nothing is the common one, and paying a full scan of a multi-gigabyte
+	// log to stay silent is not a cost an empty search should carry.
+	_ = eachRecordUntil(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) bool {
+		if r.Role == role {
+			found = true
+		}
+		return !found
+	})
+	return found
 }
 
 // EachRecordOfRole streams every record of one role with the session it came


### PR DESCRIPTION
Third and last ask of #1321. The first two merged as #1361 and #1362.

deja advertises that it indexes the work, not just the talk. On a store whose harness writes no tool calls, `deja search --role tool build` answered exactly like a query that missed — "matched nothing under role tool" — so a transcript missing half of what happened looked complete. Now the empty-result branch adds one line when the store holds no record of that role at all:

    deja: this index holds no tool records at all — the harnesses it read do not write them, or wrote none yet

That sentence is the only user-visible wording here, so it's easy to change in one line if you'd word it differently.

`HasRecordOfRole` stops at the first match, so a store that does have the records doesn't pay a full scan of records.bin to stay silent. Only asked when a role-filtered search already returned nothing.

Tests: the note appears on a talk-only store, stays quiet when the records exist but the query missed, stays quiet on a search that matched; plus present/absent/unreadable for the index helper. Both mutations verified.