### PR TITLE
fix(dsh): prefer the deja the user installed over the copy npm brought

### DIFF
--- a/packages/dsh-deja/index.js
+++ b/packages/dsh-deja/index.js
@@ -26,16 +26,32 @@ try {
 const PLATFORM = process.platform === "win32" ? "windows" : process.platform;
 const ARCH = process.arch === "x64" ? "amd64" : process.arch;
 
-// resolveDeja finds the binary: an explicit override first, then the platform
-// package npm installed next to this one, then whatever is on PATH.
+// resolveDeja picks the binary in the order a user would expect: what they
+// pointed at, then the deja they installed themselves and keep current with
+// `deja update` or a package manager, and only then the copy npm brought along
+// with this plugin. Each candidate is asked for its version rather than
+// trusted, because a name on PATH that does not run is worse than no name.
 function resolveDeja() {
-  if (process.env.DEJA_BIN) return process.env.DEJA_BIN;
   const exe = PLATFORM === "windows" ? "deja.exe" : "deja";
+  const candidates = [process.env.DEJA_BIN, exe];
   try {
-    return require.resolve(`@vshulcz/deja-vu-${PLATFORM}-${ARCH}/bin/${exe}`);
-  } catch {
-    return exe;
+    candidates.push(require.resolve(`@vshulcz/deja-vu-${PLATFORM}-${ARCH}/bin/${exe}`));
+  } catch {}
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      execFileSync(candidate, ["version"], {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      return candidate;
+    } catch {}
   }
+  // Nothing answered. Keep the plain name so the failure a user sees names the
+  // thing that is missing.
+  return exe;
 }
 
 const DEJA = resolveDeja();


### PR DESCRIPTION
The plugin resolved its binary as: DEJA_BIN, then the platform package npm installed beside it, then PATH. That order pins a DSH user to whatever deja shipped with the plugin release they installed, while their own `deja update` or `brew upgrade` changes nothing.

Now: DEJA_BIN, then PATH, then the npm copy as the fallback for someone who never installed deja. Each candidate is asked for `version` before it is used, so a name on PATH that does not run falls through instead of silently answering nothing.

Checked against dsh 0.1.1-rc.2 with the mock model: three tools registered, and the runtime-context message carries the recall.