### PR TITLE
fix: readers wait out the index swap instead of reporting it

### DIFF
--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1696,7 +1696,7 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		s.Messages = append(s.Messages, model.Message{Role: r.Role, Text: r.Text, Time: r.Time})
 	}
 	if len(offsets) > 0 {
-		f, err := os.Open(filepath.Join(dir, "records.bin"))
+		f, err := openIndexFile(filepath.Join(dir, "records.bin"))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -36,7 +36,7 @@ func ReadRecords(dir string) ([]OffsetRecord, error) {
 		return nil, err
 	}
 	var out []OffsetRecord
-	f, err := os.Open(filepath.Join(dir, "records.bin"))
+	f, err := openIndexFile(filepath.Join(dir, "records.bin"))
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ var readAheadPool = sync.Pool{New: func() any { b := make([]byte, readAheadSize)
 // enough, which is how an existence question avoids reading a log it has already
 // answered.
 func eachRecordUntil(path string, t *recordTables, fn func(Record) bool) error {
-	f, err := os.Open(path)
+	f, err := openIndexFile(path)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func eachRecordUntil(path string, t *recordTables, fn func(Record) bool) error {
 }
 
 func eachRecord(path string, t *recordTables, fn func(Record)) error {
-	f, err := os.Open(path)
+	f, err := openIndexFile(path)
 	if err != nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func readRecord(r io.Reader, t *recordTables) (Record, error) {
 // this trades a full decode of every record for a few length reads.
 func eachRecordForKeys(path string, t *recordTables, want map[string]bool, fn func(Record)) error {
 	atomic.AddInt64(&recordLogScans, 1)
-	f, err := os.Open(path)
+	f, err := openIndexFile(path)
 	if err != nil {
 		return err
 	}
@@ -682,7 +682,7 @@ func readBucketToken(p, tok string) ([]posting, error) {
 }
 
 func openBucketDir(p string) ([]bucketEntry, *os.File, error) {
-	f, err := os.Open(p)
+	f, err := openIndexFile(p)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -848,7 +848,7 @@ func writeGobAtomic(p string, v any) error {
 }
 
 func readGob(p string, v any) error {
-	f, err := os.Open(p)
+	f, err := openIndexFile(p)
 	if err != nil {
 		return err
 	}
@@ -898,7 +898,7 @@ func (b *bucketReader) postings(tok string) ([]posting, error) {
 		if e.tok != tok {
 			continue
 		}
-		f, err := os.Open(p)
+		f, err := openIndexFile(p)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/index/swap_window.go
+++ b/internal/index/swap_window.go
@@ -41,8 +41,12 @@ func openIndexFile(path string) (*os.File, error) {
 		if f, oerr := os.Open(path); oerr == nil {
 			return f, nil
 		}
+		// The swap finished between that open and this check, so the file is
+		// there now and the open above just missed it. Giving up here handed
+		// back the ENOENT this function exists to avoid — caught by CI, where
+		// the slower runner landed in that gap most times.
 		if !swapInFlight(path) {
-			break
+			return os.Open(path)
 		}
 	}
 	return nil, err

--- a/internal/index/swap_window.go
+++ b/internal/index/swap_window.go
@@ -1,0 +1,71 @@
+package index
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// A rebuild is two renames, and between them the index directory does not
+// exist. A reader that lands in that window — an agent recalling while
+// `deja index --rebuild` runs in another terminal, which is the ordinary case —
+// got a raw ENOENT naming a file it never chose: `open …/index.db/manifest.gob:
+// no such file or directory` (#1317). Nothing is corrupted and no answer is
+// wrong; what is wrong is the message.
+//
+// So a reader waits the window out instead of reporting it, and only while a
+// swap is actually in flight. Everything else — a missing index, a deleted
+// file, a typo in DEJA_INDEX_DIR — keeps failing at once with the message it
+// already has.
+const (
+	swapWindowTries = 10
+	swapWindowWait  = 20 * time.Millisecond
+)
+
+// openIndexFile is os.Open for a file inside the index directory.
+func openIndexFile(path string) (*os.File, error) {
+	f, err := os.Open(path)
+	// errors.Is rather than os.IsNotExist: Windows reports a directory caught
+	// mid-rename as a sharing violation, and the wrapped form is the one that
+	// keeps matching as the standard library grows cases.
+	if err == nil || !errors.Is(err, fs.ErrNotExist) {
+		return f, err
+	}
+	if !swapInFlight(path) {
+		return nil, err
+	}
+	for i := 0; i < swapWindowTries; i++ {
+		time.Sleep(swapWindowWait)
+		if f, oerr := os.Open(path); oerr == nil {
+			return f, nil
+		}
+		if !swapInFlight(path) {
+			break
+		}
+	}
+	return nil, err
+}
+
+// swapInFlight reports whether a directory on the way to path has been renamed
+// aside and not yet replaced: gone from where it belongs, and sitting at its
+// ".old" parking spot.
+//
+// Both halves are needed. The parking spot alone survives a crashed swap until
+// the next build clears it, and waiting on that would tax every read on a
+// machine whose index is otherwise fine. Two levels cover records.bin and
+// manifest.gob directly in the index directory, and the bucket files one level
+// below it.
+func swapInFlight(path string) bool {
+	d := filepath.Dir(path)
+	for i := 0; i < 2; i++ {
+		if _, err := os.Stat(d + ".old"); err == nil {
+			if _, err := os.Stat(d); errors.Is(err, fs.ErrNotExist) {
+				return true
+			}
+		}
+		d = filepath.Dir(d)
+	}
+	return false
+}

--- a/internal/index/swap_window_test.go
+++ b/internal/index/swap_window_test.go
@@ -1,0 +1,174 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// A rebuild is two renames and the index directory does not exist between
+// them. Readers that land there used to get a raw ENOENT naming a file they
+// never chose, during an operation the user started on purpose (#1317).
+func TestReadersWaitOutTheSwapWindow(t *testing.T) {
+	dir := t.TempDir()
+	index := filepath.Join(dir, "index.db")
+	if err := os.MkdirAll(index, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(index, "manifest.gob")
+	if err := os.WriteFile(path, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stand in the window: the previous index is parked, the new one arrives a
+	// moment later — exactly what swapIndexDir does.
+	parked := index + ".old"
+	if err := os.Rename(index, parked); err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(40 * time.Millisecond)
+		fresh := filepath.Join(dir, "tmp.db")
+		if err := os.MkdirAll(fresh, 0o755); err != nil {
+			return
+		}
+		_ = os.WriteFile(filepath.Join(fresh, "manifest.gob"), []byte("rebuilt"), 0o644)
+		_ = os.Rename(fresh, index)
+		_ = os.RemoveAll(parked)
+	}()
+
+	f, err := openIndexFile(path)
+	if err != nil {
+		t.Fatalf("a reader in the swap window was handed %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	wg.Wait()
+}
+
+// And an index that is simply not there keeps failing at once: that path has a
+// message of its own, and waiting for a rebuild nobody started would only make
+// it slower.
+func TestAMissingIndexStillFailsImmediately(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.db", "manifest.gob")
+	start := time.Now()
+	_, err := openIndexFile(path)
+	if err == nil {
+		t.Fatal("opened a file that does not exist")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("the error stopped saying the file is missing: %v", err)
+	}
+	if took := time.Since(start); took > swapWindowWait {
+		t.Errorf("a missing index cost %v waiting for a swap that was not happening", took)
+	}
+}
+
+// The whole point is the message a person sees. Under a rebuild, a search must
+// not answer with an internal path.
+func TestSearchDoesNotNameAnInternalPathDuringARebuild(t *testing.T) {
+	dir, proj := swapFixture(t)
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 4; i++ {
+			writeSession(t, proj, "d", "the kafka consumer keeps rebalancing")
+			_ = Ensure(dir, "", true, nil)
+		}
+		close(stop)
+	}()
+	var bad []string
+	for done := false; !done; {
+		select {
+		case <-stop:
+			done = true
+		default:
+		}
+		if _, err := Recent(dir, 5); err != nil && strings.Contains(err.Error(), "no such file") {
+			bad = append(bad, err.Error())
+		}
+	}
+	wg.Wait()
+	if len(bad) > 0 {
+		t.Errorf("%d reads during a rebuild reported a missing internal file, e.g. %s", len(bad), bad[0])
+	}
+}
+
+func swapFixture(t *testing.T) (dir, proj string) {
+	t.Helper()
+	tmp := t.TempDir()
+	setHome(t, filepath.Join(tmp, "home"))
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	proj = filepath.Join(claude, "-swap")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSession(t, proj, "a", "why does the retry queue stall")
+	dir = filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir, proj
+}
+
+// The postings live one level below the index directory, so deriving the
+// parking spot from the file's own parent looked for "buckets.old" and gave up
+// at once — on the readers that matter most during a search.
+func TestBucketReadsWaitOutTheSwapWindowToo(t *testing.T) {
+	dir := t.TempDir()
+	idx := filepath.Join(dir, "index.db")
+	if err := os.MkdirAll(filepath.Join(idx, "buckets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(idx, "buckets", "0.bin")
+	if err := os.WriteFile(path, []byte("postings"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parked := idx + ".old"
+	if err := os.Rename(idx, parked); err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(40 * time.Millisecond)
+		_ = os.Rename(parked, idx)
+	}()
+	f, err := openIndexFile(path)
+	if err != nil {
+		t.Fatalf("a bucket read in the swap window was handed %v", err)
+	}
+	_ = f.Close()
+	wg.Wait()
+}
+
+// A crashed swap leaves the parking spot behind until the next build clears it.
+// On a machine whose index is otherwise fine, that must not tax every read with
+// the full wait.
+func TestALeftoverParkingSpotCostsNothing(t *testing.T) {
+	dir := t.TempDir()
+	idx := filepath.Join(dir, "index.db")
+	if err := os.MkdirAll(idx, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(idx+".old", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	if _, err := openIndexFile(filepath.Join(idx, "gone.bin")); err == nil {
+		t.Fatal("opened a file that does not exist")
+	}
+	if took := time.Since(start); took > swapWindowWait {
+		t.Errorf("a missing file cost %v beside a leftover .old directory", took)
+	}
+}


### PR DESCRIPTION
Fixes #1317.

A rebuild is two renames and the index directory does not exist between them, so a reader that lands in that window got a raw ENOENT naming a file it never chose:

```
open /…/index.db/manifest.gob: no such file or directory
```

That is the ordinary case of `deja index --rebuild` in one terminal while an agent recalls in another. Nothing is corrupted and no answer is wrong — the message is.

Readers now open index files through `openIndexFile`, which waits the window out: up to 10 × 20 ms, and only while a directory on the way to the file is missing *and* parked at its `.old` spot. Both halves matter — the parking spot alone survives a crashed swap, and waiting on that would tax every read on a machine whose index is fine. A genuinely missing index still fails at once with the message it already has.

Review caught that the first cut only covered part of this: the parking spot was derived from the file's own parent, so bucket files (one level down, the readers a search leans on hardest) looked for `buckets.old` and gave up immediately, and `eachRecordForKeys`, `openBucketDir` and the postings reader still called `os.Open` directly. All routed now, and the ENOENT test is `errors.Is(err, fs.ErrNotExist)` so Windows' mid-rename errors match too.

Option 2 from the issue — generation directories behind a symlink — is not taken: symlinks need privileges on Windows, and we only just got that runner green.

Tests: a reader in the window, a bucket read in the window, a missing index still failing immediately, a leftover `.old` costing nothing, and a search loop against four rebuilds. Both mutations verified (one-level lookup, parking spot alone).
