### PR TITLE
Read Grok's spawn tree

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/nfcfold"
@@ -435,9 +436,41 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 	if note := bucketDayNote(s); note != "" {
 		fmt.Fprintln(os.Stderr, note)
 	}
+	printSpawnEdges(os.Stderr, dir, s)
 	search.PrintSession(os.Stdout, s)
 	return nil
 }
+
+// printSpawnEdges names the sessions around this one when an agent spawned it
+// or spawned others from it. A subagent's work lives in its own session, so a
+// reader who found the parent could not get to it and a reader who found the
+// child could not say what asked for it (#1385).
+func printSpawnEdges(w io.Writer, dir string, s model.Session) {
+	if s.Parent != "" {
+		by := ""
+		if s.Agent != "" {
+			by = " as " + s.Agent
+		}
+		fmt.Fprintf(w, "deja: spawned from %s%s — `deja show %s`\n", digest.Short(s.Parent), by, digest.Short(s.Parent))
+	} else if s.Kind != "" {
+		// A kind with no parent is all the harness recorded; saying which
+		// session asked for it would be a guess.
+		fmt.Fprintf(w, "deja: %s session — the harness records no parent for it\n", s.Kind)
+	}
+	children, err := ChildrenOfSession(dir, s.ID)
+	if err != nil || len(children) == 0 {
+		return
+	}
+	ids := make([]string, 0, len(children))
+	for _, c := range children {
+		ids = append(ids, digest.Short(c.ID))
+	}
+	fmt.Fprintf(w, "deja: spawned %d session%s: %s\n", len(ids), pluralS(len(ids)), strings.Join(ids, ", "))
+}
+
+// ChildrenOfSession is a thin seam so the surface can be tested without an
+// index on disk.
+var ChildrenOfSession = index.ChildrenOf
 
 // bucketDayNote explains a note bucket's date when the records inside it fall
 // on a different local day than the id claims — and stays silent otherwise, so

--- a/cmd/deja/spawn_show_test.go
+++ b/cmd/deja/spawn_show_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// After a hit on a subagent's session, the line that matters is which session
+// asked for it; after a hit on the parent, which sessions it spawned (#1385).
+func TestShowNamesTheSessionsAroundASpawn(t *testing.T) {
+	old := ChildrenOfSession
+	t.Cleanup(func() { ChildrenOfSession = old })
+	ChildrenOfSession = func(dir, id string) ([]model.Session, error) {
+		if id != "01a00a65-7a72-7102-9574-0de51ab0d0ee" {
+			return nil, nil
+		}
+		return []model.Session{{ID: "01a00a65-child-one"}, {ID: "01a00a65-child-two"}}, nil
+	}
+
+	var w bytes.Buffer
+	printSpawnEdges(&w, "", model.Session{
+		ID:     "01a00a65-child-one",
+		Kind:   "subagent_fork",
+		Parent: "01a00a65-7a72-7102-9574-0de51ab0d0ee",
+		Agent:  "general-purpose",
+	})
+	got := w.String()
+	if !strings.Contains(got, "spawned from 01a00a65") || !strings.Contains(got, "general-purpose") {
+		t.Errorf("the child does not name what asked for it:\n%s", got)
+	}
+
+	w.Reset()
+	printSpawnEdges(&w, "", model.Session{ID: "01a00a65-7a72-7102-9574-0de51ab0d0ee"})
+	got = w.String()
+	if !strings.Contains(got, "spawned 2 sessions") {
+		t.Errorf("the parent does not list its children:\n%s", got)
+	}
+
+	// A subagent whose harness recorded no parent gets a line about what it is
+	// and no guess about who started it.
+	w.Reset()
+	printSpawnEdges(&w, "", model.Session{ID: "01a00a65-orphan", Kind: "subagent"})
+	got = w.String()
+	if !strings.Contains(got, "records no parent") {
+		t.Errorf("an orphan subagent says nothing about itself:\n%s", got)
+	}
+	if strings.Contains(got, "spawned from") {
+		t.Errorf("an edge was invented:\n%s", got)
+	}
+
+	// An ordinary session gains no line at all.
+	w.Reset()
+	printSpawnEdges(&w, "", model.Session{ID: "plain-session"})
+	if w.Len() != 0 {
+		t.Errorf("a session nobody spawned still printed:\n%s", w.String())
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -146,6 +146,9 @@ when empty:
 | `lifecycle` | state of an imported promoted note: `accepted`, `rejected`, `superseded` or `stale` |
 | `lifecycle_note` | the note left with that state |
 | `lifecycle_at` | when that state was set |
+| `kind` | the harness's own word for a session an agent spawned (`subagent`, `subagent_fork`); absent for sessions a person started |
+| `parent` | the session this one was spawned from, where the harness records the edge itself — deja never infers one |
+| `agent` | name of the agent that ran a spawned session |
 
 `messages` is likewise absent rather than empty on `last`, which never returns
 turns.

--- a/docs/registry/grok.html
+++ b/docs/registry/grok.html
@@ -51,6 +51,14 @@
 <pre><code class="language-json">{&#34;timestamp&#34;:1784278802,&#34;params&#34;:{&#34;update&#34;:{&#34;sessionUpdate&#34;:&#34;agent_message_chunk&#34;,&#34;content&#34;:{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;The first chunk &#34;}},&#34;_meta&#34;:{&#34;promptId&#34;:&#34;prompt-1&#34;}}}</code></pre>
 <p><code>user_message_chunk</code> maps to <code>user</code> and <code>agent_message_chunk</code> maps to <code>assistant</code>. Content is usually <code>{ &#34;type&#34;: &#34;text&#34;, &#34;text&#34;: &#34;...&#34; }</code>; arrays of text-bearing parts are also accepted. Timestamps accept Unix seconds or milliseconds. <code>_meta.agentTimestampMs</code> is the fallback.</p>
 <p>Consecutive assistant chunks with the same <code>promptId</code> are joined. Consecutive user chunks with the same <code>promptIndex</code> are joined.</p>
+<h2 id="spawn-tree">Spawn tree</h2>
+<p><code>summary.json</code> records what a session is and where it came from:</p>
+<p><code>session_kind</code> (<code>subagent</code>, <code>subagent_fork</code>), <code>parent_session_id</code>, <code>agent_name</code></p>
+<p>and <code>forked_at</code>. deja reads the first three into the session record — they show</p>
+<p>up in <code>--json</code> as <code>kind</code>, <code>parent</code> and <code>agent</code>, and <code>deja show</code> names the</p>
+<p>session a child was spawned from and the children a parent spawned. A</p>
+<p><code>subagent</code> with no <code>parent_session_id</code> keeps its kind and no edge: which</p>
+<p>session asked for it is not written down, and deja does not guess.</p>
 <h2 id="known-quirks-and-drift">Known quirks and drift</h2>
 <ul>
 <li>The ACP stream contains large tool updates. deja filters lines for message chunk kinds before decoding JSON.</li>

--- a/docs/registry/grok.md
+++ b/docs/registry/grok.md
@@ -27,6 +27,16 @@ global `deja install` cannot wire it. Run `grok mcp add deja --command deja
 
 Consecutive assistant chunks with the same `promptId` are joined. Consecutive user chunks with the same `promptIndex` are joined.
 
+## Spawn tree
+
+`summary.json` records what a session is and where it came from:
+`session_kind` (`subagent`, `subagent_fork`), `parent_session_id`, `agent_name`
+and `forked_at`. deja reads the first three into the session record — they show
+up in `--json` as `kind`, `parent` and `agent`, and `deja show` names the
+session a child was spawned from and the children a parent spawned. A
+`subagent` with no `parent_session_id` keeps its kind and no edge: which
+session asked for it is not written down, and deja does not guess.
+
 ## Known quirks and drift
 
 - The ACP stream contains large tool updates. deja filters lines for message chunk kinds before decoding JSON.

--- a/internal/index/grok_spawn_test.go
+++ b/internal/index/grok_spawn_test.go
@@ -1,0 +1,81 @@
+package index
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// Grok Build writes the spawn edge into summary.json itself. deja treated every
+// directory as an unrelated session, so after a hit on the parent there was no
+// way to reach the child that did the work, and after a hit on the child no way
+// to name what asked for it (#1385). Fixture fields are the ones the report
+// quoted from a real store.
+func TestGrokSpawnEdgeSurvivesTheIndex(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	t.Setenv("DEJA_GROK_ROOT", filepath.Join(tmp, "grok"))
+
+	root := filepath.Join(tmp, "grok", "sessions", url.PathEscape("/work/spawn"))
+	write := func(id, summary, text string) {
+		t.Helper()
+		dir := filepath.Join(root, id)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "summary.json"), []byte(summary), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		line := `{"timestamp":1785000001,"params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"` + text + `"},"_meta":{"promptIndex":0}}}}` + "\n"
+		if err := os.WriteFile(filepath.Join(dir, "updates.jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("01a00a65-parent", `{"info":{"id":"01a00a65-parent"},"generated_title":"Parent run","created_at":"2026-08-16T21:30:00Z","updated_at":"2026-08-16T21:30:01Z"}`, "spawnparentneedle the plan")
+	write("01a00a65-child", `{"info":{"id":"01a00a65-child"},"generated_title":"Child run","created_at":"2026-08-16T21:31:19Z","updated_at":"2026-08-16T21:31:20Z","session_kind":"subagent_fork","parent_session_id":"01a00a65-parent","agent_name":"general-purpose","forked_at":"2026-08-16T21:31:19.371006700Z"}`, "spawnchildneedle the actual work")
+	// A plain subagent records no parent. deja must keep it searchable and say
+	// nothing about who spawned it.
+	write("01a00a65-orphan", `{"info":{"id":"01a00a65-orphan"},"generated_title":"Sibling run","created_at":"2026-08-16T21:32:00Z","updated_at":"2026-08-16T21:32:01Z","session_kind":"subagent"}`, "spawnorphanneedle a sibling")
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := EnsureForSearch(dir, search.Options{Query: "spawnchildneedle", Harness: "grok"}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	child, ok, err := FindByID(dir, "01a00a65-child")
+	if err != nil || !ok {
+		t.Fatalf("child missing: ok=%v err=%v", ok, err)
+	}
+	if child.Parent != "01a00a65-parent" || child.Kind != "subagent_fork" || child.Agent != "general-purpose" {
+		t.Errorf("spawn fields lost in the index: kind=%q parent=%q agent=%q", child.Kind, child.Parent, child.Agent)
+	}
+
+	kids, err := ChildrenOf(dir, "01a00a65-parent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(kids) != 1 || kids[0].ID != "01a00a65-child" {
+		t.Fatalf("children of the parent: %#v", kids)
+	}
+
+	orphan, ok, err := FindByID(dir, "01a00a65-orphan")
+	if err != nil || !ok {
+		t.Fatalf("orphan missing: ok=%v err=%v", ok, err)
+	}
+	if orphan.Kind != "subagent" {
+		t.Errorf("kind = %q, want the harness's own word", orphan.Kind)
+	}
+	if orphan.Parent != "" {
+		t.Errorf("parent = %q — deja invented an edge the harness did not record", orphan.Parent)
+	}
+	if kids, err := ChildrenOf(dir, "01a00a65-child"); err != nil || len(kids) != 0 {
+		t.Errorf("a leaf reported children: %#v err=%v", kids, err)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -159,6 +159,14 @@ type SessionMeta struct {
 	// silently stopped applying (#975). Additive: older manifests decode with
 	// it empty.
 	OrigID string `json:",omitempty"`
+	// Kind, Parent and Agent describe a session an agent spawned: the
+	// harness's own word for it, the session it was forked from, and the agent
+	// that ran it. Only filled where the harness writes the edge itself.
+	// Additive: an older manifest decodes with them empty and every surface
+	// says what it said before.
+	Kind   string `json:",omitempty"`
+	Parent string `json:",omitempty"`
+	Agent  string `json:",omitempty"`
 	// From is the machine this session was worked on. Every imported session
 	// read as "from elsewhere" and nothing more, so with three machines
 	// exchanging history there was no way to ask what the server did, and no

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1090,6 +1090,7 @@ func metaForSession(s model.Session) SessionMeta {
 		last = messageFingerprint(s.Messages[len(s.Messages)-1])
 	}
 	return SessionMeta{ID: s.ID, Harness: s.Harness, Project: s.Project, Path: s.Path, Title: title, AgentTitle: agentTitle, Started: s.Started, Updated: s.Updated, Touched: touched, TouchHits: touchHits, Counted: len(s.Messages), LastMsg: last, Asked: askedHashes(s.Messages), Hit: frictionHashes(s.Messages), GaveUp: gaveUp(s.Messages), Words: sessionWords(s.Messages),
+		Kind: s.Kind, Parent: s.Parent, Agent: s.Agent,
 		OrigID: s.OrigID, From: s.From, Lifecycle: s.Lifecycle, LifecycleNote: s.LifecycleNote, LifecycleAt: s.LifecycleAt}
 }
 
@@ -1508,6 +1509,7 @@ func sessionFromMeta(meta SessionMeta) model.Session {
 		Title: meta.Title, AgentTitle: meta.AgentTitle, Started: meta.Started, Updated: meta.Updated, Touched: meta.Touched,
 		GaveUp: meta.GaveUp,
 		Words:  meta.Words,
+		Kind:   meta.Kind, Parent: meta.Parent, Agent: meta.Agent,
 		OrigID: meta.OrigID, From: meta.From, Lifecycle: meta.Lifecycle, LifecycleNote: meta.LifecycleNote, LifecycleAt: meta.LifecycleAt,
 	}
 }

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1574,6 +1574,30 @@ func FindManyByIdentity(dir string, ids []Identity) ([]model.Session, error) {
 	return sessionsForMetas(dir, metas)
 }
 
+// ChildrenOf lists the sessions an agent spawned from this one, newest first.
+// Only the harnesses that record the edge themselves produce any: deja does
+// not guess a parent from timing or naming (#1385).
+func ChildrenOf(dir, id string) ([]model.Session, error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	if id == "" {
+		return nil, nil
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []model.Session
+	for _, meta := range m.Sessions {
+		if meta.Parent == id {
+			out = append(out, sessionFromMeta(meta))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Updated.After(out[j].Updated) })
+	return out, nil
+}
+
 // FindByID looks a session up when only its id is known. Hook payloads carry
 // one without naming the harness, and the id is unique in practice: the
 // harnesses that generate them use uuids or their own prefixed ids.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -56,6 +56,14 @@ type Session struct {
 	Lifecycle     string `json:"lifecycle,omitempty"`
 	LifecycleNote string `json:"lifecycle_note,omitempty"`
 	LifecycleAt   string `json:"lifecycle_at,omitempty"`
+	// Kind, Parent and Agent describe a session an agent spawned rather than a
+	// person: the harness's own word for it ("subagent", "subagent_fork"), the
+	// session it was forked from when the harness records one, and the name of
+	// the agent that ran it. Only harnesses that write the edge themselves fill
+	// these — deja does not infer a parent from timing or naming (#1385).
+	Kind   string `json:"kind,omitempty"`
+	Parent string `json:"parent,omitempty"`
+	Agent  string `json:"agent,omitempty"`
 }
 
 // Source identifies where a session entered this deja index. Instance is an

--- a/internal/sources/grok.go
+++ b/internal/sources/grok.go
@@ -53,6 +53,12 @@ type grokSummary struct {
 	GeneratedTitle string `json:"generated_title"`
 	CreatedAt      string `json:"created_at"`
 	UpdatedAt      string `json:"updated_at"`
+	// Grok Build records the spawn edge itself: a forked child names the
+	// session it came from, a plain subagent says only what it is. deja reads
+	// what is written and invents nothing (#1385).
+	SessionKind     string `json:"session_kind"`
+	ParentSessionID string `json:"parent_session_id"`
+	AgentName       string `json:"agent_name"`
 }
 
 func ParseGrokFile(path string) ([]model.Session, error) {
@@ -82,7 +88,8 @@ func parseGrokFileFromOffset(path string, offset int64) ([]model.Session, error)
 	if title == "" {
 		title = doc.SessionSummary
 	}
-	s := model.Session{ID: id, Harness: "grok", Project: projectName(cwd), Path: path, Title: title}
+	s := model.Session{ID: id, Harness: "grok", Project: projectName(cwd), Path: path, Title: title,
+		Kind: doc.SessionKind, Parent: doc.ParentSessionID, Agent: doc.AgentName}
 	if t, err := time.Parse(time.RFC3339Nano, doc.CreatedAt); err == nil {
 		s.Touch(t)
 	}


### PR DESCRIPTION
Closes #1385.

Grok Build already writes the edge into `summary.json` — `session_kind`, `parent_session_id`, `agent_name` — and deja treated every session directory as unrelated. Now those land in the session record: `--json` carries `kind`, `parent` and `agent`, and `deja show` names the session a child was forked from and the sessions a parent spawned.

A `subagent` with no `parent_session_id` keeps its kind and gains no edge — which session asked for it is not written down, and guessing from timing or naming would be worse than saying nothing.

Manifest fields are additive, so an index built before this decodes with them empty and every surface prints what it printed before. Tested against a fixture built from the exact JSON in the report — the Grok store on my machine is empty, so this part is not live-verified.