### PR TITLE
fix(digest): mirror three English decision markers in Russian

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -510,6 +510,11 @@ var decisionMarkers = []string{
 	"решили", "в итоге", "оказалось", "причина", "выяснилось", "вывод",
 	"выбрали", "остановились", "исправил", "починил", "заработало",
 	"не будем", "убрали", "переделали", "смержил", "выкатили",
+	// Mirrors of entries already in the English half: "works now", "passes
+	// now", "fixed". Measured over forty thousand assistant lines from a real
+	// store, Russian lines were marked 3.1% of the time against 4.3% for
+	// English, and these three phrases account for most of the gap.
+	"заработал", "готово", "зелёный",
 }
 
 // CarriesDecision reports whether a line reads as something concluded rather


### PR DESCRIPTION
The markers that tell a conclusion from a passing mention cover the two languages unevenly. Measured over forty thousand assistant lines from a real store:

```
russian lines 27968, marked 3.1%
english lines 12032, marked 4.3%
```

Among the frequent unmarked Russian lines are direct mirrors of entries the English half already has: `работает` is `works now`, `готово` is `done`, `зелёный` is `passes now`.

Adding those three closes the gap and overshoots it:

```
russian 3.1% -> 10.0%,  english 4.3% -> 5.0%
live: 78 -> 79 of 120 on questions whose subject is a short word, nothing lost
```

One line in ten is not a signal. `работает` appears in "это не работает", "работает медленно", "работает как раньше" — it describes a state, not a conclusion. The narrower forms carry the same outcome at half the rate:

```
заработал, готово, зелёный:  russian 5.5%, english 4.7% — parity
live: 78 -> 79, nothing lost, ordinary traffic identical at 112/129 and 91%
bench: every arm unchanged, bench recall 1.00/1.00, bench context unchanged
```

The outcome was the same either way, so it could not decide between them. What separates the two is how often the signal fires at all — which is worth measuring whenever a rule like this is widened, or the improvement comes from diluting it.