### PR TITLE
fix(recall): lead with the session that settled it

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -155,6 +155,10 @@ type promptReport struct {
 	// that tell one from the other are English, and half the sessions on a real
 	// store are not.
 	Decision promptArmReport `json:"decision_line"`
+	// The concluded arm: two sessions hold the subject, one only mentioned it
+	// and the other settled it. Correct means the block carries what was
+	// settled.
+	Concluded promptArmReport `json:"concluded_session"`
 	// Questions whose subject the project has never held, asked with words it
 	// has. Every fire is a false one: there is nothing to answer with.
 	//
@@ -220,7 +224,8 @@ func measurePrompt(seed int64) (promptReport, error) {
 		}
 		// Filler that only exists to fill the bucket has no question of its
 		// own; it is asked about through the bucket-answer chain below.
-		if chain.Kind == "bucket" || chain.Kind == "haystack-noise" {
+		if chain.Kind == "bucket" || chain.Kind == "haystack-noise" ||
+			chain.Kind == "concluded-noise" {
 			continue
 		}
 		terms := prompt.Terms(chain.Question)
@@ -249,6 +254,14 @@ func measurePrompt(seed int64) (promptReport, error) {
 				report.Decision.Fired++
 				report.Decision.Correct++
 			}
+		case "concluded":
+			arm = &report.Concluded
+			arm.Cases++
+			if blockCarries(indexDir, scope, terms, chain.Fact, chain.Topic) {
+				arm.Fired++
+				arm.Correct++
+			}
+			continue
 		case "decoy":
 			// Scored with the question's own terms, the way the hook builds the
 			// block. An earlier version of this arm rebuilt it from the topic
@@ -327,6 +340,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.Shown, nil)
 	finishPromptArm(&report.Decoy, nil)
 	finishPromptArm(&report.Decision, nil)
+	finishPromptArm(&report.Concluded, nil)
 	finishPromptArm(&report.AbsentSubject, nil)
 	return report, nil
 }
@@ -416,12 +430,16 @@ func blockCarries(dir, project string, terms []string, fact, topic string) bool 
 			continue
 		}
 		keep = append(keep, ranked[i])
-		break
+		if len(keep) == 2 {
+			break
+		}
 	}
 	if len(keep) == 0 {
 		return false
 	}
-	block := search.AutoRecallDigestFor(keep, 2000, terms)
+	// The same ordering the hook applies, from the same function.
+	keep = search.LeadWithConclusion(keep, terms)
+	block := search.AutoRecallDigestFor(keep[:1], 2000, terms)
 	// Skip the subject itself. It appears in every session that mentions the
 	// thing, so checking for it asks whether the block is about the subject —
 	// which it is either way — rather than whether it carries the conclusion.

--- a/cmd/deja/bench_prompt_test.go
+++ b/cmd/deja/bench_prompt_test.go
@@ -29,7 +29,7 @@ func TestPromptBenchCorpusIsMeasurable(t *testing.T) {
 		// asked about through the bucket-answer chain, whose question is the
 		// one that must go unanswered. A chain nobody asks about still has to
 		// earn its place, and this one earns it by being the wrong answer.
-		if c.Kind == "bucket" || c.Kind == "haystack-noise" {
+		if c.Kind == "bucket" || c.Kind == "haystack-noise" || c.Kind == "concluded-noise" {
 			continue
 		}
 		if topics[c.Topic] {

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -314,6 +314,45 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
+	// Two sessions hold the subject: one only ever mentioned it, the other
+	// concluded something about it. Ranking counts term matches and how rare
+	// they are, and is blind to which of the two settled anything — so the one
+	// that merely talked about it can win on saying it more often.
+	for i, c := range []promptTopic{
+		{"nightjar", "nightjar batches are flushed every 30 seconds", "what did we decide about nightjar"},
+		{"lodestone", "lodestone runs on the read replica now", "what did we decide about lodestone"},
+	} {
+		id := fmt.Sprintf("prompt-concluded-%02d", i)
+		project := fmt.Sprintf("promptbenchconcluded%02d", i)
+		t := base.Add(time.Duration(2700+i*10) * time.Minute)
+		var chatter []model.Message
+		for k := 0; k < 60; k++ {
+			chatter = append(chatter, model.Message{
+				Role: "assistant",
+				Text: "смотрел " + c.word + " ещё раз, пока ничего не трогаю",
+				Time: t.Add(time.Duration(k) * time.Minute),
+			})
+		}
+		chains = append(chains, PromptChain{
+			ID: id + "-talk", Project: project, Kind: "concluded-noise",
+			Sessions: []model.Session{{
+				ID: id + "-talk-session", Harness: "claude", Project: project,
+				Started: t, Updated: t.Add(6 * time.Minute), Messages: chatter,
+			}},
+		})
+		answer := t.Add(-200 * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: project, Kind: "concluded",
+			Topic: c.word, Question: c.question, Fact: c.fact,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: project,
+				Started: answer, Updated: answer,
+				Messages: []model.Message{
+					{Role: "assistant", Text: "в итоге решили: " + c.fact, Time: answer},
+				},
+			}},
+		})
+	}
 	// The decoy line. The session that answers also says an ordinary word the
 	// question happens to use, in a place that has nothing to do with the
 	// subject. Measured on a real store: "what did we decide about mm_status"

--- a/internal/bench/prompt_test.go
+++ b/internal/bench/prompt_test.go
@@ -22,7 +22,11 @@ func TestGeneratePromptShape(t *testing.T) {
 		// would make a query match two chains and blur the measurement; the
 		// bucket exists to measure exactly that condition — a scope holding
 		// several unrelated pieces of work and not the answer.
-		if c.Kind != "bucket" && c.Kind != "haystack" && c.Kind != "haystack-noise" && c.Kind != "russian" {
+		// The concluded pair shares a project on purpose too: the whole case is
+		// that two sessions of the same project hold the subject and only one
+		// of them settled it.
+		if c.Kind != "bucket" && c.Kind != "haystack" && c.Kind != "haystack-noise" && c.Kind != "russian" &&
+			c.Kind != "concluded" && c.Kind != "concluded-noise" {
 			if projects[c.Project] {
 				t.Fatalf("project %q shared by two chains; a query would match both", c.Project)
 			}
@@ -42,7 +46,7 @@ func TestGeneratePromptShape(t *testing.T) {
 		// asked about through the bucket-answer chain, whose question is the
 		// one that must go unanswered. A chain nobody asks about still has to
 		// earn its place, and this one earns it by being the wrong answer.
-		if c.Kind == "bucket" || c.Kind == "haystack-noise" {
+		if c.Kind == "bucket" || c.Kind == "haystack-noise" || c.Kind == "concluded-noise" {
 			continue
 		}
 		if topics[c.Topic] {

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -517,9 +517,28 @@ var decisionMarkers = []string{
 // session-start digest uses to find what a session decided; per-prompt recall
 // had no use for them and picked its line by where the query's words fell.
 func CarriesDecision(text string) bool {
+	return CarriesDecisionExcept(text, nil)
+}
+
+// CarriesDecisionExcept is the same, ignoring markers the asker used. A marker
+// that is also a word of the question makes the check circular: "в итоге" is
+// both, so a line matched on that phrase then counted as a conclusion because
+// of it. Measured on the benchmark, the question "по чему у нас в итоге
+// шардирование" promoted a session about something else entirely.
+func CarriesDecisionExcept(text string, asked []string) bool {
 	low := strings.ToLower(text)
 	for _, d := range decisionMarkers {
-		if strings.Contains(low, d) {
+		if !strings.Contains(low, d) {
+			continue
+		}
+		skip := false
+		for _, a := range asked {
+			if a != "" && strings.Contains(d, strings.ToLower(a)) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
 			return true
 		}
 	}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -237,6 +237,10 @@ var cyrPromptStop = map[string]bool{
 	// guessed: these are the words that appeared when the floor came down over
 	// live questions from this machine.
 	"про": true, "вот": true, "раз": true, "еще": true, "чтоб": true,
+	// "в итоге" is how a question asks for the outcome, not a thing to search
+	// for; it also sits in the decision markers, so keeping it made a line
+	// count as a conclusion because the asker had used the phrase.
+	"итоге": true, "итог": true, "конце": true, "концов": true,
 	"для": true, "при": true, "над": true, "под": true, "без": true,
 	"она": true, "они": true, "оно": true, "был": true, "была": true,
 	"мне": true, "нам": true, "вам": true,

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -546,6 +546,47 @@ func rankOfBestTerm(line string, terms []string) int {
 	return 0
 }
 
+// LeadWithConclusion puts a session that settled something about the query
+// first. Ranking counts how often and how rarely the query's words appear and
+// cannot see the difference between settling a question and discussing it: a
+// session that mentioned the subject sixty times outranks the one that answered
+// it in a sentence.
+func LeadWithConclusion(ss []model.Session, terms []string) []model.Session {
+	if len(ss) < 2 || ConcludedAbout(ss[0], terms) {
+		return ss
+	}
+	for i := 1; i < len(ss); i++ {
+		if ConcludedAbout(ss[i], terms) {
+			ss[0], ss[i] = ss[i], ss[0]
+			break
+		}
+	}
+	return ss
+}
+
+// ConcludedAbout reports whether the lines this session is about to show carry
+// something concluded rather than a passing mention.
+//
+// It asks about the lines the digest will pick, not about the session at large.
+// An earlier version scanned every message, and a session rose on a line the
+// digest then did not choose: measured live, that lost nine answers of 120 and
+// what the reader saw instead was "we did not decide any such thing in this
+// session".
+func ConcludedAbout(s model.Session, terms []string) bool {
+	// The first line, not any line. Promoting a session for its second line
+	// left the reader looking at the first: measured live, that lost nine
+	// answers of 120 and showed "we did not decide any such thing in this
+	// session" in their place.
+	problem, conclusions := matchedLines(s, terms)
+	if problem != "" {
+		return digest.CarriesDecisionExcept(problem, terms)
+	}
+	if len(conclusions) == 0 {
+		return false
+	}
+	return digest.CarriesDecisionExcept(conclusions[0], terms)
+}
+
 // densestLine returns the line of a message carrying the most query terms, and
 // how many, so a message is both chosen and quoted where it answers rather
 // than where it opens.


### PR DESCRIPTION
Ranking counts how often and how rarely the query's words appear, so a session that mentioned the subject sixty times outranks the one that answered it in a sentence. An arm reproduces it: two sessions of one project hold the subject, only one concluded anything.

```
concluded_session  0/2 -> 2/2
```

Getting there took three attempts, and the first two are the useful part:

```
promote if any line of the session concludes      live 78 -> 70,  9 answers lost
promote if the lines the digest picks conclude    live 78 -> 70,  the same 9
promote if the FIRST shown line concludes         live 78 -> 78,  none lost
```

All nine losses showed the same block — "мы такого не решали, я такого не делал". The session had risen on a line the reader never saw: the block holds two lines and the marker sat in the second.

The benchmark then caught what the live numbers could not. `decision_line` fell 4/5 -> 3/5, and printing which session got promoted showed why:

```
LEAD prompt-ru-01-session -> prompt-ru-04-session (terms [шардирование итоге чему])
```

`итоге` is how a Russian question asks for the outcome, and it is also a decision marker — a line matched on that phrase then counted as a conclusion because of it, and the session promoted was answering something else. Two changes close it: the markers ignore any the asker used, and "в итоге" joins the filler list.

**Live it changes nothing measurable.** 78/120 either way on questions whose subject is a short word, nothing lost, nothing gained; ordinary traffic identical on both store profiles at 112/129 and 17/41, same block sizes. An earlier draft measured +3, against a baseline that predated #1465 — with the Russian markers already in, the reorder has no live effect I can see.

So this is a benchmark-positive, live-neutral change: it fixes a shape the arm reproduces and costs nothing where I can measure.

```
real 13/13, shown_line 18/18, russian 5/5, negative controls 0 false,
haystack 3/3, decoy 2/2, decision_line 4/5 — unchanged
bench recall 1.00/1.00, bench context unchanged
```

Mutation: disabling the reorder returns the arm to 0/2.