### PR TITLE
fix(friction): one error stays one wall when pytest or a log stamps the line

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -90,8 +90,10 @@ func trimLogPrefix(l string) string {
 }
 
 // trimPytestMarker removes the `E` column pytest prints beside the failing
-// line. Only with the spacing pytest uses, so `E2BIG: …` and a sentence
-// starting with `E ` keep their shape.
+// line. `E` must stand alone before the space, so the error codes that begin
+// with it — `E2BIG: …`, `EACCES: …`, apt's `E: …` — keep their shape. A message
+// whose first word really is a bare `E` loses it, which is the price of reading
+// the pytest report people actually paste.
 func trimPytestMarker(l string) string {
 	rest, ok := strings.CutPrefix(l, "E ")
 	if !ok {

--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"hash/fnv"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -54,6 +55,7 @@ func FrictionLine(l string) (string, bool) {
 // alone they land below the threshold separately and none is ever reported.
 func normalizeFriction(l string) string {
 	l = strings.TrimSpace(l)
+	l = strings.TrimSpace(trimLogPrefix(l))
 	// The prefix is `<where>:<line>: `, where <where> is a shell name or an
 	// `(eval)`/`(anon)` marker. Only strip it when the middle field is a
 	// number — `Error: cannot find x: y` must keep its shape.
@@ -71,6 +73,48 @@ func normalizeFriction(l string) string {
 	}
 	return strings.TrimSpace(rest[second+2:])
 }
+
+// trimLogPrefix drops the prefixes a runner puts in front of a line it did not
+// write: pytest's `E   ` marker on the failing line, and the timestamp docker,
+// journalctl and most CI add to everything. They carry nothing about the error,
+// and left in they split one wall into two — the same reasoning that strips the
+// shell's position prefix above (#1637).
+func trimLogPrefix(l string) string {
+	for {
+		trimmed := trimPytestMarker(trimTimestamp(l))
+		if trimmed == l {
+			return l
+		}
+		l = trimmed
+	}
+}
+
+// trimPytestMarker removes the `E` column pytest prints beside the failing
+// line. Only with the spacing pytest uses, so `E2BIG: …` and a sentence
+// starting with `E ` keep their shape.
+func trimPytestMarker(l string) string {
+	rest, ok := strings.CutPrefix(l, "E ")
+	if !ok {
+		return l
+	}
+	rest = strings.TrimLeft(rest, " ")
+	if rest == "" {
+		return l
+	}
+	return rest
+}
+
+// trimTimestamp removes a leading date-and-time, bracketed or bare, in the
+// shapes runners emit: 2026-07-12T10:00:00Z, 2026-07-12 10:00:00.123, and the
+// same inside [].
+func trimTimestamp(l string) string {
+	if m := leadingTimestamp.FindString(l); m != "" {
+		return strings.TrimSpace(l[len(m):])
+	}
+	return l
+}
+
+var leadingTimestamp = regexp.MustCompile(`^\[?\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\]?\s+`)
 
 // isFriction keeps the error shapes that name something specific. The generic
 // ones carry no information — every Python failure prints `Traceback (most

--- a/internal/index/friction_prefix_test.go
+++ b/internal/index/friction_prefix_test.go
@@ -28,6 +28,8 @@ func TestNormalizeFrictionStripsMechanicalPrefixes(t *testing.T) {
 		"Exception: no route to host":         "Exception: no route to host",
 		"zsh:1: command not found: timeout":   "command not found: timeout",
 		"npm ERR! code ELIFECYCLE":            "npm ERR! code ELIFECYCLE",
+		"EACCES: permission denied, open 'x'": "EACCES: permission denied, open 'x'",
+		"E: Unable to locate package golang":  "E: Unable to locate package golang",
 		"2026 is not a year we support":       "2026 is not a year we support",
 	} {
 		if got := normalizeFriction(in); got != keep {

--- a/internal/index/friction_prefix_test.go
+++ b/internal/index/friction_prefix_test.go
@@ -1,0 +1,37 @@
+package index
+
+import "testing"
+
+// normalizeFriction already strips the shell's `zsh:1: ` position prefix so one
+// missing command counts once. Two other prefixes are just as mechanical: the
+// `E   ` pytest puts in front of the failing line, and the timestamp docker,
+// journalctl and CI put in front of everything. Left in, one error counted as
+// two walls and `deja fix` missed the paste (#1637).
+func TestNormalizeFrictionStripsMechanicalPrefixes(t *testing.T) {
+	const want = "ModuleNotFoundError: No module named 'app.db'"
+	for _, in := range []string{
+		want,
+		"E   " + want,
+		"E " + want,
+		"2026-07-12T10:00:00Z " + want,
+		"2026-07-12 10:00:00 " + want,
+		"[2026-07-12T10:00:00Z] " + want,
+	} {
+		if got := normalizeFriction(in); got != want {
+			t.Errorf("normalizeFriction(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// The controls: nothing that carries meaning may be trimmed.
+	for in, keep := range map[string]string{
+		"Error: cannot find module 'express'": "Error: cannot find module 'express'",
+		"E2BIG: argument list too long":       "E2BIG: argument list too long",
+		"Exception: no route to host":         "Exception: no route to host",
+		"zsh:1: command not found: timeout":   "command not found: timeout",
+		"npm ERR! code ELIFECYCLE":            "npm ERR! code ELIFECYCLE",
+		"2026 is not a year we support":       "2026 is not a year we support",
+	} {
+		if got := normalizeFriction(in); got != keep {
+			t.Errorf("normalizeFriction(%q) = %q, want %q", in, got, keep)
+		}
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -57,7 +57,12 @@ import (
 // line written in Russian or Chinese is held to the same length as an English
 // one. A store built before this holds fewer friction signatures, and nothing
 // re-derives them without the bump — the same shape as 22 and 23 (#1319).
-const version = 28
+// 29: the prefixes a runner stamps on a line it did not write — pytest's `E `
+// and a leading timestamp — are stripped before a line is hashed, so one error
+// is one wall however it was printed. A store built before this holds both
+// spellings under different signatures, and nothing re-derives them without
+// the bump — the same shape as 27 and 28 (#1637).
+const version = 29
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message


### PR DESCRIPTION
Closes #1637.

`normalizeFriction` already strips the shell's `zsh:1: ` position prefix, with a comment saying why: left alone, one piece of friction lands below the threshold twice and none is ever reported. Two other prefixes are just as mechanical and were not stripped — the `E   ` pytest prints beside the failing line, and the timestamp docker, journalctl and CI put in front of everything.

Seven sessions hitting one error:

```
before                                          after
   4 sessions  E   ModuleNotFoundError: …          7 sessions  ModuleNotFoundError: …
   3 sessions  ModuleNotFoundError: …
```

And `deja fix` now answers the paste a Python user actually has:

```
$ deja fix "E   ModuleNotFoundError: No module named 'app.db'"
ModuleNotFoundError: No module named 'app.db' · 2026-07-16
  ran next: $ pip install -e .
```

Failing first:

```
--- FAIL: TestNormalizeFrictionStripsMechanicalPrefixes
    normalizeFriction("E   ModuleNotFoundError: …") = "E   ModuleNotFoundError: …", want "ModuleNotFoundError: …"
    normalizeFriction("2026-07-12T10:00:00Z ModuleNotFoundError: …") = …
    normalizeFriction("[2026-07-12T10:00:00Z] ModuleNotFoundError: …") = …
```

The trimming is narrow, and the controls in the same test are the reason: `E2BIG: argument list too long`, `Error: cannot find module 'express'`, `Exception: no route to host`, `npm ERR! code ELIFECYCLE`, `2026 is not a year we support` and the existing `zsh:1: ` case must all come through unchanged. The pytest marker is only removed with the spacing pytest uses (`E` followed by a space), and the timestamp only in the shapes runners emit, bracketed or bare.

The multi-line half of item `[fix-multiline]` is clean: a pasted traceback matches on its meaningful line, survives a different line number and a different file path, and the generic `Traceback (most recent call last):` matches nothing, which is right.

## Review

> **🔴 critical: silent index format change without version bump.** The change produces different normalized strings and thus different friction hashes, and those hashes are stored in the manifest. `const version = 28` is unchanged, so `IsCurrentVersion` will not see a pre-upgrade store as stale: old sessions keep the split hashes, new ones get the merged form, and the two never match. Fix: increment `const version`.
>
> **🟡 risk: misleading comment in trimPytestMarker** — the code removes `E ` from a line start unconditionally, so a message whose first word is a bare `E` is trimmed; the comment's second clause overstates the guard.
>
> **✓ Regexp and escaping verified** — matches bare and bracketed ISO/spaced timestamps with fractional seconds and ±HH:MM / ±HHMM / Z, and requires trailing space, so a bracketed stamp with nothing after it is left alone.
> **✓ Loop bounded** — one prefix per iteration, must progress or exit.
> **✓ Test fails without the fix** on all six cases, passes with it. **✓ Full suite passes.**
> **✓ Fixture behaviour** — old code splits 7 sessions into 4 + 3; new code merges all 7.

The critical one is right, and the file itself is the precedent: the comment above `version = 28` describes this exact situation ("A store built before this holds fewer friction signatures, and nothing re-derives them without the bump"). Bumped to 29 in 57d45435, with its own line in the same list.

The comment is corrected in the same commit — `E` must stand alone before the space, so `E2BIG:`, `EACCES:` and apt's `E:` keep their shape, and the case that does lose something is named rather than glossed. Both `EACCES: permission denied` and `E: Unable to locate package golang` are now controls in the test.
