### PR TITLE
fix: scrub the show header like the context one

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1242,7 +1242,12 @@ func FindByPrefix(ss []model.Session, p string) (model.Session, bool) {
 }
 
 func PrintSession(w io.Writer, s model.Session) {
-	fmt.Fprintf(w, "# %s · %s · %s\n", s.Harness, s.Project, s.ID)
+	// Project and id are transcript text a harness wrote, and this is one
+	// line: an escape byte in either recolours the transcript that follows, a
+	// carriage return rewinds the header, and a newline splits it into two
+	// lines of what reads as deja's own output. PrintContext below has said
+	// this since #1090; this header was missed by it.
+	fmt.Fprintf(w, "# %s · %s · %s\n", s.Harness, SafeLine(s.Project), SafeLine(s.ID))
 	for _, m := range s.Messages {
 		txt := redact.SafeForDisplay(collapseTool(m.Text))
 		if strings.TrimSpace(txt) == "" {

--- a/internal/search/show_header_test.go
+++ b/internal/search/show_header_test.go
@@ -1,0 +1,79 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// #1090 stripped the bytes a terminal acts on from the headers these two
+// functions print. PrintContext got it; PrintSession — what `deja show` calls
+// — did not, so the same session printed a clean header through one and a
+// header carrying an escape, a carriage return or a line break through the
+// other.
+func TestPrintSessionHeaderIsOneSafeLine(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		project string
+		id      string
+	}{
+		{"escape", "w/\x1b[31mred\x1b[0m-app", "abcdef"},
+		{"carriage return", "w/app", "abc\rdef"},
+		{"newline", "w/app\nFAKE ROW pretending to be deja output", "abcdef"},
+		{"bell", "w/app\a", "abc\adef"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var b strings.Builder
+			PrintSession(&b, model.Session{
+				Harness: "claude", Project: tc.project, ID: tc.id,
+				Messages: []model.Message{{Role: "user", Text: "the retry queue stalls on staging"}},
+			})
+			header := strings.SplitN(b.String(), "\n", 2)[0]
+			for _, r := range header {
+				if unicode.IsControl(r) {
+					t.Errorf("a control character reached the header: %q in %q", r, header)
+					break
+				}
+			}
+			// One line, and the whole header on it: a break in the project
+			// name used to start a row that reads as deja's own output.
+			lines := strings.Split(b.String(), "\n")
+			if len(lines) < 2 || lines[1] != "" {
+				t.Errorf("the header spilled onto a second line: %q", b.String())
+			}
+			if !strings.HasSuffix(header, tc.id[len(tc.id)-3:]) {
+				t.Errorf("the header lost its tail: %q", header)
+			}
+		})
+	}
+}
+
+// The two headers agree on the same session, which is the point.
+func TestShowAndContextHeadersAgree(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", Project: "w/\x1b[31mred\x1b[0m-app", ID: "abc\rdef",
+		Messages: []model.Message{{Role: "user", Text: "the retry queue stalls on staging"}},
+	}
+	var show, ctx strings.Builder
+	PrintSession(&show, s)
+	PrintContext(&ctx, s, "retry")
+	showHead := strings.SplitN(show.String(), "\n", 2)[0]
+	ctxHead := strings.SplitN(ctx.String(), "\n", 2)[0]
+	if !strings.Contains(ctxHead, strings.TrimPrefix(showHead, "# ")) {
+		t.Errorf("the two headers scrub differently:\n  show    %q\n  context %q", showHead, ctxHead)
+	}
+}
+
+// A plain session is untouched.
+func TestPrintSessionHeaderUnchangedForPlainText(t *testing.T) {
+	var b strings.Builder
+	PrintSession(&b, model.Session{
+		Harness: "claude", Project: "w/app", ID: "abcdef",
+		Messages: []model.Message{{Role: "user", Text: "hello"}},
+	})
+	if got := strings.SplitN(b.String(), "\n", 2)[0]; got != "# claude · w/app · abcdef" {
+		t.Errorf("plain header changed: %q", got)
+	}
+}


### PR DESCRIPTION
Found by the night hunt, iteration 94.

#1090 stripped the bytes a terminal acts on from the headers deja prints. `PrintContext` got it, with a comment saying exactly why; `PrintSession` — what `deja show` calls — sits twenty lines above and was missed. One session through both:

```
show     "# claude · w/\x1b[31mred\x1b[0m-app · abc\rdef"
context  "# deja context: claude · w/ [31mred [0m-app · abc def"
```

And a newline in the project name split the header in two, the second line reading as deja's own output:

```
# claude · w/app
FAKE ROW pretending to be deja output · abcdef
```

Project comes from the working directory and the id from the transcript, so both are text deja did not write. The bodies below were already covered — they go through `SafeForDisplay` and `SafeText`; it was only the header.

Same `SafeLine` the sibling uses. The harness is left alone, as it is there: it comes from a fixed set.

Tests: an escape, a carriage return, a bell and a newline, each checked for control characters in the header and for the header staying one line; the two headers agreeing on the same session; and a plain session unchanged. Three mutations verified — going back to raw, using `SafeText` instead (the newline survives), or scrubbing only the project each fail.
