### PR TITLE
fix(install): stop blaming file permissions for a config deja could not parse

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -112,8 +114,10 @@ func runInstall(dir string, args []string, uninstall bool) error {
 	// choose. Everything else is still done, and what could not be is named at
 	// the end (#902).
 	var refused []string
+	var refusedErrs []error
 	note := func(t string, err error) {
 		refused = append(refused, fmt.Sprintf("%s: %v", t, err))
+		refusedErrs = append(refusedErrs, err)
 	}
 	for _, t := range targets {
 		r, err := installTarget(t, exe, uninstall)
@@ -189,8 +193,8 @@ func runInstall(dir string, args []string, uninstall bool) error {
 		if uninstall {
 			verb = "uninstall"
 		}
-		return fmt.Errorf("%s finished what it could; %d target%s refused: %s — check those paths' permissions and run it again",
-			verb, len(refused), pluralS(len(refused)), strings.Join(refused, "; "))
+		return fmt.Errorf("%s finished what it could; %d target%s refused: %s — %s",
+			verb, len(refused), pluralS(len(refused)), strings.Join(refused, "; "), refusalRemedy(refusedErrs))
 	}
 	// Every install builds, not only --auto and --all. Installing is the one
 	// moment a person has already accepted a wait — they just ran an installer
@@ -414,6 +418,25 @@ func installIndexHint(dir string) string {
 		}
 	}
 	return fmt.Sprintf("next: run `deja index` to index %d agent stores", detected)
+}
+
+// refusalRemedy picks the sentence that closes an install summary. It was one
+// hardcoded line telling the reader to check permissions, which is the wrong
+// place to send someone whose config merely has a comment in it: five JSON
+// targets refused for a syntax error and every one was blamed on file
+// permissions (#1663). Same shape as #808, #931, #907 and #1116 — an error
+// wearing a permissions label it had not earned.
+func refusalRemedy(errs []error) string {
+	perms := 0
+	for _, err := range errs {
+		if errors.Is(err, fs.ErrPermission) {
+			perms++
+		}
+	}
+	if perms > 0 && perms == len(errs) {
+		return "check those paths' permissions and run it again"
+	}
+	return "fix what each one reports and run it again"
 }
 
 func existingTargets() []string {

--- a/cmd/deja/install_refusal_remedy_test.go
+++ b/cmd/deja/install_refusal_remedy_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every refusal, whatever it was, ended with "check those paths' permissions":
+// a config with a `//` comment in it refused five targets for a syntax error
+// and sent the reader to look at file permissions on files they can read
+// perfectly well (#1663).
+func TestRefusalRemedyMatchesTheFailure(t *testing.T) {
+	parse := errors.New("invalid character '/' looking for beginning of object key string")
+	denied := &fs.PathError{Op: "open", Path: "/x/settings.json", Err: fs.ErrPermission}
+
+	cases := []struct {
+		name string
+		errs []error
+		want string
+	}{
+		{"parse errors only", []error{parse, parse}, "fix what each one reports"},
+		{"mixed", []error{denied, parse}, "fix what each one reports"},
+		{"permission errors only", []error{denied, denied}, "check those paths' permissions"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := refusalRemedy(c.errs); !strings.Contains(got, c.want) {
+				t.Errorf("remedy for %s is %q, want it to say %q", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+// The end-to-end shape: a JSON config carrying a comment is refused, and the
+// sentence that closes the run does not blame permissions.
+func TestInstallCommentedJSONDoesNotBlamePermissions(t *testing.T) {
+	hermeticEnv(t)
+	root := filepath.Join(os.Getenv("HOME"), ".gemini")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := filepath.Join(root, "settings.json")
+	if err := os.WriteFile(settings, []byte("{\n  // mine\n  \"theme\": \"dark\"\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := captureRun(t, "install", "gemini")
+	if err == nil {
+		t.Fatal("install accepted a settings.json it cannot parse")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "permissions") {
+		t.Errorf("a parse error is reported as a permissions problem: %s", msg)
+	}
+	if !strings.Contains(msg, "invalid character") {
+		t.Errorf("the refusal does not carry the parse error: %s", msg)
+	}
+}


### PR DESCRIPTION
Every refused target ended with "check those paths' permissions and run it again", whatever had actually gone wrong. A `//` comment in `~/.claude/settings.json` refuses five targets for a JSON syntax error, and all five were reported as a permissions problem on files the user can read fine.

`refusalRemedy` now picks the sentence from the errors themselves: the permissions line only when every refusal is `fs.ErrPermission`, otherwise "fix what each one reports and run it again". The refusals already carry their own error text, so nothing is lost.

Fail-before test: `TestInstallCommentedJSONDoesNotBlamePermissions` (end-to-end, refuses on a commented settings.json and asserts the summary does not say "permissions") plus `TestRefusalRemedyMatchesTheFailure` over the three cases — parse-only, mixed, permission-only. Against the parent commit the first one fails with the exact sentence quoted in the issue.

Closes #1663.

Two related findings from the same run are filed but not touched here: #1664 (deja edits Zed's JSONC without disturbing it, but refuses the same content in the other five JSON configs) and #1665 (install re-alphabetises the keys in settings.json). Both want the same fix — a text-preserving JSON edit generalised from `install_zed.go` — which is more than this PR.

Wording check: "fix what each one reports and run it again" is mine, not yours. Say the word if you want it phrased differently.
