### PR TITLE
test: stop the collision count leaking between tests

### DIFF
--- a/internal/index/collision_test.go
+++ b/internal/index/collision_test.go
@@ -8,11 +8,29 @@ import (
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
+// ownCollisionCount makes a test's collision count its own.
+//
+// The counter is package state that ReportCollisions drains, so a test that
+// asserts a number reads whatever an earlier one left behind. Under -shuffle
+// that is exactly what happened: "reported 3 collisions on a clean store",
+// from a build three tests away.
+//
+// Drained twice on purpose. Before, so the assertion is about this build; and
+// after, so a test that legitimately produces collisions does not hand them to
+// whoever runs next — which is how production reads it too, one drain per
+// build rather than one before each read.
+func ownCollisionCount(t *testing.T) {
+	t.Helper()
+	ReportCollisions()
+	t.Cleanup(func() { ReportCollisions() })
+}
+
 // Identity is harness:id and nothing guarantees it is unique: two files named
 // session-1.jsonl in different projects produced one manifest row whose project
 // came from one transcript and whose title came from the other, differently on
 // every build (#698).
 func TestSessionsSharingAnIDAreAttributedTheSameWayEveryBuild(t *testing.T) {
+	ownCollisionCount(t)
 	tmp := t.TempDir()
 	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
@@ -72,6 +90,7 @@ func TestSessionsSharingAnIDAreAttributedTheSameWayEveryBuild(t *testing.T) {
 }
 
 func TestReportCollisionsIsZeroWithoutOne(t *testing.T) {
+	ownCollisionCount(t)
 	tmp := t.TempDir()
 	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
@@ -97,6 +116,7 @@ func TestReportCollisionsIsZeroWithoutOne(t *testing.T) {
 // The incremental pass walks a map of changed files; unsorted, which session
 // won a shared id depended on that order (#698).
 func TestIncrementalPassAttributesCollisionsTheSameWay(t *testing.T) {
+	ownCollisionCount(t)
 	tmp := t.TempDir()
 	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))
@@ -152,6 +172,7 @@ func TestIncrementalPassAttributesCollisionsTheSameWay(t *testing.T) {
 // held by the transcript that did not change has to be carried over — losing it
 // was how the first attempt at #698 deleted a session.
 func TestReindexingOneHalfOfACollisionKeepsTheOther(t *testing.T) {
+	ownCollisionCount(t)
 	tmp := t.TempDir()
 	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", os.Getenv("HOME"))


### PR DESCRIPTION
Found by the night hunt, iteration 115. The suite had never been run with `-shuffle=on`. On the first run `internal/index` failed:

```
--- FAIL: TestReportCollisionsIsZeroWithoutOne
    collision_test.go:93: reported 3 collisions on a clean store
```

`collisions` is a package-level counter and `ReportCollisions` drains it, so a test asserting zero reads whatever an earlier test in the same process left behind — three collisions from a build three tests away. The default order happened to put those tests where it did not matter.

Every test in this file now takes the counter on the same footing, through a helper that drains twice: before, so the number it asserts is about its own build, and after, so a test that legitimately produces collisions does not hand them to whoever runs next. The second drain is the one that matches production, where each build reports and clears its own count.

Verified: the failing seed passes, and so do three further shuffled runs of `./internal/...` and two of `./cmd/deja`, which found nothing else.

Two mutations: making `ReportCollisions` always return zero fails the two tests that expect collisions, and making it `Load` instead of `Swap` fails this one — that is the drain the fix leans on, so it needed to be pinned rather than assumed.

The reviewer pointed at the two neighbouring tests as having the same exposure. Measured: neither reproduces today, because both drain mid-test before their own zero assertions. They are covered anyway — the point of doing this per file rather than per test is not depending on which orders I happened to be able to construct.

No product code changes.
