### PR TITLE
Say where a recalled block lost the answer's words

### DIFF
--- a/scripts/longmemeval/main.go
+++ b/scripts/longmemeval/main.go
@@ -24,6 +24,7 @@ import (
 	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/prompt"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
@@ -523,6 +524,7 @@ func runAnswerCarry(questions []lmeQuestion, limit int) {
 		questions = questions[:limit]
 	}
 	carried, carriedOne, carriedRare, blocks, silent, wantN := 0, 0, 0, 0, 0, 0
+	lostInPackaging, lostInRanking, notThere := 0, 0, 0
 	for i := range questions {
 		q := questions[i]
 		dir, cleanup, err := buildHaystackIndex(q)
@@ -569,6 +571,15 @@ func runAnswerCarry(questions []lmeQuestion, limit int) {
 		}
 		if rare >= 1 {
 			carriedRare++
+		} else {
+			switch whereLost(want, asked, spread, ranked) {
+			case "packaging":
+				lostInPackaging++
+			case "ranking":
+				lostInRanking++
+			default:
+				notThere++
+			}
 		}
 		if hits >= 2 {
 			carried++
@@ -588,7 +599,38 @@ func runAnswerCarry(questions []lmeQuestion, limit int) {
 			float64(wantN)/float64(blocks))
 		fmt.Printf("  block carries a word few sessions use:     %d (%.0f%%)\n",
 			carriedRare, 100*float64(carriedRare)/float64(blocks))
+		fmt.Printf("  missed, word sat in a quoted session:      %d (%.0f%%)\n",
+			lostInPackaging, 100*float64(lostInPackaging)/float64(blocks))
+		fmt.Printf("  missed, word sat elsewhere in the haystack:%d (%.0f%%)\n",
+			lostInRanking, 100*float64(lostInRanking)/float64(blocks))
+		fmt.Printf("  missed, no identifying word anywhere:      %d (%.0f%%)\n",
+			notThere, 100*float64(notThere)/float64(blocks))
 	}
+}
+
+// whereLost says where a question's identifying words stopped: "packaging" when
+// a session the block quoted holds one and the block still left it out,
+// "ranking" when one lives in the haystack but not in a quoted session, and
+// "absent" when the answer names nothing the haystack calls by the same word.
+func whereLost(want, asked map[string]bool, spread map[string]int, quoted []model.Session) string {
+	inHaystack := false
+	for w := range want {
+		if asked[w] || spread[w] == 0 || spread[w] > 3 {
+			continue
+		}
+		inHaystack = true
+		for _, s := range quoted {
+			for _, m := range s.Messages {
+				if carryWords(m.Text)[w] {
+					return "packaging"
+				}
+			}
+		}
+	}
+	if inHaystack {
+		return "ranking"
+	}
+	return "absent"
 }
 
 // haystackSpread counts how many of this question's sessions use each word, so

--- a/scripts/longmemeval/wherelost_test.go
+++ b/scripts/longmemeval/wherelost_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func TestWhereLostSeparatesPackagingFromRanking(t *testing.T) {
+	want := map[string]bool{"fujifilm": true}
+	asked := map[string]bool{}
+	spread := map[string]int{"fujifilm": 1}
+	quoted := []model.Session{{Messages: []model.Message{{Text: "bought a fujifilm last spring"}}}}
+
+	if got := whereLost(want, asked, spread, quoted); got != "packaging" {
+		t.Errorf("the word sits in a session the block quoted, so the block lost it: %q", got)
+	}
+	if got := whereLost(want, asked, spread, nil); got != "ranking" {
+		t.Errorf("the word is in the haystack but no quoted session holds it: %q", got)
+	}
+	if got := whereLost(want, asked, map[string]int{}, quoted); got != "absent" {
+		t.Errorf("no session uses the word at all: %q", got)
+	}
+	// A word the question already said proves nothing about the block: it was
+	// going to be there either way.
+	if got := whereLost(want, map[string]bool{"fujifilm": true}, spread, quoted); got != "absent" {
+		t.Errorf("a word the question itself used was counted as recalled: %q", got)
+	}
+	// A word the whole haystack repeats identifies nothing, so it must not
+	// count as reachable material.
+	if got := whereLost(want, asked, map[string]int{"fujifilm": 40}, quoted); got != "absent" {
+		t.Errorf("a common word was treated as identifying: %q", got)
+	}
+}


### PR DESCRIPTION
`-answer-carry` said how often the block carries an identifying word of the gold answer. It did not say where the others went, which is what decides whether to work on ranking or on packaging.

Now it splits them:

```
block carries a word few sessions use:      80 (16%)
missed, word sat in a quoted session:       54 (11%)
missed, word sat elsewhere in the haystack: 63 (13%)
missed, no identifying word anywhere:      303 (61%)
```

The last line is the honest ceiling: three fifths of the answers name nothing the haystack calls by the same word, so no retrieval can carry them. Of what is reachable, packaging loses 54 and ranking 63.

Bench tooling only; hit@1 / hit@5 / MRR untouched.