### PR TITLE
fix(prompt): keep short Russian subjects

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -322,7 +322,7 @@ func hasIdentifierTerm(terms []string) bool {
 		// something the way a five-letter Latin word does — so the bar is one
 		// letter lower there.
 		n := utf8.RuneCountInString(t)
-		if (n >= 5 || (n >= 4 && hasCyrillic(t))) && !soleWorkingWord[t] {
+		if n >= 3 && !soleWorkingWord[t] {
 			return true
 		}
 		for _, r := range t {
@@ -347,16 +347,11 @@ var soleWorkingWord = map[string]bool{
 	"commit": true, "commits": true, "deploy": true, "fixes": true, "again": true,
 	"write": true, "wrote": true, "merge": true, "start": true, "print": true,
 	"there": true, "these": true, "those": true, "which": true, "where": true,
-}
-
-// hasCyrillic reports whether the term is written in Cyrillic.
-func hasCyrillic(t string) bool {
-	for _, r := range t {
-		if r >= 0x400 && r <= 0x4FF {
-			return true
-		}
-	}
-	return false
+	// Four letters, once the bar came down to three: a question is never about
+	// "line" or "file" on its own, and the negative controls built from them
+	// started firing the moment they could reach the store.
+	"line": true, "file": true, "code": true, "read": true, "open": true,
+	"task": true, "step": true, "note": true, "logs": true, "docs": true,
 }
 
 // byIdentifying orders the query's terms by what the index says each is worth,

--- a/cmd/deja/recall_gates_test.go
+++ b/cmd/deja/recall_gates_test.go
@@ -112,10 +112,20 @@ func TestTheSingleTermBarCountsLettersNotBytes(t *testing.T) {
 	if !promptTermsWorthAsking([]string{"сеть"}) {
 		t.Fatal("a four-letter Cyrillic subject was refused")
 	}
-	if promptTermsWorthAsking([]string{"тут"}) {
-		t.Fatal("a three-letter Cyrillic filler word opened the store on its own")
+	// Through extraction, which is where filler is named. Handing the bar a
+	// word the extractor would never produce tests a contract nothing has:
+	// both floors came down to three letters, and what is work is named rather
+	// than measured.
+	if promptTermsWorthAsking(prompt.Terms("ну тут вот так")) {
+		t.Fatal("a question of nothing but filler opened the store")
 	}
-	if promptTermsWorthAsking([]string{"code"}) {
-		t.Fatal("a four-letter ordinary word opened the store on its own")
+	if promptTermsWorthAsking(prompt.Terms("add a log line here")) {
+		t.Fatal("a question about ordinary work opened the store")
+	}
+	if !promptTermsWorthAsking(prompt.Terms("напомни, что там было с кеш")) {
+		t.Fatal("a three-letter Russian subject was refused before the store was opened")
+	}
+	if !promptTermsWorthAsking(prompt.Terms("what ttl did we settle on")) {
+		t.Fatal("a three-letter acronym was refused before the store was opened")
 	}
 }

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -109,7 +109,12 @@ func cyrPromptTerm(f string) bool {
 		}
 		letters++
 	}
-	if letters < 5 || cyrPromptStop[f] {
+	// Three, because Russian keeps short subjects — кеш, хук, бот, сеть, порт,
+	// диск — and a length cannot tell them from про or вот. Measured over live
+	// prompts, dropping the floor from five to three added nine distinct words
+	// across forty-one questions, and six of the nine were closed-class words
+	// missing from the list below; naming them is what makes the floor safe.
+	if letters < 3 || cyrPromptStop[f] {
 		return false
 	}
 	// A compound made only of closed-class words is still filler: "то-то-сё"
@@ -228,6 +233,16 @@ var cyrPromptStop = map[string]bool{
 	"вообще": true, "своего": true, "свои": true, "текущую": true,
 	"текущий": true, "хочу": true, "можешь": true, "нашел": true,
 	"нашёл": true, "выясняли": true, "разбирались": true,
+	// The closed class a three-letter floor lets through. Measured rather than
+	// guessed: these are the words that appeared when the floor came down over
+	// live questions from this machine.
+	"про": true, "вот": true, "раз": true, "еще": true, "чтоб": true,
+	"для": true, "при": true, "над": true, "под": true, "без": true,
+	"она": true, "они": true, "оно": true, "был": true, "была": true,
+	"мне": true, "нам": true, "вам": true,
+	"его": true, "чем": true, "чём": true, "том": true, "тем": true,
+	"так": true, "нас": true, "вас": true, "все": true, "всё": true,
+	"два": true, "три": true, "оба": true, "иначе": true,
 }
 
 // Candidates is how many ranked sessions the hook asks for before

--- a/internal/prompt/short_cyr_test.go
+++ b/internal/prompt/short_cyr_test.go
@@ -1,0 +1,39 @@
+package prompt
+
+import (
+	"strings"
+	"testing"
+)
+
+// Russian keeps short subjects — кеш, хук, бот, сеть, порт — and the floor for
+// Cyrillic terms stood at five letters, so none of them could become a search
+// term. The English floor came down to three for the same reason; the words
+// that are work are named rather than measured.
+//
+// Measured over live questions from a real machine, dropping the floor added
+// nine distinct words across forty-one prompts, six of them closed-class words
+// missing from the list. Naming those six is what makes the floor safe: without
+// it, blocks opening on a subject word fell from 88% to 53% on a store of
+// ordinary short sessions.
+func TestShortRussianSubjectsSurvive(t *testing.T) {
+	for _, subject := range []string{"кеш", "хук", "бот", "сеть", "порт"} {
+		got := Terms("напомни, что там было с " + subject)
+		if !contains(got, subject) {
+			t.Fatalf("Terms(%q) = %v, dropped the subject", subject, got)
+		}
+	}
+	for _, filler := range []string{"ну вот про это раз", "и еще чтоб при том"} {
+		if got := Terms(filler); len(got) > 0 {
+			t.Fatalf("Terms(%q) = %v, want nothing: these are closed-class words", filler, got)
+		}
+	}
+}
+
+func contains(all []string, want string) bool {
+	for _, s := range all {
+		if strings.EqualFold(s, want) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Russian keeps short subjects — кеш, хук, бот, сеть, порт, диск — and the floor for Cyrillic terms stood at five letters, so none of them could become a search term. #1460 did the same for English acronyms; this is the other side.

Lowering the floor was tried yesterday and measured worse: on a store of ordinary short sessions, blocks opening on a subject word fell from 88% to 53%. Rather than accept that, I printed what the lower floor actually adds — nine distinct words over forty-one live questions:

```
3x шину   3x про   1x сижу   1x маке   1x вот
1x раз    1x еще   1x чтоб   1x язык
```

Six of the nine are closed-class words missing from the list this file already keeps. Naming them leaves five, all of them things a question can be about.

```
                fired    block opens on a subject term    chars/prompt
small profile   17/41    88% -> 88%                       409 -> 409
marathon       112/129   90% -> 92%                       876 -> 874
```

The regression is gone and the marathon profile gains two points.

```
bench prompt   russian 4/4, real 12/13, shown_line 15/15 -> 16/16,
               negative controls 0 false fires, haystack 3/3, decoy 2/2 — rest unchanged
bench recall   1.00/1.00,  bench context unchanged
```

Mutations, both caught: putting the floor back at five fails the new test on the first subject; removing the six named words fails it on the filler line.