### PR TITLE
fix(recall): narrow a long session by the same rule the block is built with

### DIFF
--- a/cmd/deja/focus_stem_test.go
+++ b/cmd/deja/focus_stem_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A long session is narrowed to the neighbourhood of its matches before the
+// block is built, and that narrowing matched exact forms only. The ranking
+// reaches the session through a stem fold and the digest shows a line through
+// one too, so the narrowing was the one step still spelling the word the way
+// the question happened to spell it — and when it found nothing it dropped the
+// session whole.
+//
+// Measured on a frozen copy of a real index: every block that opened on a line
+// carrying none of its terms was for a session that does hold such a line.
+func TestFocusKeepsAnInflectedMatch(t *testing.T) {
+	start := time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC)
+	msgs := make([]model.Message, 0, dejaVuMaxMessages+4)
+	for i := 0; i < dejaVuMaxMessages+2; i++ {
+		at := start.Add(time.Duration(i) * time.Minute)
+		msgs = append(msgs, model.Message{Role: "user", Text: "продолжай дальше", Time: at})
+	}
+	// The only mention, and in another case than the question asks in.
+	msgs = append(msgs, model.Message{
+		Role: "assistant",
+		Text: "решили: индексацию перенесли в фоновый воркер после записи",
+		Time: start.Add(time.Duration(len(msgs)) * time.Minute),
+	})
+
+	s := model.Session{
+		ID: "focus-1", Harness: "claude", Project: "proj",
+		Started: start, Updated: start.Add(time.Duration(len(msgs)) * time.Minute), Messages: msgs,
+	}
+	got := focusSession(s, []string{"индексация"})
+	if len(got.Messages) == 0 {
+		t.Fatal("the session was dropped whole because the question spelled the word in another case")
+	}
+	found := false
+	for _, m := range got.Messages {
+		if m.Text == "решили: индексацию перенесли в фоновый воркер после записи" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("narrowing kept %d messages and threw away the only one that answers", len(got.Messages))
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -608,10 +608,14 @@ func focusSession(s model.Session, terms []string) model.Session {
 	const window = 2
 	keep := map[int]bool{}
 	for i, m := range s.Messages {
-		text := strings.ToLower(m.Text)
 		hits := 0
 		for _, t := range terms {
-			if strings.Contains(text, strings.ToLower(t)) {
+			// The same rule the block is built with. This step spelled the
+			// word the way the question happened to spell it, while the
+			// ranking that chose the session and the digest that shows a line
+			// from it both fold the ending — so a session whose only mention
+			// was in another case was narrowed to nothing and dropped whole.
+			if search.TextCarriesTerm(m.Text, t) {
 				hits++
 			}
 		}


### PR DESCRIPTION
A session longer than three hundred messages is narrowed to the neighbourhood of its matches before the block is built. That step matched exact forms only, while the ranking that chose the session and the digest that shows a line from it both fold the ending. When it found nothing it did not narrow — it dropped the session whole and the hook moved on to a worse one.

```
question: индексация
session:  "решили: индексацию перенесли в фоновый воркер"
narrowed: nothing at all
```

The measurement that pointed here came first: of the blocks that opened on a line carrying none of their terms, **all five** were for sessions that do hold such a line. Nothing needed to change about what is shown — only about what is looked at.

Live, 45 prompts from real transcripts against a frozen index: blocks whose first shown line carries one of the terms the session was found by go 36/42 → 37/42, **86% → 88%**.

Benchmarks unchanged: real 11/12, russian 3/3, shown_line 14/14, negatives 0 false fires, haystack 3/3, `bench recall` 1.00, `bench context` 294 tokens at coverage 1.00.

2 mutations, both caught.

This is the fourth place where two sides of the same question were answered by different rules — after the hook and the benchmark disagreeing on the bar, the digest and the index disagreeing on what a word is, and the excerpt being cut before the part that matched. The remaining four blocks are the same family and the ceiling for them is measured: every one is reachable.