### PR TITLE
Quote the line after the match, not just the matched one

### DIFF
--- a/internal/search/nextline_test.go
+++ b/internal/search/nextline_test.go
@@ -1,0 +1,27 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A message names the subject on one line and settles it on the next. Quoting
+// only the line that matched hands the reader the mention without the answer.
+func TestQuoteCarriesTheLineAfterTheMatch(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "next", Project: "proj",
+		Messages: []model.Message{
+			{Role: "user", Text: "что там с pgbouncer"},
+			{Role: "assistant", Text: "смотрел pgbouncer\nв итоге держим 40 коннектов на шард\nдальше не трогали"},
+			{Role: "user", Text: "ок"},
+			{Role: "assistant", Text: "ага"},
+		},
+	}
+	got := AutoRecallDigestForAsked([]model.Session{s}, 4096,
+		[]string{"pgbouncer"}, "что там с pgbouncer")
+	if !strings.Contains(got, "40 коннектов на шард") {
+		t.Errorf("the quote stopped at the mention and left out the line that answers it:\n%s", got)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -755,7 +755,9 @@ func densestLine(text string, terms []string) (string, int) {
 	// held; the mentions and the conclusion are usually in one message, which
 	// is the case the message-level preference cannot see.
 	bestDecides := false
-	for _, line := range strings.Split(text, "\n") {
+	lines := strings.Split(text, "\n")
+	bestAt := -1
+	for i, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -766,11 +768,25 @@ func densestLine(text string, terms []string) (string, int) {
 		}
 		decides := digest.CarriesDecision(line)
 		if best == "" || (decides && !bestDecides) || (decides == bestDecides && h > bestHits) {
-			best, bestHits, bestDecides = line, h, decides
+			best, bestHits, bestDecides, bestAt = line, h, decides, i
 		}
 	}
 	if best == "" {
 		return text, 0
+	}
+	// The line that answers usually sits right under the line that names the
+	// subject, and since #1505 the quote has room for both. Taking the line
+	// after the match raised, on a real store replayed against what the agent
+	// answered next, the blocks carrying words that answer used from 26 to 27 of
+	// 100. Taking the line before it instead — the same added volume — drops
+	// them to 22, so this is the choice and not the length.
+	for _, next := range lines[bestAt+1:] {
+		next = strings.TrimSpace(next)
+		if next == "" {
+			continue
+		}
+		best += " " + next
+		break
 	}
 	return best, bestHits
 }


### PR DESCRIPTION
A message names the subject on one line and settles it on the next, and the quote stopped at the first.

Measured on a real store by replaying the sweep against the answer the agent actually gave next: blocks carrying words that answer went on to use 26 → 27 of 100, blocks carrying a conclusion 60 → 63, tokens 258 → 272 a message. Control against the metric rewarding volume: taking the line *before* the match adds the same length and drops to 22 of 100, so this is the choice and not the size. 58-question set unchanged at 52, LongMemEval unchanged at 85.0% hit@1 / MRR 0.896.