### PR TITLE
chore: pin manifests to 0.17.3

### DIFF
--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Recall your own past coding sessions, across every AI tool you use.",
   "author": {
     "name": "vshulcz",

--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,12 +1,12 @@
 {
     "architecture": {
         "64bit": {
-            "hash": "2141eaa52d619f36545838765cba8acee4064adbac1b6ccba2bec1910e9ac69a",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.17.2/deja-vu_0.17.2_windows_amd64.zip"
+            "hash": "3b3bdd1e87e244575146f35cb47327e0c7378091562c7b6eb51588ab9fa72581",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.17.3/deja-vu_0.17.3_windows_amd64.zip"
         },
         "arm64": {
-            "hash": "e1b6e9621f437c1f746edcadfe711c6a85f096c9c69b3ec930c8046b3f803c40",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.17.2/deja-vu_0.17.2_windows_arm64.zip"
+            "hash": "0cc9fbb102ed61420395f4d75a46f785c6bc0eb5c0a97dd3180a45f67b8249fa",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.17.3/deja-vu_0.17.3_windows_arm64.zip"
         }
     },
     "autoupdate": {
@@ -24,5 +24,5 @@
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
-    "version": "0.17.2"
+    "version": "0.17.3"
 }

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.17.2
+PackageVersion: 0.17.3
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.17.2/deja-vu_0.17.2_windows_amd64.zip
-  InstallerSha256: 2141EAA52D619F36545838765CBA8ACEE4064ADBAC1B6CCBA2BEC1910E9AC69A
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.17.3/deja-vu_0.17.3_windows_amd64.zip
+  InstallerSha256: 3B3BDD1E87E244575146F35CB47327E0C7378091562C7B6EB51588AB9FA72581
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.17.2/deja-vu_0.17.2_windows_arm64.zip
-  InstallerSha256: E1B6E9621F437C1F746EDCADFE711C6A85F096C9C69B3EC930C8046B3F803C40
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.17.3/deja-vu_0.17.3_windows_arm64.zip
+  InstallerSha256: 0CC9FBB102ED61420395F4D75A46F785C6BC0EB5C0A97DD3180A45F67B8249FA
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.17.2
+PackageVersion: 0.17.3
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.17.2/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.17.3/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.17.2
+PackageVersion: 0.17.3
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Post-release chore: the manifests still pointed at 0.17.2, which fails the manifests check on every open PR. Hashes taken from the v0.17.3 checksums.txt.