### PR TITLE
fix(digest): decision markers for Russian too

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -245,7 +245,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 		case "russian":
 			arm = &report.Russian
 			report.Decision.Cases++
-			if blockCarries(indexDir, scope, terms, chain.Fact) {
+			if blockCarries(indexDir, scope, terms, chain.Fact, chain.Topic) {
 				report.Decision.Fired++
 				report.Decision.Correct++
 			}
@@ -404,7 +404,7 @@ func firstShownLineCarries(dir, project string, terms []string, topic string) bo
 
 // blockCarries builds the block the hook would inject and reports whether it
 // holds a distinctive word of what the session concluded.
-func blockCarries(dir, project string, terms []string, fact string) bool {
+func blockCarries(dir, project string, terms []string, fact, topic string) bool {
 	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil || len(ranked) == 0 {
 		return false
@@ -422,8 +422,16 @@ func blockCarries(dir, project string, terms []string, fact string) bool {
 		return false
 	}
 	block := search.AutoRecallDigestFor(keep, 2000, terms)
+	// Skip the subject itself. It appears in every session that mentions the
+	// thing, so checking for it asks whether the block is about the subject —
+	// which it is either way — rather than whether it carries the conclusion.
+	// An arm that did not skip it read 2/2 even after the conclusion had been
+	// emptied of its content.
 	for _, w := range strings.Fields(fact) {
-		if len([]rune(w)) >= 7 && search.TextCarriesTerm(block, w) {
+		if len([]rune(w)) < 7 || search.TextCarriesTerm(topic, w) {
+			continue
+		}
+		if search.TextCarriesTerm(block, w) {
 			return true
 		}
 	}

--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -149,6 +149,12 @@ type promptReport struct {
 	// on the line that carries the subject rather than the one that carries the
 	// ordinary word.
 	Decoy promptArmReport `json:"decoy_line"`
+	// The decision arm: a session says its subject in passing before it
+	// concludes anything about it, in Russian. Correct means the block carries
+	// what was concluded rather than the line that put it off — the markers
+	// that tell one from the other are English, and half the sessions on a real
+	// store are not.
+	Decision promptArmReport `json:"decision_line"`
 	// Questions whose subject the project has never held, asked with words it
 	// has. Every fire is a false one: there is nothing to answer with.
 	//
@@ -238,6 +244,11 @@ func measurePrompt(seed int64) (promptReport, error) {
 			arm = &report.Haystack
 		case "russian":
 			arm = &report.Russian
+			report.Decision.Cases++
+			if blockCarries(indexDir, scope, terms, chain.Fact) {
+				report.Decision.Fired++
+				report.Decision.Correct++
+			}
 		case "decoy":
 			// Scored with the question's own terms, the way the hook builds the
 			// block. An earlier version of this arm rebuilt it from the topic
@@ -315,6 +326,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	}
 	finishPromptArm(&report.Shown, nil)
 	finishPromptArm(&report.Decoy, nil)
+	finishPromptArm(&report.Decision, nil)
 	finishPromptArm(&report.AbsentSubject, nil)
 	return report, nil
 }
@@ -386,6 +398,34 @@ func firstShownLineCarries(dir, project string, terms []string, topic string) bo
 			continue
 		}
 		return search.TextCarriesTerm(ln, topic)
+	}
+	return false
+}
+
+// blockCarries builds the block the hook would inject and reports whether it
+// holds a distinctive word of what the session concluded.
+func blockCarries(dir, project string, terms []string, fact string) bool {
+	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	if err != nil || len(ranked) == 0 {
+		return false
+	}
+	terms = byIdentifying(terms, idfOf)
+	var keep []model.Session
+	for i := range ranked {
+		if !recallWorthShowing(terms, matched[i], strong[i]) {
+			continue
+		}
+		keep = append(keep, ranked[i])
+		break
+	}
+	if len(keep) == 0 {
+		return false
+	}
+	block := search.AutoRecallDigestFor(keep, 2000, terms)
+	for _, w := range strings.Fields(fact) {
+		if len([]rune(w)) >= 7 && search.TextCarriesTerm(block, w) {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -24,6 +24,10 @@ type PromptChain struct {
 	Project  string
 	Topic    string
 	Question string
+	// Fact is what the session concluded, so an arm can ask whether the block
+	// carries the conclusion rather than merely the subject: a passing mention
+	// says the subject too.
+	Fact     string
 	Sessions []model.Session
 	Negative bool
 	// Kind names what this chain is here to measure: "" for the plain case,
@@ -283,13 +287,27 @@ func GeneratePrompt(seed int64) PromptCorpus {
 				model.Message{Role: "assistant", Text: "снова прогнал и поправил", Time: at.Add(time.Second)},
 			)
 		}
+		// The subject is said in passing before anything is concluded about it.
+		// The decision markers that separate the two are English only, and half
+		// the sessions on a real store are not.
+		// Three passing mentions and one conclusion, so that the block cannot
+		// hold both kinds: the two slots go to whichever lines win, and every
+		// way of choosing by where or how often the word fell hands them to the
+		// mentions.
+		for k := 0; k < 3; k++ {
+			msgs = append(msgs, model.Message{
+				Role: "assistant",
+				Text: "потом посмотрю про " + ru.word + ", пока не трогаю",
+				Time: t.Add(time.Duration(150+k) * time.Minute),
+			})
+		}
 		msgs = append(msgs, model.Message{
-			Role: "assistant", Text: "решили: " + ru.fact,
+			Role: "assistant", Text: "в итоге решили: " + ru.fact,
 			Time: t.Add(200 * time.Minute),
 		})
 		chains = append(chains, PromptChain{
 			ID: id, Project: project, Kind: "russian",
-			Topic: ru.word, Question: ru.question,
+			Topic: ru.word, Question: ru.question, Fact: ru.fact,
 			Sessions: []model.Session{{
 				ID: id + "-session", Harness: "claude", Project: project,
 				Started: t, Updated: t.Add(200 * time.Minute), Messages: msgs,

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -504,6 +504,12 @@ var decisionMarkers = []string{
 	"root cause", "because", "the fix", "fixed", "decided", "instead of",
 	"turned out", "the problem was", "solution", "so the answer", "conclusion",
 	"works now", "passes now", "merged", "released", "chose", "won't work",
+	// Half the sessions on a real store are in Russian, and a list of English
+	// phrases reads every line of them as a passing mention. These are the
+	// same shapes: what was concluded, what turned out, what got fixed.
+	"решили", "в итоге", "оказалось", "причина", "выяснилось", "вывод",
+	"выбрали", "остановились", "исправил", "починил", "заработало",
+	"не будем", "убрали", "переделали", "смержил", "выкатили",
 }
 
 // CarriesDecision reports whether a line reads as something concluded rather

--- a/internal/search/decision_line_test.go
+++ b/internal/search/decision_line_test.go
@@ -17,6 +17,23 @@ import (
 // within it, earliest against latest, and how many times the line repeats the
 // word. All of them read "I'll look at the shard later" and "we moved the shard
 // to the region" as the same line.
+// The same in Russian. The markers were an English list, so every line of a
+// Russian session read as a passing mention — and half the sessions on a real
+// store are Russian.
+func TestBlockPrefersTheRussianLineThatConcluded(t *testing.T) {
+	at := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	msgs := []model.Message{
+		{Role: "assistant", Text: "потом посмотрю про шардирование, пока не трогаю", Time: at},
+		{Role: "assistant", Text: "снова про шардирование, руки не дошли", Time: at.Add(time.Minute)},
+		{Role: "assistant", Text: "в итоге шардирование перенесли на регион", Time: at.Add(2 * time.Minute)},
+	}
+	s := model.Session{ID: "one", Harness: "claude", Project: "app", Started: at, Updated: at, Messages: msgs}
+	block := AutoRecallDigestFor([]model.Session{s}, 2000, []string{"шардирование"})
+	if !strings.Contains(block, "перенесли на регион") {
+		t.Fatalf("the decision was dropped in favour of two passing mentions:\n%s", block)
+	}
+}
+
 func TestBlockPrefersTheLineThatConcluded(t *testing.T) {
 	at := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
 	msgs := []model.Message{


### PR DESCRIPTION
Follows #1463, which taught per-prompt recall to prefer a line that concluded something. The markers it uses are an English list, so every line of a Russian session reads as a passing mention — and half the sessions on the store these numbers come from are Russian.

A Russian chain that says its subject three times in passing before concluding anything reproduces it:

```
decision_line  4/5
```

The arm is new: the existing Russian arm asks whether the block carries a word of the *question*, and both a mention and a conclusion carry that. This one asks whether it carries what was *concluded*.

```
decision_line   4/5 -> 5/5
russian 5/5, real 13/13, shown_line 18/18, negative controls 0 false,
haystack 3/3, decoy 2/2 — every other arm unchanged
bench recall 1.00/1.00, bench context unchanged
```

Live, on questions whose subject is a short word: 76/120 -> 78/120, misses 20 -> 18. Longer subjects unchanged at 85/120. Ordinary traffic on both store profiles: 112/129 fired at 92% -> 91% and 17/41 at 88% -> 88%, blocks two and three characters smaller.

Mutation: removing `решили` and `в итоге` fails the new Russian test.

Reproducing it took two attempts, both worth recording: the first fixture had one mention and one conclusion, and the block holds two lines, so both fitted and nothing could go wrong. Three mentions against two slots is what makes the choice visible.