### PR TITLE
feat(zed): index what a thread did, not only what it said

### DIFF
--- a/internal/sources/zed.go
+++ b/internal/sources/zed.go
@@ -260,10 +260,10 @@ func zedSession(db string, r zedRow) (model.Session, bool) {
 	// by the array itself, which is what recall actually reads.
 	for _, raw := range th.Messages {
 		role, text := zedMessage(raw)
-		if text == "" || HarnessAuthored(role) {
-			continue
+		if text != "" && !HarnessAuthored(role) {
+			s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: started})
 		}
-		s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: started})
+		s.Messages = append(s.Messages, zedWork(raw, started)...)
 	}
 	if len(s.Messages) == 0 {
 		return model.Session{}, false
@@ -361,6 +361,136 @@ func zedMessage(raw json.RawMessage) (role, text string) {
 		return "assistant", zedContentText(body, "Text")
 	}
 	return zedLegacyMessage(tagged)
+}
+
+// zedWork is what the agent did rather than what it said: the commands it ran
+// and the files it named. Zed keeps both inside the same content array as the
+// prose, tagged ToolUse, and dropping them left `deja how`, `deja blame`, the
+// files-touched line and the worked-on-most ranking blind on a Zed store —
+// measured there: 797 ToolUse blocks against 69 Agent.Text ones, so the parser
+// was indexing the talk and none of the work.
+//
+// Tool results are not here to be indexed: Zed stores the call and not what
+// came back, so a Zed session cannot pair an error with the command that
+// followed it the way `deja fix` does elsewhere.
+//
+// Modern threads only. An agent-1 message carries `segments` rather than a
+// tagged content array, and whether tool calls appear there is not something
+// this can be written against: every thread on the store measured for this was
+// version 0.3.0, and the shape of a legacy tool segment is unknown. Guessing
+// at it would be the mistake zedBody's data_type refuses to make. A legacy
+// thread keeps the behaviour it had, which is its prose.
+//
+// One record per message, as claude's parser emits: a thread that touches the
+// same file in three exchanges says so three times, and the ranking reads how
+// often a file was worked on.
+func zedWork(raw json.RawMessage, t time.Time) []model.Message {
+	var tagged map[string]json.RawMessage
+	if json.Unmarshal(raw, &tagged) != nil {
+		return nil
+	}
+	body, ok := tagged["Agent"]
+	if !ok {
+		return nil
+	}
+	var msg struct {
+		Content []struct {
+			ToolUse *struct {
+				Name  string          `json:"name"`
+				Input json.RawMessage `json:"input"`
+			} `json:"ToolUse"`
+		} `json:"content"`
+	}
+	if json.Unmarshal(body, &msg) != nil {
+		return nil
+	}
+	var out []model.Message
+	var paths []string
+	for _, block := range msg.Content {
+		if block.ToolUse == nil {
+			continue
+		}
+		if cmd := zedCommand(block.ToolUse.Name, block.ToolUse.Input); cmd != "" {
+			if IndexCommands() && worthIndexing(cmd) {
+				out = append(out, model.Message{Role: RoleCommand, Text: "$ " + cmd, Time: t})
+			}
+			continue
+		}
+		paths = append(paths, zedToolPaths(block.ToolUse.Name, block.ToolUse.Input)...)
+	}
+	if len(paths) > 0 && IndexToolPaths() {
+		out = append(out, model.Message{Role: RoleFiles, Text: strings.Join(dedupeStrings(paths), "\n"), Time: t})
+	}
+	return out
+}
+
+// zedCommand is the shell line a terminal call ran, or "" when the call is not
+// one. The name is Zed's own and stable across both thread formats.
+func zedCommand(name string, input json.RawMessage) string {
+	if name != "terminal" {
+		return ""
+	}
+	var in struct {
+		Command string `json:"command"`
+	}
+	if json.Unmarshal(input, &in) != nil {
+		return ""
+	}
+	return strings.TrimSpace(in.Command)
+}
+
+// zedPathTools are the calls whose input names a file. `terminal` is absent for
+// the reason claude's list gives: a path inside a shell command is guesswork.
+// `grep` and `find_path` are absent because they name a pattern and a scope,
+// not a file the session worked on.
+var zedPathTools = map[string][]string{
+	"edit_file":        {"path"},
+	"read_file":        {"path"},
+	"create_directory": {"path"},
+	"delete_path":      {"path"},
+	"move_path":        {"source_path", "destination_path"},
+	"open":             {"path"},
+}
+
+func zedToolPaths(name string, input json.RawMessage) []string {
+	fields, ok := zedPathTools[name]
+	if !ok {
+		return nil
+	}
+	var in map[string]json.RawMessage
+	if json.Unmarshal(input, &in) != nil {
+		return nil
+	}
+	var out []string
+	for _, f := range fields {
+		raw, ok := in[f]
+		if !ok {
+			continue
+		}
+		var p string
+		if json.Unmarshal(raw, &p) != nil {
+			continue
+		}
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// dedupeStrings keeps the first of each path: a thread reads the same file
+// many times over, and the record is about which files the work touched.
+func dedupeStrings(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := in[:0:0]
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
 }
 
 // zedContentText joins the wanted variants of a content block array. A Text

--- a/internal/sources/zed_tools_test.go
+++ b/internal/sources/zed_tools_test.go
@@ -1,0 +1,144 @@
+package sources
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// A thread that talks and works: two commands, several files, and the calls
+// that name neither. Shaped after a real store — Zed keeps tool calls in the
+// same content array as the prose, tagged ToolUse.
+const zedWorkBody = `{"version":"0.3.0","title":"worked thread","updated_at":"2026-07-19T09:00:02Z","messages":[
+{"User":{"id":"u1","content":[{"Text":"the retry queue stalls on staging"}]}},
+{"Agent":{"content":[
+ {"Text":"Let me look."},
+ {"ToolUse":{"id":"c1","name":"read_file","input":{"path":"/w/app/queue/retry.go","start_line":1,"end_line":80}}},
+ {"ToolUse":{"id":"c2","name":"terminal","input":{"command":"go test ./queue/...","cd":"/w/app"}}},
+ {"ToolUse":{"id":"c3","name":"grep","input":{"regex":"backoff","include_pattern":"**/*.go"}}}
+],"tool_results":{},"reasoning_details":null}},
+{"Agent":{"content":[
+ {"ToolUse":{"id":"c4","name":"edit_file","input":{"path":"/w/app/queue/retry.go","display_description":"spread the wakeups","mode":"edit"}}},
+ {"ToolUse":{"id":"c5","name":"read_file","input":{"path":"/w/app/queue/retry.go","start_line":1,"end_line":80}}},
+ {"ToolUse":{"id":"c6","name":"move_path","input":{"source_path":"/w/app/old.go","destination_path":"/w/app/queue/jitter.go"}}},
+ {"ToolUse":{"id":"c7","name":"terminal","input":{"command":"go build ./...","cd":"/w/app"}}},
+ {"Text":"We spread the wakeups over a second."}
+],"tool_results":{},"reasoning_details":null}}
+]}`
+
+func zedWorkedStore(t *testing.T) []string {
+	t.Helper()
+	zedHome(t)
+	hex := zedZstdHex(t, zedWorkBody)
+	sql := fmt.Sprintf("%s\ninsert into threads (id, summary, updated_at, data_type, data, folder_paths, created_at) values ('w1', 'worked thread', '2026-07-19T09:00:02Z', 'zstd', x'%s', '[\"/w/app\"]', '2026-07-19T08:00:00Z');", zedSchema, hex)
+	db := zedTestDB(t, sql)
+	if !ZstdAvailable() {
+		t.Skip("zstd not installed")
+	}
+	sessions, err := ParseZedDB(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(sessions))
+	}
+	var roles []string
+	for _, m := range sessions[0].Messages {
+		roles = append(roles, m.Role+"\t"+m.Text)
+	}
+	return roles
+}
+
+// Zed keeps what the agent did in the same place as what it said, and deja read
+// only the saying. Measured on a real 30-thread store: 797 ToolUse blocks
+// against 69 of agent prose, so `deja how`, `deja blame`, the files-touched
+// line and the worked-on-most ranking were all blind on a Zed history.
+func TestZedIndexesTheCommandsAThreadRan(t *testing.T) {
+	rows := zedWorkedStore(t)
+
+	var commands []string
+	for _, r := range rows {
+		role, text, _ := strings.Cut(r, "\t")
+		if role == RoleCommand {
+			commands = append(commands, text)
+		}
+	}
+	if len(commands) != 2 {
+		t.Fatalf("commands = %v, want the two terminal calls", commands)
+	}
+	for i, want := range []string{"$ go test ./queue/...", "$ go build ./..."} {
+		if commands[i] != want {
+			t.Errorf("command %d = %q, want %q", i, commands[i], want)
+		}
+	}
+	// The prose is still there: the work is added beside it, not instead.
+	joined := strings.Join(rows, "\n")
+	for _, said := range []string{"the retry queue stalls on staging", "We spread the wakeups over a second."} {
+		if !strings.Contains(joined, said) {
+			t.Errorf("the conversation lost %q:\n%s", said, joined)
+		}
+	}
+}
+
+func TestZedIndexesTheFilesAThreadTouched(t *testing.T) {
+	rows := zedWorkedStore(t)
+
+	var files []string
+	for _, r := range rows {
+		role, text, _ := strings.Cut(r, "\t")
+		if role == RoleFiles {
+			files = append(files, strings.Split(text, "\n")...)
+		}
+	}
+	want := []string{
+		"/w/app/queue/retry.go",
+		"/w/app/old.go",
+		"/w/app/queue/jitter.go",
+	}
+	for _, w := range want {
+		found := false
+		for _, f := range files {
+			if f == w {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s is missing from %v", w, files)
+		}
+	}
+	// A path is recorded once per message however often the thread reads it:
+	// the record is which files the work touched, not how many reads it took.
+	for _, r := range rows {
+		role, text, _ := strings.Cut(r, "\t")
+		if role != RoleFiles {
+			continue
+		}
+		seen := map[string]bool{}
+		for _, p := range strings.Split(text, "\n") {
+			if seen[p] {
+				t.Errorf("%s is listed twice in one record: %q", p, text)
+			}
+			seen[p] = true
+		}
+	}
+}
+
+// A search names a pattern and a scope, not a file the session worked on, and
+// a path inside a shell command is guesswork — the same line claude's parser
+// draws.
+func TestZedLeavesSearchesAndShellPathsOutOfTheFileRecord(t *testing.T) {
+	rows := zedWorkedStore(t)
+
+	joined := strings.Join(rows, "\n")
+	for _, absent := range []string{"backoff", "**/*.go"} {
+		if strings.Contains(joined, absent) {
+			t.Errorf("a grep's pattern reached the index: %q in\n%s", absent, joined)
+		}
+	}
+	for _, r := range rows {
+		role, text, _ := strings.Cut(r, "\t")
+		if role == RoleFiles && strings.Contains(text, "/w/app\n") {
+			t.Errorf("a terminal's working directory was recorded as a file: %q", text)
+		}
+	}
+}


### PR DESCRIPTION
Zed arrived as the eighteenth harness reading only what was said. Measured on a real 30-thread store:

```
Agent.ToolUse          797 blocks   dropped
Agent.RedactedThinking 626          dropped, correctly
Agent.Text              69          indexed
User.Text               54          indexed
User.Mention             3          indexed
```

So deja indexed 126 of 1,549 content blocks and threw away every record of what the agent actually did. On a Zed history that leaves `deja how` with no commands, `deja blame` with no file mentions, the files-touched line under a recall empty, and the worked-on-most signal — which decides what auto-recall surfaces — with nothing to rank on.

The calls carry it all: `terminal` with the shell line, `edit_file` and `read_file` with paths, `move_path` with both ends. On the same store after this change:

```
before   command 0     files 0
after    command 521   files 1472
```

`terminal` becomes a command record with the `$ ` prefix the other parsers use. The path-bearing tools become a files record. `grep` and `find_path` are left out — they name a pattern and a scope, not a file the session worked on — and so is `terminal`'s `cd`, for the reason claude's `pathTools` comment gives: a path inside a shell command is guesswork. Both feature gates and `worthIndexing` are honoured as elsewhere.

Two limits, both in the code rather than only here. Zed stores the call and not the result, so `deja fix` still cannot pair an error with the command that followed it on a Zed store. And this reads modern threads: an agent-1 message carries `segments` instead of a tagged content array, every thread on the store measured was version 0.3.0, and the shape of a legacy tool segment is unknown — guessing at it is what `zedBody`'s `data_type` refuses to do, so a legacy thread keeps the prose behaviour it had.

Tests: the two commands in order, the files including both ends of a move, paths deduped inside a record, and the searches and shell directory staying out. Five mutations verified — dropping the calls, missing the command name, treating every tool as path-bearing, listing a path once per read, and replacing the prose instead of joining it.
