### PR TITLE
fix: a greeting does not name the session

### DIFF
--- a/internal/index/greeting_title_test.go
+++ b/internal/index/greeting_title_test.go
@@ -1,0 +1,91 @@
+package index
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func titleOf(ms ...model.Message) string {
+	t, _ := sessionTitleFrom(model.Session{Messages: ms})
+	return t
+}
+
+func userAt(text string, min int) model.Message {
+	return model.Message{Role: "user", Text: text, Time: time.Date(2026, 1, 2, 3, min, 0, 0, time.UTC)}
+}
+
+// A session that opens with a greeting was named after it — 17 rows reading
+// "hi" on a real 800-session store, with the turn that says what the work was
+// one line below (#790).
+func TestAGreetingDoesNotNameTheSession(t *testing.T) {
+	for _, opener := range []string{"hi", "привет", "say ok", "hello again"} {
+		got := titleOf(userAt(opener, 0), userAt("why does the docker build fail on arm64", 1))
+		if got != "why does the docker build fail on arm64" {
+			t.Errorf("opener %q: session titled %q", opener, got)
+		}
+	}
+}
+
+// A short instruction is not a greeting, and the length rule has to leave it
+// alone: three words, or anything long enough to say what it wants.
+func TestAShortInstructionKeepsItsTitle(t *testing.T) {
+	for _, opener := range []string{"fix the build", "run the tests", "deploy staging"} {
+		got := titleOf(userAt(opener, 0), userAt("and then the deploy to staging failed again", 1))
+		if got != opener {
+			t.Errorf("instruction %q was retitled to %q", opener, got)
+		}
+	}
+}
+
+// With nothing else to go on, the short turn still names the session: a title
+// that says little beats no title at all.
+func TestAGreetingAloneStillNamesTheSession(t *testing.T) {
+	if got := titleOf(userAt("hi", 0)); got != "hi" {
+		t.Errorf("a one-turn session lost its title: %q", got)
+	}
+	if got := titleOf(userAt("hi", 0), userAt("ok", 1)); got != "hi" {
+		t.Errorf("two thin turns should keep the first: %q", got)
+	}
+}
+
+// Ordered by the clock, like every other title path — a store titled locally
+// and the same store imported elsewhere have to agree (#769).
+func TestTheReplacementTitleFollowsTheClock(t *testing.T) {
+	// The earlier turn sits later in the slice, so only the clock can pick it.
+	got := titleOf(
+		userAt("hi", 0),
+		userAt("the second thing I asked", 5),
+		userAt("the first thing I asked", 1),
+	)
+	if got != "the first thing I asked" {
+		t.Errorf("the replacement did not follow the clock: %q", got)
+	}
+	// And the other way round, so neither slice order passes by luck.
+	got = titleOf(
+		userAt("hi", 0),
+		userAt("the earlier thing I asked", 1),
+		userAt("the later thing I asked", 5),
+	)
+	if got != "the earlier thing I asked" {
+		t.Errorf("the replacement did not follow the clock: %q", got)
+	}
+	got = titleOf(
+		userAt("hi", 0),
+		userAt("the second thing I asked", 5),
+		userAt("the first thing I asked", 1),
+	)
+	if got != "the first thing I asked" {
+		t.Errorf("the replacement did not follow the clock: %q", got)
+	}
+}
+
+// The format version is what makes existing rows re-derive their titles:
+// incremental ingest reuses the row it already has, so the rules can change
+// and nothing re-reads them (#784, and #790 for this change).
+func TestTitleRulesRideOnTheFormatVersion(t *testing.T) {
+	if version < 26 {
+		t.Errorf("index version is %d — the title rules changed without the bump that re-derives them", version)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -43,7 +43,12 @@ import (
 // line with nothing — or, once the field was added, without the per-project
 // session counts the trust policy needs. The bump forces the one rebuild that
 // mines them both.
-const version = 25
+// 26: a session that opens with a greeting was titled "hi" — 17 rows of one
+// real 800-session store, and the turn that says what the work was sits one
+// line below (#790). Titles are part of this version for the reason 22 gives:
+// incremental ingest reuses the row it already has, so nothing re-derives them
+// without a bump.
+const version = 26
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1472,6 +1472,18 @@ func sessionTitle(s model.Session) string {
 // `stats`; it is named after its first output instead.
 func sessionTitleFrom(s model.Session) (title string, fromAgent bool) {
 	if t := earliestTitle(s.Messages, "user"); t != "" {
+		if thinTitle(t) {
+			// A session that opens with a greeting was named after it: on a real
+			// 800-session store, 17 rows read "hi" and 3 "привет", with the turn
+			// that says what the work was one line below (#790). No word list —
+			// any of those is language-bound, and this store has two languages
+			// in the sample already. A turn too short to name anything gives way
+			// to the next one that can, and stands on its own when there is
+			// none.
+			if next := nextSubstantialTitle(s.Messages, t); next != "" {
+				return next, false
+			}
+		}
 		return t, false
 	}
 	if t := earliestTitle(s.Messages, "assistant"); t != "" {
@@ -1514,6 +1526,42 @@ func earliestTitle(ms []model.Message, role string) string {
 		case best == "":
 		case bestAt.IsZero(), msg.Time.IsZero():
 			// Nothing to compare: the first one found stands.
+			continue
+		case !msg.Time.Before(bestAt):
+			continue
+		}
+		best, bestAt = t, msg.Time
+	}
+	return best
+}
+
+// thinTitle reports that a turn is too short to name a session by.
+//
+// Two words and twelve runes: "hi", "привет", "say ok", "reply ok" are inside
+// it, and the short instructions worth keeping — "fix the build", "run the
+// tests" — are not. A length rule rather than a vocabulary is the only version
+// of this that works in every language the store holds.
+func thinTitle(t string) bool {
+	return len(strings.Fields(t)) <= 2 && len([]rune(t)) <= 12
+}
+
+// nextSubstantialTitle is the first later user turn that can name the session.
+// Ordered by the clock like earliestTitle, so a store titled locally and the
+// same store imported elsewhere agree.
+func nextSubstantialTitle(ms []model.Message, skip string) string {
+	best := ""
+	var bestAt time.Time
+	for _, msg := range ms {
+		if msg.Role != "user" {
+			continue
+		}
+		t := strings.TrimSpace(msg.Text)
+		if t == skip || !titleWorthy(t) || thinTitle(t) {
+			continue
+		}
+		switch {
+		case best == "":
+		case bestAt.IsZero(), msg.Time.IsZero():
 			continue
 		case !msg.Time.Before(bestAt):
 			continue


### PR DESCRIPTION
Fixes #790.

A session that opens with a greeting was named after it, and the turn that says what the work was sits one line below. Re-measured on a 1552-session store while writing this: 49 titles are short enough to say nothing, and the top of that list is

```
27x "hi"    6x "say ok"    3x "reply ok"    3x "привет"    2x "say hi"    1x "скажи ок"
```

with no legitimate instruction among them.

The rule is length, not vocabulary: two words and twelve runes. Any word list is language-bound, and this store has two languages in that sample alone. A turn that thin gives way to the next user turn that can name the session, ordered by the clock like every other title path, and stands on its own when there is none — a title that says little beats no title at all. "fix the build", "run the tests" and "deploy staging" are outside the bound and keep their titles.

Title rules are part of the format version for the reason version 22 gives: incremental ingest reuses the row it already has, so the rules can change and nothing re-derives them. This is version 26, so the one rebuild that re-derives titles happens. That rebuild is much less unpleasant than it was a few PRs ago — an agent now gets told the index is being rebuilt for this version instead of waiting inside a tool call (#1309).

Tests: greetings in both languages giving way, short instructions keeping their titles, a greeting alone still naming its session, the replacement following the clock in both slice orders, and the version bump itself. Five mutations verified; three of them caught blind tests, including one where the fixture's follow-up was itself too short to be picked.
