### PR TITLE
test(bench): measure recall against a scope that cannot hold the answer

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -64,6 +64,13 @@ type promptReport struct {
 	// get answered.
 	Marathon promptArmReport `json:"marathon_sessions"`
 	Fresh    promptArmReport `json:"fresh_sessions"`
+	// The bucket arm: a question asked while the project scope is a catch-all
+	// that holds unrelated work and not the answer. Every fire here is a false
+	// one — the right behaviour is silence, because a neighbour pulled out of
+	// a catch-all is what teaches an agent to stop reading these injections.
+	// Until this existed the benchmark handed the probe the correct project
+	// every time, so it could not see a scope failure at all.
+	Bucket promptArmReport `json:"bucket_scope"`
 }
 
 func runBenchPrompt(args []string) error {
@@ -119,20 +126,39 @@ func measurePrompt(seed int64) (promptReport, error) {
 		if chain.Negative {
 			continue
 		}
+		// Filler that only exists to fill the bucket has no question of its
+		// own; it is asked about through the bucket-answer chain below.
+		if chain.Kind == "bucket" {
+			continue
+		}
 		terms := prompt.Terms(chain.Question)
-		fired, correct := promptBenchProbe(indexDir, chain.Project, chain.ID, terms)
+		// The bucket question is asked against the catch-all scope rather than
+		// against its own project — that is the whole point of the case, and
+		// it is the only arm where the probe is not handed the right answer.
+		scope := chain.Project
+		if chain.Kind == "bucket-answer" {
+			scope = bench.PromptBucketProject
+		}
+		fired, correct := promptBenchProbe(indexDir, scope, chain.ID, terms)
 		arm := &report.Real
 		switch chain.Kind {
 		case "marathon":
 			arm = &report.Marathon
 		case "fresh":
 			arm = &report.Fresh
+		case "bucket-answer":
+			arm = &report.Bucket
 		default:
 			realTerms = append(realTerms, len(terms))
 		}
 		arm.Cases++
 		if fired {
 			arm.Fired++
+			// Nothing in the bucket can be the answer, so anything it returns
+			// is a false fire.
+			if chain.Kind == "bucket-answer" {
+				arm.FalseFires++
+			}
 		}
 		if correct {
 			arm.Correct++
@@ -156,6 +182,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.Negative, negTerms)
 	finishPromptArm(&report.Marathon, nil)
 	finishPromptArm(&report.Fresh, nil)
+	finishPromptArm(&report.Bucket, nil)
 	return report, nil
 }
 

--- a/cmd/deja/bench_prompt_test.go
+++ b/cmd/deja/bench_prompt_test.go
@@ -25,6 +25,13 @@ func TestPromptBenchCorpusIsMeasurable(t *testing.T) {
 		}
 		// One topic per chain: the context corpus gives them all the same
 		// vocabulary, which scores zero no matter what the extractor does.
+		// Filler for the catch-all scope carries no question of its own: it is
+		// asked about through the bucket-answer chain, whose question is the
+		// one that must go unanswered. A chain nobody asks about still has to
+		// earn its place, and this one earns it by being the wrong answer.
+		if c.Kind == "bucket" {
+			continue
+		}
 		if topics[c.Topic] {
 			t.Fatalf("topic %q appears in more than one chain", c.Topic)
 		}
@@ -116,5 +123,27 @@ func TestFinishPromptArmHandlesEmptyArms(t *testing.T) {
 	}
 	if arm.MedianTerm == 0 {
 		t.Fatal("median term count not computed")
+	}
+}
+
+// The bucket arm measures a scope that cannot hold the answer, so nothing it
+// returns is ever right. Until it existed the benchmark handed the probe the
+// correct project on every case and could not see a scope failure at all —
+// which is how `bench prompt` reported precision 1.00 while the hook was
+// injecting a stranger's session on a real machine (2026-08-19).
+func TestBucketArmCannotBeSatisfied(t *testing.T) {
+	report, err := measurePrompt(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := report.Bucket
+	if b.Cases == 0 {
+		t.Fatal("the bucket case is not in the corpus, so a wrong scope goes unmeasured")
+	}
+	if b.Correct != 0 {
+		t.Errorf("the bucket arm scored %d correct — nothing in a catch-all scope is the answer, so the question is being asked against the right project instead", b.Correct)
+	}
+	if b.Fired != b.FalseFires {
+		t.Errorf("fired %d but counted %d false — every fire out of the bucket is a false one", b.Fired, b.FalseFires)
 	}
 }

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -28,9 +28,20 @@ type PromptChain struct {
 	Negative bool
 	// Kind names what this chain is here to measure: "" for the plain case,
 	// "marathon" for a chain whose sessions are long enough to be skipped
-	// wholesale, "fresh" for one worked on minutes ago.
+	// wholesale, "fresh" for one worked on minutes ago, "bucket" for filler
+	// sharing a catch-all scope and "bucket-answer" for the question whose
+	// answer sits outside that scope.
 	Kind string
 }
+
+// promptBucketProject is the shared scope an agent gets when it is started
+// from a directory that is not a project: everything launched from there lands
+// in it, and the repository being worked on does not.
+const promptBucketProject = "promptbenchbucket"
+
+// PromptBucketProject is that scope, exported so the benchmark can ask its
+// question against the catch-all rather than against the right answer.
+const PromptBucketProject = promptBucketProject
 
 type PromptCorpus struct {
 	Chains []PromptChain
@@ -161,6 +172,48 @@ func GeneratePrompt(seed int64) PromptCorpus {
 	chains = append(chains, promptShapeChain(rng, len(topics)+1, "fresh", promptTopic{
 		"idempotency", "the import path became idempotent by keying on the source hash", "how did we make the import idempotent?",
 	}, time.Now().Add(-2*time.Minute).UTC(), 3))
+	// The bucket case. An agent started from a parent directory — a home
+	// directory, a workspace root — gets a project scope that holds everything
+	// ever launched from there, and not the repository actually being worked
+	// on. Measured on a real machine 2026-08-19: from /Users/shulcz the scope
+	// was [shulcz, Users/shulcz], the answer lay in another project entirely,
+	// and the hook injected an unrelated session from the bucket instead.
+	//
+	// The right answer is silence. A neighbour from the bucket is worse than
+	// nothing: it spends tokens and teaches the agent to ignore the next one.
+	// One of these shares ordinary words with the question below without
+	// answering it. That is what the real miss looked like: not a session
+	// about nothing, but a neighbour carrying two of the same common words,
+	// which is enough to clear a bar meant for rare ones.
+	for i, junk := range []promptTopic{
+		{"tarpit", "the crawler tarpit was left in place deliberately", ""},
+		{"statement", "the statement cache is disabled on the read mirror after those failures", ""},
+		{"quotas", "the per-tenant quota was moved into the gateway", ""},
+	} {
+		id := fmt.Sprintf("prompt-bucket-%02d", i)
+		t := base.Add(time.Duration(900+i*10) * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: promptBucketProject, Kind: "bucket",
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: promptBucketProject,
+				Started: t, Updated: t,
+				Messages: []model.Message{{Role: "user", Text: "we decided " + junk.fact, Time: t}},
+			}},
+		})
+	}
+	// The question asked while scoped to that bucket. Its answer is in a
+	// project of its own, which the bucket scope does not contain.
+	answer := base.Add(1000 * time.Minute)
+	chains = append(chains, PromptChain{
+		ID: "prompt-bucket-answer", Project: "promptbenchelsewhere", Kind: "bucket-answer",
+		Topic:    "pgbouncer",
+		Question: "how did we deal with the pgbouncer prepared statement failures?",
+		Sessions: []model.Session{{
+			ID: "prompt-bucket-answer-session", Harness: "claude", Project: "promptbenchelsewhere",
+			Started: answer, Updated: answer,
+			Messages: []model.Message{{Role: "user", Text: "we decided prepared statements go behind pgbouncer in session mode", Time: answer}},
+		}},
+	})
 	// Negative controls share the corpus but hold none of its topics, so a
 	// question about them must not recall anything.
 	for i := 0; i < PromptNegativeCount; i++ {

--- a/internal/bench/prompt_test.go
+++ b/internal/bench/prompt_test.go
@@ -18,10 +18,16 @@ func TestGeneratePromptShape(t *testing.T) {
 	projects := map[string]bool{}
 	var real, negative, marathon, fresh int
 	for _, c := range corpus.Chains {
-		if projects[c.Project] {
-			t.Fatalf("project %q shared by two chains; a query would match both", c.Project)
+		// One project is shared on purpose. Everywhere else a shared project
+		// would make a query match two chains and blur the measurement; the
+		// bucket exists to measure exactly that condition — a scope holding
+		// several unrelated pieces of work and not the answer.
+		if c.Kind != "bucket" {
+			if projects[c.Project] {
+				t.Fatalf("project %q shared by two chains; a query would match both", c.Project)
+			}
+			projects[c.Project] = true
 		}
-		projects[c.Project] = true
 		if c.Negative {
 			negative++
 			if len(c.Sessions) == 0 {
@@ -32,6 +38,13 @@ func TestGeneratePromptShape(t *testing.T) {
 		real++
 		// One topic per chain: the context corpus gives them all the same
 		// vocabulary, and a term in every chain identifies none of them.
+		// Filler for the catch-all scope carries no question of its own: it is
+		// asked about through the bucket-answer chain, whose question is the
+		// one that must go unanswered. A chain nobody asks about still has to
+		// earn its place, and this one earns it by being the wrong answer.
+		if c.Kind == "bucket" {
+			continue
+		}
 		if topics[c.Topic] {
 			t.Fatalf("topic %q appears twice", c.Topic)
 		}


### PR DESCRIPTION
`bench prompt` reported `precision 1.00` while auto-recall was, on a real machine, injecting an unrelated session into a live conversation. Both were true, because the benchmark handed the probe the correct project on every case:

```go
index.ProjectRelevant(dir, []string{project}, terms, 8)
```

The scope was never wrong, so a wrong scope could not be measured. The probe's own comment claims it "runs the same two steps the hook runs" — the hook derives its scope from the working directory, and that is the step that failed.

What failed on 2026-08-19: an agent started from `/Users/shulcz` gets project candidates `[shulcz, Users/shulcz]`. That scope holds everything ever launched from the home directory and not the repository being worked on, so the hook picked the best of a catch-all — a review of an unrelated project — and the answer, which lived in another project, was never a candidate.

This adds the case: a shared bucket standing in for that scope, holding work that shares ordinary words with the question without answering it, and a question whose answer sits outside. The right behaviour is silence.

```
bucket_scope: cases 1, fired 1, false_fires 1
```

The other arms are untouched — real 11/12 precision 1.00, negative false_fires 0, `bench recall` 1.00/1.00, `bench context` 294 tokens at coverage 1.00.

Two corpus invariants needed explicit exemptions, both meaningful: filler in the bucket carries no question of its own (it is asked about through the answer chain), and it deliberately shares one project — the condition the case exists to measure.

3 mutations, all caught: asking against the right project after all, not counting a bucket fire as false, and a bucket with nothing that looks like an answer. `TestBucketArmCannotBeSatisfied` pins the contract so the arm cannot quietly become a normal one.

No product behaviour changes here. This is the measurement the fix will be judged by.