### PR TITLE
fix(recall): cut a shown line around the match, not from its start

### DIFF
--- a/internal/search/question_slot_test.go
+++ b/internal/search/question_slot_test.go
@@ -1,0 +1,81 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A shown line is cut to fit, and it used to be cut from the start. On a long
+// line that put the answer outside the excerpt: measured on a real store, a
+// question about "hermes" recalled the session that discusses it and displayed
+// a hundred and sixty characters of something else, because the word sat
+// further along. The reader judges the block by that line.
+func TestShownLineKeepsThePartThatMatched(t *testing.T) {
+	lead := strings.Repeat("не трогай локальный git и жди завершения задачи, ", 8)
+	line := lead + "дальше подними hermes на mini и проверь"
+
+	t.Run("without terms the cut stays at the front", func(t *testing.T) {
+		got := lineAround(line, 160, nil)
+		if !strings.HasPrefix(got, "не трогай") {
+			t.Errorf("the plain cut moved: %q", got)
+		}
+		if strings.Contains(got, "hermes") {
+			t.Errorf("nothing asked for hermes, so nothing should have gone looking for it: %q", got)
+		}
+	})
+
+	t.Run("with terms the excerpt holds the match", func(t *testing.T) {
+		got := lineAround(line, 160, []string{"hermes", "mini"})
+		if !strings.Contains(got, "hermes") {
+			t.Errorf("the excerpt was cut before the word it matched on: %q", got)
+		}
+		if !strings.HasPrefix(got, "…") {
+			t.Errorf("an excerpt taken from the middle has to say so: %q", got)
+		}
+		if r := []rune(got); len(r) > 200 {
+			t.Errorf("the excerpt outgrew its budget: %d characters", len(r))
+		}
+		// A little of what came before, so the match reads as part of a
+		// sentence rather than starting mid-thought.
+		before, _, _ := strings.Cut(got, "hermes")
+		if len([]rune(strings.TrimPrefix(before, "…"))) < 10 {
+			t.Errorf("the excerpt begins at the match with no run-up: %q", got)
+		}
+	})
+
+	t.Run("a match inside the window keeps the front", func(t *testing.T) {
+		short := "подними hermes на mini " + lead
+		got := lineAround(short, 160, []string{"hermes"})
+		if strings.HasPrefix(got, "…") {
+			t.Errorf("the excerpt moved for a match that was already visible: %q", got)
+		}
+	})
+
+	t.Run("a line that fits is left alone", func(t *testing.T) {
+		if got := lineAround("подними hermes", 160, []string{"hermes"}); got != "подними hermes" {
+			t.Errorf("a short line was rewritten: %q", got)
+		}
+	})
+}
+
+// End to end, through the block the hook injects: a long question whose
+// matching words sit past the cut has to be shown with them.
+func TestBlockShowsTheMatchingPartOfALongQuestion(t *testing.T) {
+	start := time.Date(2026, 6, 2, 9, 0, 0, 0, time.UTC)
+	lead := strings.Repeat("не трогай локальный git и жди завершения задачи, ", 8)
+	s := model.Session{
+		ID: "long-q", Harness: "claude", Project: "proj",
+		Started: start, Updated: start.Add(time.Hour),
+		Messages: []model.Message{
+			{Role: "user", Text: lead + "дальше подними hermes на mini и проверь", Time: start},
+			{Role: "assistant", Text: "поднял, работает", Time: start.Add(time.Minute)},
+		},
+	}
+	got := AutoRecallDigestFor([]model.Session{s}, 2000, []string{"hermes", "mini"})
+	if !strings.Contains(got, "hermes") {
+		t.Errorf("the question line was shown without the words it matched on:\n%s", got)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -420,10 +420,10 @@ func matchedLines(s model.Session, terms []string) (string, []string) {
 		switch m.Role {
 		case "user":
 			if !noiseMessage(m.Text) && hits > bestUser.hits {
-				bestUser = scored{i, hits, firstLine(text, 160)}
+				bestUser = scored{i, hits, lineAround(text, 160, terms)}
 			}
 		case "assistant":
-			assistants = append(assistants, scored{i, hits, firstLine(text, 220)})
+			assistants = append(assistants, scored{i, hits, lineAround(text, 220, terms)})
 		}
 	}
 	sort.SliceStable(assistants, func(i, j int) bool { return assistants[i].hits > assistants[j].hits })
@@ -567,12 +567,64 @@ func noiseMessage(s string) bool {
 func digestLine(s string) string { return SafeLine(s) }
 
 func firstLine(s string, n int) string {
+	return lineAround(s, n, nil)
+}
+
+// lineAround shortens a line to n characters, keeping the part that matched
+// rather than the part that came first.
+//
+// Cutting from the start was how a line that genuinely answered the question
+// came to be shown without the answer in it: measured on a real store, a
+// question about "hermes" and "mini" recalled the session that discusses both
+// and displayed "Домёржь PR и веди #1084 + A. Репо …", because the words sat
+// past the hundred-and-sixtieth character. The reader sees a line about
+// something else and stops reading the block.
+func lineAround(s string, n int, terms []string) string {
 	s = strings.Join(strings.Fields(s), " ")
 	r := []rune(s)
 	if len(r) <= n {
 		return s
 	}
-	return strings.TrimSpace(string(r[:n])) + "…"
+	at := -1
+	low := strings.ToLower(s)
+	for _, t := range terms {
+		if t == "" {
+			continue
+		}
+		i := strings.Index(low, strings.ToLower(t))
+		if i < 0 {
+			if stem := termStem(t); stem != "" {
+				i = strings.Index(low, stem)
+			}
+		}
+		if i >= 0 && (at < 0 || i < at) {
+			at = len([]rune(s[:i]))
+		}
+	}
+	// Nothing matched, or it matched inside the window anyway: the old cut is
+	// the right one.
+	if at < 0 || at < n {
+		return strings.TrimSpace(string(r[:n])) + "…"
+	}
+	// A little before the match, so the reader lands on a phrase rather than
+	// mid-word, and the rest of the budget after it.
+	const lead = 40
+	start := at - lead
+	if start < 0 {
+		start = 0
+	}
+	end := start + n
+	if end > len(r) {
+		end = len(r)
+	}
+	out := strings.TrimSpace(string(r[start:end]))
+	if start > 0 {
+		out = "…" + out
+	}
+	if end < len(r) {
+		out += "…"
+	}
+	return out
 }
 
 // smokeAnswerMax is how short a reply has to be to read as a token rather than


### PR DESCRIPTION
A line in a recall block is shortened to fit, and it was shortened from the front. On a long line that puts the match outside the excerpt.

Measured on a frozen copy of a real index — a question about `hermes` and `mini` recalled the session that discusses both, and displayed:

```
- User: Домёржь PR и веди #1084 + A. Репо /Users/shulcz/coding/goprojects/deja-vu. ВАЖНО: субагент impl10…
```

The words are in that line, further along than the hundred and sixtieth character. The reader judges the block by what is on screen, and what is on screen is about something else.

The excerpt now centres on the first term it can find, with forty characters of run-up so it reads as part of a sentence, and says `…` on whichever side it cut. A match already inside the window keeps the old cut, and a line short enough to fit is untouched.

Live, 45 prompts from real transcripts: blocks whose first shown line carries one of the terms the session was found by go 34/42 → 36/42, **81% → 86%**.

Benchmarks unchanged: real 11/12, russian 3/3, shown_line 14/14, negatives 0 false fires, `bench recall` 1.00, `bench context` 294 tokens at coverage 1.00.

4 mutations, all caught. Two needed the tests extended rather than counted: starting the excerpt exactly at the match was indistinguishable until a case checked for the run-up, and passing no terms to the question line was invisible until a test went through `AutoRecallDigestFor` rather than calling the helper directly.

Also here: the hypothesis I started with was wrong. I expected an unrelated question to be winning the slot on a single weak hit, built that case, and it passed on the first run — the ranking picks the right line. The defect was one step later, in how that line is displayed.