### PR TITLE
chore: name the homepage, repository and licence in the plugin manifest

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -5,6 +5,9 @@
     "name": "vshulcz",
     "url": "https://github.com/vshulcz"
   },
+  "homepage": "https://github.com/vshulcz/deja-vu",
+  "repository": "https://github.com/vshulcz/deja-vu",
+  "license": "MIT",
   "skills": "./skills/",
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
Fields a plugin directory shows next to the entry. The community marketplace pins an approved plugin to a commit and moves that pin as commits land, so no version field: setting one would freeze updates until someone bumped it by hand.