### PR TITLE
Quote three lines from a session that never concludes anything

### DIFF
--- a/internal/search/lines_cap_test.go
+++ b/internal/search/lines_cap_test.go
@@ -12,7 +12,13 @@ import (
 // A session that says the subject in twenty places must not spend twenty lines
 // saying so: the hook pays for this block on every message. Removing the cap
 // left the whole suite green.
-func TestDigestShowsAtMostTwoAssistantLinesPerSession(t *testing.T) {
+//
+// The cap is three. It was two until the labelled benchmark could measure what
+// the third line buys: on LongMemEval blocks carrying a word few sessions use
+// went from 80 to 87 of 500, and on a real store the block cost did not move,
+// because a session that concludes something is paired down to two lines before
+// this cap is reached.
+func TestDigestShowsAtMostThreeAssistantLinesPerSession(t *testing.T) {
 	now := time.Now().Add(-48 * time.Hour)
 	msgs := make([]model.Message, 0, 21)
 	for i := 0; i < 20; i++ {
@@ -38,7 +44,7 @@ func TestDigestShowsAtMostTwoAssistantLinesPerSession(t *testing.T) {
 	if quoted == 0 {
 		t.Fatalf("nothing was quoted, so the cap is untested:\n%s", block)
 	}
-	if quoted > 2 {
-		t.Errorf("session contributed %d lines; two is the cap:\n%s", quoted, block)
+	if quoted > 3 {
+		t.Errorf("session contributed %d lines; three is the cap:\n%s", quoted, block)
 	}
 }

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -637,8 +637,14 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 	if len(assistants) > 0 && assistants[0].hits > bestUser.hits {
 		bestUser = scored{}
 	}
-	if len(assistants) > 2 {
-		assistants = assistants[:2]
+	// Three quotes, not two. The pair rule above already trims to two whenever
+	// a session has a conclusion to pair with its subject, so this only widens
+	// short sessions that have neither — and there the third line is what
+	// carries the identifying word. On LongMemEval blocks carrying a word few
+	// sessions use went from 80 to 87 of 500, and the cases where that word sat
+	// in a session the block had already quoted fell from 54 to 47.
+	if len(assistants) > 3 {
+		assistants = assistants[:3]
 	}
 	// Back into the order they were said: two conclusions read as a sequence,
 	// and keeping them in score order tells the story backwards.

--- a/internal/search/threequotes_test.go
+++ b/internal/search/threequotes_test.go
@@ -1,0 +1,33 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A session that never concludes anything gets no pairing, and two quotes then
+// stop before the line that names what the reader needs.
+func TestSessionWithoutAConclusionGetsThreeQuotes(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "three", Project: "proj",
+		Messages: []model.Message{
+			{Role: "user", Text: "что там с pgbouncer"},
+			{Role: "assistant", Text: "pgbouncer поднят на стейдже"},
+			{Role: "assistant", Text: "pgbouncer смотрю логи"},
+			{Role: "assistant", Text: "pgbouncer слушает порт 6432"},
+			{Role: "assistant", Text: "pgbouncer и это всё на сегодня"},
+		},
+	}
+	got := AutoRecallDigestForAsked([]model.Session{s}, 4096,
+		[]string{"pgbouncer"}, "что там с pgbouncer")
+	if !strings.Contains(got, "порт 6432") {
+		t.Errorf("the third quote was dropped, and with it the only specific line:\n%s", got)
+	}
+	// And it stops at three: every further quote costs room a second session
+	// would have taken.
+	if strings.Contains(got, "это всё на сегодня") {
+		t.Errorf("a fourth quote made it into the block:\n%s", got)
+	}
+}


### PR DESCRIPTION
The per-session cap was two quotes. When a session has a conclusion, the pair rule already trims it to two — subject plus conclusion — so this cap only ever binds sessions that have neither, and there the third line is often the one naming a path, a port or a version.

Measured with the labelled rig added in #1509/#1510: blocks carrying a word few sessions use went 80 → 87 of 500, and the cases where such a word sat in a session the block had already quoted fell 54 → 47. On a real store the block cost did not move (465 → 464 tokens, same 100 blocks), the replay metric went 28 → 27 and conclusion-bearing blocks 64 → 63 — both inside the noise that store can resolve, and its strict count stayed at 8. Prompt bench: no arm changed. LongMemEval hit@1 85.0% / MRR 0.896 unchanged.

`TestDigestShowsAtMostTwoAssistantLinesPerSession` becomes `...AtMostThree`: the invariant it guards is that a session repeating a subject twenty times cannot spend twenty lines, and that still holds.