### PR TITLE
fix(install): refuse a goose extensions: list rather than writing a mapping into it

### DIFF
--- a/cmd/deja/goose_yaml_test.go
+++ b/cmd/deja/goose_yaml_test.go
@@ -39,6 +39,36 @@ func TestInstallGooseRefusesAnExtensionsList(t *testing.T) {
 	}
 }
 
+// An inline value is not a block: the insert missed it and appended a second
+// `extensions:` key, and a parser takes the last of two — deja's — so the
+// user's extensions vanished without a word (#1697).
+func TestInstallGooseRefusesAnInlineExtensions(t *testing.T) {
+	hermeticEnv(t)
+	if os.Getenv("DEJA_GOOSE_ROOT") == "" {
+		t.Skip("no goose root in this environment")
+	}
+	for _, inline := range []string{"extensions: [a, b]\n", "extensions: {a: {enabled: true}}\n"} {
+		cfg := filepath.Join(gooseConfigDir(), "config.yaml")
+		if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(cfg, []byte(inline), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := captureRun(t, "install", "goose"); err == nil {
+			after, _ := os.ReadFile(cfg)
+			t.Errorf("install accepted %q:\n%s", inline, after)
+		}
+		after, err := os.ReadFile(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(after) != inline {
+			t.Errorf("install changed a config it could not edit:\n%s", after)
+		}
+	}
+}
+
 // The control: a mapping — the shape goose actually uses — still gets deja's
 // entry, keeps the user's, and survives a second install and an uninstall.
 func TestInstallGooseKeepsAHandWrittenBlock(t *testing.T) {

--- a/cmd/deja/goose_yaml_test.go
+++ b/cmd/deja/goose_yaml_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// goose keys extensions by name. Writing deja's mapping entry under a key whose
+// value is a sequence leaves a mapping and a sequence under one key, which no
+// YAML parser accepts — and install said "updated" and exited 0 (#1697).
+func TestInstallGooseRefusesAnExtensionsList(t *testing.T) {
+	hermeticEnv(t)
+	dir := os.Getenv("DEJA_GOOSE_ROOT")
+	if dir == "" {
+		t.Skip("no goose root in this environment")
+	}
+	cfg := filepath.Join(gooseConfigDir(), "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const list = "extensions:\n  - developer\n  - fetch\n"
+	if err := os.WriteFile(cfg, []byte(list), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := captureRun(t, "install", "goose")
+	if err == nil {
+		t.Error("install accepted an extensions: list")
+	} else if !strings.Contains(err.Error(), "extensions") {
+		t.Errorf("the refusal does not name what it could not read: %s", err)
+	}
+	after, readErr := os.ReadFile(cfg)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(after) != list {
+		t.Errorf("install changed a config it could not read:\n%s", after)
+	}
+}
+
+// The control: a mapping — the shape goose actually uses — still gets deja's
+// entry, keeps the user's, and survives a second install and an uninstall.
+func TestInstallGooseKeepsAHandWrittenBlock(t *testing.T) {
+	hermeticEnv(t)
+	if os.Getenv("DEJA_GOOSE_ROOT") == "" {
+		t.Skip("no goose root in this environment")
+	}
+	cfg := filepath.Join(gooseConfigDir(), "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const hand = "# mine\nGOOSE_PROVIDER: anthropic\nextensions:\n  # my own\n  developer:\n    enabled: true\n    type: builtin\n"
+	if err := os.WriteFile(cfg, []byte(hand), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "goose"); err != nil {
+		t.Fatal(err)
+	}
+	names := gooseExtensionNames(t, cfg)
+	if !names["deja"] || !names["developer"] {
+		t.Fatalf("install lost an extension: %v", names)
+	}
+	first, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "goose"); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("a second install rewrote the config:\n%s\n---\n%s", first, second)
+	}
+	if _, err := captureRun(t, "uninstall", "goose"); err != nil {
+		t.Fatal(err)
+	}
+	names = gooseExtensionNames(t, cfg)
+	if names["deja"] || !names["developer"] {
+		t.Errorf("uninstall did not put the block back: %v", names)
+	}
+}
+
+// gooseExtensionNames reads the entry names under `extensions:` and fails if
+// the block mixes a mapping with a sequence — deja has no YAML parser, and
+// pulling one in for a test would check a library rather than this code.
+func gooseExtensionNames(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := map[string]bool{}
+	inBlock := false
+	for _, line := range strings.Split(string(b), "\n") {
+		if strings.HasPrefix(line, "extensions:") {
+			inBlock = true
+			continue
+		}
+		if !inBlock {
+			continue
+		}
+		if line != "" && !strings.HasPrefix(line, " ") {
+			break
+		}
+		trim := strings.TrimSpace(line)
+		if trim == "" || strings.HasPrefix(trim, "#") {
+			continue
+		}
+		// Only at the entry level: `- "mcp"` inside an entry's args is fine.
+		if strings.HasPrefix(line, "  - ") {
+			t.Fatalf("the extensions block holds a sequence item where entries go:\n%s", b)
+		}
+		// Entry names sit at exactly one level of indent; their fields deeper.
+		if strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "   ") && strings.HasSuffix(trim, ":") {
+			names[strings.TrimSuffix(trim, ":")] = true
+		}
+	}
+	return names
+}

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -27,6 +27,22 @@ import (
 // config.yaml is edited textually rather than through a YAML round-trip: it
 // holds provider settings a user wrote by hand, and re-serialising drops the
 // comments and ordering they left there.
+// inlineYAMLValue returns the value written on the same line as a top-level
+// key, or "" when the key is absent or opens a block.
+func inlineYAMLValue(doc, key string) string {
+	for _, line := range strings.Split(doc, "\n") {
+		if !strings.HasPrefix(line, key) {
+			continue
+		}
+		rest := strings.TrimSpace(strings.TrimPrefix(line, key))
+		if rest == "" || strings.HasPrefix(rest, "#") {
+			return ""
+		}
+		return rest
+	}
+	return ""
+}
+
 // yamlBlockIsSequence reports whether the block that follows a key opens with
 // a sequence item rather than a mapping entry, skipping blank lines and
 // comments. A block that is empty, or holds mapping entries, is not one.
@@ -76,6 +92,13 @@ func installGoose(exe string, uninstall bool) (installResult, error) {
 		}
 		b.WriteString("    timeout: 60\n")
 		entry := b.String()
+		// An inline value — `extensions: [a, b]` or `extensions: {…}` — is not
+		// followed by a block, so the insert below missed it and appended a
+		// second `extensions:` key. A parser takes the last of two, which is
+		// deja's, and the user's extensions were gone without a word (#1697).
+		if v := inlineYAMLValue(next, "extensions:"); v != "" {
+			return installResult{}, fmt.Errorf("%s: extensions: %s is on one line, and deja edits the block form — move it to a block and run this again", path, v)
+		}
 		if i := strings.Index("\n"+next, "\nextensions:\n"); i >= 0 {
 			at := i + len("\nextensions:\n") - 1
 			// goose keys extensions by name. Writing our mapping entry under a

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -27,6 +27,22 @@ import (
 // config.yaml is edited textually rather than through a YAML round-trip: it
 // holds provider settings a user wrote by hand, and re-serialising drops the
 // comments and ordering they left there.
+// yamlBlockIsSequence reports whether the block that follows a key opens with
+// a sequence item rather than a mapping entry, skipping blank lines and
+// comments. A block that is empty, or holds mapping entries, is not one.
+func yamlBlockIsSequence(block string) bool {
+	for _, line := range strings.Split(block, "\n") {
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			return false
+		}
+		return strings.HasPrefix(strings.TrimSpace(line), "- ")
+	}
+	return false
+}
+
 func installGoose(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(gooseConfigDir(), "config.yaml")
 	old, err := os.ReadFile(path)
@@ -62,6 +78,15 @@ func installGoose(exe string, uninstall bool) (installResult, error) {
 		entry := b.String()
 		if i := strings.Index("\n"+next, "\nextensions:\n"); i >= 0 {
 			at := i + len("\nextensions:\n") - 1
+			// goose keys extensions by name. Writing our mapping entry under a
+			// key whose value is a sequence leaves a mapping and a sequence
+			// under one key, which no parser accepts — a config that was
+			// merely wrong for goose became one nothing can read, reported as
+			// "updated" (#1697). Refuse instead, as the opencode writer does
+			// when it cannot bound the block it was asked to edit.
+			if yamlBlockIsSequence(next[at:]) {
+				return installResult{}, fmt.Errorf("%s: extensions: holds a list, and goose keys extensions by name — deja cannot add itself to it", path)
+			}
 			next = next[:at] + entry + next[at:]
 		} else {
 			if next != "" && !strings.HasSuffix(next, "\n") {


### PR DESCRIPTION
`deja install goose` found `extensions:` and inserted its mapping entry straight after it, whatever the value was. Where the value is a sequence the result is a mapping and a sequence under one key — YAML nothing can parse — written with exit 0 and reported as `updated`. A config that was merely wrong for goose came out unreadable by anything.

It now refuses, naming the file and why, and leaves it byte-identical. That is the rule the opencode writer already states for itself: refuse rather than corrupt a config that cannot be read.

`yamlBlockIsSequence` looks at the first line of the block that is neither blank nor a comment; an empty block and a mapping block are both fine and take the existing path.

Fail-before tests: `TestInstallGooseRefusesAnExtensionsList` (refuses, names `extensions`, file unchanged) and `TestInstallGooseKeepsAHandWrittenBlock` as the control — a hand-written mapping keeps its entries and comments, deja's entry joins them, a second install is byte-identical, and uninstall puts the block back exactly.

Closes #1697.

The test reads the block without a YAML library: deja has no YAML parser, and adding one for a test would check the library rather than this code. Worth knowing that my first version of that reader was wrong — it counted `- "mcp"` inside deja's own `args:` as a sequence item and failed the control; it now only looks at the entry indent level.
