### PR TITLE
fix: an excerpt near the end of a message spends its whole window

### DIFF
--- a/internal/search/excerpt_window_test.go
+++ b/internal/search/excerpt_window_test.go
@@ -1,0 +1,70 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// The excerpt is 300 runes around the match. When the match sat near the end
+// of a message the window ran off it and the rest of the budget went unspent:
+// 120 runes where the same match in the middle showed 302 — and the end of a
+// long output is where the answer sits as often as anywhere (#1319).
+func TestTheExcerptSpendsItsWindowWhereverTheMatchIs(t *testing.T) {
+	filler := strings.Repeat("filler about unrelated work, ", 30)
+	for _, tc := range []struct{ name, msg string }{
+		{"at the start", "the retry queue stalls " + filler},
+		{"in the middle", filler + " the retry queue stalls " + filler},
+		{"at the end", filler + " the retry queue stalls"},
+	} {
+		got := utf8.RuneCountInString(snippet(tc.msg, "retry queue", nil))
+		if got < 290 {
+			t.Errorf("%s: excerpt is %d runes of the 300 the message can fill", tc.name, got)
+		}
+	}
+}
+
+// The clamp at the other end is untouched: a match inside the first hundred
+// runes of a message shorter than the window still starts at the beginning,
+// with no mark claiming something was dropped in front of it.
+func TestAMatchNearTheStartIsUnchanged(t *testing.T) {
+	msg := "the retry queue stalls on staging " + strings.Repeat("and then it recovered, ", 6)
+	if n := utf8.RuneCountInString(msg); n >= 300 {
+		t.Fatalf("the fixture is %d runes, so it does not exercise the clamp", n)
+	}
+	got := snippet(msg, "retry queue", nil)
+	if strings.HasPrefix(got, "…") {
+		t.Errorf("a match at the start was marked as cut in front: %q", got)
+	}
+	if !strings.HasPrefix(got, "the retry queue") {
+		t.Errorf("the excerpt does not begin at the beginning: %.40s", got)
+	}
+}
+
+// A message shorter than the window is shown whole, with no marks claiming
+// something was cut.
+func TestAShortMessageIsShownWhole(t *testing.T) {
+	msg := "the retry queue stalls on staging when the workers wake together"
+	got := snippet(msg, "retry queue", nil)
+	if got != msg {
+		t.Errorf("a short message was changed:\n%q\n%q", got, msg)
+	}
+	if strings.Contains(got, "…") {
+		t.Errorf("a short message was marked as cut: %q", got)
+	}
+}
+
+// The match itself stays inside the window wherever it sits.
+func TestTheMatchStaysInTheExcerpt(t *testing.T) {
+	filler := strings.Repeat("filler about unrelated work, ", 30)
+	for _, msg := range []string{
+		"the retry queue stalls " + filler,
+		filler + " the retry queue stalls " + filler,
+		filler + " the retry queue stalls",
+		filler + " the retry queue stalls " + strings.Repeat("x", 40),
+	} {
+		if got := snippet(msg, "retry queue", nil); !strings.Contains(got, "retry queue") {
+			t.Errorf("the match fell outside the excerpt: %.80s", got)
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1519,7 +1519,14 @@ func snippet(s, q string, re *regexp.Regexp) string {
 	}
 	end := start + 300
 	if end > len(r) {
+		// Spend the whole window: a match near the end of a message left the
+		// tail of the budget unused and showed 120 runes where a match in the
+		// middle of the same message showed 302 — and the end is where the
+		// answer sits in a long output as often as anywhere (#1319).
 		end = len(r)
+		if start = end - 300; start < 0 {
+			start = 0
+		}
 	}
 	out := strings.TrimSpace(string(r[start:end]))
 	out = strings.Trim(out, " ,.;:-\n\t")


### PR DESCRIPTION
Found by the night hunt, iteration 81, continuing the threshold sweep.

An excerpt is 300 runes around the match: a hundred before, two hundred after. The end was clamped to the message and `start` was not pulled back, so a match near the end of a message spent only part of its window:

```
match at the start of an 893-rune message   302 runes shown
match in the middle                         303
match at the end of the same message        120
```

The budget was there and went unused, in exactly the case #1318 named — the phrase that answers the question sits at the end of a long output as often as anywhere. The window slides back now, and the same match at the end shows 301.

Measured trade, since fuller excerpts cost bytes in a budgeted payload. On a store of eight long Chinese sessions each matching at the end, `recall` with a 4096-byte budget:

| | payload | hits served |
|---|---|---|
| before | 3899 bytes | 8 |
| after | 4094 bytes | 4 |

Neither breaches the budget — the trim was never the problem. What changes is the trade inside it: four hits with a readable excerpt each rather than eight with forty characters apiece, which for CJK is barely a phrase. Worth knowing, since it is the one visible consequence beyond the fix itself.

The clamp at the other end is untouched: a match inside the first hundred runes still starts at the beginning of the message, with no mark claiming something was dropped in front of it, and a message shorter than the window is still shown whole.

Tests: the window spent wherever the match sits, the match staying inside it, the start clamp unchanged, and a short message untouched. Two mutations verified.
