### PR TITLE
fix: tell the agent how many sessions matched, not just how many came back

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -543,6 +543,13 @@ func wholeSessionForMCP(dir string, s model.Session) (model.Session, bool, error
 	return index.FindByIdentity(dir, s.Harness, s.ID)
 }
 
+// recallCountLineReserve is what the two lines around the hits cost — the
+// count above them and the "N more, call again with offset=N" below — kept out
+// of the budget the hits spend. Both are written after the loop, and the final
+// trim cut the navigation line off the end, which is the one line an agent
+// needs precisely when the answer was too big to fit.
+const recallCountLineReserve = 160
+
 func recallTextResult(dir, q, harness string, limit, offset, budget int) (string, int, int64, []string, error) {
 	if limit <= 0 {
 		limit = 5
@@ -611,9 +618,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		}
 		hits = hits[offset:]
 	}
-	remaining := 0
 	if len(hits) > limit {
-		remaining = len(hits) - limit
 		hits = hits[:limit]
 	}
 	attachAnswers(dir, hits)
@@ -634,29 +639,30 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	if note := demotedNote(hits, demoted); note != "" {
 		fmt.Fprintln(&b, note+" — read the order as the user's judgement, not as recency.")
 	}
-	if offset > 0 {
-		fmt.Fprintf(&b, "deja recall for %q (matches %d-%d of %d)\n", q, offset+1, offset+len(hits), total)
-	} else {
-		fmt.Fprintf(&b, "deja recall for %q (%d match(es))\n", q, len(hits))
-	}
+	// The hits are built first so the line above them can count what actually
+	// went out. It used to be written ahead of the loop, which also stops on
+	// the token budget: the header promised fifteen while nine arrived, and the
+	// follow-up line was trimmed off the end (#1308).
+	var hb strings.Builder
+	headerRoom := b.Len() + recallCountLineReserve
 	for i, h := range hits {
-		fmt.Fprintf(&b, "\n%d. [%s] %s · %s · %d matches", i+1,
+		fmt.Fprintf(&hb, "\n%d. [%s] %s · %s · %d matches", i+1,
 			recallListingLine(h.Session.Harness), recallListingLine(h.Session.Project), recallListingLine(h.Session.ID), h.Count)
 		// A session with no user turn is the agent's own words, and the lines
 		// below carry no role — so an assertion a model made arrived as a fact
 		// from the store (#1107, the shape #1100 fixed for the listing).
 		if h.Session.AgentTitle {
-			fmt.Fprint(&b, " · agent-opened, no human turn")
+			fmt.Fprint(&hb, " · agent-opened, no human turn")
 		}
 		if !h.Session.Updated.IsZero() {
-			fmt.Fprintf(&b, " · updated %s (%s)", h.Session.Updated.Local().Format("2006-01-02"), search.RelativeDate(h.Session.Updated))
+			fmt.Fprintf(&hb, " · updated %s (%s)", h.Session.Updated.Local().Format("2006-01-02"), search.RelativeDate(h.Session.Updated))
 		}
 		if h.Reused > 1 {
-			fmt.Fprintf(&b, " · reused %d×", h.Reused)
+			fmt.Fprintf(&hb, " · reused %d×", h.Reused)
 		}
-		fmt.Fprintln(&b)
+		fmt.Fprintln(&hb)
 		if line := lifecycleLine(h); line != "" {
-			fmt.Fprintf(&b, "%s\n", line)
+			fmt.Fprintf(&hb, "%s\n", line)
 		}
 		// A session that says it backed an approach out carries a signal the
 		// lifecycle states would carry if anyone set them by hand — on a real
@@ -665,16 +671,16 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		// end: the tried-then-fixed session is the most useful one, and the
 		// excerpts show which path was dropped.
 		if h.Session.GaveUp && h.Lifecycle == "" {
-			fmt.Fprintln(&b, "[this session abandoned one approach partway — check the excerpts for which, the rest may still hold]")
+			fmt.Fprintln(&hb, "[this session abandoned one approach partway — check the excerpts for which, the rest may still hold]")
 		}
 		if h.Superseded != "" {
-			fmt.Fprintf(&b, "[earlier attempt — a newer session in this project covers the same ground, updated %s]\n", h.Superseded)
+			fmt.Fprintf(&hb, "[earlier attempt — a newer session in this project covers the same ground, updated %s]\n", h.Superseded)
 		}
 		if h.Tier != search.TierExact {
-			fmt.Fprintf(&b, "[%s]\n", h.Tier)
+			fmt.Fprintf(&hb, "[%s]\n", h.Tier)
 		}
 		for _, sn := range h.Snippets {
-			fmt.Fprintf(&b, "- %s\n", recallListingLine(sn))
+			fmt.Fprintf(&hb, "- %s\n", recallListingLine(sn))
 		}
 		// Under the best hit only, and only when there is budget left: the
 		// excerpts say where the query words appear, which is not the same as
@@ -684,7 +690,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		// recall itself. Later hits stay excerpt-only; they are candidates to
 		// choose between, not answers.
 		if i == 0 {
-			if left := budget - b.Len() - recallConclusionsReserve; left > recallConclusionsMin {
+			if left := budget - headerRoom + hb.Len() - recallConclusionsReserve; left > recallConclusionsMin {
 				// The hit carries only the matching messages, so the decision —
 				// usually worded nothing like the query — is not in it. Read the
 				// whole session for the best hit alone, the same upgrade
@@ -694,9 +700,9 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 					whole = full
 				}
 				if cs := digest.Conclusions(whole, left, 3); len(cs) > 0 {
-					fmt.Fprintln(&b, "  what this session concluded:")
+					fmt.Fprintln(&hb, "  what this session concluded:")
 					for _, c := range cs {
-						fmt.Fprintf(&b, "  → %s\n", recallListingLine(c))
+						fmt.Fprintf(&hb, "  → %s\n", recallListingLine(c))
 					}
 				}
 				// The files that work touched, for a few dozen bytes. Without
@@ -704,17 +710,41 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 				// still has to search the tree for where — and that search
 				// costs far more context than naming the paths here does.
 				if paths := recallTouchedLine(dir, h.Session); paths != "" {
-					fmt.Fprintf(&b, "  files it touched: %s\n", paths)
+					fmt.Fprintf(&hb, "  files it touched: %s\n", paths)
 				}
 			}
 		}
 		served++
-		if b.Len() >= budget {
+		if headerRoom+hb.Len() >= budget {
 			break
 		}
 	}
-	if remaining > 0 {
-		fmt.Fprintf(&b, "\n%d more match(es) — call recall again with offset=%d.\n", remaining, offset+served)
+	// From what was served, not from the limit: the loop also stops on the
+	// token budget, and then this said "2 more" while five were left — the
+	// agent asks for offset=served and the arithmetic has to hold.
+	switch {
+	case offset > 0:
+		fmt.Fprintf(&b, "deja recall for %q (matches %d-%d of %d)\n", q, offset+1, offset+served, total)
+	case served < total && result.Tier == search.TierRelevance:
+		// The tier line above already says nothing matched; these are the
+		// nearest sessions, so calling them matches here would contradict it.
+		fmt.Fprintf(&b, "deja recall for %q (%d of %d ranked)\n", q, served, total)
+	case served < total:
+		// How many came back is not how many matched, and the agent is the
+		// reader that cannot ask a human. "(5 match(es))" reads as five exist,
+		// which is a different answer from sixteen thousand matched and here
+		// are five — one is worth acting on, the other is a sample that will
+		// fill a context window with whatever ranked highest (#1308).
+		fmt.Fprintf(&b, "deja recall for %q (%d of %d matched)\n", q, served, total)
+	default:
+		fmt.Fprintf(&b, "deja recall for %q (%d match(es))\n", q, served)
+	}
+	b.WriteString(hb.String())
+	// From what was served, not from the limit: the loop also stops on the
+	// token budget, and then this said "2 more" while five were left — the
+	// agent asks for offset=served and the arithmetic has to hold.
+	if left := total - offset - served; left > 0 {
+		fmt.Fprintf(&b, "\n%d more match(es) — call recall again with offset=%d.\n", left, offset+served)
 	}
 	out := b.String()
 	if len(out) > budget {

--- a/cmd/deja/mcp_contract_test.go
+++ b/cmd/deja/mcp_contract_test.go
@@ -134,8 +134,10 @@ func TestMCPToolContract(t *testing.T) {
 	t.Run("limit caps results", func(t *testing.T) {
 		resp := driveMCP(t, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"recall","arguments":{"query":"frobnicator","harness":"claude","limit":1}}}`)
 		text := callText(t, resp[0])
-		if !strings.Contains(text, "1 match(es)") || strings.Contains(text, "2 match(es)") {
-			t.Fatalf("limit=1 should cap to one match, got %q", text)
+		// One served out of two that matched: the count line names both
+		// numbers now, because "1 match(es)" read as "one exists" (#1308).
+		if !strings.Contains(text, "(1 of 2 matched)") {
+			t.Fatalf("limit=1 should serve one of the two matches, got %q", text)
 		}
 	})
 
@@ -147,7 +149,7 @@ func TestMCPToolContract(t *testing.T) {
 			t.Fatalf("fractional limit errored: %#v", e)
 		}
 		text := callText(t, resp[0])
-		if !strings.Contains(text, "1 match(es)") {
+		if !strings.Contains(text, "(1 of 2 matched)") {
 			t.Fatalf("limit 1.0 should cap to one match, got %q", text)
 		}
 	})

--- a/cmd/deja/mcp_match_count_test.go
+++ b/cmd/deja/mcp_match_count_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// manySessionStore writes n sessions that all carry one common word and one
+// that carries a word nothing else has.
+func manySessionStore(t *testing.T, n int) string {
+	t.Helper()
+	hermeticEnv(t)
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-work")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		line := fmt.Sprintf(`{"type":"user","message":{"role":"user","content":"the pipeline run %d stalled on retry"},"timestamp":"2026-08-02T10:00:0%dZ","sessionId":"s%d","cwd":"/work"}`, i, i%10, i) + "\n"
+		if err := os.WriteFile(filepath.Join(proj, fmt.Sprintf("s%d.jsonl", i)), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rare := `{"type":"user","message":{"role":"user","content":"the quibblesnatch parser rejects empty frames"},"timestamp":"2026-08-02T11:00:00Z","sessionId":"rare","cwd":"/work"}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "rare.jsonl"), []byte(rare), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// "(5 match(es))" means five came back and reads as five exist. An agent had no
+// way to tell "five sessions in the whole store discussed this" — worth acting
+// on — from "the store matched, here are five of them" (#1308).
+func TestRecallSaysHowManyMatchedNotJustHowManyCameBack(t *testing.T) {
+	dir := manySessionStore(t, 40)
+	text, _, _, _, err := recallTextResult(dir, "pipeline", "", 5, 0, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 40 sessions carry "pipeline"; the 41st carries neither.
+	if !strings.Contains(text, "(5 of 40 matched)") {
+		t.Errorf("the answer does not say how many sessions matched:\n%s", firstLines(text, 4))
+	}
+	// And the follow-up line agrees with it.
+	if !strings.Contains(text, "35 more match(es) — call recall again with offset=5.") {
+		t.Errorf("the numbers on the two lines do not add up:\n%s", text)
+	}
+}
+
+// A precise hit still reads as precise: everything that matched came back, so
+// there is no sample to warn about.
+func TestRecallKeepsThePlainCountWhenNothingWasHeldBack(t *testing.T) {
+	dir := manySessionStore(t, 40)
+	text, _, _, _, err := recallTextResult(dir, "quibblesnatch", "", 5, 0, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(text, "matched)") {
+		t.Errorf("a complete answer was reported as a sample:\n%s", firstLines(text, 4))
+	}
+	if !strings.Contains(text, "match(es)") {
+		t.Errorf("the count line went missing:\n%s", firstLines(text, 4))
+	}
+}
+
+func firstLines(s string, n int) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// The relevance tier answers with the nearest sessions when nothing matched,
+// and the line above the count already says so. Calling those matches would
+// contradict it on the same screen.
+func TestRelevanceHitsAreNotCalledMatches(t *testing.T) {
+	dir := manySessionStore(t, 40)
+	text, _, _, _, err := recallTextResult(dir, "pipeline stalled parser frames rejects", "", 5, 0, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "ranked by relevance") {
+		t.Skipf("this query did not reach the relevance tier:\n%s", firstLines(text, 3))
+	}
+	if strings.Contains(text, "matched)") {
+		t.Errorf("relevance-tier sessions were reported as matches:\n%s", firstLines(text, 4))
+	}
+	if !strings.Contains(text, "ranked)") {
+		t.Errorf("the count line does not say what the number is:\n%s", firstLines(text, 4))
+	}
+}
+
+// The budget can stop the loop before the limit does, and then the follow-up
+// line has to count from what was served rather than from the limit — the
+// agent asks for offset=served, so the arithmetic is what it navigates by.
+func TestTheFollowUpCountMatchesWhatWasServed(t *testing.T) {
+	dir := manySessionStore(t, 40)
+	text, served, _, _, err := recallTextResult(dir, "pipeline", "", 15, 0, 900)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if served >= 15 {
+		t.Skip("the budget did not cut this answer short")
+	}
+	want := fmt.Sprintf("%d more match(es) — call recall again with offset=%d.", 40-served, served)
+	if !strings.Contains(text, want) {
+		t.Errorf("expected %q in:\n%s", want, text)
+	}
+	// And the header counts the same thing: it used to promise the page the
+	// server prepared, so fifteen were announced and nine arrived.
+	head := fmt.Sprintf("(%d of 40 matched)", served)
+	if !strings.Contains(text, head) {
+		t.Errorf("expected %q in:\n%s", head, firstLines(text, 2))
+	}
+}


### PR DESCRIPTION
Fixes #1308.

The CLI separates a precise hit from a query that matched the whole store (`showing 15 of 16000`). The MCP answer said `(5 match(es))`, which means five came back and reads as five exist — so an agent could not tell "five sessions here discussed this", worth acting on, from "the store matched, here are five", a sample that will fill its context with whatever ranked highest.

Now:

```
deja recall for "pipeline" (8 of 40 matched)
…
32 more match(es) — call recall again with offset=8.
```

A precise hit keeps the old wording, so it still reads as precise. The relevance tier says `ranked` rather than `matched` — the line above it already says nothing matched, and calling those matches would contradict it on the same screen.

Two adjacent defects the wording exposed, both fixed here:

- the count was written before the hits, so it described the page the server prepared rather than the page the agent gets. The loop also stops on the token budget, and then the header promised fifteen while nine arrived. The hits are built first now and the count goes in front of them.
- `N more match(es)` counted from the limit rather than from what was served, and the final trim cut the line off the end entirely — the one line an agent needs precisely when the answer was too big to fit. It is counted from `served` and its length is reserved out of the budget.

`total` is taken after policy scoping, so the number never tells an agent about sessions the trust policy withholds.

Tests: the sample case, the precise case, the relevance tier, and the budget-cut case where the header, the follow-up line and `served` all have to agree. Five mutations verified.
