### PR TITLE
fix(stats): an empty top_projects is [] like its sibling, not null

### DIFF
--- a/internal/stats/empty_json_test.go
+++ b/internal/stats/empty_json_test.go
@@ -1,0 +1,40 @@
+package stats
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// On a fresh machine `harnesses` marshalled as [] and `top_projects` as null,
+// though both are declared as slices and the envelope is documented as a stable
+// shape. A consumer iterating top_projects threw on the first run and worked
+// ever after — the worst shape to diagnose (#1649).
+func TestEmptyReportHasNoNullCollections(t *testing.T) {
+	// The fresh-machine path: Build over no sessions at all.
+	r := Build(nil, time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC))
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"harnesses", "top_projects", "monthly"} {
+		v, ok := got[key]
+		if !ok {
+			t.Errorf("%s is absent from the envelope", key)
+			continue
+		}
+		if v == nil {
+			t.Errorf("%s is null on an empty report; an empty collection is []", key)
+		}
+	}
+	// The control: the sibling scalars still read as zero rather than absent,
+	// and nothing became a string.
+	if !strings.Contains(string(b), `"total_sessions":0`) {
+		t.Errorf("total_sessions changed shape: %s", b)
+	}
+}

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -204,6 +204,11 @@ func Build(ss []model.Session, now time.Time) Report {
 		out.Harnesses = append(out.Harnesses, *hs)
 	}
 	sort.Slice(out.Harnesses, func(i, j int) bool { return out.Harnesses[i].Harness < out.Harnesses[j].Harness })
+	// Built like Harnesses above rather than appended into a nil slice: on a
+	// fresh machine the nil marshalled as `null` while its sibling marshalled
+	// as `[]`, so a consumer iterating top_projects threw on the first run and
+	// worked ever after (#1649).
+	out.TopProjects = make([]ProjectStats, 0, len(byProject))
 	for project, count := range byProject {
 		out.TopProjects = append(out.TopProjects, ProjectStats{Project: project, Sessions: count})
 	}


### PR DESCRIPTION
Closes #1649.

On a fresh machine, two fields of the same declared type marshalled differently:

```
before                        after
"harnesses": [],              "harnesses": [],
"top_projects": null,         "top_projects": [],
```

`harnesses` is built with `make([]HarnessStats, 0, len(byHarness))`; `top_projects` was only appended to, so on an empty store it stayed nil. Built the same way now — one line, and the reason written next to it.

It matters on the one machine where it is most confusing: a consumer doing `for (const p of d.top_projects)` throws on the first run of a new install and works ever after.

Failing first, through the real fresh-machine path (`Build(nil, …)`):

```
--- FAIL: TestEmptyReportHasNoNullCollections
    top_projects is null on an empty report; an empty collection is []
```

The test also asserts `harnesses` and `monthly` are non-null, so the sibling cannot silently regress, and keeps a scalar control (`"total_sessions":0`) so a change of shape elsewhere is caught. `monthly` needed nothing — it always carries twelve buckets.

Measured with the binary, on an empty store and on a control store with two projects:

```
fresh    harnesses [] · top_projects [] · monthly list
two      top_projects [{"project":"a","sessions":1},{"project":"b","sessions":1}]
```

The rest of item `[stats-empty]` is clean: the heading and "nothing indexed yet — no agent history was found on this machine; `deja sources` shows where deja looked", `--impact` explaining that recall numbers appear once agents recall, `--redaction` printing zeroes, everything exit 0.

## Review

> No issues.
>
> **Test proof:** without the fix the test fails at line 32 — "top_projects is null on an empty report"; with it, it passes.
>
> **Nil vs empty:** no `== nil` / `!= nil` checks on TopProjects anywhere; every use is a range loop or a `len()`. The `[:5]` truncation works the same with a nil or an empty initial slice.
>
> **Collections swept:** stats Report — Harnesses already `make()`, Monthly assigned from a pre-allocated slice, TopProjects now fixed, Heatmap `json:"-"`. Search envelope Hits built via `make()`, never nil.
>
> **Also found (pre-existing, out of scope):** `machine_output` passes `nil` to `printRecentJSONWithheld` when there are no sessions — the same defect as this one, in `last --json`.
>
> **Card/HTML:** TopProjects is not used there; the text output uses safe range loops; `TestCardSurvivesAnEmptyReport` passes.
>
> **Full suite:** green, including the JSON contract check.

That last point is the one worth carrying forward: `last --json` has the same nil-for-empty shape, in the envelope a consumer is most likely to iterate. Filed separately rather than folded in here.
