### PR TITLE
fix(recall): do not open the block with the message being typed

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -160,6 +160,10 @@ type promptReport struct {
 	// question identifies anything, so dropping the subject leaves a working
 	// verb and the answer is never found.
 	ShortSubject promptArmReport `json:"short_subject"`
+	// The echo arm: the session holds the user's own earlier copy of the very
+	// sentence being typed now. Correct means the block opens on what was
+	// concluded rather than handing the question back.
+	Echo promptArmReport `json:"echo_line"`
 	// The concluded arm: two sessions hold the subject, one only mentioned it
 	// and the other settled it. Correct means the block carries what was
 	// settled.
@@ -287,6 +291,16 @@ func measurePrompt(seed int64) (promptReport, error) {
 				}
 			}
 			continue
+		case "echo-line":
+			arm = &report.Echo
+			arm.Cases++
+			arm.Fired++
+			if blockOpensOnEcho(indexDir, scope, terms, chain.Question) {
+				arm.FalseFires++
+			} else {
+				arm.Correct++
+			}
+			continue
 		case "decoy":
 			// Scored with the question's own terms, the way the hook builds the
 			// block. An earlier version of this arm rebuilt it from the topic
@@ -367,6 +381,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.Decision, nil)
 	finishPromptArm(&report.Concluded, nil)
 	finishPromptArm(&report.ShortSubject, nil)
+	finishPromptArm(&report.Echo, nil)
 	finishPromptArm(&report.AbsentSubject, nil)
 	return report, nil
 }
@@ -526,4 +541,34 @@ func finishPromptArm(arm *promptArmReport, terms []int) {
 	if len(terms) > 0 {
 		arm.MedianTerm = percentileInt(terms, 50)
 	}
+}
+
+// blockOpensOnEcho reports whether the first line the agent would read is the
+// question it just asked, handed back.
+func blockOpensOnEcho(dir, project string, terms []string, question string) bool {
+	ranked, matched, strong, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	if err != nil {
+		return false
+	}
+	var keep []model.Session
+	for i, s := range ranked {
+		if !recallWorthShowing(terms, matched[i], strong[i]) {
+			continue
+		}
+		keep = append(keep, s)
+		if len(keep) == 2 {
+			break
+		}
+	}
+	if len(keep) == 0 {
+		return false
+	}
+	for _, ln := range strings.Split(search.AutoRecallDigestForAsked(keep, 2000, terms, question), "\n") {
+		t := strings.TrimSpace(ln)
+		if !strings.HasPrefix(t, "- User:") && !strings.HasPrefix(t, "- Assistant:") {
+			continue
+		}
+		return strings.Contains(strings.ToLower(t), strings.ToLower(question))
+	}
+	return false
 }

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -285,7 +285,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		// way of its own to tell "mm_status" from "decide", and the session
 		// that answers often says both — measured live, ten of the answers
 		// this hook newly returns open on the ordinary word.
-		digest := search.AutoRecallDigestFor(ss, promptHookBudget-recallFrameOverhead, byIdentifying(terms, idfOf))
+		digest := search.AutoRecallDigestForAsked(ss, promptHookBudget-recallFrameOverhead, byIdentifying(terms, idfOf), string(input.Prompt))
 		if strings.TrimSpace(digest) == "" {
 			return emitNudgeOnly(stdout, plain, nudge)
 		}

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -411,6 +411,31 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
+	// The echo. A person repeats an instruction, and the session holding the
+	// earlier copy of it wins the opening line — it carries every word of the
+	// question, being the same sentence. Measured on a real store, 22 of 104
+	// injected blocks opened on a near-copy of the message the agent was
+	// reading at that moment.
+	for i, d := range []promptTopic{
+		{"cormorant", "the fix: cormorant retries are capped at four", "start the cormorant retry now"},
+		{"kittiwake", "the fix: kittiwake writes go to the replica", "start the kittiwake write now"},
+	} {
+		id := fmt.Sprintf("prompt-echo-%02d", i)
+		project := fmt.Sprintf("promptbenchecho%02d", i)
+		t := base.Add(time.Duration(3300+i*10) * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: project, Kind: "echo-line",
+			Topic: d.word, Question: d.question, Fact: d.fact,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: project,
+				Started: t, Updated: t.Add(10 * time.Minute),
+				Messages: []model.Message{
+					{Role: "user", Text: d.question, Time: t},
+					{Role: "assistant", Text: d.fact, Time: t.Add(5 * time.Minute)},
+				},
+			}},
+		})
+	}
 	// The decoy line. The session that answers also says an ordinary word the
 	// question happens to use, in a place that has nothing to do with the
 	// subject. Measured on a real store: "what did we decide about mm_status"

--- a/internal/search/echo_test.go
+++ b/internal/search/echo_test.go
@@ -1,0 +1,62 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestNearCopyTellsARepeatedInstructionFromAnAnswer(t *testing.T) {
+	asked := "да, начинай с ретрая на воркере"
+	for _, line := range []string{
+		"да, начинай с ретрая на воркере",
+		"да, начинай с ретрая на воркере 2",
+		"начинай с ретрая на воркере",
+	} {
+		if !nearCopy(line, asked) {
+			t.Errorf("a repeat of the message being typed is not recognised:\n  %q", line)
+		}
+	}
+	for _, line := range []string{
+		"ретрай на воркере теперь ограничен четырьмя попытками, дальше очередь",
+		"retries on the worker are capped at four",
+		"",
+	} {
+		if nearCopy(line, asked) {
+			t.Errorf("an answer is mistaken for a repeat of the question:\n  %q", line)
+		}
+	}
+	if nearCopy("что угодно", "") {
+		t.Error("with nothing asked there is nothing to compare against")
+	}
+}
+
+// The digest must not open by handing back the sentence being typed: the
+// session holding an earlier copy of it carries every query word, so it wins
+// the opening slot on similarity alone.
+func TestDigestDoesNotOpenWithTheMessageBeingTyped(t *testing.T) {
+	now := time.Now().Add(-48 * time.Hour)
+	s := model.Session{
+		ID: "s1", Harness: "claude", Project: "p", Started: now, Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: "start the cormorant retry now", Time: now},
+			{Role: "assistant", Text: "the fix: cormorant retries are capped at four", Time: now.Add(time.Minute)},
+		},
+	}
+	terms := []string{"cormorant", "retry", "start"}
+
+	plain := AutoRecallDigestFor([]model.Session{s}, 2000, terms)
+	if !strings.Contains(plain, "start the cormorant retry now") {
+		t.Fatalf("without the asked text the echo is expected to win, so this test proves nothing:\n%s", plain)
+	}
+
+	asked := AutoRecallDigestForAsked([]model.Session{s}, 2000, terms, "start the cormorant retry now")
+	if strings.Contains(asked, "start the cormorant retry now") {
+		t.Errorf("the block hands back the sentence being typed:\n%s", asked)
+	}
+	if !strings.Contains(asked, "capped at four") {
+		t.Errorf("the conclusion is not shown:\n%s", asked)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -53,6 +53,15 @@ func AutoRecallDigest(ss []model.Session, budget int) string {
 // on a real 8608-message session, the block an agent received carried one or
 // two of the four words it had searched for.
 func AutoRecallDigestFor(ss []model.Session, budget int, terms []string) string {
+	return AutoRecallDigestForAsked(ss, budget, terms, "")
+}
+
+// AutoRecallDigestForAsked is AutoRecallDigestFor knowing what was just typed,
+// so the block does not open by handing it back. A person repeats an
+// instruction — "да, начинай с ретрая" — and the session holding the earlier
+// copy wins the opening slot on carrying every word of it, being the same
+// sentence. Measured on a real store, that was 22 of 104 injected blocks.
+func AutoRecallDigestForAsked(ss []model.Session, budget int, terms []string, asked string) string {
 	if budget <= 0 {
 		budget = 2000
 	}
@@ -61,7 +70,7 @@ func AutoRecallDigestFor(ss []model.Session, budget int, terms []string) string 
 		if b.Len() >= budget {
 			break
 		}
-		section := autoRecallSessionFor(s, time.Now(), false, terms)
+		section := autoRecallSessionForAsked(s, time.Now(), false, terms, asked)
 		if section == "" {
 			continue
 		}
@@ -359,11 +368,15 @@ func termStem(t string) string {
 }
 
 func autoRecallSessionFor(s model.Session, now time.Time, provenance bool, terms []string) string {
+	return autoRecallSessionForAsked(s, now, provenance, terms, "")
+}
+
+func autoRecallSessionForAsked(s model.Session, now time.Time, provenance bool, terms []string, asked string) string {
 	var problem string
 	var conclusions []string
 	matched := false
 	if len(terms) > 0 {
-		problem, conclusions = matchedLines(s, terms)
+		problem, conclusions = matchedLinesAsked(s, terms, asked)
 		matched = len(conclusions) > 0
 	} else {
 		// No question yet — this is the block handed over at session start.
@@ -466,6 +479,10 @@ func autoRecallSessionFor(s model.Session, now time.Time, provenance bool, terms
 // caller's fallback, so a session that ranked through a stem fold still shows
 // something rather than nothing.
 func matchedLines(s model.Session, terms []string) (string, []string) {
+	return matchedLinesAsked(s, terms, "")
+}
+
+func matchedLinesAsked(s model.Session, terms []string, asked string) (string, []string) {
 	type scored struct {
 		idx, hits int
 		text      string
@@ -512,7 +529,7 @@ func matchedLines(s model.Session, terms []string) (string, []string) {
 		}
 		switch m.Role {
 		case "user":
-			if !noiseMessage(m.Text) && hits > bestUser.hits {
+			if !noiseMessage(m.Text) && !nearCopy(line, asked) && hits > bestUser.hits {
 				bestUser = scored{i, hits, lineAround(text, 160, terms)}
 			}
 		case "assistant":
@@ -865,6 +882,42 @@ func EarlierAttempts(ss []model.Session) map[string]string {
 				continue
 			}
 			out[a.ID] = b.Updated.Format("2006-01-02")
+		}
+	}
+	return out
+}
+
+// nearCopy reports whether a line is essentially the text just typed. Half the
+// words shared is enough: a repeated instruction comes back with a word changed
+// or a number bumped, and it is still nothing the reader does not already have
+// in front of them.
+func nearCopy(line, asked string) bool {
+	if asked == "" {
+		return false
+	}
+	a, b := contentWords(line), contentWords(asked)
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+	shared := 0
+	for w := range a {
+		if b[w] {
+			shared++
+		}
+	}
+	union := len(a) + len(b) - shared
+	return union > 0 && float64(shared)/float64(union) >= 0.5
+}
+
+func contentWords(s string) map[string]bool {
+	out := map[string]bool{}
+	wordy := func(r rune) bool {
+		return r == '_' || r == '-' || r == '.' || r == '/' ||
+			(r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r >= 0x400
+	}
+	for _, w := range strings.FieldsFunc(strings.ToLower(s), func(r rune) bool { return !wordy(r) }) {
+		if len([]rune(w)) >= 3 {
+			out[w] = true
 		}
 	}
 	return out


### PR DESCRIPTION
The block's opening line is the best-matching user line in the recalled session. A person repeats an instruction — "да, начинай с ретрая" — and the earlier copy of it wins that slot on carrying every word of the question, being the same sentence. The reader is handed back what is already in front of them.

Measured on a 1149-session store over 104 injected blocks:

```
blocks opening on a user line       61% -> 39%
of those, a near-copy of the prompt  22 -> 0
blocks opening on the assistant     38% -> 60%
```

Answers on 58 real questions are unchanged (49), as are off-topic blocks (7) and the recall rate along a session (33 of 80 messages).

New `echo_line` bench arm reproduces it: a session holding the user's own earlier copy of the question. 0/2 before, 2/2 after, no other arm moves; removing the check again reds it.