### PR TITLE
docs: memory pages for dsh, Kimi Code, Zed and Grok Build

### DIFF
--- a/cmd/deja/docs_pages_test.go
+++ b/cmd/deja/docs_pages_test.go
@@ -80,6 +80,10 @@ func TestGuidePagesShareTheirNavigation(t *testing.T) {
 			"find-a-session.html",
 			"parallel-sessions.html",
 			"memory-for-opencode.html",
+			"memory-for-dsh.html",
+			"memory-for-kimi.html",
+			"memory-for-zed.html",
+			"memory-for-grok.html",
 		} {
 			if name == sibling {
 				continue

--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -49,6 +49,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -48,6 +48,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/auditing-agents.html
+++ b/docs/guide/auditing-agents.html
@@ -49,6 +49,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -48,6 +48,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -48,6 +48,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -77,6 +77,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/export-conversations.html
+++ b/docs/guide/export-conversations.html
@@ -49,6 +49,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html" aria-current="page">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/find-a-session.html
+++ b/docs/guide/find-a-session.html
@@ -49,6 +49,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -49,6 +49,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -48,6 +48,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -48,6 +48,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/memory-for-dsh.html
+++ b/docs/guide/memory-for-dsh.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Adding memory to DeepSeek Harness — deja-vu</title>
+<meta name="description" content="How to give dsh recall over the sessions every coding agent on the machine already wrote — the plugin, the tools, and how it behaves beside the CLI install.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Adding memory to DeepSeek Harness">
+<meta property="og:description" content="How to give dsh recall over the sessions every coding agent on the machine already wrote — the plugin, the tools, and how it behaves beside the CLI install.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Adding memory to DeepSeek Harness">
+<meta name="twitter:description" content="How to give dsh recall over the sessions every coding agent on the machine already wrote — the plugin, the tools, and how it behaves beside the CLI install.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to DeepSeek Harness","description":"How to give dsh recall over the sessions every coding agent on the machine already wrote — the plugin, the tools, and how it behaves beside the CLI install.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for dsh","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Does DeepSeek Harness remember previous sessions?","acceptedAnswer":{"@type":"Answer","text":"It can search its own sessions through the built-in session-query subsystem. It cannot read what other agents on the machine recorded, and a new session starts without either."}},{"@type":"Question","name":"How do I add cross-agent memory to dsh?","acceptedAnswer":{"@type":"Answer","text":"dsh plugin add dsh-deja, or deja install dsh-auto if you have the CLI. Both give the model tools over a local index of every agent's transcripts, plus recall on the system prompt."}},{"@type":"Question","name":"Where does DeepSeek Harness store its sessions?","acceptedAnswer":{"@type":"Answer","text":"Under $DSH_HOME (~/.dsh by default), as zstd-framed JSONL — one file per session, which is why reading them needs zstd."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html" aria-current="page">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Adding memory to DeepSeek Harness</h1>
+<p class="pagelede">session-query answers about dsh; this is about everything else<span class="mins" data-mins></span></p>
+
+<p>dsh can already answer questions about its own conversations — that is what the built-in <code>session-query</code> subsystem is for. This page is about the other question: what you did in Claude Code, Codex, Cursor, opencode or Zed, on the same machine, before dsh existed on it.</p>
+
+<h2>What dsh already has</h2>
+<p>Sessions live under <code>$DSH_HOME</code> (<code>~/.dsh</code> by default) as zstd-framed JSONL, one file per session, and <code>session-query</code> searches them. Two limits: it is dsh's own history only, and a fresh session does not consult it unless you ask.</p>
+
+<h2>Adding recall</h2>
+<pre>dsh plugin add dsh-deja</pre>
+<p>The plugin runs the <a href="https://github.com/vshulcz/deja-vu">deja</a> binary, which does the indexing. npm installs a copy with the package, a <code>deja</code> already on your PATH wins over it, and <code>DEJA_BIN</code> overrides both — so your own <code>deja update</code> or <code>brew upgrade</code> is what decides the version, not whatever a plugin release froze.</p>
+<p>With the CLI instead:</p>
+<pre>deja install dsh-auto</pre>
+<p>That writes the MCP server and the <code>/deja</code> command into the profile patch layer, and adds the plugin that puts recall in front of the model. <code>deja install --auto</code> does the same for every other agent on the machine in one pass.</p>
+<p>Both at once is fine: the package looks for what the installer wrote in <code>$DSH_HOME/plugins/deja/</code> and contributes only what is missing, so you never get two <code>/deja</code> commands or the same recall twice.</p>
+
+<h2>What arrives</h2>
+<p>Six tools the model can call — search past sessions, read one in full, see a file's history, ask what fixed an error, ask how a command is really run here, store a decision — a <code>/deja</code> command for asking directly, and recall that arrives on its own: before each assembly the plugin asks whether this machine's history answers the prompt, and adds it when it does. Silence is the common case.</p>
+<p>One implementation note worth knowing if you write dsh plugins: recall goes through <code>ctx.systemPrompt.context</code>, not through a middleware on <code>agent/pre-step</code>. The obvious alternative loads fine, completes the turn, and never reaches the model — a later listener in that waterfall rebuilds its answer from the payload and the spliced message is dropped with nothing reported. That was settled by reading the requests dsh actually sent.</p>
+
+<h2>The part that is not about this harness</h2>
+<p>The index covers every agent's transcripts on the machine — twenty of them today, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in one tool answers a question asked in another, including sessions from before any of this was installed. That is the reason to index rather than to capture.</p>
+<p>Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>). An injection is capped at 1,536 bytes per prompt and about 4 KB per tool call — <a href="token-cost.html">what memory costs</a> has the measured comparison.</p>
+
+<p><a href="getting-started.html">Getting started</a> · <a href="switching-agents.html">Switching between agents</a> · <a href="https://github.com/vshulcz/deja-vu/tree/main/extensions/dsh">The plugin source</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/memory-for-grok.html
+++ b/docs/guide/memory-for-grok.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Adding memory to Grok Build — deja-vu</title>
+<meta name="description" content="How to give Grok Build recall over every coding agent's sessions on the machine — the hooks it reads, the marketplace plugin in review, and the name that is not it.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Adding memory to Grok Build">
+<meta property="og:description" content="How to give Grok Build recall over every coding agent's sessions on the machine — the hooks it reads, the marketplace plugin in review, and the name that is not it.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Adding memory to Grok Build">
+<meta name="twitter:description" content="How to give Grok Build recall over every coding agent's sessions on the machine — the hooks it reads, the marketplace plugin in review, and the name that is not it.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to Grok Build","description":"How to give Grok Build recall over every coding agent's sessions on the machine — the hooks it reads, the marketplace plugin in review, and the name that is not it.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for Grok Build","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I add memory to Grok Build?","acceptedAnswer":{"@type":"Answer","text":"Run deja install grok-auto, which writes the MCP server into ~/.grok/config.toml and the recall hooks into ~/.grok/hooks/. A plugin for the marketplace is in review."}},{"@type":"Question","name":"Where does Grok Build keep its sessions?","acceptedAnswer":{"@type":"Answer","text":"Under ~/.grok/sessions as ACP JSONL update streams with JSON metadata, plus a grok.db store — GROK_HOME moves the tree."}},{"@type":"Question","name":"Does Grok Build support recall without being asked?","acceptedAnswer":{"@type":"Answer","text":"Yes. It reads hooks in the same shape Claude Code uses, so recall can arrive at session start, on a prompt, before a tool runs and before compaction."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html" aria-current="page">Memory for Grok Build</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Adding memory to Grok Build</h1>
+<p class="pagelede">it reads Claude-shaped hooks, so all four moments work<span class="mins" data-mins></span></p>
+
+<p>Grok Build writes every session to disk and starts the next one without them. The work that would answer today's question is in those files, and in whatever other agent you used before it.</p>
+
+<h2>What Grok already has</h2>
+<p>Sessions live under <code>~/.grok/sessions</code> as ACP update streams — JSONL with JSON metadata beside them — plus a <code>grok.db</code> store (<code>GROK_HOME</code> moves the tree). Complete, and unread by anything.</p>
+
+<h2>Adding recall</h2>
+<pre>deja install grok-auto</pre>
+<p>Writes <code>[mcp_servers.deja]</code> into <code>~/.grok/config.toml</code> and a hook file of deja's own into <code>~/.grok/hooks/</code>. Grok reads hooks in the same shape Claude Code uses, which is why all four moments work here: session start, per prompt, before a tool runs, and before compaction.</p>
+<p>A plugin for the official marketplace is <a href="https://github.com/xai-org/plugin-marketplace/pull/332">in review</a>. When it lands, <code>grok plugin install deja</code> is the other path, and the two coexist: each half of the plugin stands down when it finds what the CLI already wired, so nothing is listed or injected twice.</p>
+<p>Either way it needs the binary, since a plugin delivers files rather than runtimes:</p>
+<pre>brew install vshulcz/tap/deja-vu
+# or
+curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
+
+<h2>One thing to know about the name</h2>
+<p>There is a community CLI that shares the name <code>grok</code> and the <code>~/.grok</code> directory, and it is a different product. deja reads xAI's Grok Build store; where a capability could not be verified against Grok Build itself — <code>resume</code> is the one — the <a href="../registry/grok.html">registry page</a> says so and names what was checked instead of guessing.</p>
+
+<h2>The part that is not about this harness</h2>
+<p>The index covers every agent's transcripts on the machine — twenty of them today, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in one tool answers a question asked in another, including sessions from before any of this was installed. That is the reason to index rather than to capture.</p>
+<p>Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>). An injection is capped at 1,536 bytes per prompt and about 4 KB per tool call — <a href="token-cost.html">what memory costs</a> has the measured comparison.</p>
+
+<p><a href="getting-started.html">Getting started</a> · <a href="../registry/grok.html">How Grok's store is read</a> · <a href="https://github.com/vshulcz/deja-vu/tree/main/extensions/grok">The plugin source</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/memory-for-kimi.html
+++ b/docs/guide/memory-for-kimi.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Adding memory to Kimi Code — deja-vu</title>
+<meta name="description" content="How to give Kimi Code recall over every coding agent's sessions on the machine — the plugin, the hook that fires on each prompt, and the CLI path.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Adding memory to Kimi Code">
+<meta property="og:description" content="How to give Kimi Code recall over every coding agent's sessions on the machine — the plugin, the hook that fires on each prompt, and the CLI path.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Adding memory to Kimi Code">
+<meta name="twitter:description" content="How to give Kimi Code recall over every coding agent's sessions on the machine — the plugin, the hook that fires on each prompt, and the CLI path.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to Kimi Code","description":"How to give Kimi Code recall over every coding agent's sessions on the machine — the plugin, the hook that fires on each prompt, and the CLI path.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for Kimi Code","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I give Kimi Code memory of past sessions?","acceptedAnswer":{"@type":"Answer","text":"Install the plugin with /plugins install https://github.com/vshulcz/deja-vu, or run deja install kimi-auto. Both add MCP tools over a local index of every agent's transcripts and recall on every prompt."}},{"@type":"Question","name":"Where does Kimi Code keep its session history?","acceptedAnswer":{"@type":"Answer","text":"Under ~/.kimi-code/sessions, as JSONL wire logs per agent — KIMI_CODE_HOME moves the whole tree."}},{"@type":"Question","name":"Does the Kimi plugin conflict with the deja CLI install?","acceptedAnswer":{"@type":"Answer","text":"No. Each half of the plugin stands down when it finds what deja install kimi already wired, so tools are not listed twice and recall is not injected twice."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html" aria-current="page">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Adding memory to Kimi Code</h1>
+<p class="pagelede">one /plugins install, and the sessions stop starting empty<span class="mins" data-mins></span></p>
+
+<p>Kimi Code starts each session empty, and the sessions it has kept are its own. The history that would answer today's question is usually spread across whatever else you were using in the months before.</p>
+
+<h2>What Kimi already has</h2>
+<p>Sessions are written under <code>~/.kimi-code/sessions</code> as JSONL wire logs, one per agent within a session (<code>KIMI_CODE_HOME</code> moves the tree). They are readable and complete; nothing reads them back for you.</p>
+
+<h2>Adding recall</h2>
+<pre>/plugins install https://github.com/vshulcz/deja-vu</pre>
+<p>Kimi installs the plugin from the repository — the manifest sits at the root, which is the only reason that file is there. It needs the <a href="https://github.com/vshulcz/deja-vu">deja</a> binary, which is what indexes and searches:</p>
+<pre>brew install vshulcz/tap/deja-vu
+# or
+curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
+<p>With the CLI instead, <code>deja install kimi-auto</code> writes the MCP server into <code>mcp.json</code> and a <code>[[hooks]]</code> block into <code>config.toml</code>. Having both is fine: the plugin reads those two files and skips whatever the installer already covers.</p>
+
+<h2>What arrives</h2>
+<ul>
+<li>The MCP server, with the six tools deja serves everywhere.</li>
+<li>The <code>deja-history</code> skill, so the agent knows the CLI contract when the tools are not reachable.</li>
+<li><code>/deja:recall &lt;query&gt;</code> for asking directly.</li>
+<li>Recall on every prompt, through a <code>UserPromptSubmit</code> hook — Kimi appends a hook's stdout to the turn's context, which is the whole mechanism. It stays silent when the history has no answer.</li>
+</ul>
+
+<h2>The part that is not about this harness</h2>
+<p>The index covers every agent's transcripts on the machine — twenty of them today, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in one tool answers a question asked in another, including sessions from before any of this was installed. That is the reason to index rather than to capture.</p>
+<p>Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>). An injection is capped at 1,536 bytes per prompt and about 4 KB per tool call — <a href="token-cost.html">what memory costs</a> has the measured comparison.</p>
+
+<p><a href="getting-started.html">Getting started</a> · <a href="repeated-mistakes.html">When the same wall comes back</a> · <a href="https://github.com/vshulcz/deja-vu/tree/main/extensions/kimi">The plugin source</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/memory-for-opencode.html
+++ b/docs/guide/memory-for-opencode.html
@@ -49,6 +49,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html" aria-current="page">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/memory-for-zed.html
+++ b/docs/guide/memory-for-zed.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Adding memory to Zed's agent — deja-vu</title>
+<meta name="description" content="How to give Zed's agent recall over every coding agent's sessions on the machine, why both install paths share one server id, and what Zed's API cannot do yet.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Adding memory to Zed's agent">
+<meta property="og:description" content="How to give Zed's agent recall over every coding agent's sessions on the machine, why both install paths share one server id, and what Zed's API cannot do yet.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Adding memory to Zed's agent">
+<meta name="twitter:description" content="How to give Zed's agent recall over every coding agent's sessions on the machine, why both install paths share one server id, and what Zed's API cannot do yet.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to Zed's agent","description":"How to give Zed's agent recall over every coding agent's sessions on the machine, why both install paths share one server id, and what Zed's API cannot do yet.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for Zed","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Can Zed's agent search my past sessions?","acceptedAnswer":{"@type":"Answer","text":"With a context server it can. deja adds one that searches every agent's transcripts on the machine, including Zed's own threads."}},{"@type":"Question","name":"Where does Zed store its agent threads?","acceptedAnswer":{"@type":"Answer","text":"In one SQLite database under Zed's data directory — threads/threads.db — with each thread body stored as a zstd frame, so reading them needs both sqlite3 and zstd."}},{"@type":"Question","name":"Does recall arrive automatically in Zed?","acceptedAnswer":{"@type":"Answer","text":"No. Zed exposes no lifecycle hook for the agent, so memory arrives when the agent calls a tool or when you ask. The other harnesses get session-start and per-prompt recall; Zed does not, and that is a Zed limitation rather than a choice."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html" aria-current="page">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Adding memory to Zed's agent</h1>
+<p class="pagelede">one server id, two install paths, and one honest gap<span class="mins" data-mins></span></p>
+
+<p>Zed's agent keeps its threads in its own store and starts each one without the others. And unlike the terminal agents, everything you did in them is invisible to it — including the Zed thread from last week.</p>
+
+<h2>What Zed already has</h2>
+<p>Threads live in one SQLite database under Zed's data directory — <code>threads/threads.db</code> — and each thread body is a zstd frame rather than text, which is why reading them by hand needs both <code>sqlite3</code> and <code>zstd</code>. The thread list is a list; nothing consults it while you work.</p>
+
+<h2>Adding recall</h2>
+<p>Zed takes memory as a context server, and there are two ways to get one:</p>
+<pre>deja install zed</pre>
+<p>writes the server into <code>settings.json</code>. Or install the deja extension from Zed's extension list, which brings its own copy of the binary if you have none.</p>
+<p>Both use the same server id — <code>deja-context-server</code> — and Zed keys servers by id, so whichever order you install in there is exactly one server. That was not free: with two different ids, Zed ran two servers and the agent saw every tool twice.</p>
+<p>The extension is <a href="https://github.com/zed-industries/extensions/pull/7307">still in review</a> at the time of writing; until it lands, <code>deja install zed</code> is the path, and it needs the binary:</p>
+<pre>brew install vshulcz/tap/deja-vu</pre>
+
+<h2>What arrives, and what does not</h2>
+<p>The six tools, and a <code>/deja</code> slash command in the agent panel. What Zed cannot give you today is memory that arrives unasked: its extension API covers language servers, slash commands, context servers and debuggers, and there is no lifecycle hook where recall could be injected — no session-start block, nothing before a tool call. Every other harness in the matrix gets that; Zed does not, and it is a limitation of the API rather than something we chose to skip. It becomes work the day Zed ships a hook.</p>
+<p>In practice the agent calls <code>recall</code> itself when the conversation implies earlier work, because the tool description tells it to. That covers most of the gap and none of the silence.</p>
+
+<h2>The part that is not about this harness</h2>
+<p>The index covers every agent's transcripts on the machine — twenty of them today, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in one tool answers a question asked in another, including sessions from before any of this was installed. That is the reason to index rather than to capture.</p>
+<p>Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>). An injection is capped at 1,536 bytes per prompt and about 4 KB per tool call — <a href="token-cost.html">what memory costs</a> has the measured comparison.</p>
+
+<p><a href="getting-started.html">Getting started</a> · <a href="../registry/zed.html">How Zed's store is read</a> · <a href="https://github.com/vshulcz/deja-vu/tree/main/extensions/zed">The extension source</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/parallel-sessions.html
+++ b/docs/guide/parallel-sessions.html
@@ -49,6 +49,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html" aria-current="page">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -48,6 +48,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -49,6 +49,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/rules-files.html
+++ b/docs/guide/rules-files.html
@@ -49,6 +49,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -48,6 +48,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/switching-agents.html
+++ b/docs/guide/switching-agents.html
@@ -49,6 +49,10 @@
 <a href="switching-agents.html" aria-current="page">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/sync-across-machines.html
+++ b/docs/guide/sync-across-machines.html
@@ -49,6 +49,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html" aria-current="page">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/token-cost.html
+++ b/docs/guide/token-cost.html
@@ -49,6 +49,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html" aria-current="page">What memory costs</a>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -49,6 +49,10 @@
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
 <a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -15,6 +15,10 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/find-a-session.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/parallel-sessions.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-opencode.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/agents.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/search.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/commands.html</loc><lastmod>2026-08-11</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
Four more of the shape #1688 started — one page per harness we actually ship a bundle for, and no further. The rule from that PR still holds: twenty of these would be doorway pages.

Each says what the harness already has before it says what we add. dsh has `session-query` over its own sessions; Kimi writes JSONL wire logs nobody reads back; Zed keeps threads in SQLite with zstd bodies; Grok writes ACP update streams. Then both install paths and how they behave together, since every one of these bundles stands down where `deja install` already wired the same thing.

The limits are on the pages, not omitted from them:

- **Zed** gets no unasked recall at all — its extension API has no lifecycle hook, so there is no session-start block and nothing before a tool call. The page says that plainly and calls it a Zed limitation rather than a choice. It also explains why both install paths use one server id, and that the extension is still in review.
- **Grok** notes that the marketplace plugin is in review, so `deja install grok-auto` is today's path, and warns about the community CLI that shares the name and the `~/.grok` directory.
- **dsh** carries the implementation note that recall goes through `ctx.systemPrompt.context` rather than an `agent/pre-step` middleware, because the obvious alternative loads fine and silently never reaches the model.

Capabilities on each page were taken from the registry rather than memory, and the guard now covers all seventeen problem pages.