### PR TITLE
fix(help): a hook command is documented or deliberately hidden, not skipped wholesale

### DIFF
--- a/cmd/deja/help_coverage_test.go
+++ b/cmd/deja/help_coverage_test.go
@@ -42,6 +42,17 @@ func TestHelpNamesEveryDispatchedCommand(t *testing.T) {
 			t.Errorf("deja help does not name %q", name)
 		}
 	}
+	// A hidden name must still be a real command, or helpHidden is excusing a
+	// ghost — the way a stale entry would quietly re-open the gap it was added
+	// to close (#1654).
+	for name := range helpHidden {
+		if name == "help" {
+			continue // answered before dispatch, so it is not in the map
+		}
+		if _, ok := commands[name]; !ok {
+			t.Errorf("helpHidden excuses %q, which is not a command", name)
+		}
+	}
 	// And the reverse: help must not teach a command that no longer exists.
 	for name := range documented {
 		if _, ok := commands[name]; ok {

--- a/cmd/deja/help_coverage_test.go
+++ b/cmd/deja/help_coverage_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
 )
 
@@ -13,15 +12,19 @@ import (
 // completions and from the same cause: it comes from the switch in run(), not
 // from the commands map, so lists built from that map miss it (#753).
 func TestHelpNamesEveryDispatchedCommand(t *testing.T) {
-	// Plumbing invoked by harnesses, and the wrappers whose bare form is a
-	// search rather than a command.
+	// The wrappers whose bare form is a search rather than a command, and the
+	// flag spellings.
 	internal := map[string]bool{
-		"warmup-status": true, "help": true, "aider": true, "goose": true,
+		"aider": true, "goose": true,
 		"--help": true, "-h": true, "--version": true, "-version": true,
 	}
 	var names []string
 	for name := range commands {
-		if strings.HasPrefix(name, "hook-") || internal[name] {
+		// helpHidden rather than a blanket `hook-` skip: the skip let help
+		// document five hook commands and hide five, including hook-context,
+		// with nothing to notice (#1654). A hook is now either documented or
+		// named in helpHidden, where the reason lives.
+		if helpHidden[name] || internal[name] {
 			continue
 		}
 		names = append(names, name)

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2690,6 +2690,24 @@ func wrapTargets(names []string, indent string, width int) string {
 	return b.String() + line
 }
 
+// helpHidden names the commands deliberately kept out of `deja help`. They are
+// wired by `deja install` and read by a harness, not typed by a person: the
+// session-start and compaction hooks, goose's two, the refresh worker and the
+// warmup probe. The list exists so the omission is a decision with a reason
+// rather than drift — help listed five hook commands and hid five, including
+// hook-context, because the text is hand-maintained and nothing compared it
+// with the dispatch table (#1654). TestHelpCoversEveryCommand is that
+// comparison.
+var helpHidden = map[string]bool{
+	"help":              true,
+	"hook-context":      true,
+	"hook-goose":        true,
+	"hook-goose-prompt": true,
+	"hook-precompact":   true,
+	"hook-refresh":      true,
+	"warmup-status":     true,
+}
+
 func printUsage() {
 	fmt.Print(usageText())
 }


### PR DESCRIPTION
Closes #1654.

`deja help` documents five hook commands and hides five:

```
in help:  hook-antigravity  hook-plan  hook-prompt  hook-tool  hook-tool-after
in code:  … and hook-context, hook-goose, hook-goose-prompt, hook-precompact, hook-refresh
```

All five hidden ones run, as does `warmup-status`. The half that went missing is the wrong half to lose by accident: `hook-context` is the session-start hook the whole product turns on, while the harness-specific `hook-antigravity` is listed.

**Why it drifted, which is the part worth fixing.** A guard already existed — `TestHelpNamesEveryDispatchedCommand`, added by #753 for exactly this class of omission — and it skipped every name beginning with `hook-`:

```go
if strings.HasPrefix(name, "hook-") || internal[name] {
    continue
}
```

So no hook could ever be reported missing, and half the family drifted out of the help text with nothing to notice. That blanket skip is now an explicit list in `main.go`:

```go
// helpHidden names the commands deliberately kept out of `deja help`. They are
// wired by `deja install` and read by a harness, not typed by a person …
```

A hook is now either documented or named there with a reason.

Proof the guard can fail — removing one name from `helpHidden`, which is what adding a new undocumented command looks like:

```
--- FAIL: TestHelpNamesEveryDispatchedCommand
    deja help does not name "hook-context"
```

**Your call, not mine:** whether those five should be *listed* instead of hidden. Hooks are wired by `deja install` rather than typed, which argues for hiding them — but then the five that are listed, each with a parenthetical naming its harness event, argue the other way. This PR records the status quo and stops it drifting further; moving the line either way is one edit to `helpHidden` plus the help text.

The other direction of item `[help-coverage]` is clean: every command `deja help` names exists.

## Review

> No issues.
>
> **Old guard truth:** `strings.HasPrefix(name, "hook-")` skipped all hook names wholesale; the old test passed despite hook-context being dispatched and undocumented.
>
> **helpHidden completeness:** all seven entries are dispatched and absent from `usageText()`; the five documented hooks are correctly not in it. The split between helpHidden (infrastructure, not typed by a user) and the test's `internal` map (wrappers, flag spellings) is justified.
>
> **Guard correctness:** removing an entry makes the test report `deja help does not name hook-context`. The test does not validate that a helpHidden entry is dispatched — low risk, just dead code if violated.
>
> **Over-constraint:** every dispatched command satisfies one of documented / hidden / dispatch-only-via-switch. No other code builds a command list from the same map that would disagree; `TestCompletionsListEveryUserFacingCommand` still passes with its own skip list.
>
> **Design unresolved:** the PR records the status quo without deciding whether the five hidden hooks should be documented. Appropriate for a bug hunt; the test now prevents future drift.

The one gap it names is closed in d0329ef1 — that reverse check was in my first draft and was lost when I restored this file after overwriting it, which is exactly the kind of thing a review is for:

```
--- FAIL: TestHelpNamesEveryDispatchedCommand
    helpHidden excuses "hook-nonexistent", which is not a command
```

A stale entry would otherwise sit there quietly re-opening the gap it was added to close.
