### PR TITLE
fix(opencode): send the session id with per-prompt recall

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -210,7 +210,7 @@ export const DejaRecall = async ({ $, client }) => {
     // Per-prompt recall, the same relevance pass Claude Code gets on
     // UserPromptSubmit: the session digest is ranked by the project, this is
     // ranked by what the user just asked. Silent when nothing matches.
-    "experimental.chat.messages.transform": async (_input, output) => {
+    "experimental.chat.messages.transform": async (input, output) => {
       try {
         const msgs = output.messages || []
         let last
@@ -221,7 +221,12 @@ export const DejaRecall = async ({ $, client }) => {
         const parts = (last.parts || []).filter((p) => p?.type === "text" && p.text)
         const prompt = parts.map((p) => p.text).join("\n").trim()
         if (!prompt) return
-        const raw = await $%secho ${JSON.stringify({ prompt })} | %s%q hook-prompt%s.text()
+        // The session id travels with the payload so recall can skip what it
+        // already showed this session. Without it every message re-injects the
+        // same block: measured on a real store, half of all injections were a
+        // word-for-word repeat, and all but five of those came within a minute.
+        const sessionID = input?.sessionID || last?.info?.sessionID || ""
+        const raw = await $%secho ${JSON.stringify({ prompt, session_id: sessionID })} | %s%q hook-prompt%s.text()
         if (!raw.trim()) return
         const extra = JSON.parse(raw)?.hookSpecificOutput?.additionalContext
         if (!extra) return

--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -100,6 +100,15 @@ func TestInstallOpencodePlugin(t *testing.T) {
 		t.Fatal(err)
 	}
 	s := string(b)
+	// The session id has to travel with the per-prompt payload: recall skips
+	// what it already showed a session, and without an id there is nothing to
+	// skip by. Measured on a real store, half of all injections were a
+	// word-for-word repeat, nearly all within a minute of each other.
+	for _, want := range []string{"session_id", "input?.sessionID", "last?.info?.sessionID"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("opencode plugin does not pass %q, so recall cannot dedupe:\n%s", want, s)
+		}
+	}
 	for _, want := range []string{"experimental.chat.system.transform", "/opt/deja", "hook-context", "cache"} {
 		if !strings.Contains(s, want) {
 			t.Fatalf("plugin missing %q:\n%s", want, s)


### PR DESCRIPTION
The opencode plugin piped only the prompt to `hook-prompt`. The hook skips sessions it has already shown this agent session, keyed by the session id — with no id there is nothing to key by, so every message re-injected whatever it found.

Measured in deja's own injection log on a real store: of 165 blocks, 83 were a word-for-word repeat of an earlier one, and all but five of those came within a minute. Half the tokens the tool spent said what it had just said, which is also how a block turns into wallpaper.

The plugin now passes `session_id`, taken from the transform's own input or from the last message's info. The install test pins both the field and where it comes from; two mutations red it.

No product behaviour changes for other harnesses — Claude Code, Codex and the rest already send the id.