### PR TITLE
docs: pages for the repeated wall and for switching agents

### DIFF
--- a/cmd/deja/docs_pages_test.go
+++ b/cmd/deja/docs_pages_test.go
@@ -63,10 +63,10 @@ func TestGuidePagesShareTheirNavigation(t *testing.T) {
 				t.Errorf("%s links to %s, which is not a guide page", name, m[1])
 			}
 		}
-		// Every page has to reach the two problem pages, which are the ones
-		// people arrive on: a sidebar that lists only the product pages sends
-		// a first-time reader back to the search results.
-		for _, sibling := range []string{"forgetting.html", "where-sessions-are-stored.html", "after-compaction.html"} {
+		// Every page has to reach the problem pages, which are the ones people
+		// arrive on: a sidebar that lists only the product pages sends a
+		// first-time reader back to the search results.
+		for _, sibling := range []string{"forgetting.html", "where-sessions-are-stored.html", "after-compaction.html", "repeated-mistakes.html", "switching-agents.html"} {
 			if name == sibling {
 				continue
 			}

--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -44,6 +44,8 @@
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
 <a href="after-compaction.html" aria-current="page">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -41,8 +41,10 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
-<a href="after-compaction.html">After compaction</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
 <a href="agents.html" aria-current="page">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -41,8 +41,10 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
-<a href="after-compaction.html">After compaction</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -41,8 +41,10 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
-<a href="after-compaction.html">After compaction</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html" aria-current="page">CLI reference</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -70,8 +70,10 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
-<a href="after-compaction.html">After compaction</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -42,8 +42,10 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html" aria-current="page">Why agents forget</a>
-<a href="after-compaction.html">After compaction</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -41,8 +41,10 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html" aria-current="page">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
-<a href="after-compaction.html">After compaction</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -41,8 +41,10 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
-<a href="after-compaction.html">After compaction</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -41,8 +41,10 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
-<a href="after-compaction.html">After compaction</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The agent keeps making a mistake you already fixed — deja-vu</title>
+<meta name="description" content="Why a coding agent hits the same wall it solved last month, how to see which walls a machine keeps hitting, and how to hand it the fix at the moment it fails.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/repeated-mistakes.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="When the agent repeats a mistake you already fixed">
+<meta property="og:description" content="Why a coding agent hits the same wall it solved last month, how to see which walls a machine keeps hitting, and how to hand it the fix at the moment it fails.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/repeated-mistakes.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="When the agent repeats a mistake you already fixed">
+<meta name="twitter:description" content="Why a coding agent hits the same wall it solved last month, how to see which walls a machine keeps hitting, and how to hand it the fix at the moment it fails.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"When the agent repeats a mistake you already fixed","description":"Why a coding agent hits the same wall it solved last month, how to see which walls a machine keeps hitting, and how to hand it the fix at the moment it fails.","url":"https://vshulcz.github.io/deja-vu/guide/repeated-mistakes.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/repeated-mistakes.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Repeated mistakes","item":"https://vshulcz.github.io/deja-vu/guide/repeated-mistakes.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Why does my coding agent keep making the same mistake?","acceptedAnswer":{"@type":"Answer","text":"Because the session that solved it ended and nothing reads its transcript back. The agent is not repeating a mistake it remembers making — from its side the problem is new every time."}},{"@type":"Question","name":"Should I write the fix into CLAUDE.md or AGENTS.md?","acceptedAnswer":{"@type":"Answer","text":"For a rule you already know you need, yes. It does not help for a wall you have not hit twice yet, and every line costs context on every session, so the file cannot hold everything."}},{"@type":"Question","name":"Can the agent be told the fix at the moment it fails?","acceptedAnswer":{"@type":"Answer","text":"Yes. A post-failure hook can search the machine's own history for what was run after the same error in the sessions where it did not come back, and hand that to the agent unprompted."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html" aria-current="page">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>When the agent repeats a mistake you already fixed</h1>
+<p class="pagelede">it is not repeating a mistake — from its side the problem is new<span class="mins" data-mins></span></p>
+
+<p>The agent proposes the approach you tried in March and backed out of. Or it hits <code>ModuleNotFoundError: No module named 'yaml'</code> and starts guessing, in a repository where that exact error was solved four times already.</p>
+<p>It is not being stubborn. From its side the problem is new: the session that solved it ended, and nothing read the transcript back. The word "repeats" describes your experience, not the agent's.</p>
+
+<h2>Which walls a machine actually hits again</h2>
+<p><code>deja friction</code> counts errors that appear in three or more separate sessions and names the agents that hit them:</p>
+<pre>$ deja friction
+what this machine keeps tripping over — 500 sessions read
+  16 sessions  command not found: timeout
+               claude, opencode · last Aug 23
+  11 sessions  command not found: python
+               antigravity, claude, codex, opencode · last Jul 22
+  10 sessions  ModuleNotFoundError: No module named 'yaml'
+               claude, opencode · last Aug 20</pre>
+<p>Two things worth noticing in that output. The counts are sessions, not occurrences — sixteen separate times somebody started fresh and met the same wall. And the harness column is usually more than one, which is why a memory scoped to a single agent does not close it.</p>
+
+<h2>The fix that stayed fixed</h2>
+<p>Knowing you hit something sixteen times is only half of it. The other half is what ended it:</p>
+<pre>$ deja fix "ModuleNotFoundError: No module named 'yaml'"</pre>
+<p>The answer is a command that was actually run on this machine after that error, in sessions where the error did not come back afterwards. That last clause is the whole design: a command that was run and then followed by the same failure again is not a fix, and pairing an error with whatever came next without checking would produce exactly that kind of confident wrong answer. When nothing qualifies, the command says so rather than guessing:</p>
+<pre>$ deja fix "command not found: timeout"
+deja: no session on this machine ran a command after that error</pre>
+
+<h2>Doing it without being asked</h2>
+<p>Neither command helps if you have to remember to run it, and the moment you would remember is after you have already lost the twenty minutes. So the same lookup runs from hooks, where the harness supports them:</p>
+<ul>
+<li><b>Before a command runs</b> — the invocation this project actually uses, with the flags it was run with, instead of a plausible guess.</li>
+<li><b>After one fails</b> — what followed that same error here before. This is the pair an agent never thinks to ask for, because from inside the session there is nothing to ask about.</li>
+<li><b>Before a file is edited</b> — what earlier sessions decided about that file, including a decision that was tried and reverted.</li>
+</ul>
+<p><code>deja install --auto</code> wires whichever of those the harness exposes; the <a href="agents.html">agents guide</a> lists which supports what.</p>
+
+<h2>What about a rules file</h2>
+<p><code>CLAUDE.md</code>, <code>AGENTS.md</code> and their equivalents are the right place for a rule you already know you need — the build command, the conventions, the directory nobody may touch. They do not solve this one for two reasons. Nobody writes down the wall they have not hit twice yet, and the file is read in full on every session, so it cannot hold the long tail of things that each mattered once. History is the long tail.</p>
+
+<h2>Marking what did not work</h2>
+<p>Sometimes the repeated mistake is one you already investigated and rejected. <code>deja promote &lt;id&gt; --state rejected --note "why"</code> marks that session, and every later hit for it shows that it was tried and rejected, with the reason. Nothing is deleted — <code>--state accepted</code> takes the mark back — and the note travels to the other machines you sync with.</p>
+
+<p><a href="forgetting.html">Why agents forget in the first place</a> · <a href="after-compaction.html">What compaction drops</a> · <a href="getting-started.html">Getting started</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -41,8 +41,10 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
-<a href="after-compaction.html">After compaction</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html" aria-current="page">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/switching-agents.html
+++ b/docs/guide/switching-agents.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Switching between Claude Code, Codex and Cursor without re-explaining — deja-vu</title>
+<meta name="description" content="Recall across every coding agent on the machine, and handing a live session from one to another — two different problems with two different answers.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/switching-agents.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Switching agents without re-explaining the project">
+<meta property="og:description" content="Recall across every coding agent on the machine, and handing a live session from one to another — two different problems with two different answers.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/switching-agents.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Switching agents without re-explaining the project">
+<meta name="twitter:description" content="Recall across every coding agent on the machine, and handing a live session from one to another — two different problems with two different answers.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Switching agents without re-explaining the project","description":"Recall across every coding agent on the machine, and handing a live session from one to another — two different problems with two different answers.","url":"https://vshulcz.github.io/deja-vu/guide/switching-agents.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/switching-agents.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Switching agents","item":"https://vshulcz.github.io/deja-vu/guide/switching-agents.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Can Claude Code see what I did in Codex or Cursor?","acceptedAnswer":{"@type":"Answer","text":"Not by itself — each harness reads only its own history. A shared index over all of their transcripts makes the work of one reachable from any of the others."}},{"@type":"Question","name":"How do I move a session from one agent to another?","acceptedAnswer":{"@type":"Answer","text":"Package what the session established — the problem, the conclusions, where it stopped — as plain text the next agent starts from. deja handoff --to <agent> does that from the indexed transcript."}},{"@type":"Question","name":"Do I have to re-explain the project every time I switch tools?","acceptedAnswer":{"@type":"Answer","text":"Only if the new tool starts empty. With recall over the shared history it opens knowing what the project has already decided, whichever agent decided it."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html" aria-current="page">Switching agents</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Switching agents without re-explaining the project</h1>
+<p class="pagelede">your history is not per-tool, even though every tool's memory is<span class="mins" data-mins></span></p>
+
+<p>Most people use more than one. Claude Code for the long refactor, Codex for a quick fix, Cursor because the file is already open, opencode or Zed because that is where the terminal is. Each keeps its own history, and none of them can read another's — so switching tools means explaining the project again.</p>
+
+<h2>Two different problems</h2>
+<p>They get talked about as one thing, and they are not.</p>
+<h3>Recall: the work already happened somewhere</h3>
+<p>You are in Codex now, and the answer is in a Claude Code session from July. Nothing needs to be transferred — it needs to be findable. One index over every harness's transcripts makes the question answerable from whichever agent you happen to be in:</p>
+<pre>$ deja "connection pool exhausted"
+[claude] api   · Jul 8 · 8f31c0a9 — 2 matches
+  login started failing after refresh token rotation; jwt kid mismatch in tests
+  fixed by reloading jwks cache after rotateKey and adding a clock-skew test
+[codex]  web   · Jul 1 · b77d91e2 — 1 match
+  refresh token cookie needed SameSite=Lax in local callback flow</pre>
+<p>With recall wired in, the agent runs that lookup itself when a prompt matches earlier work — including work from a tool you have since stopped using.</p>
+<h3>Handoff: this session should continue over there</h3>
+<p>The other case is a live piece of work that has to move — the model hit a usage limit, or the job is better suited to a different agent. That is not a search; it is packaging what the session established so the next one starts from it:</p>
+<pre>deja handoff --to codex</pre>
+<p>It reads the session from the index and prints what the next agent needs: the problem, what has been established, and where it stopped. <code>--exec</code> launches the target agent with it. No protocol between the two tools, nothing to install on both ends, and it works between agents that know nothing about each other.</p>
+
+<h2>Why a per-tool memory does not cover it</h2>
+<p>Every harness that ships memory scopes it to itself, which is the correct choice for them and the wrong shape for you: your history is not per-tool, and the tool you were using in March is a detail of that month, not a property of the problem. On a real machine the errors that recur are usually hit under two or three different agents — <code>deja friction</code> prints the harness names beside each one, and the list is rarely a single tool.</p>
+
+<h2>What it takes</h2>
+<pre>curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
+deja install --auto</pre>
+<p>The second command wires recall into every agent it finds on the machine and builds the index over all of their stores at once — <a href="where-sessions-are-stored.html">twenty of them today</a>, including the sessions that predate the install. Nothing is copied between tools and no history is moved: one local index, read by whichever agent is asking.</p>
+<p>Across machines rather than tools, <code>deja sync ssh &lt;host&gt;</code> moves the index itself, append-only and with no service in the middle.</p>
+
+<p><a href="forgetting.html">Why agents forget</a> · <a href="repeated-mistakes.html">When the same wall comes back</a> · <a href="agents.html">Which agent supports what</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -42,8 +42,10 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
-<a href="after-compaction.html">After compaction</a>
 <a href="where-sessions-are-stored.html" aria-current="page">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -5,6 +5,8 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/forgetting.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/after-compaction.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/repeated-mistakes.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/switching-agents.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/agents.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/search.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/commands.html</loc><lastmod>2026-08-11</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
Two more, chosen the same way — by counting how the problem is written on GitHub rather than by guessing. "same mistake" next to agent: 75 issues in June, 371 in July, 770 in August. "switch between" Claude Code and Codex with context: 818, 1,236, 891.

**When the agent repeats a mistake you already fixed.** Opens with the honest framing — it is not repeating anything, the session that solved it ended — then shows what the machine actually keeps hitting (`deja friction` output from this laptop: sixteen sessions on one `command not found`, across two harnesses), and what `deja fix` answers with, including the case where it answers nothing because no command qualified. The hooks section is the point: none of it helps if you have to remember to run it.

**Switching agents without re-explaining the project.** Separates the two problems people talk about as one — recall, where the work already happened somewhere and just needs finding, and handoff, where a live session has to move. Ends on why a per-tool memory cannot close the first one, with the friction output as evidence that recurring errors are usually hit under more than one agent.

Every command shown was run to get its output, including the empty answer. The guard from #1670 now covers all five problem pages, and the sidebar block is generated once and applied to every guide page rather than edited per file.