### PR TITLE
fix(ctx): an id-prefix answer says when the decision was taken back

### DIFF
--- a/cmd/deja/ctx_lifecycle_test.go
+++ b/cmd/deja/ctx_lifecycle_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// `deja ctx <id>` is the command the hook names to an agent, and an id is what
+// every result line hands it. It printed the whole transcript of a decision
+// that had been taken back, with nothing marking it — while the search screen
+// and `ctx <query>` both said so (#1643).
+func TestCtxByIDSaysTheDecisionWasTakenBack(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const id = "aaaa0001-1111-4000-8000-d6e7f8a9b0c1"
+	lines := []string{
+		`{"type":"user","timestamp":"2026-07-10T10:00:00Z","sessionId":"` + id + `","cwd":"/api","message":{"role":"user","content":"the pool keeps running out under load"}}`,
+		`{"type":"assistant","timestamp":"2026-07-10T10:01:00Z","sessionId":"` + id + `","cwd":"/api","message":{"role":"assistant","content":"raised the pool to 40 and it held"}}`,
+	}
+	if err := os.WriteFile(filepath.Join(store, "aaaa0001.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "promote", "aaaa0001", "--state", "rejected", "--note", "backed out, the pool was not the problem"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "ctx", "aaaa0001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "rejected") {
+		t.Errorf("ctx handed over a withdrawn decision with no sign of it:\n%s", out)
+	}
+	if !strings.Contains(out, "backed out, the pool was not the problem") {
+		t.Errorf("the correction did not travel with it:\n%s", out)
+	}
+	// The control: a session nobody took back gets no marker.
+	plain := filepath.Join(store, "bbbb0002.jsonl")
+	const other = "bbbb0002-1111-4000-8000-d6e7f8a9b0c1"
+	if err := os.WriteFile(plain, []byte(`{"type":"user","timestamp":"2026-07-11T10:00:00Z","sessionId":"`+other+`","cwd":"/api","message":{"role":"user","content":"the scheduler dispatches work"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "ctx", "bbbb0002")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "rejected") || strings.Contains(out, "tried and") {
+		t.Errorf("a session nobody touched was marked:\n%s", out)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -599,6 +599,14 @@ func ctxFromIDPrefix(dir, q string) (bool, error) {
 	// id without saying it was a choice, while show, share, resume, promote,
 	// forget and handoff all said so (#923).
 	noteAmbiguousPrefix(dir, q, "answering from")
+	// A decision that was taken back must say so here too. The search screen and
+	// ctx's own query path both mark it; the id path handed an agent the whole
+	// transcript of a withdrawn decision, reading like current truth (#1643).
+	hits := []search.Hit{{Session: s}}
+	attachLifecycles(dir, hits)
+	if line := lifecycleLine(hits[0]); line != "" {
+		fmt.Fprintln(os.Stdout, line)
+	}
 	search.PrintContext(os.Stdout, s, "")
 	return true, nil
 }


### PR DESCRIPTION
Closes #1643.

`deja ctx <id>` printed the whole transcript of a decision that had been rejected, with nothing marking it:

```
before                                          after
# deja context: claude · tmp/api · aaaa0001-…   [this was tried and rejected, 2026-08-24] backed out, the pool was not the problem
## user                                         # deja context: claude · tmp/api · aaaa0001-…
the pool keeps running out under load           ## user
…                                               …
```

The controls are the same store at the same moment: `deja pool` says "tried and rejected", and so does `deja ctx pool`. Only the id path was silent — and that is the command the hook names to an agent, reached by the id every result line hands it.

The machinery was already there. `attachLifecycles` and `lifecycleLine` are what the search screen and the MCP surface use; `ctxFromIDPrefix`, added in #1614, went straight from the lookup to `PrintContext` without them. The comment above `attachLifecycles` is the reason this exists at all: "asking about a reverted decision returned the transcript that made it, reading like current truth".

Failing first — the test promotes a session to `rejected` and then asks for it by id:

```
--- FAIL: TestCtxByIDSaysTheDecisionWasTakenBack
    ctx handed over a withdrawn decision with no sign of it:
    # deja context: claude · tmp/api · aaaa0001-…
```

Its control is a second session nobody touched, which must come back unmarked, so this cannot pass by printing a marker on everything.

The rest of item `[promote-states]` is clean: `accepted`, `rejected`, `superseded` and `stale` all take; `ACCEPTED` is accepted and stored lower-case; an unknown value and an empty one are refused by name; `--state` with no value is refused; corrections append, and the latest state is the one the surfaces report.

Related: #1624 is the same shape one layer out — an agent is not told a session was forgotten, because the MCP path cannot emit that note.

## Review

> No issues.
>
> **Test validation:** fails without the fix (no "rejected" marker, no note text), passes with it. Full suite passes.
>
> **Stream/corruption:** the marker prints to stdout as `[this was tried and rejected, 2026-08-24] <note>` before the context header, matching the MCP format at cmd/deja/mcp.go:763. Markdown-compatible, no machine-reader corruption.
>
> **Blocking/cost:** `attachLifecycles` reads notes.jsonl via `sources.PromotedLifecycles()` (file I/O, not a lock), and calls `index.AllMeta()` only lazily for imported notes. Measured: ~25 ms on the 1500-session store, ~270 ms on the 4000-message one — I/O bound, not added latency.
>
> **Note session correctness:** `deja ctx deja-note-claude-aaaa0001` returns the note itself with a single marker at the top.
>
> **Accepted state:** correctly skipped — `--state accepted` produces no marker line.
