### PR TITLE
test(bench): score the short-subject arm through the hook

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -315,9 +315,14 @@ func measurePrompt(seed int64) (promptReport, error) {
 		case "short-subject":
 			arm = &report.ShortSubject
 			arm.Cases++
-			if fired, correct := promptBenchProbe(indexDir, scope, chain.ID, terms); fired {
+			// Through the hook, not the copy of its loop above: measured by
+			// asking both about every chain in the corpus, this is the one arm
+			// of seven where they disagree — "как там pr, смержился?" scored
+			// correct here while the hook answered nothing.
+			if fired, carries := hookEndToEndAs(indexDir, scope, chain.Question, chain.Fact, chain.Topic,
+				"benchshort"); fired {
 				arm.Fired++
-				if correct {
+				if carries {
 					arm.Correct++
 				} else {
 					arm.FalseFires++
@@ -337,7 +342,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 		case "tool-only":
 			arm = &report.ToolOnly
 			arm.Cases++
-			if fired, _ := hookEndToEndAs(indexDir, scope, chain.Question, chain.Fact,
+			if fired, _ := hookEndToEndAs(indexDir, scope, chain.Question, chain.Fact, chain.Topic,
 				"benchtoolonly"); fired {
 				arm.Fired++
 				arm.FalseFires++
@@ -350,7 +355,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 			arm.Cases++
 			// Asked from the session that holds the answer: recalling it to
 			// itself spends tokens to say what is already on screen.
-			if fired, carries := hookEndToEndAs(indexDir, scope, chain.Question, chain.Fact,
+			if fired, carries := hookEndToEndAs(indexDir, scope, chain.Question, chain.Fact, chain.Topic,
 				chain.ID+"-session"); fired && carries {
 				arm.Fired++
 				arm.FalseFires++
@@ -361,7 +366,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 		case "hook-e2e":
 			arm = &report.EndToEnd
 			arm.Cases++
-			fired, carries := hookEndToEnd(indexDir, scope, chain.Question, chain.Fact)
+			fired, carries := hookEndToEnd(indexDir, scope, chain.Question, chain.Fact, chain.Topic)
 			if fired {
 				arm.Fired++
 				if carries {
@@ -662,11 +667,11 @@ func blockOpensOnEcho(dir, project string, terms []string, question string) bool
 // hookEndToEnd runs the real hook over the bench index and reports whether it
 // spoke and whether what it showed carries the fact. The probe above copies the
 // hook's loop; this calls it.
-func hookEndToEnd(dir, project, question, fact string) (fired, carries bool) {
-	return hookEndToEndAs(dir, project, question, fact, "benche2e")
+func hookEndToEnd(dir, project, question, fact, topic string) (fired, carries bool) {
+	return hookEndToEndAs(dir, project, question, fact, topic, "benche2e")
 }
 
-func hookEndToEndAs(dir, project, question, fact, sid string) (fired, carries bool) {
+func hookEndToEndAs(dir, project, question, fact, topic, sid string) (fired, carries bool) {
 	for _, suf := range []string{".hookseen", ".dejavu", ".envblock", ".injections.jsonl", ".usage.jsonl"} {
 		_ = os.Remove(dir + suf)
 	}
@@ -685,8 +690,14 @@ func hookEndToEndAs(dir, project, question, fact, sid string) (fired, carries bo
 	if !strings.Contains(got, "deja-recall") {
 		return false, false
 	}
+	// Seven runes was a guard against matching the subject itself, which every
+	// block says. It also made a fact of ordinary short words unmatchable: "the
+	// pr went in after the flake was fixed" has no word that long, so the arm
+	// scored a false fire no product change could ever fix. Skip the short
+	// words and the subject instead of the short words alone.
 	for _, w := range strings.Fields(fact) {
-		if len([]rune(w)) < 7 {
+		w = strings.Trim(w, ".,:;!?()\"'\u00ab\u00bb")
+		if len([]rune(w)) < 5 || strings.EqualFold(w, topic) {
 			continue
 		}
 		if strings.Contains(strings.ToLower(got), strings.ToLower(w)) {

--- a/internal/prompt/short_subject_test.go
+++ b/internal/prompt/short_subject_test.go
@@ -1,0 +1,34 @@
+package prompt
+
+import (
+	"slices"
+	"testing"
+)
+
+// People name a version or a pull request in two characters and nothing else in
+// the question identifies anything: "как там pr, смержился?" reduces to a verb
+// once the length floor drops the subject, and the answer is never found.
+func TestTermsKeepShortSubjects(t *testing.T) {
+	for _, tc := range []struct{ prompt, want string }{
+		{"как там pr, смержился?", "pr"},
+		{"ну что там v3 показал", "v3"},
+		{"а ci на этой ветке зелёный?", "ci"},
+	} {
+		got := Terms(tc.prompt)
+		if !slices.Contains(got, tc.want) {
+			t.Errorf("Terms(%q) = %v, want it to keep %q", tc.prompt, got, tc.want)
+		}
+	}
+}
+
+// The floor still holds for two letters that name nothing.
+func TestTermsDropTwoLetterFiller(t *testing.T) {
+	for _, tc := range []struct{ prompt, drop string }{
+		{"же он опять упал", "же"},
+		{"do it again please", "do"},
+	} {
+		if got := Terms(tc.prompt); slices.Contains(got, tc.drop) {
+			t.Errorf("Terms(%q) = %v, must not keep %q", tc.prompt, got, tc.drop)
+		}
+	}
+}


### PR DESCRIPTION
Asked every corpus chain twice — once the way its arm scores it, once through the hook itself. Six of seven kinds agree; `short_subject` did not: 2/2 by the arm, 1/2 through the hook.

Two things were wrong, both in the benchmark. The arm ran `promptBenchProbe`, a copy of the hook's loop with its own gates. And the end-to-end fact check only looked at words of seven runes or more, which "the pr went in after the flake was fixed" has none of — that case could not pass whatever the product did.

The arm now runs the hook and the check skips the subject instead of skipping short words. No arm value changes; two mutations of the short-subject rule take it to 1/2 and 0/2 and red the new unit test.