### PR TITLE
fix(search): a regex match with no width is not a match

### DIFF
--- a/internal/search/regex_empty_match_test.go
+++ b/internal/search/regex_empty_match_test.go
@@ -1,0 +1,51 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// `x*` matches the empty string, so it hits between every pair of characters.
+// Counting those made a session with no `x` in it report 88 matches and rank
+// above nothing, which is the opposite of what the reader asked for.
+func TestEmptyRegexMatchIsNotAMatch(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", Project: "p", ID: "s1",
+		Messages: []model.Message{
+			{Role: "user", Text: "the retry loop keeps firing"},
+			{Role: "user", Text: "we set retry-backoff to 5s and it held"},
+		},
+	}
+	hits, err := Run([]model.Session{s}, Options{Query: "x*", Regex: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 0 {
+		t.Errorf("`x*` found %d sessions with %d matches; text holds no x, so it holds no match",
+			len(hits), hits[0].Count)
+	}
+	// The control: the same session, a pattern that really is there.
+	hits, err = Run([]model.Session{s}, Options{Query: "retry", Regex: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 || hits[0].Count != 2 {
+		t.Fatalf("control: `retry` found %d sessions, want 1 with 2 matches", len(hits))
+	}
+}
+
+// A zero-width hit wrapped in colour paints an escape pair around nothing, once
+// per character: 977 bytes for a 44-column line.
+func TestHighlightLeavesZeroWidthMatchesAlone(t *testing.T) {
+	const line = "we set retry-backoff to 5s and it held"
+	if got := highlight(line, "x*", true, true); got != line {
+		t.Errorf("highlight painted %d bytes over a %d-byte line for a zero-width pattern:\n%q",
+			len(got), len(line), got)
+	}
+	// The control: a pattern with width still gets highlighted.
+	if got := highlight(line, "retry", true, true); !strings.Contains(got, cMatch+"retry"+cReset) {
+		t.Errorf("control: a real match is no longer highlighted: %q", got)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -229,7 +229,7 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 			// genuine match as words that never meet.
 			windowText, windowToks := low, qtoks
 			if re != nil {
-				c = len(re.FindAllStringIndex(m.Text, -1))
+				c = countRegex(re, m.Text)
 			} else {
 				c = countIn(m.Text, low, qtoks, phrases, o.FuzzyVariants)
 				// Postings are keyed on Traditional-folded CJK, so a query in
@@ -1436,14 +1436,32 @@ func Recent(ss []model.Session, n int) []model.Session {
 	return out
 }
 
+// A pattern that can match the empty string — `x*`, `foo?`, `(a|)` — matches
+// between every pair of characters. Counting those reported 88 matches in a
+// session that held none of the pattern's characters at all (#1606); a match
+// with no width is not a match.
+func countRegex(re *regexp.Regexp, s string) int {
+	n := 0
+	for _, loc := range re.FindAllStringIndex(s, -1) {
+		if loc[1] > loc[0] {
+			n++
+		}
+	}
+	return n
+}
+
 func snippet(s, q string, re *regexp.Regexp) string {
 	s = proseForSnippet(s)
 	r := []rune(s)
 	idx := 0
 	if re != nil {
-		loc := re.FindStringIndex(s)
-		if loc != nil {
-			idx = utf8.RuneCountInString(s[:loc[0]])
+		// Anchor on the first match that has width; a zero-width one points at
+		// no passage in particular (#1606).
+		for _, loc := range re.FindAllStringIndex(s, -1) {
+			if loc[1] > loc[0] {
+				idx = utf8.RuneCountInString(s[:loc[0]])
+				break
+			}
 		}
 	} else {
 		low := strings.ToLower(s)
@@ -1624,7 +1642,14 @@ func highlight(s, q string, isRe bool, color bool) string {
 	if isRe {
 		re, err := regexp.Compile("(?i)" + q)
 		if err == nil {
-			return re.ReplaceAllStringFunc(s, func(x string) string { return cMatch + x + cReset })
+			return re.ReplaceAllStringFunc(s, func(x string) string {
+				// Zero-width match: colouring it wraps an escape pair around
+				// nothing, once per character (#1606).
+				if x == "" {
+					return x
+				}
+				return cMatch + x + cReset
+			})
 		}
 	}
 	if strings.Contains(strings.ToLower(s), strings.ToLower(q)) {


### PR DESCRIPTION
Closes #1606.

`--re 'x*'` matched between every pair of characters, so a session with no `x` in it reported 88 matches and every character came back wrapped in a highlight pair around nothing — 977 bytes for a 44-column line.

Three sites counted or drew those matches: the per-message count in `runScored`, `highlight`, and `snippet`'s excerpt anchor, which would have centred on a zero-width hit at offset 0. All three now skip a match with `loc[1] == loc[0]`.

Failing first:

```
--- FAIL: TestEmptyRegexMatchIsNotAMatch
    `x*` found 1 sessions with 67 matches; text holds no x, so it holds no match
--- FAIL: TestHighlightLeavesZeroWidthMatchesAlone
    highlight painted 974 bytes over a 38-byte line for a zero-width pattern
```

Both tests carry a control on the same input — `retry` still finds its two matches and still gets highlighted — so the fix cannot pass by making regex search return nothing.

Not touched: invalid patterns already exit 1 with the parse error, and RE2 makes `(a+)+$` linear, so there is no catastrophic case to defend against. The miss line still says "try fewer words or --re" to someone who is already using `--re`; that is wording, and it belongs with the question in #1602.

## Review

> Based on my thorough review of the fix, I could not find a case where it fails. Here's what I verified:
>
> **Test execution confirms the fix works:**
> - `--re 'x*'` on text with no x: returns 0 matches (was 88 before fix)
> - `--re 'retry'`: returns 3 matches
> - `--re 'retry|'`: returns 3 matches (empty branch filtered out)
> - `--re 'retry|storm'`: returns 4 matches (both branches counted correctly)
>
> **Code analysis:**
> - countRegex and snippet both check `loc[1] > loc[0]` to filter zero-width matches — semantically consistent
> - highlight skips empty strings; no escape codes wrap nothing
> - No other FindAllStringIndex calls in production code (only test files in redact module with patterns that can't match zero-width)
> - Non-regex path uses regexp.QuoteMeta, cannot produce zero-width matches
> - All existing tests pass
>
> **One behavioral change worth noting:**
> snippet() now iterates FindAllStringIndex results instead of using FindStringIndex. If ALL matches are zero-width (e.g. pattern `^` on single-line text), the snippet anchors at position 0 instead of the first match position. This is acceptable since the pattern can't point at any actual passage anyway.
>
> **No memory issue on FindAllStringIndex(-1):** Pattern like `x*` on 87 chars returns 88 matches (one per position), which the loop processes quickly; countRegex filters them in O(n).
>
> **Limitation:** Zero-width-only patterns (`^`, `$`, `\b`, lookaheads) now report 0 matches. This is a design tradeoff to prevent the bug, not obviously wrong for a session search tool where users search for content, not anchors.
>
> No issues found.

On that last point: before this change `--re '\b'` counted a match at every word boundary and `--re '^'` one per message, which is the same noise the issue is about. A pattern made only of anchors names no text, and `\bretry\b` — the shape someone actually types — has width and is unaffected.
