### PR TITLE
fix(recall): filter Russian filler the way English filler is filtered

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -95,6 +95,17 @@ type promptReport struct {
 	// with plainly unrelated work and none with silence — the hook never says
 	// it does not know, which is what teaches an agent to stop reading it.
 	OffTopic promptArmReport `json:"off_topic"`
+	// Questions in Russian, wrapped in the filler a person types around them.
+	// The corpus was English-only, so nothing here spoke the language whose
+	// filler list had just been extended — and over-filtering is the way that
+	// change fails: put one subject word in the list by mistake and the
+	// question falls silent. Measured: adding the three subjects to the filler
+	// list takes this arm from 3/3 to 1/3.
+	//
+	// It does not see the defect that prompted the extension. That one was
+	// about which line the block opens with, and every arm here scores which
+	// session was chosen.
+	Russian promptArmReport `json:"russian_questions"`
 }
 
 func runBenchPrompt(args []string) error {
@@ -174,6 +185,8 @@ func measurePrompt(seed int64) (promptReport, error) {
 			arm = &report.Bucket
 		case "haystack":
 			arm = &report.Haystack
+		case "russian":
+			arm = &report.Russian
 		default:
 			realTerms = append(realTerms, len(terms))
 		}
@@ -219,6 +232,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	}
 	finishPromptArm(&report.Haystack, nil)
 	finishPromptArm(&report.OffTopic, nil)
+	finishPromptArm(&report.Russian, nil)
 	return report, nil
 }
 

--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -106,6 +106,12 @@ type promptReport struct {
 	// about which line the block opens with, and every arm here scores which
 	// session was chosen.
 	Russian promptArmReport `json:"russian_questions"`
+	// What the block actually shows. Every other arm scores which session was
+	// chosen; none of them looks at the lines inside it, which is how a recall
+	// that had found the right session came to open with "продолжай дальше"
+	// and read as worthless. Correct here means the first line the agent sees
+	// carries a word from the question.
+	Shown promptArmReport `json:"shown_line"`
 }
 
 func runBenchPrompt(args []string) error {
@@ -190,6 +196,16 @@ func measurePrompt(seed int64) (promptReport, error) {
 		default:
 			realTerms = append(realTerms, len(terms))
 		}
+		// What the block opens with, for the questions that have an answer to
+		// open with. Scored apart from whether the right session was picked:
+		// the two fail independently.
+		if fired && (chain.Kind == "" || chain.Kind == "russian") {
+			report.Shown.Cases++
+			if shownLineCarriesATerm(indexDir, scope, terms) {
+				report.Shown.Fired++
+				report.Shown.Correct++
+			}
+		}
 		arm.Cases++
 		if fired {
 			arm.Fired++
@@ -233,13 +249,54 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.Haystack, nil)
 	finishPromptArm(&report.OffTopic, nil)
 	finishPromptArm(&report.Russian, nil)
+	finishPromptArm(&report.Shown, nil)
 	return report, nil
+}
+
+// shownLineCarriesATerm builds the block the hook would inject and reports
+// whether its first content line holds any of the query's terms. A block whose
+// opening line came from the top of a long transcript does not, and that line
+// is the whole frame an agent reads before deciding to ignore the rest.
+func shownLineCarriesATerm(dir, project string, terms []string) bool {
+	ranked, matched, strong, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	if err != nil {
+		return false
+	}
+	var keep []model.Session
+	for i, s := range ranked {
+		if !recallWorthShowing(terms, matched[i], strong[i]) {
+			continue
+		}
+		keep = append(keep, s)
+		break
+	}
+	if len(keep) == 0 {
+		return false
+	}
+	block := search.AutoRecallDigestFor(keep, promptHookBudget-recallFrameOverhead, terms)
+	for _, line := range strings.Split(block, "\n") {
+		line = strings.TrimSpace(line)
+		// The header line names the session; the first line under it is what
+		// frames the block.
+		if !strings.HasPrefix(line, "- User:") && !strings.HasPrefix(line, "- Assistant:") {
+			continue
+		}
+		low := strings.ToLower(line)
+		for _, t := range terms {
+			if t != "" && strings.Contains(low, strings.ToLower(t)) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }
 
 // promptBenchProbe runs the same two steps the hook runs: extract terms, then
 // ask the index for this project's sessions ranked by them. Anything the hook
 // would discard downstream is discarded here too, so the number reported is
 // what a user would actually see.
+
 func promptBenchProbe(dir, project, chainID string, terms []string) (fired, correct bool) {
 	if !promptTermsWorthAsking(terms) {
 		return false, false

--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -281,9 +281,9 @@ func shownLineCarriesATerm(dir, project string, terms []string) bool {
 		if !strings.HasPrefix(line, "- User:") && !strings.HasPrefix(line, "- Assistant:") {
 			continue
 		}
-		low := strings.ToLower(line)
 		for _, t := range terms {
-			if t != "" && strings.Contains(low, strings.ToLower(t)) {
+			// The same rule the block was built with, from the same function.
+			if t != "" && search.TextCarriesTerm(line, t) {
 				return true
 			}
 		}

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -47,6 +47,9 @@ const PromptBucketProject = promptBucketProject
 // actually decided each question, so the benchmark can see which wins.
 const promptHaystackProject = "promptbenchhaystack"
 
+// promptRussianProject holds every Russian chain, so they compete.
+const promptRussianProject = "promptbenchru"
+
 // PromptHaystackProject is that project, exported so the benchmark can ask it
 // a question it never answered.
 const PromptHaystackProject = promptHaystackProject
@@ -64,6 +67,21 @@ type promptTopic struct {
 
 // Each topic is one short word plus the sentence a session would record and
 // the question someone would ask about it months later.
+// promptRussianTopics are the same shape as the English ones, with the filler
+// a person actually types around the subject. The session they answer opens
+// with filler too, so a filler term would match the wrong line as well as the
+// wrong session.
+func promptRussianTopics() []promptTopic {
+	return []promptTopic{
+		{"вебхук", "повторную доставку вебхука ограничили тремя попытками",
+			"напомни, сколько попыток у повторной доставки вебхука, и что делать дальше"},
+		{"шардирование", "шардирование по клиенту заменили на шардирование по региону",
+			"погоди, а по чему у нас в итоге шардирование, покажи ещё раз"},
+		{"индексация", "индексацию перенесли в фоновый воркер после записи",
+			"подожди, где именно теперь происходит индексация, объясни снова"},
+	}
+}
+
 func promptTopics() []promptTopic {
 	return []promptTopic{
 		{"etag", "the stale etag reuse was replaced with generation checks", "why did we replace the stale etag reuse?"},
@@ -222,6 +240,43 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			Messages: []model.Message{{Role: "user", Text: "we decided prepared statements go behind pgbouncer in session mode", Time: answer}},
 		}},
 	})
+	// Questions in Russian, asked the way they are actually typed: an
+	// interjection, a request verb, and the subject somewhere in the middle.
+	// They share one project so the filler-heavy openings of the others
+	// compete, and they guard the filler list against being over-extended —
+	// one subject word added by mistake and the question goes unanswered.
+	for i, ru := range promptRussianTopics() {
+		id := fmt.Sprintf("prompt-ru-%02d", i)
+		// One project for all three, so the filler-heavy openings of the other
+		// two compete: a filler term matches a filler line, and with nothing
+		// to compete against it the right session wins anyway and the defect
+		// stays invisible.
+		project := promptRussianProject
+		t := base.Add(time.Duration(2000+i*10) * time.Minute)
+		msgs := []model.Message{
+			{Role: "user", Text: "погоди, а что там дальше по задаче", Time: t},
+			{Role: "assistant", Text: "смотрю, сейчас продолжу", Time: t.Add(time.Minute)},
+		}
+		for k := 0; k < 40; k++ {
+			at := t.Add(time.Duration(k+2) * time.Minute)
+			msgs = append(msgs,
+				model.Message{Role: "user", Text: "давай дальше, покажи ещё раз", Time: at},
+				model.Message{Role: "assistant", Text: "снова прогнал и поправил", Time: at.Add(time.Second)},
+			)
+		}
+		msgs = append(msgs, model.Message{
+			Role: "assistant", Text: "решили: " + ru.fact,
+			Time: t.Add(200 * time.Minute),
+		})
+		chains = append(chains, PromptChain{
+			ID: id, Project: project, Kind: "russian",
+			Topic: ru.word, Question: ru.question,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: project,
+				Started: t, Updated: t.Add(200 * time.Minute), Messages: msgs,
+			}},
+		})
+	}
 	// The haystack. Measured on a frozen copy of a real index 2026-08-20: of 45
 	// live prompts, 33 were answered by one session of 38131 messages and 11 by
 	// one of 29190 — the two largest in the index, in order of size, for

--- a/internal/bench/prompt_test.go
+++ b/internal/bench/prompt_test.go
@@ -22,7 +22,7 @@ func TestGeneratePromptShape(t *testing.T) {
 		// would make a query match two chains and blur the measurement; the
 		// bucket exists to measure exactly that condition — a scope holding
 		// several unrelated pieces of work and not the answer.
-		if c.Kind != "bucket" && c.Kind != "haystack" && c.Kind != "haystack-noise" {
+		if c.Kind != "bucket" && c.Kind != "haystack" && c.Kind != "haystack-noise" && c.Kind != "russian" {
 			if projects[c.Project] {
 				t.Fatalf("project %q shared by two chains; a query would match both", c.Project)
 			}

--- a/internal/prompt/cyrillic_filler_test.go
+++ b/internal/prompt/cyrillic_filler_test.go
@@ -1,0 +1,65 @@
+package prompt
+
+import (
+	"strings"
+	"testing"
+)
+
+// The English filler list covers its own language: a question built from
+// "can you run the tests again" recalls nothing. The Russian one did not, so
+// the same question asked in Russian carried its filler into ranking — and a
+// filler term matches a filler line, which then takes the slot the reader sees
+// first.
+//
+// Measured on live prompts from this machine: about a third of the terms
+// extracted from a Russian question were words like these.
+func TestCyrillicFillerLeavesOnlyTheSubject(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		prompt  string
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "a question with one real subject",
+			prompt:  "напомни, что мы уже выясняли про can шину на omoda через adb, и что делать дальше",
+			want:    []string{"omoda"},
+			notWant: []string{"напомни", "выясняли", "через", "дальше"},
+		},
+		{
+			name:    "an interjection and a request verb",
+			prompt:  "подожди impl1084 и покажи замер RSS",
+			want:    []string{"impl1084"},
+			notWant: []string{"подожди", "покажи"},
+		},
+		{
+			// Straight from a live prompt: "нужно снова заняться фильтрацией
+			// telegram прокси по quality score".
+			name:    "adverbs of repetition and time",
+			prompt:  "нужно снова заняться фильтрацией telegram прокси, теперь потом опять проверим",
+			want:    []string{"telegram"},
+			notWant: []string{"снова", "теперь", "потом", "опять"},
+		},
+		{
+			name:    "attention words at the front",
+			prompt:  "погоди, смотри, а в singbox можно такой же роутинг сделать",
+			want:    []string{"singbox"},
+			notWant: []string{"погоди", "смотри"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Terms(tc.prompt)
+			joined := " " + strings.Join(got, " ") + " "
+			for _, w := range tc.want {
+				if !strings.Contains(joined, " "+w+" ") {
+					t.Errorf("the subject %q was dropped: %v", w, got)
+				}
+			}
+			for _, w := range tc.notWant {
+				if strings.Contains(joined, " "+w+" ") {
+					t.Errorf("filler %q survived as a term: %v", w, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -160,6 +160,23 @@ var cyrPromptStop = map[string]bool{
 	"давай": true, "было": true, "были": true, "будет": true, "быть": true,
 	"есть": true, "нет": true, "если": true, "или": true, "как": true,
 	"что": true, "где": true, "там": true, "тут": true, "уже": true, "ещё": true,
+	// Measured on live prompts from this machine: about a third of the terms
+	// extracted from a Russian question were words like these, and in the worst
+	// case four of five — `напомни, что мы уже выясняли про can шину на omoda
+	// через adb` yielded [omoda напомни выясняли через дальше]. A filler term
+	// is not harmless: it matches a filler line, and that line then takes the
+	// slot the reader sees first.
+	//
+	// The English half of this list covers its own language well — the negative
+	// controls built from "can you run the tests again" fire on nothing. These
+	// are the Russian equivalents of exactly those words.
+	"погоди": true, "подожди": true, "смотри": true, "слушай": true,
+	"напомни": true, "покажи": true, "ответь": true, "скажи": true,
+	"объясни": true, "проверь": true, "дальше": true, "через": true,
+	"снова": true, "опять": true, "потом": true, "теперь": true,
+	"вообще": true, "своего": true, "свои": true, "текущую": true,
+	"текущий": true, "хочу": true, "можешь": true, "нашел": true,
+	"нашёл": true, "выясняли": true, "разбирались": true,
 }
 
 // Candidates is how many ranked sessions the hook asks for before

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -226,9 +226,19 @@ func autoRecallSession(s model.Session, now time.Time, provenance bool) string {
 }
 
 // termHits counts how many distinct query terms a text carries. It decides
-// which lines of a matched session are worth showing, so it folds case and
-// nothing else: a term the ranking reached through a stem fold is not found
-// here, which costs that line its place and never costs correctness.
+// which lines of a matched session are worth showing.
+//
+// Case folding alone was not enough. The ranking reaches a session through a
+// stem fold, and this did not: asked "где именно теперь происходит индексация",
+// the ranking found the session that says "индексацию перенесли в фоновый
+// воркер" and this found no line in it, so the block fell back to the top of
+// the transcript and showed "погоди, а что там дальше по задаче". The comment
+// here used to say that costs the line its place and never costs correctness —
+// it costs the reader the whole block.
+//
+// So a long term also matches on its stem: inflection changes the ending, not
+// the first several characters. Short terms keep the exact rule, where a
+// trimmed prefix would match far too much.
 func termHits(text string, terms []string) int {
 	if len(terms) == 0 {
 		return 0
@@ -236,11 +246,43 @@ func termHits(text string, terms []string) int {
 	low := strings.ToLower(text)
 	n := 0
 	for _, t := range terms {
-		if t != "" && strings.Contains(low, strings.ToLower(t)) {
+		if t == "" {
+			continue
+		}
+		if strings.Contains(low, strings.ToLower(t)) {
+			n++
+			continue
+		}
+		if stem := termStem(t); stem != "" && strings.Contains(low, stem) {
 			n++
 		}
 	}
 	return n
+}
+
+// termStemMin is how long a term must be before its ending may be trimmed.
+// Deliberately not a stemmer: deja indexes a dozen languages and a real one for
+// each is a different project. Dropping two characters covers the case endings
+// that made the difference here without letting "index" match "indeed".
+const termStemMin = 7
+
+// TextCarriesTerm reports whether a line holds a term, folding case and, for a
+// long term, its inflected endings. Exported so a caller scoring what the
+// block shows applies the same rule the block was built with — the two drifted
+// once already, in the gate, and the benchmark then measured a bar the product
+// did not have.
+func TextCarriesTerm(text, term string) bool {
+	return termHits(text, []string{term}) > 0
+}
+
+// termStem is a term with its last two characters dropped, or empty when the
+// term is too short for that to still identify it.
+func termStem(t string) string {
+	r := []rune(strings.ToLower(t))
+	if len(r) < termStemMin {
+		return ""
+	}
+	return string(r[:len(r)-2])
 }
 
 func autoRecallSessionFor(s model.Session, now time.Time, provenance bool, terms []string) string {

--- a/internal/search/term_stem_test.go
+++ b/internal/search/term_stem_test.go
@@ -1,0 +1,38 @@
+package search
+
+import "testing"
+
+// A term long enough to survive losing its ending matches the inflected forms
+// of itself; a short one does not, because a trimmed prefix of it would match
+// half the language. The ranking reaches sessions through a stem fold and the
+// digest did not, so a question about "индексация" found no line in the session
+// that says "индексацию" and the block fell back to the top of the transcript.
+func TestTermStemMatchesInflectionAndNotEverything(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		text string
+		term string
+		want bool
+	}{
+		{"the same form", "индексацию перенесли в воркер", "индексацию", true},
+		{"an inflected ending", "индексацию перенесли в воркер", "индексация", true},
+		{"another case ending", "решение про индексации приняли вчера", "индексация", true},
+		// Short terms keep the exact rule: "index" trimmed to "ind" would sit
+		// inside "indeed", "independent" and a hundred others.
+		{"a short term is not trimmed", "indeed we shipped it", "index", false},
+		{"a short term still matches exactly", "the index was rebuilt", "index", true},
+		// Same root, different ending, is the point of the trim: "migrating"
+		// and "migration" are one topic.
+		{"a long term matches its own root", "the migration ran", "migrating", true},
+		// Trimming must not reach so far that a shorter unrelated word inside
+		// the same family collides.
+		{"a long term does not match a stranger", "документ подписан вчера", "документация", false},
+		{"an empty term matches nothing", "anything at all", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TextCarriesTerm(tc.text, tc.term); got != tc.want {
+				t.Errorf("TextCarriesTerm(%q, %q) = %v, want %v", tc.text, tc.term, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The prompt filler list covers English well — negative controls built from "can you run the tests again" fire on nothing. The Russian half had the closed class (`который`, `потому`, `чтобы`) and stopped there.

Measured on live prompts from a real machine: about a third of the terms extracted from a Russian question were filler, and in the worst case four of five.

```
напомни, что мы уже выясняли про can шину на omoda через adb, и что делать дальше
  before: [omoda напомни выясняли через дальше]
  after:  [omoda]

подожди impl1084 и покажи замер RSS
  before: [impl1084 подожди покажи замер]
  after:  [impl1084 замер]
```

This is not cosmetic. A filler term matches a filler line, and that line then takes the slot the reader sees first: the same query recalled a session that genuinely holds nine mentions of `omoda`, and opened the block with `продолжай дальше` — matched on `дальше`.

Live effect, 45 prompts from real transcripts against a frozen index: fire rate 100% → 93%. The three that fell silent are the ones whose question carried no subject at all once the filler was gone. Same three sessions recalled, same distribution otherwise.

Benchmarks unchanged: real 11/12 precision 1.00, negatives 0 false fires, haystack 3/3, `bench recall` 1.00, `bench context` 294 tokens at coverage 1.00. The corpus is English, so this does not move it — which is itself the point.

4 mutations, all caught. One needed the test extended rather than counted: the adverbs (`снова`, `теперь`, `потом`, `опять`) were not covered by any case, so removing them changed nothing.

Words added are the ones actually observed in live prompts plus close variants — attention words, request verbs, adverbs of repetition, and two prepositions. The list governs prompt terms only; `search.IsStopWord` is untouched, so a word typed on purpose in a search still matches.