### PR TITLE
feat(recall): take the answer that follows the mention

### DIFF
--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -504,6 +504,9 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 	}
 	var bestUser scored
 	var assistants []scored
+	// Which messages carried a query word, so the lines just after them can be
+	// considered for the conclusion slot below.
+	matchedAt := make(map[int]bool, 8)
 	for i, m := range s.Messages {
 		// Score the raw text, not what contextText returns: it joins lines and
 		// keeps only the first eight of them, so by then there is nothing left
@@ -518,6 +521,7 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 		if hits == 0 {
 			continue
 		}
+		matchedAt[i] = true
 		// Among lines that carry the question words, prefer the one that
 		// concluded something. Five ways of choosing by where and how often a
 		// word fell were measured and none moved the number; these markers are
@@ -564,6 +568,32 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 	// concluding line that does not say the subject settles some other
 	// question, and putting it first reads as an answer to this one — measured
 	// live, preferring conclusions without this cost one answer of 58.
+	// A conclusion often does not repeat the question's words — "in the end we
+	// settled on 40" follows the line that named the pool — so it never becomes
+	// a candidate at all. Take the agent's next lines after a matched one as
+	// candidates for the second slot when they conclude something: measured on
+	// a real store, of the blocks carrying no conclusion, a third had one in
+	// the session they came from, and this is why.
+	if len(matchedAt) > 0 {
+		for i, m := range s.Messages {
+			if m.Role != "assistant" || matchedAt[i] {
+				continue
+			}
+			if !nearMatch(matchedAt, i, replyWindow) {
+				continue
+			}
+			// Checked here as well as where the slot is filled: this keeps
+			// the candidate list short rather than deciding anything, so
+			// removing it changes cost and not output.
+			line, _ := densestLine(m.Text, terms)
+			if line == "" || !digest.CarriesDecision(line) {
+				continue
+			}
+			if text := contextText(line, false); strings.TrimSpace(text) != "" {
+				assistants = append(assistants, scored{i, 0, lineAround(text, 220, terms)})
+			}
+		}
+	}
 	// Two slots, and they answer different questions: one says what the session
 	// was about, the other what it settled. Filling both by word count gave two
 	// lines of the first kind — measured on a real store, 35 blocks of 100
@@ -608,6 +638,21 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 		out = append(out, a.text)
 	}
 	return bestUser.text, out
+}
+
+// replyWindow is how far after a matched line the reply to it may sit. A
+// harness writes tool calls and status lines in between, so the conclusion is
+// rarely the very next message and never far.
+const replyWindow = 4
+
+// nearMatch says whether index i follows a matched message within the window.
+func nearMatch(matched map[int]bool, i, window int) bool {
+	for j := i - window; j < i; j++ {
+		if matched[j] {
+			return true
+		}
+	}
+	return false
 }
 
 // rankOfBestTerm scores which of the query's terms a line carries, counting the

--- a/internal/search/settles_test.go
+++ b/internal/search/settles_test.go
@@ -67,3 +67,63 @@ func TestBlockKeepsTheSubjectBesideTheConclusion(t *testing.T) {
 		t.Errorf("the subject vanished from the block: %q", lines)
 	}
 }
+
+// A conclusion rarely repeats the question's words: the line that named the
+// subject comes first, and the answer follows it saying "in the end we settled
+// on 40". Scored line by line, that answer is not a candidate at all. Measured
+// on a real store, taking the agent's next lines as candidates for the
+// conclusion slot moved blocks carrying a conclusion from 44 of 100 to 49.
+func TestBlockTakesTheAnswerThatFollowsTheMention(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "\u0447\u0442\u043e \u0442\u0430\u043c \u0441 pgbouncer"},
+		{Role: "assistant", Text: "pgbouncer pool \u043c\u0435\u0442\u0440\u0438\u043a\u0438 \u0441\u043d\u044f\u043b\u0438"},
+		{Role: "assistant", Text: "\u0432 \u0438\u0442\u043e\u0433\u0435 \u043e\u0441\u0442\u0430\u043d\u043e\u0432\u0438\u043b\u0438\u0441\u044c \u043d\u0430 40"},
+		{Role: "assistant", Text: "pgbouncer pool \u043c\u0435\u0442\u0440\u0438\u043a\u0438 \u0441\u0440\u0430\u0432\u043d\u0438\u043b\u0438"},
+		{Role: "assistant", Text: "pgbouncer pool \u043c\u0435\u0442\u0440\u0438\u043a\u0438 \u043f\u043e\u0441\u0442\u0440\u043e\u0438\u043b\u0438"},
+	}}
+	_, lines := matchedLinesAsked(s, []string{"pgbouncer", "pool", "\u043c\u0435\u0442\u0440\u0438\u043a\u0438"},
+		"\u0447\u0442\u043e \u0442\u0430\u043c \u0441 pgbouncer")
+	if !quoted(lines, "\u043e\u0441\u0442\u0430\u043d\u043e\u0432\u0438\u043b\u0438\u0441\u044c \u043d\u0430 40") {
+		t.Errorf("the answer following the mention was never a candidate: %q", lines)
+	}
+}
+
+// It has to follow a line that matched, though: a conclusion from another part
+// of the session settles another question.
+func TestBlockIgnoresAFarAwayConclusion(t *testing.T) {
+	msgs := []model.Message{{Role: "user", Text: "\u0447\u0442\u043e \u0442\u0430\u043c \u0441 pgbouncer"}}
+	for i := 0; i < 3; i++ {
+		msgs = append(msgs, model.Message{Role: "assistant",
+			Text: "pgbouncer pool \u043c\u0435\u0442\u0440\u0438\u043a\u0438 \u0441\u043d\u044f\u043b\u0438"})
+	}
+	for i := 0; i < 8; i++ {
+		msgs = append(msgs, model.Message{Role: "assistant",
+			Text: "\u043f\u0440\u0430\u0432\u0438\u043c \u0441\u043e\u0432\u0441\u0435\u043c \u0434\u0440\u0443\u0433\u043e\u0435 \u043c\u0435\u0441\u0442\u043e"})
+	}
+	msgs = append(msgs, model.Message{Role: "assistant",
+		Text: "\u0432 \u0438\u0442\u043e\u0433\u0435 cron \u043f\u0435\u0440\u0435\u0435\u0445\u0430\u043b \u043d\u0430 03:17"})
+	_, lines := matchedLinesAsked(model.Session{Messages: msgs},
+		[]string{"pgbouncer", "pool", "\u043c\u0435\u0442\u0440\u0438\u043a\u0438"},
+		"\u0447\u0442\u043e \u0442\u0430\u043c \u0441 pgbouncer")
+	if quoted(lines, "cron") {
+		t.Errorf("a conclusion from elsewhere in the session was quoted: %q", lines)
+	}
+}
+
+// The line taken from beside a match has to be a conclusion. Any next line
+// qualifying would fill the second slot with whatever the agent said next —
+// "running the tests" — which is the noise the slot exists to avoid.
+func TestBlockDoesNotTakeAnOrdinaryNextLine(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "\u0447\u0442\u043e \u0442\u0430\u043c \u0441 pgbouncer"},
+		{Role: "assistant", Text: "pgbouncer pool \u043c\u0435\u0442\u0440\u0438\u043a\u0438 \u0441\u043d\u044f\u043b\u0438"},
+		{Role: "assistant", Text: "\u0433\u043e\u043d\u044e \u0442\u0435\u0441\u0442\u044b \u0434\u0430\u043b\u044c\u0448\u0435"},
+		{Role: "assistant", Text: "pgbouncer pool \u043c\u0435\u0442\u0440\u0438\u043a\u0438 \u0441\u0440\u0430\u0432\u043d\u0438\u043b\u0438"},
+		{Role: "assistant", Text: "pgbouncer pool \u043c\u0435\u0442\u0440\u0438\u043a\u0438 \u043f\u043e\u0441\u0442\u0440\u043e\u0438\u043b\u0438"},
+	}}
+	_, lines := matchedLinesAsked(s, []string{"pgbouncer", "pool", "\u043c\u0435\u0442\u0440\u0438\u043a\u0438"},
+		"\u0447\u0442\u043e \u0442\u0430\u043c \u0441 pgbouncer")
+	if quoted(lines, "\u0433\u043e\u043d\u044e \u0442\u0435\u0441\u0442\u044b") {
+		t.Errorf("an ordinary next line took the conclusion slot: %q", lines)
+	}
+}


### PR DESCRIPTION
A conclusion rarely repeats the question's words: the line that named the subject comes first, and the answer follows it saying "in the end we settled on 40". Lines are scored one by one, so that answer was never a candidate for a slot at all — measured on a real store, of the blocks carrying no conclusion, a third had one in the very session they came from, and this is why.

The agent's lines within four messages of a matched one now count as candidates for the conclusion slot, when they conclude something.

Live store, 142 ordinary messages:

| | before | after |
|---|---|---|
| blocks carrying a conclusion | 44 | 49 |
| on-topic blocks | 98 | 98 |
| off-topic | 2 | 2 |
| silent | 38 | 38 |
| tokens per message | 218.2 | 222.9 |

The 58-question set is unchanged at 48 answers. No prompt arm moves; bench recall, bench context and LongMemEval (85.0% hit@1) unchanged. Two mutations of the rule red the new tests; the third — dropping the conclusion check where candidates are collected — is a cost guard the slot re-checks, and the comment says so.