### PR TITLE
test(bench): an English mention-before-conclusion case

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -262,6 +262,14 @@ func measurePrompt(seed int64) (promptReport, error) {
 				arm.Correct++
 			}
 			continue
+		case "decision-en":
+			arm = &report.Decision
+			arm.Cases++
+			if blockCarries(indexDir, scope, terms, chain.Fact, chain.Topic) {
+				arm.Fired++
+				arm.Correct++
+			}
+			continue
 		case "decoy":
 			// Scored with the question's own terms, the way the hook builds the
 			// block. An earlier version of this arm rebuilt it from the topic

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -353,6 +353,37 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
+	// The same shape in English: a session says its subject three times in
+	// passing before it concludes anything. The decision arm was Russian only,
+	// so the English markers — the older half of the list — had nothing
+	// guarding them.
+	for i, d := range []promptTopic{
+		{"kingfisher", "kingfisher retries are capped at four", "what did we decide about kingfisher"},
+		{"saltmarsh", "saltmarsh writes go to the replica", "what did we decide about saltmarsh"},
+	} {
+		id := fmt.Sprintf("prompt-decen-%02d", i)
+		project := fmt.Sprintf("promptbenchdecen%02d", i)
+		t := base.Add(time.Duration(2900+i*10) * time.Minute)
+		msgs := make([]model.Message, 0, 4)
+		for k := 0; k < 3; k++ {
+			msgs = append(msgs, model.Message{
+				Role: "assistant",
+				Text: "will look at " + d.word + " later, not touching it yet",
+				Time: t.Add(time.Duration(k) * time.Minute),
+			})
+		}
+		msgs = append(msgs, model.Message{
+			Role: "assistant", Text: "the fix: " + d.fact, Time: t.Add(10 * time.Minute),
+		})
+		chains = append(chains, PromptChain{
+			ID: id, Project: project, Kind: "decision-en",
+			Topic: d.word, Question: d.question, Fact: d.fact,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: project,
+				Started: t, Updated: t.Add(10 * time.Minute), Messages: msgs,
+			}},
+		})
+	}
 	// The decoy line. The session that answers also says an ordinary word the
 	// question happens to use, in a place that has nothing to do with the
 	// subject. Measured on a real store: "what did we decide about mm_status"


### PR DESCRIPTION
The arm that checks whether a block carries what a session concluded had only Russian cases, added when the Russian markers were. The English markers — `root cause`, `the fix`, `decided`, `turned out` and the rest, which have been there far longer — had nothing guarding them.

Two English chains of the same shape: the session says its subject three times in passing, then concludes.

```
decision_line  5/5 -> 7/7
```

They pass, so the arm proves nothing until it can fail. Removing `the fix` from the markers:

```
decision_line  7/7 -> 5/7
```

Exactly the two new cases, which is what the arm is for.

Bench-only. Live identical on the same base — 79/120 either way, nothing lost; every other arm unchanged, `bench recall` 1.00/1.00, `bench context` unchanged.

Worth saying why this matters more than an ordinary test: every live measurement in this work comes from one store that is 52% Cyrillic and written almost entirely by one person. The English half of these rules has no live evidence at all — the benchmark is the only thing standing behind it.