### PR TITLE
fix(brief): shorten a wide project before the title floor absorbs it

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -207,9 +207,19 @@ func runBrief(dir string, w io.Writer) error {
 			// in every store state — worst on an old store, where "Jun 27
 			// 2025" is six columns longer than "today" and the three lines
 			// came out three different lengths (#1073).
-			head := fmt.Sprintf("%s [%s] %s · %s · ", label, s.Harness, s.Project, search.RelativeDate(s.Updated))
+			// The project is the only part of this prefix that grows without
+			// bound, and a CJK name is two columns per character: at 60 columns
+			// the prefix alone reached 58, the budget fell to its floor and the
+			// line ran to 71 — a wrapped row rather than a ragged end (#1592).
+			// Shorten the path first, then budget the title against what is
+			// left.
+			// Measure the line with no project in it, so the two separators and
+			// the date are all counted exactly once.
+			bare := fmt.Sprintf("%s [%s] %s · %s · ", label, s.Harness, "", search.RelativeDate(s.Updated))
+			project := fitBriefProject(s.Project, barColumns(bare))
+			head := fmt.Sprintf("%s [%s] %s · %s · ", label, s.Harness, project, search.RelativeDate(s.Updated))
 			title = trimBriefTitleTo(title, briefTitleBudget(barColumns(head)))
-			fmt.Fprintf(w, "%s %s[%s]%s %s · %s%s%s", label, dim, s.Harness, reset, s.Project, dim, search.RelativeDate(s.Updated), reset)
+			fmt.Fprintf(w, "%s %s[%s]%s %s · %s%s%s", label, dim, s.Harness, reset, project, dim, search.RelativeDate(s.Updated), reset)
 			if title != "" {
 				fmt.Fprintf(w, " · %s", title)
 			}
@@ -500,6 +510,29 @@ func printNoHistory(w io.Writer, stale bool) {
 	fmt.Fprintln(w, "  deja doctor      check the setup")
 	fmt.Fprintln(w, "  deja help        every command")
 }
+
+// fitBriefProject keeps a project name inside what the rest of the line leaves
+// it, so the title budget still has room to work with. The floor is the tail of
+// the path: "…/消费者重平衡" says which project this is, where the first
+// characters of a long prefix rarely do (#1592).
+func fitBriefProject(project string, rest int) string {
+	room := briefWidth() - rest - briefRecentTitleFloor - 1 // the title's ellipsis
+	if room < briefProjectFloor {
+		room = briefProjectFloor
+	}
+	if barColumns(project) <= room {
+		return project
+	}
+	return "…" + termwidth.CutRight(project, room-1)
+}
+
+// briefRecentTitleFloor mirrors the floor in briefTitleBudget: shortening the
+// project buys nothing if the title is then cut to nothing anyway.
+const briefRecentTitleFloor = 12
+
+// briefProjectFloor is the shortest project fragment worth printing. Below it
+// the line overflows instead, the trade the title floor already makes.
+const briefProjectFloor = 8
 
 // fitBriefWhen makes the `before` line fit by shortening the project path and
 // nothing else. Cutting the end instead drops "last worked <date>" and the

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -215,11 +215,20 @@ func runBrief(dir string, w io.Writer) error {
 			// left.
 			// Measure the line with no project in it, so the two separators and
 			// the date are all counted exactly once.
+			// Both separators are counted: the project is measured as if it
+			// were there, because that is the line it has to fit.
 			bare := fmt.Sprintf("%s [%s] %s · %s · ", label, s.Harness, "", search.RelativeDate(s.Updated))
 			project := fitBriefProject(s.Project, barColumns(bare))
-			head := fmt.Sprintf("%s [%s] %s · %s · ", label, s.Harness, project, search.RelativeDate(s.Updated))
+			head := fmt.Sprintf("%s [%s] %s · ", label, s.Harness, search.RelativeDate(s.Updated))
+			if project != "" {
+				head = fmt.Sprintf("%s [%s] %s · %s · ", label, s.Harness, project, search.RelativeDate(s.Updated))
+			}
 			title = trimBriefTitleTo(title, briefTitleBudget(barColumns(head)))
-			fmt.Fprintf(w, "%s %s[%s]%s %s · %s%s%s", label, dim, s.Harness, reset, project, dim, search.RelativeDate(s.Updated), reset)
+			if project != "" {
+				fmt.Fprintf(w, "%s %s[%s]%s %s · %s%s%s", label, dim, s.Harness, reset, project, dim, search.RelativeDate(s.Updated), reset)
+			} else {
+				fmt.Fprintf(w, "%s %s[%s]%s %s%s%s", label, dim, s.Harness, reset, dim, search.RelativeDate(s.Updated), reset)
+			}
 			if title != "" {
 				fmt.Fprintf(w, " · %s", title)
 			}
@@ -517,11 +526,16 @@ func printNoHistory(w io.Writer, stale bool) {
 // characters of a long prefix rarely do (#1592).
 func fitBriefProject(project string, rest int) string {
 	room := briefWidth() - rest - briefRecentTitleFloor - 1 // the title's ellipsis
-	if room < briefProjectFloor {
-		room = briefProjectFloor
-	}
 	if barColumns(project) <= room {
 		return project
+	}
+	if room < briefProjectFloor {
+		// Even the floors do not fit — measured with harness `antigravity` and
+		// a date carrying its year, where the rest of the line is 42 columns of
+		// a 60-column pane. An eight-column tail of a path is close to
+		// unreadable anyway, so the project goes and the title keeps its floor,
+		// rather than printing a stub and overflowing regardless (#1592).
+		return ""
 	}
 	return "…" + termwidth.CutRight(project, room-1)
 }

--- a/cmd/deja/brief_cjk_project_test.go
+++ b/cmd/deja/brief_cjk_project_test.go
@@ -74,3 +74,36 @@ func briefCJKProjectStore(t *testing.T) string {
 	}
 	return dir
 }
+
+// The longest harness name and a date carrying its year leave 42 columns of a
+// 60-column pane, and the two floors — eight for a path tail, twelve for a
+// title — do not fit in the remaining eighteen. Review found that combination
+// still printing 62–63 columns, so the project goes rather than the line
+// running past the edge with an unreadable stub of a path on it (#1592).
+func TestBriefProjectGoesWhenTheFloorsCannotFit(t *testing.T) {
+	t.Setenv("COLUMNS", "60")
+
+	// `recent    ` + ` [antigravity] ` + ` · ` + `Jul 20 2025` + ` · `
+	const restWithLongHarness = 42
+	if got := fitBriefProject("work/数据平台/消费者重平衡", restWithLongHarness); got != "" {
+		t.Errorf("project = %q, want it dropped: 60 - 42 - 12 - 1 leaves five columns", got)
+	}
+
+	// With an ordinary harness there is room, and the tail is what survives.
+	const restWithClaude = 36
+	got := fitBriefProject("work/数据平台/消费者重平衡", restWithClaude)
+	if got == "" {
+		t.Fatal("project dropped when there was room for it")
+	}
+	if !strings.HasPrefix(got, "…") || !strings.HasSuffix(got, "重平衡") {
+		t.Errorf("project = %q, want the tail of the path", got)
+	}
+	if w := termwidth.Columns(got); restWithClaude+w+briefRecentTitleFloor+1 > 60 {
+		t.Errorf("project = %q (%d columns): the line would still overflow", got, w)
+	}
+
+	// A project that already fits is untouched, whatever the floors say.
+	if got := fitBriefProject("api", restWithLongHarness); got != "api" {
+		t.Errorf("project = %q, want it left alone", got)
+	}
+}

--- a/cmd/deja/brief_cjk_project_test.go
+++ b/cmd/deja/brief_cjk_project_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/termwidth"
+)
+
+// A project name is the part of a `recent` prefix that grows without bound, and
+// a CJK one is two columns per character. At COLUMNS=60 the prefix alone was 58
+// columns, the title budget fell to its 12-column floor, and the line ended at
+// 71 — a wrapped row, not a ragged end (#1592).
+func TestBriefRecentLinesShortenAWideProject(t *testing.T) {
+	dir := briefCJKProjectStore(t)
+
+	for _, width := range []int{60, 80} {
+		t.Setenv("COLUMNS", strconv.Itoa(width))
+		var buf bytes.Buffer
+		if err := runBrief(dir, &buf); err != nil {
+			t.Fatal(err)
+		}
+		lines := recentLines(buf.String())
+		if len(lines) == 0 {
+			t.Fatalf("COLUMNS=%d: no recent lines:\n%s", width, buf.String())
+		}
+		for _, l := range lines {
+			text := visibleText(l)
+			if w := termwidth.Columns(text); w > width {
+				t.Errorf("COLUMNS=%d: %d columns: %q", width, w, text)
+			}
+			// Shortening must not take the whole title with it: the line is
+			// there to name the work, and an empty column names nothing.
+			if i := strings.LastIndex(text, " · "); i < 0 || termwidth.Columns(text[i+3:]) < 8 {
+				t.Errorf("COLUMNS=%d: nothing readable left of the title: %q", width, text)
+			}
+		}
+	}
+}
+
+func briefCJKProjectStore(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "-work-数据平台-消费者重平衡")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	const question = "为什么 kafka 消费者在预发环境不断重新平衡，日志里全是 rebalance 超时"
+	for i, age := range []time.Duration{400 * 24 * time.Hour, 380 * 24 * time.Hour, 12 * 24 * time.Hour} {
+		sid := string(rune('a'+i)) + "1b2c3d4"
+		body, err := json.Marshal(map[string]any{
+			"type": "user", "sessionId": sid, "cwd": "/work/数据平台/消费者重平衡",
+			"timestamp": time.Now().Add(-age).UTC().Format(time.RFC3339),
+			"message":   map[string]any{"role": "user", "content": question},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), append(body, '\n'), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}

--- a/internal/termwidth/width.go
+++ b/internal/termwidth/width.go
@@ -54,3 +54,19 @@ func Cut(s string, width int) string {
 	}
 	return s
 }
+
+// CutRight keeps as much of the end of s as fits in width columns. A path is
+// identified by its tail — "…/消费者重平衡" says which project this is, where
+// the first characters of a long prefix rarely do.
+func CutRight(s string, width int) string {
+	n := 0
+	runes := []rune(s)
+	for i := len(runes) - 1; i >= 0; i-- {
+		w := RuneColumns(runes[i])
+		if n+w > width {
+			return string(runes[i+1:])
+		}
+		n += w
+	}
+	return s
+}

--- a/internal/termwidth/width_test.go
+++ b/internal/termwidth/width_test.go
@@ -47,3 +47,20 @@ func TestCutStopsAtTheBudget(t *testing.T) {
 		}
 	}
 }
+
+func TestCutRightKeepsTheTail(t *testing.T) {
+	if got := CutRight("work/数据平台/消费者重平衡", 12); got != "消费者重平衡" {
+		t.Errorf("CutRight = %q, want the last six characters", got)
+	}
+	if got := Columns(CutRight("work/数据平台/消费者重平衡", 11)); got > 11 {
+		t.Errorf("CutRight returned %d columns for a budget of 11", got)
+	}
+	// A wide rune that would straddle the budget is dropped whole rather than
+	// half-printed.
+	if got := CutRight("平衡", 1); got != "" {
+		t.Errorf("CutRight = %q, want nothing to fit in one column", got)
+	}
+	if got := CutRight("abc", 10); got != "abc" {
+		t.Errorf("CutRight shortened a string that fits: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #1592.

A CJK project name is two columns per character, so `[claude] 数据平台/消费者重平衡 · Jul 20 2025 · ` used 58 of a 60-column pane on its own. `briefTitleBudget` then fell to its 12-column floor — which exists so the line says *something* — and the result ran to 71 columns: a wrapped row, not a ragged end.

The project is the only part of that prefix without a bound, so it shortens first, keeping its tail: `…/消费者重平衡` names the project where the first characters of a long path do not. When even the floors leave no room — harness `antigravity` plus a date carrying its year is 42 columns of a 60-column pane — the project goes entirely rather than printing an unreadable stub and overflowing anyway.

Failing first:

```
--- FAIL: TestBriefRecentLinesShortenAWideProject
    COLUMNS=60: 66 columns: "recent     [claude] 数据平台/消费者重平衡 · Aug 12 · 为什么 kafka…"
    COLUMNS=60: 71 columns: "           [claude] 数据平台/消费者重平衡 · Jul 20 2025 · 为什么 kafka…"
```

After, same fixture:

```
recent     [claude] …/消费者重平衡 · Aug 12 · 为什么 kafka …
           [claude] …者重平衡 · Jul 20 2025 · 为什么 kafka …
```

`termwidth.CutRight` is new and has its own test: it keeps the tail, never splits a wide rune, and returns the string untouched when it already fits.

Not CJK-only — #1588 measured `recent     [claude] goprojects/deja-vu · 1d ago · прочитай /Us…` at 63 columns with a Latin project. Wide characters just make an ordinary name reach the limit that a long path needed before.

## Review

First pass — partially refuted: with harness `antigravity` and a dated session the line still printed 62–63 columns, because `briefProjectFloor(8) + briefRecentTitleFloor(12) + 1` on top of a 42-column remainder cannot fit 60. The second commit answers it.

Second pass:

> Verdict: **not refuted** on width. […] swept: all 18 real harness names (`antigravity` is the longest at 11) plus a hypothetical `cline-vscode`; all four `relativeDate` shapes (`today`, `3d ago`, `Jan 2`, `Dec 22 2025`); projects `""`, `"-"`, `"a"`, `"工"`, a 200-column CJK name, a 200-char Latin name, an RTL path, a combining-mark path, an emoji path, a deep Latin path; CJK/Latin/one-char/empty titles; both labels; COLUMNS 20/52/60/400.
>
> COLUMNS=60 worst = **60**, COLUMNS=80 worst = **80**, COLUMNS=400 worst = 288. No overflow. The arithmetic is exact, not lucky: `fitBriefProject` guarantees `head ≤ width-13`, so `briefTitleBudget` never hits its 12 floor and `head + budget + 1 == width`. COLUMNS=20 and 52 overflow unavoidably — the label, `[antigravity]`, a dated stamp and a 12-column title floor is 53 columns with no project on the line at all. Pre-existing trade, not introduced here.
>
> Separator accounting correct in both branches; degenerate inputs (rest > width, empty project, one-rune project) safe, and the empty-project case incidentally fixes an old `[claude]  · today` double separator. Nothing depends on the project being there — only `brief_recent_policy_test.go:39` asserts a project name and it is unaffected; `statusline_memory.go` and `search.fitProject` also shorten rather than print whole. Fail-before confirmed (64 columns at COLUMNS=60 without the second commit); `go test ./cmd/deja/ ./internal/termwidth/` ok, `gofmt`/`go vet` clean.

The same review found one thing this PR does not fix: inside a three-line block the project can vanish from one line and stay on the others, because the drop depends on that line's date width. #1073's point was that the block reads as one, so that is queued as its own item rather than smuggled in here. It also noted that `recent` now truncates a project from the left while `before` and `search` truncate from the right — one screen, two conventions, worth settling separately.