### PR TITLE
fix(hook): a rare word earns the memory, not a pointer to it

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -156,6 +156,11 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	}
 	ss := make([]model.Session, 0, 2)
 	confident := false
+	// worthDigest is the payload decision, kept apart from the announcement.
+	// A word rare enough to identify something is a real match — the bar above
+	// says so and lets such a question through — but saying "you have been here"
+	// on one word teaches the reader to ignore the line, so that stays at two.
+	worthDigest := false
 	seen := alreadyInjected(dir, input.SessionID)
 	pol := policy.Load()
 	for i, s := range ranked {
@@ -176,8 +181,22 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		if !recallWorthShowing(terms, matched[i], strong[i]) {
 			continue
 		}
+		// A word rare enough to identify something is a real match on its own —
+		// the bar just above says so in as many words, and lets such a question
+		// through. The payload rule did not: it asked only for two informative
+		// terms, so whether the reader got the memory or a pointer to it turned
+		// on whether some ordinary word of the question happened to also appear
+		// in that session.
+		//
+		// Measured on a real store over sixty subjects the project holds:
+		// "напомни, что мы решали про X" returned content 63% of the time and
+		// "what did we decide about X" returned it never — the same question,
+		// the same answer sitting in the same session.
 		if matched[i] >= 2 {
 			confident = true
+		}
+		if matched[i] >= 2 || strong[i] >= 1 {
+			worthDigest = true
 		}
 		// A marathon session that touched everything matches everything, so
 		// it used to be skipped whole. But the sessions people ask about are
@@ -223,7 +242,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// keeps it discoverable — the agent learns there is history here and can
 	// ask for it — for 134 bytes against the 0.5-1.3 KB a real digest measures.
 	var body string
-	if confident {
+	if worthDigest {
 		digest := search.AutoRecallDigestFor(ss, promptHookBudget-recallFrameOverhead, terms)
 		if strings.TrimSpace(digest) == "" {
 			return emitNudgeOnly(stdout, plain, nudge)

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -224,6 +224,42 @@ func TestHookPromptRequiresRealOverlap(t *testing.T) {
 	}
 }
 
+// A question whose whole subject is one rare word still gets the memory, not a
+// pointer to it. Withholding it turned the answer on whether some ordinary word
+// of the question happened to appear in that session too: measured on a real
+// store, "напомни, что мы решали про X" returned content 63% of the time and
+// "what did we decide about X" never — the same subject in the same session. On
+// a store without marathon sessions the crisper phrasing returned content in 0
+// of 78. The "you have been here" line stays at two terms, which is what the
+// test above guards.
+func TestOneRareWordStillGetsTheMemory(t *testing.T) {
+	hermeticEnv(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-delta", "one.jsonl"), "one", []string{
+		`{"type":"user","sessionId":"one","timestamp":"` + old + `","message":{"role":"user","content":"the quetzalcoatl stampede was fixed by jittering the retry"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "delta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	var out bytes.Buffer
+	in := strings.NewReader(`{"prompt":"quetzalcoatl"}`)
+	if err := runHookPrompt(index.DefaultDir(), in, &out); err != nil {
+		t.Fatal(err)
+	}
+	// A pointer names the topic in full, so checking for the words is not
+	// enough — the quoted transcript is what separates the memory from a
+	// pointer to it.
+	if !strings.Contains(out.String(), "- User:") {
+		t.Fatalf("one rare word earned a pointer instead of the memory:\n%s", out.String())
+	}
+}
+
 func TestDejaVuTopicSkipsHarnessPlumbing(t *testing.T) {
 	s := model.Session{
 		Harness: "codex", ID: "x", Project: "app",


### PR DESCRIPTION
Whether a question gets the memory or a pointer to it depends on something the asker cannot see.

The payload rule asks for two informative terms. The bar just above it already says a single rare word is a real match — "pgbouncer answers a question, problem does not" — and lets such a question through. The payload rule ignored that, so a question whose whole subject is one word landed on the pointer path, and one padded with an ordinary word that happened to appear in the same session got the digest.

Measured over sixty subjects each store really holds, asked four ways:

```
"напомни, что мы решали про X"    38/60 = 63%   content
"почему мы выбрали X"             16/60 = 27%
"что там было с X в итоге"         0/60 =  0%   every one a pointer
"what did we decide about X"       0/60 =  0%   every one a pointer
```

All four reduce to two terms and clear the gate that opens the store. What decides is the second word: `решали` appears in those sessions, `итоге` and `decide` do not. The crisper the question, the surer the answer is a pointer.

This lets a strong term earn the digest. The "you have been here" line stays at two terms — saying it on one word teaches the reader to ignore it, which the test above the new one guards.

```
                              content with the subject      injected per prompt
store with marathon sessions      33% -> 51%                  615 -> 788 chars
store of small sessions            0% -> 64%                  264 -> 655 chars
```

On a store without marathon sessions the old rule returned content for a direct subject question **zero times in 78**.

Ordinary traffic pays nothing. Over 129 real prompts on one store and 41 on the other, fired count, block quality and injected size are identical before and after — those prompts already carry two informative terms, so the new clause never fires there.

```
marathon profile  112/129 fired, 88% opening on a subject term, 855 chars/prompt — before and after
small profile      17/41  fired, 59%,                           418 chars/prompt — before and after
```

`bench prompt` unchanged on every arm, `bench recall` 1.00/1.00, `bench context` unchanged.

Mutation: dropping the new clause fails `TestOneRareWordStillGetsTheMemory`. Two earlier drafts of that test passed under their own mutant and were rewritten — the first because its fixture already had two matching terms, the second because a pointer names the topic in full, so checking for the words in the block did not separate a memory from a pointer to one. It asserts the quoted transcript now.
