### PR TITLE
fix(install): ignore a relative XDG_CONFIG_HOME, as the spec requires

### DIFF
--- a/cmd/deja/install_sync_timer.go
+++ b/cmd/deja/install_sync_timer.go
@@ -99,11 +99,10 @@ func syncAutoPlist(exe string) string {
 }
 
 func syncAutoUnitDir() string {
-	base := os.Getenv("XDG_CONFIG_HOME")
-	if base == "" {
-		base = filepath.Join(homeDir(), ".config")
-	}
-	return filepath.Join(base, "systemd", "user")
+	// deja's own unit file, so the spec's rule applies: a relative
+	// XDG_CONFIG_HOME is ignored rather than followed into the working
+	// directory, where systemd would never look for it (#1693).
+	return filepath.Join(xdgConfigHome(), "systemd", "user")
 }
 
 func installSyncTimerSystemd(exe string, uninstall bool) (installResult, error) {

--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -35,11 +35,24 @@ type wiringState struct {
 }
 
 func wiringStatePath() string {
-	base := os.Getenv("XDG_CONFIG_HOME")
-	if base == "" {
-		base = filepath.Join(homeDir(), ".config")
+	return filepath.Join(xdgConfigHome(), "deja", "wiring.json")
+}
+
+// xdgConfigHome is the base for the files that are deja's own — the wiring
+// record and the sync timer's unit — not for the ones that mirror a harness's
+// path logic.
+//
+// The XDG spec: "All paths set in these environment variables must be
+// absolute. If an implementation encounters a relative path in any of these
+// variables it should consider the path invalid and ignore it." deja honoured
+// a relative value instead, so `XDG_CONFIG_HOME=relcfg deja install` wrote
+// wiring.json into whatever directory the command ran from, where no later run
+// would look for it (#1693).
+func xdgConfigHome() string {
+	if base := os.Getenv("XDG_CONFIG_HOME"); filepath.IsAbs(base) {
+		return base
 	}
-	return filepath.Join(base, "deja", "wiring.json")
+	return filepath.Join(homeDir(), ".config")
 }
 
 func readWiringState() wiringState {

--- a/cmd/deja/xdg_relative_test.go
+++ b/cmd/deja/xdg_relative_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The XDG spec says a relative path in one of these variables is invalid and
+// must be ignored. deja honoured it, so `XDG_CONFIG_HOME=relcfg deja install`
+// wrote its wiring record into the directory the command was run from — where
+// no later run would look for it (#1693).
+func TestRelativeXDGConfigHomeIsIgnored(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wd := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(wd); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+	t.Setenv("XDG_CONFIG_HOME", "relcfg")
+
+	if _, err := captureRun(t, "install", "claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(wd, "relcfg")); err == nil {
+		t.Error("install created relcfg/ in the working directory")
+	}
+	want := filepath.Join(home, ".config", "deja", "wiring.json")
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("the wiring record is not at the spec's fallback %s: %v", want, err)
+	}
+	if got := wiringStatePath(); !strings.HasPrefix(got, home) {
+		t.Errorf("wiringStatePath() is %q, outside the home directory", got)
+	}
+}
+
+// An absolute value is still honoured, spaces and all.
+func TestAbsoluteXDGConfigHomeIsHonoured(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	base := filepath.Join(t.TempDir(), "my cfg")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", base)
+
+	if _, err := captureRun(t, "install", "claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(base, "deja", "wiring.json")); err != nil {
+		t.Errorf("an absolute XDG_CONFIG_HOME was not used: %v", err)
+	}
+}


### PR DESCRIPTION
`XDG_CONFIG_HOME=relcfg deja install claude-code` wrote `relcfg/deja/wiring.json` into the directory the command ran from. The XDG spec says a relative path in one of these variables is invalid and must be ignored; deja followed it. The record then sits where no later run looks — `deja update`'s wiring refresh and the shared-skill guard from #1683 both read `wiringStatePath()`.

New `xdgConfigHome()` applies the spec rule, and the two paths that are **deja's own** use it: the wiring record and the sync timer's systemd unit (a unit file in the working directory is one systemd will never see).

Deliberately not changed: `opencodeConfigHome`, `gooseConfigHome` and `aiderContextPath` read the same variable to mirror *the harness's* path logic. If opencode or goose honours a relative value, deja has to look where the harness actually put the file, so the spec rule is the wrong rule there. Worth a look of its own — it needs reading each upstream, not a sweep.

Fail-before tests: `TestRelativeXDGConfigHomeIsIgnored` (nothing created in the working directory, record at the spec's fallback, `wiringStatePath()` inside the home) and `TestAbsoluteXDGConfigHomeIsHonoured`, which keeps the control that a real absolute path — spaces and all — is still used.

Closes #1693.
