### PR TITLE
Raise the per-prompt recall budget to 1536 bytes

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -30,7 +30,14 @@ import (
 
 // promptHookBudget keeps per-prompt injections small: this fires on every
 // user message, so it must be a hint, not a payload.
-const promptHookBudget = 1024
+//
+// 1024 cut the two quoted lines mid-sentence, and what it cut was the tail —
+// the paths, names and numbers an answer reuses. Measured on a real store by
+// replaying the sweep and comparing each block against what the agent actually
+// answered next: blocks carrying words the answer went on to use rose from 20%
+// to 25%, and blocks carrying a conclusion from 55 to 57 of 100, for 24 tokens
+// a message. 2048 buys nothing further (25% again, 253 tokens).
+const promptHookBudget = 1536
 
 // dejaVuMaxMessages caps how large a session can be and still read as one
 // rememberable episode. Marathon catch-all sessions rank into everything.

--- a/cmd/deja/prompt_budget_test.go
+++ b/cmd/deja/prompt_budget_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// The block can carry two sessions, each with its own quoted lines, and 1024
+// bytes cut the second one short — taking the tail, which is where the paths,
+// names and numbers live. Measured on a real store by replaying the sweep
+// against what the agent actually answered next: blocks carrying words the
+// answer went on to use rose from 20% to 25% when the budget grew to 1536, at
+// 24 tokens a message, and 2048 bought nothing further.
+func TestBudgetHoldsBothSessions(t *testing.T) {
+	filler := strings.Repeat("pgbouncer pool ", 12)
+	sessions := []model.Session{
+		{
+			Harness: "claude", ID: "first", Project: "proj",
+			Messages: []model.Message{
+				{Role: "user", Text: "что там с pgbouncer"},
+				{Role: "assistant", Text: filler + "и держим 40 на шард"},
+				{Role: "assistant", Text: "в итоге pgbouncer " + filler + "порог 0.7"},
+			},
+		},
+		{
+			Harness: "claude", ID: "second", Project: "proj",
+			Messages: []model.Message{
+				{Role: "user", Text: "pgbouncer снова"},
+				{Role: "assistant", Text: filler + "и prepared statements выключены"},
+				{Role: "assistant", Text: "в итоге pgbouncer " + filler + "режим transaction"},
+			},
+		},
+	}
+	got := search.AutoRecallDigestForAsked(sessions,
+		promptHookBudget-recallFrameOverhead, []string{"pgbouncer"}, "что там с pgbouncer")
+	if !strings.Contains(got, "second") {
+		t.Fatalf("the second session did not fit at all:\n%s", got)
+	}
+	if !strings.Contains(got, "режим transaction") {
+		t.Errorf("the budget cut the tail off the second session's conclusion:\n%s", got)
+	}
+}


### PR DESCRIPTION
The prompt hook capped its block at 1024 bytes, which cut the second quoted session mid-sentence — and the tail is where the paths, names and numbers are.

Measured on a real store by replaying the sweep and comparing each block against the answer the agent actually gave next: blocks carrying words that answer went on to use rose from 20% to 25%, conclusion-bearing blocks 55 to 57 of 100, for 24 tokens a message (223 → 247). 2048 buys nothing further (25% again, 253 tokens). Off-topic blocks, the 58-question answer count and LongMemEval (85.0% hit@1) are all unchanged.