### PR TITLE
fix(ctx): open the session a short id-prefix names instead of denying it exists

### DIFF
--- a/cmd/deja/ctx_short_prefix_test.go
+++ b/cmd/deja/ctx_short_prefix_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// ctx reads an argument as an id only from six characters up, so a shorter
+// prefix fell through to the text search and came back "no session matches" —
+// about a session `deja show` opens on the same prefix (#1614).
+func TestCtxOpensAShortIdPrefix(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(sid, ts string) string {
+		return `{"type":"user","message":{"role":"user","content":"pool exhausted"},"timestamp":"` + ts + `","sessionId":"` + sid + `","cwd":"/proj"}` + "\n"
+	}
+	for _, s := range []struct{ id, ts string }{
+		{"ffff3333-1111-4000-8000-d6e7f8a9b0c1", "2026-07-01T10:00:00Z"},
+		{"abc12aaa-2222-4000-8000-d6e7f8a9b0c1", "2026-07-02T10:00:00Z"},
+	} {
+		if err := os.WriteFile(filepath.Join(store, s.id+".jsonl"), []byte(line(s.id, s.ts)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "ctx", "ffff")
+	if err != nil {
+		t.Fatalf("ctx ffff: %v", err)
+	}
+	if !strings.Contains(out, "ffff3333-1111-4000-8000-d6e7f8a9b0c1") {
+		t.Errorf("ctx did not open the session the prefix names:\n%s", out)
+	}
+	// The control: a short word that names no session is still a miss, and
+	// still says so.
+	if _, err := captureRun(t, "ctx", "zqx"); err == nil {
+		t.Error("ctx zqx was answered, so the id fallback swallowed a real miss")
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -577,6 +577,32 @@ func parseShow(args []string) (showOptions, error) {
 	return o, nil
 }
 
+// ctxFromIDPrefix answers from the session an id-prefix names, and reports
+// whether it did. Six characters is where cmdCtx starts reading an argument as
+// an id at all — below that a token is far likelier to be a word — so this also
+// runs after the text search comes up empty, where there is no answer left to
+// shadow (#1614).
+func ctxFromIDPrefix(dir, q string) (bool, error) {
+	s, ok, err := findByPrefix(dir, q)
+	if err != nil || !ok {
+		return false, err
+	}
+	// Every other reading surface stops here when a rule denies the session's
+	// origin; ctx handed the whole session over, and it is the command the hook
+	// tells an agent to call (#1026).
+	if kept, hidden := policyFilterSessionsCounted(policy.ActivationSearch, []model.Session{s}); len(kept) == 0 {
+		fmt.Fprint(os.Stderr, policyHiddenNote(policy.ActivationSearch, hidden))
+		return false, fmt.Errorf("no session matches %q", q)
+	}
+	// The one command an agent is told to call — the hook's lead line names
+	// recall_context — answered from one of several sessions behind an elided
+	// id without saying it was a choice, while show, share, resume, promote,
+	// forget and handoff all said so (#923).
+	noteAmbiguousPrefix(dir, q, "answering from")
+	search.PrintContext(os.Stdout, s, "")
+	return true, nil
+}
+
 func cmdCtx(dir string, rest []string) error {
 	if len(rest) < 1 {
 		return idPrefixNeeded(dir, "ctx needs a query or an id-prefix",
@@ -593,25 +619,9 @@ func cmdCtx(dir string, rest []string) error {
 	}
 	q := strings.Join(rest, " ")
 	if !strings.Contains(q, " ") && len(q) >= 6 {
-		s, ok, err := findByPrefix(dir, q)
-		if err != nil {
+		done, err := ctxFromIDPrefix(dir, q)
+		if err != nil || done {
 			return err
-		}
-		if ok {
-			// Every other reading surface stops here when a rule denies the
-			// session's origin; ctx handed the whole session over, and it is
-			// the command the hook tells an agent to call (#1026).
-			if kept, hidden := policyFilterSessionsCounted(policy.ActivationSearch, []model.Session{s}); len(kept) == 0 {
-				fmt.Fprint(os.Stderr, policyHiddenNote(policy.ActivationSearch, hidden))
-				return fmt.Errorf("no session matches %q", q)
-			}
-			// The one command an agent is told to call — the hook's lead line
-			// names recall_context — answered from one of several sessions
-			// behind an elided id without saying it was a choice, while show,
-			// share, resume, promote, forget and handoff all said so (#923).
-			noteAmbiguousPrefix(dir, q, "answering from")
-			search.PrintContext(os.Stdout, s, "")
-			return nil
 		}
 	}
 	o := search.Options{Query: nfcfold.Compose(q), All: true}
@@ -670,6 +680,19 @@ func cmdCtx(dir string, rest []string) error {
 	attachLifecycles(dir, hits)
 	demoteRejected(hits)
 	if len(hits) == 0 {
+		// A prefix shorter than six characters never reached the id branch
+		// above, so a session `deja show` opens on the same argument was
+		// reported as no session at all (#1614). The query has already failed
+		// here, so there is no answer for the id to shadow.
+		if !strings.Contains(q, " ") && len(q) < 6 {
+			done, ferr := ctxFromIDPrefix(dir, q)
+			if ferr != nil {
+				return ferr
+			}
+			if done {
+				return nil
+			}
+		}
 		// Same as #834 in files and restore: an empty store is not a miss on
 		// the query.
 		if n, cerr := index.SessionCount(dir); cerr == nil && n == 0 {


### PR DESCRIPTION
Closes #1614.

`ctx` reads an argument as an id-prefix only from six characters up. A shorter one fell through to the text search, found nothing, and returned `no session matches "ffff"` — about a session `deja show ffff` opens on the same argument.

The threshold itself is right and stays: a three-letter token really is likelier a word than an id, and ctx is the command an agent is told to call with a sentence. What was missing is the case where the query path then finds nothing. The id lookup now runs there too — after the search has failed, so it cannot shadow an answer — and the branch that was inline in `cmdCtx` is a small function both paths call, policy filter and ambiguity note included.

```
$ deja ctx ffff       → # deja context: claude · tmp/hunt · ffff3333-…
$ deja ctx abc12      → deja: 2 sessions match "abc12" — answering from the most recent
$ deja ctx zqx        → deja: no session matches "zqx"        (exit 1, unchanged)
$ deja ctx retry      → answers the word, unchanged
```

Failing first:

```
--- FAIL: TestCtxOpensAShortIdPrefix
    ctx ffff: no session matches "ffff"
```

Its control is in the same test: `ctx zqx` must still fail, so the fallback cannot pass by answering everything.

The rest of item `[search-session-flag]` came back clean: `--session abc12` returns both sessions sharing the prefix, which is right for a filter rather than a selector, and `--session nosuch` says so plainly.

## Review

> No issues.
>
> **Extraction correctness:** `ctxFromIDPrefix` precisely matches the original inline code — same `findByPrefix`, `policyFilterSessionsCounted` with `policy.ActivationSearch`, error handling, `noteAmbiguousPrefix`, and `search.PrintContext` calls. Output streams (stderr for policy notes, stdout for context) preserved exactly.
>
> **Fallback placement:** Runs only after `attachLifecycles` and `demoteRejected`, and only when `len(hits) == 0`. Cannot resurrect a user-rejected session (rejected sessions remain in the demoted list, so hits won't be empty).
>
> **Guard conditions:** gated by `!strings.Contains(q, " ") && len(q) < 6` — multi-word queries never trigger it, and the >= 6 char path still uses the original code path (confirmed by testing `ctx abc12a`).
>
> **Test validation:** fails without the fix (tested against the parent commit), passes with it; the control `ctx zqx` still rejects; full suite passes.
>
> **Binary testing with fixture store:** `ctx ffff` (4 chars) opens via fallback; `ctx abc12` (5 chars) via fallback; `ctx abc12a` (6 chars) via the original path; `ctx xyz` correctly fails; `ctx "abc retry"` multi-word correctly fails (no fallback).
>
> **MCP/hooks:** `recall_context` uses a completely separate search path. No impact from this change.
>
> **Measured edge cases:** empty store, moved bucket hint, ambiguous prefixes and the existing error messages all handled in the correct order after a failed fallback.
