### PR TITLE
fix(recall): never quote a past session saying it had no memory

### DIFF
--- a/internal/search/empty_memory_test.go
+++ b/internal/search/empty_memory_test.go
@@ -1,0 +1,76 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A past session where the agent said it had no history, or was refused the
+// tool that would have found some, is the worst thing a recall can quote: it
+// hands the reader a failure of this very tool as if it were the answer.
+// Measured on a real store, 3 blocks of 119 opened on one — twice for the same
+// question about a CAN bus, once on a permission refusal.
+func TestBlockDoesNotQuoteAnEmptyMemoryAdmission(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "напомни, что мы выясняли про can шину"},
+		{Role: "assistant", Text: "I don't have any previous conversation context about the can bus work"},
+		{Role: "assistant", Text: "в итоге can шину читаем через adb shell, скорость 500 кбит"},
+	}}
+	_, lines := matchedLinesAsked(s, []string{"can", "шину"}, "напомни, что мы выясняли про can шину")
+	if len(lines) == 0 {
+		t.Fatal("nothing was quoted at all")
+	}
+	for _, ln := range lines {
+		if strings.Contains(strings.ToLower(ln), "don't have any previous") {
+			t.Errorf("the block quotes an admission that there was no memory: %q", ln)
+		}
+	}
+	if !quotedAny(lines, "500") {
+		t.Errorf("the line that actually answered was dropped: %q", lines)
+	}
+}
+
+func TestPermissionRefusalIsNotQuotedEither(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "что там с can шиной"},
+		{Role: "assistant", Text: "Нужно разрешение на использование инструмента recall, чтобы найти детали про can шину"},
+		{Role: "assistant", Text: "can шину в итоге читаем через adb, всё работает"},
+	}}
+	_, lines := matchedLinesAsked(s, []string{"can", "шину"}, "что там с can шиной")
+	for _, ln := range lines {
+		if strings.Contains(strings.ToLower(ln), "разрешение") {
+			t.Errorf("a permission refusal was quoted as memory: %q", ln)
+		}
+	}
+}
+
+func quotedAny(lines []string, want string) bool {
+	for _, ln := range lines {
+		if strings.Contains(ln, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// The conclusion slot takes lines from beside a match (#1493), and that path
+// has its own filter: without it the admission comes back through the side
+// door, since it is exactly the kind of line that follows a mention.
+func TestTheReplySlotIgnoresAnEmptyMemoryAdmission(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "\u0447\u0442\u043e \u0442\u0430\u043c \u0441 can \u0448\u0438\u043d\u043e\u0439"},
+		{Role: "assistant", Text: "can \u0448\u0438\u043d\u0443 \u0441\u043c\u043e\u0442\u0440\u0435\u043b\u0438, can \u0430\u0434\u0430\u043f\u0442\u0435\u0440 \u043f\u043e\u0434\u043a\u043b\u044e\u0447\u0451\u043d"},
+		{Role: "assistant", Text: "\u0432 \u0438\u0442\u043e\u0433\u0435 I don't have any previous conversation context about this"},
+		{Role: "assistant", Text: "can \u0448\u0438\u043d\u0443 \u043f\u0440\u043e\u0432\u0435\u0440\u044f\u043b\u0438, can \u043b\u043e\u0433\u0438 \u0441\u043e\u0431\u0440\u0430\u043d\u044b"},
+		{Role: "assistant", Text: "can \u0448\u0438\u043d\u0443 \u0447\u0438\u0442\u0430\u043b\u0438, can \u0442\u0440\u0430\u0444\u0438\u043a \u0432\u0438\u0434\u0435\u043d"},
+	}}
+	_, lines := matchedLinesAsked(s, []string{"can", "\u0448\u0438\u043d\u0443"},
+		"\u0447\u0442\u043e \u0442\u0430\u043c \u0441 can \u0448\u0438\u043d\u043e\u0439")
+	for _, ln := range lines {
+		if strings.Contains(strings.ToLower(ln), "don't have any previous") {
+			t.Errorf("the reply slot quoted an empty-memory admission: %q", ln)
+		}
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -428,7 +428,7 @@ func autoRecallSessionForAsked(s model.Session, now time.Time, provenance bool, 
 			continue
 		}
 		text := contextText(m.Text, false)
-		if strings.TrimSpace(text) == "" {
+		if strings.TrimSpace(text) == "" || saysItHasNoMemory(text) {
 			continue
 		}
 		switch m.Role {
@@ -543,6 +543,11 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 		// carrying an ordinary word the same session happens to use. Without
 		// this every query word weighs the same and "decide" wins on being
 		// said three times.
+		// Judged on the excerpt, not the line: the excerpt is what the reader
+		// sees, and it can carry the admission in from a neighbouring line.
+		if saysItHasNoMemory(contextText(line, false)) {
+			continue
+		}
 		hits = hits*len(terms) + rankOfBestTerm(line, terms)
 		text := contextText(line, false)
 		if strings.TrimSpace(text) == "" {
@@ -586,7 +591,7 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 			// the candidate list short rather than deciding anything, so
 			// removing it changes cost and not output.
 			line, _ := densestLine(m.Text, terms)
-			if line == "" || !digest.CarriesDecision(line) {
+			if line == "" || !digest.CarriesDecision(line) || saysItHasNoMemory(line) {
 				continue
 			}
 			if text := contextText(line, false); strings.TrimSpace(text) != "" {
@@ -763,6 +768,36 @@ func densestLine(text string, terms []string) (string, int) {
 		return text, 0
 	}
 	return best, bestHits
+}
+
+// emptyMemoryPhrases are what an agent says when it had no history to work
+// from, or when it was refused the tool that would have found some. Quoting
+// such a line hands the reader a past failure of this very tool as if it were
+// the answer — measured on a real store, 3 blocks of 119 opened on one, two of
+// them for the same question about a CAN bus.
+var emptyMemoryPhrases = []string{
+	"don't have any previous conversation",
+	"no previous conversation context",
+	"no prior sessions",
+	"нет данных о прошл",
+	"нет контекста о прошл",
+	"нет истории",
+	"не нашёл ничего",
+	"не нашел ничего",
+	"нужно разрешение на использование инструмента",
+	"permission to use",
+	"not granted",
+}
+
+// saysItHasNoMemory reports whether a line is one of those admissions.
+func saysItHasNoMemory(line string) bool {
+	low := strings.ToLower(line)
+	for _, p := range emptyMemoryPhrases {
+		if strings.Contains(low, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // blockedPhrases are how a harness reports that a call did not happen. They


### PR DESCRIPTION
Reading the blocks that carried no conclusion turned up a class worth its own fix: the recall was quoting the agent admitting it had nothing to recall.

```
- Assistant: I don't have any previous conversation context about Omoda CAN bus work...
- Assistant: Нужно разрешение на использование инструмента recall, чтобы найти детали...
```

Measured on a real store: 3 blocks of 119, twice for the same question. Those lines are worse than a passing mention — they tell the reader the history is empty while the tool is in the middle of proving it is not, and one of them is a permission refusal for recall itself.

Such lines are now skipped when the block picks what to quote, in all three places that pick: the matched-line pass, the fallback that walks the session, and the conclusion slot that takes lines from beside a match. Judged on the excerpt rather than the line, because the excerpt is what the reader sees and can carry the admission in from a neighbour.

Live sweep over 142 messages: those blocks 3 -> 0, on-topic 98 -> 99, blocks 102 and conclusions 53 unchanged, silence 37 unchanged; off-topic 2 -> 3 by the probe's own test, which counts a block as off-topic when the quoted lines do not name the subject — one block lost its admission line and fell into that bucket. The 58-question set is unchanged at 48 answers, no arm moves, bench context unchanged.

Three mutations red the tests.