### PR TITLE
fix(install): end deja's kimi hook block at the next comment, not the next table

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -428,7 +428,16 @@ func removeKimiHookBlock(s string) string {
 		if i < len(lines) && strings.HasPrefix(strings.TrimSpace(lines[i]), "[[hooks]]") {
 			i++
 		}
-		for i < len(lines) && !strings.HasPrefix(strings.TrimSpace(lines[i]), "[") {
+		// deja's block ends at the next table header or the next comment. It
+		// writes no comments inside its own block, so a `#` line is always
+		// someone else's — running past one deleted the note a user had
+		// written above their next hook, and swallowed the marker of a second
+		// deja block, leaving that block behind unmarked and running (#1699).
+		for i < len(lines) {
+			t := strings.TrimSpace(lines[i])
+			if strings.HasPrefix(t, "[") || strings.HasPrefix(t, "#") {
+				break
+			}
 			i++
 		}
 		i-- // the loop's own i++ steps onto the next table header

--- a/cmd/deja/kimi_hooks_test.go
+++ b/cmd/deja/kimi_hooks_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+const kimiUserHooks = `model = "kimi"
+
+# deja: auto-recall (managed by ` + "`deja install kimi-auto`" + `)
+[[hooks]]
+event = "UserPromptSubmit"
+command = "/old/deja hook-prompt --plain"
+timeout = 30
+
+# my careful note about the next hook
+[[hooks]]
+event = "PreToolUse"
+command = "my-hook"
+`
+
+// The removal ran from deja's marker to the next line starting with "[", so a
+// comment the user wrote above the *next* hook went with it (#1699).
+func TestRemoveKimiHookKeepsTheNextHooksComment(t *testing.T) {
+	got := removeKimiHookBlock(kimiUserHooks)
+	if strings.Contains(got, "/old/deja") {
+		t.Errorf("deja's own block survived:\n%s", got)
+	}
+	if !strings.Contains(got, "# my careful note about the next hook") {
+		t.Errorf("the user's comment was deleted:\n%s", got)
+	}
+	if !strings.Contains(got, "my-hook") {
+		t.Errorf("the user's hook was deleted:\n%s", got)
+	}
+}
+
+// Two marked blocks: the first removal consumed the second one's marker and
+// left the block behind, so kimi ran recall twice and nothing could find the
+// orphan again.
+func TestRemoveKimiHookTakesEveryMarkedBlock(t *testing.T) {
+	const two = `model = "kimi"
+
+# deja: auto-recall (managed by ` + "`deja install kimi-auto`" + `)
+[[hooks]]
+event = "UserPromptSubmit"
+command = "/a/deja hook-prompt --plain"
+
+# deja: auto-recall (managed by ` + "`deja install kimi-auto`" + `)
+[[hooks]]
+event = "UserPromptSubmit"
+command = "/b/deja hook-prompt --plain"
+
+[[hooks]]
+event = "PreToolUse"
+command = "my-hook"
+`
+	got := removeKimiHookBlock(two)
+	for _, gone := range []string{"/a/deja", "/b/deja", kimiHookMarker} {
+		if strings.Contains(got, gone) {
+			t.Errorf("%q survived the removal:\n%s", gone, got)
+		}
+	}
+	if !strings.Contains(got, "my-hook") {
+		t.Errorf("the user's hook was deleted:\n%s", got)
+	}
+	if n := strings.Count(got, "[[hooks]]"); n != 1 {
+		t.Errorf("expected one hook left, found %d:\n%s", n, got)
+	}
+}
+
+// The control: a block with nothing after it, and a config with no deja block
+// at all, are both left sensible.
+func TestRemoveKimiHookOnTheOrdinaryShapes(t *testing.T) {
+	const last = `model = "kimi"
+
+[[hooks]]
+event = "PreToolUse"
+command = "my-hook"
+
+# deja: auto-recall (managed by ` + "`deja install kimi-auto`" + `)
+[[hooks]]
+event = "UserPromptSubmit"
+command = "/old/deja hook-prompt --plain"
+timeout = 30
+`
+	got := removeKimiHookBlock(last)
+	if strings.Contains(got, "/old/deja") || strings.Contains(got, kimiHookMarker) {
+		t.Errorf("deja's block survived:\n%s", got)
+	}
+	if !strings.Contains(got, "my-hook") {
+		t.Errorf("the user's hook was deleted:\n%s", got)
+	}
+	const none = "model = \"kimi\"\n\n[[hooks]]\nevent = \"PreToolUse\"\ncommand = \"my-hook\"\n"
+	if got := removeKimiHookBlock(none); strings.TrimSpace(got) != strings.TrimSpace(none) {
+		t.Errorf("a config without deja was changed:\n%s", got)
+	}
+}


### PR DESCRIPTION
Removing deja's `[[hooks]]` entry ran from its marker to the next line starting with `[`, taking everything in between. Two things were in between.

A comment the user had written above their *next* hook — deleted by any reinstall, `deja update` included.

And the marker of a *second* deja block, where a config carried two. That block was left behind unmarked: kimi ran recall twice on every prompt, one of them through a stale binary path, and nothing could ever find the orphan again because `uninstall` keys on the marker.

deja writes no comments inside its own block, so the block now ends at the next table header **or** the next comment. That single change fixes both: the user's note is left alone, and the second marker is reached, matched and its block removed too.

Fail-before tests: `TestRemoveKimiHookKeepsTheNextHooksComment` and `TestRemoveKimiHookTakesEveryMarkedBlock`, with `TestRemoveKimiHookOnTheOrdinaryShapes` as the control — deja's block last in the file, and a config that never had one.

Closes #1699.

Verified end to end as well: after the fix the comment survives an install, and a config with two marked blocks comes out with exactly one deja hook and the user's own untouched.
