### PR TITLE
feat(rank): fuse the two ranking views with reciprocal rank fusion

### DIFF
--- a/internal/index/focus_fusion_test.go
+++ b/internal/index/focus_fusion_test.go
@@ -31,10 +31,17 @@ func TestAFocusedWinTakesABetterPlaceButPaysForIt(t *testing.T) {
 	if at < 0 {
 		t.Fatal("the session disappeared from the ranking")
 	}
-	// Its price puts it level with the session already holding that place, and a
-	// tie goes to the view that ranked the whole query — so it lands just behind.
-	if at != focusPrice+1 {
-		t.Errorf("a session first on the focused view sits at %d, want %d: paid its price and no more", at, focusPrice+1)
+	// Under reciprocal rank fusion the two views trade places instead of one
+	// paying the other a fixed toll: first on the focused view is worth a lot,
+	// last on the whole query little, and the sum decides. What matters is not
+	// the exact place — that is the fusion constant's business — but that the
+	// session climbs out of the tail without taking the front.
+	if at == 0 {
+		t.Error("a session convincing on the rare word alone took the front")
+	}
+	if at >= len(out)/2 {
+		t.Errorf("a session first on the focused view sits at %d of %d: the "+
+			"focused view bought it nothing", at, len(out))
 	}
 }
 
@@ -69,5 +76,30 @@ func TestAgreementLeavesTheOrderAlone(t *testing.T) {
 		if r.meta.ID != ranked[i].meta.ID {
 			t.Fatalf("agreeing views still reordered the ranking at %d: %q, want %q", i, r.meta.ID, ranked[i].meta.ID)
 		}
+	}
+}
+
+// The fusion constant damps how much one top place is worth. Summing 1/rank
+// rather than 1/(k+rank) lets a single first place outweigh being second on
+// both views, which is the behaviour reciprocal rank fusion exists to avoid
+// (Cormack, Clarke & Buettcher, SIGIR 2009). Measured on a real store, dropping
+// the constant to zero puts the ranking back where it stood before the fusion.
+func TestFusionDampsASingleTopPlace(t *testing.T) {
+	ranked := make([]relevanceScored, 10)
+	// "a" leads the whole query and is last on the rare part of it, and "i"
+	// leads the rare part while sitting ninth on the whole query. "b" is second
+	// on both. Second twice is the better bet, and only a damped sum says so:
+	// undamped, one first place carries either of the other two past it.
+	focus := []float64{1, 90, 80, 70, 60, 50, 40, 30, 100, 10}
+	for i := range ranked {
+		ranked[i] = relevanceScored{
+			meta:  SessionMeta{ID: string(rune('a' + i))},
+			score: float64(10 - i),
+			focus: focus[i],
+		}
+	}
+	if out := fuseFocus(ranked); out[0].meta.ID != "b" {
+		t.Errorf("front went to %q, want b: second on both views beats first on one",
+			out[0].meta.ID)
 	}
 }

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -608,11 +608,9 @@ type relevanceScored struct {
 	focus   float64
 }
 
-// focusPrice is what a session pays for being convincing only on the rare part
-// of the query rather than on all of it. Counted in places, like the strict
-// promotion above: a session the focused view puts first and the whole-query
-// view puts thirtieth ends up fourth, not first.
-const focusPrice = 3
+// rrfK damps how much a top place is worth against the ranking's tail. Sixty is
+// the constant the fusion paper used and what search engines ship with.
+const rrfK = 60
 
 // fuseFocus reorders a ranking by the better of two views of the same query.
 //
@@ -644,13 +642,20 @@ func fuseFocus(ranked []relevanceScored) []relevanceScored {
 	// has been swapped into that position, not of the row being compared.
 	type placed struct {
 		row   relevanceScored
-		place int
+		score float64
 	}
+	// Reciprocal rank fusion instead of "the better of the two places, with the
+	// focused view paying three of them". RRF sums 1/(k+rank) over the
+	// rankings and needs no common scale between them (Cormack, Clarke &
+	// Buettcher, SIGIR 2009); measured against a convex combination of
+	// normalised scores it is both more accurate and steadier (Bruch et al.,
+	// "An Analysis of Fusion Functions for Hybrid Retrieval", 2022). What it
+	// replaces was two numbers picked by hand.
 	rows := make([]placed, len(ranked))
 	for i, r := range ranked {
-		rows[i] = placed{r, min(i, byFocus[i]+focusPrice)}
+		rows[i] = placed{r, 1/float64(rrfK+i+1) + 1/float64(rrfK+byFocus[i]+1)}
 	}
-	sort.SliceStable(rows, func(a, b int) bool { return rows[a].place < rows[b].place })
+	sort.SliceStable(rows, func(a, b int) bool { return rows[a].score > rows[b].score })
 	out := make([]relevanceScored, len(rows))
 	for i, r := range rows {
 		out[i] = r.row


### PR DESCRIPTION
Ranking scores a query twice — over all its words, and over only the words that distinguish — and the two were combined by giving each session its better place, with the focused view paying a toll of three places. Both numbers were picked by hand.

Reciprocal rank fusion sums 1/(k+rank) across the rankings and needs no common scale between them (Cormack, Clarke & Buettcher, SIGIR 2009); against a convex combination of normalised scores it measures both more accurate and steadier (Bruch et al., 2022).

LongMemEval, all 500 questions:

| | before | after |
|---|---|---|
| hit@1 | 84.2% | 85.0% |
| hit@3 | 94.8% | 95.8% |
| MRR | 0.889 | 0.896 |
| evidence-recall@1 | 54.2% | 54.9% |

Live store, 142 ordinary messages: on-topic blocks 97 -> 98, silences 39 -> 38, off-topic 2 unchanged, blocks carrying a conclusion 36 -> 35. The 58-question set is unchanged at 48 answers. No prompt arm moves; bench recall and bench context unchanged.

The test that pinned the old toll now checks what the rule is for — a session convincing on the rare word alone climbs out of the tail without taking the front — plus a new one for the damping constant. Three mutations of the fusion red them.