### PR TITLE
docs: put automatic recall and redaction on the first screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ disk, and hands the right one back when it is needed.</p>
 
 <p align="center"><b>Every memory tool starts empty and records forward. deja starts full.</b></p>
 
-<p align="center">And nobody has to ask for it. Recall arrives at session start, on every prompt,
-before a file is edited or a command runs, and after a command fails — the moments where the
-answer is worth something. Keys, tokens and private key blocks are stripped as the index is
-built, so what reaches the model is safe to send.</p>
+<p align="center">And nobody has to ask for it: recall arrives at session start, on every prompt,
+before a file is edited or a command runs, and after one fails. Keys and tokens are stripped as
+the index is built, so what reaches the model is safe to send.</p>
 
 <p align="center">
 <b>85.3% hit@1</b> on LongMemEval-S &middot; <b>69.6%</b> on LoCoMo &middot; <b>sub-millisecond</b> lookups over 5&nbsp;GB of history<br>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ disk, and hands the right one back when it is needed.</p>
 
 <p align="center"><b>Every memory tool starts empty and records forward. deja starts full.</b></p>
 
+<p align="center">And nobody has to ask for it. Recall arrives at session start, on every prompt,
+before a file is edited or a command runs, and after a command fails — the moments where the
+answer is worth something. Keys, tokens and private key blocks are stripped as the index is
+built, so what reaches the model is safe to send.</p>
+
 <p align="center">
 <b>85.3% hit@1</b> on LongMemEval-S &middot; <b>69.6%</b> on LoCoMo &middot; <b>sub-millisecond</b> lookups over 5&nbsp;GB of history<br>
 <sub>Both harnesses ship in this repo and run on the public datasets in minutes &middot;


### PR DESCRIPTION
Two projects with the same thesis — cass and ctx — lead with the same line we do: the history is already on your machine, search it. Reading their READMEs, the differences that would actually decide a choice are ones we do not say out loud.

ctx states plainly that it needs no hooks and runs nothing inside the agent process, so its recall happens when the agent thinks to ask. Ours arrives at session start, per prompt, before a tool runs and after a command fails. ctx also states that transcript text is preserved rather than redacted; we strip credentials at index time.

Both facts were in the README already, several screens down and inside a collapsed block. This puts them under the line that claims the category.
