### PR TITLE
Give a single-rare-word match half the block

### DIFF
--- a/cmd/deja/digest_budget_test.go
+++ b/cmd/deja/digest_budget_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+// A match resting on one rare word gets half the room a two-word match gets:
+// it is the weaker claim and the one that fires on unrelated prompts.
+func TestWeakMatchGetsHalfTheBlock(t *testing.T) {
+	full := digestBudget(true)
+	weak := digestBudget(false)
+	if full != promptHookBudget-recallFrameOverhead {
+		t.Errorf("a confident match must get the whole budget, got %d", full)
+	}
+	if weak >= full {
+		t.Errorf("a weak match got %d of %d — no room was saved", weak, full)
+	}
+	if weak*2 != full {
+		t.Errorf("a weak match got %d, which is not half of %d", weak, full)
+	}
+	// Still enough to quote something: a block that cannot hold one line is a
+	// pointer, and that is a different decision made elsewhere.
+	if weak < 300 {
+		t.Errorf("a weak match got %d, too little to quote anything", weak)
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -320,7 +320,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		// way of its own to tell "mm_status" from "decide", and the session
 		// that answers often says both — measured live, ten of the answers
 		// this hook newly returns open on the ordinary word.
-		digest := search.AutoRecallDigestForAsked(ss, promptHookBudget-recallFrameOverhead, byIdentifying(terms, idfOf), string(input.Prompt))
+		digest := search.AutoRecallDigestForAsked(ss, digestBudget(confident), byIdentifying(terms, idfOf), string(input.Prompt))
 		if strings.TrimSpace(digest) == "" {
 			return emitNudgeOnly(stdout, plain, nudge)
 		}
@@ -975,6 +975,21 @@ func sessionIDs(ss []model.Session) []string {
 }
 
 const promptHookLead = "deja found prior sessions matching this request. If one genuinely helps, use it and tell the user in one short line what deja-vu recalled; otherwise ignore silently.\n"
+
+// digestBudget is how much room the block gets. A match resting on a single
+// rare word is a weaker claim than one resting on two, and it is where most of
+// the injections on unrelated prompts come from: measured on cross-paired
+// LongMemEval prompts, halving that case takes the average injected block from
+// 1077 to 977 characters. It costs nothing that can be measured on real
+// questions — 52 answers of 58 either way — because the block that answers a
+// single-word question rarely needed the second half.
+func digestBudget(confident bool) int {
+	budget := promptHookBudget - recallFrameOverhead
+	if !confident {
+		budget /= 2
+	}
+	return budget
+}
 
 // weakRecallPointer is what an unconfident match injects instead of a digest:
 // one line saying history exists and how to reach it. A single rare term is a


### PR DESCRIPTION
A match resting on one rare word is a weaker claim than one resting on two, and it is where most of the injections on unrelated prompts come from. It was getting the same room as a confident match.

Measured on cross-paired LongMemEval prompts (the answer is never present): the average injected block goes from 1077 to 977 characters. On real questions nothing is lost — 52 answers of 58 either way, the replay metric stays at 27 of 100, and the labelled carry count moves 60 → 59 of 414. On a real store the block costs 457 tokens instead of 464.

Prompt bench: no arm changed. LongMemEval hit@1 85.0% / MRR 0.896 unchanged.