### PR TITLE
fix(handoff): an empty --to is refused, not read as no target at all

### DIFF
--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -34,7 +34,11 @@ func runHandoff(dir string, args []string, stdout io.Writer) error {
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--to":
-			if i+1 >= len(args) {
+			// Empty as well as absent: an empty value fell through the
+			// `target != ""` gate below and printed the paste-only handoff, so
+			// a scripted `--to "$AGENT"` with the variable unset read like a
+			// handoff to an agent (#1647).
+			if i+1 >= len(args) || strings.TrimSpace(args[i+1]) == "" {
 				return fmt.Errorf("handoff: --to needs an agent name")
 			}
 			target = args[i+1]

--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -39,7 +39,10 @@ func runHandoff(dir string, args []string, stdout io.Writer) error {
 			// a scripted `--to "$AGENT"` with the variable unset read like a
 			// handoff to an agent (#1647).
 			if i+1 >= len(args) || strings.TrimSpace(args[i+1]) == "" {
-				return fmt.Errorf("handoff: --to needs an agent name")
+				// Named targets, like the refusal below: the reader who typed
+				// an empty --to needs the same list as the one who typed a
+				// wrong name.
+				return fmt.Errorf("handoff: --to needs an agent name: %s", strings.Join(handoffTargets(), ", "))
 			}
 			target = args[i+1]
 			i++

--- a/cmd/deja/handoff_empty_target_test.go
+++ b/cmd/deja/handoff_empty_target_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// `--to ""` fell through the `target != ""` gate and printed the paste-only
+// handoff, so a scripted `--to "$AGENT"` with the variable unset read exactly
+// like a handoff to an agent. `--to "   "` was already refused by name, which
+// is what made the empty case an oversight (#1647).
+func TestHandoffRefusesAnEmptyTarget(t *testing.T) {
+	hermeticEnv(t)
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"--to", ""},
+		{"--to", "", "cl000001"},
+		{"--to", "  ", "cl000001"},
+	} {
+		err := runHandoff(dir, args, io.Discard)
+		if err == nil {
+			t.Errorf("handoff %v was accepted", args)
+			continue
+		}
+		if !strings.Contains(err.Error(), "--to") && !strings.Contains(err.Error(), "hand off to") {
+			t.Errorf("handoff %v: %v, want it to name the flag or the target", args, err)
+		}
+	}
+	// The controls: a real target is still accepted by the parser, and no --to
+	// at all is still the paste-only path rather than an error.
+	if err := runHandoff(dir, []string{"--to", "claude"}, io.Discard); err != nil && strings.Contains(err.Error(), "--to") {
+		t.Errorf("a real target was refused: %v", err)
+	}
+	if err := runHandoff(dir, nil, io.Discard); err != nil && strings.Contains(err.Error(), "--to") {
+		t.Errorf("no --to must stay the paste path, got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #1647.

`--to ""` fell through the `target != ""` gate and printed the paste-only handoff — byte-identical to passing no `--to` at all — while `--to "   "` was already refused by name. That asymmetry is what makes it an oversight rather than a policy.

```
before                                          after
$ deja handoff --to "" cl000001                 $ deja handoff --to "" cl000001
deja: handing off claude · … · 44d old          deja: handoff: --to needs an agent name
(exit 0, the paste text)                        (exit 1)
```

The shape that produces it is a script: `deja handoff --to "$AGENT"` with `AGENT` unset reads exactly like a handoff to an agent.

Failing first:

```
--- FAIL: TestHandoffRefusesAnEmptyTarget
    handoff [--to ]: … no agent history was found on this machine …, want it to name the flag or the target
    handoff [--to  cl000001]: no session matches "cl000001", want it to name the flag or the target
```

Both pre-fix failures also show the ordering the fix gets right: the target is now checked before the store is consulted, so an empty one is a parse error rather than whatever the store happens to say. Controls in the same test: a real target still parses, and no `--to` at all stays the paste path rather than becoming an error.

`--exec` was never affected — it already required a target (`handoff --exec needs --to <agent>`).

This is the seventh instance of one family in this hunt — #1610, #1612, #1613, #1618, #1628, #1630 — an argument that was typed and did nothing.

The rest of item `[handoff-targets]` is clean: all fifteen CLI targets and the five paste-only ones behave, `agy` resolves to antigravity, an unknown target is refused and lists what exists, and every flag deja hands a target (`--prompt`, `-i`, `--message`, `-p`, `run -t`) is present in that binary's own help on this machine — thirteen of them installed and checked.

## Review

> **🟡 risk (handoff.go:41):** whitespace-only targets are now rejected before the target lookup. The old error listed the available targets (`don't know how to hand off to "   "; targets: …`); the new one says `--to needs an agent name` without the list.
>
> **✓** the paste-only path (`deja handoff` with no `--to`) still reaches the digest.
> **✓** no caller in the repo — extensions, e2e, MCP, hooks, docs — passes `--to` with a value that could be unset at runtime.
> **✓** argument order works both ways; a target starting with a dash still fails at the target lookup, not at the new check.
> **✓** the test fails without the fix (verified against the parent: `--to ""` was accepted and reached `handoffSource`).
> **✓** full suite passes.

Right, and cheap to keep: 8055c7fc gives the empty refusal the same list the wrong-name one has, so nothing is lost by catching it earlier.

```
$ deja handoff --to '' cl000001
deja: handoff: --to needs an agent name: claude, codex, opencode, cursor, copilot, gemini, qwen, antigravity, …
```
