### PR TITLE
Quote 320 characters of a recalled line instead of 220

### DIFF
--- a/internal/search/linecap_test.go
+++ b/internal/search/linecap_test.go
@@ -1,0 +1,32 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A quoted line was cut at 220 characters, and what it cut was the tail — where
+// the path, the number or the name sits. Replayed against what the agent
+// actually answered next on a real store, blocks carrying words that answer
+// went on to use rose from 25 to 26 of 100, blocks carrying a conclusion from
+// 57 to 60, for 11 tokens a message. Cutting at 440 instead loses ground again
+// (24 of 100): the longer a line, the fewer sessions fit beside it.
+func TestQuotedLineKeepsItsTail(t *testing.T) {
+	line := "про pgbouncer мы разбирались долго, " +
+		strings.Repeat("перебрали разные варианты и померили каждый, ", 4) +
+		"и держим 40 коннектов на шард"
+	s := model.Session{
+		Harness: "claude", ID: "tail", Project: "proj",
+		Messages: []model.Message{
+			{Role: "user", Text: "что там с pgbouncer"},
+			{Role: "assistant", Text: line},
+		},
+	}
+	got := AutoRecallDigestForAsked([]model.Session{s}, 4096,
+		[]string{"pgbouncer"}, "что там с pgbouncer")
+	if !strings.Contains(got, "40 коннектов на шард") {
+		t.Errorf("the line was cut before the number that answers it:\n%s", got)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -564,7 +564,7 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 				bestUser = scored{i, hits, lineAround(text, 160, terms)}
 			}
 		case "assistant":
-			assistants = append(assistants, scored{i, hits, lineAround(text, 220, terms)})
+			assistants = append(assistants, scored{i, hits, lineAround(text, 320, terms)})
 		}
 	}
 	// Among the agent's lines, prefer the ones that settled something. Within a
@@ -600,7 +600,7 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 				continue
 			}
 			if text := contextText(line, false); strings.TrimSpace(text) != "" {
-				assistants = append(assistants, scored{i, 0, lineAround(text, 220, terms)})
+				assistants = append(assistants, scored{i, 0, lineAround(text, 320, terms)})
 			}
 		}
 	}


### PR DESCRIPTION
A quoted line was cut at 220 characters and what fell off was the tail — where the path, the number or the name sits.

Measured on a real store by replaying the sweep against the answer the agent actually gave next: blocks carrying words that answer went on to use 25 → 26 of 100, blocks carrying a conclusion 57 → 60, off-topic blocks 3 → 0, tokens 247 → 258 a message. 440 characters loses ground again (24 of 100) — the longer a line, the fewer sessions fit beside it in the same budget. The 58-question set is unchanged at 52 answers, and LongMemEval stays at 85.0% hit@1 / 95.8% hit@3 / MRR 0.896.