### PR TITLE
feat(recall): quote what the session was about and what it settled

### DIFF
--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -523,6 +523,8 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 		// word fell were measured and none moved the number; these markers are
 		// what the session-start digest already uses to tell a decision from a
 		// passing mention.
+		// Among lines that carry the question words, prefer the one that
+		// concluded something.
 		if digest.CarriesDecision(line) {
 			hits++
 		}
@@ -551,7 +553,40 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 			assistants = append(assistants, scored{i, hits, lineAround(text, 220, terms)})
 		}
 	}
+	// Among the agent's lines, prefer the ones that settled something. Within a
+	// message the densest line already yields to a concluding one (#1488), but
+	// which messages get the two slots was still decided by word count alone,
+	// so a session's conclusion lost its place to a line that merely repeated
+	// the question's words. Measured live: of the blocks carrying no
+	// conclusion, a third had one in the very session they came from.
+	// The preference only counts for a line that also names what was asked
+	// about: terms arrive most-identifying first, so that is the first one. A
+	// concluding line that does not say the subject settles some other
+	// question, and putting it first reads as an answer to this one — measured
+	// live, preferring conclusions without this cost one answer of 58.
+	// Two slots, and they answer different questions: one says what the session
+	// was about, the other what it settled. Filling both by word count gave two
+	// lines of the first kind — measured on a real store, 35 blocks of 100
+	// carried a conclusion while a third of the rest had one in the same
+	// session. Filling both by conclusion gave blocks that concluded something
+	// about a neighbouring subject. One of each is what a reader needs, and it
+	// is the packaging that decides how much the retrieval is worth (surveys of
+	// agent memory put packaging above ranking for exactly this reason).
 	sort.SliceStable(assistants, func(i, j int) bool { return assistants[i].hits > assistants[j].hits })
+	if len(assistants) > 2 {
+		best := assistants[0]
+		rest := assistants[1:]
+		pick := -1
+		for i, a := range rest {
+			if digest.CarriesDecision(a.text) {
+				pick = i
+				break
+			}
+		}
+		if pick >= 0 {
+			assistants = []scored{best, rest[pick]}
+		}
+	}
 	// The block opens with what the user said, and that slot is filled by the
 	// best-matching user line whatever it carries. When the session says an
 	// ordinary word of the question in one place and answers it in another,

--- a/internal/search/settles_test.go
+++ b/internal/search/settles_test.go
@@ -1,0 +1,69 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func quoted(lines []string, want string) bool {
+	for _, ln := range lines {
+		if strings.Contains(ln, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// Two slots go to the agent's lines, and they used to go by word count alone.
+// A line repeating the question's words won them from the line that answered
+// it, so the block said "looking at pgbouncer" where the session held "in the
+// end pgbouncer pool size settled at 40". Measured on a real store: blocks
+// carrying a conclusion went from 35 of 100 to 37 with this ordering.
+//
+// The quoted lines come back in the order they were said, so what is asserted
+// here is that the conclusion is among them at all.
+func TestBlockKeepsTheLineThatSettledIt(t *testing.T) {
+	// Three lines carry every word of the query; the conclusion carries one of
+	// them. By word count it cannot reach the two slots, which is how a session
+	// that settled something came to be quoted saying anything but that.
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "\u0447\u0442\u043e \u0442\u0430\u043c \u0441 pgbouncer"},
+		{Role: "assistant", Text: "pgbouncer pool \u043c\u0435\u0442\u0440\u0438\u043a\u0438 \u0441\u043d\u044f\u043b\u0438"},
+		{Role: "assistant", Text: "pgbouncer pool \u043c\u0435\u0442\u0440\u0438\u043a\u0438 \u0441\u0440\u0430\u0432\u043d\u0438\u043b\u0438"},
+		{Role: "assistant", Text: "pgbouncer pool \u043c\u0435\u0442\u0440\u0438\u043a\u0438 \u043f\u043e\u0441\u0442\u0440\u043e\u0438\u043b\u0438"},
+		{Role: "assistant", Text: "\u0432 \u0438\u0442\u043e\u0433\u0435 pgbouncer \u043e\u0441\u0442\u0430\u043d\u043e\u0432\u0438\u043b\u0438\u0441\u044c \u043d\u0430 40"},
+	}}
+	_, lines := matchedLinesAsked(s, []string{"pgbouncer", "pool", "\u043c\u0435\u0442\u0440\u0438\u043a\u0438"},
+		"\u0447\u0442\u043e \u0442\u0430\u043c \u0441 pgbouncer")
+	if len(lines) == 0 {
+		t.Fatal("nothing was quoted at all")
+	}
+	if !quoted(lines, "\u043e\u0441\u0442\u0430\u043d\u043e\u0432\u0438\u043b\u0438\u0441\u044c \u043d\u0430 40") {
+		t.Errorf("the line that settled it was dropped for word count: %q", lines)
+	}
+	if !quoted(lines, "\u043c\u0435\u0442\u0440\u0438\u043a\u0438") {
+		t.Errorf("the line naming what the session was about was dropped: %q", lines)
+	}
+}
+
+// The two slots answer different questions: one line says what the session was
+// about, the other what it settled. Filling both by conclusion was measured and
+// rejected — it cost an answer of 58 and a block of 142 — so the line naming
+// the subject keeps its slot whatever else is quoted beside it.
+func TestBlockKeepsTheSubjectBesideTheConclusion(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "\u0447\u0442\u043e \u0442\u0430\u043c \u0441 pgbouncer"},
+		{Role: "assistant", Text: "\u0432 \u0438\u0442\u043e\u0433\u0435 \u0440\u0435\u0448\u0438\u043b\u0438: cron \u043f\u0435\u0440\u0435\u0435\u0445\u0430\u043b \u043d\u0430 03:17"},
+		{Role: "assistant", Text: "pgbouncer pool \u0434\u0435\u0440\u0436\u0438\u043c \u043d\u0430 40, pgbouncer \u043f\u0435\u0440\u0435\u0437\u0430\u043f\u0443\u0449\u0435\u043d"},
+		{Role: "assistant", Text: "pgbouncer \u043c\u0435\u0442\u0440\u0438\u043a\u0438 \u0441\u043d\u044f\u043b\u0438, pgbouncer \u0433\u0440\u0430\u0444\u0438\u043a\u0438 \u043f\u043e\u0441\u0442\u0440\u043e\u0435\u043d\u044b"},
+	}}
+	_, lines := matchedLinesAsked(s, []string{"pgbouncer", "\u0440\u0435\u0448\u0438\u043b\u0438"}, "\u0447\u0442\u043e \u0442\u0430\u043c \u0441 pgbouncer")
+	if len(lines) == 0 {
+		t.Fatal("nothing was quoted at all")
+	}
+	if !quoted(lines, "pgbouncer") {
+		t.Errorf("the subject vanished from the block: %q", lines)
+	}
+}


### PR DESCRIPTION
A block quotes two of the agent's lines, and both were picked by how many query words they held. So a session that settled something was usually quoted saying anything but that — measured on a real store, 35 blocks of 100 carried a conclusion while a third of the rest had one in the very session they came from.

The two slots now answer different questions: the first still goes to the best line by word count (what the session was about), the second to the best line that concluded something. Filling both by conclusion was measured too and rejected — it reached 47 but cost an answer of 58 and turned an on-topic block noisy, because a conclusion about a neighbouring subject reads as an answer to this question.

Live store, 142 ordinary messages:

| | before | after |
|---|---|---|
| blocks carrying a conclusion | 35 | 44 |
| on-topic blocks | 98 | 98 |
| off-topic | 2 | 2 |
| silent | 38 | 38 |
| tokens per message | 218.4 | 218.2 |
| median | 34.1 ms | 34.0 ms |

The 58-question set is unchanged (48 answers). No prompt arm moves; bench recall, bench context and LongMemEval (85.0% hit@1, MRR 0.896) unchanged — this changes what is quoted, not what is found. Three mutations of the rule red the new tests.

Direction comes from the agent-memory surveys: packaging decides how much a retrieval is worth, and a block that names the subject without saying what was decided is the common failure.