### PR TITLE
feat(zed): deja install zed

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Claude Code &middot; Cline &middot; Codex CLI &middot; opencode &middot; aider &
 | OpenClaw | ✅ | ✅ | ✅ | ✅ | — | paste | — |
 | Copilot CLI | ✅ | ✕ | ✅ | ✅ | ✅ | ✅ | — |
 | Roo Code | ✅ | ⚠ | ✅ | ✅ | ✕ | paste | — |
-| Zed | — | ✕ | — | — | ✕ | paste | sqlite3 + zstd |
+| Zed | ✅ | ✕ | — | — | ✕ | paste | sqlite3 + zstd |
 
 ✅ works &middot; — possible, not built yet &middot; ✕ the harness has no such mechanism &middot; ⚠ blocked by an upstream bug &middot; ? not investigated
 

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -848,7 +848,29 @@ func doctorMCPConfigs() []doctorMCPConfig {
 		{"copilot", guidancePath("copilot"), doctorFileWired},
 		{"hermes", filepath.Join(sources.HermesHome(), "config.yaml"), doctorHermesWired},
 		{"goose", filepath.Join(gooseConfigDir(), "config.yaml"), doctorGooseWired},
+		{"zed", sources.ZedSettingsPath(), doctorZedWired},
 	}
+}
+
+// doctorZedWired reads the same JSONC the installer writes, with the same
+// scanner. The generic probe falls back to looking for "deja" anywhere in an
+// unparseable file, which in a settings file full of comments answers a
+// different question than "is the server wired".
+func doctorZedWired(path string) bool {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	text := string(b)
+	open := zedTopLevelOpen(text)
+	if open < 0 {
+		return false
+	}
+	block := zedFindKey(text, open+1, zedServerKey)
+	if block == nil {
+		return false
+	}
+	return zedFindKey(text, block.valueOpen+1, "deja") != nil
 }
 
 func doctorFileWired(path string) bool {

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -196,6 +196,8 @@ func TestDoctorJSONGolden(t *testing.T) {
 	// Windows rather than ~/.config, so the golden keeps the posix path and
 	// the platform difference is normalised here.
 	got = strings.ReplaceAll(got, "<tmp>/home/AppData/Roaming/Block/goose/config", "<tmp>/home/.config/goose")
+	// Zed is the other one: %APPDATA%\Zed on Windows, ~/.config/zed elsewhere.
+	got = strings.ReplaceAll(got, "<tmp>/home/AppData/Roaming/Zed", "<tmp>/home/.config/zed")
 	wantRaw, err := os.ReadFile(filepath.Join("testdata", "doctor.json"))
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -540,6 +540,8 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 			return installResult{}, err
 		}
 		return installKimiAuto(exe, uninstall)
+	case "zed":
+		return installZedMCP(sources.ZedSettingsPath(), exe, uninstall)
 	case "cline":
 		return installMCPJSON(sources.ClineMCPSettingsPath(), exe, uninstall)
 	case "roo":
@@ -1509,6 +1511,9 @@ func installTargetNames() []string {
 		"cline", "cline-auto",
 		"goose", "goose-auto",
 		"grok", "grok-auto", "copilot", "roo", "aider",
+		// Zed's agent takes MCP servers and nothing else: no CLI to hand a
+		// prompt to, so there is no -auto pair to install.
+		"zed",
 		"statusline",
 	}
 }

--- a/cmd/deja/install_writes_valid_test.go
+++ b/cmd/deja/install_writes_valid_test.go
@@ -22,6 +22,12 @@ func TestEveryTargetWritesReadableFiles(t *testing.T) {
 			t.Setenv("USERPROFILE", home)
 			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 			t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+			// Windows resolvers read APPDATA rather than the home directory.
+			// Left at the package-wide value, a target that writes there lands
+			// outside the directory walked below and the check passes on a
+			// target that wrote nothing here.
+			t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+			t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
 			t.Setenv("DEJA_INDEX_DIR", filepath.Join(home, "index.db"))
 
 			if _, err := installTarget(target, "/usr/local/bin/deja", false); err != nil {

--- a/cmd/deja/install_zed.go
+++ b/cmd/deja/install_zed.go
@@ -149,17 +149,11 @@ func zedFindKey(text string, from int, key string) *zedSpan {
 	want := `"` + key + `"`
 	depth := 0
 	for i := from; i < len(text); i++ {
+		if j := zedSkipComment(text, i); j != i {
+			i = j - 1
+			continue
+		}
 		switch {
-		case text[i] == '/' && i+1 < len(text) && text[i+1] == '/':
-			for i < len(text) && text[i] != '\n' {
-				i++
-			}
-		case text[i] == '/' && i+1 < len(text) && text[i+1] == '*':
-			i += 2
-			for i+1 < len(text) && (text[i] != '*' || text[i+1] != '/') {
-				i++
-			}
-			i++
 		case text[i] == '"':
 			end := zedStringEnd(text, i)
 			if end < 0 {
@@ -189,6 +183,30 @@ func zedFindKey(text string, from int, key string) *zedSpan {
 	return nil
 }
 
+// zedSkipComment returns the index one past a comment starting at i, or i
+// itself when there is none. Both shapes, in one place: handling `//` in three
+// scanners and forgetting `/* */` in the fourth is how a settings file with a
+// block comment gets its object end read wrong and its contents mangled.
+func zedSkipComment(text string, i int) int {
+	if i+1 >= len(text) || text[i] != '/' {
+		return i
+	}
+	switch text[i+1] {
+	case '/':
+		for i < len(text) && text[i] != '\n' {
+			i++
+		}
+		return i
+	case '*':
+		i += 2
+		for i+1 < len(text) && (text[i] != '*' || text[i+1] != '/') {
+			i++
+		}
+		return i + 2
+	}
+	return i
+}
+
 // zedStringEnd is one past the closing quote of the string starting at i.
 func zedStringEnd(text string, i int) int {
 	for j := i + 1; j < len(text); j++ {
@@ -206,6 +224,10 @@ func zedStringEnd(text string, i int) int {
 func zedValueOpen(text string, from int) int {
 	seenColon := false
 	for i := from; i < len(text); i++ {
+		if j := zedSkipComment(text, i); j != i {
+			i = j - 1
+			continue
+		}
 		switch {
 		case text[i] == ':':
 			seenColon = true
@@ -215,10 +237,6 @@ func zedValueOpen(text string, from int) int {
 			}
 			return i
 		case text[i] == ' ' || text[i] == '\t' || text[i] == '\n' || text[i] == '\r':
-		case text[i] == '/' && i+1 < len(text) && text[i+1] == '/':
-			for i < len(text) && text[i] != '\n' {
-				i++
-			}
 		default:
 			return -1
 		}
@@ -230,20 +248,20 @@ func zedValueOpen(text string, from int) int {
 func zedObjectEnd(text string, open int) int {
 	depth := 0
 	for i := open; i < len(text); i++ {
-		switch {
-		case text[i] == '"':
+		if j := zedSkipComment(text, i); j != i {
+			i = j - 1
+			continue
+		}
+		switch text[i] {
+		case '"':
 			end := zedStringEnd(text, i)
 			if end < 0 {
 				return -1
 			}
 			i = end - 1
-		case text[i] == '/' && i+1 < len(text) && text[i+1] == '/':
-			for i < len(text) && text[i] != '\n' {
-				i++
-			}
-		case text[i] == '{':
+		case '{':
 			depth++
-		case text[i] == '}':
+		case '}':
 			depth--
 			if depth == 0 {
 				return i + 1

--- a/cmd/deja/install_zed.go
+++ b/cmd/deja/install_zed.go
@@ -87,6 +87,13 @@ func zedSettingsWith(text, entry string, uninstall bool) (string, error) {
 	}
 	if uninstall {
 		cut := zedEntrySpan(text, inner)
+		// If deja was the only server, the key goes too: a settings file that
+		// gains an empty "context_servers": {} after an uninstall is not the
+		// file the reader had before install. Anything else left in there —
+		// another server, or a comment someone wrote — keeps the block.
+		if strings.TrimSpace(text[block.valueOpen+1:cut[0]]+text[cut[1]:block.valueEnd-1]) == "" {
+			cut = zedEntrySpan(text, block)
+		}
 		return text[:cut[0]] + text[cut[1]:], nil
 	}
 	return text[:inner.valueOpen] + entry + text[inner.valueEnd:], nil

--- a/cmd/deja/install_zed.go
+++ b/cmd/deja/install_zed.go
@@ -160,8 +160,8 @@ func zedFindKey(text string, from int, key string) *zedSpan {
 			i = j - 1
 			continue
 		}
-		switch {
-		case text[i] == '"':
+		switch text[i] {
+		case '"':
 			end := zedStringEnd(text, i)
 			if end < 0 {
 				return nil
@@ -178,9 +178,9 @@ func zedFindKey(text string, from int, key string) *zedSpan {
 				return &zedSpan{keyStart: i, valueOpen: open, valueEnd: close}
 			}
 			i = end - 1
-		case text[i] == '{' || text[i] == '[':
+		case '{', '[':
 			depth++
-		case text[i] == '}' || text[i] == ']':
+		case '}', ']':
 			if depth == 0 {
 				return nil // end of the object we were searching
 			}
@@ -235,15 +235,15 @@ func zedValueOpen(text string, from int) int {
 			i = j - 1
 			continue
 		}
-		switch {
-		case text[i] == ':':
+		switch text[i] {
+		case ':':
 			seenColon = true
-		case text[i] == '{':
+		case '{':
 			if !seenColon {
 				return -1
 			}
 			return i
-		case text[i] == ' ' || text[i] == '\t' || text[i] == '\n' || text[i] == '\r':
+		case ' ', '\t', '\n', '\r':
 		default:
 			return -1
 		}

--- a/cmd/deja/install_zed.go
+++ b/cmd/deja/install_zed.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Zed's agent reads MCP servers from the same settings.json a person edits by
+// hand, and that file is JSONC: Zed ships it with a comment header and tolerates
+// trailing commas. Decoding it and writing the result back — what
+// installMCPJSON does for the harnesses whose MCP config is a file of its own —
+// would either fail on the first `//` or silently delete every comment the
+// reader wrote. So this edits the text and leaves the rest of the file byte for
+// byte as it was, in the spirit of #1285.
+const zedServerKey = "context_servers"
+
+// installZedMCP adds or removes deja's entry in Zed's settings.
+func installZedMCP(path, exe string, uninstall bool) (installResult, error) {
+	old, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return installResult{}, err
+	}
+	entry, err := zedEntryJSON(exe)
+	if err != nil {
+		return installResult{}, err
+	}
+
+	if len(strings.TrimSpace(string(old))) == 0 {
+		// Nothing to preserve. Uninstalling from a file that does not exist
+		// must not create one (#676).
+		if uninstall {
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return installResult{}, err
+		}
+		fresh := fmt.Sprintf("{\n  %q: {\n    \"deja\": %s\n  }\n}\n", zedServerKey, entry)
+		a, werr := writeIfChanged(path, old, []byte(fresh))
+		return installResult{Path: path, Action: a}, werr
+	}
+
+	next, err := zedSettingsWith(string(old), entry, uninstall)
+	if err != nil {
+		return installResult{}, err
+	}
+	a, werr := writeIfChanged(path, old, []byte(next))
+	return installResult{Path: path, Action: a}, werr
+}
+
+// zedEntryJSON is the server object, indented to sit at the depth Zed's own
+// settings use.
+func zedEntryJSON(exe string) (string, error) {
+	command, args := mcpCommandArgs(exe)
+	b, err := json.MarshalIndent(map[string]any{"command": command, "args": args}, "    ", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// zedSettingsWith returns the settings text with deja's entry added, replaced
+// or removed. The file is not re-serialised: every byte outside the entry —
+// comments, key order, indentation, trailing commas — survives untouched.
+func zedSettingsWith(text, entry string, uninstall bool) (string, error) {
+	open := zedTopLevelOpen(text)
+	if open < 0 {
+		return "", fmt.Errorf("zed: %s does not look like a settings object; add %q by hand", "settings.json", zedServerKey)
+	}
+	block := zedFindKey(text, open+1, zedServerKey)
+	if block == nil {
+		if uninstall {
+			return text, nil
+		}
+		insert := fmt.Sprintf("\n  %q: {\n    \"deja\": %s\n  },", zedServerKey, entry)
+		return text[:open+1] + insert + text[open+1:], nil
+	}
+	inner := zedFindKey(text, block.valueOpen+1, "deja")
+	if inner == nil {
+		if uninstall {
+			return text, nil
+		}
+		insert := fmt.Sprintf("\n    \"deja\": %s,", entry)
+		return text[:block.valueOpen+1] + insert + text[block.valueOpen+1:], nil
+	}
+	if uninstall {
+		cut := zedEntrySpan(text, inner)
+		return text[:cut[0]] + text[cut[1]:], nil
+	}
+	return text[:inner.valueOpen] + entry + text[inner.valueEnd:], nil
+}
+
+// zedSpan is where a key and its object value sit in the text.
+type zedSpan struct {
+	keyStart  int // the opening quote of the key
+	valueOpen int // the '{' that opens the value
+	valueEnd  int // one past the '}' that closes it
+}
+
+// zedEntrySpan widens a key's span to what removing it should take with it:
+// the whitespace in front of it and the comma behind, so the object left
+// behind is still well formed.
+func zedEntrySpan(text string, s *zedSpan) [2]int {
+	start := s.keyStart
+	for start > 0 && (text[start-1] == ' ' || text[start-1] == '\t' || text[start-1] == '\n') {
+		start--
+	}
+	end := s.valueEnd
+	for end < len(text) && (text[end] == ' ' || text[end] == '\t') {
+		end++
+	}
+	if end < len(text) && text[end] == ',' {
+		end++
+	}
+	return [2]int{start, end}
+}
+
+// zedTopLevelOpen is the '{' that opens the settings object, skipping the
+// comment header Zed ships.
+func zedTopLevelOpen(text string) int {
+	for i := 0; i < len(text); i++ {
+		switch {
+		case text[i] == '{':
+			return i
+		case text[i] == '/' && i+1 < len(text) && text[i+1] == '/':
+			for i < len(text) && text[i] != '\n' {
+				i++
+			}
+		case text[i] == '/' && i+1 < len(text) && text[i+1] == '*':
+			i += 2
+			for i+1 < len(text) && (text[i] != '*' || text[i+1] != '/') {
+				i++
+			}
+			i++
+		case text[i] == ' ' || text[i] == '\t' || text[i] == '\n' || text[i] == '\r':
+		default:
+			return -1
+		}
+	}
+	return -1
+}
+
+// zedFindKey locates a key at the current object depth and returns where its
+// object value begins and ends. Keys nested deeper are skipped, so a "deja"
+// under some other setting is not mistaken for ours.
+func zedFindKey(text string, from int, key string) *zedSpan {
+	want := `"` + key + `"`
+	depth := 0
+	for i := from; i < len(text); i++ {
+		switch {
+		case text[i] == '/' && i+1 < len(text) && text[i+1] == '/':
+			for i < len(text) && text[i] != '\n' {
+				i++
+			}
+		case text[i] == '/' && i+1 < len(text) && text[i+1] == '*':
+			i += 2
+			for i+1 < len(text) && (text[i] != '*' || text[i+1] != '/') {
+				i++
+			}
+			i++
+		case text[i] == '"':
+			end := zedStringEnd(text, i)
+			if end < 0 {
+				return nil
+			}
+			if depth == 0 && text[i:end] == want {
+				open := zedValueOpen(text, end)
+				if open < 0 {
+					return nil
+				}
+				close := zedObjectEnd(text, open)
+				if close < 0 {
+					return nil
+				}
+				return &zedSpan{keyStart: i, valueOpen: open, valueEnd: close}
+			}
+			i = end - 1
+		case text[i] == '{' || text[i] == '[':
+			depth++
+		case text[i] == '}' || text[i] == ']':
+			if depth == 0 {
+				return nil // end of the object we were searching
+			}
+			depth--
+		}
+	}
+	return nil
+}
+
+// zedStringEnd is one past the closing quote of the string starting at i.
+func zedStringEnd(text string, i int) int {
+	for j := i + 1; j < len(text); j++ {
+		switch text[j] {
+		case '\\':
+			j++
+		case '"':
+			return j + 1
+		}
+	}
+	return -1
+}
+
+// zedValueOpen is the '{' after a key, or -1 when the value is not an object.
+func zedValueOpen(text string, from int) int {
+	seenColon := false
+	for i := from; i < len(text); i++ {
+		switch {
+		case text[i] == ':':
+			seenColon = true
+		case text[i] == '{':
+			if !seenColon {
+				return -1
+			}
+			return i
+		case text[i] == ' ' || text[i] == '\t' || text[i] == '\n' || text[i] == '\r':
+		case text[i] == '/' && i+1 < len(text) && text[i+1] == '/':
+			for i < len(text) && text[i] != '\n' {
+				i++
+			}
+		default:
+			return -1
+		}
+	}
+	return -1
+}
+
+// zedObjectEnd is one past the '}' matching the '{' at open.
+func zedObjectEnd(text string, open int) int {
+	depth := 0
+	for i := open; i < len(text); i++ {
+		switch {
+		case text[i] == '"':
+			end := zedStringEnd(text, i)
+			if end < 0 {
+				return -1
+			}
+			i = end - 1
+		case text[i] == '/' && i+1 < len(text) && text[i+1] == '/':
+			for i < len(text) && text[i] != '\n' {
+				i++
+			}
+		case text[i] == '{':
+			depth++
+		case text[i] == '}':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return -1
+}

--- a/cmd/deja/install_zed_test.go
+++ b/cmd/deja/install_zed_test.go
@@ -52,9 +52,11 @@ func zedDejaEntry(t *testing.T, path string) map[string]any {
 	if err := json.Unmarshal(zedStripForTest(b), &root); err != nil {
 		t.Fatalf("the file Zed would read does not parse: %v\n%s", err, b)
 	}
+	// No block at all is a legitimate answer: uninstalling the only server
+	// takes the block with it.
 	servers, ok := root["context_servers"].(map[string]any)
 	if !ok {
-		t.Fatalf("no context_servers in\n%s", b)
+		return nil
 	}
 	entry, ok := servers["deja"].(map[string]any)
 	if !ok {
@@ -187,6 +189,9 @@ func TestInstallZedIsIdempotentAndReversible(t *testing.T) {
 		if !strings.Contains(string(back), line) {
 			t.Errorf("uninstall took %q with it:\n%s", line, back)
 		}
+	}
+	if string(back) != zedRealSettings {
+		t.Errorf("install then uninstall did not put the file back:\n--- want ---\n%s--- got ---\n%s", zedRealSettings, back)
 	}
 }
 
@@ -426,5 +431,59 @@ func TestInstallZedFindsTheEntryEndPastAComment(t *testing.T) {
 		if !strings.Contains(string(back), keep) {
 			t.Errorf("uninstall took %q with it:\n%s", keep, back)
 		}
+	}
+}
+
+// install then uninstall has to leave the file it was handed, byte for byte.
+// Leaving an empty "context_servers": {} behind is a change the reader did not
+// ask for and did not make.
+func TestInstallZedLeavesNoEmptyBlockBehind(t *testing.T) {
+	before := `// Zed settings
+{
+  "theme": "One Dark",
+  "buffer_font_size": 15
+}
+`
+	path := zedSettingsFile(t, before)
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	if zedDejaEntry(t, path) == nil {
+		t.Fatal("deja was not installed")
+	}
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	back, _ := os.ReadFile(path)
+	if string(back) != before {
+		t.Errorf("uninstall did not put the file back:\n--- want ---\n%s--- got ---\n%s", before, back)
+	}
+}
+
+// But a block that still holds something the reader put there stays, even when
+// deja was the only server in it.
+func TestInstallZedKeepsABlockThatStillHoldsSomething(t *testing.T) {
+	path := zedSettingsFile(t, `{
+  "context_servers": {
+    // the agent talks to these
+    "deja": {
+      "command": "/old/deja",
+      "args": ["mcp"]
+    }
+  },
+  "theme": "One Dark"
+}
+`)
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	back, _ := os.ReadFile(path)
+	for _, keep := range []string{`"context_servers"`, "// the agent talks to these", `"theme": "One Dark"`} {
+		if !strings.Contains(string(back), keep) {
+			t.Errorf("uninstall took %q with it:\n%s", keep, back)
+		}
+	}
+	if zedDejaEntry(t, path) != nil {
+		t.Errorf("deja survived:\n%s", back)
 	}
 }

--- a/cmd/deja/install_zed_test.go
+++ b/cmd/deja/install_zed_test.go
@@ -487,3 +487,55 @@ func TestInstallZedKeepsABlockThatStillHoldsSomething(t *testing.T) {
 		t.Errorf("deja survived:\n%s", back)
 	}
 }
+
+// Wiring deja into Zed and then asking doctor whether it is wired have to give
+// the same answer. Doctor's generic probe falls back to looking for "deja"
+// anywhere in a file it cannot parse, and a settings file is full of comments,
+// so Zed gets the installer's own scanner.
+func TestDoctorReportsZedWiring(t *testing.T) {
+	path := zedSettingsFile(t, `// Zed settings
+{
+  // deja is not installed here — this line only says the word
+  "context_servers": {
+    "some-other": {
+      "command": "other"
+    }
+  },
+  "ui_font_size": 16
+}
+`)
+	if doctorZedWired(path) {
+		t.Error("doctor calls Zed wired with no deja entry")
+	}
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	if !doctorZedWired(path) {
+		b, _ := os.ReadFile(path)
+		t.Errorf("doctor does not see the entry install just wrote:\n%s", b)
+	}
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	if doctorZedWired(path) {
+		b, _ := os.ReadFile(path)
+		t.Errorf("doctor still calls it wired after uninstall:\n%s", b)
+	}
+	if doctorZedWired(filepath.Join(t.TempDir(), "nothing.json")) {
+		t.Error("doctor calls a machine with no settings file wired")
+	}
+}
+
+// The zed line has to be in doctor's list at all: an install target whose
+// result doctor never reports is wiring nobody can check.
+func TestDoctorListsZed(t *testing.T) {
+	var found bool
+	for _, c := range doctorMCPConfigs() {
+		if c.name == "zed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("doctor lists no zed row, so `deja install zed` cannot be verified")
+	}
+}

--- a/cmd/deja/install_zed_test.go
+++ b/cmd/deja/install_zed_test.go
@@ -91,6 +91,13 @@ func zedStripForTest(b []byte) []byte {
 				i++
 			}
 			out = append(out, '\n')
+		case c == '/' && i+1 < len(b) && b[i+1] == '*':
+			i += 2
+			for i+1 < len(b) && (b[i] != '*' || b[i+1] != '/') {
+				i++
+			}
+			i++
+			out = append(out, ' ')
 		default:
 			out = append(out, c)
 		}
@@ -310,5 +317,114 @@ func TestInstallZedDoesNotMistakeAKeyInsideAnotherServer(t *testing.T) {
 	}
 	if entry["path"] != nil {
 		t.Errorf("the nested block was edited instead of ours: %v", entry)
+	}
+}
+
+// JSONC has two comment shapes and a settings file may use either anywhere.
+// A block comment sitting between a key and its value, or holding a brace,
+// used to be read as content: the object end came out wrong and the edit
+// landed in the middle of someone's settings.
+func TestInstallZedSurvivesBlockComments(t *testing.T) {
+	path := zedSettingsFile(t, `/* Zed settings
+   { not an object } */
+{
+  "context_servers": /* which servers the agent may call */ {
+    "some-other": {
+      /* the wrapper opens a brace here { and never closes it */
+      "command": "other"
+    }
+  },
+  "ui_font_size": 16
+}
+`)
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	for _, keep := range []string{
+		"/* Zed settings",
+		"/* which servers the agent may call */",
+		"/* the wrapper opens a brace here { and never closes it */",
+		`"ui_font_size": 16`,
+		`"some-other"`,
+	} {
+		if !strings.Contains(string(got), keep) {
+			t.Errorf("the file lost %q:\n%s", keep, got)
+		}
+	}
+	if zedDejaEntry(t, path) == nil {
+		t.Fatalf("deja was not installed:\n%s", got)
+	}
+	// One block, not two. A scanner that loses its place inside a comment
+	// reports no block at all and inserts a second one; the entry is then
+	// readable and the settings are still wrong.
+	if n := strings.Count(string(got), `"context_servers"`); n != 1 {
+		t.Errorf("the file has %d context_servers blocks:\n%s", n, got)
+	}
+
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	back, _ := os.ReadFile(path)
+	if zedDejaEntry(t, path) != nil {
+		t.Errorf("deja survived the uninstall:\n%s", back)
+	}
+	if !strings.Contains(string(back), `"some-other"`) {
+		t.Errorf("uninstall took the other server with it:\n%s", back)
+	}
+}
+
+// Someone annotates the entry deja installed, and the note holds a brace that
+// never closes. Replacing or removing that entry needs its end, and a scanner
+// that counts braces inside comments finds the wrong one — which is how an
+// uninstall takes the settings after it along too.
+func TestInstallZedFindsTheEntryEndPastAComment(t *testing.T) {
+	path := zedSettingsFile(t, `{
+  "context_servers": {
+    "deja": {
+      /* installed by deja — the wrapper opens a brace { on purpose */
+      "command": "/old/path/deja",
+      "args": ["mcp"]
+    },
+    "some-other": {
+      "command": "other"
+    }
+  },
+  "ui_font_size": 16
+}
+`)
+	// Replacing: the old path goes, everything after the entry stays.
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	entry := zedDejaEntry(t, path)
+	if entry == nil {
+		t.Fatalf("the entry was lost:\n%s", got)
+	}
+	if entry["command"] != "/usr/local/bin/deja" {
+		t.Errorf("the entry was not updated: %v", entry)
+	}
+	if strings.Contains(string(got), "/old/path/deja") {
+		t.Errorf("the old command survived beside the new one:\n%s", got)
+	}
+	for _, keep := range []string{`"some-other"`, `"ui_font_size": 16`} {
+		if !strings.Contains(string(got), keep) {
+			t.Errorf("replacing the entry took %q with it:\n%s", keep, got)
+		}
+	}
+
+	// Removing: the same end, and the same everything-after.
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	back, _ := os.ReadFile(path)
+	if zedDejaEntry(t, path) != nil {
+		t.Errorf("deja survived:\n%s", back)
+	}
+	for _, keep := range []string{`"some-other"`, `"command": "other"`, `"ui_font_size": 16`} {
+		if !strings.Contains(string(back), keep) {
+			t.Errorf("uninstall took %q with it:\n%s", keep, back)
+		}
 	}
 }

--- a/cmd/deja/install_zed_test.go
+++ b/cmd/deja/install_zed_test.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Zed ships settings.json with a comment header and tolerates trailing commas,
+// and it is the file a person edits by hand. Decoding it and writing the result
+// back — what the other JSON installers do to a config file of their own —
+// fails on the first `//` and would delete every comment if it did not.
+const zedRealSettings = `// Zed settings
+//
+// For information on how to configure Zed, see the Zed
+// documentation: https://zed.dev/docs/configuring-zed
+{
+  "git_panel": {
+    "tree_view": true
+  },
+  "ui_font_size": 16,
+  "theme": {
+    "mode": "system",
+    "light": "One Light",
+    "dark": "One Dark",
+  },
+}
+`
+
+func zedSettingsFile(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if body != "" {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return path
+}
+
+// zedDejaEntry decodes the installed entry after stripping the comments Zed
+// allows, so the test reads the file the way Zed does.
+func zedDejaEntry(t *testing.T, path string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(zedStripForTest(b), &root); err != nil {
+		t.Fatalf("the file Zed would read does not parse: %v\n%s", err, b)
+	}
+	servers, ok := root["context_servers"].(map[string]any)
+	if !ok {
+		t.Fatalf("no context_servers in\n%s", b)
+	}
+	entry, ok := servers["deja"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return entry
+}
+
+// zedStripForTest is the comment and trailing-comma tolerance Zed has, so the
+// assertions above can use encoding/json.
+func zedStripForTest(b []byte) []byte {
+	var out []byte
+	inString, escaped := false, false
+	for i := 0; i < len(b); i++ {
+		c := b[i]
+		if inString {
+			out = append(out, c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+		switch {
+		case c == '"':
+			inString = true
+			out = append(out, c)
+		case c == '/' && i+1 < len(b) && b[i+1] == '/':
+			for i < len(b) && b[i] != '\n' {
+				i++
+			}
+			out = append(out, '\n')
+		default:
+			out = append(out, c)
+		}
+	}
+	// Trailing commas.
+	var clean []byte
+	for i := 0; i < len(out); i++ {
+		if out[i] == ',' {
+			j := i + 1
+			for j < len(out) && (out[j] == ' ' || out[j] == '\n' || out[j] == '\t' || out[j] == '\r') {
+				j++
+			}
+			if j < len(out) && (out[j] == '}' || out[j] == ']') {
+				continue
+			}
+		}
+		clean = append(clean, out[i])
+	}
+	return clean
+}
+
+func TestInstallZedKeepsTheCommentsSomeoneWrote(t *testing.T) {
+	path := zedSettingsFile(t, zedRealSettings)
+
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range []string{
+		"// Zed settings",
+		"// documentation: https://zed.dev/docs/configuring-zed",
+		`"dark": "One Dark",`,
+	} {
+		if !strings.Contains(string(got), line) {
+			t.Errorf("the file lost %q:\n%s", line, got)
+		}
+	}
+	// And the settings themselves are still there, unreordered.
+	if !strings.Contains(string(got), `"ui_font_size": 16`) {
+		t.Errorf("a setting was dropped:\n%s", got)
+	}
+	entry := zedDejaEntry(t, path)
+	if entry == nil {
+		t.Fatalf("deja was not installed:\n%s", got)
+	}
+	if entry["command"] == "" {
+		t.Errorf("the entry names no command: %v", entry)
+	}
+}
+
+func TestInstallZedIsIdempotentAndReversible(t *testing.T) {
+	path := zedSettingsFile(t, zedRealSettings)
+
+	first, err := installZedMCP(path, "/usr/local/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterFirst, _ := os.ReadFile(path)
+	second, err := installZedMCP(path, "/usr/local/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterSecond, _ := os.ReadFile(path)
+
+	if first.Action == "unchanged" {
+		t.Errorf("the first install changed nothing")
+	}
+	if second.Action != "unchanged" {
+		t.Errorf("a second install rewrote the file: %s", second.Action)
+	}
+	if string(afterFirst) != string(afterSecond) {
+		t.Errorf("installing twice is not the same as once:\n%s\n---\n%s", afterFirst, afterSecond)
+	}
+
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", true); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	back, _ := os.ReadFile(path)
+	if zedDejaEntry(t, path) != nil {
+		t.Errorf("deja survived the uninstall:\n%s", back)
+	}
+	for _, line := range []string{"// Zed settings", `"ui_font_size": 16`} {
+		if !strings.Contains(string(back), line) {
+			t.Errorf("uninstall took %q with it:\n%s", line, back)
+		}
+	}
+}
+
+// A settings file that already has other servers keeps them, and deja joins
+// them rather than replacing the block.
+func TestInstallZedJoinsExistingServers(t *testing.T) {
+	path := zedSettingsFile(t, `{
+  "context_servers": {
+    "some-other": {
+      "command": "other",
+      "args": ["serve"]
+    }
+  },
+  "ui_font_size": 16
+}
+`)
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), `"some-other"`) {
+		t.Errorf("another server was dropped:\n%s", got)
+	}
+	if zedDejaEntry(t, path) == nil {
+		t.Errorf("deja was not added beside it:\n%s", got)
+	}
+	// Uninstalling takes ours and leaves theirs.
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	back, _ := os.ReadFile(path)
+	if !strings.Contains(string(back), `"some-other"`) {
+		t.Errorf("uninstall took another server with it:\n%s", back)
+	}
+	if zedDejaEntry(t, path) != nil {
+		t.Errorf("deja survived:\n%s", back)
+	}
+}
+
+// No settings file at all is the first-run case: write one Zed can read.
+func TestInstallZedWritesAFileWhenThereIsNone(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "settings.json")
+
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if zedDejaEntry(t, path) == nil {
+		b, _ := os.ReadFile(path)
+		t.Fatalf("nothing installed:\n%s", b)
+	}
+}
+
+// Uninstalling from a machine that never had deja must not create a file, nor
+// add an empty block to one (#676).
+func TestUninstallZedLeavesAnUntouchedMachineAlone(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "settings.json")
+	if _, err := installZedMCP(missing, "/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Errorf("uninstall created a settings file: %v", err)
+	}
+
+	path := zedSettingsFile(t, zedRealSettings)
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != zedRealSettings {
+		t.Errorf("uninstall rewrote a file that never mentioned deja:\n%s", got)
+	}
+}
+
+// A "deja" key belonging to some other setting is not ours to touch.
+func TestInstallZedDoesNotMistakeANestedKeyForOurs(t *testing.T) {
+	path := zedSettingsFile(t, `{
+  "lsp": {
+    "deja": {
+      "binary": {
+        "path": "/somewhere/else"
+      }
+    }
+  }
+}
+`)
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), "/somewhere/else") {
+		t.Errorf("someone else's deja settings were overwritten:\n%s", got)
+	}
+	entry := zedDejaEntry(t, path)
+	if entry == nil {
+		t.Fatalf("the server was not installed:\n%s", got)
+	}
+	if entry["command"] == "/somewhere/else" {
+		t.Errorf("the wrong block was edited: %v", entry)
+	}
+}
+
+// And a "deja" key inside another server's own configuration is not ours
+// either: the search has to stay at the depth it is looking in.
+func TestInstallZedDoesNotMistakeAKeyInsideAnotherServer(t *testing.T) {
+	path := zedSettingsFile(t, `{
+  "context_servers": {
+    "some-other": {
+      "command": "other",
+      "env": {
+        "deja": {
+          "path": "/nope"
+        }
+      }
+    }
+  }
+}
+`)
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), "/nope") {
+		t.Errorf("another server's own config was overwritten:\n%s", got)
+	}
+	entry := zedDejaEntry(t, path)
+	if entry == nil {
+		t.Fatalf("the server was not installed beside it:\n%s", got)
+	}
+	if entry["path"] != nil {
+		t.Errorf("the nested block was edited instead of ours: %v", entry)
+	}
+}

--- a/cmd/deja/install_zed_test.go
+++ b/cmd/deja/install_zed_test.go
@@ -407,7 +407,10 @@ func TestInstallZedFindsTheEntryEndPastAComment(t *testing.T) {
 	if entry == nil {
 		t.Fatalf("the entry was lost:\n%s", got)
 	}
-	if entry["command"] != "/usr/local/bin/deja" {
+	// Windows wraps the executable in cmd /c, so what the entry holds is
+	// whatever mcpCommandArgs makes of it, not the path as written.
+	wantCommand, _ := mcpCommandArgs("/usr/local/bin/deja")
+	if entry["command"] != wantCommand {
 		t.Errorf("the entry was not updated: %v", entry)
 	}
 	if strings.Contains(string(got), "/old/path/deja") {

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -244,6 +244,11 @@
       "name": "goose",
       "state": "config-missing",
       "path": "<tmp>/home/.config/goose/config.yaml"
+    },
+    {
+      "name": "zed",
+      "state": "config-missing",
+      "path": "<tmp>/home/.config/zed/settings.json"
     }
   ],
   "sqlite3": {

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -76,7 +76,7 @@
 <tr><td>OpenClaw</td><td><code>${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl</code><br><code>${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td><td>paste</td><td>—</td></tr>
 <tr><td>Copilot CLI</td><td><code>${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl</code></td><td>✅</td><td>✕</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
 <tr><td>Roo Code</td><td><code><vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json</code><br><code>${DEJA_ROO_ROOTS}/tasks/*/api_conversation_history.json</code><br><code>~/.vscode-mock/global-storage/tasks/*/api_conversation_history.json</code></td><td>✅</td><td>⚠</td><td>✅</td><td>✅</td><td>✕</td><td>paste</td><td>—</td></tr>
-<tr><td>Zed</td><td><code>~/Library/Application Support/Zed/threads/threads.db</code><br><code>${XDG_DATA_HOME}/zed/threads/threads.db</code><br><code>%LOCALAPPDATA%/Zed/threads/threads.db</code><br><code>${DEJA_ZED_ROOT}/threads/threads.db</code><br><code>${DEJA_ZED_DB}</code></td><td>—</td><td>✕</td><td>—</td><td>—</td><td>✕</td><td>paste</td><td>sqlite3 + zstd</td></tr>
+<tr><td>Zed</td><td><code>~/Library/Application Support/Zed/threads/threads.db</code><br><code>${XDG_DATA_HOME}/zed/threads/threads.db</code><br><code>%LOCALAPPDATA%/Zed/threads/threads.db</code><br><code>${DEJA_ZED_ROOT}/threads/threads.db</code><br><code>${DEJA_ZED_DB}</code></td><td>✅</td><td>✕</td><td>—</td><td>—</td><td>✕</td><td>paste</td><td>sqlite3 + zstd</td></tr>
 </table>
 <p>✅ works &middot; — possible, not built yet &middot; ✕ the harness has no such mechanism &middot; ⚠ blocked by an upstream bug &middot; ? not investigated</p>
 <ul>

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -502,7 +502,7 @@
    "last_verified": "2026-08-17",
    "display_name": "Zed",
    "capabilities": {
-    "mcp": false,
+    "mcp": true,
     "auto": false,
     "skill": false,
     "command": false,
@@ -511,10 +511,6 @@
     "prereq": "sqlite3 + zstd"
    },
    "gaps": {
-    "mcp": {
-     "state": "todo",
-     "why": "Zed runs MCP servers — it keeps a context server registry and reads them from settings — but deja has no install target that writes that wiring, so nothing here claims it works yet"
-    },
     "auto": {
      "state": "impossible",
      "why": "Zed's agent exposes no lifecycle hook: nothing in the editor runs a command before a prompt is sent, so there is no point at which recall could be injected. Becomes work the day Zed ships one",

--- a/internal/sources/zed.go
+++ b/internal/sources/zed.go
@@ -76,6 +76,35 @@ func ZedDB() string {
 	return EnvPath("DEJA_ZED_DB", filepath.Join(ZedRoot(), "threads", "threads.db"))
 }
 
+// ZedSettingsPath is the settings file Zed's agent reads MCP servers from. It
+// is the *config* directory, not the data one ZedRoot points at: on this
+// machine, measured, `~/.config/zed/settings.json` beside a data store under
+// `~/Library/Application Support/Zed`.
+//
+// macOS and Linux are the same path because Zed asks for a config dir rather
+// than following the platform convention; Windows is APPDATA. DEJA_ZED_CONFIG
+// overrides the lot, which is how this is tested without a Zed install and how
+// someone whose layout differs can point deja at it.
+func ZedSettingsPath() string {
+	if p := os.Getenv("DEJA_ZED_CONFIG"); p != "" {
+		return p
+	}
+	return filepath.Join(zedConfigDir(runtime.GOOS), "settings.json")
+}
+
+func zedConfigDir(goos string) string {
+	if goos == "windows" {
+		if p := os.Getenv("APPDATA"); p != "" {
+			return filepath.Join(p, "Zed")
+		}
+		return filepath.Join(Home(), "AppData", "Roaming", "Zed")
+	}
+	if p := os.Getenv("XDG_CONFIG_HOME"); p != "" {
+		return filepath.Join(p, "zed")
+	}
+	return filepath.Join(Home(), ".config", "zed")
+}
+
 // ZstdAvailable reports whether the zstd CLI the zed parser shells out to is
 // on PATH. Zed compresses every thread it writes, so without this the store is
 // readable but its contents are not.

--- a/internal/sources/zed_config_dir_test.go
+++ b/internal/sources/zed_config_dir_test.go
@@ -1,7 +1,6 @@
 package sources
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -47,7 +46,7 @@ func TestZedSettingsPathHonoursTheOverride(t *testing.T) {
 	if got := ZedSettingsPath(); got != want {
 		t.Errorf("ZedSettingsPath = %q, want %q", got, want)
 	}
-	os.Unsetenv("DEJA_ZED_CONFIG")
+	t.Setenv("DEJA_ZED_CONFIG", "")
 	if got := ZedSettingsPath(); got == want {
 		t.Errorf("the override outlived its variable: %q", got)
 	}

--- a/internal/sources/zed_config_dir_test.go
+++ b/internal/sources/zed_config_dir_test.go
@@ -1,0 +1,54 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Where Zed keeps settings.json differs by platform, and the installer writes
+// to whatever this returns. A wrong answer here does not fail loudly: install
+// reports success and Zed reads a file deja never touched.
+func TestZedConfigDirPerPlatform(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	// Pointed away from the profile on purpose: a roaming profile is not
+	// always under the home directory, and reading APPDATA is the only way to
+	// find it. Same answer either way proves nothing.
+	roaming := filepath.Join(t.TempDir(), "Roaming")
+	t.Setenv("APPDATA", roaming)
+	if got, want := zedConfigDir("windows"), filepath.Join(roaming, "Zed"); got != want {
+		t.Errorf("windows config dir = %q, want %q", got, want)
+	}
+	// A windows without APPDATA set still has a profile to fall back on.
+	t.Setenv("APPDATA", "")
+	if got, want := zedConfigDir("windows"), filepath.Join(home, "AppData", "Roaming", "Zed"); got != want {
+		t.Errorf("windows config dir without APPDATA = %q, want %q", got, want)
+	}
+
+	t.Setenv("XDG_CONFIG_HOME", "")
+	if got, want := zedConfigDir("linux"), filepath.Join(home, ".config", "zed"); got != want {
+		t.Errorf("posix config dir = %q, want %q", got, want)
+	}
+	xdg := filepath.Join(home, "elsewhere")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	if got, want := zedConfigDir("linux"), filepath.Join(xdg, "zed"); got != want {
+		t.Errorf("XDG_CONFIG_HOME ignored: %q, want %q", got, want)
+	}
+}
+
+// The override is what lets anyone whose layout differs point deja at the real
+// file, and it is how this is tested without a Zed install.
+func TestZedSettingsPathHonoursTheOverride(t *testing.T) {
+	want := filepath.Join(t.TempDir(), "settings.json")
+	t.Setenv("DEJA_ZED_CONFIG", want)
+	if got := ZedSettingsPath(); got != want {
+		t.Errorf("ZedSettingsPath = %q, want %q", got, want)
+	}
+	os.Unsetenv("DEJA_ZED_CONFIG")
+	if got := ZedSettingsPath(); got == want {
+		t.Errorf("the override outlived its variable: %q", got)
+	}
+}


### PR DESCRIPTION
Zed's agent panel reads MCP servers from `context_servers` in `~/.config/zed/settings.json`, but `deja install` had no target for it — Zed was the one harness where you had to hand-edit JSON to get recall.

That file is JSONC: comments and trailing commas, which `encoding/json` cannot read and re-marshalling would erase. So the installer edits the text in place, splicing the entry in and cutting it back out, and leaves every byte the reader wrote alone. On a real settings file, install then uninstall returns it byte for byte.

Two things found while testing it: uninstalling the only server left an empty `context_servers` block behind, and `doctor` had no zed row at all — an install target whose result nothing reports is wiring nobody can check. Both fixed here; doctor uses the installer's own scanner rather than the substring fallback, which in a file full of comments answers a different question.

Reopened from #1425, which GitHub closed when its base branch merged.