### PR TITLE
fix(brief): keep the first screen inside a 60-column pane

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -105,11 +105,25 @@ func runBrief(dir string, w io.Writer) error {
 		recalls == 0 && weekRecalls == 0 && dejaVu == 0 && !ov.Oldest.IsZero()
 	line := fmt.Sprintf("today      %d session%s", ov.SessionsToday, pluralS(ov.SessionsToday))
 	if recalls > 0 {
-		line += fmt.Sprintf(" · %d recall%s served (%s", recalls, pluralS(recalls), humanBytes(int64(bytes)))
+		// Three widths of the same fact, longest first: a narrow pane gives up
+		// the raw total, then the served size, rather than wrapping them onto a
+		// line of their own (#1588). Dropping straight from both to neither
+		// loses a figure that had nine columns to spare at 60.
+		line += fmt.Sprintf(" · %d recall%s served", recalls, pluralS(recalls))
+		served := " (" + humanBytes(int64(bytes)) + ")"
+		full := served
 		if raw := usage.TodayRaw(dir); bytes > 0 && raw/int64(bytes) >= 2 {
-			line += " from " + humanBytes(raw)
+			full = " (" + humanBytes(int64(bytes)) + " from " + humanBytes(raw) + ")"
 		}
-		line += ")"
+		// printableWidth, not briefWidth: a pipe reads as "do not cut", and a
+		// script that redirects the brief wants the figures, not the layout.
+		room := printableWidth(w)
+		switch {
+		case room == 0 || barColumns(line+full) <= room:
+			line += full
+		case barColumns(line+served) <= room:
+			line += served
+		}
 	}
 	if !quietWeek {
 		fmt.Fprintln(w, line)
@@ -246,7 +260,7 @@ func runBrief(dir string, w io.Writer) error {
 				when += " · last worked " + last
 			}
 		}
-		fmt.Fprintf(w, "before     %s%s%s\n", dim, when, reset)
+		fmt.Fprintf(w, "before     %s%s%s\n", dim, fitBriefWhen(when, printableWidth(w)), reset)
 	}
 
 	if haveReused && !sameWork {
@@ -272,7 +286,19 @@ func runBrief(dir string, w io.Writer) error {
 	// suggestion. Printing it twice on the one screen that has to be legible
 	// is worse than not printing it at all.
 	if q := suggestFirstQuery(dir); q != "" && !justGreeted {
-		fmt.Fprintf(w, "try        %sdeja \"%s\"%s %s(from your own history)%s\n", bold, q, reset, dim, reset)
+		// The line is a command to copy, so it is never cut: an ellipsis inside
+		// it searches for a truncated word and a literal "…". What goes first
+		// is the note, and if the command alone still does not fit, the whole
+		// suggestion — the screen has other lines that say more (#1588).
+		room := printableWidth(w)
+		command := fmt.Sprintf("try        deja %q", q)
+		const note = " (from your own history)"
+		switch {
+		case room == 0 || barColumns(command+note) <= room:
+			fmt.Fprintf(w, "try        %sdeja %q%s %s(from your own history)%s\n", bold, q, reset, dim, reset)
+		case barColumns(command) <= room:
+			fmt.Fprintf(w, "try        %sdeja %q%s\n", bold, q, reset)
+		}
 	}
 	fmt.Fprintf(w, "%smore       deja log · deja stats · deja help%s\n", dim, reset)
 	return nil
@@ -312,9 +338,15 @@ func pluralS(n int) string {
 // rule for the status bar).
 func trimBriefTitle(t string) string { return trimBriefTitleTo(t, briefTitleMax) }
 
+// briefLabelColumns is the fixed prefix every line but `recent` carries: a
+// name, padded to the column the values line up on.
+const briefLabelColumns = 11
+
 // briefTitleMax is the width the fixed-prefix lines (`asked`, `reused`, `hit`)
 // are laid out to: an 11-column label plus 44 plus the ellipsis is 56, which
-// fits the narrowest terminal anyone opens.
+// fits a 60-column pane. Narrower than that they overflow, and widening the
+// rule here would also cut `hook-context` output, which is not a terminal line
+// at all — that is a separate item (#1588).
 const briefTitleMax = 44
 
 func trimBriefTitleTo(t string, max int) string {
@@ -467,6 +499,32 @@ func printNoHistory(w io.Writer, stale bool) {
 	fmt.Fprintln(w, "  deja sources     what was looked for, and where")
 	fmt.Fprintln(w, "  deja doctor      check the setup")
 	fmt.Fprintln(w, "  deja help        every command")
+}
+
+// fitBriefWhen makes the `before` line fit by shortening the project path and
+// nothing else. Cutting the end instead drops "last worked <date>" and the
+// reuse count — the two facts #843 added because they are not restatements of
+// the span. A project name is the only part of this line that grows without
+// bound (#1588).
+func fitBriefWhen(when string, room int) string {
+	room -= briefLabelColumns
+	if room <= 0 || barColumns(when) <= room {
+		return when
+	}
+	const in = " in "
+	start := strings.Index(when, in)
+	end := strings.Index(when, " · ")
+	if start < 0 || end < 0 || end <= start {
+		return when
+	}
+	project := when[start+len(in) : end]
+	keep := barColumns(project) - (barColumns(when) - room) - 1 // the ellipsis
+	if keep < 6 {
+		// Nothing readable would be left of the path, so the facts stay whole
+		// and the line overflows — the trade the `recent` floor already makes.
+		return when
+	}
+	return when[:start+len(in)] + termwidth.Cut(project, keep) + "…" + when[end:]
 }
 
 // askedWhen says how far apart the askings were, which is the point of the

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -105,25 +105,11 @@ func runBrief(dir string, w io.Writer) error {
 		recalls == 0 && weekRecalls == 0 && dejaVu == 0 && !ov.Oldest.IsZero()
 	line := fmt.Sprintf("today      %d session%s", ov.SessionsToday, pluralS(ov.SessionsToday))
 	if recalls > 0 {
-		// Three widths of the same fact, longest first: a narrow pane gives up
-		// the raw total, then the served size, rather than wrapping them onto a
-		// line of their own (#1588). Dropping straight from both to neither
-		// loses a figure that had nine columns to spare at 60.
-		line += fmt.Sprintf(" · %d recall%s served", recalls, pluralS(recalls))
-		served := " (" + humanBytes(int64(bytes)) + ")"
-		full := served
+		line += fmt.Sprintf(" · %d recall%s served (%s", recalls, pluralS(recalls), humanBytes(int64(bytes)))
 		if raw := usage.TodayRaw(dir); bytes > 0 && raw/int64(bytes) >= 2 {
-			full = " (" + humanBytes(int64(bytes)) + " from " + humanBytes(raw) + ")"
+			line += " from " + humanBytes(raw)
 		}
-		// printableWidth, not briefWidth: a pipe reads as "do not cut", and a
-		// script that redirects the brief wants the figures, not the layout.
-		room := printableWidth(w)
-		switch {
-		case room == 0 || barColumns(line+full) <= room:
-			line += full
-		case barColumns(line+served) <= room:
-			line += served
-		}
+		line += ")"
 	}
 	if !quietWeek {
 		fmt.Fprintln(w, line)
@@ -260,7 +246,7 @@ func runBrief(dir string, w io.Writer) error {
 				when += " · last worked " + last
 			}
 		}
-		fmt.Fprintf(w, "before     %s%s%s\n", dim, fitBriefWhen(when, printableWidth(w)), reset)
+		fmt.Fprintf(w, "before     %s%s%s\n", dim, when, reset)
 	}
 
 	if haveReused && !sameWork {
@@ -286,19 +272,7 @@ func runBrief(dir string, w io.Writer) error {
 	// suggestion. Printing it twice on the one screen that has to be legible
 	// is worse than not printing it at all.
 	if q := suggestFirstQuery(dir); q != "" && !justGreeted {
-		// The line is a command to copy, so it is never cut: an ellipsis inside
-		// it searches for a truncated word and a literal "…". What goes first
-		// is the note, and if the command alone still does not fit, the whole
-		// suggestion — the screen has other lines that say more (#1588).
-		room := printableWidth(w)
-		command := fmt.Sprintf("try        deja %q", q)
-		const note = " (from your own history)"
-		switch {
-		case room == 0 || barColumns(command+note) <= room:
-			fmt.Fprintf(w, "try        %sdeja %q%s %s(from your own history)%s\n", bold, q, reset, dim, reset)
-		case barColumns(command) <= room:
-			fmt.Fprintf(w, "try        %sdeja %q%s\n", bold, q, reset)
-		}
+		fmt.Fprintf(w, "try        %sdeja \"%s\"%s %s(from your own history)%s\n", bold, q, reset, dim, reset)
 	}
 	fmt.Fprintf(w, "%smore       deja log · deja stats · deja help%s\n", dim, reset)
 	return nil
@@ -338,15 +312,9 @@ func pluralS(n int) string {
 // rule for the status bar).
 func trimBriefTitle(t string) string { return trimBriefTitleTo(t, briefTitleMax) }
 
-// briefLabelColumns is the fixed prefix every line but `recent` carries: a
-// name, padded to the column the values line up on.
-const briefLabelColumns = 11
-
 // briefTitleMax is the width the fixed-prefix lines (`asked`, `reused`, `hit`)
 // are laid out to: an 11-column label plus 44 plus the ellipsis is 56, which
-// fits a 60-column pane. Narrower than that they overflow, and widening the
-// rule here would also cut `hook-context` output, which is not a terminal line
-// at all — that is a separate item (#1588).
+// fits the narrowest terminal anyone opens.
 const briefTitleMax = 44
 
 func trimBriefTitleTo(t string, max int) string {
@@ -499,32 +467,6 @@ func printNoHistory(w io.Writer, stale bool) {
 	fmt.Fprintln(w, "  deja sources     what was looked for, and where")
 	fmt.Fprintln(w, "  deja doctor      check the setup")
 	fmt.Fprintln(w, "  deja help        every command")
-}
-
-// fitBriefWhen makes the `before` line fit by shortening the project path and
-// nothing else. Cutting the end instead drops "last worked <date>" and the
-// reuse count — the two facts #843 added because they are not restatements of
-// the span. A project name is the only part of this line that grows without
-// bound (#1588).
-func fitBriefWhen(when string, room int) string {
-	room -= briefLabelColumns
-	if room <= 0 || barColumns(when) <= room {
-		return when
-	}
-	const in = " in "
-	start := strings.Index(when, in)
-	end := strings.Index(when, " · ")
-	if start < 0 || end < 0 || end <= start {
-		return when
-	}
-	project := when[start+len(in) : end]
-	keep := barColumns(project) - (barColumns(when) - room) - 1 // the ellipsis
-	if keep < 6 {
-		// Nothing readable would be left of the path, so the facts stay whole
-		// and the line overflows — the trade the `recent` floor already makes.
-		return when
-	}
-	return when[:start+len(in)] + termwidth.Cut(project, keep) + "…" + when[end:]
 }
 
 // askedWhen says how far apart the askings were, which is the point of the

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -501,9 +501,6 @@ func printNoHistory(w io.Writer, stale bool) {
 	fmt.Fprintln(w, "  deja help        every command")
 }
 
-// askedWhen says how far apart the askings were, which is the point of the
-// line: the same question in May and again in June is worth a reader's
-// attention in a way that "asked 4 times" is not.
 // fitBriefWhen makes the `before` line fit by shortening the project path and
 // nothing else. Cutting the end instead drops "last worked <date>" and the
 // reuse count — the two facts #843 added because they are not restatements of
@@ -530,6 +527,9 @@ func fitBriefWhen(when string, room int) string {
 	return when[:start+len(in)] + termwidth.Cut(project, keep) + "…" + when[end:]
 }
 
+// askedWhen says how far apart the askings were, which is the point of the
+// line: the same question in May and again in June is worth a reader's
+// attention in a way that "asked 4 times" is not.
 func askedWhen(a index.AskedTwice) string {
 	n := len(a.Sessions)
 	newest := a.Sessions[0].Updated

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -105,18 +105,24 @@ func runBrief(dir string, w io.Writer) error {
 		recalls == 0 && weekRecalls == 0 && dejaVu == 0 && !ov.Oldest.IsZero()
 	line := fmt.Sprintf("today      %d session%s", ov.SessionsToday, pluralS(ov.SessionsToday))
 	if recalls > 0 {
-		// Three widths of the same fact, longest first: a narrow pane keeps the
-		// count and loses the sizes rather than wrapping them onto a line of
-		// their own (#1588).
-		served := fmt.Sprintf(" · %d recall%s served", recalls, pluralS(recalls))
-		sizes := fmt.Sprintf(" (%s", humanBytes(int64(bytes)))
+		// Three widths of the same fact, longest first: a narrow pane gives up
+		// the raw total, then the served size, rather than wrapping them onto a
+		// line of their own (#1588). Dropping straight from both to neither
+		// loses a figure that had nine columns to spare at 60.
+		line += fmt.Sprintf(" · %d recall%s served", recalls, pluralS(recalls))
+		served := " (" + humanBytes(int64(bytes)) + ")"
+		full := served
 		if raw := usage.TodayRaw(dir); bytes > 0 && raw/int64(bytes) >= 2 {
-			sizes += " from " + humanBytes(raw)
+			full = " (" + humanBytes(int64(bytes)) + " from " + humanBytes(raw) + ")"
 		}
-		sizes += ")"
-		line += served
-		if barColumns(line+sizes) <= briefWidth() {
-			line += sizes
+		// printableWidth, not briefWidth: a pipe reads as "do not cut", and a
+		// script that redirects the brief wants the figures, not the layout.
+		room := printableWidth(w)
+		switch {
+		case room == 0 || barColumns(line+full) <= room:
+			line += full
+		case barColumns(line+served) <= room:
+			line += served
 		}
 	}
 	if !quietWeek {
@@ -254,7 +260,7 @@ func runBrief(dir string, w io.Writer) error {
 				when += " · last worked " + last
 			}
 		}
-		fmt.Fprintf(w, "before     %s%s%s\n", dim, when, reset)
+		fmt.Fprintf(w, "before     %s%s%s\n", dim, fitBriefWhen(when, printableWidth(w)), reset)
 	}
 
 	if haveReused && !sameWork {
@@ -280,11 +286,19 @@ func runBrief(dir string, w io.Writer) error {
 	// suggestion. Printing it twice on the one screen that has to be legible
 	// is worse than not printing it at all.
 	if q := suggestFirstQuery(dir); q != "" && !justGreeted {
-		// The note is fixed wording; the query is the part that grows, so it
-		// carries the cut when the pane is narrow (#1588).
-		note := " (from your own history)"
-		q = trimBriefTitleTo(q, briefTitleBudget(briefLabelColumns+barColumns(`deja ""`)+barColumns(note)))
-		fmt.Fprintf(w, "try        %sdeja \"%s\"%s %s(from your own history)%s\n", bold, q, reset, dim, reset)
+		// The line is a command to copy, so it is never cut: an ellipsis inside
+		// it searches for a truncated word and a literal "…". What goes first
+		// is the note, and if the command alone still does not fit, the whole
+		// suggestion — the screen has other lines that say more (#1588).
+		room := printableWidth(w)
+		command := fmt.Sprintf("try        deja %q", q)
+		const note = " (from your own history)"
+		switch {
+		case room == 0 || barColumns(command+note) <= room:
+			fmt.Fprintf(w, "try        %sdeja %q%s %s(from your own history)%s\n", bold, q, reset, dim, reset)
+		case barColumns(command) <= room:
+			fmt.Fprintf(w, "try        %sdeja %q%s\n", bold, q, reset)
+		}
 	}
 	fmt.Fprintf(w, "%smore       deja log · deja stats · deja help%s\n", dim, reset)
 	return nil
@@ -322,17 +336,17 @@ func pluralS(n int) string {
 // screen, a bell rings on every refresh. The `recent` lines have printed them
 // raw since they existed; this is one place for all of them (#634 set the same
 // rule for the status bar).
-// The cap was a constant at every width, which is 56 columns with the label —
-// wider than the 50-column pane the constant's own comment claimed it fitted,
-// so `asked`, `reused` and `hit` ran off the edge of a narrow one (#1588).
-func trimBriefTitle(t string) string { return trimBriefTitleTo(t, briefTitleBudget(briefLabelColumns)) }
+func trimBriefTitle(t string) string { return trimBriefTitleTo(t, briefTitleMax) }
 
 // briefLabelColumns is the fixed prefix every line but `recent` carries: a
 // name, padded to the column the values line up on.
 const briefLabelColumns = 11
 
-// briefTitleMax is the width a wide terminal cuts titles to, so one long title
-// cannot fill the screen. Below that the terminal's own width wins.
+// briefTitleMax is the width the fixed-prefix lines (`asked`, `reused`, `hit`)
+// are laid out to: an 11-column label plus 44 plus the ellipsis is 56, which
+// fits a 60-column pane. Narrower than that they overflow, and widening the
+// rule here would also cut `hook-context` output, which is not a terminal line
+// at all — that is a separate item (#1588).
 const briefTitleMax = 44
 
 func trimBriefTitleTo(t string, max int) string {
@@ -490,6 +504,32 @@ func printNoHistory(w io.Writer, stale bool) {
 // askedWhen says how far apart the askings were, which is the point of the
 // line: the same question in May and again in June is worth a reader's
 // attention in a way that "asked 4 times" is not.
+// fitBriefWhen makes the `before` line fit by shortening the project path and
+// nothing else. Cutting the end instead drops "last worked <date>" and the
+// reuse count — the two facts #843 added because they are not restatements of
+// the span. A project name is the only part of this line that grows without
+// bound (#1588).
+func fitBriefWhen(when string, room int) string {
+	room -= briefLabelColumns
+	if room <= 0 || barColumns(when) <= room {
+		return when
+	}
+	const in = " in "
+	start := strings.Index(when, in)
+	end := strings.Index(when, " · ")
+	if start < 0 || end < 0 || end <= start {
+		return when
+	}
+	project := when[start+len(in) : end]
+	keep := barColumns(project) - (barColumns(when) - room) - 1 // the ellipsis
+	if keep < 6 {
+		// Nothing readable would be left of the path, so the facts stay whole
+		// and the line overflows — the trade the `recent` floor already makes.
+		return when
+	}
+	return when[:start+len(in)] + termwidth.Cut(project, keep) + "…" + when[end:]
+}
+
 func askedWhen(a index.AskedTwice) string {
 	n := len(a.Sessions)
 	newest := a.Sessions[0].Updated

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -105,11 +105,19 @@ func runBrief(dir string, w io.Writer) error {
 		recalls == 0 && weekRecalls == 0 && dejaVu == 0 && !ov.Oldest.IsZero()
 	line := fmt.Sprintf("today      %d session%s", ov.SessionsToday, pluralS(ov.SessionsToday))
 	if recalls > 0 {
-		line += fmt.Sprintf(" · %d recall%s served (%s", recalls, pluralS(recalls), humanBytes(int64(bytes)))
+		// Three widths of the same fact, longest first: a narrow pane keeps the
+		// count and loses the sizes rather than wrapping them onto a line of
+		// their own (#1588).
+		served := fmt.Sprintf(" · %d recall%s served", recalls, pluralS(recalls))
+		sizes := fmt.Sprintf(" (%s", humanBytes(int64(bytes)))
 		if raw := usage.TodayRaw(dir); bytes > 0 && raw/int64(bytes) >= 2 {
-			line += " from " + humanBytes(raw)
+			sizes += " from " + humanBytes(raw)
 		}
-		line += ")"
+		sizes += ")"
+		line += served
+		if barColumns(line+sizes) <= briefWidth() {
+			line += sizes
+		}
 	}
 	if !quietWeek {
 		fmt.Fprintln(w, line)
@@ -272,6 +280,10 @@ func runBrief(dir string, w io.Writer) error {
 	// suggestion. Printing it twice on the one screen that has to be legible
 	// is worse than not printing it at all.
 	if q := suggestFirstQuery(dir); q != "" && !justGreeted {
+		// The note is fixed wording; the query is the part that grows, so it
+		// carries the cut when the pane is narrow (#1588).
+		note := " (from your own history)"
+		q = trimBriefTitleTo(q, briefTitleBudget(briefLabelColumns+barColumns(`deja ""`)+barColumns(note)))
 		fmt.Fprintf(w, "try        %sdeja \"%s\"%s %s(from your own history)%s\n", bold, q, reset, dim, reset)
 	}
 	fmt.Fprintf(w, "%smore       deja log · deja stats · deja help%s\n", dim, reset)
@@ -310,11 +322,17 @@ func pluralS(n int) string {
 // screen, a bell rings on every refresh. The `recent` lines have printed them
 // raw since they existed; this is one place for all of them (#634 set the same
 // rule for the status bar).
-func trimBriefTitle(t string) string { return trimBriefTitleTo(t, briefTitleMax) }
+// The cap was a constant at every width, which is 56 columns with the label —
+// wider than the 50-column pane the constant's own comment claimed it fitted,
+// so `asked`, `reused` and `hit` ran off the edge of a narrow one (#1588).
+func trimBriefTitle(t string) string { return trimBriefTitleTo(t, briefTitleBudget(briefLabelColumns)) }
 
-// briefTitleMax is the width the fixed-prefix lines (`asked`, `reused`, `hit`)
-// are laid out to: an 11-column label plus 44 plus the ellipsis is 56, which
-// fits the narrowest terminal anyone opens.
+// briefLabelColumns is the fixed prefix every line but `recent` carries: a
+// name, padded to the column the values line up on.
+const briefLabelColumns = 11
+
+// briefTitleMax is the width a wide terminal cuts titles to, so one long title
+// cannot fill the screen. Below that the terminal's own width wins.
 const briefTitleMax = 44
 
 func trimBriefTitleTo(t string, max int) string {

--- a/cmd/deja/brief_narrow_test.go
+++ b/cmd/deja/brief_narrow_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/termwidth"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// Every line the brief prints has to fit the width it laid out for. The
+// exception is the `recent` block, where a prefix that already fills the line
+// keeps a 12-column title rather than an empty one — that floor is deliberate
+// and TestBriefRecentLinesHonourColumns pins it.
+//
+// Measured before the fix on a 1548-session store: 5 lines over at COLUMNS=60,
+// 9 at 50, 12 at 40. `today`, `before` and `try` carried no budget at all, and
+// the fixed-prefix lines were cut to a constant 44 columns — 56 with the label,
+// wider than the pane (#1588).
+func TestBriefLinesFitNarrowTerminals(t *testing.T) {
+	day := 24 * time.Hour
+	// A project path of the length people actually have, and recalls served
+	// today: the `today` line only grows past the edge once it carries the two
+	// sizes, and `before` only once the project name is long.
+	dir := briefStore(t, "work/platform/services/session-indexer", 12*day, 15*day, 19*day)
+	usage.RecordDigest(dir, usage.KindRecall, strings.Repeat("x", 4096), 3, 262144)
+	usage.RecordDigest(dir, usage.KindDejaVu, "dv digest", 2, 4096)
+
+	// 60 is the width the code lays out for — briefTitleBudget names the
+	// 60-column split pane #604 fixed — and 80 is the default. Below 60 the
+	// screen still overflows on the header, the suggestion and the `recent`
+	// floor; those are separate items, not this one.
+	for _, width := range []int{60, 80} {
+		t.Setenv("COLUMNS", strconv.Itoa(width))
+		var buf bytes.Buffer
+		if err := runBrief(dir, &buf); err != nil {
+			t.Fatal(err)
+		}
+		for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+			text := visibleText(line)
+			if strings.TrimSpace(text) == "" {
+				continue
+			}
+			if isBriefRecentLine(text) {
+				continue // the documented floor
+			}
+			// The fixed instruction lines fit 60 columns; cutting them with an
+			// ellipsis would hide the command they exist to give, so they are
+			// not budgeted at all (#1588).
+			if w := termwidth.Columns(text); w > width {
+				t.Errorf("COLUMNS=%d: %d columns: %q", width, w, text)
+			}
+		}
+	}
+}
+
+func isBriefRecentLine(text string) bool {
+	return strings.HasPrefix(text, "recent ") || (strings.HasPrefix(text, "  ") && strings.Contains(text, "] "))
+}

--- a/cmd/deja/brief_narrow_test.go
+++ b/cmd/deja/brief_narrow_test.go
@@ -58,7 +58,17 @@ func briefNarrowStore(t *testing.T) string {
 	return dir
 }
 
-func TestBriefLinesFitNarrowTerminals(t *testing.T) {
+// The three lines this fix budgets have to fit the width the brief laid out
+// for: `today`, `try`, and `before` in the shape where shortening the project
+// keeps every fact.
+//
+// Not every line on this screen fits. `withheld` is 103 columns of fixed
+// wording, `ahead` passes 60 once the count reaches three digits, `before`
+// carrying the re-use suffix is 110, and the `recent` floor keeps a 12-column
+// title rather than an empty one on purpose. Those need either a wording
+// change, which is not a layout decision, or one choke point every line goes
+// through; #1588 carries the reproductions.
+func TestBriefTodayTryAndBeforeFitTheirPane(t *testing.T) {
 	dir := briefNarrowStore(t)
 
 	// 60 is the width the code lays out for — briefTitleBudget names the
@@ -71,24 +81,20 @@ func TestBriefLinesFitNarrowTerminals(t *testing.T) {
 		if err := runBrief(dir, &buf); err != nil {
 			t.Fatal(err)
 		}
+		var seen int
 		for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
 			text := visibleText(line)
-			if strings.TrimSpace(text) == "" {
+			if !strings.HasPrefix(text, "today ") && !strings.HasPrefix(text, "try ") &&
+				!strings.HasPrefix(text, "before ") {
 				continue
 			}
-			if isBriefRecentLine(text) {
-				continue // the documented floor
-			}
-			// The fixed instruction lines fit 60 columns; cutting them with an
-			// ellipsis would hide the command they exist to give, so they are
-			// not budgeted at all (#1588).
+			seen++
 			if w := termwidth.Columns(text); w > width {
 				t.Errorf("COLUMNS=%d: %d columns: %q", width, w, text)
 			}
 		}
+		if seen < 2 {
+			t.Fatalf("COLUMNS=%d: the fixture printed %d of the three budgeted lines:\n%s", width, seen, buf.String())
+		}
 	}
-}
-
-func isBriefRecentLine(text string) bool {
-	return strings.HasPrefix(text, "recent ") || (strings.HasPrefix(text, "  ") && strings.Contains(text, "] "))
 }

--- a/cmd/deja/brief_narrow_test.go
+++ b/cmd/deja/brief_narrow_test.go
@@ -2,10 +2,15 @@ package main
 
 import (
 	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
 
 	"github.com/vshulcz/deja-vu/internal/termwidth"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -20,14 +25,41 @@ import (
 // 9 at 50, 12 at 40. `today`, `before` and `try` carried no budget at all, and
 // the fixed-prefix lines were cut to a constant 44 columns — 56 with the label,
 // wider than the pane (#1588).
-func TestBriefLinesFitNarrowTerminals(t *testing.T) {
-	day := 24 * time.Hour
-	// A project path of the length people actually have, and recalls served
-	// today: the `today` line only grows past the edge once it carries the two
-	// sizes, and `before` only once the project name is long.
-	dir := briefStore(t, "work/platform/services/session-indexer", 12*day, 15*day, 19*day)
+// briefNarrowStore seeds the lines the width contract is about: one question
+// asked in three sessions (which is what puts `asked` and `before` on the
+// screen), a project path of the length people actually have, a span that
+// carries a year, and recalls served today so the `today` line grows its
+// sizes. The first fixture for this test had none of those and passed while
+// `before` was 64 columns wide (#1588).
+func briefNarrowStore(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "-work-platform-services-kafka-consumer-rebalance")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	const question = "why does the kafka consumer rebalance keep flapping in staging"
+	for i, age := range []time.Duration{400 * 24 * time.Hour, 380 * 24 * time.Hour, 12 * 24 * time.Hour} {
+		sid := string(rune('a'+i)) + "1b2c3d4"
+		at := time.Now().Add(-age).UTC().Format(time.RFC3339)
+		body := fmt.Sprintf(`{"type":"user","sessionId":%q,"cwd":"/work/platform/services/kafka-consumer-rebalance","timestamp":%q,"message":{"role":"user","content":%q}}`,
+			sid, at, question) + "\n"
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
 	usage.RecordDigest(dir, usage.KindRecall, strings.Repeat("x", 4096), 3, 262144)
 	usage.RecordDigest(dir, usage.KindDejaVu, "dv digest", 2, 4096)
+	return dir
+}
+
+func TestBriefLinesFitNarrowTerminals(t *testing.T) {
+	dir := briefNarrowStore(t)
 
 	// 60 is the width the code lays out for — briefTitleBudget names the
 	// 60-column split pane #604 fixed — and 80 is the default. Below 60 the


### PR DESCRIPTION
Closes #1588.

`briefTitleBudget` names a 60-column split pane as the case it fixed; on a 1548-session store five lines still ran past 60. Three of them are now inside it, each with the rule that keeps its facts:

- `today` tries both figures, then the served size alone, then neither, and measures against `printableWidth(w)` so a redirect keeps everything.
- `try` never carries an ellipsis — it drops the trailing note first, then the whole line. Cutting the query gave `deja "consumer rebalanc…"`, a command that searches for a truncated word and a literal `…`.
- `before` shortens the project path and nothing else, so the re-use count and "last worked" — the two facts #843 put there — survive.

Failing first, on main:

```
--- FAIL: TestBriefTodayTryAndBeforeFitTheirPane
    brief_narrow_test.go:93: COLUMNS=60: 62 columns: "today      0 sessions · 1 recall served (4.0 KB from 260.0 KB)"
    brief_narrow_test.go:93: COLUMNS=60: 61 columns: "before     3 sessions in consumer/rebalance · Jul 19 → Aug 12"
```

Not fixed here, measured and written up in the issue: `before` carrying the re-use suffix (110 columns), `before` when the question spans two projects (88, nothing to shorten), `withheld` (103, fixed wording) and `ahead` at three-digit counts (63). Each needs either a wording decision or one choke point every line goes through. The test asserts the three lines this change owns rather than the whole screen, so it does not claim a contract the code does not keep.

**Question for Vlad:** `wire` and `more` are fixed instructions that fit 60 and overflow 50 by three columns. Split them below 56, or leave them?

## Review

First pass — refuted:

> **Verdict: refuted** — at COLUMNS=60 the `before` line is still 64 columns, and the `today` line drops a 9-column size string that would have fit; the new test misses both because its fixture never prints `before`, `try`, `asked`, `reused` or `hit`, so it validates one of the diff's three changes.

Second pass, after answering all three — refuted again on scope:

> **Verdict: REFUTED.** The three answered findings hold, but the commit's headline claim — "keep the first screen inside a 60-column pane", enforced by a test that walks *every* line — is false for four reachable inputs. […] `before` still blows past 60 in the two cases that matter most, and two unbudgeted lines (`withheld`, `ahead`) sit above it — so the guard test does not actually hold the contract its comment states.
>
> What I verified as correct: `fitBriefWhen` byte-vs-column arithmetic (Cyrillic, kana, CJK and mixed paths — every slice index lands on an ASCII marker, `termwidth.Cut` is rune-safe, the shortened result is exactly `room` columns); `printableWidth(w)` returns 0 on a bare pipe and the width when COLUMNS is exported, and both new branches behave as claimed; the `today` middle rung fires (48 columns where main printed 62); `try` never ellipsises, and nothing depends on that line being emitted; the new test fails on main and passes here; `go test ./cmd/deja/ -count=1` ok.

The third commit is the answer to the second review: the test now asserts the three lines this change budgets, and the four remaining overflows are reproduced on the issue for a follow-up that can carry a wording decision.