### PR TITLE
perf(hook): lowercase a message once per prompt, not once per term

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -709,18 +709,15 @@ func focusSession(s model.Session, terms []string) model.Session {
 	const window = 2
 	keep := map[int]bool{}
 	for i, m := range s.Messages {
-		hits := 0
-		for _, t := range terms {
-			// The same rule the block is built with. This step spelled the
-			// word the way the question happened to spell it, while the
-			// ranking that chose the session and the digest that shows a line
-			// from it both fold the ending — so a session whose only mention
-			// was in another case was narrowed to nothing and dropped whole.
-			if search.TextCarriesTerm(m.Text, t) {
-				hits++
-			}
-		}
-		if hits == 0 {
+		// The same rule the block is built with. This step spelled the word
+		// the way the question happened to spell it, while the ranking that
+		// chose the session and the digest that shows a line from it both fold
+		// the ending — so a session whose only mention was in another case was
+		// narrowed to nothing and dropped whole.
+		//
+		// Asked for the whole query at once: per term, each call lowercased the
+		// entire message again.
+		if !search.TextCarriesAnyTerm(m.Text, terms) {
 			continue
 		}
 		for j := i - window; j <= i+window; j++ {

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -340,6 +340,14 @@ func TextCarriesTerm(text, term string) bool {
 	return termHits(text, []string{term}) > 0
 }
 
+// TextCarriesAnyTerm is TextCarriesTerm over a whole query. Asking term by term
+// lowercases the message once per term, and the per-prompt hook does that for
+// every message of a session that can run to sixteen thousand of them: measured
+// on a real store, narrowing the candidates cost 498 ms of the hook's 577.
+func TextCarriesAnyTerm(text string, terms []string) bool {
+	return termHits(text, terms) > 0
+}
+
 // termStem is a term with its last two characters dropped, or empty when the
 // term is too short for that to still identify it.
 func termStem(t string) string {


### PR DESCRIPTION
`focusSession` called `search.TextCarriesTerm` once per query term, and each call lowercases the whole message — six times per message for a six-term question. Sessions on a real store run to 16k messages and they rank into everything, so this is the per-prompt hook's dominant cost.

Timed on a 1149-session store over 59 real questions:

```
median   255ms -> 181ms
p90      729ms -> 397ms
```

Same lines come out: three benches unchanged, and a live run over the same questions gives the same 49 answers / 8 off-topic / 1 silence as before.