### PR TITLE
fix(id): an id pasted in the other case opens the session it names

### DIFF
--- a/internal/index/find_case_test.go
+++ b/internal/index/find_case_test.go
@@ -1,0 +1,51 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A uuid is case-insensitive by RFC 4122 and harnesses print it either way, so
+// an id pasted in the other case is still that id. Every lookup here compared
+// bytes, and deja answered "no session matches" about a session it holds and
+// prints that id for (#1620).
+func TestFindByPrefixResolvesAnIdInTheOtherCase(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const id = "abcd1234-0001-4a1b-9c2d-000000000001"
+	body := `{"type":"user","timestamp":"2026-07-21T10:00:00Z","message":{"role":"user","content":"the pool work"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, id+".jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The precondition: the id as stored resolves.
+	if s, ok, err := FindByPrefix(dir, "abcd1234"); err != nil || !ok || s.ID != id {
+		t.Fatalf("the id as stored: %q ok=%v err=%v", s.ID, ok, err)
+	}
+	for _, p := range []string{"ABCD1234", "AbCd1234", "ABCD1234-0001-4A1B-9C2D-000000000001"} {
+		s, ok, err := FindByPrefix(dir, p)
+		if err != nil {
+			t.Fatalf("%s: %v", p, err)
+		}
+		if !ok || s.ID != id {
+			t.Errorf("%s found %q (ok=%v); it is the same id in another case", p, s.ID, ok)
+		}
+	}
+	// The control: a prefix that names nothing still names nothing.
+	if _, ok, err := FindByPrefix(dir, "ZZZZ9999"); err != nil || ok {
+		t.Errorf("ZZZZ9999 resolved (ok=%v, err=%v); case folding must not match everything", ok, err)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1446,11 +1446,30 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 			}
 		}
 	}
+	// Last, and only when every exact form found nothing: the same id in the
+	// other case. A uuid is case-insensitive by RFC 4122 and harnesses print it
+	// either way, so a pasted id was answered with "no session matches" about a
+	// session deja holds (#1620). Kept last because ids elsewhere are not all
+	// uuids — where case carries meaning, the exact match above has already won.
+	if len(matches) == 0 {
+		for _, meta := range m.Sessions {
+			if idFoldMatches(meta.ID, p) || (meta.OrigID != "" && idFoldMatches(meta.OrigID, p)) {
+				matches = append(matches, meta)
+			}
+		}
+	}
 	if len(matches) == 0 {
 		return model.Session{}, false, nil
 	}
 	sort.Slice(matches, func(i, j int) bool { return newestFirstMeta(matches[i], matches[j]) })
 	return loadSessionMeta(dir, m, matches[0])
+}
+
+// idFoldMatches is the prefix and loose tests with case ignored, for the last
+// rung of the ladder in FindByPrefix and PrefixMatches (#1620).
+func idFoldMatches(id, p string) bool {
+	lid, lp := strings.ToLower(id), strings.ToLower(p)
+	return strings.HasPrefix(lid, lp) || idLooselyMatches(lid, lp)
 }
 
 // PrefixMatches counts the sessions a prefix resolves to. FindByPrefix picks
@@ -1488,6 +1507,14 @@ func PrefixMatches(dir, p string) int {
 		// matches nothing and then watches it open (#853).
 		for _, meta := range m.Sessions {
 			if idLooselyMatches(meta.ID, p) {
+				n++
+			}
+		}
+	}
+	if n == 0 {
+		// Same last rung as the resolver: the id in the other case (#1620).
+		for _, meta := range m.Sessions {
+			if idFoldMatches(meta.ID, p) || (meta.OrigID != "" && idFoldMatches(meta.OrigID, p)) {
 				n++
 			}
 		}


### PR DESCRIPTION
Closes #1620.

`deja show AAAA0005` answered `no session matches` while `aaaa0005` opened the session. A uuid is case-insensitive by RFC 4122, harnesses print it either way, and `git show ABCDEF` resolves — so the sentence was false about a store that holds the session and prints that id for it.

`FindByPrefix` already walks a ladder: exact prefix, `OrigID`, a loose substring, the elided form a result line prints, the `harness:id` shape. Case is now the last rung, reached only when every exact form has found nothing. That ordering is the point: not every harness id is a uuid, and where case carries meaning the exact match above has already won.

`PrefixMatches` gets the same rung. #853 requires the count and the resolver to agree — a selector that opens a session while the count says zero is that bug with the sign flipped.

```
$ deja show AAAA0005                             → # claude · tmp/alpha · aaaa0005-…
$ deja show AAAA0005-1111-1111-1111-111111111111 → the same session
$ deja ctx AAAA0005 / deja resume AAAA0005       → same lookup, same fix
$ deja show ZZZZ9999                             → deja: no session matches "ZZZZ9999"   (exit 1)
```

Failing first:

```
--- FAIL: TestFindByPrefixResolvesAnIdInTheOtherCase
    ABCD1234 found "" (ok=false); it is the same id in another case
    AbCd1234 found "" (ok=false); it is the same id in another case
    ABCD1234-0001-4A1B-9C2D-000000000001 found "" (ok=false); it is the same id in another case
```

The test opens with the precondition that the id as stored resolves, and closes with the control that `ZZZZ9999` still resolves to nothing — so folding cannot pass by matching everything.

The rest of item `[show-missing]` is clean: an unknown id exits 1, `../etc/passwd` and `%s` are ordinary strings with no path or format surprise, and an ambiguous prefix says how many matched and that it took the most recent.

## Review

> **Checked thoroughly. No issues found.**
>
> **Destructive command safety (VERIFIED SAFE):** `forget --session AAAA0005` matches 0 sessions; `forget --session aaaa0005` matches 1. Destructive commands use `selectorMatches()`, which is case-sensitive (`strings.HasPrefix` + `idMatchesElided`) and does not go through `FindByPrefix` or the new `idFoldMatches`. No widening of destructive selectors.
>
> **Ladder logic (CORRECT):** case folding is the final rung, reached only when exact prefix, OrigID, substring/elided and harness:id all found nothing. For case-sensitive identifiers (`ses_…`, base62) the exact match wins first.
>
> **Collisions (NOT AN ISSUE):** uuids differing only in case are the same session by RFC 4122; folding only runs when zero exact matches exist, so nothing is shadowed. `PrefixMatches` and `FindByPrefix` keep their agreement (#853).
>
> **Test validation:** the new test fails without the fix and passes with it; the `ZZZZ9999` control matches nothing; `TestPrefixMatchesCounts` still passes; full suite green.
>
> **Performance:** a miss on the 1500-session fixture takes ~19 ms, no regression against the parent.
>
> **Binary validation:** `show AAAA0005` finds `aaaa0005`; `show aaaa0005` unchanged; `show ZZZZ9999` refuses.

That leaves one asymmetry, deliberate and worth naming: reading commands now resolve an id in either case, `forget` and `unforget` still require the exact one. It is the safe direction — a destructive selector should not widen — but it does mean `deja show AAAA0005` opens a session that `deja forget --session AAAA0005` will not touch. If you want them to agree, the change belongs in `selectorMatches` and needs its own thought about #855.
