### PR TITLE
fix: a session that grows updates what is derived from its text

### DIFF
--- a/internal/index/derived_growth_test.go
+++ b/internal/index/derived_growth_test.go
@@ -1,0 +1,172 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A store that hands the whole session over on every pass — goose does, because
+// its query filters on the session's updated_at as well as the message's — used
+// to add the same messages again each time, so the most active session in the
+// store silently deranked itself (#1304, defect 2).
+func TestARedeliveredSessionIsFoldedOnce(t *testing.T) {
+	ms := []model.Message{
+		{Role: "user", Text: "why does the retry queue stall"},
+		{Role: "assistant", Text: "the backoff is capped at one second"},
+	}
+	var meta SessionMeta
+	extendDerived(&meta, ms)
+	first := meta.Words
+	if first == 0 {
+		t.Fatal("nothing was counted")
+	}
+	for i := 0; i < 3; i++ {
+		extendDerived(&meta, ms)
+	}
+	if meta.Words != first {
+		t.Errorf("the same delivery counted again: %d words after one pass, %d after four", first, meta.Words)
+	}
+	grown := append(append([]model.Message(nil), ms...), model.Message{Role: "user", Text: "it stalls again on staging"})
+	extendDerived(&meta, grown)
+	if meta.Words <= first {
+		t.Errorf("a message appended to a re-delivered session was not counted: %d words", meta.Words)
+	}
+	if meta.Counted != 3 {
+		t.Errorf("counted %d messages, session holds 3", meta.Counted)
+	}
+}
+
+// A file yields only the region appended since last time, so the tail arrives
+// with no overlap at all — the opposite delivery from the one above, and the
+// reason a plain count could not tell them apart.
+func TestATailWithNoOverlapIsFoldedWhole(t *testing.T) {
+	var meta SessionMeta
+	extendDerived(&meta, []model.Message{{Role: "user", Text: "why does the retry queue stall"}})
+	before := meta.Words
+	extendDerived(&meta, []model.Message{
+		{Role: "assistant", Text: "the backoff is capped at one second"},
+		{Role: "user", Text: "raise it and redeploy"},
+	})
+	if meta.Counted != 3 {
+		t.Errorf("counted %d, three messages have arrived", meta.Counted)
+	}
+	if meta.Words <= before {
+		t.Errorf("the appended tail was not counted: %d words", meta.Words)
+	}
+}
+
+// The caps are the reason the manifest stays small, and it is read on every
+// search. A plain union grew on every append (#1304, defect 4).
+func TestDerivedFieldsStayCapped(t *testing.T) {
+	var meta SessionMeta
+	for round := 0; round < 6; round++ {
+		var ms []model.Message
+		for i := 0; i < 6; i++ {
+			ms = append(ms, model.Message{
+				Role: "user",
+				Text: "how do I wire the " + string(rune('a'+round)) + string(rune('a'+i)) + " adapter into the pipeline, and what should it return?",
+			})
+		}
+		extendDerived(&meta, ms)
+	}
+	if len(meta.Asked) > askedQuestionCap {
+		t.Errorf("Asked grew past its cap: %d > %d", len(meta.Asked), askedQuestionCap)
+	}
+	if len(meta.Touched) > touchedFileCap {
+		t.Errorf("Touched grew past its cap: %d > %d", len(meta.Touched), touchedFileCap)
+	}
+}
+
+// Touched is a ranking, and merging two ranked lists by position kept whichever
+// paths came first. The file a session actually worked on hardest arrived in
+// the tail and disappeared (#1304, defect 5).
+func TestTheHardestWorkedFileSurvivesTheMerge(t *testing.T) {
+	head := make([]model.Message, 0, 6)
+	for _, p := range []string{"a.go", "b.go", "c.go", "d.go", "e.go", "f.go"} {
+		head = append(head, model.Message{Role: roleFiles, Text: p})
+	}
+	var meta SessionMeta
+	extendDerived(&meta, head)
+	tail := make([]model.Message, 0, 12)
+	for i := 0; i < 12; i++ {
+		tail = append(tail, model.Message{Role: roleFiles, Text: "hot.go"})
+	}
+	extendDerived(&meta, tail)
+	if len(meta.Touched) == 0 || meta.Touched[0] != "hot.go" {
+		t.Errorf("the file worked on hardest is not first: %v", meta.Touched)
+	}
+}
+
+// Growing the loser of an id collision moved the owner's row: its Words, its
+// GaveUp, and the loser's files into its Touched — the wrong conversation
+// surfacing in blame (#1304, defect 3).
+func TestGrowingACollidingSessionLeavesTheOwnerAlone(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, filepath.Join(tmp, "home"))
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	owner := filepath.Join(claude, "-aaa")
+	loser := filepath.Join(claude, "-zzz")
+	for _, d := range []string{owner, loser} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	line := func(text string) string {
+		return `{"type":"user","sessionId":"same","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(owner, "a.jsonl"), []byte(line("the owner session discusses the retry queue")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(loser, "a.jsonl"), []byte(line("the other session discusses billing")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	before, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	was := before.Sessions["claude:same"]
+	// The loser grows.
+	grown := line("the other session discusses billing") + line("i gave up on the billing migration and reverted it")
+	if err := os.WriteFile(filepath.Join(loser, "a.jsonl"), []byte(grown), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	after, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := after.Sessions["claude:same"]
+	if now.GaveUp != was.GaveUp {
+		t.Errorf("the loser's giving up was written onto the owner's row")
+	}
+	if now.Words != was.Words {
+		t.Errorf("the owner's length moved with the loser's growth: %d then %d", was.Words, now.Words)
+	}
+}
+
+// A session that repeats a line verbatim: resuming from the first copy would
+// fold everything after it a second time on every re-delivery.
+func TestARepeatedLineDoesNotRewindTheFold(t *testing.T) {
+	same := model.Message{Role: "user", Text: "retry"}
+	ms := []model.Message{same, {Role: "assistant", Text: "the backoff is capped at one second"}, same}
+	var meta SessionMeta
+	extendDerived(&meta, ms)
+	first := meta.Words
+	extendDerived(&meta, ms)
+	if meta.Words != first {
+		t.Errorf("a repeated line rewound the fold: %d words became %d", first, meta.Words)
+	}
+	if meta.Counted != len(ms) {
+		t.Errorf("counted %d of %d messages", meta.Counted, len(ms))
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -162,6 +162,31 @@ type SessionMeta struct {
 	// before it existed decodes with it zero and ranking falls back to what it
 	// can see.
 	Words int `json:",omitempty"`
+	// Counted is how many of this session's messages the derived fields above
+	// already include, and LastMsg fingerprints the newest of them.
+	//
+	// A transcript grows after being indexed — the ordinary case, not an edge
+	// one — and the append path folded whatever it was handed. What it is
+	// handed differs by store: a file yields only the region appended since
+	// last time, while goose re-delivers a live session whole on every pass. A
+	// count alone cannot tell those apart, so it either lost the tail or
+	// counted the same messages again, and a session new to the index was
+	// derived twice at once (#1304). Finding LastMsg in what arrived answers
+	// it: what follows is new, and if it is not there at all, all of it is.
+	//
+	// A row written before this existed carries neither, which reads as
+	// "nothing counted" — so the first delivery after an upgrade is folded
+	// whole. That is right for the file stores, where a delivery is the
+	// appended region; a store that re-delivers a live session counts it once
+	// more and then settles, which is cheaper than a format bump that would
+	// make every user rebuild.
+	Counted int    `json:",omitempty"`
+	LastMsg uint64 `json:",omitempty"`
+	// TouchHits is how often each path in Touched was touched, in the same
+	// order. Touched is a ranking, and a ranking cannot be merged without the
+	// numbers behind it: a file touched once in a tail outranked one touched
+	// throughout, because position was all the merge had to go on.
+	TouchHits []int `json:",omitempty"`
 	// Hit holds hashes of the specific errors this session tripped over, so
 	// the first screen can name a wall the machine keeps running into without
 	// reading a single session. Same trade as Asked: the text is recovered

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1169,33 +1169,6 @@ func mergeTouchedCounted(have []string, hits []int, add []string, addHits []int)
 	return rankTouchedCounted(count)
 }
 
-// unionHashes appends what is new, keeping order stable so two builds of the
-// same session compare equal.
-func unionHashes(have, add []uint64) []uint64 {
-	if len(add) == 0 {
-		return have
-	}
-	seen := make(map[uint64]bool, len(have)+len(add))
-	for _, h := range have {
-		seen[h] = true
-	}
-	for _, h := range add {
-		if !seen[h] {
-			seen[h] = true
-			have = append(have, h)
-		}
-	}
-	return have
-}
-
-// mergeTouched keeps the earlier order — the ranking a full pass produced — and
-// adds paths the tail introduced, bounded the same way topTouchedFiles bounds.
-// mergeTouched fuses two ranked lists of touched paths. Both sides come out of
-// rankTouched, where position is the ranking and nothing else carries it, so the
-// merge takes one from each side in turn. Appending the new list after the old
-// one and cutting at the cap ignored the ranking it was handed: six paths from
-// an earlier batch filled the list and the file this batch worked on hardest
-// never appeared, though Touched is the files a session worked on most (#1333).
 func mergeTouched(have, add []string) []string {
 	seen := make(map[string]bool, len(have)+len(add))
 	out := make([]string, 0, touchedFileCap)

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1052,7 +1053,15 @@ func metaForSession(s model.Session) SessionMeta {
 	// rebuild reloads imported sessions out of the index itself, and rebuilding
 	// the row from scratch dropped what only the import knew — the note's state
 	// and the id it had on the machine it came from (#1049).
-	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, AgentTitle: agentTitle, Started: s.Started, Updated: s.Updated, Touched: topTouchedFiles(s.Messages), Asked: askedHashes(s.Messages), Hit: frictionHashes(s.Messages), GaveUp: gaveUp(s.Messages), Words: sessionWords(s.Messages),
+	touched, touchHits := topTouchedCounted(s.Messages)
+	// Counted, so an append that arrives in the same pass folds only what this
+	// did not already see. Without it a session new to the index was derived
+	// from here and merged again below, doubling its Words (#1304).
+	last := uint64(0)
+	if len(s.Messages) > 0 {
+		last = messageFingerprint(s.Messages[len(s.Messages)-1])
+	}
+	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, AgentTitle: agentTitle, Started: s.Started, Updated: s.Updated, Touched: touched, TouchHits: touchHits, Counted: len(s.Messages), LastMsg: last, Asked: askedHashes(s.Messages), Hit: frictionHashes(s.Messages), GaveUp: gaveUp(s.Messages), Words: sessionWords(s.Messages),
 		OrigID: s.OrigID, Lifecycle: s.Lifecycle, LifecycleNote: s.LifecycleNote, LifecycleAt: s.LifecycleAt}
 }
 
@@ -1070,24 +1079,94 @@ func metaForSession(s model.Session) SessionMeta {
 //
 // Merged rather than recomputed, because this path only ever holds the new
 // messages: the file is read from the last watermark, not from the start.
+// extendDerived folds a session's new messages into the fields derived from its
+// text. ms is the whole session as the source hands it over; meta.Counted says
+// how much of it is already in, so re-delivering a live session — which goose
+// does on every pass, and which is how a session new to this file arrives — is
+// idempotent rather than additive (#1304).
 func extendDerived(meta *SessionMeta, ms []model.Message) {
-	if len(ms) == 0 {
+	tail := newMessages(meta, ms)
+	if len(tail) == 0 {
 		return
 	}
-	meta.Words += sessionWords(ms)
-	meta.Asked = unionHashes(meta.Asked, askedHashes(ms))
-	meta.Hit = unionHashes(meta.Hit, frictionHashes(ms))
+	meta.Counted += len(tail)
+	meta.LastMsg = messageFingerprint(ms[len(ms)-1])
+	meta.Words += sessionWords(tail)
+	// Capped like the full build caps: a plain union grows on every append,
+	// and the manifest holding it is read on every search.
+	meta.Asked = mergeCappedU64(meta.Asked, askedHashes(tail), askedQuestionCap)
+	meta.Hit = mergeCappedU64(meta.Hit, frictionHashes(tail), frictionSessionCap)
 	// Giving up is a state a session reaches, never one it leaves: the phrases
 	// that set it are reversals of work already done.
-	if gaveUp(ms) {
+	if gaveUp(tail) {
 		meta.GaveUp = true
 	}
-	// topTouchedFiles ranks and caps, so the union has to be re-ranked rather
-	// than concatenated — otherwise a file touched once in the tail could
-	// outrank one touched throughout, and the cap would keep the wrong ones.
-	if touched := topTouchedFiles(ms); len(touched) > 0 {
-		meta.Touched = mergeTouched(meta.Touched, touched)
+	if paths, hits := topTouchedCounted(tail); len(paths) > 0 {
+		meta.Touched, meta.TouchHits = mergeTouchedCounted(meta.Touched, meta.TouchHits, paths, hits)
 	}
+}
+
+// newMessages is the part of a delivery the derived fields have not seen. The
+// fingerprint is matched from the end: a session that repeats a line verbatim
+// would otherwise resume from the first copy and fold the rest twice.
+func newMessages(meta *SessionMeta, ms []model.Message) []model.Message {
+	if len(ms) == 0 {
+		return nil
+	}
+	if meta.LastMsg == 0 {
+		return ms
+	}
+	for i := len(ms) - 1; i >= 0; i-- {
+		if messageFingerprint(ms[i]) == meta.LastMsg {
+			return ms[i+1:]
+		}
+	}
+	return ms
+}
+
+// messageFingerprint identifies one message well enough to find it again in a
+// later delivery of the same session. Role, time and text: two adjacent
+// messages with the same text differ by time, and a store that rewrites times
+// re-folds a tail, which costs a little accuracy and no correctness.
+func messageFingerprint(m model.Message) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(m.Role))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(strconv.FormatInt(m.Time.UnixNano(), 10)))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(m.Text))
+	// Zero means "nothing counted yet", so a message that hashes to it takes
+	// the neighbouring value rather than resetting the session's state.
+	if sum := h.Sum64(); sum != 0 {
+		return sum
+	}
+	return 1
+}
+
+// mergeTouchedCounted adds the tail's touches to the counts already held and
+// re-ranks. Position alone was all the old merge had: six paths touched once in
+// an early batch filled the list, and the file the session actually worked on
+// hardest never appeared (#1333, and its real cause #1304).
+// A path with no count behind it — the import path derives Touched from records
+// and carries none — counts as one, so it keeps its place without outranking a
+// file this session actually worked on repeatedly.
+func mergeTouchedCounted(have []string, hits []int, add []string, addHits []int) ([]string, []int) {
+	count := map[string]int{}
+	for i, p := range have {
+		n := 1
+		if i < len(hits) {
+			n = hits[i]
+		}
+		count[p] += n
+	}
+	for i, p := range add {
+		n := 1
+		if i < len(addHits) {
+			n = addHits[i]
+		}
+		count[p] += n
+	}
+	return rankTouchedCounted(count)
 }
 
 // unionHashes appends what is new, keeping order stable so two builds of the
@@ -1332,6 +1411,30 @@ func countTouchedPaths(count map[string]int, text string) {
 			count[p]++
 		}
 	}
+}
+
+// rankTouchedCounted returns the counts behind the ranking, which the
+// incremental merge needs: two ranked lists cannot be fused into a correct one
+// from position alone (#1304).
+func rankTouchedCounted(count map[string]int) ([]string, []int) {
+	paths := rankTouched(count)
+	hits := make([]int, len(paths))
+	for i, p := range paths {
+		hits[i] = count[p]
+	}
+	return paths, hits
+}
+
+// topTouchedCounted is topTouchedFiles with those counts.
+func topTouchedCounted(ms []model.Message) ([]string, []int) {
+	count := map[string]int{}
+	for _, m := range ms {
+		if m.Role != roleFiles {
+			continue
+		}
+		countTouchedPaths(count, m.Text)
+	}
+	return rankTouchedCounted(count)
 }
 
 // rankTouched orders touched paths by recurrence and caps the list, the shape
@@ -2132,7 +2235,14 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 					meta.Title, meta.AgentTitle = t, s.AgentTitle
 				}
 			}
-			extendDerived(&meta, s.Messages)
+			// Only the session that owns this row. The full build writes these
+			// fields under the same condition; here the merge ran regardless,
+			// so growing the loser of an id collision moved the owner's Words,
+			// flipped its GaveUp and put the loser's files in its Touched —
+			// the wrong conversation's files surfacing in blame (#1304).
+			if owns {
+				extendDerived(&meta, s.Messages)
+			}
 			m.Sessions[key] = meta
 			for _, msg := range s.Messages {
 				// Already redacted (and length-capped) by preRedactSessions above.

--- a/internal/index/meta_parity_test.go
+++ b/internal/index/meta_parity_test.go
@@ -126,17 +126,13 @@ func TestSessionMetadataIsTheSameWhicheverWayTheIndexGotThere(t *testing.T) {
 		// differ; Path holds a temp directory unique to each build.
 		a.Ord, b.Ord = 0, 0
 		a.Path, b.Path = "", ""
-		// Known divergence, tracked separately: a session that grows after being
-		// indexed never updates what is derived from its text, because the append
-		// path holds only the new messages and these fields cannot simply be
-		// added up — see the issue for why the obvious merge is wrong. Excluded
-		// explicitly so the rest of the row is still guarded, rather than the
-		// whole comparison being dropped.
-		a.Words, b.Words = 0, 0
-		a.Asked, b.Asked = nil, nil
-		a.Hit, b.Hit = nil, nil
-		a.Touched, b.Touched = nil, nil
-		a.GaveUp, b.GaveUp = false, false
+		// Words, Asked, Hit, Touched and GaveUp were excluded here while a
+		// session that grew never updated them (#1304). They are compared now:
+		// the append path carries enough state to fold only what it has not
+		// seen, so growing a session one message at a time reaches the same row
+		// as building the whole thing at once. LastMsg fingerprints the newest
+		// message either way and is part of that guarantee, so it is compared
+		// too.
 		if reflect.DeepEqual(a, b) {
 			continue
 		}


### PR DESCRIPTION
Fixes #1304.

A transcript that grows after being indexed never updated what is derived from its text — `Words`, `Asked`, `Hit`, `Touched`, `GaveUp` stayed frozen at whatever the first pass saw. That is the ordinary case: a session is written to while the work happens. An error hit later never entered `Hit`, so `deja fix` could not match it by signature; files touched later never entered `Touched`, so blame did not know about them; `Words` understated the length BM25 normalises by.

The issue lists five defects that killed the obvious merge. What makes it work is state on the row:

- **`Counted` and `LastMsg`** — how much of the session is folded in, and a fingerprint of the newest folded message. What a store hands over differs: a file yields the region appended since last time, while goose re-delivers a live session whole on every pass. A count alone cannot tell those apart, so it either lost the tail or counted the same messages again. Finding `LastMsg` in the delivery — searched from the end, so a repeated line does not rewind it — answers the question exactly.
- **`TouchHits`** — the per-path counts behind `Touched`. It is a ranking, and two ranked lists cannot be fused from position alone: six paths touched once filled the list while the file the session worked on hardest arrived in the tail and disappeared.
- **the caps** — `mergeCappedU64` rather than a plain union, so the manifest every search reads does not grow on every append.
- **the `owns` guard** — the full build writes these fields only for the session that owns the row; the merge ran regardless, so growing the loser of an id collision moved the owner's `Words`, flipped its `GaveUp` and put the loser's files in its `Touched`.
- **`Counted` on a fresh row** — `metaForSession` records what it derived, so a session new to the index is not folded a second time in the same pass.

No format bump: the fields are additive, and a row written before them reads as "nothing counted", so the first delivery after an upgrade is folded whole. That is right for the file stores; a store that re-delivers a live session counts it once more and then settles, which is cheaper than making every user rebuild.

The parity test from #1303 compared everything except these five fields. It compares them now, which is the real proof: growing a session one message at a time reaches the same row as building the whole corpus at once.

Tests: re-delivery folded once, a tail with no overlap folded whole, a repeated line not rewinding the fold, the caps holding across six appends, the hardest-worked file surviving the merge, and the owner's row untouched when the colliding session grows. Seven mutations verified — one of them caught a blind test.
