### PR TITLE
test: cover the guards on retiring guidance

### DIFF
--- a/cmd/deja/guidance_foreign_skill_test.go
+++ b/cmd/deja/guidance_foreign_skill_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// Retiring guidance deletes files, so it has to be sure whose they are. A
+// skill file carries frontmatter rather than deja's markers, and the only
+// thing separating ours from one someone wrote is the directory name and the
+// name field — both of which deja generates and both of which the code checks
+// before removing anything.
+//
+// Measured before this test: dropping that check and deleting any SKILL.md at
+// a retired path broke nothing in the package.
+func TestRetiringGuidanceLeavesAForeignSkillAlone(t *testing.T) {
+	hermeticEnv(t)
+	dir := filepath.Join(sources.GeminiHome(), "skills", "deja-history")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "SKILL.md")
+	// Someone else's skill, sitting where ours used to live: the directory
+	// name matches, the name field does not.
+	const foreign = "---\nname: my-own-history\ndescription: hand-written\n---\n\nkeep me\n"
+	if err := os.WriteFile(path, []byte(foreign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := dropRetiredGuidance("gemini"); err != nil {
+		t.Fatalf("dropRetiredGuidance: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("a skill deja did not write was deleted: %v", err)
+	}
+	if string(got) != foreign {
+		t.Errorf("the file was rewritten:\n%q", string(got))
+	}
+}
+
+// And ours does go: the same shape, with the name deja generates.
+func TestRetiringGuidanceRemovesOurOwnSkill(t *testing.T) {
+	hermeticEnv(t)
+	dir := filepath.Join(sources.GeminiHome(), "skills", "deja-history")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "SKILL.md")
+	const ours = "---\nname: deja-history\ndescription: search past sessions\n---\n\nrun deja\n"
+	if err := os.WriteFile(path, []byte(ours), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := dropRetiredGuidance("gemini"); err != nil {
+		t.Fatalf("dropRetiredGuidance: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("our own retired skill survived: %v", err)
+	}
+	// The directory goes too, but only because we emptied it.
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("the emptied directory survived: %v", err)
+	}
+}
+
+// A directory that still holds something of the reader's is not removed, even
+// once ours is gone from it.
+func TestRetiringGuidanceKeepsADirectoryThatIsNotEmpty(t *testing.T) {
+	hermeticEnv(t)
+	dir := filepath.Join(sources.GeminiHome(), "skills", "deja-history")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"),
+		[]byte("---\nname: deja-history\n---\n\nrun deja\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	notes := filepath.Join(dir, "notes.md")
+	if err := os.WriteFile(notes, []byte("mine\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := dropRetiredGuidance("gemini"); err != nil {
+		t.Fatalf("dropRetiredGuidance: %v", err)
+	}
+
+	if got, err := os.ReadFile(notes); err != nil || strings.TrimSpace(string(got)) != "mine" {
+		t.Errorf("a file next to ours was taken with it: %v %q", err, string(got))
+	}
+}
+
+// A relocation variable can point a harness's own directory at the shared one,
+// and then the path deja would retire for that harness is the skill seven
+// others read. CURSOR_CONFIG_DIR is taken verbatim, so pointing it at
+// ~/.agents makes cursor's retired skill path exactly sharedSkillPath().
+//
+// Removing the guard that spares it broke nothing in the package before this.
+func TestRetiringGuidanceSparesTheSharedSkill(t *testing.T) {
+	hermeticEnv(t)
+	shared := sharedSkillPath()
+	if err := os.MkdirAll(filepath.Dir(shared), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const body = "---\nname: deja-history\ndescription: search past sessions\n---\n\nrun deja\n"
+	if err := os.WriteFile(shared, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The collision the comment names.
+	t.Setenv("CURSOR_CONFIG_DIR", filepath.Dir(filepath.Dir(filepath.Dir(shared))))
+	var collides bool
+	for _, p := range retiredGuidancePaths("cursor") {
+		if p == shared {
+			collides = true
+		}
+	}
+	if !collides {
+		t.Fatalf("wrong fixture: no retired path equals %s\n  %v", shared, retiredGuidancePaths("cursor"))
+	}
+
+	if err := dropRetiredGuidance("cursor"); err != nil {
+		t.Fatalf("dropRetiredGuidance: %v", err)
+	}
+
+	got, err := os.ReadFile(shared)
+	if err != nil {
+		t.Fatalf("the skill seven harnesses read was deleted: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("the shared skill was rewritten:\n%q", string(got))
+	}
+}


### PR DESCRIPTION
Found by the night hunt, iteration 118, continuing the coverage-guided sweep from #1417.

`dropRetiredGuidance` deletes files — it removes deja's guidance from paths deja no longer writes. Three mutations of it passed the whole package:

```
nothing is ever retired                      CAUGHT (two existing tests)
any SKILL.md at a retired path is deleted    NOT CAUGHT
the path deja is about to write is retired   NOT CAUGHT
```

The second is the guard whose comment says a skill someone wrote themselves is never touched: a skill file carries frontmatter rather than deja's markers, so the only thing separating ours from theirs is the directory name and the `name:` field, and both have to match before anything is removed.

The third is the collision the code names: a relocation variable can point a harness's own directory at the shared one, and then the path deja would retire is the skill seven harnesses read. `CURSOR_CONFIG_DIR` is taken verbatim, so pointing it at `~/.agents` makes cursor's retired skill path exactly `sharedSkillPath()` — the test builds that collision and checks the file survives.

Four tests: a foreign skill survives untouched; ours goes, and the directory with it; a directory holding something else keeps that something; and the shared skill survives the collision. All three mutations are caught now.

A fourth mutation — removing only the `|| path == sharedSkillPath()` half of that guard — is not caught, and I do not think it can be: every harness with a retired skill path is in `sharedSkillHarnesses`, so whenever a retired path equals the shared skill it also equals the live path and the first half spares it. That half is belt and braces rather than an untested guard, and I left it alone rather than write a test that cannot fail.

I also wrote a fifth test for the live path and dropped it: with cursor it is the same fixture as the shared one, and the skip it carried could never fire.

No product code changes.
