### PR TITLE
fix(brief): a reader who turned colour off still gets the brief

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -416,7 +416,20 @@ func briefTitleBudget(prefixLen int) int {
 // exporting it — a child process only sees it when someone exported it on
 // purpose, which is the same override briefWidth already honours.
 func printableWidth(w io.Writer) int {
-	if os.Getenv("COLUMNS") == "" && !statColorOK(w) {
+	if os.Getenv("COLUMNS") != "" {
+		return briefWidth()
+	}
+	// briefWanted, not statColorOK: this asks whether the reader has a screen,
+	// and a reader who turned colour off still has one. Asking the colour
+	// question here handed those readers a zero — "do not cut" — so the lines
+	// this budget exists to fit wrapped instead (#1596, the same shape as
+	// #1588).
+	//
+	// The reach is wider than the brief: `files`, `restore` and `search` read
+	// this too, and a NO_COLOR terminal now gets the same layout every other
+	// terminal already had.
+	f, ok := w.(*os.File)
+	if !ok || !briefWanted(f) {
 		return 0
 	}
 	return briefWidth()

--- a/cmd/deja/brief_gate_test.go
+++ b/cmd/deja/brief_gate_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+)
+
+// The brief is gated on "can this reader take a screen", not on "does this
+// reader want colour". They were the same predicate, so NO_COLOR and TERM=dumb
+// printed the usage screen to someone sitting at a terminal with an index
+// (#1596). The drawing predicate keeps refusing both — TestDumbTerminalGetsNoDrawing
+// pins that — because a logo and a live display are escapes, and the brief is
+// text.
+func TestBriefIsNotGatedOnColour(t *testing.T) {
+	f := drawableCharDevice(t)
+
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("TERM", "xterm-256color")
+	if !briefWanted(f) {
+		t.Fatal("a character device with a real TERM stopped taking the brief")
+	}
+
+	t.Setenv("NO_COLOR", "1")
+	if !briefWanted(f) {
+		t.Error("NO_COLOR replaced the brief with the usage screen")
+	}
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("TERM", "dumb")
+	if !briefWanted(f) {
+		t.Error("TERM=dumb replaced the brief with the usage screen")
+	}
+	// Drawing still refuses both: that is a separate question and #903's
+	// answer to it stands.
+	if defaultLogoWanted(f) {
+		t.Error("TERM=dumb started drawing again")
+	}
+}

--- a/cmd/deja/brief_gate_test.go
+++ b/cmd/deja/brief_gate_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 )
 
@@ -32,5 +33,33 @@ func TestBriefIsNotGatedOnColour(t *testing.T) {
 	// answer to it stands.
 	if defaultLogoWanted(f) {
 		t.Error("TERM=dumb started drawing again")
+	}
+}
+
+// The width budget asks the same question as the gate. It used to ask whether
+// colour was wanted, so the readers the gate newly admits were told "do not
+// cut" and their narrow lines wrapped (#1596).
+func TestPrintableWidthFollowsTheScreenNotTheColour(t *testing.T) {
+	f := drawableCharDevice(t)
+	t.Setenv("COLUMNS", "")
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("NO_COLOR", "1")
+	if got := printableWidth(f); got == 0 {
+		t.Error("NO_COLOR reader was told not to cut, so the brief wraps instead of fitting")
+	}
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("TERM", "dumb")
+	if got := printableWidth(f); got == 0 {
+		t.Error("TERM=dumb reader was told not to cut")
+	}
+	// A pipe still reads as "do not cut": a script wants the text whole.
+	r, wpipe, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer wpipe.Close()
+	if got := printableWidth(wpipe); got != 0 {
+		t.Errorf("a pipe got a width of %d, want 0", got)
 	}
 }

--- a/cmd/deja/logo.go
+++ b/cmd/deja/logo.go
@@ -28,6 +28,25 @@ func visibleLen(s string) int { return len([]rune(ansiRE.ReplaceAllString(s, "")
 
 var logoWanted = defaultLogoWanted
 
+// briefWanted answers a narrower question than logoWanted: can this reader take
+// a screen at all? The brief is text — a label, a count, a title — and prints
+// without colour when colour is off. Gating it on the drawing predicate meant
+// NO_COLOR and TERM=dumb got the usage screen instead of their own history,
+// which is not what either variable asks for (#1596).
+func briefWanted(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	if fi.Mode()&os.ModeCharDevice == 0 {
+		return false
+	}
+	// Same exclusion as the drawing predicate, and for the same reason: the
+	// null device is a character device, so `deja >/dev/null` would otherwise
+	// take the interactive branch.
+	return !isNullDevice(fi)
+}
+
 func defaultLogoWanted(f *os.File) bool {
 	// TERM=dumb is a terminal that cannot do any of this: emacs shell-mode, a
 	// CI shell, an editor's built-in console. NO_COLOR was honoured and this

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -191,7 +191,10 @@ var commands = map[string]command{
 func run(args []string) error {
 	dir := index.DefaultDir()
 	if len(args) == 0 {
-		if logoWanted(os.Stdout) {
+		// briefWanted, not logoWanted: a reader who turned colour off still
+		// has an index and a terminal, and the brief is what that reader came
+		// for (#1596).
+		if briefWanted(os.Stdout) {
 			return runBrief(dir, os.Stdout)
 		}
 		printUsage()


### PR DESCRIPTION
Closes #1596.

`run()` chose between the brief and the usage screen with `logoWanted`, the predicate for *drawing*: it refuses `NO_COLOR` and `TERM=dumb` because those readers got escapes as literal text (#903). Reusing it made a colour preference mean "no first screen".

Before, on a real terminal with an index:

```
$ NO_COLOR=1 deja
deja - persistent memory for coding agents

Usage:
  deja [flags] <query>
```

After:

```
$ NO_COLOR=1 deja
deja-vu dev · 6 sessions across 1 agent
wire       no agent wired yet — `deja install --auto`
today      1 session
this week  6 sessions · 0 recalls
```

Zero escapes in that output; `TERM=dumb` prints the same; `deja | cat` still prints usage, which is documented and is what a script wants.

`briefWanted` asks the narrower question — a character device that is not the null device — and the drawing predicate is untouched, with `TestDumbTerminalGetsNoDrawing` still pinning it.

The second commit answers what the review found: `printableWidth` asked the colour question too, so the readers the gate newly admits were told "do not cut" and their lines wrapped. It now follows the same screen question. That budget is also read by `files`, `restore` and `search`, so those readers get the layout every other terminal reader already had.

On the failing-first rule: the tests name functions this change introduces, so on the parent they fail to build rather than to assert. The behavioural before is the measurement above, captured on a pty at 80 columns.

## Review

> **Verdict: not refuted.**
>
> `deja | cat`, `deja > file`, `deja > fifo`, `deja >/dev/null`, stdout closed, CI-shaped no-tty — all still take the usage branch. `briefWanted` reuses the same `ModeCharDevice` + `isNullDevice` pair, so the null-device exclusion of #1097/#862 is preserved on unix and windows; nothing on those paths reads TERM or NO_COLOR. Every other `logoWanted` reader is a drawing decision and correctly untouched — progress display, first-index greeting, install banner, the post-rebuild line, and `justGreeted` stays consistent so the `try` line prints exactly once.
>
> Rendering through a pty: 0 escapes and 0 bare CRs for both `NO_COLOR=1` and `TERM=dumb` (colour-on control shows 22). With an empty index dir and NO_COLOR the first-run build is triggered, the live display stays off, narration is plain on stderr, still 0 escapes.

Second pass, on the width commit:

> | pty | mode | before | after |
> |---|---|---|---|
> | 60 | colour | 60, 0 over | 60, 0 over |
> | 60 | NO_COLOR | **64, 1 over** (`before     3 sessions in reconciliation/pipeline · Jun 2 → today`) | 60, 0 over |
> | 50 | NO_COLOR | **64, 5 over** | 60, 3 over |
>
> The NO_COLOR rendering is now identical to the colour rendering at both widths. The three lines still over 50 in both modes are `wire`, `ahead` and `asked` — none consults `printableWidth`, so that is pre-existing and hits colour readers equally. `deja search` at pty 60 converges the same way: over-60 lines 14 → 2, where a colour reader has always had 2. Windows: `os.Stdout` is a `*os.File`, a console reports `FILE_TYPE_CHAR`, `isNullDevice` compares against `NUL`. Only movement for a non-terminal: `>/dev/null` with colour on used to be cut and now is not — a widening into a sink. `go test ./... -count=1` all green.
>
> **Verdict: not refuted.**