### PR TITLE
fix(recall): quote the line that settled it, not the densest mention

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -163,6 +163,10 @@ type promptReport struct {
 	// that tell one from the other are English, and half the sessions on a real
 	// store are not.
 	Decision promptArmReport `json:"decision_line"`
+	// The inline-decision arm: the passing mentions and the conclusion are in
+	// one message. Correct means the block quotes the conclusion rather than
+	// the denser line above it.
+	DecisionInline promptArmReport `json:"decision_inline"`
 	// The short-subject arm: the question names its subject in two characters,
 	// the way people name a version or a pull request. Nothing else in the
 	// question identifies anything, so dropping the subject leaves a working
@@ -286,6 +290,14 @@ func measurePrompt(seed int64) (promptReport, error) {
 			}
 		case "concluded":
 			arm = &report.Concluded
+			arm.Cases++
+			if blockCarries(indexDir, scope, terms, chain.Fact, chain.Topic) {
+				arm.Fired++
+				arm.Correct++
+			}
+			continue
+		case "decision-inline":
+			arm = &report.DecisionInline
 			arm.Cases++
 			if blockCarries(indexDir, scope, terms, chain.Fact, chain.Topic) {
 				arm.Fired++
@@ -449,6 +461,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.Shown, nil)
 	finishPromptArm(&report.Decoy, nil)
 	finishPromptArm(&report.Decision, nil)
+	finishPromptArm(&report.DecisionInline, nil)
 	finishPromptArm(&report.Concluded, nil)
 	finishPromptArm(&report.ShortSubject, nil)
 	finishPromptArm(&report.Echo, nil)

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -534,6 +534,36 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
+	// The conclusion and the passing mentions sit in ONE message, which is how
+	// an agent actually writes: a paragraph that names the subject twice while
+	// putting it off, then the line that settles it. The line is picked by how
+	// many query words it holds and only then asked whether it concluded
+	// anything, so the denser mention wins and the answer is never quoted.
+	// Measured on a real store: 35 of 119 blocks quoted a weaker line than one
+	// the same session held.
+	for i, d := range []promptTopic{
+		{"dunlin", "the fix: dunlin retries are capped at four",
+			"what did we decide about dunlin"},
+	} {
+		id := fmt.Sprintf("prompt-decinline-%02d", i)
+		project := fmt.Sprintf("promptbenchdecinline%02d", i)
+		t := base.Add(time.Duration(4700+i*10) * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: project, Kind: "decision-inline",
+			Topic: d.word, Question: d.question, Fact: d.fact,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: project,
+				Started: t, Updated: t.Add(10 * time.Minute),
+				Messages: []model.Message{
+					{Role: "user", Text: "\u0447\u0442\u043e \u0441 " + d.word, Time: t},
+					{Role: "assistant", Time: t.Add(5 * time.Minute), Text: "" +
+						"looked at " + d.word + " and at the " + d.word + " retries, not touching either yet\n" +
+						"still reading the " + d.word + " docs, will decide about " + d.word + " later\n" +
+						d.fact},
+				},
+			}},
+		})
+	}
 	// The decoy line. The session that answers also says an ordinary word the
 	// question happens to use, in a place that has nothing to do with the
 	// subject. Measured on a real store: "what did we decide about mm_status"

--- a/internal/search/densest_test.go
+++ b/internal/search/densest_test.go
@@ -1,0 +1,34 @@
+package search
+
+import "testing"
+
+// The mentions and the conclusion usually sit in one message: a paragraph that
+// names the subject while putting it off, then the sentence that settles it.
+// Picking the densest line first and asking about a conclusion afterwards hands
+// the slot to the paragraph. Measured on a real store, that was 35 of 119
+// blocks quoting a weaker line than the same session held.
+func TestDensestLinePrefersTheConclusion(t *testing.T) {
+	text := "looked at dunlin and at the dunlin retries, not touching either yet\n" +
+		"still reading the dunlin docs, will decide about dunlin later\n" +
+		"the fix: dunlin retries are capped at four"
+	line, hits := densestLine(text, []string{"dunlin"})
+	if line != "the fix: dunlin retries are capped at four" {
+		t.Errorf("quoted the denser mention instead of the conclusion: %q", line)
+	}
+	if hits < 1 {
+		t.Errorf("the chosen line carries the term, so hits must count it: %d", hits)
+	}
+}
+
+func TestDensestLineWithoutAnyConclusion(t *testing.T) {
+	// Hits count distinct query words, not repeats, so the second line wins on
+	// holding both of them rather than on saying "dunlin" twice.
+	text := "dunlin is slow\nthe dunlin backoff is slow too"
+	line, hits := densestLine(text, []string{"dunlin", "backoff"})
+	if line != "the dunlin backoff is slow too" {
+		t.Errorf("with nothing settled the line carrying more of the query wins: %q", line)
+	}
+	if hits != 2 {
+		t.Errorf("hits = %d, want 2", hits)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -642,13 +642,26 @@ func ConcludedAbout(s model.Session, terms []string) bool {
 // than where it opens.
 func densestLine(text string, terms []string) (string, int) {
 	best, bestHits := "", 0
+	// A line that settled something outranks a denser one that did not. The
+	// preference existed a step later, applied to whichever line this function
+	// had already picked, so a paragraph that names the subject twice while
+	// putting it off beat the sentence below it that answered. Measured on a
+	// real store, 35 of 119 blocks quoted a weaker line than the same session
+	// held; the mentions and the conclusion are usually in one message, which
+	// is the case the message-level preference cannot see.
+	bestDecides := false
 	for _, line := range strings.Split(text, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		if h := termHits(line, terms); h > bestHits {
-			best, bestHits = line, h
+		h := termHits(line, terms)
+		if h == 0 {
+			continue
+		}
+		decides := digest.CarriesDecision(line)
+		if best == "" || (decides && !bestDecides) || (decides == bestDecides && h > bestHits) {
+			best, bestHits, bestDecides = line, h, decides
 		}
 	}
 	if best == "" {


### PR DESCRIPTION
The mentions and the conclusion usually sit in one message: a paragraph that names the subject while putting it off, then the sentence that settles it. The conclusion preference was applied one step later, to whichever line had already been picked by word count, so the paragraph won.

Measured on a real store over 142 ordinary messages: blocks carrying a conclusion 21 -> 36 of 99, with on-topic, off-topic, pointer and silence counts unchanged and the median hook time flat (33.6 -> 33.3 ms). Of the blocks that quoted no conclusion, 35 of 119 had one available in the same session; that is now 33.

New arm `decision_inline` reds on main (0/1) and greens with the fix; both mutations of the new rule red it and the unit tests. bench recall and bench context unchanged.