### PR TITLE
install --auto skipped auto-recall for the two newest harnesses

### DIFF
--- a/cmd/deja/auto_target_reach_test.go
+++ b/cmd/deja/auto_target_reach_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// `deja install --auto` is the command the docs put in front of everyone, and
+// the mapping from "this harness is on the machine" to "install its deepest
+// integration" used to be a switch someone had to remember to extend. Two
+// harnesses landed after it was written and fell through to the default, so
+// --auto wired their MCP server and left auto-recall off — on a machine that
+// had it, with nothing in the output saying so.
+func TestEveryAutoTargetIsReachableFromInstallAuto(t *testing.T) {
+	for _, name := range installTargetNames() {
+		if !strings.HasSuffix(name, "-auto") {
+			continue
+		}
+		base := strings.TrimSuffix(name, "-auto")
+		// Detection reports Claude under its own name.
+		detected := base
+		if base == "claude" {
+			detected = "claude-code"
+		}
+		if got := autoTargetFor(detected); got != name {
+			t.Errorf("a machine with %s installs %q, not %q — auto-recall is silently skipped", detected, got, name)
+		}
+	}
+
+	// A harness with no -auto target keeps the plain one rather than being
+	// dropped: for the IDE extensions the MCP server is the whole integration.
+	for _, plain := range []string{"windsurf", "roo"} {
+		if got := autoTargetFor(plain); got != plain && !strings.HasPrefix(got, plain+"-auto") {
+			t.Errorf("autoTargetFor(%q) = %q", plain, got)
+		}
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -72,40 +72,7 @@ func runInstall(dir string, args []string, uninstall bool) error {
 	if targetArgs[0] == "--auto" {
 		targets = nil
 		for _, t := range existingTargets() {
-			switch t {
-			case "claude-code":
-				targets = append(targets, "claude-auto")
-			case "codex":
-				targets = append(targets, "codex-auto")
-			case "opencode":
-				targets = append(targets, "opencode-auto")
-			case "gemini":
-				targets = append(targets, "gemini-auto")
-			case "qwen":
-				targets = append(targets, "qwen-auto")
-			case "kimi":
-				targets = append(targets, "kimi-auto")
-			case "cursor":
-				targets = append(targets, "cursor-auto")
-			case "pi":
-				targets = append(targets, "pi-auto")
-			case "hermes":
-				targets = append(targets, "hermes-auto")
-			case "openclaw":
-				targets = append(targets, "openclaw-auto")
-			case "antigravity":
-				targets = append(targets, "antigravity-auto")
-			case "cline":
-				targets = append(targets, "cline-auto")
-			case "goose":
-				targets = append(targets, "goose-auto")
-			case "grok":
-				targets = append(targets, "grok-auto")
-			default:
-				// The IDE extensions: the MCP server is the deepest integration
-				// those harnesses support.
-				targets = append(targets, t)
-			}
+			targets = append(targets, autoTargetFor(t))
 		}
 		if len(targets) == 0 {
 			fmt.Println("no known agent config directories found")
@@ -1397,6 +1364,27 @@ func opencodeHasMCPKey(lines []string) bool {
 		}
 	}
 	return false
+}
+
+// autoTargetFor maps a detected harness to the deepest integration it has: the
+// -auto target where one exists, the plain one otherwise (the IDE extensions,
+// where an MCP server is as far as it goes).
+//
+// This was a hand-written switch, and the two harnesses added after it was
+// written fell through to the default — so `deja install --auto` wired their
+// MCP server and quietly left auto-recall off on a machine that has it.
+func autoTargetFor(detected string) string {
+	// Detection reports Claude as "claude-code" while its target is "claude".
+	base := detected
+	if base == "claude-code" {
+		base = "claude"
+	}
+	for _, name := range installTargetNames() {
+		if name == base+"-auto" {
+			return name
+		}
+	}
+	return detected
 }
 
 // withAutoTargets pairs each target with its -auto sibling where one exists,


### PR DESCRIPTION
Found running `deja install --auto` on a clean home that has omp and dsh and nothing else: both got their MCP server, and `deja doctor` then reported their auto-recall files missing. The command people are told to run left the feature off, and said nothing.

The cause is that `--auto` mapped a detected harness to its target through a hand-written switch. Both harnesses landed after it was written and fell through to the default branch, which is meant for the IDE extensions where MCP is the whole integration. The mapping comes from the install-target table now: if `<harness>-auto` exists, that is what `--auto` installs.

```
deepseek-auto: created …/.dsh/cordis.patch.yml
omp-auto: created …/.omp/agent/extensions/deja/index.js
```

A test walks every `-auto` target and fails if `--auto` would not reach it, so the next harness cannot repeat this. Both mutations — restoring the hand list, dropping the claude-code detection alias — turn it red.