### PR TITLE
fix(install): call a mistyped flag a flag, whether or not a target came with it

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -51,12 +51,13 @@ func runInstall(dir string, args []string, uninstall bool) error {
 	}
 	// A flag deja does not know is named plainly by every other command; here
 	// it fell into the target list, and the refusal then said the target was
-	// missing while printing the target it had been given (#1078).
-	if len(targetArgs) > 1 {
-		for _, a := range targetArgs {
-			if strings.HasPrefix(a, "--") && a != "--all" && a != "--auto" {
-				return fmt.Errorf("%s: unknown flag %q — it takes a target plus --no-guidance, --no-index or --force", verb, a)
-			}
+	// missing while printing the target it had been given (#1078). At one
+	// argument it fell through anyway and `deja install --nosuch` was reported
+	// as an unknown target, with thirty-eight harness names for a remedy
+	// (#1680). No target begins with a dash, so the shape alone settles it.
+	for _, a := range targetArgs {
+		if strings.HasPrefix(a, "-") && a != "--all" && a != "--auto" {
+			return fmt.Errorf("%s: unknown flag %q — it takes a target plus --no-guidance, --no-index or --force", verb, a)
 		}
 	}
 	if len(targetArgs) != 1 {
@@ -434,7 +435,13 @@ func refusalRemedy(errs []error) string {
 		}
 	}
 	if perms > 0 && perms == len(errs) {
+		if len(errs) == 1 {
+			return "check that path's permissions and run it again"
+		}
 		return "check those paths' permissions and run it again"
+	}
+	if len(errs) == 1 {
+		return "fix what it reports and run it again"
 	}
 	return "fix what each one reports and run it again"
 }

--- a/cmd/deja/install_unknown_target_test.go
+++ b/cmd/deja/install_unknown_target_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A lone mistyped flag was reported as an unknown target, and the remedy then
+// handed the reader thirty-eight harness names when what they needed was the
+// flag list. The same binary already said "unknown flag" when a real target
+// came with it — the guard from #1078 only ran at two arguments or more
+// (#1680).
+func TestInstallNamesALoneUnknownFlagAsAFlag(t *testing.T) {
+	hermeticEnv(t)
+	for _, arg := range []string{"--nosuch", "--al", "-all"} {
+		_, err := captureRun(t, "install", arg)
+		if err == nil {
+			t.Fatalf("install accepted %q", arg)
+		}
+		msg := err.Error()
+		if strings.Contains(msg, "unknown target") {
+			t.Errorf("install %s is reported as a target: %s", arg, msg)
+		}
+		if !strings.Contains(msg, "unknown flag") {
+			t.Errorf("install %s does not name the flag: %s", arg, msg)
+		}
+	}
+	// The control: a real mistyped target still gets the target treatment.
+	_, err := captureRun(t, "install", "claude_code")
+	if err == nil {
+		t.Fatal("install accepted claude_code")
+	}
+	if !strings.Contains(err.Error(), `did you mean "claude-code"`) {
+		t.Errorf("a mistyped target lost its suggestion: %s", err)
+	}
+}
+
+// One target refused, and the sentence said "fix what each one reports".
+func TestInstallRefusalReadsSingularAtOne(t *testing.T) {
+	hermeticEnv(t)
+	_, err := captureRun(t, "install", "nosuch")
+	if err == nil {
+		t.Fatal("install accepted nosuch")
+	}
+	if strings.Contains(err.Error(), "each one") {
+		t.Errorf("one refusal is reported in the plural: %s", err)
+	}
+	if !strings.Contains(err.Error(), "1 target refused") {
+		t.Errorf("the count itself is wrong: %s", err)
+	}
+}


### PR DESCRIPTION
`deja install --nosuch` was reported as an unknown target and answered with thirty-eight harness names. The guard that says "unknown flag" (#1078) only ran at two arguments or more, so a lone flag fell through to the target lookup. It now runs at any count, and covers a single dash too — no target begins with one, so the shape settles it. `--all` and `--auto` are exempt, as before.

Second, smaller: one refused target said "fix what each one reports". `refusalRemedy` now reads in the singular at one, in both the permissions and the general case. That sentence is mine from #1663 and it kept the old line's number-blind shape.

Fail-before tests: `TestInstallNamesALoneUnknownFlagAsAFlag` over `--nosuch`, `--al` and `-all`, with a control that a mistyped *target* still gets its "did you mean" suggestion; and `TestInstallRefusalReadsSingularAtOne`.

Closes #1680.

One thing found and deliberately not changed: `deja install claude` works — `claude` is an accepted alias of `claude-code` (install.go:488) that appears in no list, no completion and no help. Harmless, invisible, and nothing would catch it going away. Say if you want it advertised or removed; I did not want to decide that in a bug fix.
