### PR TITLE
Grok: append the new bytes instead of rewriting the whole index

### DIFF
--- a/docs/registry/grok.html
+++ b/docs/registry/grok.html
@@ -54,7 +54,12 @@
 <h2 id="known-quirks-and-drift">Known quirks and drift</h2>
 <ul>
 <li>The ACP stream contains large tool updates. deja filters lines for message chunk kinds before decoding JSON.</li>
-<li>Rewind can truncate and regrow <code>updates.jsonl</code>; changed streams are reparsed in full.</li>
+<li>Rewind can truncate and regrow <code>updates.jsonl</code>, which looks like growth from</li>
+</ul>
+<p>the outside. deja compares the prefix hash it recorded: an intact prefix takes</p>
+<p>the append path and reads only the new bytes, a moved one reparses the stream</p>
+<p>in full. A live session used to rewrite the whole index on every touch.</p>
+<ul>
 <li><code>generated_title</code> takes precedence over <code>session_summary</code>.</li>
 <li>Missing summary files fall back to directory IDs and the <code>.cwd</code> or URL-decoded path.</li>
 <li>Path encoding is ambiguous when upstream leaves separators or percent escapes in different forms.</li>

--- a/docs/registry/grok.md
+++ b/docs/registry/grok.md
@@ -30,7 +30,10 @@ Consecutive assistant chunks with the same `promptId` are joined. Consecutive us
 ## Known quirks and drift
 
 - The ACP stream contains large tool updates. deja filters lines for message chunk kinds before decoding JSON.
-- Rewind can truncate and regrow `updates.jsonl`; changed streams are reparsed in full.
+- Rewind can truncate and regrow `updates.jsonl`, which looks like growth from
+  the outside. deja compares the prefix hash it recorded: an intact prefix takes
+  the append path and reads only the new bytes, a moved one reparses the stream
+  in full. A live session used to rewrite the whole index on every touch.
 - `generated_title` takes precedence over `session_summary`.
 - Missing summary files fall back to directory IDs and the `.cwd` or URL-decoded path.
 - Path encoding is ambiguous when upstream leaves separators or percent escapes in different forms.

--- a/internal/index/grok_append_test.go
+++ b/internal/index/grok_append_test.go
@@ -1,0 +1,114 @@
+package index
+
+import (
+	"bytes"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// A live Grok session grows all day. Every touch used to reparse the whole
+// updates.jsonl and rewrite the entire index — a gigabyte of records and
+// buckets copied so a search could see one new line (#1522). Growth alone must
+// take the append path now, while a rewind still rewrites: the prefix hash is
+// what tells the two apart.
+func TestGrokGrowthAppendsInsteadOfRewriting(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	t.Setenv("DEJA_GROK_ROOT", filepath.Join(tmp, "grok"))
+
+	dir := filepath.Join(tmp, "grok", "sessions", url.PathEscape("/work/live"), "019f-grok-append")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	summary := filepath.Join(dir, "summary.json")
+	write := func(path, body string, at time.Time) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, at, at); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tick := time.Now()
+	write(summary, `{"info":{"id":"019f-grok-append"},"generated_title":"Live run","created_at":"2026-08-01T10:00:00Z","updated_at":"2026-08-01T10:00:01Z"}`, tick)
+
+	updates := filepath.Join(dir, "updates.jsonl")
+	first := `{"timestamp":1785000001,"params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"appendfirstneedle opening question"},"_meta":{"promptIndex":0}}}}` + "\n"
+	write(updates, first, tick)
+
+	indexDir := filepath.Join(tmp, "index.db")
+	if err := EnsureForSearch(indexDir, search.Options{Query: "appendfirstneedle", Harness: "grok"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// One more ACP line, and a title bump alongside it — the two changes a live
+	// session makes together.
+	tick = tick.Add(10 * time.Second)
+	second := `{"timestamp":1785000002,"params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"appendsecondneedle the answer"},"_meta":{}}}}` + "\n"
+	write(updates, first+second, tick)
+	write(summary, `{"info":{"id":"019f-grok-append"},"generated_title":"Live run continued","created_at":"2026-08-01T10:00:00Z","updated_at":"2026-08-01T10:00:09Z"}`, tick)
+
+	var progress bytes.Buffer
+	if err := EnsureForSearch(indexDir, search.Options{Query: "appendsecondneedle", Harness: "grok"}, false, &progress); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(progress.String(), "updated 1 file") {
+		t.Errorf("growth did not take the append path:\n%s", progress.String())
+	}
+	for _, needle := range []string{"appendfirstneedle", "appendsecondneedle"} {
+		ss, err := Search(indexDir, search.Options{Query: needle, Harness: "grok"})
+		if err != nil || len(ss) != 1 {
+			t.Fatalf("%s: %#v err=%v", needle, ss, err)
+		}
+	}
+	// Exactly the two turns: an append that re-reads from byte zero would
+	// index the opening question a second time and search would still look
+	// right.
+	full, ok, err := FindByID(indexDir, "019f-grok-append")
+	if err != nil || !ok {
+		t.Fatalf("session missing after append: ok=%v err=%v", ok, err)
+	}
+	if len(full.Messages) != 2 {
+		t.Errorf("%d messages after one appended line, want 2:\n%#v", len(full.Messages), full.Messages)
+	}
+
+	recent, err := Recent(indexDir, 1)
+	if err != nil || len(recent) != 1 {
+		t.Fatalf("recent: %#v err=%v", recent, err)
+	}
+	if recent[0].Title != "Live run continued" {
+		t.Errorf("title = %q — the append path dropped the summary bump", recent[0].Title)
+	}
+
+	// A rewind truncates and regrows past the old size, which looks exactly
+	// like an append until the prefix is compared. Appending onto it would
+	// leave the replaced turn in the index for good.
+	tick = tick.Add(10 * time.Second)
+	rewound := `{"timestamp":1785000003,"params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"appendrewoundneedle a different opening, written out at length so the file regrows past every byte the previous two lines occupied together, which is what makes a rewind indistinguishable from growth until the prefix itself is compared"},"_meta":{"promptIndex":0}}}}` + "\n"
+	if len(rewound) <= len(first+second) {
+		t.Fatal("rewound fixture must regrow past the indexed size")
+	}
+	write(updates, rewound, tick)
+	if err := EnsureForSearch(indexDir, search.Options{Query: "appendrewoundneedle", Harness: "grok"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := Search(indexDir, search.Options{Query: "appendfirstneedle", Harness: "grok"})
+	if err != nil || len(ss) != 0 {
+		t.Fatalf("rewind kept the replaced turn: %#v err=%v", ss, err)
+	}
+	ss, err = Search(indexDir, search.Options{Query: "appendrewoundneedle", Harness: "grok"})
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("rewind replacement missing: %#v err=%v", ss, err)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2185,7 +2185,7 @@ func canAppendIncremental(changed map[string]FileState, old map[string]FileState
 			return false
 		}
 		switch harnessForPath(p) {
-		case "claude", "codex", "codex-history", "opencode", "cursor-db", "goose-db", "deja", "pi", "copilot":
+		case "claude", "codex", "codex-history", "opencode", "cursor-db", "goose-db", "deja", "pi", "copilot", "grok":
 		default:
 			return false
 		}

--- a/internal/sources/grok.go
+++ b/internal/sources/grok.go
@@ -30,8 +30,9 @@ func GrokRoot() string {
 
 // Grok Build stores sessions by URL-encoded working directory. summary.json
 // carries metadata and updates.jsonl is the authoritative ACP conversation
-// stream. Grok can truncate and regrow the stream after a rewind, so changed
-// files are always reparsed in full.
+// stream. Grok can truncate and regrow the stream after a rewind, which looks
+// like growth from the outside — the index compares the recorded prefix hash
+// before resuming a parse, and reparses in full when it moved.
 
 func GrokSessionFiles() []string {
 	return walkFiles(filepath.Join(GrokRoot(), "sessions"), func(p string) bool {
@@ -55,6 +56,19 @@ type grokSummary struct {
 }
 
 func ParseGrokFile(path string) ([]model.Session, error) {
+	return parseGrokFileFromOffset(path, 0)
+}
+
+// ParseGrokFileFromOffset reads only the bytes appended past offset. A live
+// session's updates.jsonl grows all day and the index used to reparse and
+// rewrite the whole thing on every touch (#1522); the ingest layer only calls
+// this once the recorded prefix hash still matches, so a rewind that truncates
+// and regrows still goes the long way.
+func ParseGrokFileFromOffset(path string, offset int64) ([]model.Session, error) {
+	return parseGrokFileFromOffset(path, offset)
+}
+
+func parseGrokFileFromOffset(path string, offset int64) ([]model.Session, error) {
 	doc := readGrokSummary(path)
 	id := doc.Info.ID
 	if id == "" {
@@ -80,7 +94,7 @@ func ParseGrokFile(path string) ([]model.Session, error) {
 	// records now land between those chunks, so the join remembers where the
 	// speech was rather than assuming it was the message just added.
 	lastKey, lastSpeech := "", -1
-	err := scanGrokUpdates(path, func(event grokUpdateEvent) {
+	err := scanGrokUpdatesFrom(path, offset, func(event grokUpdateEvent) {
 		role := ""
 		switch event.Params.Update.Kind {
 		case "user_message_chunk":
@@ -245,11 +259,20 @@ var grokToolUpdate = []byte(`"sessionUpdate":"tool_call_update"`)
 // indexing cost is dominated by reading the log rather than materializing tool
 // payloads that will be discarded.
 func scanGrokUpdates(path string, fn func(grokUpdateEvent)) error {
+	return scanGrokUpdatesFrom(path, 0, fn)
+}
+
+func scanGrokUpdatesFrom(path string, offset int64, fn func(grokUpdateEvent)) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
+	if offset > 0 {
+		if _, err := f.Seek(offset, io.SeekStart); err != nil {
+			return err
+		}
+	}
 	r := bufio.NewReaderSize(f, 1024*1024)
 	for {
 		line, err := r.ReadBytes('\n')

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -181,7 +181,8 @@ func Registry() []Harness {
 				Match: func(p string) bool {
 					return hasBase(p, "updates.jsonl") && strings.HasPrefix(p, filepath.Join(GrokRoot(), "sessions"))
 				},
-				Parse: fullParse(ParseGrokFile),
+				Parse:     fullParse(ParseGrokFile),
+				ParseFrom: offsetParse(ParseGrokFileFromOffset),
 			}, {
 				// The maintained CLI writes no session files at all: one
 				// SQLite store beside the config, like opencode's.


### PR DESCRIPTION
Closes #1522.

Grok was missing from `canAppendIncremental` and its file kind had no `ParseFrom`, so every touch of a live `updates.jsonl` reparsed the stream and rewrote `records.bin` and every bucket. On the reporter's ~1.7 GB store that was a 194 s wait for a search that matched nothing.

The reason it was excluded — rewind truncates and regrows, which looks like an append — is already handled by the PrefixHash check from #453, and Grok simply never reached it. Now growth appends, a rewind still rewrites, and a summary-only title bump still lands.

The new test covers all three, plus the message count: an append that re-read from byte zero would index the first turn twice and search would still look right.