### PR TITLE
fix(recall): three fixes to which words a recall trusts

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -247,7 +249,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	resp.HookSpecificOutput.HookEventName = "UserPromptSubmit"
 	resp.HookSpecificOutput.AdditionalContext = out
 	if showLine {
-		resp.SystemMessage = dejaVuLine(ss[0], terms...)
+		resp.SystemMessage = dejaVuLine(ss[0], viaTerms(out, terms)...)
 	}
 	if resp.SystemMessage == "" {
 		// No presentable topic — inject the context silently rather than
@@ -287,13 +289,48 @@ func promptTermsWorthAsking(terms []string) bool {
 // something that reads like a term of art — long, or shaped like a symbol.
 func hasIdentifierTerm(terms []string) bool {
 	for _, t := range terms {
-		if len(t) >= 6 {
+		// Letters, not bytes. Counting bytes read "omoda" as filler and every
+		// Cyrillic word of three letters as a term of art, because Cyrillic
+		// takes two bytes a letter. Measured on a real store: "напомни, что мы
+		// уже выясняли про can шину на omoda" reduces to one term, three
+		// sessions hold it, and nothing was recalled.
+		//
+		// Russian carries its meaning in shorter words — "сеть", "порт" name
+		// something the way a five-letter Latin word does — so the bar is one
+		// letter lower there.
+		n := utf8.RuneCountInString(t)
+		if (n >= 5 || (n >= 4 && hasCyrillic(t))) && !soleWorkingWord[t] {
 			return true
 		}
 		for _, r := range t {
 			if r == '_' || r == '.' || r == '/' || r == '-' || (r >= '0' && r <= '9') {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// soleWorkingWord is the ordinary vocabulary a session is made of, long enough
+// to pass the letter bar and carrying nothing on its own. The list is consulted
+// only here, where the store has not been opened yet: keeping it shut for a
+// lone filler word is worth 62ms of the 67ms such a prompt would otherwise
+// cost, measured against a real index. Once the store is open the ranking
+// decides on evidence and no list is needed.
+var soleWorkingWord = map[string]bool{
+	"tests": true, "test": true, "retry": true, "build": true, "error": true,
+	"errors": true, "check": true, "checks": true, "files": true, "patch": true,
+	"trace": true, "output": true, "command": true, "branch": true, "suite": true,
+	"commit": true, "commits": true, "deploy": true, "fixes": true, "again": true,
+	"write": true, "wrote": true, "merge": true, "start": true, "print": true,
+	"there": true, "these": true, "those": true, "which": true, "where": true,
+}
+
+// hasCyrillic reports whether the term is written in Cyrillic.
+func hasCyrillic(t string) bool {
+	for _, r := range t {
+		if r >= 0x400 && r <= 0x4FF {
+			return true
 		}
 	}
 	return false
@@ -527,6 +564,38 @@ func recordDejaVuLine(path, sid string, now time.Time) bool {
 	return true
 }
 
+// viaTerms picks the three query terms the headline will name. Terms the block
+// underneath actually carries come first: the line is the reason given for the
+// recall, and naming words the reader cannot find below it reads as a misfire.
+// Measured on a real store, the block opened on a line carrying a term the
+// product used in 94 cases of 94, while the first three terms in extraction
+// order agreed with it in 71.
+func viaTerms(block string, terms []string) []string {
+	if len(terms) <= 3 {
+		return terms
+	}
+	out := make([]string, 0, 3)
+	for _, t := range terms {
+		if len(out) == 3 {
+			break
+		}
+		if search.TextCarriesTerm(block, t) {
+			out = append(out, t)
+		}
+	}
+	// Short of three, fill from the rest in the order they were asked, so the
+	// line still says what the question was about.
+	for _, t := range terms {
+		if len(out) == 3 {
+			break
+		}
+		if !slices.Contains(out, t) {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
 // dejaVuLine is the one visible line a déjà vu moment earns: which past
 // session answered, and how old it is.
 func dejaVuLine(s model.Session, terms ...string) string {
@@ -542,6 +611,8 @@ func dejaVuLine(s model.Session, terms ...string) string {
 	// visible reason reads as noise the first time it misfires.
 	why := ""
 	if len(terms) > 0 {
+		// Callers pass terms already chosen by viaTerms; the cap stays here so
+		// a caller that has not is still held to three.
 		if len(terms) > 3 {
 			terms = terms[:3]
 		}

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/stats"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
 )
 
 func TestHookPromptInjectsOnRelevantHit(t *testing.T) {
@@ -519,5 +520,26 @@ func TestDejaVuLineDoesNotClaimAPeersWorkAsYours(t *testing.T) {
 	// The rest of the line — the topic and why it fired — is unchanged.
 	if !strings.Contains(got, "ticker window") || !strings.Contains(got, "via: ticker") {
 		t.Errorf("the line lost what it is for: %q", got)
+	}
+}
+
+// The headline names three of the query's terms as the reason. They have to be
+// terms the block underneath actually carries: measured on a real store, the
+// block opened on a line carrying a term the product used in 94 cases of 94,
+// while the three words named above it agreed only 71 times.
+func TestTheHeadlineNamesTermsTheBlockCarries(t *testing.T) {
+	block := "- User: the pgbouncer prepared statement failures came back\n"
+	terms := []string{"deploy", "reboot", "pgbouncer", "statement"}
+	got := viaTerms(block, terms)
+	if len(got) == 0 {
+		t.Fatal("no terms chosen")
+	}
+	if !search.TextCarriesTerm(block, got[0]) {
+		t.Fatalf("headline leads with %q, which the block does not carry", got[0])
+	}
+	// Terms the block does not carry still get named once the carried ones run
+	// out — the line says what the question was about, not only what matched.
+	if len(got) != 3 {
+		t.Fatalf("via = %v, want three terms", got)
 	}
 }

--- a/cmd/deja/recall_gates_test.go
+++ b/cmd/deja/recall_gates_test.go
@@ -100,3 +100,22 @@ func TestPromptFillerIsDropped(t *testing.T) {
 		t.Fatal("filtering took the real terms with it")
 	}
 }
+
+// The single-term bar counted bytes, so it read a five-letter Latin word as
+// filler and any three-letter Cyrillic one as a term of art. Measured on a real
+// store: "напомни, что мы уже выясняли про can шину на omoda через adb"
+// reduces to one term, three sessions hold it, and the hook stayed quiet.
+func TestTheSingleTermBarCountsLettersNotBytes(t *testing.T) {
+	if !promptTermsWorthAsking([]string{"omoda"}) {
+		t.Fatal("a five-letter subject was refused before the store was opened")
+	}
+	if !promptTermsWorthAsking([]string{"сеть"}) {
+		t.Fatal("a four-letter Cyrillic subject was refused")
+	}
+	if promptTermsWorthAsking([]string{"тут"}) {
+		t.Fatal("a three-letter Cyrillic filler word opened the store on its own")
+	}
+	if promptTermsWorthAsking([]string{"code"}) {
+		t.Fatal("a four-letter ordinary word opened the store on its own")
+	}
+}

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -252,6 +252,47 @@ func TestProjectRelevantRanksByIDFNotFiller(t *testing.T) {
 	}
 }
 
+// Whether "write" also tries "writes" was decided by the whole store, so work
+// in an unrelated project could switch the fold off and leave a question
+// matching nothing in the project that answers it.
+func TestStemFoldIsDecidedByTheProjectNotTheStore(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	mk := func(project, id, text string) {
+		p := filepath.Join(claudeRoot, project)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		line := `{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(p, id+".jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The session that answers says "writes"; the exact form the question uses
+	// exists only somewhere else entirely.
+	mk("-tmp-app", "answer", "parquet writes are batched per hour, not per row")
+	mk("-tmp-other", "elsewhere", "remember to write the changelog before tagging")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, matched, _, err := ProjectRelevant(dir, []string{"app"}, []string{"write", "parquet"}, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 || got[0].ID != "answer" {
+		t.Fatalf("ranking = %v, want the session that says \"writes\"", got)
+	}
+	// Both query terms have to count. Asserting only the order passes whether
+	// or not the fold happened, because nothing else in this project holds
+	// "parquet" — the count is the fact being fixed.
+	if matched[0] != 2 {
+		t.Fatalf("matched = %d, want both terms: the fold was decided by another project's session", matched[0])
+	}
+}
+
 func TestProjectRelevantDottedTermNeedsAllSubTokens(t *testing.T) {
 	tmp := t.TempDir()
 	claudeRoot := filepath.Join(tmp, "claude")

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -783,13 +783,26 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			missed bool
 		)
 		if len(orKeys) > 1 && !isCyrToken(term) {
-			// Fold stem forms in ONLY when the exact token is absent from
-			// the corpus: "camped" with no postings tries "camping", but an
-			// exact hit is never diluted by its variants. Russian inflects
-			// too heavily for that gate — a Cyrillic term keeps its whole
-			// form union, matching сеть against сетью and сети alike.
+			// Fold stem forms in ONLY when the exact token is absent from the
+			// sessions being ranked: "camped" with no postings tries "camping",
+			// but an exact hit is never diluted by its variants. Russian
+			// inflects too heavily for that gate — a Cyrillic term keeps its
+			// whole form union, matching сеть against сетью and сети alike.
+			//
+			// Absent from *these* sessions, not from the whole store. Asking
+			// the store meant that unrelated work decided it: with "write"
+			// somewhere in the index the fold switched off, and "how often do
+			// we write parquet?" stopped matching the session that says
+			// "parquet writes are batched per hour". Measured on the benchmark,
+			// that lost the haystack arm a case — a question missing the one
+			// session that answers it because of sessions in other projects.
 			if exact, err := br.postings(orKeys[0]); err == nil && len(exact) > 0 {
-				orKeys = orKeys[:1]
+				for _, pp := range exact {
+					if _, ok := inProject[pp.Sid]; ok {
+						orKeys = orKeys[:1]
+						break
+					}
+				}
 			}
 		}
 		if len(orKeys) > 1 {


### PR DESCRIPTION
Three fixes to which words a recall trusts, each measured against a real store of about 1500 sessions.

**The stem fold was decided by the whole store.** Whether `write` also tries `writes` depended on the exact form existing *anywhere* in the index. Put `write` in an unrelated project and `how often do we write parquet?` stops matching the session that says `parquet writes are batched per hour` — a question missing the one session that answers it because of work in another repository. The fold now looks at the sessions being ranked.

**The headline named terms the block did not carry.** `via: a, b, c` took the first three terms in extraction order, so the line read `via: переключился, айфоновский, интернет` above a block about something else. Naming words the reader cannot find below reads as a misfire. It now names terms the block carries, filling from the rest to keep three.

**The single-word bar counted bytes.** Cyrillic takes two bytes a letter, so any three-letter Russian word opened the store while `omoda` did not: `напомни, что мы уже выясняли про can шину на omoda через adb` reduces to one term, three sessions hold it, and nothing was recalled. Counting letters admits it; the bar keeps ordinary working words out through the same kind of list the Russian side already has.

The bar itself stays. Measured, it earns its place: on a lone filler word the hook takes 4.8ms with the store shut and 67.1ms with it open.

```
                                     main     branch
live, 129 real prompts
  fired                             109/129   112/129
  block opens on a term the product used  92%      89%
  headline names a term the block carries 63%     100%
bench prompt   every arm unchanged (real 11/12, negatives 0 false, shown 14/14,
               haystack 3/3, russian 3/3, marathon 1/1, fresh 1/1)
bench recall   @5/@10 1.00/1.00 unchanged
bench context  294 median tokens, coverage 1.00, unchanged
```

The same number of good blocks (100), three more fires, and a headline that tells the truth.

Mutations, all caught: restoring the store-wide fold drops the benchmark's haystack arm to 2/3; `if true` in place of the block-carries check fails the headline test; `n >= 3` in place of the letter bar fails the one-word test. The first draft of the stem-fold test passed under its own mutant and was rewritten to assert the match count rather than the ranking order.
