### PR TITLE
fix(json): a stemmed answer reports the stemmed tier, not close

### DIFF
--- a/cmd/deja/json_stemmed_tier_test.go
+++ b/cmd/deja/json_stemmed_tier_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// docs/json-output.md tells a consumer to branch on the envelope's tier and
+// lists "stemmed" among its values. Retrieval reports the coarse "close"
+// alongside a stemmed flag, and that overwrote the finer name — so a word form
+// and a misspelling, which deja narrates differently on stderr, arrived as the
+// same tier (#1616).
+func TestStemmedAnswerReportsTheStemmedTier(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"the retry loop keeps firing"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"s1a2b3c4-1111-4000-8000-d6e7f8a9b0c1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s1a2b3c4-1111-4000-8000-d6e7f8a9b0c1.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(filepath.Join(tmp, "index.db"), "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	tierOf := func(q string) string {
+		t.Helper()
+		out, err := captureRun(t, "--json", "--no-embed", q)
+		if err != nil {
+			t.Fatalf("%s: %v", q, err)
+		}
+		var env struct {
+			Tier    string `json:"tier"`
+			Stemmed bool   `json:"stemmed"`
+			Fuzzy   bool   `json:"fuzzy"`
+		}
+		if err := json.Unmarshal([]byte(out), &env); err != nil {
+			t.Fatalf("%s: %v\n%s", q, err, out)
+		}
+		if q == "retries" && !env.Stemmed {
+			t.Fatalf("retries was not answered by stemming, so the test measured nothing:\n%s", out)
+		}
+		return env.Tier
+	}
+	if got := tierOf("retries"); got != "stemmed" {
+		t.Errorf("a word form reports tier %q, not the documented \"stemmed\"", got)
+	}
+	// The controls: a misspelling is still close, and an exact hit is exact.
+	if got := tierOf("retyr"); got != "close" {
+		t.Errorf("a misspelling reports tier %q, not \"close\"", got)
+	}
+	if got := tierOf("retry"); got != "exact" {
+		t.Errorf("an exact hit reports tier %q", got)
+	}
+}

--- a/cmd/deja/json_stemmed_tier_test.go
+++ b/cmd/deja/json_stemmed_tier_test.go
@@ -47,8 +47,35 @@ func TestStemmedAnswerReportsTheStemmedTier(t *testing.T) {
 		}
 		return env.Tier
 	}
+	hitTierOf := func(q string) string {
+		t.Helper()
+		out, err := captureRun(t, "--json", "--no-embed", q)
+		if err != nil {
+			t.Fatalf("%s: %v", q, err)
+		}
+		var env struct {
+			Hits []struct {
+				Tier string `json:"tier"`
+			} `json:"hits"`
+		}
+		if err := json.Unmarshal([]byte(out), &env); err != nil {
+			t.Fatalf("%s: %v\n%s", q, err, out)
+		}
+		if len(env.Hits) == 0 {
+			t.Fatalf("%s returned no hits, so the test measured nothing:\n%s", q, out)
+		}
+		return env.Hits[0].Tier
+	}
 	if got := tierOf("retries"); got != "stemmed" {
 		t.Errorf("a word form reports tier %q, not the documented \"stemmed\"", got)
+	}
+	// The envelope's tier and the hit's are the same idea at two scopes, so a
+	// consumer must not read one thing in the envelope and another in the hit.
+	if got := hitTierOf("retries"); got != "stemmed" {
+		t.Errorf("the hit reports tier %q while the envelope says stemmed", got)
+	}
+	if got := hitTierOf("retyr"); got != "close" {
+		t.Errorf("the hit for a misspelling reports tier %q, not \"close\"", got)
 	}
 	// The controls: a misspelling is still close, and an exact hit is exact.
 	if got := tierOf("retyr"); got != "close" {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -199,10 +199,10 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 		if !cut.IsZero() && s.Updated.Before(cut) {
 			continue
 		}
-		tier := o.Tier
-		if tier == "" {
-			tier = TierExact
-		}
+		// The same name the envelope carries: docs/json-output.md calls them the
+		// same idea at two scopes, and an agent reading a hit gets the tier from
+		// here (#1616).
+		tier := setTier(o)
 		doc := bm25Document{hit: Hit{Session: s, Tier: tier}, termCount: make([]int, len(qtoks)), userCount: make([]int, len(qtoks))}
 		if s.Title != "" && len(qtoks) > 0 {
 			titleLow := strings.ToLower(s.Title)
@@ -248,7 +248,7 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 			}
 			if c > 0 {
 				doc.hit.Count += c
-				if doc.hit.Tier == TierClose && doc.hit.TierDetail == "" {
+				if (doc.hit.Tier == TierClose || doc.hit.Tier == TierStemmed) && doc.hit.TierDetail == "" {
 					doc.hit.TierDetail = variantDetail(m.Text, qtoks, o.FuzzyVariants)
 				}
 				// Collect every matching message with its match count; the

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -375,6 +375,12 @@ func setTier(o Options) string {
 	switch {
 	case o.Semantic:
 		return TierSemantic
+	// Retrieval reports the coarse "close" for everything below exact and marks
+	// stemming with its own flag. Taking its word overwrote the finer name, so
+	// a word form and a misspelling — two rungs deja narrates differently —
+	// arrived at a consumer as the same tier (#1616).
+	case o.Stemmed && (o.Tier == "" || o.Tier == TierClose):
+		return TierStemmed
 	case o.Tier != "":
 		return o.Tier
 	case o.Stemmed:


### PR DESCRIPTION
Closes #1616.

`docs/json-output.md` tells a consumer to branch on the envelope's `tier` and lists `stemmed` among its values. It never came out of the binary: retrieval reports the coarse `close` for everything below exact and marks stemming with a separate flag, and `setTier` preferred the explicit tier over the flag. So a word form and a misspelling — the two rungs deja narrates apart on stderr — arrived as the same tier.

```
$ deja --no-embed retries   → deja: no exact match, trying word forms: retries -> retry
$ deja --no-embed retyr     → deja: no exact match, trying close spellings: retyr -> retry

before:  retries → tier close     retyr → tier close
after:   retries → tier stemmed   retyr → tier close
```

`setTier` already produced `TierStemmed` and `internal/search/json_signal_test.go` pinned it; the value simply never survived the CLI handing retrieval's tier back in. The version-1 booleans (`stemmed`, `fuzzy`) are untouched.

Failing first:

```
--- FAIL: TestStemmedAnswerReportsTheStemmedTier
    a word form reports tier "close", not the documented "stemmed"
```

Two controls in the same test — a misspelling must stay `close`, an exact hit must stay `exact` — so this cannot pass by renaming the tier everywhere. The test also fails loudly if the fixture stops being answered by stemming at all.

This is a visible change to `--json` for anyone currently reading `close` on stemmed answers, even though the schema documents the value.

Two questions for you rather than a silent decision, both product-facing:

1. Each hit's own `tier` still says `close` for a stemmed hit, and the doc says the envelope's tier and the hit's are the same idea at two scopes. Should the hit follow?
2. The result line prints `— 2 matches · close (retries->retry)` for a word form. Same conflation on the human surface. Changing it changes what a reader sees, so I left the word alone.

## Review

> **Testing verification:** the new test correctly fails without the fix (gets "close" instead of "stemmed"); passes with it; full suite passes; the binary reports "stemmed" for stemmed queries, "close" for fuzzy, "exact" for exact.
>
> **Logic of the fix:** the new case gates on `o.Stemmed && (o.Tier == "" || o.Tier == TierClose)` — only fires where stemming produced a match retrieval reported as close, and does not interfere with error, relevance or semantic. No hardcoded string comparisons against "close" exist, so silent branch changes are not a risk.
>
> **Issue found — 🟡 risk: Envelope and per-hit tier inconsistency.** After the fix the envelope says `"stemmed"` while each hit still says `"close"` (set from `o.Tier` in `runScored()`). The docs state the two are "the same idea at two scopes"; that invariant is now violated, and MCP clients receive per-hit tiers (`cmd/deja/mcp.go:477`).
>
> **Proper fix:** update the per-hit tier in `runScored()` to mirror `setTier()`.

Closed in cc33d51a — `runScored` now takes its tier from `setTier` like the envelope does, and the detail that used to be attached only to close hits (`retries->retry`) is attached to stemmed ones as well, so nothing is lost:

```
retries  envelope stemmed  hit stemmed  retries->retry
retyr    envelope close    hit close    retyr->retry
retry    envelope exact    hit exact
```

That answers question 1 above. It also decides question 2 by consequence, and this is the part to look at: the result line now reads

```
— 2 matches · stemmed (retries->retry)
```

where it used to read `close (retries->retry)`. The label prints the hit's tier verbatim, so consistency in the machine contract moves the human word too. `stemmed` appears nowhere else on the human surface — stderr says "trying word forms" — so if you want a different word there, or the old one, it is a one-line change in `tierLabel`.


Second pass — no issues:

> 1. **Necessity confirmed**: reverted to 017208ee, ran the test, it failed with "the hit reports tier 'close' while the envelope says stemmed".
> 2. **Fix validation**: restored cc33d51a, test passes; all 26 test packages pass.
> 3. **Case coverage verified**: `setTier()` handles every input path — semantic → TierSemantic; `TierError`/`TierRelevance` with Stemmed false unchanged; `TierClose` + Stemmed → TierStemmed; `""` + Stemmed → TierStemmed; an explicit tier returned as-is. Callers in main.go and mcp.go all set `o.Tier` before `search.Run()`.
> 4. **TierDetail condition safe**: the expanded condition fires for both misspellings and word forms; `variantDetail()` returns non-empty only when a variant exists in the map, so no false positives.
> 5. **Product-facing output correct**: `retries` → envelope and hit `stemmed`, line reads `stemmed (retries->retry)`; `retyr` → both `close`, line `close (retyr->retry)`; `retry` → both `exact`, no detail.
> 6. **Contract consistency**: envelope and per-hit tier now agree; MCP consumers reading either scope get consistent values.
