### PR TITLE
Read the answer and the tool output a dsh session actually holds

### DIFF
--- a/docs/registry/deepseek.md
+++ b/docs/registry/deepseek.md
@@ -13,16 +13,25 @@ The first line is the session header — `{"type":"session","id":"session-<uuid>
 "createdAt":<ms>,"cwd":"…"}` — and the project comes from that `cwd`. Every
 line after it is one event: `{type, seq, time, data}`.
 
-Three event types carry the conversation:
+These event types carry the conversation:
 
 - `user/message` with `data.source.kind == "user"` is what a person typed. The
   same type also carries what plugins splice into the turn — the sandbox policy
   snapshot, the skill catalogue — under other source kinds, and those are the
   harness describing itself rather than history worth recalling.
-- `assistant/chunk` with `data.chunk.type == "text-delta"` holds the answer a
-  token at a time; the deltas of one run are joined into a single message.
-- `assistant/chunk` with `data.chunk.type == "tool-result"` is tool output, kept
-  under the `tool-output` role so search can tell it from speech.
+- `assistant/message` is the agent's turn, complete: `data.message.content` is a
+  block array of `text` and `reasoning`. Only the text is recalled; reasoning is
+  the model thinking out loud rather than what it told the person.
+- `assistant/chunk` with `chunk.type == "text-delta"` is the same answer as it
+  streamed. It is read only as a fallback, for a run interrupted before the
+  complete message landed — otherwise the answer would land twice.
+- `text-chunks` is a packed row: a run of three or more consecutive deltas
+  stored as one line with the pieces in `data.texts`. A reader that knows only
+  `assistant/chunk` keeps the stray deltas and loses every long answer, which is
+  exactly the interrupted case the fallback exists for.
+- `tool/result` is tool output, whose content nests a `tool-result` block around
+  the text; it is kept under the `tool-output` role so search can tell it from
+  speech.
 
 `session/title` gives the session its name; when the model never answered, the
 harness falls back to the first prompt.
@@ -32,11 +41,14 @@ harness falls back to the first prompt.
   yet.
 - **Auto-recall**: no hook. The harness has a plugin runtime but no documented
   pre-prompt event deja can attach to.
-- **Resume**: dsh's own `--resume <session>`; deja stores the session id, and the
-  mapping is direct.
+- **Resume**: the tui app takes `--resume <session>` (a flag of the booted app,
+  not of the launcher — `dsh --profile headless --resume` is rejected). deja
+  stores the session id the flag wants, so the mapping is direct.
 - **Handoff**: paste.
 
-Format verified by installing dsh 0.1.1-rc.2, running it, and reading what it
-wrote (`@deepseek-ai/dsh-session-persistence-jsonl`).
+Format verified by installing dsh 0.1.1-rc.2, pointing it at a local model over
+an OpenAI-compatible route, and reading what it wrote across sessions that
+answered, called a tool, were interrupted mid-answer, and failed before
+answering (`@deepseek-ai/dsh-session-persistence-jsonl`).
 
 **Last verified:** 2026-08-21

--- a/fixtures/registry/deepseek/sessions/--work-pgbouncer-lab--/session-eaf5c9ac-0e47-4d2f-b982-8bae306062d1/session.jsonl
+++ b/fixtures/registry/deepseek/sessions/--work-pgbouncer-lab--/session-eaf5c9ac-0e47-4d2f-b982-8bae306062d1/session.jsonl
@@ -3,7 +3,11 @@
 {"type":"session/title","seq":10,"time":1787320263581,"data":{"title":"pgbouncer pool size","source":{"kind":"fallback"}}}
 {"type":"user/message","seq":7,"time":1787320263580,"data":{"content":[{"type":"text","text":"how many connections do we hold per shard"}],"source":{"kind":"user"},"role":"user"}}
 {"type":"user/message","seq":8,"time":1787320263580,"data":{"content":[{"type":"text","text":"Current runtime context. This snapshot supersedes earlier runtime-context snapshots."}],"source":{"kind":"plugin","plugin":"@deepseek-ai/dsh-system-prompt"},"role":"user"}}
-{"type":"assistant/chunk","seq":12,"time":1787320263585,"data":{"turn":1,"step":1,"chunk":{"type":"text-delta","text":"we hold "}}}
-{"type":"assistant/chunk","seq":13,"time":1787320263586,"data":{"turn":1,"step":1,"chunk":{"type":"text-delta","text":"40 per shard, pinned in the pgbouncer config"}}}
-{"type":"assistant/chunk","seq":14,"time":1787320263589,"data":{"turn":1,"step":1,"chunk":{"type":"finish","reason":{"kind":"stop"}}}}
-{"type":"turn/end","seq":15,"time":1787320263590,"data":{"turn":1}}
+{"type":"assistant/chunk","seq":12,"time":1787320263585,"data":{"turn":1,"step":1,"chunk":{"type":"text-delta","text":"let me "}}}
+{"type":"text-chunks","seq0":13,"time0":1787320263586,"data":{"turn":1,"step":1,"index":0,"dt":[79,75],"texts":["check ","the ","config"]}}
+{"type":"assistant/message","seq":20,"time":1787320263700,"data":{"turn":1,"step":1,"message":{"role":"assistant","content":[{"type":"reasoning","text":"the pool size lives in notes.txt"},{"type":"text","text":"let me check the config"}],"source":{"kind":"model","provider":"deepseek-official"}}}}
+{"type":"tool/call","seq":21,"time":1787320263710,"data":{"turn":1,"step":1,"callId":"c1","name":"read","arguments":"{\"file_path\":\"/work/pgbouncer-lab/notes.txt\"}"}}
+{"type":"tool/result","seq":22,"time":1787320263720,"data":{"turn":1,"step":1,"message":{"source":{"kind":"tool","callId":"c1"},"content":[{"type":"tool-result","toolCallId":"c1","content":[{"type":"text","text":"pgbouncer pool_size = 40"}]}]}}}
+{"type":"assistant/message","seq":40,"time":1787320263900,"data":{"turn":1,"step":2,"message":{"role":"assistant","content":[{"type":"text","text":"we hold 40 per shard, pinned in the pgbouncer config"}],"source":{"kind":"model","provider":"deepseek-official"}}}}
+{"type":"step/end","seq":41,"time":1787320263901,"data":{"turn":1,"step":2}}
+{"type":"turn/end","seq":42,"time":1787320263902,"data":{"turn":1}}

--- a/internal/sources/deepseek.go
+++ b/internal/sources/deepseek.go
@@ -28,11 +28,21 @@ import (
 // skill catalogue — under a different source kind, and those are the harness
 // talking to itself, not history worth recalling.
 //
-// The agent's turn arrives in pieces: `assistant/chunk` events whose
-// data.chunk.type is "text-delta" hold the text a token at a time, so they are
-// joined until something else ends the run.
+// The agent's turn is written twice. It streams as `assistant/chunk` deltas —
+// and long runs of those are packed into rows of another type entirely, so the
+// stream alone is not readable without unpacking it — and then lands complete
+// in one `assistant/message` whose data.message.content is a block array. The
+// complete one is what deja reads; the deltas are the fallback for a run that
+// was interrupted before it landed.
 //
-// Verified against dsh 0.1.1-rc.2 by running it and reading what it wrote.
+// Reasoning blocks in that array are the model thinking out loud, not what it
+// told the person, so they stay out of the transcript.
+//
+// Tool output is its own event, `tool/result`, whose content nests a
+// tool-result block around the text.
+//
+// Verified against dsh 0.1.1-rc.2 driven by a local model, over sessions that
+// answered, called a tool, and failed before answering.
 
 // DSHHome is the harness's own home directory, following its DSH_HOME variable.
 func DSHHome() string {
@@ -70,6 +80,9 @@ func ParseDeepSeekFile(path string) ([]model.Session, error) {
 		Project: "-",
 		Path:    path,
 	}
+	// Deltas of the step being streamed, kept only until that step's complete
+	// message arrives; a step that ends without one was interrupted, and then
+	// the deltas are all there is.
 	var pending []string
 	var pendingAt time.Time
 	flush := func() {
@@ -119,22 +132,39 @@ func ParseDeepSeekFile(path string) ([]model.Session, error) {
 			}
 		case "assistant/chunk":
 			chunk, _ := data["chunk"].(map[string]any)
-			kind, _ := chunk["type"].(string)
-			switch kind {
-			case "text-delta":
+			if kind, _ := chunk["type"].(string); kind == "text-delta" {
 				if text, _ := chunk["text"].(string); text != "" {
 					pending = append(pending, text)
 					pendingAt = at
 					s.Touch(at)
 				}
-			case "tool-result":
-				flush()
-				if text := deepSeekToolText(chunk); text != "" {
-					s.Messages = append(s.Messages, model.Message{Role: "tool-output", Text: text, Time: at})
-					s.Touch(at)
-				}
-			default:
-				flush()
+			}
+		case "text-chunks":
+			// A run of three or more consecutive deltas is stored as one packed
+			// row rather than as the events themselves, so a reader that knows
+			// only `assistant/chunk` loses exactly the long answers.
+			at := parseTimeAny(e["time0"])
+			for _, part := range deepSeekPackedTexts(data["texts"]) {
+				pending = append(pending, part)
+				pendingAt = at
+				s.Touch(at)
+			}
+		case "assistant/message":
+			// The complete message supersedes whatever of it was streamed.
+			pending = nil
+			msg, _ := data["message"].(map[string]any)
+			if text := deepSeekContentText(msg["content"]); text != "" {
+				s.Messages = append(s.Messages, model.Message{Role: "assistant", Text: text, Time: at})
+				s.Touch(at)
+			}
+		case "step/end", "turn/end":
+			flush()
+		case "tool/result":
+			flush()
+			msg, _ := data["message"].(map[string]any)
+			if text := deepSeekToolText(msg["content"]); text != "" {
+				s.Messages = append(s.Messages, model.Message{Role: "tool-output", Text: text, Time: at})
+				s.Touch(at)
 			}
 		}
 	}
@@ -169,6 +199,7 @@ func deepSeekContentText(v any) string {
 		if !ok {
 			continue
 		}
+		// "reasoning" is the model thinking out loud; "text" is what it said.
 		if t, _ := block["type"].(string); t != "" && t != "text" {
 			continue
 		}
@@ -179,19 +210,46 @@ func deepSeekContentText(v any) string {
 	return strings.TrimSpace(strings.Join(out, "\n"))
 }
 
-func deepSeekToolText(chunk map[string]any) string {
-	if text, _ := chunk["text"].(string); text != "" {
-		return strings.TrimSpace(text)
+// deepSeekPackedTexts reads the texts of a packed chunk row. The row keeps the
+// deltas verbatim in order; the timings beside them reconstruct each member's
+// own clock, which a transcript does not need.
+func deepSeekPackedTexts(v any) []string {
+	parts, ok := v.([]any)
+	if !ok {
+		return nil
 	}
-	if text := deepSeekContentText(chunk["content"]); text != "" {
-		return text
-	}
-	if out, ok := chunk["result"]; ok {
-		if text, _ := out.(string); text != "" {
-			return strings.TrimSpace(text)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if text, _ := p.(string); text != "" {
+			out = append(out, text)
 		}
 	}
-	return ""
+	return out
+}
+
+// deepSeekToolText unwraps tool output, which nests one block array inside
+// another: the outer block says which call this answers, the inner one carries
+// the text the tool printed.
+func deepSeekToolText(v any) string {
+	blocks, ok := v.([]any)
+	if !ok {
+		return deepSeekContentText(v)
+	}
+	var out []string
+	for _, b := range blocks {
+		block, ok := b.(map[string]any)
+		if !ok {
+			continue
+		}
+		if text := deepSeekContentText(block["content"]); text != "" {
+			out = append(out, text)
+			continue
+		}
+		if text, _ := block["text"].(string); text != "" {
+			out = append(out, text)
+		}
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
 }
 
 // readDeepSeekLog returns the log as plain JSONL. The default encoding is a

--- a/internal/sources/deepseek_test.go
+++ b/internal/sources/deepseek_test.go
@@ -8,18 +8,34 @@ import (
 	"testing"
 )
 
-// The lines are what dsh 0.1.1-rc.2 actually wrote, trimmed to the events that
-// carry the conversation.
+// Every line here is a shape dsh 0.1.1-rc.2 wrote while a local model answered
+// through it: the question, the two kinds of text a plugin splices into the
+// same event, a tool call and its result, and the complete assistant message
+// that supersedes the deltas streamed before it.
 const deepSeekLog = `{"type":"session","version":0,"id":"session-eaf5c9ac-0e47-4d2f-b982-8bae306062d1","createdAt":1787320263519,"cwd":"/work/pgbouncer-lab","delegationDepth":0}
 {"type":"permission/preset","seq":0,"time":1787320263520,"data":{"preset":"workspace-write"}}
 {"type":"session/title","seq":10,"time":1787320263581,"data":{"title":"pgbouncer pool size","source":{"kind":"fallback"}}}
 {"type":"user/message","seq":7,"time":1787320263580,"data":{"content":[{"type":"text","text":"сколько коннектов держим на шард?"}],"source":{"kind":"user"},"role":"user"}}
 {"type":"user/message","seq":8,"time":1787320263580,"data":{"content":[{"type":"text","text":"Current runtime context. This snapshot supersedes earlier ones."}],"source":{"kind":"plugin","plugin":"@deepseek-ai/dsh-system-prompt"},"role":"user"}}
 {"type":"user/message","seq":9,"time":1787320263580,"data":{"content":[{"type":"text","text":"<system-reminder>A skill is a reusable set of instructions.</system-reminder>"}],"source":{"kind":"skill-catalog"},"role":"user"}}
-{"type":"assistant/chunk","seq":12,"time":1787320263585,"data":{"turn":1,"step":1,"chunk":{"type":"text-delta","text":"держим "}}}
-{"type":"assistant/chunk","seq":13,"time":1787320263586,"data":{"turn":1,"step":1,"chunk":{"type":"text-delta","text":"40 на шард"}}}
-{"type":"assistant/chunk","seq":14,"time":1787320263589,"data":{"turn":1,"step":1,"chunk":{"type":"finish","reason":{"kind":"stop"}}}}
-{"type":"turn/end","seq":15,"time":1787320263590,"data":{"turn":1}}
+{"type":"assistant/chunk","seq":12,"time":1787320263585,"data":{"turn":1,"step":1,"chunk":{"type":"text-delta","text":"сей"}}}
+{"type":"assistant/chunk","seq":13,"time":1787320263586,"data":{"turn":1,"step":1,"chunk":{"type":"text-delta","text":"час посмотрю"}}}
+{"type":"assistant/message","seq":20,"time":1787320263700,"data":{"turn":1,"step":1,"message":{"role":"assistant","content":[{"type":"reasoning","text":"надо открыть конфиг"},{"type":"text","text":"сейчас посмотрю конфиг"}],"source":{"kind":"model","provider":"mini"}}}}
+{"type":"tool/call","seq":21,"time":1787320263710,"data":{"turn":1,"step":1,"callId":"c1","name":"read","arguments":"{\"file_path\":\"/work/pgbouncer-lab/notes.txt\"}"}}
+{"type":"tool/result","seq":22,"time":1787320263720,"data":{"turn":1,"step":1,"message":{"source":{"kind":"tool","callId":"c1"},"content":[{"type":"tool-result","toolCallId":"c1","content":[{"type":"text","text":"pgbouncer pool_size = 40"}]}]}}}
+{"type":"assistant/message","seq":40,"time":1787320263900,"data":{"turn":1,"step":2,"message":{"role":"assistant","content":[{"type":"text","text":"держим 40 на шард"}],"source":{"kind":"model","provider":"mini"}}}}
+{"type":"step/end","seq":41,"time":1787320263901,"data":{"turn":1,"step":2}}
+{"type":"turn/end","seq":42,"time":1787320263902,"data":{"turn":1}}
+`
+
+// A run killed mid-answer never writes the complete message, and a run of three
+// or more consecutive deltas is stored as one packed row rather than as the
+// events themselves. Both together are what an interrupted session looks like.
+const deepSeekInterrupted = `{"type":"session","version":0,"id":"session-81f6aa2b-d16e-47a8-9841-581fb5f0007b","createdAt":1787325263519,"cwd":"/work/pgbouncer-lab"}
+{"type":"user/message","seq":7,"time":1787325263580,"data":{"content":[{"type":"text","text":"расскажи про пул соединений"}],"source":{"kind":"user"},"role":"user"}}
+{"type":"reasoning-chunks","seq0":15,"time0":1787325263600,"data":{"turn":1,"step":1,"index":0,"dt":[76,76],"texts":["надо","подумать","как"]}}
+{"type":"text-chunks","seq0":18,"time0":1787325263700,"data":{"turn":1,"step":1,"index":0,"dt":[79,75],"texts":["пул ","держит ","соединения"]}}
+{"type":"assistant/chunk","seq":25,"time":1787325263800,"data":{"turn":1,"step":1,"chunk":{"type":"text-delta","text":" открытыми"}}}
 `
 
 func writeDeepSeekSession(t *testing.T, root, id, body string, compress bool) string {
@@ -36,8 +52,7 @@ func writeDeepSeekSession(t *testing.T, root, id, body string, compress bool) st
 		return path
 	}
 	out := path + ".zstd"
-	cmd := exec.Command("zstd", "-q", "-o", out, path)
-	if err := cmd.Run(); err != nil {
+	if err := exec.Command("zstd", "-q", "-o", out, path).Run(); err != nil {
 		t.Fatalf("zstd: %v", err)
 	}
 	if err := os.Remove(path); err != nil {
@@ -49,8 +64,7 @@ func writeDeepSeekSession(t *testing.T, root, id, body string, compress bool) st
 func TestParseDeepSeekFile(t *testing.T) {
 	root := t.TempDir()
 	// The directory is named after an older id than the header carries: a
-	// resumed session keeps its directory and writes a new header, and the
-	// header is what dsh resumes by.
+	// resumed session keeps its directory and writes a new header.
 	path := writeDeepSeekSession(t, root, "stale-directory-name", deepSeekLog, false)
 
 	ss, err := ParseDeepSeekFile(path)
@@ -73,18 +87,33 @@ func TestParseDeepSeekFile(t *testing.T) {
 	if s.Title != "pgbouncer pool size" {
 		t.Errorf("title = %q", s.Title)
 	}
-	if len(s.Messages) != 2 {
-		t.Fatalf("messages = %d, want the question and the answer:\n%+v", len(s.Messages), s.Messages)
+
+	var roles []string
+	for _, m := range s.Messages {
+		roles = append(roles, m.Role)
 	}
-	if s.Messages[0].Role != "user" || s.Messages[0].Text != "сколько коннектов держим на шард?" {
-		t.Errorf("first message = %+v", s.Messages[0])
+	want := []string{"user", "assistant", "tool-output", "assistant"}
+	if strings.Join(roles, ",") != strings.Join(want, ",") {
+		t.Fatalf("roles = %v, want %v:\n%+v", roles, want, s.Messages)
 	}
-	// The deltas are one answer, not two messages.
-	if s.Messages[1].Role != "assistant" || s.Messages[1].Text != "держим 40 на шард" {
-		t.Errorf("second message = %+v", s.Messages[1])
+	// The complete message replaces what was streamed of it; without that the
+	// same answer lands twice, once in pieces.
+	if s.Messages[1].Text != "сейчас посмотрю конфиг" {
+		t.Errorf("answer = %q; the complete message supersedes the deltas", s.Messages[1].Text)
 	}
-	if s.Started.IsZero() {
-		t.Error("started is zero; the header carries createdAt in milliseconds")
+	if strings.Contains(s.Messages[1].Text, "надо открыть конфиг") {
+		t.Error("the model's reasoning was recalled as something it said")
+	}
+	if s.Messages[2].Text != "pgbouncer pool_size = 40" {
+		t.Errorf("tool output = %q", s.Messages[2].Text)
+	}
+	if s.Messages[3].Text != "держим 40 на шард" {
+		t.Errorf("final answer = %q", s.Messages[3].Text)
+	}
+	for i, m := range s.Messages {
+		if m.Time.IsZero() {
+			t.Errorf("message %d has no time: %+v", i, m)
+		}
 	}
 }
 
@@ -105,6 +134,27 @@ func TestParseDeepSeekFileSkipsWhatPluginsSpliced(t *testing.T) {
 	}
 }
 
+func TestParseDeepSeekFileKeepsAnInterruptedAnswer(t *testing.T) {
+	root := t.TempDir()
+	path := writeDeepSeekSession(t, root, "interrupted", deepSeekInterrupted, false)
+	ss, err := ParseDeepSeekFile(path)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v, %d sessions", err, len(ss))
+	}
+	s := ss[0]
+	if len(s.Messages) != 2 {
+		t.Fatalf("messages = %d, want the question and what was streamed:\n%+v", len(s.Messages), s.Messages)
+	}
+	// Three of the four pieces were stored as one packed row; a reader that
+	// knows only the delta events keeps the last word and loses the answer.
+	if s.Messages[1].Text != "пул держит соединения открытыми" {
+		t.Errorf("streamed answer = %q", s.Messages[1].Text)
+	}
+	if strings.Contains(s.Messages[1].Text, "надо подумать") {
+		t.Error("a packed run of reasoning deltas was read as speech")
+	}
+}
+
 func TestParseDeepSeekFileReadsZstdFrames(t *testing.T) {
 	if !ZstdAvailable() {
 		t.Skip("zstd CLI not installed")
@@ -115,11 +165,11 @@ func TestParseDeepSeekFileReadsZstdFrames(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ss) != 1 || len(ss[0].Messages) != 2 {
+	if len(ss) != 1 || len(ss[0].Messages) != 4 {
 		t.Fatalf("compressed session read as %+v", ss)
 	}
-	if ss[0].Messages[1].Text != "держим 40 на шард" {
-		t.Errorf("answer = %q", ss[0].Messages[1].Text)
+	if ss[0].Messages[3].Text != "держим 40 на шард" {
+		t.Errorf("answer = %q", ss[0].Messages[3].Text)
 	}
 }
 

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -252,7 +252,12 @@ func validateRegistrySessions(t *testing.T, id string, sessions []model.Session)
 			t.Fatalf("%s fixture produced incomplete session: %#v", id, session)
 		}
 		for _, message := range session.Messages {
-			if (message.Role != "user" && message.Role != "assistant") || strings.TrimSpace(message.Text) == "" || message.Time.IsZero() {
+			// tool-output is a role the index stores and the search filters by
+			// (retrieval.go: roleToolOutput); a fixture whose harness records
+			// what a tool printed should be able to show it.
+			role := message.Role
+			if (role != "user" && role != "assistant" && role != "tool-output") ||
+				strings.TrimSpace(message.Text) == "" || message.Time.IsZero() {
 				t.Fatalf("%s fixture produced invalid message: %#v", id, message)
 			}
 		}


### PR DESCRIPTION
#1518 was written against a session dsh produced with no model configured — one prompt, no answer, no tools. Pointing dsh at a local model and running it for real showed three shapes that session could not contain, and the reader missed all three:

- The answer lands complete in `assistant/message` (`data.message.content`, blocks of `text` and `reasoning`). Reading only the streamed deltas dropped it.
- A run of three or more consecutive deltas is stored as one packed `text-chunks` row, so the delta path kept the stray pieces and lost every long answer.
- Tool output is its own `tool/result` event, not a chunk kind. `deja sources` reported the session with one message — the question — and nothing else.

Now the complete message wins, its `reasoning` blocks stay out (thinking, not speech), the packed rows feed the fallback for a run interrupted before the complete message landed, and `tool/result` is stored under `tool-output`.

Verified end to end: seven sessions written by dsh against a local model — answered, tool-calling, interrupted mid-answer, and failed-before-answering — index through `deja` and search returns them with the right text.

`registry_test.go` accepted only `user` and `assistant` in a fixture; `tool-output` is a role the index stores and the search filters by, so the fixture that shows it is legitimate and the check now says so.