### PR TITLE
fix(search): a one-word query scores on the word, not on the punctuation around it

### DIFF
--- a/internal/search/punctuation_test.go
+++ b/internal/search/punctuation_test.go
@@ -34,3 +34,39 @@ func TestOneWordQueryIgnoresPunctuation(t *testing.T) {
 		}
 	}
 }
+
+// Membership is not enough: the same query with punctuation has to rank the
+// same way. The BM25 path had its own copy of the raw-query comparison, so a
+// session that says the word three times inside a hyphenated token scored zero
+// and sorted below one that says it once (#1603).
+func TestPunctuatedQueryRanksLikeThePlainOne(t *testing.T) {
+	now := time.Now()
+	ss := []model.Session{
+		{ID: "hyp", Harness: "claude", Project: "p", Updated: now,
+			Messages: []model.Message{{Role: "user", Text: "retry-backoff retry-backoff retry-backoff again"}}},
+		{ID: "pln", Harness: "claude", Project: "p", Updated: now,
+			Messages: []model.Message{{Role: "user", Text: "one plain retry here"}}},
+	}
+
+	order := func(q string) []string {
+		hits, err := Run(ss, Options{Query: q, Limit: 10})
+		if err != nil {
+			t.Fatalf("%q: %v", q, err)
+		}
+		var ids []string
+		for _, h := range hits {
+			ids = append(ids, h.Session.ID)
+		}
+		return ids
+	}
+
+	plain := order("retry")
+	if len(plain) != 2 {
+		t.Fatalf("plain query found %d sessions, want 2: %v", len(plain), plain)
+	}
+	for _, q := range []string{"retry?", "retry!", "(retry)"} {
+		if got := order(q); len(got) != len(plain) || got[0] != plain[0] || got[1] != plain[1] {
+			t.Errorf("%q ranked %v, plain ranked %v", q, got, plain)
+		}
+	}
+}

--- a/internal/search/punctuation_test.go
+++ b/internal/search/punctuation_test.go
@@ -1,0 +1,36 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A one-word query scores on the word. The single-token fast path counted the
+// raw query instead, so "retry?" — the shape of a pasted question — matched
+// nothing while "retry" matched twice (#1603).
+func TestOneWordQueryIgnoresPunctuation(t *testing.T) {
+	ss := []model.Session{{
+		ID: "a1", Harness: "claude", Project: "work/fm", Updated: time.Now(),
+		Messages: []model.Message{{Role: "user", Text: "the retry backoff keeps hammering the queue"}},
+	}}
+
+	// Typographic punctuation — “ ” « » — is a separate question: `Tokens`
+	// trims the ASCII set only, so those stay glued to the word and the token
+	// itself is wrong before scoring ever runs. Tracked apart because the
+	// index tokenizer has to agree with any change there (#1603).
+	for _, q := range []string{"retry", "retry?", "retry!", "retry,", "(retry)", `"" retry`} {
+		hits, err := Run(ss, Options{Query: q, Limit: 10})
+		if err != nil {
+			t.Fatalf("%q: %v", q, err)
+		}
+		if len(hits) != 1 {
+			t.Errorf("%q found %d sessions, want 1", q, len(hits))
+			continue
+		}
+		if hits[0].Count < 1 {
+			t.Errorf("%q matched but scored %d", q, hits[0].Count)
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -118,12 +118,12 @@ type bm25Document struct {
 // countIn scores one message against the query the way the exact tier does:
 // a parts match first, then either a whole-query substring count for a single
 // bare token or a per-token count, plus any quoted phrases.
-func countIn(text, low string, qtoks, phrases []string, qlow string, variants map[string][]string) int {
+func countIn(text, low string, qtoks, phrases []string, variants map[string][]string) int {
 	if !MatchesParts(text, qtoks, phrases, variants) {
 		return 0
 	}
 	if len(qtoks) == 1 && len(phrases) == 0 && variants == nil {
-		// The token, not the raw query: `qlow` still carries whatever
+		// The token, not the raw query: the query string still carries whatever
 		// punctuation the reader typed, and counting that scored zero for
 		// "retry?" — the shape of a pasted question — on a session
 		// MatchesParts had already accepted (#1603).
@@ -147,11 +147,9 @@ func countIn(text, low string, qtoks, phrases []string, qlow string, variants ma
 
 func runScored(ss []model.Session, o Options) ([]Hit, error) {
 	var re *regexp.Regexp
-	qlow := strings.ToLower(o.Query)
 	qtoks, phrases := QueryParts(o.Query)
 	// Cross-script CJK: prepared once, used only when a raw match scores zero.
 	queryCJK := cjkfold.HasCJK(o.Query)
-	qlowFolded := cjkfold.String(qlow)
 	qtoksFolded, phrasesFolded := QueryParts(cjkfold.String(o.Query))
 	if o.Regex {
 		var err error
@@ -233,7 +231,7 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 			if re != nil {
 				c = len(re.FindAllStringIndex(m.Text, -1))
 			} else {
-				c = countIn(m.Text, low, qtoks, phrases, qlow, o.FuzzyVariants)
+				c = countIn(m.Text, low, qtoks, phrases, o.FuzzyVariants)
 				// Postings are keyed on Traditional-folded CJK, so a query in
 				// one script legitimately reaches a record in the other. This
 				// counting pass works on surface text and would score that
@@ -242,7 +240,7 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 				if c == 0 && queryCJK {
 					foldedLow := cjkfold.String(low)
 					c = countIn(cjkfold.String(m.Text), foldedLow, qtoksFolded,
-						phrasesFolded, qlowFolded, o.FuzzyVariants)
+						phrasesFolded, o.FuzzyVariants)
 					if c > 0 {
 						windowText, windowToks = foldedLow, qtoksFolded
 					}
@@ -264,8 +262,14 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 				}
 			}
 			doc.length += countDocumentWords(low, qtoks, o.FuzzyVariants, doc.termCount, doc.userCount, m.Role == "user")
-			if len(qtoks) == 1 && doc.termCount[0] == 0 && strings.Contains(low, qlow) {
-				n := strings.Count(low, qlow)
+			// The token, not the raw query — the same rule as countIn. This
+			// path is what scores `retry` inside `retry-backoff`, which
+			// countDocumentWords cannot match because it counts whole words
+			// and treats the hyphen as one. Comparing the raw query here left
+			// a punctuated query with a session that matched three times and
+			// scored zero, ranked below one that matched once (#1603).
+			if len(qtoks) == 1 && doc.termCount[0] == 0 && strings.Contains(low, qtoks[0]) {
+				n := strings.Count(low, qtoks[0])
 				doc.termCount[0] += n
 				if m.Role == "user" {
 					doc.userCount[0] += n
@@ -1324,7 +1328,7 @@ func PrintContext(w io.Writer, s model.Session, query string) {
 			// How much of the query the turn carries, counted the way the hit
 			// snippets already rank passages: a turn that says the word once in
 			// passing must not outrank the exchange that keeps returning to it.
-			weight = countIn(m.Text, low, terms, phrases, qlow, nil)
+			weight = countIn(m.Text, low, terms, phrases, nil)
 			if weight == 0 && strings.Contains(low, qlow) {
 				weight = 1
 			}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -122,9 +122,14 @@ func countIn(text, low string, qtoks, phrases []string, qlow string, variants ma
 	if !MatchesParts(text, qtoks, phrases, variants) {
 		return 0
 	}
-	if len(qtoks) <= 1 && len(phrases) == 0 && variants == nil {
-		if strings.Contains(low, qlow) {
-			return strings.Count(low, qlow)
+	if len(qtoks) == 1 && len(phrases) == 0 && variants == nil {
+		// The token, not the raw query: `qlow` still carries whatever
+		// punctuation the reader typed, and counting that scored zero for
+		// "retry?" — the shape of a pasted question — on a session
+		// MatchesParts had already accepted (#1603).
+		needle := qtoks[0]
+		if strings.Contains(low, needle) {
+			return strings.Count(low, needle)
 		}
 		return 0
 	}


### PR DESCRIPTION
Closes #1603.

`deja retry` finds two sessions on the hunt fixture. `deja "retry?"` finds none — and neither does `retry!`, `retry,`, `(retry)` or `"" retry`. That is the shape of a question someone pastes.

Two copies of the same mistake, one line apart in effect:

- `countIn` counted `qlow` — the raw query with its punctuation — instead of the token, so a session the matcher had already accepted scored zero and dropped out.
- The BM25 path at `search.go:267` counted `qlow` too. That one is what scores `retry` inside `retry-backoff`, which `countDocumentWords` cannot match because it counts whole words. With the first fix alone, `retry?` returned the sessions but ranked them backwards.

The dead `qlow` parameter of `countIn` is gone; removing it is what made the second site visible, and the compiler then flagged `qlow`/`qlowFolded` in `runScored` as unused.

Failing first:

```
--- FAIL: TestOneWordQueryIgnoresPunctuation
    "retry?" found 0 sessions, want 1
--- FAIL: TestPunctuatedQueryRanksLikeThePlainOne
    "retry?" ranked [pln hyp], plain ranked [hyp pln]
```

Not fixed here: typographic punctuation — `“retry”`, `«retry»`, `retry’s` — stays glued to the word, because `query.Tokens` trims the ASCII set only. That is a tokenizer question, and the index has its own tokenizer that would have to agree, so it is queued with its reproduction.

## Review

First pass — partially refuted: the fix delivered membership and counts but not ranking, with the parallel BM25 site still comparing the raw query. Second pass, after that was closed:

> **Verdict: not refuted.**
>
> ```
> == prev (10156421) ==                  == new (8619acf0) ==
> retry    hyp:3:0.34186  pln:1:0.203134    hyp:3:0.341858  pln:1:0.203133
> retry?   pln:1:0.772272 hyp:3:0.0         hyp:3:0.341858  pln:1:0.203133
> (retry)  pln:1:0.772272 hyp:3:0.0         hyp:3:0.341858  pln:1:0.203133
> ```
>
> Order and score, not just order — bit-identical at six decimals, and `retry`'s own numbers are unchanged. `deja ctx retry` is byte-identical across the two commits.
>
> No third harmful copy: `PrintContext`'s fallback can only add weight and cannot fire when it would matter; `densestMention` and `highlight` already fall through to `query.Tokens`; `internal/index` has no instance of the shape.
>
> CJK folding unchanged, measured: `调度器`, `調度器`, `調度器 重試` keep their order, counts and scores, with 1e-6 tails from the recency term — the same tree run twice moves that figure 20× further.
>
> Two more one-token-after-parsing shapes were mis-ranked by the same bug and are now correct: `the retry` (stop word dropped) and `retry retry` (deduped).

The same review surfaced a pre-existing defect it was careful to keep out of this PR: a cross-script CJK hit scores 0.0 — `countDocumentWords` and its fallback both run on unfolded text, so the folded retry that rescues the count never reaches BM25. Filed separately.