### PR TITLE
fix: keep Japanese words whole across the marks written inside them

### DIFF
--- a/internal/cjkfold/fold.go
+++ b/internal/cjkfold/fold.go
@@ -70,7 +70,32 @@ func String(s string) string {
 // scripts this package folds, and the ones written without spaces between words.
 func IsCJK(r rune) bool {
 	return unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
-		unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r)
+		unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r) ||
+		isKanaMark(r)
+}
+
+// isKanaMark covers the two marks Japanese writes inside a word that no script
+// table claims: the prolonged sound mark and its halfwidth twin. The iteration
+// marks look like the same case and are not — Go files 々 and 〻 under Han and
+// ヽヾゝゞ under their kana scripts, so adding them here changed nothing and
+// they are left to the tables that already have them.
+//
+// ー is not decoration: it appears in most loanwords — サーバー, エラー,
+// ステージング — and leaving it out of the script test split every such word
+// into two runs. The bigrams then came out of the pieces, and since the token
+// was no longer a single CJK run the query kept the whole word as a term the
+// index can never hold: searching ステージング for a session that says
+// ステージング answered on the close tier instead of the exact one (#1319).
+func isKanaMark(r rune) bool {
+	switch r {
+	case 0x30FC, // ー prolonged sound mark
+		0xFF70, // ｰ its halfwidth form
+		0xFF9E, // ﾞ halfwidth voiced sound mark, written after the kana it voices
+		0xFF9F, // ﾟ halfwidth semi-voiced
+		0x3006: // 〆, as in 〆切
+		return true
+	}
+	return false
 }
 
 // HasCJK reports whether s contains any Han, Hiragana, Katakana or Hangul
@@ -87,12 +112,23 @@ func HasCJK(s string) bool {
 // CountCJK is HasCJK by the number: how many of s's runes are written in those
 // scripts. A caller deciding whether a line is prose in one of them needs the
 // share, not the presence — a JSON blob with Chinese values has both.
+//
+// A mark counts only where there is a word for it to be part of: "ーーーー" is
+// a rule drawn with dashes, and counting it as four Japanese runes made the
+// digest read a table border as prose.
 func CountCJK(s string) int {
-	n := 0
+	n, words := 0, 0
 	for _, r := range s {
-		if IsCJK(r) {
-			n++
+		if !IsCJK(r) {
+			continue
 		}
+		n++
+		if !isKanaMark(r) {
+			words++
+		}
+	}
+	if words == 0 {
+		return 0
 	}
 	return n
 }
@@ -124,6 +160,19 @@ func Bigrams(s string) []string {
 	seen := map[string]bool{}
 	var run []rune
 	flush := func() {
+		// A run of nothing but marks is not a word: "ー" alone would take a
+		// posting and match nothing anyone means to search for.
+		allMarks := len(run) > 0
+		for _, r := range run {
+			if !isKanaMark(r) {
+				allMarks = false
+				break
+			}
+		}
+		if allMarks {
+			run = run[:0]
+			return
+		}
 		switch {
 		case len(run) == 1:
 			t := string(run)

--- a/internal/cjkfold/kana_marks_test.go
+++ b/internal/cjkfold/kana_marks_test.go
@@ -1,0 +1,83 @@
+package cjkfold
+
+import (
+	"reflect"
+	"testing"
+)
+
+// ー is not decoration: it appears in most Japanese loanwords, and Unicode
+// files it under Common rather than under Katakana. Leaving it out of the
+// script test split every such word into two runs (#1319).
+func TestTheProlongedSoundMarkIsPartOfTheWord(t *testing.T) {
+	for _, tc := range []struct {
+		word string
+		want []string
+	}{
+		{"ステージング", []string{"ステ", "テー", "ージ", "ジン", "ング"}},
+		{"サーバー", []string{"サー", "ーバ", "バー"}},
+		{"リトライ", []string{"リト", "トラ", "ライ"}},
+	} {
+		if got := Bigrams(tc.word); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%s: bigrams = %q, want %q", tc.word, got, tc.want)
+		}
+	}
+}
+
+// The iteration marks look like the same case and are not: Go's own tables
+// already file them under Han and the kana scripts. Pinned so a future change
+// there is visible here rather than as a Japanese search that stops matching.
+func TestIterationMarksStayInsideTheirWord(t *testing.T) {
+	if got := Bigrams("人々"); len(got) != 1 || got[0] != "人々" {
+		t.Errorf("人々 gave %q, want one bigram", got)
+	}
+	// Each mark on its own: two of these are ours and six come from the script
+	// tables, and this says nothing about which is which — only that a word
+	// containing any of them stays one run.
+	for _, r := range []rune{'々', 'ー', 'ヽ', 'ヾ', 'ゝ', 'ゞ', '〻', '\uFF70'} {
+		if !IsCJK(r) {
+			t.Errorf("%q is written inside a word and is not counted as part of it", r)
+		}
+	}
+}
+
+// And nothing else moved: a mark alone is still not a word, and Latin,
+// Cyrillic and punctuation are untouched.
+func TestOnlyTheMarksMoved(t *testing.T) {
+	for _, r := range []rune{'a', 'Я', '5', '-', '_', ' ', '。', '、'} {
+		if IsCJK(r) {
+			t.Errorf("%q counts as CJK", r)
+		}
+	}
+	if got := Bigrams("ー"); len(got) != 0 {
+		t.Errorf("a lone mark produced %q", got)
+	}
+	if got := Bigrams("retry queue"); len(got) != 0 {
+		t.Errorf("ASCII produced %q", got)
+	}
+}
+
+// A rule drawn with long dashes is not Japanese prose: CountCJK feeds the
+// decision, and counting a mark with no word beside it made a table border read
+// as a sentence.
+func TestMarksAloneAreNotProse(t *testing.T) {
+	if got := CountCJK("ーーーー"); got != 0 {
+		t.Errorf("a line of dashes counted %d CJK runes", got)
+	}
+	if got := CountCJK("ステージング"); got != 6 {
+		t.Errorf("a Japanese word counted %d of 6", got)
+	}
+	if got := CountCJK("サーバー"); got != 4 {
+		t.Errorf("a word with two marks counted %d of 4", got)
+	}
+}
+
+// The halfwidth voicing marks are written after the kana they voice, so a word
+// like ｻｰﾊﾞｰ is one run — they are unclaimed by every script table, the same
+// hole the prolonged mark was in.
+func TestHalfwidthVoicingMarksStayInsideTheWord(t *testing.T) {
+	if got := Bigrams("ｻｰﾊﾞｰ"); len(got) == 0 {
+		t.Fatal("a halfwidth word produced no bigrams")
+	} else if len(got) != 4 {
+		t.Errorf("ｻｰﾊﾞｰ gave %q, want four overlapping pairs", got)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -48,7 +48,12 @@ import (
 // line below (#790). Titles are part of this version for the reason 22 gives:
 // incremental ingest reuses the row it already has, so nothing re-derives them
 // without a bump.
-const version = 26
+// 27: the marks Japanese writes inside a word — ー above all, which appears in
+// most loanwords — were not counted as CJK, so every such word was indexed as
+// two runs and the bigrams came out of the pieces. A store built before this
+// holds the split keys and a query built after it asks for the joined ones, so
+// the bump is what makes the one rebuild that re-derives them happen (#1319).
+const version = 27
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/japanese_search_test.go
+++ b/internal/index/japanese_search_test.go
@@ -1,0 +1,94 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// A Japanese session, searched the way its writer would search it. The word in
+// the query is in the text verbatim, so the exact tier is what must answer —
+// it fell through to the close tier, because the query asked for a token the
+// index could never hold (#1319).
+func TestJapaneseWordsAnswerOnTheExactTier(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, filepath.Join(tmp, "home"))
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	proj := filepath.Join(claude, "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for id, text := range map[string]string{
+		"jp":  "リトライキューがステージングで止まった",
+		"jp2": "サーバーのエラーを調べた",
+	} {
+		line := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, id+".jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, q := range []string{"ステージング", "サーバー", "エラー", "リトライ"} {
+		res, err := SearchWithRecoveryDetailed(dir, query.Options{Query: q, All: true}, nil)
+		if err != nil {
+			t.Fatalf("%q: %v", q, err)
+		}
+		if len(res.Sessions) == 0 {
+			t.Errorf("%q: no session, though the word is in the text", q)
+			continue
+		}
+		if res.Tier != search.TierExact {
+			t.Errorf("%q: answered on the %s tier, though the word is in the text verbatim", q, res.Tier)
+		}
+	}
+}
+
+// Chinese and Korean were already right, and must stay so.
+func TestOtherScriptsStillAnswerExactly(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, filepath.Join(tmp, "home"))
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	proj := filepath.Join(claude, "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for id, text := range map[string]string{
+		"cn": "调度器的重试队列在预发环境卡住了",
+		"kr": "재시도 대기열이 스테이징에서 멈췄다",
+	} {
+		line := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, id+".jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, q := range []string{"重试队列", "调度器", "재시도"} {
+		res, err := SearchWithRecoveryDetailed(dir, query.Options{Query: q, All: true}, nil)
+		if err != nil {
+			t.Fatalf("%q: %v", q, err)
+		}
+		if len(res.Sessions) == 0 || res.Tier != search.TierExact {
+			t.Errorf("%q: %d sessions on the %s tier", q, len(res.Sessions), res.Tier)
+		}
+	}
+}
+
+// The posting keys for Japanese change shape with this, so a store built before
+// it holds the split keys while a query built after asks for the joined ones —
+// the same situation the NFC fold was bumped for (version 24).
+func TestTheFormatVersionRidesWithTheKeys(t *testing.T) {
+	if version < 27 {
+		t.Errorf("index version is %d — the CJK keys changed without the bump that re-derives them", version)
+	}
+}


### PR DESCRIPTION
Found by the night hunt, iteration 73, from the hypothesis "a comment promising more than the code delivers" — `cjk.go` says the query side mirrors the index side.

Measured on a round trip through a real index: a session containing ステージング, searched for ステージング, answered on the **close** tier rather than exact.

`ー` (U+30FC) is `Common` in Unicode, not `Katakana`, so `IsCJK` said no. The word became two runs, its bigrams came out of the pieces, and — because the token was then no longer a single CJK run — the query kept the whole word as a term the index can never hold. The AND could not be satisfied, so the exact tier fell through for a word that is in the text verbatim.

That mark is in most Japanese loanwords: サーバー, エラー, コンピューター, ステージング. Chinese and Korean were unaffected, which is why this survived the CJK work in #492 and #1098.

Review asked which other marks share the hole, and the measurement answered: the halfwidth voicing marks `ﾞ`/`ﾟ`, written after the kana they voice, and `〆`. They are in now. The iteration marks 々〻ヽヾゝゞ look like the same case and are not — Go's own tables already file them under Han and the kana scripts, so adding them changed nothing and they were dropped from the diff.

The same review question turned up a real regression in the first cut: `CountCJK` decides whether a line is prose in a CJK script, and counting a lone mark made `ーーーー` — a rule drawn with dashes — read as four Japanese runes. A mark now counts only where there is a word for it to be part of.

Index format bumped to 27: the posting keys for Japanese change shape, so a store built before this holds the split keys while a query built after asks for the joined ones. Same reason as the NFC fold in version 24.

Tests: bigrams for words with the mark, halfwidth voicing marks keeping their word whole, a lone mark producing nothing, marks alone not counting as prose, and — through a real index — Japanese words answering on the exact tier while Chinese and Korean still do. Eight mutations verified; two dropped call sites and one blind test came out of them.
