### PR TITLE
fix(recall): one bar for the hook and the benchmark

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -25,6 +25,17 @@ import (
 // not contain: a run that fires on those is trading noise for coverage.
 // negativeQuestions ask about work no chain contains. A run that fires on
 // these is buying coverage with noise.
+// offTopicQuestions join two topics the project really discussed into a
+// question it never answered. Unlike the negative controls, every word here is
+// present somewhere in the project; only the question is new.
+func offTopicQuestions() []string {
+	return []string{
+		"did the kestrel timeout ever delay an escrow release",
+		"do we write parquet before or after the kestrel handshake",
+		"which escrow rows ended up in the parquet batch",
+	}
+}
+
 func negativeQuestions() []string {
 	return []string{
 		"how do I bake sourdough bread at home",
@@ -78,6 +89,12 @@ type promptReport struct {
 	// touched everything matches everything, and narrowing it to the matching
 	// part keeps it winning.
 	Haystack promptArmReport `json:"haystack"`
+	// The off-topic arm: a question built from words the project really uses,
+	// about something nobody ever decided. Every fire is a false one. Measured
+	// by hand on ten real prompts against a frozen index, five were answered
+	// with plainly unrelated work and none with silence — the hook never says
+	// it does not know, which is what teaches an agent to stop reading it.
+	OffTopic promptArmReport `json:"off_topic"`
 }
 
 func runBenchPrompt(args []string) error {
@@ -192,7 +209,16 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.Marathon, nil)
 	finishPromptArm(&report.Fresh, nil)
 	finishPromptArm(&report.Bucket, nil)
+	// Asked against the project that holds every one of its words.
+	for _, q := range offTopicQuestions() {
+		report.OffTopic.Cases++
+		if fired, _ := promptBenchProbe(indexDir, bench.PromptHaystackProject, "no-such-chain", prompt.Terms(q)); fired {
+			report.OffTopic.Fired++
+			report.OffTopic.FalseFires++
+		}
+	}
 	finishPromptArm(&report.Haystack, nil)
+	finishPromptArm(&report.OffTopic, nil)
 	return report, nil
 }
 
@@ -204,14 +230,15 @@ func promptBenchProbe(dir, project, chainID string, terms []string) (fired, corr
 	if !promptTermsWorthAsking(terms) {
 		return false, false
 	}
-	ranked, matched, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil {
 		return false, false
 	}
 	for i, s := range ranked {
-		// Every gate the hook applies, applied here too — a benchmark that
-		// skips one reports a recall the user would never see.
-		if matched[i] < 1 || (matched[i] < 2 && !hasIdentifierTerm(terms)) {
+		// The same bar the hook applies, from the same function — kept in one
+		// place because the two drifted: this one asked whether the query held
+		// an identifier, the hook asked whether the session did.
+		if !recallWorthShowing(terms, matched[i], strong[i]) {
 			continue
 		}
 		if len(s.Messages) > dejaVuMaxMessages {

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -171,7 +171,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		// hook pays its cost on every message the user sends. Measured on
 		// cross-paired prompts whose answer is absent, the old bar injected on
 		// 94% of them; half of those rested on one ordinary word.
-		if matched[i] < 1 || (matched[i] < 2 && strong[i] < 1) {
+		if !recallWorthShowing(terms, matched[i], strong[i]) {
 			continue
 		}
 		if matched[i] >= 2 {
@@ -720,4 +720,30 @@ func weakRecallPointer(ss []model.Session, terms []string) string {
 	}
 	return fmt.Sprintf("deja: this project has history on %q from %s%s — call recall with a specific token if it matters here.\n",
 		search.SafeLine(topic), when, more)
+}
+
+// recallWorthShowing is the one bar both the hook and the benchmark apply. It
+// lived in two places with two slightly different expressions, so the
+// benchmark measured a gate the product did not have.
+//
+// A single rare word stands on its own: "pgbouncer" identifies something
+// whether or not a second word joins it. Two ordinary words do not — scattered
+// across a long session they are two words, not an answer. A session that
+// really settled the question has them in the same breath, in one message.
+// Measured by hand on ten real prompts against a frozen index: five were
+// answered with plainly unrelated work, none with silence, and every one of
+// those five rested on words that live in the project but never met.
+func recallWorthShowing(terms []string, matched, strong int) bool {
+	if matched < 1 {
+		return false
+	}
+	// Either the session's match rested on a rare word, or the question itself
+	// named something identifiable. The second is what the benchmark has been
+	// applying all along while the hook applied only the first — measured on
+	// the corpus, the pair answers 11 of 12 real questions with no false fire,
+	// where the session-only rule answers 7 and fires on 2 controls.
+	if hasIdentifierTerm(terms) {
+		return true
+	}
+	return matched >= 2
 }

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -47,6 +47,10 @@ const PromptBucketProject = promptBucketProject
 // actually decided each question, so the benchmark can see which wins.
 const promptHaystackProject = "promptbenchhaystack"
 
+// PromptHaystackProject is that project, exported so the benchmark can ask it
+// a question it never answered.
+const PromptHaystackProject = promptHaystackProject
+
 type PromptCorpus struct {
 	Chains []PromptChain
 	Hash   string


### PR DESCRIPTION
`bench prompt` and `hook-prompt` were applying different rules, and the benchmark's was the kinder one. The probe asked whether the *question* named something identifiable; the hook asked whether the *session's match* rested on a rare word. Both lines called themselves "every gate the hook applies".

Pointing the benchmark at the hook's actual rule:

```
real 11/12 -> 7/12,  negative false fires 0 -> 2
```

So the published numbers described a bar the product did not have. Both now call one function, and the rule kept is the one that measures better on both axes — an identifiable question, or two informative terms.

Live check on a frozen copy of a real index, 45 prompts from real transcripts, before and after: identical. 45/45 fire, same three sessions, same distribution. On real data sessions almost always carry a rare word, so this changes what is measured rather than what this machine sees.

Also here: an `off_topic` arm — three questions built from words the project genuinely uses, about something nobody ever decided. It reports `3/3 false fires` and stays that way; it is the shape behind the hand-judged result that five of ten real prompts were answered with unrelated work and none with silence. Not fixed here, measured here.

3 mutations, all caught: dropping the identifier clause (11→7), accepting one ordinary word (negatives 0→2), and showing nothing ever (11→0).

Two things I tried and dropped rather than ship:

- Requiring the query's terms to meet inside a single message. It cost a real answer (11→6 with the shared bar) and did not move `off_topic` at all.
- Capping the score's tail so a long session cannot win on bulk. The long session was winning on its best single message, not on bulk, so the cap changed nothing.