### PR TITLE
fix: budget hits, files and restore against the terminal width

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -350,6 +350,20 @@ func briefTitleBudget(prefixLen int) int {
 	return room
 }
 
+// printableWidth is briefWidth for a writer that may not be a terminal at all.
+// A pipe gets zero, which every caller reads as "do not cut": a script wants
+// the text, not the layout (#604).
+//
+// COLUMNS still counts on a pipe, because bash and zsh set it without
+// exporting it — a child process only sees it when someone exported it on
+// purpose, which is the same override briefWidth already honours.
+func printableWidth(w io.Writer) int {
+	if os.Getenv("COLUMNS") == "" && !statColorOK(w) {
+		return 0
+	}
+	return briefWidth()
+}
+
 func briefWidth() int {
 	// COLUMNS first: a reader who exports it is overriding the terminal on
 	// purpose, and scripts set it to pin the layout.

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -245,8 +245,18 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		rows = rows[:limit]
 	}
 	fmt.Fprintf(stdout, "files touched while working on %q — %d session%s%s\n", q, scanned, plural(scanned), filesReadNote(matched))
+	// The path column was a fixed 56, which on a 60-column pane leaves nothing
+	// for the count and wraps every row (#604). Budgeted against the window
+	// instead, with the same 56 when the window is wide enough or unknown.
+	col := 56
+	if w := printableWidth(stdout); w > 0 && w-6 < col {
+		col = w - 6
+		if col < 16 {
+			col = 16
+		}
+	}
 	for _, r := range rows {
-		fmt.Fprintf(stdout, "  %-56s %d\n", trimPath(r.path), r.n)
+		fmt.Fprintf(stdout, "  %-*s %d\n", col, trimPathTo(trimPath(r.path), col), r.n)
 	}
 	return nil
 }
@@ -373,6 +383,20 @@ func inRepositoryUncached(p string) bool {
 }
 
 var repoCheck sync.Map
+
+// trimPathTo bounds a path to a column width, cutting from the left so the
+// file name survives: the tail is what identifies it, and a head-first cut
+// leaves rows that all read "…/src/".
+func trimPathTo(p string, width int) string {
+	r := []rune(p)
+	if width <= 0 || len(r) <= width {
+		return p
+	}
+	if width < 4 {
+		return string(r[len(r)-width:])
+	}
+	return "…" + string(r[len(r)-(width-1):])
+}
 
 // trimPath keeps the tail that identifies a file without the home directory in
 // front of it.

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -929,6 +929,11 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 		// this one too.
 		fmt.Fprintf(os.Stderr, "deja: showing %d of %d — add --all to see the rest\n", len(hits), o.Total)
 	}
+	// The window this is being printed into, so the lines can be budgeted
+	// rather than assumed 80 wide. Only for a terminal: a pipe gets the whole
+	// line, since a script reading deja wants the text and not the layout
+	// (#604).
+	o.Width = printableWidth(os.Stdout)
 	search.Print(os.Stdout, hits, o)
 	return nil
 }

--- a/cmd/deja/restore.go
+++ b/cmd/deja/restore.go
@@ -87,9 +87,22 @@ func runRestore(dir string, args []string, stdout io.Writer) error {
 	}
 	if want == 0 {
 		fmt.Fprintf(stdout, "%d replaced spans recorded for %s\n", len(spans), path)
+		// The row carries a date, a harness, a session id and a size, and on a
+		// narrow pane it wrapped between them (#604). The id is what the reader
+		// copies into the next command, so the harness gives way first.
+		width := printableWidth(stdout)
 		for i, s := range spans {
+			harness := s.harness
+			if width > 0 {
+				fixed := len(fmt.Sprintf("  %d  %s   %s  %d B replaced%s", i+1, s.when.Format("Jan 02 15:04"), shortID(s.session), len(s.body), redactionNote(s.body)))
+				// Runes, not bytes: a harness name is ASCII today and a
+				// byte cut would produce invalid UTF-8 the day one is not.
+				if r := []rune(harness); width-fixed < len(r) && width-fixed >= 3 {
+					harness = string(r[:width-fixed-1]) + "…"
+				}
+			}
 			fmt.Fprintf(stdout, "  %d  %s  %s %s  %d B replaced%s\n",
-				i+1, s.when.Format("Jan 02 15:04"), s.harness, shortID(s.session),
+				i+1, s.when.Format("Jan 02 15:04"), harness, shortID(s.session),
 				len(s.body), redactionNote(s.body))
 		}
 		fmt.Fprintf(stdout, "\ndeja restore %s --span 1 -o recovered.txt\n", path)

--- a/cmd/deja/width_surfaces_test.go
+++ b/cmd/deja/width_surfaces_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// widthStore indexes one session that names several files inside a repository
+// on this disk — `files` only reports paths it can still find, so the fixture
+// has to build the tree as well as the transcript.
+func widthStore(t *testing.T) {
+	t.Helper()
+	hermeticEnv(t)
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var paths []string
+	for _, rel := range []string{
+		"internal/application/partner/requests.go",
+		"internal/domain/partner/webhook_delivery.go",
+	} {
+		full := filepath.Join(repo, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("package partner\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, full)
+	}
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	b.WriteString(`{"type":"user","message":{"role":"user","content":"why does the retry queue stall on staging when the workers back off with a fixed delay instead of full jitter, and every one of them wakes at the same moment"},"timestamp":"2026-08-02T10:00:00Z","sessionId":"aaa","cwd":"/app"}` + "\n")
+	for _, full := range paths {
+		esc := strings.ReplaceAll(full, `\`, `\\`)
+		b.WriteString(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"` + esc + `"}}]},"timestamp":"2026-08-02T10:01:00Z","sessionId":"aaa","cwd":"/app"}` + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(proj, "a.jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The path column was a fixed 56, so on a 60-column pane every row wrapped
+// (#604). COLUMNS is the override a reader sets on purpose, and it is what a
+// test can drive without a pty.
+func TestFilesFitsTheTerminal(t *testing.T) {
+	widthStore(t)
+	t.Setenv("COLUMNS", "50")
+	out, err := captureRun(t, "files", "retry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := 0
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "  ") {
+			continue
+		}
+		rows++
+		if len([]rune(line)) > 50 {
+			t.Errorf("a row ran to %d runes at COLUMNS=50: %q", len([]rune(line)), line)
+		}
+		if !strings.HasSuffix(strings.TrimSpace(line), "1") {
+			t.Errorf("the count fell off the row: %q", line)
+		}
+	}
+	if rows == 0 {
+		t.Fatalf("no file rows to judge:\n%s", out)
+	}
+}
+
+// The tail of a path is what identifies it, so the cut takes the head.
+func TestFilesKeepsTheFileName(t *testing.T) {
+	widthStore(t)
+	t.Setenv("COLUMNS", "44")
+	out, err := captureRun(t, "files", "retry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "requests.go") || !strings.Contains(out, "webhook_delivery.go") {
+		t.Errorf("a narrow window lost the file names:\n%s", out)
+	}
+}
+
+// A pipe is not a terminal: the whole path goes out, because a script reading
+// this wants the text rather than the layout.
+func TestFilesIsNotCutWhenPiped(t *testing.T) {
+	widthStore(t)
+	// First with a narrow window, to show the fixture's paths are long enough
+	// that cutting would be visible at all.
+	t.Setenv("COLUMNS", "44")
+	out, err := captureRun(t, "files", "retry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The width cut takes more than trimPath's head removal does, which is what
+	// gives the pipe assertion below something to be different from.
+	if strings.Contains(out, filepath.ToSlash(filepath.Join("internal", "application", "partner", "requests.go"))) {
+		t.Fatalf("a narrow window did not cut these paths, so this test means nothing:\n%s", out)
+	}
+	// Narrow enough that a terminal would have cut it, and the pipe must not.
+	t.Setenv("COLUMNS", "")
+	out, err = captureRun(t, "files", "retry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// trimPath still drops the head of a deep path (#727); what must not happen
+	// is a second, width-driven cut on top of it.
+	if !strings.Contains(out, filepath.ToSlash(filepath.Join("internal", "application", "partner", "requests.go"))) {
+		t.Errorf("the path a pipe gets was cut further than trimPath cuts:\n%s", out)
+	}
+}
+
+// And the search itself: the printer can budget all it likes, but the width has
+// to reach it from the command that owns the terminal.
+func TestSearchOutputFitsTheTerminal(t *testing.T) {
+	widthStore(t)
+	t.Setenv("COLUMNS", "50")
+	out, err := captureRun(t, "retry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := false
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "  ") {
+			continue
+		}
+		seen = true
+		if len([]rune(line)) > 50 {
+			t.Errorf("a snippet ran to %d runes at COLUMNS=50: %q", len([]rune(line)), line)
+		}
+	}
+	if !seen {
+		t.Fatalf("no snippet lines to judge:\n%s", out)
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -61,7 +61,12 @@ type Options struct {
 	// WithAnswer carries the assistant reply next to a matched user turn.
 	// Agent-facing recall sets it; human CLI output does not, because a person
 	// reading results can open the session.
-	WithAnswer                bool
+	WithAnswer bool
+	// Width is the terminal the answer is being printed into, so lines can be
+	// budgeted rather than assumed 80 columns wide. A 60-column pane is what a
+	// split editor gives you, and there every hit wrapped mid-word (#604).
+	// Zero means "not a terminal, or unknown": nothing is cut.
+	Width                     int
 	All, JSON, Fuzzy, Stemmed bool
 	NoEmbed                   bool
 	Semantic                  bool                `json:"-"`

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1126,6 +1126,11 @@ func Print(w io.Writer, hits []Hit, o Options) {
 		// line the way it would in blame. Snippets below are already SafeText'd.
 		project := SafeLine(h.Session.Project)
 		id := SafeLine(short(h.Session.ID))
+		// The project column gives way first. Cutting the line at its end takes
+		// the match count and half the word "matches" with it, and those are
+		// what a reader scans; the project is the one field that is long
+		// because a directory was named at length (#604).
+		project = fitProject(project, o.Width, h.Session.Harness, d, id, h.Count, tierLabel(h))
 		if color {
 			fmt.Fprintf(w, "%s%s %-10s %s %s %s %s %s%s%d matches%s%s\n", cBold, harnessTag(h.Session.Harness, true), project, cDim+"·"+cReset+cBold, d, cDim+"·"+cReset+cBold, id, cDim+"— "+cReset, cBold, h.Count, cReset, tierLabel(h))
 		} else {
@@ -1177,9 +1182,109 @@ func Print(w io.Writer, hits []Hit, o Options) {
 			fmt.Fprintln(w, note)
 		}
 		for _, sn := range h.Snippets {
-			fmt.Fprintf(w, "  %s\n", highlight(SafeText(sn), o.Query, o.Regex, color))
+			// Cut before the highlight, not after: the colour codes are not
+			// characters the terminal counts, so trimming the rendered string
+			// would cut a different number of visible runes on every line.
+			fmt.Fprintf(w, "  %s\n", highlight(SafeText(fitLine(sn, o.Width-2)), o.Query, o.Regex, color))
 		}
 	}
+}
+
+// fitProject bounds the one variable-width field on a hit header so the rest of
+// the line survives a narrow terminal. Six runes is the floor: below that the
+// name says nothing and the reader is better served by the ellipsis alone.
+//
+// Narrower than the rest of the line needs, the line is left to wrap. What is
+// left is the harness, the date, the session id and the count, and the id is
+// the field a reader copies into `deja show` — cutting it further would hand
+// them a prefix that matches nothing, which is the trap #859 already worded a
+// message for.
+func fitProject(project string, width int, harness, date, id string, count int, tier string) string {
+	if width <= 0 {
+		return project
+	}
+	// The column is padded to ten, so a name shorter than that costs ten either
+	// way and the budget has to say so.
+	fixed := columns(fmt.Sprintf("[%s]  · %s · %s — %d matches%s", harness, date, id, count, tier))
+	room := width - fixed
+	if room < 10 {
+		room = 10
+	}
+	if columns(project) <= room {
+		return project
+	}
+	if room < 6 {
+		room = 6
+	}
+	return cutToColumns(project, room-1) + "…"
+}
+
+// fitLine cuts a line to the width it is being printed into, counting runes
+// rather than bytes. Width zero — piped output, or a terminal that would not
+// say — leaves the line alone: a script reading deja's output wants the whole
+// thing, and truncating there would lose data rather than layout.
+func fitLine(s string, width int) string {
+	if width <= 0 {
+		return s
+	}
+	if width < 8 {
+		width = 8
+	}
+	if columns(s) <= width {
+		return s
+	}
+	// One column short of the width, for the ellipsis.
+	return strings.TrimRight(cutToColumns(s, width-1), " ") + "…"
+}
+
+// columns is how wide a string prints. A CJK character is one rune and two
+// columns, so counting runes cut a Chinese or Japanese line to twice the
+// terminal's width — worse than the wrapping this exists to prevent, since the
+// text is lost rather than reflowed.
+func columns(s string) int {
+	n := 0
+	for _, r := range s {
+		n += runeColumns(r)
+	}
+	return n
+}
+
+// runeColumns is the East Asian Wide and Fullwidth ranges, plus the emoji
+// blocks terminals render double. Everything else counts as one: this is a
+// layout budget, not a Unicode implementation, and being wrong by a column on
+// an unusual rune costs a wrap rather than data.
+func runeColumns(r rune) int {
+	switch {
+	case r >= 0x1100 && r <= 0x115F, // Hangul Jamo
+		r >= 0x2E80 && r <= 0x303E, // CJK radicals, Kangxi
+		r >= 0x3041 && r <= 0x33FF, // kana, Hangul compatibility, CJK symbols
+		r >= 0x3400 && r <= 0x4DBF, // CJK extension A
+		r >= 0x4E00 && r <= 0x9FFF, // CJK unified ideographs
+		r >= 0xA000 && r <= 0xA4CF, // Yi
+		r >= 0xAC00 && r <= 0xD7A3, // Hangul syllables
+		r >= 0xF900 && r <= 0xFAFF, // CJK compatibility ideographs
+		r >= 0xFE30 && r <= 0xFE6F, // CJK compatibility forms
+		r >= 0xFF00 && r <= 0xFF60, // fullwidth forms
+		r >= 0xFFE0 && r <= 0xFFE6,
+		r >= 0x1F300 && r <= 0x1F64F, // emoji
+		r >= 0x1F900 && r <= 0x1F9FF,
+		r >= 0x20000 && r <= 0x3FFFD: // CJK extensions B and beyond
+		return 2
+	}
+	return 1
+}
+
+// cutToColumns keeps as much of s as fits in width columns.
+func cutToColumns(s string, width int) string {
+	n := 0
+	for i, r := range s {
+		w := runeColumns(r)
+		if n+w > width {
+			return s[:i]
+		}
+		n += w
+	}
+	return s
 }
 
 func tierLabel(h Hit) string {

--- a/internal/search/width_test.go
+++ b/internal/search/width_test.go
@@ -1,0 +1,108 @@
+package search
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+func widthHit(project, snippet string) Hit {
+	return Hit{
+		Session: model.Session{
+			Harness: "claude", Project: project, ID: "abc123def456",
+			Updated: time.Date(2026, 8, 2, 10, 0, 0, 0, time.UTC),
+		},
+		Count:    3,
+		Snippets: []string{snippet},
+	}
+}
+
+// A 60-column pane is what a split editor gives you, and there every hit
+// wrapped mid-word — on the first screen a new user sees (#604).
+func TestHitsFitTheTerminal(t *testing.T) {
+	long := "we decided the retry queue should back off with full jitter rather than a fixed delay, because the fixed one synchronised every worker"
+	for _, width := range []int{40, 60, 80, 100} {
+		var buf bytes.Buffer
+		Print(&buf, []Hit{widthHit("app", long)}, query.Options{Width: width})
+		for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+			if strings.HasPrefix(line, "  ") && len([]rune(line)) > width {
+				t.Errorf("width %d: a snippet ran to %d runes: %q", width, len([]rune(line)), line)
+			}
+		}
+	}
+}
+
+// A pipe gets the whole line: a script reading deja wants the text, and cutting
+// it there would lose data rather than layout.
+func TestAPipeIsNotTruncated(t *testing.T) {
+	long := strings.Repeat("alpha beta ", 30)
+	var buf bytes.Buffer
+	Print(&buf, []Hit{widthHit("app", long)}, query.Options{})
+	if !strings.Contains(buf.String(), strings.TrimSpace(long)) {
+		t.Errorf("piped output was cut:\n%s", buf.String())
+	}
+}
+
+// The project column gives way first: cutting the line at its end takes the
+// match count with it, and that is what a reader scans.
+func TestTheProjectGivesWayBeforeTheCount(t *testing.T) {
+	var buf bytes.Buffer
+	Print(&buf, []Hit{widthHit("a-very-long-project-directory-name", "short")}, query.Options{Width: 60})
+	line := strings.Split(buf.String(), "\n")[0]
+	if !strings.Contains(line, "3 matches") {
+		t.Errorf("the count was cut off the header: %q", line)
+	}
+	if !strings.Contains(line, "…") {
+		t.Errorf("the project was not shortened: %q", line)
+	}
+	if !strings.Contains(line, "abc123") {
+		t.Errorf("the id a reader copies is gone: %q", line)
+	}
+}
+
+// And a wide terminal keeps everything.
+func TestAWideTerminalCutsNothing(t *testing.T) {
+	var buf bytes.Buffer
+	Print(&buf, []Hit{widthHit("app", "the retry queue stalls")}, query.Options{Width: 200})
+	if strings.Contains(buf.String(), "…") {
+		t.Errorf("a wide terminal still elided:\n%s", buf.String())
+	}
+}
+
+// A CJK line is one rune per two columns, so counting runes cut it to twice the
+// terminal's width — worse than the wrap this exists to prevent, because the
+// text is gone rather than reflowed.
+func TestAWideScriptLineFitsToo(t *testing.T) {
+	cjk := strings.Repeat("调度器的重试队列在预发环境卡住", 6)
+	var buf bytes.Buffer
+	Print(&buf, []Hit{widthHit("app", cjk)}, query.Options{Width: 60})
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		if !strings.HasPrefix(line, "  ") {
+			continue
+		}
+		if got := columns(line); got > 60 {
+			t.Errorf("a CJK snippet printed %d columns wide: %q", got, line)
+		}
+	}
+}
+
+// And the measure itself, since every budget above depends on it.
+func TestColumnsCountsWideRunes(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want int
+	}{
+		{"abc", 3},
+		{"调度", 4},
+		{"a调b", 4},
+		{"", 0},
+	} {
+		if got := columns(tc.in); got != tc.want {
+			t.Errorf("columns(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #604.

#1367 taught the brief, the status line and the logo to read the terminal. This is the rest of the issue's ask — the surfaces that still assumed 80 columns:

- **search hits**: snippets are cut to the window, and the project column gives way before the match count does. Cutting a line at its end takes "3 matches" and half the word with it, and that is what a reader scans; the project is the one field that is long because someone named a directory at length. The session id is never shortened further — it is what gets copied into `deja show`, and a prefix that matches nothing is the trap #859 already had to word a message for.
- **`deja files`**: the path column was a fixed 56, so at 60 columns every row wrapped. It is budgeted against the window now, and the cut takes the head — the tail of a path is what identifies it, and cutting the other way leaves rows that all read `…/src/`.
- **`deja restore`**: the harness gives way rather than the session id, same reasoning.

A pipe gets the whole line: zero width means "do not cut", because a script reading deja wants the text and not the layout. `COLUMNS` still counts on a pipe, since bash and zsh set it without exporting it — a child sees it only when someone exported it deliberately, which is the override `briefWidth` already honours.

Review caught that all of this was counting runes, which is the wrong measure for the scripts deja indexes: a CJK character is one rune and two columns, so a Chinese snippet was cut to twice the window. There is a small `columns()` now — the East Asian wide ranges plus the emoji blocks — and everything budgets in columns.

Not covered, and worth its own decision: titles are elided to 60 runes at index time, so a wide terminal cannot show more than that however much room it has. Moving that cut to print time is a format change.

Tests: hits fitting at 40/60/80/100, a pipe left whole, the project yielding before the count, a wide terminal cutting nothing, a CJK line fitting, the `columns` measure itself, and `files` at 50 and 44 columns plus piped. Six mutations verified, one of which caught a test that could not fail.
