### PR TITLE
fix: bound the status line in columns, not runes

### DIFF
--- a/cmd/deja/statusline_cjk_test.go
+++ b/cmd/deja/statusline_cjk_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/termwidth"
+)
+
+// seedCJKTitleIndex is seedLongTitleIndex with Chinese titles: same shape, same
+// shared file, a title long enough to be trimmed on any bar.
+func seedCJKTitleIndex(t *testing.T, titles []string) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-cjk")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	for i, title := range titles {
+		sid := fmt.Sprintf("cj%02d", i)
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/w/cj","timestamp":"2026-07-1` +
+			fmt.Sprint(i) + `T10:00:00Z","message":{"role":"user","content":"` + title + `"}}` + "\n" +
+			`{"type":"assistant","sessionId":"` + sid + `","cwd":"/w/cj","timestamp":"2026-07-1` +
+			fmt.Sprint(i) + `T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/w/cj/retry.go"}}]}}` + "\n"
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+var cjkTitles = []string{
+	"重试队列在预发环境卡住了工作进程同时醒来需要加抖动才能错开",
+	"重试队列在预发环境卡住了工作进程同时醒来需要加抖动才能错开二",
+	"重试队列在预发环境卡住了工作进程同时醒来需要加抖动才能错开三",
+}
+
+// #1076 bounded the bar in runes, which is the same thing as columns only for
+// Latin text. A Chinese title is one rune and two columns per character, so
+// the 38-rune cap fit an 80-column bar on paper and printed 98 columns — the
+// memory segment ran off the edge exactly as it did before that fix.
+func TestStatuslineFitsTheBarWithCJKTitle(t *testing.T) {
+	dir := seedCJKTitleIndex(t, cjkTitles)
+	// 82 is where the usage numbers start to fit by rune count and not by
+	// column count: the segment before them is 58 runes and 77 columns.
+	for _, width := range []int{60, 80, 82, 120} {
+		t.Setenv("COLUMNS", strconv.Itoa(width))
+		line := statuslineWith(t, dir, "/anywhere/cj01.jsonl")
+		if got := termwidth.Columns(line); got > width {
+			t.Errorf("%d-column bar: line prints %d columns: %q", width, got, line)
+		}
+		// The segment has to arrive whole; a title the terminal cuts loses its
+		// closing quote, which is the visible half of #1076.
+		if !strings.Contains(line, "”") {
+			t.Errorf("%d-column bar: the memory segment lost its closing quote: %q", width, line)
+		}
+	}
+}
+
+// The bar still grows with the terminal — a fixed conservative cap would pass
+// the test above and show the same stub on every width.
+func TestStatuslineCJKTitleGrowsWithTheBar(t *testing.T) {
+	dir := seedCJKTitleIndex(t, cjkTitles)
+
+	t.Setenv("COLUMNS", "60")
+	narrow := statuslineWith(t, dir, "/anywhere/cj01.jsonl")
+	t.Setenv("COLUMNS", "120")
+	wide := statuslineWith(t, dir, "/anywhere/cj01.jsonl")
+
+	if termwidth.Columns(wide) <= termwidth.Columns(narrow) {
+		t.Errorf("the line did not grow with the bar: narrow=%d wide=%d",
+			termwidth.Columns(narrow), termwidth.Columns(wide))
+	}
+	// And the trim is real on the narrow bar: the whole title is 28 characters,
+	// so a 60-column bar cannot be showing all of it.
+	if strings.Contains(narrow, "错开") {
+		t.Errorf("60-column bar shows the untrimmed title: %q", narrow)
+	}
+}
+
+// safeForStatusline is what bounds the title, and its bound is what changed.
+func TestSafeForStatuslineBoundsColumns(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		max  int
+		want int
+	}{
+		{"latin under the cap", "retry queue stalls", 38, 18},
+		// One short of the cap plus the ellipsis: the cut landed on a space,
+		// which is trimmed before the mark is added.
+		{"latin over the cap", "the retry queue stalls on staging and the workers wake together", 38, 38},
+		{"chinese over the cap", "重试队列在预发环境卡住了工作进程同时醒来需要加抖动才能错开", 38, 39},
+		{"chinese exactly at the cap", "重试队列在预发环境卡住了工作进程同", 34, 34},
+		{"kana over the cap", "リトライキューがステージングで詰まりワーカーが同時に起きる", 20, 21},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := termwidth.Columns(safeForStatusline(tc.in, tc.max))
+			if got != tc.want {
+				t.Errorf("safeForStatusline(%q, %d) prints %d columns, want %d (%q)",
+					tc.in, tc.max, got, tc.want, safeForStatusline(tc.in, tc.max))
+			}
+		})
+	}
+}

--- a/cmd/deja/statusline_memory.go
+++ b/cmd/deja/statusline_memory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/termwidth"
 )
 
 // The status line is the only surface deja has that is present *during* the
@@ -227,7 +228,12 @@ func statuslineMemoryLineTo(m fileMemory, maxTitle int) string {
 func trimStatuslineTitle(t string) string { return safeForStatusline(t, statuslineMaxTitle) }
 
 // safeForStatusline strips what a terminal would act on rather than print, and
-// bounds the length in runes.
+// bounds the length in columns.
+//
+// Columns rather than runes because the bound exists to keep the bar inside
+// the terminal: a CJK title is one rune and two columns per character, so a
+// 38-rune cap let a Chinese title print 76 columns and take the line past the
+// edge that #1076 fixed for Latin text.
 //
 // Control characters (Cc) cover the carriage return and the escape byte.
 // Format characters (Cf) are the quieter half of the same problem: U+202E
@@ -242,9 +248,8 @@ func safeForStatusline(s string, max int) string {
 		return r
 	}, s)
 	s = strings.Join(strings.Fields(s), " ")
-	r := []rune(s)
-	if len(r) > max {
-		return strings.TrimSpace(string(r[:max])) + "…"
+	if termwidth.Columns(s) > max {
+		return strings.TrimSpace(termwidth.Cut(s, max)) + "…"
 	}
 	return s
 }
@@ -273,7 +278,7 @@ func withFileMemory(dir string, in transcriptSource, usage string) string {
 	// rule: it is the half that has to survive. The title is its elastic part,
 	// with a floor so a long filename cannot cut it to a stub.
 	mem := "deja · " + statuslineMemoryLineTo(m, statuslineMaxTitle)
-	if over := visibleLen(mem) - width; over > 0 {
+	if over := barColumns(mem) - width; over > 0 {
 		budget := statuslineMaxTitle - over
 		if budget < statuslineMinTitle {
 			budget = statuslineMinTitle
@@ -284,7 +289,7 @@ func withFileMemory(dir string, in transcriptSource, usage string) string {
 	// it past the edge; dropping it is the trade this function already
 	// documents, and half of it beats a line that runs off.
 	for _, tail := range []string{shortenUsage(usage), firstUsageFact(usage)} {
-		if tail != "" && visibleLen(mem)+3+visibleLen(tail) <= width {
+		if tail != "" && barColumns(mem)+3+barColumns(tail) <= width {
 			return mem + " · " + tail
 		}
 	}
@@ -300,6 +305,10 @@ func firstUsageFact(usage string) string {
 	}
 	return parts[0]
 }
+
+// barColumns is how wide a rendered segment prints, ignoring the colour
+// escapes, which occupy no cell.
+func barColumns(s string) int { return termwidth.Columns(ansiRE.ReplaceAllString(s, "")) }
 
 // statuslineWidth is the bar deja lays out for. Same reasoning as briefWidth:
 // no dependency may be added to read the real size, 80 is wrong least often,

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/query"
 	"github.com/vshulcz/deja-vu/internal/redact"
+	"github.com/vshulcz/deja-vu/internal/termwidth"
 )
 
 const (
@@ -1172,18 +1173,18 @@ func fitProject(project string, width int, harness, date, id string, count int, 
 	}
 	// The column is padded to ten, so a name shorter than that costs ten either
 	// way and the budget has to say so.
-	fixed := columns(fmt.Sprintf("[%s]  · %s · %s — %d matches%s", harness, date, id, count, tier))
+	fixed := termwidth.Columns(fmt.Sprintf("[%s]  · %s · %s — %d matches%s", harness, date, id, count, tier))
 	room := width - fixed
 	if room < 10 {
 		room = 10
 	}
-	if columns(project) <= room {
+	if termwidth.Columns(project) <= room {
 		return project
 	}
 	if room < 6 {
 		room = 6
 	}
-	return cutToColumns(project, room-1) + "…"
+	return termwidth.Cut(project, room-1) + "…"
 }
 
 // fitLine cuts a line to the width it is being printed into, counting runes
@@ -1197,61 +1198,11 @@ func fitLine(s string, width int) string {
 	if width < 8 {
 		width = 8
 	}
-	if columns(s) <= width {
+	if termwidth.Columns(s) <= width {
 		return s
 	}
 	// One column short of the width, for the ellipsis.
-	return strings.TrimRight(cutToColumns(s, width-1), " ") + "…"
-}
-
-// columns is how wide a string prints. A CJK character is one rune and two
-// columns, so counting runes cut a Chinese or Japanese line to twice the
-// terminal's width — worse than the wrapping this exists to prevent, since the
-// text is lost rather than reflowed.
-func columns(s string) int {
-	n := 0
-	for _, r := range s {
-		n += runeColumns(r)
-	}
-	return n
-}
-
-// runeColumns is the East Asian Wide and Fullwidth ranges, plus the emoji
-// blocks terminals render double. Everything else counts as one: this is a
-// layout budget, not a Unicode implementation, and being wrong by a column on
-// an unusual rune costs a wrap rather than data.
-func runeColumns(r rune) int {
-	switch {
-	case r >= 0x1100 && r <= 0x115F, // Hangul Jamo
-		r >= 0x2E80 && r <= 0x303E, // CJK radicals, Kangxi
-		r >= 0x3041 && r <= 0x33FF, // kana, Hangul compatibility, CJK symbols
-		r >= 0x3400 && r <= 0x4DBF, // CJK extension A
-		r >= 0x4E00 && r <= 0x9FFF, // CJK unified ideographs
-		r >= 0xA000 && r <= 0xA4CF, // Yi
-		r >= 0xAC00 && r <= 0xD7A3, // Hangul syllables
-		r >= 0xF900 && r <= 0xFAFF, // CJK compatibility ideographs
-		r >= 0xFE30 && r <= 0xFE6F, // CJK compatibility forms
-		r >= 0xFF00 && r <= 0xFF60, // fullwidth forms
-		r >= 0xFFE0 && r <= 0xFFE6,
-		r >= 0x1F300 && r <= 0x1F64F, // emoji
-		r >= 0x1F900 && r <= 0x1F9FF,
-		r >= 0x20000 && r <= 0x3FFFD: // CJK extensions B and beyond
-		return 2
-	}
-	return 1
-}
-
-// cutToColumns keeps as much of s as fits in width columns.
-func cutToColumns(s string, width int) string {
-	n := 0
-	for i, r := range s {
-		w := runeColumns(r)
-		if n+w > width {
-			return s[:i]
-		}
-		n += w
-	}
-	return s
+	return strings.TrimRight(termwidth.Cut(s, width-1), " ") + "…"
 }
 
 func tierLabel(h Hit) string {

--- a/internal/search/width_test.go
+++ b/internal/search/width_test.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"bytes"
+	"github.com/vshulcz/deja-vu/internal/termwidth"
 	"strings"
 	"testing"
 	"time"
@@ -84,7 +85,7 @@ func TestAWideScriptLineFitsToo(t *testing.T) {
 		if !strings.HasPrefix(line, "  ") {
 			continue
 		}
-		if got := columns(line); got > 60 {
+		if got := termwidth.Columns(line); got > 60 {
 			t.Errorf("a CJK snippet printed %d columns wide: %q", got, line)
 		}
 	}
@@ -101,8 +102,8 @@ func TestColumnsCountsWideRunes(t *testing.T) {
 		{"a调b", 4},
 		{"", 0},
 	} {
-		if got := columns(tc.in); got != tc.want {
-			t.Errorf("columns(%q) = %d, want %d", tc.in, got, tc.want)
+		if got := termwidth.Columns(tc.in); got != tc.want {
+			t.Errorf("termwidth.Columns(%q) = %d, want %d", tc.in, got, tc.want)
 		}
 	}
 }

--- a/internal/termwidth/width.go
+++ b/internal/termwidth/width.go
@@ -1,0 +1,56 @@
+// Package termwidth measures how wide text prints in a terminal cell grid.
+//
+// Two surfaces lay text out against a width they cannot query per-character:
+// the search result line and the status bar. Both used to count runes, which
+// is right for Latin text and wrong by a factor of two for CJK — a Chinese
+// line was cut to twice the terminal's width, so the text was lost to the edge
+// rather than reflowed.
+package termwidth
+
+// Columns is how wide a string prints. A CJK character is one rune and two
+// columns.
+func Columns(s string) int {
+	n := 0
+	for _, r := range s {
+		n += RuneColumns(r)
+	}
+	return n
+}
+
+// RuneColumns is the East Asian Wide and Fullwidth ranges, plus the emoji
+// blocks terminals render double. Everything else counts as one: this is a
+// layout budget, not a Unicode implementation, and being wrong by a column on
+// an unusual rune costs a wrap rather than data.
+func RuneColumns(r rune) int {
+	switch {
+	case r >= 0x1100 && r <= 0x115F, // Hangul Jamo
+		r >= 0x2E80 && r <= 0x303E, // CJK radicals, Kangxi
+		r >= 0x3041 && r <= 0x33FF, // kana, Hangul compatibility, CJK symbols
+		r >= 0x3400 && r <= 0x4DBF, // CJK extension A
+		r >= 0x4E00 && r <= 0x9FFF, // CJK unified ideographs
+		r >= 0xA000 && r <= 0xA4CF, // Yi
+		r >= 0xAC00 && r <= 0xD7A3, // Hangul syllables
+		r >= 0xF900 && r <= 0xFAFF, // CJK compatibility ideographs
+		r >= 0xFE30 && r <= 0xFE6F, // CJK compatibility forms
+		r >= 0xFF00 && r <= 0xFF60, // fullwidth forms
+		r >= 0xFFE0 && r <= 0xFFE6,
+		r >= 0x1F300 && r <= 0x1F64F, // emoji
+		r >= 0x1F900 && r <= 0x1F9FF,
+		r >= 0x20000 && r <= 0x3FFFD: // CJK extensions B and beyond
+		return 2
+	}
+	return 1
+}
+
+// Cut keeps as much of s as fits in width columns.
+func Cut(s string, width int) string {
+	n := 0
+	for i, r := range s {
+		w := RuneColumns(r)
+		if n+w > width {
+			return s[:i]
+		}
+		n += w
+	}
+	return s
+}

--- a/internal/termwidth/width_test.go
+++ b/internal/termwidth/width_test.go
@@ -1,0 +1,49 @@
+package termwidth
+
+import "testing"
+
+func TestColumns(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"retry queue", 11},
+		{"重试队列", 8},
+		{"リトライ", 8},
+		{"한글", 4},
+		{"ｆｕｌｌ", 8},
+		{"🙂", 2},
+		{"поток", 5},
+		{"queue 队列", 10},
+	} {
+		if got := Columns(tc.in); got != tc.want {
+			t.Errorf("Columns(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+// A cut lands on a character boundary, never inside one, and never past the
+// budget — half a wide character would be a broken cell either way.
+func TestCutStopsAtTheBudget(t *testing.T) {
+	for _, tc := range []struct {
+		in    string
+		width int
+		want  string
+	}{
+		{"retry queue", 5, "retry"},
+		{"retry queue", 40, "retry queue"},
+		{"重试队列", 4, "重试"},
+		{"重试队列", 5, "重试"},
+		{"重试队列", 0, ""},
+		{"a重b", 2, "a"},
+	} {
+		got := Cut(tc.in, tc.width)
+		if got != tc.want {
+			t.Errorf("Cut(%q, %d) = %q, want %q", tc.in, tc.width, got, tc.want)
+		}
+		if Columns(got) > tc.width {
+			t.Errorf("Cut(%q, %d) prints %d columns", tc.in, tc.width, Columns(got))
+		}
+	}
+}


### PR DESCRIPTION
Found by the night hunt, iteration 83, sweeping the surfaces that count bytes or runes where a terminal counts cells.

#1076 bounded the status line so the memory segment survives the edge. It counted runes, which equals columns only for Latin text. A Chinese title is one rune and two columns per character, so on an 80-column bar:

```
title                     runes  columns
latin, trimmed by #1076      76       76
chinese, never trimmed       68       98
```

The Chinese line was not trimmed at all — 68 runes is under any budget the code checks — and the terminal cut it instead, losing the closing quote and the date. That is the exact failure #1076 describes, still present for anyone whose sessions are not in English.

`internal/search` already had the column arithmetic, added for the result line, with a comment naming this same defect. It moves to `internal/termwidth` and the status line uses it: the fit check, the usage-tail check, and the bound inside `safeForStatusline`.

After the fix the Chinese line is 59 columns on a 60-column bar and 77 on an 80, and it grows with the terminal the way the Latin one does.

ASCII is unchanged — one rune is one column, so every existing status-line test passes untouched.

Scope stops at the status line. `visibleLen` still counts runes for the stats card and the logo; the card draws its own box and needs its own measurement pass, which is a separate change.

Tests: the bar fits at four widths (82 is where the usage numbers fit by rune count but not by column count), the line grows with the bar, and the bound itself at Latin, Chinese and kana. Three mutations verified — reverting each of the three counts fails a test.
