### PR TITLE
docs: pages for exporting a session and for syncing across machines

### DIFF
--- a/cmd/deja/docs_pages_test.go
+++ b/cmd/deja/docs_pages_test.go
@@ -66,7 +66,15 @@ func TestGuidePagesShareTheirNavigation(t *testing.T) {
 		// Every page has to reach the problem pages, which are the ones people
 		// arrive on: a sidebar that lists only the product pages sends a
 		// first-time reader back to the search results.
-		for _, sibling := range []string{"forgetting.html", "where-sessions-are-stored.html", "after-compaction.html", "repeated-mistakes.html", "switching-agents.html"} {
+		for _, sibling := range []string{
+			"forgetting.html",
+			"where-sessions-are-stored.html",
+			"after-compaction.html",
+			"repeated-mistakes.html",
+			"switching-agents.html",
+			"export-conversations.html",
+			"sync-across-machines.html",
+		} {
 			if name == sibling {
 				continue
 			}

--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -46,6 +46,8 @@
 <a href="after-compaction.html" aria-current="page">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -45,6 +45,8 @@
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
 <a href="agents.html" aria-current="page">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -45,6 +45,8 @@
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -45,6 +45,8 @@
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html" aria-current="page">CLI reference</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -74,6 +74,8 @@
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/export-conversations.html
+++ b/docs/guide/export-conversations.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Export a Claude Code, Codex or Cursor conversation — deja-vu</title>
+<meta name="description" content="How to export or read a coding-agent session — the raw transcript, one readable Markdown session, the whole index as JSONL, or a local page to browse it all.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/export-conversations.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Getting a conversation out of your coding agent">
+<meta property="og:description" content="How to export or read a coding-agent session — the raw transcript, one readable Markdown session, the whole index as JSONL, or a local page to browse it all.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/export-conversations.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Getting a conversation out of your coding agent">
+<meta name="twitter:description" content="How to export or read a coding-agent session — the raw transcript, one readable Markdown session, the whole index as JSONL, or a local page to browse it all.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Getting a conversation out of your coding agent","description":"How to export or read a coding-agent session — the raw transcript, one readable Markdown session, the whole index as JSONL, or a local page to browse it all.","url":"https://vshulcz.github.io/deja-vu/guide/export-conversations.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/export-conversations.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Exporting sessions","item":"https://vshulcz.github.io/deja-vu/guide/export-conversations.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I export a Claude Code conversation?","acceptedAnswer":{"@type":"Answer","text":"The transcript is already a file — JSONL under ~/.claude/projects. For something readable, deja share <id> prints one session as Markdown with the problem, what was tried and what was decided, and re-applies redaction on the way out."}},{"@type":"Question","name":"Can I export sessions from every agent at once?","acceptedAnswer":{"@type":"Answer","text":"Yes. deja sync export <dir> writes the whole index as JSONL — every harness it read, one file per shard — and re-runs redaction on export rather than trusting what was stored."}},{"@type":"Question","name":"Is it safe to share an exported session?","acceptedAnswer":{"@type":"Answer","text":"Credentials are masked at index time and again on export, but pattern redaction is a floor, not a guarantee. Read an export before it leaves the machine and rotate anything that did leak."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html" aria-current="page">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Getting a conversation out of your coding agent</h1>
+<p class="pagelede">the transcript is already a file; the question is what shape you need it in<span class="mins" data-mins></span></p>
+
+<p>Sooner or later you want a session out of the tool: to attach it to a bug report, to hand a colleague what you already worked out, to keep a record before clearing history. Every harness writes the conversation to disk, and none of them offers a good way to get one out.</p>
+
+<h2>The raw file, if that is what you want</h2>
+<p>Most agents write JSONL — one JSON object per line, appended as the session runs. Claude Code keeps it under <code>~/.claude/projects</code>, Codex under <code>~/.codex</code>, and the rest are listed on <a href="where-sessions-are-stored.html">where each agent stores its history</a>. That file is complete and unreadable in equal measure: system prompts, tool payloads and base64 blobs sit between the sentences you were looking for.</p>
+<pre>ls -t ~/.claude/projects/*/*.jsonl | head -1 | xargs jq -r 'select(.type=="user") | .message.content'</pre>
+<p>Good enough to grep. Not something to attach to an issue.</p>
+
+<h2>One session, readable</h2>
+<pre>$ deja share 8f31c0a9
+# deja share: 8f31c0a9-…
+
+- Project: api-gateway
+- Harness: claude
+- Date: 2026-07-08T13:41:02Z
+
+## User problem statement(s)
+…
+
+## What was tried
+…
+
+## Outcome
+…</pre>
+<p>Markdown, structured as the thing a reader needs rather than as the thing the harness stored: what the problem was, what was tried, what was decided. Redaction runs again on the way out — the same rules the index applied, re-applied to what leaves.</p>
+
+<h2>Everything, as data</h2>
+<pre>$ deja sync export ./out
+deja: exported 180516 records
+deja: records were redacted at index time (566 masked). pattern redaction is a floor —
+      review the export before moving it; rotate anything that leaked.</pre>
+<p>JSONL across every harness the index read, in a shape another machine's deja can import — which is what <a href="sync-across-machines.html">syncing between machines</a> uses. It is also a plain archive: the records are ordinary JSON, and nothing needs deja to read them back.</p>
+<p>That second line is printed on every export on purpose. Redaction is pattern matching, and pattern matching has a floor: it catches the shapes it knows — AWS keys, bearer tokens, JWTs, PEM blocks, <code>scheme://user:pass@host</code> URLs, high-entropy values in secret-shaped positions — and cannot promise there is nothing else. Read an export before it leaves the machine, and rotate anything that did leak. Project exclusions are honoured by the export too, so a project you excluded does not travel.</p>
+
+<h2>Browsing rather than exporting</h2>
+<pre>deja view</pre>
+<p>Writes one local HTML file with the sessions, the recalls served and the notes, and opens it. No server, nothing uploaded — the page is a file on your disk. This is usually what people actually wanted when they went looking for an export: a way to look through what is there.</p>
+
+<h2>Before you clear history</h2>
+<p>Deleting a harness's transcripts is not the same as removing them from an index that already read them. If you keep an index, <code>deja forget &lt;id&gt;</code> removes those sessions and writes a tombstone so a later <code>deja index</code> cannot resurrect them from the source; <code>--list</code> shows the tombstones and <code>--unforget</code> reverses one. <a href="privacy.html">Privacy</a> covers the rest: what is indexed, what is stripped, and what never leaves the machine.</p>
+
+<p><a href="where-sessions-are-stored.html">Where each agent keeps its sessions</a> · <a href="privacy.html">Privacy</a> · <a href="commands.html">CLI reference</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -46,6 +46,8 @@
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -45,6 +45,8 @@
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -45,6 +45,8 @@
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -45,6 +45,8 @@
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -46,6 +46,8 @@
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html" aria-current="page">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -45,6 +45,8 @@
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html" aria-current="page">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/switching-agents.html
+++ b/docs/guide/switching-agents.html
@@ -46,6 +46,8 @@
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html" aria-current="page">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/sync-across-machines.html
+++ b/docs/guide/sync-across-machines.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sync coding-agent history between machines — deja-vu</title>
+<meta name="description" content="Move indexed coding-agent sessions between your own machines over SSH — append-only, no service in the middle — and decide what synced memory is allowed to do.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/sync-across-machines.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Keeping agent history in sync across machines">
+<meta property="og:description" content="Move indexed coding-agent sessions between your own machines over SSH — append-only, no service in the middle — and decide what synced memory is allowed to do.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/sync-across-machines.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Keeping agent history in sync across machines">
+<meta name="twitter:description" content="Move indexed coding-agent sessions between your own machines over SSH — append-only, no service in the middle — and decide what synced memory is allowed to do.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Keeping agent history in sync across machines","description":"Move indexed coding-agent sessions between your own machines over SSH — append-only, no service in the middle — and decide what synced memory is allowed to do.","url":"https://vshulcz.github.io/deja-vu/guide/sync-across-machines.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/sync-across-machines.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Across machines","item":"https://vshulcz.github.io/deja-vu/guide/sync-across-machines.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Can I share coding-agent history between my laptop and my desktop?","acceptedAnswer":{"@type":"Answer","text":"Yes. deja sync ssh <host> exchanges indexed sessions over your own SSH connection, append-only and with no service in the middle."}},{"@type":"Question","name":"Does syncing agent history need a cloud account?","acceptedAnswer":{"@type":"Answer","text":"No. The transport is ssh and scp with the credentials you already use; the remote runs its own deja to import the batch."}},{"@type":"Question","name":"Can I keep synced memory searchable but stop it being injected automatically?","acceptedAnswer":{"@type":"Answer","text":"Yes. A trust policy can allow imported memory for search and MCP while denying it on auto-recall, per origin or per peer machine."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html" aria-current="page">Across machines</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Keeping agent history in sync across machines</h1>
+<p class="pagelede">two machines, one person, one history<span class="mins" data-mins></span></p>
+
+<p>Two machines, one person. The fix you worked out on the laptop is on the laptop, and the desktop's agent has never heard of it. Neither has the work laptop you use three days a week.</p>
+
+<h2>What moves, and how</h2>
+<pre>deja sync ssh desktop           # push what this machine has learned
+deja sync ssh desktop --pull    # take what that one has
+deja sync ssh desktop --both    # both directions in one command
+deja sync                       # every machine deja already knows, both ways</pre>
+<p>The transport is your own SSH: deja exports a batch, copies it with <code>scp</code>, and runs <code>deja sync import</code> on the other side, which is why the remote needs deja installed and reachable the way you already reach it. No account, no service, nothing in the middle. The first exchange with a host records it as a peer, so <code>deja sync</code> afterwards knows who to talk to.</p>
+<p>Transfers are incremental and append-only: each side keeps a watermark and sends what the other has not seen. <code>--full</code> resends everything, which is the recovery path when a batch was lost — the error message says so at the moment it happens rather than leaving you to guess.</p>
+
+<h2>What arrives</h2>
+<p>Indexed sessions, not the harness's raw files. The receiving machine can search them, and a hit carries the machine it came from, so "we fixed this on the laptop in July" stays a fact you can see rather than one you have to remember. Redaction is re-applied on export, so what crosses the wire has been through the masking rules twice.</p>
+
+<h2>Deciding what synced memory may do</h2>
+<p>Memory from another machine is not automatically as trusted as memory from this one — a work laptop's history in a personal session, or the reverse, is a real concern. The trust policy at <code>~/.config/deja/policy.json</code> separates the paths memory can activate on: <code>search</code>, <code>mcp</code> and <code>auto</code>. Synced sessions stay searchable but never inject themselves:</p>
+<pre>{"activations": {"auto": {"imported": false}}}</pre>
+<p>The same rule can name a single peer (<code>imported:work</code>) rather than all imports. Receipts and <code>deja log --last</code> name the policy that allowed each injection, so what reached the model is inspectable after the fact rather than a matter of trust.</p>
+
+<h2>Keeping it current</h2>
+<p><code>deja install sync-timer</code> runs the exchange on a schedule, and <code>deja doctor</code> reports each peer with when it last synced — a peer that has quietly stopped is the failure mode worth catching, because everything keeps working and simply stops being shared.</p>
+
+<h2>What this is not</h2>
+<p>It is not a team feature. There is no server, no shared account and no access control beyond the SSH you already have — it moves one person's history between one person's machines. Sharing a single session with somebody else is a different job, and <a href="export-conversations.html"><code>deja share</code></a> does that one.</p>
+
+<p><a href="export-conversations.html">Exporting sessions</a> · <a href="privacy.html">Privacy and trust scopes</a> · <a href="commands.html">CLI reference</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -46,6 +46,8 @@
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -7,6 +7,8 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/after-compaction.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/repeated-mistakes.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/switching-agents.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/export-conversations.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/sync-across-machines.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/agents.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/search.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/commands.html</loc><lastmod>2026-08-11</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
Two more, same method. Monthly GitHub-issue counts for the phrasing, June → August:

| phrase | Jun | Jul | Aug |
|---|---:|---:|---:|
| "export" "claude code" conversation | 9,483 | 11,581 | **10,261** |
| "sync" agent history between machines | 879 | 1,372 | **2,532** |

**Getting a conversation out of your coding agent.** Starts with the raw file, because that is the honest first answer and it is usually the wrong shape — complete and unreadable in equal measure. Then the three things deja can hand back: one session as Markdown (`share`), the whole index as JSONL (`sync export`), and a local page to browse (`view`). The export section quotes the warning the command actually prints about redaction being a floor, because a page about exporting sessions that does not mention secrets would be the wrong page.

**Keeping agent history in sync across machines.** What moves and over what — your own ssh, deja on the far side, append-only with a watermark, `--full` as the recovery path. Then the part that matters more than the transport: deciding what synced memory may do, with the trust-policy rule that keeps imported sessions searchable but out of auto-recall. Ends by saying plainly what it is not — there is no server and no team feature in here.

Both quote output produced by running the commands. The guard now covers all seven problem pages, and the sidebar is still generated once and applied to every guide page.