### PR TITLE
fix(recall): open the block on the line that answers

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -144,6 +144,11 @@ type promptReport struct {
 	// and read as worthless. Correct here means the first line the agent sees
 	// carries a word from the question.
 	Shown promptArmReport `json:"shown_line"`
+	// The decoy arm: the session that answers also says an ordinary word of the
+	// question, three times, about something else. Correct means the block opens
+	// on the line that carries the subject rather than the one that carries the
+	// ordinary word.
+	Decoy promptArmReport `json:"decoy_line"`
 	// Questions whose subject the project has never held, asked with words it
 	// has. Every fire is a false one: there is nothing to answer with.
 	//
@@ -233,6 +238,18 @@ func measurePrompt(seed int64) (promptReport, error) {
 			arm = &report.Haystack
 		case "russian":
 			arm = &report.Russian
+		case "decoy":
+			// Scored with the question's own terms, the way the hook builds the
+			// block. An earlier version of this arm rebuilt it from the topic
+			// alone and so could never see the decoy at all — it read 2/2 while
+			// the block opened on "decide whether to decide this now".
+			arm = &report.Decoy
+			arm.Cases++
+			if firstShownLineCarries(indexDir, scope, terms, chain.Topic) {
+				arm.Fired++
+				arm.Correct++
+			}
+			continue
 		default:
 			realTerms = append(realTerms, len(terms))
 		}
@@ -297,6 +314,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 		}
 	}
 	finishPromptArm(&report.Shown, nil)
+	finishPromptArm(&report.Decoy, nil)
 	finishPromptArm(&report.AbsentSubject, nil)
 	return report, nil
 }
@@ -336,6 +354,35 @@ func shownLineCarriesATerm(dir, project string, terms []string) bool {
 			}
 		}
 		return false
+	}
+	return false
+}
+
+// firstShownLineCarries builds the block the hook would inject for this question
+// and reports whether its first quoted line carries the subject rather than an
+// ordinary word the question shares with the same session.
+func firstShownLineCarries(dir, project string, terms []string, topic string) bool {
+	ranked, matched, strong, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	if err != nil || len(ranked) == 0 {
+		return false
+	}
+	var keep []model.Session
+	for i := range ranked {
+		if !recallWorthShowing(terms, matched[i], strong[i]) {
+			continue
+		}
+		keep = append(keep, ranked[i])
+		break
+	}
+	if len(keep) == 0 {
+		return false
+	}
+	for _, ln := range strings.Split(search.AutoRecallDigestFor(keep, 2000, terms), "\n") {
+		ln = strings.TrimSpace(ln)
+		if !strings.HasPrefix(ln, "- User:") && !strings.HasPrefix(ln, "- Assistant:") {
+			continue
+		}
+		return search.TextCarriesTerm(ln, topic)
 	}
 	return false
 }

--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -324,7 +324,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 // opening line came from the top of a long transcript does not, and that line
 // is the whole frame an agent reads before deciding to ignore the rest.
 func shownLineCarriesATerm(dir, project string, terms []string) bool {
-	ranked, matched, strong, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil {
 		return false
 	}
@@ -362,10 +362,13 @@ func shownLineCarriesATerm(dir, project string, terms []string) bool {
 // and reports whether its first quoted line carries the subject rather than an
 // ordinary word the question shares with the same session.
 func firstShownLineCarries(dir, project string, terms []string, topic string) bool {
-	ranked, matched, strong, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil || len(ranked) == 0 {
 		return false
 	}
+	// Ordered the way the hook orders them, so the arm scores the block the
+	// product builds rather than one built from the raw query.
+	terms = byIdentifying(terms, idfOf)
 	var keep []model.Session
 	for i := range ranked {
 		if !recallWorthShowing(terms, matched[i], strong[i]) {
@@ -396,7 +399,7 @@ func promptBenchProbe(dir, project, chainID string, terms []string) (fired, corr
 	if !promptTermsWorthAsking(terms) {
 		return false, false
 	}
-	ranked, matched, strong, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil {
 		return false, false
 	}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -150,7 +150,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// Rank THIS project's sessions by how well they match the prompt terms
 	// (IDF-weighted), rather than reconstructing an AND query — natural
 	// prompts are full of filler that poisons an AND.
-	ranked, matched, strong, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, prompt.Candidates)
+	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, prompt.Candidates)
 	if err != nil || len(ranked) == 0 {
 		return emitNudgeOnly(stdout, plain, nudge)
 	}
@@ -243,7 +243,11 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// ask for it — for 134 bytes against the 0.5-1.3 KB a real digest measures.
 	var body string
 	if worthDigest {
-		digest := search.AutoRecallDigestFor(ss, promptHookBudget-recallFrameOverhead, terms)
+		// Hand the digest the query's words most-identifying first. It has no
+		// way of its own to tell "mm_status" from "decide", and the session
+		// that answers often says both — measured live, ten of the answers
+		// this hook newly returns open on the ordinary word.
+		digest := search.AutoRecallDigestFor(ss, promptHookBudget-recallFrameOverhead, byIdentifying(terms, idfOf))
 		if strings.TrimSpace(digest) == "" {
 			return emitNudgeOnly(stdout, plain, nudge)
 		}
@@ -353,6 +357,18 @@ func hasCyrillic(t string) bool {
 		}
 	}
 	return false
+}
+
+// byIdentifying orders the query's terms by what the index says each is worth,
+// rarest first, so a caller choosing one line out of a session can prefer the
+// word that identified the match over the word that merely appeared in it.
+func byIdentifying(terms []string, idf map[string]float64) []string {
+	if len(idf) == 0 || len(terms) < 2 {
+		return terms
+	}
+	out := append([]string(nil), terms...)
+	sort.SliceStable(out, func(i, j int) bool { return idf[out[i]] > idf[out[j]] })
+	return out
 }
 
 // citationLine pre-writes the narration so the agent copies structure instead

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -228,7 +228,7 @@ func commandDecisionLine(dir, cmd string) string {
 	if cwd == "" {
 		cwd, _ = os.Getwd()
 	}
-	ranked, matched, _, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, toolHookDecisionScan)
+	ranked, matched, _, _, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, toolHookDecisionScan)
 	if err != nil {
 		return ""
 	}

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -277,6 +277,35 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
+	// The decoy line. The session that answers also says an ordinary word the
+	// question happens to use, in a place that has nothing to do with the
+	// subject. Measured on a real store: "what did we decide about mm_status"
+	// returned that session and quoted "1. **Decide**: User settings (global) or
+	// project settings?" — the right session, the wrong line, because the
+	// digest weighs every query word alike while the ranking knows which one
+	// identified the match.
+	for i, d := range []promptTopic{
+		{"quicksilver", "quicksilver retries are capped at four", "what did we decide about quicksilver"},
+		{"harbourmaster", "harbourmaster writes its log to stderr", "what did we decide about harbourmaster"},
+	} {
+		id := fmt.Sprintf("prompt-decoy-%02d", i)
+		project := fmt.Sprintf("promptbenchdecoy%02d", i)
+		t := base.Add(time.Duration(2500+i*10) * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: project, Kind: "decoy",
+			Topic: d.word, Question: d.question,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: project,
+				Started: t, Updated: t.Add(3 * time.Minute),
+				Messages: []model.Message{
+					// The ordinary word of the question, said three times, about
+					// something else entirely.
+					{Role: "user", Text: "decide whether to decide this now or decide it later", Time: t},
+					{Role: "assistant", Text: "we decided " + d.fact, Time: t.Add(time.Minute)},
+				},
+			}},
+		})
+	}
 	// The haystack. Measured on a frozen copy of a real index 2026-08-20: of 45
 	// live prompts, 33 were answered by one session of 38131 messages and 11 by
 	// one of 29190 — the two largest in the index, in order of size, for

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -243,7 +243,7 @@ func TestProjectRelevantRanksByIDFNotFiller(t *testing.T) {
 		t.Fatal(err)
 	}
 	// A prompt full of filler plus the one rare term must rank s1 first.
-	got, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"need", "the", "quetzalcoatl"}, 2)
+	got, _, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"need", "the", "quetzalcoatl"}, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func TestStemFoldIsDecidedByTheProjectNotTheStore(t *testing.T) {
 	if err := Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	got, matched, _, err := ProjectRelevant(dir, []string{"app"}, []string{"write", "parquet"}, 3)
+	got, matched, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"write", "parquet"}, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestProjectRelevantDottedTermNeedsAllSubTokens(t *testing.T) {
 	if err := Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	got, matched, _, err := ProjectRelevant(dir, []string{"app"}, []string{"203.0.113.51"}, 4)
+	got, matched, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"203.0.113.51"}, 4)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/cyrillic_test.go
+++ b/internal/index/cyrillic_test.go
@@ -205,7 +205,7 @@ func TestRussianRelevanceFoldsInflections(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Nominative singular in the prompt, instrumental plural in the session.
-	got, matched, _, err := ProjectRelevant(dir, []string{"app"}, []string{"миграция", "репликация"}, 3)
+	got, matched, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"миграция", "репликация"}, 3)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/lock_nonblocking_test.go
+++ b/internal/index/lock_nonblocking_test.go
@@ -24,7 +24,7 @@ func TestReadsDoNotBlockWhileTheIndexIsLocked(t *testing.T) {
 	go func() {
 		defer close(done)
 		_, _, _ = FindByPrefix(dir, "nothing")
-		_, _, _, _ = ProjectRelevant(dir, []string{"p"}, []string{"term"}, 3)
+		_, _, _, _, _ = ProjectRelevant(dir, []string{"p"}, []string{"term"}, 3)
 		_, _ = RecentProject(dir, "p", 3)
 		_, _, _ = FirstMatch(dir, []string{"term"}, 3)
 	}()

--- a/internal/index/locked_read_test.go
+++ b/internal/index/locked_read_test.go
@@ -46,7 +46,7 @@ func TestReadsAnswerWhileTheIndexLockIsHeld(t *testing.T) {
 	var got int
 	go func() {
 		defer close(done)
-		sessions, _, _, rerr := ProjectRelevant(dir, []string{"app"},
+		sessions, _, _, _, rerr := ProjectRelevant(dir, []string{"app"},
 			[]string{"quetzalcoatl"}, 2)
 		if rerr != nil {
 			t.Errorf("read under the lock: %v", rerr)

--- a/internal/index/relevance_bench_test.go
+++ b/internal/index/relevance_bench_test.go
@@ -50,7 +50,7 @@ func BenchmarkRussianRelevance(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if _, _, _, err := ProjectRelevant(dir, []string{"app"}, terms, 10); err != nil {
+		if _, _, _, _, err := ProjectRelevant(dir, []string{"app"}, terms, 10); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/index/relevance_roles_test.go
+++ b/internal/index/relevance_roles_test.go
@@ -86,7 +86,7 @@ func TestRelevanceHonoursTheRequestedRole(t *testing.T) {
 // context is pasting the wrong thing.
 func TestProjectRelevantDoesNotServeWorkRecords(t *testing.T) {
 	dir := rolesIndex(t)
-	ss, _, _, err := ProjectRelevant(dir, []string{"p"}, []string{"frobnicator", "values", "rollout"}, 5)
+	ss, _, _, _, err := ProjectRelevant(dir, []string{"p"}, []string{"frobnicator", "values", "rollout"}, 5)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -525,7 +525,7 @@ const dejaVuStrongIDFFloor = 3.0
 // the prompt terms. matched reports, per returned session, how many distinct
 // INFORMATIVE terms hit (idf >= dejaVuIDFFloor) — callers gate on it so
 // generic words cannot manufacture a confident "you have been here".
-func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Session, []int, []int, error) {
+func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Session, []int, []int, map[string]float64, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -534,35 +534,35 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 	// rebuild — which every user hits on an index-format upgrade.
 	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	if ok {
 		defer unlock()
 	}
 	m, err := readManifestCached(dir)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	metas, matched, strong, rerr := relevantMetasMatched(dir, m, projects, terms, n)
+	metas, matched, strong, idf, rerr := relevantMetasMatched(dir, m, projects, terms, n)
 	if rerr != nil {
 		// A corrupt or unreadable bucket. The hook never rebuilds, so surface
 		// it rather than inject a silently short-ranked déjà vu; the caller
 		// stays quiet on an error.
-		return nil, nil, nil, rerr
+		return nil, nil, nil, nil, rerr
 	}
 	if len(metas) == 0 {
-		return nil, nil, nil, nil
+		return nil, nil, nil, nil, nil
 	}
 	out, err := sessionsServable(dir, metas, query.Options{})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	return out, matched, strong, nil
+	return out, matched, strong, idf, nil
 }
 
-func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n int) ([]SessionMeta, []int, []int, error) {
+func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n int) ([]SessionMeta, []int, []int, map[string]float64, error) {
 	rank, err := relevantMetasCounts(dir, m, projects, terms, n, nil)
-	return rank.metas, rank.informative, rank.strong, err
+	return rank.metas, rank.informative, rank.strong, rank.idf, err
 }
 
 // relevanceRanking is what one ranking pass produced. It was seven return

--- a/internal/index/sync_recall_test.go
+++ b/internal/index/sync_recall_test.go
@@ -90,7 +90,7 @@ func TestASyncedProjectIsInScopeUnderTheLocalName(t *testing.T) {
 // filter as search, so this checks it survives that too.
 func TestAutoRecallReachesSyncedWork(t *testing.T) {
 	dir := importedIndex(t)
-	ss, _, _, err := ProjectRelevant(dir, []string{"svc"}, []string{"ratelimiter", "smoothing", "window"}, 5)
+	ss, _, _, _, err := ProjectRelevant(dir, []string{"svc"}, []string{"ratelimiter", "smoothing", "window"}, 5)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/search/decoy_line_test.go
+++ b/internal/search/decoy_line_test.go
@@ -1,0 +1,44 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A session answers the question in one line and echoes an ordinary word of it
+// in another. The block has to open on the line that answers.
+//
+// The question slot took the best-matching user line whatever it carried, and
+// the block is printed with that slot first, so a session saying "decide" three
+// times about nothing led with it. Measured on a real store: "what did we decide
+// about mm_status" opened on "1. **Decide**: User settings (global) or project
+// settings?" while the answer sat below.
+func TestBlockOpensOnTheLineThatAnswers(t *testing.T) {
+	at := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	s := model.Session{
+		ID: "one", Harness: "claude", Project: "app", Started: at, Updated: at,
+		Messages: []model.Message{
+			{Role: "user", Text: "decide whether to decide this now or decide it later", Time: at},
+			{Role: "assistant", Text: "we decided quicksilver retries are capped at four", Time: at.Add(time.Minute)},
+		},
+	}
+	// Terms arrive most-identifying first, the way the hook orders them.
+	block := AutoRecallDigestFor([]model.Session{s}, 2000, []string{"quicksilver", "decide"})
+	first := ""
+	for _, ln := range strings.Split(block, "\n") {
+		ln = strings.TrimSpace(ln)
+		if strings.HasPrefix(ln, "- User:") || strings.HasPrefix(ln, "- Assistant:") {
+			first = ln
+			break
+		}
+	}
+	if first == "" {
+		t.Fatalf("no quoted line in the block:\n%s", block)
+	}
+	if !strings.Contains(first, "quicksilver") {
+		t.Fatalf("the block opens on a line that only echoes a word of the question:\n%s", first)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -478,6 +478,12 @@ func matchedLines(s model.Session, terms []string) (string, []string) {
 		if hits == 0 {
 			continue
 		}
+		// Terms arrive most-identifying first when the caller knows the order,
+		// so a line carrying the word that identified the match beats one
+		// carrying an ordinary word the same session happens to use. Without
+		// this every query word weighs the same and "decide" wins on being
+		// said three times.
+		hits = hits*len(terms) + rankOfBestTerm(line, terms)
 		text := contextText(line, false)
 		if strings.TrimSpace(text) == "" {
 			continue
@@ -492,6 +498,16 @@ func matchedLines(s model.Session, terms []string) (string, []string) {
 		}
 	}
 	sort.SliceStable(assistants, func(i, j int) bool { return assistants[i].hits > assistants[j].hits })
+	// The block opens with what the user said, and that slot is filled by the
+	// best-matching user line whatever it carries. When the session says an
+	// ordinary word of the question in one place and answers it in another,
+	// that puts the ordinary line first: measured live, "what did we decide
+	// about mm_status" opened on "1. **Decide**: User settings or project
+	// settings?" while the answer sat two lines below. If a line the agent
+	// wrote is worth more, lead with that instead of framing it with this.
+	if len(assistants) > 0 && assistants[0].hits > bestUser.hits {
+		bestUser = scored{}
+	}
 	if len(assistants) > 2 {
 		assistants = assistants[:2]
 	}
@@ -503,6 +519,17 @@ func matchedLines(s model.Session, terms []string) (string, []string) {
 		out = append(out, a.text)
 	}
 	return bestUser.text, out
+}
+
+// rankOfBestTerm scores which of the query's terms a line carries, counting the
+// earliest in the slice — the most identifying one — for the most.
+func rankOfBestTerm(line string, terms []string) int {
+	for i, t := range terms {
+		if t != "" && TextCarriesTerm(line, t) {
+			return len(terms) - i
+		}
+	}
+	return 0
 }
 
 // densestLine returns the line of a message carrying the most query terms, and

--- a/scripts/longmemeval/main.go
+++ b/scripts/longmemeval/main.go
@@ -529,7 +529,7 @@ func runHookPrecision(questions []lmeQuestion, limit int) {
 		// identifier test and a six-term cap, so measuring the gate on
 		// relevance terms measured a rule that never runs.
 		terms := prompt.Terms(questions[i].Question)
-		_, matched, strong, err := index.ProjectRelevant(dir, nil, terms, prompt.Candidates)
+		_, matched, strong, _, err := index.ProjectRelevant(dir, nil, terms, prompt.Candidates)
 		if err != nil {
 			cleanup()
 			fatal(err)


### PR DESCRIPTION
Builds on #1454, which added the arm this fixes.

The block opens with what the user said, and that slot was filled by the best-matching user line whatever it carried. A session that says an ordinary word of the question in one place and answers the question in another led with the ordinary line:

```
what did we decide about mm_status      ->  "- User: 1. **Decide**: User settings or project settings?"
what did we decide about drop-non-owner ->  "- User: Decide the integration approach given…"
```

Two changes, both small:

- the ranking now hands the digest the query's terms most-identifying first, using the idf it already computed and used to throw away. Without that, `matchedLines` weighs `mm_status` and `decide` alike;
- when a line the agent wrote is worth more than the best user line, the block leads with it rather than framing it with a line that only echoes a word.

```
                       before   after
decoy_line              0/2      2/2
real_questions         11/12    11/12
shown_line             14/14    14/14
haystack                3/3      3/3
russian_questions       3/3      3/3
negative_controls    0 false   0 false
absent_subject, off_topic, bucket, marathon, fresh — unchanged
bench recall          1.00/1.00 unchanged
bench context         unchanged
```

Live, 120 direct subject questions against a frozen index:

```
quoted answer carrying the subject   81/120 -> 83/120
quoted but missing it                   20  -> 18
pointer only                            19  -> 19
```

Ordinary traffic is unaffected on both store profiles — one with marathon sessions, one without:

```
marathon profile  112/129 fired, 88% -> 89% opening on a subject term, 855 -> 852 chars per prompt
small profile      17/41  fired, 59% -> 59%,                            418 -> 413 chars per prompt
```

Slightly smaller blocks, because a line that carried nothing is no longer printed.

The measurement caught two of my own mistakes before the fix went in: the first version of the arm rebuilt the block from the subject alone, so it read 2/2 while the block opened on the decoy; and ordering the terms alone changed nothing, because the user slot is printed first regardless of what it is worth. Both are in the commit messages of #1454 and here.
