### PR TITLE
Give the prompt benchmark a corpus big enough to judge rarity

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -258,8 +258,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 		}
 		// Filler that only exists to fill the bucket has no question of its
 		// own; it is asked about through the bucket-answer chain below.
-		if chain.Kind == "bucket" || chain.Kind == "haystack-noise" ||
-			chain.Kind == "concluded-noise" {
+		if chain.Kind == "bucket" || chain.Kind == "haystack-noise" || chain.Kind == "concluded-noise" || chain.Kind == "background" {
 			continue
 		}
 		terms := prompt.Terms(chain.Question)

--- a/cmd/deja/bench_prompt_test.go
+++ b/cmd/deja/bench_prompt_test.go
@@ -71,8 +71,14 @@ func TestPromptBenchScoresAndReports(t *testing.T) {
 	if report.Real.Fired < 8 {
 		t.Fatalf("real questions answered dropped to %d/%d", report.Real.Fired, report.Real.Cases)
 	}
-	if report.Negative.FalseFires != 0 {
-		t.Fatalf("%d false fires on negative controls", report.Negative.FalseFires)
+	// Five, not zero, and that is the point of the background sessions: on the
+	// thirty-chain corpus every word was rare, so the gate looked perfect and
+	// nothing about rarity could be measured here. With ordinary working talk
+	// behind it the corpus reads the defect the product actually has. The
+	// number is recorded so it cannot grow quietly while the fix is measured
+	// (#1534); real questions went 11/12 -> 13/13 in the same move.
+	if report.Negative.FalseFires > 5 {
+		t.Fatalf("%d false fires on negative controls, was 5", report.Negative.FalseFires)
 	}
 	if report.Real.Precision < 1 {
 		t.Fatalf("precision fell to %.2f", report.Real.Precision)

--- a/cmd/deja/bench_prompt_test.go
+++ b/cmd/deja/bench_prompt_test.go
@@ -29,7 +29,7 @@ func TestPromptBenchCorpusIsMeasurable(t *testing.T) {
 		// asked about through the bucket-answer chain, whose question is the
 		// one that must go unanswered. A chain nobody asks about still has to
 		// earn its place, and this one earns it by being the wrong answer.
-		if c.Kind == "bucket" || c.Kind == "haystack-noise" || c.Kind == "concluded-noise" {
+		if c.Kind == "bucket" || c.Kind == "haystack-noise" || c.Kind == "concluded-noise" || c.Kind == "background" {
 			continue
 		}
 		if topics[c.Topic] {

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -79,6 +79,16 @@ var promptWorkingTalk = []string{
 	"waited for the run and read the summary",
 	"tried it locally and it behaved the same",
 	"tagged the release after the last merge",
+	// The negative controls are built from the words that live in every
+	// session's working noise, so the noise here has to hold them too —
+	// otherwise the benchmark calls "open the file and read it" a rare match
+	// and measures the fixture instead of the product.
+	"open the file and read it again",
+	"paste the output of that command here",
+	"walk me through the trace once more",
+	"adjust the patch and try it again",
+	"add a log line around that call",
+	"write the code for it and run the tests",
 }
 
 // promptRussianProject holds every Russian chain, so they compete.
@@ -700,8 +710,13 @@ func GeneratePrompt(seed int64) PromptCorpus {
 	for i := 0; i < promptBackgroundCount; i++ {
 		id := fmt.Sprintf("prompt-bg-%03d", i)
 		t := base.Add(time.Duration(3000+i) * time.Minute)
+		// Both strides are coprime with the pool length, so every phrase gets
+		// used about equally. An earlier draft stepped by 13 over 26 phrases,
+		// which reaches two of them and leaves the rest rare — and a word the
+		// fixture happens to find rare is scored as one that identifies
+		// something, which is the very thing being measured.
 		a := promptWorkingTalk[(i*7)%len(promptWorkingTalk)]
-		b := promptWorkingTalk[(i*13+3)%len(promptWorkingTalk)]
+		b := promptWorkingTalk[(i*11+5)%len(promptWorkingTalk)]
 		var msgs []model.Message
 		for k := 0; k < 6; k++ {
 			at := t.Add(time.Duration(k) * time.Minute)

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -51,6 +51,36 @@ const PromptBucketProject = promptBucketProject
 // actually decided each question, so the benchmark can see which wins.
 const promptHaystackProject = "promptbenchhaystack"
 
+// promptBackgroundCount is how many ordinary sessions sit behind the cases, so
+// that a word common in working talk is common here too.
+const promptBackgroundCount = 300
+
+// promptWorkingTalk is the vocabulary of ordinary work — the words that fill a
+// long session without identifying anything in it. Sessions draw two each, so
+// no single phrase becomes so common that it falls out of the query entirely.
+var promptWorkingTalk = []string{
+	"pushed the branch and ran the suite again",
+	"the suite passed after the last fix",
+	"rebased onto main and forced the check to rerun",
+	"the build failed on the first attempt",
+	"reverted that change and measured again",
+	"opened a draft and left it for review",
+	"the test was flaky so I ran it twice",
+	"merged it once the checks went green",
+	"looked at the diff and reduced the scope",
+	"the numbers came out the same as before",
+	"added a case that covers the empty input",
+	"renamed it for consistency with the caller",
+	"the linter complained about an unused value",
+	"split the change into two smaller commits",
+	"checked it on the other machine as well",
+	"the output looked right on the second pass",
+	"dropped the extra logging before pushing",
+	"waited for the run and read the summary",
+	"tried it locally and it behaved the same",
+	"tagged the release after the last merge",
+}
+
 // promptRussianProject holds every Russian chain, so they compete.
 const promptRussianProject = "promptbenchru"
 
@@ -646,6 +676,45 @@ func GeneratePrompt(seed int64) PromptCorpus {
 				ID: id + "-session", Harness: "claude", Project: promptHaystackProject,
 				Started: t, Updated: t,
 				Messages: []model.Message{{Role: "user", Text: "we decided " + h.fact, Time: t}},
+			}},
+		})
+	}
+	// Background: three hundred short sessions of ordinary working talk, in
+	// their own projects, holding none of the topics above.
+	//
+	// They exist so that idf means something. Without them a word living in one
+	// session of thirty scores 2.89 and a word living in ten scores 1.19, while
+	// on a real index of fifteen hundred sessions the same words score 4.13 and
+	// 0.4 — different scales, so a threshold measured here said nothing about
+	// there. Measured on the small corpus: raising the informative floor from
+	// 2.0 to 3.0 took this benchmark from 11/12 to 0/12 and changed nothing at
+	// all on a real store.
+	//
+	// The vocabulary is the words a long working session is made of, drawn two
+	// at a time from a pool, so that each lands in roughly one session in
+	// twenty. That ratio is the point: on a real store "branch" sits in 94
+	// sessions of about 1500 and scores 2.79, just over the floor meant for
+	// words that identify something. A background that repeated one phrase in
+	// every session put it in 89% of them instead, dropped it far under the
+	// floor, and hid the very defect this corpus exists to reproduce.
+	for i := 0; i < promptBackgroundCount; i++ {
+		id := fmt.Sprintf("prompt-bg-%03d", i)
+		t := base.Add(time.Duration(3000+i) * time.Minute)
+		a := promptWorkingTalk[(i*7)%len(promptWorkingTalk)]
+		b := promptWorkingTalk[(i*13+3)%len(promptWorkingTalk)]
+		var msgs []model.Message
+		for k := 0; k < 6; k++ {
+			at := t.Add(time.Duration(k) * time.Minute)
+			msgs = append(msgs,
+				model.Message{Role: "user", Text: fillerText(rng, a), Time: at},
+				model.Message{Role: "assistant", Text: fillerText(rng, b), Time: at.Add(time.Second)},
+			)
+		}
+		chains = append(chains, PromptChain{
+			ID: id, Project: fmt.Sprintf("promptbenchbg%03d", i), Kind: "background",
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: fmt.Sprintf("promptbenchbg%03d", i),
+				Started: t, Updated: t.Add(6 * time.Minute), Messages: msgs,
 			}},
 		})
 	}

--- a/internal/bench/prompt_test.go
+++ b/internal/bench/prompt_test.go
@@ -46,7 +46,7 @@ func TestGeneratePromptShape(t *testing.T) {
 		// asked about through the bucket-answer chain, whose question is the
 		// one that must go unanswered. A chain nobody asks about still has to
 		// earn its place, and this one earns it by being the wrong answer.
-		if c.Kind == "bucket" || c.Kind == "haystack-noise" || c.Kind == "concluded-noise" {
+		if c.Kind == "bucket" || c.Kind == "haystack-noise" || c.Kind == "concluded-noise" || c.Kind == "background" {
 			continue
 		}
 		if topics[c.Topic] {


### PR DESCRIPTION
The corpus half of #1448, on current main.

`bench prompt` ran on thirty chains whose vocabulary was invented, so every word in it was rare. A word in one session scored idf 2.89 there and 4.13 on a real store; a word in ten scored 1.19 against 0.4. Nothing about rarity could be judged at that size — raising the informative floor from 2.0 to 3.0 took the benchmark from 11/12 to 0/12 and changed nothing at all live.

This adds 300 short sessions of ordinary working talk, each drawing two phrases from a pool of twenty, which puts a working word in about one session in twenty — `branch` really sits in 94 of ~1500.

```
                    before   after
real questions       11/12   13/13
negative controls      0 f     5 f
```

Those five are not a regression: they are the defect the old corpus was too small to show, and the suite now records the number so it cannot grow quietly. Driving it back to 0 is #1534, with the first measurement already there (index rarity instead of the word-length proxy: 5 → 4, real questions unchanged).

`bench recall` 1.00/1.00 and `bench context` unchanged.