### PR TITLE
docs: record what the conclusions budget actually does

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -784,6 +784,14 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		// recall itself. Later hits stay excerpt-only; they are candidates to
 		// choose between, not answers.
 		if i == 0 {
+			// The plus is deliberate as it stands, and measured: making it a
+			// minus — which is what the words above suggest — changes nothing
+			// on a full page (identical payloads at 4096, 3000 and 2400 bytes,
+			// with and without long conclusions) and only withholds the block
+			// on a nearly empty one, where it fits with room to spare. The
+			// outer trim is what actually bounds the payload. Left as it is
+			// rather than "corrected" blind; whoever changes it should measure
+			// the same three budgets first (#1319).
 			if left := budget - headerRoom + hb.Len() - recallConclusionsReserve; left > recallConclusionsMin {
 				// The hit carries only the matching messages, so the decision —
 				// usually worded nothing like the query — is not in it. Read the


### PR DESCRIPTION
Iteration 82 of the night hunt went looking at `recallConclusionsMin`/`Reserve` and found what looks like a sign error introduced in #1379: `budget - headerRoom + hb.Len() - reserve`, where the words around it say the block gets what the hits left over.

Measured before changing it. Making it a minus:

- identical payloads on a full page at 4096, 3000 and 2400 bytes — same bytes served, same number of conclusions, same trim;
- identical again with conclusions long enough to overrun on their own;
- the only difference is on a nearly empty payload, where the current form prints the block and the "corrected" one withholds it, with room to spare either way.

So the outer trim is what bounds the payload, not this line, and "fixing" the sign would only lose conclusions that fit. Left as it is, with the measurement written down beside it — the next person to read that expression will see the same thing I did, and this saves them the afternoon.

No behaviour change; comment only.