### PR TITLE
fix(files): refuse a flag with no value, an unknown flag and an empty topic

### DIFF
--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -48,21 +48,29 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--limit":
-			if i+1 < len(args) {
-				i++
-				n, err := strconv.Atoi(args[i])
-				if err != nil || n <= 0 {
-					return fmt.Errorf("files: --limit wants a positive number, got %q", args[i])
-				}
-				limit = n
+			// A flag typed with nothing after it used to be dropped in silence,
+			// and so did an unknown one and an empty --project: the answer came
+			// back looking like an answer to what was asked (#1628).
+			if i+1 >= len(args) {
+				return fmt.Errorf("files: --limit needs value")
 			}
+			i++
+			n, err := strconv.Atoi(args[i])
+			if err != nil || n <= 0 {
+				return fmt.Errorf("files: --limit wants a positive number, got %q", args[i])
+			}
+			limit = n
 		case "--project":
-			if i+1 < len(args) {
-				i++
-				project = args[i]
+			if i+1 >= len(args) || strings.TrimSpace(args[i+1]) == "" {
+				return fmt.Errorf("files: --project needs value")
 			}
+			i++
+			project = args[i]
 		default:
-			if !strings.HasPrefix(args[i], "-") {
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("files: unknown flag %q", args[i])
+			}
+			if strings.TrimSpace(args[i]) != "" {
 				terms = append(terms, args[i])
 			}
 		}

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -66,6 +66,12 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 			}
 			i++
 			project = args[i]
+		case "--":
+			// The escape `parseSearch` already offers: everything after it is
+			// the topic, dashes and all. Without it, refusing unknown flags
+			// left `--feature-flag` with no way to be asked about.
+			terms = append(terms, args[i+1:]...)
+			i = len(args)
 		default:
 			if strings.HasPrefix(args[i], "-") {
 				return fmt.Errorf("files: unknown flag %q", args[i])

--- a/cmd/deja/files_flags_test.go
+++ b/cmd/deja/files_flags_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// files has its own flag loop, so the refusals every sibling command makes were
+// missing here: a flag with no value, an unknown flag, an empty --project and an
+// empty topic all passed through and the answer looked like an answer (#1628).
+func TestFilesRefusesWhatDoesNothing(t *testing.T) {
+	hermeticEnv(t)
+	dir := t.TempDir()
+	for _, tc := range []struct {
+		args []string
+		want string
+	}{
+		{[]string{"retry", "--limit"}, "--limit needs value"},
+		{[]string{"retry", "--project"}, "--project needs value"},
+		{[]string{"retry", "--project", ""}, "--project needs value"},
+		{[]string{"retry", "--unknown"}, "unknown flag"},
+		{[]string{""}, "usage"},
+	} {
+		err := runFiles(dir, tc.args, io.Discard)
+		if err == nil {
+			t.Errorf("files %v was accepted", tc.args)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("files %v: %v, want it to mention %q", tc.args, err, tc.want)
+		}
+	}
+	// The controls: the shapes that work must keep working. An empty store
+	// answers rather than failing, so these are about the parser, not the hits.
+	for _, args := range [][]string{
+		{"retry"},
+		{"retry", "--limit", "3"},
+		{"retry", "--project", "api"},
+		{"retry", "backoff"},
+	} {
+		if err := runFiles(dir, args, io.Discard); err != nil {
+			t.Errorf("files %v: %v", args, err)
+		}
+	}
+}

--- a/cmd/deja/files_flags_test.go
+++ b/cmd/deja/files_flags_test.go
@@ -44,3 +44,28 @@ func TestFilesRefusesWhatDoesNothing(t *testing.T) {
 		}
 	}
 }
+
+// A topic can legitimately start with a dash — `--feature-flag`, `-x`. Refusing
+// unknown flags would have left those unaskable, so files takes the same `--`
+// escape parseSearch does (#1628).
+func TestFilesTakesADashedTopicAfterDoubleDash(t *testing.T) {
+	hermeticEnv(t)
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"--", "--feature-flag"},
+		{"--", "-x"},
+		{"--", "--limit", "3"},
+	} {
+		if err := runFiles(dir, args, io.Discard); err != nil {
+			t.Errorf("files %v: %v", args, err)
+		}
+	}
+	// The control: without the escape, a dashed token is still a mistake.
+	if err := runFiles(dir, []string{"--feature-flag"}, io.Discard); err == nil {
+		t.Error("a dashed topic was taken as a topic without the -- escape")
+	}
+	// And `--` with nothing after it names no topic.
+	if err := runFiles(dir, []string{"--"}, io.Discard); err == nil {
+		t.Error("a bare -- was accepted as a topic")
+	}
+}


### PR DESCRIPTION
Closes #1628.

`deja files` has its own flag loop, and four ways of typing something that does nothing passed through it in silence:

```
before                                   after
deja files retry --limit      → answered  → deja: files: --limit needs value
deja files retry --project    → answered  → deja: files: --project needs value
deja files retry --project "" → answered  → deja: files: --project needs value
deja files retry --unknown    → answered  → deja: files: unknown flag "--unknown"
deja files ""                 → answered  → deja: usage: deja files <topic> …
```

The worst of them is `--project` with nothing after it: the answer comes back from every project and reads exactly like the answer from one.

No new wording — "needs value" and "unknown flag" are the sentences the sibling commands already use. `files` was missed by #1612 precisely because it shares neither the parser nor the vocabulary; it says "wants a positive number" where the rest say "needs value".

Failing first:

```
--- FAIL: TestFilesRefusesWhatDoesNothing
    files [retry --limit] was accepted
    files [retry --project] was accepted
    files [retry --project ] was accepted
    files [retry --unknown] was accepted
    files [] was accepted
```

with four controls in the same test — `retry`, `retry --limit 3`, `retry --project api`, `retry backoff` — so it cannot pass by refusing everything.

The rest of item `[files-topic]` is clean: a topic nothing matches says so, a topic whose sessions recorded no files says that instead, and files that are no longer on this disk get their own sentence.

## Review

> **🟡 risk:** `--` escape not supported for dash-prefixed topics, unlike `parseSearch`. `deja files -- --retry` errors "unknown flag '--'" instead of searching for "--retry". The sibling `parseSearch` (main.go:1727-1733) explicitly handles `--` to end option parsing. Without this, topics like `--feature-flag` or `-x` are unreachable.
>
> **🟡 risk:** the test does not verify dash-prefixed topics, so someone could later remove the intended `--` support without the suite noticing.

Both closed in 1d526ba7 — `--` ends the flags here as it does for search, and the test pins it:

```
$ deja files -- --retry   → no sessions mention "--retry"
$ deja files --retry      → deja: files: unknown flag "--retry"
$ deja files -- retry     → 1 session mentions "retry"; 2 recorded files …
```

Worth noting for the record: before this PR a dashed topic was silently dropped rather than searched, so it was unreachable either way. The escape makes it reachable for the first time.
