### PR TITLE
fix(recall): a term is a mention where a word begins

### DIFF
--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -249,15 +249,80 @@ func termHits(text string, terms []string) int {
 		if t == "" {
 			continue
 		}
-		if strings.Contains(low, strings.ToLower(t)) {
+		if containsWord(low, strings.ToLower(t)) {
 			n++
 			continue
 		}
-		if stem := termStem(t); stem != "" && strings.Contains(low, stem) {
+		// The stem is checked the same way: it may run on to the right, that
+		// being the ending it exists for, but it still has to start a word.
+		// Without that "индексация" matched inside "переиндексацию".
+		if stem := termStem(t); stem != "" && containsWord(low, stem) {
 			n++
 		}
 	}
 	return n
+}
+
+// wholeWordMax is how short a term has to be before it must be a whole word.
+//
+// Traced by instrumenting the matcher on a real store: "mini" scored a hit on
+// "cron minimum granularity is 1 minute", and that row of a table then won the
+// slot the reader sees first. A word of four letters or fewer sits inside too
+// many others to be trusted as a fragment.
+//
+// Deliberately low. Requiring it of everything below seven characters was
+// measured too: it cost the benchmark 14/14 -> 13/14 and the live rate 88% ->
+// 86%, because "hermes", "score" and "tick" legitimately appear inside longer
+// words the reader wants.
+const wholeWordMax = 4
+
+// containsWord finds a term where a word starts. A short one must end there
+// too; a longer one may run on, which is what an ending or a compound looks
+// like — "hermes/config", "индексацию".
+func containsWord(text, term string) bool {
+	if term == "" {
+		return false
+	}
+	whole := len([]rune(term)) <= wholeWordMax
+	for at := 0; ; {
+		i := strings.Index(text[at:], term)
+		if i < 0 {
+			return false
+		}
+		i += at
+		startsWord := !wordRuneBefore(text, i)
+		endsWord := !whole || !wordRuneAt(text, i+len(term))
+		if startsWord && endsWord {
+			return true
+		}
+		at = i + 1
+		if at >= len(text) {
+			return false
+		}
+	}
+}
+
+// wordRuneBefore and wordRuneAt decode whole runes: indexing a byte lands in
+// the middle of a Cyrillic letter and reads it as punctuation.
+func wordRuneBefore(text string, i int) bool {
+	if i <= 0 {
+		return false
+	}
+	r, _ := utf8.DecodeLastRuneInString(text[:i])
+	return isWordRune(r)
+}
+
+func wordRuneAt(text string, i int) bool {
+	if i >= len(text) {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(text[i:])
+	return isWordRune(r)
+}
+
+func isWordRune(r rune) bool {
+	return r == '_' || (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z') || r >= 0x400
 }
 
 // termStemMin is how long a term must be before its ending may be trimmed.

--- a/internal/search/term_stem_test.go
+++ b/internal/search/term_stem_test.go
@@ -36,3 +36,36 @@ func TestTermStemMatchesInflectionAndNotEverything(t *testing.T) {
 		})
 	}
 }
+
+// A term is a mention where a word begins. Traced by instrumenting the matcher
+// on a real store: "mini" scored a hit on "cron minimum granularity is 1
+// minute", and that row of a table then won the slot the reader sees first.
+//
+// Short terms must also end the word. Requiring that of everything under seven
+// characters was measured and cost more than it saved — the benchmark went
+// 14/14 to 13/14 and the live rate 88% to 86%, because "hermes", "score" and
+// "tick" belong inside longer words. Four characters is where the trade turns.
+func TestTermIsAMentionWhereAWordBegins(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		text string
+		term string
+		want bool
+	}{
+		{"a short term inside a longer word", "cron minimum granularity is 1 minute", "mini", false},
+		{"a short term as its own word", "подними mini и проверь", "mini", true},
+		{"a short term before punctuation", "файл mini.yaml на месте", "mini", true},
+		// Long enough to be trusted as a prefix: these read as one topic.
+		{"a longer term running on", "the scoreboard was rebuilt", "score", true},
+		{"a longer term after a separator", "смотри ~/.hermes/config", "hermes", true},
+		// The stem may run on to the right; it still has to start a word.
+		{"an inflected ending", "индексацию перенесли", "индексация", true},
+		{"a stem inside a longer word", "переиндексацию отложили", "индексация", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TextCarriesTerm(tc.text, tc.term); got != tc.want {
+				t.Errorf("TextCarriesTerm(%q, %q) = %v, want %v", tc.text, tc.term, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Instrumenting the matcher on a real store, rather than guessing at it, showed what was winning the slot the reader sees first:

```
CAND role=user hits=1
  raw="| `Ns` | treat as `ceil(N/60)m` | cron minimum granularity is 1 minute |"
```

The question was about a machine called `mini`. The hit is inside `minimum`, and that row of a table about cron then framed the whole block.

A term now counts where a word begins. A short one must end there too — four characters sit inside too many longer words to be trusted as a fragment. A longer one may run on, because that is what an ending or a compound looks like: `hermes/config`, `scoreboard`, `индексацию` for `индексация`. The stem path follows the same rule, without which `индексация` matched inside `переиндексацию`.

Where the threshold sits was measured, not chosen. Requiring whole words of everything under seven characters cost `shown_line` 14/14 → 13/14 and the live rate 88% → 86%, because `hermes`, `score` and `tick` belong inside longer words. At four, nothing moves down:

```
shown_line 14/14, real 11/12, russian 3/3, negatives 0 false fires
live 37/42 = 88%, unchanged
bench recall 1.00, bench context 294 tokens at coverage 1.00
```

So this removes a wrong match without buying it with a right one. The live rate does not improve, because the metric was counting that wrong match as a success too.

5 mutations, all caught — including reading the left edge as a byte, which is how `индексация` matched inside `переиндексацию` in the first draft: indexing a byte lands in the middle of a Cyrillic letter and reads it as punctuation.

This is the same shape as four other fixes tonight: two halves of one question answered by different rules. The counting and the excerpt window now share this one.
