### PR TITLE
fix(prompt): an imperative names nothing to recall

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -83,6 +83,13 @@ func negativeQuestions() []string {
 		"add a log line here",
 		"open the file and read it",
 		"write the code for this",
+		// The same shape in Russian: an imperative that opens a message and
+		// names nothing. Measured on a real store, "продолжай DDD-рефактор"
+		// matched a session on "продолжай" and showed "продолжай и не отключай
+		// больше streisand"; five messages of 142 got a block whose only terms
+		// were words like these.
+		"продолжай",
+		"хорошо, продолжи",
 	}
 }
 

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -268,6 +268,15 @@ var cyrPromptStop = map[string]bool{
 	// for; it also sits in the decision markers, so keeping it made a line
 	// count as a conclusion because the asker had used the phrase.
 	"итоге": true, "итог": true, "конце": true, "концов": true,
+	// Imperatives that open a message and name nothing. Measured on a real
+	// store, "продолжай DDD-рефактор" matched a session on "продолжай" and
+	// showed "продолжай и не отключай больше streisand"; five messages of 142
+	// got a block whose only terms were words of this kind.
+	// Imperatives that open a message and name nothing. Measured on a real
+	// store, "продолжай DDD-рефактор" matched a session on "продолжай" and
+	// showed "продолжай и не отключай больше streisand"; five messages of 142
+	// got a block whose only terms were words of this kind.
+	"продолжай": true, "продолжи": true, "хорошо": true,
 	"для": true, "при": true, "над": true, "под": true, "без": true,
 	"она": true, "они": true, "оно": true, "был": true, "была": true,
 	"мне": true, "нам": true, "вам": true,


### PR DESCRIPTION
"продолжай", "продолжи" and "хорошо" open a message without naming anything, and they were kept as search terms. Measured on a 1149-session store: "продолжай DDD-рефактор" matched a session on "продолжай" and the block opened with "продолжай и не отключай больше streisand".

Over 142 ordinary messages:

```
blocks whose only terms were words like these   5 -> 0 (now silence)
off-topic blocks                                5 -> 4
blocks carrying a conclusion                   15 -> 21 of 99
```

Answers on 58 real questions are unchanged at 49.

Two Russian imperatives added to the negative controls reproduce it: 1 false fire of 12 before, 0 after, and removing the three words reds them again. Other arms unchanged, recall and context benches unchanged.