### PR TITLE
bench(prompt): ask the end-to-end arm from inside the answer's own session

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -318,6 +318,19 @@ func measurePrompt(seed int64) (promptReport, error) {
 				arm.Correct++
 			}
 			continue
+		case "hook-e2e-self":
+			arm = &report.EndToEnd
+			arm.Cases++
+			// Asked from the session that holds the answer: recalling it to
+			// itself spends tokens to say what is already on screen.
+			if fired, carries := hookEndToEndAs(indexDir, scope, chain.Question, chain.Fact,
+				chain.ID+"-session"); fired && carries {
+				arm.Fired++
+				arm.FalseFires++
+			} else {
+				arm.Correct++
+			}
+			continue
 		case "hook-e2e":
 			arm = &report.EndToEnd
 			arm.Cases++
@@ -621,6 +634,10 @@ func blockOpensOnEcho(dir, project string, terms []string, question string) bool
 // spoke and whether what it showed carries the fact. The probe above copies the
 // hook's loop; this calls it.
 func hookEndToEnd(dir, project, question, fact string) (fired, carries bool) {
+	return hookEndToEndAs(dir, project, question, fact, "benche2e")
+}
+
+func hookEndToEndAs(dir, project, question, fact, sid string) (fired, carries bool) {
 	for _, suf := range []string{".hookseen", ".dejavu", ".envblock", ".injections.jsonl", ".usage.jsonl"} {
 		_ = os.Remove(dir + suf)
 	}
@@ -631,7 +648,7 @@ func hookEndToEnd(dir, project, question, fact string) (fired, carries bool) {
 	defer func() { _ = os.Setenv("CLAUDE_PROJECT_DIR", old) }()
 
 	var out bytes.Buffer
-	payload := fmt.Sprintf(`{"prompt":%q,"session_id":"benche2e"}`, question)
+	payload := fmt.Sprintf(`{"prompt":%q,"session_id":%q}`, question, sid)
 	if err := runHookPromptMode(dir, strings.NewReader(payload), &out, true); err != nil {
 		return false, false
 	}

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -482,6 +482,28 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
+	// Asked from inside the session that holds the answer: the hook must not
+	// recall a session to itself, and with two cases the end-to-end arm could
+	// not see that rule at all.
+	for i, d := range []promptTopic{
+		{"whimbrel", "the fix: whimbrel retries are capped at four", "what did we decide about whimbrel"},
+	} {
+		id := fmt.Sprintf("prompt-e2eself-%02d", i)
+		project := fmt.Sprintf("promptbenche2eself%02d", i)
+		t := base.Add(time.Duration(3900+i*10) * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: project, Kind: "hook-e2e-self",
+			Topic: d.word, Question: d.question, Fact: d.fact,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: project,
+				Started: t, Updated: t.Add(10 * time.Minute),
+				Messages: []model.Message{
+					{Role: "user", Text: "смотрим " + d.word, Time: t},
+					{Role: "assistant", Text: d.fact, Time: t.Add(5 * time.Minute)},
+				},
+			}},
+		})
+	}
 	// The decoy line. The session that answers also says an ordinary word the
 	// question happens to use, in a place that has nothing to do with the
 	// subject. Measured on a real store: "what did we decide about mm_status"


### PR DESCRIPTION
The end-to-end arm added yesterday asks from a made-up session id, so it never exercised the rule that a session is not recalled to itself. This adds a third chain asked with the session id that holds the answer; correct means the block does not carry it.

The rule now has two implementations — the skip handed to the ranking and the check in the candidate loop — so disabling either alone changes nothing. With both off the arm goes 3/3 to 2/3 with one false fire, which is what the case is for.

Other arms unchanged, recall and context unchanged, tests and lint green.