### PR TITLE
Rarity: the rarer of the two verdicts wins

### DIFF
--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -333,4 +334,63 @@ func TestProjectRelevantDottedTermNeedsAllSubTokens(t *testing.T) {
 	if !found {
 		t.Fatalf("full-address session missing: got=%v matched=%v", len(got), matched)
 	}
+}
+
+// A subject word said once in each of four sessions is rarer than a working
+// word said forty times in each of three. Counting whole sessions says the
+// opposite — measured on a real store, "pgbouncer" scored 1.31 and "branch"
+// 1.50, because eleven marathon sessions hold 99% of everything ever said and
+// every one of them mentions the ordinary word.
+func TestRarityCountsMessagesNotWholeSessions(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	write := func(id string, lines []string) {
+		p := filepath.Join(claudeRoot, "-tmp-app")
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		var b strings.Builder
+		for _, text := range lines {
+			b.WriteString(`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n")
+		}
+		if err := os.WriteFile(filepath.Join(p, id+".jsonl"), []byte(b.String()), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 4; i++ {
+		write(fmt.Sprintf("subj%d", i), []string{"we put prepared statements behind pgbouncer today"})
+	}
+	for i := 0; i < 3; i++ {
+		var lines []string
+		for k := 0; k < 40; k++ {
+			lines = append(lines, fmt.Sprintf("pushed the branch again after fix %d", k))
+		}
+		write(fmt.Sprintf("work%d", i), lines)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	subj := termRarity(t, dir, "pgbouncer")
+	work := termRarity(t, dir, "branch")
+	if subj <= work {
+		t.Fatalf("pgbouncer scored %d, branch %d: the subject has to be the rarer of the two", subj, work)
+	}
+}
+
+// termRarity reports what the ranking thought one term was worth, scaled to an
+// integer so a comparison reads cleanly.
+func termRarity(t *testing.T, dir, term string) int {
+	t.Helper()
+	m, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rank, err := relevantMetasCounts(dir, m, []string{"app"}, []string{term}, 8, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return int(rank.idf[term] * 1000)
 }

--- a/internal/index/df_unit_test.go
+++ b/internal/index/df_unit_test.go
@@ -1,0 +1,149 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Rarity has two honest units and neither works alone. Counting whole sessions
+// calls a subject word common, because on a real store a handful of marathon
+// sessions hold most of everything and all of them mention it. Counting
+// messages, capped per session, fixes that and breaks the other direction: the
+// word one long session is *about* saturates that session and reads as filler —
+// which is what the name of the thing someone worked on all month looks like.
+//
+// So both are computed and the rarer verdict wins. This holds that: a word
+// living in one long session stays rare, and a word spread thinly across the
+// whole store does not become rare just because no single session repeats it.
+func TestRarityTakesTheRarerOfTheTwoVerdicts(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+
+	proj := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(sid, text string, at time.Time) string {
+		return fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":"/work/app","message":{"role":"user","content":%q}}`,
+			sid, at.UTC().Format(time.RFC3339), text) + "\n"
+	}
+	start := time.Now().Add(-72 * time.Hour)
+
+	// One marathon that is about quetzalcoatl and says it in every turn.
+	var marathon string
+	for i := 0; i < 300; i++ {
+		marathon += line("marathon", fmt.Sprintf("quetzalcoatl deploy step %d, checked the branch again", i), start.Add(time.Duration(i)*time.Minute))
+	}
+	if err := os.WriteFile(filepath.Join(proj, "marathon.jsonl"), []byte(marathon), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A hundred ordinary sessions, each saying "branch" once. Nothing repeats
+	// it, so a per-session cap never binds on it.
+	for i := 0; i < 100; i++ {
+		sid := fmt.Sprintf("ordinary-%d", i)
+		body := line(sid, fmt.Sprintf("looked at the branch and the tests for task %d", i), start.Add(time.Duration(i)*time.Hour))
+		if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, idfOf, err := ProjectRelevant(dir, []string{"app"}, []string{"quetzalcoatl", "branch"}, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subject, ordinary := idfOf["quetzalcoatl"], idfOf["branch"]
+	if subject <= ordinary {
+		t.Fatalf("the word one session is about scores %.2f, the word everywhere scores %.2f — the signal is inverted", subject, ordinary)
+	}
+	if subject < dejaVuStrongIDFFloor {
+		t.Errorf("a word living in a single session scores %.2f, below the strong floor %.2f — saturating one session made it read as filler",
+			subject, dejaVuStrongIDFFloor)
+	}
+	if ordinary >= dejaVuStrongIDFFloor {
+		t.Errorf("a word in a hundred sessions scores %.2f, at or above the strong floor %.2f", ordinary, dejaVuStrongIDFFloor)
+	}
+}
+
+// The other direction, which is the shape a real store has: a handful of
+// marathon sessions hold most of the text, an ordinary word fills them, and a
+// subject word is mentioned a few times in slightly more of them. Counting
+// sessions then says the subject is the commoner of the two — measured on a
+// real store, pgbouncer in 16 sessions scored 1.31 while branch in 13 scored
+// 1.50, the most specific word in the store ranking below the most ordinary
+// one.
+func TestRarityIsNotInvertedByMarathonSessions(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+
+	proj := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now().Add(-200 * time.Hour)
+	say := func(sid, text string, i int) string {
+		return fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":"/work/app","message":{"role":"user","content":%q}}`,
+			sid, start.Add(time.Duration(i)*time.Minute).UTC().Format(time.RFC3339), text) + "\n"
+	}
+
+	// Thirteen marathons that say "branch" all day long.
+	for s := 0; s < 13; s++ {
+		sid := fmt.Sprintf("marathon-%d", s)
+		body := ""
+		for i := 0; i < 200; i++ {
+			body += say(sid, fmt.Sprintf("branch work, run %d", i), s*300+i)
+		}
+		if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Sixteen sessions mention "pgbouncer" three times each — more sessions
+	// than "branch" lives in, a fraction of the messages.
+	for s := 0; s < 16; s++ {
+		sid := fmt.Sprintf("touched-%d", s)
+		body := ""
+		for i := 0; i < 3; i++ {
+			body += say(sid, fmt.Sprintf("pgbouncer pool question %d", i), 5000+s*10+i)
+		}
+		if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, idfOf, err := ProjectRelevant(dir, []string{"app"}, []string{"pgbouncer", "branch"}, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subject, ordinary := idfOf["pgbouncer"], idfOf["branch"]
+	if subject <= ordinary {
+		t.Fatalf("the subject scores %.2f and the word filling every marathon scores %.2f — counting whole sessions inverts the signal",
+			subject, ordinary)
+	}
+	// The floor itself is not asserted here: it is set for a store of
+	// thousands, and twenty-nine sessions cannot reach it. What this holds is
+	// the ordering, which is what was upside down.
+	if subject < ordinary*1.5 {
+		t.Errorf("the subject scores %.2f against %.2f — separated, but by a margin a threshold cannot sit in",
+			subject, ordinary)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -744,7 +744,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 	}
 	br := newBucketReader(dir)
 	defer br.close()
-	totalDocs := float64(len(m.Sessions)) + 1
+	totalDocs := float64(countedDocs(m)) + 1
 	idfOf := map[string]float64{}
 	score := map[uint32]float64{}
 	// focus is the same scoring restricted to the words that distinguish. A
@@ -825,7 +825,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		}
 		if len(orKeys) > 1 {
 			// OR path: union postings across the term's stem forms.
-			df := map[uint32]bool{}
+			df := map[uint32]map[int64]bool{}
 			hit = map[uint32]bool{}
 			tf = map[uint32]int{}
 			offs = map[uint32]map[int64]bool{}
@@ -838,7 +838,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 					continue
 				}
 				for _, pp := range posts {
-					df[pp.Sid] = true
+					noteDF(df, pp.Sid, pp.Off)
 					if _, ok := inProject[pp.Sid]; ok {
 						hit[pp.Sid] = true
 						tf[pp.Sid]++
@@ -854,7 +854,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			if len(hit) == 0 {
 				continue
 			}
-			minDF = len(df)
+			minDF = countDF(df)
 			termsKnown++
 			// fallthrough to idf/scoring below
 		} else {
@@ -869,12 +869,12 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 				}
 				// Document frequency in sessions, not postings: one marathon
 				// session repeating a term 300 times must not make it common.
-				df := map[uint32]bool{}
+				df := map[uint32]map[int64]bool{}
 				keyHit := map[uint32]bool{}
 				keyTF := map[uint32]int{}
 				keyOffs := map[uint32]map[int64]bool{}
 				for _, pp := range posts {
-					df[pp.Sid] = true
+					noteDF(df, pp.Sid, pp.Off)
 					if _, ok := inProject[pp.Sid]; ok {
 						keyHit[pp.Sid] = true
 						keyTF[pp.Sid]++
@@ -902,8 +902,8 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 				// sets the term's idf. A union would let a message containing
 				// only a common sub-token ("index" of "pkg/index") collect the
 				// full term mass, and best-message ranking amplifies that.
-				if minDF == -1 || len(df) < minDF {
-					minDF = len(df)
+				if minDF == -1 || countDF(df) < minDF {
+					minDF = countDF(df)
 					offs = keyOffs
 				}
 				if len(hit) == 0 {
@@ -2979,6 +2979,62 @@ func safe(s string) string {
 		}
 		return '_'
 	}, s)
+}
+
+// dfMessageCap is how much one session may contribute to a term's document
+// frequency. Counting whole sessions inverts the signal on a real store: eleven
+// sessions of twenty to sixty thousand messages hold 99% of everything ever
+// said, so a subject word living in sixteen of them scores 1.31 while "branch",
+// living in thirteen, scores 1.50 — the most specific word in the store ranks
+// as commoner than the most ordinary one. Counting every message instead brings
+// back the failure this deliberately avoids, where one marathon repeating a
+// word three hundred times makes it common.
+//
+// Capping the contribution keeps both. Measured on a real store, a cap of 25
+// reproduces what treating each 200-message episode as a document gives —
+// pgbouncer 3.40 against 3.37, singbox 4.17 against 4.70 — while working words
+// stay near 2: branch 2.18, suite 2.53, windows 2.15. The separation lands on
+// the strong floor that was already there.
+const dfMessageCap = 25
+
+// countedDocs is the corpus size in the unit noteDF counts: messages, with each
+// session contributing at most dfMessageCap of them. A manifest written before
+// message counts were kept degrades to one document per session, which is what
+// the ranking did before — the numbers stay consistent, they just stay coarse
+// until the index is next built.
+func countedDocs(m Manifest) int {
+	n := 0
+	for _, meta := range m.Sessions {
+		c := meta.Counted
+		if c <= 0 {
+			c = 1
+		}
+		n += min(c, dfMessageCap)
+	}
+	return n
+}
+
+// noteDF records that a term appeared in one more message of a session, up to
+// the cap.
+func noteDF(df map[uint32]map[int64]bool, sid uint32, off int64) {
+	seen := df[sid]
+	if seen == nil {
+		seen = map[int64]bool{}
+		df[sid] = seen
+	}
+	if len(seen) < dfMessageCap {
+		seen[off] = true
+	}
+}
+
+// countDF is the document frequency in the same unit the corpus size uses:
+// messages, with each session contributing at most dfMessageCap of them.
+func countDF(df map[uint32]map[int64]bool) int {
+	n := 0
+	for _, seen := range df {
+		n += len(seen)
+	}
+	return n
 }
 
 // stemMatchForms generates the same candidate surface forms stemMatches

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -794,11 +794,20 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		// term counts only where every sub-token is present; idf comes from
 		// the rarest sub-token, which is the one that actually identifies.
 		var (
-			hit    map[uint32]bool
-			tf     map[uint32]int
-			minDF  = -1
-			offs   map[uint32]map[int64]bool
-			missed bool
+			hit map[uint32]bool
+			tf  map[uint32]int
+			// minDF is in capped messages, minSess in whole sessions. Neither
+			// unit is right alone: sessions call a subject word common because
+			// the marathons everything lives in all mention it, and capped
+			// messages call a word that saturates one long session filler —
+			// which is exactly what the name of the thing you have been working
+			// on all month looks like. The rarer of the two verdicts wins, so a
+			// term has to read as ordinary under BOTH before it is treated as
+			// filler.
+			minDF   = -1
+			minSess = -1
+			offs    map[uint32]map[int64]bool
+			missed  bool
 		)
 		if len(orKeys) > 1 && !isCyrToken(term) {
 			// Fold stem forms in ONLY when the exact token is absent from the
@@ -854,7 +863,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			if len(hit) == 0 {
 				continue
 			}
-			minDF = countDF(df)
+			minDF, minSess = countDF(df), len(df)
 			termsKnown++
 			// fallthrough to idf/scoring below
 		} else {
@@ -903,7 +912,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 				// only a common sub-token ("index" of "pkg/index") collect the
 				// full term mass, and best-message ranking amplifies that.
 				if minDF == -1 || countDF(df) < minDF {
-					minDF = countDF(df)
+					minDF, minSess = countDF(df), len(df)
 					offs = keyOffs
 				}
 				if len(hit) == 0 {
@@ -916,20 +925,23 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			}
 			termsKnown++
 		}
-		idf := math.Log(totalDocs / float64(minDF+1))
+		idf := math.Max(
+			math.Log(totalDocs/float64(minDF+1)),
+			math.Log(float64(len(m.Sessions)+1)/float64(minSess+1)),
+		)
 		idfOf[term] = idf
 		if idf <= 0 {
 			// In a tiny corpus every ratio collapses to zero; a term living
 			// in only a couple of sessions still identifies them.
-			if minDF > 2 {
+			if minSess > 2 {
 				continue
 			}
 			idf = 0.1
 		}
-		informative := idf >= dejaVuIDFFloor || minDF <= 2
+		informative := idf >= dejaVuIDFFloor || minSess <= 2
 		// Rare enough to identify something on its own: either well past the
 		// ordinary bar, or living in a single session of the whole corpus.
-		strong := idf >= dejaVuStrongIDFFloor || minDF <= 1
+		strong := idf >= dejaVuStrongIDFFloor || minSess <= 1
 		for ord := range hit {
 			mm := perMessage[ord]
 			if mm == nil {


### PR DESCRIPTION
Answers the open question in #1450 without anyone having to judge the fixtures.

Neither unit is right alone. Counting whole sessions calls a subject word common, because the eleven marathon sessions that hold 99% of the store all mention it — `pgbouncer` scores 1.31 against `branch` at 1.50. Counting messages capped per session fixes that, but then a word saturating one long session reads as filler, which is exactly what the name of the thing you have worked on all month looks like.

So compute both and take the rarer verdict. A term has to read as ordinary under **both** before it is treated as filler.

Live, 59 real questions from this machine's own history, each binary against its own untouched copy of a frozen index (the hook writes a seen-file beside it — sharing one directory lets the first run decide what the second is allowed to say, which is how an earlier reading of this got a phantom regression):

```
             answered  silent  pointer-only
main            41       17         1
capped only     43       16         0
rarer-of-two    43       16         0
```

Two questions gained, none lost.

The fixtures are the guard, and they are untouched: with the cap alone, `TestHookPromptSkipsMarathonSessions`, `TestHookPromptNamesTheEarlierAttempt`, `TestHookPromptDoesNotReadASessionItAlreadyShowed` and `TestToolHookCommandLineCarriesWhatHappenedLastTime` all fail — that is the saturating-subject case failing loudly. With the rarer-of-two rule the whole suite is green as it stands, so #1450's "three tests fail and the question is worth deciding" no longer needs deciding: the rule keeps what they assert.

`bench prompt` 13/13 real questions and 5 false fires, identical to main (the bench corpus's sessions are short, so the cap never binds there — that arm is #1534's business). `bench recall` 1.00/1.00, `bench context` 294 median tokens, coverage 1.00 — both unchanged. No manifest change and no reindex: the per-session message count is already stored, and a manifest written before it degrades to one document per session, which is today's behaviour.