### PR TITLE
fix: measure proximity against every place, not a sample of one word's

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -654,40 +654,22 @@ func freshnessDecay(updated, now time.Time) float64 {
 	return 1 / (1 + age)
 }
 
-// windowOccurrenceCap bounds how many places of one token are weighed when
-// measuring how close the query's words come together; windowScanLimit bounds
-// how many are walked to choose them, and windowSegments how many are sampled
-// when even the rarest query word runs past that. Without either, a long
+// windowScanLimit bounds how many places of one token are enumerated when
+// measuring how close the query's words come together. Without it, a long
 // transcript message full of a common word makes this quadratic.
 //
-// The places kept are spread across the whole text rather than taken from the
-// front. Taking the first N was the first version, and it moved the defect
-// rather than removing it: a message repeating one query word sixty times
-// before the phrase that actually answers the question was still measured
-// against the sixtieth repetition instead of the phrase.
+// Every place inside that bound is weighed. Sampling a subset was the earlier
+// shape and it lost the tight cluster whenever all the query's words were
+// common: the sample is chosen without knowing where the meeting is (#1319).
 const (
-	windowOccurrenceCap = 32
-	windowScanLimit     = 4096
+	windowScanLimit = 4096
 	// windowSegments is how many equal slices of a message get one sampled
-	// place each. Twice the cap, so spread still has more places than it keeps
-	// and can choose them.
-	windowSegments = windowOccurrenceCap * 2
+	// place each, for a word that runs past the scan limit. A word that common
+	// has a place near everything, so which ones are looked at stops mattering
+	// — what matters is that the sample covers the whole text rather than its
+	// first few kilobytes.
+	windowSegments = 64
 )
-
-// spread picks at most cap of the places, evenly across them, always keeping
-// the first and the last — the tightest cluster is as often at the end of a
-// message as at the start.
-func spread(at []int, cap int) []int {
-	if len(at) <= cap {
-		return at
-	}
-	out := make([]int, 0, cap)
-	step := float64(len(at)-1) / float64(cap-1)
-	for i := 0; i < cap; i++ {
-		out = append(out, at[int(float64(i)*step+0.5)])
-	}
-	return out
-}
 
 // tokenWindow is the tightest character span in this text that contains every
 // query token.
@@ -737,75 +719,60 @@ func tokenSpan(low string, qtoks []string) (span, start int) {
 	type occurrence struct{ at, tok int }
 	var occs []occurrence
 
-	// Anchor on the rarest token. Sampling each token's places independently
-	// cannot find a tight cluster it did not happen to sample: a message that
-	// repeats one query word thousands of times and says the phrase once, in the
-	// middle, was measured against whichever repetition the sampling kept —
-	// hundreds of characters from the phrase (#1318). Anchoring instead asks the
-	// question that proximity actually is: for this place of the rare word,
-	// where is the nearest place of every other one?
-	anchor := -1
-	var at, buf []int
+	// Every place of every token, not a sample of one token's places.
+	//
+	// The sampled version anchored on the rarest token and asked, for each of 32
+	// of its places, where the nearest other tokens were (#1318). That is exact
+	// when one query word is rare and blind when they are all common: in a 33 KB
+	// message where three query words each appear about eighty times and meet
+	// once, in one sentence, it measured 229 against a true 19 — across the
+	// boundary where the proximity boost and the excerpt centring live, so the
+	// passage that actually answered the question lost both (#1319).
+	//
+	// Collecting them all is the same walk the sampling already did to find the
+	// rarest token, and the sliding window below is linear in what it is handed.
 	for ti, tok := range qtoks {
-		buf = buf[:0]
-		for i := 0; i < len(low) && len(buf) < windowScanLimit; {
+		n := 0
+		for i := 0; i < len(low) && n < windowScanLimit; {
 			j := strings.Index(low[i:], tok)
 			if j < 0 {
 				break
 			}
-			buf = append(buf, i+j)
+			occs = append(occs, occurrence{i + j, ti})
+			n++
 			i += j + 1
 		}
-		if len(buf) == 0 {
+		if n == 0 {
 			return 0, 0
 		}
-		// Counting the places is the same walk as finding them, and the walk is
-		// already capped, so the rarest token costs nothing extra to identify.
-		if anchor < 0 || len(buf) < len(at) {
-			anchor = ti
-			at = append(at[:0], buf...)
+		if n < windowScanLimit {
+			continue
 		}
-	}
-	atok := qtoks[anchor]
-	if len(at) == windowScanLimit {
-		// The rare token is itself everywhere, so every place has a neighbour
-		// close by and which places are looked at stops mattering. Take one per
-		// segment of the text, which costs one pass instead of tens of thousands
-		// of searches, and keep the last — the tightest cluster is as often at
-		// the very end as anywhere.
-		at = at[:0]
+		// The word runs past the scan limit, so the walk above stopped part way
+		// through the message and everything after it is unseen. Replace those
+		// places with a sample spread across the whole text plus the last one:
+		// the phrase that answers the question sits at the end of a long output
+		// as often as anywhere (#1318).
+		occs = occs[:len(occs)-n]
 		for i, seg := 0, 0; i < len(low) && seg < windowSegments; {
-			j := strings.Index(low[i:], atok)
+			j := strings.Index(low[i:], tok)
 			if j < 0 {
 				break
 			}
-			p := i + j
-			at = append(at, p)
-			seg = p*windowSegments/len(low) + 1
-			if next := len(low) * seg / windowSegments; next > p {
+			at := i + j
+			occs = append(occs, occurrence{at, ti})
+			seg = at*windowSegments/len(low) + 1
+			if next := len(low) * seg / windowSegments; next > at {
 				i = next
 			} else {
-				i = p + 1
+				i = at + 1
 			}
 		}
-		if last := strings.LastIndex(low, atok); len(at) > 0 && last > at[len(at)-1] {
-			at = append(at, last)
-		}
-	}
-	for _, p := range spread(at, windowOccurrenceCap) {
-		occs = append(occs, occurrence{p, anchor})
-		for ti, tok := range qtoks {
-			if ti == anchor {
-				continue
-			}
-			if l := strings.LastIndex(low[:min(p+len(tok), len(low))], tok); l >= 0 {
-				occs = append(occs, occurrence{l, ti})
-			}
-			if r := strings.Index(low[p:], tok); r >= 0 {
-				occs = append(occs, occurrence{p + r, ti})
-			}
+		if last := strings.LastIndex(low, tok); last >= 0 {
+			occs = append(occs, occurrence{last, ti})
 		}
 	}
+
 	sort.Slice(occs, func(a, b int) bool { return occs[a].at < occs[b].at })
 
 	// Slide a window along the occurrences, shrinking it from the left for as

--- a/internal/search/span_exact_test.go
+++ b/internal/search/span_exact_test.go
@@ -1,0 +1,160 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// minSpanBrute is the answer tokenSpan has to give: the tightest window holding
+// one occurrence of every token.
+func minSpanBrute(low string, toks []string) int {
+	places := make([][]int, len(toks))
+	for i, tok := range toks {
+		for at := 0; ; {
+			j := strings.Index(low[at:], tok)
+			if j < 0 {
+				break
+			}
+			places[i] = append(places[i], at+j)
+			at += j + 1
+		}
+		if len(places[i]) == 0 {
+			return 0
+		}
+	}
+	best := 1 << 30
+	for _, p := range places[0] {
+		lo, hi := p, p+len(toks[0])
+		for i := 1; i < len(toks); i++ {
+			bestGap, at := 1<<30, -1
+			for _, q := range places[i] {
+				gap := q - p
+				if gap < 0 {
+					gap = -gap
+				}
+				if gap < bestGap {
+					bestGap, at = gap, q
+				}
+			}
+			if at < lo {
+				lo = at
+			}
+			if at+len(toks[i]) > hi {
+				hi = at + len(toks[i])
+			}
+		}
+		if hi-lo < best {
+			best = hi - lo
+		}
+	}
+	return best
+}
+
+// The case sampling could not see: every query word common, and the sentence
+// where they meet sitting once, anywhere. Anchoring on the rarest token (#1318)
+// answers it when one word is rare; when none is, the sample is chosen without
+// knowing where the meeting is, and a 33 KB message measured 229 against a true
+// 19 — across the boundary the proximity boost and the excerpt centring live on
+// (#1319).
+func TestTheTightestClusterIsFoundWhereverItSits(t *testing.T) {
+	toks := []string{"retry", "queue", "staging"}
+	for _, where := range []float64{0.03, 0.31, 0.5, 0.68, 0.97} {
+		var b strings.Builder
+		const n = 300
+		at := int(float64(n) * where)
+		for i := 0; i < n; i++ {
+			switch {
+			case i == at:
+				b.WriteString("retry queue staging ")
+			case i%3 == 0:
+				b.WriteString("retry " + strings.Repeat("filler ", 15))
+			case i%3 == 1:
+				b.WriteString("queue " + strings.Repeat("filler ", 15))
+			default:
+				b.WriteString("staging " + strings.Repeat("filler ", 15))
+			}
+		}
+		low := b.String()
+		got := tokenWindow(low, toks)
+		want := minSpanBrute(low, toks)
+		if got != want {
+			t.Errorf("meeting at %.0f%% of a %d-byte message: span %d, tightest is %d", where*100, len(low), got, want)
+		}
+		if got > proximityNear {
+			t.Errorf("meeting at %.0f%%: span %d is past the %d boundary, so the hit loses its boost and its excerpt",
+				where*100, got, proximityNear)
+		}
+	}
+}
+
+// And the answer is the tightest one on ordinary text too, wherever the real
+// path runs. Where the first-occurrence bound already reads as one thought the
+// cheap answer stands by design — it is an upper bound, it costs 101 ns against
+// 122 µs for refining it, and both figures are inside the boost's flat end.
+// Every message here is checked for which path it took.
+func TestTheSpanMatchesTheBruteForceMinimum(t *testing.T) {
+	words := []string{"retry", "queue", "staging", "jitter", "worker", "deploy"}
+	toks := []string{"retry", "queue", "staging"}
+	exact := 0
+	for n := 0; n < 100; n++ {
+		var b strings.Builder
+		seed := n*7 + 3
+		for i := 0; i < 600; i++ {
+			if (i*seed)%23 == 0 {
+				b.WriteString(words[(i*seed)%len(words)] + " ")
+			} else {
+				b.WriteString("filler ")
+			}
+		}
+		low := b.String()
+		got, want := tokenWindow(low, toks), minSpanBrute(low, toks)
+		if want == 0 {
+			continue
+		}
+		if cheapBound(low, toks) <= proximityNear {
+			// The cheap path answered. It must still never claim the words sit
+			// closer than they do.
+			if got < want {
+				t.Fatalf("message %d: the cheap bound %d is tighter than the true %d", n, got, want)
+			}
+			continue
+		}
+		exact++
+		if got != want {
+			t.Fatalf("message %d: span %d, tightest is %d", n, got, want)
+		}
+	}
+	if exact == 0 {
+		t.Fatal("no message reached the exact path, so this test proves nothing")
+	}
+}
+
+// cheapBound is the first-occurrence span tokenSpan uses to decide whether
+// refining is worth it.
+func cheapBound(low string, toks []string) int {
+	first, last := -1, -1
+	for _, tok := range toks {
+		i := strings.Index(low, tok)
+		if i < 0 {
+			return 0
+		}
+		if first < 0 || i < first {
+			first = i
+		}
+		if end := i + len(tok); end > last {
+			last = end
+		}
+	}
+	return last - first
+}
+
+// A token the text does not carry still means no window, and a single-token
+// query has none by definition.
+func TestNoWindowWithoutEveryToken(t *testing.T) {
+	if got := tokenWindow("the retry queue stalls", []string{"retry", "absent"}); got != 0 {
+		t.Errorf("a missing token produced a window of %d", got)
+	}
+	if got := tokenWindow("the retry queue stalls", []string{"retry"}); got != 0 {
+		t.Errorf("a single token produced a window of %d", got)
+	}
+}

--- a/internal/search/token_window_test.go
+++ b/internal/search/token_window_test.go
@@ -35,10 +35,10 @@ func TestAMissingTokenHasNoWindow(t *testing.T) {
 }
 
 // The tightest cluster can be anywhere, including behind a long run of one of
-// the words — the case the occurrence cap has to survive.
+// the words — the case the scan has to survive.
 func TestTheCapDoesNotHideTheTightestCluster(t *testing.T) {
 	text := strings.ToLower(
-		strings.Repeat("pool ", windowOccurrenceCap*2) + "connection pool exhausted")
+		strings.Repeat("pool ", 64) + "connection pool exhausted")
 	got := tokenWindow(text, []string{"connection", "pool", "exhausted"})
 	if got > 40 {
 		t.Errorf("window is %d characters: the cap stopped before the cluster", got)


### PR DESCRIPTION
Found by the night hunt, iteration 74, from the hypothesis "places where the cost is measured and the quality is not — for example `windowOccurrenceCap = 32` with three or more query words".

`tokenSpan` measures how close the query's words come together. The result feeds a graded proximity boost — `1 + 0.35 × 200/(200+span)` — and decides whether an excerpt centres on the words meeting. It anchored on the rarest token and kept 32 of its places, spread across the text.

That is exact when one query word is rare. It is blind when they are all common, because the sample is chosen without knowing where the meeting is. Measured on a 33 KB message where three query words each appear about eighty times and meet once, in one sentence:

```
span 229, tightest is 19
```

229 is past the 200 boundary, so the passage that actually answered the question lost both its boost and its excerpt — in every placement of the meeting from 3% to 97% through the message.

Now every place of every token is collected, bounded by the existing scan limit, and the sliding window that was already there finds the tightest cluster. A word that runs past the limit falls back to a sample spread across the whole message plus its last place, which is what #1318 needed and what my first cut broke — the tests for the phrase at the end and in the middle caught it.

It is also cheaper, because the sampling did 32 × 2 × (k−1) index searches over long spans while this does k linear scans:

| case | before | after |
|---|---|---|
| 2000-word message | 36 µs | 13.9 µs |
| 10000-word message | 104 µs | 62 µs |
| worst case: 64 KB, ten query words | 265 µs | 195 µs |

The cheap first-occurrence early return stays: dropping it was measured at 101 ns against 122 µs on the ordinary case, and both answers sit in the flat end of the boost.

Tests: the tightest cluster found wherever it sits in a message where every word is common, agreement with a brute-force minimum on a hundred messages that reach the exact path, and no window without every token. Four mutations verified.
