### PR TITLE
Carry two lines past the match in a quote, not one

### DIFF
--- a/internal/search/nextline_two_test.go
+++ b/internal/search/nextline_two_test.go
@@ -1,0 +1,32 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// An answer often takes one sentence to set up and the next to land, so the
+// quote carries two lines past the match rather than one.
+func TestQuoteCarriesTwoLinesAfterTheMatch(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "two", Project: "proj",
+		Messages: []model.Message{
+			{Role: "user", Text: "что там с pgbouncer"},
+			{Role: "assistant", Text: "смотрел pgbouncer\nпробовали и 20, и 60\nостановились на 40 коннектах\nдальше не трогали"},
+			{Role: "user", Text: "ок"},
+			{Role: "assistant", Text: "ага"},
+		},
+	}
+	got := AutoRecallDigestForAsked([]model.Session{s}, 4096,
+		[]string{"pgbouncer"}, "что там с pgbouncer")
+	if !strings.Contains(got, "остановились на 40 коннектах") {
+		t.Errorf("the quote stopped one line short of the answer:\n%s", got)
+	}
+	// And it stops there. Every further line costs room another session would
+	// have taken, which on a real store is what a third line gives up.
+	if strings.Contains(got, "дальше не трогали") {
+		t.Errorf("the quote ran past the answer into the next subject:\n%s", got)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -780,13 +780,22 @@ func densestLine(text string, terms []string) (string, int) {
 	// answered next, the blocks carrying words that answer used from 26 to 27 of
 	// 100. Taking the line before it instead — the same added volume — drops
 	// them to 22, so this is the choice and not the length.
+	// Two lines, not one: an answer often takes a sentence to set up and a
+	// sentence to land. Replayed on a real store, blocks carrying words the
+	// answer later used went 27 to 28 of 100 for 11 tokens a message, while the
+	// equal-volume control — one line before the match and one after — falls to
+	// 25, so the gain is the direction and not the size.
+	took := 0
 	for _, next := range lines[bestAt+1:] {
 		next = strings.TrimSpace(next)
 		if next == "" {
 			continue
 		}
 		best += " " + next
-		break
+		took++
+		if took == 2 {
+			break
+		}
 	}
 	return best, bestHits
 }


### PR DESCRIPTION
An answer often takes one sentence to set up and the next to land, and the quote stopped after the first of them.

Measured on a real store by replaying the sweep against the answer the agent actually gave next: blocks carrying words that answer used 27 → 28 of 100, blocks carrying a conclusion 63 → 64, tokens 272 → 284 a message. Equal-volume control (one line before the match plus one after) drops to 25 of 100, so the gain is direction rather than length. A third line was not taken — it costs the room a second session needs. 58-question set unchanged at 52, LongMemEval unchanged at 85.0% hit@1 / MRR 0.896.