### PR TITLE
fix(statusline): the quiet-day line counts one recall as one

### DIFF
--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -84,7 +84,11 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 			return nil
 		}
 		if wr, wb, _, _ := usage.Week(dir); wr > 0 {
-			fmt.Fprint(stdout, withFileMemory(dir, in, fmt.Sprintf("deja · quiet today · %d agent recalls, %s re-used this week", wr, humanBytes(int64(wb)))))
+			// The line below this one already branches at one; this one said
+			// "1 agent recalls" all day, on the surface the reader looks at
+			// most (#1600).
+			fmt.Fprint(stdout, withFileMemory(dir, in, fmt.Sprintf("deja · quiet today · %d agent recall%s, %s re-used this week",
+				wr, pluralS(wr), humanBytes(int64(wb)))))
 			return nil
 		}
 		fmt.Fprint(stdout, withFileMemory(dir, in, "deja · no recalls yet today · 0 B injected"))

--- a/cmd/deja/statusline_quiet_test.go
+++ b/cmd/deja/statusline_quiet_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// The quiet-day line is what the bar shows all day when the week has recalls
+// and today has none, and it counted in plural regardless: "1 agent recalls"
+// (#1600). The line directly below it in the same file already branches at one.
+func TestQuietStatuslineCountsInSingularAtOne(t *testing.T) {
+	dir := quietWeekIndex(t, 1)
+	var buf bytes.Buffer
+	if err := runStatusline(dir, strings.NewReader(`{"session_id":"x","cwd":"/work/one"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if strings.Contains(got, "1 agent recalls") {
+		t.Errorf("quiet line says %q", got)
+	}
+	if !strings.Contains(got, "1 agent recall,") {
+		t.Errorf("quiet line lost the count: %q", got)
+	}
+
+	// Two keeps the plural.
+	dir = quietWeekIndex(t, 2)
+	buf.Reset()
+	if err := runStatusline(dir, strings.NewReader(`{"session_id":"x","cwd":"/work/one"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); !strings.Contains(got, "2 agent recalls") {
+		t.Errorf("quiet line lost its plural above one: %q", got)
+	}
+}
+
+// quietWeekIndex writes n recall events two days old — inside the week, before
+// today — straight into the usage log, which is the only way to have a week
+// that today does not repeat.
+func quietWeekIndex(t *testing.T, n int) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	var lines []string
+	for i := 0; i < n; i++ {
+		e := usage.Event{Time: time.Now().Add(-48 * time.Hour), Kind: usage.KindRecall, Bytes: 1500, Sessions: 1}
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines = append(lines, string(b))
+	}
+	if err := os.WriteFile(usage.Path(dir), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}


### PR DESCRIPTION
Closes #1600.

The quiet-day line is what the bar shows all day when the week has recalls and today has none. It counted in plural regardless, while the line directly below it in the same file already branched at one.

Before:

```
deja · quiet today · 1 agent recalls, 1.5 KB re-used this week
```

After:

```
deja · quiet today · 1 agent recall, 1.5 KB re-used this week
deja · quiet today · 2 agent recalls, 2.9 KB re-used this week
```

Failing first:

```
--- FAIL: TestQuietStatuslineCountsInSingularAtOne
    statusline_quiet_test.go:27: quiet line says "deja · quiet today · 1 agent recalls, 1.5 KB re-used this week"
```

The test seeds the usage log directly with events two days old, because that is the only way to have a week the current day does not repeat; it asserts the plural is still there at two.

Same literal as #1598. The remaining instances — sync, install, doctor, friction, search, the MCP payload — are queued as one sweep; this one is split out because it is the line a reader looks at most.

## Review

> **Verdict: not refuted.** The fix is correct and the test is sound.
>
> **Branch enumeration.** In order: warmup-in-progress, warmup-just-requested, policy line, then `recalls==0` → `injected>0` → `week>0` (the patched line) → nothing-yet, and the non-quiet bottom line. No other branch can print a bad "1 recalls": `injected > 0` prints "no agent recalls today" and is reached only when today's recalls are 0, where the plural is right; the bottom line already had its own switch at 1; the warmup and policy branches carry no counts.
>
> **Count proof.** `usage.Event`'s tags are `t/kind/bytes/sessions`, the test marshals that struct and `usage.read` unmarshals the same type, so the names match by construction; `usage.Path(dir)` is where the reader looks. Reverting the format string produced literally `1 agent recalls, 1.5 KB re-used this week` — 1500 bytes → 1.5 KB confirms exactly one event was read.
>
> **Timezones.** No guard needed, and this differs from `seedAgedSessions`, which skips only for sub-day ages. At `now-48h` both predicates are one-sided: today's local midnight is at most ~26h back even under a DST step, and `Week`'s cutoff is a rolling seven days, so the event is inside the week and outside today in every offset.
>
> **Other readers.** `usage.Week` is read by `brief.go:98` (already pluralised) and `stats.go:169` (a JSON field). No screenshot, golden or doc carries the old wording. `shortenUsage` keeps the first two facts, so the count survives truncation when file memory is present.
>
> `go test ./... -count=1` fully green; the new test fails on the pre-fix string and passes with the fix.