### PR TITLE
Pin scoop, winget and the codex plugin to 0.18.0

### DIFF
--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.17.3",
+  "version": "0.18.0",
   "description": "Recall your own past coding sessions, across every AI tool you use.",
   "author": {
     "name": "vshulcz",

--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,12 +1,12 @@
 {
     "architecture": {
         "64bit": {
-            "hash": "3b3bdd1e87e244575146f35cb47327e0c7378091562c7b6eb51588ab9fa72581",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.17.3/deja-vu_0.17.3_windows_amd64.zip"
+            "hash": "e2c5a442afb3f208aa1389be031b2ac595de3c79b1179856fb843a1f1b042391",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_amd64.zip"
         },
         "arm64": {
-            "hash": "0cc9fbb102ed61420395f4d75a46f785c6bc0eb5c0a97dd3180a45f67b8249fa",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.17.3/deja-vu_0.17.3_windows_arm64.zip"
+            "hash": "f814fe2117f69ae1d2cc2202e6c3d37e90ef7cde705c3e3c6de1dfdfa4743b25",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_arm64.zip"
         }
     },
     "autoupdate": {
@@ -24,5 +24,5 @@
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
-    "version": "0.17.3"
+    "version": "0.18.0"
 }

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.17.3
+PackageVersion: 0.18.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.17.3/deja-vu_0.17.3_windows_amd64.zip
-  InstallerSha256: 3B3BDD1E87E244575146F35CB47327E0C7378091562C7B6EB51588AB9FA72581
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_amd64.zip
+  InstallerSha256: E2C5A442AFB3F208AA1389BE031B2AC595DE3C79B1179856FB843A1F1B042391
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.17.3/deja-vu_0.17.3_windows_arm64.zip
-  InstallerSha256: 0CC9FBB102ED61420395F4D75A46F785C6BC0EB5C0A97DD3180A45F67B8249FA
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_arm64.zip
+  InstallerSha256: F814FE2117F69AE1D2CC2202E6C3D37E90EF7CDE705C3E3C6DE1DFDFA4743B25
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.17.3
+PackageVersion: 0.18.0
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.17.3/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.18.0/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.17.3
+PackageVersion: 0.18.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Release manifests for v0.18.0, from the published checksums. `pinmanifests -check` agrees.