### PR TITLE
test(bench): give the Russian fact a word the arm can look for

### DIFF
--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -87,7 +87,7 @@ func promptRussianTopics() []promptTopic {
 		// Russian as readily as in English. Measured on a real store, one direct
 		// question in seven that got no answer at all was this: the subject word
 		// never became a search term, so nothing could match it.
-		{"коорд-сообщение", "коорд-сообщение теперь шлём одно на всю группу",
+		{"коорд-сообщение", "коорд-сообщение теперь шлём одним пакетом на всю группу",
 			"напомни, что мы решали про коорд-сообщение"},
 		// Four letters, which is where Russian keeps its short subjects — сеть,
 		// порт, диск, кеш. The floor for Cyrillic stands at five, so none of

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -510,6 +510,11 @@ var decisionMarkers = []string{
 	"решили", "в итоге", "оказалось", "причина", "выяснилось", "вывод",
 	"выбрали", "остановились", "исправил", "починил", "заработало",
 	"не будем", "убрали", "переделали", "смержил", "выкатили",
+	// Mirrors of entries already in the English half: "works now", "passes
+	// now", "fixed". Measured over forty thousand assistant lines from a real
+	// store, Russian lines were marked 3.1% of the time against 4.3% for
+	// English, and these three phrases account for most of the gap.
+	"заработал", "готово", "зелёный",
 }
 
 // CarriesDecision reports whether a line reads as something concluded rather


### PR DESCRIPTION
`decision_line` sat at 4 of 5 through every change to the markers, including the ones that moved the other arms. Printing the failing case explains why:

```
DEC5 topic="коорд-сообщение" fact="коорд-сообщение теперь шлём одно на всю группу"
   line: - Assistant: потом посмотрю про коорд-сообщение, пока не трогаю
   line: - Assistant: в итоге решили: коорд-сообщение теперь шлём одно на всю группу
```

The block holds the conclusion. The arm looks for a word of the fact that is at least seven letters and is not the subject — and that fact has none: `теперь`, `шлём`, `одно`, `всю`, `группу` are all shorter, and `коорд-сообщение` is the subject, which the arm skips on purpose because every session that mentions the thing carries it.

So the case was unmeasurable by construction, not failing. One word in the fixture fixes that:

```
decision_line  4/5 -> 5/5
```

The arm also got sharper: without the Russian markers it now reads 1/5 where it read 2/5 before, because it can finally see all five cases.

Bench-only. Live is identical on the same base — 79/120 either way on questions whose subject is a short word, nothing lost; every other arm unchanged, `bench recall` 1.00/1.00.

That is three arms tonight that measured something other than what they were named for. The one that catches it is printing the case that fails rather than reading the total.