### PR TITLE
fix(completion): offer every role deja accepts, not the three it once had

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -25,6 +25,9 @@ func runCompletion(args []string) error {
 	script = strings.ReplaceAll(script, "%INSTALL_TARGETS%", strings.Join(installTargetNames(), " "))
 	script = strings.ReplaceAll(script, "%HARNESSES%", strings.Join(sources.HarnessNames(), " "))
 	script = strings.ReplaceAll(script, "%HANDOFF_TARGETS%", strings.Join(handoffTargets(), " "))
+	// The last hand-written list: seven copies of "user assistant tool" while
+	// --role accepted four more (#1658).
+	script = strings.ReplaceAll(script, "%ROLES%", strings.Join(knownRoles, " "))
 	_, err := fmt.Fprint(os.Stdout, script)
 	return err
 }
@@ -106,7 +109,7 @@ _deja_completion() {
             if [[ "$prev" == "--harness" ]]; then
                 COMPREPLY=( $(compgen -W "$harnesses" -- "$cur") )
             elif [[ "$prev" == "--role" ]]; then
-                COMPREPLY=( $(compgen -W "user assistant tool" -- "$cur") )
+                COMPREPLY=( $(compgen -W "%ROLES%" -- "$cur") )
             else
                 COMPREPLY=( $(compgen -W "--harness --project --since --role" -- "$cur") )
             fi
@@ -235,7 +238,7 @@ _deja() {
       _arguments '--no-guidance[skip guidance files]' "1:target:($install_targets)"
       ;;
     last)
-      _arguments '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(user assistant tool)' '1:count:'
+      _arguments '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(%ROLES%)' '1:count:'
       ;;
     remember)
       _arguments '--project=[note project]:project:' '1:text:'
@@ -244,7 +247,7 @@ _deja() {
       _arguments '--exec[launch the native harness]' '1:session ID prefix:'
       ;;
     stats)
-      _arguments '--json[print JSON]' '--impact[measured impact report]' '--html=[write HTML timeline]:path:_files' '--redaction[include redaction facts]' '--card=[write SVG card]:path:_files' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(user assistant tool)'
+      _arguments '--json[print JSON]' '--impact[measured impact report]' '--html=[write HTML timeline]:path:_files' '--redaction[include redaction facts]' '--card=[write SVG card]:path:_files' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(%ROLES%)'
       ;;
     sync)
       if (( CURRENT == 3 )); then
@@ -260,7 +263,7 @@ _deja() {
     check|ctx|embed|hook-precompact|hook-prompt|mcp|share|show|sources|statusline|update|version|warmup)
       ;;
     *)
-      _arguments '--json[print JSON]' '--re[interpret query as a regular expression]' '--all[include all results]' '--no-embed[skip semantic reranking]' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(user assistant tool)' '--session=[only one session]:id:' '--rebuild[force a full rebuild]'
+      _arguments '--json[print JSON]' '--re[interpret query as a regular expression]' '--all[include all results]' '--no-embed[skip semantic reranking]' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(%ROLES%)' '--session=[only one session]:id:' '--rebuild[force a full rebuild]'
       ;;
   esac
 }
@@ -280,7 +283,7 @@ complete -c deja -n '__deja_needs_command' -l no-embed -d 'Skip semantic reranki
 complete -c deja -n '__deja_needs_command' -l harness -r -a '%HARNESSES%'
 complete -c deja -n '__deja_needs_command' -l project -r
 complete -c deja -n '__deja_needs_command' -l since -r
-complete -c deja -n '__deja_needs_command' -l role -r -a 'user assistant tool'
+complete -c deja -n '__deja_needs_command' -l role -r -a '%ROLES%'
 complete -c deja -n '__deja_needs_command' -l session -r
 complete -c deja -n '__deja_needs_command' -l rebuild
 
@@ -313,7 +316,7 @@ complete -c deja -n '__fish_seen_subcommand_from install uninstall' -l no-guidan
 complete -c deja -n '__fish_seen_subcommand_from last' -l harness -r -a '%HARNESSES%'
 complete -c deja -n '__fish_seen_subcommand_from last' -l project -r
 complete -c deja -n '__fish_seen_subcommand_from last' -l since -r
-complete -c deja -n '__fish_seen_subcommand_from last' -l role -r -a 'user assistant tool'
+complete -c deja -n '__fish_seen_subcommand_from last' -l role -r -a '%ROLES%'
 complete -c deja -n '__fish_seen_subcommand_from remember' -l project -r
 complete -c deja -n '__fish_seen_subcommand_from resume' -l exec
 complete -c deja -n '__fish_seen_subcommand_from stats' -l json
@@ -324,7 +327,7 @@ complete -c deja -n '__fish_seen_subcommand_from stats' -l card -r
 complete -c deja -n '__fish_seen_subcommand_from stats' -l harness -r -a '%HARNESSES%'
 complete -c deja -n '__fish_seen_subcommand_from stats' -l project -r
 complete -c deja -n '__fish_seen_subcommand_from stats' -l since -r
-complete -c deja -n '__fish_seen_subcommand_from stats' -l role -r -a 'user assistant tool'
+complete -c deja -n '__fish_seen_subcommand_from stats' -l role -r -a '%ROLES%'
 complete -c deja -n '__fish_seen_subcommand_from sync; and not __fish_seen_subcommand_from export import ssh' -a 'export import ssh'
 complete -c deja -n '__fish_seen_subcommand_from export' -l full
 complete -c deja -n '__fish_seen_subcommand_from export' -F

--- a/cmd/deja/completion_lists_test.go
+++ b/cmd/deja/completion_lists_test.go
@@ -62,3 +62,25 @@ func TestCompletionSubstitutesEveryPlaceholder(t *testing.T) {
 		}
 	}
 }
+
+// The roles list was the one hand-maintained copy left: seven of them across
+// the three shells, all reading "user assistant tool" while `--role` accepted
+// four more — tool-output, files, command and edit, the channels that record
+// which files a session touched, which commands it ran and which edits it made
+// (#1658). Substituted from knownRoles now, like the harnesses above.
+func TestCompletionOffersEveryRole(t *testing.T) {
+	if len(knownRoles) < 5 {
+		t.Fatalf("knownRoles holds %d entries, so this test proves nothing", len(knownRoles))
+	}
+	want := strings.Join(knownRoles, " ")
+	for _, shell := range []string{"bash", "zsh", "fish"} {
+		script := emittedCompletion(t, shell)
+		if !strings.Contains(script, want) {
+			t.Errorf("%s completion does not offer every role deja accepts", shell)
+		}
+		// And no copy of the old short list may survive alongside it.
+		if strings.Contains(script, "user assistant tool)") || strings.Contains(script, "'user assistant tool'") {
+			t.Errorf("%s completion still holds a hand-written role list", shell)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1658.

`--role` accepts seven values; the completions offered three, in seven hand-written copies across bash, zsh and fish.

```
$ deja pool --role nosuch
deja: "nosuch" is not a role deja knows — one of: user, assistant, tool, tool-output, files, command, edit

before:  user assistant tool
after:   user assistant tool tool-output files command edit      (all three shells)
```

`tool-output`, `files`, `command` and `edit` are the newer channels — which files a session touched, which commands it ran, which edits it made — so the CLI grew and the list stayed behind.

The fix is the pattern the file already uses and explains: every list a shell offers is substituted rather than duplicated, because "three hand-maintained copies is how this one fell seven harnesses behind". `%ROLES%` now joins `knownRoles`, alongside `%HARNESSES%`, `%INSTALL_TARGETS%` and `%HANDOFF_TARGETS%`.

Failing first:

```
--- FAIL: TestCompletionOffersEveryRole
    bash completion does not offer every role deja accepts
    bash completion still holds a hand-written role list
    zsh …  fish …
```

Two assertions per shell on purpose: the full list must appear, *and* no copy of the old short one may survive beside it — otherwise adding the missing roles in one place while five copies keep the old answer would pass.

The rest of item `[completion-lists]` is clean, and worth recording because it is the control for the finding: the harness list (21 names, identical to `sources.HarnessNames()` in all three shells), the install targets (38, identical to what `deja install` accepts) and `promote --state` all match exactly. The command list differs from `deja help` by exactly the five hook commands, which the completions deliberately skip — consistent with the decision recorded in #1654, not drift.

## Review

> **Substitution sites (all seven legitimate):** bash `compgen -W "%ROLES%"` inside `if [[ "$prev" == "--role" ]]`; three zsh `role:(%ROLES%)` (last, stats, default); three fish `-a '%ROLES%'` (global, last, stats). None in a comment, a description or a different flag.
>
> **Shell syntax:** `tool-output` is safe unquoted in all three constructs — bash `compgen -W` is space-delimited and a dash is not special; zsh `role:(…)` and fish `-a '…'` likewise. bash loaded without errors; zsh syntax valid.
>
> **knownRoles source:** expands to the wire values a user types — `user`, `assistant`, `tool`, `tool-output`, `files`, `command`, `edit` — not Go constant names; `tool` and `tool-output` are both accepted, as its comment says.
>
> **Test strength:** the positive check would fail on a three-item list, and the two negative checks catch a surviving zsh or fish remnant. Fails without the fix on all three shells, passes with it.
>
> **Full suite:** all `ok`. **No issues.**

The site-by-site audit is what I wanted checked: a blind replace of a literal string is exactly the kind of edit that quietly changes a description or a neighbouring flag, and this one did not.
