### PR TITLE
docs: two more pages for questions people type, and a guard for the set

### DIFF
--- a/cmd/deja/docs_pages_test.go
+++ b/cmd/deja/docs_pages_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The guide pages share one sidebar, one head shape and one sitemap. Each is
+// hand-written HTML, so the way they drift is silent: a page that is not in the
+// sitemap is a page search engines never fetch, a page whose sidebar forgets a
+// sibling is a page readers cannot leave, and a page marking two entries as
+// current is one nobody notices until it looks wrong in a screenshot.
+func TestGuidePagesShareTheirNavigation(t *testing.T) {
+	root := filepath.Join("..", "..")
+	dir := filepath.Join(root, "docs", "guide")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var pages []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".html") {
+			pages = append(pages, e.Name())
+		}
+	}
+	if len(pages) < 8 {
+		t.Fatalf("only %d guide pages found; the glob is wrong", len(pages))
+	}
+
+	sitemap, err := os.ReadFile(filepath.Join(root, "docs", "sitemap.xml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	link := regexp.MustCompile(`href="([a-z0-9-]+\.html)"`)
+	known := map[string]bool{}
+	for _, p := range pages {
+		known[p] = true
+	}
+
+	for _, name := range pages {
+		b, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		page := string(b)
+
+		if n := strings.Count(page, `aria-current="page"`); n != 1 {
+			t.Errorf("%s marks %d sidebar entries as current, want exactly one", name, n)
+		}
+		if !strings.Contains(string(sitemap), "guide/"+name) {
+			t.Errorf("%s is not in docs/sitemap.xml, so it is a page nobody is sent to", name)
+		}
+		if !strings.Contains(page, `<link rel="canonical"`) {
+			t.Errorf("%s has no canonical link", name)
+		}
+		for _, m := range link.FindAllStringSubmatch(page, -1) {
+			if !known[m[1]] {
+				t.Errorf("%s links to %s, which is not a guide page", name, m[1])
+			}
+		}
+		// Every page has to reach the two problem pages, which are the ones
+		// people arrive on: a sidebar that lists only the product pages sends
+		// a first-time reader back to the search results.
+		for _, sibling := range []string{"forgetting.html", "where-sessions-are-stored.html", "after-compaction.html"} {
+			if name == sibling {
+				continue
+			}
+			if !strings.Contains(page, `href="`+sibling+`"`) {
+				t.Errorf("%s does not link to %s", name, sibling)
+			}
+		}
+	}
+}

--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>What compaction drops, and how to get it back — deja-vu</title>
+<meta name="description" content="What a context compaction keeps and what it silently drops — measured over 43 real compactions — and how to recover the commands, errors and edits the summary left out.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/after-compaction.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="What compaction drops, and how to get it back">
+<meta property="og:description" content="What a context compaction keeps and what it silently drops — measured over 43 real compactions — and how to recover the commands, errors and edits the summary left out.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/after-compaction.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="What compaction drops, and how to get it back">
+<meta name="twitter:description" content="What a context compaction keeps and what it silently drops — measured over 43 real compactions — and how to recover the commands, errors and edits the summary left out.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"What compaction drops, and how to get it back","description":"What a context compaction keeps and what it silently drops — measured over 43 real compactions — and how to recover the commands, errors and edits the summary left out.","url":"https://vshulcz.github.io/deja-vu/guide/after-compaction.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/after-compaction.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"After compaction","item":"https://vshulcz.github.io/deja-vu/guide/after-compaction.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What does context compaction actually keep?","acceptedAnswer":{"@type":"Answer","text":"Measured over 43 real compactions: 77% of the decisions survived the summary and 0.2% of the commands that had been run. Reasoning is summarised; the exact invocations, error text and edited spans are dropped."}},{"@type":"Question","name":"Can I recover what a compaction dropped?","acceptedAnswer":{"@type":"Answer","text":"Yes, if the full transcript is still on disk. Harnesses write the whole session to a log file; the compaction only shortens what is in the model context, not what was written."}},{"@type":"Question","name":"How do I stop losing work to compaction?","acceptedAnswer":{"@type":"Answer","text":"Index the transcripts and let the agent search them, so the summary stops being the only copy. Indexing before compaction runs keeps the session searchable even after the window collapses."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html" aria-current="page">After compaction</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>What compaction drops, and how to get it back</h1>
+<p class="pagelede">the summary keeps the reasoning and drops the work<span class="mins" data-mins></span></p>
+
+<p>A long session compacts: the harness replaces earlier turns with a summary so the window keeps fitting. The session continues, the agent sounds like it remembers, and the specific thing you will need in twenty minutes is already gone.</p>
+
+<h2>What survives, measured</h2>
+<p>Over 43 real compactions taken from one machine's history, comparing each summary against the full transcript it replaced:</p>
+<ul>
+<li><b>77%</b> of the decisions survived — the conclusions, the "we went with X because Y".</li>
+<li><b>0.2%</b> of the commands that had actually been run survived.</li>
+</ul>
+<p>The method, the corpus and the script are in the repository under <a href="benchmarks.html">benchmarks</a>, and the ratio holds across harnesses because they all summarise prose the same way.</p>
+<p>That split is the whole problem. A summary is written in the language of intent, and the things that cost you an afternoon are not intent: the invocation with the four flags that finally worked, the error text you pasted, the exact span an edit replaced, the path of the file that turned out to matter. Ask after a compaction and you get a confident paraphrase of the plan with none of the parts you would have copied.</p>
+
+<h2>What compaction does not touch</h2>
+<p>The transcript. Compaction shortens what is in the model's context; it does not go back and rewrite the log the harness has been appending to since the session opened. Every command, every tool result, every edit is still on disk — see <a href="where-sessions-are-stored.html">where each agent keeps it</a>.</p>
+<p>So "lost to compaction" is a retrieval problem, not a data-loss problem. The work is there; nothing reads it back.</p>
+
+<h2>Getting it back</h2>
+<p>Two moments matter, and they are different.</p>
+<h3>During the session</h3>
+<p>Index before the window collapses. Claude Code exposes a <code>PreCompact</code> hook that fires just before summarising, which is exactly when the full transcript is still complete and still the current session's. <code>deja install --auto</code> wires that hook, so the session that is about to be summarised is searchable a moment later — including the parts the summary is about to drop.</p>
+<h3>Afterwards</h3>
+<p>Ask for the specific thing rather than the story:</p>
+<pre>deja how "go test"          # the invocation this project actually uses, with its flags
+deja fix "pq: too many connections"   # what was run after this error, where it stayed fixed
+deja blame internal/index/ingest.go   # which sessions discussed this file, and what they decided</pre>
+<p>Those three questions map onto exactly what a summary drops: commands, failures and file-level decisions. With recall wired in, the agent asks them itself — before it runs a command, after one fails, and when a prompt matches earlier work.</p>
+
+<h2>What this does not fix</h2>
+<p>Compaction is not a defect to be switched off. The window is finite, summarising is the right response, and a memory layer does not change that — it stops the summary from being the only copy. If the harness never wrote the session to disk, none of this applies, and the answer really is gone.</p>
+
+<p><a href="forgetting.html">Why agents forget between sessions</a> · <a href="where-sessions-are-stored.html">Where the transcripts live</a> · <a href="getting-started.html">Getting started</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -41,6 +41,8 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
 <a href="agents.html" aria-current="page">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -41,6 +41,8 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -41,6 +41,8 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html" aria-current="page">CLI reference</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -70,6 +70,8 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -42,6 +42,8 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html" aria-current="page">Why agents forget</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -41,6 +41,8 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html" aria-current="page">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -41,6 +41,8 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -41,6 +41,8 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -41,6 +41,8 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html" aria-current="page">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Where each coding agent stores its conversation history — deja-vu</title>
+<meta name="description" content="The on-disk location and format of session history for twenty coding agents — Claude Code, Codex, Cursor, opencode, Zed and more — with how to read them.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Where each coding agent stores its conversation history">
+<meta property="og:description" content="The on-disk location and format of session history for twenty coding agents — Claude Code, Codex, Cursor, opencode, Zed and more — with how to read them.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Where each coding agent stores its conversation history">
+<meta name="twitter:description" content="The on-disk location and format of session history for twenty coding agents — Claude Code, Codex, Cursor, opencode, Zed and more — with how to read them.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Where each coding agent stores its conversation history","description":"The on-disk location and format of session history for twenty coding agents — Claude Code, Codex, Cursor, opencode, Zed and more — with how to read them.","url":"https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Where history lives","item":"https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Where does Claude Code store its conversation history?","acceptedAnswer":{"@type":"Answer","text":"In JSONL files under ~/.claude/projects, one directory per project and one file per session. CLAUDE_CONFIG_DIR moves the whole tree."}},{"@type":"Question","name":"Where does Codex CLI keep its sessions?","acceptedAnswer":{"@type":"Answer","text":"Under ~/.codex: rollout JSONL files in sessions/, plus history.jsonl. CODEX_HOME moves both."}},{"@type":"Question","name":"Can I read those files myself?","acceptedAnswer":{"@type":"Answer","text":"Yes. Most are JSONL you can read with jq; opencode, Hermes and Zed use SQLite, and Zed compresses each thread body with zstd."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="where-sessions-are-stored.html" aria-current="page">Where history lives</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Where each coding agent stores its conversation history</h1>
+<p class="pagelede">twenty agents, twenty formats, one table<span class="mins" data-mins></span></p>
+
+<p>Every coding agent writes what you said and what it did to a file on your machine. The formats differ, the locations differ, and none of them is documented in one place — so here is that place, generated from the same registry deja's parsers are written against.</p>
+
+<h2>Where each one writes</h2>
+<table>
+<thead><tr><th>Agent</th><th>Where the sessions live</th><th>Format</th></tr></thead>
+<tbody>
+<tr><td><a href="../registry/aider.html">aider</a></td><td><code>~/.aider.chat.history.md</code></td><td>one Markdown log</td></tr>
+<tr><td><a href="../registry/antigravity.html">Antigravity</a></td><td><code>~/.gemini/antigravity*/brain/*/.system_generated/logs/transcript.jsonl</code></td><td>JSONL, one record per line</td></tr>
+<tr><td><a href="../registry/claude-code.html">Claude Code</a></td><td><code>${CLAUDE_CONFIG_DIR:-~/.claude}/projects/**/*.jsonl</code></td><td>JSONL, one record per line</td></tr>
+<tr><td><a href="../registry/cline.html">Cline</a></td><td><code>${CLINE_SESSION_DATA_DIR:-${CLINE_DATA_DIR:-${CLINE_DIR:-~/.cline}/data}/sessions}/*/*.messages.json</code></td><td>JSON files</td></tr>
+<tr><td><a href="../registry/codex.html">Codex CLI</a></td><td><code>${CODEX_HOME:-~/.codex}/sessions/**/rollout-*.jsonl</code></td><td>JSONL rollouts plus a history file</td></tr>
+<tr><td><a href="../registry/copilot.html">Copilot CLI</a></td><td><code>${DEJA_COPILOT_ROOT:-~/.copilot/session-state}/*/events.jsonl</code></td><td>JSONL, one record per line</td></tr>
+<tr><td><a href="../registry/cursor.html">Cursor</a></td><td><code>~/Library/Application Support/Cursor/User/{globalStorage,workspaceStorage/*}/state.vscdb</code></td><td>SQLite key-value store, or JSONL</td></tr>
+<tr><td><a href="../registry/deepseek.html">DeepSeek Harness</a></td><td><code>${DSH_HOME:-~/.dsh}/sessions/*/session-*/session.jsonl.zstd</code></td><td>JSONL, one record per line</td></tr>
+<tr><td><a href="../registry/gemini.html">Gemini CLI</a></td><td><code>${GEMINI_CLI_HOME:-~}/.gemini/tmp/*/chats/**/*.{json,jsonl}</code></td><td>JSON or JSONL</td></tr>
+<tr><td><a href="../registry/goose.html">Goose</a></td><td><code>${GOOSE_PATH_ROOT}/data/sessions/sessions.db</code></td><td>JSONL, with a SQLite index</td></tr>
+<tr><td><a href="../registry/grok.html">Grok Build</a></td><td><code>${GROK_HOME:-~/.grok}/sessions/**/updates.jsonl</code></td><td>JSONL events with JSON metadata</td></tr>
+<tr><td><a href="../registry/hermes.html">Hermes</a></td><td><code>~/.hermes/profiles/*/state.db</code></td><td>SQLite database</td></tr>
+<tr><td><a href="../registry/kimi.html">Kimi Code</a></td><td><code>${KIMI_CODE_HOME:-~/.kimi-code}/sessions/*/*/agents/main/wire.jsonl</code></td><td>JSONL, one record per line</td></tr>
+<tr><td><a href="../registry/omp.html">omp (Oh My Pi)</a></td><td><code>~/.omp/profiles/*/agent/sessions/**/*.jsonl</code></td><td>JSONL, one record per line</td></tr>
+<tr><td><a href="../registry/openclaw.html">OpenClaw</a></td><td><code>${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl</code></td><td>JSONL, one record per line</td></tr>
+<tr><td><a href="../registry/opencode.html">opencode</a></td><td><code>~/.local/share/opencode/opencode.db</code></td><td>SQLite database</td></tr>
+<tr><td><a href="../registry/pi.html">pi</a></td><td><code>${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl</code></td><td>JSONL, one record per line</td></tr>
+<tr><td><a href="../registry/qwen.html">Qwen Code</a></td><td><code>${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl</code></td><td>JSONL, one record per line</td></tr>
+<tr><td><a href="../registry/roo.html">Roo Code</a></td><td><code><vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json</code></td><td>JSON files</td></tr>
+<tr><td><a href="../registry/zed.html">Zed</a></td><td><code>~/Library/Application Support/Zed/threads/threads.db</code></td><td>SQLite database</td></tr>
+</tbody>
+</table>
+<p>Each row links to that harness's page in the <a href="../registry/README.html">session format registry</a>, which documents the record schema, how roles map, the override variables, and what deja could not verify. Every entry carries the date it was last checked against a real store.</p>
+
+<h2>Reading them yourself</h2>
+<p>Most are JSONL — one JSON object per line, appended as the session runs:</p>
+<pre>ls -t ~/.claude/projects/*/*.jsonl | head -1 | xargs tail -5 | jq -r '.message.content'</pre>
+<p>Three are databases rather than files. opencode keeps <code>opencode.db</code>, Hermes a <code>state.db</code> per profile, and Zed one SQLite store for every thread with each body compressed as a zstd frame — so <code>sqlite3</code> alone will show you rows of binary, and you need <code>zstd</code> to read a thread. Cursor is the awkward one: older versions keep a key-value blob inside <code>state.vscdb</code>, newer builds write JSONL transcripts per project.</p>
+<p>Two practical notes. Paths move: Claude Code honours <code>CLAUDE_CONFIG_DIR</code>, Codex <code>CODEX_HOME</code>, Kimi <code>KIMI_CODE_HOME</code>, Goose and opencode follow <code>XDG_DATA_HOME</code>. And these files hold whatever your session held, including any secret that was pasted or printed — treat them like the logs they are.</p>
+
+<h2>What to do with them</h2>
+<p>Reading one file answers "what did I do in that session". The useful question is usually the other one — "which session was it" — and that needs an index across all of them. That is what <a href="https://github.com/vshulcz/deja-vu">deja</a> builds: one local index over every store above, searchable from the command line and readable by the agents themselves over MCP.</p>
+<pre>curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
+deja "connection pool exhausted"</pre>
+<p>No capture step and nothing to switch on first: the files are already there, including the months before you installed anything. <a href="privacy.html">Indexing and search stay local</a>, and credentials are stripped as the index is built.</p>
+
+<p><a href="../registry/README.html">The full registry</a> · <a href="forgetting.html">Why agents forget in the first place</a> · <a href="getting-started.html">Getting started</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,6 +3,8 @@
   <url><loc>https://vshulcz.github.io/deja-vu/</loc><lastmod>2026-08-11</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/getting-started.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/forgetting.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/after-compaction.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/agents.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/search.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/commands.html</loc><lastmod>2026-08-11</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
Two more pages in the shape #1667 started, picked by counting how the problem is written rather than by guessing. Monthly counts of GitHub issues carrying each phrase, June → August:

| phrase | Jun | Jul | Aug |
|---|---:|---:|---:|
| "compaction" lost / "after compact" lost context | 2,206 | 3,940 | **4,420** |
| "claude code" conversation history location | 1,646 | 2,612 | **2,558** |
| "same mistake" agent repeats | 75 | 371 | 770 |

**Where each coding agent stores its conversation history.** The table is generated from `docs/registry/registry.json`, so the paths are the ones the parsers are actually written against and cannot drift from them; each row links to that harness's registry page for the record schema and the override variables. Then how to read the files yourself — `jq` for the JSONL ones, and the three that are databases, including Zed where every thread body is a zstd frame and `sqlite3` alone shows you binary. This is a reference nobody else publishes and we already maintain.

**What compaction drops, and how to get it back.** The 77%-of-decisions, 0.2%-of-commands measurement over 43 real compactions, why that split is the whole problem, and the part people miss: compaction shortens the model's context, not the transcript on disk, so it is a retrieval problem rather than data loss. Then the two moments — the `PreCompact` hook that indexes the session before the window collapses, and the three questions afterwards that map onto exactly what a summary drops.

Neither page is a landing page with a download button. Both name the alternatives, both link the evidence, and the compaction one says plainly what a memory layer does not fix.

Also a guard, because these pages only work as a set: `TestGuidePagesShareTheirNavigation` fails if a guide page is missing from the sitemap, marks two sidebar entries as current, links a page that does not exist, or stops linking the three problem pages. Sabotage-checked both ways before committing.
