### PR TITLE
fix(extensions): carry the licence into the Zed extension directory

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -151,5 +151,13 @@ jobs:
                 bad++;
               }
             }
+            // Zed reads the licence from the extension directory the registry
+            // builds, not from the repository root: a monorepo entry with the
+            // licence only at the top fails packaging with "No license was
+            // found."
+            if (!fs.existsSync("extensions/zed/LICENSE")) {
+              console.error("extensions/zed: no LICENSE where Zed looks for it");
+              bad++;
+            }
             process.exit(bad ? 1 : 0);
           '

--- a/extensions/zed/LICENSE
+++ b/extensions/zed/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vladislav Shulcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The registry packages from the directory `extensions.toml` points at, and looks for the licence there — a licence at the repository root is invisible to it. zed-industries/extensions#7307 failed on exactly that after the move: `Error: No license was found.`

Adds `extensions/zed/LICENSE` and a CI check so the next monorepo extension does not rediscover it. Follow-on from #1561.