### PR TITLE
fix(greeting): count in singular when there is one of something

### DIFF
--- a/cmd/deja/logo.go
+++ b/cmd/deja/logo.go
@@ -234,12 +234,16 @@ func firstIndexInfo(b index.BuildSummary, tryLine string) []string {
 		if h.Messages == 0 {
 			continue
 		}
-		info = append(info, fmt.Sprintf("%-*s  %s%6d%s messages · %d session%s",
-			nameW, h.Name, logoBold, h.Messages, logoReset, h.Sessions, pluralS(h.Sessions)))
+		// One session and one message is what a first run on a fresh machine
+		// looks like, and this line used to greet it with "1 messages" three
+		// words from a brief that said "1 session" (#1598).
+		info = append(info, fmt.Sprintf("%-*s  %s%6d%s message%s · %d session%s",
+			nameW, h.Name, logoBold, h.Messages, logoReset, pluralS(h.Messages), h.Sessions, pluralS(h.Sessions)))
 	}
 	return append(info,
 		"",
-		fmt.Sprintf("indexed %s%d%s messages across %s%d%s agents", logoBold, b.Messages, logoReset, logoBold, b.Harnesses, logoReset),
+		fmt.Sprintf("indexed %s%d%s message%s across %s%d%s agent%s",
+			logoBold, b.Messages, logoReset, pluralS(b.Messages), logoBold, b.Harnesses, logoReset, pluralS(b.Harnesses)),
 		tryLine,
 	)
 }

--- a/cmd/deja/logo.go
+++ b/cmd/deja/logo.go
@@ -237,7 +237,9 @@ func firstIndexInfo(b index.BuildSummary, tryLine string) []string {
 		// One session and one message is what a first run on a fresh machine
 		// looks like, and this line used to greet it with "1 messages" three
 		// words from a brief that said "1 session" (#1598).
-		info = append(info, fmt.Sprintf("%-*s  %s%6d%s message%s · %d session%s",
+		// The noun is padded as well as the number: with one harness at 1 and
+		// another at 1000, a bare plural moved the separator a column left.
+		info = append(info, fmt.Sprintf("%-*s  %s%6d%s message%-2s · %d session%s",
 			nameW, h.Name, logoBold, h.Messages, logoReset, pluralS(h.Messages), h.Sessions, pluralS(h.Sessions)))
 	}
 	return append(info,

--- a/cmd/deja/logo_plural_test.go
+++ b/cmd/deja/logo_plural_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A first run on a fresh machine has one session and one message, and the
+// greeting counted them in plural: "1 messages across 1 agents", three words
+// from a brief that said "1 session across 1 agent" (#1598).
+func TestGreetingCountsInSingularAtOne(t *testing.T) {
+	one := index.BuildSummary{
+		Messages:   1,
+		Sessions:   1,
+		Harnesses:  1,
+		PerHarness: []index.HarnessCount{{Name: "claude", Messages: 1, Sessions: 1}},
+	}
+	for _, line := range firstIndexInfo(one, `try: deja "something you fixed weeks ago"`) {
+		text := visibleText(line)
+		for _, wrong := range []string{"1 messages", "1 agents", "1 sessions"} {
+			if strings.Contains(text, wrong) {
+				t.Errorf("greeting says %q: %q", wrong, text)
+			}
+		}
+	}
+
+	many := index.BuildSummary{
+		Messages:   4,
+		Sessions:   2,
+		Harnesses:  3,
+		PerHarness: []index.HarnessCount{{Name: "claude", Messages: 4, Sessions: 2}},
+	}
+	joined := strings.Join(firstIndexInfo(many, ""), "\n")
+	for _, want := range []string{"4 messages", "3 agents", "2 sessions"} {
+		if !strings.Contains(visibleText(joined), want) {
+			t.Errorf("greeting lost its plural at more than one: %q missing from\n%s", want, joined)
+		}
+	}
+}

--- a/cmd/deja/logo_plural_test.go
+++ b/cmd/deja/logo_plural_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/stats"
 )
 
 // A first run on a fresh machine has one session and one message, and the
@@ -36,6 +38,31 @@ func TestGreetingCountsInSingularAtOne(t *testing.T) {
 	for _, want := range []string{"4 messages", "3 agents", "2 sessions"} {
 		if !strings.Contains(visibleText(joined), want) {
 			t.Errorf("greeting lost its plural at more than one: %q missing from\n%s", want, joined)
+		}
+	}
+}
+
+// The whole stats screen has to agree with itself: review found "1 sessions
+// 1 messages" under By harness, eight lines above a Highlights block that had
+// just been fixed to say "1 message" (#1598).
+func TestStatsScreenCountsInSingularAtOne(t *testing.T) {
+	var buf bytes.Buffer
+	printStats(&buf, stats.Report{
+		TotalSessions: 1,
+		TotalMessages: 1,
+		Harnesses:     []stats.HarnessStats{{Harness: "claude", Sessions: 1, Messages: 1}},
+		Longest:       stats.SessionStat{Messages: 1, Harness: "claude", Title: "why the migration lock times out"},
+		BusiestDay:    stats.DayStat{Date: "2026-08-23", Messages: 1},
+		WeekRecalls:   1,
+		WeekInjected:  1,
+	})
+
+	for _, line := range strings.Split(buf.String(), "\n") {
+		text := visibleText(line)
+		for _, wrong := range []string{"1 sessions", "1 messages", "1 recalls", "1 auto-injections", "1 prompts"} {
+			if strings.Contains(text, wrong) {
+				t.Errorf("stats says %q: %q", wrong, text)
+			}
 		}
 	}
 }

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -334,8 +334,8 @@ func printStats(w io.Writer, r stats.Report) {
 	fmt.Fprintln(w)
 
 	fmt.Fprintf(w, "%sHighlights%s\n", bold, reset)
-	fmt.Fprintf(w, "  Longest session  %d messages · %s · %s\n", r.Longest.Messages, statHarnessTag(r.Longest.Harness, color), valueOrDash(r.Longest.Title))
-	fmt.Fprintf(w, "  Busiest day      %s · %d messages\n", valueOrDash(r.BusiestDay.Date), r.BusiestDay.Messages)
+	fmt.Fprintf(w, "  Longest session  %d message%s · %s · %s\n", r.Longest.Messages, pluralS(r.Longest.Messages), statHarnessTag(r.Longest.Harness, color), valueOrDash(r.Longest.Title))
+	fmt.Fprintf(w, "  Busiest day      %s · %d message%s\n", valueOrDash(r.BusiestDay.Date), r.BusiestDay.Messages, pluralS(r.BusiestDay.Messages))
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "%sRecall%s\n", bold, reset)
 	// The log keeps the last 14 days once it passes 1MB, so the count is not a

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -296,7 +296,11 @@ func printStats(w io.Writer, r stats.Report) {
 		if pad < 1 {
 			pad = 1
 		}
-		fmt.Fprintf(w, "  %s%s %4d sessions  %5d messages\n", tag, strings.Repeat(" ", pad), h.Sessions, h.Messages)
+		// The counts are padded columns, but the nouns are prose: a machine
+		// with one session read "1 sessions  1 messages" eight lines above the
+		// Highlights block that says "1 message" (#1598).
+		fmt.Fprintf(w, "  %s%s %4d session%-2s %5d message%s\n", tag, strings.Repeat(" ", pad),
+			h.Sessions, pluralS(h.Sessions), h.Messages, pluralS(h.Messages))
 	}
 	fmt.Fprintln(w)
 
@@ -328,7 +332,7 @@ func printStats(w io.Writer, r stats.Report) {
 		// if the visible bar were the whole shape — while Range, two lines
 		// above, names months the chart never draws (#854).
 		if shown, total := monthlyTotal(r.Monthly), r.TotalMessages; total > shown && shown*2 < total {
-			fmt.Fprintf(w, "  %d of %d messages are older than the chart — see the range above\n", total-shown, total)
+			fmt.Fprintf(w, "  %d of %d message%s are older than the chart — see the range above\n", total-shown, total, pluralS(total))
 		}
 	}
 	fmt.Fprintln(w)
@@ -351,7 +355,8 @@ func printStats(w io.Writer, r stats.Report) {
 			fmt.Fprintf(w, "  Distilled        %s served from %s of transcripts — ~%d× less context\n", humanBytes(int64(r.Recall.Bytes)), humanBytes(r.Recall.RawBytes), ratio)
 		}
 	}
-	fmt.Fprintf(w, "  This week        %d recalls by your agents · %s re-used (plus %d auto-injections)\n", r.WeekRecalls, humanBytes(int64(r.WeekBytes)), r.WeekInjected)
+	fmt.Fprintf(w, "  This week        %d recall%s by your agents · %s re-used (plus %d auto-injection%s)\n",
+		r.WeekRecalls, pluralS(r.WeekRecalls), humanBytes(int64(r.WeekBytes)), r.WeekInjected, pluralS(r.WeekInjected))
 	if r.Recall.DejaVuMoments > 0 {
 		fmt.Fprintf(w, "  Déjà vu          %d prompt%s your own history already answered\n", r.Recall.DejaVuMoments, pluralS(r.Recall.DejaVuMoments))
 	}
@@ -361,7 +366,7 @@ func printStats(w io.Writer, r stats.Report) {
 	if r.HandoffsIn > 0 {
 		fmt.Fprintf(w, "  Handoffs         %d session%s started from a handoff\n", r.HandoffsIn, pluralS(r.HandoffsIn))
 	}
-	fmt.Fprintf(w, "  Injections       %d · %d sessions · %s\n", r.Recall.Injections, r.Recall.InjectedSessions, humanBytes(int64(r.Recall.InjectedBytes)))
+	fmt.Fprintf(w, "  Injections       %d · %d session%s · %s\n", r.Recall.Injections, r.Recall.InjectedSessions, pluralS(r.Recall.InjectedSessions), humanBytes(int64(r.Recall.InjectedBytes)))
 	fmt.Fprintf(w, "  Empty results    %.1f%%\n", r.Recall.EmptyResultRate*100)
 }
 


### PR DESCRIPTION
Closes #1598.

A first run on a fresh machine has one session and one message, and the greeting counted them in plural — three words from a brief that got it right:

```
    claude       1 messages · 1 session

    indexed 1 messages across 1 agents

deja-vu dev · 1 session across 1 agent
```

`session%s` already went through `pluralS`; `messages` and `agents` were literal. Review then found the same symptom inside `deja stats` — `1 sessions  1 messages` under **By harness**, eight lines above the Highlights block the first commit had just fixed — so the second commit does that whole screen: By harness, This week, Injections, and the line about messages older than the chart.

After, same fixture:

```
    claude       1 message · 1 session
    indexed 1 message across 1 agent

By harness
  [claude]          1 session      1 message
```

Failing first:

```
--- FAIL: TestGreetingCountsInSingularAtOne
    greeting says "1 messages": "claude       1 messages · 1 session"
    greeting says "1 messages": "indexed 1 messages across 1 agents"
    greeting says "1 agents": "indexed 1 messages across 1 agents"
--- FAIL: TestStatsScreenCountsInSingularAtOne
    stats says "1 recalls": "  This week        1 recalls by your agents · 0 B re-used (plus 1 auto-injections)"
```

Both tests assert the plural is still there above one, so the fix cannot go the other way. The greeting's noun is padded as well as its number: with one harness at 1 message and another at 1000, a bare plural moved the separator a column left.

**Question for Vlad:** `cmd/deja/main.go:1307` prints "every one of the 1 indexed sessions is older than that window". Making that grammatical means rewriting the sentence rather than adding an `s`, and `TestSinceOlderThanWholeStoreSaysSo` pins the current words — so I left it. Reword it to something like "the one indexed session is older than that window — it is from <date>", or leave it?

Not in this PR: the same literal appears on fifteen more lines — statusline, sync, install, doctor, friction, search, the MCP payload — each reachable at n=1, and `sync_ssh.go` disagrees with `sync.go` where the identical sentence is already pluralised. That is a sweep of its own, queued rather than smuggled in here.

## Review

First pass:

> **Verdict: refuted on completeness — `deja stats` still prints "1 sessions  1 messages" eight lines above the two lines this commit fixed.**
>
> The change itself is correct. New test passes with the fix; against a byte-for-byte copy of the pre-fix `firstIndexInfo` it trips 3 assertions. Plural branch at 4/3/2 still holds. No opposite error: labels untouched, `stats --json` marshals the struct and is not on this path. `go test ./... -count=1` exit 0. No docs, README or golden quotes the old strings; the one test that quotes the format builds "Longest session 24 messages" and still matches.
>
> One real nit: `%6d` pads the number but the noun now varies, so with `1000 messages` and `1 message` the `·` no longer lines up.

The second commit answers both the refutation and the nit.