### PR TITLE
fix(recall): do not recall the harness checks run against the tool

### DIFF
--- a/internal/search/empty_memory_test.go
+++ b/internal/search/empty_memory_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/model"
 )
@@ -72,5 +73,60 @@ func TestTheReplySlotIgnoresAnEmptyMemoryAdmission(t *testing.T) {
 		if strings.Contains(strings.ToLower(ln), "don't have any previous") {
 			t.Errorf("the reply slot quoted an empty-memory admission: %q", ln)
 		}
+	}
+}
+
+// A harness check is a conversation with the tool, not about the work: one
+// message asks for an exact string back and the next repeats it. Such a session
+// has nothing to recall, so none of it is shown — measured on a real store, 4
+// blocks of 119 quoted one, and 11% of that store's sessions hold one, because
+// the tool is developed against it.
+func TestAHarnessCheckIsNotRecalledAtAll(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "smoke", Project: "proj",
+		Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: "Reply with exactly: openclaw deja harness live test alpha"},
+			{Role: "assistant", Text: "openclaw deja harness live test alpha"},
+		},
+	}
+	if got := autoRecallSessionForAsked(s, time.Now(), true, []string{"harness"},
+		"\u0447\u0442\u043e \u0442\u0430\u043c \u0441 harness"); got != "" {
+		t.Errorf("a harness check reached the block:\n%s", got)
+	}
+}
+
+// Work that merely mentions the harness is ordinary work and stays.
+func TestWorkAboutTheHarnessIsStillRecalled(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "real", Project: "proj",
+		Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: "\u0447\u0442\u043e \u0442\u0430\u043c \u0441 harness"},
+			{Role: "assistant", Text: "\u0432 \u0438\u0442\u043e\u0433\u0435 harness \u043f\u043e\u0434\u043a\u043b\u044e\u0447\u0451\u043d \u0447\u0435\u0440\u0435\u0437 \u043f\u043b\u0430\u0433\u0438\u043d"},
+		},
+	}
+	got := autoRecallSessionForAsked(s, time.Now(), true, []string{"harness"},
+		"\u0447\u0442\u043e \u0442\u0430\u043c \u0441 harness")
+	if !strings.Contains(got, "\u043f\u043b\u0430\u0433\u0438\u043d") {
+		t.Errorf("ordinary work about the harness was dropped:\n%s", got)
+	}
+}
+
+// Each phrase carries its own weight: a check written as a search for the
+// fixture string, without the "reply with exactly" wording, is the shape the
+// live harness sweep actually leaves behind.
+func TestAHarnessCheckWrittenAsASearchIsIgnored(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "smoke2", Project: "proj",
+		Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: "search for openclaw deja harness live test alpha and name the harness"},
+			{Role: "assistant", Text: "openclaw"},
+		},
+	}
+	if got := autoRecallSessionForAsked(s, time.Now(), true, []string{"harness"},
+		"\u0447\u0442\u043e \u0442\u0430\u043c \u0441 harness"); got != "" {
+		t.Errorf("a harness check reached the block:\n%s", got)
 	}
 }

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -387,6 +387,11 @@ func autoRecallSessionFor(s model.Session, now time.Time, provenance bool, terms
 }
 
 func autoRecallSessionForAsked(s model.Session, now time.Time, provenance bool, terms []string, asked string) string {
+	// A harness check has nothing to recall: it exists to prove the wiring
+	// works, and quoting it hands the reader a test fixture.
+	if isHarnessCheck(s) {
+		return ""
+	}
 	var problem string
 	var conclusions []string
 	matched := false
@@ -789,12 +794,40 @@ var emptyMemoryPhrases = []string{
 	"not granted",
 }
 
+// selfTestPhrases are the shape of a harness check: a message asking for an
+// exact string back, and the echo of it. They are conversations with the tool
+// rather than about the work, and quoting one tells the reader nothing.
+// Measured on a real store, 4 blocks of 119 quoted "Reply with exactly:
+// openclaw deja harness live test alpha" or its echo.
+var selfTestPhrases = []string{
+	"reply with exactly",
+	"ответь ровно",
+	"harness live test",
+	"smoke test alpha",
+}
+
 // saysItHasNoMemory reports whether a line is one of those admissions.
 func saysItHasNoMemory(line string) bool {
 	low := strings.ToLower(line)
 	for _, p := range emptyMemoryPhrases {
 		if strings.Contains(low, p) {
 			return true
+		}
+	}
+	return false
+}
+
+// isHarnessCheck reports whether a session is a conversation with the tool
+// rather than about the work: one message asks for an exact string back and the
+// next repeats it. Measured on a real store, 11% of sessions hold one, and 4
+// blocks of 119 quoted one back as if it were memory.
+func isHarnessCheck(s model.Session) bool {
+	for _, m := range s.Messages {
+		low := strings.ToLower(m.Text)
+		for _, p := range selfTestPhrases {
+			if strings.Contains(low, p) {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
Reading blocks that were on topic and still said nothing turned up the next class: recall was quoting the smoke tests run against deja itself.

```
- User: Reply with exactly: openclaw deja harness live test alpha
- Assistant: openclaw deja harness live test alpha
```

On a real store 11% of sessions hold such a check — the tool is developed against them — and 4 blocks of 119 quoted one. They count as on topic by every measure I have (the words match, the session is recent) while telling the reader nothing.

A session whose messages carry that shape is now not recalled at all. Not line by line: the whole session exists to prove the wiring works, and its other lines are the echo.

Live sweep over 142 messages: blocks quoting a check 4 -> 0, blocks 102 -> 101, carrying a conclusion 53 -> 55, on-topic 99 -> 98 (the lost one was a check that counted as on-topic because the query word appeared in it), silence 37 -> 39. The 58-question set is unchanged at 48 answers, no arm moves.

Three mutations red the tests, including dropping either phrase from the list — each is pinned by its own case, since the two shapes the sweep leaves behind differ.