### PR TITLE
perf(hook): lowercase a candidate's messages once, not twice

### DIFF
--- a/cmd/deja/focus_case_test.go
+++ b/cmd/deja/focus_case_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Narrowing a marathon session lowercases every message once and hands the
+// result to the density pass as well. Both passes have to keep matching text
+// the user typed in another case, in either alphabet.
+func TestFocusSessionIgnoresCase(t *testing.T) {
+	msgs := make([]model.Message, 0, 12)
+	for i := 0; i < 10; i++ {
+		msgs = append(msgs, model.Message{Role: "assistant", Text: "unrelated chatter"})
+	}
+	msgs = append(msgs,
+		model.Message{Role: "assistant", Text: "PgBouncer pool size settled at 40"},
+		model.Message{Role: "assistant", Text: "Индексацию перенесли в фоновый воркер"})
+
+	got := focusSession(model.Session{Messages: msgs}, []string{"pgbouncer"})
+	if len(got.Messages) == 0 {
+		t.Fatal("a session mentioning the term in another case was narrowed to nothing")
+	}
+	var found bool
+	for _, m := range got.Messages {
+		if m.Text == "PgBouncer pool size settled at 40" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the matching message was dropped by the narrowing")
+	}
+
+	got = focusSession(model.Session{Messages: msgs}, []string{"индексация"})
+	found = false
+	for _, m := range got.Messages {
+		if m.Text == "Индексацию перенесли в фоновый воркер" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the Cyrillic term matched in its own case only")
+	}
+}
+
+func TestDensestMessagesUsesTheLoweredText(t *testing.T) {
+	msgs := []model.Message{
+		{Role: "assistant", Text: "PgBouncer and the POOL both appear here"},
+		{Role: "assistant", Text: "nothing to see"},
+		{Role: "assistant", Text: "pool alone"},
+	}
+	low := make([]string, len(msgs))
+	for i, m := range msgs {
+		low[i] = strings.ToLower(m.Text)
+	}
+	got := densestMessages(msgs, low, []string{"pgbouncer", "pool"}, 1)
+	if len(got) != 1 || got[0].Text != "PgBouncer and the POOL both appear here" {
+		t.Errorf("kept %v, want the message carrying both terms", got)
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -776,7 +776,15 @@ func focusSession(s model.Session, terms []string) model.Session {
 	focusCalls++
 	const window = 2
 	keep := map[int]bool{}
+	// Lowercase every message once and hand the result to both passes: the
+	// narrowing below and, when the session stays too big, the density pass
+	// after it. Each of them used to lowercase the whole session again, and a
+	// marathon session is thousands of messages.
+	low := make([]string, len(s.Messages))
 	for i, m := range s.Messages {
+		low[i] = strings.ToLower(m.Text)
+	}
+	for i := range s.Messages {
 		// The same rule the block is built with. This step spelled the word
 		// the way the question happened to spell it, while the ranking that
 		// chose the session and the digest that shows a line from it both fold
@@ -785,7 +793,7 @@ func focusSession(s model.Session, terms []string) model.Session {
 		//
 		// Asked for the whole query at once: per term, each call lowercased the
 		// entire message again.
-		if !search.TextCarriesAnyTerm(m.Text, terms) {
+		if search.TermHitsLowered(low[i], terms) == 0 {
 			continue
 		}
 		for j := i - window; j <= i+window; j++ {
@@ -809,7 +817,7 @@ func focusSession(s model.Session, terms []string) model.Session {
 	// windows — the places where the most distinct terms land together are
 	// where the answer is, and the rest is the session's background noise.
 	if len(focused) > dejaVuMaxMessages {
-		s.Messages = densestMessages(s.Messages, terms, dejaVuMaxMessages)
+		s.Messages = densestMessages(s.Messages, low, terms, dejaVuMaxMessages)
 		return s
 	}
 	s.Messages = focused
@@ -818,16 +826,15 @@ func focusSession(s model.Session, terms []string) model.Session {
 
 // densestMessages keeps the cap best messages by how many distinct terms each
 // one carries, in original order so the exchange still reads as a conversation.
-func densestMessages(msgs []model.Message, terms []string, cap int) []model.Message {
+func densestMessages(msgs []model.Message, low, terms []string, cap int) []model.Message {
 	type scored struct {
 		i, hits int
 	}
 	var ranked []scored
-	for i, m := range msgs {
-		text := strings.ToLower(m.Text)
+	for i := range msgs {
 		hits := 0
 		for _, t := range terms {
-			if strings.Contains(text, strings.ToLower(t)) {
+			if strings.Contains(low[i], t) {
 				hits++
 			}
 		}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -252,13 +252,28 @@ func termHits(text string, terms []string) int {
 	if len(terms) == 0 {
 		return 0
 	}
-	low := strings.ToLower(text)
+	return TermHitsLowered(strings.ToLower(text), terms)
+}
+
+// TermHitsLowered is termHits over text a caller has already lowercased. The
+// terms are expected lowercase too, which is what the extractor produces —
+// prompt.Terms lowercases the whole prompt before splitting it.
+// The
+// per-prompt hook asks the same question of every message of a candidate twice
+// — once to narrow the session, once to rank what is left — and a marathon
+// session is thousands of messages, so lowercasing them once rather than twice
+// is worth the second entry point. Measured on a real store, narrowing a
+// candidate was 147 ms of the 284 an answering call takes.
+func TermHitsLowered(low string, terms []string) int {
+	if len(terms) == 0 {
+		return 0
+	}
 	n := 0
 	for _, t := range terms {
 		if t == "" {
 			continue
 		}
-		if containsWord(low, strings.ToLower(t)) {
+		if containsWord(low, t) {
 			n++
 			continue
 		}


### PR DESCRIPTION
Timed on a real store, split by outcome: a call that actually answers costs 284 ms, a silent one 14. Of those 284, ranking is 3.5 ms and reading the sessions 62; 147 go into narrowing a marathon candidate to the part that matched. Turning the narrowing off makes an answering call 567 ms, so it earns its keep — it was just doing the same work twice.

It lowercased every message to find the matches, then the density pass lowercased them all again, and each term was lowercased once per message on top of that (a Cyrillic term allocates every time).

Narrowing 147 -> 85 ms, answering call 284 -> 238 ms. No arm moves, bench recall and bench context unchanged, and the live sweep is identical: 97 on topic, 2 off, 4 pointers, 39 silent, 36 of 99 blocks carrying a conclusion. Three mutations of the rule red the new tests.