### PR TITLE
release: open the page with what changed, not with the install command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,18 @@ jobs:
 
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
+      # The release page opens with the changelog section for this version, so
+      # a reader arriving from Homebrew or npm learns what the release is
+      # before being told how to install it.
+      - name: Read this version's changelog section
+        run: |
+          {
+            echo 'RELEASE_LEDE<<RELEASE_LEDE_EOF'
+            go run ./scripts/relnotes "${GITHUB_REF_NAME#v}"
+            echo
+            echo RELEASE_LEDE_EOF
+          } >> "$GITHUB_ENV"
+
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ deja-stats.svg
 /pinmanifests
 /planbench
 /rankdiff
+/relnotes
 /reusebench
 /searchbench
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -100,7 +100,17 @@ release:
   # changelog nobody can reply to, and an empty Discussions tab that reads as
   # an empty room.
   discussion_category_name: Announcements
+  # What changed goes first. The CHANGELOG section for this version is written
+  # by hand and says what the release is; the generated commit list below it
+  # says which pull requests carried it. Install is the last thing a reader
+  # needs and used to be the first thing on the page — a release page that
+  # opened with `curl … | sh` and never said what was new.
+  #
+  # RELEASE_LEDE is filled by the release workflow from CHANGELOG.md. Empty is
+  # a valid answer: a release cut before its changelog entry lands still ships.
   header: |
+    {{ envOrDefault "RELEASE_LEDE" "" }}
+  footer: |
     ## Install
 
     ```sh

--- a/scripts/relnotes/main.go
+++ b/scripts/relnotes/main.go
@@ -1,0 +1,97 @@
+// Command relnotes prints the CHANGELOG section for one version, so a release
+// page opens with what changed rather than with an install command.
+//
+// The section is already written by hand for every release — a lede paragraph
+// and the Added/Changed/Fixed lists with their PR numbers. The release notes
+// used to carry none of it: goreleaser's header was the install block and the
+// body was a machine-generated list of commit subjects. Whoever landed on the
+// page from Homebrew or npm read `curl … | sh` first and never learned what the
+// release was.
+//
+//	go run ./scripts/relnotes 0.18.0        # section body, empty if absent
+//	go run ./scripts/relnotes -check        # every released tag has a section
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+const changelogPath = "CHANGELOG.md"
+
+func main() {
+	check := flag.Bool("check", false, "verify every version heading has a body")
+	path := flag.String("changelog", changelogPath, "path to CHANGELOG.md")
+	flag.Parse()
+
+	body, err := os.ReadFile(*path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "relnotes: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *check {
+		if err := checkSections(string(body)); err != nil {
+			fmt.Fprintf(os.Stderr, "relnotes: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if flag.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: relnotes <version>")
+		os.Exit(2)
+	}
+	// A missing section is not an error: a release can be cut before the
+	// changelog entry lands, and a release page with only the generated list is
+	// worse than a failed release.
+	fmt.Print(Section(string(body), flag.Arg(0)))
+}
+
+var versionHeading = regexp.MustCompile(`^## \[([^\]]+)\]`)
+
+// Section returns the body under `## [version]`, without the heading, trimmed.
+func Section(changelog, version string) string {
+	version = strings.TrimPrefix(version, "v")
+	var out []string
+	inside := false
+	s := bufio.NewScanner(strings.NewReader(changelog))
+	s.Buffer(make([]byte, 4096), 1<<20)
+	for s.Scan() {
+		line := s.Text()
+		if m := versionHeading.FindStringSubmatch(line); m != nil {
+			if inside {
+				break
+			}
+			inside = strings.TrimPrefix(m[1], "v") == version
+			continue
+		}
+		if inside {
+			out = append(out, line)
+		}
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+// checkSections reports a version heading with nothing under it. An empty
+// section reads on the release page as a release that did nothing.
+func checkSections(changelog string) error {
+	var empty []string
+	for _, m := range versionHeading.FindAllStringSubmatch(changelog, -1) {
+		v := m[1]
+		if strings.EqualFold(v, "Unreleased") {
+			continue
+		}
+		if Section(changelog, v) == "" {
+			empty = append(empty, v)
+		}
+	}
+	if len(empty) > 0 {
+		return fmt.Errorf("changelog sections with no body: %s", strings.Join(empty, ", "))
+	}
+	return nil
+}

--- a/scripts/relnotes/main_test.go
+++ b/scripts/relnotes/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sample = `# Changelog
+
+## [Unreleased]
+
+### Added
+- something not out yet
+
+## [0.18.0] - 2026-08-22
+
+Two new harnesses, and a recall path rebuilt.
+
+### Added
+- omp is the nineteenth harness (#1455)
+
+## [0.17.3] - 2026-08-19
+
+### Fixed
+- a thing (#1400)
+`
+
+func TestSectionStopsAtTheNextVersion(t *testing.T) {
+	got := Section(sample, "0.18.0")
+	if !strings.HasPrefix(got, "Two new harnesses") {
+		t.Fatalf("section does not start with the lede:\n%s", got)
+	}
+	if strings.Contains(got, "0.17.3") || strings.Contains(got, "a thing") {
+		t.Fatalf("section ran into the next release:\n%s", got)
+	}
+	if strings.Contains(got, "not out yet") {
+		t.Fatalf("section picked up Unreleased:\n%s", got)
+	}
+}
+
+// The tag carries a v; the changelog heading does not.
+func TestSectionAcceptsATag(t *testing.T) {
+	if Section(sample, "v0.18.0") != Section(sample, "0.18.0") {
+		t.Fatal("v-prefixed tag returned a different section")
+	}
+}
+
+// A release cut before its changelog entry lands must not fail the release.
+func TestMissingSectionIsEmptyNotAnError(t *testing.T) {
+	if got := Section(sample, "9.9.9"); got != "" {
+		t.Fatalf("unknown version returned %q", got)
+	}
+}
+
+// The real file is what ships, so it is the one that has to parse.
+func TestTheRepositoryChangelogHasABodyForEveryRelease(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("..", "..", "CHANGELOG.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkSections(string(b)); err != nil {
+		t.Fatal(err)
+	}
+	if s := Section(string(b), "0.18.0"); !strings.Contains(s, "###") {
+		t.Fatalf("0.18.0 section looks wrong:\n%s", s)
+	}
+}


### PR DESCRIPTION
Every release page so far opened with `## Install` and a curl block, then a generated list of commit subjects. Somebody arriving from Homebrew, npm or the releases feed read the install command first and never learned what the release was — while the section that says exactly that is already written by hand in `CHANGELOG.md` for every version.

The release workflow now reads that section and goreleaser puts it at the top; install moves to the footer, and the generated commit list stays where it was, between them.

`scripts/relnotes` does the extraction: section body for a version, empty when there is none — a release cut before its changelog entry lands still ships rather than failing. `-check` reports a version heading with nothing under it, and the test asserts that against the real `CHANGELOG.md`.

Rendering is exercised by the existing `goreleaser check` job, which runs a real snapshot release.