### PR TITLE
docs: refresh the outside-contribution numbers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ are bounded, and each one names the case it is wrong on, so you can reproduce
 before you change anything.
 
 Every pull request from outside the project so far has been answered the same
-day: 29 merged of 33, median four hours from opening to merge, the slowest 15
+day: 31 merged of 35, median four hours from opening to merge, the slowest 15
 hours, none left waiting. If yours sits longer than that, something went wrong
 on our side — say so in the thread.
 


### PR DESCRIPTION
Recounted across all 946 pull requests: 35 opened from outside, 31 merged, median 4.0h from opening to merge, slowest 14.7h, 18 people. The file said 29 of 33.

It is the one measured promise CONTRIBUTING makes, so it should not drift.