### PR TITLE
fix(uninstall): take the shared skill file with the last harness that read it

### DIFF
--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -254,7 +254,10 @@ func sharedSkillStillWanted(leaving string) bool {
 	}
 	for _, t := range targets {
 		other := guidanceHarness(t)
-		if other != leaving && sharedSkillHarnesses[other] {
+		if other == leaving || removingTargets[other] {
+			continue
+		}
+		if sharedSkillHarnesses[other] {
 			return true
 		}
 	}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -102,6 +102,13 @@ func runInstall(dir string, args []string, uninstall bool) error {
 	exe, _ = filepath.Abs(exe)
 	// Remembered so a later upgrade can refresh exactly these and nothing
 	// else: the generators change, the files on disk do not.
+	if uninstall {
+		removingTargets = make(map[string]bool, len(targets))
+		for _, t := range targets {
+			removingTargets[guidanceHarness(t)] = true
+		}
+		defer func() { removingTargets = nil }()
+	}
 	defer recordWiring(targets, uninstall)
 	banner := !uninstall && (targetArgs[0] == "--auto" || targetArgs[0] == "--all") && logoWanted(os.Stdout)
 	type lineItem struct{ target, action, path string }
@@ -717,6 +724,15 @@ func backupOnce(path string) (bool, error) {
 // exist, is an empty config it then creates (#676). The flag is process-wide
 // because the command is: one run, one direction.
 var removingWiring bool
+
+// removingTargets names the targets the current uninstall run is removing.
+// The shared-skill guard asks whether any other harness still reads
+// ~/.agents/skills/deja-history/SKILL.md, and answers from the wiring record —
+// which still lists every harness during `uninstall --all`, because
+// recordWiring runs at the end. So each target in turn found another "still
+// wanting" reader and the file was kept every time (#1683). A harness being
+// removed in this same run is not a reader.
+var removingTargets map[string]bool
 
 // forceGuidance is set by `deja install --force`: replace a skill deja can see
 // has been edited since it wrote it.

--- a/cmd/deja/uninstall_shared_skill_test.go
+++ b/cmd/deja/uninstall_shared_skill_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// `deja uninstall --all` left ~/.agents/skills/deja-history/SKILL.md on disk
+// with deja's guidance in it. The guard that protects the shared file from one
+// harness leaving asked readWiringState(), which still lists every harness
+// during the run that removes them all (#1683).
+func TestUninstallAllRemovesTheSharedSkill(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	// codex is a shared-skill harness: its guidance lives in ~/.agents.
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".cursor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "--all"); err != nil {
+		t.Fatal(err)
+	}
+	shared := filepath.Join(home, ".agents", "skills", "deja-history", "SKILL.md")
+	if _, err := os.Stat(shared); err != nil {
+		t.Fatalf("install did not write the shared skill, wrong fixture: %v", err)
+	}
+	if _, err := captureRun(t, "uninstall", "--all"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(shared); err == nil {
+		b, _ := os.ReadFile(shared)
+		t.Errorf("uninstall --all left the shared skill behind:\n%s", string(b[:min(len(b), 200)]))
+	}
+}
+
+// One harness leaving must still not take the file from the rest — that is what
+// the guard is for, and the fix must not cost it.
+func TestUninstallOneKeepsTheSharedSkillForTheOthers(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	for _, d := range []string{".codex", ".cursor"} {
+		if err := os.MkdirAll(filepath.Join(home, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRun(t, "install", "--all"); err != nil {
+		t.Fatal(err)
+	}
+	shared := filepath.Join(home, ".agents", "skills", "deja-history", "SKILL.md")
+	if _, err := captureRun(t, "uninstall", "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(shared); err != nil {
+		t.Errorf("uninstalling codex took the shared skill from cursor: %v", err)
+	}
+}


### PR DESCRIPTION
`deja uninstall --all` left `~/.agents/skills/deja-history/SKILL.md` on disk, guidance intact, and reported "guidance kept" for every shared-skill harness in turn.

The guard is right in principle — one harness leaving must not take the file from the six that still read it — but it answered from `readWiringState().Targets`, which still lists every harness during the run that removes them all, because `recordWiring` runs deferred at the end. So each target found another "still wanting" reader, every time.

`removingTargets` now names what this run is removing, and a harness in that set is not counted as a reader. Set only on the uninstall path, cleared on return, in the same shape as `removingWiring` next to it.

Fail-before tests: `TestUninstallAllRemovesTheSharedSkill`, and `TestUninstallOneKeepsTheSharedSkillForTheOthers` for the property the guard exists to protect — uninstalling codex alone still leaves the file for cursor.

Closes #1683.

Not fixed here: the same round trip leaves nine empty MCP configs and four empty directories that did not exist before, including `.agents/skills` after this change. That is #1684 — a different code path (`writeIfChanged` treats `{"mcpServers": {}}` as content) and a bigger change than this one.
