### PR TITLE
chore: open a discussion with every release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -96,6 +96,10 @@ changelog:
       - "^test:"
 
 release:
+  # Every release opens a thread people can answer in. The alternative is a
+  # changelog nobody can reply to, and an empty Discussions tab that reads as
+  # an empty room.
+  discussion_category_name: Announcements
   header: |
     ## Install
 


### PR DESCRIPTION
The Discussions tab has six categories and zero threads, which reads as an empty room to anyone who opens it. goreleaser can attach each release to a category, so every release becomes a thread people can reply to — the same text as now, with somewhere to answer it.