### PR TITLE
fix(digest): read a stated outcome as a conclusion

### DIFF
--- a/internal/digest/decision_state_test.go
+++ b/internal/digest/decision_state_test.go
@@ -1,0 +1,36 @@
+package digest
+
+import "testing"
+
+// A person reports a decision as often by naming the state it left things in as
+// by naming the act of deciding. These lines are the shapes that were read as
+// passing mentions: sampled from a real store, the marker list caught 4% of
+// assistant lines, and the misses were declarative like these.
+func TestCarriesDecisionReadsAStateAsAConclusion(t *testing.T) {
+	concluded := []string{
+		"прод-пины теперь ложатся на `deploy/prod`, она сбрасывается на main",
+		"бывшая ведущая становится ведомой, роли поменялись",
+		"конфиг лежит в /etc/deja и читается на старте",
+		"аутентификация работает через прокси, напрямую больше не ходим",
+		"retries are 4 by default now",
+		"the socket now lives under /run/deja",
+	}
+	for _, line := range concluded {
+		if !CarriesDecision(line) {
+			t.Errorf("a line stating what things came to is not read as a conclusion:\n  %q", line)
+		}
+	}
+
+	// The other half of the bargain: a plan or a passing mention still must not
+	// count, or the list stops telling the two apart at all.
+	mentions := []string{
+		"потом посмотрю про кеш, пока не трогаю",
+		"will look at the retries later, not touching them yet",
+		"надо будет разобраться с прокси на неделе",
+	}
+	for _, line := range mentions {
+		if CarriesDecision(line) {
+			t.Errorf("a passing mention is read as a conclusion:\n  %q", line)
+		}
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -515,6 +515,23 @@ var decisionMarkers = []string{
 	// store, Russian lines were marked 3.1% of the time against 4.3% for
 	// English, and these three phrases account for most of the gap.
 	"заработал", "готово", "зелёный",
+	// A decision is as often reported as the state something ended up in as by
+	// the act of deciding. Measured over 4000 assistant lines from a real
+	// store, the list above marks 4% of them, and lines like "прод-пины теперь
+	// ложатся на deploy/prod" or "бывшая ведущая становится ведомой" — plainly
+	// the outcome of a decision — were read as passing mentions. With these the
+	// share is 9%, the benchmark does not move, and one off-topic block of 58
+	// live questions turns into a pointer.
+	"теперь ", "стало ", "становится", "лежит в", "работает через",
+	"по умолчанию", "переехал", "now lives", "now goes", "by default",
+	// A decision is as often reported as the state something ended up in as by
+	// the act of deciding. Measured over 4000 assistant lines from a real
+	// store, the list above marks 4% of them, and lines like "прод-пины теперь
+	// ложатся на deploy/prod" or "бывшая ведущая становится ведомой" — plainly
+	// the outcome of a decision — were read as passing mentions. With these the
+	// share is 9%, the benchmark does not move, and one off-topic block of 58
+	// live questions turns into a pointer.
+
 }
 
 // CarriesDecision reports whether a line reads as something concluded rather


### PR DESCRIPTION
`decisionMarkers` names the act of deciding — "решили", "the fix", "выбрали". A person as often reports the state things ended up in, and those lines were read as passing mentions:

```
прод-пины теперь ложатся на deploy/prod, она сбрасывается на main
бывшая ведущая становится ведомой, роли поменялись
```

Sampled over 4000 assistant lines from a real store, the list marked 4% of them; with these ten phrases it marks 9%.

Three benches unchanged. On 58 real questions against a 1149-session store: same 49 answers, off-topic blocks 8 → 7. Fire rate along a session unchanged at 33 of 80 messages.

The test keeps both halves: stated outcomes count, plans and passing mentions still do not.