### PR TITLE
test(bench): ask about another project's topic, not an invented word

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -47,10 +47,16 @@ func offTopicQuestions() []string {
 // The right answer is silence, and it is the one case tonight where firing
 // less often is the improvement.
 func absentSubjectQuestions() []string {
+	// The subjects are real topics of *other* projects in this corpus, not
+	// invented words. That is the live shape: measured on a real store,
+	// "айфоновский" appears in two sessions on this machine and in none of
+	// this project's, so the question is about work that happened elsewhere.
+	// A word that exists nowhere at all is a different and much weaker
+	// signal — nothing can answer it, here or anywhere.
 	return []string{
-		"did the kestrel timeout ever affect the zeppelin mast",
-		"how does escrow release interact with the anemometer",
-		"which parquet batch carried the quetzalcoatl rows",
+		"did the kestrel timeout ever affect the etag reuse",
+		"how does escrow release interact with the oauth rotation",
+		"which parquet batch carried the gzip streaming rows",
 	}
 }
 


### PR DESCRIPTION
The `absent_subject` questions asked about things that exist nowhere at all — a zeppelin mast, an anemometer, a quetzalcoatl. That is not the shape the arm was built for.

Measured on a real store, the live case is a subject this project has never held while the machine has:

```
term            this project   anywhere
айфоновский              0          2
раздачи                  0          5
интернета                0          5
hermes                   5          5
```

A word nobody has ever used is a weaker and different signal: nothing can answer it, here or anywhere, and the ordinary bar already handles most of those. A word that lives in another project is the one that says *this question is not about this repository* — and that is the case worth measuring.

The questions now name real topics of other chains in the corpus.

Arms unchanged: `absent_subject` still reads 3/3 with 3 false fires, real 11/12, russian 3/3, off_topic 3/3, shown_line 14/14, negatives 0.

No fix here. Two were tried against the old fixture and reverted, both with numbers in the journal: requiring the winning session to hold a rare word of the question (real 11/12 → 0/12), and gating on how many query terms the corpus knows (real → 7/12 or 9/12, and the Russian arm to 0/3 or 1/3, because an English corpus knows fewer of a Russian question's words by construction).

The signal that ought to work — the term exists in the index but not in this project's scope — does not yet show up in the benchmark: instrumenting the ranking, `termsKnown` and an in-scope count came out equal on every call, including with these questions. Until that distinction is visible here, there is nothing to build a rule on.
