### PR TITLE
fix(search): a filter flag given an empty value is a mistake, not a wildcard

### DIFF
--- a/cmd/deja/empty_filter_value_test.go
+++ b/cmd/deja/empty_filter_value_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -59,5 +60,24 @@ func TestEveryFilterParserRefusesAnEmptyValue(t *testing.T) {
 	}
 	if _, _, _, err := parseBlame([]string{"main.go", "--harness", "claude"}); err != nil {
 		t.Errorf("blame --harness claude: %v", err)
+	}
+}
+
+// stats and forget parse their flags inside their run functions, so they need
+// the store to reach the guard. Both were named as untested in review.
+func TestStatsAndForgetRefuseAnEmptyValue(t *testing.T) {
+	hermeticEnv(t)
+	dir := os.Getenv("DEJA_INDEX_DIR")
+	if err := runStats(dir, []string{"--harness", ""}); err == nil {
+		t.Error("stats --harness \"\" was accepted")
+	}
+	if err := runForget(dir, []string{"--project", "", "--dry-run"}); err == nil {
+		t.Error("forget --project \"\" was accepted")
+	}
+	// The control: --unforget keeps its own refusal, which asks for an id
+	// rather than offering the flags that forget instead of restoring.
+	err := runForget(dir, []string{"--unforget", ""})
+	if err == nil || !strings.Contains(err.Error(), "needs an id") {
+		t.Errorf("--unforget \"\" lost its own refusal: %v", err)
 	}
 }

--- a/cmd/deja/empty_filter_value_test.go
+++ b/cmd/deja/empty_filter_value_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Empty is how "no filter" is spelled internally, so a flag given an empty
+// value used to reach the search as no filter at all — `--project ""` from a
+// script with an unset variable searched the whole store and read as a scoped
+// answer (#1612).
+func TestFilterFlagsRefuseAnEmptyValue(t *testing.T) {
+	for _, flag := range []string{"--harness", "--project", "--role", "--session"} {
+		o, err := parseSearch([]string{"retry", flag, ""})
+		if err == nil {
+			t.Errorf("%s \"\" was accepted: harness=%q project=%q role=%q session=%q",
+				flag, o.Harness, o.Project, o.Role, o.Session)
+			continue
+		}
+		if !strings.Contains(err.Error(), flag) {
+			t.Errorf("%s: error does not name the flag: %v", flag, err)
+		}
+	}
+	// The control: real values still parse, and a flag left out stays unset.
+	o, err := parseSearch([]string{"retry", "--harness", "claude", "--role", "user"})
+	if err != nil {
+		t.Fatalf("parseSearch with real values: %v", err)
+	}
+	if o.Harness != "claude" || o.Role != "user" || o.Project != "" {
+		t.Errorf("harness=%q role=%q project=%q", o.Harness, o.Role, o.Project)
+	}
+}
+
+// `deja last` parses its own flags, and had the same hole.
+func TestLastFlagsRefuseAnEmptyValue(t *testing.T) {
+	for _, flag := range []string{"--harness", "--project", "--role", "--from"} {
+		if _, _, _, err := parseLast([]string{flag, ""}); err == nil {
+			t.Errorf("last %s \"\" was accepted", flag)
+		}
+	}
+	if _, o, _, err := parseLast([]string{"--harness", "claude"}); err != nil || o.Harness != "claude" {
+		t.Errorf("last --harness claude = %q, %v", o.Harness, err)
+	}
+}

--- a/cmd/deja/empty_filter_value_test.go
+++ b/cmd/deja/empty_filter_value_test.go
@@ -42,3 +42,22 @@ func TestLastFlagsRefuseAnEmptyValue(t *testing.T) {
 		t.Errorf("last --harness claude = %q, %v", o.Harness, err)
 	}
 }
+
+// The other four parsers had the same block. Review found them after the first
+// fix landed on `deja` and `deja last` only (#1612).
+func TestEveryFilterParserRefusesAnEmptyValue(t *testing.T) {
+	if _, err := parseShow([]string{"abc", "--harness", ""}); err == nil {
+		t.Error("show --harness \"\" was accepted")
+	}
+	if _, err := parseShow([]string{"abc", "--harness", "claude"}); err != nil {
+		t.Errorf("show --harness claude: %v", err)
+	}
+	for _, flag := range []string{"--harness", "--project"} {
+		if _, _, _, err := parseBlame([]string{"main.go", flag, ""}); err == nil {
+			t.Errorf("blame %s \"\" was accepted", flag)
+		}
+	}
+	if _, _, _, err := parseBlame([]string{"main.go", "--harness", "claude"}); err != nil {
+		t.Errorf("blame --harness claude: %v", err)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -534,6 +534,10 @@ func parseShow(args []string) (showOptions, error) {
 				return o, fmt.Errorf("%s needs value", a)
 			}
 			i++
+			if strings.TrimSpace(args[i]) == "" {
+				// Empty is how "no filter" is spelled inside deja (#1612).
+				return o, fmt.Errorf("%s needs value", a)
+			}
 			if a == "--harness" {
 				o.harness = args[i]
 				continue
@@ -1804,6 +1808,10 @@ func parseBlame(args []string) (string, search.BlameOptions, bool, error) {
 				return "", o, false, fmt.Errorf("%s needs value", a)
 			}
 			i++
+			if strings.TrimSpace(args[i]) == "" {
+				// Empty is how "no filter" is spelled inside deja (#1612).
+				return "", o, false, fmt.Errorf("%s needs value", a)
+			}
 			switch a {
 			case "--harness":
 				o.Harness = args[i]
@@ -2238,6 +2246,13 @@ func runForget(dir string, args []string) error {
 				return fmt.Errorf("forget: %s needs a value", args[i])
 			}
 			i++
+			// Empty is how "no filter" is spelled inside deja, and here it
+			// would widen a deletion rather than a search (#1612). --unforget
+			// keeps its own refusal, which asks for an id rather than offering
+			// the flags that forget instead of restoring.
+			if strings.TrimSpace(args[i]) == "" && args[i-1] != "--unforget" {
+				return fmt.Errorf("forget: %s needs a value", args[i-1])
+			}
 			switch args[i-1] {
 			case "--session":
 				o.Session = index.PastedSelector(args[i])

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1581,6 +1581,14 @@ func parseLast(args []string) (int, search.Options, string, error) {
 			}
 			i++
 			v := args[i]
+			// Empty is how "no filter" is spelled inside deja, so an empty
+			// argument reached the search as no filter at all and a scripted
+			// `--project "$PROJECT"` with the variable unset quietly returned
+			// the whole store (#1612). It is the same mistake as leaving the
+			// value off, so it gets the same sentence.
+			if strings.TrimSpace(v) == "" {
+				return n, o, sinceRaw, fmt.Errorf("%s needs value", a)
+			}
 			switch a {
 			case "--harness":
 				o.Harness = v
@@ -1706,6 +1714,14 @@ func parseSearch(args []string) (search.Options, error) {
 			}
 			i++
 			v := args[i]
+			// Empty is how "no filter" is spelled inside deja, so an empty
+			// argument reached the search as no filter at all and a scripted
+			// `--project "$PROJECT"` with the variable unset quietly returned
+			// the whole store (#1612). It is the same mistake as leaving the
+			// value off, so it gets the same sentence.
+			if strings.TrimSpace(v) == "" {
+				return o, fmt.Errorf("%s needs value", a)
+			}
 			switch a {
 			case "--harness":
 				o.Harness = v

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -83,6 +83,10 @@ func runStats(dir string, args []string) error {
 			}
 			v := args[i+1]
 			i++
+			if strings.TrimSpace(v) == "" {
+				// Empty is how "no filter" is spelled inside deja (#1612).
+				return fmt.Errorf("stats: %s needs value", args[i-1])
+			}
 			switch args[i-1] {
 			case "--harness":
 				options.Harness = v


### PR DESCRIPTION
Closes #1612.

`--harness ""`, `--project ""`, `--role ""` and `--session ""` were accepted and the filter dropped: empty is how "no filter" is spelled inside deja, so by the time `checkHarness` sees it, a flag that was typed and a flag that was never given look the same. The shape that produces it is `deja "$q" --project "$PROJECT"` with the variable unset — a whole-store answer that reads as a scoped one.

Both parsers had it. `parseLast` is a separate loop with the same block, and `deja last --project ""` behaved the same way; the fix and its test cover both.

No new wording: the parsers already say `--harness needs value` when the flag is last on the line, and an empty argument is that same mistake one character later.

Failing first:

```
--- FAIL: TestFilterFlagsRefuseAnEmptyValue
    --harness "" was accepted: harness="" project="" role="" session=""
    --project "" was accepted: …
--- FAIL: TestLastFlagsRefuseAnEmptyValue
    last --harness "" was accepted
```

Controls in both tests: real values still parse, and a flag left off stays unset — so this cannot pass by refusing filters in general.

Not touched: the MCP tools take the same fields as JSON, where an omitted key and `""` are also indistinguishable in Go. Fixing that means presence tracking on the argument structs, which is a bigger change than this one and belongs on its own.

The rest of item `[search-harness-unknown]` came back clean: `nosuch`, `cluade`, `claude,codex`, `claude codex`, `CLAUDE`, `Claude` and whitespace-padded names all exit 1 listing every harness deja knows.

## Review

First pass refuted the fix as incomplete, with a measurement:

> **🟡 risk: Incomplete fix — empty filter-flag values still accepted by 4 other parsers**
>
> The fix addresses parseSearch (line 1711) and parseLast (line 1578), but misses identical holes in:
> - cmd/deja/main.go:532 (parseShow) — --harness accepts empty value
> - cmd/deja/main.go:1802 (parseBlame) — --harness and --project accept empty values
> - cmd/deja/stats.go:80 (runStats) — --harness, --project, --since, --role accept empty values
> - cmd/deja/main.go:2236 (runForget) — --session and --project accept empty values
>
> Verified by binary: `deja blame --harness "" internal/search/search.go` searches all 40 indexed sessions instead of rejecting the empty filter.
>
> **TrimSpace approach is sound:** the guard checks `strings.TrimSpace(v) == ""` but assigns the original `v` (no silent trimming); it catches empty and whitespace-only values; legitimate whitespace-only harness/project/role names cannot exist (hardcoded names, filesystem paths).
>
> **Fix verified working for search and last:** both tests pass, `deja search --project "" test` and `deja last --harness ""` are rejected, `--harness claude` still accepted.

Closed in 5b8ab3ed. All four now refuse, each keeping its own phrasing (`stats: --harness needs value`, `forget: --project needs a value`):

```
$ deja blame --harness "" internal/search/search.go   → deja: --harness needs value
$ deja stats --harness ""                             → deja: stats: --harness needs value
$ deja show abc --harness ""                          → deja: --harness needs value
$ deja forget --project "" --dry-run                  → deja: forget: --project needs a value
```

One exception, and it is why `forget` needed care rather than the same line: `--unforget ""` keeps its own refusal — "--unforget needs an id", which deliberately does not offer `--project`/`--before`, since those forget rather than restore (`TestAnEmptyUnforgetAsksForAnId`). That test caught the guard the moment it was too broad.


Second pass — not refuted:

> **Code coverage — all filter parsers guarded:** parseShow (main.go:537), parseLast (1593), parseSearch (1726), parseBlame (1811), runForget (2253, exception for --unforget), runStats (stats.go:86). All guards use `strings.TrimSpace(v) == ""` correctly — catches whitespace-only, leaves real values unmodified.
>
> **--unforget exception:** correctly scoped; PastedSelector handles it separately and returns "needs an id"; whitespace-only values still rejected there.
>
> **Binary tests — all guards operational:** `search --harness ''`, `show id --harness ' '`, `blame file.go --project ''`, `stats --harness ''`, `forget --session '' --dry-run` all rejected; `forget --unforget ''` rejected with its own message.
>
> **Full test suite:** All tests pass.
>
> **Test file gaps:** parseBlame's empty `--since`, runStats and runForget have guards but no test.

Those three are covered in 3e848302 — `TestStatsAndForgetRefuseAnEmptyValue` drives `runStats` and `runForget` through a hermetic store and keeps the `--unforget` message as its control. Verified failing without the guards:

```
--- FAIL: TestEveryFilterParserRefusesAnEmptyValue
    show --harness "" was accepted
    blame --harness "" was accepted
--- FAIL: TestStatsAndForgetRefuseAnEmptyValue
```
