### PR TITLE
fix: do not print a negative age on the handoff receipt

### DIFF
--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -117,6 +117,15 @@ func runHandoff(dir string, args []string, stdout io.Writer) error {
 
 func humanAge(d time.Duration) string {
 	switch {
+	case d < 0:
+		// A timestamp ahead of the clock. Transcripts carry whatever time the
+		// machine that wrote them had, and a store synced from a machine whose
+		// clock runs fast brings that here — measured as "-576000m old" on a
+		// session dated a year ahead, since every negative duration fell into
+		// the minutes branch. The receipt exists for the reader to sanity-check
+		// what is being handed off, so it says what it knows rather than a
+		// number that cannot be true.
+		return "unknown age"
 	case d < time.Hour:
 		return fmt.Sprintf("%dm old", int(d.Minutes()))
 	case d < 48*time.Hour:

--- a/cmd/deja/handoff_future_age_test.go
+++ b/cmd/deja/handoff_future_age_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The handoff receipt exists for the reader to check what is being handed off
+// before it lands. A timestamp ahead of the clock — a store synced from a
+// machine whose clock runs fast — put a negative number on that line, and
+// every negative duration fell into the minutes branch: a session dated a year
+// ahead read "-576000m old".
+func TestHumanAgeOnATimestampAheadOfTheClock(t *testing.T) {
+	for _, tc := range []struct {
+		d    time.Duration
+		want string
+	}{
+		{-30 * time.Minute, "unknown age"},
+		{-3 * time.Hour, "unknown age"},
+		{-400 * 24 * time.Hour, "unknown age"},
+		// The boundary stays where it was: now is an age, not a mystery.
+		{0, "0m old"},
+		{90 * time.Minute, "1h old"},
+		{50 * time.Hour, "2d old"},
+	} {
+		if got := humanAge(tc.d); got != tc.want {
+			t.Errorf("humanAge(%s) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+	// Nothing may print a negative number, whatever the shape of the input.
+	for _, d := range []time.Duration{-time.Nanosecond, -time.Hour, -99999 * time.Hour} {
+		if strings.Contains(humanAge(d), "-") {
+			t.Errorf("humanAge(%s) = %q", d, humanAge(d))
+		}
+	}
+}
+
+// End to end: the receipt line the user reads.
+func TestHandoffReceiptOnAFutureSession(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-f")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	ahead := time.Now().Add(400 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	body := `{"type":"user","sessionId":"f1","cwd":"/w/f","timestamp":"` + ahead +
+		`","message":{"role":"user","content":"the retry queue stalls on staging and the workers wake together"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "f1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRunStderr(t, "handoff", "f1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "handing off") {
+		t.Fatalf("no receipt: %q", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "handing off") && strings.Contains(line, "m old") && strings.Contains(line, "-") {
+			t.Errorf("the receipt claims a negative age: %q", line)
+		}
+	}
+	if !strings.Contains(out, "unknown age") {
+		t.Errorf("the receipt does not say the age is unknown: %q", out)
+	}
+}


### PR DESCRIPTION
Found by the night hunt, iteration 91.

The handoff receipt is there for the reader to check what is being handed off before it lands — harness, project, id, age. The age is `humanAge(time.Since(s.Updated))`, and a timestamp ahead of the clock makes that negative. Every negative duration fell into the first branch, which formats minutes:

```
-30m     "-30m old"
-3h      "-180m old"
-400d    "-576000m old"
```

Transcripts carry whatever time the machine that wrote them had, and a store synced from a machine whose clock runs fast brings that here — deja does not clamp it anywhere.

It now says "unknown age", which the same function already uses when the timestamp is missing entirely. Naming the clock skew would be more precise, but this is a receipt line, not a diagnosis, and reusing the wording that already means "deja cannot tell you" keeps it one line.

The stale-session warning above it is unaffected: it compares the same duration against seven days, which no negative value reaches.

Tests: the negative cases, the boundary at zero, the positive buckets unchanged, and the receipt itself on a session dated a year ahead. Two mutations verified — removing the branch or moving its boundary over zero each fail.
