### PR TITLE
fix(install): name the config a permission error stopped, not deja's scratch file

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -860,8 +860,14 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 		// chmod-ed or found (#1686, the shape of #865). Rewriting the path in
 		// place keeps the error a *PathError, so errors.Is still sees the
 		// permission underneath and the remedy still names permissions.
+		//
+		// Only for a permission denial: the destination is the right thing to
+		// name when the directory refuses us, and the wrong thing when the
+		// failure is about the scratch file itself — "config.toml: no such
+		// file or directory" would send the reader after a directory that is
+		// the actual problem.
 		var pe *os.PathError
-		if errors.As(terr, &pe) {
+		if errors.Is(terr, fs.ErrPermission) && errors.As(terr, &pe) {
 			pe.Path = path
 		}
 		return "", terr

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -854,6 +854,16 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 	}
 	tmp, terr := os.CreateTemp(filepath.Dir(path), ".deja-tmp-")
 	if terr != nil {
+		// The scratch file is deja's business; the reader's is the config it
+		// could not write. A read-only ~/.codex was reported as a permission
+		// error on ~/.codex/.deja-tmp-4168817699, which cannot be looked at,
+		// chmod-ed or found (#1686, the shape of #865). Rewriting the path in
+		// place keeps the error a *PathError, so errors.Is still sees the
+		// permission underneath and the remedy still names permissions.
+		var pe *os.PathError
+		if errors.As(terr, &pe) {
+			pe.Path = path
+		}
 		return "", terr
 	}
 	tmpName := tmp.Name()

--- a/cmd/deja/install_readonly_test.go
+++ b/cmd/deja/install_readonly_test.go
@@ -1,71 +1,72 @@
 package main
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-// A config directory deja cannot write to is ordinary: a managed machine, a
-// directory owned by another account, a mount gone read-only. Install has to
-// say so and leave the file as it was. Silently reporting success is the worse
-// half — the user believes memory is wired and it is not.
-func TestInstallReportsAReadOnlyConfigDir(t *testing.T) {
+// A read-only config directory was reported as a permission error on
+// ~/.codex/.deja-tmp-4168817699 — the scratch file writeIfChanged creates to
+// write atomically. The reader cannot look at it, chmod it, or find it (#1686).
+func TestInstallNamesTheConfigNotTheTempFile(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Skip("root ignores the permission bits this test relies on")
+		t.Skip("root writes through a read-only directory")
 	}
-	for _, tc := range []struct{ target, rel string }{
-		{"qwen-auto", ".qwen/settings.json"},
-		{"codex-auto", ".codex/hooks.json"},
-	} {
-		t.Run(tc.target, func(t *testing.T) {
-			home := t.TempDir()
-			t.Setenv("HOME", home)
-			t.Setenv("USERPROFILE", home)
-			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-			t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
-			t.Setenv("DEJA_INDEX_DIR", filepath.Join(home, "index.db"))
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// No config to back up: with one present the backup step fails first and
+	// names a real path, and the temp name never surfaces.
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
 
-			path := filepath.Join(home, filepath.FromSlash(tc.rel))
-			dir := filepath.Dir(path)
-			if err := os.MkdirAll(dir, 0o755); err != nil {
-				t.Fatal(err)
-			}
-			const theirs = "{\"theirs\":true}\n"
-			if err := os.WriteFile(path, []byte(theirs), 0o644); err != nil {
-				t.Fatal(err)
-			}
-			if err := os.Chmod(dir, 0o500); err != nil {
-				t.Skipf("cannot make the directory read-only: %v", err)
-			}
-			t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
-			// Windows ignores the permission bits on a directory, so ask the
-			// filesystem whether the change took rather than assuming it.
-			probe := filepath.Join(dir, "deja-write-probe")
-			if err := os.WriteFile(probe, []byte("x"), 0o644); err == nil {
-				_ = os.Remove(probe)
-				t.Skip("this filesystem still allows writes into a read-only directory")
-			}
+	_, err := captureRun(t, "install", "codex")
+	if err == nil {
+		t.Fatal("install wrote into a read-only directory")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "deja-tmp") {
+		t.Errorf("the refusal names deja's scratch file: %s", msg)
+	}
+	if !strings.Contains(msg, filepath.Join(".codex", "config.toml")) {
+		t.Errorf("the refusal does not name the config it could not write: %s", msg)
+	}
+	// The remedy still has to read as a permissions problem, which means the
+	// error must stay an fs.ErrPermission after the path is rewritten.
+	if !strings.Contains(msg, "permissions") {
+		t.Errorf("a permission denial lost its remedy: %s", msg)
+	}
+}
 
-			_, err := installTarget(tc.target, "/usr/local/bin/deja", false)
-			after, rerr := os.ReadFile(path)
-			if rerr != nil {
-				t.Fatalf("their config is gone: %v", rerr)
-			}
-			if string(after) != theirs {
-				t.Fatalf("their config changed under a read-only directory:\n%s", after)
-			}
-			if err == nil {
-				t.Error("install reported success while unable to write")
-				return
-			}
-			// The message has to name the path, or the reader has nothing to
-			// act on.
-			if !strings.Contains(err.Error(), filepath.Base(path)) &&
-				!strings.Contains(err.Error(), dir) {
-				t.Errorf("the error does not say which file it could not write: %v", err)
-			}
-		})
+// writeIfChanged's own error, checked directly: the path is the config, and
+// errors.Is still sees the permission underneath.
+func TestWriteIfChangedReportsTheDestination(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root writes through a read-only directory")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	path := filepath.Join(dir, "config.toml")
+	_, err := writeIfChanged(path, nil, []byte("x\n"))
+	if err == nil {
+		t.Fatal("writeIfChanged wrote into a read-only directory")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("error names %q, not the destination %q", err, path)
+	}
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Errorf("error is no longer a permission error: %v", err)
 	}
 }

--- a/cmd/deja/install_readonly_test.go
+++ b/cmd/deja/install_readonly_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -13,8 +14,8 @@ import (
 // ~/.codex/.deja-tmp-4168817699 — the scratch file writeIfChanged creates to
 // write atomically. The reader cannot look at it, chmod it, or find it (#1686).
 func TestInstallNamesTheConfigNotTheTempFile(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("root writes through a read-only directory")
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("the directory mode is not enforced here")
 	}
 	hermeticEnv(t)
 	home := os.Getenv("HOME")
@@ -50,8 +51,8 @@ func TestInstallNamesTheConfigNotTheTempFile(t *testing.T) {
 // writeIfChanged's own error, checked directly: the path is the config, and
 // errors.Is still sees the permission underneath.
 func TestWriteIfChangedReportsTheDestination(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("root writes through a read-only directory")
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("the directory mode is not enforced here")
 	}
 	dir := t.TempDir()
 	if err := os.Chmod(dir, 0o555); err != nil {


### PR DESCRIPTION
With `~/.codex` read-only and no config in it yet, install refused the target and named `~/.codex/.deja-tmp-4168817699` — the scratch file `writeIfChanged` creates to write atomically. The reader cannot look at it, chmod it, or find it. The claude-code half of the same line already named a real path.

`os.CreateTemp`'s `*PathError` now has its `Path` rewritten to the destination before it is returned. Rewriting in place rather than wrapping keeps it a `*PathError`, so `errors.Is(err, fs.ErrPermission)` still holds and `refusalRemedy` still ends the run with the permissions sentence — that is asserted in the test, because the obvious alternative (wrapping in a new error) would quietly cost it.

Fail-before tests: `TestWriteIfChangedReportsTheDestination` on the helper directly, and `TestInstallNamesTheConfigNotTheTempFile` end to end. The second one needed care — with a config already present the *backup* step fails first and names a real path, so the fixture has to leave the read-only directory empty, which is the original reproduction. Both skip as root.

Closes #1686.

Everything else about the read-only case was already right and is quoted in the issue: exit 1, one line per refused target, the run continues to the writable harnesses, an unreadable config names itself, and a read-only *file* in a writable directory installs with its mode and content preserved.

`cmd/deja/update.go:500` stages through `.deja-update-*` and returns that error raw too. Same one line, different command, its own reproduction — left alone.
