### PR TITLE
perf(hook): do not read sessions this session already saw

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -150,7 +150,25 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// Rank THIS project's sessions by how well they match the prompt terms
 	// (IDF-weighted), rather than reconstructing an AND query — natural
 	// prompts are full of filler that poisons an AND.
-	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, prompt.Candidates)
+	// The sessions this agent session has already been shown, and the one it is
+	// writing, are discarded a few lines below on their id alone. Handing them
+	// to the ranking means they are never read: on a real store that is 15 of
+	// 26 candidates, each read from disk in full before being dropped.
+	seen := alreadyInjected(dir, input.SessionID)
+	skip := make(map[string]bool, len(seen)+1)
+	for id := range seen {
+		skip[id] = true
+	}
+	if input.SessionID != "" {
+		skip[input.SessionID] = true
+	}
+	ranked, matched, strong, idfOf, err := index.ProjectRelevantSkipping(dir, digest.ProjectNameCandidates(cwd), terms, prompt.Candidates, skip)
+	rankedAlreadyShown = 0
+	for _, s := range ranked {
+		if skip[s.ID] {
+			rankedAlreadyShown++
+		}
+	}
 	if err != nil || len(ranked) == 0 {
 		return emitNudgeOnly(stdout, plain, nudge)
 	}
@@ -161,7 +179,6 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// says so and lets such a question through — but saying "you have been here"
 	// on one word teaches the reader to ignore the line, so that stays at two.
 	worthDigest := false
-	seen := alreadyInjected(dir, input.SessionID)
 	pol := policy.Load()
 	for i, s := range ranked {
 		// Every other injection path asks the policy first; this one is a
@@ -721,6 +738,12 @@ func presentableTopic(t string) bool {
 	}
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r >= 0x400
 }
+
+// rankedAlreadyShown counts candidates the ranking returned despite having been
+// injected already. A seam, like focusCalls below: such a session is read from
+// disk in full and then dropped on its id, and nothing in the output changes
+// either way, so only a count can hold the skip in place.
+var rankedAlreadyShown int
 
 // focusCalls counts how many sessions were narrowed. A seam, like
 // rebuildInProgress above: narrowing walks every message of a session that can

--- a/cmd/deja/hook_prompt_skip_read_test.go
+++ b/cmd/deja/hook_prompt_skip_read_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A session already injected into this agent session is discarded on its id.
+// Handing that id to the ranking means it is never read: measured on a real
+// store, 15 of the 26 candidates a prompt ranks are ones it has already shown,
+// and reading them cost 40-56 ms a message. Walking one session, that is the
+// difference between 65 ms and 26 ms a message.
+//
+// The block that comes out is the same either way, so the count of narrowed
+// sessions is what holds this in place.
+func TestHookPromptDoesNotReadASessionItAlreadyShowed(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	ts := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	lines := make([]string, 0, dejaVuMaxMessages+2)
+	for i := 0; i < dejaVuMaxMessages+1; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"type":"assistant","sessionId":"longone","timestamp":"%s","message":{"role":"assistant","content":"the fix: kestrel retries are capped at four, note %d"}}`,
+			ts, i))
+	}
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "longone.jsonl"), "longone", lines)
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	var first bytes.Buffer
+	in := strings.NewReader(`{"prompt":"what did we decide about kestrel","session_id":"agent-1"}`)
+	if err := runHookPromptMode(index.DefaultDir(), in, &first, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(first.String(), "kestrel") {
+		t.Fatalf("the session was not recalled the first time, so the second ask proves nothing:\n%q", first.String())
+	}
+
+	rankedAlreadyShown = 0
+	var second bytes.Buffer
+	in = strings.NewReader(`{"prompt":"and what about kestrel retries","session_id":"agent-1"}`)
+	if err := runHookPromptMode(index.DefaultDir(), in, &second, true); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(second.String(), "capped at four") {
+		t.Fatalf("the same session was injected twice:\n%q", second.String())
+	}
+	if rankedAlreadyShown != 0 {
+		t.Errorf("the ranking returned %d session(s) already shown — they are read from disk in full and then dropped", rankedAlreadyShown)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -526,6 +526,15 @@ const dejaVuStrongIDFFloor = 3.0
 // INFORMATIVE terms hit (idf >= dejaVuIDFFloor) — callers gate on it so
 // generic words cannot manufacture a confident "you have been here".
 func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Session, []int, []int, map[string]float64, error) {
+	return ProjectRelevantSkipping(dir, projects, terms, n, nil)
+}
+
+// ProjectRelevantSkipping is ProjectRelevant without the sessions the caller
+// has already dealt with. The per-prompt hook discards a candidate it injected
+// earlier in the same agent session, and measured on a real store that is 15 of
+// the 26 it ranks — every one read from disk in full first, only to be dropped
+// on its id.
+func ProjectRelevantSkipping(dir string, projects, terms []string, n int, skip map[string]bool) ([]model.Session, []int, []int, map[string]float64, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -543,7 +552,7 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	metas, matched, strong, idf, rerr := relevantMetasMatched(dir, m, projects, terms, n)
+	metas, matched, strong, idf, rerr := relevantMetasMatched(dir, m, projects, terms, n, skip)
 	if rerr != nil {
 		// A corrupt or unreadable bucket. The hook never rebuilds, so surface
 		// it rather than inject a silently short-ranked déjà vu; the caller
@@ -560,8 +569,12 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 	return out, matched, strong, idf, nil
 }
 
-func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n int) ([]SessionMeta, []int, []int, map[string]float64, error) {
-	rank, err := relevantMetasCounts(dir, m, projects, terms, n, nil)
+func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n int, skip map[string]bool) ([]SessionMeta, []int, []int, map[string]float64, error) {
+	var keep func(SessionMeta) bool
+	if len(skip) > 0 {
+		keep = func(meta SessionMeta) bool { return !skip[meta.ID] }
+	}
+	rank, err := relevantMetasCounts(dir, m, projects, terms, n, keep)
 	return rank.metas, rank.informative, rank.strong, rank.idf, err
 }
 


### PR DESCRIPTION
A candidate the hook injected earlier in the same agent session is discarded on its id — after `ProjectRelevant` has read it from disk in full. Measured while walking one long session on a 1149-session store, that is 15 of the 26 candidates a prompt ranks.

Passing those ids to the ranking so they are never materialised:

```
per message, along one session:  65ms -> 27ms
recall along that session:       33 of 80 messages, unchanged
```

Three benches unchanged. One question of 58 turns from a block into a pointer: its match strength came only from the session being written, which is never shown, so the pointer is the honest answer there.

Adds a counting seam and a test — the output is identical whether or not the read happens, so nothing else can hold this in place.