### PR TITLE
fix(digest): a plan is not a decision

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -547,8 +547,70 @@ func CarriesDecision(text string) bool {
 // both, so a line matched on that phrase then counted as a conclusion because
 // of it. Measured on the benchmark, the question "по чему у нас в итоге
 // шардирование" promoted a session about something else entirely.
+
+// planAfterMarker are what follows a state word when the sentence is a plan
+// rather than an outcome: "теперь давай", "now let's". The state markers were
+// added because a decision is as often reported as the state something ended up
+// in — but the same words open the next task. Measured by reading ten lines the
+// rule counted as conclusions, four were plans: "Go-структуры готовы. Теперь
+// SQL — 2 SELECT" and "PR открыт. Теперь главное — сделать так, чтобы деплой не
+// мог соврать".
+var planAfterMarker = []string{
+	"теперь давай", "теперь главное", "теперь нужно", "теперь надо",
+	"теперь буду", "теперь сделаю", "теперь я", "now let's", "now i'll",
+	"now we need", "now i will",
+}
+
+// blankOpeningNow removes "теперь" where it opens a clause, which is how a
+// plan starts — "Теперь SQL — 2 SELECT" — and leaves it where it reports a
+// state: "прод-пины теперь ложатся на deploy/prod". Both readings were counted
+// as decisions; reading ten such lines on a real store, four were plans.
+func blankOpeningNow(low string) string {
+	const word = "теперь"
+	out := low
+	for i := 0; ; {
+		j := strings.Index(out[i:], word)
+		if j < 0 {
+			return out
+		}
+		at := i + j
+		opens := true
+		for k := at - 1; k >= 0; k-- {
+			r := rune(out[k])
+			if r == ' ' || r == '\t' || r == '*' || r == '#' {
+				continue
+			}
+			opens = !isWordByte(out[k])
+			break
+		}
+		if opens {
+			out = out[:at] + strings.Repeat(" ", len(word)) + out[at+len(word):]
+		}
+		i = at + len(word)
+	}
+}
+
+// isWordByte says whether a byte belongs to a word rather than to punctuation.
+// Cyrillic is multi-byte, and every continuation byte is >= 0x80, so this reads
+// "part of a word" for them too.
+func isWordByte(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', b >= '0' && b <= '9':
+		return true
+	case b >= 0x80:
+		return true
+	}
+	return false
+}
+
 func CarriesDecisionExcept(text string, asked []string) bool {
 	low := strings.ToLower(text)
+	for _, p := range planAfterMarker {
+		// A plan may still report an outcome elsewhere in the line, so this
+		// blanks the plan wording rather than disqualifying the whole line.
+		low = strings.ReplaceAll(low, p, " ")
+	}
+	low = blankOpeningNow(low)
 	for _, d := range decisionMarkers {
 		if !strings.Contains(low, d) {
 			continue

--- a/internal/digest/plan_marker_test.go
+++ b/internal/digest/plan_marker_test.go
@@ -1,0 +1,49 @@
+package digest
+
+import "testing"
+
+// The state markers ("теперь", "стало") were added because a decision is as
+// often reported as the state something ended up in. The same words open the
+// next task, and then the line is a plan. Measured by reading ten lines the
+// rule counted as conclusions on a real store, four were plans: "Go-структуры
+// готовы. Теперь SQL — 2 SELECT, INSERT, UPDATE" and "PR открыт. Теперь
+// главное — сделать так, чтобы деплой не мог соврать".
+func TestAPlanIsNotADecision(t *testing.T) {
+	for _, line := range []string{
+		"Go-структуры готовы. Теперь SQL — 2 SELECT, INSERT, UPDATE + apply-блок",
+		"PR открыт. Теперь главное — сделать так, чтобы деплой не мог соврать",
+		"теперь нужно прогнать бенч ещё раз",
+		"now let's wire the plugin",
+		// Mid-sentence plan wording: the clause rule cannot see this one, the
+		// phrase list has to.
+		"ладно, а теперь давай прогоним бенч",
+	} {
+		if CarriesDecision(line) {
+			t.Errorf("a plan counted as a decision: %q", line)
+		}
+	}
+}
+
+// And a state that really is an outcome still counts, including in the same
+// sentence shape.
+func TestAStateStillCountsAsADecision(t *testing.T) {
+	for _, line := range []string{
+		"позиция восстановления теперь точная, дампы 389 МБ ежедневно",
+		"PR #810 теперь закрывает #813 и #814",
+		"прод-пины теперь ложатся на deploy/prod",
+		"the retry budget now lives in config",
+	} {
+		if !CarriesDecision(line) {
+			t.Errorf("an outcome stopped counting as a decision: %q", line)
+		}
+	}
+}
+
+// A line that plans and reports in one breath keeps its decision: the plan
+// wording only disqualifies the state marker it sits on.
+func TestAPlanBesideAnOutcomeKeepsTheOutcome(t *testing.T) {
+	line := "в итоге остановились на 40. теперь давай посмотрим логи"
+	if !CarriesDecision(line) {
+		t.Errorf("an outcome was lost because a plan followed it: %q", line)
+	}
+}


### PR DESCRIPTION
Checking the metric I have been optimising all night: I read ten lines the rule counted as conclusions on a real store. Four were plans.

```
Go-структуры готовы. Теперь SQL — 2 SELECT, INSERT, UPDATE + apply-блок
PR открыт. Теперь главное — сделать так, чтобы деплой не мог соврать
```

The state markers were added because a decision is as often reported as the state something ended up in — "прод-пины теперь ложатся на deploy/prod". The same word opens the next task, and position tells them apart: mid-sentence it reports, at the start of a clause it plans. A short list catches the mid-sentence plans ("а теперь давай") that position cannot.

Live sweep over 142 messages: blocks quoting a plan as their conclusion 4 -> 0; blocks 101, carrying a conclusion 55, on-topic 98, off-topic 3, silence 39 — all unchanged, since the lines that stop qualifying are replaced by others in the same slot. The 58-question set is unchanged, no arm moves.

Three mutations red the tests: not blanking a clause-opening "теперь", blanking every "теперь", and emptying the phrase list.