### PR TITLE
fix: cut agent-facing text on rune boundaries

### DIFF
--- a/cmd/deja/agent_text_cuts_test.go
+++ b/cmd/deja/agent_text_cuts_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The conventions block and the environment block are text an agent reads. Both
+// cut long entries at a byte count, which lands mid-character on anything but
+// ASCII — a decision recorded in Russian reached the model as invalid UTF-8
+// (#1319).
+func TestAgentFacingTextIsCutOnRuneBoundaries(t *testing.T) {
+	long := map[string]string{
+		"cyrillic": strings.Repeat("решение про очередь повторов ", 20),
+		"cjk":      strings.Repeat("重试队列的决定 ", 40),
+		"ascii":    strings.Repeat("the retry queue decision ", 20),
+	}
+	for name, text := range long {
+		got := conventionLine(sources.PromotedNote{Text: text})
+		if !utf8.ValidString(got) {
+			t.Errorf("conventions line for %s is not valid UTF-8: %q", name, got)
+		}
+		if got == "" {
+			t.Errorf("conventions line for %s came back empty", name)
+		}
+	}
+}
+
+// A note that fits keeps its whole text, and a title still wins over the body.
+func TestAShortConventionKeepsItsText(t *testing.T) {
+	if got := conventionLine(sources.PromotedNote{Text: "queue retries with full jitter"}); got != "queue retries with full jitter" {
+		t.Errorf("a short note was changed: %q", got)
+	}
+	if got := conventionLine(sources.PromotedNote{Title: "retry policy", Text: "long body"}); got != "retry policy" {
+		t.Errorf("the title should name the note: %q", got)
+	}
+	// The first sentence, when there is one.
+	if got := conventionLine(sources.PromotedNote{Text: "Retry three times. Then give up."}); got != "Retry three times." {
+		t.Errorf("the first sentence was not taken: %q", got)
+	}
+}
+
+// The mark left where text was cut has to be the character, not what a
+// mis-decoded copy of it turns into: this constant held the Shift_JIS reading
+// of "…" and the plan hook appended that to every truncated finding.
+func TestTheTruncationMarkIsAnEllipsis(t *testing.T) {
+	got := truncatePlanBytes(strings.Repeat("a", 100), 20)
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncation mark is %q", got[len(got)-6:])
+	}
+	if strings.Contains(got, "窶") {
+		t.Errorf("the mangled ellipsis is still there: %q", got)
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("truncated text is not valid UTF-8: %q", got)
+	}
+}
+
+// The environment block names the walls this machine keeps hitting, and it cut
+// each one at 96 bytes — mid-character on a wall recorded in Russian or
+// Chinese, and the block goes straight into the model's context. Through the
+// block itself, since that is where the cut lives.
+func TestTheEnvironmentBlockCutsOnRuneBoundaries(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-w")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	// English shape so it is recognised as a wall, Cyrillic tail so the 96-byte
+	// cut lands inside a character. 105 bytes: past the 96-byte cut, inside the
+	// 120-byte bound on what counts as a wall, and with the cut falling on an
+	// odd offset into two-byte letters — at the obvious phrasing it fell on a
+	// boundary and the test could not fail.
+	wall := "ModuleNotFoundError: No module named очередьповторовпредпродакшенмодуля"
+	for i := 0; i < index.FrictionMinSessions; i++ {
+		sid := fmt.Sprintf("w%02d", i)
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/w/w","timestamp":"2026-07-2` +
+			fmt.Sprint(i%10) + `T10:00:00Z","message":{"role":"user","content":"run the checks"}}` + "\n" +
+			`{"type":"user","sessionId":"` + sid + `","cwd":"/w/w","timestamp":"2026-07-2` +
+			fmt.Sprint(i%10) + `T10:05:00Z","message":{"role":"user","content":[{"type":"tool_result",` +
+			`"content":"` + wall + `"}]}}` + "\n"
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	got := environmentBlock(dir, policy.ActivationAuto)
+	if got == "" {
+		t.Fatal("no environment block to judge")
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("a wall in Russian was cut mid-character:\n%q", got)
+	}
+}
+
+// The friction screen prints walls to a terminal, and cut each at 76 bytes.
+func TestFrictionLinesCutOnRuneBoundaries(t *testing.T) {
+	for _, pad := range []string{"", "a", "ab"} {
+		got := trimFriction(pad + strings.Repeat("ошибка подключения ", 20))
+		if !utf8.ValidString(got) {
+			t.Errorf("pad %q: a wall printed as broken bytes: %q", pad, got)
+		}
+		if len(got) > 79 {
+			t.Errorf("pad %q: the line ran past its bound at %d bytes", pad, len(got))
+		}
+	}
+	short := "npm ERR! code ELIFECYCLE"
+	if got := trimFriction(short); got != short {
+		t.Errorf("a short wall was changed: %q", got)
+	}
+}

--- a/cmd/deja/environment.go
+++ b/cmd/deja/environment.go
@@ -72,9 +72,9 @@ func environmentBlock(dir, activation string) string {
 	b.WriteString("This machine, from deja's index of past sessions across every agent used here:\n")
 	for _, w := range walls {
 		text := w.Text
-		if len(text) > environmentMax {
-			text = text[:environmentMax] + "…"
-		}
+		// Same cut, same reason as the conventions line: bytes, not runes, so a
+		// wall recorded in Russian or Chinese reached the model in pieces.
+		text = truncatePlanBytes(text, environmentMax)
 		fmt.Fprintf(&b, "- %d separate sessions hit `%s`\n", len(w.Sessions), text)
 	}
 	// Without this line the block reads as trivia. With it the model has

--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -150,8 +150,8 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 }
 
 func trimFriction(l string) string {
-	if len(l) > 76 {
-		return l[:76] + "…"
-	}
-	return l
+	// Rune-safe: a wall recorded in Russian or Chinese was cut mid-character
+	// and printed as a broken byte (#1319). The bound includes the mark, so a
+	// line loses one character rather than gaining one.
+	return truncatePlanBytes(l, 79)
 }

--- a/cmd/deja/hook_conventions.go
+++ b/cmd/deja/hook_conventions.go
@@ -84,9 +84,8 @@ func conventionLine(n sources.PromotedNote) string {
 			return strings.TrimSpace(text[:i+1])
 		}
 	}
-	const cap = 200
-	if len(text) > cap {
-		return strings.TrimSpace(text[:cap])
-	}
-	return text
+	// Rune-safe: a 200-byte cut lands mid-character on anything but ASCII, and
+	// the line goes to an agent as invalid UTF-8 — reproduced on a Russian note
+	// and on a Chinese one (#1319).
+	return truncatePlanBytes(text, 200)
 }

--- a/cmd/deja/hook_plan.go
+++ b/cmd/deja/hook_plan.go
@@ -392,7 +392,10 @@ func truncatePlanBytes(text string, limit int) string {
 	if len(text) <= limit {
 		return text
 	}
-	const ellipsis = "窶ｦ"
+	// The character, not what a mis-decoded copy of it turns into: this held
+	// the Shift_JIS reading of "…" and the plan hook appended that to every
+	// truncated finding an agent was shown (#1319).
+	const ellipsis = "…"
 	if limit <= len(ellipsis) {
 		return ""
 	}

--- a/cmd/deja/hook_plan_test.go
+++ b/cmd/deja/hook_plan_test.go
@@ -233,7 +233,7 @@ func TestPlanHookBudgetIncludesRecallFrame(t *testing.T) {
 	if len(framed) > planHookBudget {
 		t.Fatalf("framed payload = %d bytes, budget = %d", len(framed), planHookBudget)
 	}
-	if !strings.Contains(payload, "窶ｦ") {
+	if !strings.Contains(payload, "…") {
 		t.Fatalf("oversized finding was not visibly truncated: %q", payload)
 	}
 }

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -917,11 +917,19 @@ func signalLines(text string) string {
 		// output, and the head alone is the least informative part of exactly
 		// the records that matched nothing.
 		if len(text) > signalFloor {
-			head := text[:signalFloor]
+			// Rune-safe: this text is indexed and served back through recall,
+			// so a character split here is a broken byte in an answer (#1319).
+			head := text[:runeBoundary(text, signalFloor)]
 			if len(text) <= signalFloor+signalTail {
 				return text
 			}
-			return head + "\n" + text[len(text)-signalTail:]
+			// Both ends: the tail is cut from the other side, and a character
+			// split there is the same broken byte in the same answer.
+			tail := text[len(text)-signalTail:]
+			for len(tail) > 0 && !utf8.ValidString(tail) {
+				tail = tail[1:]
+			}
+			return head + "\n" + tail
 		}
 		return text
 	}
@@ -935,6 +943,18 @@ func signalLines(text string) string {
 // store, outputs above this threshold are 7% of the records and 74% of the
 // bytes, and they are where the posting explosion comes from.
 const signalFloor = 8192
+
+// runeBoundary is n, or the largest offset below it that does not split a
+// character.
+func runeBoundary(s string, n int) int {
+	if n >= len(s) {
+		return len(s)
+	}
+	for n > 0 && !utf8.ValidString(s[:n]) {
+		n--
+	}
+	return n
+}
 
 func signalLine(l string) bool {
 	for _, p := range []string{"FAIL", "fail", "Error", "error", "panic:", "fatal",

--- a/internal/index/signal_cut_test.go
+++ b/internal/index/signal_cut_test.go
@@ -1,0 +1,42 @@
+package index
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// A long tool output is stored as its head plus its tail, and both ends were
+// cut at a byte count. The result is indexed and served back through recall, so
+// a character split there is a broken byte inside an answer (#1319). One byte
+// of padding moves the cut off the boundary it happened to land on.
+func TestSignalLinesCutsOnRuneBoundaries(t *testing.T) {
+	for _, pad := range []string{"", "a", "ab"} {
+		text := pad + strings.Repeat("сборка упала на предпродакшене ", 400)
+		got := signalLines(text)
+		if !utf8.ValidString(got) {
+			t.Errorf("pad %q: the stored output is not valid UTF-8", pad)
+		}
+		if len(got) == 0 {
+			t.Errorf("pad %q: nothing was kept", pad)
+		}
+	}
+}
+
+// The keeping rule itself is unchanged: a short output survives whole, and a
+// long one keeps both ends rather than only its head.
+func TestSignalLinesStillKeepsBothEnds(t *testing.T) {
+	short := "npm ERR! code ELIFECYCLE"
+	if got := signalLines(short); got != short {
+		t.Errorf("a short output was changed: %q", got)
+	}
+	head := strings.Repeat("a", signalFloor)
+	tail := "the error at the very end: ELIFECYCLE"
+	got := signalLines(head + strings.Repeat("b", signalTail*2) + tail)
+	if !strings.Contains(got, tail) {
+		t.Errorf("the tail, where errors cluster, was dropped:\n%q", got[max(0, len(got)-80):])
+	}
+	if !strings.HasPrefix(got, "aaa") {
+		t.Errorf("the head was dropped: %q", got[:20])
+	}
+}

--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -438,10 +438,10 @@ func firstLineTrim(s string) string {
 	if i := strings.IndexByte(s, '\n'); i > 0 {
 		s = s[:i]
 	}
-	if len(s) > 120 {
-		s = s[:120]
-	}
-	return s
+	// Rune-safe: a prompt in any non-ASCII language was cut mid-character and
+	// the broken byte went into the stored title, which every surface shows
+	// (#1319).
+	return truncateRunes(s, 120)
 }
 
 // ClinePluginsDir is where the CLI looks for plugins. Note it is not under

--- a/internal/sources/title_cut_test.go
+++ b/internal/sources/title_cut_test.go
@@ -1,0 +1,30 @@
+package sources
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// A Cline prompt becomes the session's stored title, which every surface shows
+// and sync carries to other machines. It was cut at 120 bytes, so a prompt in
+// any non-ASCII language kept a broken byte forever (#1319). The padding moves
+// the cut off whichever boundary it happened to land on.
+func TestClineTitleCutsOnRuneBoundaries(t *testing.T) {
+	for _, pad := range []string{"", "a", "ab"} {
+		got := firstLineTrim(pad + strings.Repeat("ошибка подключения ", 20))
+		if !utf8.ValidString(got) {
+			t.Errorf("pad %q: the stored title is not valid UTF-8: %q", pad, got)
+		}
+		if len(got) > 120 {
+			t.Errorf("pad %q: the title ran past its bound at %d bytes", pad, len(got))
+		}
+	}
+}
+
+// A short prompt is untouched, and the first line is still what names it.
+func TestClineTitleKeepsShortPrompts(t *testing.T) {
+	if got := firstLineTrim("fix the retry queue\nand then deploy"); got != "fix the retry queue" {
+		t.Errorf("title = %q", got)
+	}
+}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -582,3 +582,16 @@ func commandStrings(in map[string]any, d toolDialect) []string {
 func HarnessAuthored(role string) bool {
 	return role == "developer" || role == "system"
 }
+
+// truncateRunes cuts a string to at most n bytes without splitting a character.
+// Callers store or display the result, so a broken byte survives far past the
+// cut that made it.
+func truncateRunes(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	for n > 0 && !utf8.ValidString(s[:n]) {
+		n--
+	}
+	return s[:n]
+}


### PR DESCRIPTION
Found by the night hunt, iteration 72, from the hypothesis "use the coverage gate as a detector — a function held barely above its floor is where untested behaviour lives". `conventionLine` was at 16.7%, and it had two defects. Asking where else the cause lives found four more places, three of them named by review.

Every one of these cuts a string at a **byte** count and hands the result to an agent, a terminal, or the index:

| where | cut at | what it feeds |
|---|---|---|
| `conventionLine` | 200 | the conventions block an agent reads at session start |
| `environment.go` | 96 | the walls block, straight into the model's context |
| `trimFriction` | 76 | `deja friction`, printed to a terminal |
| `firstLineTrim` (cline) | 120 | the stored session title, which sync carries to other machines |
| `signalLines` head and tail | 8192 | the text that gets postings and comes back through recall |

On anything but ASCII the cut lands inside a character. Reproduced on each with one byte of padding, which moves the boundary — without the padding a fixture can sit exactly on it and prove nothing, which is how the first version of two of these tests passed against the broken code.

Separately, and worse in its way: the plan hook's truncation mark was the literal bytes `e7 aa b6 ef bd a6` — the Shift_JIS reading of `…` — so every truncated finding an agent saw ended in mojibake. Its test asserted the mangled value, so the guard was confirming the defect. I scanned the tree for that shape and for the other classic mis-decodings; those two files were the only ones (`internal/cjkfold` has a legitimate CJK table).

All of it goes through the rune-safe helper the plan hook already had, or a local equivalent where the package boundary made sharing worse than copying four lines.

Tests: each site cut with three paddings so one of them must land mid-character, the truncation mark being an ellipsis, and the behaviour around the cuts unchanged — short input untouched, a note's title still winning over its body, the signal head and tail both still kept. Eight mutations verified, one of which caught a fixture that could not fail.
