### PR TITLE
Roadmap: four of the linked issues are closed

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,21 +6,19 @@ the place to discuss design.
 
 ## Now
 
-- **Windows correctness.** Several `internal/index` tests use Unix-shaped path
-  fixtures that only pass off Windows by accident, and the exclude-on-rebuild
-  path reads paths differently under Windows semantics — so a real privacy
-  control is unverified there ([#1119](https://github.com/vshulcz/deja-vu/issues/1119)).
-  The Windows CI leg now runs on `main`, on the weekly canary and on any pull
-  request labelled `windows`, rather than on every commit: it took twenty
-  minutes against two for the other platforms, and varied by a third between
-  identical runs ([#1229](https://github.com/vshulcz/deja-vu/issues/1229)). That
-  buys back the development loop and moves the burden onto keeping the label
-  habit, so the gap between "green on Linux and macOS" and "correct on Windows"
-  has to be closed deliberately rather than by CI running all the time.
-- **Keep the claims measured.** Every ranking signal — outcome, reuse, decision,
-  point-of-action — has an in-repo benchmark, and a change ships with the
-  before/after. Extend the agent-in-the-loop A/B beyond the point-of-action hook
-  to the rest of the recall path.
+- **Does the block carry the answer.** The per-prompt hook is judged on one
+  question now: whether what it injects holds what the question was about, not
+  whether it matched a word. That is measured three ways — the prompt benchmark
+  on a corpus large enough for rarity to mean something, LongMemEval end to end,
+  and a replay of real prompts against a frozen index — and every change ships
+  with the before and after. The next piece is the same treatment for the block
+  a tool call gets, where the reader is an agent about to run something.
+- **Windows correctness.** The Windows leg runs on `main`, on the weekly canary
+  and on any pull request labelled `windows` rather than on every commit, so the
+  gap between "green on Linux and macOS" and "correct on Windows" has to be
+  closed deliberately. Path-shaped fixtures and the exclude-on-rebuild path are
+  verified there; anything touching paths, output or the filesystem gets the
+  label.
 - Maintain the security model, signed checksums, provenance and release SBOMs as
   release and harness formats change.
 
@@ -32,13 +30,19 @@ the place to discuss design.
   both stronger and precise without lifting an off-topic session.
 - **Point-of-action beyond codex and Claude.** Carry the file's or command's
   prior decision into other harnesses as their hook contracts allow.
-- Derive canonical project identity from a repository remote so same-named repos
-  and worktrees do not collide ([#44](https://github.com/vshulcz/deja-vu/issues/44)).
+- **Follow the work an agent handed off.** A subagent's run is its own session
+  now, and where a harness records the edge — Grok's `summary.json`, Claude's
+  sidechain files — recall can name the parent and the children. Cursor writes
+  subagent transcripts too and their shape is unread; the rest of the harnesses
+  that spawn agents are the same question.
+- **Close the matrix from upstream.** What is left in the support table is
+  someone else's to ship: aider has no MCP client and no custom commands, Roo's
+  hooks are in flight, Zed exposes no lifecycle hook. Each becomes work the day
+  it lands, and the registry records the source so the claim can be rechecked
+  rather than assumed.
 
 ## Later
 
-- Expose recent sessions as an MCP resource alongside bounded recall pagination
-  ([#12](https://github.com/vshulcz/deja-vu/issues/12)).
 - Mature the optional semantic tier (`deja embed`): still off by default and
   external to the binary, it should degrade and recover as cleanly as the lexical
   ladder does.


### PR DESCRIPTION
Every issue the roadmap linked has shipped — the Windows path fixtures (#1119), the CI split (#1229), canonical project identity (#44) and the MCP sessions resource (#12) — so the page was describing work that is done as work in progress.

Rewritten from where the work actually is: recall judged on whether the injected block carries the answer (and the same treatment owed to the tool-call block next), Windows correctness as a standing habit rather than an open bug, following the work an agent hands to a subagent, and the matrix gaps that are upstream to ship.