### PR TITLE
feat(zed): record the paths the remaining file tools name

### DIFF
--- a/internal/sources/zed.go
+++ b/internal/sources/zed.go
@@ -443,13 +443,19 @@ func zedCommand(name string, input json.RawMessage) string {
 // the reason claude's list gives: a path inside a shell command is guesswork.
 // `grep` and `find_path` are absent because they name a pattern and a scope,
 // not a file the session worked on.
+// `list_directory` is absent for the same reason: it names a directory being
+// looked around in, not a file the work touched.
 var zedPathTools = map[string][]string{
-	"edit_file":        {"path"},
-	"read_file":        {"path"},
-	"create_directory": {"path"},
-	"delete_path":      {"path"},
-	"move_path":        {"source_path", "destination_path"},
-	"open":             {"path"},
+	"edit_file":              {"path"},
+	"read_file":              {"path"},
+	"create_directory":       {"path"},
+	"delete_path":            {"path"},
+	"move_path":              {"source_path", "destination_path"},
+	"copy_path":              {"source_path", "destination_path"},
+	"open":                   {"path"},
+	"diagnostics":            {"path"},
+	"save_file":              {"paths"},
+	"restore_file_from_disk": {"paths"},
 }
 
 func zedToolPaths(name string, input json.RawMessage) []string {
@@ -467,12 +473,23 @@ func zedToolPaths(name string, input json.RawMessage) []string {
 		if !ok {
 			continue
 		}
+		// Two shapes for the same thing: most tools take one path, and the
+		// ones that act on a selection take a list under `paths`.
 		var p string
-		if json.Unmarshal(raw, &p) != nil {
+		if json.Unmarshal(raw, &p) == nil {
+			if p = strings.TrimSpace(p); p != "" {
+				out = append(out, p)
+			}
 			continue
 		}
-		if p = strings.TrimSpace(p); p != "" {
-			out = append(out, p)
+		var ps []string
+		if json.Unmarshal(raw, &ps) != nil {
+			continue
+		}
+		for _, p := range ps {
+			if p = strings.TrimSpace(p); p != "" {
+				out = append(out, p)
+			}
 		}
 	}
 	return out

--- a/internal/sources/zed_tools_test.go
+++ b/internal/sources/zed_tools_test.go
@@ -22,6 +22,10 @@ const zedWorkBody = `{"version":"0.3.0","title":"worked thread","updated_at":"20
  {"ToolUse":{"id":"c5","name":"read_file","input":{"path":"/w/app/queue/retry.go","start_line":1,"end_line":80}}},
  {"ToolUse":{"id":"c6","name":"move_path","input":{"source_path":"/w/app/old.go","destination_path":"/w/app/queue/jitter.go"}}},
  {"ToolUse":{"id":"c7","name":"terminal","input":{"command":"go build ./...","cd":"/w/app"}}},
+ {"ToolUse":{"id":"c8","name":"copy_path","input":{"source_path":"/w/app/queue/retry.go","destination_path":"/w/app/queue/retry_backup.go"}}},
+ {"ToolUse":{"id":"c9","name":"save_file","input":{"paths":["/w/app/queue/jitter.go","/w/app/README.md"]}}},
+ {"ToolUse":{"id":"c10","name":"diagnostics","input":{"path":"/w/app/queue/lint.go"}}},
+ {"ToolUse":{"id":"c11","name":"list_directory","input":{"path":"/w/app/vendor"}}},
  {"Text":"We spread the wakeups over a second."}
 ],"tool_results":{},"reasoning_details":null}}
 ]}`
@@ -94,6 +98,14 @@ func TestZedIndexesTheFilesAThreadTouched(t *testing.T) {
 		"/w/app/queue/retry.go",
 		"/w/app/old.go",
 		"/w/app/queue/jitter.go",
+		// A copy names both ends, the same as a move.
+		"/w/app/queue/retry_backup.go",
+		// save_file and restore_file_from_disk act on a selection, so their
+		// paths arrive as a list rather than one string.
+		"/w/app/README.md",
+		// Asking for a file's diagnostics is the agent looking at that file,
+		// the same as reading it.
+		"/w/app/queue/lint.go",
 	}
 	for _, w := range want {
 		found := false
@@ -140,5 +152,9 @@ func TestZedLeavesSearchesAndShellPathsOutOfTheFileRecord(t *testing.T) {
 		if role == RoleFiles && strings.Contains(text, "/w/app\n") {
 			t.Errorf("a terminal's working directory was recorded as a file: %q", text)
 		}
+	}
+	// Listing a directory is looking around, not working on a file.
+	if strings.Contains(joined, "/w/app/vendor") {
+		t.Errorf("a directory listing reached the file record:\n%s", joined)
 	}
 }


### PR DESCRIPTION
A census of a real 30-thread Zed store: 2589 ToolUse blocks over 16 distinct tools. Four of them name files and none were recorded — `copy_path` (both ends, like a move), `save_file` and `restore_file_from_disk` (a list under `paths`, a shape the reader could not read), and `diagnostics` (the agent looking at a file, same as reading it).

`list_directory` stays out for the reason `grep` and `find_path` do: it names somewhere being looked around in, not a file the work touched.

On that store the change adds 47 records.