### PR TITLE
fix: keep the evidence a fix pair needs until a second session confirms it

### DIFF
--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -36,6 +36,10 @@ const (
 	fixCommandMax = 200
 	// fixesMax bounds the whole file. Newest wins.
 	fixesMax = 2000
+	// fixesCandidateMax bounds the sightings held for a second confirmation.
+	// Newest first, like the pairs themselves, so a candidate ages out rather
+	// than displacing one that just arrived.
+	fixesCandidateMax = 2000
 )
 
 // FixPair is one error and the command that followed it without the error
@@ -56,6 +60,14 @@ type FixPair struct {
 	// Empty on a pair mined before this field existed; the version bump that
 	// ships it forces the rebuild that fills it.
 	Project string
+	// Candidate marks a sighting that is not a pair yet: the remedy named
+	// nothing the error named, and no other session has done the same thing
+	// after the same error. Evidence of the second kind accumulates across
+	// sessions, and sessions arrive one at a time — so judging a candidate
+	// against the update it arrived in threw it away before the session that
+	// would have confirmed it existed, and the pair was lost for good (#1301).
+	// Kept, and promoted on the second sighting; never served to a caller.
+	Candidate bool `json:",omitempty"`
 }
 
 func fixesPath(dir string) string { return filepath.Join(dir, fixesFile) }
@@ -85,7 +97,15 @@ func buildFixes(tmp string, ss []model.Session, keyOf func(model.Session) string
 	for _, p := range all {
 		if sharesTerm(p.Error, p.Command) || repeats[fixKey(p)] >= 2 {
 			out = append(out, p)
+			continue
 		}
+		// Not a pair, and not nothing: the second kind of evidence accumulates
+		// across sessions, and sessions arrive one at a time. Dropping a
+		// sighting here meant the session that would have confirmed it found
+		// nothing to confirm, so a full build reached pairs the same corpus
+		// grown one session at a time never did (#1301).
+		p.Candidate = true
+		out = append(out, p)
 	}
 	if len(out) == 0 {
 		return
@@ -97,15 +117,29 @@ func buildFixes(tmp string, ss []model.Session, keyOf func(model.Session) string
 	// and dropping all but its newest occurrence deleted the pair for every
 	// other signature it settled.
 	seen := map[string]bool{}
+	candidates, pairs := 0, 0
 	kept := out[:0]
 	for _, p := range out {
+		if p.Candidate {
+			if candidates >= fixesCandidateMax {
+				continue
+			}
+			candidates++
+		} else {
+			if pairs >= fixesMax {
+				continue
+			}
+			pairs++
+		}
 		k := fixKey(p)
 		if seen[k] {
 			continue
 		}
 		seen[k] = true
 		kept = append(kept, p)
-		if len(kept) >= fixesMax {
+		// Candidates have their own budget above, so the pair cap is what it
+		// was and this one bounds the file as a whole.
+		if len(kept) >= fixesMax+fixesCandidateMax {
 			break
 		}
 	}
@@ -324,23 +358,50 @@ func mergeFixes(dir, tmp string, replacements []model.Session, replaced map[stri
 	for _, p := range fresh {
 		repeats[fixKey(p)]++
 	}
+	// A candidate already on file is the evidence a later session needs, so it
+	// counts towards the second sighting — and once something is promoted, the
+	// candidate copy of it goes. Not redundant with the deduplication below:
+	// two sessions carrying the same timestamp sort either way, and when the
+	// candidate copy sorts first it is the one that survives, so the pair the
+	// second sighting just earned is never served.
+	promoted := map[string]bool{}
 	for _, p := range fresh {
 		k := fixKey(p)
 		if sharesTerm(p.Error, p.Command) || repeats[k]+seen[k] >= 2 {
+			p.Candidate = false
 			kept = append(kept, p)
+			promoted[k] = true
+			continue
+		}
+		p.Candidate = true
+		kept = append(kept, p)
+	}
+	for i := range kept {
+		if promoted[fixKey(kept[i])] {
+			kept[i].Candidate = false
 		}
 	}
 	sort.SliceStable(kept, func(i, j int) bool { return kept[i].When.After(kept[j].When) })
 	written := map[string]bool{}
 	out := kept[:0]
+	candidates := 0
 	for _, p := range kept {
 		k := fixKey(p)
 		if written[k] {
 			continue
 		}
+		// Candidates are bounded on their own. They serve nobody until a second
+		// session confirms them, so letting them share the pair budget would
+		// push real answers out of a table that is read whole.
+		if p.Candidate {
+			if candidates >= fixesCandidateMax {
+				continue
+			}
+			candidates++
+		}
 		written[k] = true
 		out = append(out, p)
-		if len(out) >= fixesMax {
+		if len(out) >= fixesMax+fixesCandidateMax {
 			break
 		}
 	}
@@ -384,6 +445,11 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 	var out []FixPair
 	for _, p := range ReadFixes(dir) {
 		if !sigs[p.Sig] {
+			continue
+		}
+		// One session doing something after an error is not evidence that it
+		// worked; it is half of it.
+		if p.Candidate {
 			continue
 		}
 		if allow != nil && !allow(p.Project) {

--- a/internal/index/fixpair_growth_test.go
+++ b/internal/index/fixpair_growth_test.go
@@ -1,0 +1,184 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// pairStore writes one session per call into the same project and re-indexes,
+// so sessions arrive the way they really do: one at a time.
+func pairStore(t *testing.T) (dir, proj string) {
+	t.Helper()
+	tmp := t.TempDir()
+	setHome(t, filepath.Join(tmp, "home"))
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	proj = filepath.Join(claude, "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(tmp, "index.db"), proj
+}
+
+// writePairSession puts an error and the command run after it into one session.
+func writePairSession(t *testing.T, proj, id, errText, cmd string) {
+	t.Helper()
+	line := func(role, text string) string {
+		switch role {
+		case "tool":
+			return `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":[{"type":"tool_result","content":"` + text + `"}]}}` + "\n"
+		default:
+			return `{"type":"assistant","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"` + text + `"}}]}}` + "\n"
+		}
+	}
+	body := line("tool", errText) + line("cmd", cmd)
+	if err := os.WriteFile(filepath.Join(proj, id+".jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A pair whose only evidence is that another session did the same thing after
+// the same error was lost when the sessions arrived one at a time: the first
+// candidate was rejected and forgotten, so the second had nothing to count
+// against (#1301).
+func TestACrossSessionPairSurvivesOneAtATimeArrival(t *testing.T) {
+	dir, proj := pairStore(t)
+	const errText = "undefined: renderInvoice in vendor/billing/api.go"
+	const cmd = "go mod vendor \\u0026\\u0026 go build ./..."
+
+	writePairSession(t, proj, "one", errText, cmd)
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := FixesFor(dir, errText, 3, nil); len(got) != 0 {
+		t.Fatalf("one session is not evidence yet, got %d pairs", len(got))
+	}
+
+	writePairSession(t, proj, "two", errText, cmd)
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	got := FixesFor(dir, errText, 3, nil)
+	if len(got) == 0 {
+		t.Fatalf("the second session confirmed the remedy and the pair is still missing")
+	}
+}
+
+// The whole-corpus build and the one-at-a-time build have to agree, which is
+// the measurement the issue reported failing.
+func TestPairsAgreeWhicheverWayTheIndexGotThere(t *testing.T) {
+	const errText = "undefined: renderInvoice in vendor/billing/api.go"
+	const cmd = "go mod vendor \\u0026\\u0026 go build ./..."
+
+	grownDir, grownProj := pairStore(t)
+	writePairSession(t, grownProj, "one", errText, cmd)
+	if err := Ensure(grownDir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	writePairSession(t, grownProj, "two", errText, cmd)
+	if err := Ensure(grownDir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	wholeDir, wholeProj := pairStore(t)
+	writePairSession(t, wholeProj, "one", errText, cmd)
+	writePairSession(t, wholeProj, "two", errText, cmd)
+	if err := Ensure(wholeDir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	whole := len(FixesFor(wholeDir, errText, 3, nil))
+	grown := len(FixesFor(grownDir, errText, 3, nil))
+	if whole != grown {
+		t.Errorf("built whole gives %d pairs, grown one session at a time gives %d", whole, grown)
+	}
+}
+
+// A candidate is not an answer. Until a second session confirms it, nothing
+// serves it — one session doing something after an error is half the evidence.
+func TestACandidateIsNeverServed(t *testing.T) {
+	dir, proj := pairStore(t)
+	const errText = "undefined: renderInvoice in vendor/billing/api.go"
+	writePairSession(t, proj, "one", errText, "go mod vendor \\u0026\\u0026 go build ./...")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := FixesFor(dir, errText, 3, nil); len(got) != 0 {
+		t.Errorf("a single sighting was served as a pair: %+v", got)
+	}
+	// It is on file, though — that is the point.
+	held := 0
+	for _, p := range ReadFixes(dir) {
+		if p.Candidate {
+			held++
+		}
+	}
+	if held == 0 {
+		t.Error("the sighting was thrown away, so a later session has nothing to confirm")
+	}
+}
+
+// The incremental path has its own merge, and it is the one a live machine
+// actually runs: sessions arrive one at a time, and the carried table is where
+// the earlier sighting has to be waiting.
+func TestTheIncrementalMergePromotesACarriedCandidate(t *testing.T) {
+	dir := t.TempDir()
+	const errText = "psql: connection refused on port 5432"
+	const cmd = "brew services start postgresql"
+	carried := []FixPair{{
+		Sig: frictionHash(errText), Error: errText, Command: cmd,
+		Key: "claude:one", When: time.Now().Add(-time.Hour), Candidate: true,
+	}}
+	if err := writeGob(fixesPath(dir), carried); err != nil {
+		t.Fatal(err)
+	}
+	// A second session does the same thing after the same error.
+	second := model.Session{Harness: "claude", ID: "two", Messages: []model.Message{
+		{Role: roleToolOutput, Text: errText, Time: time.Now()},
+		{Role: roleCommand, Text: cmd, Time: time.Now()},
+	}}
+	mergeFixes(dir, dir, []model.Session{second}, map[string]bool{})
+	served := 0
+	for _, p := range ReadFixes(dir) {
+		if !p.Candidate {
+			served++
+		}
+	}
+	if served == 0 {
+		t.Errorf("a carried sighting plus a fresh one did not make a pair: %+v", ReadFixes(dir))
+	}
+	// And the candidate copy of the same thing is gone, so the table does not
+	// carry both readings of one fact.
+	for _, p := range ReadFixes(dir) {
+		if p.Candidate && p.Command == cmd {
+			t.Errorf("the promoted pair is still marked a candidate: %+v", p)
+		}
+	}
+}
+
+// And the merge keeps a sighting it sees for the first time, so the session
+// that arrives tomorrow has something to confirm. Two updates, one session
+// each, which is what a live machine does all day.
+func TestTheIncrementalMergeKeepsAFirstSighting(t *testing.T) {
+	dir := t.TempDir()
+	const errText = "psql: connection refused on port 5432"
+	const cmd = "brew services start postgresql"
+	session := func(id string, when time.Time) model.Session {
+		return model.Session{Harness: "claude", ID: id, Messages: []model.Message{
+			{Role: roleToolOutput, Text: errText, Time: when},
+			{Role: roleCommand, Text: cmd, Time: when.Add(time.Second)},
+		}}
+	}
+	mergeFixes(dir, dir, []model.Session{session("one", time.Now().Add(-time.Hour))}, map[string]bool{})
+	if got := FixesFor(dir, errText, 3, nil); len(got) != 0 {
+		t.Fatalf("one sighting was served as a pair: %+v", got)
+	}
+	mergeFixes(dir, dir, []model.Session{session("two", time.Now())}, map[string]bool{})
+	if got := FixesFor(dir, errText, 3, nil); len(got) == 0 {
+		t.Errorf("the second update confirmed the remedy and nothing was served: %+v", ReadFixes(dir))
+	}
+}

--- a/internal/index/fixpair_test.go
+++ b/internal/index/fixpair_test.go
@@ -62,9 +62,18 @@ func TestBuildFixesDropsTheUnrelatedNextCommand(t *testing.T) {
 	}
 	dir := t.TempDir()
 	buildFixes(dir, []model.Session{unrelated, related}, func(s model.Session) string { return s.Harness + ":" + s.ID })
-	got := ReadFixes(dir)
+	// The unrelated one is kept as a candidate — a second session doing the
+	// same thing after the same error is the other half of the evidence, and
+	// sessions arrive one at a time (#1301). It is never served; that is what
+	// the lookup below checks.
+	var got []FixPair
+	for _, p := range ReadFixes(dir) {
+		if !p.Candidate {
+			got = append(got, p)
+		}
+	}
 	if len(got) != 1 {
-		t.Fatalf("want only the related pair, got %d: %+v", len(got), got)
+		t.Fatalf("want only the related pair served, got %d: %+v", len(got), ReadFixes(dir))
 	}
 	if got[0].Key != "claude:s2" {
 		t.Errorf("kept the wrong pair: %+v", got[0])


### PR DESCRIPTION
Fixes #1301.

A fix pair is kept when the command names something the error named, **or** when the same remedy followed the same error in another session. The second kind of evidence accumulates across sessions — and sessions arrive one at a time. The first candidate was rejected and forgotten, so when the second arrived there was nothing left to count it against, and the pair was lost for good:

```
built whole:                 undefined: renderInvoice in vendor/billing/api.go
                               ran next: $ go mod vendor && go build ./...
grown one session at a time: deja: no session on this machine ran a command after that error
```

So the evidence survives being rejected. A sighting that fails the rule is stored marked `Candidate`: it counts towards the second sighting, it is never served to anyone, and it is promoted when a later session does the same thing after the same error. Both mining paths do it — the full build and the incremental merge — since either can be the one that sees a session first.

The issue's rejected approach (replaying `records.bin` per session) is not taken, for the four reasons measured there.

Details worth knowing:

- **Candidates have their own budget.** They serve nobody until confirmed, so sharing the pair budget would push real answers out of a table that is read whole.
- **The promoted copy wins.** Clearing the mark is not redundant with the deduplication: two sessions indexed in one pass carry the same timestamp, the sort is stable, and when the candidate copy sorts first it is the one that survives. Removing that loop breaks the end-to-end test, which is how I know.
- **Candidates go through the same scrub** as carried pairs, and are mined from sessions already redacted, so nothing is persisted that a pair would not have been.
- Additive field: an index built before this simply has no candidates and starts collecting them on the next update.

Tests: a cross-session pair surviving one-at-a-time arrival, whole and grown builds agreeing on the count, a candidate never being served but being on file, the incremental merge keeping a first sighting, and the same merge promoting a carried one. Six mutations verified; two of them caught blind tests, and one proved a line I had thought redundant is load-bearing.
