### PR TITLE
fix: the brief obeys one trust rule across the whole screen

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -30,11 +30,13 @@ func briefWithholdingReach(activation string) string {
 }
 
 // briefWithholdingRule names the activation whose rule withholds the whole
-// store, preferring auto because that is the path the reader never sees fail.
-// Returns auto when nothing withholds everything, so the caller's comparison
-// simply fails and the line stays off.
+// store, preferring search: that is the rule this screen itself obeys, so when
+// two rules withhold everything the reader is told the one that emptied what
+// they are looking at (#1312). Auto comes next — the path they never see fail —
+// and is also the fallback when nothing withholds everything, so the caller's
+// comparison simply fails and the line stays off.
 func briefWithholdingRule(withheld map[string]int, total int) string {
-	for _, a := range []string{policy.ActivationAuto, policy.ActivationSearch, policy.ActivationMCP} {
+	for _, a := range []string{policy.ActivationSearch, policy.ActivationAuto, policy.ActivationMCP} {
 		if withheld[a] == total {
 			return a
 		}
@@ -202,9 +204,15 @@ func runBrief(dir string, w io.Writer) error {
 	// noticed themselves: a question they asked in more than one session. A
 	// count of sessions is reporting; this is the thing the tool is for.
 	briefPol := policy.Load()
-	asked, haveAsked := index.FindAskedTwice(dir, func(project string) bool {
-		return briefPol.Allows(policy.ActivationAuto, project)
-	})
+	// The search rule, like `recent` above and every other terminal surface.
+	// These lines print the reader's own session text on the reader's own
+	// screen; filtering them by auto meant a policy that keeps work out of
+	// casual greps printed "all N sessions are withheld from your own
+	// searches" and quoted three of them underneath (#1312).
+	briefAllows := func(project string) bool {
+		return briefPol.Allows(policy.ActivationSearch, project)
+	}
+	asked, haveAsked := index.FindAskedTwice(dir, briefAllows)
 	askedText := ""
 	if haveAsked {
 		askedText = trimBriefTitle(asked.Text)
@@ -213,7 +221,7 @@ func runBrief(dir string, w io.Writer) error {
 	// What the counters above cannot say: which memory kept being worth
 	// recalling. "63 recalls" is a rate; a named piece of work is the thing a
 	// person repeats to a colleague (#579).
-	r, haveReused := findReusedMemory(dir)
+	r, haveReused := findReusedMemory(dir, briefAllows)
 
 	// What you keep asking is what keeps getting recalled, so these two land on
 	// the same work more often than not — and then the screen printed one title
@@ -250,9 +258,7 @@ func runBrief(dir string, w io.Writer) error {
 	// counter: a wall this machine keeps running into. Manifest-only, like the
 	// asked line above it — the command that reports the full list reads the
 	// record log, which is a hundred times this screen's budget.
-	if f, ok := index.FindFriction(dir, func(project string) bool {
-		return briefPol.Allows(policy.ActivationAuto, project)
-	}); ok {
+	if f, ok := index.FindFriction(dir, briefAllows); ok {
 		fmt.Fprintf(w, "hit        %s%s%s\n", bold, trimBriefTitle(f.Text), reset)
 		fmt.Fprintf(w, "again      %s%d sessions · last %s · deja friction%s\n",
 			dim, len(f.Sessions), search.RelativeDate(f.Last), reset)

--- a/cmd/deja/brief_contradiction_test.go
+++ b/cmd/deja/brief_contradiction_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The brief is the owner's own screen, and browsing is what the `search` rule
+// governs — `recent` honours it. Two lines below it, `asked` and `hit` were
+// filtered by `auto` instead, so a policy that keeps work out of casual greps
+// while leaving auto-recall on printed "all N sessions are withheld from your
+// own searches" and the text of those sessions underneath (#1312).
+func TestBriefHonoursOneRuleAcrossTheWholeScreen(t *testing.T) {
+	dir := seedAgedSessions(t, map[string]agedSession{
+		"a1": {"why does the docker build fail on arm64", 40 * 24 * time.Hour},
+		"a2": {"why does the docker build fail on arm64", 6 * 24 * time.Hour},
+	})
+	writePolicy(t, `{"activations":{"search":{"local":false},"auto":{"local":true}}}`)
+	var buf bytes.Buffer
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "search rule keeps them out of your own searches") {
+		t.Fatalf("the screen does not report the rule under test:\n%s", out)
+	}
+	if strings.Contains(out, "docker build fail on arm64") {
+		t.Errorf("session text printed under a line saying it is all withheld:\n%s", out)
+	}
+}
+
+// The reverse policy — browsing allowed, auto-recall denied — must keep those
+// lines, since nothing withholds them from the reader.
+func TestBriefKeepsItsInsightsWhenOnlyTheAgentIsDenied(t *testing.T) {
+	dir := seedAgedSessions(t, map[string]agedSession{
+		"a1": {"why does the docker build fail on arm64", 40 * 24 * time.Hour},
+		"a2": {"why does the docker build fail on arm64", 6 * 24 * time.Hour},
+	})
+	writePolicy(t, `{"activations":{"search":{"local":true},"auto":{"local":false}}}`)
+	var buf bytes.Buffer
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "asked      ") {
+		t.Errorf("a rule that only stops the agent emptied the reader's own screen:\n%s", out)
+	}
+}
+
+// The withheld line itself names whichever rule withholds everything, and it
+// prefers auto; on this policy the rule that emptied the screen is search.
+func TestBriefNamesTheRuleThatEmptiedTheScreen(t *testing.T) {
+	storeWith(t, false)
+	writePolicy(t, `{"activations":{"search":{"local":false},"auto":{"local":true}}}`)
+	var buf bytes.Buffer
+	if err := runBrief(index.DefaultDir(), &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "withheld") {
+		t.Fatalf("no withheld line on a store the policy withholds:\n%s", out)
+	}
+	if !strings.Contains(out, "search rule") {
+		t.Errorf("the line names a rule other than the one that emptied the screen:\n%s", out)
+	}
+	if strings.Contains(out, "recent ") {
+		t.Errorf("sessions listed under a line saying they are all withheld:\n%s", out)
+	}
+}
+
+// When two rules withhold everything, the reader is told the one that emptied
+// the screen in front of them rather than the one they never see fail.
+func TestBriefPrefersTheRuleItObeys(t *testing.T) {
+	storeWith(t, false)
+	writePolicy(t, `{"activations":{"search":{"local":false},"auto":{"local":false}}}`)
+	var buf bytes.Buffer
+	if err := runBrief(index.DefaultDir(), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if out := buf.String(); !strings.Contains(out, "search rule keeps them out of your own searches") {
+		t.Errorf("with both rules withholding, the screen names the one it does not obey:\n%s", out)
+	}
+}

--- a/cmd/deja/brief_policy_test.go
+++ b/cmd/deja/brief_policy_test.go
@@ -150,8 +150,10 @@ func askedLine(out string) string {
 // still the same question asked twice — the one line the brief exists to show.
 // Imported sessions used to carry no asked hashes, so the repeat crossed a sync
 // boundary unseen; stats' RepeatQuestions (from records) counted it and the two
-// screens disagreed. It stays gated on the auto rule: a machine that withholds
-// imported memory must not surface an all-imported repeat.
+// screens disagreed. It stays gated: a machine that withholds imported memory
+// from this screen must not surface an all-imported repeat. The rule is the
+// reader's own — `search`, like the rest of the brief — since a rule aimed at
+// agents leaves work the reader can still grep for themselves (#1312).
 func TestBriefAskedTwiceCountsImportedAndHonoursPolicy(t *testing.T) {
 	q := "how do I configure the retry queue for delivery?"
 
@@ -192,15 +194,26 @@ func TestBriefAskedTwiceCountsImportedAndHonoursPolicy(t *testing.T) {
 		t.Fatalf("asked-twice did not count the imported repeat; asked line = %q\n%s", ln, buf.String())
 	}
 
-	// A rule that withholds imported memory from agents must drop the line: the
-	// only thing keeping the count at two is a session the reader chose to hide.
-	writePolicy(t, `{"activations":{"auto":{"local":true,"imported":false}}}`)
+	// A rule that keeps imported memory off the reader's own screen must drop
+	// the line: the only thing keeping the count at two is a session they chose
+	// to hide. The whole brief reads `search` — a rule aimed at agents alone
+	// leaves this screen intact, since the reader can still grep the same
+	// session (#1312).
+	writePolicy(t, `{"activations":{"search":{"local":true,"imported":false}}}`)
 	buf.Reset()
 	if err := runBrief(dir, &buf); err != nil {
 		t.Fatal(err)
 	}
 	if ln := askedLine(buf.String()); ln != "" {
-		t.Errorf("asked-twice surfaced an all-imported repeat under auto:local-only:\n%s", ln)
+		t.Errorf("asked-twice surfaced an all-imported repeat under search:local-only:\n%s", ln)
+	}
+	writePolicy(t, `{"activations":{"auto":{"local":true,"imported":false}}}`)
+	buf.Reset()
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if ln := askedLine(buf.String()); ln == "" {
+		t.Errorf("a rule aimed at agents emptied the reader's own screen:\n%s", buf.String())
 	}
 }
 
@@ -217,8 +230,8 @@ func hitLine(out string) string {
 // A wall a peer kept hitting, arriving by sync, is a wall — `deja friction` and
 // stats both count it, and the brief's one friction line used to be the lone
 // holdout because imported sessions carried no Hit hashes. Populate meta.Hit on
-// import and gate the brief's lookup on the auto rule, the same shape as the
-// asked-twice fix above.
+// import and gate the brief's lookup on the search rule, the same shape as the
+// asked-twice test above.
 func TestBriefFrictionCountsImportedAndHonoursPolicy(t *testing.T) {
 	tmp := hermeticEnv(t)
 	exp := filepath.Join(tmp, "transfer")
@@ -246,12 +259,21 @@ func TestBriefFrictionCountsImportedAndHonoursPolicy(t *testing.T) {
 		t.Fatalf("friction line did not count the imported wall; hit line = %q\n%s", ln, buf.String())
 	}
 
-	writePolicy(t, `{"activations":{"auto":{"local":true,"imported":false}}}`)
+	writePolicy(t, `{"activations":{"search":{"local":true,"imported":false}}}`)
 	buf.Reset()
 	if err := runBrief(dir, &buf); err != nil {
 		t.Fatal(err)
 	}
 	if ln := hitLine(buf.String()); ln != "" {
-		t.Errorf("friction surfaced an all-imported wall under auto:local-only:\n%s", ln)
+		t.Errorf("friction surfaced an all-imported wall under search:local-only:\n%s", ln)
+	}
+	// And a rule that only stops agents leaves the reader's own screen alone.
+	writePolicy(t, `{"activations":{"auto":{"local":true,"imported":false}}}`)
+	buf.Reset()
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if ln := hitLine(buf.String()); ln == "" {
+		t.Errorf("a rule aimed at agents emptied the reader's own screen:\n%s", buf.String())
 	}
 }

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -355,7 +355,10 @@ func runHookContext(dir string, plain bool) error {
 		// earned its keep more than once, it is named here rather than only
 		// on a screen someone has to decide to open (#579).
 		earned := ""
-		if r, ok := findReusedMemory(dir); ok {
+		hookPol := policy.Load()
+		if r, ok := findReusedMemory(dir, func(project string) bool {
+			return hookPol.Allows(policy.ActivationAuto, project)
+		}); ok {
 			earned = fmt.Sprintf(" · most re-used recently: %q, %d×", trimBriefTitle(r.Title), r.Times)
 		}
 		// The receipt is read at a glance, and several hosts show it in a

--- a/cmd/deja/reused.go
+++ b/cmd/deja/reused.go
@@ -35,7 +35,11 @@ type reusedMemory struct {
 
 // findReusedMemory picks the session agents recalled most, ignoring the ones
 // still being worked on. Usage log plus manifest: no record read.
-func findReusedMemory(dir string) (reusedMemory, bool) {
+//
+// allow is the trust rule of whichever screen is asking — the reader's own is
+// not the agent's. Without one this printed the title of a session the policy
+// withholds, on a screen that had just said every session was withheld (#1312).
+func findReusedMemory(dir string, allow func(string) bool) (reusedMemory, bool) {
 	worn := usage.WornSessions(dir)
 	if len(worn) == 0 {
 		return reusedMemory{}, false
@@ -69,6 +73,9 @@ func findReusedMemory(dir string) (reusedMemory, bool) {
 		}
 		m := found[0]
 		if strings.TrimSpace(m.Title) == "" {
+			continue
+		}
+		if allow != nil && !allow(m.Project) {
 			continue
 		}
 		// A session with no parseable timestamp is not old, it is undated —

--- a/cmd/deja/reused_test.go
+++ b/cmd/deja/reused_test.go
@@ -59,7 +59,7 @@ func TestFindReusedMemoryNamesTheMostRecalled(t *testing.T) {
 		"r2": {"readme wording pass", 72 * time.Hour, 2},
 		"r3": {"one off question", 72 * time.Hour, 1},
 	})
-	got, ok := findReusedMemory(dir)
+	got, ok := findReusedMemory(dir, nil)
 	if !ok {
 		t.Fatal("nothing named, though one session was recalled four times")
 	}
@@ -80,7 +80,7 @@ func TestFindReusedMemoryIgnoresTodaysWork(t *testing.T) {
 		"live": {"the session happening right now", time.Minute, 40},
 		"old":  {"pgbouncer prepared statements", 72 * time.Hour, 3},
 	})
-	got, ok := findReusedMemory(dir)
+	got, ok := findReusedMemory(dir, nil)
 	if !ok {
 		t.Fatal("nothing named")
 	}
@@ -98,7 +98,7 @@ func TestFindReusedMemorySilentBelowTwo(t *testing.T) {
 	dir := seedReuse(t, map[string]seedSession{
 		"r1": {"asked once", 72 * time.Hour, 1},
 	})
-	if got, ok := findReusedMemory(dir); ok {
+	if got, ok := findReusedMemory(dir, nil); ok {
 		t.Fatalf("named %q at %d×, floor is %d", got.Title, got.Times, reusedMinTimes)
 	}
 }
@@ -107,11 +107,11 @@ func TestFindReusedMemorySilentWithoutUsage(t *testing.T) {
 	dir := seedReuse(t, map[string]seedSession{
 		"r1": {"never recalled", 72 * time.Hour, 0},
 	})
-	if _, ok := findReusedMemory(dir); ok {
+	if _, ok := findReusedMemory(dir, nil); ok {
 		t.Fatal("nothing was ever served, so nothing can be re-used")
 	}
 	hermeticEnv(t)
-	if _, ok := findReusedMemory(filepath.Join(t.TempDir(), "missing")); ok {
+	if _, ok := findReusedMemory(filepath.Join(t.TempDir(), "missing"), nil); ok {
 		t.Fatal("no index, nothing to name")
 	}
 }
@@ -126,7 +126,7 @@ func TestFindReusedMemorySkipsUntitledSessions(t *testing.T) {
 	for i := 0; i < 9; i++ {
 		usage.RecordServedSessions(dir, usage.KindRecall, 100, 1, false, 1000, []string{"ghost-session"})
 	}
-	got, ok := findReusedMemory(dir)
+	got, ok := findReusedMemory(dir, nil)
 	if !ok {
 		t.Fatal("nothing named")
 	}
@@ -143,7 +143,7 @@ func TestFindReusedMemorySkipsBlankTitles(t *testing.T) {
 		"blank": {"   ", 72 * time.Hour, 9},
 		"named": {"pgbouncer prepared statements", 72 * time.Hour, 2},
 	})
-	got, ok := findReusedMemory(dir)
+	got, ok := findReusedMemory(dir, nil)
 	if !ok {
 		t.Fatal("nothing named, though a titled session was re-used twice")
 	}
@@ -186,7 +186,7 @@ func TestFindReusedMemorySkipsAmbiguousIDs(t *testing.T) {
 	}
 	// Repeatedly, because the defect is non-determinism: a map decides.
 	for i := 0; i < 50; i++ {
-		if got, ok := findReusedMemory(dir); ok {
+		if got, ok := findReusedMemory(dir, nil); ok {
 			t.Fatalf("named %q on an id two harnesses share; the count belongs to both", got.Title)
 		}
 	}
@@ -241,7 +241,7 @@ func TestFindReusedMemorySkipsUndatedSessions(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		usage.RecordServedSessions(dir, usage.KindRecall, 100, 1, false, 1000, []string{"dated"})
 	}
-	got, ok := findReusedMemory(dir)
+	got, ok := findReusedMemory(dir, nil)
 	if !ok {
 		t.Fatal("nothing named, though a dated session was re-used twice")
 	}


### PR DESCRIPTION
Fixes #1312.

Bare `deja` is the reader's own screen, and browsing is what the `search` rule governs — `recent` already honoured it. `asked`, `hit` and `reused` were filtered by `auto` instead (`reused` by nothing at all), so a policy that keeps work out of casual greps while leaving auto-recall on printed

```
withheld   all N sessions — your trust policy's search rule keeps them out of your own searches
asked      why does the docker build fail on arm64
```

on one screen. Every line that prints session text now goes through one predicate on `search`; `findReusedMemory` takes the caller's rule, and the hook keeps `auto`, which is the agent's channel.

The `withheld` line also preferred `auto` when several rules withhold everything. It prefers `search` now — the rule this screen obeys — so the reader is told what emptied what is in front of them.

Two existing tests pinned the old `auto` behaviour on the asked and friction lines. They now pin the search rule, and each gained the other half: a rule aimed at agents alone must leave the reader's own screen intact, which is the case that made the contradiction visible.

Tests: the contradiction in both directions, the insight lines surviving an agent-only deny, and the rule preference when both withhold. Mutations verified on the predicate and on the preference order.
