### PR TITLE
fix(hook): forget what a session was shown when its context is compacted

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -121,6 +121,11 @@ func endsAValue(b []byte) bool {
 func runHookPrecompact(dir string) {
 	var input precompactHookInput
 	_ = json.Unmarshal(readHookStdin(), &input)
+	// Compaction throws away the blocks this session was shown, and the list
+	// that stops them repeating outlives them — so the memory the agent just
+	// lost is exactly the memory recall refuses to send again. Forget what this
+	// session was shown; everything else in the file belongs to other sessions.
+	forgetInjected(dir, input.SessionID)
 	requestWarmup(dir)
 }
 

--- a/cmd/deja/hook_precompact_forget_test.go
+++ b/cmd/deja/hook_precompact_forget_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Compaction throws away the blocks a session was shown; the list that stops
+// them repeating used to outlive them, so the memory the agent had just lost
+// was exactly the memory recall refused to send again.
+func TestPrecompactForgetsWhatThisSessionWasShown(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "compactterm", []string{
+		`{"type":"user","sessionId":"compactterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	payload := `{"prompt":"do we need pgbouncer here","session_id":"agent-1"}`
+	var first bytes.Buffer
+	if err := runHookPromptMode(index.DefaultDir(), strings.NewReader(payload), &first, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(first.String(), "transaction mode") {
+		t.Fatalf("nothing was recalled to begin with:\n%q", first.String())
+	}
+
+	// Another session's entry, which compaction here must leave alone.
+	f, err := os.OpenFile(index.DefaultDir()+".hookseen", os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("agent-2 someone-elses-block\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	withHookStdin(t, `{"session_id":"agent-1","hook_event_name":"PreCompact"}`)
+	runHookPrecompact(index.DefaultDir())
+
+	if got := alreadyInjected(index.DefaultDir(), "agent-1"); len(got) != 0 {
+		t.Errorf("compaction left this session's seen list behind: %v", got)
+	}
+	if got := alreadyInjected(index.DefaultDir(), "agent-2"); !got["someone-elses-block"] {
+		t.Error("compaction in one session cleared another session's entries")
+	}
+
+	var second bytes.Buffer
+	if err := runHookPromptMode(index.DefaultDir(), strings.NewReader(payload), &second, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(second.String(), "transaction mode") {
+		t.Errorf("after compaction the memory was still withheld:\n%q", second.String())
+	}
+}
+
+// A payload without a session id must not wipe the file: a harness that sends
+// no id would otherwise clear every session's dedupe on its first compaction.
+func TestPrecompactWithoutASessionIDKeepsTheList(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	if err := os.WriteFile(dir+".hookseen", []byte("agent-1 block-a\nagent-2 block-b\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	forgetInjected(dir, "")
+	for sid, block := range map[string]string{"agent-1": "block-a", "agent-2": "block-b"} {
+		if !alreadyInjected(dir, sid)[block] {
+			t.Errorf("%s lost %s to a compaction that named no session", sid, block)
+		}
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -563,6 +563,37 @@ func recentlyInjected(dir, sid string, window int) map[string]bool {
 	return out
 }
 
+// forgetInjected drops one agent session's entries from the seen list, so
+// recall may send it again what it was already shown. Used when the harness
+// truncates the conversation and the blocks go with it.
+func forgetInjected(dir, sid string) {
+	// An early return, not a rule: with no id the filter below matches nothing
+	// and the file is rewritten unchanged, so this saves a read and a write.
+	if sid == "" {
+		return
+	}
+	p := dir + ".hookseen"
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return
+	}
+	var kept []string
+	for _, line := range strings.Split(string(b), "\n") {
+		if line == "" {
+			continue
+		}
+		if parts := strings.Fields(line); len(parts) >= 2 && parts[0] == sid {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	out := ""
+	if len(kept) > 0 {
+		out = strings.Join(kept, "\n") + "\n"
+	}
+	_ = atomicfile.Write(p, []byte(out), 0o600)
+}
+
 func rememberInjected(dir, sid string, ss []model.Session) {
 	if sid == "" {
 		return


### PR DESCRIPTION
Recall will not show the same block to the same agent session twice (#1497). Compaction truncates that session's conversation and the blocks go with it — but the seen list survives, so from then on the memory the agent has just lost is precisely the memory recall refuses to send again.

PreCompact now drops this session's entries from the list. Only this session's: another agent's dedupe is untouched, and a payload without a session id changes nothing.

Measured where it can be: no prompt arm moves and the live sweep is unchanged (102 blocks, 53 carrying a conclusion, 38.9 ms) — compaction does not occur in either rig, which is the point. Two mutations red the tests; the third, dropping the empty-id early return, is unobservable because the filter matches nothing without an id, and the comment says so.

Found while measuring repeat questions: of 142 real messages, 10 asked the same thing twice in one session and 4 got silence the second time. That is correct while the first block is still in context — and wrong the moment compaction removes it.