### PR TITLE
feat(kimi): a Kimi Code plugin that recalls what the other agents wrote

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -120,6 +120,44 @@ jobs:
             exit 1
           }
 
+  kimi:
+    name: kimi-deja
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: extensions/kimi
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+
+      - name: The plugin has to parse
+        run: node --check lib.mjs && node --check hooks/recall.mjs && node --check bin/deja-mcp.mjs
+
+      - run: npm test
+
+      - name: The manifest has to stay loadable by Kimi
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const m = JSON.parse(fs.readFileSync("kimi.plugin.json", "utf8"));
+            let bad = 0;
+            // Kimi ignores what it does not know, and reports it as a
+            // diagnostic nobody reads: a typo here is a capability that
+            // silently never arrives.
+            const known = new Set(["name", "version", "description", "keywords", "author", "homepage", "license", "interface", "skills", "agents", "commands", "sessionStart", "skillInstructions", "systemPrompt", "systemPromptPath", "mcpServers", "hooks"]);
+            for (const key of Object.keys(m)) {
+              if (!known.has(key)) { console.error("unknown manifest field: " + key); bad++; }
+            }
+            for (const rel of [m.skills, m.commands, ...(m.hooks ?? []).map((h) => h.command.split(" ").pop()), ...Object.values(m.mcpServers ?? {}).flatMap((s) => s.args ?? [])]) {
+              if (typeof rel !== "string" || !rel.startsWith("./")) { console.error("path must start with ./ : " + rel); bad++; continue; }
+              if (!fs.existsSync(rel)) { console.error("manifest points outside the plugin: " + rel); bad++; }
+            }
+            process.exit(bad ? 1 : 0);
+          '
+
   metadata:
     name: packages point at this repository
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,21 @@ jobs:
           go run ./scripts/mcpb -version "${GITHUB_REF_NAME#v}" -in dist -out dist/mcpb
           go run ./scripts/mcpb -registry -version "${GITHUB_REF_NAME#v}" -out dist/mcpb
 
+      # Kimi Code installs a plugin from a local path, a zip URL or a GitHub
+      # repository — and the repository form looks for the manifest at the root
+      # or in one top-level directory, which a monorepo does not have. The zip
+      # is how extensions/kimi reaches a Kimi user.
+      - name: Pack the Kimi Code plugin
+        run: |
+          cd extensions/kimi
+          zip -qr "$GITHUB_WORKSPACE/dist/kimi-deja.zip" . -x 'test/*' 'package.json'
+          unzip -l "$GITHUB_WORKSPACE/dist/kimi-deja.zip" | grep -q kimi.plugin.json
+
+      - name: Attach the Kimi Code plugin to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" dist/kimi-deja.zip --clobber
+
       # Regenerate the Windows manifests from the checksums this run produced,
       # and attach them so the scoop and winget submissions have a canonical
       # file even before the repository catches up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- A Kimi Code plugin, in `extensions/kimi`. One `/plugins install` gives Kimi the MCP tools, the shared skill, a `/deja:recall` command and recall on every prompt through its `UserPromptSubmit` hook. It stands down where `deja install kimi` already wired the same thing, so having both is not two of anything.
+
 
 ## [0.18.0] - 2026-08-22
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ keeping those descriptions checked against the parsers.
 
 ### Harnesses with a package of their own
 
-`deja install --auto` wires all three of these like every other harness, and
+`deja install --auto` wires all four of these like every other harness, and
 that stays the shortest path. They also have a package in their own ecosystem,
 for people who install extensions there rather than from a CLI:
 
@@ -272,11 +272,12 @@ for people who install extensions there rather than from a CLI:
 | opencode | npm `opencode-deja` | `opencode plugin opencode-deja` |
 | DeepSeek Harness | npm `dsh-deja` | `dsh plugin add dsh-deja` |
 | Zed | `deja-context-server` | Zed → Extensions → deja |
+| Kimi Code | plugin `deja` | `/plugins install .../releases/latest/download/kimi-deja.zip` |
 
-Either path is enough on its own, and having both is not a problem: the opencode
-and dsh packages read what `deja install` wrote and contribute only what is
-missing, and in Zed both halves use one server id, so there is nothing to have
-twice whichever order you install in.
+Either path is enough on its own, and having both is not a problem: the
+opencode, dsh and Kimi packages read what `deja install` wrote and contribute
+only what is missing, and in Zed both halves use one server id, so there is
+nothing to have twice whichever order you install in.
 
 Each uses the deja you already have; the copy it bundles is only the fallback.
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ for people who install extensions there rather than from a CLI:
 | opencode | npm `opencode-deja` | `opencode plugin opencode-deja` |
 | DeepSeek Harness | npm `dsh-deja` | `dsh plugin add dsh-deja` |
 | Zed | `deja-context-server` | Zed → Extensions → deja |
-| Kimi Code | plugin `deja` | `/plugins install .../releases/latest/download/kimi-deja.zip` |
+| Kimi Code | plugin `deja` | `/plugins install https://github.com/vshulcz/deja-vu` |
 
 Either path is enough on its own, and having both is not a problem: the
 opencode, dsh and Kimi packages read what `deja install` wrote and contribute

--- a/README.zh.md
+++ b/README.zh.md
@@ -42,15 +42,17 @@ deja install --auto
 
 也不必特意去问——开启自动召回后，会话一打开，智能体就已经知道你在这个项目里解决过什么。
 
-opencode、DeepSeek Harness 和 Zed 也有各自生态里的包，习惯在那边装扩展的人可以直接用：
+opencode、DeepSeek Harness、Zed 和 Kimi Code 也有各自生态里的包，习惯在那边装扩展的人
+可以直接用：
 
 ```sh
 opencode plugin opencode-deja
 dsh plugin --profile web add dsh-deja
 # Zed：扩展面板里搜 deja
+# Kimi Code：/plugins install <kimi-deja.zip 的发布地址>
 ```
 
-`deja install --auto` 已经把这三个接好了，两条路走哪条都够。两边都装也没问题：包会看
+`deja install --auto` 已经把这四个接好了，两条路走哪条都够。两边都装也没问题：包会看
 `deja install` 写了什么，只补上缺的部分，不会重复注册工具、也不会重复召回。详见
 [`extensions/`](extensions)。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -49,7 +49,7 @@ opencode、DeepSeek Harness、Zed 和 Kimi Code 也有各自生态里的包，�
 opencode plugin opencode-deja
 dsh plugin --profile web add dsh-deja
 # Zed：扩展面板里搜 deja
-# Kimi Code：/plugins install <kimi-deja.zip 的发布地址>
+# Kimi Code：/plugins install https://github.com/vshulcz/deja-vu
 ```
 
 `deja install --auto` 已经把这四个接好了，两条路走哪条都够。两边都装也没问题：包会看

--- a/cmd/deja/codex_plugin_test.go
+++ b/cmd/deja/codex_plugin_test.go
@@ -95,6 +95,7 @@ func TestBundledSkillsMatchInstaller(t *testing.T) {
 	for _, p := range []string{
 		"codex-plugin/skills/deja-history/SKILL.md",
 		"claude-plugin/skills/deja-history/SKILL.md",
+		"extensions/kimi/skills/deja-history/SKILL.md",
 	} {
 		got := string(repoFile(t, p))
 		if want := guidanceText("claude"); got != want {

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -808,6 +808,13 @@ func doctorMCP(w io.Writer) {
 				status = "not wired"
 			}
 		}
+		// The Kimi Code plugin declares the same server, and stands down when
+		// this file already has it. Reporting a machine that installed the
+		// plugin as "not wired" sends someone to run an install that only
+		// pushes the plugin aside.
+		if status != "wired" && c.name == "kimi" && kimiPluginInstalled() {
+			status = "plugin"
+		}
 		fmt.Fprintf(w, "  %-12s %-14s guidance %-11s %s\n", c.name, status, guidanceStatus(guidanceHarness(c.name)), c.path)
 		if note := doctorWiringNote(c.name); note != "" && status == "wired" {
 			fmt.Fprintf(w, "  %-12s %s\n", "", note)

--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -94,6 +94,13 @@ func doctorAutoRecall(w io.Writer) {
 		if a.kind != "" {
 			note = "  (" + a.kind + ")"
 		}
+		// Same as the MCP line: the plugin carries this harness's recall, and
+		// its own hook is the one that runs when the installer has not written
+		// here at all.
+		if a.name == "kimi" && kimiPluginInstalled() && (err != nil || !strings.Contains(string(b), a.marker)) {
+			fmt.Fprintf(w, "  %-12s %-11s %s  (the Kimi Code plugin recalls on every prompt)\n", a.name, "plugin", path)
+			continue
+		}
 		switch {
 		case err != nil:
 			fmt.Fprintf(w, "  %-12s %-11s %s%s\n", a.name, "missing", path, note)

--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -98,7 +98,13 @@ func doctorAutoRecall(w io.Writer) {
 		// its own hook is the one that runs when the installer has not written
 		// here at all.
 		if a.name == "kimi" && kimiPluginInstalled() && (err != nil || !strings.Contains(string(b), a.marker)) {
-			fmt.Fprintf(w, "  %-12s %-11s %s  (the Kimi Code plugin recalls on every prompt)\n", a.name, "plugin", path)
+			// Behind is the line worth the width: what it does is in the
+			// README, what to run is not obvious from anywhere.
+			note := kimiPluginNote()
+			if note == "" || note == "v"+kimiPluginVersion {
+				note = "the Kimi Code plugin recalls on every prompt"
+			}
+			fmt.Fprintf(w, "  %-12s %-11s %s  (%s)\n", a.name, "plugin", path, note)
 			continue
 		}
 		switch {

--- a/cmd/deja/kimi_doctor_test.go
+++ b/cmd/deja/kimi_doctor_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeKimiPlugin(t *testing.T, home string, enabled bool) {
+	t.Helper()
+	root := filepath.Join(home, "plugins", "managed", "deja")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "kimi.plugin.json"), []byte(`{"name":"deja"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	record := `{"version":1,"plugins":[{"id":"deja","root":` + strconvQuote(root) +
+		`,"source":"local-path","enabled":` + boolText(enabled) + `,"installedAt":"2026-08-23T00:00:00Z"}]}`
+	if err := os.WriteFile(filepath.Join(home, "plugins", "installed.json"), []byte(record), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func strconvQuote(s string) string { return `"` + strings.ReplaceAll(s, `\`, `\\`) + `"` }
+
+func boolText(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// A machine that installed the plugin is wired: the plugin declares the same
+// MCP server and recalls on every prompt. Reporting it as "not wired" is how
+// someone ends up running an install that only pushes the plugin aside.
+func TestDoctorCountsTheKimiPlugin(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "mcp.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var before bytes.Buffer
+	doctorMCP(&before)
+	doctorAutoRecall(&before)
+	if !strings.Contains(kimiLine(before.String()), "not wired") {
+		t.Fatalf("without the plugin kimi should read as not wired:\n%s", before.String())
+	}
+
+	writeKimiPlugin(t, home, true)
+	var after bytes.Buffer
+	doctorMCP(&after)
+	doctorAutoRecall(&after)
+	for _, want := range []string{"plugin", "the Kimi Code plugin recalls on every prompt"} {
+		if !strings.Contains(after.String(), want) {
+			t.Fatalf("doctor does not report the plugin (%q missing):\n%s", want, after.String())
+		}
+	}
+	if strings.Contains(kimiLine(after.String()), "not wired") {
+		t.Fatalf("kimi still reads as not wired with the plugin installed:\n%s", after.String())
+	}
+}
+
+// A disabled plugin runs nothing, so it cannot stand in for the wiring.
+func TestDoctorIgnoresADisabledKimiPlugin(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+	writeKimiPlugin(t, home, false)
+	if kimiPluginInstalled() {
+		t.Fatal("a disabled plugin counted as installed")
+	}
+}
+
+// The record can outlive the files it points at — a managed copy removed by
+// hand, or a home restored from a backup.
+func TestKimiPluginNeedsItsManifest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+	writeKimiPlugin(t, home, true)
+	if err := os.Remove(filepath.Join(home, "plugins", "managed", "deja", "kimi.plugin.json")); err != nil {
+		t.Fatal(err)
+	}
+	if kimiPluginInstalled() {
+		t.Fatal("a record pointing at nothing counted as installed")
+	}
+}
+
+func kimiLine(out string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "kimi") {
+			return line
+		}
+	}
+	return ""
+}

--- a/cmd/deja/kimi_plugin.go
+++ b/cmd/deja/kimi_plugin.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// kimiPluginInstalled reports whether the Kimi Code plugin from
+// extensions/kimi is installed and enabled. It provides the same MCP server and
+// the same per-prompt recall the installer writes, and stands down when the
+// installer's copy is there — so a machine with only the plugin is wired, and
+// doctor saying "not wired" would send someone to run an install they do not
+// need.
+//
+// Kimi keeps the record in plugins/installed.json and runs the plugin from the
+// managed copy that record points at, so both have to be there.
+func kimiPluginInstalled() bool {
+	b, err := os.ReadFile(filepath.Join(sources.KimiConfigDir(), "plugins", "installed.json"))
+	if err != nil {
+		return false
+	}
+	var installed struct {
+		Plugins []struct {
+			ID      string `json:"id"`
+			Root    string `json:"root"`
+			Enabled bool   `json:"enabled"`
+		} `json:"plugins"`
+	}
+	if err := json.Unmarshal(b, &installed); err != nil {
+		return false
+	}
+	for _, p := range installed.Plugins {
+		if p.ID != "deja" || !p.Enabled || p.Root == "" {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(p.Root, "kimi.plugin.json")); err == nil {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/deja/kimi_plugin.go
+++ b/cmd/deja/kimi_plugin.go
@@ -8,19 +8,50 @@ import (
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
+// kimiPluginVersion is the version in extensions/kimi/kimi.plugin.json. Kimi
+// only offers an update for a plugin it installed from its own marketplace, so
+// for a repository or zip install nothing tells the user their copy is behind.
+// deja knows both numbers, and doctor is where someone looks.
+const kimiPluginVersion = "0.1.0"
+
+// kimiPluginInstalledVersion returns the version of the installed copy, or ""
+// when the plugin is not there.
+func kimiPluginInstalledVersion() string {
+	root, ok := kimiPluginRoot()
+	if !ok {
+		return ""
+	}
+	b, err := os.ReadFile(filepath.Join(root, "kimi.plugin.json"))
+	if err != nil {
+		return ""
+	}
+	var manifest struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(b, &manifest); err != nil {
+		return ""
+	}
+	return manifest.Version
+}
+
 // kimiPluginInstalled reports whether the Kimi Code plugin from
 // extensions/kimi is installed and enabled. It provides the same MCP server and
 // the same per-prompt recall the installer writes, and stands down when the
 // installer's copy is there — so a machine with only the plugin is wired, and
 // doctor saying "not wired" would send someone to run an install they do not
 // need.
-//
-// Kimi keeps the record in plugins/installed.json and runs the plugin from the
-// managed copy that record points at, so both have to be there.
 func kimiPluginInstalled() bool {
+	_, ok := kimiPluginRoot()
+	return ok
+}
+
+// kimiPluginRoot finds the managed copy Kimi runs. The record lives in
+// plugins/installed.json and points at the directory Kimi actually loads, so
+// both have to be there.
+func kimiPluginRoot() (string, bool) {
 	b, err := os.ReadFile(filepath.Join(sources.KimiConfigDir(), "plugins", "installed.json"))
 	if err != nil {
-		return false
+		return "", false
 	}
 	var installed struct {
 		Plugins []struct {
@@ -30,15 +61,28 @@ func kimiPluginInstalled() bool {
 		} `json:"plugins"`
 	}
 	if err := json.Unmarshal(b, &installed); err != nil {
-		return false
+		return "", false
 	}
 	for _, p := range installed.Plugins {
 		if p.ID != "deja" || !p.Enabled || p.Root == "" {
 			continue
 		}
 		if _, err := os.Stat(filepath.Join(p.Root, "kimi.plugin.json")); err == nil {
-			return true
+			return p.Root, true
 		}
 	}
-	return false
+	return "", false
+}
+
+// kimiPluginNote is what doctor adds after "plugin": which version is running,
+// and whether this deja ships a newer one.
+func kimiPluginNote() string {
+	got := kimiPluginInstalledVersion()
+	if got == "" {
+		return ""
+	}
+	if got != kimiPluginVersion {
+		return "v" + got + " installed, v" + kimiPluginVersion + " ships with this deja — reinstall it in Kimi to update"
+	}
+	return "v" + got
 }

--- a/cmd/deja/kimi_plugin_test.go
+++ b/cmd/deja/kimi_plugin_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Kimi Code loads the plugin from this manifest and nothing else: a path that
+// does not exist, or a field it does not know, becomes a diagnostic in
+// /plugins and the capability silently never arrives.
+func TestKimiPluginManifest(t *testing.T) {
+	var manifest struct {
+		Name        string `json:"name"`
+		Version     string `json:"version"`
+		Skills      string `json:"skills"`
+		Commands    string `json:"commands"`
+		SessionStrt struct {
+			Skill string `json:"skill"`
+		} `json:"sessionStart"`
+		MCPServers map[string]struct {
+			Command string   `json:"command"`
+			Args    []string `json:"args"`
+		} `json:"mcpServers"`
+		Hooks []struct {
+			Event   string `json:"event"`
+			Command string `json:"command"`
+			Timeout int    `json:"timeout"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(repoFile(t, "extensions/kimi/kimi.plugin.json"), &manifest); err != nil {
+		t.Fatalf("kimi.plugin.json: %v", err)
+	}
+
+	// The name is the plugin id, and Kimi rejects anything else.
+	if !regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,63}$`).MatchString(manifest.Name) {
+		t.Fatalf("plugin id %q is not a name Kimi accepts", manifest.Name)
+	}
+	if manifest.Version == "" {
+		t.Fatal("no version: the marketplace and the update check both read it")
+	}
+
+	// UserPromptSubmit is the only event whose output Kimi appends to the
+	// turn. A SessionStart hook runs and its answer goes nowhere.
+	if len(manifest.Hooks) != 1 || manifest.Hooks[0].Event != "UserPromptSubmit" {
+		t.Fatalf("recall has to hang off UserPromptSubmit, got %+v", manifest.Hooks)
+	}
+	if manifest.Hooks[0].Timeout < 1 || manifest.Hooks[0].Timeout > 600 {
+		t.Fatalf("timeout %d is outside the 1-600s Kimi allows", manifest.Hooks[0].Timeout)
+	}
+
+	// `command: "node"` is the one form Kimi rewrites to its own runtime when
+	// it ships as a native binary, so the server starts on a machine with no
+	// node on PATH.
+	server, ok := manifest.MCPServers["deja"]
+	if !ok || server.Command != "node" || len(server.Args) != 1 {
+		t.Fatalf("mcpServers.deja should run node with one script, got %+v", manifest.MCPServers)
+	}
+
+	if manifest.SessionStrt.Skill != "deja-history" {
+		t.Fatalf("sessionStart.skill %q does not name the bundled skill", manifest.SessionStrt.Skill)
+	}
+
+	for _, rel := range []string{
+		strings.TrimPrefix(server.Args[0], "./"),
+		strings.TrimPrefix(strings.Fields(manifest.Hooks[0].Command)[1], "./"),
+		strings.TrimPrefix(manifest.Skills, "./"),
+		strings.TrimPrefix(manifest.Commands, "./"),
+		"skills/deja-history/SKILL.md",
+		"commands/recall.md",
+	} {
+		if _, err := os.Stat(filepath.Join("..", "..", "extensions", "kimi", rel)); err != nil {
+			t.Fatalf("manifest points at %s, which is not in the plugin: %v", rel, err)
+		}
+	}
+}
+
+// The plugin stands down by looking for the comment the installer writes above
+// its own hook. If either side edits that string alone, the two stop
+// recognising each other and the user reads the same recall twice.
+func TestKimiPluginKnowsTheInstallersMarker(t *testing.T) {
+	lib := string(repoFile(t, "extensions/kimi/lib.mjs"))
+	if !strings.Contains(lib, kimiHookMarker) {
+		t.Fatalf("extensions/kimi/lib.mjs does not carry the marker the installer writes:\n%s", kimiHookMarker)
+	}
+}

--- a/cmd/deja/kimi_plugin_test.go
+++ b/cmd/deja/kimi_plugin_test.go
@@ -87,3 +87,35 @@ func TestKimiPluginKnowsTheInstallersMarker(t *testing.T) {
 		t.Fatalf("extensions/kimi/lib.mjs does not carry the marker the installer writes:\n%s", kimiHookMarker)
 	}
 }
+
+// The version doctor compares against has to be the version the plugin ships,
+// and the manifest a GitHub install reads has to be the same plugin as the one
+// in the zip — only its paths differ.
+func TestKimiManifestsAgree(t *testing.T) {
+	var plugin, root map[string]any
+	if err := json.Unmarshal(repoFile(t, "extensions/kimi/kimi.plugin.json"), &plugin); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(repoFile(t, "kimi.plugin.json"), &root); err != nil {
+		t.Fatal(err)
+	}
+	if plugin["version"] != kimiPluginVersion {
+		t.Fatalf("kimiPluginVersion is %q, the manifest says %v", kimiPluginVersion, plugin["version"])
+	}
+	for _, key := range []string{"name", "version", "description", "license", "sessionStart"} {
+		a, _ := json.Marshal(plugin[key])
+		b, _ := json.Marshal(root[key])
+		if string(a) != string(b) {
+			t.Fatalf("%s differs between the two manifests: %s vs %s", key, a, b)
+		}
+	}
+	// The root manifest addresses the same files from one directory up.
+	if root["skills"] != "./extensions/kimi/skills/" || root["commands"] != "./extensions/kimi/commands/" {
+		t.Fatalf("root manifest does not point into extensions/kimi: %v %v", root["skills"], root["commands"])
+	}
+	for _, rel := range []string{"extensions/kimi/hooks/recall.mjs", "extensions/kimi/bin/deja-mcp.mjs"} {
+		if _, err := os.Stat(filepath.Join("..", "..", rel)); err != nil {
+			t.Fatalf("root manifest points at %s, which is not there: %v", rel, err)
+		}
+	}
+}

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -10,7 +10,7 @@ same local index.
 | [`opencode/`](opencode) | npm `opencode-deja` | `opencode plugin opencode-deja` |
 | [`dsh/`](dsh) | npm `dsh-deja` | `dsh plugin add dsh-deja` |
 | [`zed/`](zed) | Zed extension `deja-context-server` | Zed → Extensions → deja |
-| [`kimi/`](kimi) | Kimi Code plugin `deja` | `/plugins install <kimi-deja.zip url>` |
+| [`kimi/`](kimi) | Kimi Code plugin `deja` | `/plugins install https://github.com/vshulcz/deja-vu` |
 
 Two more integrations live outside this directory because their registries read
 a fixed path in this repository: `claude-plugin/` (Claude Code marketplace) and
@@ -32,11 +32,16 @@ repository as a submodule and builds `extensions/zed`. A new version means
 bumping `version` in `extensions/zed/extension.toml` and opening a PR there that
 moves the submodule to the new commit.
 
-The Kimi Code plugin ships as the `kimi-deja.zip` release asset, built by
-goreleaser from `extensions/kimi`. Kimi installs a plugin from a local path, a
-zip URL or a GitHub repository — and the repository form looks for
-`kimi.plugin.json` at the repository root or in a single top-level directory, so
-a monorepo has to go through the zip.
+The Kimi Code plugin has two routes, and both are ours to keep working. The
+repository form (`/plugins install https://github.com/vshulcz/deja-vu`) reads
+`kimi.plugin.json` at the repository root — the only reason that file exists —
+and records the release it came from, which is what Kimi's update check reads.
+The `kimi-deja.zip` release asset carries the same plugin at 16 KB for a
+marketplace entry. `TestKimiManifestsAgree` keeps the two manifests one plugin.
+
+Kimi notifies about updates only for plugins installed from its own
+marketplace, so `deja doctor` reports the installed plugin version against the
+one this deja ships.
 
 ## Rules that cost us time once
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -10,6 +10,7 @@ same local index.
 | [`opencode/`](opencode) | npm `opencode-deja` | `opencode plugin opencode-deja` |
 | [`dsh/`](dsh) | npm `dsh-deja` | `dsh plugin add dsh-deja` |
 | [`zed/`](zed) | Zed extension `deja-context-server` | Zed → Extensions → deja |
+| [`kimi/`](kimi) | Kimi Code plugin `deja` | `/plugins install <kimi-deja.zip url>` |
 
 Two more integrations live outside this directory because their registries read
 a fixed path in this repository: `claude-plugin/` (Claude Code marketplace) and
@@ -31,6 +32,12 @@ repository as a submodule and builds `extensions/zed`. A new version means
 bumping `version` in `extensions/zed/extension.toml` and opening a PR there that
 moves the submodule to the new commit.
 
+The Kimi Code plugin ships as the `kimi-deja.zip` release asset, built by
+goreleaser from `extensions/kimi`. Kimi installs a plugin from a local path, a
+zip URL or a GitHub repository — and the repository form looks for
+`kimi.plugin.json` at the repository root or in a single top-level directory, so
+a monorepo has to go through the zip.
+
 ## Rules that cost us time once
 
 - **Resolve the binary in this order, everywhere:** an explicit setting or
@@ -39,9 +46,10 @@ moves the submodule to the new commit.
   `brew upgrade` has to win over whatever we bundled.
 - **Recall is optional.** A harness must never lose a turn because history was
   unavailable: every call is wrapped, every failure is silent.
-- **Assume the other install is there too.** `deja install` wires these three
+- **Assume the other install is there too.** `deja install` wires these four
   harnesses as well, so a user can end up with both at once — opencode loads the
-  package and the installer's plugin file side by side, dsh composes both into
+  package and the installer's plugin file side by side, Kimi runs a plugin hook
+  next to the one in `config.toml`, dsh composes both into
   one profile, Zed reads both context servers. Whatever the installer writes
   wins, because it is the copy `deja install` keeps current: each package looks
   for those files and drops the part they already cover.

--- a/extensions/kimi/LICENSE
+++ b/extensions/kimi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vladislav Shulcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/kimi/README.md
+++ b/extensions/kimi/README.md
@@ -8,14 +8,25 @@ recall arrives with the prompt, and the agent can search history itself.
 ## Install
 
 ```
-/plugins install https://github.com/vshulcz/deja-vu/releases/latest/download/kimi-deja.zip
+/plugins install https://github.com/vshulcz/deja-vu
 /reload
 ```
 
-Installing from the repository URL does not work: Kimi looks for
-`kimi.plugin.json` at the repository root or in a single top-level directory,
-and this is a monorepo. From a clone, `/plugins install <path>/extensions/kimi`
-does work.
+That form pins the latest release and records where it came from, which is what
+Kimi's update check reads. There is also a `kimi-deja.zip` release asset — 16 KB
+instead of a 3 MB repository — for a marketplace entry or an install that should
+not pull the whole project.
+
+## Updates
+
+Kimi only notifies about updates for plugins installed from its own
+marketplace. For a repository install, `/plugins install` again pulls the
+current release, and `deja doctor` says when the copy you have is behind the
+one this deja ships:
+
+```
+kimi  plugin  ~/.kimi-code/config.toml  (v0.1.0 installed, v0.2.0 ships with this deja — reinstall it in Kimi to update)
+```
 
 Then install the binary if you do not have it:
 

--- a/extensions/kimi/README.md
+++ b/extensions/kimi/README.md
@@ -1,0 +1,58 @@
+# deja for Kimi Code
+
+[deja](https://github.com/vshulcz/deja-vu) indexes the session files coding
+agents already write to disk — Claude Code, Codex, Cursor, opencode and sixteen
+more — and answers from them. This plugin brings that index into Kimi Code:
+recall arrives with the prompt, and the agent can search history itself.
+
+## Install
+
+```
+/plugins install https://github.com/vshulcz/deja-vu/releases/latest/download/kimi-deja.zip
+/reload
+```
+
+Installing from the repository URL does not work: Kimi looks for
+`kimi.plugin.json` at the repository root or in a single top-level directory,
+and this is a monorepo. From a clone, `/plugins install <path>/extensions/kimi`
+does work.
+
+Then install the binary if you do not have it:
+
+```
+curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
+```
+
+Plugins load from the managed copy, so run `/reload` or `/new` after installing.
+
+## What you get
+
+- **Recall on every prompt.** A `UserPromptSubmit` hook runs `deja hook-prompt`
+  and Kimi appends what it finds to the turn. Silent when nothing matches.
+- **Tools.** The plugin declares `deja mcp` as an MCP server: `recall`,
+  `recall_context`, `blame` and `remember`.
+- **`/deja:recall <query>`** to search history directly.
+- **The `deja-history` skill**, loaded at session start, so the agent knows to
+  look before re-debugging something.
+
+## Which binary
+
+In order: `DEJA_BIN`, then the deja you installed yourself (`~/.local/bin`,
+`/usr/local/bin`, `/opt/homebrew/bin`), then `deja` on `PATH`. Your own
+`deja update` or `brew upgrade deja` wins over anything a plugin release
+pinned.
+
+## If you also ran `deja install kimi`
+
+The CLI writes the same MCP server into `~/.kimi-code/mcp.json` and the same
+hook into `config.toml`. Kimi runs a plugin's server under its own namespace
+(`plugin-deja:deja`), so both would run: every tool listed twice, recall
+appended twice.
+
+This plugin checks for the installer's wiring and stands down when it finds it —
+the CLI's copy is the one `deja install` keeps current. `deja uninstall kimi`
+hands ownership back to the plugin.
+
+## License
+
+MIT

--- a/extensions/kimi/README.md
+++ b/extensions/kimi/README.md
@@ -51,7 +51,15 @@ appended twice.
 
 This plugin checks for the installer's wiring and stands down when it finds it —
 the CLI's copy is the one `deja install` keeps current. `deja uninstall kimi`
-hands ownership back to the plugin.
+hands ownership back to the plugin, with no reinstall in between: the check runs
+when the hook fires and when the server starts, not once at install time.
+
+`deja doctor` reports `plugin` for kimi when the plugin is what carries the
+wiring, so a plugin-only machine does not read as unwired.
+
+Two things it cannot see: an MCP entry you added by hand under a name other than
+`deja` (it would run beside this one), and a hook you wrote yourself that calls
+deja without the installer's marker comment.
 
 ## License
 

--- a/extensions/kimi/bin/deja-mcp.mjs
+++ b/extensions/kimi/bin/deja-mcp.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// The plugin's MCP server: `deja mcp` over stdio, with the binary resolved the
+// way the user expects rather than pinned to whatever this release bundled.
+//
+// Kimi registers a plugin's server as `plugin-<id>:<name>`, so it does not
+// merge with the `deja` entry `deja install kimi` writes into mcp.json — both
+// would run, and the agent would see every tool twice. When the installer has
+// already wired it, this stands down and says why: the CLI's copy is the one
+// `deja install` keeps current.
+
+import { spawn } from "node:child_process"
+import { installerOwns, kimiHome, resolveDeja } from "../lib.mjs"
+
+if (installerOwns("mcp")) {
+  process.stderr.write(
+    `deja is already an MCP server in ${kimiHome()}/mcp.json, from \`deja install kimi\`. ` +
+      "This plugin's copy stays out of the way so the tools are not listed twice — " +
+      "run `deja uninstall kimi` to let the plugin own it instead.\n",
+  )
+  process.exit(0)
+}
+
+const child = spawn(resolveDeja(), ["mcp"], { stdio: "inherit" })
+child.on("error", (err) => {
+  process.stderr.write(
+    `deja could not start: ${err.message}. Install it with: ` +
+      "curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh\n",
+  )
+  process.exit(1)
+})
+child.on("close", (code) => process.exit(code ?? 0))

--- a/extensions/kimi/commands/recall.md
+++ b/extensions/kimi/commands/recall.md
@@ -1,0 +1,22 @@
+---
+name: recall
+description: Search this machine's past AI coding sessions (deja-vu)
+---
+
+Search the user's own past sessions across every AI coding tool on this
+machine, then answer from what you find.
+
+Run the recall tool with the user's words as the query — the most specific
+tokens win (an exact error string, a function name, a file path, a flag).
+If a result looks right but is too short to act on, follow up with
+recall_context using a term from it.
+
+If the deja MCP tools are unavailable, fall back to the CLI:
+
+```bash
+deja "$ARGUMENTS"
+```
+
+Answer with what actually happened in those sessions — when it was, which
+project and tool, what was decided or fixed. Say plainly if nothing matched
+rather than filling the gap from general knowledge.

--- a/extensions/kimi/hooks/recall.mjs
+++ b/extensions/kimi/hooks/recall.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// UserPromptSubmit: hand Kimi the sessions this machine already has that match
+// what the user just asked. Kimi appends a hook's stdout to the turn's context,
+// which is the whole mechanism — its structured output only carries permission
+// decisions.
+//
+// Silence is the normal case. Nothing here may cost the user a turn: every
+// failure exits 0 with no output, which Kimi treats as "nothing to add".
+
+import { spawn } from "node:child_process"
+import { installerOwns, resolveDeja } from "../lib.mjs"
+
+const TIMEOUT_MS = 20000
+
+async function main() {
+  // `deja install kimi-auto` writes the same hook into config.toml. Kimi runs
+  // both, and the user would read the same recall twice, every prompt.
+  if (installerOwns("hook")) return
+
+  const payload = await readStdin()
+  if (!payload.trim()) return
+
+  const out = await run(resolveDeja(), ["hook-prompt", "--plain"], payload)
+  if (out.trim()) process.stdout.write(out)
+}
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = ""
+    const done = () => resolve(data)
+    if (process.stdin.isTTY) return resolve("")
+    process.stdin.setEncoding("utf8")
+    process.stdin.on("data", (chunk) => (data += chunk))
+    process.stdin.on("end", done)
+    process.stdin.on("error", done)
+  })
+}
+
+function run(bin, args, input) {
+  return new Promise((resolve) => {
+    let child
+    try {
+      child = spawn(bin, args, { stdio: ["pipe", "pipe", "ignore"] })
+    } catch {
+      return resolve("")
+    }
+    let out = ""
+    const timer = setTimeout(() => {
+      child.kill()
+      resolve("")
+    }, TIMEOUT_MS)
+    child.stdout.setEncoding("utf8")
+    child.stdout.on("data", (chunk) => (out += chunk))
+    child.on("error", () => {
+      clearTimeout(timer)
+      resolve("")
+    })
+    child.on("close", (code) => {
+      clearTimeout(timer)
+      resolve(code === 0 ? out : "")
+    })
+    child.stdin.on("error", () => {})
+    child.stdin.end(input)
+  })
+}
+
+main().then(
+  () => process.exit(0),
+  // Recall is optional everywhere. A plugin that throws here would be a plugin
+  // that costs the user their turn.
+  () => process.exit(0),
+)

--- a/extensions/kimi/kimi.plugin.json
+++ b/extensions/kimi/kimi.plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "deja",
+  "version": "0.1.0",
+  "description": "Recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and sixteen more, including work from before deja was installed.",
+  "keywords": ["memory", "recall", "sessions", "search", "history"],
+  "author": "vshulcz",
+  "homepage": "https://github.com/vshulcz/deja-vu",
+  "license": "MIT",
+  "interface": {
+    "displayName": "deja",
+    "shortDescription": "Search your own past AI coding sessions, from every tool on this machine.",
+    "longDescription": "deja indexes the session files coding agents already write to disk — Claude Code, Codex, Cursor, opencode, Gemini, Zed and more — and answers from them. Ask what you fixed before instead of debugging it twice. The index is local: no LLM, no embeddings, nothing leaves the machine. Needs the deja binary: https://github.com/vshulcz/deja-vu",
+    "developerName": "vshulcz",
+    "websiteURL": "https://github.com/vshulcz/deja-vu"
+  },
+  "skills": "./skills/",
+  "commands": "./commands/",
+  "sessionStart": {
+    "skill": "deja-history"
+  },
+  "mcpServers": {
+    "deja": {
+      "command": "node",
+      "args": ["./bin/deja-mcp.mjs"]
+    }
+  },
+  "hooks": [
+    {
+      "event": "UserPromptSubmit",
+      "command": "node ./hooks/recall.mjs",
+      "timeout": 30
+    }
+  ]
+}

--- a/extensions/kimi/lib.mjs
+++ b/extensions/kimi/lib.mjs
@@ -62,8 +62,30 @@ function executable(path) {
 // recall appended twice on every prompt.
 export const installerHookMarker = "# deja: auto-recall (managed by `deja install kimi-auto`)"
 
+// The marker alone is not enough: an install from an older deja can leave a
+// block that no longer calls anything Kimi consumes — its output went to
+// SessionStart, which Kimi runs and then ignores. Standing down for a block
+// like that would mean no recall at all, from either half. `deja doctor` calls
+// the same state stale, and reads this file the same way.
 export function installerHookPresent(configToml) {
-  return String(configToml || "").includes(installerHookMarker)
+  const text = String(configToml || "")
+  const at = text.indexOf(installerHookMarker)
+  if (at < 0) return false
+  return blockAfter(text.slice(at + installerHookMarker.length)).includes("hook-prompt")
+}
+
+// blockAfter returns the marked entry and stops at the next table header, so a
+// [[hooks]] rule the user wrote below ours is not read as part of it.
+function blockAfter(rest) {
+  const lines = []
+  let started = false
+  for (const line of rest.split("\n")) {
+    const header = line.trimStart().startsWith("[")
+    if (header && started) break
+    if (header) started = true
+    lines.push(line)
+  }
+  return lines.join("\n")
 }
 
 // installerMcpPresent reports whether `deja install kimi` already declared the

--- a/extensions/kimi/lib.mjs
+++ b/extensions/kimi/lib.mjs
@@ -1,0 +1,100 @@
+// The pure half of the Kimi Code plugin: where the binary is, and what
+// `deja install kimi` has already wired up. No process, no host — index.js has
+// no place here because Kimi loads a plugin as data, not as a module; the two
+// entry points are hooks/recall.mjs and bin/deja-mcp.mjs.
+
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { accessSync, constants, readFileSync } from "node:fs"
+
+const WINDOWS = process.platform === "win32"
+export const EXE = WINDOWS ? "deja.exe" : "deja"
+
+// kimiHome mirrors sources.KimiConfigDir() in the installer: KIMI_CODE_HOME
+// wins, else ~/.kimi-code. Kimi sets that variable for plugin hooks and plugin
+// MCP servers, so the two always agree on which config they are reading.
+export function kimiHome(env = process.env, home = homedir()) {
+  return env.KIMI_CODE_HOME || join(home, ".kimi-code")
+}
+
+// wellKnown is where a user's own install lands. PATH answers first in the
+// normal case; these cover a Kimi started from a launcher whose PATH never
+// sourced a shell profile.
+export function wellKnown(home = homedir(), platform = process.platform) {
+  if (platform === "win32") {
+    const local = process.env.LOCALAPPDATA || join(home, "AppData", "Local")
+    return [join(local, "deja", "bin", "deja.exe"), join(home, ".local", "bin", "deja.exe")]
+  }
+  return [
+    join(home, ".local", "bin", "deja"),
+    "/usr/local/bin/deja",
+    "/opt/homebrew/bin/deja",
+    "/usr/bin/deja",
+  ]
+}
+
+// resolveDeja picks the binary in the order a user would expect: what they
+// pointed at, then the deja they installed themselves and keep current with
+// `deja update` or brew, and only then a copy shipped alongside. Their own
+// update has to win over whatever a plugin release froze.
+export function resolveDeja(env = process.env, home = homedir(), exists = executable) {
+  const candidates = [env.DEJA_BIN, ...wellKnown(home)]
+  for (const candidate of candidates) {
+    if (candidate && exists(candidate)) return candidate
+  }
+  // Nothing on disk answered. The bare name keeps PATH in play and makes the
+  // failure name the thing that is missing rather than a path nobody chose.
+  return EXE
+}
+
+function executable(path) {
+  try {
+    accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// installerHookMarker is the comment `deja install kimi-auto` writes above its
+// own [[hooks]] entry. Kimi runs every matching hook, so without this check a
+// user who ran the installer and then added the plugin would get the same
+// recall appended twice on every prompt.
+export const installerHookMarker = "# deja: auto-recall (managed by `deja install kimi-auto`)"
+
+export function installerHookPresent(configToml) {
+  return String(configToml || "").includes(installerHookMarker)
+}
+
+// installerMcpPresent reports whether `deja install kimi` already declared the
+// server in mcp.json. Kimi namespaces a plugin's server as
+// `plugin-<id>:<name>`, so it does not collide with the installer's entry — it
+// runs a second `deja mcp` and shows the agent every tool twice.
+export function installerMcpPresent(mcpJson) {
+  const text = String(mcpJson || "").trim()
+  if (!text) return false
+  try {
+    return Boolean(JSON.parse(text)?.mcpServers?.deja)
+  } catch {
+    // A config we cannot read is not evidence that deja is in it.
+    return false
+  }
+}
+
+export function readFileOrEmpty(path) {
+  try {
+    return readFileSync(path, "utf8")
+  } catch {
+    return ""
+  }
+}
+
+// installerOwns answers the one question both entry points ask: has the CLI
+// already wired this up? The installer's copy wins — it is the one
+// `deja install` keeps current when the binary moves or the flags change.
+export function installerOwns(what, env = process.env, home = homedir()) {
+  const dir = kimiHome(env, home)
+  if (what === "hook") return installerHookPresent(readFileOrEmpty(join(dir, "config.toml")))
+  if (what === "mcp") return installerMcpPresent(readFileOrEmpty(join(dir, "mcp.json")))
+  return false
+}

--- a/extensions/kimi/package.json
+++ b/extensions/kimi/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "kimi-deja",
+  "private": true,
+  "description": "Kimi Code plugin for deja \u2014 installed through Kimi's plugin manager, not npm. This file only carries the test script; the plugin itself is .mjs so it never depends on it.",
+  "license": "MIT",
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/extensions/kimi/skills/deja-history/SKILL.md
+++ b/extensions/kimi/skills/deja-history/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: deja-history
+description: Search the user's past AI coding sessions. Use when they say things like 'didn't we fix this before', 'what did we decide about X', or before re-debugging an error that may already be solved.
+---
+
+Search deja before re-deriving past work: when the user refers to earlier sessions or decisions, before debugging an error, and before implementing something that may already exist. It searches this machine's own history across every AI coding tool used on it, going back further than deja itself was installed.
+
+If these tools are not available in this session, the same index is reachable through the shell: `deja search --json "<query>"`, `deja ctx <query>`, `deja blame <path> --json`.
+
+## Finding something
+
+- recall: search with the most specific token available — an exact error string, function name, file path, or flag. Several words are ANDed. Not for library docs or general knowledge; only this user's own sessions.
+- recall_context: a full digest of the single best-matching session, once a recall hit looks right and the reasoning behind it matters.
+- blame: before editing, refactoring or deleting a file, the prior sessions that discussed it, so you know why it is shaped the way it is. Session history, not git authorship.
+- fix: paste a failing output verbatim to see the commands that followed that same error before, in sessions where it did not come back.
+- how: the real command with the real flags this machine runs for a build, test, deploy or script, ordered by how many sessions ran it. A guessed invocation is plausible and fails on this setup.
+- remember: store one durable decision after it is settled, as a single self-contained fact. Not transcripts, not anything already obvious from the code.
+
+## Reading a result
+
+A result may carry a bracketed marker with a date — that is the user's own later judgement on that session, and it is not advisory. Do not repeat a rejected approach. Prefer a replacement over what it replaced. Treat a stale result as needing confirmation before acting on it. A result with no marker carries no judgement in either direction.
+
+## Saying what you used
+
+When recalled history genuinely helps — a reused fix, a skipped re-debug, even a partial hint that changed your approach — tell the user in one short line what was recalled and how you used it: "deja-vu recalled: we hit this JWT skew in March — reusing that fix". Say nothing about recalls that did not help. This is provenance, not advertising; a note on every call would be noise.
+
+## Limits worth respecting
+
+- Result windows are bounded. Do not report corpus-wide counts, or claim a complete audit, from the number of hits you got back.
+- If deja is unavailable or the index is empty, say that history search is unavailable. Do not invent what it might have found.
+- Vary the wording and try a second query before concluding nothing is there. Exact tokens match best, so an error string beats a paraphrase of it.

--- a/extensions/kimi/test/pure.test.mjs
+++ b/extensions/kimi/test/pure.test.mjs
@@ -1,0 +1,105 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import {
+  installerHookMarker,
+  installerHookPresent,
+  installerMcpPresent,
+  installerOwns,
+  kimiHome,
+  resolveDeja,
+  wellKnown,
+} from "../lib.mjs"
+
+test("kimiHome follows KIMI_CODE_HOME, which is what Kimi hands its plugins", () => {
+  assert.equal(kimiHome({ KIMI_CODE_HOME: "/tmp/k" }, "/home/x"), "/tmp/k")
+  assert.equal(kimiHome({}, "/home/x"), join("/home/x", ".kimi-code"))
+})
+
+test("installerHookPresent finds the marker deja install kimi-auto writes", () => {
+  const written = `${installerHookMarker}\n[[hooks]]\nevent = "UserPromptSubmit"\n`
+  assert.equal(installerHookPresent(written), true)
+  assert.equal(installerHookPresent('[[hooks]]\nevent = "Stop"\n'), false)
+  assert.equal(installerHookPresent(""), false)
+  assert.equal(installerHookPresent(undefined), false)
+})
+
+test("installerMcpPresent reads mcp.json, and a broken one is not evidence", () => {
+  assert.equal(installerMcpPresent('{"mcpServers":{"deja":{"command":"deja"}}}'), true)
+  assert.equal(installerMcpPresent('{"mcpServers":{"other":{}}}'), false)
+  assert.equal(installerMcpPresent("{"), false)
+  assert.equal(installerMcpPresent(""), false)
+})
+
+test("installerOwns reads the real files under the config home", () => {
+  const dir = mkdtempSync(join(tmpdir(), "deja-kimi-"))
+  try {
+    const env = { KIMI_CODE_HOME: dir }
+    assert.equal(installerOwns("hook", env), false)
+    assert.equal(installerOwns("mcp", env), false)
+
+    writeFileSync(join(dir, "config.toml"), `${installerHookMarker}\n[[hooks]]\n`)
+    writeFileSync(join(dir, "mcp.json"), '{"mcpServers":{"deja":{"command":"deja"}}}')
+    assert.equal(installerOwns("hook", env), true)
+    assert.equal(installerOwns("mcp", env), true)
+    assert.equal(installerOwns("something-else", env), false)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("resolveDeja prefers DEJA_BIN, then the user's own install", () => {
+  const seen = []
+  const exists = (path) => {
+    seen.push(path)
+    return path.endsWith(join(".local", "bin", "deja"))
+  }
+  assert.equal(resolveDeja({ DEJA_BIN: "/opt/deja" }, "/home/x", () => true), "/opt/deja")
+  assert.equal(resolveDeja({}, "/home/x", exists), join("/home/x", ".local", "bin", "deja"))
+  // A DEJA_BIN that is not there must not win over a deja that is.
+  assert.equal(resolveDeja({ DEJA_BIN: "/nope/deja" }, "/home/x", exists), join("/home/x", ".local", "bin", "deja"))
+})
+
+test("resolveDeja falls back to the bare name so the error names deja", () => {
+  assert.equal(resolveDeja({}, "/home/x", () => false), process.platform === "win32" ? "deja.exe" : "deja")
+})
+
+test("wellKnown covers where an install actually lands", () => {
+  const unix = wellKnown("/home/x", "linux")
+  assert.ok(unix.includes("/usr/local/bin/deja"))
+  assert.ok(unix.includes("/opt/homebrew/bin/deja"))
+  assert.ok(unix[0].startsWith("/home/x"))
+  const win = wellKnown("C:\\Users\\x", "win32")
+  assert.ok(win.every((p) => p.endsWith("deja.exe")))
+})
+
+// The hook is the whole integration: Kimi appends a UserPromptSubmit hook's
+// stdout to the turn. This runs the real script the way Kimi runs it.
+test("the hook stands down when the installer already wired the same recall", async () => {
+  const { execFileSync } = await import("node:child_process")
+  const dir = mkdtempSync(join(tmpdir(), "deja-kimi-hook-"))
+  try {
+    const fake = join(dir, "deja")
+    writeFileSync(fake, "#!/bin/sh\necho RECALLED\n")
+    chmodSync(fake, 0o755)
+    const script = new URL("../hooks/recall.mjs", import.meta.url).pathname
+    const payload = JSON.stringify({ hook_event_name: "UserPromptSubmit", prompt: "anything", cwd: dir })
+    const call = () =>
+      execFileSync(process.execPath, [script], {
+        input: payload,
+        encoding: "utf8",
+        env: { ...process.env, DEJA_BIN: fake, KIMI_CODE_HOME: dir },
+      })
+
+    assert.match(call(), /RECALLED/)
+
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, "config.toml"), `${installerHookMarker}\n[[hooks]]\n`)
+    assert.equal(call().trim(), "")
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/extensions/kimi/test/pure.test.mjs
+++ b/extensions/kimi/test/pure.test.mjs
@@ -103,3 +103,43 @@ test("the hook stands down when the installer already wired the same recall", as
     rmSync(dir, { recursive: true, force: true })
   }
 })
+
+// The MCP launcher is the plugin's other entry point: Kimi starts it, and
+// whatever it does with stdio is the server the agent talks to.
+test("the MCP launcher stands down when the installer already declared the server", async () => {
+  const { execFileSync } = await import("node:child_process")
+  const dir = mkdtempSync(join(tmpdir(), "deja-kimi-mcp-"))
+  try {
+    const fake = join(dir, "deja")
+    writeFileSync(fake, "#!/bin/sh\necho STARTED\nexit 7\n")
+    chmodSync(fake, 0o755)
+    const script = new URL("../bin/deja-mcp.mjs", import.meta.url).pathname
+    const call = () => {
+      try {
+        return {
+          out: execFileSync(process.execPath, [script], {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "pipe"],
+            env: { ...process.env, DEJA_BIN: fake, KIMI_CODE_HOME: dir },
+          }),
+          code: 0,
+        }
+      } catch (err) {
+        return { out: String(err.stdout ?? ""), code: err.status }
+      }
+    }
+
+    // Nothing wired: the launcher runs deja and hands its exit code back, so a
+    // server that dies is reported as dead rather than as an empty success.
+    const ran = call()
+    assert.match(ran.out, /STARTED/)
+    assert.equal(ran.code, 7)
+
+    writeFileSync(join(dir, "mcp.json"), '{"mcpServers":{"deja":{"command":"deja"}}}')
+    const stoodDown = call()
+    assert.doesNotMatch(stoodDown.out, /STARTED/)
+    assert.equal(stoodDown.code, 0)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/extensions/kimi/test/pure.test.mjs
+++ b/extensions/kimi/test/pure.test.mjs
@@ -20,11 +20,26 @@ test("kimiHome follows KIMI_CODE_HOME, which is what Kimi hands its plugins", ()
 })
 
 test("installerHookPresent finds the marker deja install kimi-auto writes", () => {
-  const written = `${installerHookMarker}\n[[hooks]]\nevent = "UserPromptSubmit"\n`
+  const written = `${installerHookMarker}\n[[hooks]]\nevent = "UserPromptSubmit"\ncommand = "deja hook-prompt --plain"\n`
   assert.equal(installerHookPresent(written), true)
   assert.equal(installerHookPresent('[[hooks]]\nevent = "Stop"\n'), false)
   assert.equal(installerHookPresent(""), false)
   assert.equal(installerHookPresent(undefined), false)
+})
+
+// An older deja wired kimi through SessionStart, whose output Kimi runs and
+// then ignores. That block still carries the marker, and standing down for it
+// would leave the user with no recall from either half.
+test("a stale installer block does not count as wiring", () => {
+  const stale = `${installerHookMarker}\n[[hooks]]\nevent = "SessionStart"\ncommand = "deja hook-context"\ntimeout = 10\n`
+  assert.equal(installerHookPresent(stale), false)
+
+  // A live block followed by the user's own rule is still a live block, and a
+  // hook-prompt call in *their* rule is not ours to stand down for.
+  const followed = `${installerHookMarker}\n[[hooks]]\ncommand = "deja hook-prompt --plain"\n\n[[hooks]]\nevent = "Stop"\n`
+  assert.equal(installerHookPresent(followed), true)
+  const theirs = `${installerHookMarker}\n[[hooks]]\nevent = "SessionStart"\ncommand = "deja hook-context"\n\n[[hooks]]\ncommand = "deja hook-prompt --plain"\n`
+  assert.equal(installerHookPresent(theirs), false)
 })
 
 test("installerMcpPresent reads mcp.json, and a broken one is not evidence", () => {
@@ -41,7 +56,7 @@ test("installerOwns reads the real files under the config home", () => {
     assert.equal(installerOwns("hook", env), false)
     assert.equal(installerOwns("mcp", env), false)
 
-    writeFileSync(join(dir, "config.toml"), `${installerHookMarker}\n[[hooks]]\n`)
+    writeFileSync(join(dir, "config.toml"), `${installerHookMarker}\n[[hooks]]\ncommand = "deja hook-prompt --plain"\n`)
     writeFileSync(join(dir, "mcp.json"), '{"mcpServers":{"deja":{"command":"deja"}}}')
     assert.equal(installerOwns("hook", env), true)
     assert.equal(installerOwns("mcp", env), true)
@@ -97,7 +112,7 @@ test("the hook stands down when the installer already wired the same recall", as
     assert.match(call(), /RECALLED/)
 
     mkdirSync(dir, { recursive: true })
-    writeFileSync(join(dir, "config.toml"), `${installerHookMarker}\n[[hooks]]\n`)
+    writeFileSync(join(dir, "config.toml"), `${installerHookMarker}\n[[hooks]]\ncommand = "deja hook-prompt --plain"\n`)
     assert.equal(call().trim(), "")
   } finally {
     rmSync(dir, { recursive: true, force: true })

--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "deja",
+  "version": "0.1.0",
+  "description": "Recall the sessions your other coding agents already wrote \u2014 Claude Code, Codex, Cursor, opencode and sixteen more, including work from before deja was installed.",
+  "keywords": [
+    "memory",
+    "recall",
+    "sessions",
+    "search",
+    "history"
+  ],
+  "author": "vshulcz",
+  "homepage": "https://github.com/vshulcz/deja-vu",
+  "license": "MIT",
+  "interface": {
+    "displayName": "deja",
+    "shortDescription": "Search your own past AI coding sessions, from every tool on this machine.",
+    "longDescription": "deja indexes the session files coding agents already write to disk \u2014 Claude Code, Codex, Cursor, opencode, Gemini, Zed and more \u2014 and answers from them. Ask what you fixed before instead of debugging it twice. The index is local: no LLM, no embeddings, nothing leaves the machine. Needs the deja binary: https://github.com/vshulcz/deja-vu",
+    "developerName": "vshulcz",
+    "websiteURL": "https://github.com/vshulcz/deja-vu"
+  },
+  "skills": "./extensions/kimi/skills/",
+  "commands": "./extensions/kimi/commands/",
+  "sessionStart": {
+    "skill": "deja-history"
+  },
+  "mcpServers": {
+    "deja": {
+      "command": "node",
+      "args": [
+        "./extensions/kimi/bin/deja-mcp.mjs"
+      ]
+    }
+  },
+  "hooks": [
+    {
+      "event": "UserPromptSubmit",
+      "command": "node ./extensions/kimi/hooks/recall.mjs",
+      "timeout": 30
+    }
+  ]
+}


### PR DESCRIPTION
Closes #1572.

`extensions/kimi` — a Kimi Code plugin: `deja mcp` as an MCP server, the shared `deja-history` skill loaded at session start, `/deja:recall`, and recall on every prompt through a `UserPromptSubmit` hook.

What a reviewer would otherwise have to reconstruct:

- **Both entry points are `.mjs`, and the manifest declares `command: "node"`.** That exact spelling is the one form Kimi rewrites to its own runtime when it ships as a native binary (`withPluginMcpRuntime`), so the server starts on a machine with no node on PATH. Nothing imports a `.js` file, so the plugin does not depend on the `package.json` — which is why the release zip excludes it.
- **Standing down is the whole duplication story.** Kimi namespaces a plugin's MCP server as `plugin-deja:deja`, so it does not collide with the `deja` entry `deja install kimi` writes into `mcp.json` — both would run. The hook and the server both check what the installer wrote (the marker comment in `config.toml`, the server in `mcp.json`) and stay out of the way when it is there. Whichever order you install in, exactly one of each runs.
- **Installing from the repository URL cannot work** — Kimi looks for `kimi.plugin.json` at the repository root or in a single top-level directory. Hence `kimi-deja.zip`, packed from `extensions/kimi` and attached at release, which is the same route Tencent CloudBase takes.

Verified against a real Kimi Code 0.28.1, not only by reading the docs — with a spy binary on `DEJA_BIN` so each call is attributable:

```
plugin only:   argv: mcp            argv: hook-prompt --plain     (plugin's copies ran)
both installs: installer spy: mcp, hook-prompt --plain
               plugin spy:    (empty)                             (plugin stood down)
```

The second run is the counter-case: the same two files, and the only difference is whether `config.toml`/`mcp.json` carry the installer's wiring. The last check ran against the exact zip that ships.

Tests: `extensions/kimi/test/pure.test.mjs` covers the stand-down matrix and binary resolution, and runs the real hook script the way Kimi runs it. On the Go side `TestKimiPluginManifest` pins the manifest against the loader's rules, `TestKimiPluginKnowsTheInstallersMarker` fails if either side edits the marker alone, and the bundled skill is pinned to the installer's text. New `kimi-deja` CI job alongside the other three.

The marketplace PR is not part of this — it needs the release asset to exist first, and it is a submission outside our own repositories.