### PR TITLE
fix(how): match the command as a word, and refuse a flag that does nothing

### DIFF
--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -42,21 +42,33 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--limit":
-			if i+1 < len(args) {
-				i++
-				n, err := strconv.Atoi(args[i])
-				if err != nil || n <= 0 {
-					return fmt.Errorf("how: --limit wants a positive number, got %q", args[i])
-				}
-				limit = n
+			// What was typed has to do something: a flag with nothing after it,
+			// an unknown flag and an empty argument all used to pass through in
+			// silence, the same holes files had (#1630, #1628).
+			if i+1 >= len(args) {
+				return fmt.Errorf("how: --limit needs value")
 			}
+			i++
+			n, err := strconv.Atoi(args[i])
+			if err != nil || n <= 0 {
+				return fmt.Errorf("how: --limit wants a positive number, got %q", args[i])
+			}
+			limit = n
 		case "--project":
-			if i+1 < len(args) {
-				i++
-				project = args[i]
+			if i+1 >= len(args) || strings.TrimSpace(args[i+1]) == "" {
+				return fmt.Errorf("how: --project needs value")
 			}
+			i++
+			project = args[i]
+		case "--":
+			// A command can start with a dash — `deja how -- -run`.
+			terms = append(terms, args[i+1:]...)
+			i = len(args)
 		default:
-			if !strings.HasPrefix(args[i], "-") {
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("how: unknown flag %q", args[i])
+			}
+			if strings.TrimSpace(args[i]) != "" {
 				terms = append(terms, args[i])
 			}
 		}
@@ -125,7 +137,7 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 		}
 		low := strings.ToLower(cmd)
 		for _, t := range terms {
-			if !strings.Contains(low, strings.ToLower(t)) {
+			if !commandMentions(low, strings.ToLower(t)) {
 				return
 			}
 		}
@@ -174,4 +186,40 @@ func pluralSessions(n int) string {
 		return "1 session"
 	}
 	return fmt.Sprintf("%d sessions", n)
+}
+
+// commandMentions is the membership test for `how`: the term has to appear in
+// the command as a word, not inside a longer one. A raw substring test answered
+// `how go` with `golangci-lint run ./...`, and ranked it first (#1630) — and the
+// short names are exactly the ones people ask about: go, gh, rg, jq, sed, cd.
+//
+// A word here ends at anything that is not a letter, a digit, an underscore or
+// a dash, so `go` matches `go test` and `/usr/local/bin/go` but not `golangci`.
+// A term that itself carries a separator (`go test`, `./x`) is matched as
+// written: it is already more specific than one word.
+func commandMentions(low, term string) bool {
+	if term == "" {
+		return false
+	}
+	if strings.ContainsFunc(term, func(r rune) bool { return !isCommandWordRune(r) }) {
+		return strings.Contains(low, term)
+	}
+	for at := 0; ; {
+		i := strings.Index(low[at:], term)
+		if i < 0 {
+			return false
+		}
+		i += at
+		beforeOK := i == 0 || !isCommandWordRune(rune(low[i-1]))
+		end := i + len(term)
+		afterOK := end == len(low) || !isCommandWordRune(rune(low[end]))
+		if beforeOK && afterOK {
+			return true
+		}
+		at = i + 1
+	}
+}
+
+func isCommandWordRune(r rune) bool {
+	return r == '_' || r == '-' || (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
 }

--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -193,8 +193,11 @@ func pluralSessions(n int) string {
 // `how go` with `golangci-lint run ./...`, and ranked it first (#1630) — and the
 // short names are exactly the ones people ask about: go, gh, rg, jq, sed, cd.
 //
-// A word here ends at anything that is not a letter, a digit, an underscore or
-// a dash, so `go` matches `go test` and `/usr/local/bin/go` but not `golangci`.
+// A word here ends at anything that is not a letter or a digit, so `go` matches
+// `go test` and `/usr/local/bin/go` but not `golangci` — and a dash or an
+// underscore is a boundary like any other, so `lint` still finds
+// `golangci-lint` and `node` still finds `node_modules`, which is how people
+// name the halves of a hyphenated tool.
 // A term that itself carries a separator (`go test`, `./x`) is matched as
 // written: it is already more specific than one word.
 func commandMentions(low, term string) bool {
@@ -221,5 +224,5 @@ func commandMentions(low, term string) bool {
 }
 
 func isCommandWordRune(r rune) bool {
-	return r == '_' || r == '-' || (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
 }

--- a/cmd/deja/how_match_test.go
+++ b/cmd/deja/how_match_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+func howFixture(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := func(cmd, ts string) string {
+		return `{"type":"assistant","timestamp":"` + ts + `","sessionId":"ffff0001-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"` + cmd + `"}}]}}`
+	}
+	lines := []string{
+		rec("go test ./internal/search/ -run Retry", "2026-07-10T10:01:00Z"),
+		rec("go test ./internal/search/ -run Retry -v", "2026-07-10T10:02:00Z"),
+		rec("golangci-lint run ./...", "2026-07-10T10:03:00Z"),
+	}
+	if err := os.WriteFile(filepath.Join(store, "ffff0001.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// `how go` asks how this machine runs go. Matching was a raw substring test, so
+// golangci-lint answered — and answered first (#1630).
+func TestHowDoesNotMatchInsideAnotherWord(t *testing.T) {
+	dir := howFixture(t)
+	var b bytes.Buffer
+	if err := runHow(dir, []string{"go"}, &b); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	if strings.Contains(out, "golangci-lint") {
+		t.Errorf("`how go` answered with golangci-lint:\n%s", out)
+	}
+	if !strings.Contains(out, "go test ./internal/search/") {
+		t.Errorf("`how go` lost the go commands:\n%s", out)
+	}
+	// The controls: the full name still finds the linter, and a multi-word
+	// query still narrows.
+	b.Reset()
+	if err := runHow(dir, []string{"golangci-lint"}, &b); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), "golangci-lint run") {
+		t.Errorf("`how golangci-lint` lost it:\n%s", b.String())
+	}
+	b.Reset()
+	if err := runHow(dir, []string{"go", "test"}, &b); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), "go test") || strings.Contains(b.String(), "golangci") {
+		t.Errorf("`how go test`:\n%s", b.String())
+	}
+}
+
+// The same flag loop files had: what you typed has to do something (#1630).
+func TestHowRefusesWhatDoesNothing(t *testing.T) {
+	dir := howFixture(t)
+	for _, tc := range []struct {
+		args []string
+		want string
+	}{
+		{[]string{"go", "--limit"}, "--limit needs value"},
+		{[]string{"go", "--project"}, "--project needs value"},
+		{[]string{"go", "--project", ""}, "--project needs value"},
+		{[]string{"go", "--unknown"}, "unknown flag"},
+		{[]string{""}, "usage"},
+	} {
+		if err := runHow(dir, tc.args, io.Discard); err == nil {
+			t.Errorf("how %v was accepted", tc.args)
+		} else if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("how %v: %v, want it to mention %q", tc.args, err, tc.want)
+		}
+	}
+	for _, args := range [][]string{{"go"}, {"go", "--limit", "3"}, {"go", "--project", "api"}, {"--", "-run"}} {
+		if err := runHow(dir, args, io.Discard); err != nil {
+			t.Errorf("how %v: %v", args, err)
+		}
+	}
+}

--- a/cmd/deja/how_match_test.go
+++ b/cmd/deja/how_match_test.go
@@ -94,3 +94,27 @@ func TestHowRefusesWhatDoesNothing(t *testing.T) {
 		}
 	}
 }
+
+// A dash or an underscore is a boundary, not part of the word: people ask for
+// the half of a hyphenated tool they remember. Review named this as the cost of
+// the first attempt, where both counted as word characters (#1630).
+func TestHowFindsTheHalfOfAHyphenatedCommand(t *testing.T) {
+	dir := howFixture(t)
+	for _, term := range []string{"lint", "golangci", "golangci-lint"} {
+		var b bytes.Buffer
+		if err := runHow(dir, []string{term}, &b); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(b.String(), "golangci-lint run") {
+			t.Errorf("`how %s` lost golangci-lint:\n%s", term, b.String())
+		}
+	}
+	// The control that started all this: `go` must still not match golangci.
+	var b bytes.Buffer
+	if err := runHow(dir, []string{"go"}, &b); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(b.String(), "golangci") {
+		t.Errorf("`how go` matched inside golangci again:\n%s", b.String())
+	}
+}


### PR DESCRIPTION
Closes #1630.

Two things, both in `deja how`.

**`how go` answered with `golangci-lint`.** Membership was a raw substring test, so a short tool name matched inside a longer word — and the entry that is not an answer sorted first:

```
before                                    after
$ golangci-lint run ./...                 $ go test ./internal/search/ -run Retry -v
$ go test ./internal/search/ -run Retry -v  $ go test ./internal/search/ -run Retry
```

The short names are the ones people ask this command about — go, gh, rg, jq, sed, cd, ls, mv — and the ones that hide inside other words. A term now has to appear as a word: bounded by anything that is not a letter, digit, underscore or dash, so `go` matches `go test` and `/usr/local/bin/go` but not `golangci`. A term that already carries a separator (`go test`, `./x`) is matched as written, since it is more specific than one word.

**The flag loop.** `how` carries its own copy of what `files` had in #1628: a flag with nothing after it, an unknown flag, an empty `--project` and an empty argument all passed through in silence. Same sentences as the siblings, plus the `--` escape so a command that starts with a dash stays askable (`deja how -- -run`).

Failing first:

```
--- FAIL: TestHowDoesNotMatchInsideAnotherWord
    `how go` answered with golangci-lint:
    $ golangci-lint run ./...
--- FAIL: TestHowRefusesWhatDoesNothing
    how [go --limit] was accepted
    how [go --project] was accepted
    how [go --project ] was accepted
    how [go --unknown] was accepted
    how [] was accepted
```

Controls in both: `how golangci-lint` still returns the linter, `how go test` still narrows to the two lines, and `go`, `--limit 3`, `--project api`, `-- -run` all still work.

One note for the reader of the diff: the helpers live at the end of the file because putting them above `howEntries` separated that function from its doc comment, and `TestDocCommentsNameWhatTheyDocument` caught it.

The rest of item `[how-unknown]` is clean: a tool nobody ran gets `no command on this machine mentions "kubectl"`, matching is case-insensitive, and a multi-word query narrows.

## Review

> No issues.
>
> Tested systematically: match behaviour for 15+ search patterns including edge terms (`go.mod`, `pytest -k test_x.y`, `docker-compose`); word-boundary logic with dash/underscore as word runes; flag parsing (empty args, missing values, unknown flags, `--` escape); UTF-8 edge cases (Cyrillic, emoji); and the full test suite. All passing.
>
> The design intentionally treats dash and underscore as word characters, creating regressions where `compose` no longer matches `docker-compose`, `lint` no longer matches `golangci-lint`, and `node` no longer matches `node_modules`. This is the documented trade-off to fix #1630. Byte-level indexing in `commandMentions` is safe for valid UTF-8 from `strings.Index`; `isCommandWordRune` only handles ASCII, but non-ASCII characters are correctly treated as word boundaries. All new tests pass, fail without the fix, and the full suite (including `TestDocCommentsNameWhatTheyDocument`) passes.

The verdict is clean, but the trade-off it names was not one worth taking, so 82d0375e removes it: a dash and an underscore are now boundaries like any other non-alphanumeric character. That keeps the fix — `go` still does not match inside `golangci`, because the `go` there is followed by `l` — and gives back the queries the first attempt lost:

```
how go             → $ go test ./internal/search/ -run Retry -v
how lint           → $ golangci-lint run ./...
how golangci       → $ golangci-lint run ./...
how test           → $ go test ./internal/search/ -run Retry -v
```

`TestHowFindsTheHalfOfAHyphenatedCommand` pins all four, with `how go` as its control.
