### PR TITLE
docs(zh): point the dsh plugin link at extensions/dsh

### DIFF
--- a/README.zh.md
+++ b/README.zh.md
@@ -49,7 +49,7 @@ dsh plugin --profile web add dsh-deja
 ```
 
 它带来三个模型可调用的工具（`deja_recall`、`deja_session`、`deja_blame`）、`/deja` 命令，
-以及可选的自动召回。详见 [vshulcz/dsh-deja](https://github.com/vshulcz/dsh-deja)。
+以及可选的自动召回。详见 [`extensions/dsh`](extensions/dsh)。
 
 其他安装方式：`brew install vshulcz/tap/deja-vu`、
 `go install github.com/vshulcz/deja-vu/cmd/deja@latest`，或者用


### PR DESCRIPTION
The Chinese README still linked vshulcz/dsh-deja, which is now back in this repo under extensions/dsh.