### PR TITLE
fix(install): refuse when deja cannot find a home directory, instead of wiring the working directory

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -22,6 +22,19 @@ import (
 type installResult struct{ Path, Action string }
 
 func runInstall(dir string, args []string, uninstall bool) error {
+	// Every path deja writes hangs off the home directory, and homeDir()
+	// answers "" when it cannot find one. filepath.Join("", ".claude") is
+	// ".claude", so with HOME unset install wrote .claude/, .claude.json and
+	// .config/deja/wiring.json into whatever directory it was run from — a
+	// repository, usually — and reported success (#1690). A config directory
+	// only means anything at an absolute location.
+	if homeDir() == "" {
+		verb := "install"
+		if uninstall {
+			verb = "uninstall"
+		}
+		return fmt.Errorf("%s cannot find your home directory — set HOME to the account deja should wire", verb)
+	}
 	removingWiring = uninstall
 	defer func() { removingWiring = false }()
 	guidance := true

--- a/cmd/deja/install_home_test.go
+++ b/cmd/deja/install_home_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// With HOME unset every filepath.Join(homeDir(), …) became a relative path, so
+// install wrote .claude/, .claude.json and .config/deja/wiring.json into the
+// working directory — a repository, usually — and reported success (#1690).
+func TestInstallRefusesWhenHomeIsUnknown(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("USERPROFILE and the profile APIs make an unset HOME a different question here")
+	}
+	hermeticEnv(t)
+	t.Setenv("HOME", "")
+
+	wd := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(wd); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	_, err = captureRun(t, "install", "claude-code")
+	if err == nil {
+		t.Error("install accepted a run with no home directory")
+	} else if !strings.Contains(err.Error(), "home") {
+		t.Errorf("the refusal does not say what is missing: %s", err)
+	}
+
+	for _, name := range []string{".claude", ".claude.json", ".agents", ".config"} {
+		if _, statErr := os.Stat(filepath.Join(wd, name)); statErr == nil {
+			t.Errorf("install created %s in the working directory", name)
+		}
+	}
+}
+
+// The neighbouring case must keep working: a home that exists is not affected.
+func TestInstallStillWorksWithAHome(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude.json")); err != nil {
+		t.Errorf("install did not write into the real home: %v", err)
+	}
+}


### PR DESCRIPTION
With `HOME` unset, `deja install claude-code` wrote `.claude/`, `.claude.json`, `.agents/` and `.config/deja/wiring.json` into the current working directory and exited 0. `homeDir()` returns `""` when `os.UserHomeDir()` fails, and `filepath.Join("", ".claude")` is `.claude` — so every destination became relative. Run from a repository, which is where a person runs a CLI, that is deja's wiring dropped into their working tree, reported as a successful install.

`runInstall` now refuses at the top, for both verbs: nothing is written, exit 1, and the message says what is missing rather than what deja failed to find on disk. Four paths, zero files after the fix.

Fail-before test: `TestInstallRefusesWhenHomeIsUnknown` runs in a temp working directory and asserts both halves — the refusal, and that none of the four paths appears. `TestInstallStillWorksWithAHome` is the control that a real home is untouched by the guard. Skipped on Windows, where `USERPROFILE` and the profile APIs make an unset `HOME` a different question.

Closes #1690.

The guard is deliberately at `runInstall` rather than inside `homeDir()`. Nineteen call sites go through that helper, plus `internal/sources.Home()` and two in `internal/index` with the same swallow-the-error shape; changing it underneath all of them is a bigger change than this, and the reading paths mostly want "find nothing" rather than "refuse". Worth its own pass — what does `deja index`, or a hook, do with no HOME?
