### PR TITLE
feat(grok): a Grok Build plugin, and a licence in every bundle

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -199,9 +199,14 @@ jobs:
               ...Object.values(mcp.mcpServers ?? {}).flatMap((s) => s.args ?? []),
               ...Object.values(hooks.hooks ?? {}).flat().flatMap((g) => (g.hooks ?? []).map((h) => h.command)),
             ];
+            // The variable is spelled without its braces here: shellcheck reads
+            // a ${...} inside this single-quoted script as a shell expansion
+            // that was meant to expand, and fails the lint.
+            const rootVar = "GROK_PLUGIN_ROOT}/";
             for (const command of commands) {
-              if (!String(command).includes("${GROK_PLUGIN_ROOT}")) { console.error("path is not rooted at the plugin: " + command); bad++; continue; }
-              const rel = String(command).split("${GROK_PLUGIN_ROOT}/")[1].replace(/"$/, "");
+              const at = String(command).indexOf(rootVar);
+              if (at < 0) { console.error("path is not rooted at the plugin: " + command); bad++; continue; }
+              const rel = String(command).slice(at + rootVar.length).replace(/"$/, "");
               if (!fs.existsSync(rel)) { console.error("points at a file that is not in the bundle: " + rel); bad++; }
             }
             process.exit(bad ? 1 : 0);

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -158,6 +158,55 @@ jobs:
             process.exit(bad ? 1 : 0);
           '
 
+  grok:
+    name: grok-deja
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: extensions/grok
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+
+      - name: The plugin has to parse
+        run: node --check lib.mjs && node --check hooks/recall.mjs && node --check bin/deja-mcp.mjs
+
+      - run: node --test test/*.test.mjs
+
+      - name: The bundle has to stay loadable by Grok
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            let bad = 0;
+            // Grok discovers components from fixed paths, so a rename here is a
+            // capability that silently never arrives.
+            for (const path of [".grok-plugin/plugin.json", ".mcp.json", "hooks/hooks.json", "commands/recall.md", "skills/deja-history/SKILL.md"]) {
+              if (!fs.existsSync(path)) { console.error("missing: " + path); bad++; }
+            }
+            const manifest = JSON.parse(fs.readFileSync(".grok-plugin/plugin.json", "utf8"));
+            for (const key of ["name", "version", "description", "license"]) {
+              if (!manifest[key]) { console.error("manifest has no " + key); bad++; }
+            }
+            // Every command Grok runs from this bundle is resolved against
+            // GROK_PLUGIN_ROOT: a bare relative path would be resolved against
+            // the session directory instead, which is wherever the user is.
+            const mcp = JSON.parse(fs.readFileSync(".mcp.json", "utf8"));
+            const hooks = JSON.parse(fs.readFileSync("hooks/hooks.json", "utf8"));
+            const commands = [
+              ...Object.values(mcp.mcpServers ?? {}).flatMap((s) => s.args ?? []),
+              ...Object.values(hooks.hooks ?? {}).flat().flatMap((g) => (g.hooks ?? []).map((h) => h.command)),
+            ];
+            for (const command of commands) {
+              if (!String(command).includes("${GROK_PLUGIN_ROOT}")) { console.error("path is not rooted at the plugin: " + command); bad++; continue; }
+              const rel = String(command).split("${GROK_PLUGIN_ROOT}/")[1].replace(/"$/, "");
+              if (!fs.existsSync(rel)) { console.error("points at a file that is not in the bundle: " + rel); bad++; }
+            }
+            process.exit(bad ? 1 : 0);
+          '
+
   metadata:
     name: packages point at this repository
     runs-on: ubuntu-latest

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -199,9 +199,9 @@ jobs:
               ...Object.values(mcp.mcpServers ?? {}).flatMap((s) => s.args ?? []),
               ...Object.values(hooks.hooks ?? {}).flat().flatMap((g) => (g.hooks ?? []).map((h) => h.command)),
             ];
-            // The variable is spelled without its braces here: shellcheck reads
-            // a ${...} inside this single-quoted script as a shell expansion
-            // that was meant to expand, and fails the lint.
+            // Spelled without its opening brace on purpose: shellcheck reads a
+            // dollar-brace sequence inside this single-quoted script as a shell
+            // expansion someone forgot to quote, and fails the lint.
             const rootVar = "GROK_PLUGIN_ROOT}/";
             for (const command of commands) {
               const at = String(command).indexOf(rootVar);

--- a/README.md
+++ b/README.md
@@ -274,9 +274,10 @@ for people who install extensions there rather than from a CLI:
 | Zed | `deja-context-server` | Zed → Extensions → deja |
 | Kimi Code | plugin `deja` | `/plugins install https://github.com/vshulcz/deja-vu` |
 | Codex CLI | plugin `deja-vu` | `codex plugin marketplace add https://github.com/vshulcz/deja-vu` then `codex plugin add deja-vu@deja-vu` |
+| Grok Build | plugin `deja` | `grok plugin marketplace add xai-org/plugin-marketplace` then `grok plugin install deja` |
 
 Either path is enough on its own, and having both is not a problem: the
-opencode, dsh, Kimi and Codex packages read what `deja install` wrote and
+opencode, dsh, Kimi, Grok and Codex packages read what `deja install` wrote and
 contribute only what is missing, and in Zed both halves use one server id, so
 there is nothing to have twice whichever order you install in.
 

--- a/claude-plugin/LICENSE
+++ b/claude-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vladislav Shulcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -1,0 +1,39 @@
+# deja for Claude Code
+
+The plugin bundle Claude Code, Cursor, Qwen, OpenClaw and Copilot install from
+this repository's marketplace:
+
+```sh
+claude plugin marketplace add vshulcz/deja-vu && claude plugin install deja-vu@deja-vu
+```
+
+It carries deja's MCP server, the `deja-history` skill, the `/deja` command and
+the session-start, pre-compact, pre-tool and post-failure hooks — the same
+wiring `deja install --auto` writes, packaged the way those harnesses install
+things.
+
+[deja](https://github.com/vshulcz/deja-vu) indexes the session transcripts
+twenty coding agents already write to disk, including sessions from before it
+was installed, and answers from them locally: BM25 over the transcripts, no
+model and no embeddings, credentials redacted as the index is built.
+
+The binary is not in the bundle — plugins carry files, not native binaries:
+
+```sh
+brew install vshulcz/tap/deja-vu
+```
+
+or
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
+```
+
+Having both this bundle and `deja install` is fine: the hooks here stand down
+when the installer has already wired the same ones, so nothing is recalled
+twice.
+
+Details, the harness matrix and the benchmarks are in the
+[repository README](../README.md). Security policy: [SECURITY.md](../SECURITY.md).
+
+MIT, same as deja.

--- a/cmd/deja/codex_plugin_test.go
+++ b/cmd/deja/codex_plugin_test.go
@@ -97,6 +97,8 @@ func TestBundledSkillsMatchInstaller(t *testing.T) {
 		"codex-plugin/skills/deja-history/SKILL.md",
 		"claude-plugin/skills/deja-history/SKILL.md",
 		"extensions/kimi/skills/deja-history/SKILL.md",
+		"extensions/grok/skills/deja-history/SKILL.md",
+		"extensions/kimi/skills/deja-history/SKILL.md",
 	} {
 		got := string(repoFile(t, p))
 		if want := guidanceText("claude"); got != want {

--- a/codex-plugin/LICENSE
+++ b/codex-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vladislav Shulcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/codex-plugin/README.md
+++ b/codex-plugin/README.md
@@ -1,0 +1,35 @@
+# deja for Codex
+
+The plugin bundle Codex installs from this repository's marketplace:
+
+```sh
+codex plugin marketplace add vshulcz/deja-vu && codex plugin add deja-vu@deja-vu
+```
+
+It carries deja's MCP server and the `deja-history` skill.
+
+[deja](https://github.com/vshulcz/deja-vu) indexes the session transcripts
+twenty coding agents already write to disk, including sessions from before it
+was installed, and answers from them locally: BM25 over the transcripts, no
+model and no embeddings, credentials redacted as the index is built.
+
+The binary is not in the bundle — plugins carry files, not native binaries:
+
+```sh
+brew install vshulcz/tap/deja-vu
+```
+
+or
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
+```
+
+`deja install codex` wires the same MCP server plus the session-start hook
+Codex reads from `hooks.json`, which the bundle cannot carry. Either path
+works, and having both does not wire anything twice.
+
+Details, the harness matrix and the benchmarks are in the
+[repository README](../README.md). Security policy: [SECURITY.md](../SECURITY.md).
+
+MIT, same as deja.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -11,6 +11,7 @@ same local index.
 | [`dsh/`](dsh) | npm `dsh-deja` | `dsh plugin add dsh-deja` |
 | [`zed/`](zed) | Zed extension `deja-context-server` | Zed → Extensions → deja |
 | [`kimi/`](kimi) | Kimi Code plugin `deja` | `/plugins install https://github.com/vshulcz/deja-vu` |
+| [`grok/`](grok) | Grok Build plugin `deja` | `grok plugin install deja` |
 
 Two more integrations live outside this directory because their registries read
 a fixed path in this repository: `claude-plugin/` (Claude Code marketplace) and
@@ -36,6 +37,12 @@ Publishing by hand is still possible when a fix should not wait for a release:
 cd extensions/opencode && npm publish --access public
 cd extensions/dsh      && npm publish --access public
 ```
+
+The Grok plugin is published by a catalog entry, not by us: the entry in
+`xai-org/plugin-marketplace` pins a full commit SHA of this repository and a
+`path` of `extensions/grok`, and Grok re-verifies the SHA after cloning. A new
+version of the plugin means a pull request there that moves the pin — nothing
+ships until it does.
 
 The Zed extension is not published by us: `zed-industries/extensions` pins this
 repository as a submodule and builds `extensions/zed`. A new version means

--- a/extensions/grok/.grok-plugin/plugin.json
+++ b/extensions/grok/.grok-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "deja",
+  "version": "0.1.0",
+  "description": "Recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and sixteen more, including work from before deja was installed.",
+  "keywords": ["memory", "recall", "sessions", "search", "history"],
+  "author": {
+    "name": "vshulcz",
+    "url": "https://github.com/vshulcz"
+  },
+  "homepage": "https://github.com/vshulcz/deja-vu",
+  "repository": "https://github.com/vshulcz/deja-vu",
+  "license": "MIT"
+}

--- a/extensions/grok/.mcp.json
+++ b/extensions/grok/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "deja": {
+      "command": "node",
+      "args": ["${GROK_PLUGIN_ROOT}/bin/deja-mcp.mjs"]
+    }
+  }
+}

--- a/extensions/grok/LICENSE
+++ b/extensions/grok/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vladislav Shulcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/grok/README.md
+++ b/extensions/grok/README.md
@@ -1,0 +1,85 @@
+# deja for Grok Build
+
+Grok remembers its own sessions. This plugin answers the other question: what
+you did in Claude Code, Codex, Cursor, opencode, Zed and fifteen more agents on
+this machine — including the months before you installed anything.
+
+It runs [deja](https://github.com/vshulcz/deja-vu), a local Go binary that
+indexes the transcripts those agents already wrote to disk. No LLM, no
+embeddings, nothing leaves the machine.
+
+## Install
+
+```sh
+grok plugin marketplace add xai-org/plugin-marketplace
+grok plugin install deja
+```
+
+Install the binary first — plugins deliver files, not runtimes or native
+binaries:
+
+```sh
+brew install vshulcz/tap/deja-vu
+```
+
+or
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
+```
+
+`deja install --auto` reaches Grok too, and is the shorter path when you have
+the CLI: it writes `[mcp_servers.deja]` into `~/.grok/config.toml` and the four
+hooks into `~/.grok/hooks/deja.json`. Either path is enough on its own.
+
+## What you get
+
+The MCP server, with the tools deja serves everywhere: `recall`,
+`recall_context`, `blame`, `fix`, `how` and `remember`.
+
+The `deja-history` skill, so the agent knows the CLI contract when the tools are
+not reachable.
+
+`/deja:recall <query>` for the times you want to ask directly.
+
+Recall nobody has to ask for: a `UserPromptSubmit` hook searches this machine's
+history for what the prompt is actually about, and stays silent when nothing
+matches.
+
+## Having both is fine
+
+`deja install grok` and this plugin wire the same two things, and Grok would run
+both — every tool listed twice, the same recall read twice on every prompt. So
+each half stands down when it finds the installer's copy:
+
+- the MCP server exits with a line saying why when `~/.grok/config.toml` has
+  `[mcp_servers.deja]`;
+- the hook returns without output when `~/.grok/hooks/deja.json` has deja's
+  hooks in it.
+
+Whatever `deja install` wrote wins, because that is the copy it keeps current.
+`deja uninstall grok` hands ownership back to the plugin.
+
+## Which binary
+
+In order: `DEJA_BIN`, then a `deja` you installed yourself (`~/.local/bin`,
+`/usr/local/bin`, `/opt/homebrew/bin`, `/usr/bin`), then the bare name so `PATH`
+still has a say. Your own `deja update` or `brew upgrade` wins over anything a
+plugin release froze.
+
+Without deja anywhere, the hook stays silent and the MCP server says what is
+missing instead of pretending the history is empty.
+
+## Unverified here
+
+`${GROK_PLUGIN_ROOT}` is what Grok's own plugin guide documents for hook
+commands, and it is used the same way in `.mcp.json` above. That second use is
+not something this machine could check against a running Grok Build — the `grok`
+CLI installed here is the community project that shares the name and the
+`~/.grok` directory, not xAI's Grok Build. If the variable is not expanded for
+MCP servers, the server fails to start and the CLI-wired path still works; say
+so in an issue and it will be fixed rather than guessed at again.
+
+## License
+
+MIT

--- a/extensions/grok/bin/deja-mcp.mjs
+++ b/extensions/grok/bin/deja-mcp.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// The plugin's MCP server: `deja mcp` over stdio, with the binary resolved the
+// way the user expects rather than pinned to whatever this release bundled.
+//
+// A plugin server and the `[mcp_servers.deja]` entry `deja install grok` writes
+// are two servers to Grok, not one — both would run and the agent would see
+// every tool twice. When the installer has already wired it, this stands down
+// and says why: the CLI's copy is the one `deja install` keeps current.
+
+import { spawn } from "node:child_process"
+import { grokHome, installerOwns, resolveDeja } from "../lib.mjs"
+
+if (installerOwns("mcp")) {
+  process.stderr.write(
+    `deja is already an MCP server in ${grokHome()}/config.toml, from \`deja install grok\`. ` +
+      "This plugin's copy stays out of the way so the tools are not listed twice — " +
+      "run `deja uninstall grok` to let the plugin own it instead.\n",
+  )
+  process.exit(0)
+}
+
+const child = spawn(resolveDeja(), ["mcp"], { stdio: "inherit" })
+child.on("error", (err) => {
+  process.stderr.write(
+    `deja could not start: ${err.message}. Install it with: ` +
+      "curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh\n",
+  )
+  process.exit(1)
+})
+child.on("close", (code) => process.exit(code ?? 0))

--- a/extensions/grok/commands/recall.md
+++ b/extensions/grok/commands/recall.md
@@ -1,0 +1,22 @@
+---
+name: recall
+description: Search this machine's past AI coding sessions (deja-vu)
+---
+
+Search the user's own past sessions across every AI coding tool on this
+machine, then answer from what you find.
+
+Run the recall tool with the user's words as the query — the most specific
+tokens win (an exact error string, a function name, a file path, a flag).
+If a result looks right but is too short to act on, follow up with
+recall_context using a term from it.
+
+If the deja MCP tools are unavailable, fall back to the CLI:
+
+```bash
+deja "$ARGUMENTS"
+```
+
+Answer with what actually happened in those sessions — when it was, which
+project and tool, what was decided or fixed. Say plainly if nothing matched
+rather than filling the gap from general knowledge.

--- a/extensions/grok/hooks/hooks.json
+++ b/extensions/grok/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${GROK_PLUGIN_ROOT}/hooks/recall.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/extensions/grok/hooks/recall.mjs
+++ b/extensions/grok/hooks/recall.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// UserPromptSubmit: hand Grok the sessions this machine already has that match
+// what the user just asked. Grok reads hooks in Claude Code's shape and feeds a
+// hook's stdout back as context, which is the whole mechanism.
+//
+// Silence is the normal case, and nothing here may cost a turn: every failure
+// exits 0 with no output, which Grok treats as "nothing to add".
+
+import { spawn } from "node:child_process"
+import { installerOwns, resolveDeja } from "../lib.mjs"
+
+const TIMEOUT_MS = 20000
+
+async function main() {
+  // `deja install grok-auto` writes the same hook into ~/.grok/hooks/deja.json.
+  // Grok runs every file in that directory, so without this the user reads the
+  // same recall twice on every prompt.
+  if (installerOwns("hook")) return
+
+  const payload = await readStdin()
+  if (!payload.trim()) return
+
+  const out = await run(resolveDeja(), ["hook-prompt", "--plain"], payload)
+  if (out.trim()) process.stdout.write(out)
+}
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = ""
+    if (process.stdin.isTTY) {
+      resolve("")
+      return
+    }
+    process.stdin.setEncoding("utf8")
+    process.stdin.on("data", (chunk) => {
+      data += chunk
+    })
+    process.stdin.on("end", () => resolve(data))
+    process.stdin.on("error", () => resolve(""))
+  })
+}
+
+function run(bin, args, input) {
+  return new Promise((resolve) => {
+    let out = ""
+    let settled = false
+    const done = (value) => {
+      if (settled) return
+      settled = true
+      resolve(value)
+    }
+    let child
+    try {
+      child = spawn(bin, args, { stdio: ["pipe", "pipe", "ignore"] })
+    } catch {
+      done("")
+      return
+    }
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL")
+      done("")
+    }, TIMEOUT_MS)
+    child.stdout.setEncoding("utf8")
+    child.stdout.on("data", (chunk) => {
+      out += chunk
+    })
+    child.on("error", () => {
+      clearTimeout(timer)
+      done("")
+    })
+    child.on("close", (code) => {
+      clearTimeout(timer)
+      done(code === 0 ? out : "")
+    })
+    child.stdin.on("error", () => {})
+    child.stdin.end(input)
+  })
+}
+
+main().catch(() => {})

--- a/extensions/grok/lib.mjs
+++ b/extensions/grok/lib.mjs
@@ -1,0 +1,100 @@
+// The pure half of the Grok Build plugin: where the binary is, and what
+// `deja install grok` has already wired. No process and no host here — Grok
+// loads a plugin as data, and the two entry points are bin/deja-mcp.mjs and
+// hooks/recall.mjs.
+
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { accessSync, constants, readFileSync } from "node:fs"
+
+const WINDOWS = process.platform === "win32"
+export const EXE = WINDOWS ? "deja.exe" : "deja"
+
+// grokHome mirrors sources.GrokHome() in the installer: GROK_HOME wins, else
+// ~/.grok. Both sides have to agree on which config they are reading, or the
+// stand-down below reads the wrong file and does nothing.
+export function grokHome(env = process.env, home = homedir()) {
+  return env.GROK_HOME || join(home, ".grok")
+}
+
+// wellKnown is where a user's own install lands. PATH answers first in the
+// normal case; these cover a Grok started from a launcher whose PATH never
+// sourced a shell profile.
+export function wellKnown(home = homedir(), platform = process.platform) {
+  if (platform === "win32") {
+    const local = process.env.LOCALAPPDATA || join(home, "AppData", "Local")
+    return [join(local, "deja", "bin", "deja.exe"), join(home, ".local", "bin", "deja.exe")]
+  }
+  return [
+    join(home, ".local", "bin", "deja"),
+    "/usr/local/bin/deja",
+    "/opt/homebrew/bin/deja",
+    "/usr/bin/deja",
+  ]
+}
+
+// resolveDeja picks the binary in the order a user would expect: what they
+// pointed at, then the deja they installed themselves and keep current with
+// `deja update` or brew. Their own update has to win over whatever a plugin
+// release froze.
+export function resolveDeja(env = process.env, home = homedir(), exists = executable) {
+  const candidates = [env.DEJA_BIN, ...wellKnown(home)]
+  for (const candidate of candidates) {
+    if (candidate && exists(candidate)) return candidate
+  }
+  // Nothing on disk answered. The bare name keeps PATH in play and makes the
+  // failure name the thing that is missing rather than a path nobody chose.
+  return EXE
+}
+
+function executable(path) {
+  try {
+    accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// `deja install grok` writes `[mcp_servers.deja]` into config.toml, and
+// `deja install grok-auto` writes ~/.grok/hooks/deja.json with the four hooks
+// this plugin would otherwise add a second time. Grok runs every hook file in
+// that directory and every server it is given, so without these checks the
+// user reads the same recall twice and sees every tool listed twice.
+export function installerOwns(what, env = process.env, home = homedir()) {
+  const dir = grokHome(env, home)
+  if (what === "mcp") return mcpPresent(readFileOrEmpty(join(dir, "config.toml")))
+  if (what === "hook") return hooksPresent(readFileOrEmpty(join(dir, "hooks", "deja.json")))
+  return false
+}
+
+// The installer's TOML block is `[mcp_servers.deja]`. Matched on its own line
+// so a mention inside a string or a comment is not read as the section.
+export function mcpPresent(toml) {
+  return String(toml)
+    .split("\n")
+    .some((line) => line.trim() === "[mcp_servers.deja]")
+}
+
+// The installer's hook file is deja's alone — it writes the whole file — so
+// any deja command in it means the hooks are already wired.
+export function hooksPresent(json) {
+  const text = String(json).trim()
+  if (!text) return false
+  try {
+    return JSON.stringify(JSON.parse(text)).includes("hook-prompt")
+  } catch {
+    // A file that will not parse is a file Grok will not run either. Treating
+    // it as absent keeps the plugin working on a machine with a broken config
+    // rather than standing down for a hook that never fires.
+    return false
+  }
+}
+
+function readFileOrEmpty(path) {
+  try {
+    return readFileSync(path, "utf8")
+  } catch {
+    return ""
+  }
+}

--- a/extensions/grok/skills/deja-history/SKILL.md
+++ b/extensions/grok/skills/deja-history/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: deja-history
+description: Search the user's past AI coding sessions. Use when they say things like 'didn't we fix this before', 'what did we decide about X', or before re-debugging an error that may already be solved.
+---
+
+Search deja before re-deriving past work: when the user refers to earlier sessions or decisions, before debugging an error, and before implementing something that may already exist. It searches this machine's own history across every AI coding tool used on it, going back further than deja itself was installed.
+
+If these tools are not available in this session, the same index is reachable through the shell: `deja search --json "<query>"`, `deja ctx <query>`, `deja blame <path> --json`.
+
+## Finding something
+
+- recall: search with the most specific token available — an exact error string, function name, file path, or flag. Several words are ANDed. Not for library docs or general knowledge; only this user's own sessions.
+- recall_context: a full digest of the single best-matching session, once a recall hit looks right and the reasoning behind it matters.
+- blame: before editing, refactoring or deleting a file, the prior sessions that discussed it, so you know why it is shaped the way it is. Session history, not git authorship.
+- fix: paste a failing output verbatim to see the commands that followed that same error before, in sessions where it did not come back.
+- how: the real command with the real flags this machine runs for a build, test, deploy or script, ordered by how many sessions ran it. A guessed invocation is plausible and fails on this setup.
+- remember: store one durable decision after it is settled, as a single self-contained fact. Not transcripts, not anything already obvious from the code.
+
+## Reading a result
+
+A result may carry a bracketed marker with a date — that is the user's own later judgement on that session, and it is not advisory. Do not repeat a rejected approach. Prefer a replacement over what it replaced. Treat a stale result as needing confirmation before acting on it. A result with no marker carries no judgement in either direction.
+
+## Saying what you used
+
+When recalled history genuinely helps — a reused fix, a skipped re-debug, even a partial hint that changed your approach — tell the user in one short line what was recalled and how you used it: "deja-vu recalled: we hit this JWT skew in March — reusing that fix". Say nothing about recalls that did not help. This is provenance, not advertising; a note on every call would be noise.
+
+## Limits worth respecting
+
+- Result windows are bounded. Do not report corpus-wide counts, or claim a complete audit, from the number of hits you got back.
+- If deja is unavailable or the index is empty, say that history search is unavailable. Do not invent what it might have found.
+- Vary the wording and try a second query before concluding nothing is there. Exact tokens match best, so an error string beats a paraphrase of it.

--- a/extensions/grok/test/pure.test.mjs
+++ b/extensions/grok/test/pure.test.mjs
@@ -1,0 +1,70 @@
+// The plugin's decisions, tested without Grok: which binary it picks, and when
+// it stands down because `deja install grok` already wired the same thing.
+// Each case pins a rule that was got wrong once somewhere in this repository.
+
+import assert from "node:assert/strict"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import test from "node:test"
+
+import { grokHome, hooksPresent, installerOwns, mcpPresent, resolveDeja, wellKnown } from "../lib.mjs"
+
+test("grokHome follows GROK_HOME, the same variable the installer reads", () => {
+  assert.equal(grokHome({ GROK_HOME: "/tmp/grok" }, "/home/x"), "/tmp/grok")
+  assert.equal(grokHome({}, "/home/x"), join("/home/x", ".grok"))
+})
+
+test("the user's own binary wins over anything a release froze", () => {
+  const exists = (p) => p === "/opt/homebrew/bin/deja"
+  assert.equal(resolveDeja({}, "/home/x", exists), "/opt/homebrew/bin/deja")
+  assert.equal(resolveDeja({ DEJA_BIN: "/custom/deja" }, "/home/x", () => true), "/custom/deja")
+})
+
+test("nothing on disk still leaves PATH in play", () => {
+  assert.equal(resolveDeja({}, "/home/x", () => false), process.platform === "win32" ? "deja.exe" : "deja")
+})
+
+test("the well-known list is platform-specific", () => {
+  assert.ok(wellKnown("/home/x", "win32").every((p) => p.endsWith("deja.exe")))
+  assert.ok(wellKnown("/home/x", "darwin").includes("/opt/homebrew/bin/deja"))
+})
+
+// `[mcp_servers.deja]` is what `deja install grok` writes. A mention inside a
+// comment or a string is not the section.
+test("the MCP section is matched on its own line", () => {
+  assert.equal(mcpPresent('[mcp_servers.deja]\ncommand = "deja"\n'), true)
+  assert.equal(mcpPresent("  [mcp_servers.deja]  \n"), true)
+  assert.equal(mcpPresent('# see [mcp_servers.deja] for the format\n'), false)
+  assert.equal(mcpPresent('[mcp_servers.other]\ncommand = "x"\n'), false)
+  assert.equal(mcpPresent(""), false)
+})
+
+test("a hook file that will not parse counts as absent", () => {
+  assert.equal(hooksPresent('{"hooks":{"UserPromptSubmit":[{"hooks":[{"command":"deja hook-prompt"}]}]}}'), true)
+  assert.equal(hooksPresent('{"hooks":{"SessionStart":[]}}'), false)
+  assert.equal(hooksPresent("{not json"), false)
+  assert.equal(hooksPresent(""), false)
+})
+
+test("installerOwns reads the two files the installer writes", () => {
+  const dir = mkdtempSync(join(tmpdir(), "deja-grok-"))
+  try {
+    const env = { GROK_HOME: dir }
+    assert.equal(installerOwns("mcp", env, "/home/x"), false)
+    assert.equal(installerOwns("hook", env, "/home/x"), false)
+
+    writeFileSync(join(dir, "config.toml"), '[mcp_servers.deja]\ncommand = "deja"\n')
+    mkdirSync(join(dir, "hooks"), { recursive: true })
+    writeFileSync(
+      join(dir, "hooks", "deja.json"),
+      '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"deja hook-prompt"}]}]}}',
+    )
+
+    assert.equal(installerOwns("mcp", env, "/home/x"), true)
+    assert.equal(installerOwns("hook", env, "/home/x"), true)
+    assert.equal(installerOwns("nonsense", env, "/home/x"), false)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Grok Build installs plugins from a marketplace, and xAI's own catalog takes third-party entries as a remote source: a repository URL, a subdirectory, and a pinned commit SHA it re-verifies after cloning. This is our side of that.

`extensions/grok/` carries what Grok discovers from fixed paths — `.grok-plugin/plugin.json`, `.mcp.json`, `hooks/hooks.json`, `commands/recall.md`, `skills/deja-history/` — with the MCP server behind a small shim so the binary is resolved the way the user expects rather than pinned to whatever a plugin release froze.

Both halves stand down where `deja install grok` already wired the same thing: `[mcp_servers.deja]` in `~/.grok/config.toml` for the server, deja's own hook file in `~/.grok/hooks/` for the prompt hook. Grok runs every hook file in that directory and every server it is given, so without this the user reads the same recall twice and sees every tool listed twice — the defect we fixed for opencode, dsh and Zed in #1567, #1570 and #1571.

Paths inside the bundle use `${GROK_PLUGIN_ROOT}`, which is what Grok's plugin guide documents for hook commands. Its use in `.mcp.json` is the one thing this machine could not verify against a running Grok Build — the `grok` here is the community CLI that shares the name and the `~/.grok` directory, not xAI's Grok Build. If the variable is not expanded for MCP servers the server fails to start and the CLI-wired path still works; the README says so rather than implying it was tested.

Also in here, because a scanner run on the awesome-ai-plugins submission surfaced it: `claude-plugin/` and `codex-plugin/` had neither a licence nor a README. Directory scanners and registries read those from the bundle, not from the repository root — the same rule Zed already caught us on. Both now have them, as does the new bundle.

Tests: seven cases on the plugin's own decisions (binary resolution, and the two stand-down checks against real files on disk), a CI job that fails if a discovery path moves or a command stops being rooted at the plugin, and the skill-drift invariant widened to cover the Kimi and Grok bundles.

The catalog entry in `xai-org/plugin-marketplace` comes next, in its own pull request there, pinned to whatever commit this lands as.
