### PR TITLE
CLI search stops waiting for a full index rewrite

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -564,7 +564,7 @@ func cmdCtx(dir string, rest []string) error {
 		}
 	}
 	o := search.Options{Query: nfcfold.Compose(q), All: true}
-	if err := index.EnsureForSearch(dir, o, false, os.Stderr); err != nil {
+	if err := ensureForCLISearch(dir, o, false, os.Stderr); err != nil {
 		if !staleUnwritableIndex(dir, err) {
 			return err
 		}
@@ -782,6 +782,30 @@ func cmdSearch(dir string, rest []string, sourceInstance string) error {
 	return runSearch(dir, rest, sourceInstance)
 }
 
+// ensureForCLISearch keeps a search off the rewrite path. Appending the new
+// bytes of a grown transcript is cheap and stays inline; work that rewrites the
+// index — a store that rewrote itself, a removed file, a harness with no append
+// path — is handed to the detached warmup, and the search answers from the
+// index it already has. MCP made that trade at #1305 because a rebuild blows
+// the client's timeout; the CLI kept waiting, and on a 1.7 GB store a query
+// that matched nothing took 194 s while a live Grok session grew (#1521).
+//
+// `--rebuild` still waits: someone who asked for the rebuild wants its result.
+func ensureForCLISearch(dir string, o search.Options, force bool, progress io.Writer) error {
+	if force {
+		return index.EnsureForSearch(dir, o, true, progress)
+	}
+	stale, err := index.EnsureForSearchStale(dir, o, progress)
+	if err != nil {
+		return err
+	}
+	if stale {
+		requestWarmup(dir)
+		fmt.Fprintln(progress, "deja: answering from the index as it was — refreshing in the background")
+	}
+	return nil
+}
+
 func runSearch(dir string, args []string, sourceInstance string) error {
 	force := false
 	var filtered []string
@@ -806,7 +830,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	o.SourceInstance = sourceInstance
 	o.RecallWorn = usage.WornSessions(dir)
 	prepareFirstIndexGreeting(dir)
-	if err := withBuildProgress(func() error { return index.EnsureForSearch(dir, o, force, os.Stderr) }); err != nil {
+	if err := withBuildProgress(func() error { return ensureForCLISearch(dir, o, force, os.Stderr) }); err != nil {
 		// A store that cannot be written still has an index that can be read:
 		// answering from it beats answering nothing (#904).
 		if !staleUnwritableIndex(dir, err) {

--- a/cmd/deja/search_stale_test.go
+++ b/cmd/deja/search_stale_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A search must not pay for a rewrite of the whole index. When a store deja
+// cannot append to has changed, the answer comes from the index as it stands
+// and the refresh is detached — on a 1.7 GB store the old behaviour turned a
+// query that matched nothing into a 194 s wait (#1521). A store deja *can*
+// append to stays inline, because reading the new bytes is cheap.
+func TestSearchDoesNotWaitForARewrite(t *testing.T) {
+	tmp := hermeticEnv(t)
+
+	claude := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	transcript := filepath.Join(claude, "s1.jsonl")
+	line := func(text, stamp string) string {
+		return `{"type":"user","message":{"role":"user","content":"` + text + `"},"timestamp":"` + stamp + `","sessionId":"s1","cwd":"/proj"}` + "\n"
+	}
+	first := line("staleneedle the first turn", "2026-07-02T10:00:00Z")
+	if err := os.WriteFile(transcript, []byte(first), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	aiderDir := filepath.Join(tmp, "aider")
+	if err := os.MkdirAll(aiderDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	history := filepath.Join(aiderDir, ".aider.chat.history.md")
+	if err := os.WriteFile(history, []byte("# aider chat started at 2026-07-02 10:00:00\n\n#### rewriteneedle first\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Claude appends: cheap, so it stays on the search thread and the new turn
+	// is in this very answer.
+	if err := os.WriteFile(transcript, []byte(first+line("appendedneedle the second turn", "2026-07-02T10:05:00Z")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRunStderr(t, "search", "appendedneedle")
+	if err != nil {
+		t.Fatalf("search after append: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "refreshing in the background") {
+		t.Errorf("an append was deferred to the warmup instead of run inline:\n%s", out)
+	}
+
+	// aider has no append path, so its growth is rewrite-grade work.
+	body := "# aider chat started at 2026-07-02 10:00:00\n\n#### rewriteneedle first\n\n#### deferredneedle second\n"
+	if err := os.WriteFile(history, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRunStderr(t, "search", "deferredneedle")
+	if err != nil && !strings.Contains(err.Error(), "no session matches") {
+		t.Fatalf("search during a rewrite: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "refreshing in the background") {
+		t.Errorf("the search waited for the rewrite:\n%s", out)
+	}
+
+	// --rebuild is the escape hatch: someone who asked for the rebuild waits
+	// for it and sees the result.
+	out, err = captureRunStderr(t, "search", "--rebuild", "deferredneedle")
+	if err != nil {
+		t.Fatalf("rebuild search: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "refreshing in the background") {
+		t.Errorf("--rebuild deferred the work it was asked to do:\n%s", out)
+	}
+}


### PR DESCRIPTION
Closes #1521.

`deja <query>` and `deja search` called blocking `EnsureForSearch`, so any dirty store that deja cannot append to made the search pay for a whole rewrite of `records.bin` and every bucket first. The reporter measured 194 s for a query that matched nothing, on a ~1.7 GB index with a live Grok session growing.

Now they use the same contract MCP took at #1305: appends stay inline (cheap, and the new turn is in this answer), rewrite-grade work is handed to the detached warmup and the search says it answered from the index as it was. `--rebuild` still waits — someone who asked for the rebuild wants its result.

Grok's own case is gone separately in #1530: it appends now instead of rewriting.