### PR TITLE
fix(recall): catch the other wordings of an empty memory

### DIFF
--- a/internal/search/empty_memory_test.go
+++ b/internal/search/empty_memory_test.go
@@ -130,3 +130,32 @@ func TestAHarnessCheckWrittenAsASearchIsIgnored(t *testing.T) {
 		t.Errorf("a harness check reached the block:\n%s", got)
 	}
 }
+
+// The same failure has more than one wording, and the first list caught one of
+// them. Reading ten blocks the sweep counted as on topic turned up three more:
+// the agent announcing it is about to look, that it looked and found nothing,
+// or that it may not look at all. Measured after the first list, 4 blocks of
+// 114 still opened on one of these.
+func TestBlockDoesNotQuoteTheAgentAboutToLook(t *testing.T) {
+	for _, line := range []string{
+		"\u041f\u0440\u043e\u0432\u0435\u0440\u044e \u043f\u0430\u043c\u044f\u0442\u044c \u0438 \u0438\u0441\u0442\u043e\u0440\u0438\u044e \u043f\u0440\u043e\u0448\u043b\u044b\u0445 \u0441\u0435\u0441\u0441\u0438\u0439 \u043f\u043e can \u0448\u0438\u043d\u0435",
+		"\u041c\u043d\u0435 \u043d\u0443\u0436\u043d\u043e \u0440\u0430\u0437\u0440\u0435\u0448\u0435\u043d\u0438\u0435 \u043d\u0430 \u0434\u043e\u0441\u0442\u0443\u043f \u043a \u043c\u043e\u0435\u0439 \u043f\u0430\u043c\u044f\u0442\u0438 \u043f\u0440\u043e can \u0448\u0438\u043d\u0443",
+		"\u042f \u043d\u0435 \u043d\u0430\u0448\u0435\u043b \u0438\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u044e \u043f\u0440\u043e can \u0448\u0438\u043d\u0443 \u0432 \u043c\u043e\u0435\u0439 \u043f\u0430\u043c\u044f\u0442\u0438",
+	} {
+		s := model.Session{Messages: []model.Message{
+			{Role: "user", Text: "\u0447\u0442\u043e \u0442\u0430\u043c \u0441 can \u0448\u0438\u043d\u043e\u0439"},
+			{Role: "assistant", Text: line},
+			{Role: "assistant", Text: "can \u0448\u0438\u043d\u0443 \u0432 \u0438\u0442\u043e\u0433\u0435 \u0447\u0438\u0442\u0430\u0435\u043c \u0447\u0435\u0440\u0435\u0437 adb, \u0441\u043a\u043e\u0440\u043e\u0441\u0442\u044c 500"},
+		}}
+		_, lines := matchedLinesAsked(s, []string{"can", "\u0448\u0438\u043d\u0443"},
+			"\u0447\u0442\u043e \u0442\u0430\u043c \u0441 can \u0448\u0438\u043d\u043e\u0439")
+		for _, ln := range lines {
+			if strings.Contains(ln, "\u043f\u0430\u043c\u044f\u0442") {
+				t.Errorf("the block quotes the agent talking about its memory: %q", ln)
+			}
+		}
+		if !quotedAny(lines, "500") {
+			t.Errorf("the line that answered was dropped for %q: %q", line, lines)
+		}
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -781,6 +781,17 @@ func densestLine(text string, terms []string) (string, int) {
 // the answer — measured on a real store, 3 blocks of 119 opened on one, two of
 // them for the same question about a CAN bus.
 var emptyMemoryPhrases = []string{
+	// The same failure in the wordings a second reading turned up: the agent
+	// announcing it is about to look, or that it looked and found nothing, or
+	// that it may not look at all. Measured on a real store after the first
+	// list, 4 blocks of 114 still opened on one of these.
+	"проверю память",
+	"проверю историю прошлых",
+	"поищу в памяти",
+	"не нашел информаци",
+	"не нашёл информаци",
+	"разрешение на доступ",
+	"в моей памяти нет",
 	"don't have any previous conversation",
 	"no previous conversation context",
 	"no prior sessions",


### PR DESCRIPTION
The first list (#1499) caught "I don't have any previous conversation context" and one permission refusal. Reading ten blocks the sweep counted as on topic turned up three more shapes of the same thing:

```
- Assistant: Проверю память и историю прошлых сессий по этой теме.
- Assistant: Мне нужно разрешение на доступ к моей памяти из прошлых сессий.
- Assistant: Я не нашел информацию об этом в моей памяти.
```

All three are the tool talking about itself: about to look, looked and found nothing, or not allowed to look. Quoting one tells the reader the history is empty while the block is proving otherwise, and it counts as on topic because the subject word is in the sentence.

Live sweep over 142 messages: blocks opening on one 4 -> 0; blocks 101, conclusions 55, on-topic 98, off-topic 3, silence 39 all unchanged; the 58-question set unchanged at 48 answers; no arm moves.

Three mutations red the tests, one per phrase.