### PR TITLE
fix(extensions): stop recalling twice when both installs are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ install`. Those packages live in [`extensions/`](extensions):
 | Zed | `deja-context-server` | Zed → Extensions → deja |
 
 Each uses the deja you already have; the copy it bundles is only the fallback.
+`deja install` also wires all three, so running both is fine: the package finds
+what the installer wrote and drops the part it already covers, rather than
+recalling twice.
 
 ## Semantic recall (optional)
 

--- a/cmd/deja/install_zed.go
+++ b/cmd/deja/install_zed.go
@@ -28,6 +28,14 @@ func installZedMCP(path, exe string, uninstall bool) (installResult, error) {
 		return installResult{}, err
 	}
 
+	// The Zed extension declares a context server of its own, and Zed records
+	// it in this same file under its extension id. Adding ours next to it
+	// starts `deja mcp` twice and shows the agent every tool twice, so the
+	// extension wins: it is the thing the user installed from Zed's UI.
+	if !uninstall && zedExtensionPresent(string(old)) {
+		return installResult{Path: path, Action: "skipped: the Zed extension already provides it"}, nil
+	}
+
 	if len(strings.TrimSpace(string(old))) == 0 {
 		// Nothing to preserve. Uninstalling from a file that does not exist
 		// must not create one (#676).
@@ -98,6 +106,26 @@ func zedSettingsWith(text, entry string, uninstall bool) (string, error) {
 	}
 	return text[:inner.valueOpen] + entry + text[inner.valueEnd:], nil
 }
+
+// zedExtensionPresent reports whether Zed's own extension already declares the
+// server. Zed writes the extension's id into context_servers when the user
+// installs it, so the id in the settings is the signal — the extension
+// directory moved between Zed versions, the settings key did not.
+func zedExtensionPresent(text string) bool {
+	open := zedTopLevelOpen(text)
+	if open < 0 {
+		return false
+	}
+	block := zedFindKey(text, open+1, zedServerKey)
+	if block == nil {
+		return false
+	}
+	return zedFindKey(text, block.valueOpen+1, zedExtensionServerID) != nil
+}
+
+// zedExtensionServerID is the id in extensions/zed/extension.toml. Zed keys the
+// settings entry by it, so the two have to stay the same string.
+const zedExtensionServerID = "deja-context-server"
 
 // zedSpan is where a key and its object value sit in the text.
 type zedSpan struct {

--- a/cmd/deja/install_zed_test.go
+++ b/cmd/deja/install_zed_test.go
@@ -542,3 +542,48 @@ func TestDoctorListsZed(t *testing.T) {
 		t.Error("doctor lists no zed row, so `deja install zed` cannot be verified")
 	}
 }
+
+// A user who installs the Zed extension and then runs `deja install --auto`
+// would otherwise get two context servers pointing at the same binary: Zed's
+// own entry for the extension and ours. Both start `deja mcp`, and the agent
+// sees every tool twice.
+func TestZedInstallSkipsWhenExtensionIsPresent(t *testing.T) {
+	body := `{
+  "context_servers": {
+    "deja-context-server": {
+      "enabled": true,
+      "settings": {}
+    }
+  }
+}
+`
+	path := zedSettingsFile(t, body)
+	res, err := installZedMCP(path, "deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(res.Action, "skipped") {
+		t.Fatalf("action = %q, want a skip", res.Action)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != body {
+		t.Fatalf("settings were rewritten:\n%s", after)
+	}
+}
+
+// The skip keys off the extension's id, so the id in the manifest Zed reads and
+// the constant here have to be the same string. They are edited in different
+// files, months apart.
+func TestZedExtensionIDMatchesManifest(t *testing.T) {
+	manifest := string(repoFile(t, "extensions/zed/extension.toml"))
+	want := "id = \"" + zedExtensionServerID + "\""
+	if !strings.Contains(manifest, want) {
+		t.Fatalf("extension.toml does not declare %s:\n%s", want, manifest)
+	}
+	if !strings.Contains(manifest, "[context_servers."+zedExtensionServerID+"]") {
+		t.Fatalf("extension.toml does not register the context server under %q:\n%s", zedExtensionServerID, manifest)
+	}
+}

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -39,6 +39,12 @@ moves the submodule to the new commit.
   `brew upgrade` has to win over whatever we bundled.
 - **Recall is optional.** A harness must never lose a turn because history was
   unavailable: every call is wrapped, every failure is silent.
+- **Assume the other install is there too.** `deja install` wires these three
+  harnesses as well, so a user can end up with both at once — opencode loads the
+  package and the installer's plugin file side by side, dsh composes both into
+  one profile, Zed reads both context servers. Whatever the installer writes
+  wins, because it is the copy `deja install` keeps current: each package looks
+  for those files and drops the part they already cover.
 - **Verify by running.** Each of these had a failure that was invisible in the
   source and obvious the moment the real host executed it — a peer dependency
   the host does not install, a hook that accepts input and drops it, a 60-second

--- a/extensions/dsh/index.js
+++ b/extensions/dsh/index.js
@@ -7,6 +7,9 @@
 
 import { createRequire } from "node:module";
 import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 const require = createRequire(import.meta.url);
 
@@ -289,9 +292,31 @@ function isHuman(message) {
   return Boolean(message) && (!message.source || message.source.kind === "user");
 }
 
+// cliPluginDir is where `deja install dsh` writes plugins of its own. A user
+// who ran the installer and then added this package has both in the profile:
+// two `/deja` commands and the same recall on the system prompt twice. The
+// files on disk win — the installer keeps them current — and this package then
+// contributes only what they do not: the model-facing tools.
+function cliPluginDir() {
+  const home = process.env.DSH_HOME || join(homedir(), ".dsh");
+  return join(home, "plugins", "deja");
+}
+
+function installedByCLI(file) {
+  try {
+    return existsSync(join(cliPluginDir(), file));
+  } catch {
+    return false;
+  }
+}
+
 function apply(ctx, config) {
   tools(ctx);
-  command(ctx);
+  // Each half stands down on its own: `deja install dsh` writes command.js,
+  // and only `deja install dsh-auto` adds auto.js, so a profile can have the
+  // command from the installer and still want recall from here.
+  if (!installedByCLI("command.js")) command(ctx);
+  if (installedByCLI("auto.js")) return;
   if (!config || config.autoRecall !== false) autoRecall(ctx);
 }
 

--- a/extensions/dsh/package.json
+++ b/extensions/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-deja",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Brings the session history of nineteen other coding agents into DeepSeek Harness: recall, session digest and per-file history tools over a local index, plus optional automatic recall before each step.",
   "type": "module",
   "main": "index.js",

--- a/extensions/dsh/test/pure.test.js
+++ b/extensions/dsh/test/pure.test.js
@@ -6,8 +6,12 @@
 // rule that was wrong once, not to prove the file is correct.
 
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
+
+import apply from "../index.js";
 
 const source = readFileSync(new URL("../index.js", import.meta.url), "utf8");
 
@@ -50,4 +54,65 @@ test("every file the manifest ships is present", () => {
       `package.json lists ${file}, which is not in the repository`,
     );
   }
+});
+
+// `deja install dsh` writes plugins of its own into DSH_HOME, and dsh composes
+// both them and this package into one profile: two `/deja` commands and the
+// same recall on the system prompt twice. Each half stands down separately,
+// because the command is installed by `deja install dsh` and the recall only by
+// `deja install dsh-auto`.
+function fakeCtx() {
+  const seen = { tools: 0, commands: [], context: [] };
+  return {
+    seen,
+    tools: { register: () => seen.tools++ },
+    commands: { register: (c) => seen.commands.push(c.name) },
+    systemPrompt: { context: (c) => seen.context.push(c.name) },
+  };
+}
+
+function withDSHHome(files, run) {
+  const dir = mkdtempSync(join(tmpdir(), "deja-dsh-"));
+  mkdirSync(join(dir, "plugins", "deja"), { recursive: true });
+  for (const file of files) writeFileSync(join(dir, "plugins", "deja", file), "// installed by deja\n");
+  const previous = process.env.DSH_HOME;
+  process.env.DSH_HOME = dir;
+  try {
+    return run();
+  } finally {
+    if (previous === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = previous;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("nothing installed by the CLI: the package contributes everything", () => {
+  const ctx = withDSHHome([], () => {
+    const ctx = fakeCtx();
+    apply(ctx, {});
+    return ctx;
+  });
+  assert.deepEqual(ctx.seen.commands, ["deja"]);
+  assert.deepEqual(ctx.seen.context, ["deja:recall"]);
+});
+
+test("the CLI's command file stands the package's command down", () => {
+  const ctx = withDSHHome(["command.js"], () => {
+    const ctx = fakeCtx();
+    apply(ctx, {});
+    return ctx;
+  });
+  assert.deepEqual(ctx.seen.commands, []);
+  assert.deepEqual(ctx.seen.context, ["deja:recall"], "recall was not installed by the CLI, so it stays here");
+});
+
+test("the CLI's auto file stands the package's recall down", () => {
+  const ctx = withDSHHome(["command.js", "auto.js"], () => {
+    const ctx = fakeCtx();
+    apply(ctx, {});
+    return ctx;
+  });
+  assert.deepEqual(ctx.seen.commands, []);
+  assert.deepEqual(ctx.seen.context, []);
+  assert.ok(ctx.seen.tools >= 0, "tools are never duplicated: the CLI install does not register any");
 });

--- a/extensions/opencode/index.js
+++ b/extensions/opencode/index.js
@@ -11,9 +11,9 @@ import { execFile } from "node:child_process"
 import { promisify } from "node:util"
 import { homedir } from "node:os"
 import { join } from "node:path"
-import { accessSync, constants } from "node:fs"
+import { accessSync, constants, existsSync } from "node:fs"
 
-import { clampLimit, contextText, lastUserText } from "./lib.js"
+import { clampLimit, cliPluginPath, contextText, lastUserText } from "./lib.js"
 
 const require = createRequire(import.meta.url)
 const run_ = promisify(execFile)
@@ -188,6 +188,15 @@ export const DejaPlugin = async ({ client, directory }, options = {}) => {
   }
 
   if (config.autoRecall === false) return hooks
+
+  // `deja install opencode-auto` writes a plugin of its own, and opencode loads
+  // it alongside this package: two entries in the resolved plugin list, both
+  // pushing the same recall onto the system prompt and both raising the same
+  // toast. The file on disk wins because the installer keeps it current; this
+  // package keeps its tools and drops only the duplicated recall.
+  try {
+    if (existsSync(cliPluginPath(process.env, homedir()))) return hooks
+  } catch {}
 
   // opencode has no session-start hook. The system prompt is assembled on
   // every request, so the session digest is fetched once and pushed there —

--- a/extensions/opencode/lib.js
+++ b/extensions/opencode/lib.js
@@ -1,3 +1,5 @@
+import { join } from "node:path"
+
 // The pure half of the plugin: everything that reads deja's output or
 // opencode's message shape, with no process and no host. Kept apart from
 // index.js because opencode loads every function a plugin module exports —
@@ -32,6 +34,16 @@ export function lastUserText(messages) {
     return { parts, prompt: parts.map((p) => p.text).join("\n").trim() }
   }
   return { parts: [], prompt: "" }
+}
+
+// cliPluginPath is where `deja install opencode-auto` writes its own plugin.
+// opencode loads that file and this package side by side — both are entries in
+// the resolved `plugin` list — and both push recall onto the system prompt, so
+// whoever finds the other has to stand down. Mirrors opencodeConfigHome() in
+// the installer: XDG_CONFIG_HOME wins, else ~/.config.
+export function cliPluginPath(env, home) {
+  const base = (env && env.XDG_CONFIG_HOME) || join(home || "", ".config")
+  return join(base, "opencode", "plugins", "deja.js")
 }
 
 // clampLimit keeps a model that asks for a hundred sessions from spending the

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-deja",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Brings the session history of nineteen other coding agents into opencode: recall, session digest and per-file history tools over a local index, plus automatic recall on every request.",
   "type": "module",
   "main": "index.js",

--- a/extensions/opencode/test/pure.test.js
+++ b/extensions/opencode/test/pure.test.js
@@ -1,7 +1,12 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
-import { clampLimit, contextText, lastUserText } from "../lib.js"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { clampLimit, cliPluginPath, contextText, lastUserText } from "../lib.js"
+import { DejaPlugin } from "../index.js"
 
 test("contextText reads the hook shape deja prints", () => {
   const raw = JSON.stringify({
@@ -39,4 +44,53 @@ test("clampLimit keeps the window small", () => {
   assert.equal(clampLimit(0), 1)
   assert.equal(clampLimit(500), 20)
   assert.equal(clampLimit(NaN), 5)
+})
+
+test("cliPluginPath follows the installer's own config home", () => {
+  assert.equal(
+    cliPluginPath({ XDG_CONFIG_HOME: "/cfg" }, "/home/x"),
+    join("/cfg", "opencode", "plugins", "deja.js"),
+  )
+  assert.equal(
+    cliPluginPath({}, "/home/x"),
+    join("/home/x", ".config", "opencode", "plugins", "deja.js"),
+  )
+})
+
+// opencode resolves both installs into one plugin list — verified with
+// `opencode debug config` against a config home holding both — and each pushed
+// the same recall onto the system prompt and raised the same toast.
+test("the plugin stands down when the installer's own plugin is on disk", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "deja-oc-"))
+  mkdirSync(join(dir, "opencode", "plugins"), { recursive: true })
+  writeFileSync(join(dir, "opencode", "plugins", "deja.js"), "// installed by deja\n")
+
+  const client = { tui: { showToast: async () => {} } }
+  const env = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = dir
+  try {
+    const hooks = await DejaPlugin({ client, directory: dir })
+    assert.equal(hooks["experimental.chat.system.transform"], undefined)
+    assert.equal(hooks["experimental.chat.messages.transform"], undefined)
+  } finally {
+    if (env === undefined) delete process.env.XDG_CONFIG_HOME
+    else process.env.XDG_CONFIG_HOME = env
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("without it the recall hooks are installed", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "deja-oc-"))
+  const client = { tui: { showToast: async () => {} } }
+  const env = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = dir
+  try {
+    const hooks = await DejaPlugin({ client, directory: dir })
+    assert.equal(typeof hooks["experimental.chat.system.transform"], "function")
+    assert.equal(typeof hooks["experimental.chat.messages.transform"], "function")
+  } finally {
+    if (env === undefined) delete process.env.XDG_CONFIG_HOME
+    else process.env.XDG_CONFIG_HOME = env
+    rmSync(dir, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
`deja install` wires opencode, dsh and Zed as well as the packages under `extensions/`, so a user can end up with both at once. Verified with `opencode debug config`: it resolves the npm package and the installer's `plugins/deja.js` into one plugin list, and both push the same recall onto the system prompt and raise the same toast.

Whatever the installer wrote wins, since that is the copy `deja install` keeps current. The opencode package drops its recall hooks when it finds `plugins/deja.js`; the dsh package drops the `/deja` command when `command.js` is there and its recall when `auto.js` is; `deja install zed` leaves settings alone when Zed already has the extension's context server.