### PR TITLE
feat(sync): carry the machine a memory came from

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -749,7 +749,7 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 		// Project, id and title are text a harness wrote, and this is one
 		// line: an escape byte in any of them recolours the rest of the
 		// listing and a carriage return rewinds it (#1090).
-		fmt.Printf("[%s · %s · %s · %s]", s.Harness, redact.SafeForDisplay(s.Project), when, redact.SafeForDisplay(s.ID))
+		fmt.Printf("[%s · %s · %s · %s]", s.Harness, redact.SafeForDisplay(displayProject(s)), when, redact.SafeForDisplay(s.ID))
 		title := s.Title
 		if title == "" {
 			title = firstUserTitle(s)
@@ -1495,7 +1495,7 @@ func parseLast(args []string) (int, search.Options, string, error) {
 		switch a {
 		case "--json":
 			o.JSON = true
-		case "--harness", "--project", "--since", "--role":
+		case "--harness", "--project", "--since", "--role", "--from":
 			if i+1 >= len(args) {
 				return n, o, sinceRaw, fmt.Errorf("%s needs value", a)
 			}
@@ -1508,6 +1508,8 @@ func parseLast(args []string) (int, search.Options, string, error) {
 				o.Project = v
 			case "--role":
 				o.Role = v
+			case "--from":
+				o.From = v
 			default:
 				d, err := parseDur(v)
 				if err != nil {
@@ -1532,6 +1534,12 @@ func parseLast(args []string) (int, search.Options, string, error) {
 }
 
 func filterRecentSources(ss []model.Session, o search.Options) []model.Session {
+	// These are sessions read straight off this machine's stores, so they are
+	// local by definition: asking for another machine's work must not hand
+	// back this one's.
+	if o.From != "" && !strings.EqualFold(o.From, "local") {
+		return nil
+	}
 	if o.Harness == "" && o.Project == "" && o.Since <= 0 && o.Role == "" {
 		return ss
 	}
@@ -2536,7 +2544,7 @@ Usage:
   deja sync export <dir> [--full]
   deja sync import <dir>
   deja sync ssh <host> [--pull] [--full]
-  deja last [n] [--json] [--project name] [--harness name] [--since duration] [--role user|assistant|tool|files|command|edit]
+  deja last [n] [--json] [--project name] [--harness name] [--from machine|local] [--since duration] [--role user|assistant|tool|files|command|edit]
   deja sources
   deja completion <bash|zsh|fish>
   deja forget --session <id-prefix> [--project <substring>] [--before <duration|date>] [--dry-run] [--all-matches]

--- a/cmd/deja/provenance.go
+++ b/cmd/deja/provenance.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// displayProject is the project label a reader sees. A session that arrived by
+// sync carries its project under an "imported:" prefix, which says the work
+// happened somewhere else and stops there. With three machines exchanging
+// history that is the whole answer to "where did this come from" — so where
+// the sending machine named itself, its name goes in place of the prefix.
+//
+// The stored project is untouched: "imported:" is what the trust policy reads,
+// what resume checks before offering a command for another machine's session,
+// and what the note lifecycle keys on. This is the rendering, not the record.
+func displayProject(s model.Session) string {
+	if s.From == "" {
+		return s.Project
+	}
+	rest, ok := strings.CutPrefix(s.Project, "imported:")
+	if !ok {
+		return s.Project
+	}
+	return s.From + ":" + rest
+}

--- a/cmd/deja/provenance_test.go
+++ b/cmd/deja/provenance_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// "imported:" tells a reader the work happened somewhere else and stops there.
+// Where the sending machine named itself, the listing says which one.
+func TestDisplayProjectNamesTheMachine(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   model.Session
+		want string
+	}{
+		{"local work is untouched",
+			model.Session{Project: "deja-vu"}, "deja-vu"},
+		{"an import names its machine",
+			model.Session{Project: "imported:deja-vu", From: "mini"}, "mini:deja-vu"},
+		{"an import from an older deja keeps the old label",
+			model.Session{Project: "imported:deja-vu"}, "imported:deja-vu"},
+		// The prefix is what the trust policy, resume and the note lifecycle
+		// read. A machine name arriving on a project that never carried the
+		// prefix must not invent one.
+		{"a local project is not relabelled",
+			model.Session{Project: "deja-vu", From: "mini"}, "deja-vu"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := displayProject(tc.in); got != tc.want {
+				t.Errorf("displayProject = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLastParsesTheFromFlag(t *testing.T) {
+	_, o, _, err := parseLast([]string{"--from", "mini"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.From != "mini" {
+		t.Errorf("--from was not read: %q", o.From)
+	}
+	if _, _, _, err := parseLast([]string{"--from"}); err == nil {
+		t.Error("a --from with no value was accepted")
+	}
+}
+
+// The recent-sources path reads this machine's own stores directly, without
+// the index. Asking for another machine's work there must hand back nothing
+// rather than this machine's sessions wearing someone else's name.
+func TestRecentSourcesAreLocalOnly(t *testing.T) {
+	ss := []model.Session{{ID: "a", Harness: "claude", Project: "p"}}
+	if got := filterRecentSources(ss, search.Options{From: "mini"}); len(got) != 0 {
+		t.Errorf("--from mini returned %d local sessions", len(got))
+	}
+	if got := filterRecentSources(ss, search.Options{From: "local"}); len(got) != 1 {
+		t.Errorf("--from local dropped this machine's work: %d", len(got))
+	}
+	if got := filterRecentSources(ss, search.Options{}); len(got) != 1 {
+		t.Errorf("no filter dropped a session: %d", len(got))
+	}
+}
+
+func TestUsageMentionsTheFromFlag(t *testing.T) {
+	if !strings.Contains(usageText(), "--from") {
+		t.Error("`deja help` does not mention --from, so nobody will find it")
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -142,6 +142,7 @@ when empty:
 | `gave_up` | the session's own text reports something being tried and backed out |
 | `words` | length of the whole session in words, as the index counted it; ranking normalises by it |
 | `orig_id` | id this session had on the machine it was imported from |
+| `from` | machine the session was worked on, for sessions that arrived by sync; absent for local work and for batches written before deja stamped an origin. `deja last --from <machine>` filters by it, `--from local` for this machine's own |
 | `lifecycle` | state of an imported promoted note: `accepted`, `rejected`, `superseded` or `stale` |
 | `lifecycle_note` | the note left with that state |
 | `lifecycle_at` | when that state was set |

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -159,6 +159,13 @@ type SessionMeta struct {
 	// silently stopped applying (#975). Additive: older manifests decode with
 	// it empty.
 	OrigID string `json:",omitempty"`
+	// From is the machine this session was worked on. Every imported session
+	// read as "from elsewhere" and nothing more, so with three machines
+	// exchanging history there was no way to ask what the server did, and no
+	// way to notice one of them had stopped sending. Additive: a manifest
+	// written before it existed decodes with it empty, and a batch from an
+	// older deja carries no origin, so both degrade to what they said before.
+	From string `json:",omitempty"`
 	// Lifecycle is the state of a promoted note that arrived by sync. The
 	// local states live in notes.jsonl, which the other machine does not have,
 	// so a decision retracted there read as accepted here (#975).

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1090,7 +1090,7 @@ func metaForSession(s model.Session) SessionMeta {
 		last = messageFingerprint(s.Messages[len(s.Messages)-1])
 	}
 	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, AgentTitle: agentTitle, Started: s.Started, Updated: s.Updated, Touched: touched, TouchHits: touchHits, Counted: len(s.Messages), LastMsg: last, Asked: askedHashes(s.Messages), Hit: frictionHashes(s.Messages), GaveUp: gaveUp(s.Messages), Words: sessionWords(s.Messages),
-		OrigID: s.OrigID, Lifecycle: s.Lifecycle, LifecycleNote: s.LifecycleNote, LifecycleAt: s.LifecycleAt}
+		OrigID: s.OrigID, From: s.From, Lifecycle: s.Lifecycle, LifecycleNote: s.LifecycleNote, LifecycleAt: s.LifecycleAt}
 }
 
 // extendDerived folds messages appended to an already-indexed session into the
@@ -1508,7 +1508,7 @@ func sessionFromMeta(meta SessionMeta) model.Session {
 		Title: meta.Title, AgentTitle: meta.AgentTitle, Started: meta.Started, Updated: meta.Updated, Touched: meta.Touched,
 		GaveUp: meta.GaveUp,
 		Words:  meta.Words,
-		OrigID: meta.OrigID, Lifecycle: meta.Lifecycle, LifecycleNote: meta.LifecycleNote, LifecycleAt: meta.LifecycleAt,
+		OrigID: meta.OrigID, From: meta.From, Lifecycle: meta.Lifecycle, LifecycleNote: meta.LifecycleNote, LifecycleAt: meta.LifecycleAt,
 	}
 }
 

--- a/internal/index/machine.go
+++ b/internal/index/machine.go
@@ -1,0 +1,29 @@
+package index
+
+import (
+	"os"
+	"strings"
+)
+
+// MachineName is what this machine calls itself in a sync batch, so the
+// receiving side can say where a memory came from.
+//
+// Without it every imported session reads as "from elsewhere" and nothing
+// more: with three machines exchanging history there is no way to ask what the
+// server worked on, and no way to see that one of them stopped sending days
+// ago. The hostname is what a person already uses to ssh there, which is the
+// name they will recognise; DEJA_MACHINE overrides it for anyone whose
+// hostname is not something they want stamped on every record.
+func MachineName() string {
+	if n := sanitizeSyncField(os.Getenv("DEJA_MACHINE"), syncFieldMax); n != "" {
+		return n
+	}
+	host, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+	// macOS hands back "name.local" and DHCP hands back fully qualified names;
+	// the first label is the part someone recognises.
+	host, _, _ = strings.Cut(host, ".")
+	return sanitizeSyncField(host, syncFieldMax)
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1681,6 +1681,9 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		if o.Project != "" && !strings.Contains(strings.ToLower(meta.Project), strings.ToLower(o.Project)) {
 			return
 		}
+		if !fromMatches(meta.From, o.From) {
+			return
+		}
 		if o.Since > 0 && meta.Updated.Before(time.Now().Add(-o.Since)) {
 			return
 		}
@@ -1818,11 +1821,28 @@ func sessionMetaByOrd(m Manifest) map[uint32]SessionMeta {
 	return out
 }
 
+// fromMatches answers whether a session belongs to the machine asked for.
+// "local" means this machine's own work, which is every session that did not
+// arrive by sync — the one name a person always has, whatever their hosts are
+// called.
+func fromMatches(sessionFrom, want string) bool {
+	if want == "" {
+		return true
+	}
+	if strings.EqualFold(want, "local") {
+		return sessionFrom == ""
+	}
+	return strings.EqualFold(sessionFrom, want)
+}
+
 func sessionMetaMatches(meta SessionMeta, o query.Options) bool {
 	if o.Harness != "" && !harnessMatches(meta.Harness, o.Harness) {
 		return false
 	}
 	if o.Project != "" && !strings.Contains(strings.ToLower(meta.Project), strings.ToLower(o.Project)) {
+		return false
+	}
+	if !fromMatches(meta.From, o.From) {
 		return false
 	}
 	if o.Since > 0 && meta.Updated.Before(time.Now().Add(-o.Since)) {

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -28,6 +28,27 @@ type SyncRecord struct {
 	Role      string    `json:"role"`
 	Text      string    `json:"text"`
 	Time      time.Time `json:"time"`
+	// Origin is the machine that exported the record. Additive: a batch
+	// written before this field existed decodes with it empty, and the
+	// receiving side then says only that the session came from elsewhere,
+	// which is what it said before.
+	Origin syncName `json:"origin,omitempty"`
+}
+
+// syncName is a metadata string that survives being sent the wrong shape. A
+// batch is another machine's file, and this machine may be older or newer than
+// the one that wrote it: decoding a plain string field strictly means one
+// record carrying an object where a name was expected refuses the entire file
+// and imports nothing. A name deja cannot read is worth losing; the history
+// behind it is not.
+type syncName string
+
+func (n *syncName) UnmarshalJSON(b []byte) error {
+	var s string
+	if json.Unmarshal(b, &s) == nil {
+		*n = syncName(s)
+	}
+	return nil
 }
 
 // Export writes records newer than the watermarks for an unnamed peer (a
@@ -113,6 +134,7 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 		m.ExportWatermarks = map[string]int64{}
 	}
 	bySource := map[string][]SyncRecord{}
+	self := MachineName()
 	nextWatermarks := map[string]int64{}
 	for k, v := range m.ExportWatermarks {
 		nextWatermarks[k] = v
@@ -178,7 +200,12 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 			return
 		}
 		text, _ := redact.Text(r.Text)
-		rec := SyncRecord{Harness: meta.Harness, SessionID: meta.ID, Project: meta.Project, Role: r.Role, Text: text, Time: r.Time}
+		// Always this machine: an export never forwards what arrived by sync
+		// (the syncImportPath check above), so nothing here was worked on
+		// anywhere else. If records ever do transit, this becomes meta.From
+		// with a fallback — a machine that relays must not sign someone else's
+		// work as its own.
+		rec := SyncRecord{Harness: meta.Harness, SessionID: meta.ID, Project: meta.Project, Role: r.Role, Text: text, Time: r.Time, Origin: syncName(self)}
 		bySource[source] = append(bySource[source], rec)
 		touched[wk] = true
 		tn := r.Time.UnixNano()
@@ -554,7 +581,7 @@ func Import(dir, inDir string) (int, error) {
 			recsByKey[key] = append(recsByKey[key], Record{Key: key, Role: sr.Role, Text: text, Time: sr.Time, SourcePath: syncImportPath})
 			meta := metas[key]
 			if meta.ID == "" {
-				meta = SessionMeta{ID: importID, Harness: sr.Harness, Project: "imported:" + sr.Project, Path: syncImportPath, OrigID: origID}
+				meta = SessionMeta{ID: importID, Harness: sr.Harness, Project: "imported:" + sr.Project, Path: syncImportPath, OrigID: origID, From: string(sr.Origin)}
 			}
 			if meta.Started.IsZero() || (!sr.Time.IsZero() && sr.Time.Before(meta.Started)) {
 				meta.Started = sr.Time
@@ -770,6 +797,9 @@ func readSyncFile(path string, fn func(SyncRecord) error) error {
 		rec.Project = sanitizeSyncField(rec.Project, syncFieldMax)
 		rec.Harness = sanitizeSyncField(rec.Harness, syncFieldMax)
 		rec.Role = sanitizeSyncField(rec.Role, syncFieldMax)
+		// The origin is rendered into the same result lines, from the same
+		// other machine's text, so it takes the same flattening.
+		rec.Origin = syncName(sanitizeSyncField(string(rec.Origin), syncFieldMax))
 		if err := fn(rec); err != nil {
 			return err
 		}

--- a/internal/index/sync_provenance_test.go
+++ b/internal/index/sync_provenance_test.go
@@ -1,0 +1,183 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// A batch written on one machine and read on another has to say which machine
+// it came from. Without it every imported session reads as "from elsewhere"
+// and nothing more: with three machines exchanging history there is no way to
+// ask what the server worked on, and no way to see one of them fall behind.
+func TestSyncCarriesTheMachineItCameFrom(t *testing.T) {
+	t.Setenv("DEJA_MACHINE", "mini")
+	src, tmp := syncPeerIndex(t, msgLine("2026-01-02T03:04:05Z", "the pool keeps running dry on staging"))
+
+	batch := filepath.Join(tmp, "batch")
+	if _, err := ExportFull(src, batch); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	// The wire carries it, so a machine on an older deja is not required to
+	// have written the field for the rest to work.
+	var rec SyncRecord
+	line := firstBatchLine(t, batch)
+	if err := json.Unmarshal([]byte(line), &rec); err != nil {
+		t.Fatalf("batch line does not decode: %v\n%s", err, line)
+	}
+	if rec.Origin != "mini" {
+		t.Errorf("the batch does not say where it came from: %q", rec.Origin)
+	}
+
+	// And the receiving side keeps it.
+	dst := filepath.Join(tmp, "dst")
+	t.Setenv("DEJA_MACHINE", "laptop")
+	if _, err := Import(dst, batch); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	metas, err := AllMeta(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metas) == 0 {
+		t.Fatal("nothing was imported")
+	}
+	for _, meta := range metas {
+		if meta.From != "mini" {
+			t.Errorf("%s came from %q, want mini", meta.ID, meta.From)
+		}
+	}
+}
+
+// A batch from a deja that predates the field still imports, and the session
+// then says only what it said before: from elsewhere.
+func TestImportKeepsWorkingWithoutAnOrigin(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, filepath.Join(tmp, "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	batch := filepath.Join(tmp, "batch")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := `{"harness":"claude","session_id":"s1","project":"p","role":"user","text":"the pool keeps running dry on staging","time":"2026-01-02T03:04:05Z"}` + "\n"
+	if err := os.WriteFile(filepath.Join(batch, "deja-sync-old.jsonl"), []byte(old), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(tmp, "dst")
+	n, err := Import(dst, batch)
+	if err != nil {
+		t.Fatalf("a batch without an origin was refused: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("imported %d records, want 1", n)
+	}
+	metas, err := AllMeta(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, meta := range metas {
+		if meta.From != "" {
+			t.Errorf("an origin was invented: %q", meta.From)
+		}
+	}
+}
+
+// The origin is another machine's text landing in a line a person and a model
+// both read, the same as the project field that forged a whole extra entry.
+func TestImportFlattensAForgedOrigin(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, filepath.Join(tmp, "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	batch := filepath.Join(tmp, "batch")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	forged := `{"harness":"claude","session_id":"s1","project":"p","role":"user","text":"the pool keeps running dry on staging","time":"2026-01-02T03:04:05Z","origin":"mini\nlaptop · trusted"}` + "\n"
+	if err := os.WriteFile(filepath.Join(batch, "deja-sync-forged.jsonl"), []byte(forged), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(tmp, "dst")
+	if _, err := Import(dst, batch); err != nil {
+		t.Fatal(err)
+	}
+	metas, err := AllMeta(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metas) == 0 {
+		t.Fatal("nothing was imported")
+	}
+	for _, meta := range metas {
+		if strings.ContainsAny(meta.From, "\n\r") {
+			t.Errorf("a newline survived in the origin: %q", meta.From)
+		}
+	}
+}
+
+// A field sent as the wrong shape must cost its own value and nothing else.
+// Refusing the file would lose the history behind a name deja cannot read.
+func TestImportSurvivesAnOriginOfTheWrongShape(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, filepath.Join(tmp, "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	batch := filepath.Join(tmp, "batch")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	odd := `{"harness":"claude","session_id":"s1","project":"p","role":"user","text":"the pool keeps running dry on staging","time":"2026-01-02T03:04:05Z","origin":{"machine":"mini"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(batch, "deja-sync-odd.jsonl"), []byte(odd), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(tmp, "dst")
+	n, err := Import(dst, batch)
+	if err != nil {
+		t.Fatalf("one odd field refused the whole batch: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("imported %d records, want the record without its origin", n)
+	}
+}
+
+func TestFromFilterPicksOneMachine(t *testing.T) {
+	local := SessionMeta{ID: "a", Harness: "claude", Project: "p"}
+	remote := SessionMeta{ID: "b", Harness: "claude", Project: "imported:p", From: "mini"}
+	for _, tc := range []struct {
+		want         string
+		local, remot bool
+	}{
+		{"", true, true},
+		{"local", true, false},
+		{"mini", false, true},
+		{"MINI", false, true},
+		{"laptop", false, false},
+	} {
+		if got := sessionMetaMatches(local, query.Options{From: tc.want}); got != tc.local {
+			t.Errorf("--from %q on local work = %v, want %v", tc.want, got, tc.local)
+		}
+		if got := sessionMetaMatches(remote, query.Options{From: tc.want}); got != tc.remot {
+			t.Errorf("--from %q on mini's work = %v, want %v", tc.want, got, tc.remot)
+		}
+	}
+}
+
+func firstBatchLine(t *testing.T, dir string) string {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(dir, "*.jsonl"))
+	if err != nil || len(paths) == 0 {
+		t.Fatalf("no batch written into %s", dir)
+	}
+	b, err := os.ReadFile(paths[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	line, _, _ := strings.Cut(strings.TrimSpace(string(b)), "\n")
+	return line
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -46,6 +46,10 @@ type Session struct {
 	// promoted note stopped looking like one across a machine boundary and the
 	// rules written for notes stopped applying to it (#975).
 	OrigID string `json:"orig_id,omitempty"`
+	// From is the machine this session was worked on, when it arrived by sync.
+	// Empty for local work and for batches written by a deja that did not
+	// stamp an origin.
+	From string `json:"from,omitempty"`
 	// Lifecycle carries the state of a promoted note that arrived by sync: the
 	// states live in the other machine's notes.jsonl, which never travels
 	// (#975).

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -47,8 +47,13 @@ type Options struct {
 	// Finding the session by what was said and then searching inside it — for a
 	// command, a file, an error — took reopening the transcript by hand (#1321).
 	Session string
-	Since   time.Duration
-	Limit   int
+	// From narrows to the machine a session was worked on: "mini" for what the
+	// server did, "local" for this machine's own work. Without it a history
+	// gathered from three machines is one undifferentiated pile, and there is
+	// no way to ask what any one of them has been doing.
+	From  string
+	Since time.Duration
+	Limit int
 	// Total and Capped travel from RunDetailed to Print so the JSON envelope
 	// can report how many sessions matched before the cap, not merely how many
 	// survived it. Counting the survivors measures the cap.


### PR DESCRIPTION
First of four on making a multi-machine setup actually work. Right now every session that arrives by sync is labelled `imported:` and that is the whole story — with three machines exchanging history you cannot ask what the server has been doing, and you cannot see that one of them stopped sending a week ago.

A batch now stamps the machine that wrote it (`DEJA_MACHINE`, else the hostname's first label). Import keeps it, `deja last --from mini` filters by it, `--from local` gives this machine's own work, and the listing prints `mini:proj` where it used to print `imported:proj`. The stored project is untouched — `imported:` is what the trust policy, resume and the note lifecycle read, so this is the rendering, not the record.

Two things the wire format needed: the origin is another machine's text landing in a line a person and a model both read, so it gets the same flattening the project field got after #1080; and a field sent as the wrong shape now costs its own value instead of refusing the whole file, which is what a strict decode did the moment the existing forward-compat test sent `"origin"` as an object.

Measured end to end on a real 246k-record export: `origin: mini` on the wire, `from: mini` in `--json`, and `--from mini` / `--from local` splitting a mixed index cleanly.

8 mutations on the wire and filter paths, 4 on the rendering — all caught.