### PR TITLE
fix(help): wrap the install target list to the terminal, not to a fixed 76 columns

### DIFF
--- a/cmd/deja/help_install_targets_test.go
+++ b/cmd/deja/help_install_targets_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -51,4 +52,60 @@ func TestHelpTargetListWraps(t *testing.T) {
 			t.Errorf("target %q did not survive wrapping: %q", n, got)
 		}
 	}
+}
+
+// The list is the one block in help whose layout is computed, and it was
+// computed to a fixed 76 columns — the same six lines came out of a 30-column
+// pane and a 120-column one, while the brief, files, restore and search all
+// tracked the terminal (#1660).
+func TestHelpTargetListFollowsTheTerminal(t *testing.T) {
+	hermeticEnv(t)
+	for _, width := range []int{40, 120} {
+		t.Setenv("COLUMNS", strconv.Itoa(width))
+		out, err := captureRun(t, "help")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var widest int
+		for _, line := range strings.Split(out, "\n") {
+			if !strings.HasPrefix(line, "      ") || !strings.Contains(line, "claude-code") && !strings.Contains(line, ",") {
+				continue
+			}
+			if !isTargetLine(line) {
+				continue
+			}
+			if n := len(line); n > widest {
+				widest = n
+			}
+			if len(line) > width {
+				t.Errorf("COLUMNS=%d: target line is %d columns: %q", width, len(line), line)
+			}
+		}
+		if widest == 0 {
+			t.Fatalf("COLUMNS=%d: found no target lines in help", width)
+		}
+		// A wide pane must actually use it, or "fits" is met by never growing.
+		if width == 120 && widest <= 76 {
+			t.Errorf("COLUMNS=120: widest target line is %d columns, still laid out for 76", widest)
+		}
+	}
+}
+
+// isTargetLine reports whether an indented help line is part of the install
+// target listing rather than some other indented block.
+func isTargetLine(line string) bool {
+	fields := strings.Split(strings.TrimSpace(line), ", ")
+	if len(fields) < 2 {
+		return false
+	}
+	known := map[string]bool{}
+	for _, n := range installTargetNames() {
+		known[n] = true
+	}
+	for _, f := range fields {
+		if !known[strings.TrimSuffix(f, ",")] {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2794,7 +2794,21 @@ Examples:
   deja install --all
 
 See README.md for the full CLI reference.
-`, wrapTargets(installTargetNames(), "      ", 76))
+`, wrapTargets(installTargetNames(), "      ", usageWidth()))
+}
+
+// usageWidth is the column budget for the one block in help that is laid out
+// rather than typed. It follows the terminal, as the brief, files, restore and
+// search already do — the list was computed to a fixed 76 and so came out the
+// same six lines on a 30-column pane and a 120-column one (#1660).
+//
+// Off a terminal printableWidth answers 0, and the fixed 76 stands: piped and
+// redirected help keeps the byte-identical output that goldens and CI compare.
+func usageWidth() int {
+	if w := printableWidth(os.Stdout); w > 0 {
+		return w
+	}
+	return 76
 }
 
 // helpForCommand answers `deja <cmd> --help`. Every command rejected it as an


### PR DESCRIPTION
The install target list is the only block in `deja help` that is laid out rather than typed, and it was laid out to a hardcoded 76 columns — identical six lines on a 30-column pane and a 120-column one, while the brief, `files`, `restore` and `search` all follow the terminal. It now asks `printableWidth` too.

Off a terminal `printableWidth` answers 0 and the fixed 76 stands, so piped and redirected help stays byte-identical — that is what keeps goldens and CI stable, and it is why the existing `TestHelpTargetListWraps` still pins 76 explicitly.

Fail-before test: `TestHelpTargetListFollowsTheTerminal`, which checks both directions — nothing over the pane at COLUMNS=40, and the list actually widening past 76 at COLUMNS=120 (otherwise "fits" is satisfied by never growing).

Closes #1660.

The rest of the help page is hand-written and 148 columns at its widest — 12 of its 84 lines wrap on a default 80-column terminal. That is a wording/layout decision rather than a fix, so it is #1661, not this PR.
