### PR TITLE
feat(log): record which agent session an injection went to

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -316,7 +316,8 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		}
 	}
 	out := frameRecall(body)
-	usage.RecordDigestTerms(dir, usage.KindDejaVu, out, len(ss), rawSize(ss), terms, sessionIDs(ss)...)
+	usage.RecordDigestInto(dir, usage.KindDejaVu, out, input.SessionID, len(ss), rawSize(ss),
+		terms, sessionIDs(ss)...)
 	if plain {
 		fmt.Fprintln(stdout, out)
 		return nil

--- a/cmd/deja/hook_prompt_into_test.go
+++ b/cmd/deja/hook_prompt_into_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// The injection log records what went out; without who received it, the only
+// way to tell whether a recall was used is the sentence the block asks the
+// agent to say — measured on a real store, that follows 22 of 1218 injections.
+// The hook knows the agent session from its own payload, so it writes it down.
+func TestHookPromptRecordsTheSessionItAnswered(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "intoterm", []string{
+		`{"type":"user","sessionId":"intoterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	var out bytes.Buffer
+	in := strings.NewReader(`{"prompt":"do we need pgbouncer here","session_id":"ses_from_harness"}`)
+	if err := runHookPromptMode(index.DefaultDir(), in, &out, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "transaction mode") {
+		t.Fatalf("the hook said nothing, so there is no injection to record:\n%q", out.String())
+	}
+
+	b, err := os.ReadFile(usage.SnapshotPath(index.DefaultDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		var snap usage.Snapshot
+		if json.Unmarshal([]byte(line), &snap) != nil {
+			continue
+		}
+		if snap.Kind == usage.KindDejaVu && snap.Into == "ses_from_harness" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the injection log does not say which agent session got the block:\n%s", b)
+	}
+}

--- a/internal/usage/into_test.go
+++ b/internal/usage/into_test.go
@@ -1,0 +1,54 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The injection log said what was injected and never to whom, so the only way
+// to tell whether a recall was used was the sentence the block asks the agent
+// to say. Measured on a real store, that sentence follows 22 of 1218
+// injections — a measure of reporting, not of use. With the receiving session
+// recorded, a reader can pair an injection with what the agent did next.
+func TestSnapshotRecordsWhoReceivedIt(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	RecordDigestInto(dir, KindDejaVu, "a block worth reading", "ses_1234", 2, 900,
+		[]string{"pgbouncer"}, "claude:abc")
+
+	b, err := os.ReadFile(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := strings.TrimSpace(string(b))
+	if line == "" {
+		t.Fatal("nothing was written to the injection log")
+	}
+	var got Snapshot
+	if err := json.Unmarshal([]byte(line), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Into != "ses_1234" {
+		t.Errorf("into = %q, want the agent session that received the block", got.Into)
+	}
+	if got.Kind != KindDejaVu || got.Sessions != 2 {
+		t.Errorf("the rest of the record changed: %+v", got)
+	}
+}
+
+// A caller that does not know the session still writes a usable record, and the
+// field is omitted rather than written empty — older readers see what they saw.
+func TestSnapshotWithoutAReceiverOmitsTheField(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	RecordDigestTerms(dir, KindDejaVu, "a block", 1, 100, nil)
+
+	b, err := os.ReadFile(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "\"into\"") {
+		t.Errorf("empty receiver was written out: %s", strings.TrimSpace(string(b)))
+	}
+}

--- a/internal/usage/log_json_contract_test.go
+++ b/internal/usage/log_json_contract_test.go
@@ -40,8 +40,12 @@ func TestLogJSONShapesAreStable(t *testing.T) {
 		"t": true, "kind": true, "bytes": true, "sessions": true,
 		"empty": true, "raw": true, "ids": true,
 	})
+	// "into" is additive and optional: it names the agent session an injection
+	// went to, which the log never recorded. Without it the only measure of
+	// whether a recall was used is the sentence the block asks the agent to
+	// say — 22 of 1218 injections on a real store, which counts reporting.
 	assertShape(t, "Snapshot", topLevelJSONKeys(Snapshot{}), map[string]bool{
 		"t": true, "kind": true, "sessions": true, "bytes": true,
-		"policy": true, "terms": true, "digest": true,
+		"policy": true, "terms": true, "into": true, "digest": true,
 	})
 }

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -25,8 +25,14 @@ type Snapshot struct {
 	Policy string `json:"policy,omitempty"`
 	// Terms are the query terms behind a déjà vu firing, kept so a wrong
 	// "you have been here" can be explained after the fact.
-	Terms  []string `json:"terms,omitempty"`
-	Digest string   `json:"digest"`
+	Terms []string `json:"terms,omitempty"`
+	// Into is the agent session this went to, as the harness names it. Without
+	// it the log says what was injected and never to whom, so the only way to
+	// tell whether a recall was used is the sentence the block asks the agent
+	// to say — measured on a real store, that sentence appears after 22 of 1218
+	// injections, which measures reporting rather than use.
+	Into   string `json:"into,omitempty"`
+	Digest string `json:"digest"`
 }
 
 const (
@@ -55,8 +61,14 @@ func RecordDigest(indexDir, kind, digest string, sessions int, raw int64) {
 // It is the only signal deja has that the *user* came back, as opposed to an
 // agent pulling something, and it could not reach ranking at all.
 func RecordDigestTerms(indexDir, kind, digest string, sessions int, raw int64, terms []string, ids ...string) {
+	RecordDigestInto(indexDir, kind, digest, "", sessions, raw, terms, ids...)
+}
+
+// RecordDigestInto is RecordDigestTerms knowing which agent session received
+// the injection, so a later reading of the store can ask whether it was used.
+func RecordDigestInto(indexDir, kind, digest, into string, sessions int, raw int64, terms []string, ids ...string) {
 	RecordServedSessions(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids)
-	snapshotWriteTerms(indexDir, kind, digest, sessions, "", terms)
+	snapshotWriteInto(indexDir, kind, digest, into, sessions, "", terms)
 }
 
 // RecordDigestPolicy is RecordDigest plus the name of the policy that allowed
@@ -82,6 +94,10 @@ func snapshotWrite(indexDir, kind, digest string, sessions int, policyName strin
 }
 
 func snapshotWriteTerms(indexDir, kind, digest string, sessions int, policyName string, terms []string) {
+	snapshotWriteInto(indexDir, kind, digest, "", sessions, policyName, terms)
+}
+
+func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policyName string, terms []string) {
 	if digest == "" {
 		return
 	}
@@ -95,7 +111,8 @@ func snapshotWriteTerms(indexDir, kind, digest string, sessions int, policyName 
 		return
 	}
 	defer func() { _ = f.Close() }()
-	b, err := json.Marshal(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions, Bytes: len(digest), Policy: policyName, Terms: terms, Digest: digest})
+	b, err := json.Marshal(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions,
+		Bytes: len(digest), Policy: policyName, Terms: terms, Into: into, Digest: digest})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The injection log records what was injected, when, on which terms — and never to whom. So the only way to tell whether a recall was used is the sentence the block asks the agent to say, and on a real store that sentence follows 22 of 1218 injections. That measures reporting, not use: an agent that reads the block and acts on it silently looks exactly like one that ignored it.

The hook already knows the agent session from its own payload. Writing it down makes the question answerable: pair an injection with what that session did next.

Additive and optional — `into` is omitted when a caller has no session, so existing readers see what they saw. The --json contract test is updated with the new key and says why.

No arm moves, bench context and the live sweep are unchanged (100 blocks, 49 carrying a conclusion, 33 ms median). Three mutations red the tests, including one on the hook itself passing an empty session.