### PR TITLE
fix(stats): the impact screen reads at one recall

### DIFF
--- a/cmd/deja/stats_impact.go
+++ b/cmd/deja/stats_impact.go
@@ -52,8 +52,11 @@ func printImpact(w io.Writer, r usage.ImpactReport, credits int, jsonOut bool) e
 		return nil
 	}
 	fmt.Fprintln(w, "deja impact — measured on this machine, nothing modeled")
-	fmt.Fprintf(w, "  recalls served     %d agent-initiated recalls returned matches\n", r.Recalls)
-	fmt.Fprintf(w, "  memory at start    %d session starts began with project memory\n", r.Injections)
+	// pluralS on all three counts: n=1 is this screen's commonest state — the
+	// first recall on a machine — and it read "1 agent-initiated recalls"
+	// (#1652). The verbs are already invariant.
+	fmt.Fprintf(w, "  recalls served     %d agent-initiated recall%s returned matches\n", r.Recalls, pluralS(r.Recalls))
+	fmt.Fprintf(w, "  memory at start    %d session start%s began with project memory\n", r.Injections, pluralS(r.Injections))
 	if r.RawBytes > 0 && r.ServedBytes > 0 {
 		// The frame, the header and the session lines cost more than the text
 		// they wrap when sessions are short — which is exactly the state a new
@@ -77,7 +80,7 @@ func printImpact(w io.Writer, r usage.ImpactReport, credits int, jsonOut bool) e
 		fmt.Fprintf(w, "  knowledge re-used  %d session%s recalled 2+ times — fixes that keep paying\n", r.ReusedTwice, pluralS(r.ReusedTwice))
 	}
 	if r.DejaVuMoments > 0 {
-		fmt.Fprintf(w, "  déjà vu moments    %d prompts matched work you had already done\n", r.DejaVuMoments)
+		fmt.Fprintf(w, "  déjà vu moments    %d prompt%s matched work you had already done\n", r.DejaVuMoments, pluralS(r.DejaVuMoments))
 	}
 	served := r.Recalls + r.Injections
 	switch {

--- a/cmd/deja/stats_impact_plural_test.go
+++ b/cmd/deja/stats_impact_plural_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// n=1 is this screen's most common state, not its edge case: it is what a new
+// user sees the first time an agent recalls anything, and it read "1
+// agent-initiated recalls returned matches" (#1652).
+func TestImpactScreenReadsAtOne(t *testing.T) {
+	var b bytes.Buffer
+	r := usage.ImpactReport{Recalls: 1, Injections: 1, DejaVuMoments: 1, ReusedTwice: 1, RawBytes: 400, ServedBytes: 200}
+	if err := printImpact(&b, r, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	for _, wrong := range []string{
+		"1 agent-initiated recalls",
+		"1 session starts",
+		"1 prompts",
+		"1 sessions recalled",
+	} {
+		if strings.Contains(out, wrong) {
+			t.Errorf("reads %q:\n%s", wrong, out)
+		}
+	}
+	for _, want := range []string{
+		"1 agent-initiated recall ",
+		"1 session start began",
+		"1 prompt matched",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q:\n%s", want, out)
+		}
+	}
+	// The control: at two the plural comes back.
+	b.Reset()
+	r = usage.ImpactReport{Recalls: 2, Injections: 2, DejaVuMoments: 2, ReusedTwice: 2, RawBytes: 400, ServedBytes: 200}
+	if err := printImpact(&b, r, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"2 agent-initiated recalls", "2 session starts", "2 prompts matched"} {
+		if !strings.Contains(b.String(), want) {
+			t.Errorf("plural lost at two: missing %q:\n%s", want, b.String())
+		}
+	}
+}

--- a/cmd/deja/stats_impact_test.go
+++ b/cmd/deja/stats_impact_test.go
@@ -25,9 +25,10 @@ func TestStatsImpactCountsAndArithmetic(t *testing.T) {
 	got := out.String()
 	for _, want := range []string{
 		"2 agent-initiated recalls",
-		"1 session starts began with project memory",
+		// Singular at one, as the rest of the screen already read (#1652).
+		"1 session start began with project memory",
 		"1 session recalled 2+ times",
-		"1 prompts matched work",
+		"1 prompt matched work",
 		"50× less",
 	} {
 		if !strings.Contains(got, want) {


### PR DESCRIPTION
Closes #1652.

```
before                                                after
1 agent-initiated recalls returned matches            1 agent-initiated recall returned matches
1 session starts began with project memory            1 session start began with project memory
1 prompts matched work you had already done           1 prompt matched work you had already done
```

n=1 is this screen's commonest state, not its edge case: it is what a new user sees the first time an agent recalls anything. The control was already on the same screen — `knowledge re-used %d session%s recalled 2+ times` used `pluralS`, and `credited aloud none of 1 yet` reads correctly — so this was three literals rather than a policy.

These are exactly the three lines the hunt's queue named when #1599 pluralised the brief and `deja stats` and deliberately parked the rest. The wider sweep stays parked; this closes the impact screen.

Failing first:

```
--- FAIL: TestImpactScreenReadsAtOne
    reads "1 agent-initiated recalls"
    reads "1 session starts"
    reads "1 prompts"
    missing "1 agent-initiated recall "
    missing "1 session start began"
    missing "1 prompt matched"
```

with the control in the same test: at two, every plural must come back.

One existing test pinned two of the wrong forms — `stats_impact_test.go` asserted `"1 session starts began with project memory"` and `"1 prompts matched work"`. Both updated, with the reason written next to them rather than silently.

The rest of item `[stats-impact-one]` is clean: zero recalls prints "no recall activity recorded yet — impact numbers appear once agents start recalling", and the ratio line says "short sessions, so the digest frame costs more than the text" instead of claiming a saving that did not happen (#731).

## Review

> No issues.
>
> - the test updates in `stats_impact_test.go` reflect plurality only; the arithmetic validation is unchanged
> - `TestImpactScreenReadsAtOne` fails without the fix (confirmed against the parent) and passes with it
> - the screen reads correctly at n=0 (early return), n=1 (singular) and n≥2 (plural)
> - the "knowledge re-used" and "déjà vu moments" lines are correctly gated behind `> 0`
> - "credited aloud" uses the invariant verb "said" and reads at every n
> - the three changed literals match the commit message's scope exactly
> - the verbs are indeed invariant, so only the nouns needed it
> - full suite: 45 packages, 0 failures
> - the parked sweep (fifteen other literals, e.g. `doctor.go:1029 "patterns"`) confirmed separate

The last line is the one I wanted checked rather than taken on my word: the claim that the wider sweep is a different item, not a convenient way to leave work undone.
