### PR TITLE
fix: bound a title the source authored like a derived one

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1068,6 +1068,14 @@ func metaForSession(s model.Session) SessionMeta {
 		// composer name, the first user message — and are persisted in
 		// sessions.gob, so they need the same scrubbing as record text.
 		title, _ = redact.Text(title)
+		// And the same bound. A title the source authored went to the
+		// one-line surfaces whole: measured at 384 characters with the
+		// newlines still in it, so one session printed several rows of
+		// `deja last` and the text after the break began "[claude · …",
+		// which is deja's own listing format (#1090 covers the escape bytes;
+		// this is the line break). Derived titles have been collapsed and cut
+		// since they existed.
+		title = boundSourceTitle(s.Harness, title)
 	}
 	// The import fields travel with the session, not with the transcript: a
 	// rebuild reloads imported sessions out of the index itself, and rebuilding
@@ -1677,6 +1685,22 @@ func titleWorthy(t string) bool {
 		!strings.HasPrefix(t, "Caveat:")
 }
 
+// boundSourceTitle collapses and bounds a title the source authored, the way
+// a derived one has always been.
+//
+// Notes are exempt. A promoted note's title ends in its state — "… [rejected]"
+// — and the state is what every one-line surface reads it for, so cutting the
+// tail would drop exactly the part that matters and, worse, make a state
+// change invisible to the comparison that decides whether to rewrite the row
+// (#R11). Note titles are deja's own text, so the injection this bound exists
+// to stop cannot arrive through them.
+func boundSourceTitle(harness, title string) string {
+	if harness == "deja" {
+		return title
+	}
+	return truncateTitle(title, 60)
+}
+
 func truncateTitle(s string, n int) string {
 	s = strings.Join(strings.Fields(s), " ")
 	r := []rune(s)
@@ -2272,8 +2296,8 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 				// one-line surface — `deja last`, the digest, the citation the
 				// hook hands the agent to say aloud — reading "[accepted]"
 				// until an unrelated rebuild happened to run (#R11).
-				if t, _ := redact.Text(s.Title); t != meta.Title {
-					meta.Title, meta.AgentTitle = t, s.AgentTitle
+				if t, _ := redact.Text(s.Title); boundSourceTitle(s.Harness, t) != meta.Title {
+					meta.Title, meta.AgentTitle = boundSourceTitle(s.Harness, t), s.AgentTitle
 				}
 			}
 			// Only the session that owns this row. The full build writes these

--- a/internal/index/source_title_test.go
+++ b/internal/index/source_title_test.go
@@ -1,0 +1,97 @@
+package index
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A title the source authored — a cursor composer name, a goose description, a
+// zed thread summary — reached the one-line surfaces whole: 384 characters
+// with the line breaks still in it, so one session printed several rows of
+// `deja last` and the text after a break began "[claude · …", which is that
+// listing's own format. Derived titles have been collapsed and bounded since
+// they existed; this is the same bound on the other branch.
+func TestSourceTitleIsBoundedLikeADerivedOne(t *testing.T) {
+	msg := model.Message{Role: "user", Text: "the retry queue stalls on staging and every worker wakes at once, needs jitter"}
+	for _, tc := range []struct {
+		name  string
+		title string
+	}{
+		{"multiline", "retry queue jitter\n[claude · fake · 2026-08-19 · deadbeef] a line in the listing's own format"},
+		{"long", strings.Repeat("the retry queue stalls on staging and the workers wake together ", 6)},
+		{"tabbed", "retry\tqueue\tjitter\tand\tbackoff"},
+		{"carriage return", "retry queue jitter\r[claude · fake] rewound"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := metaForSession(model.Session{
+				Harness: "cursor", ID: "c1", Project: "p", Title: tc.title,
+				Messages: []model.Message{msg},
+			})
+			if strings.ContainsAny(m.Title, "\n\r\t") {
+				t.Errorf("the title still breaks the line: %q", m.Title)
+			}
+			// 61 is the ceiling, not the length: 60 characters plus the mark,
+			// and TrimSpace can leave it shorter.
+			if n := utf8.RuneCountInString(m.Title); n > 61 {
+				t.Errorf("the title is %d characters: %q", n, m.Title)
+			}
+		})
+	}
+}
+
+// What the source said still wins over what deja would derive, and a title
+// that already fits arrives untouched — no mark claiming something was cut.
+func TestSourceTitleShortEnoughIsUnchanged(t *testing.T) {
+	const title = "retry queue jitter"
+	m := metaForSession(model.Session{
+		Harness: "cursor", ID: "c1", Project: "p", Title: title,
+		Messages: []model.Message{{Role: "user", Text: "something else entirely"}},
+	})
+	if m.Title != title {
+		t.Errorf("metaForSession rewrote a title that fits: %q", m.Title)
+	}
+	if m.AgentTitle {
+		t.Error("a source title is not an agent title")
+	}
+}
+
+// A derived title is unchanged by this: it was already collapsed and cut.
+func TestDerivedTitleUnchanged(t *testing.T) {
+	m := metaForSession(model.Session{
+		Harness: "claude", ID: "d1", Project: "p",
+		Messages: []model.Message{{Role: "user", Text: strings.Repeat("the retry queue stalls on staging ", 8)}},
+	})
+	if n := utf8.RuneCountInString(m.Title); n > 61 {
+		t.Errorf("derived title is %d characters: %q", n, m.Title)
+	}
+	if !strings.HasSuffix(m.Title, "…") {
+		t.Errorf("a cut derived title lost its mark: %q", m.Title)
+	}
+}
+
+// A promoted note's title ends in its state, and the state is what the
+// one-line surfaces read it for. The bound must not cut it off, and a state
+// change must still be visible to whatever compares the two.
+func TestPromotedNoteTitleKeepsItsState(t *testing.T) {
+	long := strings.Repeat("the retry queue stalls on staging ", 3)
+	for _, state := range []string{"accepted", "rejected", "superseded"} {
+		title := strings.TrimSpace(long) + " [" + state + "]"
+		m := metaForSession(model.Session{
+			Harness: "deja", ID: "deja-2026-08-19-app", Project: "p", Title: title,
+			Messages: []model.Message{{Role: "user", Text: "[" + state + "] the retry queue needs jitter"}},
+		})
+		if !strings.HasSuffix(m.Title, "["+state+"]") {
+			t.Errorf("the state was cut off the note title: %q", m.Title)
+		}
+	}
+	// And a note whose state changes has a different title, so the row is
+	// rewritten rather than left saying the old one.
+	one := metaForSession(model.Session{Harness: "deja", ID: "n", Title: strings.TrimSpace(long) + " [accepted]"})
+	two := metaForSession(model.Session{Harness: "deja", ID: "n", Title: strings.TrimSpace(long) + " [rejected]"})
+	if one.Title == two.Title {
+		t.Errorf("two states produced one title: %q", one.Title)
+	}
+}


### PR DESCRIPTION
Found by the night hunt, iteration 93.

Session titles arrive two ways. A derived one — the first user message — goes through `redact.Text` and then `truncateTitle(60)`, which collapses whitespace and bounds the length. A title the source authored — a cursor composer name, a goose description, a zed summary, grok, roo — went through `redact.Text` only. Measured through `metaForSession`:

```
derived            60 characters, one line
source, short      18, unchanged
source, multiline  92, newline intact
source, long      384, trailing spaces intact
source, tabbed     18, tabs intact
```

The line break is the part that matters. `deja last` prints one row per session, and the text after a break in a title starts a row of its own — in the fixture it begins "[claude · …", which is that listing's own format. #1090 stripped the escape bytes from these surfaces; the break was left, because titles were assumed to be one line already.

The bound is the same 60 the derived branch has always used, applied in `metaForSession` and on the incremental path, so an unchanged title is not rewritten every pass.

Notes are exempt, and that is the one interesting part. A promoted note's title ends in its state — "… [rejected]" — which is what every one-line surface reads it for, and which the loader rewrites on every correction (#R11). Cutting the tail would drop exactly that and make a state change invisible to the comparison that decides whether to rewrite the row. Note titles are deja's own text, so nothing can be injected through them.

Tests: the four shapes above, a short title left untouched, a derived title unchanged, and the note state surviving all three of its values plus a state change still producing a different title. Three mutations verified — dropping the bound, dropping the notes exemption, or widening it to every harness each fail.
