### PR TITLE
fix(index): keep the commands that repair a build, not only the ones that fail

### DIFF
--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -473,12 +473,16 @@ func IndexCommands() bool { return os.Getenv("DEJA_INDEX_COMMANDS") != "0" }
 // ecosystem: `git status` and `git log` missed it 2,270 times, and a person
 // working in LaTeX, Python or the JVM saw nothing at all. Widening it takes the
 // same store from 6,770 commands to 12,661, and 1.03 MB to 1.41 MB.
-var meaningfulCommand = regexp.MustCompile(`\b(go (test|build|vet|run)|golangci-lint|gofmt|pytest|python3? -m|uv (run|pip)|pip install|ruff|mypy|npm|npx|pnpm|yarn|bun |cargo |make\b|cmake|ctest|ninja|meson|bazel|buck2|gh (pr|run|release|issue|workflow|api)|git [a-z-]+|docker|kubectl|helm|terraform|psql|mysql|latexmk|mvn|gradle|dotnet|swift (build|test)|bundle exec|rails|rake|rspec|phpunit|composer (install|update|require)|tox|nox|jest|vitest|playwright|cypress|deno|tsc|sbt|stack (build|test|run|exec)|cabal|ghc|dune|zig|nix|rustc|clang\+\+|clang|g\+\+|gcc|pdm run|poetry run|deja )`)
+var meaningfulCommand = regexp.MustCompile(`\b(go (test|build|vet|run|mod|get|install|generate|work|clean)|brew (install|upgrade|uninstall|reinstall|tap)|golangci-lint|gofmt|pytest|python3? -m|uv (run|pip)|pip install|ruff|mypy|npm|npx|pnpm|yarn|bun |cargo |make\b|cmake|ctest|ninja|meson|bazel|buck2|gh (pr|run|release|issue|workflow|api)|git [a-z-]+|docker|kubectl|helm|terraform|psql|mysql|latexmk|mvn|gradle|dotnet|swift (build|test)|bundle exec|rails|rake|rspec|phpunit|composer (install|update|require)|tox|nox|jest|vitest|playwright|cypress|deno|tsc|sbt|stack (build|test|run|exec)|cabal|ghc|dune|zig|nix|rustc|clang\+\+|clang|g\+\+|gcc|pdm run|poetry run|deja )`)
 
 var trivialCommand = regexp.MustCompile(`^\s*(ls|cd|pwd|cat|head|tail|echo|grep|rg|find|which|wc|sed|awk|sleep|mkdir|rm|cp|mv|chmod|export|source|touch|open|printf)\b`)
 
 // worthIndexing keeps the commands that say what happened — a test run, a build,
-// a deploy, a git or gh operation — and drops navigation. On the corpus that set
+// a deploy, a git or gh operation — and drops navigation. It also keeps the
+// subcommands that change a build's inputs (`go mod tidy`, `go get`, `brew
+// install`): those are the remedies `deja fix` exists to name, and enumerating
+// only `go test|build|vet|run` meant the failure was indexed and the repair was
+// not (#1635). On the corpus that set
 // the first allowlist, roughly a fifth of command text was worth keeping (5k of
 // 24k); the list has since grown to cover more build and test toolchains
 // (bazel, jest, deno, sbt, cabal, zig, compilers) that were being dropped.

--- a/internal/sources/commands_remedy_test.go
+++ b/internal/sources/commands_remedy_test.go
@@ -1,0 +1,40 @@
+package sources
+
+import "testing"
+
+// The allowlist enumerated `go test|build|vet|run` and stopped, so every `go`
+// subcommand that changes the build's inputs was dropped — and those are the
+// remedies. `deja fix` could see the failure and never the thing that repaired
+// it (#1635).
+func TestWorthIndexingKeepsTheCommandsThatFixABuild(t *testing.T) {
+	for _, c := range []string{
+		"go mod tidy",
+		"go mod vendor",
+		"go mod download",
+		"go get ./...",
+		"go get github.com/x/y@latest",
+		"go install ./cmd/deja",
+		"go generate ./...",
+		"go work sync",
+		"go clean -modcache",
+		"brew install jq",
+		"brew upgrade",
+		"cd repo && go mod tidy",
+	} {
+		if !worthIndexing(c) {
+			t.Errorf("dropped the remedy: %q", c)
+		}
+	}
+	// The controls: navigation stays dropped, and a meaningful name inside a
+	// navigation command's argument is still not a command.
+	for _, c := range []string{
+		"cat go.mod | grep module",
+		"ls go.sum",
+		"echo 'go mod tidy'",
+		"grep 'brew install' notes.md",
+	} {
+		if worthIndexing(c) {
+			t.Errorf("kept navigation: %q", c)
+		}
+	}
+}

--- a/internal/sources/commands_remedy_test.go
+++ b/internal/sources/commands_remedy_test.go
@@ -17,6 +17,10 @@ func TestWorthIndexingKeepsTheCommandsThatFixABuild(t *testing.T) {
 		"go generate ./...",
 		"go work sync",
 		"go clean -modcache",
+		// brew belongs here for the same reason, and by the same measurement:
+		// `brew install jq` was in the eleven-command fixture and was dropped
+		// with the rest. "the tool is missing" is an error people paste, and
+		// the remedy is an install.
 		"brew install jq",
 		"brew upgrade",
 		"cd repo && go mod tidy",


### PR DESCRIPTION
Closes #1635.

The allowlist enumerated `go (test|build|vet|run)` and stopped, so every `go` subcommand that changes a build's inputs was dropped at parse time — and those are the remedies. `deja fix` could see the failure and never the repair.

Three sessions, each hitting one error and each running `go mod vendor` right after it:

```
before                                              after
$ deja fix "…undefined: snorblefunc"                $ deja fix "…undefined: snorblefunc"
deja: no session on this machine ran a command      …undefined: snorblefunc · 2026-07-12
after that error                                      ran next: $ go mod vendor
```

`friction` already saw that error three times, which is what made the silence from `fix` worth chasing: the error was indexed, the fix for it was not.

Added: `go mod|get|install|generate|work|clean`, and `brew install|upgrade|uninstall|reinstall|tap`, which is the same shape (`brew install jq` was dropped too).

Failing first, twelve of them:

```
--- FAIL: TestWorthIndexingKeepsTheCommandsThatFixABuild
    dropped the remedy: "go mod tidy"
    dropped the remedy: "go get ./..."
    dropped the remedy: "go install ./cmd/deja"
    dropped the remedy: "brew install jq"
    …
```

with the controls that keep the allowlist honest — `cat go.mod | grep module`, `ls go.sum`, `echo 'go mod tidy'` and `grep 'brew install' notes.md` must all stay dropped, since a meaningful name inside a navigation command's argument is not a command. The existing allowlist tests are untouched and still pass.

One argument worth answering, because the code makes it: the comment above `worthIndexing` says dropped commands are "actively bad to keep", since `cat internal/index/index.go` answers a query about the index with nothing. That holds for navigation and does not hold here — `go mod tidy` is a real action with a real effect, and it is exactly what the reader came for.

The item this came from — `[fix-stdin]` — is clean: `deja fix` reads a pipe, handles a multi-line paste with its stack, CRLF, ANSI colour and a missing trailing newline, refuses politely when given neither an argument nor a pipe, and reads stdin only when it is a pipe, so a terminal never hangs.

## Review

> **No false positives in pattern matching.** Word boundaries and space requirements prevent matches in similar names (homebrew, logo, ego, django, mongo). Navigation commands stay dropped via the trivialCommand prefix check even when they contain meaningful names as arguments. Twenty edge cases tested — path contexts, chaining operators, piping, compounded names, argument contexts — all pass.
>
> **Test fails without fix.** All 12 cases fail with the old pattern. **Full test suite passes.**
>
> **Go commands justified by principle** — mod (including vendor/download), get, install, generate, work, clean all change build inputs.
>
> **BREW ADDITION NOT JUSTIFIED.** Scope creep: the pattern adds 5 brew subcommands with no justification, the fixtures contain zero brew commands so it is untested with real data, and the test comment references only the go issue. Should be split into a separate issue if desired.

One correction, because the reasoning rests on it: the fixtures do contain brew. `home5` is the eleven-command session used for the measurement in #1635, and `brew install jq` is in it — dropped before the change, kept after, in the same `deja show` output the issue quotes. The issue also names it explicitly ("`brew install` is the same shape and is also absent; worth deciding at the same time").

So it is measured, not inferred. What was missing is the reason sitting next to the cases, which is a fair hit — added in e00280b0: "the tool is missing" is an error people paste, and the remedy is an install, which is the same argument as `go mod tidy` after a missing import.

If you would still rather have brew on its own, it is one alternative in the regexp and two test lines to lift out.
