### PR TITLE
fix(brief): fit the wire line into a 60-column pane

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -88,7 +88,10 @@ func runBrief(dir string, w io.Writer) error {
 	// header because that is the only line a first-time reader is certain to
 	// read.
 	if nothingWired() {
-		fmt.Fprintf(w, "wire       %sno agent is wired to this yet%s — `deja install --auto`\n", bold, reset)
+		// 53 columns: every line of the brief fits a 60-column pane (#604),
+		// and the longer wording left `--auto` wrapped alone on its own line
+		// of the first screen a fresh install shows (#1411).
+		fmt.Fprintf(w, "wire       %sno agent wired yet%s — `deja install --auto`\n", bold, reset)
 	}
 
 	recalls, bytes, _ := usage.TodayWithInjections(dir)

--- a/cmd/deja/brief_width_test.go
+++ b/cmd/deja/brief_width_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -166,5 +167,36 @@ func TestBriefRecentLinesHonourColumns(t *testing.T) {
 		if w := visibleWidth(l); w > 80 {
 			t.Errorf("COLUMNS=not-a-number: line is %d columns: %q", w, l)
 		}
+	}
+}
+
+// #604 budgeted the brief's transcript lines against the terminal, but deja's
+// own copy was not budgeted: the wire line ran to 64 columns and wrapped
+// `--auto` alone onto a second line of the first screen a fresh install shows
+// (#1411). Every line of the brief fits a 60-column pane, this one included.
+func TestBriefWireLineFitsSixtyColumns(t *testing.T) {
+	day := 24 * time.Hour
+	dir := briefStore(t, "tmp/projc", time.Hour, 2*day, 5*day)
+
+	for _, cols := range []int{60, 80, 120} {
+		t.Run(strconv.Itoa(cols), func(t *testing.T) {
+			t.Setenv("COLUMNS", strconv.Itoa(cols))
+			var buf bytes.Buffer
+			if err := runBrief(dir, &buf); err != nil {
+				t.Fatal(err)
+			}
+			var wire string
+			for _, l := range strings.Split(buf.String(), "\n") {
+				if strings.Contains(l, "install --auto") {
+					wire = l
+				}
+			}
+			if wire == "" {
+				t.Fatalf("no wire line on an unwired store:\n%s", buf.String())
+			}
+			if w := visibleWidth(wire); w > 60 {
+				t.Errorf("COLUMNS=%d: wire line is %d columns, wraps on a 60-column pane: %q", cols, w, wire)
+			}
+		})
 	}
 }

--- a/cmd/deja/first_run_wiring_test.go
+++ b/cmd/deja/first_run_wiring_test.go
@@ -63,7 +63,7 @@ func TestTheBriefStopsSayingItOnceWired(t *testing.T) {
 	if err := runBrief(index.DefaultDir(), &out); err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(out.String(), "no agent is wired") {
+	if strings.Contains(out.String(), "no agent wired yet") {
 		t.Errorf("a wired machine is still being told to wire itself:\n%s", out.String())
 	}
 }

--- a/cmd/deja/first_run_wiring_test.go
+++ b/cmd/deja/first_run_wiring_test.go
@@ -63,7 +63,10 @@ func TestTheBriefStopsSayingItOnceWired(t *testing.T) {
 	if err := runBrief(index.DefaultDir(), &out); err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(out.String(), "no agent wired yet") {
+	// On the label rather than the sentence: the sentence is copy and has been
+	// reworded once already (#1411), and a guard that reads a literal quietly
+	// stops guarding the moment the words change.
+	if strings.Contains(out.String(), "deja install --auto") {
 		t.Errorf("a wired machine is still being told to wire itself:\n%s", out.String())
 	}
 }


### PR DESCRIPTION
## Summary

The brief's wire line ran to 64 columns and wrapped `--auto` alone onto a second line of the first screen a fresh install shows (#1411). #604 budgeted the transcript lines against a 60-column pane, but deja's own copy was not budgeted.

The fix is the shorter wording suggested in the issue — "no agent wired yet — `deja install --auto`", 53 columns. No other line of the brief changes.

## Test plan

- Added `TestBriefWireLineFitsSixtyColumns`: renders the brief on an unwired store at COLUMNS=60, 80 and 120 and asserts the wire line stays within 60 columns.
- Sabotage check: with the old wording restored, the new test fails at every width with `wire line is 64 columns`; with the fix it passes.
- Updated `first_run_wiring_test.go` to match the new wording (the "goes quiet once wired" test asserted against the old string).
- `go vet ./...` clean; `go test -race ./...` passes in full locally (macOS, go 1.25.0); cmd/deja coverage 89.9% (floor 88).

## Notes

- First-time contributor; I commented on the issue before starting, per the thread where it was held for a first-time contributor.
- Chose the "no agent wired yet" shape (53 columns) over "nothing wired yet" (52) since it keeps saying what is missing. Happy to switch if you prefer the other.
