### PR TITLE
docs: finding an old session, and several agents on one repository

### DIFF
--- a/cmd/deja/docs_pages_test.go
+++ b/cmd/deja/docs_pages_test.go
@@ -77,6 +77,8 @@ func TestGuidePagesShareTheirNavigation(t *testing.T) {
 			"token-cost.html",
 			"rules-files.html",
 			"auditing-agents.html",
+			"find-a-session.html",
+			"parallel-sessions.html",
 		} {
 			if name == sibling {
 				continue

--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -43,9 +43,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html" aria-current="page">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -42,9 +42,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/auditing-agents.html
+++ b/docs/guide/auditing-agents.html
@@ -43,9 +43,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -42,9 +42,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -42,9 +42,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -71,9 +71,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/export-conversations.html
+++ b/docs/guide/export-conversations.html
@@ -43,9 +43,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html" aria-current="page">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/find-a-session.html
+++ b/docs/guide/find-a-session.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Find the coding session where you solved it — deja-vu</title>
+<meta name="description" content="How to find an old coding-agent session by the error, the file or the flag you remember — across every agent on the machine — and reopen it where it ran.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/find-a-session.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Finding the session where you solved it">
+<meta property="og:description" content="How to find an old coding-agent session by the error, the file or the flag you remember — across every agent on the machine — and reopen it where it ran.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/find-a-session.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Finding the session where you solved it">
+<meta name="twitter:description" content="How to find an old coding-agent session by the error, the file or the flag you remember — across every agent on the machine — and reopen it where it ran.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Finding the session where you solved it","description":"How to find an old coding-agent session by the error, the file or the flag you remember — across every agent on the machine — and reopen it where it ran.","url":"https://vshulcz.github.io/deja-vu/guide/find-a-session.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/find-a-session.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Finding a session","item":"https://vshulcz.github.io/deja-vu/guide/find-a-session.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I find the session where I fixed something?","acceptedAnswer":{"@type":"Answer","text":"Search the transcripts by the most specific thing you remember — an exact error string, a function name, a file path or a flag. Those match a session even when you have forgotten which tool, project or month it was."}},{"@type":"Question","name":"Can I reopen an old session in the agent that ran it?","acceptedAnswer":{"@type":"Answer","text":"For fifteen of the twenty harnesses deja reads, yes: deja resume <id> hands the id back to that harness and it continues the conversation. The rest have no resume path of their own."}},{"@type":"Question","name":"What if I only remember roughly when it was?","acceptedAnswer":{"@type":"Answer","text":"Time is a hint rather than a filter: a date in the query weighs recent sessions up without hiding older ones, and deja last lists the most recent sessions by project, role or harness."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html" aria-current="page">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Finding the session where you solved it</h1>
+<p class="pagelede">search by the token you remember, not the topic you half-remember<span class="mins" data-mins></span></p>
+
+<p>You fixed it. You remember the error, roughly. You do not remember whether it was Claude Code or Codex, which project it was under, or whether it was three weeks or three months ago — and the harness's own history list is a wall of titles, in one tool, in reverse order.</p>
+
+<h2>Search by the most specific thing you remember</h2>
+<p>Not the topic — the token. An exact error string, a function name, a file path, a flag. Those survive in a transcript verbatim, and they are what separates the session you want from forty that discuss the same subject:</p>
+<pre>$ deja "connection pool exhausted"
+[claude] api   · Jul 8 · 8f31c0a9 — 2 matches
+  login started failing after refresh token rotation; jwt kid mismatch in tests
+  fixed by reloading jwks cache after rotateKey and adding a clock-skew test
+[codex]  web   · Jul 1 · b77d91e2 — 1 match
+  refresh token cookie needed SameSite=Lax in local callback flow</pre>
+<p>Several words are ANDed, quotes require the exact phrase, and when nothing matches exactly the search falls back to word forms and close spellings rather than returning nothing. The harness column matters more than it looks: the session you want is often in the tool you were <em>not</em> thinking of.</p>
+
+<h2>Narrowing without guessing</h2>
+<ul>
+<li><code>--harness claude</code>, <code>--project api-gateway</code> — when you are sure, and only then.</li>
+<li><code>--since 30d</code> — a hard filter. A date inside the query is the softer version: it weighs recent sessions up without hiding older ones, because "I think it was in spring" is a hint and should not throw away the answer if it was April.</li>
+<li><code>--role user</code> — search only what you typed, which is a good filter when you remember your own words but not the answer.</li>
+<li><code>deja last 20 --project api</code> — no query at all, just the recent sessions in one project.</li>
+</ul>
+
+<h2>Reading it, then continuing it</h2>
+<p>A hit gives you a session id. Two things to do with it:</p>
+<pre>deja show 8f31c0a9      # read the session
+deja ctx  8f31c0a9      # a Markdown digest to paste into whatever you are doing now
+deja resume 8f31c0a9    # reopen it in the agent that ran it</pre>
+<p><code>resume</code> hands the id back to the harness that owns the session, with the project directory where that harness scopes its list to one. It works for fifteen of the twenty harnesses deja reads — Claude Code, Codex, Cursor, opencode, Gemini CLI, Cline, Copilot, Goose, Kimi, Qwen, pi, omp, OpenClaw, Antigravity and Hermes. The remaining five — aider, Grok Build, Roo Code, DeepSeek Harness and Zed — have no resume path of their own, and deja says so rather than pretending.</p>
+<p>Ids are matched by prefix, so the eight characters a result prints are enough to type.</p>
+
+<h2>When the answer is a command rather than a session</h2>
+<p>Often what you actually want is not the conversation but one line out of it:</p>
+<pre>deja how "docker compose up"    # the invocation this project really uses
+deja fix "pq: too many connections"   # what was run after that error, where it stayed fixed
+deja blame path/to/file.go      # which sessions decided what about this file</pre>
+<p>Those skip the reading step entirely.</p>
+
+<p><a href="where-sessions-are-stored.html">Where the transcripts live</a> · <a href="search.html">How search and ranking work</a> · <a href="switching-agents.html">When the session was in another agent</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -43,9 +43,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html" aria-current="page">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -42,9 +42,11 @@
 <a href="getting-started.html" aria-current="page">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -42,9 +42,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/parallel-sessions.html
+++ b/docs/guide/parallel-sessions.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Several agents on one repository — deja-vu</title>
+<meta name="description" content="Running coding agents in parallel on one repository: the worktree trap in project identity, what one session can know of another, and what stays hard.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/parallel-sessions.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Several agents on one repository">
+<meta property="og:description" content="Running coding agents in parallel on one repository: the worktree trap in project identity, what one session can know of another, and what stays hard.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/parallel-sessions.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Several agents on one repository">
+<meta name="twitter:description" content="Running coding agents in parallel on one repository: the worktree trap in project identity, what one session can know of another, and what stays hard.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Several agents on one repository","description":"Running coding agents in parallel on one repository: the worktree trap in project identity, what one session can know of another, and what stays hard.","url":"https://vshulcz.github.io/deja-vu/guide/parallel-sessions.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/parallel-sessions.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Parallel sessions","item":"https://vshulcz.github.io/deja-vu/guide/parallel-sessions.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Can two coding agents work on the same repository at once?","acceptedAnswer":{"@type":"Answer","text":"Yes, and most people run them in separate git worktrees so the checkouts do not collide. Each session records its own transcript; nothing shares context between them by default."}},{"@type":"Question","name":"Why does my agent memory treat each worktree as a different project?","acceptedAnswer":{"@type":"Answer","text":"Because project identity is usually keyed on the working directory, and a worktree has a different path from the main checkout. Resolving worktrees back to the repository keeps one project instead of several."}},{"@type":"Question","name":"How do I see what a parallel session already tried?","acceptedAnswer":{"@type":"Answer","text":"Search the shared history rather than the running session: an indexed transcript is readable while the other session is still going, so what it established is available without a live channel between them."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html" aria-current="page">Parallel sessions</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Several agents on one repository</h1>
+<p class="pagelede">same repository, separate worktrees, no idea about each other<span class="mins" data-mins></span></p>
+
+<p>Two agents on one repository is now ordinary: one grinding through a refactor in a worktree, another fixing something small on main, a third reviewing. They do not know about each other. Each writes its own transcript, each starts empty, and the second one cheerfully re-derives what the first worked out an hour ago.</p>
+
+<h2>The worktree trap</h2>
+<p>Parallel work usually means <code>git worktree</code>, and that quietly breaks project identity for anything keyed on the working directory. <code>~/src/api</code> and <code>~/src/api-worktrees/fix-pool</code> are the same repository and different paths, so a memory scoped by path sees two projects, and neither can see the other's history. Claude Code's own auto-memory has the same behaviour — <a href="https://github.com/anthropics/claude-code/issues/81833">anthropics/claude-code#81833</a>.</p>
+<p>The fix is to ask git rather than the path. deja resolves a directory's worktree roots and treats every one of them as the same project, so a session recorded in <code>fix-pool</code> is recalled while you work in <code>api</code>, and two unrelated repositories that happen to share a directory name stay apart because the full path still matches first.</p>
+
+<h2>What one session can see of another</h2>
+<p>Nothing, live — and that is the right default. But "live" is rarely what is needed: the useful thing is what the other session <em>established</em>, and that is already written to its transcript as it goes. Indexed, it is searchable while that session is still running:</p>
+<pre>deja "pool size"            # what the other session concluded, in your session
+deja blame internal/pool.go # what has been decided about this file today
+deja last --project api     # what has been running here, newest first</pre>
+<p>With recall wired in, a fresh session opens already knowing the project's recent decisions, whichever agent made them. That covers most of what people build an inter-agent channel for.</p>
+
+<h2>When you do want to hand work over</h2>
+<p>Moving a live piece of work is a different job from searching, and it does not need a protocol between the two tools: <code>deja handoff --to codex</code> packages what a session established — the problem, the conclusions, where it stopped — as text the next agent starts from. <a href="switching-agents.html">Switching agents</a> covers that case in full.</p>
+
+<h2>What stays hard</h2>
+<p>Two agents editing the same files at the same time is a coordination problem, and no memory layer fixes it — worktrees and small scopes do. Ordering is not guaranteed either: an index sees a session when its transcript is written, so a conclusion reached seconds ago may not be searchable yet. And a session that never wrote its reasoning down cannot be read by anyone, human or agent.</p>
+
+<p><a href="switching-agents.html">Switching between agents</a> · <a href="find-a-session.html">Finding the session you need</a> · <a href="agents.html">Which harness supports what</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -42,9 +42,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -43,9 +43,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html" aria-current="page">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/rules-files.html
+++ b/docs/guide/rules-files.html
@@ -43,9 +43,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -42,9 +42,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/switching-agents.html
+++ b/docs/guide/switching-agents.html
@@ -43,9 +43,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html" aria-current="page">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/sync-across-machines.html
+++ b/docs/guide/sync-across-machines.html
@@ -43,9 +43,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html" aria-current="page">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/token-cost.html
+++ b/docs/guide/token-cost.html
@@ -43,9 +43,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html" aria-current="page">What memory costs</a>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -43,9 +43,11 @@
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
 <a href="where-sessions-are-stored.html" aria-current="page">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -12,6 +12,8 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/token-cost.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/rules-files.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/auditing-agents.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/find-a-session.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/parallel-sessions.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/agents.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/search.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/commands.html</loc><lastmod>2026-08-11</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
Fifth batch. Two clear signals, monthly GitHub-issue counts June → August:

| phrase | Jun | Jul | Aug |
|---|---:|---:|---:|
| "find" the session where I fixed | 27,937 | 45,720 | **59,612** |
| "which session" did I / "what session" | 8,426 | 21,487 | **36,777** |
| "parallel" agents same repository sessions | 4,319 | 6,839 | **8,744** |
| "git worktree" claude code sessions | 3,768 | 7,012 | 6,561 |

**Finding the session where you solved it** is the biggest phrasing measured so far, and it folds in the `resume`/`--continue` intent from the fourth batch. The advice is specific: search by the token you remember, not the topic — an exact error string, a function name, a flag — because those survive verbatim in a transcript. Then the narrowing flags, then what to do with the id, including which fifteen of the twenty harnesses `deja resume` can actually reopen and which five have no resume path at all, named.

**Several agents on one repository** carries something we verified rather than read: parallel work means worktrees, and worktrees break project identity for anything keyed on the working directory — the same behaviour we filed against Claude Code's own auto-memory in anthropics/claude-code#81833. deja asks git for the worktree roots instead of trusting the path, which is why a session recorded in one worktree is recalled from another. The page also says what stays hard: two agents editing the same files is coordination, not memory, and an index sees a conclusion only once the transcript is written.

The sidebar block and sitemap are now generated by one script over one list, and it refuses to run if a listed page does not exist — the guard covers all twelve problem pages.