### PR TITLE
fix(extensions): one rule for what a package adds next to deja install

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,11 @@ variable is honored too. The
 the observed paths, record schemas and role mapping per harness, with synthetic fixtures
 keeping those descriptions checked against the parsers.
 
-### Harnesses with their own package format
+### Harnesses with a package of their own
 
-Three of them install extensions their own way rather than through `deja
-install`. Those packages live in [`extensions/`](extensions):
+`deja install --auto` wires all three of these like every other harness, and
+that stays the shortest path. They also have a package in their own ecosystem,
+for people who install extensions there rather than from a CLI:
 
 | Harness | Package | Install |
 | --- | --- | --- |
@@ -272,10 +273,12 @@ install`. Those packages live in [`extensions/`](extensions):
 | DeepSeek Harness | npm `dsh-deja` | `dsh plugin add dsh-deja` |
 | Zed | `deja-context-server` | Zed → Extensions → deja |
 
+Either path is enough on its own, and having both is not a problem: each package
+looks at what `deja install` wrote and contributes only what is missing, so
+nothing is recalled or registered twice. The one pair that cannot see itself is
+a Zed extension installed after `deja install zed`, and `deja doctor` says so.
+
 Each uses the deja you already have; the copy it bundles is only the fallback.
-`deja install` also wires all three, so running both is fine: the package finds
-what the installer wrote and drops the part it already covers, rather than
-recalling twice.
 
 ## Semantic recall (optional)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -42,14 +42,17 @@ deja install --auto
 
 也不必特意去问——开启自动召回后，会话一打开，智能体就已经知道你在这个项目里解决过什么。
 
-DeepSeek Harness 用户可以直接装插件：
+opencode、DeepSeek Harness 和 Zed 也有各自生态里的包，习惯在那边装扩展的人可以直接用：
 
 ```sh
+opencode plugin opencode-deja
 dsh plugin --profile web add dsh-deja
+# Zed：扩展面板里搜 deja
 ```
 
-它带来三个模型可调用的工具（`deja_recall`、`deja_session`、`deja_blame`）、`/deja` 命令，
-以及可选的自动召回。详见 [`extensions/dsh`](extensions/dsh)。
+`deja install --auto` 已经把这三个接好了，两条路走哪条都够。两边都装也没问题：包会看
+`deja install` 写了什么，只补上缺的部分，不会重复注册工具、也不会重复召回。详见
+[`extensions/`](extensions)。
 
 其他安装方式：`brew install vshulcz/tap/deja-vu`、
 `go install github.com/vshulcz/deja-vu/cmd/deja@latest`，或者用

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -106,6 +106,7 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir strin
 	// machine without claude settings, which is exactly a machine whose other
 	// harnesses may still be wired to a binary that moved.
 	doctorWiringExe(w)
+	doctorDoubleWiring(w)
 	fmt.Fprintln(w)
 	doctorIndex(w, report.Index, dir)
 	fmt.Fprintln(w)

--- a/cmd/deja/doctor_double_wiring.go
+++ b/cmd/deja/doctor_double_wiring.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// Zed is the one harness where deja can end up wired twice with nothing to
+// catch it. `deja install zed` writes a context server into settings.json and
+// skips when the extension is already there — but a user who installs the
+// extension afterwards has both, and neither side can see the other: the
+// extension runs inside Zed's WASM sandbox and reads no settings.
+//
+// Nothing breaks. Both entries start `deja mcp` and answer the same, so the
+// cost is the agent seeing every tool twice — invisible unless something says
+// it out loud.
+func doctorDoubleWiring(w io.Writer) {
+	if !zedWiredTwice(sources.ZedSettingsPath()) {
+		return
+	}
+	fmt.Fprintf(w, "  %-12s %-11s %s\n", "zed", "twice",
+		"deja is in settings and the Zed extension is installed — `deja uninstall zed` keeps the extension")
+}
+
+// zedWiredTwice reports deja's own context server and the extension's sitting
+// in the same settings file. The extension's key is its id, which Zed writes
+// when the extension is installed.
+func zedWiredTwice(path string) bool {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	text := string(b)
+	open := zedTopLevelOpen(text)
+	if open < 0 {
+		return false
+	}
+	block := zedFindKey(text, open+1, zedServerKey)
+	if block == nil {
+		return false
+	}
+	return zedFindKey(text, block.valueOpen+1, "deja") != nil &&
+		zedFindKey(text, block.valueOpen+1, zedExtensionServerID) != nil
+}

--- a/cmd/deja/doctor_double_wiring_test.go
+++ b/cmd/deja/doctor_double_wiring_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func zedSettings(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// Installing the extension after `deja install zed` leaves both entries, and
+// neither side can see the other: the install skip only fires the other way
+// round, and the extension reads no settings.
+func TestZedWiredTwiceOnlyWhenBothAreThere(t *testing.T) {
+	both := zedSettings(t, `{
+  "context_servers": {
+    "deja": {"command": "deja", "args": ["mcp"]},
+    "deja-context-server": {"enabled": true}
+  }
+}`)
+	if !zedWiredTwice(both) {
+		t.Error("both entries present, reported as fine")
+	}
+
+	for name, body := range map[string]string{
+		"only ours":               `{"context_servers": {"deja": {"command": "deja"}}}`,
+		"only the extension":      `{"context_servers": {"deja-context-server": {"enabled": true}}}`,
+		"another server entirely": `{"context_servers": {"other": {}}}`,
+		"no block at all":         `{"theme": "One Dark"}`,
+	} {
+		if zedWiredTwice(zedSettings(t, body)) {
+			t.Errorf("%s: reported as wired twice", name)
+		}
+	}
+
+	if zedWiredTwice(filepath.Join(t.TempDir(), "nothing.json")) {
+		t.Error("a machine with no settings file is not wired twice")
+	}
+}
+
+// The line has to name the fix, not just the problem: a warning nobody can act
+// on is noise in the one command people run when memory misbehaves.
+func TestDoctorDoubleWiringNamesTheFix(t *testing.T) {
+	t.Setenv("DEJA_ZED_CONFIG", zedSettings(t, `{
+  "context_servers": {
+    "deja": {"command": "deja"},
+    "deja-context-server": {"enabled": true}
+  }
+}`))
+	var out bytes.Buffer
+	doctorDoubleWiring(&out)
+	got := out.String()
+	if !strings.Contains(got, "zed") || !strings.Contains(got, "deja uninstall zed") {
+		t.Fatalf("doctor line does not say what to do:\n%s", got)
+	}
+
+	t.Setenv("DEJA_ZED_CONFIG", zedSettings(t, `{"context_servers": {"deja": {"command": "deja"}}}`))
+	out.Reset()
+	doctorDoubleWiring(&out)
+	if out.Len() != 0 {
+		t.Fatalf("a single entry printed a warning:\n%s", out.String())
+	}
+}

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -82,6 +82,11 @@ qwen   extensions install https://github.com/vshulcz/deja-vu
 openclaw plugins install ./deja-vu/claude-plugin
 copilot plugin marketplace add vshulcz/deja-vu &amp;&amp; copilot plugin install deja-vu@deja-vu</pre>
 <div class="note">Cursor, Qwen, OpenClaw and Copilot read the Claude plugin format directly, so all six install from the one bundle in this repository, which carries the hooks, the <code>/deja</code> command and the MCP server. OpenClaw runs hooks only from its own packs — <code>deja install openclaw-auto</code> writes one — and Copilot runs the plugin hooks but drops their context, so recall there is MCP plus the skill. The plugin stands down if <code>deja install</code> already wired the same hooks, so having both does not recall twice.</div>
+<p>Three more keep their extensions in an ecosystem of their own:</p>
+<pre>opencode plugin opencode-deja
+dsh plugin add dsh-deja
+# Zed: Extensions → deja</pre>
+<div class="note">Either path is enough — <code>deja install --auto</code> wires all three as well. Each package reads what the installer wrote and contributes only what is missing, so having both does not register a tool or recall a session twice. The one pair that cannot see itself is a Zed extension installed after <code>deja install zed</code>; <code>deja doctor</code> reports it, and <code>deja uninstall zed</code> keeps the extension.</div>
 <p>After that, an agent can call <code>recall</code> the moment you reference past work — see <a href="agents.html">Agents &amp; MCP</a>. Confirm the wiring any time with <code>deja doctor</code>.</p>
 <h2>Optional: semantic recall</h2>
 <p>If you run a local embedding endpoint (Ollama, LM Studio), <code>deja embed</code> adds a vector sidecar so rephrased queries still match. Without one, deja works exactly as before. See <a href="search.html">Search</a>.</p>

--- a/extensions/dsh/README.md
+++ b/extensions/dsh/README.md
@@ -22,9 +22,15 @@ The plugin runs the `deja` binary. It is pulled in as a dependency, so npm
 installs it with the plugin; a `deja` already on `PATH` is used as-is, and
 `DEJA_BIN` overrides both.
 
+If you have the CLI, `deja install --auto` wires dsh too — it adds deja's MCP
+server and a `/deja` command to your profile — and that is the shorter path.
+Having both is fine: this plugin looks for what the installer wrote in
+`$DSH_HOME/plugins/deja/` and contributes only what is missing, so the tools and
+the command are never registered twice.
+
 ## What it adds
 
-Three tools the model can call:
+Six tools the model can call:
 
 | Tool | Answers |
 |---|---|

--- a/extensions/dsh/README.zh.md
+++ b/extensions/dsh/README.zh.md
@@ -14,9 +14,12 @@ dsh plugin --profile web add dsh-deja
 
 插件调用 `deja` 可执行文件。它作为依赖随插件一起安装；如果 `PATH` 上已有 `deja` 就直接使用，`DEJA_BIN` 可覆盖两者。
 
+装了 CLI 的话，`deja install --auto` 也会把 dsh 接好——写入 deja 的 MCP 服务端和 `/deja` 命令——那条路更短。
+两边都装也没问题：插件会检查 `$DSH_HOME/plugins/deja/` 下安装器写了什么，只补缺的部分，工具和命令不会注册两次。
+
 ## 提供的能力
 
-三个模型可调用的工具：
+六个模型可调用的工具：
 
 | 工具 | 回答什么 |
 |---|---|

--- a/extensions/dsh/index.js
+++ b/extensions/dsh/index.js
@@ -11,6 +11,8 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { contributions } from "./lib.js";
+
 const require = createRequire(import.meta.url);
 
 // The tool registry lives in the host. A plugin that throws on a missing peer
@@ -292,11 +294,16 @@ function isHuman(message) {
   return Boolean(message) && (!message.source || message.source.kind === "user");
 }
 
-// cliPluginDir is where `deja install dsh` writes plugins of its own. A user
-// who ran the installer and then added this package has both in the profile:
-// two `/deja` commands and the same recall on the system prompt twice. The
-// files on disk win — the installer keeps them current — and this package then
-// contributes only what they do not: the model-facing tools.
+// `deja install dsh` writes plugins of its own into DSH_HOME and adds them to
+// the profile, so a user who ran the installer and then added this package has
+// both: two `/deja` commands, the same recall on the system prompt twice, and
+// deja's MCP server answering the same six questions the tools here do. What
+// the installer wrote wins — it is the copy `deja install` keeps current — and
+// this package contributes only the parts that are missing.
+//
+// The two halves are separate on purpose: `deja install dsh` writes command.js
+// and the MCP row, and only `deja install dsh-auto` adds auto.js. A profile can
+// have the command from the installer and still want recall from here.
 function cliPluginDir() {
   const home = process.env.DSH_HOME || join(homedir(), ".dsh");
   return join(home, "plugins", "deja");
@@ -311,13 +318,13 @@ function installedByCLI(file) {
 }
 
 function apply(ctx, config) {
-  tools(ctx);
-  // Each half stands down on its own: `deja install dsh` writes command.js,
-  // and only `deja install dsh-auto` adds auto.js, so a profile can have the
-  // command from the installer and still want recall from here.
-  if (!installedByCLI("command.js")) command(ctx);
-  if (installedByCLI("auto.js")) return;
-  if (!config || config.autoRecall !== false) autoRecall(ctx);
+  const adds = contributions(
+    { command: installedByCLI("command.js"), auto: installedByCLI("auto.js") },
+    config,
+  );
+  if (adds.tools) tools(ctx);
+  if (adds.command) command(ctx);
+  if (adds.recall) autoRecall(ctx);
 }
 
 apply.inject = ["tools", "commands", "systemPrompt"];

--- a/extensions/dsh/lib.js
+++ b/extensions/dsh/lib.js
@@ -1,0 +1,22 @@
+// The plugin's decision, kept out of index.js because a host is free to treat
+// anything a plugin module exports as part of the plugin — opencode does
+// exactly that with its own — and this is a helper, not a second plugin.
+
+// contributions says what this package adds, given what `deja install` already
+// wrote into DSH_HOME and what the profile turned off. The rule is the same
+// everywhere: fill the gaps, never repeat the installer.
+//
+// command.js and the mcp-deja profile row are written by the same install, so
+// the command file standing there means the model can already reach deja —
+// registering these tools would list every answer twice. auto.js is separate:
+// only `deja install dsh-auto` writes it, so a profile can take the command
+// from the installer and still want recall from here.
+export function contributions(wiring, config) {
+  const wired = wiring || {};
+  const settings = config || {};
+  return {
+    tools: !wired.command,
+    command: !wired.command,
+    recall: settings.autoRecall !== false && !wired.auto,
+  };
+}

--- a/extensions/dsh/package.json
+++ b/extensions/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-deja",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "description": "Brings the session history of nineteen other coding agents into DeepSeek Harness: recall, session digest and per-file history tools over a local index, plus optional automatic recall before each step.",
   "type": "module",
   "main": "index.js",
@@ -10,6 +10,7 @@
   },
   "files": [
     "index.js",
+    "lib.js",
     "cordis.patch.yml",
     "README.md",
     "README.zh.md",

--- a/extensions/dsh/test/pure.test.js
+++ b/extensions/dsh/test/pure.test.js
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 import apply from "../index.js";
+import { contributions } from "../lib.js";
 
 const source = readFileSync(new URL("../index.js", import.meta.url), "utf8");
 
@@ -92,16 +93,21 @@ test("nothing installed by the CLI: the package contributes everything", () => {
     apply(ctx, {});
     return ctx;
   });
+  // The tool count is not asserted: registering them needs the dsh-tools peer,
+  // which the host provides and this test does not have.
   assert.deepEqual(ctx.seen.commands, ["deja"]);
   assert.deepEqual(ctx.seen.context, ["deja:recall"]);
 });
 
-test("the CLI's command file stands the package's command down", () => {
+test("the CLI's install stands the command and the tools down", () => {
+  // command.js and the mcp-deja profile row are written by the same install, so
+  // its presence means the six answers are already reachable over MCP.
   const ctx = withDSHHome(["command.js"], () => {
     const ctx = fakeCtx();
     apply(ctx, {});
     return ctx;
   });
+  assert.equal(ctx.seen.tools, 0);
   assert.deepEqual(ctx.seen.commands, []);
   assert.deepEqual(ctx.seen.context, ["deja:recall"], "recall was not installed by the CLI, so it stays here");
 });
@@ -112,7 +118,18 @@ test("the CLI's auto file stands the package's recall down", () => {
     apply(ctx, {});
     return ctx;
   });
+  assert.equal(ctx.seen.tools, 0);
   assert.deepEqual(ctx.seen.commands, []);
   assert.deepEqual(ctx.seen.context, []);
-  assert.ok(ctx.seen.tools >= 0, "tools are never duplicated: the CLI install does not register any");
+});
+
+// The registration decision on its own: the cases above cannot see the tools,
+// because registering them needs the dsh-tools peer the host provides.
+test("contributions fills the gaps and never repeats the installer", () => {
+  assert.deepEqual(contributions({}, {}), { tools: true, command: true, recall: true });
+  assert.deepEqual(contributions({ command: true }, {}), { tools: false, command: false, recall: true });
+  assert.deepEqual(contributions({ command: true, auto: true }, {}), { tools: false, command: false, recall: false });
+  assert.deepEqual(contributions({ auto: true }, {}), { tools: true, command: true, recall: false });
+  assert.deepEqual(contributions({}, { autoRecall: false }), { tools: true, command: true, recall: false });
+  assert.deepEqual(contributions(undefined, undefined), { tools: true, command: true, recall: true });
 });

--- a/extensions/opencode/README.md
+++ b/extensions/opencode/README.md
@@ -20,6 +20,12 @@ embeddings, nothing leaves the machine.
 opencode installs the package on start. The deja binary comes with it, but a
 deja you installed yourself always wins — see [Which binary](#which-binary).
 
+`deja install --auto` wires opencode too, and is the shorter path if you have
+the CLI: it adds deja's MCP server and writes a plugin of its own. Having both
+is fine. This package reads what the installer left — the MCP entry in
+`opencode.json`, the plugin file in `plugins/deja.js` — and contributes only
+what is missing, so nothing is registered or recalled twice.
+
 ## What you get
 
 Six tools the model can call:
@@ -51,8 +57,9 @@ And recall nobody has to ask for:
 
 - `autoRecall` (default `true`) — the three hooks above. Turn off to keep only
   the tools.
-- `tools` (default `true`) — the six tools. Turn off if you already reach deja
-  through its MCP server and do not want them twice.
+- `tools` (default `true`) — the six tools. They are skipped on their own when
+  `deja install` already wired the MCP server; set this to `false` to drop them
+  when you reach deja some other way.
 - `bin` — path to a specific deja binary.
 
 ## Which binary

--- a/extensions/opencode/index.js
+++ b/extensions/opencode/index.js
@@ -11,9 +11,17 @@ import { execFile } from "node:child_process"
 import { promisify } from "node:util"
 import { homedir } from "node:os"
 import { join } from "node:path"
-import { accessSync, constants, existsSync } from "node:fs"
+import { accessSync, constants, existsSync, readFileSync } from "node:fs"
 
-import { clampLimit, cliPluginPath, contextText, lastUserText } from "./lib.js"
+import {
+  clampLimit,
+  cliPluginPath,
+  configPaths,
+  contextText,
+  contributions,
+  lastUserText,
+  mcpWired,
+} from "./lib.js"
 
 const require = createRequire(import.meta.url)
 const run_ = promisify(execFile)
@@ -99,6 +107,27 @@ const MISSING =
   "deja is not installed on this machine, so there is no history to search. " +
   "Install it with: curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh"
 
+// installerWiring reads what `deja install` left on disk for opencode: the MCP
+// server in the config, and the plugin file `--auto` writes. Both reads are
+// wrapped — a config we cannot read means "not wired", so the worst case is
+// this package doing the work twice rather than not at all.
+function installerWiring() {
+  const wiring = { mcp: false, recall: false }
+  try {
+    wiring.recall = existsSync(cliPluginPath(process.env, homedir()))
+  } catch {}
+  try {
+    for (const path of configPaths(process.env, homedir())) {
+      if (!existsSync(path)) continue
+      if (mcpWired(readFileSync(path, "utf8"))) {
+        wiring.mcp = true
+        break
+      }
+    }
+  } catch {}
+  return wiring
+}
+
 export const DejaPlugin = async ({ client, directory }, options = {}) => {
   const config = options || {}
   const bin = resolveDeja(typeof config.bin === "string" ? config.bin : "")
@@ -117,7 +146,15 @@ export const DejaPlugin = async ({ client, directory }, options = {}) => {
 
   const hooks = {}
 
-  if (config.tools !== false && tool) {
+  // What `deja install` already wired for opencode is not repeated here. It
+  // writes an MCP server (the same six answers, under their own names) and,
+  // with --auto, a plugin file of its own that opencode loads beside this
+  // package — verified with `opencode debug config`, which resolves both into
+  // one plugin list. Whatever the installer wrote wins, because that is the
+  // copy `deja install` keeps current; this package fills the gaps.
+  const adds = contributions(installerWiring(), config)
+
+  if (adds.tools && tool) {
     const schema = tool.schema
     hooks.tool = {
       deja_recall: tool({
@@ -187,16 +224,7 @@ export const DejaPlugin = async ({ client, directory }, options = {}) => {
     }
   }
 
-  if (config.autoRecall === false) return hooks
-
-  // `deja install opencode-auto` writes a plugin of its own, and opencode loads
-  // it alongside this package: two entries in the resolved plugin list, both
-  // pushing the same recall onto the system prompt and both raising the same
-  // toast. The file on disk wins because the installer keeps it current; this
-  // package keeps its tools and drops only the duplicated recall.
-  try {
-    if (existsSync(cliPluginPath(process.env, homedir()))) return hooks
-  } catch {}
+  if (!adds.recall) return hooks
 
   // opencode has no session-start hook. The system prompt is assembled on
   // every request, so the session digest is fetched once and pushed there —

--- a/extensions/opencode/lib.js
+++ b/extensions/opencode/lib.js
@@ -46,6 +46,78 @@ export function cliPluginPath(env, home) {
   return join(base, "opencode", "plugins", "deja.js")
 }
 
+// configPaths are the two names opencode accepts for the global config, in the
+// order `deja install opencode` looks for them.
+export function configPaths(env, home) {
+  const base = (env && env.XDG_CONFIG_HOME) || join(home || "", ".config")
+  return [join(base, "opencode", "opencode.json"), join(base, "opencode", "opencode.jsonc")]
+}
+
+// mcpWired reports whether that config already runs deja as an MCP server,
+// which is what `deja install opencode` writes. The tools this package
+// registers do the same six things, so when the server is there they are a
+// second copy of it in the model's tool list.
+//
+// The file is JSONC — opencode ships it with comments — so comments come out
+// before the parse. A config this cannot read is treated as not wired: losing
+// the tools on a file we misread is worse than listing them twice.
+export function mcpWired(text) {
+  try {
+    const config = JSON.parse(stripJSONComments(String(text || "")))
+    return Boolean(config && config.mcp && config.mcp.deja)
+  } catch {
+    return false
+  }
+}
+
+// stripJSONComments removes // and /* */ outside strings. Small on purpose: it
+// only has to survive the file our own installer writes.
+export function stripJSONComments(text) {
+  let out = ""
+  let inString = false
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i]
+    if (inString) {
+      out += c
+      if (c === "\\") {
+        out += text[++i] || ""
+      } else if (c === '"') {
+        inString = false
+      }
+      continue
+    }
+    if (c === '"') {
+      inString = true
+      out += c
+      continue
+    }
+    if (c === "/" && text[i + 1] === "/") {
+      while (i < text.length && text[i] !== "\n") i++
+      out += "\n"
+      continue
+    }
+    if (c === "/" && text[i + 1] === "*") {
+      i += 2
+      while (i + 1 < text.length && !(text[i] === "*" && text[i + 1] === "/")) i++
+      i++
+      continue
+    }
+    out += c
+  }
+  return out
+}
+
+// contributions decides what this package adds, given what `deja install`
+// already wired and what the user turned off in their config. It is the whole
+// rule in one place: fill the gaps, never repeat the installer.
+export function contributions(wiring, config = {}) {
+  const wired = wiring || {}
+  return {
+    tools: config.tools !== false && !wired.mcp,
+    recall: config.autoRecall !== false && !wired.recall,
+  }
+}
+
 // clampLimit keeps a model that asks for a hundred sessions from spending the
 // window on a tail nobody reads.
 export function clampLimit(value, fallback = 5) {

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-deja",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Brings the session history of nineteen other coding agents into opencode: recall, session digest and per-file history tools over a local index, plus automatic recall on every request.",
   "type": "module",
   "main": "index.js",

--- a/extensions/opencode/test/pure.test.js
+++ b/extensions/opencode/test/pure.test.js
@@ -5,7 +5,15 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { clampLimit, cliPluginPath, contextText, lastUserText } from "../lib.js"
+import {
+  clampLimit,
+  cliPluginPath,
+  contextText,
+  contributions,
+  lastUserText,
+  mcpWired,
+  stripJSONComments,
+} from "../lib.js"
 import { DejaPlugin } from "../index.js"
 
 test("contextText reads the hook shape deja prints", () => {
@@ -46,6 +54,22 @@ test("clampLimit keeps the window small", () => {
   assert.equal(clampLimit(NaN), 5)
 })
 
+// The plugin reads the installer's own config home, so the tests point it at a
+// temporary one rather than at the machine's.
+async function withConfigHome(dir, run) {
+  const previous = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = dir
+  try {
+    await run()
+  } finally {
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME
+    else process.env.XDG_CONFIG_HOME = previous
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+const quietClient = () => ({ tui: { showToast: async () => {} } })
+
 test("cliPluginPath follows the installer's own config home", () => {
   assert.equal(
     cliPluginPath({ XDG_CONFIG_HOME: "/cfg" }, "/home/x"),
@@ -64,33 +88,65 @@ test("the plugin stands down when the installer's own plugin is on disk", async 
   const dir = mkdtempSync(join(tmpdir(), "deja-oc-"))
   mkdirSync(join(dir, "opencode", "plugins"), { recursive: true })
   writeFileSync(join(dir, "opencode", "plugins", "deja.js"), "// installed by deja\n")
-
-  const client = { tui: { showToast: async () => {} } }
-  const env = process.env.XDG_CONFIG_HOME
-  process.env.XDG_CONFIG_HOME = dir
-  try {
-    const hooks = await DejaPlugin({ client, directory: dir })
+  await withConfigHome(dir, async () => {
+    const hooks = await DejaPlugin({ client: quietClient(), directory: dir })
     assert.equal(hooks["experimental.chat.system.transform"], undefined)
     assert.equal(hooks["experimental.chat.messages.transform"], undefined)
-  } finally {
-    if (env === undefined) delete process.env.XDG_CONFIG_HOME
-    else process.env.XDG_CONFIG_HOME = env
-    rmSync(dir, { recursive: true, force: true })
-  }
+  })
 })
 
 test("without it the recall hooks are installed", async () => {
   const dir = mkdtempSync(join(tmpdir(), "deja-oc-"))
-  const client = { tui: { showToast: async () => {} } }
-  const env = process.env.XDG_CONFIG_HOME
-  process.env.XDG_CONFIG_HOME = dir
-  try {
-    const hooks = await DejaPlugin({ client, directory: dir })
+  await withConfigHome(dir, async () => {
+    const hooks = await DejaPlugin({ client: quietClient(), directory: dir })
     assert.equal(typeof hooks["experimental.chat.system.transform"], "function")
     assert.equal(typeof hooks["experimental.chat.messages.transform"], "function")
-  } finally {
-    if (env === undefined) delete process.env.XDG_CONFIG_HOME
-    else process.env.XDG_CONFIG_HOME = env
-    rmSync(dir, { recursive: true, force: true })
+  })
+})
+
+test("mcpWired reads the entry the installer writes, comments and all", () => {
+  const config = `{
+  // deja was wired by \`deja install opencode\`
+  "mcp": {
+    "deja": {"type":"local","command":["/usr/local/bin/deja","mcp"]}
   }
+}`
+  assert.equal(mcpWired(config), true)
+  assert.equal(mcpWired(`{"mcp": {"other": {}}}`), false)
+  assert.equal(mcpWired("{}"), false)
+  assert.equal(mcpWired("not json"), false)
+  assert.equal(mcpWired(""), false)
+})
+
+test("stripJSONComments leaves what is inside strings alone", () => {
+  assert.equal(stripJSONComments(`{"a":"http://x"} // tail`).trim(), `{"a":"http://x"}`)
+  assert.equal(stripJSONComments(`{/* off */"a":1}`), `{"a":1}`)
+  assert.equal(stripJSONComments(`{"a":"say \\"//\\" here"}`), `{"a":"say \\"//\\" here"}`)
+})
+
+test("an MCP server in the config leaves recall as this package's job", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "deja-oc-"))
+  mkdirSync(join(dir, "opencode"), { recursive: true })
+  writeFileSync(
+    join(dir, "opencode", "opencode.json"),
+    JSON.stringify({ mcp: { deja: { type: "local", command: ["deja", "mcp"] } } }),
+  )
+  await withConfigHome(dir, async () => {
+    const hooks = await DejaPlugin({ client: quietClient(), directory: dir })
+    assert.equal(typeof hooks["experimental.chat.system.transform"], "function")
+  })
+})
+
+// The registration decision itself, since the hook tests above cannot see the
+// tools: registering those needs opencode's own plugin package, which the host
+// provides and the test environment does not.
+test("contributions fills the gaps and never repeats the installer", () => {
+  assert.deepEqual(contributions({}, {}), { tools: true, recall: true })
+  assert.deepEqual(contributions({ mcp: true }, {}), { tools: false, recall: true })
+  assert.deepEqual(contributions({ recall: true }, {}), { tools: true, recall: false })
+  assert.deepEqual(contributions({ mcp: true, recall: true }, {}), { tools: false, recall: false })
+  // The user's own switches still win over an empty machine.
+  assert.deepEqual(contributions({}, { tools: false }), { tools: false, recall: true })
+  assert.deepEqual(contributions({}, { autoRecall: false }), { tools: true, recall: false })
+  assert.deepEqual(contributions(undefined, {}), { tools: true, recall: true })
 })

--- a/extensions/zed/README.md
+++ b/extensions/zed/README.md
@@ -23,6 +23,14 @@ Install the extension from Zed's extension list. On first use it downloads a
 release build of the `deja` binary into its own directory; if you already have
 one, point at it:
 
+`deja install --auto` reaches Zed too, and writes a context server into
+`settings.json` directly — the shorter path when you have the CLI. It leaves
+settings alone if this extension is already installed. The reverse order is the
+one case nothing can catch by itself: install the extension after the CLI and
+both entries are there, each starting its own `deja mcp`, so the agent sees
+every tool twice. `deja doctor` reports it, and `deja uninstall zed` removes
+deja's own entry and keeps the extension.
+
 ```json
 {
   "context_servers": {


### PR DESCRIPTION
Follow-up to #1567, which stopped the duplicated recall but left the tools: with `deja install` having wired the MCP server, the six tools each package registers are the same six answers a second time in the model's tool list.

One rule now, in one function per package: read what the installer wrote, contribute only what is missing. opencode looks for the MCP entry in `opencode.json` and for `plugins/deja.js`; dsh looks for `command.js` (written by the same install as the `mcp-deja` row) and `auto.js`. Checked against this machine's real opencode setup — both wired — and the package now adds nothing at all.

Zed is the one pair neither side can see: the extension runs in Zed's sandbox and reads no settings, so installing it after `deja install zed` leaves two context servers. `deja doctor` reports that and names the fix.

Docs say the same everywhere: `deja install --auto` stays the short path, the packages are for people who install extensions in their own ecosystem, and having both is fine. Also fixed two package READMEs that said "three tools" over a table of six.