### PR TITLE
fix(prompt): a compound name with short halves is still a name

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -171,6 +171,10 @@ type promptReport struct {
 	// sentence being typed now. Correct means the block opens on what was
 	// concluded rather than handing the question back.
 	Echo promptArmReport `json:"echo_line"`
+	// The compound arm: a hyphenated subject whose parts are short. The floor
+	// for a single Cyrillic word is three letters; a compound needed five in one
+	// part, so ordinary names fell through.
+	Compound promptArmReport `json:"compound_subject"`
 	// The concluded arm: two sessions hold the subject, one only mentioned it
 	// and the other settled it. Correct means the block carries what was
 	// settled.
@@ -308,6 +312,18 @@ func measurePrompt(seed int64) (promptReport, error) {
 				arm.Correct++
 			}
 			continue
+		case "compound-subject":
+			arm = &report.Compound
+			arm.Cases++
+			if fired, correct := promptBenchProbe(indexDir, scope, chain.ID, terms); fired {
+				arm.Fired++
+				if correct {
+					arm.Correct++
+				} else {
+					arm.FalseFires++
+				}
+			}
+			continue
 		case "decoy":
 			// Scored with the question's own terms, the way the hook builds the
 			// block. An earlier version of this arm rebuilt it from the topic
@@ -389,6 +405,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.Concluded, nil)
 	finishPromptArm(&report.ShortSubject, nil)
 	finishPromptArm(&report.Echo, nil)
+	finishPromptArm(&report.Compound, nil)
 	finishPromptArm(&report.AbsentSubject, nil)
 	return report, nil
 }

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -436,6 +436,31 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
+	// A compound name whose parts are short. The Cyrillic floor is three
+	// letters for a single word — "кеш", "хук" — but a hyphenated word needed a
+	// part of five, so "стоп-лист" and "прод-бд" were dropped entirely and the
+	// question was left holding a verb. Measured on a real store, compound
+	// subjects come back on topic 68% of the time against 100% for plain ones.
+	for i, d := range []promptTopic{
+		{"стоп-лист", "в итоге решили: стоп-лист держим в редисе", "что мы решали про стоп-лист"},
+		{"прод-бд", "в итоге решили: прод-бд читаем только с реплики", "что мы решали про прод-бд"},
+	} {
+		id := fmt.Sprintf("prompt-compound-%02d", i)
+		project := fmt.Sprintf("promptbenchcompound%02d", i)
+		t := base.Add(time.Duration(3500+i*10) * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: project, Kind: "compound-subject",
+			Topic: d.word, Question: d.question, Fact: d.fact,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: project,
+				Started: t, Updated: t.Add(10 * time.Minute),
+				Messages: []model.Message{
+					{Role: "user", Text: "смотрим " + d.word, Time: t},
+					{Role: "assistant", Text: d.fact, Time: t.Add(5 * time.Minute)},
+				},
+			}},
+		})
+	}
 	// The decoy line. The session that answers also says an ordinary word the
 	// question happens to use, in a place that has nothing to do with the
 	// subject. Measured on a real store: "what did we decide about mm_status"

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -119,8 +119,13 @@ func cyrPromptTerm(f string) bool {
 	}
 	// A compound made only of closed-class words is still filler: "то-то-сё"
 	// names nothing. One part that carries meaning is enough.
+	// Three letters, the same floor a single Cyrillic word gets: "кеш" and
+	// "хук" name things, and so do the halves of "стоп-лист" and "прод-бд".
+	// Demanding five in one part dropped those compounds entirely, leaving the
+	// question holding a verb — measured on a real store, compound subjects
+	// came back on topic 68% of the time against 100% for plain ones.
 	for _, part := range strings.Split(f, "-") {
-		if len([]rune(part)) >= 5 && !cyrPromptStop[part] {
+		if len([]rune(part)) >= 3 && !cyrPromptStop[part] {
 			return true
 		}
 	}


### PR DESCRIPTION
`cyrPromptTerm` accepts a single Cyrillic word at three letters — "кеш", "хук" name things — but required five letters in one part of a hyphenated word. So "стоп-лист" and "прод-бд" yielded no term at all and the question was left holding a verb.

Measured on a 1149-session store, 25 compound subjects against 25 plain ones, each said at least five times in its own session:

```
compound subjects on topic   68% -> 72%
plain subjects on topic     100% (unchanged)
answers on 58 real questions  49 (unchanged)
```

New `compound_subject` bench arm: 0/2 before, 2/2 after, no other arm moves; putting the five back reds it again. Recall and context benches unchanged.