### PR TITLE
fix(recall): say nothing when the working directory is not a project

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -19,6 +20,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/prompt"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
 
 	"github.com/vshulcz/deja-vu/internal/atomicfile"
@@ -144,6 +146,21 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
 	if cwd == "" {
 		cwd, _ = os.Getwd()
+	}
+	// A home directory is not a project. Everything ever launched from there
+	// shares its name, so ranking "this project" over that scope ranks
+	// unrelated work against each other and the repository actually being
+	// worked on is not in it at all. Measured on a real machine 2026-08-19:
+	// an agent started from /Users/shulcz got the scope [shulcz, Users/shulcz]
+	// and the hook injected a review of a different project into a
+	// conversation about this one, while the answer sat in a project the
+	// scope did not cover.
+	//
+	// Silence is the right answer there, and the cheap one: a wrong injection
+	// costs tokens twice, once to carry it and again when the agent learns to
+	// stop reading them.
+	if scopeIsNotAProject(cwd) {
+		return emitNudgeOnly(stdout, plain, nudge)
 	}
 	// Rank THIS project's sessions by how well they match the prompt terms
 	// (IDF-weighted), rather than reconstructing an AND query — natural
@@ -720,4 +737,26 @@ func weakRecallPointer(ss []model.Session, terms []string) string {
 	}
 	return fmt.Sprintf("deja: this project has history on %q from %s%s — call recall with a specific token if it matters here.\n",
 		search.SafeLine(topic), when, more)
+}
+
+// scopeIsNotAProject reports whether a working directory is one of the places
+// that collects unrelated work rather than holding one project: the home
+// directory itself, or a filesystem root. Both are ordinary places to start an
+// agent from — a scheduled job, a shell that never cd'd anywhere — and neither
+// says anything about what is being worked on.
+//
+// Deliberately narrow. A directory that is not a git repository is still a
+// perfectly good project; only the catch-alls are refused.
+func scopeIsNotAProject(cwd string) bool {
+	// An empty path cleans to "." and "." is its own parent, so the root check
+	// below answers that case too — no separate branch, which would be one
+	// that no test could ever distinguish.
+	clean := filepath.Clean(cwd)
+	if clean == filepath.Dir(clean) { // "", "/" and a volume root are their own parent
+		return true
+	}
+	if home := sources.Home(); home != "" && clean == filepath.Clean(home) {
+		return true
+	}
+	return false
 }

--- a/cmd/deja/hook_prompt_scope_test.go
+++ b/cmd/deja/hook_prompt_scope_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A home directory is not a project: everything ever launched from there
+// shares its name, and the repository being worked on is not in that scope at
+// all. Measured on a real store 2026-08-19 — an agent started from
+// /Users/shulcz recalled a session about a different project into a
+// conversation about this one, while the answer sat in a project the scope did
+// not cover.
+func TestScopeIsNotAProject(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	for _, tc := range []struct {
+		name string
+		cwd  string
+		want bool
+	}{
+		{"the home directory itself", home, true},
+		{"the home directory with a trailing slash", home + string(filepath.Separator), true},
+		{"a filesystem root", string(filepath.Separator), true},
+		{"nothing at all", "", true},
+		{"a project inside the home directory", filepath.Join(home, "code", "proj"), false},
+		{"a project elsewhere", filepath.Join(t.TempDir(), "proj"), false},
+		// A directory that is not a repository is still somebody's project.
+		// The rule refuses catch-alls, not un-versioned work.
+		{"a plain directory", filepath.Join(home, "notes"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := scopeIsNotAProject(tc.cwd); got != tc.want {
+				t.Errorf("scopeIsNotAProject(%q) = %v, want %v", tc.cwd, got, tc.want)
+			}
+		})
+	}
+}
+
+// The gate has to hold in the hook, not only in the predicate: the point is
+// that nothing is injected from a catch-all scope.
+func TestPromptHookStaysSilentFromTheHomeDirectory(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-scope")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("CLAUDE_PROJECT_DIR", "")
+	at := time.Now().AddDate(0, 0, -2).UTC().Format(time.RFC3339)
+	body := `{"type":"user","sessionId":"sc1","cwd":"` + filepath.ToSlash(root) + `","timestamp":"` + at + `","message":{"role":"user","content":"the pgbouncer prepared statements keep failing"}}` + "\n" +
+		`{"type":"assistant","sessionId":"sc1","cwd":"` + filepath.ToSlash(root) + `","timestamp":"` + at + `","message":{"role":"assistant","content":[{"type":"text","text":"decision: run pgbouncer in session mode"}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "sc1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// And a session recorded while sitting in the home directory itself. This
+	// is what makes the test able to fail: without the gate the hook ranks
+	// this one under the home scope and injects it, because it carries the
+	// same words. It is not an answer to anything — it is the neighbour a
+	// catch-all scope hands back.
+	home := sourcesHomeForTest()
+	hroot := filepath.Join(tmp, "claude", "proj-home")
+	if err := os.MkdirAll(hroot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hbody := `{"type":"user","sessionId":"hm1","cwd":"` + filepath.ToSlash(home) + `","timestamp":"` + at + `","message":{"role":"user","content":"unrelated errand where pgbouncer statements were merely mentioned"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(hroot, "hm1.jsonl"), []byte(hbody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	ask := func(cwd string) string {
+		var out bytes.Buffer
+		payload := `{"prompt":"the pgbouncer prepared statements keep failing","cwd":"` + filepath.ToSlash(cwd) + `"}`
+		t.Setenv("CLAUDE_PROJECT_DIR", "")
+		if err := runHookPromptMode(dir, strings.NewReader(payload), &out, false); err != nil {
+			t.Fatal(err)
+		}
+		return out.String()
+	}
+
+	// The fixture has to answer from its own project, or silence from the home
+	// directory would prove nothing.
+	if got := ask(root); !strings.Contains(got, "pgbouncer") {
+		t.Fatalf("the fixture recalls nothing even from its own project, so this test cannot fail honestly: %q", got)
+	}
+	if got := ask(sourcesHomeForTest()); strings.Contains(got, "deja-recall") {
+		t.Errorf("the hook recalled from a home-directory scope: %q", got)
+	}
+}
+
+func sourcesHomeForTest() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE")
+}


### PR DESCRIPTION
An agent started from a home directory gets project candidates `[shulcz, Users/shulcz]`. That scope holds everything ever launched from there and does not hold the repository being worked on, so ranking "this project's sessions" ranks unrelated work against each other and picks the best of a catch-all.

Measured on a real store, same prompt, same index, only the binary differs:

```
before  deja-vu — you have been here: "Ночной loop deja-vu, продолжение. Итерация 4 (на…"
after   (nothing)
```

The injected session was about a different piece of work entirely. The answer the prompt was actually about lived in a project the scope never covered.

Silence is both the right answer and the cheap one: a wrong injection costs tokens twice — once to carry it, and again when the agent learns to stop reading them.

The rule is deliberately narrow: the home directory itself and a filesystem root. A directory that is not a git repository is still somebody's project and is left alone.

Benchmarks, before → after: real 11/12 precision 1.00 → unchanged, negative false_fires 0 → unchanged, marathon and fresh unchanged, `bench recall` 1.00/1.00 unchanged, `bench context` 294 tokens at coverage 1.00 unchanged.

`bucket_scope` still reports 1 false fire, and that is honest: that arm models the other half of the problem — a scope with a legitimate project name that nonetheless holds unrelated work sharing ordinary words with the question. A cwd rule cannot answer that one; term selection or a stronger bar has to.

5 mutations, all caught. Two were not, at first: removing the gate entirely changed nothing until the fixture gained a session recorded *in* the home directory — without it the end-to-end test could not fail — and an `if cwd == ""` branch turned out to be unreachable, since `filepath.Clean("")` is `"."` and `"."` is its own parent. The branch is gone rather than left as code no test could distinguish.