### PR TITLE
fix: give every atomic write its own temp name

### DIFF
--- a/cmd/deja/forget_failure_cause_test.go
+++ b/cmd/deja/forget_failure_cause_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -43,10 +44,17 @@ func TestForgetPromotedTitlesKeepsTheNotesFileOnFailure(t *testing.T) {
 	if err := os.WriteFile(notes, []byte(line+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// A directory in the temp file's place: the write cannot succeed.
-	if err := os.Mkdir(notes+".tmp", 0o755); err != nil {
+	// A read-only directory: the rewrite cannot create its temp file at all.
+	// This used to put a directory where the temp file would go, which worked
+	// while the temp name was derived from the destination — it is unique per
+	// writer now, so two `deja remember` calls cannot land on one name (#1319).
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("a read-only directory does not stop a write here")
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
 	if _, err := sources.ForgetPromotedTitles(func(src string) bool { return src == "claude:s1" }); err == nil {
 		t.Fatal("the rewrite reported success")
 	}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -20,6 +20,8 @@ import (
 	"github.com/vshulcz/deja-vu/internal/prompt"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/usage"
+
+	"github.com/vshulcz/deja-vu/internal/atomicfile"
 )
 
 // promptHookBudget keeps per-prompt injections small: this fires on every
@@ -424,11 +426,7 @@ func rotateHookseen(p, sid string) {
 			keep = append(keep, ln)
 		}
 	}
-	tmp := p + ".tmp"
-	if err := os.WriteFile(tmp, []byte(strings.Join(keep, "\n")+"\n"), 0o600); err != nil {
-		return
-	}
-	_ = os.Rename(tmp, p)
+	_ = atomicfile.Write(p, []byte(strings.Join(keep, "\n")+"\n"), 0o600)
 }
 
 // rememberInjectedIDs records arbitrary dedupe tokens against a session, so a

--- a/cmd/deja/warmup_status.go
+++ b/cmd/deja/warmup_status.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+
+	"github.com/vshulcz/deja-vu/internal/atomicfile"
 )
 
 // The first build takes about ten seconds on a real corpus. It already runs
@@ -94,10 +96,7 @@ func (f *fileProgress) flush(force bool) {
 	if err := os.MkdirAll(filepath.Dir(f.path), 0o700); err != nil {
 		return
 	}
-	tmp := f.path + ".tmp"
-	if os.WriteFile(tmp, b, 0o600) == nil {
-		_ = os.Rename(tmp, f.path)
-	}
+	_ = atomicfile.Write(f.path, b, 0o600)
 }
 
 func (f *fileProgress) done() { _ = os.Remove(f.path) }

--- a/cmd/deja/warmup_status_concurrent_test.go
+++ b/cmd/deja/warmup_status_concurrent_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// "Written whole and renamed: a reader must never see half a record" is the
+// invariant on the status file. It held for one writer and not for two — and
+// two is ordinary, since two agents starting together each spawn a detached
+// build. Both derived the temp name from the destination, so one truncated what
+// the other was renaming: 180 of 18049 reads came back unparseable (#1319).
+func TestTwoBuildsNeverPublishHalfAStatus(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	p := warmupStatusPath(dir)
+
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			f := &fileProgress{path: p}
+			for i := 0; i < 400 && !stop.Load(); i++ {
+				f.st = warmupStatus{Phase: "claude", Done: i * (w + 1), Total: i * 100, Stores: 7}
+				f.flush(true)
+			}
+		}(w)
+	}
+	var reads, empty, bad int64
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !stop.Load() {
+			raw, err := os.ReadFile(p)
+			if err != nil {
+				continue
+			}
+			atomic.AddInt64(&reads, 1)
+			if len(raw) == 0 {
+				atomic.AddInt64(&empty, 1)
+				continue
+			}
+			var got warmupStatus
+			if json.Unmarshal(raw, &got) != nil {
+				atomic.AddInt64(&bad, 1)
+			}
+		}
+	}()
+	time.Sleep(300 * time.Millisecond)
+	stop.Store(true)
+	wg.Wait()
+	if reads == 0 {
+		t.Fatal("the reader never saw the file, so this proves nothing")
+	}
+	// Every unparseable read tells a surface no build is running while one is:
+	// readWarmupStatus returns nil on a record it cannot decode, and the agent
+	// is handed silence in the one state the sentence exists for.
+	if bad > 0 || empty > 0 {
+		t.Errorf("%d of %d reads saw a torn status (%d empty) — two writers shared one temp name", bad+empty, reads, empty)
+	}
+}

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -1,0 +1,112 @@
+// Package atomicfile replaces a file's contents in one step, for the writers
+// that are not behind a lock.
+//
+// Writing a temp file and renaming it is the shape deja already uses
+// everywhere, and it holds as long as one writer is doing it. The temp name was
+// derived from the destination, so two writers shared it: the second truncates
+// what the first is still writing, the first renames a half-written file into
+// place, and a reader gets a record that parses as nothing. Measured on the
+// warmup status file, which two agents starting together both write: 180 of
+// 18049 reads came back unparseable, and every one of those told the agent no
+// build was running while one was (#1319).
+//
+// The index's own writers are excluded from this by `lockDir`, which is why
+// they can keep their fixed temp names.
+package atomicfile
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// sweptDirs remembers the directories this process has already tidied, so the
+// sweep below costs one listing per directory per run rather than one per
+// write — the warmup status is written four times a second.
+var sweptDirs sync.Map
+
+// sweepStale removes temp files this package left behind. A fixed temp name was
+// reused by the next writer and so cleaned itself up; a unique one is not, and
+// a process killed between creating it and renaming it leaves a file nothing
+// would ever look at again. An hour is well past any write: these are one
+// buffer and one rename apart.
+func sweepStale(dir, base string) {
+	if _, done := sweptDirs.LoadOrStore(dir+"\x00"+base, true); done {
+		return
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "."+base+".tmp-*"))
+	if err != nil {
+		return
+	}
+	for _, m := range matches {
+		if fi, err := os.Stat(m); err == nil && time.Since(fi.ModTime()) > time.Hour {
+			_ = os.Remove(m)
+		}
+	}
+}
+
+// WriteStream is Write for content too large to hold twice: the embedding
+// sidecar is megabytes of vectors, and buffering it to hand over as one slice
+// would double that for no gain. fn writes the whole file; if it returns an
+// error nothing is published.
+func WriteStream(path string, perm os.FileMode, fn func(io.Writer) error) error {
+	defer sweepStale(filepath.Dir(path), filepath.Base(path))
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	if err := fn(f); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Chmod(tmp, perm); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// Write replaces path with b. The temp file is created beside it, so the rename
+// stays on one filesystem, and its name is unique, so concurrent writers do not
+// share it. On any failure the temp file is removed rather than left on a disk
+// that may have just filled up.
+func Write(path string, b []byte, perm os.FileMode) error {
+	defer sweepStale(filepath.Dir(path), filepath.Base(path))
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	if _, err := f.Write(b); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Chmod(tmp, perm); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -22,6 +22,26 @@ import (
 	"time"
 )
 
+// publish renames the temp file into place, retrying briefly.
+//
+// Windows refuses a rename onto a file another handle has open, and a reader is
+// exactly what these files have — the warmup status is polled by every surface
+// while a build writes it. Measured on windows CI: three of four concurrent
+// writers were denied. Unix succeeds on the first attempt and pays nothing.
+func publish(tmp, path string) error {
+	err := os.Rename(tmp, path)
+	for i := 0; err != nil && i < renameTries; i++ {
+		time.Sleep(renameWait)
+		err = os.Rename(tmp, path)
+	}
+	return err
+}
+
+const (
+	renameTries = 20
+	renameWait  = 5 * time.Millisecond
+)
+
 // sweptDirs remembers the directories this process has already tidied, so the
 // sweep below costs one listing per directory per run rather than one per
 // write — the warmup status is written four times a second.
@@ -72,7 +92,7 @@ func WriteStream(path string, perm os.FileMode, fn func(io.Writer) error) error 
 		_ = os.Remove(tmp)
 		return err
 	}
-	if err := os.Rename(tmp, path); err != nil {
+	if err := publish(tmp, path); err != nil {
 		_ = os.Remove(tmp)
 		return err
 	}
@@ -104,7 +124,7 @@ func Write(path string, b []byte, perm os.FileMode) error {
 		_ = os.Remove(tmp)
 		return err
 	}
-	if err := os.Rename(tmp, path); err != nil {
+	if err := publish(tmp, path); err != nil {
 		_ = os.Remove(tmp)
 		return err
 	}

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -95,6 +96,11 @@ func TestWriteLeavesNoTempAndKeepsTheMode(t *testing.T) {
 	fi, err := os.Stat(path)
 	if err != nil {
 		t.Fatal(err)
+	}
+	// Windows has no permission bits to keep — chmod there toggles read-only
+	// and nothing else, so the mode a caller asks for is a unix promise.
+	if runtime.GOOS == "windows" {
+		return
 	}
 	if fi.Mode().Perm() != 0o600 {
 		t.Errorf("mode is %v, want 0600 — these files hold the user's own history", fi.Mode().Perm())

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -1,0 +1,181 @@
+package atomicfile
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The point of the package: several writers at once, and a reader that only
+// ever sees one of their payloads whole.
+func TestConcurrentWritersNeverPublishAMix(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "status.json")
+	payloads := [][]byte{
+		bytes.Repeat([]byte("a"), 4000),
+		bytes.Repeat([]byte("b"), 4000),
+		bytes.Repeat([]byte("c"), 4000),
+		bytes.Repeat([]byte("d"), 4000),
+	}
+	if err := Write(path, payloads[0], 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stop atomic.Bool
+	var wg, writers sync.WaitGroup
+	for w := range payloads {
+		writers.Add(1)
+		go func(w int) {
+			defer writers.Done()
+			for i := 0; i < 500 && !stop.Load(); i++ {
+				if err := Write(path, payloads[w], 0o600); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}(w)
+	}
+	var reads, mixed int64
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !stop.Load() {
+			got, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			atomic.AddInt64(&reads, 1)
+			ok := false
+			for _, want := range payloads {
+				if bytes.Equal(got, want) {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				atomic.AddInt64(&mixed, 1)
+			}
+		}
+	}()
+	// The writers finish first, then the reader is told to stop: waiting on the
+	// reader before setting the flag is a deadlock, which is how the first cut
+	// of this test hung.
+	writers.Wait()
+	stop.Store(true)
+	wg.Wait()
+	if reads == 0 {
+		t.Fatal("the reader never saw the file, so this proves nothing")
+	}
+	if mixed > 0 {
+		t.Errorf("%d of %d reads saw neither payload whole", mixed, reads)
+	}
+}
+
+// Nothing is left behind on the way, and the mode is the one asked for.
+func TestWriteLeavesNoTempAndKeepsTheMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	if err := Write(path, []byte("one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Errorf("a temp file survived the write: %s", e.Name())
+		}
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Errorf("mode is %v, want 0600 — these files hold the user's own history", fi.Mode().Perm())
+	}
+	// A mode other than the one CreateTemp happens to give, so the chmod is
+	// doing something rather than agreeing with the default by luck.
+	other := filepath.Join(dir, "shared.jsonl")
+	if err := Write(other, []byte("two\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if fi, err := os.Stat(other); err != nil {
+		t.Fatal(err)
+	} else if fi.Mode().Perm() != 0o640 {
+		t.Errorf("mode is %v, want 0640 — the caller's choice was dropped", fi.Mode().Perm())
+	}
+}
+
+// A rename that cannot land must not leave the temp file on the way. The
+// destination here is a directory, which CreateTemp is happy to write beside
+// and rename can never replace.
+func TestAFailedRenameLeavesNoTemp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "occupied")
+	if err := os.MkdirAll(filepath.Join(path, "child"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := Write(path, []byte("x"), 0o600); err == nil {
+		t.Fatal("replacing a non-empty directory reported success")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Errorf("the failed rename left %s behind", e.Name())
+		}
+	}
+}
+
+// A destination whose directory does not exist fails and leaves nothing: the
+// caller decides whether to make the directory, and a half-written temp file in
+// some other directory would be litter it never looks for.
+func TestWriteToAMissingDirectoryFailsCleanly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gone", "status.json")
+	if err := Write(path, []byte("x"), 0o600); err == nil {
+		t.Error("writing into a missing directory reported success")
+	}
+	if entries, err := os.ReadDir(dir); err == nil && len(entries) != 0 {
+		t.Errorf("the failed write left %d entries behind", len(entries))
+	}
+}
+
+// A process killed between creating the temp file and renaming it leaves one
+// behind, and a unique name is never reused — so the next write in that
+// directory clears the old ones.
+func TestStaleTempsAreSwept(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "status.json")
+	stale := filepath.Join(dir, ".status.json.tmp-abandoned")
+	if err := os.WriteFile(stale, []byte("half a record"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+	fresh := filepath.Join(dir, ".status.json.tmp-inflight")
+	if err := os.WriteFile(fresh, []byte("another writer, right now"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Write(path, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("an abandoned temp file survived: %v", err)
+	}
+	// A temp file that is being written right now must not be touched: it
+	// belongs to another writer mid-flight.
+	if _, err := os.Stat(fresh); err != nil {
+		t.Errorf("a live temp file was swept: %v", err)
+	}
+}

--- a/internal/embed/sidecar.go
+++ b/internal/embed/sidecar.go
@@ -235,38 +235,48 @@ func Read(dir string) (Sidecar, error) {
 // leave a sidecar that decodes as nothing (#1319).
 func write(dir string, s Sidecar) error {
 	return atomicfile.WriteStream(Path(dir), 0o600, func(w io.Writer) error {
-		if _, err := w.Write(magic[:]); err != nil {
-			return err
-		}
-		for _, v := range []any{sidecarVersion, uint16(s.Dim)} {
-			if err := binary.Write(w, binary.LittleEndian, v); err != nil {
-				return err
-			}
-		}
-		if err := writeString(w, s.Model); err != nil {
-			return err
-		}
-		if err := writeString(w, s.Generation); err != nil {
-			return err
-		}
-		for _, n := range []uint64{uint64(len(s.Vectors)), uint64(s.Covered)} {
-			if err := binary.Write(w, binary.LittleEndian, n); err != nil {
-				return err
-			}
-		}
+		// An error-remembering writer rather than a check after every field:
+		// the fields are a fixed sequence, the first failure is the one worth
+		// reporting, and the checks were branches nothing could reach.
+		ew := &errWriter{w: w}
+		ew.write(magic[:])
+		ew.num(sidecarVersion)
+		ew.num(uint16(s.Dim))
+		ew.str(s.Model)
+		ew.str(s.Generation)
+		ew.num(uint64(len(s.Vectors)))
+		ew.num(uint64(s.Covered))
 		for _, v := range s.Vectors {
-			if err := binary.Write(w, binary.LittleEndian, v.Offset); err != nil {
-				return err
-			}
-			if err := writeString(w, v.Key); err != nil {
-				return err
-			}
-			if err := binary.Write(w, binary.LittleEndian, v.Values); err != nil {
-				return err
-			}
+			ew.num(v.Offset)
+			ew.str(v.Key)
+			ew.num(v.Values)
 		}
-		return nil
+		return ew.err
 	})
+}
+
+// errWriter keeps the first error and ignores everything after it.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) write(b []byte) {
+	if e.err == nil {
+		_, e.err = e.w.Write(b)
+	}
+}
+
+func (e *errWriter) num(v any) {
+	if e.err == nil {
+		e.err = binary.Write(e.w, binary.LittleEndian, v)
+	}
+}
+
+func (e *errWriter) str(v string) {
+	if e.err == nil {
+		e.err = writeString(e.w, v)
+	}
 }
 
 func writeString(w interface{ Write([]byte) (int, error) }, s string) error {

--- a/internal/embed/sidecar.go
+++ b/internal/embed/sidecar.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+
+	"github.com/vshulcz/deja-vu/internal/atomicfile"
 )
 
 const sidecarVersion uint16 = 1
@@ -227,59 +229,46 @@ func Read(dir string) (Sidecar, error) {
 	return out, nil
 }
 
+// write publishes the sidecar in one step. The temp name used to be the
+// destination plus ".tmp", and EmbedIndex takes no lock — two embeds at once
+// shared that name, so one could rename a file the other was still writing and
+// leave a sidecar that decodes as nothing (#1319).
 func write(dir string, s Sidecar) error {
-	tmp := Path(dir) + ".tmp"
-	f, err := os.Create(tmp)
-	if err != nil {
-		return err
-	}
-	good := false
-	defer func() {
-		if !good {
-			_ = os.Remove(tmp)
+	return atomicfile.WriteStream(Path(dir), 0o600, func(w io.Writer) error {
+		if _, err := w.Write(magic[:]); err != nil {
+			return err
 		}
-	}()
-	if _, err = f.Write(magic[:]); err == nil {
-		err = binary.Write(f, binary.LittleEndian, sidecarVersion)
-	}
-	if err == nil {
-		err = binary.Write(f, binary.LittleEndian, uint16(s.Dim))
-	}
-	if err == nil {
-		err = writeString(f, s.Model)
-	}
-	if err == nil {
-		err = writeString(f, s.Generation)
-	}
-	if err == nil {
-		err = binary.Write(f, binary.LittleEndian, uint64(len(s.Vectors)))
-	}
-	if err == nil {
-		err = binary.Write(f, binary.LittleEndian, uint64(s.Covered))
-	}
-	for _, v := range s.Vectors {
-		if err == nil {
-			err = binary.Write(f, binary.LittleEndian, v.Offset)
+		for _, v := range []any{sidecarVersion, uint16(s.Dim)} {
+			if err := binary.Write(w, binary.LittleEndian, v); err != nil {
+				return err
+			}
 		}
-		if err == nil {
-			err = writeString(f, v.Key)
+		if err := writeString(w, s.Model); err != nil {
+			return err
 		}
-		if err == nil {
-			err = binary.Write(f, binary.LittleEndian, v.Values)
+		if err := writeString(w, s.Generation); err != nil {
+			return err
 		}
-	}
-	if cerr := f.Close(); err == nil {
-		err = cerr
-	}
-	if err != nil {
-		return err
-	}
-	if err = os.Rename(tmp, Path(dir)); err != nil {
-		return err
-	}
-	good = true
-	return nil
+		for _, n := range []uint64{uint64(len(s.Vectors)), uint64(s.Covered)} {
+			if err := binary.Write(w, binary.LittleEndian, n); err != nil {
+				return err
+			}
+		}
+		for _, v := range s.Vectors {
+			if err := binary.Write(w, binary.LittleEndian, v.Offset); err != nil {
+				return err
+			}
+			if err := writeString(w, v.Key); err != nil {
+				return err
+			}
+			if err := binary.Write(w, binary.LittleEndian, v.Values); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
+
 func writeString(w interface{ Write([]byte) (int, error) }, s string) error {
 	if err := binary.Write(w, binary.LittleEndian, uint32(len(s))); err != nil {
 		return err

--- a/internal/embed/sidecar_write_test.go
+++ b/internal/embed/sidecar_write_test.go
@@ -37,6 +37,13 @@ func TestWriteLeavesTheOldSidecarWhenItCannotFinish(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("root ignores the permissions this test needs")
 	}
+	// Chmod succeeds on Windows and changes nothing, so the mode bits are not
+	// evidence — whether the directory actually refuses a new file is.
+	if probe, err := os.Create(filepath.Join(parent, "probe")); err == nil {
+		probe.Close()
+		_ = os.Remove(probe.Name())
+		t.Skip("the directory still accepts writes when read-only")
+	}
 	if err := write(dir, Sidecar{Model: "m", Dim: 1, Generation: "g2"}); err == nil {
 		t.Error("a write into a read-only directory reported success")
 	}

--- a/internal/embed/sidecar_write_test.go
+++ b/internal/embed/sidecar_write_test.go
@@ -1,0 +1,93 @@
+package embed
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The sidecar is published in one step, so a write that cannot finish must
+// leave the previous one in place rather than a half-file — the reader decodes
+// it as nothing, and semantic search then answers from an index it thinks is
+// empty.
+func TestWriteLeavesTheOldSidecarWhenItCannotFinish(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	good := Sidecar{Model: "m", Dim: 1, Generation: "g1", Covered: 1,
+		Vectors: []Vector{{Offset: 0, Key: "claude:a", Values: []float32{1}}}}
+	if err := write(dir, good); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The parent is where the temp file goes, so a read-only one stops the
+	// write before anything is published.
+	parent := filepath.Dir(Path(dir))
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Skip("cannot make the directory read-only here")
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permissions this test needs")
+	}
+	if err := write(dir, Sidecar{Model: "m", Dim: 1, Generation: "g2"}); err == nil {
+		t.Error("a write into a read-only directory reported success")
+	}
+	after, err := os.ReadFile(Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Error("the sidecar changed on a write that failed")
+	}
+}
+
+// A vector whose key cannot be written is the same situation one level down:
+// nothing is published, and the error reaches the caller rather than being
+// swallowed into a truncated file.
+func TestWriteReportsAFailureMidway(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A key longer than the sidecar's length prefix can hold does not exist;
+	// what does is a disk that stops accepting bytes, and the closest thing a
+	// test can do is take the directory away mid-write.
+	s := Sidecar{Model: "m", Dim: 1, Generation: "g", Covered: 2, Vectors: []Vector{
+		{Offset: 0, Key: "claude:a", Values: []float32{1}},
+		{Offset: 8, Key: "claude:b", Values: []float32{2}},
+	}}
+	if err := write(dir, s); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Vectors) != 2 || got.Covered != 2 {
+		t.Errorf("round trip lost content: %d vectors, covered %d", len(got.Vectors), got.Covered)
+	}
+	if got.Model != "m" || got.Generation != "g" {
+		t.Errorf("round trip lost the header: %+v", got)
+	}
+}
+
+// And a directory that is not there at all fails with something the caller can
+// act on rather than a partial file.
+func TestWriteToAMissingIndexDirectoryFails(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "gone", "index.db")
+	err := write(dir, Sidecar{Model: "m", Dim: 1})
+	if err == nil {
+		t.Fatal("writing into a missing directory reported success")
+	}
+	if !errors.Is(err, os.ErrNotExist) && !strings.Contains(err.Error(), "no such") {
+		t.Errorf("the error does not say the directory is missing: %v", err)
+	}
+}

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vshulcz/deja-vu/internal/atomicfile"
 	"github.com/vshulcz/deja-vu/internal/cjkfold"
 	"github.com/vshulcz/deja-vu/internal/model"
 )
@@ -632,18 +633,14 @@ func rewriteNotes(edit func(map[string]any) (map[string]any, bool)) (int, error)
 	if changed == 0 {
 		return 0, nil
 	}
-	tmp := path + ".tmp"
 	body := strings.Join(lines, "\n")
 	if body != "" {
 		body += "\n"
 	}
-	if err := os.WriteFile(tmp, []byte(body), 0o600); err != nil {
-		// A rewrite that ran out of room left its temp file behind, on the
-		// filesystem that just filled up (#808).
-		_ = os.Remove(tmp)
-		return 0, err
-	}
-	if err := os.Rename(tmp, path); err != nil {
+	// A rewrite that ran out of room used to leave its temp file behind, on the
+	// filesystem that just filled up (#808); atomicfile removes it on any
+	// failure, and gives it a name a second writer cannot land on (#1319).
+	if err := atomicfile.Write(path, []byte(body), 0o600); err != nil {
 		return 0, err
 	}
 	return changed, nil

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -2,11 +2,14 @@ package usage
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/vshulcz/deja-vu/internal/atomicfile"
 )
 
 // A Snapshot is the full text of one served digest, kept so `deja log` can
@@ -105,18 +108,14 @@ func rotateSnapshots(p string) {
 		return
 	}
 	snaps := snapshotsFrom(p, snapshotsToKeep) // newest first
-	tmp := p + ".tmp"
-	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return
-	}
+	var buf bytes.Buffer
 	for i := len(snaps) - 1; i >= 0; i-- {
 		if b, err := json.Marshal(snaps[i]); err == nil {
-			_, _ = f.Write(append(b, '\n'))
+			buf.Write(append(b, '\n'))
 		}
 	}
-	_ = f.Close()
-	_ = os.Rename(tmp, p)
+	// Same shared-temp-name defect as the usage log above (#1319).
+	_ = atomicfile.Write(p, buf.Bytes(), 0o600)
 }
 
 // snapshotsFrom reads a snapshot file and returns up to n entries, newest

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -6,11 +6,14 @@ package usage
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/vshulcz/deja-vu/internal/atomicfile"
 )
 
 // Event kinds. Search is tracked too but statusline only counts memory
@@ -301,23 +304,18 @@ func rotate(p string) {
 	if len(keep) == len(all) {
 		return
 	}
-	tmp := p + ".tmp"
-	f, err := os.Create(tmp)
-	if err != nil {
-		return
-	}
-	w := bufio.NewWriter(f)
+	// One buffer, then one atomic replace. The temp name used to be derived
+	// from the log's own path, and this is the one writer in deja with no lock
+	// at all by design — two rotations at once shared that name and could
+	// publish a half-written log, which read as no history rather than as one
+	// lost event (#1319).
+	var buf bytes.Buffer
 	for _, e := range keep {
 		if b, err := json.Marshal(e); err == nil {
-			_, _ = w.Write(append(b, '\n'))
+			buf.Write(append(b, '\n'))
 		}
 	}
-	flushed := w.Flush()
-	if f.Close() != nil || flushed != nil {
-		_ = os.Remove(tmp)
-		return
-	}
-	_ = os.Rename(tmp, p)
+	_ = atomicfile.Write(p, buf.Bytes(), 0o600)
 }
 
 // WornSessions counts, per session id, how often agent-initiated recalls


### PR DESCRIPTION
Found by the night hunt, iteration 70, from the hypothesis list after 35: the invariant written in prose at `warmup_status.go` — *"Written whole and renamed: a reader must never see half a record."*

It held for one writer. The temp name was derived from the destination, so two writers shared it — and two is ordinary, since two agents starting together each spawn a detached `deja index`. One truncates what the other is renaming. Measured before the fix, four writers and one reader on the status file:

```
reads 18049, empty 5, unparseable 180
```

Every one of those told the agent nothing was building while a build was running: `readWarmupStatus` returns nil on a record it cannot decode, and then `buildingNowForAgent`, the brief and the status line all go quiet — in the one state that sentence exists for. After: `reads 12031, empty 0, unparseable 0`.

New `internal/atomicfile` writes to a unique temp beside the destination and renames. Asking where else the same cause lives found four more writers with no lock excluding them, and review named three of them:

- the usage log's rotation and the snapshot file — the one part of deja that is lock-free by design, where a torn publish loses the whole window rather than the one event the design accepts losing;
- the embedding sidecar, which `EmbedIndex` writes without a lock;
- the notes rewrite behind `deja remember` and `deja forget`.

Everything under `lockDir` is left alone: the lock is what excludes the second writer there, and its fixed temp names are fine.

One thing the unique name costs: it is never reused, so a process killed between creating it and renaming leaves a file behind where the fixed name would have been overwritten. `sweepStale` clears siblings older than an hour, once per directory per process — a live temp file belonging to another writer is not touched.

`TestForgetPromotedTitlesKeepsTheNotesFileOnFailure` forced its failure by putting a directory where the temp file would go. That trick was the bug, so the test now makes the directory read-only instead, and skips where that does not hold.

Tests: four writers publishing only whole records, the same for the warmup status through its real flush path, no temp left after a failed rename, the caller's mode kept, and stale temps swept while live ones are not. Six mutations verified, two of which caught blind tests.
