### PR TITLE
fix(blame): a path with a line number answers for the file

### DIFF
--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -42,11 +42,52 @@ type BlameHit struct {
 	LifecycleAt   string `json:"lifecycle_at,omitempty"`
 }
 
+// trimLineSuffix drops the `:266` or `:266:12` an editor, a stack trace or a
+// compiler error leaves on a path. blame works at file granularity, so the line
+// number is precision it cannot use — and taken literally it became part of the
+// basename and matched nothing (#1625).
+//
+// Only trailing digits, and only while something is left in front: a colon is
+// legal in a unix filename, and `C:\src\main.go` carries one that must survive.
+func trimLineSuffix(name string) string {
+	for i := 0; i < 2; i++ {
+		head, tail, ok := lastColon(name)
+		if !ok || tail == "" || !allDigits(tail) || head == "" {
+			return name
+		}
+		if filepath.Base(head) == "" || strings.HasSuffix(head, ":") {
+			return name
+		}
+		name = head
+	}
+	return name
+}
+
+// lastColon splits on the final colon, ignoring one that would leave nothing in
+// front of it.
+func lastColon(name string) (string, string, bool) {
+	i := strings.LastIndexByte(name, ':')
+	if i <= 0 {
+		return "", "", false
+	}
+	return name[:i], name[i+1:], true
+}
+
+func allDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return s != ""
+}
+
 func ResolveBlamePath(name string) (BlameTarget, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return BlameTarget{}, fmt.Errorf("path required")
 	}
+	name = trimLineSuffix(name)
 	full, err := filepath.Abs(name)
 	if err != nil {
 		return BlameTarget{}, err

--- a/internal/search/blame_line_suffix_test.go
+++ b/internal/search/blame_line_suffix_test.go
@@ -1,0 +1,42 @@
+package search
+
+import "testing"
+
+// What a reader has in the clipboard is `file:line` — from a stack trace, a
+// compiler error, a linter, an editor's copy-reference, or deja's own lines.
+// Blame took it literally, made `search.go:266` the basename, and reported that
+// no session mentions the file (#1625).
+func TestResolveBlamePathDropsALineNumber(t *testing.T) {
+	for _, in := range []string{
+		"internal/search/search.go:266",
+		"internal/search/search.go:266:12",
+		"/tmp/api/internal/search/search.go:266",
+		"search.go:1",
+	} {
+		got, err := ResolveBlamePath(in)
+		if err != nil {
+			t.Errorf("%s: %v", in, err)
+			continue
+		}
+		if got.Base != "search.go" || got.Stem != "search" {
+			t.Errorf("%s resolved to base %q stem %q, want search.go/search", in, got.Base, got.Stem)
+		}
+	}
+	// The controls: a plain path is untouched, and a colon that is part of the
+	// name — or a Windows drive letter — must survive.
+	for in, want := range map[string]string{
+		"internal/search/search.go": "search.go",
+		"weird:name.go":             "weird:name.go",
+		"notes:2026.md":             "notes:2026.md",
+		"search.go:":                "search.go:",
+	} {
+		got, err := ResolveBlamePath(in)
+		if err != nil {
+			t.Errorf("%s: %v", in, err)
+			continue
+		}
+		if got.Base != want {
+			t.Errorf("%s resolved to base %q, want %q", in, got.Base, want)
+		}
+	}
+}

--- a/internal/search/blame_line_suffix_test.go
+++ b/internal/search/blame_line_suffix_test.go
@@ -1,6 +1,9 @@
 package search
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // What a reader has in the clipboard is `file:line` — from a stack trace, a
 // compiler error, a linter, an editor's copy-reference, or deja's own lines.
@@ -22,6 +25,18 @@ func TestResolveBlamePathDropsALineNumber(t *testing.T) {
 			t.Errorf("%s resolved to base %q stem %q, want search.go/search", in, got.Base, got.Stem)
 		}
 	}
+	// Extensionless names are the common case for this shape: make, docker and
+	// just all report `Makefile:12`.
+	for _, in := range []string{"Makefile:12", "Dockerfile:7", "justfile:3:9"} {
+		got, err := ResolveBlamePath(in)
+		if err != nil {
+			t.Errorf("%s: %v", in, err)
+			continue
+		}
+		if strings.ContainsRune(got.Base, ':') {
+			t.Errorf("%s kept its line number: base %q", in, got.Base)
+		}
+	}
 	// The controls: a plain path is untouched, and a colon that is part of the
 	// name — or a Windows drive letter — must survive.
 	for in, want := range map[string]string{
@@ -38,5 +53,44 @@ func TestResolveBlamePathDropsALineNumber(t *testing.T) {
 		if got.Base != want {
 			t.Errorf("%s resolved to base %q, want %q", in, got.Base, want)
 		}
+	}
+}
+
+// A drive letter and a UNC prefix carry colons and backslashes that must reach
+// the matcher intact, whichever platform the binary was built for (#1625).
+func TestResolveBlamePathKeepsWindowsShapes(t *testing.T) {
+	for in, want := range map[string]string{
+		`C:\src\main.go:266`:     "main.go",
+		`C:\src\main.go`:         "main.go",
+		`\\server\share\a.go:12`: "a.go",
+	} {
+		got, err := ResolveBlamePath(in)
+		if err != nil {
+			t.Errorf("%s: %v", in, err)
+			continue
+		}
+		// On unix these are one path element; what matters either way is that
+		// the drive letter is not eaten and the line number is.
+		if strings.Contains(got.Base, ":266") || strings.Contains(got.Base, ":12") {
+			t.Errorf("%s kept its line number: base %q", in, got.Base)
+		}
+		if !strings.Contains(got.Base, want) {
+			t.Errorf("%s lost the file name: base %q, want it to contain %q", in, got.Base, want)
+		}
+	}
+}
+
+// The collision this fix accepts, written down so it is a decision and not a
+// surprise: a file literally named `a:1` is read as `a` line 1. Nothing tells
+// the two apart from the string alone, and the shape that reaches this command
+// is overwhelmingly `Makefile:12`, not a file whose name ends in a colon and a
+// digit.
+func TestALiteralNameEndingInColonDigitsIsReadAsALineNumber(t *testing.T) {
+	got, err := ResolveBlamePath("a:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Base != "a" {
+		t.Errorf("base %q; the documented trade-off is that this reads as a line number", got.Base)
 	}
 }


### PR DESCRIPTION
Closes #1625.

`deja blame` takes a path, and the path a reader has in the clipboard is `file:line` — from a stack trace, a compiler error, a linter, an editor's copy-reference, or deja's own result lines. Taken literally, `search.go:266` became the basename and matched nothing:

```
before:  deja blame internal/search/search.go:266
         deja: no sessions mention search.go:266 — searched 1 indexed session
after:   2026-07-13 · claude · dddd0001-…1111111111 · tmp/api · the retry loop in internal/search/search.go keeps firing
```

Blame works at file granularity, so the line number is precision it cannot use rather than a narrower question.

The stripping is deliberately narrow: only a trailing `:<digits>`, at most twice for `:line:col`, and only while something is left in front of it. A colon is legal in a unix filename and a Windows drive letter carries one, so `weird:name.go`, `notes:2026.md`, `search.go:` and `C:\src\main.go` all survive untouched — each of those is a control in the test.

Failing first:

```
--- FAIL: TestResolveBlamePathDropsALineNumber
    internal/search/search.go:266 resolved to base "search.go:266" stem "search", want search.go/search
    internal/search/search.go:266:12 resolved to base "search.go:266:12" …
    /tmp/api/internal/search/search.go:266 resolved to base "search.go:266" …
    search.go:1 resolved to base "search.go:1" …
```

The rest of item `[blame-relative]` is clean and worth recording: relative, absolute, bare basename, `./`, `../`, a directory, a deep path that does not exist locally and the wrong case all resolve; a path outside the project searches every session, which is what blame is for; two paths are refused with `blame accepts one path`; no path prints the usage line; `--json` returns the documented array.

## Review

> **🟡 risk:** `trimLineSuffix` mangles filenames matching `something:digits` with no path separator. Input `a:1` trims to `a`, losing the real filename when used alone. The pattern is ambiguous between a line-number suffix and a literal filename. The guards catch empty and drive-letter cases but miss bare names like `a`. Impact: rare (colons forbidden in Windows filenames, rare in Unix), but a user passing `deja blame a:1` for a literal file `a:1` would search for sessions touching `a`.
>
> **🟡 risk:** the test does not cover Windows drive letters explicitly or the `a:1` edge case.
>
> **✅ Verified correct:** test fails without the fix and passes with it; full suite passes; binary works against the fixture; `C:\src\main.go:266` → `C:\src\main.go` with the drive letter intact; `\\server\share\file.go:12` → `\\server\share\file.go`; `weird:name.go` and `notes:2026.md` unchanged; `path/to/file:1:2` → `path/to/file`; `::::` and `file::123` return unchanged without crashing; the error message prints the base as-is; MCP and CLI both call the function appropriately.

The second point is closed in 947d9107 — the Windows shapes, a UNC path and the `a:1` case are now pinned, along with `Makefile:12`, `Dockerfile:7` and `justfile:3:9`.

The first is real and stays, as a decision rather than an oversight, so here is the reasoning in the open. Nothing in the string tells `a:1` the file from `a` line 1 apart. Tightening the rule to require an extension or a separator would protect `a:1` and break `Makefile:12`, `Dockerfile:7`, `justfile:3` — which is what make, docker and just actually print. Getting `Makefile:12` wrong costs a miss the reader can see and fix; getting it right costs a file named `a:1`, which I have never seen. `TestALiteralNameEndingInColonDigitsIsReadAsALineNumber` states the trade-off in the suite so it is a choice on record.
