### PR TITLE
test(hook): hold the cheap discards ahead of narrowing

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -722,11 +722,20 @@ func presentableTopic(t string) bool {
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r >= 0x400
 }
 
+// focusCalls counts how many sessions were narrowed. A seam, like
+// rebuildInProgress above: narrowing walks every message of a session that can
+// run to sixteen thousand of them, and the two cheap reasons to discard a
+// candidate are checked before it. Nothing else can hold that order in place —
+// the output is identical either way and only the time differs, and a test that
+// watches a clock is a test that fails on someone else's machine.
+var focusCalls int
+
 // focusSession narrows a long session to the neighbourhood of the messages
 // that matched, so a haystack contributes its relevant part rather than being
 // dropped or flooding the digest. Two messages either side keeps the exchange
 // readable: a question without its answer recalls nothing useful.
 func focusSession(s model.Session, terms []string) model.Session {
+	focusCalls++
 	const window = 2
 	keep := map[int]bool{}
 	for i, m := range s.Messages {

--- a/cmd/deja/hook_prompt_focus_order_test.go
+++ b/cmd/deja/hook_prompt_focus_order_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Narrowing a candidate walks every message it holds, and the session being
+// written is the longest one on a real store — measured there, doing it before
+// the two cheap discards cost 45 ms of the hook's 181. The output is the same
+// either way, so only a count can hold the order in place.
+func TestHookPromptDoesNotNarrowASessionItWillDiscard(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	ts := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
+
+	// Long enough to be narrowed, and it is the session asking.
+	lines := make([]string, 0, dejaVuMaxMessages+2)
+	for i := 0; i < dejaVuMaxMessages+1; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"type":"assistant","sessionId":"selflong","timestamp":"%s","message":{"role":"assistant","content":"kestrel notes %d"}}`,
+			ts, i))
+	}
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "selflong.jsonl"), "selflong", lines)
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	focusCalls = 0
+	var out bytes.Buffer
+	in := strings.NewReader(`{"prompt":"what did we decide about kestrel","session_id":"selflong"}`)
+	if err := runHookPromptMode(index.DefaultDir(), in, &out, true); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "kestrel notes") {
+		t.Fatalf("the session being written was recalled to itself:\n%q", out.String())
+	}
+	if focusCalls != 0 {
+		t.Errorf("narrowed %d session(s) that were then discarded — the cheap checks must come first", focusCalls)
+	}
+}


### PR DESCRIPTION
`focusSession` walks every message of a candidate, and the two cheap reasons to discard one — it is the session being written, or it was already injected — are checked before it. Moving them ahead took the hook's median from 181ms to 136ms on a 1149-session store, and nothing in the suite noticed either way: the block that comes out is identical, only the time differs.

A clock-watching test fails on someone else's machine, so this counts narrowed sessions instead. Put the order back and it fails with "narrowed 1 session(s) that were then discarded".

Three benches unchanged.