### PR TITLE
fix: a recall payload does not pay twice for one answer

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -528,6 +528,77 @@ func attachAnswers(dir string, hits []search.Hit) {
 	}
 }
 
+// shownAnswers counts the excerpts that are answer lines rather than matched
+// text, which is how many conclusions the drop below can take.
+func shownAnswers(snippets []string) int {
+	n := 0
+	for _, sn := range snippets {
+		if strings.HasPrefix(strings.TrimSpace(sn), "→ ") {
+			n++
+		}
+	}
+	return n
+}
+
+// withoutShownAnswer drops conclusions the excerpts above already carry. The
+// comparison is on the text alone: the answer line is written with an arrow
+// prefix and a conclusion is not, and the same sentence can be trimmed to a
+// different number of sentences on the two paths, so the shorter one being a
+// prefix of the longer counts as the same fact.
+func withoutShownAnswer(cs []string, snippets []string) []string {
+	if len(cs) == 0 || len(snippets) == 0 {
+		return cs
+	}
+	shown := make([]string, 0, len(snippets))
+	for _, sn := range snippets {
+		if t := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(sn), "→ ")); t != sn {
+			shown = append(shown, t)
+		}
+	}
+	if len(shown) == 0 {
+		return cs
+	}
+	out := cs[:0:0]
+	for _, c := range cs {
+		dup := false
+		for _, sh := range shown {
+			if sameFact(c, sh) {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// sameFact reports whether two lines say the same thing. One being a prefix of
+// the other counts, because the answer line and the conclusions list trim to a
+// different number of sentences — but only when the shorter one is long enough
+// to be a fact rather than an opening: "We decided to" is the start of every
+// second conclusion an agent writes, and dropping the specific line behind it
+// would lose the answer to keep the preamble.
+func sameFact(a, b string) bool {
+	if a == b {
+		return true
+	}
+	short, long := a, b
+	if len(short) > len(long) {
+		short, long = long, short
+	}
+	if len(short) < sameFactFloor {
+		return false
+	}
+	return strings.HasPrefix(long, short)
+}
+
+// sameFactFloor is how much of a sentence has to agree before two lines count
+// as one fact. Forty characters is past any shared opening — "we decided to
+// use" is nineteen — and inside the shortest conclusion worth printing.
+const sameFactFloor = 40
+
 // recallListingLine makes one line of the recall listing safe to hand a model.
 //
 // The listing is built here rather than by the search printer, so it never
@@ -722,7 +793,19 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 				if full, ok, ferr := wholeSessionForMCP(dir, whole); ferr == nil && ok {
 					whole = full
 				}
-				if cs := digest.Conclusions(whole, left, 3); len(cs) > 0 {
+				// Not the line already shown as this hit's answer. The answer
+				// under the excerpt and the newest conclusion are usually the
+				// same sentence, and printing it twice charged the agent twice
+				// for one fact — 16% of a small payload — while costing the
+				// conclusions list one of its three slots (#1319).
+				// Ask for as many extra as there are answer lines above: the
+				// drop below can take any of them, and asking for a fixed one
+				// more still showed two where three were available.
+				want := 3 + shownAnswers(h.Snippets)
+				if cs := withoutShownAnswer(digest.Conclusions(whole, left, want), h.Snippets); len(cs) > 0 {
+					if len(cs) > 3 {
+						cs = cs[:3]
+					}
 					fmt.Fprintln(&hb, "  what this session concluded:")
 					for _, c := range cs {
 						fmt.Fprintf(&hb, "  → %s\n", recallListingLine(c))

--- a/cmd/deja/recall_no_repeat_test.go
+++ b/cmd/deja/recall_no_repeat_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// twoDecisionStore writes a session that decided one thing and then decided
+// otherwise, so the answer under the excerpt and the newest conclusion are the
+// same sentence.
+func twoDecisionStore(t *testing.T) string {
+	t.Helper()
+	hermeticEnv(t)
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	turns := []struct{ role, text string }{
+		{"user", "how do we handle the retry queue backoff"},
+		{"assistant", "FIRST: we used a fixed one second delay and it synchronised every worker."},
+		{"user", "filler about something else entirely"},
+		{"assistant", "unrelated chatter that says nothing about the decision at hand."},
+		{"user", "what did we decide about the retry queue backoff in the end"},
+		{"assistant", "SECOND: we settled on full jitter with three attempts, then give up."},
+	}
+	var b strings.Builder
+	for i, m := range turns {
+		b.WriteString(`{"type":"` + m.role + `","sessionId":"a","timestamp":"2026-01-02T03:0` +
+			string(rune('0'+i)) + `:00Z","message":{"role":"` + m.role + `","content":"` + m.text + `"}}` + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(proj, "a.jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The answer under the excerpt and the newest conclusion are usually the same
+// sentence, and it was printed twice — 16% of a small payload spent saying one
+// thing, while the conclusions list lost one of its three slots (#1319).
+func TestRecallDoesNotPayTwiceForOneAnswer(t *testing.T) {
+	dir := twoDecisionStore(t)
+	text, _, _, _, err := recallTextResult(dir, "decide retry queue backoff end", "", 5, 0, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]int{}
+	for _, ln := range strings.Split(text, "\n") {
+		ln = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(ln), "- "))
+		if !strings.HasPrefix(ln, "→ ") {
+			continue
+		}
+		seen[ln]++
+	}
+	for line, n := range seen {
+		if n > 1 {
+			t.Errorf("the payload says this %d times: %q", n, line)
+		}
+	}
+	// The freed slot goes to the fact that was pushed out.
+	if !strings.Contains(text, "SECOND") {
+		t.Errorf("the answer is missing:\n%s", text)
+	}
+	if !strings.Contains(text, "FIRST") {
+		t.Errorf("the earlier decision was dropped rather than promoted:\n%s", text)
+	}
+}
+
+// A conclusion that is not the answer stays, and a hit with no answer line at
+// all keeps every conclusion.
+func TestConclusionsSurviveWhenTheyAreNotTheAnswer(t *testing.T) {
+	if got := withoutShownAnswer([]string{"we capped retries at three"}, []string{"the retry queue stalls"}); len(got) != 1 {
+		t.Errorf("a conclusion was dropped against a plain excerpt: %q", got)
+	}
+	if got := withoutShownAnswer([]string{"we capped retries at three"}, nil); len(got) != 1 {
+		t.Errorf("a conclusion was dropped with no excerpts at all: %q", got)
+	}
+	// The two paths can trim the same sentence differently, so a prefix counts
+	// — in both directions, since either side can be the longer one.
+	long := "we capped retries at three attempts with full jitter. then we raised it."
+	shortForm := "we capped retries at three attempts with full jitter."
+	if got := withoutShownAnswer([]string{shortForm}, []string{"→ " + long}); len(got) != 0 {
+		t.Errorf("the conclusion was the shorter form and was printed twice: %q", got)
+	}
+	if got := withoutShownAnswer([]string{long}, []string{"→ " + shortForm}); len(got) != 0 {
+		t.Errorf("the conclusion was the longer form and was printed twice: %q", got)
+	}
+	// A shared opening is not a shared fact.
+	if got := withoutShownAnswer([]string{"we decided to use exponential backoff"}, []string{"→ we decided to"}); len(got) != 1 {
+		t.Errorf("a distinct conclusion was dropped for sharing an opening: %q", got)
+	}
+}
+
+// Dropping the repeat must not cost the block a line: the conclusions are asked
+// for one more than they show, so three still arrive when the session has four
+// things to say.
+func TestTheFreedSlotIsFilled(t *testing.T) {
+	hermeticEnv(t)
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	turns := []struct{ role, text string }{
+		// The matched question comes last, so its answer is also the newest
+		// conclusion — which is the case where the repeat costs a slot.
+		{"user", "the timeouts"},
+		{"assistant", "TIMEOUTS: the read timeout stays at thirty seconds for now."},
+		{"user", "the pool"},
+		{"assistant", "POOL: capped the connection pool at sixteen per worker."},
+		{"user", "the alerts"},
+		{"assistant", "ALERTS: page only on the second consecutive failure."},
+		{"user", "what did we decide about the retry queue backoff in the end"},
+		{"assistant", "ANSWER: we settled on full jitter with three attempts, then give up."},
+	}
+	var b strings.Builder
+	for i, m := range turns {
+		b.WriteString(`{"type":"` + m.role + `","sessionId":"a","timestamp":"2026-01-02T03:0` +
+			string(rune('0'+i)) + `:00Z","message":{"role":"` + m.role + `","content":"` + m.text + `"}}` + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(proj, "a.jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	text, _, _, _, err := recallTextResult(dir, "decide retry queue backoff end", "", 5, 0, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block := text[strings.Index(text, "what this session concluded:"):]
+	if n := strings.Count(block, "→ "); n != 3 {
+		t.Errorf("the block shows %d conclusions, want 3:\n%s", n, block)
+	}
+	if strings.Count(text, "ANSWER: we settled") != 1 {
+		t.Errorf("the answer is repeated or missing:\n%s", text)
+	}
+}


### PR DESCRIPTION
Found by the night hunt, iteration 76.

A recall payload shows, per hit, the matched excerpts, then the answer to the matched turn as `→ …`, and for the best hit a block of what the session concluded. The newest conclusion is usually the answer to the last thing asked — which is the same sentence that was just printed above it:

```
- what did we decide about the retry queue backoff in the end
- → SECOND: we settled on full jitter with three attempts, then give up.
  what this session concluded:
  → SECOND: we settled on full jitter with three attempts, then give up.
  → FIRST: we used a fixed one second delay and it synchronised every worker.
```

16% of a 451-byte payload spent saying one thing twice, in a budget measured in tokens, and the conclusions block lost one of its three slots to the repeat.

A conclusion an excerpt already carries is dropped now, and the block asks for as many extra as there are answer lines above it, so nothing is lost to the drop. The comparison tolerates a prefix, because the two paths trim to a different number of sentences — with a floor of forty characters, since "we decided to use" is the opening of every second conclusion an agent writes and dropping the specific line behind a shared opening would keep the preamble and lose the answer.

Two things measured rather than argued while doing this:

- `attachAnswers` takes the first user message of the hit, which looked like the same "first instead of best" shape. It is not: a hit's messages lead with the best match, so on a session where both questions match the query the answer attached is the one the excerpt shows. Left alone.
- `digest.Conclusions` is correct about order — newest first, and under a tight budget it keeps the newest. The repeat was the whole of it.

Tests: no line printed twice for a session that decided twice, the freed slot filled when the session has four things to say, the prefix rule in both directions, and a shared opening not counting as a shared fact. Six mutations verified — one of which showed my first fixture could not fail, because its four "DECISION …" lines shared an opening and the digest deduplicated them before any of this ran.
