### PR TITLE
fix: the greeting stops claiming an empty machine once history arrives

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -65,7 +65,7 @@ func runBrief(dir string, w io.Writer) error {
 			}
 		}
 		if ov.Sessions == 0 {
-			printNoHistory(w)
+			printNoHistory(w, staleEmptyIndex(dir))
 			return nil
 		}
 	}
@@ -396,11 +396,43 @@ func buildForFirstRun(dir string) (bool, error) {
 // printNoHistory is the honest empty state: the index built and found nothing.
 // It names where deja looked, because the usual cause is that the agent stores
 // live somewhere this machine does not have.
-func printNoHistory(w io.Writer) {
+// staleEmptyIndex reports whether the empty index is out of date — the stores
+// have changed since it was written.
+//
+// The order anyone trying a new tool follows: install it, run `deja` to see
+// what it does (nothing yet), work for a day, run it again. The first run wrote
+// an empty index, and the refresh above only fires when there is no manifest at
+// all, so the second run kept saying the machine had no history while twelve
+// sessions sat on disk (#1313). Answering by rebuilding is not open to this
+// screen — measured at 7.0s behind another index's lock, exit 1 on a read-only
+// index directory, and indexing narration through the layout — so it says the
+// true thing cheaply instead. UpToDate reads the manifest and stats the stores;
+// it builds nothing and takes no lock, and it is only asked when the index
+// holds no sessions at all. Measured at 3.4ms over 1552 files in a 950 MB
+// store, which is a quarter of what this screen already spends.
+func staleEmptyIndex(dir string) bool {
+	if !index.HasManifest(dir) {
+		return false
+	}
+	fresh, _ := index.UpToDate(dir, "")
+	return !fresh
+}
+
+func printNoHistory(w io.Writer, stale bool) {
+	if stale {
+		fmt.Fprintln(w, "deja-vu "+version+" · history found, not indexed yet")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "your agents have written since deja last looked — run `deja index`")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "  deja index       read what is new")
+		fmt.Fprintln(w, "  deja sources     what was looked for, and where")
+		fmt.Fprintln(w, "  deja help        every command")
+		return
+	}
 	fmt.Fprintln(w, "deja-vu "+version+" · no agent history found yet")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "deja reads the session stores your agents already write —")
-	fmt.Fprintln(w, "Claude Code, Codex, opencode, Cursor, Gemini, Copilot and ten more.")
+	fmt.Fprintln(w, "Claude Code, Codex, opencode, Cursor, Gemini, Copilot and twelve more.")
 	fmt.Fprintln(w, "Nothing was found on this machine, which usually means no agent has")
 	fmt.Fprintln(w, "run here yet, or its store lives somewhere else.")
 	fmt.Fprintln(w)

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -393,9 +393,6 @@ func buildForFirstRun(dir string) (bool, error) {
 	return before.Initial && before.Messages > 0 && logoWanted(os.Stdout), nil
 }
 
-// printNoHistory is the honest empty state: the index built and found nothing.
-// It names where deja looked, because the usual cause is that the agent stores
-// live somewhere this machine does not have.
 // staleEmptyIndex reports whether the empty index is out of date — the stores
 // have changed since it was written.
 //
@@ -418,6 +415,10 @@ func staleEmptyIndex(dir string) bool {
 	return !fresh
 }
 
+// printNoHistory is the empty state, in its two honest forms: the index built
+// and found nothing, or it found nothing because it has not looked since the
+// stores changed. The first names where deja looked, because the usual cause is
+// that the agent stores live somewhere this machine does not have.
 func printNoHistory(w io.Writer, stale bool) {
 	if stale {
 		fmt.Fprintln(w, "deja-vu "+version+" · history found, not indexed yet")

--- a/cmd/deja/brief_stale_empty_test.go
+++ b/cmd/deja/brief_stale_empty_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The order anyone trying a new tool follows: run it once on an empty machine,
+// work for a day, run it again. The first run leaves an empty index, and the
+// second kept reporting a machine with no history while the sessions were on
+// disk and the very next command indexed them (#1313).
+func TestBriefSaysHistoryArrivedAfterAnEmptyFirstRun(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	var first bytes.Buffer
+	if err := runBrief(dir, &first); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(first.String(), "no agent history found yet") {
+		t.Fatalf("an empty machine did not get the empty-state screen:\n%s", first.String())
+	}
+
+	// A day of work lands in the store deja already knows about.
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-work")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"why does the retry queue stall"},"timestamp":"2026-08-02T10:00:00Z","sessionId":"aaa","cwd":"/work"}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "a.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var second bytes.Buffer
+	if err := runBrief(dir, &second); err != nil {
+		t.Fatal(err)
+	}
+	out := second.String()
+	if strings.Contains(out, "no agent history found yet") {
+		t.Errorf("the screen still reports an empty machine after the store filled up:\n%s", out)
+	}
+	if !strings.Contains(out, "deja index") {
+		t.Errorf("the screen does not say what to run:\n%s", out)
+	}
+}
+
+// And it must not build, take the lock, or narrate: that rule is why the
+// obvious fix was rejected. The store is left untouched by the brief, so the
+// session count stays at zero until something else indexes it.
+func TestBriefStillIndexesNothingWhenItSaysSo(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	var buf bytes.Buffer
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-work")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"why does the retry queue stall"},"timestamp":"2026-08-02T10:00:00Z","sessionId":"aaa","cwd":"/work"}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "a.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if ov, err := index.Overview(dir); err != nil || ov.Sessions != 0 {
+		t.Errorf("the brief indexed on its own: %d sessions, err %v", ov.Sessions, err)
+	}
+	for _, narration := range []string{"incremental index", "indexing sessions into"} {
+		if strings.Contains(buf.String(), narration) {
+			t.Errorf("indexing narration landed on the brief:\n%s", buf.String())
+		}
+	}
+}
+
+// A machine that genuinely has nothing still gets the original screen — the
+// one that explains what deja reads and where to look.
+func TestBriefKeepsTheEmptyStateWhenNothingArrived(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	var buf bytes.Buffer
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "no agent history found yet") {
+		t.Errorf("a machine with no history was told to index something:\n%s", buf.String())
+	}
+}
+
+// A machine that excludes every project has files in the stores that will
+// never be indexed. Telling that reader to run `deja index` on every screen
+// would be a nag they can do nothing about.
+func TestBriefDoesNotNagAboutExcludedProjects(t *testing.T) {
+	hermeticEnv(t)
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "work")
+	dir := index.DefaultDir()
+	var buf bytes.Buffer
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-work")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"why does the retry queue stall"},"timestamp":"2026-08-02T10:00:00Z","sessionId":"aaa","cwd":"/work"}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "a.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Index once: the excluded work is read and produces nothing, which is the
+	// state the reader is left in.
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "history found, not indexed yet") {
+		t.Errorf("the screen asks for an index that would change nothing:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
Fixes #1313.

Install it, run `deja` once to see what it does, work for a day, run it again — and the second run still says "no agent history found yet" while twelve sessions sit on disk. The first run wrote an empty index, and the refresh only fires when there is no manifest at all, so the branch never runs again.

Rebuilding from the brief is not open to this screen, and the issue has the numbers: 7.0s behind another index's lock, exit 1 on a read-only index directory, and indexing narration through the layout. So it says the true thing cheaply instead — when the index holds no sessions and the stores have changed since it was written:

```
deja-vu 0.17.2 · history found, not indexed yet

your agents have written since deja last looked — run `deja index`
```

`index.UpToDate` answers that without building or taking the lock; measured at 3.4 ms over 1552 files in a 950 MB store, and only asked when the index has zero sessions.

Also fixed the harness count in the line below it: "and ten more" is now "and twelve more" (18 in the registry, 6 named).

Tests: the second run after the store fills up, the brief still indexing nothing and narrating nothing, a genuinely empty machine keeping the original screen, and a machine that excludes every project not being nagged forever. Mutation verified on the staleness check.
