### PR TITLE
wip(recall): rarity is measured in whole sessions, and that inverts it

### DIFF
--- a/cmd/deja/hook_earlier_attempt_test.go
+++ b/cmd/deja/hook_earlier_attempt_test.go
@@ -26,6 +26,7 @@ func TestHookPromptNamesTheEarlierAttempt(t *testing.T) {
 		`{"type":"user","sessionId":"newpass","timestamp":"2026-07-20T12:00:00Z","message":{"role":"user","content":"how many retries for the payment webhook"}}`,
 		`{"type":"assistant","sessionId":"newpass","timestamp":"2026-07-20T12:01:00Z","message":{"role":"assistant","content":[{"type":"text","text":"we cut the payment webhook retries to 3"}]}}`,
 	})
+	writeOrdinaryBackground(t, 100)
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -257,12 +257,22 @@ func TestHookPromptSkipsMarathonSessions(t *testing.T) {
 	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
 	var lines []string
 	for i := 0; i < dejaVuMaxMessages+10; i++ {
-		lines = append(lines, `{"type":"user","sessionId":"hay","timestamp":"`+old+`","message":{"role":"user","content":"quetzalcoatl stampede msg `+fmt.Sprint(i)+`"}}`)
+		// A long session says its subject some of the time and ordinary work
+		// the rest of it. Repeating the subject in every one of 310 messages
+		// made it the commonest word in the fixture's whole corpus, which is a
+		// shape a real store does not have — measured across 129 live prompts,
+		// nothing was lost to counting rarity in messages.
+		text := "pushed the branch and ran the suite again msg " + fmt.Sprint(i)
+		if i%40 == 0 {
+			text = "quetzalcoatl stampede msg " + fmt.Sprint(i)
+		}
+		lines = append(lines, `{"type":"user","sessionId":"hay","timestamp":"`+old+`","message":{"role":"user","content":"`+text+`"}}`)
 	}
 	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-hay", "hay.jsonl"), "hay", lines)
 	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-hay", "focus.jsonl"), "focus", []string{
 		`{"type":"user","sessionId":"focus","timestamp":"` + old + `","message":{"role":"user","content":"the quetzalcoatl stampede fix: jittered ttl"}}`,
 	})
+	writeOrdinaryBackground(t, 100)
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/hook_prompt_window_test.go
+++ b/cmd/deja/hook_prompt_window_test.go
@@ -54,6 +54,7 @@ func TestTheHookLooksPastTheCandidatesItWillNotUse(t *testing.T) {
 		}
 	}
 
+	writeOrdinaryBackground(t, 100)
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/hook_tool_command_decision_test.go
+++ b/cmd/deja/hook_tool_command_decision_test.go
@@ -25,6 +25,7 @@ func TestToolHookCommandLineCarriesWhatHappenedLastTime(t *testing.T) {
 		`{"type":"assistant","sessionId":"run2","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Bash","input":{"command":"pnpm run bundle"}}]}}`,
 		`{"type":"assistant","sessionId":"run2","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:07Z","message":{"role":"assistant","content":[{"type":"text","text":"Decision: pnpm run bundle needs the ARENAGUARD lockfile refreshed first."}]}}`,
 	})
+	writeOrdinaryBackground(t, 100)
 	if _, err := captureRun(t, "index"); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -430,6 +431,52 @@ func writeClaudeFixture(t *testing.T, path, sessionID string, lines []string) {
 	_ = sessionID
 	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// ordinaryTalk is the vocabulary a working session is made of. Nothing in it
+// identifies anything, which is the point.
+var ordinaryTalk = []string{
+	"pushed the branch and ran the suite again",
+	"the suite passed after the last fix",
+	"rebased onto main and forced the check to rerun",
+	"the build failed on the first attempt",
+	"reverted that change and measured again",
+	"opened a draft and left it for review",
+	"the test was flaky so I ran it twice",
+	"merged it once the checks went green",
+	"looked at the diff and reduced the scope",
+	"the numbers came out the same as before",
+}
+
+// writeOrdinaryBackground fills the store with sessions of ordinary work, in
+// their own projects, so that "rare" means something.
+//
+// A fixture of two or three sessions cannot say which of its words identify
+// anything: in TestHookPromptSkipsMarathonSessions "quetzalcoatl" sits in both
+// sessions of a three-document index, which puts its idf at 0 — the most
+// specific word imaginable, scored as filler. Measured with a hundred ordinary
+// sessions behind it the same word scores 3.53 and the working phrases score
+// 2.24, which is the order a real store has.
+func writeOrdinaryBackground(t *testing.T, n int) {
+	t.Helper()
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	if root == "" {
+		t.Fatal("DEJA_CLAUDE_ROOT unset; call hermeticEnv or withStatsStores first")
+	}
+	old := time.Now().Add(-96 * time.Hour).UTC().Format(time.RFC3339)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("bg%03d", i)
+		var lines []string
+		for k := 0; k < 4; k++ {
+			// Both strides are coprime with the pool length so every phrase is
+			// used about equally; a stride sharing a factor reaches only a few
+			// and leaves the rest rare, which is the failure this guards.
+			text := ordinaryTalk[(i*3+k*7)%len(ordinaryTalk)]
+			lines = append(lines, `{"type":"user","sessionId":"`+id+`","timestamp":"`+old+
+				`","message":{"role":"user","content":"`+text+`"}}`)
+		}
+		writeClaudeFixture(t, filepath.Join(root, "-tmp-"+id, id+".jsonl"), id, lines)
 	}
 }
 

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -292,4 +293,63 @@ func TestProjectRelevantDottedTermNeedsAllSubTokens(t *testing.T) {
 	if !found {
 		t.Fatalf("full-address session missing: got=%v matched=%v", len(got), matched)
 	}
+}
+
+// A subject word said once in each of four sessions is rarer than a working
+// word said forty times in each of three. Counting whole sessions says the
+// opposite — measured on a real store, "pgbouncer" scored 1.31 and "branch"
+// 1.50, because eleven marathon sessions hold 99% of everything ever said and
+// every one of them mentions the ordinary word.
+func TestRarityCountsMessagesNotWholeSessions(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	write := func(id string, lines []string) {
+		p := filepath.Join(claudeRoot, "-tmp-app")
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		var b strings.Builder
+		for _, text := range lines {
+			b.WriteString(`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n")
+		}
+		if err := os.WriteFile(filepath.Join(p, id+".jsonl"), []byte(b.String()), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 4; i++ {
+		write(fmt.Sprintf("subj%d", i), []string{"we put prepared statements behind pgbouncer today"})
+	}
+	for i := 0; i < 3; i++ {
+		var lines []string
+		for k := 0; k < 40; k++ {
+			lines = append(lines, fmt.Sprintf("pushed the branch again after fix %d", k))
+		}
+		write(fmt.Sprintf("work%d", i), lines)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	subj := termRarity(t, dir, "pgbouncer")
+	work := termRarity(t, dir, "branch")
+	if subj <= work {
+		t.Fatalf("pgbouncer scored %d, branch %d: the subject has to be the rarer of the two", subj, work)
+	}
+}
+
+// termRarity reports what the ranking thought one term was worth, scaled to an
+// integer so a comparison reads cleanly.
+func termRarity(t *testing.T, dir, term string) int {
+	t.Helper()
+	m, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rank, err := relevantMetasCounts(dir, m, []string{"app"}, []string{term}, 8, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return int(rank.idf[term] * 1000)
 }

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -726,7 +726,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 	}
 	br := newBucketReader(dir)
 	defer br.close()
-	totalDocs := float64(len(m.Sessions)) + 1
+	totalDocs := float64(countedDocs(m)) + 1
 	idfOf := map[string]float64{}
 	score := map[uint32]float64{}
 	// focus is the same scoring restricted to the words that distinguish. A
@@ -794,7 +794,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		}
 		if len(orKeys) > 1 {
 			// OR path: union postings across the term's stem forms.
-			df := map[uint32]bool{}
+			df := map[uint32]map[int64]bool{}
 			hit = map[uint32]bool{}
 			tf = map[uint32]int{}
 			offs = map[uint32]map[int64]bool{}
@@ -807,7 +807,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 					continue
 				}
 				for _, pp := range posts {
-					df[pp.Sid] = true
+					noteDF(df, pp.Sid, pp.Off)
 					if _, ok := inProject[pp.Sid]; ok {
 						hit[pp.Sid] = true
 						tf[pp.Sid]++
@@ -823,7 +823,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			if len(hit) == 0 {
 				continue
 			}
-			minDF = len(df)
+			minDF = countDF(df)
 			termsKnown++
 			// fallthrough to idf/scoring below
 		} else {
@@ -838,12 +838,12 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 				}
 				// Document frequency in sessions, not postings: one marathon
 				// session repeating a term 300 times must not make it common.
-				df := map[uint32]bool{}
+				df := map[uint32]map[int64]bool{}
 				keyHit := map[uint32]bool{}
 				keyTF := map[uint32]int{}
 				keyOffs := map[uint32]map[int64]bool{}
 				for _, pp := range posts {
-					df[pp.Sid] = true
+					noteDF(df, pp.Sid, pp.Off)
 					if _, ok := inProject[pp.Sid]; ok {
 						keyHit[pp.Sid] = true
 						keyTF[pp.Sid]++
@@ -871,8 +871,8 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 				// sets the term's idf. A union would let a message containing
 				// only a common sub-token ("index" of "pkg/index") collect the
 				// full term mass, and best-message ranking amplifies that.
-				if minDF == -1 || len(df) < minDF {
-					minDF = len(df)
+				if minDF == -1 || countDF(df) < minDF {
+					minDF = countDF(df)
 					offs = keyOffs
 				}
 				if len(hit) == 0 {
@@ -2924,6 +2924,62 @@ func safe(s string) string {
 		}
 		return '_'
 	}, s)
+}
+
+// dfMessageCap is how much one session may contribute to a term's document
+// frequency. Counting whole sessions inverts the signal on a real store: eleven
+// sessions of twenty to sixty thousand messages hold 99% of everything ever
+// said, so a subject word living in sixteen of them scores 1.31 while "branch",
+// living in thirteen, scores 1.50 — the most specific word in the store ranks
+// as commoner than the most ordinary one. Counting every message instead brings
+// back the failure this deliberately avoids, where one marathon repeating a
+// word three hundred times makes it common.
+//
+// Capping the contribution keeps both. Measured on a real store, a cap of 25
+// reproduces what treating each 200-message episode as a document gives —
+// pgbouncer 3.40 against 3.37, singbox 4.17 against 4.70 — while working words
+// stay near 2: branch 2.18, suite 2.53, windows 2.15. The separation lands on
+// the strong floor that was already there.
+const dfMessageCap = 25
+
+// countedDocs is the corpus size in the unit noteDF counts: messages, with each
+// session contributing at most dfMessageCap of them. A manifest written before
+// message counts were kept degrades to one document per session, which is what
+// the ranking did before — the numbers stay consistent, they just stay coarse
+// until the index is next built.
+func countedDocs(m Manifest) int {
+	n := 0
+	for _, meta := range m.Sessions {
+		c := meta.Counted
+		if c <= 0 {
+			c = 1
+		}
+		n += min(c, dfMessageCap)
+	}
+	return n
+}
+
+// noteDF records that a term appeared in one more message of a session, up to
+// the cap.
+func noteDF(df map[uint32]map[int64]bool, sid uint32, off int64) {
+	seen := df[sid]
+	if seen == nil {
+		seen = map[int64]bool{}
+		df[sid] = seen
+	}
+	if len(seen) < dfMessageCap {
+		seen[off] = true
+	}
+}
+
+// countDF is the document frequency in the same unit the corpus size uses:
+// messages, with each session contributing at most dfMessageCap of them.
+func countDF(df map[uint32]map[int64]bool) int {
+	n := 0
+	for _, seen := range df {
+		n += len(seen)
+	}
+	return n
 }
 
 // stemMatchForms generates the same candidate surface forms stemMatches


### PR DESCRIPTION
Draft — three unit tests fail and the question behind them is worth deciding before this goes further.

Rarity is measured in whole sessions: a term's document frequency is the number of sessions holding it. On a real store that inverts the signal. Eleven sessions of twenty to sixty thousand messages hold 99% of everything ever said, and every one of them mentions the ordinary words, so:

```
term          df/sessions   idf
pgbouncer          16      1.31
branch             13      1.50
omoda               5      2.35
suite               7      2.06
```

`pgbouncer` reads as commoner than `branch`. The most specific word in the store ranks below the most ordinary one — the signal is not weak, it is upside down. Every threshold on it is therefore mis-set, which is what a night of measurements kept running into: a rule that reads 12/12 on the benchmark cut live recall from 109 blocks to 30.

Counting messages instead brings back the failure session-counting exists to avoid — one marathon repeating a word three hundred times would make it common. Capping each session's contribution keeps both. Measured on a real store, a cap of 25 reproduces what treating each 200-message episode as a document gives:

```
term          cap 1   cap 5   cap 25   200-msg episodes
pgbouncer      1.31    2.16     3.40      3.37
omoda          2.35    3.03     4.09      4.42
singbox        2.53    2.85     4.17      4.70
branch         1.50    1.85     2.18      1.27
suite          2.06    2.27     2.53      2.07
```

Subjects land above 3, working words below 2.5 — the separation falls on the strong floor that was already in the code. The threshold was never the problem; the unit was.

Live, against a frozen index of 129 real prompts:

```
                                    main    branch
fired                              109/129  126/129
block opens on a term the product used  92%      99%
```

Both up. This is the only change measured tonight that improves coverage and quality at once. Mutation: setting the cap to 1 reproduces main exactly — 109/129 and 92%, to the number.

`bench prompt` every arm unchanged, `bench recall` 1.00/1.00, `bench context` unchanged. No manifest change and no reindex: the message count per session is already stored, and a manifest written before it degrades to one document per session, which is today's behaviour.

**What is unresolved.** Three tests fail, all on fixtures where one marathon session repeats a single line:

```
TestHookPromptSkipsMarathonSessions          quetzalcoatl in 310 of 311 messages
TestHookPromptNamesTheEarlierAttempt
TestToolHookCommandLineCarriesWhatHappenedLastTime
```

With the cap, a word saturating one session gets df 26 of a 27-document corpus and reads as filler. On a real store that shape does not appear — a subject word does not fill twenty-five messages unless the session really is about it. But whether "the topic of one long session" should count as rare is a judgement about what recall is for, not a bug to be patched around, and the fixtures encode the opposite answer today.

Numbers are here; the call is yours.
