### PR TITLE
fix: keep the digest headers on their own lines

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -29,8 +29,8 @@ func Share(s model.Session, budget int) string {
 	if !s.Updated.IsZero() {
 		date = s.Updated.Format(time.RFC3339)
 	}
-	fmt.Fprintf(&b, "# deja share: %s\n\n", s.ID)
-	fmt.Fprintf(&b, "- Project: %s\n", s.Project)
+	fmt.Fprintf(&b, "# deja share: %s\n\n", oneLine(s.ID))
+	fmt.Fprintf(&b, "- Project: %s\n", oneLine(s.Project))
 	fmt.Fprintf(&b, "- Harness: %s\n", s.Harness)
 	fmt.Fprintf(&b, "- Date: %s\n\n", date)
 	appendSection := func(title string, messages []model.Message) {
@@ -400,7 +400,7 @@ func Handoff(s model.Session, budget int) string {
 	if !s.Updated.IsZero() {
 		date = s.Updated.Format(time.RFC3339)
 	}
-	fmt.Fprintf(&b, "You are picking up work handed off from a %s session (project %s, %s). ", s.Harness, s.Project, date)
+	fmt.Fprintf(&b, "You are picking up work handed off from a %s session (project %s, %s). ", s.Harness, oneLine(s.Project), date)
 	b.WriteString("Below is the packaged context: the problem, key conclusions so far, and where it stopped. Continue from there instead of re-deriving what is already done.\n\n")
 	body := Share(s, budget*3/4)
 	// Drop the share header line; the framing above replaces it.
@@ -415,8 +415,35 @@ func Handoff(s model.Session, budget int) string {
 	// The digest is a lossy slice by construction. Tell the receiving agent it
 	// can pull deeper instead of being stuck with the summary: push+pull, not
 	// one-shot push.
-	fmt.Fprintf(&b, "\n\nThis is a compact slice of session %s. If anything you need is missing — an exact error, a file, a decision — search the full history with `deja \"<term>\"` or `deja show %s`, or call the deja MCP tools recall / recall_context if available.\n", Short(s.ID), Short(s.ID))
+	// The head, not the joined form: this id is meant to be typed back as
+	// `deja show <id>`, and that matches on a prefix. Measured on an id with a
+	// break in it — `deja show x1abcdef` finds the session, `deja show
+	// "x1abcdef fake"` matches nothing.
+	short := idSelector(Short(s.ID))
+	fmt.Fprintf(&b, "\n\nThis is a compact slice of session %s. If anything you need is missing — an exact error, a file, a decision — search the full history with `deja \"<term>\"` or `deja show %s`, or call the deja MCP tools recall / recall_context if available.\n", short, short)
 	return strings.TrimSpace(b.String()) + "\n"
+}
+
+// oneLine is a session field made safe for a line of a document deja writes.
+//
+// Project and id are text deja did not author — a directory name, a
+// harness-assigned id — and both land in structured headers here: a break in
+// either splits a markdown header in two, and the stray half then reads as
+// part of the digest. The handoff framing shows it plainly: it strips the
+// share header by cutting at the first newline, so an id containing one left
+// the rest of that id standing at the top of what another agent is handed.
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(redact.SafeForDisplay(s)), " ")
+}
+
+// idSelector is an id cut to something the reader can type back. oneLine
+// keeps every word so the header still names the session in full; here only
+// the leading run is useful, because a prefix is what the lookup takes.
+func idSelector(s string) string {
+	if f := strings.Fields(redact.SafeForDisplay(s)); len(f) > 0 {
+		return f[0]
+	}
+	return ""
 }
 
 // tailSection returns the last few substantive exchanges verbatim so the

--- a/internal/digest/header_fields_test.go
+++ b/internal/digest/header_fields_test.go
@@ -1,0 +1,101 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func hostileSession() model.Session {
+	return model.Session{
+		Harness: "claude",
+		Project: "app\x1b[31mred\x1b[0m",
+		ID:      "x1\nfake",
+		Messages: []model.Message{
+			{Role: "user", Text: "the retry queue stalls on staging and every worker wakes at once"},
+			{Role: "assistant", Text: "We spread the wakeups over a second. The jitter is bounded by the poll interval."},
+		},
+	}
+}
+
+// The share document's header is markdown: "# deja share: <id>" and
+// "- Project: <name>". Both fields are text deja did not author — a directory
+// name and a harness-assigned id — and a break in either split the header in
+// two, leaving the stray half standing as a line of the document.
+func TestShareHeaderFieldsStayOnTheirLines(t *testing.T) {
+	out := Share(hostileSession(), 4000)
+	lines := strings.Split(out, "\n")
+	if !strings.HasPrefix(lines[0], "# deja share: ") {
+		t.Fatalf("no header: %q", lines[0])
+	}
+	if strings.Contains(lines[0], "\n") || lines[1] != "" {
+		t.Errorf("the header spilled: %q / %q", lines[0], lines[1])
+	}
+	if !strings.Contains(lines[0], "fake") {
+		t.Errorf("the id lost its tail rather than joining it: %q", lines[0])
+	}
+	var project string
+	for _, l := range lines {
+		if strings.HasPrefix(l, "- Project: ") {
+			project = l
+		}
+	}
+	if project == "" {
+		t.Fatalf("no project line: %q", out)
+	}
+	for _, r := range project {
+		if unicode.IsControl(r) {
+			t.Errorf("a control character reached the project line: %q in %q", r, project)
+			break
+		}
+	}
+}
+
+// The handoff framing strips the share header by cutting at the first newline.
+// An id carrying one left the rest of that id standing at the top of what
+// another agent is handed.
+func TestHandoffDropsTheWholeShareHeader(t *testing.T) {
+	out := Handoff(hostileSession(), 4000)
+	if strings.Contains(out, "deja share") {
+		t.Errorf("the share header survived into the handoff: %q", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) == "fake" {
+			t.Errorf("the tail of the id is standing on its own line:\n%s", out)
+		}
+	}
+	first := strings.SplitN(out, "\n", 2)[0]
+	for _, r := range first {
+		if unicode.IsControl(r) {
+			t.Errorf("a control character reached the framing line: %q in %q", r, first)
+			break
+		}
+	}
+}
+
+// A plain session is unchanged.
+func TestShareHeaderUnchangedForPlainFields(t *testing.T) {
+	s := hostileSession()
+	s.Project, s.ID = "app", "x1"
+	out := Share(s, 4000)
+	if !strings.HasPrefix(out, "# deja share: x1\n\n- Project: app\n") {
+		t.Errorf("plain header changed: %q", strings.SplitN(out, "\n\n", 2)[0])
+	}
+}
+
+// The id in the handoff's closing advice is meant to be typed back, and the
+// lookup matches on a prefix: the head of an id with a break in it finds the
+// session, the joined form matches nothing.
+func TestHandoffAdviceIDIsTypeable(t *testing.T) {
+	s := hostileSession()
+	s.ID = "x1abcdef\nfake"
+	out := Handoff(s, 4000)
+	if !strings.Contains(out, "deja show x1abcdef`") {
+		t.Errorf("the advice does not name a usable id:\n%s", out)
+	}
+	if strings.Contains(out, "x1abcdef fake`") {
+		t.Errorf("the advice names the joined form, which matches nothing:\n%s", out)
+	}
+}


### PR DESCRIPTION
Found by the night hunt, iteration 95. Three separate misses of the #1090 scrub have turned up this week (#1400, #1406, #1407), each found one at a time, so this one swept every place that prints a session-derived field instead. Two survived.

`digest.Share` writes a markdown header:

```
# deja share: x1
fake

- Project: app<ESC>[31mred<ESC>[0m
```

The id had a newline in it. `digest.Handoff` then strips the share header by cutting at the first newline, so the rest of that id stood at the top of what another agent is handed — and the framing line above it carried the escape into that agent's context.

Both fields are text deja did not author: a directory name and a harness-assigned id.

`oneLine` — `redact.SafeForDisplay` then collapse — for the header fields, so the document stays structured and the id is still named in full. `internal/digest` cannot import `internal/search`, which owns `SafeLine`, because search imports digest; the helper is four lines.

The closing advice takes the head of the id rather than the joined form, because that line is meant to be typed back and the lookup matches on a prefix. Measured: `deja show x1abcdef` finds the session, `deja show "x1abcdef fake"` matches nothing.

The other eleven candidates the sweep turned up were already covered — `recallListingLine`, `digestLine`, `trimBriefTitle`, `filesRowPath` — or write to a file rather than a screen.

Tests: the share header staying on its lines with the id whole, the handoff dropping the header completely and leaving no orphan, the framing line clean, the advice id typeable, and a plain session unchanged. Five mutations verified.
