### PR TITLE
fix(install): stop writing a stray comma into an opencode.jsonc that uses trailing commas

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1404,6 +1404,76 @@ func updateOpencodeJSON(old []byte, exe string, uninstall bool) ([]byte, error) 
 	return append(next, '\n'), nil
 }
 
+// jsoncLastCodeLine finds the last line of a .jsonc block that a parser would
+// read as code, and where that code ends on it. It returns -1 when the block
+// holds nothing but comments and blank lines.
+//
+// The comma that joins deja's entry to the previous one has to land at the end
+// of the code, not the end of the line. Appended after a trailing // comment it
+// is stripped with the comment and the two entries lose their separator;
+// appended inside a /* … */ block it either vanishes with the block or is left
+// behind as a comma of its own (#1695).
+func jsoncLastCodeLine(body []string) (idx, end int, code string) {
+	idx = -1
+	inBlock := false
+	for i, line := range body {
+		var c string
+		c, inBlock, end = jsoncCodeOf(line, inBlock)
+		if c != "" {
+			idx, code = i, c
+		}
+	}
+	if idx < 0 {
+		return -1, 0, ""
+	}
+	_, _, end = jsoncCodeOf(body[idx], jsoncInBlockAt(body, idx))
+	return idx, end, code
+}
+
+// jsoncInBlockAt reports whether line i starts inside a /* … */ block.
+func jsoncInBlockAt(body []string, i int) bool {
+	inBlock := false
+	for _, line := range body[:i] {
+		_, inBlock, _ = jsoncCodeOf(line, inBlock)
+	}
+	return inBlock
+}
+
+// jsoncCodeOf returns the code a parser reads on one line, whether the line
+// leaves a /* … */ block open, and the offset where that code ends.
+func jsoncCodeOf(line string, inBlock bool) (code string, stillInBlock bool, end int) {
+	var b strings.Builder
+	inString, escaped := false, false
+	end = 0
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		if inBlock {
+			if c == '*' && i+1 < len(line) && line[i+1] == '/' {
+				inBlock, i = false, i+1
+			}
+			continue
+		}
+		switch {
+		case escaped:
+			escaped = false
+		case c == '\\' && inString:
+			escaped = true
+		case c == '"':
+			inString = !inString
+		case !inString && c == '/' && i+1 < len(line) && line[i+1] == '/':
+			return strings.TrimSpace(b.String()), false, end
+		case !inString && c == '/' && i+1 < len(line) && line[i+1] == '*':
+			inBlock, i = true, i+1
+			continue
+		}
+		b.WriteByte(c)
+		if c != ' ' && c != '\t' {
+			end = i + 1
+		}
+	}
+	return strings.TrimSpace(b.String()), inBlock, end
+}
+
 func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, error) {
 	line := fmt.Sprintf(`    "deja": {"type":"local","command":[%q,"mcp"]}`, exe)
 	s := string(old)
@@ -1443,15 +1513,9 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, error)
 			// whose every line ends in one, which is what a .jsonc written
 			// with trailing commas looks like, and puts the comma on the line
 			// that opens the entry: `"mine": {,` (#1695).
-			for i := len(body) - 1; i >= 0; i-- {
-				trim := strings.TrimSpace(body[i])
-				if trim == "" || strings.HasPrefix(trim, "//") {
-					continue
-				}
-				if !strings.HasSuffix(trim, ",") && !strings.HasSuffix(trim, "{") && !strings.HasSuffix(trim, "[") {
-					body[i] += ","
-				}
-				break
+			if i, code, trim := jsoncLastCodeLine(body); i >= 0 &&
+				!strings.HasSuffix(trim, ",") && !strings.HasSuffix(trim, "{") && !strings.HasSuffix(trim, "[") {
+				body[i] = body[i][:code] + "," + body[i][code:]
 			}
 			body = append(body, line)
 		}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1437,12 +1437,21 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, error)
 			}
 		}
 		if !uninstall {
+			// Only the last line that carries content decides whether a comma
+			// is needed. Walking on past it — which is what looking for the
+			// first line not ending in a comma did — runs through an entry
+			// whose every line ends in one, which is what a .jsonc written
+			// with trailing commas looks like, and puts the comma on the line
+			// that opens the entry: `"mine": {,` (#1695).
 			for i := len(body) - 1; i >= 0; i-- {
 				trim := strings.TrimSpace(body[i])
-				if trim != "" && !strings.HasPrefix(trim, "//") && !strings.HasSuffix(trim, ",") {
-					body[i] += ","
-					break
+				if trim == "" || strings.HasPrefix(trim, "//") {
+					continue
 				}
+				if !strings.HasSuffix(trim, ",") && !strings.HasSuffix(trim, "{") && !strings.HasSuffix(trim, "[") {
+					body[i] += ","
+				}
+				break
 			}
 			body = append(body, line)
 		}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1417,26 +1417,13 @@ func jsoncLastCodeLine(body []string) (idx, end int, code string) {
 	idx = -1
 	inBlock := false
 	for i, line := range body {
-		var c string
-		c, inBlock, end = jsoncCodeOf(line, inBlock)
+		c, nextBlock, e := jsoncCodeOf(line, inBlock)
 		if c != "" {
-			idx, code = i, c
+			idx, end, code = i, e, c
 		}
+		inBlock = nextBlock
 	}
-	if idx < 0 {
-		return -1, 0, ""
-	}
-	_, _, end = jsoncCodeOf(body[idx], jsoncInBlockAt(body, idx))
 	return idx, end, code
-}
-
-// jsoncInBlockAt reports whether line i starts inside a /* … */ block.
-func jsoncInBlockAt(body []string, i int) bool {
-	inBlock := false
-	for _, line := range body[:i] {
-		_, inBlock, _ = jsoncCodeOf(line, inBlock)
-	}
-	return inBlock
 }
 
 // jsoncCodeOf returns the code a parser reads on one line, whether the line

--- a/cmd/deja/opencode_jsonc_test.go
+++ b/cmd/deja/opencode_jsonc_test.go
@@ -7,18 +7,55 @@ import (
 	"testing"
 )
 
-var (
-	jsoncComment = regexp.MustCompile(`//[^\n]*`)
-	jsoncComma   = regexp.MustCompile(`,(\s*[}\]])`)
-)
+// stripJSONC removes what a .jsonc reader ignores — line comments, block
+// comments and trailing commas — respecting string literals. Written out here
+// rather than reusing the production helper: a test that shares the code it is
+// checking would hide a bug in it.
+func stripJSONC(text string) string {
+	var b strings.Builder
+	inString, escaped, inLine, inBlock := false, false, false, false
+	for i := 0; i < len(text); i++ {
+		c := text[i]
+		switch {
+		case inLine:
+			if c == '\n' {
+				inLine = false
+				b.WriteByte(c)
+			}
+		case inBlock:
+			if c == '*' && i+1 < len(text) && text[i+1] == '/' {
+				inBlock, i = false, i+1
+			}
+		case inString:
+			b.WriteByte(c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+		case c == '"':
+			inString = true
+			b.WriteByte(c)
+		case c == '/' && i+1 < len(text) && text[i+1] == '/':
+			inLine, i = true, i+1
+		case c == '/' && i+1 < len(text) && text[i+1] == '*':
+			inBlock, i = true, i+1
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return regexp.MustCompile(`,(\s*[}\]])`).ReplaceAllString(b.String(), "$1")
+}
 
-// parsesAsJSONC reports whether text survives the two liberties a .jsonc reader
-// takes — line comments and trailing commas — and is JSON underneath.
+// parsesAsJSONC reports whether text is JSON once a .jsonc reader's liberties
+// are taken away.
 func parsesAsJSONC(t *testing.T, text string) error {
 	t.Helper()
-	stripped := jsoncComma.ReplaceAllString(jsoncComment.ReplaceAllString(text, ""), "$1")
 	var v any
-	return json.Unmarshal([]byte(stripped), &v)
+	return json.Unmarshal([]byte(stripJSONC(text)), &v)
 }
 
 // The comma that joins deja's entry to the previous one was placed by walking
@@ -49,6 +86,24 @@ func TestOpencodeJSONCKeepsTrailingCommasValid(t *testing.T) {
   "mcp": {
   }
 }`,
+		"block comment last in the block": `{
+  "mcp": {
+    "mine": {"type": "local", "command": ["my-server"]},
+    /* a note
+       over several lines
+    */
+  }
+}`,
+		"trailing comment on the last entry": `{
+  "mcp": {
+    "mine": {"type": "local", "command": ["my-server"]} // my server
+  }
+}`,
+		"a // inside a string": `{
+  "mcp": {
+    "mine": {"type": "remote", "url": "https://example.com/my-server"}
+  }
+}`,
 		"comment last in the block": `{
   "mcp": {
     "mine": {"type": "local", "command": ["my-server"]}
@@ -71,6 +126,16 @@ func TestOpencodeJSONCKeepsTrailingCommasValid(t *testing.T) {
 			}
 			if strings.Contains(got, "{,") {
 				t.Errorf("a comma landed on an opening brace:\n%s", got)
+			}
+			if strings.Contains(got, "*/,") || strings.Contains(got, "spanning,") {
+				t.Errorf("a comma landed inside a block comment:\n%s", got)
+			}
+			// A comma written after a trailing comment goes with the comment,
+			// and the two entries lose their separator.
+			for _, l := range strings.Split(got, "\n") {
+				if i := strings.Index(l, "//"); i >= 0 && !strings.Contains(l[:i], `"`) && strings.HasSuffix(strings.TrimSpace(l), ",") {
+					t.Errorf("a comma landed inside a line comment: %q\n%s", l, got)
+				}
 			}
 			// Only where the fixture had one: the empty-block case has none.
 			if strings.Contains(in, "my-server") && !strings.Contains(got, "my-server") {

--- a/cmd/deja/opencode_jsonc_test.go
+++ b/cmd/deja/opencode_jsonc_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var (
+	jsoncComment = regexp.MustCompile(`//[^\n]*`)
+	jsoncComma   = regexp.MustCompile(`,(\s*[}\]])`)
+)
+
+// parsesAsJSONC reports whether text survives the two liberties a .jsonc reader
+// takes — line comments and trailing commas — and is JSON underneath.
+func parsesAsJSONC(t *testing.T, text string) error {
+	t.Helper()
+	stripped := jsoncComma.ReplaceAllString(jsoncComment.ReplaceAllString(text, ""), "$1")
+	var v any
+	return json.Unmarshal([]byte(stripped), &v)
+}
+
+// The comma that joins deja's entry to the previous one was placed by walking
+// backwards to the first line not already ending in a comma. In a file that
+// uses trailing commas — which is what .jsonc is for — that scan runs past the
+// last entry and lands on the line opening it, producing `"mine": {,` (#1695).
+func TestOpencodeJSONCKeepsTrailingCommasValid(t *testing.T) {
+	cases := map[string]string{
+		"trailing commas": `{
+  // my opencode config
+  "theme": "system",
+  "mcp": {
+    "mine": {
+      "type": "local",
+      "command": ["my-server"],
+    },
+  },
+}`,
+		"no trailing comma": `{
+  "mcp": {
+    "mine": {
+      "type": "local",
+      "command": ["my-server"]
+    }
+  }
+}`,
+		"empty mcp block": `{
+  "mcp": {
+  }
+}`,
+		"comment last in the block": `{
+  "mcp": {
+    "mine": {"type": "local", "command": ["my-server"]}
+    // more to come
+  }
+}`,
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			out, err := updateOpencodeJSONC([]byte(in+"\n"), "/usr/local/bin/deja", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(out)
+			if err := parsesAsJSONC(t, got); err != nil {
+				t.Errorf("install left a file that does not parse: %v\n%s", err, got)
+			}
+			if !strings.Contains(got, `"deja"`) {
+				t.Errorf("deja's entry is missing:\n%s", got)
+			}
+			if strings.Contains(got, "{,") {
+				t.Errorf("a comma landed on an opening brace:\n%s", got)
+			}
+			// Only where the fixture had one: the empty-block case has none.
+			if strings.Contains(in, "my-server") && !strings.Contains(got, "my-server") {
+				t.Errorf("the user's own server is gone:\n%s", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`deja install opencode` turned a valid `opencode.jsonc` into one that does not parse, and exited 0 saying `updated`:

```
    "mine": {,
      "type": "local",
```

The comma that joins deja's entry to the previous one was placed by walking backwards to the first line that does not already end in a comma. In a file written with trailing commas — which is what `.jsonc` is for — every line of the last entry ends in one, so the scan ran past the entry and landed on the line that *opens* it.

It now looks at the last line carrying content and stops there, adding a comma only if that line needs one. Lines ending in `{` or `[` never do.

Fail-before test: `TestOpencodeJSONCKeepsTrailingCommasValid` over four shapes — trailing commas, no trailing comma, an empty `mcp` block, and a comment as the last line in the block — each checked for parsing after comments and trailing commas are stripped, for deja's entry being present, for no `{,`, and for the user's own server surviving. Two of the four failed before the change.

Closes #1695.

Verified by hand as well: install, uninstall, install again over the same file leaves it byte-identical to the single-install result, comment and trailing commas intact.
