### PR TITLE
fix(sync): a pull no longer shares a watermark with hand-run exports

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2541,7 +2541,7 @@ Usage:
   deja friction [--limit n]
   deja fix "<error text>" [--limit n]  (what was run after this error before)
   deja how <what> [--project name] [--limit n]  (commands this machine actually ran)
-  deja sync export <dir> [--full]
+  deja sync export <dir> [--full] [--peer name]
   deja sync import <dir>
   deja sync ssh <host> [--pull] [--full]
   deja last [n] [--json] [--project name] [--harness name] [--from machine|local] [--since duration] [--role user|assistant|tool|files|command|edit]

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -47,9 +47,23 @@ func runSync(dir string, args []string) error {
 		full := false
 		rest := args[1:]
 		out := ""
-		for _, a := range rest {
+		peer := ""
+		for i := 0; i < len(rest); i++ {
+			a := rest[i]
 			if a == "--full" {
 				full = true
+				continue
+			}
+			// Who this batch is for. Watermarks are per peer: without a name
+			// every export shares one, so a backup taken by hand and a pull
+			// from another machine each settle records the other still needs
+			// — and the second one silently sends almost nothing.
+			if a == "--peer" {
+				if i+1 >= len(rest) {
+					return fmt.Errorf("sync export: --peer needs a name")
+				}
+				i++
+				peer = rest[i]
 				continue
 			}
 			// A dropped flag fell back to the incremental path, which on a
@@ -57,7 +71,7 @@ func runSync(dir string, args []string) error {
 			// records into an empty directory while the reader believed they
 			// had carried their whole memory to another machine (#745).
 			if strings.HasPrefix(a, "-") {
-				return fmt.Errorf("sync export: unknown flag %q — only --full is accepted", a)
+				return fmt.Errorf("sync export: unknown flag %q — only --full and --peer are accepted", a)
 			}
 			out = a
 		}
@@ -76,7 +90,7 @@ func runSync(dir string, args []string) error {
 		if full {
 			n, err = index.ExportFull(dir, out)
 		} else {
-			n, err = index.Export(dir, out)
+			n, err = index.ExportTo(dir, out, peer)
 		}
 		if err != nil {
 			// `open …/deja-sync-b9849e838232-1785639771368128000.jsonl:

--- a/cmd/deja/sync_pull_peer_test.go
+++ b/cmd/deja/sync_pull_peer_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Watermarks are per peer, and a pull left the remote's export unnamed — so it
+// shared one watermark with every `deja sync export` run by hand there. Take a
+// backup on the server, then pull from it, and the pull receives almost
+// nothing: the backup already settled those records. Measured on a real index,
+// the second unnamed export sent 2 records where the first sent 246822.
+func TestSyncPullNamesThisMachineToTheRemote(t *testing.T) {
+	setupLocalIndex(t)
+	t.Setenv("DEJA_MACHINE", "laptop")
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	var exportCmd string
+	sshRunner = func(name string, args ...string) (string, error) {
+		switch {
+		case name == "ssh" && args[1] == "mktemp -d":
+			return "/tmp/remote-out", nil
+		case name == "ssh" && strings.Contains(args[1], "sync export"):
+			exportCmd = args[1]
+			return "deja: exported 0 records", nil
+		}
+		return "", nil
+	}
+	if err := runSyncSSH(os.Getenv("DEJA_INDEX_DIR"), []string{"mini", "--pull"}); err != nil {
+		t.Fatal(err)
+	}
+	// The whole remote command is quoted again for `sh -lc`, so the name
+	// arrives escaped; what matters is that the flag and the name are in it.
+	if !strings.Contains(exportCmd, "--peer") || !strings.Contains(exportCmd, "laptop") {
+		t.Errorf("the pull did not tell the remote who it is: %s", exportCmd)
+	}
+}
+
+// A machine name is not guaranteed to be a bare word, and it is spliced into a
+// command the remote shell runs.
+func TestSyncPullQuotesAnAwkwardMachineName(t *testing.T) {
+	setupLocalIndex(t)
+	t.Setenv("DEJA_MACHINE", "lap; rm -rf ~")
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	var exportCmd string
+	sshRunner = func(name string, args ...string) (string, error) {
+		switch {
+		case name == "ssh" && args[1] == "mktemp -d":
+			return "/tmp/remote-out", nil
+		case name == "ssh" && strings.Contains(args[1], "sync export"):
+			exportCmd = args[1]
+			return "deja: exported 0 records", nil
+		}
+		return "", nil
+	}
+	if err := runSyncSSH(os.Getenv("DEJA_INDEX_DIR"), []string{"mini", "--pull"}); err != nil {
+		t.Fatal(err)
+	}
+	// Unwrap the one level `sh -lc '…'` added: what is left is the command the
+	// remote shell sees, and the semicolon in the name must still be inside a
+	// quoted word there.
+	inner := strings.ReplaceAll(exportCmd, `'"'"'`, "'")
+	inner = strings.TrimSuffix(strings.TrimPrefix(inner, "sh -lc '"), "'")
+	if !strings.Contains(inner, `'lap; rm -rf ~'`) {
+		t.Errorf("the machine name reached the remote shell unquoted: %s", inner)
+	}
+}
+
+// The flag is refused by a deja too old to know it, which is what stops a typo
+// from exporting nothing. Both machines are not upgraded at the same moment,
+// so a pull falls back to the shared watermark rather than failing.
+func TestSyncPullFallsBackWhenTheRemoteIsOlder(t *testing.T) {
+	setupLocalIndex(t)
+	t.Setenv("DEJA_MACHINE", "laptop")
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	var commands []string
+	sshRunner = func(name string, args ...string) (string, error) {
+		switch {
+		case name == "ssh" && args[1] == "mktemp -d":
+			return "/tmp/remote-out", nil
+		case name == "ssh" && strings.Contains(args[1], "sync export"):
+			commands = append(commands, args[1])
+			if strings.Contains(args[1], "--peer") {
+				return `deja: sync export: unknown flag "--peer" — only --full is accepted`, errors.New("exit status 1")
+			}
+			return "deja: exported 0 records", nil
+		}
+		return "", nil
+	}
+	if err := runSyncSSH(os.Getenv("DEJA_INDEX_DIR"), []string{"mini", "--pull"}); err != nil {
+		t.Fatalf("a pull from an older remote failed instead of falling back: %v", err)
+	}
+	if len(commands) != 2 {
+		t.Fatalf("ran %d remote exports, want the named one and the fallback: %v", len(commands), commands)
+	}
+	if strings.Contains(commands[1], "--peer") {
+		t.Errorf("the fallback still carried the flag: %s", commands[1])
+	}
+}
+
+// A remote error that is not about the flag must not be retried: running the
+// export twice would advance the remote's watermark a second time.
+func TestSyncPullDoesNotRetryOtherFailures(t *testing.T) {
+	setupLocalIndex(t)
+	t.Setenv("DEJA_MACHINE", "laptop")
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	var calls int
+	sshRunner = func(name string, args ...string) (string, error) {
+		switch {
+		case name == "ssh" && args[1] == "mktemp -d":
+			return "/tmp/remote-out", nil
+		case name == "ssh" && strings.Contains(args[1], "sync export"):
+			calls++
+			return "deja: no sessions indexed yet", errors.New("exit status 1")
+		}
+		return "", nil
+	}
+	if err := runSyncSSH(os.Getenv("DEJA_INDEX_DIR"), []string{"mini", "--pull"}); err == nil {
+		t.Fatal("a failing remote export was reported as success")
+	}
+	if calls != 1 {
+		t.Errorf("the remote export ran %d times, want once", calls)
+	}
+}
+
+// The flag on this side: a named peer keeps its own watermark, so a second
+// export for a different name still carries the whole history.
+func TestExportPeerKeepsItsOwnWatermark(t *testing.T) {
+	tmp := setupLocalIndex(t)
+	dir := os.Getenv("DEJA_INDEX_DIR")
+
+	first := filepath.Join(tmp, "backup")
+	if err := runSync(dir, []string{"export", first}); err != nil {
+		t.Fatal(err)
+	}
+	if n := batchRecordCount(t, first); n == 0 {
+		t.Fatal("the first export sent nothing")
+	}
+
+	// Same records, different peer: the backup above must not have settled
+	// them for this one.
+	named := filepath.Join(tmp, "toMini")
+	if err := runSync(dir, []string{"export", named, "--peer", "mini"}); err != nil {
+		t.Fatal(err)
+	}
+	if n := batchRecordCount(t, named); n == 0 {
+		t.Error("a hand-taken backup starved the export for a named peer")
+	}
+
+	// And the same peer twice sends nothing the second time, which is the
+	// point of a watermark.
+	again := filepath.Join(tmp, "toMiniAgain")
+	if err := runSync(dir, []string{"export", again, "--peer", "mini"}); err != nil {
+		t.Fatal(err)
+	}
+	if n := batchRecordCount(t, again); n != 0 {
+		t.Errorf("the same peer received %d records twice", n)
+	}
+}
+
+func TestExportRejectsAPeerWithNoName(t *testing.T) {
+	tmp := setupLocalIndex(t)
+	err := runSync(os.Getenv("DEJA_INDEX_DIR"), []string{"export", filepath.Join(tmp, "out"), "--peer"})
+	if err == nil {
+		t.Fatal("--peer with no name was accepted")
+	}
+	if !strings.Contains(err.Error(), "--peer") {
+		t.Errorf("the error does not name the flag: %v", err)
+	}
+}
+
+func batchRecordCount(t *testing.T, dir string) int {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(dir, "*.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for _, p := range paths {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+			if strings.TrimSpace(line) != "" {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+var _ = index.MachineName

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -121,9 +121,27 @@ func syncSSHPull(dir, host string, full bool) error {
 	if full {
 		exportCmd += " --full"
 	}
-	remote := fmt.Sprintf(`d=$(command -v deja || echo "$HOME/.local/bin/deja"); "$d" %s %s`, exportCmd, shellQuote(rtmp))
-	out, err := sshRunner("ssh", host, "sh -lc "+shellQuote(remote))
+	// Name this machine, so the remote settles what it sent us against us and
+	// nobody else. Without it a pull shares one watermark with every hand-run
+	// `deja sync export` there: whichever ran first settles the records, and
+	// the other silently receives almost nothing.
+	pullCmd := exportCmd
+	if self := index.MachineName(); self != "" {
+		pullCmd += " --peer " + shellQuote(self)
+	}
+	remoteCmd := func(c string) string {
+		return fmt.Sprintf(`d=$(command -v deja || echo "$HOME/.local/bin/deja"); "$d" %s %s`, c, shellQuote(rtmp))
+	}
+	out, err := sshRunner("ssh", host, "sh -lc "+shellQuote(remoteCmd(pullCmd)))
 	out = strings.TrimSpace(out)
+	// A deja too old to know --peer refuses the flag rather than ignoring it,
+	// which is the behaviour that stops a typo from exporting nothing (#745).
+	// Upgrading both machines at once is not something a person does, so fall
+	// back to the shared watermark rather than failing the pull.
+	if err != nil && strings.Contains(out, "unknown flag") && pullCmd != exportCmd {
+		out, err = sshRunner("ssh", host, "sh -lc "+shellQuote(remoteCmd(exportCmd)))
+		out = strings.TrimSpace(out)
+	}
 	if err != nil {
 		return fmt.Errorf("remote export: %v: %s", err, out)
 	}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -63,6 +63,13 @@ func ExportFull(dir, outDir string) (int, error) {
 	return exportRecords(dir, outDir, "", true)
 }
 
+// ExportTo is Export for a named peer: the watermark it advances is that
+// peer's alone. An empty name keeps the shared one, which is what a hand-taken
+// backup uses.
+func ExportTo(dir, outDir, peer string) (int, error) {
+	return exportRecords(dir, outDir, peer, false)
+}
+
 // ExportDeferred writes batches like Export but does not advance the
 // watermarks; the returned commit persists them once the receiver has
 // acknowledged the batch. Watermarked sync must be acknowledged delivery:


### PR DESCRIPTION
Found while wiring up multi-machine sync. Watermarks are scoped per peer, but the export a `sync ssh --pull` runs on the remote was unnamed — so it shared one watermark with every `deja sync export` run by hand there. Take a backup on the server, then pull from it, and the pull gets almost nothing: the backup already settled those records, silently.

Measured on a real index: two unnamed exports in a row sent 246822 records and then 2. With `--peer` the second sends the whole history again, as it should for a peer that has received nothing.

So `sync export` takes `--peer <name>`, and a pull tells the remote who is asking. A deja too old to know the flag refuses it rather than ignoring it (that refusal is what stops a typo from exporting nothing, #745), so the pull falls back once to the shared watermark — nobody upgrades both machines in the same second. Other remote failures are not retried: running the export twice would advance the remote's watermark again.

Stacked on #1430 for `MachineName()`.

6 mutations, all caught — including the one that splices an awkward machine name into the remote shell unquoted.