### PR TITLE
fix: recognise the sentence ends Chinese and Japanese write

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -602,6 +602,25 @@ func Conclusions(s model.Session, budget int, max int) []string {
 	return out
 }
 
+// isCJKSentenceEnd is the full stop, exclamation and question mark Chinese and
+// Japanese write. They are separate characters from the ASCII ones, so a
+// message in either script contained no sentence end as far as this file was
+// concerned (#1319).
+//
+// The fullwidth full stop U+FF0E is deliberately absent: it is also how a
+// decimal point is written in fullwidth digits, and the space rule that keeps
+// "v1.2" together cannot help here — these scripts put no space after a stop,
+// so the rule has to be dropped for them. The enumeration comma and the
+// fullwidth semicolon are absent for the plainer reason that neither ends a
+// sentence.
+func isCJKSentenceEnd(r rune) bool {
+	switch r {
+	case '\u3002', '\uff01', '\uff1f':
+		return true
+	}
+	return false
+}
+
 // firstSentences keeps the opening n sentences of a message: a conclusion
 // states itself up front and then explains, and recall pays for every byte.
 func firstSentences(s string, n int) string {
@@ -611,16 +630,21 @@ func firstSentences(s string, n int) string {
 	}
 	count := 0
 	for i, r := range s {
-		if r != '.' && r != '!' && r != '?' {
-			continue
-		}
-		// "v1.2" and "e.g." are not sentence ends: require a space after.
-		if i+1 < len(s) && s[i+1] != ' ' {
+		switch {
+		case r == '.' || r == '!' || r == '?':
+			// "v1.2" and "e.g." are not sentence ends: require a space after.
+			if i+1 < len(s) && s[i+1] != ' ' {
+				continue
+			}
+		case isCJKSentenceEnd(r):
+			// No space rule here: these scripts put none after the stop, so
+			// requiring one would find no sentence at all.
+		default:
 			continue
 		}
 		count++
 		if count == n {
-			return strings.TrimSpace(s[:i+1])
+			return strings.TrimSpace(s[:i+utf8.RuneLen(r)])
 		}
 	}
 	const cap = 240

--- a/internal/digest/sentence_cjk_test.go
+++ b/internal/digest/sentence_cjk_test.go
@@ -1,0 +1,126 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// firstSentences is what makes a long conclusion fit the recall budget: it
+// states itself up front, so the opening sentence is kept and the explanation
+// is dropped. Chinese and Japanese end a sentence with 。, not with a period
+// and a space, so the function found no sentence at all and handed the whole
+// message back — which then did not fit and was dropped whole.
+func TestFirstSentencesFindsCJKSentenceEnds(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		in    string
+		n     int
+		want  string
+		short bool // the result must be shorter than the input
+	}{
+		{
+			"chinese",
+			"重试队列在预发环境卡住了。所有工作进程同时醒来，所以我们把它们分散到一秒内。抖动的上限是轮询间隔。",
+			1,
+			"重试队列在预发环境卡住了。",
+			true,
+		},
+		{
+			"japanese",
+			"リトライキューがステージングで詰まりました。ワーカーが同時に起きるので、一秒の範囲に分散させました。",
+			1,
+			"リトライキューがステージングで詰まりました。",
+			true,
+		},
+		{
+			"chinese question",
+			"为什么重试预算在两次尝试之间被重置？我们查了上传队列的代码。",
+			1,
+			"为什么重试预算在两次尝试之间被重置？",
+			true,
+		},
+		{
+			"fullwidth exclamation",
+			"部署已经回滚了！后面的改动都不需要了。",
+			1,
+			"部署已经回滚了！",
+			true,
+		},
+		{
+			"two sentences",
+			"重试队列在预发环境卡住了。所有工作进程同时醒来。抖动的上限是轮询间隔。",
+			2,
+			"重试队列在预发环境卡住了。所有工作进程同时醒来。",
+			true,
+		},
+		// English and Russian are untouched: the ASCII rule, space and all.
+		{
+			"english",
+			"The retry queue stalls on staging. Every worker wakes at the same moment.",
+			1,
+			"The retry queue stalls on staging.",
+			true,
+		},
+		{
+			"russian",
+			"Очередь повторов зависает на предпродакшене. Все воркеры просыпаются разом.",
+			1,
+			"Очередь повторов зависает на предпродакшене.",
+			true,
+		},
+		// The space rule still protects a version number from reading as an end.
+		{
+			"version number",
+			"We pinned it to v1.2.3 and the flapping stopped. Then we moved on.",
+			1,
+			"We pinned it to v1.2.3 and the flapping stopped.",
+			true,
+		},
+		// And the fullwidth full stop is not a sentence end, because it is
+		// also the decimal point in fullwidth digits — where the space rule
+		// cannot protect it.
+		{
+			"fullwidth decimal",
+			"\uff11\uff0e\uff12\u7248\u672c\u5df2\u7ecf\u53d1\u5e03\u4e86\u3002\u56de\u6eda\u4e0d\u9700\u8981\u4e86\u3002",
+			1,
+			"\uff11\uff0e\uff12\u7248\u672c\u5df2\u7ecf\u53d1\u5e03\u4e86\u3002",
+			true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := firstSentences(tc.in, tc.n)
+			if got != tc.want {
+				t.Errorf("firstSentences(%q, %d) =\n  %q\nwant\n  %q", tc.in, tc.n, got, tc.want)
+			}
+			if tc.short && utf8.RuneCountInString(got) >= utf8.RuneCountInString(tc.in) {
+				t.Errorf("nothing was trimmed: %d characters in, %d out",
+					utf8.RuneCountInString(tc.in), utf8.RuneCountInString(got))
+			}
+			// Whatever comes back is a prefix of the input, whole characters
+			// only: a cut through a three-byte stop would be invalid UTF-8.
+			if !strings.HasPrefix(tc.in, got) {
+				t.Errorf("the result is not a prefix of the input: %q", got)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("invalid UTF-8: %q", got)
+			}
+		})
+	}
+}
+
+// A message with no sentence end at all still falls back to the byte cap, and
+// the cap cuts whole characters.
+func TestFirstSentencesFallsBackWithoutAnEnd(t *testing.T) {
+	long := strings.Repeat("重试队列在预发环境卡住了", 40) // no stop anywhere
+	got := firstSentences(long, 1)
+	if !utf8.ValidString(got) {
+		t.Errorf("invalid UTF-8 from the fallback cut: %q", got)
+	}
+	if len(got) >= len(long) {
+		t.Errorf("the fallback did not cut: %d bytes in, %d out", len(long), len(got))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("the cut is not marked: %q", got)
+	}
+}


### PR DESCRIPTION
Found by the night hunt, iteration 92.

`firstSentences` is what makes a long conclusion fit the recall budget: the claim is stated up front, so the opening sentence is kept and the explanation dropped. The caller retries with one sentence when a line does not fit, and breaks out of the loop when even that is too long.

It recognised only `.`, `!` and `?` followed by a space. Chinese and Japanese end a sentence with `。`, so those messages had no sentence end at all:

```
english   150 chars in →  34 out
russian   155 chars in →  44 out
chinese    49 chars in →  49 out
japanese   68 chars in →  68 out
```

Nothing was trimmed, so the retry shrank nothing, so the conclusion was dropped — and with it every conclusion behind it, because the loop breaks rather than skips. A session written in either script contributed nothing to the digest where an English one contributed its opening claim. Same shape as #1340, which fixed the prose gate one function away for the same reason.

`。`, `！` and `？` are sentence ends now, with no trailing-space rule — these scripts put no space after a stop, so requiring one would find nothing.

The fullwidth full stop `．` is deliberately left out: it is also the decimal point in fullwidth digits, and the rule that keeps "v1.2" together is exactly the rule that has to be dropped here. `、` and `；` are out for the plainer reason that neither ends a sentence. There is a test for the decimal.

The cut moved from `i+1` to `i+utf8.RuneLen(r)` — a three-byte stop cut at one byte is invalid UTF-8.

The 240-byte fallback cap is untouched: it only runs when there is no sentence end at all, and the budget it serves is counted in bytes.

Tests: five CJK shapes, English and Russian unchanged, the version number, the fullwidth decimal, and the no-sentence fallback. Five mutations verified — dropping the CJK ends, cutting by one byte, applying the space rule to them, narrowing them to the full stop alone, or putting `．` back each fail.
