### PR TITLE
fix(stats): pluralise singular impact counts

### DIFF
--- a/cmd/deja/stats_impact.go
+++ b/cmd/deja/stats_impact.go
@@ -52,8 +52,8 @@ func printImpact(w io.Writer, r usage.ImpactReport, credits int, jsonOut bool) e
 		return nil
 	}
 	fmt.Fprintln(w, "deja impact — measured on this machine, nothing modeled")
-	fmt.Fprintf(w, "  recalls served     %d agent-initiated recalls returned matches\n", r.Recalls)
-	fmt.Fprintf(w, "  memory at start    %d session starts began with project memory\n", r.Injections)
+	fmt.Fprintf(w, "  recalls served     %d agent-initiated recall%s returned matches\n", r.Recalls, pluralS(r.Recalls))
+	fmt.Fprintf(w, "  memory at start    %d session start%s began with project memory\n", r.Injections, pluralS(r.Injections))
 	if r.RawBytes > 0 && r.ServedBytes > 0 {
 		// The frame, the header and the session lines cost more than the text
 		// they wrap when sessions are short — which is exactly the state a new

--- a/cmd/deja/stats_impact_test.go
+++ b/cmd/deja/stats_impact_test.go
@@ -24,8 +24,8 @@ func TestStatsImpactCountsAndArithmetic(t *testing.T) {
 	}
 	got := out.String()
 	for _, want := range []string{
-		"2 agent-initiated recalls",
-		"1 session starts began with project memory",
+		"2 agent-initiated recalls returned matches",
+		"1 session start began with project memory",
 		"1 session recalled 2+ times",
 		"1 prompts matched work",
 		"50× less",
@@ -45,6 +45,22 @@ func TestStatsImpactCountsAndArithmetic(t *testing.T) {
 	}
 	if r.Recalls != 2 || r.Injections != 1 || r.ReusedTwice != 1 || r.DejaVuMoments != 1 || r.ServedBytes != 3500 || r.RawBytes != 175000 {
 		t.Fatalf("json report wrong: %+v", r)
+	}
+}
+
+func TestPrintImpactSingularGrammar(t *testing.T) {
+	var out bytes.Buffer
+	if err := printImpact(&out, usage.ImpactReport{Recalls: 1, Injections: 1}, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"1 agent-initiated recall returned matches",
+		"1 session start began with project memory",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("impact output missing %q:\n%s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- make the impact report use singular nouns for one recall and one session start
- reuse the existing plural helper and add regression coverage for both singular lines

Closes #1586

## Test plan

- `go test ./cmd/deja -run 'TestStatsImpactCountsAndArithmetic|TestPrintImpactSingularGrammar'`
- `go vet ./...`
- `go build ./cmd/deja`
- `gofmt -s -d cmd/deja/stats_impact.go cmd/deja/stats_impact_test.go`
- `git diff --check`

## Notes

The race-enabled suite could not run on this Windows host because `gcc` is unavailable. A broader non-race Windows run also encountered existing executable-bit/worktree-path failures and an `os/exec.LookPath` timeout; the affected package tests above pass.