### PR TITLE
fix(digest): "вывод" as a conclusion, not as program output

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -507,7 +507,7 @@ var decisionMarkers = []string{
 	// Half the sessions on a real store are in Russian, and a list of English
 	// phrases reads every line of them as a passing mention. These are the
 	// same shapes: what was concluded, what turned out, what got fixed.
-	"решили", "в итоге", "оказалось", "причина", "выяснилось", "вывод",
+	"решили", "в итоге", "оказалось", "причина", "выяснилось", "вывод:", "мой вывод",
 	"выбрали", "остановились", "исправил", "починил", "заработало",
 	"не будем", "убрали", "переделали", "смержил", "выкатили",
 	// Mirrors of entries already in the English half: "works now", "passes


### PR DESCRIPTION
Counting which marker fires shows the load is carried by very few, and one of them is ambiguous:

```
lines 40000, marked 5.2%

  422  зелёный   | Main зелёный (5/5) после Goose-мержа
  402  вывод     | ...
  282  готово    | Готово к отправке — цель проверена
  221  merged    | #88 перф | 15.1s → 9.9s cold rebuild | merged
  210  причина   | Нашлась причина — не пайплайн, а auth
```

Sampling the `вывод` hits, about half are the wrong sense — substring matching catches `выводом`, `выводит`, `с выводом`, and in a store about writing software that word is program output far more often than it is a conclusion:

```
Мой вывод: преимущество есть, но узкое и небольшое.        <- conclusion
пункт закрывается запуском команды и её выводом            <- output
Есть seedClaude + recallTextResult. Пишу тест...           <- output
```

`вывод:` and `мой вывод` keep the sense and drop the collision:

```
russian 5.5% -> 4.2%,  english 4.7% -> 4.6%   — the two languages now match
live: 79/120 either way, nothing lost
ordinary traffic: 112/129 at 91%, one character larger
bench: every arm unchanged, bench recall 1.00/1.00, bench context unchanged
```

No outcome moved, which is the point: the same answers with a signal that fires a fifth less often has more room to mean something the next time it is used.