### PR TITLE
test(windows): fix the two tests that fail on every Windows checkout

### DIFF
--- a/cmd/deja/cap_note_test.go
+++ b/cmd/deja/cap_note_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,7 +76,14 @@ func TestFilesSaysWhenItCutTheList(t *testing.T) {
 		if err := os.WriteFile(name, []byte("package p\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		lines = append(lines, `{"type":"assistant","timestamp":"2026-07-01T10:0`+string(rune('0'+i))+`:00Z","sessionId":"aaaa0001-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"`+name+`"}}]}}`)
+		// The path goes in as JSON, not as text: on Windows it starts `D:\a\`
+		// and a pasted backslash is an invalid escape, so the whole record was
+		// dropped and the test saw an uncut list (#1676).
+		quoted, err := json.Marshal(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines = append(lines, `{"type":"assistant","timestamp":"2026-07-01T10:0`+string(rune('0'+i))+`:00Z","sessionId":"aaaa0001-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":`+string(quoted)+`}}]}}`)
 	}
 	lines = append(lines, `{"type":"user","timestamp":"2026-07-01T10:09:00Z","sessionId":"aaaa0001-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"user","content":"the retry loop keeps firing"}}`)
 	if err := os.WriteFile(filepath.Join(store, "aaaa0001.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {

--- a/cmd/deja/codex_plugin_test.go
+++ b/cmd/deja/codex_plugin_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -141,12 +142,19 @@ func TestCodexPluginHooks(t *testing.T) {
 		}
 	}
 
-	info, err := os.Stat(filepath.Join("..", "..", "codex-plugin", "hooks", "deja.sh"))
-	if err != nil {
+	script := filepath.Join("..", "..", "codex-plugin", "hooks", "deja.sh")
+	if _, err := os.Stat(script); err != nil {
 		t.Fatalf("the script the hooks point at is missing: %v", err)
 	}
-	if info.Mode()&0o111 == 0 {
-		t.Fatalf("codex-plugin/hooks/deja.sh is not executable (%v) — Codex runs it directly", info.Mode())
+	// What ships is the mode git records, not the one this checkout happens to
+	// have: a Windows checkout reports -rw-rw-rw- for every file, so reading it
+	// off the disk failed the whole matrix (#1671).
+	out, err := exec.Command("git", "ls-files", "-s", "--", script).Output()
+	if err != nil {
+		t.Skipf("git is not available to read the recorded mode: %v", err)
+	}
+	if mode, _, ok := strings.Cut(strings.TrimSpace(string(out)), " "); !ok || mode != "100755" {
+		t.Fatalf("codex-plugin/hooks/deja.sh is recorded as %q, not 100755 — Codex runs it directly", mode)
 	}
 
 	var manifest struct {


### PR DESCRIPTION
`test / windows-latest` is red on the collector and therefore on every PR cut from it. Two independent test defects, both invisible off Windows:

`TestFilesSaysWhenItCutTheList` pasted a filesystem path straight into a JSON string. The runner's workspace is `D:\a\deja-vu\deja-vu\…`, so the fixture line carried `"file_path":"D:\a\…"` — `\a` is not a valid JSON escape, every record was dropped, and `files` had nothing to cut. It now marshals the path. Closes #1676.

`TestCodexPluginHooks` read the executable bit off the checkout. A Windows checkout reports `-rw-rw-rw-` for every file, so the assertion could never hold there. It now reads the mode git records (`git ls-files -s` → `100755`), which is what actually ships, and skips if git is unavailable. Closes #1671.

Control that these are not caused by any branch in flight: a run of the collector with no changes at all fails identically — https://github.com/vshulcz/deja-vu/actions/runs/32710471938
