### PR TITLE
fix: keep an event from the future out of today and this week

### DIFF
--- a/internal/usage/future_event_test.go
+++ b/internal/usage/future_event_test.go
@@ -1,0 +1,116 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+)
+
+func appendAt(t *testing.T, dir string, at time.Time, kind string, bytes int) {
+	t.Helper()
+	f, err := os.OpenFile(Path(dir), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	b, err := json.Marshal(Event{Time: at.UTC(), Kind: kind, Bytes: bytes, Sessions: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The counters are windows on the recent past, and an event dated ahead of the
+// window sits inside every one of them. A clock that ran fast before it was
+// corrected leaves one behind, and the rotation that bounds the log keeps
+// whatever is newer than its cutoff — so it was counted in "today" every day
+// until its own date arrived.
+func TestCountersIgnoreAnEventFromTheFuture(t *testing.T) {
+	dir := t.TempDir()
+	Record(dir, KindRecall, 900)
+	appendAt(t, dir, time.Now().AddDate(1, 0, 0), KindRecall, 4000)
+
+	if r, b, _ := TodayWithInjections(dir); r != 1 || b != 900 {
+		t.Errorf("today counted the future event: %d recalls, %d bytes", r, b)
+	}
+	if r, b, _, _ := Week(dir); r != 1 || b != 900 {
+		t.Errorf("this week counted the future event: %d recalls, %d bytes", r, b)
+	}
+}
+
+func TestDejaVuWeekIgnoresTheFuture(t *testing.T) {
+	dir := t.TempDir()
+	appendAt(t, dir, time.Now().Add(-time.Hour), KindDejaVu, 400)
+	appendAt(t, dir, time.Now().AddDate(0, 1, 0), KindDejaVu, 400)
+	if n := DejaVuWeek(dir); n != 1 {
+		t.Errorf("DejaVuWeek = %d, want 1", n)
+	}
+}
+
+func TestTodayRawIgnoresTheFuture(t *testing.T) {
+	dir := t.TempDir()
+	RecordResultRaw(dir, KindRecall, 900, 1, false, 5000)
+	f, err := os.OpenFile(Path(dir), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(Event{Time: time.Now().UTC().AddDate(1, 0, 0), Kind: KindRecall, Bytes: 4000, RawBytes: 90000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	if got := TodayRaw(dir); got != 5000 {
+		t.Errorf("TodayRaw = %d, want 5000", got)
+	}
+}
+
+// Ordinary skew is not a false event: something stamped later today still
+// counts, and so does the last moment of the day.
+func TestOrdinarySkewStillCounts(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	endOfDay := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, now.Location())
+	appendAt(t, dir, endOfDay, KindRecall, 700)
+	if r, _, _ := TodayWithInjections(dir); r != 1 {
+		t.Errorf("an event stamped later today was dropped: %d recalls", r)
+	}
+	if r, _, _, _ := Week(dir); r != 1 {
+		t.Errorf("this week dropped it too: %d recalls", r)
+	}
+}
+
+// The window is half-open: an event stamped at the midnight that ends today
+// belongs to tomorrow, and one a microsecond before it belongs to today.
+func TestTheDayBoundaryIsHalfOpen(t *testing.T) {
+	now := time.Now()
+	end := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).AddDate(0, 0, 1)
+
+	inside := t.TempDir()
+	appendAt(t, inside, end.Add(-time.Microsecond), KindRecall, 700)
+	if r, _, _ := TodayWithInjections(inside); r != 1 {
+		t.Errorf("the last instant of today was dropped: %d recalls", r)
+	}
+
+	outside := t.TempDir()
+	appendAt(t, outside, end, KindRecall, 700)
+	if r, _, _ := TodayWithInjections(outside); r != 0 {
+		t.Errorf("tomorrow's first instant counted as today: %d recalls", r)
+	}
+}
+
+// Totals still report what the log holds: the guard is on the windows, not on
+// the record.
+func TestTotalsStillSeeTheFutureEvent(t *testing.T) {
+	dir := t.TempDir()
+	Record(dir, KindRecall, 900)
+	appendAt(t, dir, time.Now().AddDate(1, 0, 0), KindRecall, 4000)
+	if got := Totals(dir).Recalls; got != 2 {
+		t.Errorf("Totals hid a recorded event: %d, want 2", got)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -88,6 +88,22 @@ const (
 	keepWindow = 14 * 24 * time.Hour
 )
 
+// ahead reports a timestamp past the end of the reader's day — a clock that
+// ran fast before it was corrected, or a log carried over from such a machine.
+//
+// The counters are windows on the recent past, and an event dated ahead of the
+// window sits inside every one of them: measured with a single event stamped a
+// year out, "today" reported it every day for a year, and the rotation that
+// bounds the log keeps whatever is newer than its cutoff, so it never aged
+// out. The end of the day rather than the instant, because a few minutes of
+// ordinary skew is not a false event — a year is.
+func ahead(t, now time.Time) bool {
+	// The window is half-open, as every other one here is: midnight belongs to
+	// the day it opens, not to the one it closes.
+	end := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).AddDate(0, 0, 1)
+	return !t.Before(end)
+}
+
 // Path returns the usage log location for an index dir: a sibling file, like
 // the .lock file, so it survives full index rebuilds.
 func Path(indexDir string) string {
@@ -146,7 +162,7 @@ func TodayWithInjections(indexDir string) (recalls, bytes, injected int) {
 	now := time.Now()
 	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	for _, e := range read(Path(indexDir)) {
-		if e.Time.Before(midnight) {
+		if e.Time.Before(midnight) || ahead(e.Time, now) {
 			continue
 		}
 		switch e.Kind {
@@ -165,10 +181,11 @@ func TodayWithInjections(indexDir string) (recalls, bytes, injected int) {
 // DejaVuWeek counts this week's déjà vu moments — prompts the user's own
 // history already answered.
 func DejaVuWeek(indexDir string) int {
-	cut := time.Now().AddDate(0, 0, -7)
+	now := time.Now()
+	cut := now.AddDate(0, 0, -7)
 	n := 0
 	for _, e := range read(Path(indexDir)) {
-		if e.Kind == KindDejaVu && e.Time.After(cut) && e.Sessions > 0 {
+		if e.Kind == KindDejaVu && e.Time.After(cut) && !ahead(e.Time, now) && e.Sessions > 0 {
 			n++
 		}
 	}
@@ -181,7 +198,7 @@ func TodayRaw(indexDir string) int64 {
 	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	var raw int64
 	for _, e := range read(Path(indexDir)) {
-		if e.Time.Before(midnight) {
+		if e.Time.Before(midnight) || ahead(e.Time, now) {
 			continue
 		}
 		switch e.Kind {
@@ -231,9 +248,10 @@ func Totals(indexDir string) Summary {
 // calls) — the honest demand-side number — while injected counts the hook
 // deliveries deja pushed unprompted.
 func Week(indexDir string) (recalls, bytes, injected, injectedBytes int) {
-	cut := time.Now().Add(-7 * 24 * time.Hour)
+	now := time.Now()
+	cut := now.Add(-7 * 24 * time.Hour)
 	for _, e := range read(Path(indexDir)) {
-		if e.Time.Before(cut) || e.Empty {
+		if e.Time.Before(cut) || ahead(e.Time, now) || e.Empty {
 			continue
 		}
 		switch e.Kind {
@@ -274,7 +292,10 @@ func read(p string) []Event {
 }
 
 // rotate rewrites the log keeping only the recent window once it grows past
-// rotateAt. Concurrent writers may lose an event during the swap; usage data
+// rotateAt. An event dated ahead of the window is kept rather than dropped:
+// the counters ignore it (see ahead), it costs one line, and deleting a
+// recorded event on a guess about someone's clock is the one thing here that
+// cannot be undone. Concurrent writers may lose an event during the swap; usage data
 // is advisory, so that trade keeps the hot path lock-free.
 //
 // Size is the trigger, but the window is what actually bounds the file, and


### PR DESCRIPTION
Found by the night hunt, iteration 96, finishing the clock hypothesis #1404 started.

The usage counters are windows on the recent past — today, this week. An event whose timestamp is ahead of the window sits inside every one of them. One event stamped a year out, on a log holding one real recall:

```
today : recalls=2 bytes=4900
week  : recalls=2 bytes=4900
```

And it stays there. The rotation that bounds the log keeps whatever is newer than its cutoff, so a future event is never dropped — it would be counted in "today" every day until its own date arrived.

Where such a stamp comes from is the same place #1404's did: a clock that ran fast before it was corrected, or a log carried over from such a machine. Nothing in deja clamps it.

`ahead` guards the four window readers. The boundary is the end of the reader's day, not the instant — a few minutes of ordinary skew is not a false event; a year is. Half-open, like every other window here: midnight belongs to the day it opens.

`Totals` still sees the event, and `rotate` still keeps it. Deleting a recorded event on a guess about someone's clock is the one thing here that cannot be undone, and it costs a line.

Tests: the four readers each ignoring a future event, an event stamped later today still counting, both sides of the midnight boundary, and totals still reporting what the log holds. Six mutations verified — dropping the guard from any of the four readers, moving the boundary to the instant, or making it inclusive each fail.
