### PR TITLE
fix(hook): don't recall a session that only a tool mentioned the subject in

### DIFF
--- a/cmd/deja/bench.go
+++ b/cmd/deja/bench.go
@@ -180,6 +180,44 @@ func containsRelevant(hits []search.Hit, ids []string, limit int) bool {
 	return false
 }
 
+// benchTranscriptLine writes one message the way the harness would have
+// recorded it.
+//
+// Tool output is not a role in a Claude transcript: it arrives as a user line
+// whose content is a tool_result block, and the reader labels it tool-output
+// on the way in. Writing the string "tool-output" into the type field instead
+// produced a line the reader skips entirely, so the corpus could hold no tool
+// output at all — a benchmark arm built on it was green because the message
+// was missing, not because the behaviour was right.
+func benchTranscriptLine(sid string, m model.Message) (string, error) {
+	type message struct {
+		Role    string `json:"role"`
+		Content any    `json:"content"`
+	}
+	line := struct {
+		Type    string  `json:"type"`
+		ID      string  `json:"sessionId"`
+		Time    string  `json:"timestamp"`
+		Message message `json:"message"`
+	}{Type: m.Role, ID: sid, Time: m.Time.UTC().Format(time.RFC3339),
+		Message: message{Role: m.Role, Content: m.Text}}
+	if m.Role == benchRoleToolOutput {
+		line.Type = "user"
+		line.Message = message{Role: "user", Content: []map[string]string{
+			{"type": "tool_result", "content": m.Text},
+		}}
+	}
+	b, err := json.Marshal(line)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// benchRoleToolOutput is the role a corpus chain uses to say "a tool printed
+// this". It mirrors sources.RoleToolOutput.
+const benchRoleToolOutput = "tool-output"
+
 func writeBenchCorpus(root string, sessions []model.Session) error {
 	for _, s := range sessions {
 		path := filepath.Join(root, s.Project, s.ID+".jsonl")
@@ -191,24 +229,12 @@ func writeBenchCorpus(root string, sessions []model.Session) error {
 			return err
 		}
 		for _, m := range s.Messages {
-			line := struct {
-				Type    string `json:"type"`
-				ID      string `json:"sessionId"`
-				Time    string `json:"timestamp"`
-				Message struct {
-					Role    string `json:"role"`
-					Content string `json:"content"`
-				} `json:"message"`
-			}{Type: m.Role, ID: s.ID, Time: m.Time.UTC().Format(time.RFC3339), Message: struct {
-				Role    string `json:"role"`
-				Content string `json:"content"`
-			}{Role: m.Role, Content: m.Text}}
-			b, marshalErr := json.Marshal(line)
+			b, marshalErr := benchTranscriptLine(s.ID, m)
 			if marshalErr != nil {
 				_ = f.Close()
 				return marshalErr
 			}
-			if _, writeErr := fmt.Fprintln(f, string(b)); writeErr != nil {
+			if _, writeErr := fmt.Fprintln(f, b); writeErr != nil {
 				_ = f.Close()
 				return writeErr
 			}

--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -181,6 +181,10 @@ type promptReport struct {
 	// lives in the hook — the order of the gates, what the block opens with,
 	// whether a pointer goes out — moves no number here at all.
 	EndToEnd promptArmReport `json:"hook_end_to_end"`
+	// The tool-only arm: another session holds the subject, but every mention
+	// of it was printed by a tool. Nothing there answers the question, so
+	// correct means the hook stays silent.
+	ToolOnly promptArmReport `json:"tool_only"`
 	// The concluded arm: two sessions hold the subject, one only mentioned it
 	// and the other settled it. Correct means the block carries what was
 	// settled.
@@ -318,6 +322,17 @@ func measurePrompt(seed int64) (promptReport, error) {
 				arm.Correct++
 			}
 			continue
+		case "tool-only":
+			arm = &report.ToolOnly
+			arm.Cases++
+			if fired, _ := hookEndToEndAs(indexDir, scope, chain.Question, chain.Fact,
+				"benchtoolonly"); fired {
+				arm.Fired++
+				arm.FalseFires++
+			} else {
+				arm.Correct++
+			}
+			continue
 		case "hook-e2e-self":
 			arm = &report.EndToEnd
 			arm.Cases++
@@ -439,6 +454,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.Echo, nil)
 	finishPromptArm(&report.Compound, nil)
 	finishPromptArm(&report.EndToEnd, nil)
+	finishPromptArm(&report.ToolOnly, nil)
 	finishPromptArm(&report.AbsentSubject, nil)
 	return report, nil
 }

--- a/cmd/deja/bench_toolout_test.go
+++ b/cmd/deja/bench_toolout_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// A corpus chain that says "a tool printed this" has to reach the index as tool
+// output. Written as a transcript line of type "tool-output" it reached nothing
+// at all: the Claude reader knows "user" and "assistant", so the message was
+// dropped and a benchmark arm built on it passed because the corpus was empty.
+func TestBenchCorpusCarriesToolOutput(t *testing.T) {
+	when := time.Date(2099, time.January, 1, 0, 0, 0, 0, time.UTC)
+	session := model.Session{ID: "toolout", Project: "toolproject", Harness: "claude",
+		Started: when, Updated: when.Add(time.Minute), Messages: []model.Message{
+			{Role: "user", Text: "прогони пайплайн", Time: when},
+			{Role: "tool-output", Text: "[toil.leader] Job 'WDLStartJob' v41 is completely failed",
+				Time: when.Add(30 * time.Second)},
+		}}
+
+	root := t.TempDir()
+	if err := writeBenchCorpus(root, []model.Session{session}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "toolproject", "toolout.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawToolResult bool
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		var entry struct {
+			Type    string `json:"type"`
+			Message struct {
+				Content json.RawMessage `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(entry.Message.Content), `"tool_result"`) {
+			sawToolResult = true
+			if entry.Type != "user" {
+				t.Errorf("tool output written under type %q, which the reader skips", entry.Type)
+			}
+		}
+	}
+	if !sawToolResult {
+		t.Fatal("no tool_result block written, so the corpus cannot hold tool output")
+	}
+
+	dir := filepath.Join(t.TempDir(), "index.db")
+	restore := isolateBenchEnv(t.TempDir(), root, dir)
+	defer restore()
+	if err := index.EnsureForSearch(dir, query.Options{All: true}, true, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := index.Search(dir, query.Options{Query: "v41", Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, s := range ss {
+		for _, m := range s.Messages {
+			if strings.Contains(m.Text, "v41") && m.Role == "tool-output" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("the indexed session holds no tool-output message carrying v41")
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -179,6 +179,13 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// says so and lets such a question through — but saying "you have been here"
 	// on one word teaches the reader to ignore the line, so that stays at two.
 	worthDigest := false
+	// The one word of the question that identifies something, kept apart for
+	// the test below: asking whether any term was spoken lets "показал" answer
+	// for "v11", and nearly every session says a word like that.
+	leadTerms := terms
+	if ordered := byIdentifying(terms, idfOf); len(ordered) > 0 {
+		leadTerms = ordered[:1]
+	}
 	pol := policy.Load()
 	for i, s := range ranked {
 		// Every other injection path asks the policy first; this one is a
@@ -227,6 +234,14 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		// line. Measured on a 1149-session store, moving these two checks up
 		// takes the hook's median from 181 ms to 136 ms.
 		if s.ID == input.SessionID {
+			continue
+		}
+		if !search.SpeechCarriesAnyTerm(s, leadTerms) {
+			// The subject matched, but only where a tool printed it: a
+			// failing job line, a bumped dependency, a pinned action
+			// version. Nobody in that session said anything about it, and a
+			// block built from those lines answers a different question
+			// than the one asked.
 			continue
 		}
 		if seen[s.ID] {

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -504,6 +504,36 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
+	// The subject appears in another session only in what a tool printed, and
+	// in the part of that output the index keeps: a failing job line, a
+	// dependency bump. Nobody there said anything about it, so the answer is
+	// silence. Measured on a real store, of the eight questions the hook still
+	// answers with unrelated work, six are exactly this shape — every match in
+	// the session it showed carried the role tool-output and no other.
+	for i, d := range []promptTopic{
+		{"v41", "[2026-08-16T20:43:05+0300] [MainThread] [W] [toil.leader] Job 'WDLStartJob' " +
+			"kind-WDLStartJob/instance-z1bqhro3 v41 is completely failed",
+			"ну что там v41 показал"},
+	} {
+		id := fmt.Sprintf("prompt-toolonly-%02d", i)
+		project := fmt.Sprintf("promptbenchtoolonly%02d", i)
+		t := base.Add(time.Duration(4300+i*10) * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: project, Kind: "tool-only",
+			Topic: d.word, Question: d.question, Fact: d.fact,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: project,
+				Started: t, Updated: t.Add(10 * time.Minute),
+				Messages: []model.Message{
+					{Role: "user", Text: "\u043f\u0440\u043e\u0433\u043e\u043d\u0438 \u043f\u0430\u0439\u043f\u043b\u0430\u0439\u043d \u0435\u0449\u0451 \u0440\u0430\u0437", Time: t},
+					{Role: "tool-output", Text: d.fact, Time: t.Add(time.Minute)},
+					{Role: "tool-output", Text: "error: bump github.com/pion/stun/" + d.word +
+						" from 3.1.1 to 3.1.5 failed", Time: t.Add(2 * time.Minute)},
+					{Role: "assistant", Text: "\u043f\u0435\u0440\u0435\u0437\u0430\u043f\u0443\u0441\u0442\u0438\u043b, \u0434\u0430\u043b\u044c\u0448\u0435 \u0441\u043c\u043e\u0442\u0440\u044e \u043b\u043e\u0433\u0438", Time: t.Add(5 * time.Minute)},
+				},
+			}},
+		})
+	}
 	// The decoy line. The session that answers also says an ordinary word the
 	// question happens to use, in a place that has nothing to do with the
 	// subject. Measured on a real store: "what did we decide about mm_status"

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -571,6 +571,31 @@ func rankOfBestTerm(line string, terms []string) int {
 	return 0
 }
 
+// SpeechCarriesAnyTerm reports whether anyone in the session said one of these
+// words, as opposed to a tool printing it. A version label that appears only in
+// a failing job line, a dependency bump or a pinned action is in the session
+// and answers nothing about that version.
+//
+// Measured on a real store, of the eight questions the per-prompt hook answered
+// with unrelated work, six had every match in the session it showed under the
+// role tool-output — a temp path /var/folders/v3/, an npm notice, a line of
+// someone else's source. The role is already recorded, so this needs no guess
+// about what a line looks like.
+func SpeechCarriesAnyTerm(s model.Session, terms []string) bool {
+	if len(terms) == 0 {
+		return true
+	}
+	for _, m := range s.Messages {
+		if m.Role == roleToolOutput {
+			continue
+		}
+		if TextCarriesAnyTerm(m.Text, terms) {
+			return true
+		}
+	}
+	return false
+}
+
 // LeadWithConclusion puts a session that settled something about the query
 // first. Ranking counts how often and how rarely the query's words appear and
 // cannot see the difference between settling a question and discussing it: a

--- a/internal/search/speech_test.go
+++ b/internal/search/speech_test.go
@@ -1,0 +1,39 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A version label printed by a failing job, a dependency bump and a pinned
+// action is in the session and answers nothing about that version. Measured on
+// a real store: of eight questions the per-prompt hook answered with unrelated
+// work, six had every match under the role tool-output.
+func TestSpeechCarriesAnyTermIgnoresToolOutput(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "прогони пайплайн ещё раз"},
+		{Role: "tool-output", Text: "[toil.leader] Job 'WDLStartJob' v41 is completely failed"},
+		{Role: "tool-output", Text: "uses: golangci/golangci-lint-action@v41"},
+		{Role: "assistant", Text: "перезапустил, дальше смотрю логи"},
+	}}
+	terms := []string{"v41"}
+	if !TextCarriesAnyTerm(s.Messages[1].Text, terms) {
+		t.Fatal("the term is in the session; the plain test must still see it")
+	}
+	if SpeechCarriesAnyTerm(s, terms) {
+		t.Error("only a tool printed v41, so nobody there answered anything about it")
+	}
+	s.Messages = append(s.Messages, model.Message{
+		Role: "assistant", Text: "на v41 раскладка ломается, чинит только Ensure"})
+	if !SpeechCarriesAnyTerm(s, terms) {
+		t.Error("now someone said it, and that must count")
+	}
+}
+
+func TestSpeechCarriesAnyTermWithoutTerms(t *testing.T) {
+	s := model.Session{Messages: []model.Message{{Role: "assistant", Text: "что угодно"}}}
+	if !SpeechCarriesAnyTerm(s, nil) {
+		t.Error("no terms means nothing to withhold on")
+	}
+}


### PR DESCRIPTION
Six of the eight questions the per-prompt hook still answered with unrelated work on a real store matched only under the role `tool-output` — an npm notice, a temp path like `/var/folders/v3/`, a pinned `@v6` action, a line of someone else's source. Nobody in those sessions said anything about the subject.

The gate asks whether the question's most identifying word was spoken by someone rather than printed by a tool. Asking for any term instead lets "показал" answer for "v11", which changed nothing.

Live measure, 58 real questions: blocks that were off topic 7 -> 4, answers 49 -> 48, silence 1 -> 5. bench recall and bench context unchanged; no existing prompt arm moved.

Also fixes the corpus: it wrote the role into the transcript's `type` field, which the Claude reader skips, so tool output never reached the bench index and the new `tool_only` arm passed for the wrong reason. With the writer fixed the arm reds on main and greens with the gate.