### PR TITLE
fix(search): stop telling a reader who typed --all to add --all

### DIFF
--- a/cmd/deja/limit_all_note_test.go
+++ b/cmd/deja/limit_all_note_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The truncation note pointed at --all whatever the reader had typed, so
+// `--all --limit 3` answered "add --all to see the rest" — advice that changes
+// nothing, since with --all on it is the limit holding the list (#1608).
+func TestCappedNoteDoesNotAdviseAllWhenAllIsAlreadyOn(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for i := 0; i < 6; i++ {
+		id := fmt.Sprintf("sess-%02d", i)
+		line := fmt.Sprintf(`{"type":"user","sessionId":%q,"cwd":"/tmp/hunt","timestamp":"2026-05-0%dT10:00:00Z","message":{"role":"user","content":"the retry loop keeps firing"}}`, id, i+1)
+		writeClaudeFixture(t, filepath.Join(root, "projects", "-tmp-hunt", id+".jsonl"), id, []string{line})
+	}
+	if err := index.Ensure(os.Getenv("DEJA_INDEX_DIR"), "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	_ = tmp
+
+	out, err := captureRunStderr(t, "--no-embed", "--all", "--limit", "3", "retry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "showing 3 of 6") {
+		t.Fatalf("no truncation note, so the test measured nothing:\n%s", out)
+	}
+	if strings.Contains(out, "add --all") {
+		t.Errorf("--all is already on and the note still advises it:\n%s", out)
+	}
+
+	// The control: without --all the advice is the whole point of the line.
+	out, err = captureRunStderr(t, "--no-embed", "--limit", "3", "retry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "add --all to see the rest") {
+		t.Errorf("without --all the note lost its advice:\n%s", out)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -997,7 +997,16 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 		// answer, and nothing says another N are waiting behind --all. deja
 		// narrates every other place the ladder hides a session, so it says
 		// this one too.
-		fmt.Fprintf(os.Stderr, "deja: showing %d of %d — add --all to see the rest\n", len(hits), o.Total)
+		//
+		// Except to a reader who already typed --all: there the list was cut by
+		// an explicit --limit, or by the relevance tier's own retrieval window,
+		// and neither of those lifts with the flag they are being sent to
+		// (#1608). Say what is shown and leave the advice out.
+		if o.All {
+			fmt.Fprintf(os.Stderr, "deja: showing %d of %d\n", len(hits), o.Total)
+		} else {
+			fmt.Fprintf(os.Stderr, "deja: showing %d of %d — add --all to see the rest\n", len(hits), o.Total)
+		}
 	}
 	// The window this is being printed into, so the lines can be budgeted
 	// rather than assumed 80 wide. Only for a terminal: a pipe gets the whole


### PR DESCRIPTION
Closes #1608.

The truncation note is one fixed sentence, printed whenever the list was cut. With `--all` on, the flag it advises is already there and lifts nothing: an explicit `--limit` is what held the list at three, and in the relevance tier it is the 50-hit retrieval window, which `--all` does not touch either (`relevance_envelope_test.go:82` pins that: `--all` returns 50 of 61 with `capped` still true).

So the note keeps its words, and drops the advice when the reader has already asked for everything:

```
$ deja retry --all --limit 3
deja: showing 3 of 40          (was: showing 3 of 40 — add --all to see the rest)
$ deja retry --limit 3
deja: showing 3 of 40 — add --all to see the rest
```

`TestCappedNoteDoesNotAdviseAllWhenAllIsAlreadyOn` fails before the change on the first line and carries the second as its control, so the fix cannot pass by dropping the advice everywhere.

Question for you rather than a silent decision: should `--all` win over an explicit `--limit` outright, so the case stops existing? That reads well — all means all — but it ignores a number the reader typed, so I left the precedence alone. And if the shorter line should instead say what is holding the list ("showing 3 of 40 — raise --limit for more"), that is your wording to pick.

The rest of item `[search-limit]` came back clean: `0`, `-1`, `abc`, `1e2`, `0x2`, `101` and a twenty-digit number all exit 1 with `--limit needs an integer from 1 to 100`, and nothing clamps silently.

## Review

> No issues.
>
> **Verification summary:**
>
> - o.All condition is correct: only true when user passes --all flag (line 1699 in parseSearch), no implicit paths set it
> - No path between parseSearch and the message check modifies o.All
> - Proof test fails without fix: reverted main.go to parent, test fails with "add --all" still appearing when it shouldn't
> - Proof test passes with fix: with the new code, test passes
> - relevance_envelope_test passes and shows correct message format: "showing 50 of 61" with --all, "showing 50 of 61 — add --all to see the rest" without
> - No golden files or docs assert the exact strings "add --all to see the rest" or "showing %d of %d"
> - Binary behavior verified with fixture: --all --limit 3 prints "showing 3 of 40" without advice; --limit 3 prints "showing 3 of 40 — add --all to see the rest"
> - capped flag remains true in both cases (correct: --limit is the constraint, not the retrieval cap)
> - Test is not flaky: deterministic session timestamps, identical content across all 6 sessions, no embed or time-based ranking involved
> - All cmd/deja tests pass (47.2s run, no failures)
