### PR TITLE
fix(last): a bare argument that is not a count is refused, not ignored

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -390,7 +390,9 @@ func TestRunDispatchAdditionalCommands(t *testing.T) {
 	if out, err := captureRun(t, "ctx", "claude"); err != nil || !strings.Contains(out, "# deja context:") {
 		t.Fatalf("ctx prefix out=%q err=%v", out, err)
 	}
-	if out, err := captureRun(t, "last", "bad"); err != nil || !strings.Contains(out, "claude") {
+	// A bare argument that is not a count used to be dropped in silence, which
+	// answered `deja last api-gateway` with every project (#1618).
+	if out, err := captureRun(t, "last", "bad"); err == nil || !strings.Contains(err.Error(), "is not a count") {
 		t.Fatalf("last bad n out=%q err=%v", out, err)
 	}
 	if err := run([]string{"show", "no-such-prefix"}); err == nil || !strings.Contains(err.Error(), "no session matches") {

--- a/cmd/deja/last_count_test.go
+++ b/cmd/deja/last_count_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// `deja last` took its count from the first bare argument that parsed as a
+// number and dropped everything else without a word, so `deja last api-gateway`
+// — the filter spelled `--project api-gateway` in the help — returned the
+// default ten sessions from every project (#1618).
+func TestLastRefusesAnArgumentThatIsNotACount(t *testing.T) {
+	for _, arg := range []string{"abc", "api-gateway", "0", "3.5"} {
+		n, _, _, err := parseLast([]string{arg})
+		if err == nil {
+			t.Errorf("last %q was accepted and left the count at %d", arg, n)
+			continue
+		}
+		if !strings.Contains(err.Error(), arg) {
+			t.Errorf("last %q: the refusal does not name what was typed: %v", arg, err)
+		}
+	}
+	// The controls: a real count still works, with or without flags, and an
+	// omitted count keeps the default.
+	if n, _, _, err := parseLast([]string{"3"}); err != nil || n != 3 {
+		t.Errorf("last 3 = %d, %v", n, err)
+	}
+	if n, o, _, err := parseLast([]string{"3", "--project", "api"}); err != nil || n != 3 || o.Project != "api" {
+		t.Errorf("last 3 --project api = %d, %q, %v", n, o.Project, err)
+	}
+	if n, _, _, err := parseLast(nil); err != nil || n != 10 {
+		t.Errorf("last = %d, %v; want the default 10", n, err)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1637,12 +1637,18 @@ func parseLast(args []string) (int, search.Options, string, error) {
 			if strings.HasPrefix(a, "-") {
 				return n, o, sinceRaw, fmt.Errorf("last: unknown flag %q", a)
 			}
-			if !seenN {
-				if x, err := strconv.Atoi(a); err == nil {
-					n = x
-					seenN = true
-				}
+			// The only bare argument last takes is the count. Dropping anything
+			// else in silence answered `deja last api-gateway` — the filter the
+			// help spells `--project api-gateway` — with ten sessions from every
+			// project and no sign the word did nothing (#1618).
+			x, err := strconv.Atoi(a)
+			if err != nil || x < 1 {
+				return n, o, sinceRaw, fmt.Errorf("last: %q is not a count — use `deja last 5`, or --project/--harness to narrow", a)
 			}
+			if seenN {
+				return n, o, sinceRaw, fmt.Errorf("last takes one count, got %d and %q", n, a)
+			}
+			n, seenN = x, true
 		}
 	}
 	return n, o, sinceRaw, nil

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -310,9 +310,11 @@ func TestLastParserAndSourceFilters(t *testing.T) {
 	if raw != "7d" {
 		t.Fatalf("sinceRaw = %q, want the flag as typed", raw)
 	}
-	n, o, raw, err = parseLast([]string{"bad"})
-	if err != nil || n != 10 || o.Harness != "" || o.Project != "" || raw != "" {
-		t.Fatalf("parseLast compatibility = n:%d options:%#v raw:%q err:%v", n, o, raw, err)
+	// The count is the only bare argument last takes. Ignoring anything else
+	// left the reader with the default ten from every project and no sign that
+	// the word they typed did nothing (#1618).
+	if _, _, _, err := parseLast([]string{"bad"}); err == nil || !strings.Contains(err.Error(), "is not a count") {
+		t.Fatalf("parseLast bad count err=%v", err)
 	}
 	if _, _, _, err := parseLast([]string{"--unknown"}); err == nil || !strings.Contains(err.Error(), "unknown flag") {
 		t.Fatalf("parseLast unknown flag err=%v", err)


### PR DESCRIPTION
Closes #1618.

`deja last` took its count from the first bare argument that parsed as a number and dropped everything else without a word. So `deja last api-gateway` — the filter the help spells `--project api-gateway` — came back with the default ten sessions from every project, which reads exactly like ten from the project you asked for. `last 0` returned the whole store while `--limit 0` exits 1, and a second count was dropped in silence.

```
$ deja last abc          → deja: last: "abc" is not a count — use `deja last 5`, or --project/--harness to narrow
$ deja last 0            → the same refusal
$ deja last 3 3          → deja: last takes one count, got 3 and "3"
$ deja last 3            → 3 sessions, unchanged
$ deja last --project tmp/alpha   → 6 sessions, unchanged
```

Failing first:

```
--- FAIL: TestLastRefusesAnArgumentThatIsNotACount
    last "abc" was accepted and left the count at 10
    last "api-gateway" was accepted and left the count at 10
    last "0" was accepted and left the count at 0
    last "3.5" was accepted and left the count at 10
```

with controls in the same test: `last 3`, `last 3 --project api` and the bare default must all still work.

Two existing tests pinned the old leniency — `coverage_extra_test.go` and the case labelled "parseLast compatibility" in `main_test.go`, both dating to #121 where the filters were added. That was preserved leniency rather than a documented promise: the argument it tolerated never did anything. Both now assert the refusal, with the reason next to them.

New wording, so it is yours to keep or change: `last: "abc" is not a count — use `deja last 5`, or --project/--harness to narrow`. It points at the two things the reader probably meant.

Worth naming plainly: this turns a silently-ignored argument into exit 1, so a script that passes a stray word to `deja last` now fails instead of quietly returning the default.

## Review

> No issues.
>
> **Callers of `deja last` with bare arguments:** searched shell completions (bash, zsh, fish only show flags), skills/, extensions/, .github/, cmd/deja/, scripts/. Zero callers pass a non-numeric bare argument. The only invocation in e2e.sh is `deja last 5`.
>
> **`deja log` parser:** its own implementation in cmd/deja/log.go:30–38. Already rejects non-numeric arguments as "unknown flag" per d43623ec (#734). Does not share the old `parseLast` hole; no fix needed there.
>
> **Test coverage:** the old assertions pinned the bug (since #121, labelled "compatibility"). Both rewrites now check that `deja last bad` fails with "is not a count"; the new test covers "abc", "api-gateway", "0", "3.5" and the controls.
>
> **Boundary cases tested with the binary:** `0` and `00` rejected; `+3` accepted as 3; `007` accepted as 7 (decimal, not octal); `999999` accepted; count before or after flags accepted; `--project 5` consumes the 5 as the project rather than the count; `3 5` rejected; `3.5` rejected.
>
> **Proof of failure without fix:** reverted main.go to the parent, the new test failed on all four inputs; restored, it passes.
>
> **Full suite:** `go test ./...` passes all packages.
