### PR TITLE
fix(install): write a config back with the line endings it already had

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -732,7 +732,47 @@ func mentionsDeja(b []byte) bool {
 	return false
 }
 
+// lfText is the text of a config normalised to LF, for the writers that splice
+// blocks by counting newlines. They then work in one convention and
+// writeIfChanged puts the file's own endings back (#1668).
+func lfText(b []byte) string {
+	return strings.ReplaceAll(string(b), "\r\n", "\n")
+}
+
+// matchLineEndings writes back the line endings the file already had. A
+// Windows user's configs are CRLF, and install rewrote the JSON ones LF-only
+// while leaving the TOML and YAML ones half and half — deja's appended block in
+// LF inside a CRLF file (#1668). install_goose.go and guidance.go already did
+// this for their own two files; every other writer comes through here.
+//
+// Only a file whose endings are *all* CRLF is treated as a CRLF file. A mixed
+// one is left alone: converting it whole would rewrite lines deja never touched,
+// which is the thing this exists to avoid.
+func matchLineEndings(old, next []byte) []byte {
+	if len(old) == 0 || !bytes.Contains(old, []byte("\r\n")) {
+		return next
+	}
+	if bytes.Count(old, []byte("\n")) != bytes.Count(old, []byte("\r\n")) {
+		return next
+	}
+	// Only the newlines that are not already CRLF, so a writer that converted
+	// its own output first is not given a second carriage return.
+	var b bytes.Buffer
+	b.Grow(len(next) + bytes.Count(next, []byte("\n")))
+	for i := 0; i < len(next); i++ {
+		if next[i] == '\n' && (i == 0 || next[i-1] != '\r') {
+			b.WriteByte('\r')
+		}
+		b.WriteByte(next[i])
+	}
+	return b.Bytes()
+}
+
 func writeIfChanged(path string, old, next []byte) (string, error) {
+	// Before the comparison, not after: a CRLF config converted afterwards
+	// would differ from `old` on every run, so each repeat install would
+	// rewrite the file and report it changed.
+	next = matchLineEndings(old, next)
 	if bytes.Equal(old, next) {
 		return "unchanged", nil
 	}
@@ -1090,7 +1130,10 @@ func installGrok(exe string, uninstall bool) (installResult, error) {
 
 func installTOML(path, block string, uninstall bool) (installResult, error) {
 	old, _ := os.ReadFile(path)
-	s := removeCodexDejaBlock(string(old))
+	// The splicing below counts newlines, so it works in LF and writeIfChanged
+	// puts the file's own endings back. Left as read, a CRLF file grew a blank
+	// line per install: TrimRight("\n") leaves the carriage return behind.
+	s := removeCodexDejaBlock(lfText(old))
 	s = strings.TrimRight(s, "\n")
 	if !uninstall {
 		if s != "" {

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -399,7 +399,7 @@ const kimiHookMarker = "# deja: auto-recall (managed by `deja install kimi-auto`
 func installKimiAuto(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(sources.KimiConfigDir(), "config.toml")
 	old, _ := os.ReadFile(path)
-	s := strings.TrimRight(removeKimiHookBlock(string(old)), "\n")
+	s := strings.TrimRight(removeKimiHookBlock(lfText(old)), "\n")
 	if !uninstall {
 		block := kimiHookMarker + "\n[[hooks]]\nevent = \"UserPromptSubmit\"\ncommand = " +
 			strconv.Quote(exe+" hook-prompt --plain") + "\ntimeout = 30\n"

--- a/cmd/deja/install_crlf_test.go
+++ b/cmd/deja/install_crlf_test.go
@@ -1,63 +1,124 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-// A config written on Windows, or by an editor set that way, uses CRLF. deja
-// edits several of them as text, splitting on "\n" — which leaves a stray "\r"
-// on the end of every line it inspects. The risk is not cosmetic: a key
-// compared against "extensions:" never matches "extensions:\r", so deja adds a
-// second one and the file stops parsing.
-func TestCRLFConfigSurvivesInstall(t *testing.T) {
-	for _, tc := range []struct {
-		target, rel, before string
-		keep                []string
-	}{
-		{"goose-auto", ".config/goose/config.yaml",
-			"GOOSE_PROVIDER: openai\r\nextensions:\r\n  theirs:\r\n    enabled: true\r\n",
-			[]string{"GOOSE_PROVIDER: openai", "theirs:"}},
-		{"kimi-auto", ".kimi-code/config.toml",
-			"default_model = \"theirs\"\r\n\r\n[providers.theirs]\r\ntype = \"openai\"\r\n",
-			[]string{`default_model = "theirs"`, "[providers.theirs]"}},
-	} {
-		t.Run(tc.target, func(t *testing.T) {
-			home := t.TempDir()
-			t.Setenv("HOME", home)
-			t.Setenv("USERPROFILE", home)
-			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-			t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
-			t.Setenv("DEJA_INDEX_DIR", filepath.Join(home, "index.db"))
+// A Windows user's configs are CRLF, and install rewrote the JSON ones LF-only
+// while leaving the TOML and YAML ones half and half — deja's appended block in
+// LF inside a CRLF file (#1668).
+func TestInstallKeepsCRLFConfigs(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	files := map[string]string{
+		".gemini/settings.json":  "{\n  \"theme\": \"dark\"\n}\n",
+		".cursor/mcp.json":       "{\n  \"mcpServers\": {}\n}\n",
+		".codex/config.toml":     "model = \"o3\"\n",
+		".kimi-code/config.toml": "model = \"kimi\"\n",
+	}
+	for rel, text := range files {
+		p := filepath.Join(home, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		crlf := strings.ReplaceAll(text, "\n", "\r\n")
+		if err := os.WriteFile(p, []byte(crlf), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRun(t, "install", "--auto"); err != nil {
+		t.Fatal(err)
+	}
+	for rel := range files {
+		p := filepath.Join(home, filepath.FromSlash(rel))
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lf := bytes.Count(b, []byte("\n"))
+		crlf := bytes.Count(b, []byte("\r\n"))
+		if lf == 0 {
+			t.Errorf("%s: no lines at all after install", rel)
+			continue
+		}
+		if crlf != lf {
+			t.Errorf("%s: %d of %d line endings are CRLF, the file was written CRLF throughout", rel, crlf, lf)
+		}
+	}
+}
 
-			path := filepath.Join(home, filepath.FromSlash(tc.rel))
-			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := os.WriteFile(path, []byte(tc.before), 0o644); err != nil {
-				t.Fatal(err)
-			}
-			if _, err := installTarget(tc.target, "/usr/local/bin/deja", false); err != nil {
-				t.Fatalf("install: %v", err)
-			}
-			after := readFile(t, path)
-			for _, want := range tc.keep {
-				if !strings.Contains(after, want) {
-					t.Errorf("install lost %q from a CRLF config:\n%q", want, after)
-				}
-			}
-			if !strings.Contains(after, "/usr/local/bin/deja") {
-				t.Fatalf("install wrote nothing into a CRLF config:\n%q", after)
-			}
-			// The shape that breaks the file: a key deja failed to recognise
-			// and therefore wrote again.
-			for _, key := range []string{"extensions:", "[[hooks]]"} {
-				if n := strings.Count(after, key); n > 1 {
-					t.Errorf("%q appears %d times after install:\n%q", key, n, after)
-				}
-			}
-		})
+// A file that was LF must not be converted the other way, and a file deja
+// creates itself stays LF.
+func TestInstallLeavesLFConfigsAlone(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	p := filepath.Join(home, ".gemini", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte("{\n  \"theme\": \"dark\"\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "--auto"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(b, []byte("\r")) {
+		t.Errorf("an LF config came back with CR in it:\n%q", string(b))
+	}
+}
+
+// Idempotence has to survive the conversion: the CRLF file is compared after
+// the endings are matched, not before, or every repeat install rewrites it.
+func TestInstallCRLFStaysUnchangedOnRepeat(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	seed := map[string]string{
+		".gemini/settings.json":  "{\n  \"theme\": \"dark\"\n}\n",
+		".cursor/mcp.json":       "{\n  \"mcpServers\": {}\n}\n",
+		".codex/config.toml":     "model = \"o3\"\n",
+		".kimi-code/config.toml": "model = \"kimi\"\n",
+		".grok/config.toml":      "[mcp_servers.mine]\ncommand = \"my-server\"\n",
+		".hermes/config.yaml":    "model: hermes-3\n",
+	}
+	for rel, text := range seed {
+		p := filepath.Join(home, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		crlf := strings.ReplaceAll(text, "\n", "\r\n")
+		if err := os.WriteFile(p, []byte(crlf), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRun(t, "install", "--auto"); err != nil {
+		t.Fatal(err)
+	}
+	first := map[string][]byte{}
+	for rel := range seed {
+		b, err := os.ReadFile(filepath.Join(home, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		first[rel] = b
+	}
+	if _, err := captureRun(t, "install", "--auto"); err != nil {
+		t.Fatal(err)
+	}
+	for rel := range seed {
+		b, err := os.ReadFile(filepath.Join(home, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(first[rel], b) {
+			t.Errorf("%s: the second install rewrote a CRLF config:\nfirst:  %q\nsecond: %q", rel, string(first[rel]), string(b))
+		}
 	}
 }

--- a/cmd/deja/install_crlf_test.go
+++ b/cmd/deja/install_crlf_test.go
@@ -87,6 +87,7 @@ func TestInstallCRLFStaysUnchangedOnRepeat(t *testing.T) {
 		".kimi-code/config.toml": "model = \"kimi\"\n",
 		".grok/config.toml":      "[mcp_servers.mine]\ncommand = \"my-server\"\n",
 		".hermes/config.yaml":    "model: hermes-3\n",
+		".dsh/cordis.patch.yml":  "# dsh patch\n- insert:\n    - id: mine\n      name: my-plugin\n",
 	}
 	for rel, text := range seed {
 		p := filepath.Join(home, filepath.FromSlash(rel))

--- a/cmd/deja/install_deepseek.go
+++ b/cmd/deja/install_deepseek.go
@@ -302,6 +302,6 @@ func installDeepSeek(exe string, uninstall, withAuto bool) (installResult, error
 	} else if err := os.Remove(dshAutoPath()); err != nil && !os.IsNotExist(err) {
 		return installResult{}, err
 	}
-	a, err := writeIfChanged(path, old, []byte(dshPatchWith(string(old), dshPatchBlock(exe, withAuto))))
+	a, err := writeIfChanged(path, old, []byte(dshPatchWith(lfText(old), dshPatchBlock(exe, withAuto))))
 	return installResult{Path: path, Action: a}, err
 }

--- a/cmd/deja/install_hermes.go
+++ b/cmd/deja/install_hermes.go
@@ -148,7 +148,7 @@ func installHermesMCP(exe string, uninstall bool) (installResult, error) {
 	if err != nil && !os.IsNotExist(err) {
 		return installResult{}, err
 	}
-	next := removeHermesMCPBlock(string(old))
+	next := removeHermesMCPBlock(lfText(old))
 	if !uninstall {
 		entry := "  deja:\n    command: " + yamlQuote(exe) + "\n    args:\n      - mcp\n    enabled: true\n"
 		if i := strings.Index(next, "\nmcp_servers:\n"); i >= 0 {
@@ -201,7 +201,7 @@ func setHermesPluginEnabled(on bool) error {
 			return err
 		}
 	}
-	s := string(old)
+	s := lfText(old)
 	listed := strings.Contains(s, "\n    - deja\n")
 	switch {
 	case on && listed, !on && !listed:


### PR DESCRIPTION
A CRLF config came back LF-only from the five JSON targets, and half and half from the TOML/YAML ones — deja's appended block in LF inside a file that was CRLF throughout. Every writer already hands `writeIfChanged` both the old bytes and the new ones, so that is where the endings are restored: `matchLineEndings` converts the new content to CRLF when the file it is replacing was CRLF throughout. A mixed file is left alone — converting it whole would rewrite lines deja never touched.

The conversion happens **before** the `bytes.Equal(old, next)` comparison, or a repeat install would rewrite every CRLF config and report it changed.

That exposed a second defect the CRLF loss was hiding, fixed here too (see the issue comment for the transcript): `installKimiAuto`, `installHermesMCP` and `setHermesPluginEnabled` splice by counting `\n`, so on a CRLF file they do not recognise their own block from last time — kimi grows a blank line per install and hermes appends `mcp_servers:` and `plugins.enabled` again. They now work on LF text via `lfText` and let `writeIfChanged` put the endings back. Today this is invisible because the first install flattens the file to LF; preserving the endings makes it reachable, so the two changes have to land together.

Fail-before tests: `TestInstallKeepsCRLFConfigs` (four configs, all CRLF after install), `TestInstallCRLFStaysUnchangedOnRepeat` (six configs, byte-identical on the second run — this is the one that caught the duplication) and `TestInstallLeavesLFConfigsAlone` (no CR appears in a file that had none).

Closes #1668.
