### PR TITLE
fix: agent tools say when the index is being rebuilt, instead of rebuilding inline

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -255,6 +256,13 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 				return "", err
 			}
 		}
+		// blame reaches index.EnsureForSearch through findBlameHits, which
+		// blocks and can run the whole build inside this call. The CLI keeps
+		// that — someone typed it and watches the progress — but an agent gets
+		// the same sentence as every other tool (#1306).
+		if line := buildingNowForAgent(dir); line != "" {
+			return line, nil
+		}
 		text, hits, err := blameTextResult(dir, search.BlameOptions{Harness: a.Harness, Project: a.Project, Since: since, All: a.All}, a.Path, int(a.Limit))
 		if err == nil {
 			// blame answers the agent the way recall does, and hands over more
@@ -276,7 +284,12 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Error) == "" {
 			return "", fmt.Errorf("error text required")
 		}
-		if err := index.Ensure(dir, "", false, mcpProgress()); err != nil {
+		// Before the read, not after: the rebuild used to happen first and the
+		// guard ran when there was nothing left to report (#1306, #1309).
+		if line := buildingNowForAgent(dir); line != "" {
+			return line, nil
+		}
+		if _, err := index.EnsureForSearchStale(dir, search.Options{}, mcpProgress()); err != nil {
 			return "", err
 		}
 		pol := policy.Load()
@@ -310,7 +323,10 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.What) == "" {
 			return "", fmt.Errorf("what required")
 		}
-		if err := index.Ensure(dir, "", false, mcpProgress()); err != nil {
+		if line := buildingNowForAgent(dir); line != "" {
+			return line, nil
+		}
+		if _, err := index.EnsureForSearchStale(dir, search.Options{}, mcpProgress()); err != nil {
 			return "", err
 		}
 		entries, hidden, err := howEntries(dir, strings.Fields(a.What), a.Project, policy.ActivationMCP)
@@ -360,6 +376,13 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		}
 		if err := notesWriteError(sources.AppendNoteTagged(a.Project, a.Text, a.Tags, time.Now())); err != nil {
 			return "", err
+		}
+		// The note is on disk either way; what is left is making it findable.
+		// On upgrade day that meant rebuilding the whole index inside the call
+		// (#1309), so the agent is told instead — the detached warmup picks it
+		// up with everything else.
+		if line := buildingNowForAgent(dir); line != "" {
+			return "Saved. " + line, nil
 		}
 		if err := index.EnsureForSearch(dir, search.Options{All: true}, false, mcpProgress()); err != nil {
 			return "", err
@@ -869,14 +892,29 @@ func (n *mcpNumber) UnmarshalJSON(b []byte) error {
 // — an internal path and an errno, handed to a model as a broken tool (#972).
 // Every other surface says the same thing in words.
 func buildingNowForAgent(dir string) string {
-	if index.HasManifest(dir) {
-		return ""
-	}
 	if st := readWarmupStatus(dir); st != nil {
 		return "deja is indexing this machine's history (" + st.progress() + "). Recall comes online in a few seconds; ask again then."
 	}
 	if index.RebuildInProgress(dir) || warmupJustRequested(dir) {
 		return "deja is indexing this machine's history. Recall comes online in a few seconds; ask again then."
 	}
+	// An index this build cannot read is not one it can answer from, and that
+	// is the state a version bump leaves behind. HasManifest called it present,
+	// so the first agent call after an upgrade rebuilt 16000 sessions inside
+	// the tool call — 2.86s against 0.22s steady state, nothing said, and MCP
+	// clients have timeouts (#1309). Hand it to the detached warmup, the way
+	// every other surface repairs this, and say so.
+	if index.HasManifest(dir) && indexNeedsRebuild(dir) {
+		// "Ask again then" has to be true. A read-only index directory is the
+		// one state that never repairs itself, and telling an agent to come
+		// back would loop it forever (the shape #1048 fixed at session start).
+		if !indexDirWritable(dir) {
+			return "deja's index was written by another version of deja and " + filepath.Dir(dir) + " is not writable, so it cannot be rebuilt. Tell the user to run `deja index`, which says what to change."
+		}
+		requestWarmup(dir)
+		return "deja is rebuilding its index for this version of deja. Recall comes online shortly; ask again then."
+	}
+	// Nothing indexed yet and nothing building: this is a first run, and
+	// building it here is how an install with no hooks ever gets an index.
 	return ""
 }

--- a/cmd/deja/mcp_resources.go
+++ b/cmd/deja/mcp_resources.go
@@ -21,7 +21,16 @@ const mcpResourceNameMax = 80
 // mcpResourcesList exposes recent sessions as browsable MCP resources, so an
 // agent can look around without guessing search terms first.
 func mcpResourcesList(dir string) (any, int, string) {
-	if err := index.Ensure(dir, "", false, mcpProgress()); err != nil {
+	// A browse is not worth a rebuild inside the handler: on a stale store
+	// index.Ensure ran the whole build here, and on a cold one the answer was
+	// a raw errno carrying an internal manifest path (#1306).
+	if line := buildingNowForAgent(dir); line != "" {
+		// An empty list, in the shape the protocol defines — the browse has
+		// nothing to show yet, and the sentence belongs on the tools an agent
+		// calls rather than in a result schema clients validate.
+		return map[string]any{"resources": []map[string]any{}}, 0, ""
+	}
+	if _, err := index.EnsureForSearchStale(dir, search.Options{}, mcpProgress()); err != nil {
 		return nil, -32603, err.Error()
 	}
 	ss, err := index.Recent(dir, mcpResourceLimit*2)

--- a/cmd/deja/mcp_upgrade_day_test.go
+++ b/cmd/deja/mcp_upgrade_day_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"encoding/gob"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// upgradeDayStore builds an index and then rewrites its manifest version, which
+// is what a release with a format change leaves behind: the file is there, and
+// this build cannot read it.
+func upgradeDayStore(t *testing.T) string {
+	t.Helper()
+	storeWith(t, true)
+	dir := index.DefaultDir()
+	path := filepath.Join(dir, "manifest.gob")
+	var core map[string]any
+	// The manifest is a gob of a private struct, so the version is bent by
+	// writing a decodable stand-in: any manifest this build cannot decode is
+	// the same state to every caller under test.
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b) == 0 {
+		t.Fatal("no manifest to age")
+	}
+	_ = core
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(struct{ Version int }{Version: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !index.HasManifest(dir) {
+		t.Fatal("the fixture removed the manifest instead of ageing it")
+	}
+	if index.IsCurrentVersion(dir) {
+		t.Fatal("the fixture did not age the manifest")
+	}
+	if index.FormatDirection(dir) != -1 {
+		t.Fatalf("the fixture produced some other broken state (%d), not an older format", index.FormatDirection(dir))
+	}
+	return dir
+}
+
+// The first agent call after an upgrade rebuilt the whole index inside the tool
+// call and said nothing (#1309). The sentence for this state existed; its
+// condition asked whether the manifest file was present, which on upgrade day
+// it is.
+func TestAgentToolsSayWhenTheIndexIsBeingRebuiltForThisVersion(t *testing.T) {
+	dir := upgradeDayStore(t)
+	line := buildingNowForAgent(dir)
+	if line == "" {
+		t.Fatal("an index this build cannot read was reported as ready to answer")
+	}
+	if !strings.Contains(line, "ask again") {
+		t.Errorf("the line does not tell the agent what to do: %q", line)
+	}
+}
+
+// And the tools that reach the index say it rather than rebuilding inline.
+// resources/list, fix, how and blame all called the blocking index.Ensure
+// (#1306); fix and how are described to the model as things to call before
+// diagnosing an error or inventing a command, so they sit on the latency path
+// by design.
+func TestReadOnlyToolsDoNotRebuildInsideTheCall(t *testing.T) {
+	dir := upgradeDayStore(t)
+	for _, tc := range []struct{ name, args string }{
+		{"fix", `{"error":"undefined: parseThing"}`},
+		{"how", `{"what":"run the tests"}`},
+		{"blame", `{"path":"cmd/deja/main.go"}`},
+	} {
+		out, err := callTool(t, dir, tc.name, tc.args)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if !strings.Contains(out, "ask again") {
+			t.Errorf("%s answered without saying the index is being rebuilt:\n%s", tc.name, out)
+		}
+	}
+	// resources/list answers in the shape the protocol defines: an empty list,
+	// not an error carrying an internal manifest path, and not a rebuild.
+	res, code, msg := mcpResourcesList(dir)
+	if msg != "" || code != 0 {
+		t.Fatalf("resources/list returned an error rather than an empty browse: %d %s", code, msg)
+	}
+	body, _ := res.(map[string]any)
+	list, ok := body["resources"].([]map[string]any)
+	if !ok || len(list) != 0 {
+		t.Errorf("resources/list served a browse from an index this build cannot read: %#v", res)
+	}
+	if len(body) != 1 {
+		t.Errorf("resources/list result carries fields the protocol does not define: %#v", body)
+	}
+}
+
+// A machine with no index at all is a first run, and building it there is the
+// only way an install without hooks ever gets one. That must not change.
+func TestAFirstRunStillBuildsFromTheAgentCall(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if index.HasManifest(dir) {
+		t.Fatal("the fixture is not a fresh machine")
+	}
+	if line := buildingNowForAgent(dir); line != "" {
+		t.Errorf("a fresh machine was told to ask again, and nothing would have built the index: %q", line)
+	}
+}
+
+// callTool drives one MCP tool through the server the way a client does.
+func callTool(t *testing.T, dir, name, args string) (string, error) {
+	t.Helper()
+	in := `{"jsonrpc":"2.0","id":"x","method":"tools/call","params":{"name":"` + name + `","arguments":` + args + `}}` + "\n"
+	var out bytes.Buffer
+	if err := serveMCP(dir, strings.NewReader(in), &out); err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
+// remember has to keep working: it writes the note either way, and says the
+// note is not findable yet rather than rebuilding the index to make it so.
+func TestRememberSavesOnUpgradeDayWithoutRebuilding(t *testing.T) {
+	dir := upgradeDayStore(t)
+	out, err := callTool(t, dir, "remember", `{"text":"the staging retry queue needs a longer backoff"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "Saved") {
+		t.Errorf("remember did not confirm the note:\n%s", out)
+	}
+	if !strings.Contains(out, "ask again") {
+		t.Errorf("remember said nothing about the note not being findable yet:\n%s", out)
+	}
+}
+
+// And a read-only index directory never repairs itself, so the agent must not
+// be told to come back.
+func TestNoAskAgainWhenTheIndexCannotBeRebuilt(t *testing.T) {
+	dir := upgradeDayStore(t)
+	// The parent, not the index directory: a rebuild writes index.db.tmp
+	// beside it and renames, so that is the directory whose permissions decide
+	// whether it can happen at all.
+	parent := filepath.Dir(dir)
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Skip("cannot make the index directory read-only here")
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+	line := buildingNowForAgent(dir)
+	if strings.Contains(line, "ask again") {
+		t.Errorf("an agent was told to ask again about a rebuild that cannot happen: %q", line)
+	}
+	if !strings.Contains(line, "deja index") {
+		t.Errorf("the line does not name the command that says what to change: %q", line)
+	}
+}


### PR DESCRIPTION
Fixes #1309 and #1306.

A version bump makes the previous index unreadable, so the first agent call after an upgrade rebuilt it — inside the tool call, with nothing said. Measured on a 16000-session store: 2.86s against 0.22s steady state, and on a larger one that is tens of seconds against MCP clients with timeouts. The failure mode on upgrade day is not "slow once", it is "the memory tool appears broken once", on the day a user has reason to look at it.

The sentence for this state already existed; its condition asked whether `manifest.gob` was present, which on upgrade day it is. It now asks whether the index is one this build can answer from, and hands the rebuild to the detached warmup — the same repair every other surface uses — before returning `deja is rebuilding its index for this version of deja … ask again then`.

#1306's handlers go with it: `resources/list`, `fix` and `how` no longer call the blocking `index.Ensure` (they check the guard, then `EnsureForSearchStale`), and MCP `blame` checks it before reaching `findBlameHits`. The CLI's blame path is untouched — someone typed that and watches the progress.

Two states deliberately kept as they are:

- **A machine with no index at all.** That is a first run, and building it there is the only way an install without hooks ever gets an index. Pinned by a test so a later change has to mean it.
- **`remember`.** It writes the note either way; it now says the note is not findable yet rather than rebuilding to make it so.

From review: `requestWarmup` cannot help when the index directory's parent is not writable, and that state never repairs itself — so instead of "ask again then" the agent is told to have the user run `deja index`, which says what to change. And `resources/list` returns an empty list in the shape the protocol defines rather than an extra field a strict client could reject.

Tests: the guard on an aged manifest (pinned to an older-format state, not merely a damaged one), all four tools answering rather than rebuilding, the first-run path unchanged, remember saving, and the read-only case. Six mutations verified.
