### PR TITLE
A Claude sidechain is the subagent's own session

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -461,11 +461,18 @@ func printSpawnEdges(w io.Writer, dir string, s model.Session) {
 	if err != nil || len(children) == 0 {
 		return
 	}
-	ids := make([]string, 0, len(children))
-	for _, c := range children {
+	// A long session spawns a hundred agents; naming them all buries the line
+	// that says how many there were.
+	const named = 3
+	ids := make([]string, 0, named)
+	for _, c := range children[:min(named, len(children))] {
 		ids = append(ids, digest.Short(c.ID))
 	}
-	fmt.Fprintf(w, "deja: spawned %d session%s: %s\n", len(ids), pluralS(len(ids)), strings.Join(ids, ", "))
+	rest := ""
+	if len(children) > len(ids) {
+		rest = fmt.Sprintf(" and %d more", len(children)-len(ids))
+	}
+	fmt.Fprintf(w, "deja: spawned %d session%s: %s%s\n", len(children), pluralS(len(children)), strings.Join(ids, ", "), rest)
 }
 
 // ChildrenOfSession is a thin seam so the surface can be tested without an

--- a/cmd/deja/skill_cli.go
+++ b/cmd/deja/skill_cli.go
@@ -49,6 +49,7 @@ When recalled history genuinely helps — a reused fix, a skipped re-debug, even
 
 - Result windows are bounded. Do not report corpus-wide counts, or claim a complete audit, from the number of hits you got back.
 - If ` + "`deja`" + ` is not on PATH or the index is empty, say that history search is unavailable. Do not invent what it might have found.
+- Work a subagent did is not in the index by default. A Claude Task or a Cursor subagent writes its turns and tool calls to its own transcript, and the parent session keeps only the launch and a summary of what came back — so a hit on the parent can look complete while the actual run is missing. ` + "`DEJA_INCLUDE_SUBAGENTS=1`" + ` takes those transcripts in, as sessions of their own.
 - Vary the wording and try a second query before concluding nothing is there. Exact tokens match best, so an error string beats a paraphrase of it.`
 
 // cliSkillPath is the cross-agent skills directory, the same one the MCP skill

--- a/cmd/deja/spawn_show_test.go
+++ b/cmd/deja/spawn_show_test.go
@@ -39,6 +39,29 @@ func TestShowNamesTheSessionsAroundASpawn(t *testing.T) {
 		t.Errorf("the parent does not list its children:\n%s", got)
 	}
 
+	// One long session spawns a hundred agents. Naming every child buries the
+	// count, which is the part a reader can act on.
+	many := make([]model.Session, 0, 161)
+	for i := 0; i < 161; i++ {
+		many = append(many, model.Session{ID: "aa" + strings.Repeat("b", 8) + string(rune('a'+i%26))})
+	}
+	ChildrenOfSession = func(dir, id string) ([]model.Session, error) { return many, nil }
+	w.Reset()
+	printSpawnEdges(&w, "", model.Session{ID: "busy-parent"})
+	got = w.String()
+	if !strings.Contains(got, "spawned 161 sessions") || !strings.Contains(got, "and 158 more") {
+		t.Errorf("the children line is not summarised:\n%s", got)
+	}
+	if len(got) > 200 {
+		t.Errorf("the children line is %d characters long:\n%s", len(got), got)
+	}
+	ChildrenOfSession = func(dir, id string) ([]model.Session, error) {
+		if id != "01a00a65-7a72-7102-9574-0de51ab0d0ee" {
+			return nil, nil
+		}
+		return []model.Session{{ID: "01a00a65-child-one"}, {ID: "01a00a65-child-two"}}, nil
+	}
+
 	// A subagent whose harness recorded no parent gets a line about what it is
 	// and no guess about who started it.
 	w.Reset()

--- a/docs/registry/claude-code.html
+++ b/docs/registry/claude-code.html
@@ -38,6 +38,15 @@
 <h1>Claude Code session format</h1>
 <h2 id="store-and-files">Store and files</h2>
 <p>Claude Code writes transcripts below <code>${CLAUDE_CONFIG_DIR:-~/.claude}/projects/</code>. deja can point only session reads elsewhere with <code>DEJA_CLAUDE_ROOT</code>. Files are JSONL and normally named for a session ID. A project directory encodes an absolute path by replacing both separators and literal hyphens with <code>-</code>; nested <code>subagents/*.jsonl</code> files are excluded unless <code>DEJA_INCLUDE_SUBAGENTS=1</code>.</p>
+<p>A subagent&#39;s transcript is not a copy of its parent. The parent keeps the launch,</p>
+<p>the <code>agentId</code> and a summary of what came back; the child&#39;s own turns and tool</p>
+<p>stream exist only in the sidechain file, where every line carries</p>
+<p><code>isSidechain: true</code>, the parent&#39;s <code>sessionId</code>, its own <code>agentId</code> and an</p>
+<p><code>attributionAgent</code> naming which agent ran. The default skip is about index size,</p>
+<p>not about the work being there twice — with the env var set, deja indexes each</p>
+<p>sidechain as its own session keyed by <code>agentId</code>, with the parent recorded as its</p>
+<p><code>parent</code> (#1384). Keying on <code>sessionId</code>, which the child repeats, folded the two</p>
+<p>together and one of them won.</p>
 <p>The top-level <code>~/.claude.json</code> is not a transcript. When <code>CLAUDE_CONFIG_DIR</code> is set, Claude moves that file to <code>$CLAUDE_CONFIG_DIR/.claude.json</code>.</p>
 <h2 id="records">Records</h2>
 <p>Message records have <code>type</code>, <code>sessionId</code>, <code>timestamp</code>, and a <code>message</code> object. <code>message.content</code> is either a string or an array whose useful parts have <code>text</code> or <code>content</code>.</p>

--- a/docs/registry/claude-code.md
+++ b/docs/registry/claude-code.md
@@ -4,6 +4,16 @@
 
 Claude Code writes transcripts below `${CLAUDE_CONFIG_DIR:-~/.claude}/projects/`. deja can point only session reads elsewhere with `DEJA_CLAUDE_ROOT`. Files are JSONL and normally named for a session ID. A project directory encodes an absolute path by replacing both separators and literal hyphens with `-`; nested `subagents/*.jsonl` files are excluded unless `DEJA_INCLUDE_SUBAGENTS=1`.
 
+A subagent's transcript is not a copy of its parent. The parent keeps the launch,
+the `agentId` and a summary of what came back; the child's own turns and tool
+stream exist only in the sidechain file, where every line carries
+`isSidechain: true`, the parent's `sessionId`, its own `agentId` and an
+`attributionAgent` naming which agent ran. The default skip is about index size,
+not about the work being there twice — with the env var set, deja indexes each
+sidechain as its own session keyed by `agentId`, with the parent recorded as its
+`parent` (#1384). Keying on `sessionId`, which the child repeats, folded the two
+together and one of them won.
+
 The top-level `~/.claude.json` is not a transcript. When `CLAUDE_CONFIG_DIR` is set, Claude moves that file to `$CLAUDE_CONFIG_DIR/.claude.json`.
 
 ## Records

--- a/docs/registry/cursor.html
+++ b/docs/registry/cursor.html
@@ -38,7 +38,11 @@
 <h1>Cursor session format</h1>
 <h2 id="stores-and-files">Stores and files</h2>
 <p>Cursor IDE stores chats in <code>state.vscdb</code> under <code>globalStorage/</code> and <code>workspaceStorage/*/</code>. The user root is <code>~/Library/Application Support/Cursor/User</code> on macOS and <code>~/.config/Cursor/User</code> on other systems; an existing <code>$XDG_CONFIG_HOME/Cursor/User</code> is used when available. <code>DEJA_CURSOR_ROOT</code> overrides IDE discovery.</p>
-<p>Cursor CLI writes <code>projects/&lt;encoded-path&gt;/agent-transcripts/**/*.jsonl</code> below <code>${CURSOR_CONFIG_DIR:-~/.cursor}</code>. <code>DEJA_CURSOR_CLI_ROOT</code> overrides transcript reads. Subagent transcripts are excluded unless <code>DEJA_INCLUDE_SUBAGENTS=1</code>.</p>
+<p>Cursor CLI writes <code>projects/&lt;encoded-path&gt;/agent-transcripts/**/*.jsonl</code> below <code>${CURSOR_CONFIG_DIR:-~/.cursor}</code>. <code>DEJA_CURSOR_CLI_ROOT</code> overrides transcript reads. Subagent transcripts are excluded unless <code>DEJA_INCLUDE_SUBAGENTS=1</code> — for index</p>
+<p>size, not because the parent already holds that work. Unlike Claude&#39;s sidechain</p>
+<p>files, Cursor&#39;s have not been read here: what the parent keeps and what only the</p>
+<p>child has is unverified for this harness, so deja indexes them as it finds them</p>
+<p>rather than deriving an edge it has not seen.</p>
 <h2 id="ide-sqlite-records">IDE SQLite records</h2>
 <p>The <code>cursorDiskKV(key, value)</code> table has session values at <code>composerData:&lt;id&gt;</code> and message values at <code>bubbleId:&lt;composer-id&gt;:&lt;bubble-id&gt;</code>.</p>
 <pre><code class="language-json">{&#34;composerId&#34;:&#34;composer-7&#34;,&#34;name&#34;:&#34;Fix cache invalidation&#34;,&#34;createdAt&#34;:1784278800000,&#34;lastUpdatedAt&#34;:1784278802000}

--- a/docs/registry/cursor.md
+++ b/docs/registry/cursor.md
@@ -4,7 +4,11 @@
 
 Cursor IDE stores chats in `state.vscdb` under `globalStorage/` and `workspaceStorage/*/`. The user root is `~/Library/Application Support/Cursor/User` on macOS and `~/.config/Cursor/User` on other systems; an existing `$XDG_CONFIG_HOME/Cursor/User` is used when available. `DEJA_CURSOR_ROOT` overrides IDE discovery.
 
-Cursor CLI writes `projects/<encoded-path>/agent-transcripts/**/*.jsonl` below `${CURSOR_CONFIG_DIR:-~/.cursor}`. `DEJA_CURSOR_CLI_ROOT` overrides transcript reads. Subagent transcripts are excluded unless `DEJA_INCLUDE_SUBAGENTS=1`.
+Cursor CLI writes `projects/<encoded-path>/agent-transcripts/**/*.jsonl` below `${CURSOR_CONFIG_DIR:-~/.cursor}`. `DEJA_CURSOR_CLI_ROOT` overrides transcript reads. Subagent transcripts are excluded unless `DEJA_INCLUDE_SUBAGENTS=1` — for index
+size, not because the parent already holds that work. Unlike Claude's sidechain
+files, Cursor's have not been read here: what the parent keeps and what only the
+child has is unverified for this harness, so deja indexes them as it finds them
+rather than deriving an edge it has not seen.
 
 ## IDE SQLite records
 

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -41,8 +41,11 @@ func ClaudeFiles() []string {
 }
 
 // ClaudeFileWanted reports whether a path under the Claude root belongs in
-// the index. Subagent transcripts mostly duplicate their parent session, so
-// they are skipped unless DEJA_INCLUDE_SUBAGENTS=1.
+// the index. A subagent's transcript is not a copy of its parent: the parent
+// keeps the launch, the agent id and a summary of what came back, while the
+// turns and the tool stream live only in the child file. They are skipped for
+// index size, not because the work is already there — DEJA_INCLUDE_SUBAGENTS=1
+// takes them in, as their own sessions (#1384).
 func ClaudeFileWanted(p string) bool {
 	if !strings.HasSuffix(p, ".jsonl") {
 		return false
@@ -75,7 +78,16 @@ func parseClaudeGenericFromOffset(path string, offset int64) ([]model.Session, e
 		if typ != "user" && typ != "assistant" {
 			return
 		}
-		if id, _ := m["sessionId"].(string); id != "" {
+		side, _ := m["isSidechain"].(bool)
+		agent, _ := m["agentId"].(string)
+		if side && agent != "" {
+			s.ID = agent
+			s.Kind = "sidechain"
+			s.Parent, _ = m["sessionId"].(string)
+			if name, _ := m["attributionAgent"].(string); name != "" {
+				s.Agent = name
+			}
+		} else if id, _ := m["sessionId"].(string); id != "" {
 			s.ID = id
 		}
 		t := parseTimeAny(m["timestamp"])

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -34,6 +34,13 @@ type claudeLine struct {
 	SessionID string          `json:"sessionId"`
 	Timestamp json.RawMessage `json:"timestamp"`
 	Message   *claudeMessage  `json:"message"`
+	// A sidechain file is a subagent's own run. Every line in it repeats the
+	// parent's sessionId, so keying on that folded the child's work into the
+	// parent and one of the two won (#1384). agentId is what identifies the
+	// child, and attributionAgent names which agent it was.
+	IsSidechain      bool   `json:"isSidechain"`
+	AgentID          string `json:"agentId"`
+	AttributionAgent string `json:"attributionAgent"`
 }
 
 type claudeMessage struct {
@@ -57,7 +64,16 @@ func parseClaudeTypedFromOffset(path string, offset int64) ([]model.Session, err
 		if v.Type != "user" && v.Type != "assistant" {
 			return
 		}
-		if v.SessionID != "" {
+		if v.IsSidechain && v.AgentID != "" {
+			// The child is its own session, spawned by the parent whose id
+			// every one of these lines carries.
+			s.ID = v.AgentID
+			s.Kind = "sidechain"
+			s.Parent = v.SessionID
+			if v.AttributionAgent != "" {
+				s.Agent = v.AttributionAgent
+			}
+		} else if v.SessionID != "" {
 			s.ID = v.SessionID
 		}
 		t := claudeTime(v.Timestamp)

--- a/internal/sources/claude_sidechain_test.go
+++ b/internal/sources/claude_sidechain_test.go
@@ -1,0 +1,75 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Every line of a sidechain file repeats the parent's sessionId, so keying on
+// it folded a subagent's whole run into the parent and one of the two won. The
+// durable id is agentId (#1384). Fixture fields are the ones a real Claude
+// Code 2.1.226 sidechain carries.
+func TestClaudeSidechainIsItsOwnSession(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	t.Setenv("DEJA_INCLUDE_SUBAGENTS", "1")
+
+	parentID := "2915986c-9f79-4f59-aed1-6cb929ca62b8"
+	dir := filepath.Join(root, "-work-app", parentID, "subagents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "agent-a768d0f31f74ee0f2.jsonl")
+	line := func(role, text string) string {
+		return `{"type":"` + role + `","isSidechain":true,"agentId":"a768d0f31f74ee0f2","attributionAgent":"caveman:cavecrew-reviewer","sessionId":"` + parentID + `","timestamp":"2026-08-18T15:29:17.173Z","cwd":"/work/app","message":{"role":"` + role + `","content":"` + text + `"}}` + "\n"
+	}
+	if err := os.WriteFile(path, []byte(line("user", "review the diff")+line("assistant", "two findings")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ss, err := ParseClaudeFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d", len(ss))
+	}
+	s := ss[0]
+	if s.ID != "a768d0f31f74ee0f2" {
+		t.Errorf("id = %q — the child took the parent's id and the two collide", s.ID)
+	}
+	if s.Parent != parentID {
+		t.Errorf("parent = %q, want the session that launched it", s.Parent)
+	}
+	if s.Kind != "sidechain" || s.Agent != "caveman:cavecrew-reviewer" {
+		t.Errorf("kind = %q agent = %q", s.Kind, s.Agent)
+	}
+	if len(s.Messages) != 2 {
+		t.Errorf("the child's turns did not survive: %#v", s.Messages)
+	}
+
+	// The generic parser is the reference the typed one is proved against, so
+	// it has to read the same file the same way.
+	ref, err := parseClaudeGenericFromOffset(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ref) != 1 || ref[0].ID != s.ID || ref[0].Parent != s.Parent || ref[0].Kind != s.Kind || ref[0].Agent != s.Agent {
+		t.Errorf("reference parser disagrees: %#v", ref)
+	}
+
+	// A parent transcript is untouched: no kind, no parent, its own id.
+	top := filepath.Join(root, "-work-app", parentID+".jsonl")
+	plain := `{"type":"user","sessionId":"` + parentID + `","timestamp":"2026-08-18T15:00:00.000Z","cwd":"/work/app","message":{"role":"user","content":"launch a reviewer"}}` + "\n"
+	if err := os.WriteFile(top, []byte(plain), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ps, err := ParseClaudeFile(top)
+	if err != nil || len(ps) != 1 {
+		t.Fatalf("parent: %#v err=%v", ps, err)
+	}
+	if ps[0].ID != parentID || ps[0].Kind != "" || ps[0].Parent != "" {
+		t.Errorf("an ordinary session was marked as spawned: %#v", ps[0])
+	}
+}

--- a/skills/deja-search/SKILL.md
+++ b/skills/deja-search/SKILL.md
@@ -36,4 +36,5 @@ When recalled history genuinely helps — a reused fix, a skipped re-debug, even
 
 - Result windows are bounded. Do not report corpus-wide counts, or claim a complete audit, from the number of hits you got back.
 - If `deja` is not on PATH or the index is empty, say that history search is unavailable. Do not invent what it might have found.
+- Work a subagent did is not in the index by default. A Claude Task or a Cursor subagent writes its turns and tool calls to its own transcript, and the parent session keeps only the launch and a summary of what came back — so a hit on the parent can look complete while the actual run is missing. `DEJA_INCLUDE_SUBAGENTS=1` takes those transcripts in, as sessions of their own.
 - Vary the wording and try a second query before concluding nothing is there. Exact tokens match best, so an error string beats a paraphrase of it.


### PR DESCRIPTION
Closes #1384.

The registry called subagent transcripts duplicates of the parent. On a real store they are not: the parent keeps the launch, the `agentId` and a summary of what came back, while the child's turns and tool stream exist only in the sidechain file. Checked here — 346 of them on this machine, every line carrying `isSidechain: true`, the parent's `sessionId`, its own `agentId` and an `attributionAgent`.

Three things change:

- With `DEJA_INCLUDE_SUBAGENTS=1` a sidechain is indexed as its own session keyed by `agentId`, with the parent as its `parent` and the agent name as `agent`. Keying on `sessionId`, which the child repeats, folded the two together. `deja show` then names the parent from a child and the children from a parent (capped — one session here spawned 161).
- The default skip stays, and now says what it costs: index size, not work that is already there.
- The CLI-only skill gains one line, because that path has no other way to learn it.

Cursor's own subagent files I have none of, so its wording says what is unverified rather than assuming Claude's shape.