### PR TITLE
fix(how,files): say when the list was cut at the limit

### DIFF
--- a/cmd/deja/cap_note_test.go
+++ b/cmd/deja/cap_note_test.go
@@ -35,20 +35,24 @@ func TestHowSaysWhenItCutTheList(t *testing.T) {
 	if err := runHow(dir, []string{"go", "test", "--limit", "3"}, &b); err != nil {
 		t.Fatal(err)
 	}
-	out := b.String()
-	if strings.Count(out, "$ go test") != 3 {
-		t.Fatalf("expected three entries, got:\n%s", out)
+	if n := strings.Count(b.String(), "$ go test"); n != 3 {
+		t.Fatalf("expected three entries, got %d:\n%s", n, b.String())
 	}
-	if !strings.Contains(out, "13") || !strings.Contains(out, "--limit") {
-		t.Errorf("the cut is silent — nothing says how many there were or how to see them:\n%s", out)
-	}
-	// The control: an uncut list says nothing extra.
-	b.Reset()
-	if err := runHow(dir, []string{"go", "test", "--limit", "20"}, &b); err != nil {
+	// The note goes where search puts its own: stderr, so stdout stays the list.
+	note, err := captureRunStderr(t, "how", "go", "test", "--limit", "3")
+	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(b.String(), "--limit") {
-		t.Errorf("a complete answer still advertised the flag:\n%s", b.String())
+	if !strings.Contains(note, "showing 3 of 13") || !strings.Contains(note, "--limit") {
+		t.Errorf("the cut is silent — nothing says how many there were or how to see them:\n%s", note)
+	}
+	// The control: an uncut list says nothing extra.
+	note, err = captureRunStderr(t, "how", "go", "test", "--limit", "20")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(note, "showing") {
+		t.Errorf("a complete answer still advertised the flag:\n%s", note)
 	}
 }
 
@@ -82,19 +86,19 @@ func TestFilesSaysWhenItCutTheList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var b bytes.Buffer
-	if err := runFiles(dir, []string{"retry", "--limit", "2"}, &b); err != nil {
+	note, err := captureRunStderr(t, "files", "retry", "--limit", "2")
+	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(b.String(), "--limit") {
-		t.Errorf("files cut the list in silence:\n%s", b.String())
+	if !strings.Contains(note, "showing 2 of 6") {
+		t.Errorf("files cut the list in silence:\n%s", note)
 	}
 	// The control: nothing cut, nothing said.
-	b.Reset()
-	if err := runFiles(dir, []string{"retry", "--limit", "50"}, &b); err != nil {
+	note, err = captureRunStderr(t, "files", "retry", "--limit", "50")
+	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(b.String(), "--limit") {
-		t.Errorf("a complete answer still advertised the flag:\n%s", b.String())
+	if strings.Contains(note, "showing") {
+		t.Errorf("a complete answer still advertised the flag:\n%s", note)
 	}
 }

--- a/cmd/deja/cap_note_test.go
+++ b/cmd/deja/cap_note_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Both commands stopped at their limit without a word, so eight of thirteen
+// read as thirteen — the misread #1608 fixed on the search screen, in the two
+// places it was still true (#1632).
+func TestHowSaysWhenItCutTheList(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 13; i++ {
+		id := "0000000" + string(rune('a'+i)) + "-1111-4000-8000-d6e7f8a9b0c1"
+		line := `{"type":"assistant","timestamp":"2026-07-0` + string(rune('1'+i%9)) + `T10:00:00Z","sessionId":"` + id + `","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go test ./... -run Case` + string(rune('a'+i)) + `"}}]}}`
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	if err := runHow(dir, []string{"go", "test", "--limit", "3"}, &b); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	if strings.Count(out, "$ go test") != 3 {
+		t.Fatalf("expected three entries, got:\n%s", out)
+	}
+	if !strings.Contains(out, "13") || !strings.Contains(out, "--limit") {
+		t.Errorf("the cut is silent — nothing says how many there were or how to see them:\n%s", out)
+	}
+	// The control: an uncut list says nothing extra.
+	b.Reset()
+	if err := runHow(dir, []string{"go", "test", "--limit", "20"}, &b); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(b.String(), "--limit") {
+		t.Errorf("a complete answer still advertised the flag:\n%s", b.String())
+	}
+}
+
+// files caps the same way and was equally silent (#1632).
+func TestFilesSaysWhenItCutTheList(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Real files under a real repository: files skips paths it cannot find on
+	// this disk, and the cap is only reached once rows survive that.
+	repo := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var lines []string
+	for i := 0; i < 6; i++ {
+		name := filepath.Join(repo, "file"+string(rune('a'+i))+".go")
+		if err := os.WriteFile(name, []byte("package p\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		lines = append(lines, `{"type":"assistant","timestamp":"2026-07-01T10:0`+string(rune('0'+i))+`:00Z","sessionId":"aaaa0001-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"`+name+`"}}]}}`)
+	}
+	lines = append(lines, `{"type":"user","timestamp":"2026-07-01T10:09:00Z","sessionId":"aaaa0001-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"user","content":"the retry loop keeps firing"}}`)
+	if err := os.WriteFile(filepath.Join(store, "aaaa0001.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	if err := runFiles(dir, []string{"retry", "--limit", "2"}, &b); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), "--limit") {
+		t.Errorf("files cut the list in silence:\n%s", b.String())
+	}
+	// The control: nothing cut, nothing said.
+	b.Reset()
+	if err := runFiles(dir, []string{"retry", "--limit", "50"}, &b); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(b.String(), "--limit") {
+		t.Errorf("a complete answer still advertised the flag:\n%s", b.String())
+	}
+}

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -280,9 +280,9 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprintf(stdout, "  %s%s %d\n", path, strings.Repeat(" ", max(0, col-termwidth.Columns(path))), r.n)
 	}
 	// Same as `how`: a list cut at the limit without a word reads as the whole
-	// list (#1632).
+	// list, and the line goes where search puts it (#1632).
 	if cut > 0 {
-		fmt.Fprintf(stdout, "showing %d of %d — raise --limit for the rest\n", len(rows), cut)
+		fmt.Fprintf(os.Stderr, "deja: showing %d of %d — raise --limit for the rest\n", len(rows), cut)
 	}
 	return nil
 }

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -256,7 +256,9 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		}
 		return rows[i].score > rows[j].score
 	})
+	cut := 0
 	if len(rows) > limit {
+		cut = len(rows)
 		rows = rows[:limit]
 	}
 	fmt.Fprintf(stdout, "files touched while working on %q — %d session%s%s\n", q, scanned, plural(scanned), filesReadNote(matched))
@@ -276,6 +278,11 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		// counts stopped lining up in a column of their own.
 		path := filesRowPath(r.path, col)
 		fmt.Fprintf(stdout, "  %s%s %d\n", path, strings.Repeat(" ", max(0, col-termwidth.Columns(path))), r.n)
+	}
+	// Same as `how`: a list cut at the limit without a word reads as the whole
+	// list (#1632).
+	if cut > 0 {
+		fmt.Fprintf(stdout, "showing %d of %d — raise --limit for the rest\n", len(rows), cut)
 	}
 	return nil
 }

--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -104,9 +104,10 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 			pluralRuns(e.Runs), pluralSessions(len(e.Sessions)), when)
 	}
 	// The cap said nothing, so eight of thirteen ways to run the tests read as
-	// thirteen — the misread the search screen already avoids (#1632).
+	// thirteen — the misread the search screen already avoids (#1632). On
+	// stderr, where search puts the same line: stdout stays the list.
 	if len(entries) > limit {
-		fmt.Fprintf(stdout, "showing %d of %d — raise --limit for the rest\n", limit, len(entries))
+		fmt.Fprintf(os.Stderr, "deja: showing %d of %d — raise --limit for the rest\n", limit, len(entries))
 	}
 	return nil
 }

--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -103,6 +103,11 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprintf(stdout, "  ran %s in %s%s\n",
 			pluralRuns(e.Runs), pluralSessions(len(e.Sessions)), when)
 	}
+	// The cap said nothing, so eight of thirteen ways to run the tests read as
+	// thirteen — the misread the search screen already avoids (#1632).
+	if len(entries) > limit {
+		fmt.Fprintf(stdout, "showing %d of %d — raise --limit for the rest\n", limit, len(entries))
+	}
 	return nil
 }
 


### PR DESCRIPTION
Closes #1632.

`how` stops at 8 entries and `files` at 10, and neither said so. On a store with thirteen distinct `go test` invocations, "how do we run the tests here" answered with eight of them and no reason to look further:

```
$ deja how "go test"
…
$ go test ./... -run Case5
  ran once in 1 session · last 2026-07-06
showing 8 of 13 — raise --limit for the rest      ← new
```

The search screen already refuses to do this, and the comment above it (`cmd/deja/main.go:992`) states the principle — "15 results look like the whole answer, and nothing says another N are waiting". These were the two commands where that was still true.

The note names `--limit`, not `--all`: neither command has `--all`.

Failing first:

```
--- FAIL: TestHowSaysWhenItCutTheList
    the cut is silent — nothing says how many there were or how to see them
--- FAIL: TestFilesSaysWhenItCutTheList
    files cut the list in silence
```

Both carry the control that matters for a line like this: an uncut answer must stay quiet, or the note becomes noise on every small store.

The rest of item `[how-flags]` is clean and worth recording, since it is what the item actually asked: invocations differing only by flags are kept apart, each with its own run and session counts; ordering is by sessions then recency, so the way the team really runs it leads; case and surrounding whitespace collapse into one entry.

## Review

> **🟡 risk (how.go:109, files.go:259-286):** the cap note goes to stdout instead of stderr. Search writes cap metadata to stderr precisely to keep stdout parseable (main.go:1034-1036); how/files mix metadata into stdout. No current machine consumers parse this output (no --json mode, no MCP tool calls runHow, no scripts found), but following search's pattern would be more consistent and future-proof.
>
> **🟡 risk (out of scope):** the MCP `how` tool duplicates the logic of `runHow` instead of calling it, so agents won't see the new cap note. Pre-existing gap.
>
> **Verified correct:** the counts are the right pair in both files ("shown of total"); empty lists, exactly-at-limit and over-limit all behave; the tests fail without the fix and pass with it; the full suite passes; the binary shows `showing 3 of 13 — raise --limit for the rest` and stays silent at `--limit 20`; the wording difference (`--limit` rather than `--all`) is justified because these commands have no `--all`.

Moved in 02881b34 — the note is on stderr now, prefixed the way deja's other notes are, and the tests read it there:

```
$ deja how "go test" 2>/dev/null | tail -1     → $ go test ./... -run Case5   (the list, nothing else)
$ deja how "go test" 2>&1 >/dev/null           → deja: showing 8 of 13 — raise --limit for the rest
```

The second point is filed as #1634. It is the duplication that is the defect, not the missing line: two implementations of one answer drift, and this is the drift showing.
