### PR TITLE
fix(prompt): a hyphen inside a Russian word no longer drops it

### DIFF
--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -79,6 +79,12 @@ func promptRussianTopics() []promptTopic {
 			"погоди, а по чему у нас в итоге шардирование, покажи ещё раз"},
 		{"индексация", "индексацию перенесли в фоновый воркер после записи",
 			"подожди, где именно теперь происходит индексация, объясни снова"},
+		// A compound written with a hyphen, which is how people name things in
+		// Russian as readily as in English. Measured on a real store, one direct
+		// question in seven that got no answer at all was this: the subject word
+		// never became a search term, so nothing could match it.
+		{"коорд-сообщение", "коорд-сообщение теперь шлём одно на всю группу",
+			"напомни, что мы решали про коорд-сообщение"},
 	}
 }
 

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -94,14 +94,32 @@ func Terms(prompt string) []string {
 // search on. Short words carry no signal and the closed class is noise, so
 // both are dropped; what is left is roughly what techTerm keeps for ASCII.
 func cyrPromptTerm(f string) bool {
-	n := 0
+	// A hyphen joins two words into one name as readily in Russian as in
+	// English. Requiring every rune to be Cyrillic threw the whole compound
+	// away, and the ASCII path would not take it either, so "коорд-сообщение"
+	// could not become a search term at all — measured on a real store, one
+	// direct question in seven that got no answer was exactly this.
+	letters := 0
 	for _, r := range f {
+		if r == '-' {
+			continue
+		}
 		if r < 0x400 || r > 0x4ff {
 			return false
 		}
-		n++
+		letters++
 	}
-	return n >= 5 && !cyrPromptStop[f]
+	if letters < 5 || cyrPromptStop[f] {
+		return false
+	}
+	// A compound made only of closed-class words is still filler: "то-то-сё"
+	// names nothing. One part that carries meaning is enough.
+	for _, part := range strings.Split(f, "-") {
+		if len([]rune(part)) >= 5 && !cyrPromptStop[part] {
+			return true
+		}
+	}
+	return !strings.Contains(f, "-")
 }
 func hasCJKRune(s string) bool {
 	for _, r := range s {


### PR DESCRIPTION
A hyphen joins two words into one name in Russian as readily as in English. The extractor required every rune of a Cyrillic term to be a Cyrillic letter, so the hyphen failed that check — and the ASCII path would not take the word either, because it holds Cyrillic. The whole compound was dropped, and nothing downstream could match it.

```
коорд-сообщение  ->  []                 dropped
notes-изоляции   ->  [notes-изоляции]   mixed script, kept
fail-closed      ->  [fail-closed]      Latin, kept
```

Found while measuring how often a direct question about a subject the store holds gets no answer at all: on a store of ordinary short sessions, seven of thirty-nine were silent, and one of those seven was this — the subject never became a search term.

A Russian arm with a hyphenated subject reproduces it before the fix:

```
russian_questions  3/4
```

With the fix, and one more case in `shown_line` for the same reason:

```
russian_questions  4/4
shown_line        15/15
real_questions    11/12   unchanged
negative_controls  0 false fires
haystack           3/3
bench recall       1.00/1.00,  bench context unchanged
```

A compound made only of closed-class words is still filler — one part has to carry meaning on its own, so `то-то-сё` stays out while `коорд-сообщение` gets in.

Live it changes nothing on either store profile: 112/129 fired at 88% and 855 chars per prompt, before and after. The one live case that prompted this is silent for a different reason — it sits in a home-directory scope, where staying quiet is deliberate and guarded by the `bucket_scope` arm.

Mutation: putting the rune check back takes the arm to 3/4.
