### PR TITLE
test(bench): the answering session also says an ordinary word, and the block opens on it

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -144,6 +144,11 @@ type promptReport struct {
 	// and read as worthless. Correct here means the first line the agent sees
 	// carries a word from the question.
 	Shown promptArmReport `json:"shown_line"`
+	// The decoy arm: the session that answers also says an ordinary word of the
+	// question, three times, about something else. Correct means the block opens
+	// on the line that carries the subject rather than the one that carries the
+	// ordinary word.
+	Decoy promptArmReport `json:"decoy_line"`
 	// Questions whose subject the project has never held, asked with words it
 	// has. Every fire is a false one: there is nothing to answer with.
 	//
@@ -233,6 +238,18 @@ func measurePrompt(seed int64) (promptReport, error) {
 			arm = &report.Haystack
 		case "russian":
 			arm = &report.Russian
+		case "decoy":
+			// Scored with the question's own terms, the way the hook builds the
+			// block. An earlier version of this arm rebuilt it from the topic
+			// alone and so could never see the decoy at all — it read 2/2 while
+			// the block opened on "decide whether to decide this now".
+			arm = &report.Decoy
+			arm.Cases++
+			if firstShownLineCarries(indexDir, scope, terms, chain.Topic) {
+				arm.Fired++
+				arm.Correct++
+			}
+			continue
 		default:
 			realTerms = append(realTerms, len(terms))
 		}
@@ -297,6 +314,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 		}
 	}
 	finishPromptArm(&report.Shown, nil)
+	finishPromptArm(&report.Decoy, nil)
 	finishPromptArm(&report.AbsentSubject, nil)
 	return report, nil
 }
@@ -336,6 +354,35 @@ func shownLineCarriesATerm(dir, project string, terms []string) bool {
 			}
 		}
 		return false
+	}
+	return false
+}
+
+// firstShownLineCarries builds the block the hook would inject for this question
+// and reports whether its first quoted line carries the subject rather than an
+// ordinary word the question shares with the same session.
+func firstShownLineCarries(dir, project string, terms []string, topic string) bool {
+	ranked, matched, strong, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	if err != nil || len(ranked) == 0 {
+		return false
+	}
+	var keep []model.Session
+	for i := range ranked {
+		if !recallWorthShowing(terms, matched[i], strong[i]) {
+			continue
+		}
+		keep = append(keep, ranked[i])
+		break
+	}
+	if len(keep) == 0 {
+		return false
+	}
+	for _, ln := range strings.Split(search.AutoRecallDigestFor(keep, 2000, terms), "\n") {
+		ln = strings.TrimSpace(ln)
+		if !strings.HasPrefix(ln, "- User:") && !strings.HasPrefix(ln, "- Assistant:") {
+			continue
+		}
+		return search.TextCarriesTerm(ln, topic)
 	}
 	return false
 }

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -277,6 +277,35 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
+	// The decoy line. The session that answers also says an ordinary word the
+	// question happens to use, in a place that has nothing to do with the
+	// subject. Measured on a real store: "what did we decide about mm_status"
+	// returned that session and quoted "1. **Decide**: User settings (global) or
+	// project settings?" — the right session, the wrong line, because the
+	// digest weighs every query word alike while the ranking knows which one
+	// identified the match.
+	for i, d := range []promptTopic{
+		{"quicksilver", "quicksilver retries are capped at four", "what did we decide about quicksilver"},
+		{"harbourmaster", "harbourmaster writes its log to stderr", "what did we decide about harbourmaster"},
+	} {
+		id := fmt.Sprintf("prompt-decoy-%02d", i)
+		project := fmt.Sprintf("promptbenchdecoy%02d", i)
+		t := base.Add(time.Duration(2500+i*10) * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: project, Kind: "decoy",
+			Topic: d.word, Question: d.question,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: project,
+				Started: t, Updated: t.Add(3 * time.Minute),
+				Messages: []model.Message{
+					// The ordinary word of the question, said three times, about
+					// something else entirely.
+					{Role: "user", Text: "decide whether to decide this now or decide it later", Time: t},
+					{Role: "assistant", Text: "we decided " + d.fact, Time: t.Add(time.Minute)},
+				},
+			}},
+		})
+	}
 	// The haystack. Measured on a frozen copy of a real index 2026-08-20: of 45
 	// live prompts, 33 were answered by one session of 38131 messages and 11 by
 	// one of 29190 — the two largest in the index, in order of size, for


### PR DESCRIPTION
A defect the benchmark could not see, with an arm that now sees it.

The session that answers a question often also says an ordinary word the question happens to use, somewhere unrelated. The digest weighs every query word alike, so the block opens on the ordinary one. Measured on a real store after the payload rule changed in #1453:

```
what did we decide about mm_status      ->  "- User: 1. **Decide**: User settings or project settings?"
what did we decide about drop-non-owner ->  "- User: Decide the integration approach given…"
```

Right session, wrong line. Ten of the thirty-nine answers that #1453 converted from a pointer to a memory landed this way, against twenty-nine that carried the subject.

The arm puts a session in a project of its own: one message saying `decide` three times about nothing, one message holding the subject. The question is `what did we decide about <subject>`. Correct means the first quoted line carries the subject.

```
decoy_line  0/2
```

Every other arm is unchanged — real 11/12, shown_line 14/14, haystack 3/3, russian 3/3, negative controls 0 false fires; `bench recall` 1.00/1.00.

The first draft of this arm read 2/2 and would have hidden the very thing it was written for: it rebuilt the block from the subject alone rather than from the question's terms, so the decoy never competed. It scores the block the hook actually builds now.

No fix here. What it points at: the ranking knows which term made the match strong and does not pass that down, so `matchedLines` cannot tell `decide` from `mm_status`. Four cheaper signals for the same job were measured and rejected — rarity within the session, frequency within the session, position in the session, and mention count — each worse than the current rule on a real store.
