### PR TITLE
fix(recall): lower the idf floors to the scale a real store has

### DIFF
--- a/internal/index/floor_scale_test.go
+++ b/internal/index/floor_scale_test.go
@@ -1,0 +1,41 @@
+package index
+
+import (
+	"fmt"
+	"testing"
+)
+
+// A word in fifteen sessions of a hundred is what a subject looks like on a real
+// store: not unique, not filler. The informativeness floor has to count it.
+//
+// It was set at 2.0 against a corpus where document frequency runs over whole
+// sessions — and eleven marathon sessions holding 99% of everything ever said
+// squash the whole scale, so a word like this scores 1.84 and was thrown away.
+// Measured over 129 live prompts, the old floor answered 112 of them with 89%
+// of blocks opening on a term the question used; this one answers 129 with 97%.
+func TestTheInformativeFloorCountsASubjectInOneSessionOfSeven(t *testing.T) {
+	var texts []string
+	for i := 0; i < 100; i++ {
+		if i%7 == 0 {
+			texts = append(texts, fmt.Sprintf("the kestrel timeout came up again in run %d", i))
+			continue
+		}
+		texts = append(texts, fmt.Sprintf("pushed the branch and ran the suite again in run %d", i))
+	}
+	dir := nlIndex(t, texts...)
+	m, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rank, err := relevantMetasCounts(dir, m, []string{"p"}, []string{"kestrel"}, 8, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rank.informative) == 0 {
+		t.Fatal("the sessions holding the subject did not rank at all")
+	}
+	if rank.informative[0] < 1 {
+		t.Fatalf("kestrel scored %.2f and was not counted: a subject in one session of seven is not filler",
+			rank.idf["kestrel"])
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -503,7 +503,7 @@ func relevanceResult(ss []model.Session, matched int, idf map[string]float64) Se
 // sessions. Conversational filler ("post", "text", "claude") is frequent in
 // any large corpus and clears nothing. Terms living in one or two sessions
 // are informative regardless — small corpora never reach the ratio bar.
-const dejaVuIDFFloor = 2.0
+const dejaVuIDFFloor = 1.5
 
 // dejaVuStrongIDFFloor is the bar for a term rare enough to justify an
 // UNPROMPTED recall on its own. The ordinary floor admits words that merely
@@ -513,7 +513,7 @@ const dejaVuIDFFloor = 2.0
 // Measured on cross-paired prompts (the answer never present), the hook would
 // have injected on 94% of them; requiring a strong term for the single-match
 // case removes the half that rests on one ordinary word.
-const dejaVuStrongIDFFloor = 3.0
+const dejaVuStrongIDFFloor = 2.3
 
 // ProjectRelevant ranks the current project's sessions by how well they match
 // the prompt terms — without reconstructing an AND query, which poisons on


### PR DESCRIPTION
The informativeness floor is 2.0 and the strong floor 3.0. Measured on a real store, both sit above where the subjects are.

Document frequency runs over whole sessions. Eleven sessions of twenty to sixty thousand messages hold 99% of everything ever said, and every one of them mentions the ordinary words, so the whole scale squashes together:

```
term          df/sessions   idf
pgbouncer          16      1.31
branch             13      1.50
omoda               5      2.35
suite               7      2.06
```

`pgbouncer` reads as commoner than `branch`. With the scale compressed like that, a floor of 2.0 discards words that identify something: a subject appearing in one session of seven scores 1.84 and is thrown away as filler.

Lowering the pair to 1.5 and 2.3, against a frozen index of 129 real prompts:

```
                                      before    after
fired                                112/129   129/129
block opens on a term the question used  89%       97%
headline names a term the block carries 100%      100%
```

Every prompt gets an answer and the answers are better. The curve is flat, not a point: 1.0/1.7 measures the same 129 and 97%, so this is not a value fitted to one number.

`bench prompt` is unchanged on every arm — real 11/12, negative controls 0 false fires, shown_line 14/14, haystack 3/3, russian 3/3, marathon and fresh 1/1, off_topic and bucket as before. `bench recall` 1.00/1.00, `bench context` 294 median tokens at coverage 1.00.

Mutation: putting the floor back at 2.0 fails the new test with `kestrel scored 1.84 and was not counted`.

The deeper fix is to stop measuring rarity in whole sessions at all — a 200-message episode as the document puts `pgbouncer` at 3.37 against `branch` at 1.27, which is the right order rather than a compressed one. That needs the document unit to change and is worth doing separately; this moves the thresholds to where the scale actually is.
