### PR TITLE
fix(pi,openclaw): send the session id with per-prompt recall

### DIFF
--- a/cmd/deja/install_openclaw_plugin.go
+++ b/cmd/deja/install_openclaw_plugin.go
@@ -151,10 +151,14 @@ export default {
       async (event) => {
         const prompt = typeof event?.prompt === "string" ? event.prompt.trim() : "";
         if (!prompt) return;
+        // Recall skips what it already showed this agent session, keyed by the
+        // session id. A payload without one turns that off: measured on a real
+        // store, half of all injections were then a word-for-word repeat.
+        const sessionID = event?.sessionId || event?.session_id || event?.session?.id || "";
         let recall = "";
         try {
           recall = execFileSync(DEJA, ["hook-prompt", "--plain"], {
-            input: JSON.stringify({ prompt, cwd: process.cwd() }),
+            input: JSON.stringify({ prompt, session_id: sessionID, cwd: process.cwd() }),
             encoding: "utf8",
             timeout: 10000,
             maxBuffer: 4 * 1024 * 1024,

--- a/cmd/deja/install_pi.go
+++ b/cmd/deja/install_pi.go
@@ -132,7 +132,10 @@ export default function (pi: any) {
         }
         return;
       }
-      const raw = run(["hook-prompt"], JSON.stringify({ prompt: event.prompt || "" }));
+      // The session id lets recall skip what it already showed this session;
+      // without one it repeats itself on every message.
+      const sessionID = event.sessionId || event.session_id || ctx?.session?.id || "";
+      const raw = run(["hook-prompt"], JSON.stringify({ prompt: event.prompt || "", session_id: sessionID }));
       if (!raw) return;
       const resp = JSON.parse(raw);
       if (resp && resp.systemMessage) ctx.ui.notify(resp.systemMessage, "info");

--- a/cmd/deja/install_session_id_test.go
+++ b/cmd/deja/install_session_id_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Every per-prompt integration has to send the agent session id. The hook skips
+// what it already showed a session, keyed by that id, and writes down what it
+// shows — with no id both halves are off and the same block goes out again on
+// the next message. Measured in deja's own injection log on a real store: of
+// 165 blocks, 83 were a word-for-word repeat of an earlier one, and all but
+// five of those came within a minute.
+func TestPerPromptPayloadsCarryTheSessionID(t *testing.T) {
+	for _, tc := range []struct {
+		name, src string
+	}{
+		{"pi", piExtensionTS("/bin/deja")},
+		{"openclaw", openclawPluginJS("/bin/deja")},
+	} {
+		if !strings.Contains(tc.src, "hook-prompt") {
+			t.Fatalf("%s: no per-prompt recall in the generated plugin", tc.name)
+		}
+		// The field has to be in the payload, not merely mentioned: reading a
+		// session id and then not sending it is the same defect.
+		if !strings.Contains(tc.src, "session_id: sessionID") {
+			t.Errorf("%s: payload has no session_id, so recall repeats itself:\n%s",
+				tc.name, tc.src)
+		}
+		// And it has to come from the harness rather than be an empty string
+		// threaded through to look right.
+		if !strings.Contains(tc.src, "event?.sessionId") && !strings.Contains(tc.src, "event.sessionId") {
+			t.Errorf("%s: the session id is not read from the event:\n%s", tc.name, tc.src)
+		}
+	}
+}


### PR DESCRIPTION
After the same fix for opencode (#1495), two more generated integrations were checked and had the same hole: the pi extension and the openclaw plugin piped a payload with no session id.

The hook keys two things on that id — the list of sessions it has already shown this agent session, and the record of what it just showed. With no id, both are off and the block repeats on every message. Measured in deja's own injection log on a real store: of 165 blocks, 83 were a word-for-word repeat, and all but five of those came within a minute of each other.

Of the five generated per-prompt integrations, three were missing it (opencode, pi, openclaw); cline and hermes already sent it. This closes the last two.

The id is read from the harness event with a plain fallback to empty, so behaviour is unchanged where the API exposes nothing. Three mutations red the new test: dropping the field from either payload, and reading an empty id instead of the event's.