### PR TITLE
fix(mcp): recall_context opens the session an id names

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -898,6 +898,42 @@ func recallContext(dir, q string) (string, error) {
 	return text, err
 }
 
+// idContext is what contextByID reports alongside the text: the session it
+// opened and what that session weighs, both of which the caller records.
+type idContext struct {
+	session string
+	size    int64
+}
+
+// contextByID answers from the session an id-prefix names, for the tool an
+// agent calls with whatever deja printed at it (#1622). Empty when the string
+// is not an id, when it names nothing, or when this machine's policy withholds
+// what it names.
+func contextByID(dir, q string) (string, idContext, bool) {
+	if strings.ContainsAny(q, " \t\n") {
+		return "", idContext{}, false
+	}
+	// index.FindByPrefix directly, never the CLI's findByPrefix: that one calls
+	// index.Ensure first and blocks on the index lock, and this path serves a
+	// client that cannot wait (mcp_no_block_test.go guards it). The resource
+	// reader resolves an id the same way.
+	s, ok, err := index.FindByPrefix(dir, q)
+	if err != nil || !ok {
+		return "", idContext{}, false
+	}
+	kept, _ := policyFilterSessionsCounted(policy.ActivationMCP, []model.Session{s})
+	if len(kept) == 0 {
+		return "", idContext{}, false
+	}
+	whole := kept[0]
+	if full, ok, ferr := wholeSessionForMCP(dir, whole); ferr == nil && ok {
+		whole = full
+	}
+	var b bytes.Buffer
+	search.PrintContext(&b, whole, "")
+	return b.String(), idContext{session: whole.ID, size: rawSize([]model.Session{whole})}, true
+}
+
 func recallContextResult(dir, q, harness string) (string, int, int64, []string, error) {
 	o := search.Options{Query: nfcfold.Compose(q), Harness: harness, All: true, RecallWorn: usage.WornSessions(dir)}
 	if stale, err := index.EnsureForSearchStale(dir, o, mcpProgress()); err != nil {
@@ -938,6 +974,15 @@ func recallContextResult(dir, q, harness string) (string, int, int64, []string, 
 		hits, _ = policyFilterHitsCounted(policy.ActivationMCP, hits)
 	}
 	if len(hits) == 0 {
+		// The words found nothing, so try the string as an id. Every line deja
+		// prints carries one, and `deja ctx <id>` opens the session it names —
+		// but the tool an agent is told to call took words only, and answered
+		// "no prior deja sessions matched" about a session deja holds (#1622).
+		// After the search, like the CLI does since #1614: there is no answer
+		// left for the id to shadow.
+		if text, id, ok := contextByID(dir, q); ok {
+			return text, 1, id.size, []string{id.session}, nil
+		}
 		return emptyRecallAnswerPolicy(dir, q, policyHidden), 0, 0, nil, nil
 	}
 	// The same order the search screen shows: this handed the agent a session

--- a/cmd/deja/mcp_ctx_by_id_test.go
+++ b/cmd/deja/mcp_ctx_by_id_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Every result line deja prints carries an id, and `deja ctx <id>` opens the
+// session it names. The MCP tool an agent is told to call took the same string
+// as words only, so an agent holding an id deja had just printed was told the
+// session does not exist (#1622).
+func TestRecallContextOpensASessionByID(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const id = "hhhh0001-1111-4000-8000-d6e7f8a9b0c1"
+	line := `{"type":"user","message":{"role":"user","content":"the pool exhausted again"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"` + id + `","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, q := range []string{"hhhh0001", id} {
+		text, n, _, ids, err := recallContextResult(dir, q, "")
+		if err != nil {
+			t.Fatalf("%s: %v", q, err)
+		}
+		if n != 1 || len(ids) != 1 || ids[0] != id {
+			t.Errorf("%s returned n=%d ids=%v; the id names one session\n%s", q, n, ids, text)
+			continue
+		}
+		if !strings.Contains(text, id) {
+			t.Errorf("%s: the context does not name the session:\n%s", q, text)
+		}
+	}
+	// The controls: words still answer, and a string that names nothing still
+	// comes back empty rather than opening something.
+	if _, n, _, _, err := recallContextResult(dir, "pool exhausted", ""); err != nil || n != 1 {
+		t.Errorf("words: n=%d err=%v", n, err)
+	}
+	if text, n, _, _, err := recallContextResult(dir, "zzzz9999", ""); err != nil || n != 0 {
+		t.Errorf("a string that names nothing returned n=%d err=%v:\n%s", n, err, text)
+	}
+}


### PR DESCRIPTION
Closes #1622.

Every line deja prints carries a session id, and `deja ctx <id>` opens the session it names. The MCP tool the hook tells an agent to call took the same string as words only, so an agent holding an id deja had just printed was told the session does not exist.

```
before:  recall_context {"query":"hhhh0001"} → No prior deja sessions matched "hhhh0001".
after:   recall_context {"query":"hhhh0001"} → # deja context: claude · tmp/huge · hhhh0001-…
         recall_context {"query":"retry backoff"} → unchanged, 8248 bytes
         recall_context {"query":"zzzz9999"}      → unchanged, still empty
```

The lookup runs after the search comes up empty, the same shape the CLI took in #1614: words keep priority — an agent asks in sentences — and there is no answer left for the id to shadow. Policy scoping applies to it (`ActivationMCP`), so a withheld session stays withheld.

One thing the repo's own guard caught, and it is the reason this is worth reading twice: the first attempt called the CLI's `findByPrefix`, and `mcp_no_block_test.go` failed with

```
mcp.go:916 reaches findByPrefix, which blocks on the index lock; this path serves a client that cannot wait
```

That helper runs `index.Ensure` first, which can rebuild the whole index inside the call. The handler now uses `index.FindByPrefix` directly, the way `mcpResourceRead` already resolves an id.

Failing first:

```
--- FAIL: TestRecallContextOpensASessionByID
    hhhh0001 returned n=0 ids=[]; the id names one session
    hhhh0001-1111-4000-8000-d6e7f8a9b0c1 returned n=0 ids=[]; the id names one session
```

with both controls in the same test: words still answer, and a string that names nothing still returns empty rather than opening something.

Not changed, and a question for you: the `recall` tool still takes words only. It answers with a hit list rather than a context block, so an id there would have to mean "the one session", which is what `recall_context` is for. Leaving it is defensible; making it resolve too is a one-line addition if you want the tools to share the vocabulary.

The item this came from — `[ctx-budget]` — is clean: a 4.4 MB session of 4000 messages gives 8097 bytes over 36 lines, and a session whose single message is 2.3 MB gives 8098 bytes.

## Review

> **Blocking behaviour verified:** `index.FindByPrefix` uses `tryLockDir` with `syscall.LOCK_NB` (lock_unix.go:70) and returns false rather than waiting; `policyFilterSessionsCounted` just calls `policy.Filter()`; `wholeSessionForMCP` → `index.FindByIdentity` is non-blocking too; `rawSize` is a pure loop; `search.PrintContext` writes to the `bytes.Buffer` it is given, not to stdout or stderr. No `index.Ensure` on this path. `TestNothingTheMCPServerServesUsesTheBlockingLookup` passes, scanning every mcp*.go for the blocking helper.
>
> **Policy filtering verified:** `contextByID` calls `policyFilterSessionsCounted(policy.ActivationMCP, …)`; a withheld session is filtered out and the function returns false.
>
> **JSON-RPC protocol:** driven against the real fixture — valid responses, multi-line context correctly escaped inside the JSON string, no stray writes.
>
> **Scope creep:** the `strings.ContainsAny(q, " \t\n")` guard keeps multi-word queries off the id path, and the word search runs first, so the id path only fires on zero hits. Measured: `"hhhh0001 the retry"` is answered by the text search; a single token `"1111"` with no text match resolves as an id prefix.
>
> **Counters:** returns `(text, 1, rawSize(whole), []string{whole.ID})`, the same shape the word path returns.
>
> **Test validation:** fails without the fix for both the prefix and the full uuid, passes with it; full suite (26 packages) green.
>
> **Not addressed, out of scope:** forgotten/tombstoned sessions — this path does not call `filterTombstoned`, but neither does the CLI when it resolves through `FindByPrefix`, and the MCP path has no way to emit `noteForgottenSource`.

That last point is worth a follow-up of its own rather than a change here: `deja ctx` prints "this session was forgotten" alongside the answer, and an agent gets the context with no such line. Filed separately.
