### PR TITLE
fix(search): --since refuses a window that is not positive

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -1943,11 +1944,39 @@ func withFileTouchers(dir string, ss []model.Session, target search.BlameTarget)
 	}
 	return ss
 }
+
+// parseDur is the window a reader asked to look back over, so it has to be one:
+// zero or less used to parse and then disappear, because every caller cuts on
+// `Since > 0` — `--since -1d` searched the whole store and nothing in the answer
+// said the filter had been dropped (#1610). parseDurAny is the raw form, for
+// `forget --before`, which has its own word for the same mistake.
 func parseDur(s string) (time.Duration, error) {
+	d, err := parseDurAny(s)
+	if err != nil {
+		return 0, err
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%q is not a window — --since counts back from now, so it needs a positive duration like 30d", s)
+	}
+	return d, nil
+}
+
+// maxDurationDays is how many whole days fit in a time.Duration: past it the
+// multiplication wraps, and `--since 365000d` — the way to say "all of it" —
+// came out negative and dropped the filter it was asked for.
+const maxDurationDays = int(math.MaxInt64 / (24 * int64(time.Hour)))
+
+func parseDurAny(s string) (time.Duration, error) {
 	if strings.HasSuffix(s, "d") {
 		n, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
 		if err != nil {
 			return 0, durationError(s)
+		}
+		if n > maxDurationDays {
+			return time.Duration(math.MaxInt64), nil
+		}
+		if n < -maxDurationDays {
+			return time.Duration(math.MinInt64), nil
 		}
 		return time.Duration(n) * 24 * time.Hour, nil
 	}
@@ -2201,7 +2230,7 @@ func runForget(dir string, args []string) error {
 			case "--unforget":
 				unforget, unforgetGiven = index.PastedSelector(args[i]), true
 			case "--before":
-				if d, err := parseDur(args[i]); err == nil {
+				if d, err := parseDurAny(args[i]); err == nil {
 					// "older than 0 days" is the whole store, and the typo that
 					// produces it is 0 for 30. The neighbouring value behaves
 					// the opposite way — --before 9999d matches nothing — and a

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -636,9 +636,10 @@ func TestActiveFiltersNamesWhatEmptiedTheResult(t *testing.T) {
 	if strings.Contains(got, "168h") {
 		t.Errorf("echoed the parsed duration instead of the flag: %q", got)
 	}
-	// parseDur accepts a negative, and filterRecentSources applies no time
-	// filter for one — so naming it would report a filter that never ran and
-	// suppress the empty-store advice, which is the right answer there.
+	// parseDur refuses a negative now (#1610), so this can no longer arrive
+	// from the command line. It stays here because filterRecentSources applies
+	// no time filter for one, and naming it would report a filter that never
+	// ran and suppress the empty-store advice.
 	if got := activeFilters(search.Options{Since: -time.Hour}, "-1h"); got != "" {
 		t.Errorf("named a filter that was never applied: %q", got)
 	}

--- a/cmd/deja/since_positive_test.go
+++ b/cmd/deja/since_positive_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A window of zero or less parsed, and every caller then skipped the cut it
+// asked for: `--since -1d` searched the whole store and said nothing about it
+// (#1610). Refusing it is the only answer that cannot be mistaken for a result.
+func TestParseDurRefusesAWindowThatIsNotPositive(t *testing.T) {
+	for _, in := range []string{"0d", "0", "-0d", "-1d", "-12h", "-90m"} {
+		d, err := parseDur(in)
+		if err == nil {
+			t.Errorf("parseDur(%q) = %v with no error; a window has to be positive", in, d)
+			continue
+		}
+		if !strings.Contains(err.Error(), in) {
+			t.Errorf("parseDur(%q) does not name what was typed: %v", in, err)
+		}
+	}
+	// The control: the windows deja documents still parse.
+	for _, in := range []string{"30d", "12h", "90m", "45s"} {
+		if _, err := parseDur(in); err != nil {
+			t.Errorf("parseDur(%q) = %v, want a window", in, err)
+		}
+	}
+}
+
+// 365000d is a thousand years and the way people say "all of it". Multiplied
+// out it overflows time.Duration and came back negative, so the window that was
+// meant to hold everything held nothing and the filter was skipped (#1610).
+func TestHugeDayWindowSaturatesInsteadOfWrapping(t *testing.T) {
+	d, err := parseDur("365000d")
+	if err != nil {
+		t.Fatalf("parseDur(365000d) = %v", err)
+	}
+	if d <= 0 {
+		t.Errorf("parseDur(365000d) = %v, want the largest window it can hold", d)
+	}
+}


### PR DESCRIPTION
Closes #1610.

`--since -1d` and `--since 0d` parsed, and then the window vanished: every caller cuts on `Since > 0`, so the search ran over the whole store with nothing in the answer saying the filter had been dropped. Same through `deja last`, `deja stats` and the MCP `blame` tool.

Fixing it turned up a second way into the same silent path: `--since 365000d` — a thousand years, which is how people say "all of it" — overflows `time.Duration` when multiplied out and lands negative. `TestLastFiltersSinceAndRole` and `TestStatsCardCommand` both pass that value meaning "everything" and only passed because an unfiltered result looks the same. Days now saturate at the largest duration instead of wrapping, so those two keep their meaning honestly.

`forget --before` already refuses a non-positive age with its own sentence from #739 and a better one — "means older than now, which is every session". It now reads the raw value through `parseDurAny` so that wording survives; `parseDur` is the window form and is what everything else uses.

Failing first:

```
--- FAIL: TestParseDurRefusesAWindowThatIsNotPositive
    parseDur("0d") = 0s with no error; a window has to be positive
    parseDur("-1d") = -24h0m0s with no error; a window has to be positive
--- FAIL: TestHugeDayWindowSaturatesInsteadOfWrapping
    parseDur(365000d) = -2562047h47m16.854775808s, want the largest window it can hold
```

Both carry the documented windows (`30d`, `12h`, `90m`, `45s`) as their control.

New wording, so it is yours to keep or change: `"-1d" is not a window — --since counts back from now, so it needs a positive duration like 30d`. The existing sentence could not be reused, since `-1d` *is* a duration deja understands.

## Review

> No issues.
>
> **Verification complete:**
>
> 1. **All six parseDur callers** (cmd/deja/main.go:1594, 1725, 1797; cmd/deja/mcp.go:254; cmd/deja/stats.go:94; cmd/deja/forget --before): Now reject non-positive values at parse time. For --since, this is correct (users must specify a positive window); for forget --before, the repoint to parseDurAny preserves intent and then --before explicitly rejects d <= 0 with helpful text. MCP blame passes errors up to the caller, which is the correct way to fail — a hook that passes invalid since values has a bug in the hook, not in deja.
> 2. **maxDurationDays arithmetic**: `int(math.MaxInt64 / (24 * int64(time.Hour)))` = 106751 days. Confirmed no overflow or underflow: 106751d → valid; 106752d and 365000d → saturate to MaxInt64; 9223372036854775807d → MaxInt64; out-of-range Atoi rejects with error. All correct.
> 3. **New tests**: Both fail without the fix (accept 0d/-1d, wrap 365000d to negative), pass with it. Test coverage is complete for the fix.
> 4. **Full suite**: `go test ./...` all pass (56s on cmd/deja, no failures across internal packages).
> 5. **Binary**: Tested --since 0d (error), -1d (error), 365000d (accepted, saturated), 106751d (accepted), 9223372036854775807d (accepted), 9223372036854775808d (strconv overflow, error), 30d (works). Tested forget --before 0 (error, correct rejection).
> 6. **Docs/schema**: Help shows 30d, 12h; no promise of --since 0 as a filter bypass; MCP schema says "Age such as 30d or 24h" (positive). No contradictions.
> 7. **Comment update**: Accurately reflects that parseDur now refuses negative (L639 in main_test.go).
