### PR TITLE
Admit a one-word question when the session keeps returning to that word

### DIFF
--- a/cmd/deja/aboutness_test.go
+++ b/cmd/deja/aboutness_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func sessionSaying(text string, times int) model.Session {
+	msgs := make([]model.Message, 0, times)
+	for i := 0; i < times; i++ {
+		msgs = append(msgs, model.Message{Role: "assistant", Text: text})
+	}
+	return model.Session{Harness: "claude", ID: "s", Project: "p", Messages: msgs}
+}
+
+// A single ordinary word earns an injection when the session keeps coming back
+// to it. Rarity in the language cannot tell "my hamster" from a stranger's
+// passing mention of one; repetition can.
+func TestSessionIsAboutNeedsRepetition(t *testing.T) {
+	terms := []string{"hamster"}
+
+	once := model.Session{Messages: []model.Message{
+		{Role: "assistant", Text: "someone walked past with a hamster"},
+	}}
+	if got := sessionIsAbout(once, terms); got != 0 {
+		t.Errorf("one mention is not a subject, got %d", got)
+	}
+
+	// Literal counts, not the constant: a test written against the constant
+	// stays green when the constant moves, and the number is the rule.
+	if got := sessionIsAbout(sessionSaying("the hamster again", 16), terms); got != 1 {
+		t.Errorf("sixteen mentions is a subject, got %d", got)
+	}
+	if got := sessionIsAbout(sessionSaying("the hamster again", 8), terms); got != 0 {
+		t.Errorf("eight mentions is not enough to inject on one word, got %d", got)
+	}
+
+	// Case and position must not matter: the word is usually capitalised
+	// somewhere and buried in a long message.
+	long := strings.Repeat("filler ", 200) + strings.Repeat("Hamster ", 16)
+	if got := sessionIsAbout(model.Session{Messages: []model.Message{{Text: long}}}, terms); got != 1 {
+		t.Errorf("a long message repeating the word was missed, got %d", got)
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -224,7 +224,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		// hook pays its cost on every message the user sends. Measured on
 		// cross-paired prompts whose answer is absent, the old bar injected on
 		// 94% of them; half of those rested on one ordinary word.
-		if !recallWorthShowing(terms, matched[i], strong[i]) {
+		if !recallWorthShowing(terms, matched[i], sessionIsAbout(s, terms)) {
 			continue
 		}
 		// A word rare enough to identify something is a real match on its own —
@@ -989,6 +989,48 @@ func digestBudget(confident bool) int {
 		budget /= 2
 	}
 	return budget
+}
+
+// sessionIsAbout reports how strong a single-term match is, by asking whether
+// the session keeps returning to that word. It replaces the language-wide
+// rarity test, which admitted a stranger's passing mention of an unusual word
+// and refused a person's own question about an ordinary one — "what is the name
+// of my hamster" was measured silent while the answer sat in the store.
+//
+// Measured on LongMemEval: blocks carrying an identifying word of the answer go
+// from 60 to 73 of 500, silence from 86 to 47, and injections on prompts whose
+// answer is absent from 346 to 339.
+const (
+	aboutMentions     = 16
+	aboutScanMessages = 400
+)
+
+func sessionIsAbout(s model.Session, terms []string) int {
+	lead := terms
+	if len(lead) > 3 {
+		lead = lead[:3]
+	}
+	for _, t := range lead {
+		t = strings.ToLower(strings.TrimSpace(t))
+		if t == "" {
+			continue
+		}
+		mentions := 0
+		// Folding every message of a marathon session costs more than this hook
+		// may spend on a keystroke, and a session that is about a word says it
+		// early: measured on a real store, capping the scan keeps the median at
+		// 44 ms instead of 52 and changes no gate decision on the benchmark.
+		for i, m := range s.Messages {
+			if i >= aboutScanMessages {
+				break
+			}
+			mentions += strings.Count(strings.ToLower(m.Text), t)
+			if mentions >= aboutMentions {
+				return 1
+			}
+		}
+	}
+	return 0
 }
 
 // weakRecallPointer is what an unconfident match injects instead of a digest:


### PR DESCRIPTION
A question whose whole subject is one ordinary word — "what is the name of my hamster", "how long was I in Korea for" — was refused because the word is not rare in the language. Reading the silences on LongMemEval, 37 of 45 reachable ones are exactly that shape.

Rarity in the store does not fix it: a stranger's haystack mentions those words once too, so admitting on store-rarity took false injections from 69% to 87%. Repetition is not symmetric — a session that says the word sixteen times is about it — and it moves all three numbers the right way:

```
blocks carrying an identifying word of the answer   60 → 73 of 500
silent, answer reachable                            45 → 23
injections on prompts whose answer is absent       346 → 339
```

On a real store nothing regresses: 52 answers of 58 either way, replay metric 27 of 100, 457 tokens a block, no off-topic blocks. Median hook time goes 42 → 47 ms, which is why the scan stops after 400 messages. Prompt bench: no arm changed. LongMemEval hit@1 85.0% / MRR 0.896 unchanged.