### PR TITLE
fix(recall): stop framing a matched answer with the top of the transcript

### DIFF
--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -270,7 +270,18 @@ func autoRecallSessionFor(s model.Session, now time.Time, provenance bool, terms
 		// from the top of the session: on a real block that padding read as
 		// "two schedulers were live after the failover" under an answer about
 		// the retry budget.
-		if matched && m.Role == "assistant" {
+		//
+		// The same holds for the question line, and it was not applied there.
+		// When nothing the user said matched, this loop took the first thing
+		// they said in the whole session — on a long one that is "carry on
+		// then". Measured on a real store: a recall that had found the right
+		// session opened with "продолжай дальше" and read as worthless, which
+		// is how a correct answer teaches an agent to stop reading these.
+		// Better to show the matched line alone than to frame it with filler.
+		// With terms in hand this skips the question line too; without them the
+		// block still opens with the session's own first question, which is
+		// what the session-start digest is for.
+		if matched && (m.Role == "assistant" || len(terms) > 0) {
 			continue
 		}
 		text := contextText(m.Text, false)

--- a/internal/search/recall_shown_line_test.go
+++ b/internal/search/recall_shown_line_test.go
@@ -1,0 +1,51 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The line a recall block opens with is the first thing an agent reads, and on
+// a long session it was taken from the top of the transcript rather than from
+// the part that matched. Measured on a real store: for a question about a car's
+// CAN bus, the block led with "продолжай дальше" while the matching line sat
+// three lines below — the recall was right and looked worthless.
+func TestRecallBlockDoesNotOpenWithFillerFromTheTop(t *testing.T) {
+	start := time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
+	msgs := []model.Message{
+		{Role: "user", Text: "carry on then", Time: start},
+		{Role: "assistant", Text: "opened the file and looked around", Time: start.Add(time.Minute)},
+	}
+	for i := 0; i < 200; i++ {
+		at := start.Add(time.Duration(i+2) * time.Minute)
+		msgs = append(msgs,
+			model.Message{Role: "user", Text: "keep going", Time: at},
+			model.Message{Role: "assistant", Text: "adjusted it and ran the suite again", Time: at.Add(time.Second)},
+		)
+	}
+	// The answer, deep in the session, and no user turn naming the subject —
+	// which is the case the fallback used to handle by grabbing the top.
+	msgs = append(msgs, model.Message{
+		Role: "assistant",
+		Text: "the kestrel handshake had to be retried twice before the socket settled",
+		Time: start.Add(400 * time.Minute),
+	})
+
+	s := model.Session{
+		ID: "long-1", Harness: "claude", Project: "proj",
+		Started: start, Updated: start.Add(400 * time.Minute), Messages: msgs,
+	}
+	got := AutoRecallDigestFor([]model.Session{s}, 2000, []string{"kestrel", "handshake"})
+	if got == "" {
+		t.Fatal("nothing was recalled, so this test cannot see what it is about")
+	}
+	if strings.Contains(got, "carry on then") {
+		t.Errorf("the block opens with the first line of the session instead of the part that matched:\n%s", got)
+	}
+	if !strings.Contains(got, "kestrel") {
+		t.Errorf("the block does not show the line that matched:\n%s", got)
+	}
+}


### PR DESCRIPTION
A recall block opens with a `User:` line, and that line is the first thing an agent reads. When the question matched only assistant lines, the block filled that slot by walking the transcript from the top — which on a long session is whatever was said first.

Measured on a real store: a question about a car's CAN bus recalled the session that genuinely holds nine mentions of it, and led with `продолжай дальше`. The recall was right and read as worthless.

The assistant slot already worked this way — "one line that answers beats that line plus a filler" — and the same reasoning was never applied to the question slot. Now it is, but only when terms were given: the session-start digest has no question to match against and still opens with the session's own first one.

Benchmarks unchanged: real 11/12 precision 1.00, negatives 0 false fires, haystack 3/3, `bench recall` 1.00, `bench context` 294 tokens at coverage 1.00.

2 mutations, both caught: restoring the old fill, and never filling at all.

This is one of two mechanisms behind that block, and the smaller one. The other is visible in the same example and is not fixed here: the terms extracted from `напомни, что мы уже выясняли про can шину на omoda через adb` are `[omoda напомни выясняли через дальше]` — four of the five are filler. `продолжай дальше` matched on `дальше`. The filler list in `internal/prompt` has Russian entries (`который`, `потому`, `чтобы`) but not these, so Russian prompts carry filler into ranking where English ones do not.