### PR TITLE
test(bench): the words a long session is made of, not its subject

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -47,16 +47,24 @@ func offTopicQuestions() []string {
 // The right answer is silence, and it is the one case tonight where firing
 // less often is the improvement.
 func absentSubjectQuestions() []string {
-	// The subjects are real topics of *other* projects in this corpus, not
-	// invented words. That is the live shape: measured on a real store,
-	// "айфоновский" appears in two sessions on this machine and in none of
-	// this project's, so the question is about work that happened elsewhere.
-	// A word that exists nowhere at all is a different and much weaker
-	// signal — nothing can answer it, here or anywhere.
+	// The subject belongs to another project; the rest is the vocabulary a
+	// long working session is made of. That combination is the live shape,
+	// found by printing the candidates rather than reasoning about them:
+	//
+	//   q     = which branch was the oauth rotation on when the suite passed
+	//   terms = [branch oauth rotation suite passed]
+	//   cand  = the 1000-message noise session, matched=3 strong=3
+	//
+	// The subject contributes nothing. "branch", "suite" and "passed" carry
+	// the match, and the session that says them most often wins — which is
+	// whichever session is longest. Two earlier drafts of these questions
+	// measured something else: one joined the absent subject to a topic the
+	// project really holds, so answering was reasonable, and one used words
+	// that exist nowhere, where the hook already stays silent (0/3).
 	return []string{
-		"did the kestrel timeout ever affect the etag reuse",
-		"how does escrow release interact with the oauth rotation",
-		"which parquet batch carried the gzip streaming rows",
+		"did the etag reuse ever break the branch during a suite run",
+		"which branch was the oauth rotation on when the suite passed",
+		"does the gzip streaming touch the branch the suite builds",
 	}
 }
 


### PR DESCRIPTION
Three iterations went into guessing why the `absent_subject` arm fires and building rules against those guesses. All three were wrong. Printing the candidates answered it in one run:

```
q     = which branch was the oauth rotation on when the suite passed
terms = [branch oauth rotation suite passed]
cand  = the 1000-message noise session, matched=3 strong=3
```

The subject contributes nothing. `branch`, `suite` and `passed` carry the whole match — the vocabulary any long working session is made of — and the session that says them most often is whichever session is longest.

That is the live shape, and the arm was not measuring it. Two earlier drafts of these questions measured something else:

- joined the absent subject to a topic the project really holds (`kestrel timeout`), so the winner was the genuine kestrel session and answering was reasonable;
- used words that exist nowhere at all, where the hook already stays silent — `0/3` fired, no defect to see.

With the questions written as they are now, the arm discriminates: removing their ordinary words drops it from 3 fires to 2, and not counting a fire as false drops the false count to 0. Both mutations caught, where the previous version caught only one and I said so in its description.

Arms otherwise unchanged: real 11/12, russian 3/3, off_topic 3/3, shown_line 14/14, negatives 0 false fires, `bench recall` 1.00.

No fix here. What it points at is the same family as the Russian filler work merged earlier tonight — ordinary working vocabulary clearing a bar meant for words that identify something. The difference is that this time the evidence comes from the ranking's own candidates rather than from a theory about them.
