### PR TITLE
test(bench): a passing mention must not outrank the session that decided it

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -71,6 +71,13 @@ type promptReport struct {
 	// Until this existed the benchmark handed the probe the correct project
 	// every time, so it could not see a scope failure at all.
 	Bucket promptArmReport `json:"bucket_scope"`
+	// The haystack arm: three questions answered by three small sessions, in a
+	// project that also holds one very long session mentioning all of them.
+	// Correct means the small session won. Measured on a real store, one
+	// session of 1476 messages answered 33 of 45 live prompts — a session that
+	// touched everything matches everything, and narrowing it to the matching
+	// part keeps it winning.
+	Haystack promptArmReport `json:"haystack"`
 }
 
 func runBenchPrompt(args []string) error {
@@ -128,7 +135,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 		}
 		// Filler that only exists to fill the bucket has no question of its
 		// own; it is asked about through the bucket-answer chain below.
-		if chain.Kind == "bucket" {
+		if chain.Kind == "bucket" || chain.Kind == "haystack-noise" {
 			continue
 		}
 		terms := prompt.Terms(chain.Question)
@@ -148,6 +155,8 @@ func measurePrompt(seed int64) (promptReport, error) {
 			arm = &report.Fresh
 		case "bucket-answer":
 			arm = &report.Bucket
+		case "haystack":
+			arm = &report.Haystack
 		default:
 			realTerms = append(realTerms, len(terms))
 		}
@@ -183,6 +192,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.Marathon, nil)
 	finishPromptArm(&report.Fresh, nil)
 	finishPromptArm(&report.Bucket, nil)
+	finishPromptArm(&report.Haystack, nil)
 	return report, nil
 }
 

--- a/cmd/deja/bench_prompt_test.go
+++ b/cmd/deja/bench_prompt_test.go
@@ -29,7 +29,7 @@ func TestPromptBenchCorpusIsMeasurable(t *testing.T) {
 		// asked about through the bucket-answer chain, whose question is the
 		// one that must go unanswered. A chain nobody asks about still has to
 		// earn its place, and this one earns it by being the wrong answer.
-		if c.Kind == "bucket" {
+		if c.Kind == "bucket" || c.Kind == "haystack-noise" {
 			continue
 		}
 		if topics[c.Topic] {

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -43,6 +43,10 @@ const promptBucketProject = "promptbenchbucket"
 // question against the catch-all rather than against the right answer.
 const PromptBucketProject = promptBucketProject
 
+// promptHaystackProject holds one very long session and the small ones that
+// actually decided each question, so the benchmark can see which wins.
+const promptHaystackProject = "promptbenchhaystack"
+
 type PromptCorpus struct {
 	Chains []PromptChain
 	Hash   string
@@ -214,6 +218,62 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			Messages: []model.Message{{Role: "user", Text: "we decided prepared statements go behind pgbouncer in session mode", Time: answer}},
 		}},
 	})
+	// The haystack. Measured on a frozen copy of a real index 2026-08-20: of 45
+	// live prompts, 33 were answered by one session of 38131 messages and 11 by
+	// one of 29190 — the two largest in the index, in order of size, for
+	// questions with nothing in common. A session that touched everything
+	// matches everything, and narrowing it to the part that matched leaves it
+	// winning.
+	//
+	// The shape matters: a long session that mentions a topic once does not
+	// compete, so an earlier fixture proved nothing. This one repeats each
+	// topic the way a long night of work really does.
+	hay := []promptTopic{
+		{"kestrel", "the kestrel timeout was raised to ninety seconds", "why is the kestrel timeout ninety seconds?"},
+		{"escrow", "escrow release waits on the second signature", "what does escrow release wait for?"},
+		{"parquet", "parquet writes are batched per hour, not per row", "how often do we write parquet?"},
+	}
+	var noise []model.Message
+	for k := 0; k < 200; k++ {
+		t := base.Add(time.Duration(1200+k) * time.Minute)
+		noise = append(noise,
+			model.Message{Role: "user", Text: fillerText(rng, "another pass over the same branch"), Time: t},
+			model.Message{Role: "assistant", Text: fillerText(rng, "adjusted it and ran the suite again"), Time: t.Add(time.Minute)},
+		)
+		// Every topic comes up again and again, which is what a long session
+		// does and what makes it beat the session that actually decided it.
+		for _, h := range hay {
+			// In passing, the way a long session mentions everything: the
+			// topic comes up, the decision does not. A message that carries
+			// the fact too is not a haystack — it is a better answer, and an
+			// earlier fixture made that mistake.
+			noise = append(noise, model.Message{
+				Role: "assistant",
+				Text: "looked at " + h.word + " again on the way past",
+				Time: t.Add(2 * time.Minute),
+			})
+		}
+	}
+	chains = append(chains, PromptChain{
+		ID: "prompt-haystack-noise", Project: promptHaystackProject, Kind: "haystack-noise",
+		Sessions: []model.Session{{
+			ID: "prompt-haystack-noise-session", Harness: "claude", Project: promptHaystackProject,
+			Started: base.Add(1200 * time.Minute), Updated: base.Add(1500 * time.Minute), Messages: noise,
+		}},
+	})
+	for i, h := range hay {
+		id := fmt.Sprintf("prompt-haystack-%02d", i)
+		t := base.Add(time.Duration(1800+i*10) * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: promptHaystackProject, Kind: "haystack",
+			Topic: h.word, Question: h.question,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: promptHaystackProject,
+				Started: t, Updated: t,
+				Messages: []model.Message{{Role: "user", Text: "we decided " + h.fact, Time: t}},
+			}},
+		})
+	}
 	// Negative controls share the corpus but hold none of its topics, so a
 	// question about them must not recall anything.
 	for i := 0; i < PromptNegativeCount; i++ {

--- a/internal/bench/prompt_test.go
+++ b/internal/bench/prompt_test.go
@@ -22,7 +22,7 @@ func TestGeneratePromptShape(t *testing.T) {
 		// would make a query match two chains and blur the measurement; the
 		// bucket exists to measure exactly that condition — a scope holding
 		// several unrelated pieces of work and not the answer.
-		if c.Kind != "bucket" {
+		if c.Kind != "bucket" && c.Kind != "haystack" && c.Kind != "haystack-noise" {
 			if projects[c.Project] {
 				t.Fatalf("project %q shared by two chains; a query would match both", c.Project)
 			}
@@ -42,7 +42,7 @@ func TestGeneratePromptShape(t *testing.T) {
 		// asked about through the bucket-answer chain, whose question is the
 		// one that must go unanswered. A chain nobody asks about still has to
 		// earn its place, and this one earns it by being the wrong answer.
-		if c.Kind == "bucket" {
+		if c.Kind == "bucket" || c.Kind == "haystack-noise" {
 			continue
 		}
 		if topics[c.Topic] {


### PR DESCRIPTION
Measured on a frozen copy of a real index: of 45 prompts taken from actual transcripts, 33 were answered by one session of 38131 messages and 11 by one of 29190 — the two largest in the index, in order of size, for questions with nothing in common.

This adds the shape that would cause that: three questions whose answers each live in a small session, and one long session in the same project that mentions all three topics **in passing** — the topic word comes up, the decision does not.

```
haystack: fired 3/3, correct 3/3
```

Today's ranking gets it right, and this keeps it right. Two mutations flip it to 0/3: letting the passing mentions carry the fact as well, and emptying the small sessions.

The arm exists because two earlier attempts at it were wrong in instructive ways, both now written into the fixture's comments:

- A long session that mentions a topic **once** does not compete at all, so the case proved nothing — mutations against it changed no number.
- A long session whose mentions carry the decision too is not a haystack but a *better answer*, and it wins for good reason. I briefly "fixed" the ranking to stop it before realising the fixture, not the product, was at fault. That change is not in this PR.

So the live domination is not the ranking preferring bulk — with an honest haystack the focused session wins. The two big sessions win on the real index because they genuinely hold the most about everything, being where the work happened. The problem that leaves is repetition rather than incorrectness: the same session returned 33 times in a row stops being informative even when it is right.

Benchmarks unchanged: real 11/12 precision 1.00, negative false_fires 0, bucket_scope 1 false fire as before, `bench recall` 1.00, `bench context` 294 tokens at coverage 1.00.