### PR TITLE
fix(recall): ignore the scripted tool checks too

### DIFF
--- a/internal/search/empty_memory_test.go
+++ b/internal/search/empty_memory_test.go
@@ -159,3 +159,45 @@ func TestBlockDoesNotQuoteTheAgentAboutToLook(t *testing.T) {
 		}
 	}
 }
+
+// The other shape of a harness check: call the tool and answer in a fixed form.
+// Measured on a real store, 2 blocks of 114 quoted one, and the "answer" one of
+// them counted as was itself a check — the question set used to score the tool
+// contains its own smoke tests.
+func TestAScriptedToolCheckIsNotRecalled(t *testing.T) {
+	for _, ask := range []string{
+		"Call the deja recall MCP tool with query 'connection pool exhausted'. Answer one line: did it find anything",
+		"\u0432\u044b\u0437\u043e\u0432\u0438 deja recall \u0441 \u0437\u0430\u043f\u0440\u043e\u0441\u043e\u043c 'connection pool exhausted', \u0438 \u0437\u0430\u043a\u043e\u043d\u0447\u0438 \u043e\u0442\u0432\u0435\u0442 \u0441\u043b\u043e\u0432\u043e\u043c \u0433\u043e\u0442\u043e\u0432\u043e",
+	} {
+		s := model.Session{
+			Harness: "claude", ID: "scripted", Project: "proj",
+			Updated: time.Now(),
+			Messages: []model.Message{
+				{Role: "user", Text: ask},
+				{Role: "assistant", Text: "pgbouncer pool exhausted, \u0433\u043e\u0442\u043e\u0432\u043e"},
+			},
+		}
+		if got := autoRecallSessionForAsked(s, time.Now(), true, []string{"pool"},
+			"connection pool exhausted"); got != "" {
+			t.Errorf("a scripted tool check reached the block:\n%s", got)
+		}
+	}
+}
+
+// Asking the tool to check its memory is ordinary work when the question is
+// real: "проверь память deja, напомни, что мы решали про прокси" must survive.
+func TestARealRequestToCheckMemorySurvives(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "real2", Project: "proj",
+		Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: "\u043f\u0440\u043e\u0432\u0435\u0440\u044c \u043f\u0430\u043c\u044f\u0442\u044c deja, \u043d\u0430\u043f\u043e\u043c\u043d\u0438 \u043f\u0440\u043e \u043f\u0440\u043e\u043a\u0441\u0438"},
+			{Role: "assistant", Text: "\u0432 \u0438\u0442\u043e\u0433\u0435 \u043f\u0440\u043e\u043a\u0441\u0438 \u0444\u0438\u043b\u044c\u0442\u0440\u0443\u0435\u043c \u043f\u043e quality score, \u043f\u043e\u0440\u043e\u0433 0.7"},
+		},
+	}
+	got := autoRecallSessionForAsked(s, time.Now(), true, []string{"\u043f\u0440\u043e\u043a\u0441\u0438"},
+		"\u0447\u0442\u043e \u0442\u0430\u043c \u0441 \u043f\u0440\u043e\u043a\u0441\u0438")
+	if !strings.Contains(got, "0.7") {
+		t.Errorf("a real question about the work was filtered as a tool check:\n%s", got)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -812,6 +812,11 @@ var emptyMemoryPhrases = []string{
 // openclaw deja harness live test alpha" or its echo.
 var selfTestPhrases = []string{
 	"reply with exactly",
+	// The same check in its other shape: call the tool and answer in a fixed
+	// form. Measured on a real store, 2 blocks of 114 quoted one of these.
+	"answer one line",
+	"закончи ответ",
+	"ответь одной строкой",
 	"ответь ровно",
 	"harness live test",
 	"smoke test alpha",


### PR DESCRIPTION
Blocks that quote deja's own output split in two on reading: acknowledgements ("deja-vu recalled: this exact pgx/pgbouncer clash from Nov 2025 — reused the diagnosis") carry real content and stay, while instructions to call the tool and answer in a fixed form are fixtures:

```
- User: Call the deja recall MCP tool with query 'connection pool exhausted'. Answer one line: did it find anything
- User: вызови deja recall с запросом 'connection pool exhausted', и закончи ответ словом готово
```

Same class as "Reply with exactly" (#1500), same treatment: the session is not recalled.

Live sweep over 142 messages: blocks quoting such an instruction 3 -> 1 (the one left is a real question that happens to say "проверь память deja"), blocks 101 -> 100, on-topic 98 -> 97, conclusions 55 unchanged, silence 39 -> 40.

The 58-question set drops 48 -> 47, and the question that changed is worth naming: "проверь в deja, обсуждали ли мы connection pool exhausted... ровно в формате из подсказки инструмента" — the scoring set contains its own smoke tests, and one of them was being answered by another. Turning that into silence is the fix working, not a regression.

Three mutations red the tests; a real request to check memory is pinned by its own case so the filter cannot eat ordinary work.