### PR TITLE
test(bench): read the arms the report only printed

### DIFF
--- a/cmd/deja/bench_prompt_test.go
+++ b/cmd/deja/bench_prompt_test.go
@@ -80,6 +80,44 @@ func TestPromptBenchScoresAndReports(t *testing.T) {
 	if report.CorpusHash == "" {
 		t.Fatal("report carries no corpus hash, so results cannot be compared across runs")
 	}
+	// Every other arm was reported and nothing read it. Over one night three
+	// separate changes moved shown_line, haystack and russian_questions and the
+	// suite stayed green — the numbers only appeared in a PR description, where
+	// they are worth exactly as much as whoever remembered to look.
+	//
+	// Floors, not equalities: an arm that improves must not need this file
+	// edited, and the three arms that still read false fires are held at their
+	// current count so the known defects cannot quietly grow.
+	if report.Shown.Correct < report.Shown.Cases {
+		t.Fatalf("shown_line %d/%d: a block opened on a line carrying none of the question",
+			report.Shown.Correct, report.Shown.Cases)
+	}
+	if report.Haystack.Correct < 3 {
+		t.Fatalf("haystack %d/%d: a long session that mentions everything won again",
+			report.Haystack.Correct, report.Haystack.Cases)
+	}
+	if report.Russian.Correct < 3 {
+		t.Fatalf("russian_questions %d/%d", report.Russian.Correct, report.Russian.Cases)
+	}
+	if report.Marathon.Fired < 1 || report.Fresh.Fired < 1 {
+		t.Fatalf("marathon %d/%d, fresh %d/%d: a shape the gates turn away",
+			report.Marathon.Fired, report.Marathon.Cases, report.Fresh.Fired, report.Fresh.Cases)
+	}
+	// Known defects, held where they are. Each has its own entry in the loop
+	// journal and none has a fix that survived measurement on a real store.
+	for _, k := range []struct {
+		name string
+		arm  promptArmReport
+		max  int
+	}{
+		{"absent_subject", report.AbsentSubject, 3},
+		{"off_topic", report.OffTopic, 3},
+		{"bucket_scope", report.Bucket, 1},
+	} {
+		if k.arm.FalseFires > k.max {
+			t.Fatalf("%s false fires rose to %d of %d, was %d", k.name, k.arm.FalseFires, k.arm.Cases, k.max)
+		}
+	}
 }
 
 func TestRunBenchPromptWritesJSONAndText(t *testing.T) {


### PR DESCRIPTION
`bench prompt` reports eleven arms. One test reads two of them.

Everything else — `shown_line`, `haystack`, `russian_questions`, `marathon_sessions`, `fresh_sessions`, `decoy_line`, and the three that still count false fires — is printed and forgotten. Over one night three separate changes moved `shown_line`, `haystack` and `russian_questions` while `go test ./...` stayed green; the numbers lived only in PR descriptions, where they are worth what whoever remembered to look made them worth.

This reads them. Floors rather than equalities, so an arm that improves does not need this file edited:

```
shown_line          every block opens on a line carrying the question
haystack            at least 3 of 3 — the small session that decided it still wins
russian_questions   at least 3 of 3
marathon, fresh     at least one fire each — the shapes the gates turn away
absent_subject      false fires held at 3
off_topic           held at 3
bucket_scope        held at 1
```

The last three are known defects with entries in the loop journal and no fix that survived measurement on a real store; holding them at their current count keeps them from quietly growing.

Mutation: filling the question slot from the top of the session again — the defect fixed earlier — takes `shown_line` to 11/14 and the test fails with the arm and the count. Before this it passed.
