### PR TITLE
test: cover the filter that keeps the machinery out of the context

### DIFF
--- a/internal/search/context_work_records_test.go
+++ b/internal/search/context_work_records_test.go
@@ -1,0 +1,59 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The context digest is the conversation, not the machinery under it. What an
+// agent did — the files it touched, the spans it replaced, the commands it ran
+// — is indexed and searchable by role, and before those roles were labelled
+// honestly (#560) they arrived as `user` and filled this with blocks nobody
+// meant by context.
+//
+// Measured by removing the filter: with isWorkRecord returning false, the
+// digest grew "## files" and "## edit" blocks and no test in this package
+// failed. This is that test.
+func TestContextDigestLeavesTheMachineryOut(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", Project: "work", ID: "w1",
+		Messages: []model.Message{
+			{Role: "user", Text: "the retry queue stalls on staging and every worker wakes at once"},
+			{Role: roleToolOutput, Text: "npm ERR! code ELIFECYCLE\nnpm ERR! errno 1"},
+			{Role: "command", Text: "$ npm test"},
+			{Role: "files", Text: "/w/app/retry.go\n/w/app/queue.go"},
+			{Role: "edit", Text: "/w/app/retry.go\nthe body that was replaced"},
+			{Role: "assistant", Text: "We spread the wakeups over a second, bounded by the poll interval."},
+		},
+	}
+	var b strings.Builder
+	PrintContext(&b, s, "retry")
+	out := b.String()
+
+	// The conversation is there, or the assertions below pass on an empty
+	// digest.
+	if !strings.Contains(out, "the retry queue stalls on staging") {
+		t.Fatalf("wrong fixture, the conversation is missing:\n%s", out)
+	}
+	if !strings.Contains(out, "We spread the wakeups over a second") {
+		t.Fatalf("wrong fixture, the answer is missing:\n%s", out)
+	}
+
+	for _, marker := range []string{"## files", "## edit", "## tool-output", "## command"} {
+		if strings.Contains(out, marker) {
+			t.Errorf("the digest carries a %s block:\n%s", marker, out)
+		}
+	}
+	// And not just the headings: the bodies must not arrive under another
+	// role either. These are what actually bite — a stubbed isWorkRecord
+	// leaks the files and edit blocks, while tool output and commands are
+	// held back by the query filter above as well, so their absence here is
+	// weaker evidence than it looks.
+	for _, body := range []string{"/w/app/queue.go", "the body that was replaced", "npm ERR!", "$ npm test"} {
+		if strings.Contains(out, body) {
+			t.Errorf("the digest carries %q:\n%s", body, out)
+		}
+	}
+}


### PR DESCRIPTION
Found by the night hunt, iteration 112, widening the sweep #1413 started: stub a function's body and see whether the package's tests notice.

All 58 unexported helpers in `internal/search` that return a simple type, stubbed one at a time. Fifty-seven were caught. One was not: `isWorkRecord`.

It keeps the machinery out of the context digest an agent reads — the files a session touched, the spans it replaced, the commands it ran. That is the regression #560 fixed, when those turns still arrived labelled `user` and filled the digest with blocks nobody means by context. Measured with it stubbed to false:

```
intact    133 bytes, no "## files", no "## edit"
stubbed   195 bytes, both present
```

and every test in the package still passed.

The test pins the digest: none of those blocks, and none of their bodies under another role either, after a fixture check that the conversation itself is there — an empty digest would satisfy every other assertion.

Three mutations verified: nothing is a work record, only tool output is, everything is.

One assertion in it is weaker than it looks and says so in a comment: tool-output and command turns are also held back by the query filter, so only the files and edit blocks actually depend on this function.

I also wrote a second test, for the other caller — `EarlierAttempts`, which uses the same rule to decide which turns feed the earlier-attempt signal. It passed under all three mutations, and no fixture I tried made it depend on the function: that signal needs a written reason, not only word overlap, so the paths never reach the comparison. A test that cannot fail is not a test, so it is not in this diff.

No product code changes.
