### PR TITLE
fix: measure the files column in columns, not runes

### DIFF
--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/termwidth"
 )
 
 // `deja files <topic>` answers which files a piece of work actually touched.
@@ -256,7 +257,11 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		}
 	}
 	for _, r := range rows {
-		fmt.Fprintf(stdout, "  %-*s %d\n", col, trimPathTo(trimPath(r.path), col), r.n)
+		// Padded here rather than with %-*s, whose width is runes: a path under
+		// a Chinese directory is one rune and two columns per character, so the
+		// counts stopped lining up in a column of their own.
+		path := trimPathTo(trimPath(r.path), col)
+		fmt.Fprintf(stdout, "  %s%s %d\n", path, strings.Repeat(" ", max(0, col-termwidth.Columns(path))), r.n)
 	}
 	return nil
 }
@@ -388,14 +393,28 @@ var repoCheck sync.Map
 // file name survives: the tail is what identifies it, and a head-first cut
 // leaves rows that all read "…/src/".
 func trimPathTo(p string, width int) string {
-	r := []rune(p)
-	if width <= 0 || len(r) <= width {
+	if width <= 0 || termwidth.Columns(p) <= width {
 		return p
 	}
 	if width < 4 {
-		return string(r[len(r)-width:])
+		return tailToColumns(p, width)
 	}
-	return "…" + string(r[len(r)-(width-1):])
+	return "…" + tailToColumns(p, width-1)
+}
+
+// tailToColumns is the last width columns of s, cut on a character boundary.
+// A wide character that would only half fit is dropped rather than split.
+func tailToColumns(s string, width int) string {
+	r := []rune(s)
+	n := 0
+	for i := len(r) - 1; i >= 0; i-- {
+		w := termwidth.RuneColumns(r[i])
+		if n+w > width {
+			return string(r[i+1:])
+		}
+		n += w
+	}
+	return s
 }
 
 // trimPath keeps the tail that identifies a file without the home directory in

--- a/cmd/deja/files_trim_columns_test.go
+++ b/cmd/deja/files_trim_columns_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/termwidth"
+)
+
+// The path column is a column, and a path under a Chinese directory is one
+// rune and two columns per character. Counting runes let a 27-rune path fill
+// 46 of a 30-column budget, so the counts beside it landed wherever the text
+// ended (#604 budgeted the column; this is the same column measured right).
+func TestTrimPathToBoundsColumns(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		in    string
+		width int
+	}{
+		{"latin", "…/very/long/directory/name/retry_backoff_handler.go", 30},
+		{"chinese", "…/项目/内部服务/重试队列/退避处理器实现文件.go", 30},
+		{"mixed", "…/项目/src/内部服务/queue/退避处理器.go", 24},
+		{"narrow", "…/项目/内部服务/重试队列/退避处理器实现文件.go", 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := trimPathTo(tc.in, tc.width)
+			if n := termwidth.Columns(got); n > tc.width {
+				t.Errorf("trimPathTo(%q, %d) prints %d columns: %q", tc.in, tc.width, n, got)
+			}
+			// What comes back has to be a literal tail of the input, mark
+			// aside: a cut through a wide character would leave text that is
+			// the right width and not the same path.
+			if tail := strings.TrimPrefix(got, "…"); !strings.HasSuffix(tc.in, tail) {
+				t.Errorf("trimPathTo(%q, %d) = %q, which is not a tail of it", tc.in, tc.width, got)
+			}
+		})
+	}
+}
+
+// A path that already fits is not touched, and a wide character is never cut
+// in half to reach the budget exactly.
+func TestTrimPathToLeavesWhatFits(t *testing.T) {
+	short := "…/项目/退避.go"
+	if got := trimPathTo(short, 30); got != short {
+		t.Errorf("a path inside the budget was trimmed: %q", got)
+	}
+	// 12 columns of a path whose characters are two columns wide: the cut has
+	// to stop at 12, not at 13 with half a character.
+	got := trimPathTo("…/项目/内部服务/重试队列/退避处理器.go", 12)
+	if n := termwidth.Columns(got); n > 12 {
+		t.Errorf("cut to %d columns: %q", n, got)
+	}
+	if !strings.HasPrefix(got, "…") {
+		t.Errorf("the cut is not marked: %q", got)
+	}
+}
+
+// End to end: every row of the table has to end its path in the same column,
+// or the counts do not read as a column at all.
+func TestFilesTableAlignsCJKPaths(t *testing.T) {
+	tmp := hermeticEnv(t)
+	repo := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var paths []string
+	for _, rel := range []string{
+		"项目/内部服务/重试队列/退避处理器实现文件.go",
+		"项目/内部服务/重试队列/工作进程唤醒抖动逻辑.go",
+		"src/app/internal/queue/retry_backoff_handler.go",
+	} {
+		full := filepath.Join(repo, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("package x\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, full)
+	}
+
+	root := filepath.Join(tmp, "claude", "proj-cj")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	var body strings.Builder
+	body.WriteString(`{"type":"user","sessionId":"c1","cwd":"` + repo + `","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"the retry storm on checkout"}}` + "\n")
+	for _, p := range paths {
+		body.WriteString(`{"type":"assistant","sessionId":"c1","cwd":"` + repo + `","timestamp":"2026-07-20T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` + p + `"}}]}}` + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(root, "c1.jsonl"), []byte(body.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	var buf strings.Builder
+	if err := runFiles(index.DefaultDir(), []string{"retry"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	var widths []int
+	var rows []string
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if !strings.HasPrefix(line, "  ") {
+			continue
+		}
+		rows = append(rows, line)
+		widths = append(widths, termwidth.Columns(line))
+	}
+	if len(rows) != 3 {
+		t.Fatalf("wrong fixture: %d rows in %q", len(rows), buf.String())
+	}
+	// One of them has to be a CJK path, or the test is about Latin alignment.
+	if !strings.Contains(strings.Join(rows, ""), "项目") {
+		t.Fatalf("no CJK row in the table: %q", rows)
+	}
+	// And each row still names a real file: padding to a column budget must
+	// not be reached by cutting through a character.
+	for _, row := range rows {
+		shown := strings.TrimPrefix(strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(row), "1")), "…")
+		var named bool
+		for _, p := range paths {
+			if strings.HasSuffix(filepath.ToSlash(p), shown) {
+				named = true
+				break
+			}
+		}
+		if !named {
+			t.Errorf("row names no seeded file: %q", row)
+		}
+	}
+	for i, w := range widths {
+		if w != widths[0] {
+			t.Errorf("row %d is %d columns, row 0 is %d:\n%s", i, w, widths[0], strings.Join(rows, "\n"))
+		}
+	}
+}

--- a/cmd/deja/files_trim_columns_test.go
+++ b/cmd/deja/files_trim_columns_test.go
@@ -88,9 +88,9 @@ func TestFilesTableAlignsCJKPaths(t *testing.T) {
 	}
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	var body strings.Builder
-	body.WriteString(`{"type":"user","sessionId":"c1","cwd":"` + repo + `","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"the retry storm on checkout"}}` + "\n")
+	body.WriteString(`{"type":"user","sessionId":"c1","cwd":` + jsonString(repo) + `,"timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"the retry storm on checkout"}}` + "\n")
 	for _, p := range paths {
-		body.WriteString(`{"type":"assistant","sessionId":"c1","cwd":"` + repo + `","timestamp":"2026-07-20T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` + p + `"}}]}}` + "\n")
+		body.WriteString(`{"type":"assistant","sessionId":"c1","cwd":` + jsonString(repo) + `,"timestamp":"2026-07-20T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":` + jsonString(p) + `}}]}}` + "\n")
 	}
 	if err := os.WriteFile(filepath.Join(root, "c1.jsonl"), []byte(body.String()), 0o644); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Found by the night hunt, iteration 84, continuing the sweep #1398 started. Stacked on #1398 — it adds `internal/termwidth`; merge that first.

#604 budgeted the path column against the window so `deja files` stops wrapping in a narrow pane. The budget is columns and the code counted runes, which is the same number only for Latin text. Three files from one session, one of them under a Chinese directory:

```
  …/app/internal/queue/retry_backoff_handler.go            1     60 columns
  …/项目/内部服务/重试队列/工作进程唤醒抖动逻辑.go                             1     80
  …/项目/内部服务/重试队列/退避处理器实现文件.go                              1     79
```

Two things go wrong at once. The path is never trimmed — 27 runes is inside any budget the code checks — and `%-*s` pads to a rune count, so no two rows end in the same place and the counts stop being a column. A reader whose project directories are in Chinese sees this on every row.

`trimPathTo` now bounds by columns and cuts from the left on a character boundary; the row is padded explicitly rather than by `%-*s`. All three rows come out at 60.

The cut still marks itself and still keeps the tail, which is the part that identifies the file. A wide character that would only half fit is dropped rather than split — half a character is the right width and the wrong path.

Tests: the bound at Latin, Chinese, mixed and a width of 3; a path inside the budget left alone; and the table itself, where every row must end in the same column and still name a file that was actually seeded. Three mutations verified — reverting the bound, the padding, or the boundary check each fails a test.
