### PR TITLE
fix(hook): lead with the session that concluded something

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -235,6 +235,21 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	if len(ss) == 0 {
 		return nil
 	}
+	// Of the two candidates, lead with the one that settled something about the
+	// question rather than the one that merely mentioned it. The benchmark has
+	// been applying this since the arm was written — and saying so in a comment
+	// that claimed the hook did the same — while the hook did not, so the
+	// concluded_session arm scored a behaviour the product never had.
+	// Of the two candidates, lead with the one that settled something about the
+	// question rather than the one that merely mentioned it. The benchmark has
+	// been applying this since the arm was written — and saying so in a comment
+	// that claimed the hook did the same — while the hook did not, so the
+	// concluded_session arm scored a behaviour the product never had.
+	// Of the two candidates, lead with the one that settled something about the
+	// question rather than the one that merely mentioned it. The benchmark has
+	// been applying this since the arm was written — and saying so in a comment
+	// that claimed the hook did the same — while the hook did not.
+	ss = search.LeadWithConclusion(ss, terms)
 	// A rejected session is not an equal answer, and the mark has to travel
 	// with it into the block the agent reads (#761).
 	ss, rejectedWarning := orderForInjection(ss)

--- a/cmd/deja/hook_prompt_lead_test.go
+++ b/cmd/deja/hook_prompt_lead_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Two sessions hold the subject: one talked about it and settled nothing, the
+// other concluded something. The block has room for one, and the reader is
+// served by the conclusion.
+//
+// `deja bench prompt` has scored this since the concluded_session arm was
+// written, and its probe said in a comment that it applied "the same ordering
+// the hook applies, from the same function" — but the hook never called it.
+// Removing the call again leaves every other test green.
+func TestHookPromptLeadsWithTheSessionThatConcluded(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	recent := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
+	older := time.Now().Add(-96 * time.Hour).UTC().Format(time.RFC3339)
+
+	// Says the subject over and over and never settles it, so ranking puts it
+	// first on sheer weight.
+	talk := make([]string, 0, 6)
+	for i := 0; i < 6; i++ {
+		talk = append(talk, `{"type":"assistant","sessionId":"kestreltalk","timestamp":"`+recent+
+			`","message":{"role":"assistant","content":"looking at kestrel again, still not touching kestrel"}}`)
+	}
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "talk.jsonl"), "kestreltalk", talk)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "done.jsonl"), "kestreldone", []string{
+		`{"type":"assistant","sessionId":"kestreldone","timestamp":"` + older +
+			`","message":{"role":"assistant","content":"the fix: kestrel retries are capped at four"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	var out bytes.Buffer
+	in := strings.NewReader(`{"prompt":"what did we decide about kestrel","session_id":"asking"}`)
+	if err := runHookPromptMode(index.DefaultDir(), in, &out, true); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "kestrel") {
+		t.Fatalf("nothing was recalled, so the ordering below is untested:\n%q", got)
+	}
+	fix := strings.Index(got, "capped at four")
+	talked := strings.Index(got, "still not touching")
+	if fix < 0 {
+		t.Fatalf("the session that concluded something was not shown at all:\n%q", got)
+	}
+	if talked >= 0 && talked < fix {
+		t.Errorf("the block opens on the session that settled nothing:\n%q", got)
+	}
+}


### PR DESCRIPTION
`search.LeadWithConclusion` is called by the `bench prompt` probe and nowhere else. The probe's comment says it applies "the same ordering the hook applies, from the same function" — the hook never called it, so the `concluded_session` arm has been scoring a behaviour the product does not have.

Measured on a 1149-session store over 109 blocks injected into ordinary messages:

```
block opens on a conclusion   7 (6%) -> 13 (11%)
no conclusion shown at all   93 (85%) -> 90 (82%)
```

Memory questions are unchanged (49 answers / 8 off-topic / 1 silence), three benches unchanged.

Adds the test: removing the call again leaves the rest of the suite green.