### PR TITLE
fix(friction): the trust note counts the sessions it hid, not their error lines

### DIFF
--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -52,13 +52,16 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 	// imported content from every other browsing surface. Browsing is the search
 	// activation, as in `last` and `stats` (#937, and its friction gap #1120).
 	pol := policy.Load()
-	withheld := 0
+	// Sessions, not records: the note says "hides N matching sessions", and
+	// counting the callback's firings reported one hidden session with ten
+	// error lines as ten (#1639).
+	withheldSessions := map[string]bool{}
 	// One pass over the record log rather than a load per session: loading by
 	// identity walks the whole log each time, which put this command at 2m46s
 	// on a 1150-session store.
 	if err := index.EachToolOutput(dir, func(meta index.SessionMeta, r index.Record) {
 		if !pol.Allows(policy.ActivationSearch, meta.Project) {
-			withheld++
+			withheldSessions[meta.Harness+":"+meta.ID] = true
 			return
 		}
 		key := meta.Harness + ":" + meta.ID
@@ -82,7 +85,7 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 	}); err != nil {
 		return fmt.Errorf("friction: %w", err)
 	}
-	if note := policyHiddenNote(policy.ActivationSearch, withheld); note != "" {
+	if note := policyHiddenNote(policy.ActivationSearch, len(withheldSessions)); note != "" {
 		fmt.Fprintln(os.Stderr, note)
 	}
 

--- a/cmd/deja/friction_withheld_test.go
+++ b/cmd/deja/friction_withheld_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The withheld count is a sentence about the trust policy — how much of their
+// own history a rule keeps from the reader — and friction counted records where
+// the sentence says sessions, so one hidden session with ten error lines was
+// reported as ten (#1639).
+func TestFrictionCountsWithheldSessionsNotRecords(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var lines []string
+	for i := 0; i < 10; i++ {
+		lines = append(lines, `{"type":"user","timestamp":"2026-07-10T10:0`+string(rune('0'+i))+`:00Z","sessionId":"bbbb0001-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"a`+string(rune('0'+i))+`","content":"connection refused on port 5432"}]}}`)
+	}
+	if err := os.WriteFile(filepath.Join(store, "bbbb0001.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	pol := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(pol, []byte(`{"activations":{"search":{"*":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", pol)
+
+	note, err := captureRunStderr(t, "friction")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note, "hides 1 matching session") {
+		t.Errorf("the store holds one session; the note says otherwise:\n%s", note)
+	}
+	if strings.Contains(note, "hides 10") {
+		t.Errorf("record count reported as sessions:\n%s", note)
+	}
+}


### PR DESCRIPTION
Closes #1639.

`deja friction` incremented its withheld counter inside `EachToolOutput`, which fires once per record, and passed that number to a sentence that says *sessions*. One hidden session with ten error lines came out as ten:

```
before:  deja: the trust policy hides 10 matching sessions on this path (search: local+imported) — see …
after:   deja: the trust policy hides 1 matching session on this path (search: local+imported) — see …

           nothing recurring — none of the 1 indexed session recorded tool output
```

The store holds one session, and the line under the note says so.

Every other caller of `policyHiddenNote` passes a session or hit count — `policyFilterHitsCounted`, `policyFilterSessionsCounted` — so the helper's wording was right and this number was wrong. It now collects `harness:id` into a set, the same key friction already uses for the counts it prints.

This one is worth the fuss because of what the sentence is for: it tells a reader how much of their own history a trust rule is keeping from them, and it overstated that by however many error lines each session happened to record.

Failing first:

```
--- FAIL: TestFrictionCountsWithheldSessionsNotRecords
    record count reported as sessions:
    deja: the trust policy hides 10 matching sessions on this path …
```

The rest of item `[friction-threshold]` is clean, which is the part the item actually asked about: exactly three sessions is reported and two is not; ten sightings inside one session never reach the threshold, and the empty line explains it — "no error hit 3 separate sessions"; the counts on screen are session counts throughout.

## Review

> **Key correctness verified.** `meta.Harness+":"+meta.ID` is the session identity friction already uses and the codebase uses elsewhere; no collision, and multiple records from one session count once.
>
> **Memory:** ~330 KB on a 10k-session store where everything is withheld. Negligible.
>
> **Pre-existing defect in other callers:** `cmd/deja/how.go:134` has the same records-as-sessions bug — `howEntries` increments `hidden` per record — affecting `how.go:87` and `mcp.go:341`. Should be a separate issue.
>
> **Note wording ("matching session"):** correct. "Matching" means the session matched the search activation policy check, not a query.
>
> **Test defect (out of scope):** the test creates `type="user"` records with tool_result content, not `role="tool-output"`, so `EachToolOutput` never fires and the test passes trivially.
>
> **Full suite passes. No issues.**

The `how` finding is real and is now #1641 — same fix, two callers including the MCP tool, so an agent sees the inflated number too.

The test claim is wrong, and it is worth showing rather than asserting, since a test that cannot fail is the one thing this PR must not ship. Against the parent commit:

```
--- FAIL: TestFrictionCountsWithheldSessionsNotRecords
    the store holds one session; the note says otherwise:
    deja: the trust policy hides 10 matching sessions on this path …
    record count reported as sessions:
```

It fails for the stated reason, on the stated number. `EachToolOutput` does fire on those records — a claude `tool_result` is what becomes a `tool-output` record, which is exactly how the shipped fixtures under `~/.cache/deja-hunt/2026-08-23/031/` were built. And it cannot pass trivially either: the first assertion requires `hides 1 matching session` to be **present**, so an absent note fails the test.
