### PR TITLE
test: pin the quoting a redacted value keeps

### DIFF
--- a/internal/redact/quote_balance_test.go
+++ b/internal/redact/quote_balance_test.go
@@ -1,0 +1,86 @@
+package redact
+
+import "testing"
+
+// A masked value keeps the quoting of the value it replaced. The line a secret
+// arrives on is usually a config or a JSON fragment someone will read, or paste
+// back, and dropping the closing quote leaves it unparseable — the mask is
+// meant to hide the value, not to break the line around it.
+//
+// Measured by removing the guard: with closingQuote returning "", every quoted
+// secret came back with an opening quote and no closing one, and no test in
+// this package failed.
+func TestRedactedValueKeepsItsQuoting(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			"aws secret in double quotes",
+			`aws_secret_access_key = "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY"`,
+			`aws_secret_access_key = "[redacted:aws-secret]"`,
+		},
+		{
+			"aws secret bare",
+			`aws_secret_access_key = wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY`,
+			`aws_secret_access_key = [redacted:aws-secret]`,
+		},
+		{
+			"credential in single quotes",
+			`password: 'hunter2hunter2hunter2hunter2'`,
+			`password: '[redacted:credential]'`,
+		},
+		{
+			"credential in double quotes",
+			`api_key="abcdefghijklmnopqrstuvwxyz0123456789"`,
+			`api_key="[redacted:credential]"`,
+		},
+		{
+			"credential bare",
+			`api_key=abcdefghijklmnopqrstuvwxyz0123456789`,
+			`api_key=[redacted:credential]`,
+		},
+		// A closing quote with nothing opening it is not the value's quoting:
+		// echoing it would leave a line with one quote in it, which is worse
+		// than the line that arrived.
+		{
+			"stray closing quote, aws",
+			`aws_secret_access_key = wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY"`,
+			`aws_secret_access_key = [redacted:aws-secret]`,
+		},
+		{
+			"stray closing quote, credential",
+			`api_key=abcdefghijklmnopqrstuvwxyz0123456789"`,
+			`api_key=[redacted:credential]`,
+		},
+		{
+			"stray single quote, credential",
+			`api_key=abcdefghijklmnopqrstuvwxyz0123456789'`,
+			`api_key=[redacted:credential]`,
+		},
+		// Mismatched quotes are whatever the line had: the mask replaces the
+		// value, not the punctuation around it, so the closing character is
+		// the one that closed it and not a copy of the one that opened it.
+		{
+			"opened double, closed single",
+			`api_key="abcdefghijklmnopqrstuvwxyz0123456789'`,
+			`api_key="[redacted:credential]'`,
+		},
+		{
+			"opened single, closed double",
+			`api_key='abcdefghijklmnopqrstuvwxyz0123456789"`,
+			`api_key='[redacted:credential]"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, counts := Text(tc.in)
+			if counts.Total() == 0 {
+				t.Fatalf("wrong fixture, nothing was redacted: %q", got)
+			}
+			if got != tc.want {
+				t.Errorf("Text(%q) =\n  %q\nwant\n  %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Found by the night hunt, iteration 113, running the sweep from #1414 over the rest of the packages: stub a helper, see whether its package's tests notice.

`internal/digest` — 12 helpers, all caught. `internal/usage` — 1, caught. `internal/redact` — 21, two unnoticed.

One of them, `isHexish`, turned out not to be a guard at all. Nothing I could feed it changed the output: `charClasses` and the entropy threshold already reject everything it rejects, mixed-case hex included. It is a fast path, and a fast path has no behaviour to test. Left alone.

The other, `closingQuote`, does have behaviour. With it stubbed to "":

```
intact    aws_secret_access_key = "[redacted:aws-secret]"
stubbed   aws_secret_access_key = "[redacted:aws-secret]
```

and no test in the package failed. The line a secret arrives on is usually config or a JSON fragment someone will read or paste back, and a mask that eats the closing quote leaves it unparseable — the point is to hide the value, not to break the line around it.

The test pins five shapes: both quote styles, a bare value, a stray closing quote with nothing opening it (which the guard deliberately drops rather than echoing into an odd count), and mismatched quotes, where the closing character is whatever closed it rather than a copy of what opened it.

Three mutations verified: dropping the closing quote, echoing it unconditionally, and echoing the opening one instead. The first two need the quoted and the stray cases respectively; the third needs the mismatched ones, which is why all three shapes are in there.

I also tried a sixth assertion — that redaction never changes how many quotes a line holds — and dropped it: it is false by design for the stray case, where the guard removes one. The exact expectations say more and say it correctly.

No product code changes.
