### PR TITLE
fix: count a wall's length in characters, not bytes

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/model"
 )
@@ -76,7 +77,13 @@ func normalizeFriction(l string) string {
 // recent call last):`, and clustering those put an empty line at the top of
 // every measurement this was built from.
 func isFriction(l string) bool {
-	if len(l) < frictionLineMin || len(l) > frictionLineMax {
+	// Characters, not bytes. The bound is about how much of a line a person can
+	// recognise, and in bytes it held a Russian error to 60 characters and a
+	// Chinese one to 40 while giving English 120: an 89-character Russian line
+	// was dropped where an 80-character English one was kept, so the wall a
+	// Russian-speaking user keeps hitting never reached `deja friction`, the
+	// environment block or `deja fix` (#1319).
+	if n := utf8.RuneCountInString(l); n < frictionLineMin || n > frictionLineMax {
 		return false
 	}
 	for _, generic := range []string{

--- a/internal/index/friction_script_test.go
+++ b/internal/index/friction_script_test.go
@@ -1,0 +1,67 @@
+package index
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// The bound on what counts as a wall is about how much of a line a person can
+// recognise, and it was counted in bytes — so a Russian error line was held to
+// 60 characters and a Chinese one to 40, while English got 120. An
+// 89-character Russian line was dropped where an 80-character English one was
+// kept, and the wall a Russian-speaking user keeps hitting never reached
+// `deja friction`, the environment block or `deja fix` (#1319).
+func TestFrictionBoundsCountCharactersNotBytes(t *testing.T) {
+	// Carries an English marker, as most real error lines do, so only the
+	// length decides.
+	for _, l := range []string{
+		"ОШИБКА при развёртывании: connection refused при подключении к очереди повторов",
+		"ОШИБКА при развёртывании сервиса доставки: connection refused при подключении к очереди",
+	} {
+		if n := utf8.RuneCountInString(l); n > frictionLineMax {
+			t.Fatalf("the fixture is %d characters, past the bound itself", n)
+		}
+		if len(l) <= frictionLineMax {
+			t.Fatalf("the fixture is %d bytes, inside the byte bound, so it proves nothing", len(l))
+		}
+		if _, ok := FrictionLine(l); !ok {
+			t.Errorf("a %d-character line was dropped for being %d bytes: %.40s",
+				utf8.RuneCountInString(l), len(l), l)
+		}
+	}
+}
+
+// The bounds still bound: a line too short to name anything, and one past the
+// limit in characters, are both out.
+func TestFrictionBoundsStillHold(t *testing.T) {
+	if _, ok := FrictionLine("panic: x"); ok {
+		t.Error("a line under the minimum was accepted")
+	}
+	long := "connection refused " + strings.Repeat("очень длинное описание ", 12)
+	if n := utf8.RuneCountInString(long); n <= frictionLineMax {
+		t.Fatalf("the fixture is only %d characters", n)
+	}
+	if _, ok := FrictionLine(long); ok {
+		t.Error("a line past the maximum in characters was accepted")
+	}
+}
+
+// And English is unchanged, since bytes and characters agree there.
+func TestFrictionKeepsEnglishAsItWas(t *testing.T) {
+	if _, ok := FrictionLine("ModuleNotFoundError: No module named yaml while building the image"); !ok {
+		t.Error("an ordinary English error line stopped counting as a wall")
+	}
+	if _, ok := FrictionLine("connection refused " + strings.Repeat("x", 200)); ok {
+		t.Error("a very long English line was accepted")
+	}
+}
+
+// The gate decides what gets a friction signature at ingest, so a store built
+// before this keeps fewer of them — the bump is what makes the one rebuild
+// that re-derives them happen.
+func TestTheFrictionBoundRidesOnTheFormatVersion(t *testing.T) {
+	if version < 27 {
+		t.Errorf("index version is %d — the friction gate changed without the bump that re-derives it", version)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -53,7 +53,11 @@ import (
 // two runs and the bigrams came out of the pieces. A store built before this
 // holds the split keys and a query built after it asks for the joined ones, so
 // the bump is what makes the one rebuild that re-derives them happen (#1319).
-const version = 27
+// 28: what counts as a wall is bounded in characters rather than bytes, so a
+// line written in Russian or Chinese is held to the same length as an English
+// one. A store built before this holds fewer friction signatures, and nothing
+// re-derives them without the bump — the same shape as 22 and 23 (#1319).
+const version = 28
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message


### PR DESCRIPTION
Found by the night hunt, iteration 78, from the hypothesis "list the thresholds that decide behaviour and ask what stands on either side of each".

`frictionLineMin`/`Max` (20 and 120) gate what counts as a wall. A line inside them earns a friction signature, and that signature is what `deja friction` clusters on, what the environment block names at session start, and what `deja fix` matches a pasted error against. The bound was counted in **bytes**, so a Russian line was held to about 60 characters and a Chinese one to 40, while English got 120.

Measured with lines carrying an English marker, so only the length decides:

```
ru  79 characters (131 bytes)  rejected
ru 114 characters (197 bytes)  rejected
en  80 characters ( 80 bytes)  kept
```

A wall a Russian-speaking user keeps hitting simply never reached any of those three surfaces. Counted in characters now.

The measurement took two corrections worth recording. The real store turned out to hold no tool-output records at all just then, so the probe read 0 of 0 — a number that says nothing, and the same "the data did not arrive" trap as before; the answer came from a synthetic corpus instead. And the first fixtures were rejected by the marker list rather than by length, which would have made a green result meaningless — the ones above carry a marker on purpose.

Index format bumped to 27: the gate runs at ingest, so a store built before this holds fewer signatures and nothing re-derives them without the bump. If #1392 lands first this becomes 28 on rebase — it bumps for the same kind of reason, on the CJK posting keys.

Tests: a long non-ASCII line kept, both bounds still bounding, English unchanged, and the version bump itself. Four mutations verified.
