### PR TITLE
fix(completion): the bash function survives a shell with set -u

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -43,8 +43,11 @@ _deja_completion() {
     if (( COMP_CWORD > 0 )); then
         prev="${COMP_WORDS[COMP_CWORD-1]}"
     fi
-    command="${COMP_WORDS[1]}"
-    action="${COMP_WORDS[2]}"
+    # Defaulted, like prev above: a shell with set -u is one people run, and
+    # reading these bare made the first Tab after "deja " print
+    # "COMP_WORDS[2]: unbound variable" instead of the candidates (#1656).
+    command="${COMP_WORDS[1]-}"
+    action="${COMP_WORDS[2]-}"
 
     local commands="blame bench check completion ctx doctor embed files fix forget friction handoff help how index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup"
     local harnesses="%HARNESSES%"

--- a/cmd/deja/completion_nounset_test.go
+++ b/cmd/deja/completion_nounset_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// A shell with `set -u` is a shell people actually run — it is standard advice
+// and it follows them into interactive use. The function guarded `prev` against
+// an unbound index and read COMP_WORDS[1] and [2] bare, so the first Tab after
+// `deja ` printed "COMP_WORDS[2]: unbound variable" and no candidates (#1656).
+func TestBashCompletionSurvivesNounset(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not on PATH")
+	}
+	script := bashCompletion
+	// The state right after `deja <Tab>`: two words, the cursor on the second.
+	const drive = `
+set -u
+COMP_WORDS=(deja '')
+COMP_CWORD=1
+_deja_completion
+printf '%s\n' "${#COMPREPLY[@]}"
+`
+	out, err := exec.Command(bash, "-c", script+drive).CombinedOutput()
+	got := string(out)
+	if err != nil {
+		t.Fatalf("completion failed under set -u: %v\n%s", err, got)
+	}
+	if strings.Contains(got, "unbound variable") {
+		t.Errorf("unbound variable under set -u:\n%s", got)
+	}
+	if strings.TrimSpace(got) == "0" {
+		t.Errorf("no candidates offered:\n%s", got)
+	}
+}


### PR DESCRIPTION
Closes #1656.

In a shell with `set -u`, the first Tab after `deja ` printed an error instead of candidates:

```
before                                              after
COMP_WORDS[2]: unbound variable                     47 candidates
(no candidates)                                     deja last --<Tab> → --harness --project --since --role
                                                    deja install <Tab> → 41 targets
```

The tell is three lines up in the same function: `prev` is guarded with `if (( COMP_CWORD > 0 ))`, while `command` and `action` read `COMP_WORDS[1]` and `[2]` bare. So `set -u` was not an unsupported configuration — it was an oversight in two of three reads. Both are now defaulted with `-`, the same shape the guard above expresses.

Failing first, driving the function the way bash does at the moment of Tab:

```
--- FAIL: TestBashCompletionSurvivesNounset
    completion failed under set -u: exit status 127
    bash: line 10: COMP_WORDS[2]: unbound variable
```

The test skips when bash is not on PATH, and asserts both halves — no "unbound variable" in the output, and a non-zero candidate count, so it cannot pass by completing nothing.

The rest of item `[completion-scripts]` is clean: bash registers `complete -F _deja_completion deja`; zsh, sourced after `compinit` as a real shell does, registers `_deja`; sourcing twice is clean in both; `set -e` is clean; `deja completion tcsh` and a bare `deja completion` are each refused by name.

**One third of the item is unverified and I would rather say so than imply otherwise:** fish is not installed on this machine, and installing software here is outside what the hunt should do. The generated fish script was read — 58 `complete` lines behind a `__deja_needs_command` guard — but reading is not running, so `deja completion fish` remains unchecked in a real shell.

## Review

> **Operator choice is correct:** `-` is the precise one here. At `deja <Tab>` the element exists and is empty, so `${COMP_WORDS[1]-}` returns the empty string; `:-` would substitute a default for a value that is genuinely there.
>
> **Test validates the fix:** the parent version fails with "COMP_WORDS[2]: unbound variable", the test catches it, the fix resolves it.
>
> **Deeper states under `set -u`, all clean:** `deja <Tab>` 47 candidates, `deja install <Tab>` 41, `deja blame x --harness <Tab>` 21, `deja sync export <Tab>` 1, `deja bench recall <Tab>` 1.
>
> **Line 41 unguarded but safe:** `cur="${COMP_WORDS[COMP_CWORD]}"` has no default, but bash guarantees that element exists — it is the word being completed. Confirmed across all states.
>
> **zsh clean:** tested under `setopt nounset` — no array violation; the script returns early before reading `words[2]` when only two words exist.
>
> **fish unverified but not installed:** honest call. Fish's model does not enforce unset variables the same way; no obvious problem in the script, but untested.
>
> **All tests pass. No issues.**

The two answers I wanted from someone other than me: that `-` rather than `:-` is right for an element that exists and is empty, and that the deeper branches my one-line drive never reached are clean under `set -u` too.
