### PR TITLE
test: hold what doctor's blocked-index lines are for

### DIFF
--- a/cmd/deja/doctor_unreadable_index_test.go
+++ b/cmd/deja/doctor_unreadable_index_test.go
@@ -35,7 +35,41 @@ func TestDoctorNamesAnUnreadableIndex(t *testing.T) {
 	if !strings.Contains(got, "unreadable") || !strings.Contains(got, "permission denied") {
 		t.Errorf("a blocked index was not named unreadable:\n%s", got)
 	}
+	// And what to do about it. doctor is the command someone runs to find out
+	// why nothing is recalled, so the half that names the fix is the half that
+	// earns the line — measured, it could be deleted with every test still
+	// passing, because "unreadable" alone appears in more than one of doctor's
+	// lines. The variable is the unambiguous part of that advice: "permission"
+	// appears in the diagnosis too.
+	if !strings.Contains(got, "DEJA_INDEX_DIR") {
+		t.Errorf("the line does not say what to do about it:\n%s", got)
+	}
 	if strings.Contains(got, "not built (run `deja warmup`)") {
 		t.Errorf("a blocked index was called not-built:\n%s", got)
+	}
+}
+
+// The same shape one branch over: an index that is behind and cannot be
+// written says so, and says what to do. Nothing covered that line either.
+func TestDoctorNamesAnIndexItCannotWrite(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	doctorIndex(&out, doctorComponent{State: "stale-readonly", Path: dir, StaleStores: 2}, dir)
+	got := out.String()
+
+	if !strings.Contains(got, "cannot be written") {
+		t.Errorf("a read-only index was not named:\n%s", got)
+	}
+	if !strings.Contains(got, "DEJA_INDEX_DIR") {
+		t.Errorf("the line does not say what to do about it:\n%s", got)
+	}
+	// And it still says what is stale, or the reader cannot tell whether it
+	// matters: two stores behind is a different sentence from none.
+	if !strings.Contains(got, "2 stores") {
+		t.Errorf("the line does not say how much is behind:\n%s", got)
 	}
 }


### PR DESCRIPTION
Found by the night hunt, iteration 122, chasing the shape #1421 turned up: an assertion satisfied by a line the test was not about.

I looked for it systematically — needles asserted with `strings.Contains` that the same product file prints in two or more places — and worked the list. Most were false alarms: the same phrase in two different commands cannot collide in one test's output. One held.

`doctor.go` prints "unreadable" in several of its lines, and the test for the blocked-index line asserted only "unreadable" and "permission denied". Measured: deleting the advice half of that line — what to actually do about it — kept every test in the package passing. Replacing the whole line is caught, so the test held the line's identity; it did not hold what the line is for, which on a diagnostic command is the half that earns its place.

The assertion now requires the environment variable it points at. That is the unambiguous part: "permission" appears in the diagnosis too, so asserting the word alone would pass on the sentence that is already there — the reviewer's catch, and it kept the fix from repeating the mistake it was written for.

The reviewer also measured the same gap one branch over: the line for an index that is behind and cannot be written carries the same shape of advice and had no test at all. It has one now, covering the advice and the count of what is stale.

Four mutations verified: either line losing its advice, the blocked line turning into the not-built one, and the read-only line dropping the count.

No product code changes.
