### PR TITLE
The registry pages were counting seventeen other formats

### DIFF
--- a/cmd/deja/page_titles_count_test.go
+++ b/cmd/deja/page_titles_count_test.go
@@ -35,4 +35,43 @@ func TestPageTitlesCountTheRestOfTheHarnesses(t *testing.T) {
 			t.Errorf("%s does not say %q — the registry has %d harnesses", c.file, want, n)
 		}
 	}
+
+	// The registry pages close with "deja reads this format and N others". The
+	// word was typed into the generator's template, so all twenty pages kept
+	// saying seventeen for three harnesses running.
+	dir := filepath.Join(root, "docs", "registry")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("registry pages: %v", err)
+	}
+	want := fmt.Sprintf("this format and %s others", countWordForTest(n-1))
+	pages := 0
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".html" || e.Name() == "README.html" {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("%s: %v", e.Name(), err)
+		}
+		pages++
+		if !strings.Contains(string(b), want) {
+			t.Errorf("docs/registry/%s does not say %q", e.Name(), want)
+		}
+	}
+	if pages != n {
+		t.Errorf("%d registry pages for %d harnesses", pages, n)
+	}
+}
+
+// countWordForTest spells the number the generator's template spells.
+func countWordForTest(n int) string {
+	words := []string{"zero", "one", "two", "three", "four", "five", "six", "seven",
+		"eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen",
+		"sixteen", "seventeen", "eighteen", "nineteen", "twenty", "twenty-one",
+		"twenty-two", "twenty-three", "twenty-four", "twenty-five"}
+	if n < 0 || n >= len(words) {
+		return fmt.Sprint(n)
+	}
+	return words[n]
 }

--- a/docs/registry/README.html
+++ b/docs/registry/README.html
@@ -75,7 +75,7 @@
 <p>SQLite fixture sources are stored as SQL so changes remain reviewable. The conformance test materializes them in a temporary directory before parsing.</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/aider.html
+++ b/docs/registry/aider.html
@@ -65,7 +65,7 @@ The query misses the tenant predicate.
 <p><strong>Last verified:</strong> 2026-07-27</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/antigravity.html
+++ b/docs/registry/antigravity.html
@@ -57,7 +57,7 @@
 <p><strong>Last verified:</strong> 2026-07-17</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/claude-code.html
+++ b/docs/registry/claude-code.html
@@ -62,7 +62,7 @@
 <p><strong>Last verified:</strong> 2026-07-17</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/cline.html
+++ b/docs/registry/cline.html
@@ -67,7 +67,7 @@
 <p><strong>Last verified:</strong> 2026-07-28</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/codex.html
+++ b/docs/registry/codex.html
@@ -57,7 +57,7 @@
 <p><strong>Last verified:</strong> 2026-07-17</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/copilot.html
+++ b/docs/registry/copilot.html
@@ -85,7 +85,7 @@
 <p><strong>Last verified:</strong> 2026-08-14</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/cursor.html
+++ b/docs/registry/cursor.html
@@ -69,7 +69,7 @@
 <p><strong>Last verified:</strong> 2026-07-17</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/deepseek.html
+++ b/docs/registry/deepseek.html
@@ -139,7 +139,7 @@
 <p><strong>Last verified:</strong> 2026-08-21</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/gemini.html
+++ b/docs/registry/gemini.html
@@ -62,7 +62,7 @@
 <p><strong>Last verified:</strong> 2026-07-24</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/goose.html
+++ b/docs/registry/goose.html
@@ -57,7 +57,7 @@
 <p><strong>Last verified:</strong> 2026-07-28</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/grok.html
+++ b/docs/registry/grok.html
@@ -75,7 +75,7 @@
 <p><strong>Last verified:</strong> 2026-07-27</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/hermes.html
+++ b/docs/registry/hermes.html
@@ -55,7 +55,7 @@
 <p><strong>Last verified:</strong> 2026-07-28</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/kimi.html
+++ b/docs/registry/kimi.html
@@ -62,7 +62,7 @@
 <p><strong>Last verified:</strong> 2026-07-28</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/omp.html
+++ b/docs/registry/omp.html
@@ -155,7 +155,7 @@
 <p><strong>Last verified:</strong> 2026-08-21</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/openclaw.html
+++ b/docs/registry/openclaw.html
@@ -73,7 +73,7 @@
 <p><strong>Last verified:</strong> 2026-07-23</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/opencode.html
+++ b/docs/registry/opencode.html
@@ -58,7 +58,7 @@ part(id, message_id, data)</code></pre>
 <p><strong>Last verified:</strong> 2026-07-17</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/pi.html
+++ b/docs/registry/pi.html
@@ -94,7 +94,7 @@
 <p><strong>Last verified:</strong> 2026-07-19</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/qwen.html
+++ b/docs/registry/qwen.html
@@ -58,7 +58,7 @@
 <p><strong>Last verified:</strong> 2026-07-17</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/roo.html
+++ b/docs/registry/roo.html
@@ -59,7 +59,7 @@
 <p><strong>Last verified:</strong> 2026-07-27</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/docs/registry/zed.html
+++ b/docs/registry/zed.html
@@ -94,7 +94,7 @@
 <p><strong>Last verified:</strong> 2026-08-21</p>
 
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and nineteen others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>

--- a/scripts/genregistry/main.go
+++ b/scripts/genregistry/main.go
@@ -65,7 +65,7 @@ func run() error {
 	}
 	sort.Strings(paths)
 	// Every page lists every other one. This is the reason the registry is
-	// worth publishing at all: eighteen pages that answer "where does this
+	// worth publishing at all: a page per format that answers "where does this
 	// agent keep its history" are each other's best route in, for a reader
 	// and for a crawler that would otherwise reach none of them.
 	var links []link
@@ -215,7 +215,7 @@ var pageTemplate = template.Must(template.New("page").Parse(`<!DOCTYPE html>
 <h1>{{.Heading}}</h1>
 {{.Body}}
 <hr>
-<p>deja reads this format and seventeen others, and turns what it finds into memory your
+<p>deja reads this format and {{.Others}} others, and turns what it finds into memory your
 agents can search. See the <a href="../guide/harnesses.html">harness matrix</a> for what is
 wired where, or <a href="../guide/getting-started.html">install it</a> and search your own
 history.</p>
@@ -227,8 +227,24 @@ history.</p>
 
 type pageData struct {
 	Title, Description, Heading, URL, Site string
-	Article, Crumbs                        any
-	Sidebar, Body                          template.HTML
+	// Others is how many other formats deja reads, spelled out. It was a word
+	// typed into the template, so every one of these twenty pages kept saying
+	// seventeen after three harnesses landed.
+	Others          string
+	Article, Crumbs any
+	Sidebar, Body   template.HTML
+}
+
+// countWord spells a small number the way the pages read it.
+func countWord(n int) string {
+	words := []string{"zero", "one", "two", "three", "four", "five", "six", "seven",
+		"eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen",
+		"sixteen", "seventeen", "eighteen", "nineteen", "twenty", "twenty-one",
+		"twenty-two", "twenty-three", "twenty-four", "twenty-five"}
+	if n < 0 || n >= len(words) {
+		return fmt.Sprint(n)
+	}
+	return words[n]
 }
 
 func render(m meta, body string, others []link) string {
@@ -253,6 +269,10 @@ func render(m meta, body string, others []link) string {
 	err := pageTemplate.Execute(&b, pageData{
 		Title: m.Title, Description: m.Description, Heading: m.Heading,
 		URL: url, Site: site, Article: article, Crumbs: crumbs,
+		// Every page but this one. The list is one page per harness format —
+		// README is skipped when it is built — so this is the count the
+		// sentence means.
+		Others: countWord(len(others) - 1),
 		// The body is HTML this generator built from markdown it escaped on
 		// the way through; the sidebar is built from registry names, escaped
 		// there. Both are already safe, which is what template.HTML asserts.


### PR DESCRIPTION
Every one of the twenty registry pages closes with *"deja reads this format and seventeen others"*. The word was a literal in the generator's page template, so it stopped being true when omp landed and stayed wrong through DeepSeek Harness and Zed — on the pages written specifically to be found by someone searching where their agent keeps its history.

It comes from the registry now (`this format and nineteen others`), and the count test covers all twenty pages plus the page count itself. Making the generator off by one turns it red.