### PR TITLE
fix(install): refuse a cordis.patch.yml where one of deja's markers is missing

### DIFF
--- a/cmd/deja/dsh_patch_test.go
+++ b/cmd/deja/dsh_patch_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
 const dshDejaBlock = dshBlockStart + `
@@ -29,6 +33,44 @@ func TestDSHPatchRefusesAHalfMarkedBlock(t *testing.T) {
 	noStart := strings.ReplaceAll(dshDejaBlock, dshBlockStart, "")
 	if _, err := dshPatchWith(noStart, "BLOCK"); err == nil {
 		t.Error("a block with no start marker was edited anyway")
+	}
+	// Both markers, in the wrong order: the skip still runs to end of file.
+	wrongOrder := dshBlockEnd + "\n- insert:\n    - id: mcp-deja\n" + dshBlockStart + "\n" + dshUserPatch
+	if _, err := dshPatchWith(wrongOrder, "BLOCK"); err == nil {
+		t.Error("a block whose end marker comes first was edited anyway")
+	}
+	// A marker quoted inside a value is not a marker.
+	quoted := dshUserPatch + "\n    - id: note\n      name: \"" + dshBlockEnd + "\"\n"
+	if _, err := dshPatchWith(quoted, "BLOCK"); err != nil {
+		t.Errorf("a marker quoted inside a value was taken for one: %v", err)
+	}
+}
+
+// Uninstall is exactly when someone with a hand-edited file needs their own
+// content left alone, and it called stripDSHBlock with no check at all.
+func TestUninstallDeepSeekRefusesAHalfMarkedBlock(t *testing.T) {
+	hermeticEnv(t)
+	dir := sources.DSHHome()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "cordis.patch.yml")
+	half := strings.ReplaceAll(dshDejaBlock, dshBlockEnd, "") + "\n" + dshUserPatch + "\n"
+	if err := os.WriteFile(path, []byte(half), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "uninstall", "deepseek"); err == nil {
+		t.Error("uninstall edited a file it could not bound")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != half {
+		t.Errorf("uninstall changed the file:\n%s", after)
+	}
+	if !strings.Contains(string(after), "my-plugin") {
+		t.Errorf("uninstall deleted the user's patch:\n%s", after)
 	}
 }
 

--- a/cmd/deja/dsh_patch_test.go
+++ b/cmd/deja/dsh_patch_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+const dshDejaBlock = dshBlockStart + `
+- insert:
+    - id: mcp-deja
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: deja
+` + dshBlockEnd
+
+const dshUserPatch = `# my own patch
+- insert:
+    - id: my-plugin
+      name: "my-plugin.js"`
+
+// The block's own first line says "safe to delete", and deleting half of it
+// cost the user the patch they had written below: the skip ran to end of file
+// (#1701).
+func TestDSHPatchRefusesAHalfMarkedBlock(t *testing.T) {
+	noEnd := strings.ReplaceAll(dshDejaBlock, dshBlockEnd, "") + "\n" + dshUserPatch
+	if _, err := dshPatchWith(noEnd, "BLOCK"); err == nil {
+		t.Error("a block with no end marker was edited anyway")
+	}
+	noStart := strings.ReplaceAll(dshDejaBlock, dshBlockStart, "")
+	if _, err := dshPatchWith(noStart, "BLOCK"); err == nil {
+		t.Error("a block with no start marker was edited anyway")
+	}
+}
+
+// The control: both markers present, and no deja block at all, are both edited
+// as before — the user's patch kept, deja's block replaced or appended once.
+func TestDSHPatchKeepsTheUsersPatch(t *testing.T) {
+	both := dshUserPatch + "\n" + dshDejaBlock
+	got, err := dshPatchWith(both, "BLOCK")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "my-plugin") {
+		t.Errorf("the user's patch was dropped:\n%s", got)
+	}
+	if strings.Contains(got, "mcp-deja") {
+		t.Errorf("the old deja block survived:\n%s", got)
+	}
+	if n := strings.Count(got, "BLOCK"); n != 1 {
+		t.Errorf("expected one new block, found %d:\n%s", n, got)
+	}
+
+	got, err = dshPatchWith(dshUserPatch, "BLOCK")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "my-plugin") || strings.Count(got, "BLOCK") != 1 {
+		t.Errorf("a file deja had never touched came out wrong:\n%s", got)
+	}
+}

--- a/cmd/deja/install_deepseek.go
+++ b/cmd/deja/install_deepseek.go
@@ -210,11 +210,25 @@ func autoRow(withAuto bool) string {
 }
 
 // dshPatchWith returns the layer with deja's block present exactly once.
-func dshPatchWith(old, block string) string {
-	if trimmed := stripDSHBlock(old); trimmed != "" {
-		return trimmed + "\n" + block + "\n"
+func dshPatchWith(old, block string) (string, error) {
+	// One marker without the other means the block cannot be bounded. Skipping
+	// from the start marker to end of file deleted a patch the user had written
+	// below it; leaving an unmarked block in place installed deja twice, with
+	// the orphan invisible to every later run (#1701). The first line of the
+	// block says "safe to delete", which is an invitation to edit exactly this.
+	hasStart := strings.Contains(old, dshBlockStart)
+	hasEnd := strings.Contains(old, dshBlockEnd)
+	if hasStart != hasEnd {
+		missing := "end"
+		if hasEnd {
+			missing = "start"
+		}
+		return "", fmt.Errorf("deja's block in cordis.patch.yml has no %s marker — put it back, or delete the block entirely", missing)
 	}
-	return block + "\n"
+	if trimmed := stripDSHBlock(old); trimmed != "" {
+		return trimmed + "\n" + block + "\n", nil
+	}
+	return block + "\n", nil
 }
 
 // stripDSHBlock removes deja's block and the empty-array literal a generated
@@ -302,6 +316,10 @@ func installDeepSeek(exe string, uninstall, withAuto bool) (installResult, error
 	} else if err := os.Remove(dshAutoPath()); err != nil && !os.IsNotExist(err) {
 		return installResult{}, err
 	}
-	a, err := writeIfChanged(path, old, []byte(dshPatchWith(lfText(old), dshPatchBlock(exe, withAuto))))
+	patched, perr := dshPatchWith(lfText(old), dshPatchBlock(exe, withAuto))
+	if perr != nil {
+		return installResult{}, perr
+	}
+	a, err := writeIfChanged(path, old, []byte(patched))
 	return installResult{Path: path, Action: a}, err
 }

--- a/cmd/deja/install_deepseek.go
+++ b/cmd/deja/install_deepseek.go
@@ -216,19 +216,48 @@ func dshPatchWith(old, block string) (string, error) {
 	// below it; leaving an unmarked block in place installed deja twice, with
 	// the orphan invisible to every later run (#1701). The first line of the
 	// block says "safe to delete", which is an invitation to edit exactly this.
-	hasStart := strings.Contains(old, dshBlockStart)
-	hasEnd := strings.Contains(old, dshBlockEnd)
-	if hasStart != hasEnd {
-		missing := "end"
-		if hasEnd {
-			missing = "start"
-		}
-		return "", fmt.Errorf("deja's block in cordis.patch.yml has no %s marker — put it back, or delete the block entirely", missing)
+	if err := checkDSHMarkers(old); err != nil {
+		return "", err
 	}
 	if trimmed := stripDSHBlock(old); trimmed != "" {
 		return trimmed + "\n" + block + "\n", nil
 	}
 	return block + "\n", nil
+}
+
+// checkDSHMarkers reports whether deja's block can be bounded: both markers
+// present, each on a line of its own, the start before the end.
+//
+// One without the other, or the two in the wrong order, sends stripDSHBlock's
+// skip to the end of the file and deletes whatever the user wrote below —
+// which the block's own "safe to delete" invites them to have edited (#1701).
+// Matching whole lines rather than substrings keeps a marker quoted inside a
+// value from counting.
+func checkDSHMarkers(doc string) error {
+	start, end := -1, -1
+	for i, line := range strings.Split(doc, "\n") {
+		switch t := strings.TrimSpace(line); {
+		case strings.HasPrefix(t, dshBlockStart):
+			if start < 0 {
+				start = i
+			}
+		case t == dshBlockEnd:
+			if end < 0 {
+				end = i
+			}
+		}
+	}
+	switch {
+	case start < 0 && end < 0:
+		return nil
+	case start < 0:
+		return fmt.Errorf("deja's block in cordis.patch.yml has no start marker — put it back, or delete the block entirely")
+	case end < 0:
+		return fmt.Errorf("deja's block in cordis.patch.yml has no end marker — put it back, or delete the block entirely")
+	case end < start:
+		return fmt.Errorf("deja's block in cordis.patch.yml has its end marker above its start marker — put them in order, or delete the block entirely")
+	}
+	return nil
 }
 
 // stripDSHBlock removes deja's block and the empty-array literal a generated
@@ -276,6 +305,13 @@ func installDeepSeek(exe string, uninstall, withAuto bool) (installResult, error
 	if uninstall {
 		if len(old) == 0 || !strings.Contains(string(old), dshBlockStart) {
 			return installResult{Path: path, Action: "unchanged"}, nil
+		}
+		// The same check the install side makes: skipping from a start marker
+		// with no end runs to end of file and takes the user's own patch with
+		// it, and uninstall is exactly when someone with a hand-edited file
+		// needs their content left alone (#1701).
+		if err := checkDSHMarkers(lfText(old)); err != nil {
+			return installResult{}, err
 		}
 		rest := stripDSHBlock(string(old))
 		if strings.TrimSpace(rest) == "" {

--- a/cmd/deja/install_deepseek_test.go
+++ b/cmd/deja/install_deepseek_test.go
@@ -11,7 +11,10 @@ import (
 // the literal has to go — otherwise dsh refuses the whole profile and the only
 // symptom is a harness that will not boot.
 func TestDeepSeekPatchReplacesTheEmptyArray(t *testing.T) {
-	got := dshPatchWith("# a comment\n[]\n", dshPatchBlock("/usr/local/bin/deja", false))
+	got, err := dshPatchWith("# a comment\n[]\n", dshPatchBlock("/usr/local/bin/deja", false))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if strings.Contains(got, "[]") {
 		t.Errorf("the empty-array literal survived:\n%s", got)
 	}
@@ -30,8 +33,14 @@ func TestDeepSeekPatchReplacesTheEmptyArray(t *testing.T) {
 }
 
 func TestDeepSeekPatchIsRewrittenNotRepeated(t *testing.T) {
-	first := dshPatchWith("[]\n", dshPatchBlock("/old/deja", false))
-	second := dshPatchWith(first, dshPatchBlock("/new/deja", false))
+	first, err := dshPatchWith("[]\n", dshPatchBlock("/old/deja", false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := dshPatchWith(first, dshPatchBlock("/new/deja", false))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if strings.Count(second, dshBlockStart) != 1 {
 		t.Errorf("the block was added twice:\n%s", second)
 	}


### PR DESCRIPTION
deja's block in `cordis.patch.yml` is delimited by two comments, and its first line says "safe to delete". Delete one of them and:

- with the **end** marker gone, the skip ran to end of file and took a patch the user had written below deja's block — silently, exit 0;
- with the **start** marker gone, the orphaned block stayed and a second one was appended, so dsh loaded the MCP client twice and no later install or uninstall could find the orphan.

`dshPatchWith` now returns an error when one marker is present without the other: the file is left byte-identical and the message says which marker is missing. Same rule as `updateOpencodeJSONC` states for itself and as `installGoose` took on in #1697.

Fail-before test: `TestDSHPatchRefusesAHalfMarkedBlock`, with `TestDSHPatchKeepsTheUsersPatch` as the control — both markers present, and a file deja never touched, are edited exactly as before.

Closes #1701.

The function grew an error return, so its two existing tests now check it; nothing else calls it.

Verified end to end: with the end marker removed and a user patch below it, install refuses, the patch is still there and the file is unchanged; with the start marker removed, there is still exactly one `id: mcp-deja`.
