### PR TITLE
fix(zed): read a cut-short sqlite3 answer as the rows it delivered

### DIFF
--- a/internal/sources/zed.go
+++ b/internal/sources/zed.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -222,21 +223,37 @@ func zedRows(db, cols, where string) ([]zedRow, error) {
 		_ = cmd.Wait()
 		return nil, fmt.Errorf("zed: bad sqlite json")
 	}
+	// An answer that stops before its closing bracket is a query that was cut
+	// short, and the exit status is the only thing that says so: a real sqlite3
+	// dying mid-stream returns one. So a stream that simply ends is read as the
+	// rows it did deliver, and a non-zero exit is the error. Which of the two
+	// steps below notices the missing bytes depends on the toolchain — Go 1.25
+	// ended the loop and reported io.EOF from the closing token, Go 1.27 stays
+	// in the loop and fails the decode — so neither decides on its own.
 	var rows []zedRow
+	var cut error
 	for dec.More() {
 		var r zedRow
 		if err := dec.Decode(&r); err != nil {
-			_ = cmd.Wait()
-			return nil, err
+			cut = err
+			break
 		}
 		rows = append(rows, r)
 	}
-	if _, err := dec.Token(); err != nil && err != io.EOF {
-		_ = cmd.Wait()
-		return nil, err
+	if cut == nil {
+		if _, err := dec.Token(); err != nil && err != io.EOF {
+			cut = err
+		}
 	}
 	if err := cmd.Wait(); err != nil {
 		return nil, err
+	}
+	// Anything that is not a truncation — output that was never JSON, a row
+	// whose shape is wrong — still fails: the store is then unreadable rather
+	// than short.
+	var syntax *json.SyntaxError
+	if cut != nil && !errors.As(cut, &syntax) && !errors.Is(cut, io.ErrUnexpectedEOF) {
+		return nil, cut
 	}
 	return rows, nil
 }

--- a/internal/sources/zed_test.go
+++ b/internal/sources/zed_test.go
@@ -516,7 +516,11 @@ func TestParseZedDBSurvivesASqlite3ThatDoesNotAnswerInRows(t *testing.T) {
 	}{
 		{name: "not json at all", stdout: "not json\n", wantErr: true},
 		{name: "a json object rather than an array", stdout: `{"id":"x"}`, wantErr: true},
-		{name: "an array that stops mid-row", stdout: `[{"id":"x",`, wantErr: true},
+		// Stopping mid-row is the same cut-short answer as stopping between
+		// rows, and with a clean exit it is read the same way: whatever rows
+		// arrived whole. Go 1.25 told the two apart by which step failed, Go
+		// 1.27 does not, and the exit status was always the better signal.
+		{name: "an array that stops mid-row", stdout: `[{"id":"x",`, wantErr: false},
 		// A truncated array that still exits 0 is read as the rows it did
 		// deliver: the exit status is what says the query was cut short, and a
 		// real sqlite3 that dies mid-stream returns one. Asserting an error


### PR DESCRIPTION
On Go 1.27 the decoder fails inside the loop where 1.25 ended it and reported EOF from the closing token, so a truncated answer became an error and the whole Zed store read failed instead of returning what arrived. The exit status decides now — which is what the comment there already claimed — and a non-zero exit is still an error.

Only visible to anyone building with a toolchain newer than the 1.25 CI pins, but it fails the suite locally today and would fail CI the day the pin moves.