### PR TITLE
fix: apply the exclude list where data leaves the machine

### DIFF
--- a/cmd/deja/exclude_retro_test.go
+++ b/cmd/deja/exclude_retro_test.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// excludeStore indexes one ordinary project and one the user later decides is
+// private. Nothing is excluded at build time: the point of #1307 is what
+// happens when the pattern is set afterwards.
+func excludeStore(t *testing.T) string {
+	t.Helper()
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for name, text := range map[string]string{
+		"-work":    "why does the retry queue stall on staging",
+		"-private": "the quibblesnatch acquisition price is confidential",
+	} {
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		line := `{"type":"user","message":{"role":"user","content":"` + text + `"},"timestamp":"2026-08-02T10:00:00Z","sessionId":"s` + name + `","cwd":"/` + strings.TrimPrefix(name, "-") + `"}` + "\n"
+		if err := os.WriteFile(filepath.Join(dir, "a.jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The sequence a careful person performs — realise a project should not be
+// shared, set the exclusion, sync — was the one that shipped it. The export is
+// where data leaves the machine, so the pattern holds there whether or not the
+// index has been rebuilt.
+func TestExportHonoursAnExclusionSetAfterTheBuild(t *testing.T) {
+	dir := excludeStore(t)
+	out := filepath.Join(t.TempDir(), "batch")
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "private")
+	if _, err := index.ExportFull(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	shipped := readBatch(t, out)
+	if strings.Contains(shipped, "quibblesnatch") {
+		t.Errorf("the excluded project was exported:\n%s", shipped)
+	}
+	if !strings.Contains(shipped, "retry queue") {
+		t.Errorf("the export dropped work nothing excluded:\n%s", shipped)
+	}
+}
+
+// And with no pattern set, everything still goes.
+func TestExportWithoutExclusionsShipsEverything(t *testing.T) {
+	dir := excludeStore(t)
+	out := filepath.Join(t.TempDir(), "batch")
+	shipped := ""
+	if _, err := index.ExportFull(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	shipped = readBatch(t, out)
+	for _, want := range []string{"quibblesnatch", "retry queue"} {
+		if !strings.Contains(shipped, want) {
+			t.Errorf("export dropped %q with no exclusion set:\n%s", want, shipped)
+		}
+	}
+}
+
+// The other half: `deja index` used to return silently having applied nothing,
+// which reads exactly like success. This is the up-to-date path — nothing
+// changed on disk, which is the most misleading moment to stay quiet.
+func TestIndexSaysAnExclusionNeedsARebuildWhenNothingChanged(t *testing.T) {
+	excludeStore(t)
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "private")
+	out, err := captureRunStderr(t, "index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "up to date") {
+		t.Fatalf("this test means to exercise the up-to-date path:\n%s", out)
+	}
+	if !strings.Contains(out, "exclude list changed") {
+		t.Errorf("index said nothing about the exclusion it did not apply:\n%s", out)
+	}
+}
+
+// And after an incremental build, which writes a fresh manifest and could
+// otherwise stamp the new patterns as applied without having applied them to
+// anything already indexed.
+func TestIndexSaysAnExclusionNeedsARebuildAfterAnIncrementalBuild(t *testing.T) {
+	excludeStore(t)
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "private")
+	newWork := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-work", "b.jsonl")
+	line := `{"type":"user","message":{"role":"user","content":"the retry queue stalled again today"},"timestamp":"2026-08-03T10:00:00Z","sessionId":"sb","cwd":"/work"}` + "\n"
+	if err := os.WriteFile(newWork, []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRunStderr(t, "index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "up to date") {
+		t.Fatalf("this test means to exercise a real build:\n%s", out)
+	}
+	if !strings.Contains(out, "exclude list changed") {
+		t.Errorf("an incremental build claimed the new exclusion set without applying it:\n%s", out)
+	}
+	// The rebuild does apply it, and then the line has to stop.
+	if _, err := captureRunStderr(t, "index", "--rebuild"); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRunStderr(t, "index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "exclude list changed") {
+		t.Errorf("index still asks for a rebuild it already got:\n%s", out)
+	}
+	// And the excluded project is gone from search, which is what the rebuild
+	// was for.
+	hits, err := captureRun(t, "quibblesnatch")
+	if err == nil && strings.Contains(hits, "quibblesnatch") {
+		t.Errorf("the rebuild kept the excluded project searchable:\n%s", hits)
+	}
+}
+
+// A machine with no exclusions must never see the line.
+func TestIndexStaysQuietWithoutExclusions(t *testing.T) {
+	excludeStore(t)
+	out, err := captureRunStderr(t, "index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "exclude list") {
+		t.Errorf("a machine with no exclusions was told to rebuild:\n%s", out)
+	}
+}
+
+func readBatch(t *testing.T, dir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var all strings.Builder
+	for _, e := range entries {
+		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		all.Write(b)
+	}
+	return all.String()
+}
+
+// An exclusion is a decision, not a deletion. The incremental export resumes
+// from a per-source watermark, so letting it run past a record it held back
+// would settle that work forever: remove the pattern later and it never syncs
+// again.
+//
+// Notes are the case where this is reachable — one store file carries every
+// note, and `--project` puts them in different projects, so an included record
+// can advance a watermark past an excluded one in the same source. Measured on
+// a real 227-source index: two sources carry several projects each, the worst
+// of them five.
+func TestAnExcludedRecordIsNotSettledByTheWatermark(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if _, err := captureRun(t, "remember", "the quibblesnatch acquisition price", "--project", "private"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "remember", "the retry queue stalls on staging", "--project", "work"); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "batch")
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "private")
+	if _, err := index.Export(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	shipped := readBatch(t, out)
+	if strings.Contains(shipped, "quibblesnatch") {
+		t.Fatalf("the excluded note was exported:\n%s", shipped)
+	}
+	if !strings.Contains(shipped, "retry queue") {
+		t.Fatalf("this test needs the other note in the same source to be sent:\n%s", shipped)
+	}
+	// The user changes their mind.
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "")
+	again := filepath.Join(t.TempDir(), "batch2")
+	if _, err := index.Export(dir, again); err != nil {
+		t.Fatal(err)
+	}
+	if shipped := readBatch(t, again); !strings.Contains(shipped, "quibblesnatch") {
+		t.Errorf("work held back by an exclusion never synced after the pattern was removed:\n%s", shipped)
+	}
+}
+
+// share hands a session to another person, which is the same boundary as an
+// export.
+func TestShareRefusesAnExcludedProject(t *testing.T) {
+	excludeStore(t)
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "private")
+	id := sessionIDFor(t, "quibblesnatch")
+	if id == "" {
+		t.Skip("no session to share")
+	}
+	out, err := captureRun(t, "share", id)
+	if err == nil {
+		t.Errorf("share handed over a project the exclude list covers:\n%s", out)
+	}
+	if err != nil && !strings.Contains(err.Error(), "exclude list") {
+		t.Errorf("share refused for the wrong reason: %v", err)
+	}
+}
+
+// sessionIDFor finds the id of the session holding a phrase, before any
+// exclusion is set.
+func sessionIDFor(t *testing.T, phrase string) string {
+	t.Helper()
+	metas, err := index.AllMeta(index.DefaultDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range metas {
+		if strings.Contains(m.Project, "private") {
+			return m.ID
+		}
+	}
+	return ""
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -280,6 +280,12 @@ func cmdIndex(dir string, rest []string) error {
 		// agent memory is on its way (#839).
 		clearWarmupSentinel()
 		fmt.Fprintf(os.Stderr, "deja: index is up to date (%d session%s)\n", n, pluralS(n))
+		// "Up to date" is the most misleading place to stay quiet about it:
+		// nothing changed on disk, so this is exactly where an exclusion set
+		// after the build looks applied and is not.
+		if index.ExclusionsChanged(dir) {
+			fmt.Fprintln(os.Stderr, "deja: the exclude list changed since this index was built — `deja index --rebuild` applies it to sessions already indexed")
+		}
 		return nil
 	}
 	stopProgress()
@@ -316,6 +322,13 @@ func cmdIndex(dir string, rest []string) error {
 		}
 		fmt.Fprintf(os.Stderr, "deja: %s: %d path%s could not be read — `deja doctor` names %s\n",
 			name, e.FailedFiles, pluralS(e.FailedFiles), pluralWhich(e.FailedFiles))
+	}
+	// An exclusion applies at ingest, so it covers nothing already indexed —
+	// and the sequence someone actually performs is to set the pattern, run
+	// this command, and sync. That used to return silently having applied
+	// nothing, and the export that followed still carried the project (#1307).
+	if index.ExclusionsChanged(dir) {
+		fmt.Fprintln(os.Stderr, "deja: the exclude list changed since this index was built — `deja index --rebuild` applies it to sessions already indexed")
 	}
 	// The parse count and the indexed count differ by exactly these, and this
 	// is where both are on screen (#868).

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/redact"
+	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
 func runShare(dir string, args []string, w io.Writer) error {
@@ -33,6 +34,13 @@ func runShare(dir string, args []string, w io.Writer) error {
 	}
 	if err := denyPolicyHidden(args[0], s, os.Stderr); err != nil {
 		return err
+	}
+	// The exclude list is a privacy control, and share is the command whose
+	// whole purpose is handing a session to someone else. It only ran at
+	// ingest, so a project excluded after the index was built was still
+	// shareable by id (#1307).
+	if sources.ExcludedProject(s.Project) {
+		return fmt.Errorf("%s is in a project your exclude list covers — `deja index --rebuild` drops it from the index, or remove the pattern to share it", args[0])
 	}
 	printSanitized(w, digest.Share(s, digest.ShareBudget))
 	return nil

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -43,7 +43,10 @@ location. The directory contains:
 Privacy control files are primary data, not cache data: the XDG-aware
 `~/.config/deja/tombstones` list prevents forgotten source sessions from being
 re-ingested, and `~/.config/deja/exclude` contains project patterns skipped at
-ingest. `DEJA_EXCLUDE_PROJECTS` adds comma-separated patterns. A full `forget`
+ingest. `DEJA_EXCLUDE_PROJECTS` adds comma-separated patterns. Patterns also
+apply at `sync export`, so a project excluded after the index was built does not
+leave the machine; what is already indexed stays searchable locally until
+`deja index --rebuild`, and `deja index` says so when the list has changed. A full `forget`
 rebuild replaces the index atomically before the tombstone list is used by the
 next index pass.
 

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -64,7 +64,7 @@
 <p>Secrets are stripped at index time — API keys, JWTs, PEM/PGP private-key blocks, bearer and HTTP Basic auth, provider tokens, <code>scheme://user:pass@host</code> URLs, and (since 0.14.2) bare high-entropy values in secret-shaped positions: the value side of any assignment or a token alone on its own line — before anything is written. Redaction runs on the full message before any size cap, so a secret straddling the cap boundary can't slip through. Redacted output is what search, MCP recall, share and sync all serve.</p>
 <h2>Control what's kept</h2>
 <ul>
-<li><b>Exclude at ingest</b> — <code>~/.config/deja/exclude</code> patterns or <code>DEJA_EXCLUDE_PROJECTS</code> skip projects entirely.</li>
+<li><b>Exclude</b> — <code>~/.config/deja/exclude</code> patterns or <code>DEJA_EXCLUDE_PROJECTS</code> skip projects at index time, and <code>sync export</code> honours them too, so a project excluded later does not leave the machine. Sessions indexed before the pattern existed stay searchable locally until <code>deja index --rebuild</code>; <code>deja index</code> tells you when that is the case.</li>
 <li><b>Forget</b> — <code>deja forget</code> removes sessions and records a tombstone so they don't come back on the next index; <code>--dry-run</code> to preview, <code>--list</code> to see the tombstones, <code>--unforget &lt;id&gt;</code> to reverse one.</li>
 <li><b>Redaction report</b> — <code>deja stats --redaction</code> shows what was masked, per rule and harness.</li>
 <li><b>Audit what agents received</b> — <code>deja log</code> lists recent recalls and injections; <code>deja log --last</code> prints the exact digest most recently served.</li>

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -216,6 +216,13 @@ type Manifest struct {
 	// that last touched it: malformed JSONL lines and files that failed to
 	// parse. Silent loss must be diagnosable (`deja doctor --json`).
 	IngestHealth map[string]HarnessIngest `json:"ingest_health,omitempty"`
+	// ExcludeFingerprint identifies the exclusion patterns in force when this
+	// index was built. They apply at ingest, so a pattern added later leaves
+	// what is already indexed searchable and exportable — silently, until this
+	// told `deja index` to say so (#1307). Additive: a manifest written before
+	// it decodes with it empty, and an empty one means "not recorded", which
+	// says nothing rather than guessing.
+	ExcludeFingerprint string `json:"exclude_fingerprint,omitempty"`
 }
 
 // HarnessIngest is one harness's ingestion health from its last indexing pass.
@@ -245,6 +252,8 @@ type manifestCore struct {
 	RecordsSize      int64
 	BucketFiles      int
 	IngestHealth     map[string]HarnessIngest
+	// ExcludeFingerprint: see Manifest.
+	ExcludeFingerprint string
 }
 
 type RedactionStats struct {

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -322,8 +322,14 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	// what a peer already pushed, not only what arrives next.
 	ss = append(ss, sources.FilterSessions(imported.sessions)...)
 	ss = filterTombstonedSet(ss, dead)
+	// A full build passes every session through the exclusion patterns, so
+	// this is the one place the current set can be claimed as applied. An
+	// incremental build carries the old stamp forward: it keeps records it
+	// wrote under the previous patterns, which is why `deja index` has to ask
+	// for a rebuild rather than quietly declaring the new list in force (#1307).
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
-		ExportWatermarks: imported.watermarks, ExportBoundary: imported.boundary, ImportedRecords: imported.dedupe}
+		ExportWatermarks: imported.watermarks, ExportBoundary: imported.boundary, ImportedRecords: imported.dedupe,
+		ExcludeFingerprint: sources.ExclusionFingerprint()}
 	recPath := filepath.Join(tmp, "records.bin")
 	rf, err := os.OpenFile(recPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
@@ -648,7 +654,8 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	writtenMessages := 0
 	lastIngestFiles = len(files)
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
-		ExportWatermarks: imp.watermarks, ExportBoundary: imp.boundary, ImportedRecords: imp.dedupe}
+		ExportWatermarks: imp.watermarks, ExportBoundary: imp.boundary, ImportedRecords: imp.dedupe,
+		ExcludeFingerprint: sources.ExclusionFingerprint()}
 	recPath := filepath.Join(tmp, "records.bin")
 	rf, err := os.OpenFile(recPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
@@ -1785,7 +1792,11 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	// generation.
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(),
 		Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
-		ExportWatermarks: old.ExportWatermarks, ExportBoundary: old.ExportBoundary, ImportedRecords: old.ImportedRecords}
+		ExportWatermarks: old.ExportWatermarks, ExportBoundary: old.ExportBoundary, ImportedRecords: old.ImportedRecords,
+		// Kept from the old index: this build reuses records written under
+		// those patterns, so claiming today's set would be a lie the reader
+		// cannot check.
+		ExcludeFingerprint: old.ExcludeFingerprint}
 	skipRedactions := map[string]bool{}
 	for p := range changed {
 		skipRedactions[p] = true

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
 // IsCurrentVersion reports whether the index on disk was written by this
@@ -194,7 +196,7 @@ func readManifest(dir string) (Manifest, error) {
 	if err := readGob(filepath.Join(dir, "manifest.gob"), &core); err != nil {
 		return Manifest{}, err
 	}
-	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ExportBoundary: core.ExportBoundary, ImportedRecords: core.ImportedRecords, RecordStrings: core.RecordStrings, RecordsSize: core.RecordsSize, BucketFiles: core.BucketFiles, IngestHealth: core.IngestHealth, Sessions: map[string]SessionMeta{}}
+	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ExportBoundary: core.ExportBoundary, ImportedRecords: core.ImportedRecords, RecordStrings: core.RecordStrings, RecordsSize: core.RecordsSize, BucketFiles: core.BucketFiles, IngestHealth: core.IngestHealth, ExcludeFingerprint: core.ExcludeFingerprint, Sessions: map[string]SessionMeta{}}
 	if err := readGob(filepath.Join(dir, "sessions.gob"), &m.Sessions); err != nil {
 		return Manifest{}, err
 	}
@@ -205,7 +207,7 @@ func readManifest(dir string) (Manifest, error) {
 // for updates that change only core fields (e.g. export watermarks) where the
 // caller has not loaded sessions and must not clobber them.
 func writeManifestOnly(dir string, m Manifest) error {
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, ExcludeFingerprint: m.ExcludeFingerprint}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}
@@ -221,7 +223,7 @@ func writeManifestOnly(dir string, m Manifest) error {
 // rather than serving a fresh-looking index whose sessions are stale.
 func writeManifest(dir string, m Manifest) error {
 	mergeIngestDiag(&m)
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, ExcludeFingerprint: m.ExcludeFingerprint}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}
@@ -230,6 +232,23 @@ func writeManifest(dir string, m Manifest) error {
 		return err
 	}
 	return writeGobAtomic(filepath.Join(dir, "manifest.gob"), core)
+}
+
+// ExclusionsChanged reports whether the exclude patterns in force differ from
+// the ones this index was built under.
+//
+// They apply at ingest, so setting one today does nothing about what was
+// ingested yesterday — and `deja index` returned silently having applied
+// nothing, which is the answer that reads most like success (#1307). False
+// when the index predates the fingerprint or no patterns are set: an unknown
+// state is not a reason to tell someone to rebuild.
+func ExclusionsChanged(dir string) bool {
+	now := sources.ExclusionFingerprint()
+	m, err := readManifestCached(dir)
+	if err != nil || m.ExcludeFingerprint == "" {
+		return false
+	}
+	return m.ExcludeFingerprint != now
 }
 
 // hasBucketFile reports whether the postings directory holds anything at all.

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -132,6 +132,18 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 	// Only sources this export actually touched may have their watermark or
 	// boundary rewritten; pushing project B must leave project A's alone.
 	touched := map[string]bool{}
+	// The exclude list is a privacy control, and it only ran at ingest — so
+	// setting it and syncing, which is exactly what someone does the moment
+	// they realise a project should not be shared, was the sequence that
+	// shipped it to another machine (#1307). Applied here too: the export is
+	// where data leaves, and a pattern set after the index was built has to
+	// hold at that boundary whether or not the index has been rebuilt.
+	ex := sources.NewExcluder()
+	// The oldest instant held back per source. A watermark that ran past an
+	// excluded record would settle it forever: remove the pattern later and
+	// that work never syncs again, because the source resumes from a point
+	// beyond it. Held records are not sent, and they are not settled either.
+	heldFrom := map[string]int64{}
 	err = eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
 		if r.SourcePath == syncImportPath {
 			return
@@ -157,6 +169,14 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 		if !ok {
 			return
 		}
+		if !ex.Empty() && ex.Match(meta.Project) {
+			if tn := r.Time.UnixNano(); !r.Time.IsZero() {
+				if cur, seen := heldFrom[wk]; !seen || tn < cur {
+					heldFrom[wk] = tn
+				}
+			}
+			return
+		}
 		text, _ := redact.Text(r.Text)
 		rec := SyncRecord{Harness: meta.Harness, SessionID: meta.ID, Project: meta.Project, Role: r.Role, Text: text, Time: r.Time}
 		bySource[source] = append(bySource[source], rec)
@@ -178,6 +198,13 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 	})
 	if err != nil {
 		return 0, nil, err
+	}
+	// Clamp each source's next watermark below the oldest record it held back.
+	for wk, held := range heldFrom {
+		if nextWatermarks[wk] >= held {
+			nextWatermarks[wk] = held - 1
+			delete(nextBoundary, wk)
+		}
 	}
 	total := 0
 	for source, recs := range bySource {
@@ -679,7 +706,11 @@ func initEmptyIndex(dir string) error {
 	// history invisible until a full rebuild. An empty file set makes the next
 	// index treat every local file as new and ingest it, next to the imported
 	// records this manifest carries.
-	m := Manifest{Version: version, Files: map[string]FileState{}, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), ExportWatermarks: map[string]int64{}, ImportedRecords: map[string]bool{}}
+	// An empty index holds nothing, so whatever the patterns are now, they are
+	// applied to all of it. Leaving this blank would read as "written before
+	// deja recorded this" and keep `deja index` quiet forever after (#1307).
+	m := Manifest{Version: version, Files: map[string]FileState{}, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), ExportWatermarks: map[string]int64{}, ImportedRecords: map[string]bool{},
+		ExcludeFingerprint: sources.ExclusionFingerprint()}
 	return writeManifest(dir, m)
 }
 

--- a/internal/sources/privacy.go
+++ b/internal/sources/privacy.go
@@ -2,9 +2,12 @@ package sources
 
 import (
 	"bufio"
+	"hash/fnv"
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -77,6 +80,33 @@ func (e Excluder) Match(project string) bool {
 }
 
 func ExcludedProject(project string) bool { return NewExcluder().Match(project) }
+
+// ExclusionFingerprint identifies the pattern set in force, so an index can
+// record which one it was built under.
+//
+// The patterns only ever ran at ingest, and nothing noticed when they changed:
+// setting one and running `deja index` applied nothing and said nothing, while
+// the project stayed searchable and kept going out over sync (#1307). Order and
+// case do not matter — the same set written differently is the same set, and a
+// reshuffled exclude file is not a reason to tell someone to rebuild.
+func ExclusionFingerprint() string {
+	patterns := ExclusionPatterns()
+	// "none" rather than an empty string: an index built with no exclusions has
+	// recorded that fact, and a manifest written before this existed has not.
+	// Collapsing the two would have kept the note silent in the ordinary case —
+	// index first, decide a project is private afterwards.
+	if len(patterns) == 0 {
+		return "none"
+	}
+	sorted := append([]string(nil), patterns...)
+	sort.Strings(sorted)
+	h := fnv.New64a()
+	for _, p := range sorted {
+		_, _ = h.Write([]byte(p))
+		_, _ = h.Write([]byte{0})
+	}
+	return strconv.FormatUint(h.Sum64(), 16)
+}
 
 // CountSessions reports how many conversations a slice of parsed transcripts
 // amounts to. The index keys a session on harness+id, so two transcripts that


### PR DESCRIPTION
Fixes #1307.

`DEJA_EXCLUDE_PROJECTS` and `~/.config/deja/exclude` are documented as privacy controls but only ran at ingest, so the sequence someone actually performs — realise a project should not be shared, set the exclusion, sync — was the one that shipped it. `deja index` returned silently having applied nothing, and the export that followed carried the project to a machine with no exclusion of its own.

Two halves:

- **The patterns apply where data leaves.** `sync export` filters records whose project matches, and `deja share` refuses an excluded session by name rather than handing it over. Both are the boundary; what is already indexed stays searchable locally until a rebuild.
- **`deja index` says so.** The manifest records a fingerprint of the pattern set, and only a full build stamps the current one — an incremental build keeps records written under the old patterns, so it carries the old stamp forward. When they differ: `the exclude list changed since this index was built — deja index --rebuild applies it to sessions already indexed`. An empty set is recorded as `none`, so it is distinguishable from a manifest written before the field existed; otherwise the note would never fire in the ordinary case of indexing first and deciding a project is private afterwards.

From review, one thing worth calling out: an excluded record must not let the source's watermark run past it, or removing the pattern later would mean that work never syncs again. Notes are where this is reachable — one store file, several projects — and it is real on my own index, where two of 227 sources carry up to five projects each.

Not covered here, and worth deciding separately: `deja view`, `deja stats --html/--card`, `handoff` and the MCP resource list still show sessions from a project excluded after the build. Those are local surfaces governed by the trust policy rather than machine boundaries, so I left them alone rather than widening this.

Tests: export honours a pattern set after the build; export with no pattern still ships everything; held-back work syncs once the pattern is removed; `deja index` says it on both the up-to-date and the incremental path and stops after a rebuild; a machine with no exclusions never sees the line; share refuses. Six mutations verified, one of which caught a blind test.
