### PR TITLE
perf(hook): drop a candidate before narrowing it, not after

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -198,6 +198,23 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		if matched[i] >= 2 || strong[i] >= 1 {
 			worthDigest = true
 		}
+		// The session being written right now is never worth recalling to
+		// itself. Work merely fresh is a different case: "what did we just
+		// change" is a question about the last ten minutes, so age alone no
+		// longer withholds an answer — it only withholds the unprompted
+		// déjà vu line below.
+		//
+		// Asked before the narrowing below, not after: narrowing scans every
+		// message, the session being written is usually the longest one on the
+		// store, and it was scanned in full only to be dropped on the next
+		// line. Measured on a 1149-session store, moving these two checks up
+		// takes the hook's median from 181 ms to 136 ms.
+		if s.ID == input.SessionID {
+			continue
+		}
+		if seen[s.ID] {
+			continue
+		}
 		// A marathon session that touched everything matches everything, so
 		// it used to be skipped whole. But the sessions people ask about are
 		// exactly the long ones — measured here, only 2% of sessions cross
@@ -209,17 +226,6 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 			if len(s.Messages) == 0 {
 				continue
 			}
-		}
-		// The session being written right now is never worth recalling to
-		// itself. Work merely fresh is a different case: "what did we just
-		// change" is a question about the last ten minutes, so age alone no
-		// longer withholds an answer — it only withholds the unprompted
-		// déjà vu line below.
-		if s.ID == input.SessionID {
-			continue
-		}
-		if seen[s.ID] {
-			continue
 		}
 		ss = append(ss, s)
 		if len(ss) == 2 {

--- a/cmd/deja/hook_prompt_self_test.go
+++ b/cmd/deja/hook_prompt_self_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The session being written right now must never be recalled to itself: its
+// text is already in front of the agent, and quoting it back spends tokens to
+// say nothing. The hook has skipped it for a long time and nothing held that
+// in place — removing the check left every test passing, which is how the
+// order of the checks came to be changed without anything noticing.
+func TestHookPromptDoesNotRecallTheSessionBeingWritten(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "self.jsonl"), "selfsession", []string{
+		`{"type":"user","sessionId":"selfsession","timestamp":"` + old + `","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	var other bytes.Buffer
+	in := strings.NewReader(`{"prompt":"do we need pgbouncer here","session_id":"another"}`)
+	if err := runHookPromptMode(index.DefaultDir(), in, &other, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(other.String(), "transaction mode") {
+		t.Fatalf("the fixture is not recalled at all, so the test below proves nothing:\n%q", other.String())
+	}
+
+	var self bytes.Buffer
+	in = strings.NewReader(`{"prompt":"do we need pgbouncer here","session_id":"selfsession"}`)
+	if err := runHookPromptMode(index.DefaultDir(), in, &self, true); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(self.String(), "transaction mode") {
+		t.Errorf("the session being written was recalled to itself:\n%q", self.String())
+	}
+}


### PR DESCRIPTION
`focusSession` scans every message of a candidate, and the two cheap reasons to discard one — it is the session being written, or it was already injected this session — were checked after that scan. The session being written is usually the longest on the store, so the hook narrowed 16k messages and threw the result away on the next line.

Timed on a 1149-session store over 59 real questions:

```
median   181ms -> 136ms
p90      397ms -> 304ms
```

Recall is unchanged (same 49 answers / 8 off-topic / 1 silence), three benches unchanged.

Also adds the test for the self-skip: removing that check left the whole suite green, which is how the ordering could be changed unnoticed.