### PR TITLE
fix(lifecycle): a promote note is clipped like every other line on the screen

### DIFF
--- a/cmd/deja/lifecycle.go
+++ b/cmd/deja/lifecycle.go
@@ -156,7 +156,7 @@ func lifecycleLine(h search.Hit) string {
 		// note spanning several lines prints a "2. [claude] …" header and a
 		// "- …" snippet that no session in the store produced — the forgery
 		// #1080 fixed for imported project names, here on the note channel.
-		b.WriteString(" " + recallListingLine(h.LifecycleNote))
+		b.WriteString(" " + search.SafeNote(recallListingLine(h.LifecycleNote)))
 	}
 	return b.String()
 }

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -363,7 +363,7 @@ func BlameLifecycleLine(h BlameHit) string {
 		head += " (" + SafeLine(h.LifecycleAt) + ")"
 	}
 	if h.LifecycleNote != "" {
-		head += ": " + SafeLine(h.LifecycleNote)
+		head += ": " + SafeNote(h.LifecycleNote)
 	}
 	return head
 }

--- a/internal/search/lifecycle_note_cap_test.go
+++ b/internal/search/lifecycle_note_cap_test.go
@@ -1,0 +1,32 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// A promote note is free text a person wrote, and every surface printed it in
+// full on one line: a 4000-character note came out as a 4051-column line on a
+// screen budgeted to 80, and as 4074 of 4347 bytes in an agent's context
+// answer (#1645).
+func TestLifecycleNoteIsClippedLikeEveryOtherLine(t *testing.T) {
+	long := strings.Repeat("x", 4000)
+	h := Hit{Lifecycle: "rejected", LifecycleAt: "2026-08-24", LifecycleNote: long}
+	got := lifecycleSummary(h)
+	if len(got) > answerCap+80 {
+		t.Errorf("the search screen prints %d characters for one note", len(got))
+	}
+	b := BlameLifecycleLine(BlameHit{Lifecycle: "rejected", LifecycleAt: "2026-08-24", LifecycleNote: long})
+	if len(b) > answerCap+80 {
+		t.Errorf("blame prints %d characters for one note", len(b))
+	}
+	// The controls: a short note survives whole, and the state still reads.
+	short := "backed out, the pool was not the problem"
+	got = lifecycleSummary(Hit{Lifecycle: "rejected", LifecycleAt: "2026-08-24", LifecycleNote: short})
+	if !strings.Contains(got, short) || !strings.Contains(got, "tried and rejected") {
+		t.Errorf("a short note or its state was lost: %q", got)
+	}
+	if b = BlameLifecycleLine(BlameHit{Lifecycle: "stale", LifecycleNote: short}); !strings.Contains(b, short) {
+		t.Errorf("blame lost a short note: %q", b)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -855,7 +855,7 @@ func lifecycleSummary(h Hit) string {
 		head += " (" + SafeLine(h.LifecycleAt) + ")"
 	}
 	if h.LifecycleNote != "" {
-		head += ": " + SafeLine(h.LifecycleNote)
+		head += ": " + SafeNote(h.LifecycleNote)
 	}
 	return head
 }
@@ -2007,6 +2007,16 @@ func SafeText(s string) string {
 		}
 		return r
 	}, s)
+}
+
+// SafeNote is SafeLine bounded to the length of an answer, for the one string
+// on these screens that a person wrote at whatever length they liked. Printed
+// whole, a 4000-character promote note came out as a 4051-column line on a
+// screen budgeted to 80, and as 4074 of the 4347 bytes an agent got back
+// (#1645). The full note stays readable where a whole note belongs: `deja show`
+// on the promoted note prints it as a message.
+func SafeNote(s string) string {
+	return clip(SafeLine(s))
 }
 
 // SafeLine is SafeText confined to a single line, for the places that print


### PR DESCRIPTION
Closes #1645.

`deja promote --note` takes free text, and three places print it back on one line with no bound — the search screen (`lifecycleSummary`), `blame` (`BlameLifecycleLine`), and `ctx`/MCP (`lifecycleLine`). A 4000-character note came out as a 4051-column line on a screen budgeted to 80, sitting above the answer the reader asked for:

```
                 before   after
search screen     4051     314
ctx by id         4042     305
```

Every neighbouring line is budgeted — `fitLine`, the 56-column path column in `files`, `briefTitleBudget`, the width work in #1588/#1592/#1594. The note was the one string that was not.

Bounded with the `clip` that already existed for answers: 260 characters, with the CJK word-boundary handling from #1319 (a cut at the cap split a character and put an invalid byte into a recall payload). Exposed as `search.SafeNote` so all three callers share one rule rather than three.

Failing first:

```
--- FAIL: TestLifecycleNoteIsClippedLikeEveryOtherLine
    the search screen prints 4033 characters for one note
    blame prints 4042 characters for one note
```

Controls in the same test: a short note survives whole and the state still reads, on both surfaces — so this cannot pass by clipping the note away.

Nothing changes about what is stored: the note is kept verbatim, quotes and all, and the full text stays readable where a whole note belongs — `deja show` on the promoted note prints it as a message.

One claim from the issue is corrected in a comment there rather than left standing: the MCP figure I quoted was the note *session's* own message, which `ctx` is meant to print in full and which stays inside the 8 KB budget measured in #1622. It was not the marker and is not this defect.

The rest of item `[promote-note]` is clean: quotes stored verbatim, newlines kept in the record and flattened for the one-line marker, `--note` with no value refused, `--note ""` falling back to the generated summary.

## Review

> **No issues found.**
>
> 1. **UTF-8 safety of `clip`:** verified across CJK, emoji, RTL, combining and zero-width characters and multibyte sequences on the boundary — `utf8.RuneStart` keeps the cut off the middle of a rune; every output is valid UTF-8.
> 2. **Double clipping in lifecycle.go:** `recallListingLine` is `SafeLine`, so `SafeNote` applies it twice — redundant but harmless, and the first call is what #1080 requires to collapse newlines before display.
> 3. **Ellipsis handling:** the ellipsis can push the clipped string past 260 bytes; the test's `answerCap + 80` allowance covers the surrounding "[rejected] " and date. Worst case measured ~297 bytes.
> 4. **JSON output not clipped:** `lifecycle_note` in the JSON schema carries the full value. Clipping applies only in the three display functions.
> 5. **Full note availability:** a promoted note is a session with harness="deja" whose message is the note, so `deja show` prints it whole — the PR's claim holds.
> 6. **Test coverage:** fails without the fix (4033 and 4042 characters), passes with it; controls verify short notes and state labels survive; full suite green.
> 7. **Fixture:** `deja pool` max line 298 bytes, down from 4000+.

Point 4 is the one that mattered most to check, and it settles the contract question: the machine-readable field is untouched, and only what a person or an agent reads as a line is bounded.
