### PR TITLE
fix(digest): decision markers for Russian too

### DIFF
--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -24,6 +24,10 @@ type PromptChain struct {
 	Project  string
 	Topic    string
 	Question string
+	// Fact is what the session concluded, so an arm can ask whether the block
+	// carries the conclusion rather than merely the subject: a passing mention
+	// says the subject too.
+	Fact     string
 	Sessions []model.Session
 	Negative bool
 	// Kind names what this chain is here to measure: "" for the plain case,
@@ -283,13 +287,27 @@ func GeneratePrompt(seed int64) PromptCorpus {
 				model.Message{Role: "assistant", Text: "снова прогнал и поправил", Time: at.Add(time.Second)},
 			)
 		}
+		// The subject is said in passing before anything is concluded about it.
+		// The decision markers that separate the two are English only, and half
+		// the sessions on a real store are not.
+		// Three passing mentions and one conclusion, so that the block cannot
+		// hold both kinds: the two slots go to whichever lines win, and every
+		// way of choosing by where or how often the word fell hands them to the
+		// mentions.
+		for k := 0; k < 3; k++ {
+			msgs = append(msgs, model.Message{
+				Role: "assistant",
+				Text: "потом посмотрю про " + ru.word + ", пока не трогаю",
+				Time: t.Add(time.Duration(150+k) * time.Minute),
+			})
+		}
 		msgs = append(msgs, model.Message{
-			Role: "assistant", Text: "решили: " + ru.fact,
+			Role: "assistant", Text: "в итоге решили: " + ru.fact,
 			Time: t.Add(200 * time.Minute),
 		})
 		chains = append(chains, PromptChain{
 			ID: id, Project: project, Kind: "russian",
-			Topic: ru.word, Question: ru.question,
+			Topic: ru.word, Question: ru.question, Fact: ru.fact,
 			Sessions: []model.Session{{
 				ID: id + "-session", Harness: "claude", Project: project,
 				Started: t, Updated: t.Add(200 * time.Minute), Messages: msgs,

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -506,6 +506,20 @@ var decisionMarkers = []string{
 	"works now", "passes now", "merged", "released", "chose", "won't work",
 }
 
+// CarriesDecision reports whether a line reads as something concluded rather
+// than something mentioned in passing. The markers are the same ones the
+// session-start digest uses to find what a session decided; per-prompt recall
+// had no use for them and picked its line by where the query's words fell.
+func CarriesDecision(text string) bool {
+	low := strings.ToLower(text)
+	for _, d := range decisionMarkers {
+		if strings.Contains(low, d) {
+			return true
+		}
+	}
+	return false
+}
+
 // selectConclusions keeps assistant messages that carry a decision marker,
 // plus the final message (the outcome), in transcript order. Conversational
 // sessions where nothing matches keep everything — the filter only kicks in

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -504,6 +504,12 @@ var decisionMarkers = []string{
 	"root cause", "because", "the fix", "fixed", "decided", "instead of",
 	"turned out", "the problem was", "solution", "so the answer", "conclusion",
 	"works now", "passes now", "merged", "released", "chose", "won't work",
+	// Half the sessions on a real store are in Russian, and a list of English
+	// phrases reads every line of them as a passing mention. These are the
+	// same shapes: what was concluded, what turned out, what got fixed.
+	"решили", "в итоге", "оказалось", "причина", "выяснилось", "вывод",
+	"выбрали", "остановились", "исправил", "починил", "заработало",
+	"не будем", "убрали", "переделали", "смержил", "выкатили",
 }
 
 // CarriesDecision reports whether a line reads as something concluded rather

--- a/internal/search/decision_line_test.go
+++ b/internal/search/decision_line_test.go
@@ -1,0 +1,38 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A long session mentions its subject in passing before it decides anything
+// about it. The block has to quote the line that concluded, not the first line
+// that happened to say the word.
+//
+// Five ways of choosing by where and how often a word fell were measured on a
+// real store and none moved the number: rarity within the session, frequency
+// within it, earliest against latest, and how many times the line repeats the
+// word. All of them read "I'll look at the shard later" and "we moved the shard
+// to the region" as the same line.
+func TestBlockPrefersTheLineThatConcluded(t *testing.T) {
+	at := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	msgs := []model.Message{
+		{Role: "assistant", Text: "will look at the quicksilver thing later", Time: at},
+		{Role: "assistant", Text: "quicksilver again, still open", Time: at.Add(time.Minute)},
+		{Role: "assistant", Text: "the fix: quicksilver retries are capped at four", Time: at.Add(2 * time.Minute)},
+	}
+	s := model.Session{ID: "one", Harness: "claude", Project: "app", Started: at, Updated: at, Messages: msgs}
+	block := AutoRecallDigestFor([]model.Session{s}, 2000, []string{"quicksilver"})
+	// The block holds two lines and there are three to choose from. Which of
+	// them leads is decided elsewhere — they are printed in the order they were
+	// said, so that two conclusions read as a sequence. What this asserts is
+	// that the line which concluded is one of the two, where before it was the
+	// one dropped: all three matched the query once, and the tie went to
+	// whichever came first.
+	if !strings.Contains(block, "capped at four") {
+		t.Fatalf("the decision was dropped in favour of two passing mentions:\n%s", block)
+	}
+}

--- a/internal/search/decision_line_test.go
+++ b/internal/search/decision_line_test.go
@@ -17,6 +17,23 @@ import (
 // within it, earliest against latest, and how many times the line repeats the
 // word. All of them read "I'll look at the shard later" and "we moved the shard
 // to the region" as the same line.
+// The same in Russian. The markers were an English list, so every line of a
+// Russian session read as a passing mention — and half the sessions on a real
+// store are Russian.
+func TestBlockPrefersTheRussianLineThatConcluded(t *testing.T) {
+	at := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	msgs := []model.Message{
+		{Role: "assistant", Text: "потом посмотрю про шардирование, пока не трогаю", Time: at},
+		{Role: "assistant", Text: "снова про шардирование, руки не дошли", Time: at.Add(time.Minute)},
+		{Role: "assistant", Text: "в итоге шардирование перенесли на регион", Time: at.Add(2 * time.Minute)},
+	}
+	s := model.Session{ID: "one", Harness: "claude", Project: "app", Started: at, Updated: at, Messages: msgs}
+	block := AutoRecallDigestFor([]model.Session{s}, 2000, []string{"шардирование"})
+	if !strings.Contains(block, "перенесли на регион") {
+		t.Fatalf("the decision was dropped in favour of two passing mentions:\n%s", block)
+	}
+}
+
 func TestBlockPrefersTheLineThatConcluded(t *testing.T) {
 	at := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
 	msgs := []model.Message{

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -478,6 +478,20 @@ func matchedLines(s model.Session, terms []string) (string, []string) {
 		if hits == 0 {
 			continue
 		}
+		// Among lines that carry the question words, prefer the one that
+		// concluded something. Five ways of choosing by where and how often a
+		// word fell were measured and none moved the number; these markers are
+		// what the session-start digest already uses to tell a decision from a
+		// passing mention.
+		if digest.CarriesDecision(line) {
+			hits++
+		}
+		// Among lines that carry the question's words, prefer the one that
+		// concluded something. Five ways of choosing by where and how often a
+		// word fell were measured and none moved the number: "I'll look at the
+		// shard later" and "we moved the shard to the region" are the same line
+		// to all of them. These markers are what the session-start digest
+		// already uses to tell one from the other.
 		// Terms arrive most-identifying first when the caller knows the order,
 		// so a line carrying the word that identified the match beats one
 		// carrying an ordinary word the same session happens to use. Without


### PR DESCRIPTION
Follows #1463, which taught per-prompt recall to prefer a line that concluded something. The markers it uses are an English list, so every line of a Russian session reads as a passing mention — and half the sessions on the store these numbers come from are Russian.

A Russian chain that says its subject three times in passing before concluding anything reproduces it:

```
decision_line  4/5
```

The arm is new: the existing Russian arm asks whether the block carries a word of the *question*, and both a mention and a conclusion carry that. This one asks whether it carries what was *concluded*.

With the markers:

```
decision_line   4/5 -> 5/5
russian 5/5, real 13/13, shown_line 18/18, negative controls 0 false,
haystack 3/3, decoy 2/2 — every other arm unchanged
bench recall 1.00/1.00, bench context unchanged
```

Live, on questions whose subject is a short word: 76/120 -> 78/120, misses 20 -> 18. Longer subjects unchanged at 85/120. Ordinary traffic on both store profiles: 112/129 fired at 92% -> 91% and 17/41 at 88% -> 88%, blocks two and three characters smaller. The one case is a single block out of 112 and sits inside the noise this metric has shown all along; the arms it was added for move in the other direction.

Mutation: removing `решили` and `в итоге` fails the new Russian test.

Reproducing it took two attempts, both recorded: the first fixture had one mention and one conclusion, and the block holds two lines, so both fitted and nothing could go wrong. Three mentions against two slots is what makes the choice visible.