### PR TITLE
fix(prompt): keep three-letter acronyms

### DIFF
--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -96,6 +96,13 @@ func promptTopics() []promptTopic {
 		{"dns", "dns lookups are cached for 30 seconds inside the pool", "how long do we cache dns lookups?"},
 		{"panic", "a panic in the parser is recovered and logged as a corrupt file", "what happens when the parser panics?"},
 		{"wal", "wal mode is enabled so readers stop blocking the writer", "why did we turn on wal mode?"},
+		// Asked with nothing but the subject and filler around it. The other
+		// three-letter topics here are asked in sentences carrying words the
+		// answering session also uses — "settle", "mode" — so they pass on
+		// those and the floor never shows. Measured: "what ttl did we settle
+		// on" reduces to [settle], and the ttl case is answered by a word that
+		// has nothing to do with ttl.
+		{"tls", "tls verification stays on for the internal mesh", "напомни, что там было с tls"},
 	}
 }
 

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -113,6 +113,21 @@ func hasCJKRune(s string) bool {
 	return false
 }
 
+// shortWord is the three-letter English words that are work, not subjects. A
+// question is about "ttl" or "dns"; it is never about "log" on its own.
+var shortWord = map[string]bool{
+	"log": true, "run": true, "fix": true, "add": true, "set": true,
+	"get": true, "put": true, "new": true, "old": true, "the": true,
+	"and": true, "for": true, "but": true, "not": true, "all": true,
+	"any": true, "one": true, "two": true, "out": true, "off": true,
+	"top": true, "end": true, "use": true, "see": true, "way": true,
+	"day": true, "now": true, "how": true, "why": true, "who": true,
+	"its": true, "has": true, "was": true, "are": true, "can": true,
+	"did": true, "let": true, "try": true, "job": true, "bug": true,
+	"yes": true, "may": true, "our": true, "his": true, "her": true,
+	"you": true, "too": true, "own": true, "per": true, "via": true,
+}
+
 // promptFiller is the short English filler a four-character floor lets
 // through. search.IsStopWord is deliberately not extended: it governs search
 // queries too, where "about" typed on purpose should still match.
@@ -155,6 +170,14 @@ func techTerm(f string) bool {
 	// and no false fire on any negative control; three scores higher still
 	// but starts keeping words like "log" and "run", so four is where the
 	// evidence stops being comfortable.
+	if long == 3 {
+		// Three letters is where the acronyms live — ttl, dns, wal, api, ssh,
+		// mcp, tls — and the reason the floor stood at four is that it is also
+		// where "log" and "run" live. Naming those instead of measuring their
+		// length keeps both: the list is closed-class English, the same kind
+		// the Russian half of this file already carries.
+		return !shortWord[f]
+	}
 	return long >= 4
 }
 


### PR DESCRIPTION
`ttl`, `dns`, `wal`, `api`, `ssh`, `tls`, `mcp`, `cpu` — none of them could become a search term.

The floor stands at four letters, and the comment above it says why: three keeps more but starts keeping `log` and `run`. That reasoning is sound and the same comment names `ttl` as a word people type. Both are true; the length was doing two jobs at once.

The benchmark could not see it. It has `ttl`, `dns` and `wal` as topics, and asks about them in sentences that carry other words the answering session also uses:

```
"what ttl did we settle on"  ->  [settle]
```

The ttl case passes on `settle`. A case asking with nothing but the subject and filler around it reproduces the defect:

```
real_questions  11/13
```

The fix names the three-letter words that are work rather than measuring their length — closed-class English, the same kind of list the Russian side of this file already carries.

```
                  before   after
real_questions    11/13    12/13
shown_line        14/14    15/15
negative_controls  0 false fires, unchanged
russian, haystack, decoy, marathon, fresh, absent_subject, off_topic, bucket — unchanged
bench recall       1.00/1.00,  bench context unchanged
```

Live, on two store profiles — one made of marathon sessions, one of ordinary short ones:

```
                fired      block opens on a subject term    headline agrees   chars/prompt
marathon      112/129      88% -> 91%                       100% -> 100%      855 -> 876
small          17/41       59% -> 88%                        71% -> 100%      418 -> 409
```

Same number of recalls, better ones. The small-store profile is where it shows most, which is where most people are.

Mutation: putting the floor back at four takes the arm to 11/13 and `shown_line` to 14/14.

The new benchmark case had to be given its own topic — `TestPromptBenchCorpusIsMeasurable` caught it reusing `dns` and refused, which is the guard doing its job.
