### PR TITLE
stats: make the impact screen agree with a count of one

### DIFF
--- a/cmd/deja/stats_impact.go
+++ b/cmd/deja/stats_impact.go
@@ -52,8 +52,8 @@ func printImpact(w io.Writer, r usage.ImpactReport, credits int, jsonOut bool) e
 		return nil
 	}
 	fmt.Fprintln(w, "deja impact — measured on this machine, nothing modeled")
-	fmt.Fprintf(w, "  recalls served     %d agent-initiated recalls returned matches\n", r.Recalls)
-	fmt.Fprintf(w, "  memory at start    %d session starts began with project memory\n", r.Injections)
+	fmt.Fprintf(w, "  recalls served     %d agent-initiated recall%s returned matches\n", r.Recalls, pluralS(r.Recalls))
+	fmt.Fprintf(w, "  memory at start    %d session start%s began with project memory\n", r.Injections, pluralS(r.Injections))
 	if r.RawBytes > 0 && r.ServedBytes > 0 {
 		// The frame, the header and the session lines cost more than the text
 		// they wrap when sessions are short — which is exactly the state a new
@@ -77,7 +77,7 @@ func printImpact(w io.Writer, r usage.ImpactReport, credits int, jsonOut bool) e
 		fmt.Fprintf(w, "  knowledge re-used  %d session%s recalled 2+ times — fixes that keep paying\n", r.ReusedTwice, pluralS(r.ReusedTwice))
 	}
 	if r.DejaVuMoments > 0 {
-		fmt.Fprintf(w, "  déjà vu moments    %d prompts matched work you had already done\n", r.DejaVuMoments)
+		fmt.Fprintf(w, "  déjà vu moments    %d prompt%s matched work you had already done\n", r.DejaVuMoments, pluralS(r.DejaVuMoments))
 	}
 	served := r.Recalls + r.Injections
 	switch {

--- a/cmd/deja/stats_impact_test.go
+++ b/cmd/deja/stats_impact_test.go
@@ -25,9 +25,9 @@ func TestStatsImpactCountsAndArithmetic(t *testing.T) {
 	got := out.String()
 	for _, want := range []string{
 		"2 agent-initiated recalls",
-		"1 session starts began with project memory",
+		"1 session start began with project memory",
 		"1 session recalled 2+ times",
-		"1 prompts matched work",
+		"1 prompt matched work",
 		"50× less",
 	} {
 		if !strings.Contains(got, want) {
@@ -55,5 +55,64 @@ func TestStatsImpactEmpty(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "no recall activity recorded yet") {
 		t.Fatalf("empty state wrong:\n%s", out.String())
+	}
+}
+
+// TestStatsImpactAgreesWithCount covers #1586: the impact screen hardcoded
+// plural nouns, so a usage log holding exactly one of each — the state a new
+// user is in — rendered "1 agent-initiated recalls returned matches".
+func TestStatsImpactAgreesWithCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		recalls int
+		want    []string
+		absent  []string
+	}{
+		{
+			name:    "singular",
+			recalls: 1,
+			want: []string{
+				"1 agent-initiated recall returned matches",
+				"1 session start began with project memory",
+				"1 prompt matched work you had already done",
+			},
+			absent: []string{"1 agent-initiated recalls", "1 session starts", "1 prompts"},
+		},
+		{
+			name:    "plural",
+			recalls: 2,
+			want: []string{
+				"2 agent-initiated recalls returned matches",
+				"1 session start began with project memory",
+				"1 prompt matched work you had already done",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), "index.db")
+			for i := 0; i < tt.recalls; i++ {
+				usage.RecordServedSessions(dir, usage.KindRecall, 100, 1, false, 1000, []string{"s1"})
+			}
+			usage.RecordResultRaw(dir, usage.KindHook, 100, 1, false, 1000)
+			usage.RecordResult(dir, usage.KindDejaVu, 100, 1, false)
+
+			var out bytes.Buffer
+			if err := runStatsImpact(&out, dir, false); err != nil {
+				t.Fatal(err)
+			}
+			got := out.String()
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("impact output missing %q:\n%s", want, got)
+				}
+			}
+			for _, absent := range tt.absent {
+				if strings.Contains(got, absent) {
+					t.Errorf("impact output still contains hardcoded plural %q:\n%s", absent, got)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #1586.

`deja stats --impact` hardcoded plural nouns, so a usage log holding one recall and one injection — the state a new user is in — rendered:

```
  recalls served     1 agent-initiated recalls returned matches
  memory at start    1 session starts began with project memory
```

## The judgement call the issue asked about

No verb helper, and no rewording. Both verbs on these lines are past tense, and English past tense does not inflect for number: `returned` and `began` are already correct at one and at many. Only the nouns disagreed, so `pluralS` on `recall`, `session start` and `prompt` is the whole fix.

That is why I did not add a `wasWere`-style helper — there is nothing for it to do here. If a line ever needs `is`/`are`, that is the point to add one, against a real case.

## One line beyond the issue text

The issue names two lines and reports the sweep found no other reachable case. There is a third on the same screen:

```go
// stats_impact.go:80
fmt.Fprintf(w, "  déjà vu moments    %d prompts matched work you had already done\n", r.DejaVuMoments)
```

It is guarded only by `> 0`, so it is reachable at one, and `TestStatsImpactCountsAndArithmetic` was already asserting `"1 prompts matched work"` — the existing test encoded the bug rather than catching it. Fixing two of the three would have left the same screen wrong for the same user in the same session, so I included it. Happy to split it into its own issue and PR if you would rather keep this one to the two lines you filed.

## Tests

- `TestStatsImpactAgreesWithCount` (new, table-driven, stdlib) — renders the screen at one and at many, asserts the singular forms appear and that the hardcoded plurals (`1 agent-initiated recalls`, `1 session starts`, `1 prompts`) do not. Both subtests fail on `main` before the change.
- `TestStatsImpactCountsAndArithmetic` — updated the two assertions that spelled the bug; its JSON assertions are untouched, since no report field changed.

Hermetic: index path is `t.TempDir()`, no HOME or `DEJA_*` read on this path, no platform-specific behavior.

## Verification

```text
go test ./... -race -count=1     # all pass
go vet ./...                     # clean
go build ./cmd/deja              # ok
gofmt -s -l cmd/deja/            # no output

go test ./cmd/deja/ -coverprofile=coverage.out
ok  github.com/vshulcz/deja-vu/cmd/deja  69.788s  coverage: 89.8% of statements
go tool cover -func=coverage.out | tail -1
total: (statements) 89.9%
```

`cmd/deja` floor in CI is 88; this stays above it. No documentation mentions these strings.