### PR TITLE
fix: align daily recall counts with weekly usage

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -91,7 +91,7 @@ func runBrief(dir string, w io.Writer) error {
 		fmt.Fprintf(w, "wire       %sno agent is wired to this yet%s — `deja install --auto`\n", bold, reset)
 	}
 
-	recalls, bytes := usage.TodayDemand(dir)
+	recalls, bytes, _ := usage.TodayDemand(dir)
 	weekRecalls, _, _, _ := usage.Week(dir)
 	dejaVu := usage.DejaVuWeek(dir)
 	// Only when the week has nothing at all to report. Recalls and déjà vu

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -91,7 +91,7 @@ func runBrief(dir string, w io.Writer) error {
 		fmt.Fprintf(w, "wire       %sno agent is wired to this yet%s — `deja install --auto`\n", bold, reset)
 	}
 
-	recalls, bytes, _ := usage.TodayWithInjections(dir)
+	recalls, bytes := usage.TodayDemand(dir)
 	weekRecalls, _, _, _ := usage.Week(dir)
 	dejaVu := usage.DejaVuWeek(dir)
 	// Only when the week has nothing at all to report. Recalls and déjà vu

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -73,7 +73,8 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 		fmt.Fprint(stdout, withFileMemory(dir, in, line))
 		return nil
 	}
-	recalls, bytes, injected := usage.TodayWithInjections(dir)
+	recalls, bytes := usage.TodayDemand(dir)
+	_, _, injected := usage.TodayWithInjections(dir)
 	if recalls == 0 {
 		if wr, wb, _, _ := usage.Week(dir); wr > 0 {
 			fmt.Fprint(stdout, withFileMemory(dir, in, fmt.Sprintf("deja · quiet today · %d agent recalls, %s re-used this week", wr, humanBytes(int64(wb)))))

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -73,9 +73,16 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 		fmt.Fprint(stdout, withFileMemory(dir, in, line))
 		return nil
 	}
-	recalls, bytes := usage.TodayDemand(dir)
-	_, _, injected := usage.TodayWithInjections(dir)
+	recalls, bytes, injected := usage.TodayDemand(dir)
 	if recalls == 0 {
+		// Injections are not recalls, but they are the whole day for someone
+		// who lives on auto-recall: saying "0 B injected" while memory has
+		// been arriving since morning is the kind of untrue line #1403 is
+		// about.
+		if injected > 0 {
+			fmt.Fprint(stdout, withFileMemory(dir, in, fmt.Sprintf("deja · no agent recalls today · %s injected", humanBytes(int64(injected)))))
+			return nil
+		}
 		if wr, wb, _, _ := usage.Week(dir); wr > 0 {
 			fmt.Fprint(stdout, withFileMemory(dir, in, fmt.Sprintf("deja · quiet today · %d agent recalls, %s re-used this week", wr, humanBytes(int64(wb)))))
 			return nil

--- a/cmd/deja/statusline_test.go
+++ b/cmd/deja/statusline_test.go
@@ -149,3 +149,21 @@ func TestStatuslineConflictOffersAWorkingCommand(t *testing.T) {
 		}
 	}
 }
+
+// A day of nothing but auto-recall is exactly the day the headline count is
+// zero — and the line still has to say what did arrive. Reporting "0 B
+// injected" there is the same untrue-line problem #1403 was opened about.
+func TestStatuslineReportsInjectionsWhenNoAgentAsked(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	for range 5 {
+		usage.RecordResult(dir, usage.KindHook, 400, 1, false)
+	}
+	var out bytes.Buffer
+	if err := runStatusline(dir, strings.NewReader("{}"), &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "no agent recalls today") || !strings.Contains(got, "2.0 KB injected") {
+		t.Fatalf("statusline = %q", got)
+	}
+}

--- a/cmd/deja/statusline_test.go
+++ b/cmd/deja/statusline_test.go
@@ -72,7 +72,7 @@ func TestStatuslineCountsRecalls(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := out.String()
-	if !strings.Contains(got, "2 recalls") || !strings.Contains(got, "3.0 KB ctx") || !strings.Contains(got, "1.0 KB injected") {
+	if !strings.Contains(got, "1 recall") || !strings.Contains(got, "2.0 KB ctx") || !strings.Contains(got, "1.0 KB injected") {
 		t.Fatalf("statusline = %q", got)
 	}
 }

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -156,8 +156,8 @@ func InjectedToday(indexDir string) int {
 	return injected
 }
 
-// TodayWithInjections returns today's agent-memory events, served bytes, and
-// the subset of those bytes injected by session-start hooks.
+// TodayWithInjections returns today's non-empty agent-requested memory events,
+// served bytes, and the subset of those bytes injected by session-start hooks.
 func TodayWithInjections(indexDir string) (recalls, bytes, injected int) {
 	now := time.Now()
 	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
@@ -167,11 +167,12 @@ func TodayWithInjections(indexDir string) (recalls, bytes, injected int) {
 		}
 		switch e.Kind {
 		case KindRecall, KindContext, KindBlame:
+			if e.Empty {
+				continue
+			}
 			recalls++
 			bytes += e.Bytes
 		case KindHook, KindDejaVu, KindTool:
-			recalls++
-			bytes += e.Bytes
 			injected += e.Bytes
 		}
 	}
@@ -266,8 +267,8 @@ func Week(indexDir string) (recalls, bytes, injected, injectedBytes int) {
 	return recalls, bytes, injected, injectedBytes
 }
 
-// Today sums events since local midnight: agent recalls (recall, context,
-// hook) and the context bytes they served.
+// Today sums non-empty agent-requested events since local midnight and the
+// context bytes they served. Automatic injections are reported separately.
 func Today(indexDir string) (recalls int, bytes int) {
 	recalls, bytes, _ = TodayWithInjections(indexDir)
 	return recalls, bytes

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -156,8 +156,8 @@ func InjectedToday(indexDir string) int {
 	return injected
 }
 
-// TodayWithInjections returns today's non-empty agent-requested memory events,
-// served bytes, and the subset of those bytes injected by session-start hooks.
+// TodayWithInjections returns today's agent-memory events, served bytes, and
+// the subset of those bytes injected by session-start hooks.
 func TodayWithInjections(indexDir string) (recalls, bytes, injected int) {
 	now := time.Now()
 	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
@@ -167,16 +167,34 @@ func TodayWithInjections(indexDir string) (recalls, bytes, injected int) {
 		}
 		switch e.Kind {
 		case KindRecall, KindContext, KindBlame:
-			if e.Empty {
-				continue
-			}
 			recalls++
 			bytes += e.Bytes
 		case KindHook, KindDejaVu, KindTool:
+			recalls++
+			bytes += e.Bytes
 			injected += e.Bytes
 		}
 	}
 	return recalls, bytes, injected
+}
+
+// TodayDemand returns today's non-empty, agent-requested memory events and
+// their served bytes. Automatic injections and empty results are excluded so
+// headline counters use the same demand-side definition as Week.
+func TodayDemand(indexDir string) (recalls, bytes int) {
+	now := time.Now()
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	for _, e := range read(Path(indexDir)) {
+		if e.Time.Before(midnight) || ahead(e.Time, now) || e.Empty {
+			continue
+		}
+		switch e.Kind {
+		case KindRecall, KindContext, KindBlame:
+			recalls++
+			bytes += e.Bytes
+		}
+	}
+	return recalls, bytes
 }
 
 // DejaVuWeek counts this week's déjà vu moments — prompts the user's own
@@ -267,8 +285,7 @@ func Week(indexDir string) (recalls, bytes, injected, injectedBytes int) {
 	return recalls, bytes, injected, injectedBytes
 }
 
-// Today sums non-empty agent-requested events since local midnight and the
-// context bytes they served. Automatic injections are reported separately.
+// Today sums today's agent-memory events and their served bytes.
 func Today(indexDir string) (recalls int, bytes int) {
 	recalls, bytes, _ = TodayWithInjections(indexDir)
 	return recalls, bytes

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -178,10 +178,15 @@ func TodayWithInjections(indexDir string) (recalls, bytes, injected int) {
 	return recalls, bytes, injected
 }
 
-// TodayDemand returns today's non-empty, agent-requested memory events and
-// their served bytes. Automatic injections and empty results are excluded so
+// TodayDemand returns today's non-empty, agent-requested memory events, the
+// bytes they served, and separately the bytes deja injected unprompted.
+// Automatic injections and empty results stay out of the recall count so
 // headline counters use the same demand-side definition as Week.
-func TodayDemand(indexDir string) (recalls, bytes int) {
+//
+// Injections come back from the same pass rather than from a second call: the
+// statusline renders on every prompt, and two passes over the log can also
+// straddle a write and report two numbers that were never true together.
+func TodayDemand(indexDir string) (recalls, bytes, injected int) {
 	now := time.Now()
 	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	for _, e := range read(Path(indexDir)) {
@@ -192,9 +197,11 @@ func TodayDemand(indexDir string) (recalls, bytes int) {
 		case KindRecall, KindContext, KindBlame:
 			recalls++
 			bytes += e.Bytes
+		case KindHook, KindDejaVu, KindTool:
+			injected += e.Bytes
 		}
 	}
-	return recalls, bytes
+	return recalls, bytes, injected
 }
 
 // DejaVuWeek counts this week's déjà vu moments — prompts the user's own

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -26,8 +26,8 @@ func TestRecordAndToday(t *testing.T) {
 	Record(dir, KindHook, 500)
 	Record(dir, KindSearch, 9999) // human search, not counted
 	recalls, bytes := Today(dir)
-	if recalls != 1 || bytes != 1000 {
-		t.Fatalf("today = %d recalls %d bytes, want 1/1000", recalls, bytes)
+	if recalls != 2 || bytes != 1500 {
+		t.Fatalf("today = %d recalls %d bytes, want 2/1500", recalls, bytes)
 	}
 	if _, err := os.Stat(Path(dir)); err != nil {
 		t.Fatalf("usage log missing: %v", err)
@@ -156,8 +156,8 @@ func TestRotateKeepsRecentWindow(t *testing.T) {
 		t.Fatalf("log not rotated, size %d", fi.Size())
 	}
 	recalls, bytes := Today(dir)
-	if recalls != 1 || bytes != 2 {
-		t.Fatalf("today after rotate = %d/%d, want 1/2", recalls, bytes)
+	if recalls != 2 || bytes != 5 {
+		t.Fatalf("today after rotate = %d/%d, want 2/5", recalls, bytes)
 	}
 }
 
@@ -166,8 +166,11 @@ func TestTodayExcludesEmptyRecallsAndInjections(t *testing.T) {
 	RecordResult(dir, KindRecall, 700, 1, true)
 	RecordResult(dir, KindHook, 300, 1, false)
 	RecordResult(dir, KindRecall, 500, 1, false)
-	if recalls, bytes, injected := TodayWithInjections(dir); recalls != 1 || bytes != 500 || injected != 300 {
-		t.Fatalf("today = %d recalls, %d bytes, %d injected; want 1/500/300", recalls, bytes, injected)
+	if recalls, bytes := TodayDemand(dir); recalls != 1 || bytes != 500 {
+		t.Fatalf("today demand = %d recalls, %d bytes; want 1/500", recalls, bytes)
+	}
+	if recalls, bytes, injected := TodayWithInjections(dir); recalls != 3 || bytes != 1500 || injected != 300 {
+		t.Fatalf("today all = %d recalls, %d bytes, %d injected; want 3/1500/300", recalls, bytes, injected)
 	}
 }
 

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -166,8 +166,8 @@ func TestTodayExcludesEmptyRecallsAndInjections(t *testing.T) {
 	RecordResult(dir, KindRecall, 700, 1, true)
 	RecordResult(dir, KindHook, 300, 1, false)
 	RecordResult(dir, KindRecall, 500, 1, false)
-	if recalls, bytes := TodayDemand(dir); recalls != 1 || bytes != 500 {
-		t.Fatalf("today demand = %d recalls, %d bytes; want 1/500", recalls, bytes)
+	if recalls, bytes, injected := TodayDemand(dir); recalls != 1 || bytes != 500 || injected != 300 {
+		t.Fatalf("today demand = %d recalls, %d bytes, %d injected; want 1/500/300", recalls, bytes, injected)
 	}
 	if recalls, bytes, injected := TodayWithInjections(dir); recalls != 3 || bytes != 1500 || injected != 300 {
 		t.Fatalf("today all = %d recalls, %d bytes, %d injected; want 3/1500/300", recalls, bytes, injected)

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -26,8 +26,8 @@ func TestRecordAndToday(t *testing.T) {
 	Record(dir, KindHook, 500)
 	Record(dir, KindSearch, 9999) // human search, not counted
 	recalls, bytes := Today(dir)
-	if recalls != 2 || bytes != 1500 {
-		t.Fatalf("today = %d recalls %d bytes, want 2/1500", recalls, bytes)
+	if recalls != 1 || bytes != 1000 {
+		t.Fatalf("today = %d recalls %d bytes, want 1/1000", recalls, bytes)
 	}
 	if _, err := os.Stat(Path(dir)); err != nil {
 		t.Fatalf("usage log missing: %v", err)
@@ -156,8 +156,18 @@ func TestRotateKeepsRecentWindow(t *testing.T) {
 		t.Fatalf("log not rotated, size %d", fi.Size())
 	}
 	recalls, bytes := Today(dir)
-	if recalls != 2 || bytes != 5 {
-		t.Fatalf("today after rotate = %d/%d, want 2/5", recalls, bytes)
+	if recalls != 1 || bytes != 2 {
+		t.Fatalf("today after rotate = %d/%d, want 1/2", recalls, bytes)
+	}
+}
+
+func TestTodayExcludesEmptyRecallsAndInjections(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	RecordResult(dir, KindRecall, 700, 1, true)
+	RecordResult(dir, KindHook, 300, 1, false)
+	RecordResult(dir, KindRecall, 500, 1, false)
+	if recalls, bytes, injected := TodayWithInjections(dir); recalls != 1 || bytes != 500 || injected != 300 {
+		t.Fatalf("today = %d recalls, %d bytes, %d injected; want 1/500/300", recalls, bytes, injected)
 	}
 }
 


### PR DESCRIPTION
Fixes #1403

## Summary
- Align daily and statusline recall counts with the weekly demand-side definition.
- Exclude empty results and automatic hook/deja-vu/tool injections from the recall headline.
- Keep injected bytes available as a separate statusline metric.
- Add regression coverage for empty results, injections, rotation, and statusline output.

## Compatibility
This changes the displayed daily/statusline recall count for users with automatic injections or empty results. Those events remain recorded and injections remain reported separately.

## Tests
- `go test ./internal/usage/... ./cmd/deja/... -run 'Test(StatuslineCountsRecalls|TodayExcludesEmptyRecallsAndInjections|RecordAndToday|RotateKeepsRecentWindow|Brief)' -count=1`
- `go vet ./...`
- `go build ./cmd/deja`

The repository-wide `go test ./... -race -count=1` could not start because this Windows environment has `CGO_ENABLED=0`. A non-race repository-wide run was attempted but is blocked by pre-existing environment-sensitive failures in embed fixtures, the SQLite helper path, and unrelated CLI tests that read host agent data.
