### PR TITLE
ci: publish the harness packages from the release, at the release version

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -127,6 +127,15 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+
+      # The release publishes these packages, so the decisions it makes about
+      # versions are tested here rather than discovered during a release.
+      - name: The release script's version rules
+        run: node --test scripts/release_npm_test.mjs
+
       # Published metadata is what a user follows back to the source. When a
       # package moves, npm keeps serving the old repository field until someone
       # notices; this notices.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -18,8 +18,18 @@ submitted.
 
 ## Publishing
 
-npm packages publish from their own directory, which is why each carries its own
-`LICENSE` and a `repository.directory` field:
+The release publishes the npm packages at the release's own version, so
+`opencode-deja@0.21.0` and `dsh-deja@0.21.0` are the ones built against
+`deja 0.21.0` — `scripts/release-npm.mjs` sets the version and the
+`@vshulcz/deja-vu` dependency together. Each package keeps its own `LICENSE`
+and `repository.directory` because npm publishes from that directory.
+
+The two packages were versioned independently before this, so a release whose
+version is still behind what npm serves is skipped with a line saying so,
+rather than moving the `latest` tag backwards. They join the release version as
+soon as it passes them.
+
+Publishing by hand is still possible when a fix should not wait for a release:
 
 ```
 cd extensions/opencode && npm publish --access public

--- a/scripts/release-npm.mjs
+++ b/scripts/release-npm.mjs
@@ -2,10 +2,13 @@
 // Build and publish npm packages from goreleaser release archives.
 // Usage: node scripts/release-npm.mjs <version> <dist-dir>
 //   <dist-dir> must contain deja-vu_<version>_<os>_<arch>.{tar.gz,zip}
-// Publishes @vshulcz/deja-vu-<os>-<arch> for each platform, then @vshulcz/deja-vu.
-// The harness packages under extensions/ publish separately, by hand: a plugin
-// fix should not wait for a deja release, and a deja release should not
-// republish a plugin that has not changed.
+// Publishes @vshulcz/deja-vu-<os>-<arch> for each platform, then @vshulcz/deja-vu,
+// then the harness packages under extensions/ at the same version.
+//
+// One version for everything is the point: a user reading `dsh-deja@0.21.0`
+// knows which deja it was built against, and nobody has to remember to publish
+// a plugin by hand — which is how opencode-deja sat unpublished while its
+// install instructions were already in the README.
 // Requires NODE_AUTH_TOKEN (set by actions/setup-node from the NPM_TOKEN secret).
 import { execSync } from "node:child_process";
 import fs from "node:fs";
@@ -66,4 +69,62 @@ main.optionalDependencies = Object.fromEntries(
 fs.writeFileSync(mainPkgPath, JSON.stringify(main, null, 2));
 run("npm publish --access public", mainDir);
 
-console.log(`published ${platforms.length} platform packages + @vshulcz/deja-vu@${version}`);
+// The harness packages ride the same version. Two of them were versioned
+// independently before this, so a release whose version is behind what npm
+// already has would move the `latest` tag backwards: skip those and say so,
+// and the lines converge on their own as soon as deja passes them.
+const extensions = ["opencode", "dsh"];
+const published = [];
+for (const name of extensions) {
+  const dir = path.join("extensions", name);
+  const pkg = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"));
+  const live = npmLatest(pkg.name);
+  if (live && compareVersions(version, live) <= 0) {
+    console.log(`skipping ${pkg.name}: npm has ${live}, this release is ${version}`);
+    continue;
+  }
+  const out = path.join(work, name);
+  fs.cpSync(dir, out, { recursive: true });
+  const outPkgPath = path.join(out, "package.json");
+  const outPkg = JSON.parse(fs.readFileSync(outPkgPath, "utf8"));
+  outPkg.version = version;
+  if (outPkg.dependencies?.["@vshulcz/deja-vu"]) {
+    outPkg.dependencies["@vshulcz/deja-vu"] = `^${version}`;
+  }
+  fs.writeFileSync(outPkgPath, JSON.stringify(outPkg, null, 2) + "\n");
+  run("npm publish --access public", out);
+  published.push(outPkg.name);
+}
+
+console.log(
+  `published ${platforms.length} platform packages + @vshulcz/deja-vu@${version}` +
+    (published.length ? ` + ${published.join(", ")}@${version}` : ""),
+);
+
+// npmLatest is the version npm serves as `latest`, or "" when the package has
+// never been published.
+function npmLatest(name) {
+  try {
+    return execSync(`npm view ${name} version`, { encoding: "utf8" }).trim();
+  } catch {
+    return "";
+  }
+}
+
+// compareVersions orders two plain x.y.z versions. Releases here are always
+// plain, so this deliberately does not try to be a semver implementation — a
+// prerelease would be a reason to stop and think rather than to publish.
+function compareVersions(a, b) {
+  const parse = (v) => {
+    const parts = v.split(".").map(Number);
+    if (parts.length !== 3 || parts.some((n) => !Number.isInteger(n))) {
+      throw new Error(`not a plain version: ${v}`);
+    }
+    return parts;
+  };
+  const [x, y] = [parse(a), parse(b)];
+  for (let i = 0; i < 3; i++) {
+    if (x[i] !== y[i]) return x[i] < y[i] ? -1 : 1;
+  }
+  return 0;
+}

--- a/scripts/release_npm_test.mjs
+++ b/scripts/release_npm_test.mjs
@@ -1,0 +1,47 @@
+// The release script publishes to npm, so the parts worth testing are the two
+// decisions it makes on its own: which version wins, and what it does when npm
+// is already ahead. Both are pinned here because getting them wrong moves the
+// `latest` tag backwards, which cannot be undone by publishing again.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const source = fs.readFileSync(new URL("./release-npm.mjs", import.meta.url), "utf8");
+
+// The functions live in a script that publishes on import, so they are read out
+// of it rather than imported. A rename breaks this loudly instead of silently
+// testing nothing.
+function extract(name) {
+  const at = source.indexOf(`function ${name}(`);
+  assert.notEqual(at, -1, `${name} is gone from release-npm.mjs`);
+  const end = source.indexOf("\n}", at);
+  return eval(`(${source.slice(at, end + 2)})`); // eslint-disable-line no-eval
+}
+
+const compareVersions = extract("compareVersions");
+
+test("plain versions order by number, not by string", () => {
+  assert.equal(compareVersions("0.18.0", "0.20.3"), -1);
+  assert.equal(compareVersions("0.21.0", "0.20.3"), 1);
+  assert.equal(compareVersions("0.18.0", "0.18.0"), 0);
+  // "0.9.0" > "0.10.0" as strings, which is the whole reason this exists.
+  assert.equal(compareVersions("0.10.0", "0.9.0"), 1);
+});
+
+test("anything that is not a plain x.y.z stops the release", () => {
+  assert.throws(() => compareVersions("0.21.0-rc.1", "0.20.3"), /not a plain version/);
+  assert.throws(() => compareVersions("0.21", "0.20.3"), /not a plain version/);
+});
+
+test("the extension packages are published from the release version", () => {
+  // The dependency has to move with it: a plugin pinned to an older deja is a
+  // plugin that ships the wrong binary as its fallback.
+  assert.match(source, /outPkg\.version = version/);
+  assert.match(source, /outPkg\.dependencies\["@vshulcz\/deja-vu"\] = `\^\$\{version\}`/);
+  assert.match(source, /const extensions = \["opencode", "dsh"\]/);
+});
+
+test("a release behind npm skips instead of moving latest backwards", () => {
+  assert.match(source, /compareVersions\(version, live\) <= 0/);
+  assert.match(source, /skipping \$\{pkg\.name\}/);
+});


### PR DESCRIPTION
`opencode-deja` was never published while the README already told people to install it, and `dsh-deja` was published by hand. Both now go out with the release, at the release's version, with their `@vshulcz/deja-vu` dependency moved to match — so `dsh-deja@0.21.0` is the one built against deja 0.21.0.

The two lines were versioned independently before this, so a release still behind npm is skipped with a printed reason instead of moving `latest` backwards; they converge as soon as deja passes them. The version comparison and the skip rule are tested in CI rather than discovered mid-release.