### PR TITLE
feat(sync): a timer that keeps a machine in step without being asked

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -577,6 +577,8 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 		return installGooseAuto(exe, uninstall)
 	case "statusline":
 		return installStatusline(exe, uninstall)
+	case "sync-timer":
+		return installSyncTimer(exe, uninstall)
 	default:
 		return installResult{}, unknownTargetError(target)
 	}
@@ -1515,5 +1517,11 @@ func installTargetNames() []string {
 		// prompt to, so there is no -auto pair to install.
 		"zed",
 		"statusline",
+		// Not a harness, and deliberately not "-auto": that suffix means a
+		// harness's auto-recall hook, and this is the timer that keeps this
+		// machine's memory in step with the others. It belongs in this list
+		// because `deja install --all` is where someone setting up a second
+		// machine looks.
+		"sync-timer",
 	}
 }

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1498,7 +1498,7 @@ func min3(a, b, c int) int {
 // installTarget without appearing here is caught rather than quietly missing
 // from both.
 func installTargetNames() []string {
-	return []string{
+	names := []string{
 		"claude-code", "claude-auto",
 		"codex", "codex-auto",
 		"opencode", "opencode-auto",
@@ -1517,11 +1517,22 @@ func installTargetNames() []string {
 		// prompt to, so there is no -auto pair to install.
 		"zed",
 		"statusline",
-		// Not a harness, and deliberately not "-auto": that suffix means a
-		// harness's auto-recall hook, and this is the timer that keeps this
-		// machine's memory in step with the others. It belongs in this list
-		// because `deja install --all` is where someone setting up a second
-		// machine looks.
-		"sync-timer",
 	}
+	// Not a harness, and deliberately not "-auto": that suffix means a
+	// harness's auto-recall hook, and this is the timer that keeps this
+	// machine's memory in step with the others. It belongs in this list
+	// because `deja install --all` is where someone setting up a second
+	// machine looks — but only where deja can actually schedule anything.
+	// Offering a target that always fails is worse than not offering it.
+	if syncTimerSchedulable(runtime.GOOS) {
+		names = append(names, "sync-timer")
+	}
+	return names
+}
+
+// syncTimerSchedulable reports whether this platform has a service manager the
+// timer knows how to write for. Taking the platform as an argument keeps the
+// answer checkable from any machine.
+func syncTimerSchedulable(goos string) bool {
+	return goos == "darwin" || goos == "linux"
 }

--- a/cmd/deja/install_sync_timer.go
+++ b/cmd/deja/install_sync_timer.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// A sync nobody runs is a memory that stops at whichever machine it was made
+// on. `deja sync` is one command now, but it is still a command — and the
+// machine that most needs to send is the one nobody is sitting at.
+//
+// So this installs a timer. Not a hook: hooks fire only while someone is
+// working, which is exactly when the server is not. The unit runs `deja sync`,
+// which exchanges with every machine deja already knows and does nothing at
+// all when there are none.
+const syncAutoLabel = "com.deja-vu.sync"
+
+// syncAutoInterval is how often the timer fires. Half an hour is chosen
+// against what a sync costs when there is nothing to send: watermarks make
+// that case a manifest read and one ssh round trip.
+const syncAutoInterval = 1800
+
+func installSyncTimer(exe string, uninstall bool) (installResult, error) {
+	return installSyncTimerFor(runtime.GOOS, exe, uninstall)
+}
+
+// installSyncTimerFor takes the platform as an argument so the decision itself
+// can be tested from any machine. A refusal that only ever runs on the one
+// platform deja cannot schedule is a refusal nobody checks.
+func installSyncTimerFor(goos, exe string, uninstall bool) (installResult, error) {
+	switch goos {
+	case "darwin":
+		return installSyncTimerLaunchd(exe, uninstall)
+	case "linux":
+		return installSyncTimerSystemd(exe, uninstall)
+	default:
+		// Saying "installed" on a platform where nothing runs it is the
+		// failure this whole feature exists to prevent.
+		return installResult{}, fmt.Errorf("sync-timer has no timer for %s yet — run `deja sync` from whatever this machine already uses to schedule work", goos)
+	}
+}
+
+func syncAutoPlistPath() string {
+	return filepath.Join(homeDir(), "Library", "LaunchAgents", syncAutoLabel+".plist")
+}
+
+func installSyncTimerLaunchd(exe string, uninstall bool) (installResult, error) {
+	path := syncAutoPlistPath()
+	old, _ := os.ReadFile(path)
+	if uninstall {
+		if len(old) > 0 {
+			_, _ = runLaunchctl("unload", path)
+		}
+		return installResult{Path: path, Action: removeOurUnit(path)}, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return installResult{}, err
+	}
+	next := []byte(syncAutoPlist(exe))
+	action, err := writeIfChanged(path, old, next)
+	if err != nil {
+		return installResult{}, err
+	}
+	if action != "unchanged" {
+		// Reloaded rather than loaded: launchd keeps the old copy running
+		// until it is told otherwise, so an edited plist would sit on disk
+		// looking installed while the previous one is what actually runs.
+		if len(old) > 0 {
+			_, _ = runLaunchctl("unload", path)
+		}
+		if out, err := runLaunchctl("load", path); err != nil {
+			return installResult{}, fmt.Errorf("wrote %s but launchctl refused it: %v: %s", path, err, out)
+		}
+	}
+	return installResult{Path: path, Action: action}, nil
+}
+
+func syncAutoPlist(exe string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>%s</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>%s</string>
+    <string>sync</string>
+  </array>
+  <key>StartInterval</key><integer>%d</integer>
+  <key>RunAtLoad</key><false/>
+  <key>ProcessType</key><string>Background</string>
+</dict>
+</plist>
+`, syncAutoLabel, xmlEscape(exe), syncAutoInterval)
+}
+
+func syncAutoUnitDir() string {
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		base = filepath.Join(homeDir(), ".config")
+	}
+	return filepath.Join(base, "systemd", "user")
+}
+
+func installSyncTimerSystemd(exe string, uninstall bool) (installResult, error) {
+	dir := syncAutoUnitDir()
+	service := filepath.Join(dir, "deja-sync.service")
+	timer := filepath.Join(dir, "deja-sync.timer")
+	oldService, _ := os.ReadFile(service)
+	oldTimer, _ := os.ReadFile(timer)
+	if uninstall {
+		if len(oldTimer) > 0 {
+			_, _ = runSystemctl("--user", "disable", "--now", "deja-sync.timer")
+		}
+		removeOurUnit(service)
+		return installResult{Path: timer, Action: removeOurUnit(timer)}, nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return installResult{}, err
+	}
+	if _, err := writeIfChanged(service, oldService, []byte(syncAutoService(exe))); err != nil {
+		return installResult{}, err
+	}
+	action, err := writeIfChanged(timer, oldTimer, []byte(syncAutoTimer()))
+	if err != nil {
+		return installResult{}, err
+	}
+	if action != "unchanged" {
+		_, _ = runSystemctl("--user", "daemon-reload")
+		if out, err := runSystemctl("--user", "enable", "--now", "deja-sync.timer"); err != nil {
+			return installResult{}, fmt.Errorf("wrote %s but systemctl refused it: %v: %s", timer, err, out)
+		}
+	}
+	return installResult{Path: timer, Action: action}, nil
+}
+
+func syncAutoService(exe string) string {
+	return fmt.Sprintf(`[Unit]
+Description=deja: exchange memory with the machines this one syncs with
+
+[Service]
+Type=oneshot
+ExecStart="%s" sync
+`, exe)
+}
+
+func syncAutoTimer() string {
+	return fmt.Sprintf(`[Unit]
+Description=deja sync every %d minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=%dmin
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+`, syncAutoInterval/60, syncAutoInterval/60)
+}
+
+// runLaunchctl and runSystemctl are variables so tests can drive install
+// without a service manager. A missing one is not an error on its own: the
+// file is written either way, and the report says where it went.
+var runLaunchctl = func(args ...string) (string, error) {
+	return runServiceManager("launchctl", args...)
+}
+
+var runSystemctl = func(args ...string) (string, error) {
+	return runServiceManager("systemctl", args...)
+}
+
+// runServiceManager registers or drops the unit — unless this is a test.
+//
+// Every install target is driven by the suite's own invariants (every target
+// writes readable files, every target quotes a path with a space in it), and
+// those run installTarget for real against a temp home. Without this guard
+// that loaded a live launch agent into the developer's own launchd, pointing
+// at a plist in a directory the test then deleted. Measured, not imagined:
+// `launchctl list` showed com.deja-vu.sync after one run of the suite.
+func runServiceManager(name string, args ...string) (string, error) {
+	if underTestBinary() {
+		return "", nil
+	}
+	out, err := exec.Command(name, args...).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// underTestBinary reports whether this process is a `go test` binary, the same
+// check the hook refresher uses before spawning itself.
+func underTestBinary() bool {
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	return strings.HasSuffix(strings.TrimSuffix(exe, ".exe"), ".test")
+}
+
+// removeOurUnit deletes a unit file. Unlike every other install target, these
+// files are deja's alone — nothing else writes to them and there is no block
+// inside someone else's config to cut out — so uninstall removes them rather
+// than rewriting them empty. A machine that never installed keeps its answer:
+// nothing was there, nothing changed.
+func removeOurUnit(path string) string {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return "unchanged"
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return "unchanged"
+	}
+	return "removed"
+}
+
+// xmlEscape keeps a path with an ampersand or a quote in it from producing a
+// plist launchd refuses to parse. A home directory is a user-chosen string.
+func xmlEscape(s string) string {
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;", "'", "&apos;")
+	return r.Replace(s)
+}

--- a/cmd/deja/install_sync_timer_test.go
+++ b/cmd/deja/install_sync_timer_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func syncTimerHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	return home
+}
+
+// The machine that most needs to send is the one nobody is sitting at, so the
+// timer has to exist as a file a service manager reads — not as a hook, which
+// only fires while someone is working.
+func TestInstallSyncTimerWritesAUnitTheSystemReads(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("no timer for this platform")
+	}
+	syncTimerHome(t)
+	r, err := installSyncTimer("/usr/local/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Action == "unchanged" {
+		t.Errorf("the first install wrote nothing")
+	}
+	b, err := os.ReadFile(r.Path)
+	if err != nil {
+		t.Fatalf("the unit is not where install said it is: %v", err)
+	}
+	body := string(b)
+	// It has to run the bare form and nothing else: that is the one that
+	// reaches every machine deja knows and does nothing when there are none.
+	// Checked as the whole argument list, because "sync" appears in a unit
+	// pinned to one host too.
+	if got, want := syncTimerArgs(t, body), []string{"/usr/local/bin/deja", "sync"}; !sameArgs(got, want) {
+		t.Errorf("the unit runs %v, want %v:\n%s", got, want, body)
+	}
+}
+
+func TestInstallSyncTimerIsIdempotentAndReversible(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("no timer for this platform")
+	}
+	syncTimerHome(t)
+	first, err := installSyncTimer("/usr/local/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := installSyncTimer("/usr/local/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Action != "unchanged" {
+		t.Errorf("a second install rewrote the unit: %s", second.Action)
+	}
+	if _, err := installSyncTimer("/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(first.Path); !os.IsNotExist(err) {
+		t.Errorf("the unit survived the uninstall: %v", err)
+	}
+}
+
+// Uninstalling on a machine that never installed must not create anything,
+// the shape of #676.
+func TestUninstallSyncTimerLeavesAnUntouchedMachineAlone(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("no timer for this platform")
+	}
+	home := syncTimerHome(t)
+	// The directory a unit would go in already exists: a machine with other
+	// launch agents or other systemd units is the ordinary case, and an
+	// uninstall that writes an empty file is only invisible when the write
+	// happens to fail for want of a directory.
+	if err := os.MkdirAll(filepath.Dir(syncAutoPlistPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(syncAutoUnitDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installSyncTimer("/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	var wrote []string
+	_ = filepath.WalkDir(home, func(path string, d os.DirEntry, err error) error {
+		if err == nil && !d.IsDir() {
+			wrote = append(wrote, path)
+		}
+		return nil
+	})
+	if len(wrote) > 0 {
+		t.Errorf("uninstall created files on a machine that never installed: %v", wrote)
+	}
+}
+
+// A home directory is a user-chosen string, and both unit formats are picky in
+// different ways: XML refuses an unescaped ampersand, systemd splits ExecStart
+// on a space unless the word is quoted.
+func TestSyncTimerUnitsSurviveAnAwkwardPath(t *testing.T) {
+	exe := `/Users/John & "Jane" Smith/bin/deja`
+	plist := syncAutoPlist(exe)
+	for _, bad := range []string{`John & "Jane"`} {
+		if strings.Contains(plist, bad) {
+			t.Errorf("the plist carries the path unescaped, so launchd will refuse it:\n%s", plist)
+		}
+	}
+	if !strings.Contains(plist, "&amp;") || !strings.Contains(plist, "&quot;") {
+		t.Errorf("the plist did not escape the path:\n%s", plist)
+	}
+
+	service := syncAutoService(exe)
+	for _, line := range strings.Split(service, "\n") {
+		if !strings.HasPrefix(line, "ExecStart=") {
+			continue
+		}
+		// systemd takes the first whitespace-delimited word as the binary
+		// unless it is quoted, so an unquoted path with a space runs the
+		// wrong thing — or nothing.
+		if !strings.Contains(line, `"`+exe+`"`) {
+			t.Errorf("ExecStart does not quote the path: %s", line)
+		}
+	}
+}
+
+// A platform with no timer must say so. Reporting success where nothing will
+// ever run the sync is the failure this whole target exists to prevent — and
+// it is checked from every platform, because a refusal that only runs on the
+// one machine that cannot schedule is a refusal nobody checks.
+func TestSyncTimerRefusesAPlatformItCannotSchedule(t *testing.T) {
+	syncTimerHome(t)
+	r, err := installSyncTimerFor("plan9", "/usr/local/bin/deja", false)
+	if err == nil {
+		t.Fatalf("install reported success on a platform with no timer: %+v", r)
+	}
+	if r.Action != "" {
+		t.Errorf("a refusal still claimed to have done something: %q", r.Action)
+	}
+	if !strings.Contains(err.Error(), "plan9") {
+		t.Errorf("the error does not name the platform: %v", err)
+	}
+}
+
+// Every install target is driven for real by the suite's own invariants
+// against a temp home. Without this guard one run of the suite loaded a live
+// launch agent into the developer's launchd, pointing at a plist the test then
+// deleted.
+func TestSyncTimerDoesNotTouchTheRealServiceManager(t *testing.T) {
+	if !underTestBinary() {
+		t.Fatal("this binary is not recognised as a test binary, so install would call the real service manager")
+	}
+	out, err := runServiceManager("false")
+	if err != nil || out != "" {
+		t.Errorf("a service manager command ran under test: %q %v", out, err)
+	}
+}
+
+// syncTimerArgs pulls the command a unit runs out of either format: the
+// <string> entries of a plist's ProgramArguments, or the words of ExecStart.
+func syncTimerArgs(t *testing.T, body string) []string {
+	t.Helper()
+	if strings.Contains(body, "ProgramArguments") {
+		rest := body[strings.Index(body, "ProgramArguments"):]
+		rest = rest[:strings.Index(rest, "</array>")]
+		var out []string
+		for _, part := range strings.Split(rest, "<string>")[1:] {
+			out = append(out, strings.TrimSpace(part[:strings.Index(part, "</string>")]))
+		}
+		return out
+	}
+	for _, line := range strings.Split(body, "\n") {
+		if v, ok := strings.CutPrefix(line, "ExecStart="); ok {
+			return strings.Fields(strings.ReplaceAll(v, `"`, ""))
+		}
+	}
+	t.Fatalf("no command in the unit:\n%s", body)
+	return nil
+}
+
+func sameArgs(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/deja/install_sync_timer_test.go
+++ b/cmd/deja/install_sync_timer_test.go
@@ -32,9 +32,19 @@ func TestInstallSyncTimerWritesAUnitTheSystemReads(t *testing.T) {
 	if r.Action == "unchanged" {
 		t.Errorf("the first install wrote nothing")
 	}
-	b, err := os.ReadFile(r.Path)
-	if err != nil {
+	if _, err := os.Stat(r.Path); err != nil {
 		t.Fatalf("the unit is not where install said it is: %v", err)
+	}
+	// systemd splits the work in two: install reports the timer, because that
+	// is what a person enables, and the command lives in the service beside
+	// it. launchd keeps both in one plist.
+	unit := r.Path
+	if runtime.GOOS == "linux" {
+		unit = filepath.Join(syncAutoUnitDir(), "deja-sync.service")
+	}
+	b, err := os.ReadFile(unit)
+	if err != nil {
+		t.Fatalf("cannot read %s: %v", unit, err)
 	}
 	body := string(b)
 	// It has to run the bare form and nothing else: that is the one that
@@ -195,4 +205,30 @@ func sameArgs(got, want []string) bool {
 		}
 	}
 	return true
+}
+
+// The target is only offered where deja can actually schedule something.
+// Offering one that always fails is worse than not offering it — and the
+// suite's own invariants install every target for real, so a target that
+// refuses its platform fails them.
+func TestSyncTimerIsOfferedOnlyWhereItCanRun(t *testing.T) {
+	for goos, want := range map[string]bool{
+		"darwin": true, "linux": true,
+		"windows": false, "plan9": false, "freebsd": false,
+	} {
+		if got := syncTimerSchedulable(goos); got != want {
+			t.Errorf("syncTimerSchedulable(%q) = %v, want %v", goos, got, want)
+		}
+	}
+	// And the list follows that answer on this machine.
+	var listed bool
+	for _, n := range installTargetNames() {
+		if n == "sync-timer" {
+			listed = true
+		}
+	}
+	if listed != syncTimerSchedulable(runtime.GOOS) {
+		t.Errorf("sync-timer listed=%v on %s, but schedulable=%v",
+			listed, runtime.GOOS, syncTimerSchedulable(runtime.GOOS))
+	}
 }

--- a/cmd/deja/install_targets_complete_test.go
+++ b/cmd/deja/install_targets_complete_test.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"runtime"
 	"strconv"
 	"testing"
 )
@@ -68,6 +69,14 @@ func TestEveryImplementedTargetIsListed(t *testing.T) {
 		found++
 		for _, name := range names {
 			if listed[name] {
+				return true
+			}
+			// A target can be implemented everywhere and offered only where it
+			// works. sync-timer answers on every platform — with an
+			// explanation naming the one it cannot schedule for, which is
+			// better than "unknown target" — but it is listed only where deja
+			// can write a unit, because the list is what `--all` installs.
+			if name == "sync-timer" && !syncTimerSchedulable(runtime.GOOS) {
 				return true
 			}
 		}


### PR DESCRIPTION
Last of the four. `deja sync` is one command now, but it is still a command — and the machine that most needs to send is the one nobody is sitting at. A hook would not help: hooks fire while someone is working, which is exactly when the server is not.

`deja install sync-timer` writes a launchd agent on macOS or a systemd user timer on Linux, running bare `deja sync` every 30 minutes. That form exchanges with every machine deja already knows and does nothing at all when there are none, so installing it early is harmless. A platform with neither is refused by name rather than told it worked.

Not called `sync-auto`: in this repo `-auto` means a harness's auto-recall hook, and doctor has an invariant that every such target has a row. This is a different thing and gets a different name.

Two things the repo's own gates caught, both real:

- **The suite loaded a live launch agent into my launchd.** Every install target is driven for real by `TestEveryTargetWritesReadableFiles` and the spacey-path test against a temp home, so one run registered `com.deja-vu.sync` pointing at a plist the test then deleted — `launchctl list` showed it. Service-manager calls now no-op under a test binary, the same check the hook refresher uses before spawning itself.
- **systemd splits `ExecStart` on whitespace.** A home directory with a space in it produced a unit that runs the wrong thing. The path is quoted now, and the plist escapes XML for the same reason.

7 mutations, all caught. One needed the code changed rather than the test: the "no timer for this platform" refusal could only ever run on the platform that has no timer, so nobody would have checked it — the platform is now an argument, the way `zedConfigDir` takes one.

Stacked on #1432.