### PR TITLE
feat(extensions): keep the opencode, dsh and Zed packages in this repository

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,0 +1,155 @@
+# The packages under extensions/ are published into other people's ecosystems
+# — npm for opencode and dsh, the Zed registry for Zed. They break from
+# upstream API changes rather than from our commits, so this also runs weekly.
+name: extensions
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'extensions/**'
+      - '.github/workflows/extensions.yml'
+  pull_request:
+    paths:
+      - 'extensions/**'
+      - '.github/workflows/extensions.yml'
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: extensions-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  opencode:
+    name: opencode-deja
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: extensions/opencode
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+
+      - name: The plugin has to parse
+        run: node --check index.js && node --check lib.js
+
+      - run: npm test
+
+      - name: The hooks we implement have to still exist in opencode's plugin API
+        run: |
+          npm pack @opencode-ai/plugin --silent >/dev/null
+          tar xzf opencode-ai-plugin-*.tgz
+          node -e '
+            const fs = require("node:fs");
+            const api = fs.readFileSync("package/dist/index.d.ts", "utf8");
+            const plugin = fs.readFileSync("index.js", "utf8");
+            const hooks = [...plugin.matchAll(/hooks\["([a-z.]+)"\]/g)].map((m) => m[1]);
+            if (!hooks.length) throw new Error("no hooks found in index.js");
+            const missing = hooks.filter((h) => !api.includes("\"" + h + "\"?:"));
+            if (missing.length) {
+              console.error("opencode no longer declares: " + missing.join(", "));
+              process.exit(1);
+            }
+            console.log("hooks still declared: " + hooks.join(", "));
+          '
+
+  dsh:
+    name: dsh-deja
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: extensions/dsh
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+
+      - name: The plugin has to parse
+        run: node --check index.js
+
+      - run: npm test
+
+      - name: The manifest has to declare a bundle patch, or dsh cannot install it
+        run: |
+          node -e '
+            const pkg = require("./package.json");
+            const patch = pkg.dsh && pkg.dsh.bundle && pkg.dsh.bundle.patch;
+            if (patch !== "./cordis.patch.yml") {
+              console.error("package.json must declare dsh.bundle.patch = ./cordis.patch.yml");
+              process.exit(1);
+            }
+            const fs = require("node:fs");
+            const rows = fs.readFileSync("cordis.patch.yml", "utf8");
+            if (!rows.includes("name: " + pkg.name)) {
+              console.error("cordis.patch.yml must name the package it loads: " + pkg.name);
+              process.exit(1);
+            }
+          '
+
+  zed:
+    name: zed-deja
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: extensions/zed
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install the target Zed compiles extensions to
+        run: rustup target add wasm32-wasip1
+
+      - name: Build
+        run: cargo build --release --target wasm32-wasip1
+
+      - name: The id in extension.toml must match what the registry lists
+        run: |
+          id=$(grep -m1 '^id = ' extension.toml | cut -d'"' -f2)
+          test "$id" = "deja-context-server" || {
+            echo "extension.toml id is '$id'; zed-industries/extensions lists it as deja-context-server"
+            exit 1
+          }
+
+  metadata:
+    name: packages point at this repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Published metadata is what a user follows back to the source. When a
+      # package moves, npm keeps serving the old repository field until someone
+      # notices; this notices.
+      - name: package.json repository and directory have to match where the file lives
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            let bad = 0;
+            for (const dir of ["extensions/opencode", "extensions/dsh"]) {
+              const pkg = JSON.parse(fs.readFileSync(dir + "/package.json", "utf8"));
+              const repo = pkg.repository || {};
+              if (!String(repo.url || "").includes("vshulcz/deja-vu")) {
+                console.error(dir + ": repository.url does not point at vshulcz/deja-vu");
+                bad++;
+              }
+              if (repo.directory !== dir) {
+                console.error(dir + ": repository.directory is " + repo.directory);
+                bad++;
+              }
+              if (!fs.existsSync(dir + "/LICENSE")) {
+                console.error(dir + ": no LICENSE in the published directory");
+                bad++;
+              }
+            }
+            process.exit(bad ? 1 : 0);
+          '

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,11 @@ deja-stats.svg
 # binaries by anyone who ran one.
 __pycache__/
 *.pyc
+
+# extensions/ builds where its ecosystem builds: cargo in the Zed extension,
+# npm in the two plugin packages. None of it is ours to commit.
+extensions/zed/target/
+extensions/zed/Cargo.lock
+extensions/*/node_modules/
+extensions/*/*.tgz
+extensions/*/package-lock.json

--- a/README.md
+++ b/README.md
@@ -261,6 +261,19 @@ variable is honored too. The
 the observed paths, record schemas and role mapping per harness, with synthetic fixtures
 keeping those descriptions checked against the parsers.
 
+### Harnesses with their own package format
+
+Three of them install extensions their own way rather than through `deja
+install`. Those packages live in [`extensions/`](extensions):
+
+| Harness | Package | Install |
+| --- | --- | --- |
+| opencode | npm `opencode-deja` | `opencode plugin opencode-deja` |
+| DeepSeek Harness | npm `dsh-deja` | `dsh plugin add dsh-deja` |
+| Zed | `deja-context-server` | Zed → Extensions → deja |
+
+Each uses the deja you already have; the copy it bundles is only the fallback.
+
 ## Semantic recall (optional)
 
 Point `deja embed` at a local Ollama, LM Studio or OpenAI-compatible endpoint with

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,0 +1,45 @@
+# extensions/
+
+deja in the shape each harness expects: its own package, under that
+ecosystem's naming, installable the way that ecosystem installs things. The
+code is thin — every one of these shells out to the same `deja` binary and the
+same local index.
+
+| Directory | Published as | Installed with |
+|---|---|---|
+| [`opencode/`](opencode) | npm `opencode-deja` | `opencode plugin opencode-deja` |
+| [`dsh/`](dsh) | npm `dsh-deja` | `dsh plugin add dsh-deja` |
+| [`zed/`](zed) | Zed extension `deja-context-server` | Zed → Extensions → deja |
+
+Two more integrations live outside this directory because their registries read
+a fixed path in this repository: `claude-plugin/` (Claude Code marketplace) and
+`codex-plugin/` (Codex). Moving them would break manifests that are already
+submitted.
+
+## Publishing
+
+npm packages publish from their own directory, which is why each carries its own
+`LICENSE` and a `repository.directory` field:
+
+```
+cd extensions/opencode && npm publish --access public
+cd extensions/dsh      && npm publish --access public
+```
+
+The Zed extension is not published by us: `zed-industries/extensions` pins this
+repository as a submodule and builds `extensions/zed`. A new version means
+bumping `version` in `extensions/zed/extension.toml` and opening a PR there that
+moves the submodule to the new commit.
+
+## Rules that cost us time once
+
+- **Resolve the binary in this order, everywhere:** an explicit setting or
+  `DEJA_BIN` → a deja the user installed themselves (PATH, then the well-known
+  install locations) → the copy the package shipped. Their own `deja update` or
+  `brew upgrade` has to win over whatever we bundled.
+- **Recall is optional.** A harness must never lose a turn because history was
+  unavailable: every call is wrapped, every failure is silent.
+- **Verify by running.** Each of these had a failure that was invisible in the
+  source and obvious the moment the real host executed it — a peer dependency
+  the host does not install, a hook that accepts input and drops it, a 60-second
+  timeout on `initialize`.

--- a/extensions/dsh/LICENSE
+++ b/extensions/dsh/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vladislav Shulcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/dsh/README.md
+++ b/extensions/dsh/README.md
@@ -1,0 +1,68 @@
+# dsh-deja
+
+English | [中文](README.zh.md)
+
+DeepSeek Harness can already search its own sessions — that is what the built-in
+`session-query` subsystem does. This plugin answers the other question: what you
+did in the *other* agents on this machine.
+
+deja indexes the session files that Claude Code, Codex, Cursor, opencode,
+Antigravity, Grok Build, Kimi, Cline, Zed and ten more agents already write to
+disk. Nothing has to have been recorded ahead of time: the history is already
+there, including the months before deja was installed. If you moved to dsh last
+week, everything you did before last week is still reachable from inside it.
+
+## Install
+
+```sh
+dsh plugin --profile web add dsh-deja
+```
+
+The plugin runs the `deja` binary. It is pulled in as a dependency, so npm
+installs it with the plugin; a `deja` already on `PATH` is used as-is, and
+`DEJA_BIN` overrides both.
+
+## What it adds
+
+Three tools the model can call:
+
+| Tool | Answers |
+|---|---|
+| `deja_recall` | Sessions matching an error string, function name, file path or flag. |
+| `deja_session` | The full digest of one past session, when the reasoning behind it matters. |
+| `deja_blame` | The sessions that discussed a file, before you edit or delete it. |
+| `deja_fix` | What this machine ran after that same error before. |
+| `deja_how` | The real invocation for a build, test or deploy, from what ran here. |
+| `deja_remember` | Stores one settled decision for later recall. |
+
+One command: `/deja <what to look for>`.
+
+And, unless you turn it off, automatic recall: before each step the plugin asks
+deja whether this machine's history answers the prompt, and adds the answer to
+the runtime context. Silence is the common case — it speaks only when there is
+something to say.
+
+```yaml
+- insert:
+    - id: deja
+      name: dsh-deja
+      config:
+        autoRecall: false   # tools and /deja only
+```
+
+## How it is wired
+
+Recall arrives through `ctx.systemPrompt.context`, evaluated on every assembly.
+The obvious alternative — a middleware on `agent/pre-step` that splices a
+message into the step — loads fine, completes the turn, and never reaches the
+model: a later listener in that waterfall rebuilds its answer from the payload
+and the added message is dropped with nothing reported. This was settled by
+reading the requests dsh 0.1.1-rc.2 actually sent.
+
+## What it does not do
+
+No LLM, no embeddings, no network. The index is a local BM25 store over files
+that already exist, so a query answers in about a millisecond and nothing leaves
+the machine. Secrets are redacted at index time.
+
+Part of [deja-vu](https://github.com/vshulcz/deja-vu). MIT.

--- a/extensions/dsh/README.zh.md
+++ b/extensions/dsh/README.zh.md
@@ -1,0 +1,50 @@
+# dsh-deja
+
+[English](README.md) | 中文
+
+DeepSeek Harness 自带的 `session-query` 已经可以检索它自己的会话。这个插件回答的是另一个问题：你在这台机器上**其他**智能体里做过什么。
+
+deja 索引 Claude Code、Codex、Cursor、opencode、Antigravity、Grok Build、Kimi、Cline、Zed 等二十个智能体本来就写在磁盘上的会话文件。不需要提前录制：历史已经在那里，包括安装 deja 之前的那些月份。如果你上周才转到 dsh，上周之前做过的事仍然可以在 dsh 里查到。
+
+## 安装
+
+```sh
+dsh plugin --profile web add dsh-deja
+```
+
+插件调用 `deja` 可执行文件。它作为依赖随插件一起安装；如果 `PATH` 上已有 `deja` 就直接使用，`DEJA_BIN` 可覆盖两者。
+
+## 提供的能力
+
+三个模型可调用的工具：
+
+| 工具 | 回答什么 |
+|---|---|
+| `deja_recall` | 匹配报错文本、函数名、文件路径或命令行参数的历史会话。 |
+| `deja_session` | 单个历史会话的完整摘要，用于需要当时的判断依据时。 |
+| `deja_blame` | 在修改或删除某个文件之前，讨论过这个文件的历史会话。 |
+| `deja_fix` | 这台机器上同样的报错之后跑过什么。 |
+| `deja_how` | 构建、测试或部署在这台机器上真实的执行命令。 |
+| `deja_remember` | 把一条已确定的决定存下来，供以后召回。 |
+
+一个命令：`/deja <要查什么>`。
+
+以及默认开启的自动召回：每一步之前，插件会问 deja 这台机器的历史能否回答当前提问，并把结果加入运行时上下文。多数情况下它保持沉默，只有确实有内容时才开口。
+
+```yaml
+- insert:
+    - id: deja
+      name: dsh-deja
+      config:
+        autoRecall: false   # 只保留工具和 /deja
+```
+
+## 接入方式
+
+召回通过 `ctx.systemPrompt.context` 注入，该回调在每次 assembly 时求值。另一种看起来可行的做法——在 `agent/pre-step` 中间件里往这一步的消息列表里插入一条消息——插件能加载、回合也能正常结束，但内容到不了模型：该 waterfall 中后续的监听器会基于 payload 重建返回值，插入的消息被丢弃且没有任何报错。这一点是通过读取 dsh 0.1.1-rc.2 实际发出的请求确认的。
+
+## 不做什么
+
+不用大模型，不用向量嵌入，不联网。索引是本地 BM25，建立在本来就存在的文件之上，一次查询约一毫秒，数据不离开本机。密钥在建立索引时被脱敏。
+
+属于 [deja-vu](https://github.com/vshulcz/deja-vu) 项目。MIT 许可。

--- a/extensions/dsh/cordis.patch.yml
+++ b/extensions/dsh/cordis.patch.yml
@@ -1,0 +1,3 @@
+- insert:
+    - id: deja
+      name: dsh-deja

--- a/extensions/dsh/index.js
+++ b/extensions/dsh/index.js
@@ -1,0 +1,300 @@
+// dsh-deja — the history you already have, inside DeepSeek Harness.
+//
+// dsh answers questions about its own sessions through the built-in
+// session-query subsystem. This plugin answers the other question: what you did
+// in Claude Code, Codex, Cursor, opencode and sixteen more agents, on this
+// machine, before dsh existed. The index is deja's; this file is the seam.
+
+import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
+
+const require = createRequire(import.meta.url);
+
+// The tool registry lives in the host. A plugin that throws on a missing peer
+// takes the whole profile down with it, so this degrades: without dsh-tools the
+// command and automatic recall still work, only the model-facing tools are
+// skipped.
+let defineTool = null;
+try {
+  ({ defineTool } = await import("@deepseek-ai/dsh-tools"));
+} catch {}
+
+const PLATFORM = process.platform === "win32" ? "windows" : process.platform;
+const ARCH = process.arch === "x64" ? "amd64" : process.arch;
+
+// resolveDeja picks the binary in the order a user would expect: what they
+// pointed at, then the deja they installed themselves and keep current with
+// `deja update` or a package manager, and only then the copy npm brought along
+// with this plugin. Each candidate is asked for its version rather than
+// trusted, because a name on PATH that does not run is worse than no name.
+function resolveDeja() {
+  const exe = PLATFORM === "windows" ? "deja.exe" : "deja";
+  const candidates = [process.env.DEJA_BIN, exe];
+  try {
+    candidates.push(require.resolve(`@vshulcz/deja-vu-${PLATFORM}-${ARCH}/bin/${exe}`));
+  } catch {}
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      execFileSync(candidate, ["version"], {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      return candidate;
+    } catch {}
+  }
+  // Nothing answered. Keep the plain name so the failure a user sees names the
+  // thing that is missing.
+  return exe;
+}
+
+const DEJA = resolveDeja();
+
+// run returns stdout, or "" when deja is missing or says nothing. Memory is
+// optional everywhere: a throw here would end the turn.
+function run(args, input) {
+  try {
+    return execFileSync(DEJA, args, {
+      encoding: "utf8",
+      timeout: 20000,
+      maxBuffer: 8 * 1024 * 1024,
+      input,
+      stdio: [input === undefined ? "ignore" : "pipe", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+const NOTHING = "Nothing in this machine's history matches that.";
+const MISSING =
+  "deja is not installed on this machine, so there is no history to search. " +
+  "Install it with: curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh";
+
+// installed answers whether the binary picked at load actually runs. Without
+// this every tool would report an empty history to a user who simply never
+// installed deja, which reads as "you have no past" rather than "nothing is
+// here to read it".
+const INSTALLED = run(["version"]) !== "";
+
+function answer(text) {
+  if (INSTALLED) return text || NOTHING;
+  return MISSING;
+}
+
+function tools(ctx) {
+  if (!defineTool) return;
+
+  // Every tool here answers with the text deja printed, so one output
+  // declaration serves them all. The schema is plain JSON Schema — a
+  // schemastery instance is rejected as "schema must be a value schema object",
+  // because the host validates that this is an ordinary JSON record.
+  const TEXT_OUTPUT = {
+    schema: { type: "string" },
+    render: (_args, value) => [{ type: "text", text: String(value) }],
+  };
+
+  ctx.tools.register(defineTool({
+    name: "deja_recall",
+    description:
+      "Search this machine's own past AI coding sessions — every agent used on it, including months before deja was installed. Use before debugging an error or re-implementing anything that may already exist. Match on the most specific token available: an exact error string, function name, file path or flag.",
+    parameters: {
+      query: {
+        type: "string",
+        required: true,
+        description: "Specific tokens to match. Several words are ANDed.",
+      },
+      limit: {
+        type: "number",
+        description: "How many sessions to return. Default 5.",
+      },
+    },
+    output: TEXT_OUTPUT,
+    execute(args) {
+      // deja itself caps the window; asking for a hundred sessions would
+      // spend the model's context on a tail nobody reads.
+      const asked = Number.isFinite(args.limit) ? Math.trunc(args.limit) : 5;
+      const limit = String(Math.min(20, Math.max(1, asked)));
+      return Promise.resolve(answer(run(["search", "--json", "--limit", limit, String(args.query)])));
+    },
+  }));
+
+  ctx.tools.register(defineTool({
+    name: "deja_session",
+    description:
+      "A full digest of the single best-matching past session — what was tried, what was decided, what it cost. Use after deja_recall when the reasoning behind an earlier decision matters, not just that it happened.",
+    parameters: {
+      query: {
+        type: "string",
+        required: true,
+        description: "A query, or a session id prefix returned by deja_recall.",
+      },
+    },
+    output: TEXT_OUTPUT,
+    execute(args) {
+      return Promise.resolve(answer(run(["ctx", String(args.query)])));
+    },
+  }));
+
+  ctx.tools.register(defineTool({
+    name: "deja_blame",
+    description:
+      "The past sessions that discussed a file, so you know why it is shaped the way it is before editing, refactoring or deleting it. Session history, not git authorship.",
+    parameters: {
+      path: {
+        type: "string",
+        required: true,
+        description: "Path to the file, absolute or relative to the workspace.",
+      },
+    },
+    output: TEXT_OUTPUT,
+    execute(args) {
+      return Promise.resolve(answer(run(["blame", String(args.path), "--json"])));
+    },
+  }));
+
+  ctx.tools.register(defineTool({
+    name: "deja_fix",
+    description:
+      "What this machine ran after that same error before, in the sessions where the error did not come back. Paste the failing output verbatim rather than a paraphrase — the match is on the error's own words.",
+    parameters: {
+      error: {
+        type: "string",
+        required: true,
+        description: "The failing output, copied as it was printed.",
+      },
+    },
+    output: TEXT_OUTPUT,
+    execute(args) {
+      return Promise.resolve(answer(run(["fix", String(args.error)])));
+    },
+  }));
+
+  ctx.tools.register(defineTool({
+    name: "deja_how",
+    description:
+      "The real invocation this machine uses for a build, test, deploy or script, with the flags it actually ran, ordered by how many sessions ran it. A guessed command is plausible and fails on this setup.",
+    parameters: {
+      what: {
+        type: "string",
+        required: true,
+        description: "The thing to run: a tool, a task, a script name.",
+      },
+    },
+    output: TEXT_OUTPUT,
+    execute(args) {
+      return Promise.resolve(answer(run(["how", String(args.what)])));
+    },
+  }));
+
+  ctx.tools.register(defineTool({
+    name: "deja_remember",
+    description:
+      "Store one durable decision once it is settled, as a single self-contained fact that will make sense months later. Not transcripts, not a summary of the conversation, and not anything already obvious from the code.",
+    parameters: {
+      text: {
+        type: "string",
+        required: true,
+        description: "The decision, in one or two sentences, with the reason it was taken.",
+      },
+    },
+    output: TEXT_OUTPUT,
+    execute(args) {
+      const written = run(["remember", String(args.text)]);
+      if (!INSTALLED) return Promise.resolve(MISSING);
+      return Promise.resolve(written || "deja did not record that.");
+    },
+  }));
+}
+
+function command(ctx) {
+  ctx.commands.register({
+    name: "deja",
+    description: "Search this machine's past AI coding sessions",
+    input: { hint: "what to look for" },
+    async handler(invocation) {
+      const query = String((invocation && invocation.rawInput) || "").trim();
+      if (!query) {
+        return { kind: "error", text: "Say what to look for: /deja <error, file, or decision>" };
+      }
+      const out = run([query]);
+      return { kind: INSTALLED ? "success" : "error", text: answer(out) };
+    },
+  });
+}
+
+function userText(message) {
+  const content = message && message.content;
+  if (!Array.isArray(content)) return typeof content === "string" ? content.trim() : "";
+  return content
+    .filter((part) => part && part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("\n")
+    .trim();
+}
+
+// autoRecall puts the answer in front of the model without anyone asking for
+// it, through the seam the host evaluates on every assembly. The obvious
+// alternative — splicing a message into the "agent/pre-step" waterfall — looks
+// like it works and does not: a later listener rebuilds its answer from the
+// payload, and the added message is dropped with nothing reported.
+function autoRecall(ctx) {
+  let asked = "";
+  let recalled = "";
+
+  ctx.systemPrompt.context({
+    name: "deja:recall",
+    order: 120,
+    text: (assembly) => {
+      const agent = assembly && assembly.agent;
+      if (!agent) return "";
+      const prompt = lastHumanText(agent);
+      if (!prompt) return "";
+      if (prompt !== asked) {
+        asked = prompt;
+        recalled = run(["hook-prompt", "--plain"], JSON.stringify({ prompt, cwd: process.cwd() }));
+      }
+      // Silence is the common case: this speaks only when the history answers.
+      return recalled;
+    },
+  });
+}
+
+// lastHumanText is the newest thing the person actually typed. At assembly
+// time the message has already left the inbox and has not been appended as a
+// "user/message" yet — the only durable record of it is the inbox splice that
+// carried it in, so both are read. Anything a plugin contributed is skipped:
+// those carry a source of their own.
+function lastHumanText(agent) {
+  const events = agent && agent.session && agent.session.events;
+  if (!Array.isArray(events)) return "";
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (!event) continue;
+    if (event.type === "user/message" && isHuman(event.data)) return userText(event.data);
+    if (event.type === "agent/inbox/spliced") {
+      const inserted = event.data && event.data.inserted;
+      if (!Array.isArray(inserted)) continue;
+      for (let j = inserted.length - 1; j >= 0; j--) {
+        if (isHuman(inserted[j])) return userText(inserted[j]);
+      }
+    }
+  }
+  return "";
+}
+
+function isHuman(message) {
+  return Boolean(message) && (!message.source || message.source.kind === "user");
+}
+
+function apply(ctx, config) {
+  tools(ctx);
+  command(ctx);
+  if (!config || config.autoRecall !== false) autoRecall(ctx);
+}
+
+apply.inject = ["tools", "commands", "systemPrompt"];
+
+export default apply;

--- a/extensions/dsh/package.json
+++ b/extensions/dsh/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "dsh-deja",
+  "version": "0.20.1",
+  "description": "Brings the session history of nineteen other coding agents into DeepSeek Harness: recall, session digest and per-file history tools over a local index, plus optional automatic recall before each step.",
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "index.js",
+    "cordis.patch.yml",
+    "README.md",
+    "README.zh.md",
+    "LICENSE"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vshulcz/deja-vu.git",
+    "directory": "extensions/dsh"
+  },
+  "homepage": "https://github.com/vshulcz/deja-vu/tree/main/extensions/dsh",
+  "bugs": {
+    "url": "https://github.com/vshulcz/deja-vu/issues"
+  },
+  "keywords": [
+    "dsh",
+    "dsh-plugin",
+    "deepseek-harness",
+    "memory",
+    "recall",
+    "session-history",
+    "migration"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
+  "dependencies": {
+    "@vshulcz/deja-vu": "^0.18.0"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  }
+}

--- a/extensions/dsh/test/pure.test.js
+++ b/extensions/dsh/test/pure.test.js
@@ -1,0 +1,53 @@
+// The plugin's pure helpers, tested without dsh.
+//
+// index.js registers itself against a live host on import, so the parts worth
+// testing are copied here as the file states them. That is a real risk — a
+// change in index.js will not fail these tests — so each case exists to pin a
+// rule that was wrong once, not to prove the file is correct.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const source = readFileSync(new URL("../index.js", import.meta.url), "utf8");
+
+test("the recall limit is bounded on both sides", () => {
+  const clamp = (asked) => Math.min(20, Math.max(1, asked));
+  assert.equal(clamp(0), 1);
+  assert.equal(clamp(-3), 1);
+  assert.equal(clamp(7), 7);
+  assert.equal(clamp(9999), 20);
+});
+
+test("tool output declares a plain JSON schema", () => {
+  // A schemastery instance is rejected by the host with "schema must be a
+  // value schema object", and the profile then fails to load at all.
+  assert.match(source, /schema: \{ type: "string" \}/);
+  assert.doesNotMatch(source, /schema: z\./);
+});
+
+test("automatic recall does not use the pre-step waterfall", () => {
+  // A message spliced there is dropped by a later listener before the request
+  // is built, with nothing reported.
+  // The comment explaining why names the event, so the check is on the
+  // registration rather than on the words.
+  assert.doesNotMatch(source, /ctx\.on\("agent\/pre-step"/);
+  assert.match(source, /ctx\.systemPrompt\.context\(/);
+});
+
+test("the patch names the package the host has to load", () => {
+  const patch = readFileSync(new URL("../cordis.patch.yml", import.meta.url), "utf8");
+  const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+  assert.match(patch, new RegExp(`name: ${pkg.name}`));
+  assert.equal(pkg.dsh.bundle.patch, "./cordis.patch.yml");
+});
+
+test("every file the manifest ships is present", () => {
+  const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+  for (const file of pkg.files) {
+    assert.doesNotThrow(
+      () => readFileSync(new URL(`../${file}`, import.meta.url)),
+      `package.json lists ${file}, which is not in the repository`,
+    );
+  }
+});

--- a/extensions/opencode/LICENSE
+++ b/extensions/opencode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vladislav Shulcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/opencode/README.md
+++ b/extensions/opencode/README.md
@@ -1,0 +1,70 @@
+# opencode-deja
+
+opencode remembers its own sessions. This plugin answers the other question:
+what you did in Claude Code, Codex, Cursor, Gemini, Zed and fifteen more agents
+on this machine — including the months before you installed anything.
+
+It runs [deja](https://github.com/vshulcz/deja-vu), a local Go binary that
+indexes the transcripts those agents already wrote to disk. No LLM, no
+embeddings, nothing leaves the machine.
+
+## Install
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-deja"]
+}
+```
+
+opencode installs the package on start. The deja binary comes with it, but a
+deja you installed yourself always wins — see [Which binary](#which-binary).
+
+## What you get
+
+Six tools the model can call:
+
+| Tool | Answers |
+|---|---|
+| `deja_recall` | past sessions matching an error, function, file or flag |
+| `deja_session` | the full digest of one past session — what was tried and decided |
+| `deja_blame` | the sessions that discussed a file, before you edit it |
+| `deja_fix` | what this machine ran after that same error, where it stayed fixed |
+| `deja_how` | the real build/test/deploy invocation, with the flags actually used |
+| `deja_remember` | store one durable decision |
+
+And recall nobody has to ask for:
+
+- the project's recent sessions are pushed onto the system prompt once per
+  session, with a one-time toast so you know memory arrived;
+- each prompt gets a relevance pass of its own — silent when nothing matches;
+- before compaction the working transcript is indexed, so the session survives
+  the window collapsing.
+
+## Options
+
+```json
+{
+  "plugin": [["opencode-deja", { "autoRecall": false, "tools": true }]]
+}
+```
+
+- `autoRecall` (default `true`) — the three hooks above. Turn off to keep only
+  the tools.
+- `tools` (default `true`) — the six tools. Turn off if you already reach deja
+  through its MCP server and do not want them twice.
+- `bin` — path to a specific deja binary.
+
+## Which binary
+
+In order: `bin` from the options, `DEJA_BIN`, a `deja` on `PATH`, the usual
+install locations (`~/.local/bin`, `/usr/local/bin`, `/opt/homebrew/bin`), and
+only then the copy npm installed with this package. Your own `deja update` or
+`brew upgrade deja` wins over whatever version this package shipped with.
+
+Without deja anywhere, the tools say so instead of reporting an empty history,
+and the hooks stay quiet.
+
+## License
+
+MIT

--- a/extensions/opencode/index.js
+++ b/extensions/opencode/index.js
@@ -1,0 +1,260 @@
+// opencode-deja — the sessions you already have, inside opencode.
+//
+// opencode remembers its own sessions. This plugin answers the other question:
+// what you did in Claude Code, Codex, Cursor, Gemini and sixteen more agents on
+// this machine, including months before deja existed. The index is deja's; this
+// file is the seam: six tools the model can call, plus recall that arrives
+// without being asked for.
+
+import { createRequire } from "node:module"
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { accessSync, constants } from "node:fs"
+
+import { clampLimit, contextText, lastUserText } from "./lib.js"
+
+const require = createRequire(import.meta.url)
+const run_ = promisify(execFile)
+
+const WINDOWS = process.platform === "win32"
+const PLATFORM = WINDOWS ? "windows" : process.platform
+const ARCH = process.arch === "x64" ? "amd64" : process.arch
+const EXE = WINDOWS ? "deja.exe" : "deja"
+
+// The tool helper is a peer of the host, not of us: it is identity plus a zod
+// re-export. Without it the hooks still run and only the model-facing tools are
+// skipped — a missing peer must not take the plugin down.
+let tool = null
+try {
+  ;({ tool } = await import("@opencode-ai/plugin"))
+} catch {}
+
+// wellKnown lists the places a user's own install lands. PATH is the normal
+// answer; these cover the case where opencode was started from a launcher with
+// a PATH that never sourced a shell profile.
+function wellKnown() {
+  const home = homedir()
+  if (WINDOWS) {
+    const local = process.env.LOCALAPPDATA || join(home, "AppData", "Local")
+    return [join(local, "deja", "bin", EXE), join(home, ".local", "bin", EXE)]
+  }
+  return [
+    join(home, ".local", "bin", EXE),
+    "/usr/local/bin/deja",
+    "/opt/homebrew/bin/deja",
+    "/usr/bin/deja",
+  ]
+}
+
+// resolveDeja picks the binary in the order a user would expect: what they
+// pointed at, then the deja they installed themselves and keep current with
+// `deja update` or brew, and only last the copy npm brought along with this
+// plugin. Pinning them to our bundled copy would freeze their memory at
+// whatever version this package was released against.
+function resolveDeja(setting) {
+  const candidates = [setting, process.env.DEJA_BIN, EXE, ...wellKnown()]
+  try {
+    candidates.push(require.resolve(`@vshulcz/deja-vu-${PLATFORM}-${ARCH}/bin/${EXE}`))
+  } catch {}
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    if (candidate.includes("/") || candidate.includes("\\")) {
+      try {
+        accessSync(candidate, constants.X_OK)
+      } catch {
+        continue
+      }
+    }
+    return candidate
+  }
+  // Nothing to check further; keep the plain name so a failure names the thing
+  // that is missing rather than a path nobody chose.
+  return EXE
+}
+
+// deja is asked for text, never for control flow: memory is optional
+// everywhere, and a throw here would end someone's turn.
+async function run(bin, args, input, cwd, timeout = 20000) {
+  try {
+    const child = run_(bin, args, {
+      encoding: "utf8",
+      timeout,
+      cwd,
+      maxBuffer: 8 * 1024 * 1024,
+    })
+    if (input !== undefined) {
+      child.child.stdin.end(input)
+    }
+    const { stdout } = await child
+    return stdout.trim()
+  } catch {
+    return ""
+  }
+}
+
+const NOTHING = "Nothing in this machine's history matches that."
+const MISSING =
+  "deja is not installed on this machine, so there is no history to search. " +
+  "Install it with: curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh"
+
+export const DejaPlugin = async ({ client, directory }, options = {}) => {
+  const config = options || {}
+  const bin = resolveDeja(typeof config.bin === "string" ? config.bin : "")
+  const cwd = directory || process.cwd()
+  // Every call runs in the session's own directory: deja ranks by project.
+  const ask = (args, input, timeout) => run(bin, args, input, cwd, timeout)
+
+  // Whether the binary answers at all is asked once. Without it every tool
+  // would report an empty history to someone who simply never installed deja,
+  // which reads as "you have no past" rather than "nothing is here to read it".
+  const installed = (await ask(["version"], undefined, 5000)) !== ""
+  const answer = (text) => (installed ? text || NOTHING : MISSING)
+
+  const digests = new Map()
+  const told = new Set()
+
+  const hooks = {}
+
+  if (config.tools !== false && tool) {
+    const schema = tool.schema
+    hooks.tool = {
+      deja_recall: tool({
+        description:
+          "Search this machine's own past AI coding sessions — every agent used on it, including months before deja was installed. Use before debugging an error or re-implementing anything that may already exist. Match on the most specific token available: an exact error string, function name, file path or flag.",
+        args: {
+          query: schema.string().describe("Specific tokens to match. Several words are ANDed."),
+          limit: schema.number().optional().describe("How many sessions to return. Default 5."),
+        },
+        async execute(args) {
+          const limit = String(clampLimit(args.limit))
+          return answer(await ask(["search", "--json", "--limit", limit, String(args.query)]))
+        },
+      }),
+      deja_session: tool({
+        description:
+          "A full digest of the single best-matching past session — what was tried, what was decided, what it cost. Use after deja_recall when the reasoning behind an earlier decision matters, not just that it happened.",
+        args: {
+          query: schema.string().describe("A query, or a session id prefix returned by deja_recall."),
+        },
+        async execute(args) {
+          return answer(await ask(["ctx", String(args.query)]))
+        },
+      }),
+      deja_blame: tool({
+        description:
+          "The past sessions that discussed a file, so you know why it is shaped the way it is before editing, refactoring or deleting it. Session history, not git authorship.",
+        args: {
+          path: schema.string().describe("Path to the file, absolute or relative to the project."),
+        },
+        async execute(args) {
+          return answer(await ask(["blame", String(args.path), "--json"]))
+        },
+      }),
+      deja_fix: tool({
+        description:
+          "What this machine ran after that same error before, in the sessions where the error did not come back. Paste the failing output verbatim rather than a paraphrase — the match is on the error's own words.",
+        args: {
+          error: schema.string().describe("The failing output, copied as it was printed."),
+        },
+        async execute(args) {
+          return answer(await ask(["fix", String(args.error)]))
+        },
+      }),
+      deja_how: tool({
+        description:
+          "The real invocation this machine uses for a build, test, deploy or script, with the flags it actually ran, ordered by how many sessions ran it. A guessed command is plausible and fails on this setup.",
+        args: {
+          what: schema.string().describe("The thing to run: a tool, a task, a script name."),
+        },
+        async execute(args) {
+          return answer(await ask(["how", String(args.what)]))
+        },
+      }),
+      deja_remember: tool({
+        description:
+          "Store one durable decision once it is settled, as a single self-contained fact that will make sense months later. Not transcripts, not a summary of the conversation, and not anything already obvious from the code.",
+        args: {
+          text: schema.string().describe("The decision, in one or two sentences, with the reason it was taken."),
+        },
+        async execute(args) {
+          const written = await ask(["remember", String(args.text)])
+          if (!installed) return MISSING
+          return written || "deja did not record that."
+        },
+      }),
+    }
+  }
+
+  if (config.autoRecall === false) return hooks
+
+  // opencode has no session-start hook. The system prompt is assembled on
+  // every request, so the session digest is fetched once and pushed there —
+  // the same place Claude Code's SessionStart output lands.
+  hooks["experimental.chat.system.transform"] = async (input, output) => {
+    try {
+      const key = input?.sessionID || "default"
+      if (!digests.has(key)) {
+        const { context, receipt } = contextText(await ask(["hook-context"], undefined, 30000))
+        digests.set(key, context)
+        // The receipt is the only sign the user gets that memory arrived. Once
+        // per session: repeating it every turn is wallpaper. The hook's own
+        // output is model context, so the toast is the only channel for it.
+        if (receipt && !told.has(key)) {
+          told.add(key)
+          await client.tui.showToast({
+            body: { message: receipt, variant: "info", duration: 6000 },
+          })
+        }
+      }
+      const context = digests.get(key)
+      if (context) {
+        output.system.push(context)
+        return
+      }
+      // Nothing recalled: either this machine has no history yet, or the first
+      // index is still building. Only the second is worth saying, and saying it
+      // drops the empty answer so the next turn asks again.
+      if (told.has(key)) return
+      const status = await ask(["warmup-status"], undefined, 5000)
+      if (!status) return
+      told.add(key)
+      digests.delete(key)
+      await client.tui.showToast({
+        body: { message: status, variant: "info", duration: 6000 },
+      })
+    } catch {
+      // memory is optional: never break the session over it
+    }
+  }
+
+  // Per-prompt recall, the relevance pass Claude Code gets on
+  // UserPromptSubmit: the digest above is ranked by the project, this is ranked
+  // by what the user just asked. Silent when nothing matches.
+  hooks["experimental.chat.messages.transform"] = async (_input, output) => {
+    try {
+      const { parts, prompt } = lastUserText(output?.messages)
+      if (!prompt) return
+      const raw = await ask(["hook-prompt"], JSON.stringify({ prompt, cwd }))
+      if (!raw) return
+      const extra = JSON.parse(raw)?.hookSpecificOutput?.additionalContext
+      if (!extra) return
+      parts[parts.length - 1].text += "\n\n" + extra
+    } catch {
+      // memory is optional: never break the session over it
+    }
+  }
+
+  // Compaction is about to throw the working transcript away. Index what
+  // exists now, so the session survives in memory after the window collapses.
+  hooks["experimental.session.compacting"] = async () => {
+    try {
+      await ask(["hook-precompact"], undefined, 60000)
+    } catch {
+      // memory is optional: never break a compaction over it
+    }
+  }
+
+  return hooks
+}

--- a/extensions/opencode/lib.js
+++ b/extensions/opencode/lib.js
@@ -1,0 +1,43 @@
+// The pure half of the plugin: everything that reads deja's output or
+// opencode's message shape, with no process and no host. Kept apart from
+// index.js because opencode loads every function a plugin module exports —
+// a helper exported next to the plugin gets called as one.
+
+// contextText pulls the recall out of whatever hook-context printed. deja
+// answers in the Claude Code hook shape; older builds and `--plain` print bare
+// text, so both are accepted.
+export function contextText(raw) {
+  const text = String(raw || "").trim()
+  if (!text) return { context: "", receipt: "" }
+  try {
+    const parsed = JSON.parse(text)
+    return {
+      context: parsed?.hookSpecificOutput?.additionalContext || "",
+      receipt: parsed?.systemMessage || "",
+    }
+  } catch {
+    return { context: text, receipt: "" }
+  }
+}
+
+// lastUserText is what the person typed on this turn, which is what the
+// per-prompt recall is ranked against. Parts a plugin appended earlier are
+// part of the same message, so the text is joined and matched whole.
+export function lastUserText(messages) {
+  const list = Array.isArray(messages) ? messages : []
+  for (let i = list.length - 1; i >= 0; i--) {
+    if (list[i]?.info?.role !== "user") continue
+    const parts = (list[i].parts || []).filter((p) => p?.type === "text" && p.text)
+    if (!parts.length) return { parts: [], prompt: "" }
+    return { parts, prompt: parts.map((p) => p.text).join("\n").trim() }
+  }
+  return { parts: [], prompt: "" }
+}
+
+// clampLimit keeps a model that asks for a hundred sessions from spending the
+// window on a tail nobody reads.
+export function clampLimit(value, fallback = 5) {
+  const asked = Number(value)
+  if (!Number.isFinite(asked)) return fallback
+  return Math.min(20, Math.max(1, Math.trunc(asked)))
+}

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "opencode-deja",
+  "version": "0.1.0",
+  "description": "Brings the session history of nineteen other coding agents into opencode: recall, session digest and per-file history tools over a local index, plus automatic recall on every request.",
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "index.js",
+    "lib.js",
+    "README.md",
+    "LICENSE"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vshulcz/deja-vu.git",
+    "directory": "extensions/opencode"
+  },
+  "homepage": "https://github.com/vshulcz/deja-vu/tree/main/extensions/opencode",
+  "bugs": {
+    "url": "https://github.com/vshulcz/deja-vu/issues"
+  },
+  "keywords": [
+    "opencode",
+    "opencode-plugin",
+    "memory",
+    "recall",
+    "session-history",
+    "agent"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@opencode-ai/plugin": ">=1.0.0",
+    "@vshulcz/deja-vu": "^0.18.0"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  }
+}

--- a/extensions/opencode/test/pure.test.js
+++ b/extensions/opencode/test/pure.test.js
@@ -1,0 +1,42 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { clampLimit, contextText, lastUserText } from "../lib.js"
+
+test("contextText reads the hook shape deja prints", () => {
+  const raw = JSON.stringify({
+    systemMessage: "deja: recalled 3 prior sessions",
+    hookSpecificOutput: { additionalContext: "past work" },
+  })
+  assert.deepEqual(contextText(raw), { context: "past work", receipt: "deja: recalled 3 prior sessions" })
+})
+
+test("contextText falls back to bare text", () => {
+  assert.deepEqual(contextText("  past work  "), { context: "past work", receipt: "" })
+  assert.deepEqual(contextText(""), { context: "", receipt: "" })
+})
+
+test("lastUserText joins the newest user message, ignoring the assistant's", () => {
+  const messages = [
+    { info: { role: "user" }, parts: [{ type: "text", text: "old" }] },
+    { info: { role: "assistant" }, parts: [{ type: "text", text: "reply" }] },
+    { info: { role: "user" }, parts: [{ type: "text", text: "why" }, { type: "text", text: "this" }] },
+  ]
+  const { prompt, parts } = lastUserText(messages)
+  assert.equal(prompt, "why\nthis")
+  assert.equal(parts.length, 2)
+})
+
+test("lastUserText is empty when there is nothing to rank against", () => {
+  assert.equal(lastUserText([]).prompt, "")
+  assert.equal(lastUserText(undefined).prompt, "")
+  assert.equal(lastUserText([{ info: { role: "user" }, parts: [{ type: "file" }] }]).prompt, "")
+})
+
+test("clampLimit keeps the window small", () => {
+  assert.equal(clampLimit(undefined), 5)
+  assert.equal(clampLimit("3"), 3)
+  assert.equal(clampLimit(0), 1)
+  assert.equal(clampLimit(500), 20)
+  assert.equal(clampLimit(NaN), 5)
+})

--- a/extensions/zed/Cargo.toml
+++ b/extensions/zed/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "zed_deja"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT"
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+schemars = "0.8"
+serde = "1.0"
+zed_extension_api = "0.7.0"
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true

--- a/extensions/zed/README.md
+++ b/extensions/zed/README.md
@@ -1,0 +1,41 @@
+# deja for Zed
+
+[deja](https://github.com/vshulcz/deja-vu) indexes the session files that
+coding agents already write to disk — Claude Code, Codex, Cursor, opencode and
+sixteen more — and answers from them. This extension serves that index to Zed's
+agent panel as a context server, so a thread can search what you did before,
+including work from before deja was installed.
+
+## What the agent gets
+
+| Tool | Answers |
+|---|---|
+| `recall` | Sessions matching an error string, function name, file path or flag. |
+| `recall_context` | The full digest of one past session, when the reasoning behind it matters. |
+| `blame` | The sessions that discussed a file, before you edit or delete it. |
+| `fix` | What this machine ran after that same error before. |
+| `how` | The real invocation for a build, test or deploy, from what ran here. |
+| `remember` | Stores one durable decision for later recall. |
+
+## Install
+
+Install the extension from Zed's extension list. On first use it downloads a
+release build of the `deja` binary into its own directory; if you already have
+one, point at it:
+
+```json
+{
+  "context_servers": {
+    "deja-context-server": {
+      "settings": {
+        "binary": "/opt/homebrew/bin/deja"
+      }
+    }
+  }
+}
+```
+
+Indexing and search are local. Nothing is sent anywhere, and credentials are
+redacted as the index is built.
+
+MIT, same as deja.

--- a/extensions/zed/configuration/installation_instructions.md
+++ b/extensions/zed/configuration/installation_instructions.md
@@ -1,0 +1,34 @@
+deja indexes the session files your other coding agents already wrote to disk —
+Claude Code, Codex, Cursor, opencode and more — and answers from them over MCP,
+including sessions from before it was installed. No LLM, no embeddings, nothing
+leaves the machine.
+
+If deja is already installed — the install script, Homebrew, `go install` — the
+extension uses that binary, and you keep it current the way you always did.
+Otherwise the first start downloads a release build into the extension's own
+directory, about 12 MB. On a slow connection that download
+can outlast the sixty seconds Zed allows a context server to answer, and the
+server is reported as timed out; starting it again uses the downloaded copy and
+connects immediately.
+
+A downloaded copy is checked against the current release about once a week, and
+any failure in that check keeps the copy already on disk — an old deja answers,
+an unreachable GitHub does not.
+
+To name a specific binary:
+
+```json
+{
+  "context_servers": {
+    "deja-context-server": {
+      "settings": {
+        "binary": "/opt/homebrew/bin/deja"
+      }
+    }
+  }
+}
+```
+
+The first query builds the index over whatever history is already on the
+machine, which takes a few seconds; later queries answer in about a
+millisecond.

--- a/extensions/zed/extension.toml
+++ b/extensions/zed/extension.toml
@@ -1,0 +1,14 @@
+id = "deja-context-server"
+name = "deja"
+description = "Search the sessions your other coding agents already wrote to disk, from inside Zed"
+version = "0.1.0"
+schema_version = 1
+authors = ["vshulcz <vshulcz@gmail.com>"]
+repository = "https://github.com/vshulcz/deja-vu"
+
+[context_servers.deja-context-server]
+name = "deja"
+
+[slash_commands.deja]
+description = "Search the sessions your other coding agents already wrote"
+requires_argument = true

--- a/extensions/zed/src/lib.rs
+++ b/extensions/zed/src/lib.rs
@@ -1,0 +1,312 @@
+//! deja as a Zed context server.
+//!
+//! deja indexes the session files that other coding agents on the same machine
+//! already wrote — Claude Code, Codex, Cursor, opencode and more — and answers
+//! from them over MCP. This extension starts `deja mcp` for Zed's agent panel.
+//!
+//! A context server cannot look at $PATH — the extension API hands it a
+//! project, and only a worktree can answer `which`. So the binary comes from
+//! the `binary` setting when one is given, and otherwise from the project's
+//! own GitHub releases, downloaded into the extension's directory.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use zed::settings::ContextServerSettings;
+use zed_extension_api::{
+    self as zed, Architecture, Command, ContextServerConfiguration, ContextServerId,
+    DownloadedFileType, GithubReleaseOptions, Os, Project, Result, SlashCommand,
+    SlashCommandOutput, SlashCommandOutputSection, Worktree,
+};
+
+const REPOSITORY: &str = "vshulcz/deja-vu";
+const BINARY: &str = "deja";
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct DejaSettings {
+    /// Path to an installed deja binary. Leave it unset and the extension
+    /// downloads a release build of its own.
+    binary: Option<String>,
+}
+
+struct DejaExtension {
+    cached_binary_path: Option<String>,
+}
+
+impl DejaExtension {
+    /// The binary Zed should run: the configured one if the user named it,
+    /// then the copy this extension downloaded earlier, and only then a fresh
+    /// download of the current release.
+    fn binary_path(&mut self, project: &Project) -> Result<String> {
+        let settings = ContextServerSettings::for_project("deja-context-server", project)
+            .ok()
+            .and_then(|settings| settings.settings)
+            .and_then(|value| zed::serde_json::from_value::<DejaSettings>(value).ok())
+            .unwrap_or_default();
+
+        if let Some(path) = settings.binary {
+            return Ok(path);
+        }
+
+        if let Some(path) = self.cached_binary_path.clone() {
+            return Ok(path);
+        }
+
+        // An installed deja is the one the user keeps current with `deja
+        // update` or their package manager, so it wins over anything this
+        // extension downloaded. A context server cannot ask the worktree for
+        // $PATH, hence the well-known locations.
+        if let Some(path) = installed_binary() {
+            self.cached_binary_path = Some(path.clone());
+            return Ok(path);
+        }
+
+        // A copy from an earlier session is worth more than a fresh one: asking
+        // GitHub for the latest release is a network round trip, and it happens
+        // inside the window Zed gives the server to answer `initialize`. Sixty
+        // seconds is generous for a handshake and thin for a download.
+        //
+        // Left alone, though, that copy is the one this user runs forever. So
+        // once a week the check is allowed to happen, and every failure inside
+        // it falls back to what is already on disk: a stale deja answers, an
+        // unreachable GitHub does not.
+        if let Some(path) = downloaded_binary() {
+            if !due_for_check() {
+                self.cached_binary_path = Some(path.clone());
+                return Ok(path);
+            }
+            record_check();
+            match self.download_release() {
+                Ok(fresh) => {
+                    self.cached_binary_path = Some(fresh.clone());
+                    return Ok(fresh);
+                }
+                Err(_) => {
+                    self.cached_binary_path = Some(path.clone());
+                    return Ok(path);
+                }
+            }
+        }
+
+        self.download_release()
+    }
+
+    /// Fetch the current release and unpack it beside the older ones.
+    fn download_release(&mut self) -> Result<String> {
+
+        // This is the one place an offline or firewalled machine gives up, so
+        // the message has to say what to do rather than repeat the transport
+        // error.
+        let release = zed::latest_github_release(
+            REPOSITORY,
+            GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false,
+            },
+        )
+        .map_err(|error| {
+            format!(
+                "no deja binary was found and the release could not be fetched ({error}). \
+                 Install deja — curl -fsSL \
+                 https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh, or \
+                 brew install vshulcz/tap/deja-vu — and it will be used from there"
+            )
+        })?;
+
+        let (os, arch) = zed::current_platform();
+        // Release archives are named deja-vu_<version>_<os>_<arch>, with the
+        // version carrying no leading v.
+        let version = release.version.trim_start_matches('v');
+        let (platform, extension, file_type) = match (os, arch) {
+            (Os::Mac, Architecture::Aarch64) => ("darwin_arm64", "tar.gz", DownloadedFileType::GzipTar),
+            (Os::Mac, Architecture::X8664) => ("darwin_amd64", "tar.gz", DownloadedFileType::GzipTar),
+            (Os::Linux, Architecture::Aarch64) => ("linux_arm64", "tar.gz", DownloadedFileType::GzipTar),
+            (Os::Linux, Architecture::X8664) => ("linux_amd64", "tar.gz", DownloadedFileType::GzipTar),
+            (Os::Windows, Architecture::Aarch64) => ("windows_arm64", "zip", DownloadedFileType::Zip),
+            (Os::Windows, Architecture::X8664) => ("windows_amd64", "zip", DownloadedFileType::Zip),
+            _ => {
+                return Err(format!(
+                    "deja publishes no release build for this platform, so it has to be built \
+                     from source: go install github.com/vshulcz/deja-vu/cmd/deja@latest, then \
+                     set the \"binary\" setting to the path it lands in"
+                ));
+            }
+        };
+
+        let asset_name = format!("deja-vu_{version}_{platform}.{extension}");
+        let asset = release
+            .assets
+            .into_iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or_else(|| format!("no asset named {asset_name} in the deja-vu release"))?;
+
+        let version_dir = format!("deja-{version}");
+        let binary_path = if os == Os::Windows {
+            format!("{version_dir}/{BINARY}.exe")
+        } else {
+            format!("{version_dir}/{BINARY}")
+        };
+
+        zed::download_file(&asset.download_url, &version_dir, file_type)
+            .map_err(|error| format!("downloading {asset_name} failed: {error}"))?;
+        zed::make_file_executable(&binary_path)
+            .map_err(|error| format!("{binary_path} is not executable: {error}"))?;
+
+        self.cached_binary_path = Some(binary_path.clone());
+        Ok(binary_path)
+    }
+}
+
+const CHECK_MARKER: &str = ".last-release-check";
+const CHECK_EVERY: u64 = 60 * 60 * 24 * 7;
+
+/// Whether a week has passed since the last time the release was looked up.
+/// An unreadable or unwritable marker means yes: a check that costs one request
+/// is cheaper than a user pinned to an old binary forever.
+fn due_for_check() -> bool {
+    let Ok(text) = std::fs::read_to_string(CHECK_MARKER) else {
+        return true;
+    };
+    let Ok(then) = text.trim().parse::<u64>() else {
+        return true;
+    };
+    now_seconds().is_none_or(|now| now.saturating_sub(then) >= CHECK_EVERY)
+}
+
+fn record_check() {
+    if let Some(now) = now_seconds() {
+        let _ = std::fs::write(CHECK_MARKER, now.to_string());
+    }
+}
+
+fn now_seconds() -> Option<u64> {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|since| since.as_secs())
+}
+
+/// deja as installed by the user, if it sits in one of the places the install
+/// script, Homebrew and `go install` put it.
+fn installed_binary() -> Option<String> {
+    if zed::current_platform().0 == Os::Windows {
+        return None;
+    }
+    let home = std::env::var("HOME").ok()?;
+    let candidates = [
+        format!("{home}/.local/bin/deja"),
+        "/opt/homebrew/bin/deja".to_string(),
+        "/usr/local/bin/deja".to_string(),
+        format!("{home}/go/bin/deja"),
+    ];
+    candidates
+        .into_iter()
+        .find(|path| std::fs::metadata(path).is_ok())
+}
+
+/// The newest `deja-<version>/deja` this extension downloaded before, if any.
+fn downloaded_binary() -> Option<String> {
+    let name = if zed::current_platform().0 == Os::Windows {
+        "deja.exe"
+    } else {
+        "deja"
+    };
+    let mut found: Vec<String> = std::fs::read_dir(".")
+        .ok()?
+        .flatten()
+        .filter_map(|entry| {
+            let dir = entry.file_name().to_string_lossy().into_owned();
+            if !dir.starts_with("deja-") {
+                return None;
+            }
+            let candidate = format!("{dir}/{name}");
+            std::fs::metadata(&candidate).ok().map(|_| candidate)
+        })
+        .collect();
+    found.sort();
+    found.pop()
+}
+
+impl zed::Extension for DejaExtension {
+    fn new() -> Self {
+        Self {
+            cached_binary_path: None,
+        }
+    }
+
+    fn context_server_command(
+        &mut self,
+        _context_server_id: &ContextServerId,
+        project: &Project,
+    ) -> Result<Command> {
+        Ok(Command {
+            command: self.binary_path(project)?,
+            args: vec!["mcp".into()],
+            env: vec![],
+        })
+    }
+
+    /// `/deja <query>` — the same search the terminal gives, dropped into the
+    /// thread. Unlike the context server this runs in the extension itself, so
+    /// it can ask the worktree where `deja` is before falling back to the copy
+    /// downloaded for the server.
+    fn run_slash_command(
+        &self,
+        _command: SlashCommand,
+        args: Vec<String>,
+        worktree: Option<&Worktree>,
+    ) -> Result<SlashCommandOutput> {
+        let query = args.join(" ");
+        if query.trim().is_empty() {
+            return Err("say what to look for: /deja <error, file or decision>".into());
+        }
+
+        let binary = worktree
+            .and_then(|worktree| worktree.which(BINARY))
+            .or_else(downloaded_binary)
+            .ok_or_else(|| {
+                "deja is not on PATH and this extension has not downloaded a copy yet. Open the \
+                 agent panel once so the context server fetches one, or install deja: curl -fsSL \
+                 https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh"
+                    .to_string()
+            })?;
+
+        let output = zed::process::Command::new(binary)
+            .arg(query.clone())
+            .envs(worktree.map(|worktree| worktree.shell_env()).unwrap_or_default())
+            .output()?;
+
+        let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let text = if text.is_empty() {
+            "Nothing in this machine's history matches that.".to_string()
+        } else {
+            text
+        };
+
+        Ok(SlashCommandOutput {
+            sections: vec![SlashCommandOutputSection {
+                range: (0..text.len() as u32).into(),
+                label: format!("deja: {query}"),
+            }],
+            text,
+        })
+    }
+
+    fn context_server_configuration(
+        &mut self,
+        _context_server_id: &ContextServerId,
+        _project: &Project,
+    ) -> Result<Option<ContextServerConfiguration>> {
+        let installation_instructions =
+            include_str!("../configuration/installation_instructions.md").to_string();
+        let settings_schema = zed::serde_json::to_string(&schemars::schema_for!(DejaSettings))
+            .map_err(|e| e.to_string())?;
+
+        Ok(Some(ContextServerConfiguration {
+            installation_instructions,
+            default_settings: "{}".into(),
+            settings_schema,
+        }))
+    }
+}
+
+zed::register_extension!(DejaExtension);


### PR DESCRIPTION
Closes #1561.

`extensions/opencode`, `extensions/dsh` and `extensions/zed` — the three harness-native packages, moved out of their own repositories and into this one. Nothing about how they are installed changes: npm keeps serving `opencode-deja` and `dsh-deja`, Zed keeps building `deja-context-server`.

The parts a reviewer would otherwise have to reconstruct:

- npm publishes from a subdirectory, so each package carries its own `LICENSE` and a `repository.directory`. The `metadata` CI job fails if either drifts — published metadata is what a user follows back to the source, and npm keeps serving a stale `repository` field until somebody notices.
- Zed builds `extensions/zed` through a `path` key in the registry's `extensions.toml`; the submodule in zed-industries/extensions#7307 moves to this repository in a follow-up push there.
- One workflow, four jobs, weekly: these break from an upstream API change, not from our commits. The opencode job re-checks that the three hooks it implements are still declared in `@opencode-ai/plugin`.
- `claude-plugin/` and `codex-plugin/` stay at the root — their manifests are already submitted against those paths, and `cmd/deja` tests assert them.

`dsh-deja` goes out as 0.20.1 (metadata only). `opencode-deja` has not been published yet.