### PR TITLE
fix(prompt): keep two-character subjects like v3 and pr

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -155,6 +155,11 @@ type promptReport struct {
 	// that tell one from the other are English, and half the sessions on a real
 	// store are not.
 	Decision promptArmReport `json:"decision_line"`
+	// The short-subject arm: the question names its subject in two characters,
+	// the way people name a version or a pull request. Nothing else in the
+	// question identifies anything, so dropping the subject leaves a working
+	// verb and the answer is never found.
+	ShortSubject promptArmReport `json:"short_subject"`
 	// The concluded arm: two sessions hold the subject, one only mentioned it
 	// and the other settled it. Correct means the block carries what was
 	// settled.
@@ -270,6 +275,18 @@ func measurePrompt(seed int64) (promptReport, error) {
 				arm.Correct++
 			}
 			continue
+		case "short-subject":
+			arm = &report.ShortSubject
+			arm.Cases++
+			if fired, correct := promptBenchProbe(indexDir, scope, chain.ID, terms); fired {
+				arm.Fired++
+				if correct {
+					arm.Correct++
+				} else {
+					arm.FalseFires++
+				}
+			}
+			continue
 		case "decoy":
 			// Scored with the question's own terms, the way the hook builds the
 			// block. An earlier version of this arm rebuilt it from the topic
@@ -349,6 +366,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.Decoy, nil)
 	finishPromptArm(&report.Decision, nil)
 	finishPromptArm(&report.Concluded, nil)
+	finishPromptArm(&report.ShortSubject, nil)
 	finishPromptArm(&report.AbsentSubject, nil)
 	return report, nil
 }

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -384,6 +384,33 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
+	// The short subject. Measured on a real store over the questions the user
+	// actually typed: five of the nine that recalled nothing named their
+	// subject in two characters — "как там pr, смержился?", "ну что там v3
+	// показал". The extractor's length floor drops those, the question is left
+	// holding a working verb, and the gate then correctly refuses to answer on
+	// one working word. Correct here means the session that concluded about the
+	// short subject is found.
+	for i, d := range []promptTopic{
+		{"v3", "v3 of the exporter halved the scrape time", "ну что там v3 показал"},
+		{"pr", "the pr went in after the flake was fixed", "как там pr, смержился?"},
+	} {
+		id := fmt.Sprintf("prompt-short-%02d", i)
+		project := fmt.Sprintf("promptbenchshort%02d", i)
+		t := base.Add(time.Duration(3100+i*10) * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: project, Kind: "short-subject",
+			Topic: d.word, Question: d.question, Fact: d.fact,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: project,
+				Started: t, Updated: t.Add(10 * time.Minute),
+				Messages: []model.Message{
+					{Role: "user", Text: "смотрим " + d.word, Time: t},
+					{Role: "assistant", Text: d.fact, Time: t.Add(5 * time.Minute)},
+				},
+			}},
+		})
+	}
 	// The decoy line. The session that answers also says an ordinary word the
 	// question happens to use, in a place that has nothing to do with the
 	// subject. Measured on a real store: "what did we decide about mm_status"

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -50,7 +50,7 @@ func Terms(prompt string) []string {
 		// Only the edges are trimmed. A dot inside a token is what makes an IP
 		// address, a version or a filename one word.
 		f = strings.Trim(f, "._-/")
-		if len(f) < 3 || query.IsStopWord(f) || seen[f] || !techTerm(f) {
+		if (len(f) < 3 && !shortSubject(f)) || query.IsStopWord(f) || seen[f] || !techTerm(f) {
 			continue
 		}
 		if add(f) {
@@ -176,6 +176,9 @@ func techTerm(f string) bool {
 	if promptFiller[f] {
 		return false
 	}
+	if shortSubjectWord[f] {
+		return true
+	}
 	long := 0
 	for _, r := range f {
 		if r == '_' || r == '.' || r == '/' || r == '-' || (r >= '0' && r <= '9') {
@@ -202,6 +205,30 @@ func techTerm(f string) bool {
 		return !shortWord[f]
 	}
 	return long >= 4
+}
+
+// shortSubject keeps the two-character words that name a thing rather than
+// describe one. The floor at three exists to stop "in", "on" and "to" from
+// earning a recall, and it also drops the way people name versions and pull
+// requests: measured on the questions the user actually typed, five of the nine
+// that recalled nothing named their subject in two characters — "ну что там v3
+// показал", "как там pr, смержился?" — leaving the question holding a working
+// verb and nothing to search for.
+func shortSubject(f string) bool {
+	if len(f) != 2 {
+		return false
+	}
+	// A version label: one letter and one digit.
+	if f[0] >= 'a' && f[0] <= 'z' && f[1] >= '0' && f[1] <= '9' {
+		return true
+	}
+	return shortSubjectWord[f]
+}
+
+// Closed class, the same shape as shortWord below it: named rather than
+// measured, because two letters cannot be told apart by length.
+var shortSubjectWord = map[string]bool{
+	"pr": true, "mr": true, "ci": true, "db": true, "ui": true, "qa": true,
 }
 
 // The closed class plus the handful of verbs that open half of all questions.


### PR DESCRIPTION
Questions like `ну что там v3 показал` or `как там pr, смержился?` recalled nothing: the extractor's length floor is measured in bytes, so the subject was dropped and the question was left holding a working verb, which the gate then correctly refuses to answer on.

Measured on the questions actually typed against a frozen store — five of the nine questions that got silence named their subject in two characters.

Adds a `short_subject` bench arm that reproduces it (0/2 before, 2/2 after). No other arm moves; negative controls stay at zero false fires.