### PR TITLE
bench(prompt): run the hook itself, not a copy of its loop

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -175,6 +176,11 @@ type promptReport struct {
 	// for a single Cyrillic word is three letters; a compound needed five in one
 	// part, so ordinary names fell through.
 	Compound promptArmReport `json:"compound_subject"`
+	// The end-to-end arm: the hook itself, not the copy of its loop this file
+	// carries. Every other arm reaches into the index directly, so a change that
+	// lives in the hook — the order of the gates, what the block opens with,
+	// whether a pointer goes out — moves no number here at all.
+	EndToEnd promptArmReport `json:"hook_end_to_end"`
 	// The concluded arm: two sessions hold the subject, one only mentioned it
 	// and the other settled it. Correct means the block carries what was
 	// settled.
@@ -312,6 +318,19 @@ func measurePrompt(seed int64) (promptReport, error) {
 				arm.Correct++
 			}
 			continue
+		case "hook-e2e":
+			arm = &report.EndToEnd
+			arm.Cases++
+			fired, carries := hookEndToEnd(indexDir, scope, chain.Question, chain.Fact)
+			if fired {
+				arm.Fired++
+				if carries {
+					arm.Correct++
+				} else {
+					arm.FalseFires++
+				}
+			}
+			continue
 		case "compound-subject":
 			arm = &report.Compound
 			arm.Cases++
@@ -406,6 +425,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.ShortSubject, nil)
 	finishPromptArm(&report.Echo, nil)
 	finishPromptArm(&report.Compound, nil)
+	finishPromptArm(&report.EndToEnd, nil)
 	finishPromptArm(&report.AbsentSubject, nil)
 	return report, nil
 }
@@ -595,4 +615,37 @@ func blockOpensOnEcho(dir, project string, terms []string, question string) bool
 		return strings.Contains(strings.ToLower(t), strings.ToLower(question))
 	}
 	return false
+}
+
+// hookEndToEnd runs the real hook over the bench index and reports whether it
+// spoke and whether what it showed carries the fact. The probe above copies the
+// hook's loop; this calls it.
+func hookEndToEnd(dir, project, question, fact string) (fired, carries bool) {
+	for _, suf := range []string{".hookseen", ".dejavu", ".envblock", ".injections.jsonl", ".usage.jsonl"} {
+		_ = os.Remove(dir + suf)
+	}
+	old := os.Getenv("CLAUDE_PROJECT_DIR")
+	if err := os.Setenv("CLAUDE_PROJECT_DIR", "/"+project); err != nil {
+		return false, false
+	}
+	defer func() { _ = os.Setenv("CLAUDE_PROJECT_DIR", old) }()
+
+	var out bytes.Buffer
+	payload := fmt.Sprintf(`{"prompt":%q,"session_id":"benche2e"}`, question)
+	if err := runHookPromptMode(dir, strings.NewReader(payload), &out, true); err != nil {
+		return false, false
+	}
+	got := out.String()
+	if !strings.Contains(got, "deja-recall") {
+		return false, false
+	}
+	for _, w := range strings.Fields(fact) {
+		if len([]rune(w)) < 7 {
+			continue
+		}
+		if strings.Contains(strings.ToLower(got), strings.ToLower(w)) {
+			return true, true
+		}
+	}
+	return true, false
 }

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -461,6 +461,27 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
+	// Two chains for the end-to-end arm, which runs the hook itself.
+	for i, d := range []promptTopic{
+		{"ptarmigan", "the fix: ptarmigan retries are capped at four", "what did we decide about ptarmigan"},
+		{"godwit", "в итоге решили: godwit пишет только в реплику", "что мы решали про godwit"},
+	} {
+		id := fmt.Sprintf("prompt-e2e-%02d", i)
+		project := fmt.Sprintf("promptbenche2e%02d", i)
+		t := base.Add(time.Duration(3700+i*10) * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: project, Kind: "hook-e2e",
+			Topic: d.word, Question: d.question, Fact: d.fact,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: project,
+				Started: t, Updated: t.Add(10 * time.Minute),
+				Messages: []model.Message{
+					{Role: "user", Text: "смотрим " + d.word, Time: t},
+					{Role: "assistant", Text: d.fact, Time: t.Add(5 * time.Minute)},
+				},
+			}},
+		})
+	}
 	// The decoy line. The session that answers also says an ordinary word the
 	// question happens to use, in a place that has nothing to do with the
 	// subject. Measured on a real store: "what did we decide about mm_status"


### PR DESCRIPTION
`promptBenchProbe` reimplements the hook's loop, and every arm uses it. So a change that lives in the hook — the order of the gates, what the block opens with, whether a pointer goes out — moves no number in `bench prompt` at all. Checked by printing from inside `runHookPromptMode` during a bench run: not one line.

Adds `hook_end_to_end`: two chains asked through `runHookPromptMode`, correct when the block carries the fact. 2/2 on main, and it drops to 1/2 when the payload rule is mutated so a pointer always goes out.

Two cases catch only some hook changes — the self-skip and the gate mutations still pass — but it is the first arm that executes the hook at all. No other arm moves; recall and context benches unchanged.