### PR TITLE
fix(recall): stop guessing which words are specific by counting letters

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -306,13 +306,13 @@ func measurePrompt(seed int64) (promptReport, error) {
 // opening line came from the top of a long transcript does not, and that line
 // is the whole frame an agent reads before deciding to ignore the rest.
 func shownLineCarriesATerm(dir, project string, terms []string) bool {
-	ranked, matched, strong, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, covered, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil {
 		return false
 	}
 	var keep []model.Session
 	for i, s := range ranked {
-		if !recallWorthShowing(terms, matched[i], strong[i]) {
+		if !recallWorthShowing(terms, matched[i], strong[i], covered) {
 			continue
 		}
 		keep = append(keep, s)
@@ -349,7 +349,7 @@ func promptBenchProbe(dir, project, chainID string, terms []string) (fired, corr
 	if !promptTermsWorthAsking(terms) {
 		return false, false
 	}
-	ranked, matched, strong, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, covered, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil {
 		return false, false
 	}
@@ -357,7 +357,7 @@ func promptBenchProbe(dir, project, chainID string, terms []string) (fired, corr
 		// The same bar the hook applies, from the same function — kept in one
 		// place because the two drifted: this one asked whether the query held
 		// an identifier, the hook asked whether the session did.
-		if !recallWorthShowing(terms, matched[i], strong[i]) {
+		if !recallWorthShowing(terms, matched[i], strong[i], covered) {
 			continue
 		}
 		if len(s.Messages) > dejaVuMaxMessages {

--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -209,7 +209,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 		}
 		// Filler that only exists to fill the bucket has no question of its
 		// own; it is asked about through the bucket-answer chain below.
-		if chain.Kind == "bucket" || chain.Kind == "haystack-noise" {
+		if chain.Kind == "bucket" || chain.Kind == "haystack-noise" || chain.Kind == "background" {
 			continue
 		}
 		terms := prompt.Terms(chain.Question)

--- a/cmd/deja/bench_prompt_test.go
+++ b/cmd/deja/bench_prompt_test.go
@@ -29,7 +29,7 @@ func TestPromptBenchCorpusIsMeasurable(t *testing.T) {
 		// asked about through the bucket-answer chain, whose question is the
 		// one that must go unanswered. A chain nobody asks about still has to
 		// earn its place, and this one earns it by being the wrong answer.
-		if c.Kind == "bucket" || c.Kind == "haystack-noise" {
+		if c.Kind == "bucket" || c.Kind == "haystack-noise" || c.Kind == "background" {
 			continue
 		}
 		if topics[c.Topic] {

--- a/cmd/deja/hook_earlier_attempt_test.go
+++ b/cmd/deja/hook_earlier_attempt_test.go
@@ -26,6 +26,7 @@ func TestHookPromptNamesTheEarlierAttempt(t *testing.T) {
 		`{"type":"user","sessionId":"newpass","timestamp":"2026-07-20T12:00:00Z","message":{"role":"user","content":"how many retries for the payment webhook"}}`,
 		`{"type":"assistant","sessionId":"newpass","timestamp":"2026-07-20T12:01:00Z","message":{"role":"assistant","content":[{"type":"text","text":"we cut the payment webhook retries to 3"}]}}`,
 	})
+	writeOrdinaryBackground(t, 100)
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -148,7 +148,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// Rank THIS project's sessions by how well they match the prompt terms
 	// (IDF-weighted), rather than reconstructing an AND query — natural
 	// prompts are full of filler that poisons an AND.
-	ranked, matched, strong, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, prompt.Candidates)
+	ranked, matched, strong, covered, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, prompt.Candidates)
 	if err != nil || len(ranked) == 0 {
 		return emitNudgeOnly(stdout, plain, nudge)
 	}
@@ -171,7 +171,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		// hook pays its cost on every message the user sends. Measured on
 		// cross-paired prompts whose answer is absent, the old bar injected on
 		// 94% of them; half of those rested on one ordinary word.
-		if !recallWorthShowing(terms, matched[i], strong[i]) {
+		if !recallWorthShowing(terms, matched[i], strong[i], covered) {
 			continue
 		}
 		if matched[i] >= 2 {
@@ -737,7 +737,7 @@ func weakRecallPointer(ss []model.Session, terms []string) string {
 // Measured by hand on ten real prompts against a frozen index: five were
 // answered with plainly unrelated work, none with silence, and every one of
 // those five rested on words that live in the project but never met.
-func recallWorthShowing(terms []string, matched, strong int) bool {
+func recallWorthShowing(terms []string, matched, strong, covered int) bool {
 	if matched < 1 {
 		return false
 	}
@@ -752,5 +752,13 @@ func recallWorthShowing(terms []string, matched, strong int) bool {
 	// store is open. Measured: the proxy calls "output", "command" and "adjust"
 	// identifiers and fires on "paste the output of that command", and the
 	// `matched >= 2` fallback fires on "adjust the patch and try again".
-	return strong >= 1
+	if strong < 1 {
+		return false
+	}
+	// The session has to account for every identifying word this project has an
+	// answer for. Holding only some of them is what a question that joins work
+	// nobody joined looks like: "did the kestrel timeout ever delay an escrow
+	// release" wins on kestrel and timeout while escrow and release were decided
+	// in another session entirely.
+	return covered == 0 || strong >= covered
 }

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -288,13 +289,47 @@ func promptTermsWorthAsking(terms []string) bool {
 // something that reads like a term of art — long, or shaped like a symbol.
 func hasIdentifierTerm(terms []string) bool {
 	for _, t := range terms {
-		if len(t) >= 6 {
+		// Letters, not bytes. Counting bytes read "omoda" as filler and every
+		// Cyrillic word of three letters as a term of art, because Cyrillic
+		// takes two bytes a letter. Measured on a real store: "напомни, что мы
+		// уже выясняли про can шину на omoda" reduces to one term, three
+		// sessions hold it, and nothing was recalled.
+		//
+		// Russian carries its meaning in shorter words — "сеть", "порт" name
+		// something the way a five-letter Latin word does — so the bar is one
+		// letter lower there.
+		n := utf8.RuneCountInString(t)
+		if (n >= 5 || (n >= 4 && hasCyrillic(t))) && !soleWorkingWord[t] {
 			return true
 		}
 		for _, r := range t {
 			if r == '_' || r == '.' || r == '/' || r == '-' || (r >= '0' && r <= '9') {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// soleWorkingWord is the ordinary vocabulary a session is made of, long enough
+// to pass the letter bar and carrying nothing on its own. The list is consulted
+// only here, where the store has not been opened yet: keeping it shut for a
+// lone filler word is worth 62ms of the 67ms such a prompt would otherwise
+// cost, measured against a real index. Once the store is open the ranking
+// decides on evidence and no list is needed.
+var soleWorkingWord = map[string]bool{
+	"tests": true, "test": true, "retry": true, "build": true, "error": true,
+	"errors": true, "check": true, "checks": true, "files": true, "patch": true,
+	"trace": true, "output": true, "command": true, "branch": true, "suite": true,
+	"commit": true, "commits": true, "deploy": true, "fixes": true, "again": true,
+	"there": true, "these": true, "those": true, "which": true, "where": true,
+}
+
+// hasCyrillic reports whether the term is written in Cyrillic.
+func hasCyrillic(t string) bool {
+	for _, r := range t {
+		if r >= 0x400 && r <= 0x4FF {
+			return true
 		}
 	}
 	return false

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -746,8 +746,11 @@ func recallWorthShowing(terms []string, matched, strong int) bool {
 	// applying all along while the hook applied only the first — measured on
 	// the corpus, the pair answers 11 of 12 real questions with no false fire,
 	// where the session-only rule answers 7 and fires on 2 controls.
-	if hasIdentifierTerm(terms) {
-		return true
-	}
-	return matched >= 2
+	// Whether the question named something specific is a guess when all we have
+	// is its words, and the index has already answered it — so use that instead
+	// of the length proxy `promptTermsWorthAsking` has to rely on before the
+	// store is open. Measured: the proxy calls "output", "command" and "adjust"
+	// identifiers and fires on "paste the output of that command", and the
+	// `matched >= 2` fallback fires on "adjust the patch and try again".
+	return strong >= 1
 }

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -247,7 +248,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	resp.HookSpecificOutput.HookEventName = "UserPromptSubmit"
 	resp.HookSpecificOutput.AdditionalContext = out
 	if showLine {
-		resp.SystemMessage = dejaVuLine(ss[0], terms...)
+		resp.SystemMessage = dejaVuLine(ss[0], viaTerms(out, terms)...)
 	}
 	if resp.SystemMessage == "" {
 		// No presentable topic — inject the context silently rather than
@@ -527,6 +528,38 @@ func recordDejaVuLine(path, sid string, now time.Time) bool {
 	return true
 }
 
+// viaTerms picks the three query terms the headline will name. Terms the block
+// underneath actually carries come first: the line is the reason given for the
+// recall, and naming words the reader cannot find below it reads as a misfire.
+// Measured on a real store, the block opened on a line carrying a term the
+// product used in 94 cases of 94, while the first three terms in extraction
+// order agreed with it in 71.
+func viaTerms(block string, terms []string) []string {
+	if len(terms) <= 3 {
+		return terms
+	}
+	out := make([]string, 0, 3)
+	for _, t := range terms {
+		if len(out) == 3 {
+			break
+		}
+		if search.TextCarriesTerm(block, t) {
+			out = append(out, t)
+		}
+	}
+	// Short of three, fill from the rest in the order they were asked, so the
+	// line still says what the question was about.
+	for _, t := range terms {
+		if len(out) == 3 {
+			break
+		}
+		if !slices.Contains(out, t) {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
 // dejaVuLine is the one visible line a déjà vu moment earns: which past
 // session answered, and how old it is.
 func dejaVuLine(s model.Session, terms ...string) string {
@@ -542,6 +575,8 @@ func dejaVuLine(s model.Session, terms ...string) string {
 	// visible reason reads as noise the first time it misfires.
 	why := ""
 	if len(terms) > 0 {
+		// Callers pass terms already chosen by viaTerms; the cap stays here so
+		// a caller that has not is still held to three.
 		if len(terms) > 3 {
 			terms = terms[:3]
 		}

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -263,6 +263,7 @@ func TestHookPromptSkipsMarathonSessions(t *testing.T) {
 	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-hay", "focus.jsonl"), "focus", []string{
 		`{"type":"user","sessionId":"focus","timestamp":"` + old + `","message":{"role":"user","content":"the quetzalcoatl stampede fix: jittered ttl"}}`,
 	})
+	writeOrdinaryBackground(t, 100)
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/stats"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
 )
 
 func TestHookPromptInjectsOnRelevantHit(t *testing.T) {
@@ -520,5 +521,26 @@ func TestDejaVuLineDoesNotClaimAPeersWorkAsYours(t *testing.T) {
 	// The rest of the line — the topic and why it fired — is unchanged.
 	if !strings.Contains(got, "ticker window") || !strings.Contains(got, "via: ticker") {
 		t.Errorf("the line lost what it is for: %q", got)
+	}
+}
+
+// The headline names three of the query's terms as the reason. They have to be
+// terms the block underneath actually carries: measured on a real store, the
+// block opened on a line carrying a term the product used in 94 cases of 94,
+// while the three words named above it agreed only 71 times.
+func TestTheHeadlineNamesTermsTheBlockCarries(t *testing.T) {
+	block := "- User: the pgbouncer prepared statement failures came back\n"
+	terms := []string{"deploy", "reboot", "pgbouncer", "statement"}
+	got := viaTerms(block, terms)
+	if len(got) == 0 {
+		t.Fatal("no terms chosen")
+	}
+	if !search.TextCarriesTerm(block, got[0]) {
+		t.Fatalf("headline leads with %q, which the block does not carry", got[0])
+	}
+	// Terms the block does not carry still get named once the carried ones run
+	// out — the line says what the question was about, not only what matched.
+	if len(got) != 3 {
+		t.Fatalf("via = %v, want three terms", got)
 	}
 }

--- a/cmd/deja/hook_prompt_window_test.go
+++ b/cmd/deja/hook_prompt_window_test.go
@@ -54,6 +54,7 @@ func TestTheHookLooksPastTheCandidatesItWillNotUse(t *testing.T) {
 		}
 	}
 
+	writeOrdinaryBackground(t, 100)
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -228,7 +228,7 @@ func commandDecisionLine(dir, cmd string) string {
 	if cwd == "" {
 		cwd, _ = os.Getwd()
 	}
-	ranked, matched, _, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, toolHookDecisionScan)
+	ranked, matched, _, _, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, toolHookDecisionScan)
 	if err != nil {
 		return ""
 	}

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -430,6 +431,52 @@ func writeClaudeFixture(t *testing.T, path, sessionID string, lines []string) {
 	_ = sessionID
 	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// ordinaryTalk is the vocabulary a working session is made of. Nothing in it
+// identifies anything, which is the point.
+var ordinaryTalk = []string{
+	"pushed the branch and ran the suite again",
+	"the suite passed after the last fix",
+	"rebased onto main and forced the check to rerun",
+	"the build failed on the first attempt",
+	"reverted that change and measured again",
+	"opened a draft and left it for review",
+	"the test was flaky so I ran it twice",
+	"merged it once the checks went green",
+	"looked at the diff and reduced the scope",
+	"the numbers came out the same as before",
+}
+
+// writeOrdinaryBackground fills the store with sessions of ordinary work, in
+// their own projects, so that "rare" means something.
+//
+// A fixture of two or three sessions cannot say which of its words identify
+// anything: in TestHookPromptSkipsMarathonSessions "quetzalcoatl" sits in both
+// sessions of a three-document index, which puts its idf at 0 — the most
+// specific word imaginable, scored as filler. Measured with a hundred ordinary
+// sessions behind it the same word scores 3.53 and the working phrases score
+// 2.24, which is the order a real store has.
+func writeOrdinaryBackground(t *testing.T, n int) {
+	t.Helper()
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	if root == "" {
+		t.Fatal("DEJA_CLAUDE_ROOT unset; call hermeticEnv or withStatsStores first")
+	}
+	old := time.Now().Add(-96 * time.Hour).UTC().Format(time.RFC3339)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("bg%03d", i)
+		var lines []string
+		for k := 0; k < 4; k++ {
+			// Both strides are coprime with the pool length so every phrase is
+			// used about equally; a stride sharing a factor reaches only a few
+			// and leaves the rest rare, which is the failure this guards.
+			text := ordinaryTalk[(i*3+k*7)%len(ordinaryTalk)]
+			lines = append(lines, `{"type":"user","sessionId":"`+id+`","timestamp":"`+old+
+				`","message":{"role":"user","content":"`+text+`"}}`)
+		}
+		writeClaudeFixture(t, filepath.Join(root, "-tmp-"+id, id+".jsonl"), id, lines)
 	}
 }
 

--- a/cmd/deja/recall_gates_test.go
+++ b/cmd/deja/recall_gates_test.go
@@ -118,3 +118,22 @@ func TestASessionMustAccountForEveryIdentifyingWord(t *testing.T) {
 		t.Fatal("a rare match with nothing to compare against must still show")
 	}
 }
+
+// The single-term bar counted bytes, so it read a five-letter Latin word as
+// filler and any three-letter Cyrillic one as a term of art. Measured on a real
+// store: "напомни, что мы уже выясняли про can шину на omoda через adb"
+// reduces to one term, three sessions hold it, and the hook stayed quiet.
+func TestTheSingleTermBarCountsLettersNotBytes(t *testing.T) {
+	if !promptTermsWorthAsking([]string{"omoda"}) {
+		t.Fatal("a five-letter subject was refused before the store was opened")
+	}
+	if !promptTermsWorthAsking([]string{"сеть"}) {
+		t.Fatal("a four-letter Cyrillic subject was refused")
+	}
+	if promptTermsWorthAsking([]string{"тут"}) {
+		t.Fatal("a three-letter Cyrillic filler word opened the store on its own")
+	}
+	if promptTermsWorthAsking([]string{"code"}) {
+		t.Fatal("a four-letter ordinary word opened the store on its own")
+	}
+}

--- a/cmd/deja/recall_gates_test.go
+++ b/cmd/deja/recall_gates_test.go
@@ -100,3 +100,21 @@ func TestPromptFillerIsDropped(t *testing.T) {
 		t.Fatal("filtering took the real terms with it")
 	}
 }
+
+// A question can join two things the project decided separately. The session
+// that wins holds one of them, and answering with it is worse than silence.
+func TestASessionMustAccountForEveryIdentifyingWord(t *testing.T) {
+	terms := []string{"kestrel", "timeout", "escrow", "release"}
+	// The project has an answer for all four, this session covers two.
+	if recallWorthShowing(terms, 2, 2, 4) {
+		t.Fatal("half of the question is not an answer to it")
+	}
+	// The session that covers all four is worth showing.
+	if !recallWorthShowing(terms, 4, 4, 4) {
+		t.Fatal("the session holding every identifying word was withheld")
+	}
+	// Nothing identifying in the project: the older bar decides alone.
+	if !recallWorthShowing(terms, 1, 1, 0) {
+		t.Fatal("a rare match with nothing to compare against must still show")
+	}
+}

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -47,6 +47,36 @@ const PromptBucketProject = promptBucketProject
 // actually decided each question, so the benchmark can see which wins.
 const promptHaystackProject = "promptbenchhaystack"
 
+// promptBackgroundCount is how many ordinary sessions sit behind the cases, so
+// that a word common in working talk is common here too.
+const promptBackgroundCount = 300
+
+// promptWorkingTalk is the vocabulary of ordinary work — the words that fill a
+// long session without identifying anything in it. Sessions draw two each, so
+// no single phrase becomes so common that it falls out of the query entirely.
+var promptWorkingTalk = []string{
+	"pushed the branch and ran the suite again",
+	"the suite passed after the last fix",
+	"rebased onto main and forced the check to rerun",
+	"the build failed on the first attempt",
+	"reverted that change and measured again",
+	"opened a draft and left it for review",
+	"the test was flaky so I ran it twice",
+	"merged it once the checks went green",
+	"looked at the diff and reduced the scope",
+	"the numbers came out the same as before",
+	"added a case that covers the empty input",
+	"renamed it for consistency with the caller",
+	"the linter complained about an unused value",
+	"split the change into two smaller commits",
+	"checked it on the other machine as well",
+	"the output looked right on the second pass",
+	"dropped the extra logging before pushing",
+	"waited for the run and read the summary",
+	"tried it locally and it behaved the same",
+	"tagged the release after the last merge",
+}
+
 // promptRussianProject holds every Russian chain, so they compete.
 const promptRussianProject = "promptbenchru"
 
@@ -330,6 +360,45 @@ func GeneratePrompt(seed int64) PromptCorpus {
 				ID: id + "-session", Harness: "claude", Project: promptHaystackProject,
 				Started: t, Updated: t,
 				Messages: []model.Message{{Role: "user", Text: "we decided " + h.fact, Time: t}},
+			}},
+		})
+	}
+	// Background: three hundred short sessions of ordinary working talk, in
+	// their own projects, holding none of the topics above.
+	//
+	// They exist so that idf means something. Without them a word living in one
+	// session of thirty scores 2.89 and a word living in ten scores 1.19, while
+	// on a real index of fifteen hundred sessions the same words score 4.13 and
+	// 0.4 — different scales, so a threshold measured here said nothing about
+	// there. Measured on the small corpus: raising the informative floor from
+	// 2.0 to 3.0 took this benchmark from 11/12 to 0/12 and changed nothing at
+	// all on a real store.
+	//
+	// The vocabulary is the words a long working session is made of, drawn two
+	// at a time from a pool, so that each lands in roughly one session in
+	// twenty. That ratio is the point: on a real store "branch" sits in 94
+	// sessions of about 1500 and scores 2.79, just over the floor meant for
+	// words that identify something. A background that repeated one phrase in
+	// every session put it in 89% of them instead, dropped it far under the
+	// floor, and hid the very defect this corpus exists to reproduce.
+	for i := 0; i < promptBackgroundCount; i++ {
+		id := fmt.Sprintf("prompt-bg-%03d", i)
+		t := base.Add(time.Duration(3000+i) * time.Minute)
+		a := promptWorkingTalk[(i*7)%len(promptWorkingTalk)]
+		b := promptWorkingTalk[(i*13+3)%len(promptWorkingTalk)]
+		var msgs []model.Message
+		for k := 0; k < 6; k++ {
+			at := t.Add(time.Duration(k) * time.Minute)
+			msgs = append(msgs,
+				model.Message{Role: "user", Text: fillerText(rng, a), Time: at},
+				model.Message{Role: "assistant", Text: fillerText(rng, b), Time: at.Add(time.Second)},
+			)
+		}
+		chains = append(chains, PromptChain{
+			ID: id, Project: fmt.Sprintf("promptbenchbg%03d", i), Kind: "background",
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: fmt.Sprintf("promptbenchbg%03d", i),
+				Started: t, Updated: t.Add(6 * time.Minute), Messages: msgs,
 			}},
 		})
 	}

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -75,6 +75,16 @@ var promptWorkingTalk = []string{
 	"waited for the run and read the summary",
 	"tried it locally and it behaved the same",
 	"tagged the release after the last merge",
+	// The negative controls are built from the words that live in every
+	// session's working noise, so the noise here has to hold them too —
+	// otherwise the benchmark calls "open the file and read it" a rare match
+	// and measures the fixture instead of the product.
+	"open the file and read it again",
+	"paste the output of that command here",
+	"walk me through the trace once more",
+	"adjust the patch and try it again",
+	"add a log line around that call",
+	"write the code for it and run the tests",
 }
 
 // promptRussianProject holds every Russian chain, so they compete.
@@ -384,8 +394,13 @@ func GeneratePrompt(seed int64) PromptCorpus {
 	for i := 0; i < promptBackgroundCount; i++ {
 		id := fmt.Sprintf("prompt-bg-%03d", i)
 		t := base.Add(time.Duration(3000+i) * time.Minute)
+		// Both strides are coprime with the pool length, so every phrase gets
+		// used about equally. An earlier draft stepped by 13 over 26 phrases,
+		// which reaches two of them and leaves the rest rare — and a word the
+		// fixture happens to find rare is scored as one that identifies
+		// something, which is the very thing being measured.
 		a := promptWorkingTalk[(i*7)%len(promptWorkingTalk)]
-		b := promptWorkingTalk[(i*13+3)%len(promptWorkingTalk)]
+		b := promptWorkingTalk[(i*11+5)%len(promptWorkingTalk)]
 		var msgs []model.Message
 		for k := 0; k < 6; k++ {
 			at := t.Add(time.Duration(k) * time.Minute)

--- a/internal/bench/prompt_test.go
+++ b/internal/bench/prompt_test.go
@@ -42,7 +42,7 @@ func TestGeneratePromptShape(t *testing.T) {
 		// asked about through the bucket-answer chain, whose question is the
 		// one that must go unanswered. A chain nobody asks about still has to
 		// earn its place, and this one earns it by being the wrong answer.
-		if c.Kind == "bucket" || c.Kind == "haystack-noise" {
+		if c.Kind == "bucket" || c.Kind == "haystack-noise" || c.Kind == "background" {
 			continue
 		}
 		if topics[c.Topic] {

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -243,7 +243,7 @@ func TestProjectRelevantRanksByIDFNotFiller(t *testing.T) {
 		t.Fatal(err)
 	}
 	// A prompt full of filler plus the one rare term must rank s1 first.
-	got, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"need", "the", "quetzalcoatl"}, 2)
+	got, _, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"need", "the", "quetzalcoatl"}, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func TestStemFoldIsDecidedByTheProjectNotTheStore(t *testing.T) {
 	if err := Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	got, matched, _, err := ProjectRelevant(dir, []string{"app"}, []string{"write", "parquet"}, 3)
+	got, matched, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"write", "parquet"}, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestProjectRelevantDottedTermNeedsAllSubTokens(t *testing.T) {
 	if err := Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	got, matched, _, err := ProjectRelevant(dir, []string{"app"}, []string{"203.0.113.51"}, 4)
+	got, matched, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"203.0.113.51"}, 4)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -252,6 +252,47 @@ func TestProjectRelevantRanksByIDFNotFiller(t *testing.T) {
 	}
 }
 
+// Whether "write" also tries "writes" was decided by the whole store, so work
+// in an unrelated project could switch the fold off and leave a question
+// matching nothing in the project that answers it.
+func TestStemFoldIsDecidedByTheProjectNotTheStore(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	mk := func(project, id, text string) {
+		p := filepath.Join(claudeRoot, project)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		line := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(p, id+".jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The session that answers says "writes"; the exact form the question uses
+	// exists only somewhere else entirely.
+	mk("-tmp-app", "answer", "parquet writes are batched per hour, not per row")
+	mk("-tmp-other", "elsewhere", "remember to write the changelog before tagging")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, matched, _, err := ProjectRelevant(dir, []string{"app"}, []string{"write", "parquet"}, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 || got[0].ID != "answer" {
+		t.Fatalf("ranking = %v, want the session that says \"writes\"", got)
+	}
+	// Both query terms have to count. Asserting only the order passes whether
+	// or not the fold happened, because nothing else in this project holds
+	// "parquet" — the count is the fact being fixed.
+	if matched[0] != 2 {
+		t.Fatalf("matched = %d, want both terms: the fold was decided by another project's session", matched[0])
+	}
+}
+
 func TestProjectRelevantDottedTermNeedsAllSubTokens(t *testing.T) {
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -334,3 +334,43 @@ func TestProjectRelevantDottedTermNeedsAllSubTokens(t *testing.T) {
 		t.Fatalf("full-address session missing: got=%v matched=%v", len(got), matched)
 	}
 }
+
+// An agent started from a home directory gets a scope holding everything ever
+// launched from there and not the repository being worked on. The word that
+// identifies the question then lives in another project, and a neighbour from
+// the catch-all is worse than silence.
+func TestTheWordThatIdentifiesMustBeInScope(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	mk := func(project, id, text string) {
+		p := filepath.Join(claudeRoot, project)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		line := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(p, id+".jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("-tmp-bucket", "neighbour", "the statement cache is disabled on the read mirror after those failures")
+	mk("-tmp-elsewhere", "answer", "prepared statements go behind pgbouncer in session mode")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	terms := []string{"pgbouncer", "statement", "failures"}
+	_, _, strong, covered, err := ProjectRelevant(dir, []string{"bucket"}, terms, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(strong) == 0 {
+		t.Fatal("the neighbour did not rank at all; the fixture no longer reproduces the case")
+	}
+	// The count the caller compares against has to exceed what any session
+	// here can hold, because "pgbouncer" is not in this scope at all.
+	if covered <= strong[0] {
+		t.Fatalf("covered = %d, best session holds %d: a neighbour would be shown for a word this scope does not have", covered, strong[0])
+	}
+}

--- a/internal/index/cyrillic_test.go
+++ b/internal/index/cyrillic_test.go
@@ -205,7 +205,7 @@ func TestRussianRelevanceFoldsInflections(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Nominative singular in the prompt, instrumental plural in the session.
-	got, matched, _, err := ProjectRelevant(dir, []string{"app"}, []string{"миграция", "репликация"}, 3)
+	got, matched, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"миграция", "репликация"}, 3)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/lock_nonblocking_test.go
+++ b/internal/index/lock_nonblocking_test.go
@@ -24,7 +24,7 @@ func TestReadsDoNotBlockWhileTheIndexIsLocked(t *testing.T) {
 	go func() {
 		defer close(done)
 		_, _, _ = FindByPrefix(dir, "nothing")
-		_, _, _, _ = ProjectRelevant(dir, []string{"p"}, []string{"term"}, 3)
+		_, _, _, _, _ = ProjectRelevant(dir, []string{"p"}, []string{"term"}, 3)
 		_, _ = RecentProject(dir, "p", 3)
 		_, _, _ = FirstMatch(dir, []string{"term"}, 3)
 	}()

--- a/internal/index/locked_read_test.go
+++ b/internal/index/locked_read_test.go
@@ -46,7 +46,7 @@ func TestReadsAnswerWhileTheIndexLockIsHeld(t *testing.T) {
 	var got int
 	go func() {
 		defer close(done)
-		sessions, _, _, rerr := ProjectRelevant(dir, []string{"app"},
+		sessions, _, _, _, rerr := ProjectRelevant(dir, []string{"app"},
 			[]string{"quetzalcoatl"}, 2)
 		if rerr != nil {
 			t.Errorf("read under the lock: %v", rerr)

--- a/internal/index/relevance_bench_test.go
+++ b/internal/index/relevance_bench_test.go
@@ -50,7 +50,7 @@ func BenchmarkRussianRelevance(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if _, _, _, err := ProjectRelevant(dir, []string{"app"}, terms, 10); err != nil {
+		if _, _, _, _, err := ProjectRelevant(dir, []string{"app"}, terms, 10); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/index/relevance_roles_test.go
+++ b/internal/index/relevance_roles_test.go
@@ -86,7 +86,7 @@ func TestRelevanceHonoursTheRequestedRole(t *testing.T) {
 // context is pasting the wrong thing.
 func TestProjectRelevantDoesNotServeWorkRecords(t *testing.T) {
 	dir := rolesIndex(t)
-	ss, _, _, err := ProjectRelevant(dir, []string{"p"}, []string{"frobnicator", "values", "rollout"}, 5)
+	ss, _, _, _, err := ProjectRelevant(dir, []string{"p"}, []string{"frobnicator", "values", "rollout"}, 5)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -562,7 +562,14 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 
 func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n int) ([]SessionMeta, []int, []int, int, error) {
 	rank, err := relevantMetasCounts(dir, m, projects, terms, n, nil)
-	return rank.metas, rank.informative, rank.strong, rank.strongInProject, err
+	covered := rank.strongInProject
+	if rank.hasTopStrong && !rank.topStrongInProject {
+		// The word that identifies the question best is not in this scope at
+		// all. Count it anyway: no session here can reach the total, so the
+		// caller stays quiet instead of returning a neighbour.
+		covered++
+	}
+	return rank.metas, rank.informative, rank.strong, covered, err
 }
 
 // relevanceRanking is what one ranking pass produced. It was seven return
@@ -582,6 +589,9 @@ type relevanceRanking struct {
 	// holds an answer for anywhere. A session that accounts for fewer of them
 	// than the project has is answering part of the question.
 	strongInProject int
+	// hasTopStrong says the query had an identifying word at all, and
+	// topStrongInProject whether this project holds the best one of them.
+	hasTopStrong, topStrongInProject bool
 	// idf is what each query term was worth, so a caller choosing which message
 	// to show can weigh it the same way the ranking weighed the session rather
 	// than approximating it.
@@ -754,6 +764,22 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 	msgIDF := map[uint32]map[int64]float64{}
 	termsKnown := 0
 	strongInProject := 0
+	topStrongIDF := -1.0
+	topStrongInProject := false
+	// A word the store knows and this project does not never reaches the
+	// scoring below — it is dropped as soon as the in-project hit set comes up
+	// empty. It still has to count: if the word that identifies the question
+	// best lives somewhere else entirely, nothing in this scope can answer it.
+	noteAbsentStrong := func(df int) {
+		if df == 0 {
+			return
+		}
+		idf := math.Log(totalDocs / float64(df+1))
+		if (idf >= dejaVuStrongIDFFloor || df <= 1) && idf > topStrongIDF {
+			topStrongIDF = idf
+			topStrongInProject = false
+		}
+	}
 	for _, term := range terms {
 		keys := queryKeys(term)
 		if len(keys) == 0 {
@@ -839,6 +865,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 				}
 			}
 			if len(hit) == 0 {
+				noteAbsentStrong(len(df))
 				continue
 			}
 			minDF = len(df)
@@ -894,6 +921,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 					offs = keyOffs
 				}
 				if len(hit) == 0 {
+					noteAbsentStrong(len(df))
 					missed = true
 					break
 				}
@@ -923,6 +951,15 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			// for all of them, or only for part of a question that joins work
 			// nobody joined.
 			strongInProject++
+		}
+		if strong && minDF > 0 && idf > topStrongIDF {
+			// The word that identifies the question best, whether or not this
+			// project holds it. When the project does not, nothing here can
+			// account for the question — an agent started from a home directory
+			// gets a scope full of unrelated work, and the neighbour it returns
+			// costs tokens and teaches the agent to ignore the next one.
+			topStrongIDF = idf
+			topStrongInProject = len(hit) > 0
 		}
 		for ord := range hit {
 			mm := perMessage[ord]
@@ -1024,14 +1061,16 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		strong = append(strong, r.strong)
 	}
 	return relevanceRanking{
-		metas:           metas,
-		informative:     matched,
-		any:             anyMatched,
-		strong:          strong,
-		termsKnown:      termsKnown,
-		strongInProject: strongInProject,
-		total:           matchedTotal,
-		idf:             idfOf,
+		metas:              metas,
+		informative:        matched,
+		any:                anyMatched,
+		strong:             strong,
+		termsKnown:         termsKnown,
+		strongInProject:    strongInProject,
+		topStrongInProject: topStrongInProject,
+		hasTopStrong:       topStrongIDF >= 0,
+		total:              matchedTotal,
+		idf:                idfOf,
 	}, readErr
 }
 

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -525,7 +525,7 @@ const dejaVuStrongIDFFloor = 3.0
 // the prompt terms. matched reports, per returned session, how many distinct
 // INFORMATIVE terms hit (idf >= dejaVuIDFFloor) — callers gate on it so
 // generic words cannot manufacture a confident "you have been here".
-func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Session, []int, []int, error) {
+func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Session, []int, []int, int, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -534,35 +534,35 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 	// rebuild — which every user hits on an index-format upgrade.
 	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, 0, err
 	}
 	if ok {
 		defer unlock()
 	}
 	m, err := readManifestCached(dir)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, 0, err
 	}
-	metas, matched, strong, rerr := relevantMetasMatched(dir, m, projects, terms, n)
+	metas, matched, strong, covered, rerr := relevantMetasMatched(dir, m, projects, terms, n)
 	if rerr != nil {
 		// A corrupt or unreadable bucket. The hook never rebuilds, so surface
 		// it rather than inject a silently short-ranked déjà vu; the caller
 		// stays quiet on an error.
-		return nil, nil, nil, rerr
+		return nil, nil, nil, 0, rerr
 	}
 	if len(metas) == 0 {
-		return nil, nil, nil, nil
+		return nil, nil, nil, 0, nil
 	}
 	out, err := sessionsServable(dir, metas, query.Options{})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, 0, err
 	}
-	return out, matched, strong, nil
+	return out, matched, strong, covered, nil
 }
 
-func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n int) ([]SessionMeta, []int, []int, error) {
+func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n int) ([]SessionMeta, []int, []int, int, error) {
 	rank, err := relevantMetasCounts(dir, m, projects, terms, n, nil)
-	return rank.metas, rank.informative, rank.strong, err
+	return rank.metas, rank.informative, rank.strong, rank.strongInProject, err
 }
 
 // relevanceRanking is what one ranking pass produced. It was seven return
@@ -578,6 +578,10 @@ type relevanceRanking struct {
 	// termsKnown is how many of the query's terms the corpus contains at all,
 	// and total how many sessions the ranking scored before n truncated it.
 	termsKnown, total int
+	// strongInProject is how many of the query's identifying words this project
+	// holds an answer for anywhere. A session that accounts for fewer of them
+	// than the project has is answering part of the question.
+	strongInProject int
 	// idf is what each query term was worth, so a caller choosing which message
 	// to show can weigh it the same way the ranking weighed the session rather
 	// than approximating it.
@@ -749,6 +753,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 	// total it collects across thousands of them.
 	msgIDF := map[uint32]map[int64]float64{}
 	termsKnown := 0
+	strongInProject := 0
 	for _, term := range terms {
 		keys := queryKeys(term)
 		if len(keys) == 0 {
@@ -912,6 +917,13 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		// Rare enough to identify something on its own: either well past the
 		// ordinary bar, or living in a single session of the whole corpus.
 		strong := idf >= dejaVuStrongIDFFloor || minDF <= 1
+		if strong && len(hit) > 0 {
+			// This project has an answer for this word somewhere. Counting them
+			// lets a caller ask whether the session it is about to show accounts
+			// for all of them, or only for part of a question that joins work
+			// nobody joined.
+			strongInProject++
+		}
 		for ord := range hit {
 			mm := perMessage[ord]
 			if mm == nil {
@@ -1012,13 +1024,14 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		strong = append(strong, r.strong)
 	}
 	return relevanceRanking{
-		metas:       metas,
-		informative: matched,
-		any:         anyMatched,
-		strong:      strong,
-		termsKnown:  termsKnown,
-		total:       matchedTotal,
-		idf:         idfOf,
+		metas:           metas,
+		informative:     matched,
+		any:             anyMatched,
+		strong:          strong,
+		termsKnown:      termsKnown,
+		strongInProject: strongInProject,
+		total:           matchedTotal,
+		idf:             idfOf,
 	}, readErr
 }
 

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -783,13 +783,26 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			missed bool
 		)
 		if len(orKeys) > 1 && !isCyrToken(term) {
-			// Fold stem forms in ONLY when the exact token is absent from
-			// the corpus: "camped" with no postings tries "camping", but an
-			// exact hit is never diluted by its variants. Russian inflects
-			// too heavily for that gate — a Cyrillic term keeps its whole
-			// form union, matching сеть against сетью and сети alike.
+			// Fold stem forms in ONLY when the exact token is absent from the
+			// sessions being ranked: "camped" with no postings tries "camping",
+			// but an exact hit is never diluted by its variants. Russian
+			// inflects too heavily for that gate — a Cyrillic term keeps its
+			// whole form union, matching сеть against сетью and сети alike.
+			//
+			// Absent from *these* sessions, not from the whole store. Asking
+			// the store meant that unrelated work decided it: with "write"
+			// somewhere in the index the fold switched off, and "how often do
+			// we write parquet?" stopped matching the session that says
+			// "parquet writes are batched per hour". Measured on the benchmark,
+			// that lost the haystack arm a case — a question missing the one
+			// session that answers it because of sessions in other projects.
 			if exact, err := br.postings(orKeys[0]); err == nil && len(exact) > 0 {
-				orKeys = orKeys[:1]
+				for _, pp := range exact {
+					if _, ok := inProject[pp.Sid]; ok {
+						orKeys = orKeys[:1]
+						break
+					}
+				}
 			}
 		}
 		if len(orKeys) > 1 {

--- a/internal/index/sync_recall_test.go
+++ b/internal/index/sync_recall_test.go
@@ -90,7 +90,7 @@ func TestASyncedProjectIsInScopeUnderTheLocalName(t *testing.T) {
 // filter as search, so this checks it survives that too.
 func TestAutoRecallReachesSyncedWork(t *testing.T) {
 	dir := importedIndex(t)
-	ss, _, _, err := ProjectRelevant(dir, []string{"svc"}, []string{"ratelimiter", "smoothing", "window"}, 5)
+	ss, _, _, _, err := ProjectRelevant(dir, []string{"svc"}, []string{"ratelimiter", "smoothing", "window"}, 5)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scripts/longmemeval/main.go
+++ b/scripts/longmemeval/main.go
@@ -529,7 +529,7 @@ func runHookPrecision(questions []lmeQuestion, limit int) {
 		// identifier test and a six-term cap, so measuring the gate on
 		// relevance terms measured a rule that never runs.
 		terms := prompt.Terms(questions[i].Question)
-		_, matched, strong, err := index.ProjectRelevant(dir, nil, terms, prompt.Candidates)
+		_, matched, strong, _, err := index.ProjectRelevant(dir, nil, terms, prompt.Candidates)
 		if err != nil {
 			cleanup()
 			fatal(err)


### PR DESCRIPTION
Two fixes to what recall counts as specific, and the corpus that made them measurable.

**The corpus.** `bench prompt` had about thirty sessions. At that size a word living in one of them scores idf 2.89 and a word living in ten scores 1.19; on a real store of ~1500 sessions the same words score 4.13 and 0.4. Measured on the small corpus, raising the informative floor from 2.0 to 3.0 took the benchmark from 11/12 to 0/12 and changed nothing at all on a real store — so nothing about rarity could be judged here. This adds 300 short sessions of ordinary working talk, each drawing two phrases from a pool of twenty, which puts a working word in about one session in twenty. `branch` really sits in 94 of ~1500.

**`hasIdentifierTerm` counted letters.** Any word of six letters was treated as naming something, so `paste the output of that command` and `walk me through the trace` recalled. The index has already answered the question that proxy is guessing at, so `recallWorthShowing` now asks it: a session is worth showing when it matched a term the index finds rare. The length rule stays in `promptTermsWorthAsking`, which runs before the store is opened and has nothing better.

**A session could answer half a question.** `did the kestrel timeout ever delay an escrow release` won on `kestrel` and `timeout` while `escrow` and `release` were decided in a different session entirely — the shape of a question that joins work nobody joined. The ranking now reports how many identifying words this project has an answer for anywhere, and a session is only worth showing when it accounts for all of them.

**The stem fold was decided by the whole store.** Whether `write` also tries `writes` depended on the exact form existing *anywhere* in the index. Put `write` in an unrelated project and `how often do we write parquet?` stops matching the session that says `parquet writes are batched per hour` — a question missing the one session that answers it because of work in another repository. The fold now looks at the sessions being ranked.

```
                     before    after
real_questions        11/12     12/12
negative_controls       0 f       0 f     (against a corpus that now holds working noise)
absent_subject          3 f       0 f
off_topic               3 f       1 f
shown_line            14/14     15/15
haystack (correct)      3/3       3/3
russian, marathon, fresh, bucket — unchanged
bench recall @5/@10   1.00/1.00 unchanged
bench context         294 median tokens, coverage 1.00, unchanged
live (45 real prompts, frozen index)   42 fired, 88% — identical to main
```

Live is unchanged either way: ordinary Russian words score 3.5 on a real store, so they clear the rarity bar there regardless. The gain here is that the benchmark now reads the defect instead of hiding it, and two proxies are gone.

Three unit fixtures needed a background before rarity could mean anything in them: in `TestHookPromptSkipsMarathonSessions`, `quetzalcoatl` sat in both sessions of a three-document index, giving it idf 0 — the most specific word imaginable, scored as filler. With a hundred ordinary sessions behind it the same word scores 3.53 and the working phrases 2.24.

On a real store the coverage rule blocks nothing: traced over 42 live recall decisions, the winning session accounted for every identifying word every time. It costs no recall there and removes a third of the false fires here.

Mutations, all caught: restoring the length rule gives 3 false negatives and 3 on `absent_subject`; restoring the `matched >= 2` fallback gives 4; restoring the store-wide fold drops `haystack` to 2/3; dropping the coverage rule puts `off_topic` back to 3 false; shrinking the fixture background to 3 sessions makes the marathon test fail again. The first draft of the stem-fold test passed under its own mutant and was rewritten to assert the match count rather than the order.
