### PR TITLE
test: check the exclusion count on every store line

### DIFF
--- a/cmd/deja/privacy_test.go
+++ b/cmd/deja/privacy_test.go
@@ -114,6 +114,25 @@ func TestSourcesReportsActiveExclusions(t *testing.T) {
 	if err != nil || !strings.Contains(out, "excluded-patterns=1") || !strings.Contains(out, "excluded-sessions=") {
 		t.Fatalf("sources=%q err=%v", out, err)
 	}
+	// On every store line, not merely somewhere in the output: three separate
+	// places print this count, so asserting the string alone passed with the
+	// harness loop's copy removed — another line carried it.
+	var checked int
+	for _, line := range strings.Split(out, "\n") {
+		name, rest, ok := strings.Cut(line, "\t")
+		if !ok || name == "" || !strings.Contains(rest, "sessions=") {
+			continue
+		}
+		checked++
+		if !strings.Contains(line, "excluded-patterns=1") {
+			t.Errorf("the %s line does not name the active patterns: %q", name, line)
+		}
+	}
+	// Enough lines to be the listing rather than one store that happens to
+	// carry it; the exact number is deja's business, not this test's.
+	if checked < 5 {
+		t.Fatalf("wrong fixture: only %d store lines in\n%s", checked, out)
+	}
 }
 
 // The transcript on disk does not change when a session is forgotten, so the


### PR DESCRIPTION
Found by the night hunt, iteration 121, continuing the coverage-guided sweep — this one over `printSources`, the `deja sources` listing.

Four mutations, three caught: hiding the permission-denied note, dropping the excluded-sessions count, zeroing the message count. The fourth — removing the per-harness `excluded-patterns=N` — passed, and the reason is worth more than the fix.

Three separate places in `printSources` emit that string, and the existing assertion was `strings.Contains(out, "excluded-patterns=1")`. With the harness loop's copy deleted, the aider line further down still carried it, so the whole listing could stop naming active exclusions and the test would go on passing.

The assertion now walks the output and requires the count on every store line rather than somewhere in the output. That also covers the other two emitters: dropping the aider copy is caught as well, which the old assertion could not have done either.

Five mutations verified against it now, including that one.

The line is picked by "has a name before the first tab and a `sessions=` after it" rather than by naming harnesses, so the check does not depend on which stores the fixture happens to create, and the guard asks for at least five store lines rather than an exact count — how many stores deja knows about is deja's business, not this test's.

No product code changes.
