### PR TITLE
test: stop a recall test from skipping itself into silence

### DIFF
--- a/cmd/deja/mcp_match_count_test.go
+++ b/cmd/deja/mcp_match_count_test.go
@@ -84,12 +84,20 @@ func firstLines(s string, n int) string {
 // contradict it on the same screen.
 func TestRelevanceHitsAreNotCalledMatches(t *testing.T) {
 	dir := manySessionStore(t, 40)
-	text, _, _, _, err := recallTextResult(dir, "pipeline stalled parser frames rejects", "", 5, 0, 4096)
+	// The query mixes words from both halves of the fixture: "parser rejects
+	// frames" appears only in the rare session, "pipeline stalled" only in the
+	// forty bulk ones. No session can hold all of them, so exact matching has
+	// nothing to return and the relevance tier answers — a property of how the
+	// store is built rather than of how ranking happens to score today.
+	text, _, _, _, err := recallTextResult(dir, "parser rejects frames the pipeline stalled", "", 5, 0, 4096)
 	if err != nil {
 		t.Fatal(err)
 	}
+	// A fixture that stops reaching the tier makes this test guard nothing,
+	// and skipping there hides that: the query above stopped reaching it once
+	// already, and the test went quiet instead of saying so.
 	if !strings.Contains(text, "ranked by relevance") {
-		t.Skipf("this query did not reach the relevance tier:\n%s", firstLines(text, 3))
+		t.Fatalf("the fixture no longer reaches the relevance tier, so this test guards nothing:\n%s", firstLines(text, 3))
 	}
 	if strings.Contains(text, "matched)") {
 		t.Errorf("relevance-tier sessions were reported as matches:\n%s", firstLines(text, 4))
@@ -108,8 +116,12 @@ func TestTheFollowUpCountMatchesWhatWasServed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Same rule as above. This one is the more fragile of the two — it holds
+	// only while 900 bytes is smaller than fifteen served sessions — so it
+	// fails loudly rather than skipping: a message format that shrinks enough
+	// to fit them all should stop this test, not quiet it.
 	if served >= 15 {
-		t.Skip("the budget did not cut this answer short")
+		t.Fatalf("the budget no longer cuts this answer short (served %d of 15), so this test guards nothing", served)
 	}
 	want := fmt.Sprintf("%d more match(es) — call recall again with offset=%d.", 40-served, served)
 	if !strings.Contains(text, want) {


### PR DESCRIPTION
Found by the night hunt, iteration 109. The hypothesis was about the tests rather than the product: a test that skips on its fixture rather than on the platform guards nothing the day the fixture drifts, and says nothing when it does.

Sweeping the test files tonight's merges touched turned up two such skips, both in this file. One of them is skipping today — its query stopped reaching the relevance tier, so the test has been quiet for a while.

Measured, with the product deliberately broken so relevance-tier sessions are reported as matches again — the exact regression this test exists to catch:

```
old test, product intact : PASS (SKIPPED)
old test, product broken : PASS (SKIPPED)
new test, product broken : FAIL
new test, product intact : PASS
```

The new query mixes words from both halves of the fixture: "parser rejects frames" appears only in the rare session, "pipeline stalled" only in the forty bulk ones. No session can hold all of them, so exact matching has nothing to return and the relevance tier answers — a property of how the store is built rather than of how ranking happens to score today.

Both skips are now `t.Fatalf`. If a fixture stops producing the state under test, that is a broken test, and a broken test should stop the build rather than go quiet. The second one — the budget no longer cutting fifteen sessions short of 900 bytes — is the more fragile of the two and says so in a comment.

No product code changes. Two mutations verified against the current tests: reporting relevance hits as matches, and counting the follow-up line from the limit instead of from what was served.
