### PR TITLE
test(bench): a Russian question whose subject is three letters

### DIFF
--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -85,6 +85,12 @@ func promptRussianTopics() []promptTopic {
 		// never became a search term, so nothing could match it.
 		{"коорд-сообщение", "коорд-сообщение теперь шлём одно на всю группу",
 			"напомни, что мы решали про коорд-сообщение"},
+		// Four letters, which is where Russian keeps its short subjects — сеть,
+		// порт, диск, кеш. The floor for Cyrillic stands at five, so none of
+		// them can become a search term at all, the same way ttl and dns could
+		// not before the English floor was named rather than measured.
+		{"кеш", "кеш инвалидируем по версии схемы, а не по времени",
+			"напомни, что там было с кеш"},
 	}
 }
 


### PR DESCRIPTION
Russian keeps short subjects — кеш, хук, сеть, порт, диск, бот — and the extractor's floor for Cyrillic stands at five letters, so none of them can become a search term. The English floor came down to three in #1460 for exactly this reason; this is the same defect on the other side.

```
кеш хук сеть порт диск бот  ->  []
ветка                       ->  [ветка]
```

The arm reproduces it:

```
russian_questions  4/5
```

**The fix is not here, because it was measured and it loses.** Lowering the Cyrillic floor to three and naming the short words that are work reads well on the benchmark — russian 4/5 -> 5/5, real 11/12 -> 12/12, shown_line 15/15 -> 17/17, negative controls still zero — and on a store of ordinary short sessions it takes blocks opening on a subject word from 88% to 53% and adds two recalls that carry nothing:

```
                    fired    block opens on a subject term
before               17/41            15/17 = 88%
Cyrillic floor 3     19/41            10/19 = 53%
```

The same held with the pre-store bar left where it was, so it is the extraction change itself, not the gate: more Russian terms means more matches on ordinary words, and the block that comes back is worse.

So the case stays as a reproduction with no fix, the way `absent_subject`, `off_topic` and `bucket_scope` do. The arm reads 4 of 5 and the guard added in #1457 holds it at three, so it cannot quietly fall further.