### PR TITLE
fix(recall): prefer the line that concluded something

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -506,6 +506,20 @@ var decisionMarkers = []string{
 	"works now", "passes now", "merged", "released", "chose", "won't work",
 }
 
+// CarriesDecision reports whether a line reads as something concluded rather
+// than something mentioned in passing. The markers are the same ones the
+// session-start digest uses to find what a session decided; per-prompt recall
+// had no use for them and picked its line by where the query's words fell.
+func CarriesDecision(text string) bool {
+	low := strings.ToLower(text)
+	for _, d := range decisionMarkers {
+		if strings.Contains(low, d) {
+			return true
+		}
+	}
+	return false
+}
+
 // selectConclusions keeps assistant messages that carry a decision marker,
 // plus the final message (the outcome), in transcript order. Conversational
 // sessions where nothing matches keep everything — the filter only kicks in

--- a/internal/search/decision_line_test.go
+++ b/internal/search/decision_line_test.go
@@ -1,0 +1,38 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A long session mentions its subject in passing before it decides anything
+// about it. The block has to quote the line that concluded, not the first line
+// that happened to say the word.
+//
+// Five ways of choosing by where and how often a word fell were measured on a
+// real store and none moved the number: rarity within the session, frequency
+// within it, earliest against latest, and how many times the line repeats the
+// word. All of them read "I'll look at the shard later" and "we moved the shard
+// to the region" as the same line.
+func TestBlockPrefersTheLineThatConcluded(t *testing.T) {
+	at := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	msgs := []model.Message{
+		{Role: "assistant", Text: "will look at the quicksilver thing later", Time: at},
+		{Role: "assistant", Text: "quicksilver again, still open", Time: at.Add(time.Minute)},
+		{Role: "assistant", Text: "the fix: quicksilver retries are capped at four", Time: at.Add(2 * time.Minute)},
+	}
+	s := model.Session{ID: "one", Harness: "claude", Project: "app", Started: at, Updated: at, Messages: msgs}
+	block := AutoRecallDigestFor([]model.Session{s}, 2000, []string{"quicksilver"})
+	// The block holds two lines and there are three to choose from. Which of
+	// them leads is decided elsewhere — they are printed in the order they were
+	// said, so that two conclusions read as a sequence. What this asserts is
+	// that the line which concluded is one of the two, where before it was the
+	// one dropped: all three matched the query once, and the tie went to
+	// whichever came first.
+	if !strings.Contains(block, "capped at four") {
+		t.Fatalf("the decision was dropped in favour of two passing mentions:\n%s", block)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -478,6 +478,20 @@ func matchedLines(s model.Session, terms []string) (string, []string) {
 		if hits == 0 {
 			continue
 		}
+		// Among lines that carry the question words, prefer the one that
+		// concluded something. Five ways of choosing by where and how often a
+		// word fell were measured and none moved the number; these markers are
+		// what the session-start digest already uses to tell a decision from a
+		// passing mention.
+		if digest.CarriesDecision(line) {
+			hits++
+		}
+		// Among lines that carry the question's words, prefer the one that
+		// concluded something. Five ways of choosing by where and how often a
+		// word fell were measured and none moved the number: "I'll look at the
+		// shard later" and "we moved the shard to the region" are the same line
+		// to all of them. These markers are what the session-start digest
+		// already uses to tell one from the other.
 		// Terms arrive most-identifying first when the caller knows the order,
 		// so a line carrying the word that identified the match beats one
 		// carrying an ordinary word the same session happens to use. Without


### PR DESCRIPTION
Which line of a long session the block quotes was decided by where the query's words fell. Five ways of doing that were measured on a real store and none of them worked:

```
rarity of the word within the session      68% -> 63%
frequency of the word within the session   68% -> 63%
latest mention instead of earliest         83/120 -> 79/120,  73/120 -> 73/120
how often the line repeats the word        83/120 -> 76/120,  73/120 -> 74/120
ordering the terms by idf                  no change on its own
```

All five count where and how many times a word appeared. None of them can tell "I'll look at the shard later" from "we moved the shard to the region".

The thing that can was already here. `internal/digest` keeps a list of decision markers and uses it to find what a session concluded for the session-start digest; per-prompt recall never asked. This gives a line that carries one an extra point, so it wins a tie against a passing mention.

```
                                        before   after
live, questions whose subject is short   73/120   76/120   misses 23 -> 20
live, longer subjects                    84/120   85/120   misses 18 -> 17
```

Precision on ordinary traffic is untouched on both store profiles — 112/129 fired at 92% and 17/41 at 88%, before and after, with blocks 8 and 3 characters larger.

```
bench prompt   real 13/13, russian 5/5, shown_line 18/18, negative controls 0 false,
               haystack 3/3, decoy 2/2 — every arm unchanged
bench recall   1.00/1.00,  bench context unchanged
```

Mutation: removing the extra point drops the decision out of the block and fails the new test.

The first version of that test asserted the decision line comes *first* and failed on the fix, which was correct of it — the two lines are printed in the order they were said, so that a pair of conclusions reads as a sequence. What changed is which two are chosen: before, all three lines matched once and the tie went to the two earliest, so the one that concluded was dropped.