### PR TITLE
fix(recall): a full stop is not part of the word before it

### DIFF
--- a/internal/prompt/cyrillic_filler_test.go
+++ b/internal/prompt/cyrillic_filler_test.go
@@ -63,3 +63,61 @@ func TestCyrillicFillerLeavesOnlyTheSubject(t *testing.T) {
 		})
 	}
 }
+
+// A word at the end of a sentence arrives with its full stop attached. The dot
+// then does two things at once: it marks the token as an identifier, so the
+// term counts as one, and it stops the term from ever matching the text, which
+// spells the word without it. Measured on a live prompt: "quality score. с чего
+// начать" produced the term "score.", which matched nothing anywhere while
+// still earning the recall its place.
+func TestTermsTrimSentencePunctuationButKeepPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		prompt  string
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "a full stop is not part of the word",
+			prompt:  "нужно заняться фильтрацией telegram прокси по quality score. с чего начать",
+			want:    []string{"score"},
+			notWant: []string{"score."},
+		},
+		{
+			// The dot inside is what makes these one word, and trimming the
+			// edges must not reach them.
+			name:   "an address keeps its dots",
+			prompt: "4 поду подняли 109.120.139.223 подключай ее в кластер",
+			want:   []string{"109.120.139.223"},
+		},
+		{
+			// A directory named mid-sentence keeps a trailing separator, and a
+			// flag quoted mid-sentence keeps a trailing dash. Neither belongs
+			// to the word.
+			name:    "a trailing separator is not part of the word",
+			prompt:  "посмотри в cmd/deja/, там баг с флагом --verbose-",
+			want:    []string{"cmd/deja"},
+			notWant: []string{"cmd/deja/"},
+		},
+		{
+			name:   "a path keeps its slashes and extension",
+			prompt: "посмотри cmd/deja/hook_prompt.go и main.go, там баг",
+			want:   []string{"cmd/deja/hook_prompt.go", "main.go"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Terms(tc.prompt)
+			joined := " " + strings.Join(got, " ") + " "
+			for _, w := range tc.want {
+				if !strings.Contains(joined, " "+w+" ") {
+					t.Errorf("%q is missing from the terms: %v", w, got)
+				}
+			}
+			for _, w := range tc.notWant {
+				if strings.Contains(joined, " "+w+" ") {
+					t.Errorf("%q survived as a term: %v", w, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -40,6 +40,16 @@ func Terms(prompt string) []string {
 		return len(out) == 6
 	}
 	for _, f := range fields {
+		// A word at the end of a sentence arrives with its full stop attached,
+		// and the dot then does two things at once: it marks the token as an
+		// identifier, so "score." counts as one, and it stops the token from
+		// ever matching the text, which says "score". Measured on live prompts:
+		// "quality score. с чего начать" yielded the term "score.", which
+		// matched nothing anywhere while still earning the recall its place.
+		//
+		// Only the edges are trimmed. A dot inside a token is what makes an IP
+		// address, a version or a filename one word.
+		f = strings.Trim(f, "._-/")
 		if len(f) < 3 || query.IsStopWord(f) || seen[f] || !techTerm(f) {
 			continue
 		}


### PR DESCRIPTION
Taking the blocks that open on a line carrying none of the terms they were found by, and reading them one at a time, the first thing that fell out was punctuation:

```
нужно снова заняться фильтрацией telegram прокси по quality score. с чего начать
  terms: [telegram quality score. заняться фильтрацией прокси]
```

`score.` does two things at once. The dot marks the token as an identifier — that is how paths and versions are recognised — so it counts toward the bar that decides whether to recall at all. And it can never match the text, which says `score`. A term that earns the recall its place and then contributes nothing to what is shown.

Only the edges are trimmed, because a dot *inside* a token is what makes an IP address or a filename one word:

```
109.120.139.223            unchanged
cmd/deja/hook_prompt.go    unchanged
cmd/deja/,                 -> cmd/deja
```

Live, on a frozen copy of a real index, 45 prompts from real transcripts: blocks whose first shown line carries one of the terms the session was found by go 34/42 → 35/42, 81% → 83%. Small, and in the right direction.

Benchmarks unchanged: real 11/12, russian 3/3, shown_line 14/14, negatives 0 false fires, haystack 3/3, `bench recall` 1.00, `bench context` 294 tokens at coverage 1.00.

3 mutations, all caught. One needed the test extended rather than counted: trimming only dots looked identical until a case with a trailing separator existed (`посмотри в cmd/deja/, там`).

The remaining 17% is not this. Reading those blocks, the pattern is a long unrelated `user:` line winning the question slot — same shape as #1439 but through a different path, since that fix only covers the case where nothing matched at all.