### PR TITLE
feat(sync): one command for every machine, and a report that shows a sync going stale

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -99,6 +99,8 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir strin
 	fmt.Fprintln(w)
 	doctorMCP(w)
 	fmt.Fprintln(w)
+	doctorPeers(w, dir, time.Now())
+	fmt.Fprintln(w)
 	doctorHooks(w)
 	// After doctorHooks, not inside it: that function returns early on a
 	// machine without claude settings, which is exactly a machine whose other

--- a/cmd/deja/doctor_peers.go
+++ b/cmd/deja/doctor_peers.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/peers"
+)
+
+// doctorPeers reports the machines this one exchanges memory with, and when
+// memory last moved each way.
+//
+// A sync that stops does not announce itself. The agent still answers, the
+// history is still there, and it quietly stops growing — an expired key or a
+// laptop that has not been opened in a fortnight look exactly like a week with
+// nothing to send. This is the screen where that shows.
+func doctorPeers(w io.Writer, dir string, now time.Time) {
+	list := peers.Load()
+	fmt.Fprintln(w, "Sync:")
+	if len(list) == 0 {
+		fmt.Fprintf(w, "  %-12s no other machines yet — `deja sync ssh <host>` once, then `deja sync` keeps them all in step\n", "peers")
+		return
+	}
+	from := index.ImportedByMachine(dir)
+	for _, p := range list {
+		fmt.Fprintf(w, "  %-12s %s\n", p.Host, peerLine(p, from[p.Host], now))
+	}
+}
+
+// peerLine is one machine's state in one line: how long since memory moved,
+// which way it has not moved, and how much of this index came from there.
+func peerLine(p peers.Peer, sessions int, now time.Time) string {
+	line := ""
+	switch {
+	case p.Last().IsZero():
+		line = "never exchanged"
+	default:
+		line = "last exchange " + doctorAgo(now.Sub(p.Last()))
+	}
+	// Push and pull fail apart, and a host that takes what this machine sends
+	// while sending nothing back is a broken sync that reads as a working one.
+	switch {
+	case p.LastPush.IsZero() && !p.LastPull.IsZero():
+		line += ", nothing sent yet"
+	case p.LastPull.IsZero() && !p.LastPush.IsZero():
+		line += ", nothing received yet"
+	}
+	if sessions > 0 {
+		line += fmt.Sprintf(", %s from there", doctorCount(sessions, "session"))
+	}
+	if p.LastError != "" {
+		line += " — last attempt failed: " + p.LastError
+	}
+	return line
+}
+
+// doctorAgo is a rough age. Anything under a minute is "just now": a sync that
+// ran seconds ago and one that ran forty seconds ago are the same news.
+func doctorAgo(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%s ago", doctorCount(int(d.Minutes()), "minute"))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%s ago", doctorCount(int(d.Hours()), "hour"))
+	default:
+		return fmt.Sprintf("%s ago", doctorCount(int(d.Hours()/24), "day"))
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2543,7 +2543,8 @@ Usage:
   deja how <what> [--project name] [--limit n]  (commands this machine actually ran)
   deja sync export <dir> [--full] [--peer name]
   deja sync import <dir>
-  deja sync ssh <host> [--pull] [--full]
+  deja sync                       (exchange with every machine deja knows, both ways)
+  deja sync ssh <host> [--pull] [--both] [--full]
   deja last [n] [--json] [--project name] [--harness name] [--from machine|local] [--since duration] [--role user|assistant|tool|files|command|edit]
   deja sources
   deja completion <bash|zsh|fish>

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -37,8 +37,14 @@ func ownCopyLine(own int) string {
 }
 
 func runSync(dir string, args []string) error {
+	// Bare `deja sync` is every machine deja already knows, both ways: the
+	// point of a memory that spans machines is that keeping it in step is not
+	// a chore anyone has to remember the hosts for.
+	if len(args) == 0 || (len(args) == 1 && args[0] == "--full") {
+		return runSyncAll(dir, len(args) == 1)
+	}
 	if len(args) < 2 {
-		return fmt.Errorf("sync needs export <dir>, import <dir>, or ssh <host>")
+		return fmt.Errorf("sync needs export <dir>, import <dir>, ssh <host> — or no argument at all, for every machine deja knows")
 	}
 	switch args[0] {
 	case "ssh":

--- a/cmd/deja/sync_all_test.go
+++ b/cmd/deja/sync_all_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/peers"
+)
+
+// Naming the host every time is what makes a three-machine setup six commands
+// and a thing to remember. One exchange is enough for deja to know a machine.
+func TestSyncRemembersAHostItHasTalkedTo(t *testing.T) {
+	setupLocalIndex(t)
+	t.Setenv("DEJA_PEERS_FILE", os.Getenv("DEJA_INDEX_DIR")+"-peers.json")
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	sshRunner = fakeSSHOK()
+
+	if err := runSync(os.Getenv("DEJA_INDEX_DIR"), []string{"ssh", "mini"}); err != nil {
+		t.Fatal(err)
+	}
+	list := peers.Load()
+	if len(list) != 1 || list[0].Host != "mini" {
+		t.Fatalf("the host was not remembered: %+v", list)
+	}
+	if list[0].LastPush.IsZero() {
+		t.Error("a push was not recorded")
+	}
+}
+
+// A failed exchange is recorded too, or a peer that has been broken for a week
+// looks exactly like one with nothing to send.
+func TestSyncRecordsAFailedExchange(t *testing.T) {
+	setupLocalIndex(t)
+	t.Setenv("DEJA_PEERS_FILE", os.Getenv("DEJA_INDEX_DIR")+"-peers.json")
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	sshRunner = func(name string, args ...string) (string, error) {
+		return "no route to host", errors.New("exit status 255")
+	}
+	if err := runSync(os.Getenv("DEJA_INDEX_DIR"), []string{"ssh", "mini"}); err == nil {
+		t.Fatal("an unreachable host was reported as success")
+	}
+	list := peers.Load()
+	if len(list) != 1 {
+		t.Fatalf("the host was not remembered: %+v", list)
+	}
+	if list[0].LastError == "" {
+		t.Error("the failure was not recorded")
+	}
+	if !list[0].Last().IsZero() {
+		t.Error("a failed exchange was recorded as memory having moved")
+	}
+}
+
+func TestBareSyncSaysWhatToDoWithNoPeers(t *testing.T) {
+	setupLocalIndex(t)
+	t.Setenv("DEJA_PEERS_FILE", os.Getenv("DEJA_INDEX_DIR")+"-peers.json")
+	err := runSync(os.Getenv("DEJA_INDEX_DIR"), nil)
+	if err == nil {
+		t.Fatal("a sync with no peers reported success")
+	}
+	if !strings.Contains(err.Error(), "deja sync ssh") {
+		t.Errorf("the error does not say how to add one: %v", err)
+	}
+}
+
+// The point of the bare form: every machine, both ways, without being told.
+func TestBareSyncExchangesWithEveryPeerBothWays(t *testing.T) {
+	setupLocalIndex(t)
+	t.Setenv("DEJA_PEERS_FILE", os.Getenv("DEJA_INDEX_DIR")+"-peers.json")
+	for _, h := range []string{"mini", "laptop"} {
+		if err := peers.Record(h, false, time.Now(), nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	var hosts []string
+	var pulls, pushes int
+	sshRunner = func(name string, args ...string) (string, error) {
+		if name == "ssh" && len(args) > 1 {
+			hosts = append(hosts, args[0])
+			switch {
+			case strings.Contains(args[1], "sync export"):
+				pulls++
+				return "deja: exported 0 records", nil
+			case strings.Contains(args[1], "sync import"):
+				pushes++
+				return "deja: imported 0 records", nil
+			}
+		}
+		if args[len(args)-1] == "mktemp -d" || (len(args) > 1 && args[1] == "mktemp -d") {
+			return "/tmp/remote-out", nil
+		}
+		return "", nil
+	}
+	if err := runSync(os.Getenv("DEJA_INDEX_DIR"), nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"mini", "laptop"} {
+		found := false
+		for _, h := range hosts {
+			if h == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s was never contacted: %v", want, hosts)
+		}
+	}
+	if pulls == 0 {
+		t.Error("nothing was pulled, so this machine only ever sends")
+	}
+}
+
+// One unreachable laptop must not stop the server from getting what the
+// desktop did.
+func TestBareSyncKeepsGoingPastAnUnreachableMachine(t *testing.T) {
+	setupLocalIndex(t)
+	t.Setenv("DEJA_PEERS_FILE", os.Getenv("DEJA_INDEX_DIR")+"-peers.json")
+	for _, h := range []string{"broken", "mini"} {
+		if err := peers.Record(h, false, time.Now(), nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := sshRunner
+	defer func() { sshRunner = old }()
+	reached := map[string]bool{}
+	ok := fakeSSHOK()
+	sshRunner = func(name string, args ...string) (string, error) {
+		if len(args) > 0 {
+			reached[args[0]] = true
+			if args[0] == "broken" {
+				return "no route to host", errors.New("exit status 255")
+			}
+		}
+		return ok(name, args...)
+	}
+	if err := runSync(os.Getenv("DEJA_INDEX_DIR"), nil); err != nil {
+		t.Fatalf("one broken machine failed the whole sync: %v", err)
+	}
+	if !reached["mini"] {
+		t.Error("mini was skipped because broken came first")
+	}
+}
+
+func TestPeerLineNamesWhatIsWrong(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name string
+		p    peers.Peer
+		want []string
+	}{
+		{"a healthy peer",
+			peers.Peer{Host: "mini", LastPush: now.Add(-2 * time.Hour), LastPull: now.Add(-2 * time.Hour)},
+			[]string{"2 hours ago"}},
+		{"one that takes but never sends",
+			peers.Peer{Host: "mini", LastPush: now.Add(-time.Hour)},
+			[]string{"nothing received yet"}},
+		{"one this machine never sent to",
+			peers.Peer{Host: "mini", LastPull: now.Add(-time.Hour)},
+			[]string{"nothing sent yet"}},
+		{"one that has been failing",
+			peers.Peer{Host: "mini", LastPush: now.Add(-8 * 24 * time.Hour), LastPull: now.Add(-8 * 24 * time.Hour), LastError: "no route to host"},
+			[]string{"8 days ago", "no route to host"}},
+		{"one never reached at all",
+			peers.Peer{Host: "mini"},
+			[]string{"never exchanged"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := peerLine(tc.p, 0, now)
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("peer line %q does not say %q", got, want)
+				}
+			}
+		})
+	}
+	// The count answers "did anything ever actually arrive from there".
+	if got := peerLine(peers.Peer{Host: "mini", LastPull: now}, 41, now); !strings.Contains(got, "41 sessions from there") {
+		t.Errorf("the line does not say how much came from there: %q", got)
+	}
+}
+
+func TestDoctorReportsTheMachinesItSyncsWith(t *testing.T) {
+	setupLocalIndex(t)
+	t.Setenv("DEJA_PEERS_FILE", os.Getenv("DEJA_INDEX_DIR")+"-peers.json")
+	var buf bytes.Buffer
+	doctorPeers(&buf, os.Getenv("DEJA_INDEX_DIR"), time.Now())
+	if !strings.Contains(buf.String(), "deja sync ssh") {
+		t.Errorf("with no peers, doctor does not say how to add one:\n%s", buf.String())
+	}
+
+	if err := peers.Record("mini", false, time.Now().Add(-6*24*time.Hour), nil); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	doctorPeers(&buf, os.Getenv("DEJA_INDEX_DIR"), time.Now())
+	out := buf.String()
+	for _, want := range []string{"Sync:", "mini", "6 days ago"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the report does not say %q:\n%s", want, out)
+		}
+	}
+}
+
+// fakeSSHOK is a remote that answers every step of a push and a pull.
+func fakeSSHOK() func(string, ...string) (string, error) {
+	return func(name string, args ...string) (string, error) {
+		if name != "ssh" || len(args) < 2 {
+			return "", nil
+		}
+		switch {
+		case args[1] == "mktemp -d":
+			return "/tmp/remote-out", nil
+		case strings.Contains(args[1], "sync export"):
+			return "deja: exported 0 records", nil
+		case strings.Contains(args[1], "sync import"):
+			return "deja: imported 0 records", nil
+		}
+		return "", nil
+	}
+}

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -7,8 +7,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/peers"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
@@ -30,10 +32,13 @@ var sshRunner = func(name string, args ...string) (string, error) {
 func runSyncSSH(dir string, args []string) error {
 	host := ""
 	pull, full := false, false
+	both := false
 	for _, a := range args {
 		switch a {
 		case "--pull":
 			pull = true
+		case "--both":
+			both = true
 		case "--full":
 			full = true
 		default:
@@ -49,10 +54,64 @@ func runSyncSSH(dir string, args []string) error {
 	if host == "" {
 		return fmt.Errorf("sync ssh needs a host (an ssh alias or user@host)")
 	}
-	if pull {
-		return syncSSHPull(dir, host, full)
+	return syncSSHHost(dir, host, pull, full, both)
+}
+
+// syncSSHHost runs one exchange and records it, so the next `deja sync` knows
+// this host without being told again.
+func syncSSHHost(dir, host string, pull, full, both bool) error {
+	if both {
+		if err := syncOneWay(dir, host, false, full); err != nil {
+			return err
+		}
+		return syncOneWay(dir, host, true, full)
 	}
-	return syncSSHPush(dir, host, full)
+	return syncOneWay(dir, host, pull, full)
+}
+
+func syncOneWay(dir, host string, pull, full bool) error {
+	var err error
+	if pull {
+		err = syncSSHPull(dir, host, full)
+	} else {
+		err = syncSSHPush(dir, host, full)
+	}
+	// Recorded either way: a peer that has been failing for a week is exactly
+	// what the report exists to show, and it is invisible if only successes
+	// are written down.
+	if rerr := peers.Record(host, pull, time.Now(), err); rerr != nil && err == nil {
+		fmt.Fprintf(os.Stderr, "deja: synced with %s, but could not record it: %v\n", host, rerr)
+	}
+	return err
+}
+
+// runSyncAll exchanges with every machine this one already syncs with. The
+// host had to be typed every time, which with three machines is six commands
+// and a thing to remember rather than a thing that happens. Records do not
+// travel through a third machine — an export never forwards what arrived by
+// sync — so every pair has to meet directly, and that is what this does.
+func runSyncAll(dir string, full bool) error {
+	list := peers.Load()
+	if len(list) == 0 {
+		return fmt.Errorf("no machines to sync with yet — name one once with `deja sync ssh <host>` and deja will remember it")
+	}
+	var failed int
+	for _, p := range list {
+		fmt.Fprintf(os.Stdout, "deja: %s\n", p.Host)
+		if err := syncSSHHost(dir, p.Host, false, full, true); err != nil {
+			// One unreachable laptop must not stop the server from getting
+			// what the desktop did.
+			fmt.Fprintf(os.Stderr, "deja: %s: %v\n", p.Host, err)
+			failed++
+		}
+	}
+	if failed == len(list) {
+		return fmt.Errorf("none of the %d machines could be reached", len(list))
+	}
+	if failed > 0 {
+		fmt.Fprintf(os.Stderr, "deja: %d of %d machines could not be reached\n", failed, len(list))
+	}
+	return nil
 }
 
 func syncSSHPush(dir, host string, full bool) error {

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -78,6 +78,26 @@ func ImportedSessionCounts(dir string) map[string]int {
 	return out
 }
 
+// ImportedByMachine counts indexed sessions per machine they were worked on.
+// A peer line that says "last exchange two days ago" and nothing else leaves
+// open whether anything ever actually arrived from there.
+func ImportedByMachine(dir string) map[string]int {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		return nil
+	}
+	out := map[string]int{}
+	for _, meta := range m.Sessions {
+		if meta.From != "" {
+			out[meta.From]++
+		}
+	}
+	return out
+}
+
 // HasManifest reports whether this directory holds an index. A rebuild's swap
 // takes the directory away for a moment, and answering "no" there sent every
 // hook down the no-index path: it asked for a rebuild that was already running

--- a/internal/peers/peers.go
+++ b/internal/peers/peers.go
@@ -1,0 +1,165 @@
+// Package peers remembers the machines this one exchanges memory with.
+//
+// A sync had to be told its host every time, so with three machines it was six
+// commands and a thing to remember rather than a thing that happens. Worse,
+// nothing recorded that an exchange had happened at all: a laptop whose ssh key
+// stopped working kept answering from a history that quietly stopped growing,
+// and there was no screen anywhere that would have said so.
+package peers
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// Peer is one machine and when memory last moved each way. Push and pull are
+// kept apart because they fail apart: a host that accepts what this machine
+// sends but has stopped sending back is a broken sync that looks fine.
+type Peer struct {
+	Host     string    `json:"host"`
+	LastPush time.Time `json:"last_push,omitempty"`
+	LastPull time.Time `json:"last_pull,omitempty"`
+	// LastError is why the most recent exchange failed, empty once one
+	// succeeds. A peer that has been failing for a week is the thing this file
+	// exists to make visible.
+	LastError string `json:"last_error,omitempty"`
+}
+
+// Last is the more recent of the two directions.
+func (p Peer) Last() time.Time {
+	if p.LastPull.After(p.LastPush) {
+		return p.LastPull
+	}
+	return p.LastPush
+}
+
+type file struct {
+	Peers []Peer `json:"peers"`
+}
+
+// Path is where the list lives. Beside policy.json rather than inside the
+// index: which machines you sync with outlives any one index, and a rebuild
+// must not lose them.
+func Path() string {
+	if p := os.Getenv("DEJA_PEERS_FILE"); p != "" {
+		return p
+	}
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		base = filepath.Join(sources.Home(), ".config")
+	}
+	return filepath.Join(base, "deja", "peers.json")
+}
+
+// Load reads the list. Any read or parse failure means no peers — a sync must
+// not break because a config file is malformed, and doctor is where that gets
+// reported.
+func Load() []Peer {
+	var f file
+	b, err := os.ReadFile(Path())
+	if err != nil {
+		return nil
+	}
+	if json.Unmarshal(b, &f) != nil {
+		return nil
+	}
+	out := f.Peers[:0:0]
+	for _, p := range f.Peers {
+		if p.Host = strings.TrimSpace(p.Host); p.Host == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Host < out[j].Host })
+	return out
+}
+
+// Record notes an exchange with a host: which way it went, and whether it
+// worked. A host is added the first time it is named, so `deja sync ssh mini`
+// once is all it takes for `deja sync` to know about mini afterwards.
+func Record(host string, pulled bool, when time.Time, err error) error {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return nil
+	}
+	list := Load()
+	i := -1
+	for k := range list {
+		if list[k].Host == host {
+			i = k
+			break
+		}
+	}
+	if i < 0 {
+		list = append(list, Peer{Host: host})
+		i = len(list) - 1
+	}
+	if err != nil {
+		// The failure is recorded, the timestamp is not: "last exchanged
+		// tuesday" has to mean memory actually moved.
+		list[i].LastError = trimError(err.Error())
+	} else {
+		list[i].LastError = ""
+		if pulled {
+			list[i].LastPull = when.UTC()
+		} else {
+			list[i].LastPush = when.UTC()
+		}
+	}
+	return save(list)
+}
+
+// Forget drops a host from the list. Reports whether it was there.
+func Forget(host string) (bool, error) {
+	host = strings.TrimSpace(host)
+	list := Load()
+	out := list[:0:0]
+	found := false
+	for _, p := range list {
+		if p.Host == host {
+			found = true
+			continue
+		}
+		out = append(out, p)
+	}
+	if !found {
+		return false, nil
+	}
+	return true, save(out)
+}
+
+func save(list []Peer) error {
+	sort.Slice(list, func(i, j int) bool { return list[i].Host < list[j].Host })
+	b, err := json.MarshalIndent(file{Peers: list}, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := Path()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	// Written whole through a temp file: a sync interrupted midway must not
+	// leave a half-written list that Load then silently reads as no peers.
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(b, '\n'), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// trimError keeps a failure short enough to sit on one line of a report. The
+// whole of an ssh failure is several lines of remote banner.
+func trimError(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	const max = 160
+	if r := []rune(s); len(r) > max {
+		return strings.TrimSpace(string(r[:max])) + "…"
+	}
+	return s
+}

--- a/internal/peers/peers_test.go
+++ b/internal/peers/peers_test.go
@@ -1,0 +1,162 @@
+package peers
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func peersFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", path)
+	return path
+}
+
+// Naming a host once is what makes `deja sync` know about it afterwards.
+func TestRecordRemembersAHostAndWhichWayMemoryMoved(t *testing.T) {
+	peersFile(t)
+	push := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	pull := time.Date(2026, 8, 2, 10, 0, 0, 0, time.UTC)
+
+	if err := Record("mini", false, push, nil); err != nil {
+		t.Fatal(err)
+	}
+	list := Load()
+	if len(list) != 1 || list[0].Host != "mini" {
+		t.Fatalf("the host was not remembered: %+v", list)
+	}
+	if !list[0].LastPush.Equal(push) {
+		t.Errorf("push time = %v, want %v", list[0].LastPush, push)
+	}
+	if !list[0].LastPull.IsZero() {
+		t.Errorf("a push wrote a pull time: %v", list[0].LastPull)
+	}
+
+	if err := Record("mini", true, pull, nil); err != nil {
+		t.Fatal(err)
+	}
+	list = Load()
+	if len(list) != 1 {
+		t.Fatalf("the second exchange added a second host: %+v", list)
+	}
+	if !list[0].LastPull.Equal(pull) || !list[0].LastPush.Equal(push) {
+		t.Errorf("the two directions were not kept apart: %+v", list[0])
+	}
+	if got := list[0].Last(); !got.Equal(pull) {
+		t.Errorf("Last = %v, want the more recent of the two", got)
+	}
+}
+
+// A peer that has been failing for a week is what the report exists to show,
+// and it is invisible if only successes are written down. The timestamp must
+// not move: "last exchange yesterday" has to mean memory actually moved.
+func TestRecordKeepsTheFailureAndNotTheTime(t *testing.T) {
+	peersFile(t)
+	ok := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	if err := Record("mini", false, ok, nil); err != nil {
+		t.Fatal(err)
+	}
+	later := time.Date(2026, 8, 9, 10, 0, 0, 0, time.UTC)
+	if err := Record("mini", false, later, errors.New("ssh: no route to host")); err != nil {
+		t.Fatal(err)
+	}
+	p := Load()[0]
+	if !p.LastPush.Equal(ok) {
+		t.Errorf("a failed exchange moved the clock: %v", p.LastPush)
+	}
+	if p.LastError == "" {
+		t.Error("the failure was not recorded")
+	}
+	// And it clears once one works again.
+	if err := Record("mini", false, later, nil); err != nil {
+		t.Fatal(err)
+	}
+	if p := Load()[0]; p.LastError != "" {
+		t.Errorf("the old failure outlived a successful exchange: %q", p.LastError)
+	}
+}
+
+func TestForgetDropsOneHost(t *testing.T) {
+	peersFile(t)
+	now := time.Now()
+	for _, h := range []string{"mini", "laptop"} {
+		if err := Record(h, false, now, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	found, err := Forget("mini")
+	if err != nil || !found {
+		t.Fatalf("Forget(mini) = %v, %v", found, err)
+	}
+	list := Load()
+	if len(list) != 1 || list[0].Host != "laptop" {
+		t.Errorf("the wrong host was dropped: %+v", list)
+	}
+	if found, _ := Forget("nobody"); found {
+		t.Error("forgetting an unknown host reported a hit")
+	}
+}
+
+// A malformed file must not break a sync: doctor is where a bad config gets
+// reported, the same rule the trust policy follows.
+func TestLoadTreatsAnUnreadableFileAsNoPeers(t *testing.T) {
+	path := peersFile(t)
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if list := Load(); len(list) != 0 {
+		t.Errorf("a malformed file produced peers: %+v", list)
+	}
+	// A field of the wrong type is the dangerous one. json.Unmarshal fills in
+	// every entry it could read and returns an error alongside them — measured:
+	// three peers where the middle host is a number yields two usable entries
+	// and one blank. Handing those back would be worse than handing back
+	// nothing, because the next exchange writes the list it was given and the
+	// damage becomes the file.
+	bad := `{"peers":[{"host":"mini"},{"host":123},{"host":"laptop"}]}`
+	if err := os.WriteFile(path, []byte(bad), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if list := Load(); len(list) != 0 {
+		t.Errorf("a partly-decoded file produced a list a later write would make permanent: %+v", list)
+	}
+	if err := Record("newhost", false, time.Now(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if list := Load(); len(list) != 1 || list[0].Host != "newhost" {
+		t.Errorf("recording after a bad file did not start clean: %+v", list)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A nameless entry is not a machine anyone can reach.
+	if err := os.WriteFile(path, []byte(`{"peers":[{"host":"  "},{"host":"mini"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	list := Load()
+	if len(list) != 1 || list[0].Host != "mini" {
+		t.Errorf("a nameless peer survived: %+v", list)
+	}
+}
+
+// The list is read on every sync and rewritten on every exchange; a crash
+// midway must not leave something Load silently reads as no peers.
+func TestSaveReplacesTheFileWhole(t *testing.T) {
+	path := peersFile(t)
+	if err := Record("mini", false, time.Now(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("the temp file was left behind: %v", err)
+	}
+	if err := Record("laptop", false, time.Now(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if list := Load(); len(list) != 2 {
+		t.Errorf("a second write lost the first host: %+v", list)
+	}
+}


### PR DESCRIPTION
Two of the four. Sync had to be told its host every time — with three machines that is six commands and a thing to remember rather than a thing that happens. And nothing recorded that an exchange had happened at all, so a laptop whose key expired kept answering from a history that quietly stopped growing, with no screen anywhere that would have said so.

deja now remembers a host the first time it is named, in `peers.json` beside `policy.json` (outside the index, so a rebuild does not lose it). Bare `deja sync` then exchanges with all of them, both ways, and one unreachable machine does not stop the rest. This matters more than convenience: records do not transit — an export never forwards what arrived by sync — so every pair has to meet directly, and the bare form is what makes that happen.

`doctor` gains a Sync section:

```
Sync:
  laptop       last exchange 12 minutes ago, nothing received yet
  mini         last exchange 6 days ago, 1552 sessions from there
  oldbox       last exchange 30 days ago, nothing received yet — last attempt failed: ssh: connect to host oldbox port 22: No route to host
```

Push and pull are kept apart because they fail apart: a host that takes what this machine sends while sending nothing back is a broken sync that otherwise reads as a working one. A failed exchange records the failure but not the time — "last exchange yesterday" has to mean memory actually moved.

Stacked on #1431.

10 mutations, all caught. One needed the fixture rewritten: a syntax error leaves `json.Unmarshal` filling in nothing, so refusing a malformed peers file looked equivalent to accepting it. A *type* error is the real case — measured, three peers with a numeric host yields two usable entries and a blank — and there handing back the partial list is worse than handing back nothing, because the next exchange writes it and the damage becomes the file.