### PR TITLE
feat(codex): the plugin brings its own recall, not just tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- The Codex plugin carries its own hooks: a marketplace install now brings session-start recall, per-prompt recall and pre-compaction capture with it, instead of only tools and the skill. It stands down where `deja install codex-auto` already wrote the same hook into Codex's own hooks.json.
 - A Kimi Code plugin, in `extensions/kimi`. One `/plugins install` gives Kimi the MCP tools, the shared skill, a `/deja:recall` command and recall on every prompt through its `UserPromptSubmit` hook. It stands down where `deja install kimi` already wired the same thing, so having both is not two of anything.
 
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ keeping those descriptions checked against the parsers.
 
 ### Harnesses with a package of their own
 
-`deja install --auto` wires all four of these like every other harness, and
+`deja install --auto` wires all five of these like every other harness, and
 that stays the shortest path. They also have a package in their own ecosystem,
 for people who install extensions there rather than from a CLI:
 
@@ -273,11 +273,12 @@ for people who install extensions there rather than from a CLI:
 | DeepSeek Harness | npm `dsh-deja` | `dsh plugin add dsh-deja` |
 | Zed | `deja-context-server` | Zed → Extensions → deja |
 | Kimi Code | plugin `deja` | `/plugins install https://github.com/vshulcz/deja-vu` |
+| Codex CLI | plugin `deja-vu` | `codex plugin marketplace add https://github.com/vshulcz/deja-vu` then `codex plugin add deja-vu@deja-vu` |
 
 Either path is enough on its own, and having both is not a problem: the
-opencode, dsh and Kimi packages read what `deja install` wrote and contribute
-only what is missing, and in Zed both halves use one server id, so there is
-nothing to have twice whichever order you install in.
+opencode, dsh, Kimi and Codex packages read what `deja install` wrote and
+contribute only what is missing, and in Zed both halves use one server id, so
+there is nothing to have twice whichever order you install in.
 
 Each uses the deja you already have; the copy it bundles is only the fallback.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -42,7 +42,7 @@ deja install --auto
 
 也不必特意去问——开启自动召回后，会话一打开，智能体就已经知道你在这个项目里解决过什么。
 
-opencode、DeepSeek Harness、Zed 和 Kimi Code 也有各自生态里的包，习惯在那边装扩展的人
+opencode、DeepSeek Harness、Zed、Kimi Code 和 Codex CLI 也有各自生态里的包，习惯在那边装扩展的人
 可以直接用：
 
 ```sh
@@ -50,9 +50,10 @@ opencode plugin opencode-deja
 dsh plugin --profile web add dsh-deja
 # Zed：扩展面板里搜 deja
 # Kimi Code：/plugins install https://github.com/vshulcz/deja-vu
+# Codex CLI：codex plugin marketplace add https://github.com/vshulcz/deja-vu && codex plugin add deja-vu@deja-vu
 ```
 
-`deja install --auto` 已经把这四个接好了，两条路走哪条都够。两边都装也没问题：包会看
+`deja install --auto` 已经把这五个接好了，两条路走哪条都够。两边都装也没问题：包会看
 `deja install` 写了什么，只补上缺的部分，不会重复注册工具、也不会重复召回。详见
 [`extensions/`](extensions)。
 

--- a/cmd/deja/codex_plugin.go
+++ b/cmd/deja/codex_plugin.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// codexPluginEntry matches the config line `codex plugin add` writes:
+// [plugins."deja-vu@<marketplace>"], enabled on the next line.
+var codexPluginEntry = regexp.MustCompile(`(?m)^\[plugins\."deja-vu@[^"]+"\]\s*\n(?:[^\[]*\n)?\s*enabled\s*=\s*true`)
+
+// codexPluginInstalled reports whether the Codex plugin from codex-plugin/ is
+// installed and enabled. It carries the same MCP server and the same hooks the
+// installer writes, and stands down where the installer already wired them —
+// so a machine with only the plugin is wired, and doctor calling it "not
+// wired" would send someone to run an install they do not need.
+func codexPluginInstalled() bool {
+	b, err := os.ReadFile(filepath.Join(sources.CodexHome(), "config.toml"))
+	if err != nil {
+		return false
+	}
+	return codexPluginEntry.Match(b)
+}

--- a/cmd/deja/codex_plugin_test.go
+++ b/cmd/deja/codex_plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -101,5 +102,78 @@ func TestBundledSkillsMatchInstaller(t *testing.T) {
 		if want := guidanceText("claude"); got != want {
 			t.Fatalf("%s has drifted from guidanceText:\n--- file ---\n%s\n--- installer ---\n%s", p, got, want)
 		}
+	}
+}
+
+// The plugin's own hooks are what a marketplace install gets instead of
+// `deja install codex-auto`. Codex discovers them at hooks/hooks.json and
+// expands ${PLUGIN_ROOT}; a path it cannot resolve is a hook that never runs.
+func TestCodexPluginHooks(t *testing.T) {
+	var file struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+				Timeout int    `json:"timeout"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(repoFile(t, "codex-plugin/hooks/hooks.json"), &file); err != nil {
+		t.Fatalf("hooks.json: %v", err)
+	}
+	want := map[string]string{
+		"SessionStart":     "hook-context",
+		"UserPromptSubmit": "hook-prompt",
+		"PreCompact":       "hook-precompact",
+	}
+	for event, sub := range want {
+		groups, ok := file.Hooks[event]
+		if !ok || len(groups) == 0 || len(groups[0].Hooks) == 0 {
+			t.Fatalf("no %s hook in the plugin", event)
+		}
+		cmd := groups[0].Hooks[0].Command
+		if !strings.HasPrefix(cmd, "${PLUGIN_ROOT}/hooks/deja.sh ") || !strings.HasSuffix(cmd, sub) {
+			t.Fatalf("%s runs %q, not the plugin's own script with %s", event, cmd, sub)
+		}
+		if groups[0].Hooks[0].Type != "command" || groups[0].Hooks[0].Timeout <= 0 {
+			t.Fatalf("%s entry is not a command with a timeout: %+v", event, groups[0].Hooks[0])
+		}
+	}
+
+	info, err := os.Stat(filepath.Join("..", "..", "codex-plugin", "hooks", "deja.sh"))
+	if err != nil {
+		t.Fatalf("the script the hooks point at is missing: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Fatalf("codex-plugin/hooks/deja.sh is not executable (%v) — Codex runs it directly", info.Mode())
+	}
+
+	var manifest struct {
+		Hooks []string `json:"hooks"`
+	}
+	if err := json.Unmarshal(repoFile(t, "codex-plugin/.codex-plugin/plugin.json"), &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.Hooks) != 1 || manifest.Hooks[0] != "./hooks/hooks.json" {
+		t.Fatalf("the manifest does not declare the hooks file: %v", manifest.Hooks)
+	}
+}
+
+// The plugin stands down when `deja install codex-auto` has already written
+// the same hook into Codex's own hooks.json. If the installer's command stops
+// matching what the script greps for, both fire and the digest arrives twice.
+func TestCodexPluginStandsDownForTheInstaller(t *testing.T) {
+	script := string(repoFile(t, "codex-plugin/hooks/deja.sh"))
+	if !strings.Contains(script, "CODEX_HOME") {
+		t.Fatal("the script does not honour CODEX_HOME, so a relocated Codex home hides the installer's wiring")
+	}
+	pattern := regexp.MustCompile(`deja[^"]*hook-(context|prompt|precompact)`)
+	written, err := json.Marshal(map[string]any{"command": "/opt/homebrew/bin/deja hook-context"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pattern.MatchString(string(written)) {
+		t.Fatalf("the script's own pattern does not match what the installer writes: %s", written)
 	}
 }

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -211,6 +211,14 @@ func doctorWiringExe(w io.Writer) {
 func doctorCodexHook(w io.Writer) {
 	hooksPath := filepath.Join(sources.CodexHome(), "hooks.json")
 	if _, err := os.Stat(hooksPath); err != nil {
+		// The plugin ships the same hooks under its own root, and codex trusts
+		// those the same way. Nothing was installed here, and nothing is
+		// missing either.
+		if codexPluginInstalled() {
+			fmt.Fprintf(w, "  %-12s %-11s %s  (the Codex plugin carries the hooks; codex asks once to trust them)\n",
+				"codex-hook", "plugin", hooksPath)
+			return
+		}
 		fmt.Fprintf(w, "  %-12s missing      %s\n", "codex-hook", hooksPath)
 		return
 	}
@@ -813,6 +821,11 @@ func doctorMCP(w io.Writer) {
 		// plugin as "not wired" sends someone to run an install that only
 		// pushes the plugin aside.
 		if status != "wired" && c.name == "kimi" && kimiPluginInstalled() {
+			status = "plugin"
+		}
+		// Same for Codex: `codex plugin add deja-vu@deja-vu` brings the server
+		// and the hooks with it.
+		if status != "wired" && c.name == "codex" && codexPluginInstalled() {
 			status = "plugin"
 		}
 		fmt.Fprintf(w, "  %-12s %-14s guidance %-11s %s\n", c.name, status, guidanceStatus(guidanceHarness(c.name)), c.path)

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -9,13 +9,21 @@
   "homepage": "https://github.com/vshulcz/deja-vu",
   "repository": "https://github.com/vshulcz/deja-vu",
   "license": "MIT",
-  "keywords": ["memory", "recall", "sessions", "search"],
+  "keywords": [
+    "memory",
+    "recall",
+    "sessions",
+    "search"
+  ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
+  "hooks": [
+    "./hooks/hooks.json"
+  ],
   "interface": {
     "displayName": "deja-vu",
     "shortDescription": "Search and recall your own past AI coding sessions.",
-    "longDescription": "deja indexes the sessions you already have on this machine — Claude Code, Codex, Cursor, opencode and a dozen others — and gives Codex tools to search them. Ask what you fixed before instead of debugging it twice.",
+    "longDescription": "deja indexes the sessions you already have on this machine \u2014 Claude Code, Codex, Cursor, opencode and a dozen others \u2014 and gives Codex tools to search them. Ask what you fixed before instead of debugging it twice.",
     "developerName": "vshulcz",
     "category": "Productivity",
     "capabilities": [],

--- a/codex-plugin/hooks/deja.sh
+++ b/codex-plugin/hooks/deja.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Bridges Codex's hooks to the deja binary.
+#
+# The plugin can be installed before deja itself is, so a missing binary must
+# not look like a broken hook: we say once, through the hook's own JSON, how to
+# get it, and otherwise stay silent. Exit status is always 0 — a hook that fails
+# is a hook that interrupts the user.
+set -u
+
+find_deja() {
+	if [ -n "${DEJA_BIN:-}" ] && [ -x "${DEJA_BIN}" ]; then
+		printf '%s' "$DEJA_BIN"
+		return
+	fi
+	if command -v deja >/dev/null 2>&1; then
+		command -v deja
+		return
+	fi
+	for candidate in \
+		"$HOME/.local/bin/deja" \
+		"/opt/homebrew/bin/deja" \
+		"/usr/local/bin/deja" \
+		"$HOME/go/bin/deja"; do
+		if [ -x "$candidate" ]; then
+			printf '%s' "$candidate"
+			return
+		fi
+	done
+}
+
+# `deja install codex-auto` writes the same SessionStart hook into Codex's own
+# hooks.json. Codex runs both files, so without this the digest arrives twice —
+# and the installer's copy is the one `deja install` keeps current.
+HOOKS="${CODEX_HOME:-$HOME/.codex}/hooks.json"
+# The installer records an absolute path to the binary, so match the
+# subcommand rather than a bare `deja hook-`.
+if [ -f "$HOOKS" ] && grep -qE 'deja[^"]*hook-(context|prompt|precompact)' "$HOOKS" 2>/dev/null; then
+	cat >/dev/null 2>&1 || true
+	exit 0
+fi
+
+DEJA=$(find_deja)
+
+if [ -z "${DEJA:-}" ]; then
+	# Drain stdin so Codex never blocks on the pipe.
+	cat >/dev/null 2>&1 || true
+	if [ "${1:-}" = "hook-context" ]; then
+		printf '{"systemMessage":"the deja-vu plugin is installed but the deja binary is not on PATH — install it with: brew install vshulcz/tap/deja-vu  (or: go install github.com/vshulcz/deja-vu/cmd/deja@latest)"}\n'
+	fi
+	exit 0
+fi
+
+exec "$DEJA" "$@"

--- a/codex-plugin/hooks/hooks.json
+++ b/codex-plugin/hooks/hooks.json
@@ -1,0 +1,42 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/deja.sh hook-context",
+            "timeout": 10,
+            "statusMessage": "Recalling past sessions…"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/deja.sh hook-prompt",
+            "timeout": 10,
+            "statusMessage": "Searching past sessions…"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "manual|auto",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/deja.sh hook-precompact",
+            "timeout": 30,
+            "statusMessage": "Saving this session to memory…"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #1582.

`codex-plugin/hooks/hooks.json` plus the script it points at: SessionStart (`hook-context`), UserPromptSubmit (`hook-prompt`) and PreCompact (`hook-precompact`), all through `${PLUGIN_ROOT}/hooks/deja.sh`. A marketplace install now carries recall, not only the tools and the skill.

What a reviewer would otherwise reconstruct:

- **Codex expands `${PLUGIN_ROOT}`, not `$CODEX_PLUGIN_ROOT`** (`codex-mcp/src/agent_plugin_config.rs`), and finds a plugin's hooks at `hooks/hooks.json` by convention — the manifest declares it anyway, so the file is not silently optional.
- **Standing down is the duplication rule.** `deja install codex-auto` writes the same SessionStart hook into `~/.codex/hooks.json`; Codex runs both files. The script greps that file — honouring `CODEX_HOME` — for a deja hook command and exits 0 without touching stdin when it finds one. The installer's copy wins: it is the one `deja install` keeps current.
- **`deja doctor` no longer calls a plugin-only machine unwired**: the MCP line and the `codex-hook` line both read `plugin`, and the hook line says Codex will ask once to trust it.

Verified on codex 0.142.4, installed through a real marketplace (`codex plugin marketplace add` + `codex plugin add deja-vu@deja-vu`), with a spy binary on `DEJA_BIN` so each call is attributable:

```
plugin only:            hook: SessionStart / hook: UserPromptSubmit
                        plugin spy: hook-context, hook-prompt --plain

installer hooks present: installer spy: hook-context
                         plugin spy:    (empty)
```

The second run is the counter-case — same plugin, the only difference is whether `~/.codex/hooks.json` carries the installer's wiring.

Also checked live: `codex plugin marketplace add https://github.com/vshulcz/deja-vu` clones this repo and lists `deja-vu@deja-vu`, so the install line in the README is the one people can run.

Tests: `TestCodexPluginHooks` pins the events, the `${PLUGIN_ROOT}` commands and the executable bit; `TestCodexPluginStandsDownForTheInstaller` fails if the script's pattern stops matching what the installer writes.