### PR TITLE
docs: when the rules file grows, and auditing what an agent did

### DIFF
--- a/cmd/deja/docs_pages_test.go
+++ b/cmd/deja/docs_pages_test.go
@@ -75,6 +75,8 @@ func TestGuidePagesShareTheirNavigation(t *testing.T) {
 			"export-conversations.html",
 			"sync-across-machines.html",
 			"token-cost.html",
+			"rules-files.html",
+			"auditing-agents.html",
 		} {
 			if name == sibling {
 				continue

--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -49,6 +49,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -48,6 +48,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html" aria-current="page">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/auditing-agents.html
+++ b/docs/guide/auditing-agents.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Auditing what a coding agent actually did — deja-vu</title>
+<meta name="description" content="How to find which sessions touched a file, what commands an agent ran, what an edit replaced, and exactly what memory it was handed.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/auditing-agents.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Auditing what an agent actually did">
+<meta property="og:description" content="How to find which sessions touched a file, what commands an agent ran, what an edit replaced, and exactly what memory it was handed.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/auditing-agents.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Auditing what an agent actually did">
+<meta name="twitter:description" content="How to find which sessions touched a file, what commands an agent ran, what an edit replaced, and exactly what memory it was handed.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Auditing what an agent actually did","description":"How to find which sessions touched a file, what commands an agent ran, what an edit replaced, and exactly what memory it was handed.","url":"https://vshulcz.github.io/deja-vu/guide/auditing-agents.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/auditing-agents.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Auditing an agent","item":"https://vshulcz.github.io/deja-vu/guide/auditing-agents.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How can I see what a coding agent actually did in a session?","acceptedAnswer":{"@type":"Answer","text":"The transcript records more than the conversation: the files each turn opened, the commands it ran with their exit status, and the exact spans an edit replaced. Indexing those makes them searchable after the fact."}},{"@type":"Question","name":"Which sessions touched this file?","acceptedAnswer":{"@type":"Answer","text":"deja blame <path> lists the sessions that discussed or changed a file, with what was decided and when — session history rather than git authorship."}},{"@type":"Question","name":"Can I see what memory was given to the agent?","acceptedAnswer":{"@type":"Answer","text":"Yes. deja log lists every recall and injection with its size and the sessions it served, and deja log --last prints the exact text most recently handed over."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html" aria-current="page">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Auditing what an agent actually did</h1>
+<p class="pagelede">the diff says what changed; the transcript says what was tried<span class="mins" data-mins></span></p>
+
+<p>An agent changed something a week ago and you want to know what and why. Or a build broke and the last person to touch it was a session, not a person. Or a review asks a question the diff cannot answer: what else did it try first.</p>
+
+<h2>The transcript records more than the conversation</h2>
+<p>What the harness writes is not only the words. Each turn carries the files it opened, the commands it ran and what they exited with, and the exact text an edit replaced. That is the part every summary throws away and the part an audit needs — a summary can tell you it "fixed the pool exhaustion"; only the record tells you which file, which command, and what the code said before.</p>
+
+<h2>Asking about a file</h2>
+<pre>deja blame internal/index/ingest.go</pre>
+<p>The sessions that discussed or changed it, newest first, each with the project, the agent and the line that settled something. Session history rather than git authorship: it answers <em>why</em> for changes that a commit message reduced to "fix ingest", and it covers work that never became a commit at all.</p>
+<p>The reverse question is <code>deja files &lt;topic&gt;</code> — which files the work on a topic actually touched — and it answers plainly when nothing matched rather than inventing a list:</p>
+<pre>$ deja files "zed extension licence"
+0 sessions mention "zed extension licence", none of them recorded a file near it</pre>
+
+<h2>Asking what the agent was told</h2>
+<p>An audit of the agent is incomplete without an audit of what it was handed. <code>deja log</code> lists every recall and injection — when, which kind, how much, and how many sessions it drew on:</p>
+<pre>$ deja log
+2026-08-24 12:11  dejavu   895 B · 2 sessions
+2026-08-24 10:50  hook     2.2 KB · 3 sessions</pre>
+<p><code>deja log --last</code> prints the exact digest most recently served, so "what did it actually see" is a question with an answer rather than an inference. Where a trust policy is in force, the receipt names the rule that allowed the injection.</p>
+
+<h2>What this is not</h2>
+<p>It is not a compliance trail. The records are whatever the harness wrote and whatever survived redaction — nothing here proves an agent did not do something, and a harness that logs sparsely leaves gaps that no index can fill. <a href="../registry/README.html">The format registry</a> documents, per harness, what is recorded and what deja could not verify, including the gaps.</p>
+<p>It is also not free of judgement: recall ranks, and ranking can be wrong. For an audit, read the session — <code>deja show &lt;id&gt;</code> and <code>deja resume &lt;id&gt;</code> open the real thing rather than a digest of it.</p>
+
+<p><a href="where-sessions-are-stored.html">Where the transcripts live</a> · <a href="privacy.html">What is indexed and what is stripped</a> · <a href="commands.html">CLI reference</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -48,6 +48,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -48,6 +48,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html" aria-current="page">CLI reference</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -77,6 +77,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/export-conversations.html
+++ b/docs/guide/export-conversations.html
@@ -49,6 +49,8 @@
 <a href="export-conversations.html" aria-current="page">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -49,6 +49,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -48,6 +48,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -48,6 +48,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -48,6 +48,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -49,6 +49,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/rules-files.html
+++ b/docs/guide/rules-files.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>When CLAUDE.md and AGENTS.md get too long — deja-vu</title>
+<meta name="description" content="What belongs in CLAUDE.md or AGENTS.md, what does not, and where the facts you keep adding to it should live instead.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/rules-files.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="When your rules file gets too long">
+<meta property="og:description" content="What belongs in CLAUDE.md or AGENTS.md, what does not, and where the facts you keep adding to it should live instead.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/rules-files.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="When your rules file gets too long">
+<meta name="twitter:description" content="What belongs in CLAUDE.md or AGENTS.md, what does not, and where the facts you keep adding to it should live instead.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"When your rules file gets too long","description":"What belongs in CLAUDE.md or AGENTS.md, what does not, and where the facts you keep adding to it should live instead.","url":"https://vshulcz.github.io/deja-vu/guide/rules-files.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/rules-files.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"When CLAUDE.md grows","item":"https://vshulcz.github.io/deja-vu/guide/rules-files.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What belongs in CLAUDE.md or AGENTS.md?","acceptedAnswer":{"@type":"Answer","text":"Standing instructions that apply to every session: the build and test commands, conventions the agent cannot infer, directories it must not touch, and how to run things locally. Not history, and not anything that was true once."}},{"@type":"Question","name":"Why does a long CLAUDE.md make the agent worse?","acceptedAnswer":{"@type":"Answer","text":"It is read in full on every session, so every line costs context on every turn and competes with the instructions that matter. Rules that contradict each other or no longer hold are worse than absent ones."}},{"@type":"Question","name":"Where should the things I remove from it go?","acceptedAnswer":{"@type":"Answer","text":"Facts that were true once belong in searchable history rather than in a file read every session — the transcripts already hold them, and recall can fetch the relevant one when it matters."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html" aria-current="page">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>When your rules file gets too long</h1>
+<p class="pagelede">read in full, every session — so every line is paid for on every turn<span class="mins" data-mins></span></p>
+
+<p>It starts as five lines about the build command. Six months later it is four hundred, half of it describing a migration that finished in spring, and the agent seems to be reading less of it rather than more.</p>
+
+<h2>The cost of a rules file is paid every session</h2>
+<p><code>CLAUDE.md</code>, <code>AGENTS.md</code>, <code>GEMINI.md</code> and the rest are read in full at the start of every session. That is the point of them — and it is also the constraint. Every line competes for context with the actual task, and unlike a search result nothing weighs it against relevance: the paragraph about a database you no longer run arrives with the same authority as the build command.</p>
+<p>Three failure modes follow, in the order people hit them:</p>
+<ul>
+<li><b>Stale rules.</b> Something that was true once and is now wrong. This is the expensive one: the agent follows it confidently.</li>
+<li><b>Contradiction.</b> Two rules added months apart that cannot both hold. The model picks one, usually the later or the longer.</li>
+<li><b>Dilution.</b> Nothing is wrong, there is just too much, and the three lines that mattered are surrounded by two hundred that did not.</li>
+</ul>
+
+<h2>What belongs in it</h2>
+<p>A rule earns its place if it is true on every session and the agent cannot work it out from the repository:</p>
+<ul>
+<li>How to build, test and run locally, with the flags this project actually needs.</li>
+<li>Conventions that are not visible in the code — the reason a pattern is used, not the pattern itself.</li>
+<li>Boundaries: what must not be touched, what must never be committed, what needs a human.</li>
+<li>Where things are, when the layout is surprising.</li>
+</ul>
+<p>If you can imagine a session where the line is irrelevant, it is not a rule; it is a fact about one moment.</p>
+
+<h2>What does not, and where it goes instead</h2>
+<p>Facts about one moment are the bulk of what makes these files grow: the incident in March, the flag that turned out to matter for one service, the approach that was tried and reverted. They are worth keeping — just not in a file the agent re-reads every time.</p>
+<p>They are already kept. The session where you worked it out is on disk, written by the harness itself, and <a href="where-sessions-are-stored.html">it is still there</a>. An index over those transcripts answers the same question at the moment it comes up rather than paying for it every session:</p>
+<pre>deja how "go test"                    # the invocation this project actually uses
+deja fix "pq: too many connections"   # what was run after that error, where it stayed fixed
+deja blame internal/index/ingest.go   # what earlier sessions decided about this file</pre>
+<p>With recall wired in the agent asks those itself, and the block is absent when the history has no answer — which is the property a rules file cannot have.</p>
+
+<h2>A way to shorten one</h2>
+<p>Go through the file line by line and ask two questions. Is this true on every session? Could the agent find it out from the repository in one step? A line that fails the first is history; a line that fails the second is noise. What survives is usually a page, and the rest is not deleted so much as moved to where it can be retrieved on demand.</p>
+<p>One caution: do not convert a rules file into a memory system by hand. Writing down each fact you might need later is the same manual step that made the file long, and the sessions already contain them.</p>
+
+<p><a href="forgetting.html">Why agents forget</a> · <a href="token-cost.html">What memory costs in tokens</a> · <a href="repeated-mistakes.html">When the same wall comes back</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -48,6 +48,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents & MCP</a>
 <a href="search.html" aria-current="page">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/switching-agents.html
+++ b/docs/guide/switching-agents.html
@@ -49,6 +49,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/sync-across-machines.html
+++ b/docs/guide/sync-across-machines.html
@@ -49,6 +49,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html" aria-current="page">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/token-cost.html
+++ b/docs/guide/token-cost.html
@@ -49,6 +49,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html" aria-current="page">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -49,6 +49,8 @@
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
 <a href="agents.html">Agents &amp; MCP</a>
 <a href="search.html">Search</a>
 <a href="commands.html">CLI reference</a>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -10,6 +10,8 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/export-conversations.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/sync-across-machines.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/token-cost.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/rules-files.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/auditing-agents.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/agents.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/search.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/commands.html</loc><lastmod>2026-08-11</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
Fourth batch of phrasings, counted the same way. Two stood out, both roughly doubling or tripling since June:

| phrase | Jun | Jul | Aug |
|---|---:|---:|---:|
| "CLAUDE.md" too long / bloated | 26,879 | 48,368 | **59,751** |
| "audit" what the agent did session | 11,637 | 26,653 | **37,779** |
| "AGENTS.md" what to put in | 6,228 | 15,601 | 29,685 |

(Also measured and discarded: "agent reinvented or rewrote existing code" returns 800k issues — the query matches everything and measures nothing.)

**When your rules file gets too long** covers both files, since the question is the same one. It is opinionated: a rule earns its place only if it is true on every session and the agent cannot work it out from the repository, and the three failure modes are named in the order people hit them — stale, contradictory, diluted. The part that makes it ours rather than generic advice is where the removed lines go: facts about one moment are already recorded in the transcripts, and can be retrieved on demand instead of being paid for every session. It ends by warning against the obvious wrong turn — hand-writing a memory system into the rules file.

**Auditing what an agent actually did** leans on the thing summaries drop: the files a turn opened, the commands with their exit status, the spans an edit replaced. `blame` for a file, `files` for a topic — quoted with its real empty answer — and `log`/`log --last` for what the agent was handed, because auditing the agent without auditing its input is half a job. It says plainly that this is not a compliance trail and that ranking can be wrong, and points at reading the session itself.

Guard extended to all ten problem pages.