### PR TITLE
feat(hook): stop repeating the block, not the session it came from

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -154,9 +156,22 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// writing, are discarded a few lines below on their id alone. Handing them
 	// to the ranking means they are never read: on a real store that is 15 of
 	// 26 candidates, each read from disk in full before being dropped.
+	// What this agent session was already shown, by the text of the block
+	// rather than by the session it came from. Banning the session banned
+	// everything else it holds: measured on a real store, walking one working
+	// session of eighty messages, the second half got three blocks where the
+	// same messages without the ban got thirty-eight, and only seven of those
+	// were word-for-word repeats. The same past session answers many questions
+	// in a day, and after the first answer it went silent.
 	seen := alreadyInjected(dir, input.SessionID)
-	skip := make(map[string]bool, len(seen)+1)
-	for id := range seen {
+	// A session shown a moment ago is skipped before it is read — that is what
+	// keeps an answering call from reading every candidate off disk. A session
+	// shown an hour ago is fair game again: the same past work answers many
+	// questions in a day, and what stops it repeating itself is the block
+	// fingerprint below, not a ban on where it came from.
+	recent := recentlyInjected(dir, input.SessionID, injectionCooldown)
+	skip := make(map[string]bool, len(recent)+1)
+	for id := range recent {
 		skip[id] = true
 	}
 	if input.SessionID != "" {
@@ -244,9 +259,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 			// than the one asked.
 			continue
 		}
-		if seen[s.ID] {
-			continue
-		}
+
 		// A marathon session that touched everything matches everything, so
 		// it used to be skipped whole. But the sessions people ask about are
 		// exactly the long ones — measured here, only 2% of sessions cross
@@ -285,7 +298,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// A rejected session is not an equal answer, and the mark has to travel
 	// with it into the block the agent reads (#761).
 	ss, rejectedWarning := orderForInjection(ss)
-	rememberInjected(dir, input.SessionID, ss)
+
 	// "You have been here" on the strength of one word teaches the user to
 	// ignore the line. The recall itself still goes in.
 	showLine := confident && dejaVuLineDue(dir, input.SessionID)
@@ -315,7 +328,15 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 			body += "\n" + nudge
 		}
 	}
+	// The same block twice is wallpaper, and the reader stops looking. Judged
+	// on what would be shown, so a session whose other lines answer the next
+	// question still gets to answer it.
+	if seen[blockFingerprint(body)] {
+		return emitNudgeOnly(stdout, plain, nudge)
+	}
 	out := frameRecall(body)
+	rememberInjectedIDs(dir, input.SessionID, blockFingerprint(body))
+	rememberInjected(dir, input.SessionID, ss)
 	usage.RecordDigestInto(dir, usage.KindDejaVu, out, input.SessionID, len(ss), rawSize(ss),
 		terms, sessionIDs(ss)...)
 	if plain {
@@ -492,10 +513,52 @@ func alreadyInjected(dir, sid string) map[string]bool {
 		return out
 	}
 	for _, line := range strings.Split(string(b), "\n") {
+		// Two fields when the entry is a block fingerprint, three when it is a
+		// session with the time it was shown.
 		parts := strings.Fields(line)
-		if len(parts) == 2 && parts[0] == sid {
+		if len(parts) >= 2 && parts[0] == sid {
 			out[parts[1]] = true
 		}
+	}
+	return out
+}
+
+// blockFingerprint identifies what a block says, so the same words are not
+// shown to the same agent session twice while the session they came from stays
+// available for what else it holds.
+func blockFingerprint(body string) string {
+	sum := sha256.Sum256([]byte(strings.Join(strings.Fields(body), " ")))
+	return hex.EncodeToString(sum[:8])
+}
+
+// injectionCooldown is how many later injections a session sits out after
+// being shown. Counted in injections rather than minutes because that is what
+// the reader experiences: a run of messages about one thing should not keep
+// re-reading the same session, and a day that comes back to it should get it
+// again. Ten is the length of a short stretch of work.
+const injectionCooldown = 10
+
+// recentlyInjected is alreadyInjected narrowed to the last few things this
+// agent session was shown.
+func recentlyInjected(dir, sid string, window int) map[string]bool {
+	out := map[string]bool{}
+	if sid == "" || window <= 0 {
+		return out
+	}
+	b, err := os.ReadFile(dir + ".hookseen")
+	if err != nil {
+		return out
+	}
+	lines := strings.Split(string(b), "\n")
+	// Newest first: the window counts injections, and the file is append-only.
+	kept := 0
+	for i := len(lines) - 1; i >= 0 && kept < window; i-- {
+		parts := strings.Fields(lines[i])
+		if len(parts) < 2 || parts[0] != sid {
+			continue
+		}
+		kept++
+		out[parts[1]] = true
 	}
 	return out
 }
@@ -518,8 +581,9 @@ func rememberInjected(dir, sid string, ss []model.Session) {
 		return
 	}
 	defer f.Close()
+	stamp := time.Now().UTC().Format(time.RFC3339)
 	for _, s := range ss {
-		fmt.Fprintf(f, "%s %s\n", sid, s.ID)
+		fmt.Fprintf(f, "%s %s %s\n", sid, s.ID, stamp)
 	}
 }
 

--- a/cmd/deja/hook_prompt_seen_block_test.go
+++ b/cmd/deja/hook_prompt_seen_block_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// What must not repeat is what the reader sees, not where it came from. Banning
+// the session banned everything else it held: measured on a real store, walking
+// one working session of eighty messages, the second half got three blocks
+// where the same messages without the ban got thirty-eight — and only seven of
+// those were word-for-word repeats. The same past work answers many questions
+// in a day.
+func TestBlockFingerprintIgnoresSpacingAndSeparatesContent(t *testing.T) {
+	a := blockFingerprint("- Assistant: pgbouncer pool size settled at 40\n")
+	b := blockFingerprint("- Assistant:   pgbouncer pool size settled at 40")
+	if a != b {
+		t.Errorf("the same block fingerprinted differently after re-wrapping: %s vs %s", a, b)
+	}
+	c := blockFingerprint("- Assistant: pgbouncer pool size settled at 41")
+	if a == c {
+		t.Error("two different blocks share a fingerprint")
+	}
+}
+
+// The cooldown counts injections, not minutes: a run of messages about one
+// thing should not keep re-reading the same session, and a session that comes
+// back to it later should get it again.
+func TestRecentlyInjectedCountsTheLastFew(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	var b strings.Builder
+	b.WriteString("agent old-1 2020-01-01T00:00:00Z\n")
+	for i := 0; i < injectionCooldown; i++ {
+		b.WriteString("agent filler 2020-01-01T00:00:00Z\n")
+	}
+	b.WriteString("agent fresh-1 2020-01-01T00:00:00Z\n")
+	if err := os.WriteFile(dir+".hookseen", []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := recentlyInjected(dir, "agent", injectionCooldown)
+	if !got["fresh-1"] {
+		t.Error("a session shown a moment ago is not in the window")
+	}
+	if got["old-1"] {
+		t.Error("a session shown long before the window still counts as recent")
+	}
+	if other := recentlyInjected(dir, "someone-else", injectionCooldown); len(other) != 0 {
+		t.Errorf("another agent session's history leaked in: %v", other)
+	}
+}
+
+// Entries written before this carried two fields, and the plan hook still
+// writes two. Both shapes have to read back.
+func TestAlreadyInjectedReadsBothLineShapes(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	if err := os.WriteFile(dir+".hookseen",
+		[]byte("agent two-fields\nagent three-fields 2020-01-01T00:00:00Z\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := alreadyInjected(dir, "agent")
+	for _, want := range []string{"two-fields", "three-fields"} {
+		if !got[want] {
+			t.Errorf("%q was not read back from the seen list: %v", want, got)
+		}
+	}
+}
+
+// Asking the same thing twice in one agent session must not print the same
+// block twice: the second time it is wallpaper, and a reader who sees wallpaper
+// stops reading. What is banned is the text, so the session it came from can
+// still answer the next question with other lines.
+func TestHookPromptDoesNotRepeatTheSameBlock(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "repeatterm", []string{
+		`{"type":"user","sessionId":"repeatterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	payload := `{"prompt":"do we need pgbouncer here","session_id":"agent-1"}`
+	var first bytes.Buffer
+	if err := runHookPromptMode(index.DefaultDir(), strings.NewReader(payload), &first, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(first.String(), "transaction mode") {
+		t.Fatalf("nothing was recalled the first time:\n%q", first.String())
+	}
+	// Push that session out of the cooldown window, so the ranking offers it
+	// again and the only thing left to stop a repeat is the block itself.
+	f, err := os.OpenFile(index.DefaultDir()+".hookseen", os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < injectionCooldown+2; i++ {
+		if _, err := f.WriteString("agent-1 filler-" + strconv.Itoa(i) + "\n"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var second bytes.Buffer
+	if err := runHookPromptMode(index.DefaultDir(), strings.NewReader(payload), &second, true); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(second.String(), "transaction mode") {
+		t.Errorf("the same block was shown twice:\n%q", second.String())
+	}
+}


### PR DESCRIPTION
Recall would not show an agent session the same past session twice. That bans everything else the past session holds — and in a working day the same two or three sessions answer many questions. Walking one real session of 80 messages in order:

| | before | after |
|---|---|---|
| blocks, first half | 12 | 26 |
| blocks, second half | 3 | 26 |
| carrying a conclusion | 2 | 34 |
| word-for-word repeats | 0 | 0 |
| silent | 63 | 27 |

The second half used to get three blocks and none of them said what was decided. Removing the ban entirely was measured too: 77 blocks on 80 messages, of which only 7 were repeats — the ban was throwing away four fifths of the memory to prevent one twelfth of it.

So the unit changed. What may not repeat is the text of the block, by fingerprint. Where it came from sits out ten injections — long enough that a run of messages about one thing does not re-read it, short enough that a day can come back to it. That keeps the cheap pre-ranking skip that stops an answering call reading every candidate off disk.

Live sweep over 142 ordinary messages: on-topic 98 -> 99, off-topic 2 -> 3, blocks 100 -> 102, carrying a conclusion 49 -> 53, silent 38 -> 37, tokens 222.9 -> 230.7 per message, median 33.5 -> 39.7 ms. The 58-question set is unchanged at 48 answers; no prompt arm moves; bench recall and bench context unchanged.

Four mutations red the tests, including one that only bites once the session is out of the cooldown window.