### PR TITLE
Share the aboutness rule between the hook and the benchmark

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -224,7 +224,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		// hook pays its cost on every message the user sends. Measured on
 		// cross-paired prompts whose answer is absent, the old bar injected on
 		// 94% of them; half of those rested on one ordinary word.
-		if !recallWorthShowing(terms, matched[i], sessionIsAbout(s, terms)) {
+		if !recallWorthShowing(terms, matched[i], search.SessionIsAbout(s, terms)) {
 			continue
 		}
 		// A word rare enough to identify something is a real match on its own —
@@ -989,48 +989,6 @@ func digestBudget(confident bool) int {
 		budget /= 2
 	}
 	return budget
-}
-
-// sessionIsAbout reports how strong a single-term match is, by asking whether
-// the session keeps returning to that word. It replaces the language-wide
-// rarity test, which admitted a stranger's passing mention of an unusual word
-// and refused a person's own question about an ordinary one — "what is the name
-// of my hamster" was measured silent while the answer sat in the store.
-//
-// Measured on LongMemEval: blocks carrying an identifying word of the answer go
-// from 60 to 73 of 500, silence from 86 to 47, and injections on prompts whose
-// answer is absent from 346 to 339.
-const (
-	aboutMentions     = 16
-	aboutScanMessages = 400
-)
-
-func sessionIsAbout(s model.Session, terms []string) int {
-	lead := terms
-	if len(lead) > 3 {
-		lead = lead[:3]
-	}
-	for _, t := range lead {
-		t = strings.ToLower(strings.TrimSpace(t))
-		if t == "" {
-			continue
-		}
-		mentions := 0
-		// Folding every message of a marathon session costs more than this hook
-		// may spend on a keystroke, and a session that is about a word says it
-		// early: measured on a real store, capping the scan keeps the median at
-		// 44 ms instead of 52 and changes no gate decision on the benchmark.
-		for i, m := range s.Messages {
-			if i >= aboutScanMessages {
-				break
-			}
-			mentions += strings.Count(strings.ToLower(m.Text), t)
-			if mentions >= aboutMentions {
-				return 1
-			}
-		}
-	}
-	return 0
 }
 
 // weakRecallPointer is what an unconfident match injects instead of a digest:

--- a/internal/search/aboutness.go
+++ b/internal/search/aboutness.go
@@ -1,0 +1,49 @@
+package search
+
+import (
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// SessionIsAbout reports how strong a single-term match is, by asking whether
+// the session keeps returning to that word. It replaces the language-wide
+// rarity test, which admitted a stranger's passing mention of an unusual word
+// and refused a person's own question about an ordinary one — "what is the name
+// of my hamster" was measured silent while the answer sat in the store.
+//
+// Measured on LongMemEval: blocks carrying an identifying word of the answer go
+// from 60 to 73 of 500, silence from 86 to 47, and injections on prompts whose
+// answer is absent from 346 to 339.
+const (
+	aboutMentions     = 16
+	aboutScanMessages = 400
+)
+
+func SessionIsAbout(s model.Session, terms []string) int {
+	lead := terms
+	if len(lead) > 3 {
+		lead = lead[:3]
+	}
+	for _, t := range lead {
+		t = strings.ToLower(strings.TrimSpace(t))
+		if t == "" {
+			continue
+		}
+		mentions := 0
+		// Folding every message of a marathon session costs more than this hook
+		// may spend on a keystroke, and a session that is about a word says it
+		// early: measured on a real store, capping the scan keeps the median at
+		// 44 ms instead of 52 and changes no gate decision on the benchmark.
+		for i, m := range s.Messages {
+			if i >= aboutScanMessages {
+				break
+			}
+			mentions += strings.Count(strings.ToLower(m.Text), t)
+			if mentions >= aboutMentions {
+				return 1
+			}
+		}
+	}
+	return 0
+}

--- a/internal/search/aboutness_test.go
+++ b/internal/search/aboutness_test.go
@@ -1,4 +1,4 @@
-package main
+package search
 
 import (
 	"strings"
@@ -24,23 +24,23 @@ func TestSessionIsAboutNeedsRepetition(t *testing.T) {
 	once := model.Session{Messages: []model.Message{
 		{Role: "assistant", Text: "someone walked past with a hamster"},
 	}}
-	if got := sessionIsAbout(once, terms); got != 0 {
+	if got := SessionIsAbout(once, terms); got != 0 {
 		t.Errorf("one mention is not a subject, got %d", got)
 	}
 
 	// Literal counts, not the constant: a test written against the constant
 	// stays green when the constant moves, and the number is the rule.
-	if got := sessionIsAbout(sessionSaying("the hamster again", 16), terms); got != 1 {
+	if got := SessionIsAbout(sessionSaying("the hamster again", 16), terms); got != 1 {
 		t.Errorf("sixteen mentions is a subject, got %d", got)
 	}
-	if got := sessionIsAbout(sessionSaying("the hamster again", 8), terms); got != 0 {
+	if got := SessionIsAbout(sessionSaying("the hamster again", 8), terms); got != 0 {
 		t.Errorf("eight mentions is not enough to inject on one word, got %d", got)
 	}
 
 	// Case and position must not matter: the word is usually capitalised
 	// somewhere and buried in a long message.
 	long := strings.Repeat("filler ", 200) + strings.Repeat("Hamster ", 16)
-	if got := sessionIsAbout(model.Session{Messages: []model.Message{{Text: long}}}, terms); got != 1 {
+	if got := SessionIsAbout(model.Session{Messages: []model.Message{{Text: long}}}, terms); got != 1 {
 		t.Errorf("a long message repeating the word was missed, got %d", got)
 	}
 }

--- a/scripts/longmemeval/gates_test.go
+++ b/scripts/longmemeval/gates_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -12,29 +13,32 @@ func spoke(text string) model.Session {
 
 func TestPassHookGatesDropsWhatTheHookWouldNotInject(t *testing.T) {
 	terms := []string{"pgbouncer", "shard"}
+
+	// One mention of one term is a hint, not a subject.
 	weak := spoke("pgbouncer looks fine on the shard")
-	got := passHookGates([]model.Session{weak}, []int{1}, []int{0}, terms)
-	if len(got) != 0 {
-		t.Errorf("one ordinary term is not enough to inject, kept %d", len(got))
+	if got := passHookGates([]model.Session{weak}, []int{1}, nil, terms); len(got) != 0 {
+		t.Errorf("one ordinary mention is not enough to inject, kept %d", len(got))
 	}
 
-	got = passHookGates([]model.Session{weak}, []int{1}, []int{1}, terms)
-	if len(got) != 1 {
-		t.Errorf("a term rare enough to identify something earns an injection, kept %d", len(got))
+	// A session that keeps returning to the term is admitted on that term alone,
+	// which is the rule the hook ships (#1515).
+	about := spoke(strings.Repeat("pgbouncer again ", 20))
+	if got := passHookGates([]model.Session{about}, []int{1}, nil, terms); len(got) != 1 {
+		t.Errorf("a session that repeats the term is about it, kept %d", len(got))
 	}
 
 	// Matched only where a tool printed the word: nobody spoke about it.
 	quiet := model.Session{Messages: []model.Message{
-		{Role: "tool-output", Text: "pgbouncer shard restart"},
+		{Role: "tool-output", Text: strings.Repeat("pgbouncer shard restart ", 20)},
 	}}
-	if got := passHookGates([]model.Session{quiet}, []int{2}, []int{1}, terms); len(got) != 0 {
+	if got := passHookGates([]model.Session{quiet}, []int{2}, nil, terms); len(got) != 0 {
 		t.Errorf("a session that only matched inside tool output was kept: %d", len(got))
 	}
 
 	// The block carries at most two sessions.
 	many := []model.Session{spoke("pgbouncer shard one"), spoke("pgbouncer shard two"),
 		spoke("pgbouncer shard three")}
-	if got := passHookGates(many, []int{2, 2, 2}, []int{1, 1, 1}, terms); len(got) != 2 {
+	if got := passHookGates(many, []int{2, 2, 2}, nil, terms); len(got) != 2 {
 		t.Errorf("kept %d sessions; the block carries two", len(got))
 	}
 }

--- a/scripts/longmemeval/main.go
+++ b/scripts/longmemeval/main.go
@@ -630,10 +630,10 @@ func runAnswerCarry(questions []lmeQuestion, limit int) {
 // about the subject. Without these the benchmark measured a path no user gets:
 // it assumed every question produces a block, while the hook stays silent on
 // 86 of these 500.
-func passHookGates(ranked []model.Session, matched, strong []int, terms []string) []model.Session {
+func passHookGates(ranked []model.Session, matched, _ []int, terms []string) []model.Session {
 	kept := ranked[:0]
 	for i, s := range ranked {
-		if i < len(matched) && matched[i] < 2 && (i >= len(strong) || strong[i] < 1) {
+		if i < len(matched) && matched[i] < 2 && search.SessionIsAbout(s, terms) < 1 {
 			continue
 		}
 		if !search.SpeechCarriesAnyTerm(s, terms) {
@@ -791,18 +791,19 @@ func runHookPrecision(questions []lmeQuestion, limit int) {
 		// identifier test and a six-term cap, so measuring the gate on
 		// relevance terms measured a rule that never runs.
 		terms := prompt.Terms(questions[i].Question)
-		_, matched, strong, _, err := index.ProjectRelevant(dir, nil, terms, prompt.Candidates)
+		ranked, matched, strong, _, err := index.ProjectRelevant(dir, nil, terms, prompt.Candidates)
 		if err != nil {
 			cleanup()
 			fatal(err)
 		}
-		best, bestStrong := 0, 0
-		for k, m := range matched {
-			if m > best {
-				best = m
-			}
-			if k < len(strong) && strong[k] > bestStrong {
-				bestStrong = strong[k]
+		best, _ := bestSignals(matched, strong)
+		// The gate admits a single term when the session keeps returning to it,
+		// so this arm asks the same question the hook asks.
+		about := 0
+		for _, cand := range ranked {
+			if search.SessionIsAbout(cand, terms) > 0 {
+				about = 1
+				break
 			}
 		}
 		switch {
@@ -811,7 +812,7 @@ func runHookPrecision(questions []lmeQuestion, limit int) {
 			wouldInject++
 		case best == 1:
 			oneTerm++
-			if bestStrong >= 1 {
+			if about >= 1 {
 				wouldInject++ // a rare term still earns a single-match inject
 			}
 		}


### PR DESCRIPTION
`-answer-carry` and `-hook-precision` reimplemented the injection gate instead of calling it. That was already wrong once (#1512 fixed the missing gates) and became wrong again the moment #1515 changed how a single-term match is admitted: the benchmark kept measuring the rarity test the hook no longer uses.

`sessionIsAbout` moves to `internal/search.SessionIsAbout` and both callers use it. No behaviour change for users — prompt bench unchanged, LongMemEval hit@1 85.0% / MRR 0.896 unchanged, a real store still injects 100 blocks of 142 messages at 457 tokens.

What changes is what the benchmark reports, and #1515 looks different under it:

```
                        before #1515   after #1515 (measured with the real rule)
blocks carrying an identifying word   60            63
silent, answer reachable              45            34
injections where the answer is absent 346 (69%)    303 (61%)
```

Still a win on all three axes, but a smaller one than the estimate in #1515, which came from a rig-side approximation of the rule rather than the rule.