### PR TITLE
fix: a hook running during a rebuild no longer decides there is no index

### DIFF
--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -78,15 +78,20 @@ func ImportedSessionCounts(dir string) map[string]int {
 	return out
 }
 
+// HasManifest reports whether this directory holds an index. A rebuild's swap
+// takes the directory away for a moment, and answering "no" there sent every
+// hook down the no-index path: it asked for a rebuild that was already running
+// and served the prompt without recall (#1319).
 func HasManifest(dir string) bool {
 	if dir == "" {
 		dir = DefaultDir()
 	}
-	_, err := os.Stat(filepath.Join(dir, "manifest.gob"))
-	if err != nil {
+	if _, err := statIndexFile(filepath.Join(dir, "manifest.gob")); err != nil {
 		return false
 	}
-	_, err = os.Stat(filepath.Join(dir, "sessions.gob"))
+	// Plain stat: the wait above has already closed the window by the time
+	// this runs, and a call site that cannot be made to fail is not a fix.
+	_, err := os.Stat(filepath.Join(dir, "sessions.gob"))
 	return err == nil
 }
 
@@ -100,7 +105,7 @@ func ManifestBuiltAt(dir string) time.Time {
 	if err == nil && !m.BuiltAt.IsZero() {
 		return m.BuiltAt
 	}
-	if fi, err := os.Stat(filepath.Join(dir, "manifest.gob")); err == nil {
+	if fi, err := statIndexFile(filepath.Join(dir, "manifest.gob")); err == nil {
 		return fi.ModTime()
 	}
 	return time.Time{}
@@ -292,6 +297,9 @@ func recordsIntactSized(dir string, m Manifest, tolerateLonger bool) bool {
 	if m.RecordsSize <= 0 {
 		return true // empty index, or one written before the size stamp existed
 	}
+	// Plain stat, deliberately: every caller reads the manifest first, and that
+	// read waits the swap out — measured, removing the wait here changes
+	// nothing (#1319).
 	fi, err := os.Stat(filepath.Join(dir, "records.bin"))
 	if err != nil {
 		return false
@@ -374,12 +382,35 @@ func Damaged(dir string) bool {
 		// already. One that is there but will not decode is a different story:
 		// doctor stats the file, calls the index built and up to date, and the
 		// next search rebuilds it from scratch.
-		if _, statErr := os.Stat(filepath.Join(dir, "manifest.gob")); statErr == nil {
+		if _, statErr := statIndexFile(filepath.Join(dir, "manifest.gob")); statErr == nil {
 			return true
 		}
 		return false
 	}
-	return !recordsIntact(dir, m)
+	if recordsIntact(dir, m) {
+		return false
+	}
+	// The manifest and the record log were read a moment apart, and a rebuild
+	// can land between them: the manifest is the old one, records.bin is the
+	// new one, and their sizes disagree for reasons that have nothing to do
+	// with damage. Measured on the hook predicate during eight rebuilds, 19 of
+	// 13124 asks came back damaged, and each one served a prompt with no recall
+	// (#1319).
+	//
+	// Only while a build actually holds the lock: a store that is short with
+	// nothing running is short, and answering that immediately is what every
+	// other caller depends on.
+	if !RebuildInProgress(dir) {
+		return true
+	}
+	time.Sleep(swapWindowWait)
+	m2, err := readManifest(dir)
+	if err != nil {
+		// The manifest went away under us, which is the swap itself rather than
+		// damage; the next call sees the new one.
+		return false
+	}
+	return !recordsIntact(dir, m2)
 }
 
 // RebuildInProgress reports whether another process holds the index lock. A

--- a/internal/index/manifest_cache.go
+++ b/internal/index/manifest_cache.go
@@ -28,6 +28,8 @@ var manifestCache struct {
 }
 
 func readManifestCached(dir string) (Manifest, error) {
+	// Plain stat: a failure here falls through to readManifest, which waits the
+	// swap out itself, so a wait added here cannot be made to fail (#1319).
 	fi, err := os.Stat(filepath.Join(dir, "manifest.gob"))
 	if err != nil {
 		return readManifest(dir)

--- a/internal/index/swap_stat_test.go
+++ b/internal/index/swap_stat_test.go
@@ -1,0 +1,133 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// "Is there an index" is the first question every hook asks, and during a
+// rebuild's swap the answer was no. The hook then asked for a rebuild that was
+// already running and served the prompt without recall — memory lost because a
+// directory was missing for a millisecond (#1319).
+func TestHasManifestWaitsOutTheSwap(t *testing.T) {
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, "index.db")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"manifest.gob", "sessions.gob"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	parked := dir + ".old"
+	if err := os.Rename(dir, parked); err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(40 * time.Millisecond)
+		_ = os.Rename(parked, dir)
+	}()
+	if !HasManifest(dir) {
+		t.Error("a hook landing in the swap window was told there is no index")
+	}
+	wg.Wait()
+}
+
+// An index that is simply not there still answers at once: waiting for a
+// rebuild nobody started would make every first run slower.
+func TestAMissingIndexAnswersImmediately(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	start := time.Now()
+	if HasManifest(dir) {
+		t.Fatal("found an index that does not exist")
+	}
+	if took := time.Since(start); took > swapWindowWait {
+		t.Errorf("a missing index cost %v", took)
+	}
+}
+
+// Damaged compares the manifest against the record log, and a rebuild can land
+// between those two reads: the manifest is the old one, records.bin the new
+// one, their sizes disagree, and a healthy index reads as broken. Measured on
+// the hook predicate during eight rebuilds, 19 of 13124 asks said damaged —
+// and every one of them served a prompt with no recall.
+//
+// The disagreement is staged here rather than raced: records.bin is short when
+// the check starts and whole a moment later, which is what the second read is
+// for.
+func TestDamagedRereadsAPairThatDisagreed(t *testing.T) {
+	dir, body := damagedFixture(t)
+	path := filepath.Join(dir, "records.bin")
+	if err := os.WriteFile(path, body[:len(body)-1], 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A build holds the lock, which is the state that makes a disagreement
+	// worth a second look rather than a verdict.
+	unlock, err := lockDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(5 * time.Millisecond)
+		_ = os.WriteFile(path, body, 0o600)
+	}()
+	if Damaged(dir) {
+		t.Error("a store that agrees with its manifest a moment later was called damaged")
+	}
+	wg.Wait()
+}
+
+// And a store that is really short stays damaged: the second read is a second
+// look, not a second chance.
+func TestRealDamageSurvivesTheReread(t *testing.T) {
+	dir, body := damagedFixture(t)
+	if err := os.WriteFile(filepath.Join(dir, "records.bin"), body[:len(body)/2], 0o600); err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	if !Damaged(dir) {
+		t.Error("a truncated record log was reported healthy")
+	}
+	// And answers at once: the second look is for a build that is running, and
+	// with none running the verdict is already final. Every hook asks this.
+	if took := time.Since(start); took >= swapWindowWait {
+		t.Errorf("a damaged store with no build running cost %v to report", took)
+	}
+}
+
+// damagedFixture builds a small index and hands back its record log.
+func damagedFixture(t *testing.T) (dir string, records []byte) {
+	t.Helper()
+	tmp := t.TempDir()
+	setHome(t, filepath.Join(tmp, "home"))
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	proj := filepath.Join(claude, "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSession(t, proj, "a", "the retry queue stalls on staging")
+	dir = filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if Damaged(dir) {
+		t.Fatal("the fixture is damaged before the test starts")
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "records.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir, body
+}

--- a/internal/index/swap_window.go
+++ b/internal/index/swap_window.go
@@ -52,6 +52,32 @@ func openIndexFile(path string) (*os.File, error) {
 	return nil, err
 }
 
+// statIndexFile is os.Stat for a file inside the index directory, waiting out a
+// swap the same way openIndexFile does.
+//
+// "Is there an index" is asked by every hook before it serves anything, and
+// during the swap the answer was no — measured at 894 of 18912 asks while
+// rebuilds ran. The hook then asked for another rebuild and returned without
+// recall, so a prompt submitted in that window lost its memory because a
+// directory was missing for a millisecond (#1319).
+func statIndexFile(path string) (os.FileInfo, error) {
+	fi, err := os.Stat(path)
+	if err == nil || !errors.Is(err, fs.ErrNotExist) {
+		return fi, err
+	}
+	for i := 0; i < swapWindowTries; i++ {
+		inFlight := swapInFlight(path)
+		if fi, serr := os.Stat(path); serr == nil {
+			return fi, nil
+		}
+		if !inFlight {
+			return nil, err
+		}
+		time.Sleep(swapWindowWait)
+	}
+	return nil, err
+}
+
 // swapInFlight reports whether a directory on the way to path has been renamed
 // aside and not yet replaced: gone from where it belongs, and sitting at its
 // ".old" parking spot.


### PR DESCRIPTION
Found by the night hunt, iteration 71, from the hypothesis list after 45: the reverse of #1317 — what else a reader sees during a rebuild.

#1317 and #1378 made file *opens* wait out the index swap. The same window seen through *stat* was still open, and it is the first question every hook asks. `indexNeedsRebuild` is `!HasManifest || !IsCurrentVersion || Damaged`, and during a rebuild it said yes — measured with four goroutines asking while eight rebuilds ran:

```
before: 885 of 17012 asks said "this index needs rebuilding"
after:    1 of 12973
```

That is not cosmetic. `hook_prompt.go:138` returns the nudge and nothing else on that branch, so **a prompt submitted during a rebuild was served with no recall at all**, and `hook_context.go:571` does the same at session start — both also spawning another `deja index` for a rebuild already running.

Two causes, both measured:

- **`HasManifest` stats the manifest**, and during the swap the directory is gone. It waits the window out now, the same way `openIndexFile` does, and answers immediately when there is genuinely no index.
- **`Damaged` reads the manifest and the record log a moment apart**, so a rebuild landing between them compares an old manifest against a new `records.bin`, and the sizes disagree for reasons that have nothing to do with damage. That was the whole residue after the first fix: 19 of 13124. It takes a second look now — but only while a build actually holds the lock, so a store that is short with nothing running is still reported at once, which is what every caller depends on.

Four more call sites were tried and dropped: the `sessions.gob` stat, the `records.bin` and `buckets` stats, and the manifest-cache stat. Each mutation passed, and an A/B measured them at 14/13472 against 10/12473 — noise. An earlier swap-aware read has already closed the window by the time they run, and a fix that cannot be made to fail is not a fix.

Tests: `HasManifest` waiting out a staged swap, a missing index still answering at once, `Damaged` re-reading a pair that disagreed while a build holds the lock, and real damage surviving that second look — and being reported without the wait. Five mutations verified; two caught call sites that turned out to be unreachable, which is how they came out of the diff.
