### PR TITLE
test: hold the line cap and the asked-marker skip

### DIFF
--- a/internal/digest/decision_asked_test.go
+++ b/internal/digest/decision_asked_test.go
@@ -1,0 +1,25 @@
+package digest
+
+import "testing"
+
+// A marker that is also a word of the question makes the check circular: the
+// line counts as a conclusion because the asker used the phrase. Measured on
+// the benchmark, "по чему у нас в итоге шардирование" promoted a session about
+// something else entirely on the words "в итоге".
+//
+// Removing the skip left the whole suite green.
+func TestCarriesDecisionIgnoresAMarkerTheAskerUsed(t *testing.T) {
+	line := "в итоге посмотрим на это позже, пока ничего не трогаем"
+
+	if !CarriesDecision(line) {
+		t.Fatalf("premise: the line carries the marker %q", line)
+	}
+	if CarriesDecisionExcept(line, []string{"итоге"}) {
+		t.Error("a marker the asker used still counted as a conclusion")
+	}
+	// A different marker in the same line must still count, or the skip would
+	// silence real conclusions whenever a question happens to share a word.
+	if !CarriesDecisionExcept("в итоге решили откатить", []string{"итоге"}) {
+		t.Error("another marker in the line no longer counts")
+	}
+}

--- a/internal/search/lines_cap_test.go
+++ b/internal/search/lines_cap_test.go
@@ -1,0 +1,44 @@
+package search
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A session that says the subject in twenty places must not spend twenty lines
+// saying so: the hook pays for this block on every message. Removing the cap
+// left the whole suite green.
+func TestDigestShowsAtMostTwoAssistantLinesPerSession(t *testing.T) {
+	now := time.Now().Add(-48 * time.Hour)
+	msgs := make([]model.Message, 0, 21)
+	for i := 0; i < 20; i++ {
+		msgs = append(msgs, model.Message{
+			Role: "assistant",
+			Text: fmt.Sprintf("kestrel retries look wrong in case %d, still kestrel", i),
+			Time: now.Add(time.Duration(i) * time.Minute),
+		})
+	}
+	s := model.Session{
+		ID: "s1", Harness: "claude", Project: "p", Started: now,
+		Updated: now.Add(20 * time.Minute), Messages: msgs,
+	}
+
+	block := AutoRecallDigestFor([]model.Session{s}, 4000, []string{"kestrel", "retries"})
+	quoted := 0
+	for _, ln := range strings.Split(block, "\n") {
+		t := strings.TrimSpace(ln)
+		if strings.HasPrefix(t, "- User:") || strings.HasPrefix(t, "- Assistant:") {
+			quoted++
+		}
+	}
+	if quoted == 0 {
+		t.Fatalf("nothing was quoted, so the cap is untested:\n%s", block)
+	}
+	if quoted > 2 {
+		t.Errorf("session contributed %d lines; two is the cap:\n%s", quoted, block)
+	}
+}


### PR DESCRIPTION
Second mutation sweep, six branches of line selection and the digest. Four were caught, two were not:

- `assistants[:2]` — the cap on how many lines one session contributes, which is what keeps the per-message block small
- the skip in `CarriesDecisionExcept` for markers the asker used, which stops "в итоге" counting as a conclusion because the question said it

Two tests, both mutation-checked, no product change.