### PR TITLE
fix(install): say when it replaced a skill file it has no record of writing

### DIFF
--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -296,9 +297,19 @@ func writeGuidanceFile(path string, old, next []byte) (string, error) {
 		fmt.Printf("skill: kept your edited %s — `deja install --force` to take deja's version\n", shortHome(path))
 		return "kept", nil
 	}
+	// deja cannot tell its own pre-marks copy from a file someone else wrote at
+	// the same path, and treating every unmarked file as a stranger's would
+	// freeze the skill on every machine installed before marks existed
+	// (skill_marks.go). What it can do is say what it replaced, rather than
+	// calling it an update and leaving the backup unmentioned (#1703).
+	replacing := len(old) > 0 && !bytes.Equal(old, next) && !skillIsMarked(path)
 	action, err := writeIfChanged(path, old, next)
 	if err != nil {
 		return action, err
+	}
+	if replacing && action != "unchanged" {
+		fmt.Printf("skill: replaced %s, which deja has no record of writing — your copy is at %s\n",
+			shortHome(path), shortHome(path+".bak"))
 	}
 	rememberSkill(path, next)
 	return action, nil

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -303,6 +303,16 @@ func writeGuidanceFile(path string, old, next []byte) (string, error) {
 	// (skill_marks.go). What it can do is say what it replaced, rather than
 	// calling it an update and leaving the backup unmentioned (#1703).
 	replacing := len(old) > 0 && !bytes.Equal(old, next) && !skillIsMarked(path)
+	if replacing {
+		// backupOnce keeps the first .bak it ever made and skips the rest, so
+		// the promise below would have named a copy of some older file while
+		// the one being destroyed went unsaved. This copy is of the content
+		// deja is about to replace, which is the only one the message can
+		// honestly point at (#1703).
+		if err := os.WriteFile(path+".bak", old, 0o600); err != nil {
+			return "", err
+		}
+	}
 	action, err := writeIfChanged(path, old, next)
 	if err != nil {
 		return action, err

--- a/cmd/deja/skill_marks.go
+++ b/cmd/deja/skill_marks.go
@@ -77,3 +77,9 @@ func skillWasEdited(path string, old []byte) bool {
 	}
 	return mark != contentMark(old)
 }
+
+// skillIsMarked reports whether deja has a record of writing this file.
+func skillIsMarked(path string) bool {
+	_, ok := skillMarks()[path]
+	return ok
+}

--- a/cmd/deja/skill_unmarked_test.go
+++ b/cmd/deja/skill_unmarked_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// deja cannot tell its own pre-marks copy from a file someone else wrote at the
+// same path, and treating every unmarked file as a stranger's would freeze the
+// skill on every machine installed before marks existed. What it can do is say
+// what it replaced: this came out as "guidance updated", with the backup
+// unmentioned (#1703).
+func TestInstallReportsReplacingAnUnmarkedSkill(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	dir := filepath.Join(home, ".claude", "skills", "deja-history")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "SKILL.md")
+	const mine = "---\nname: deja-history\ndescription: MY OWN skill\n---\n\nI wrote this by hand.\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "install", "claude-code")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "replaced") {
+		t.Errorf("the run does not say a file was replaced:\n%s", out)
+	}
+	if !strings.Contains(out, ".bak") {
+		t.Errorf("the run does not name the backup:\n%s", out)
+	}
+	b, readErr := os.ReadFile(path + ".bak")
+	if readErr != nil {
+		t.Fatalf("no backup was written: %v", readErr)
+	}
+	if string(b) != mine {
+		t.Errorf("the backup is not what the user had:\n%s", b)
+	}
+}
+
+// The control: a file deja wrote and recorded is updated quietly, and a fresh
+// install with no file says nothing about replacing anything.
+func TestInstallDoesNotCryReplacedForItsOwnSkill(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "install", "claude-code")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "replaced") {
+		t.Errorf("a first install claims to have replaced something:\n%s", out)
+	}
+	out, err = captureRun(t, "install", "claude-code")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "replaced") {
+		t.Errorf("a second install claims to have replaced something:\n%s", out)
+	}
+}

--- a/cmd/deja/skill_unmarked_test.go
+++ b/cmd/deja/skill_unmarked_test.go
@@ -44,6 +44,43 @@ func TestInstallReportsReplacingAnUnmarkedSkill(t *testing.T) {
 	}
 }
 
+// backupOnce keeps the first .bak it ever wrote, so a second replacement — a
+// machine whose mark record was lost — would have promised a copy of the first
+// file while the one being destroyed went unsaved (#1703, found in review).
+func TestReplacedSkillBackupHoldsWhatWasReplaced(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	dir := filepath.Join(home, ".claude", "skills", "deja-history")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "SKILL.md")
+	if err := os.WriteFile(path, []byte("A: my first file\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	// The marks record is lost — a wiped cache — and a different file is there.
+	if err := os.Remove(skillMarksPath()); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	const second = "C: my second file, written later\n"
+	if err := os.WriteFile(path, []byte(second), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path + ".bak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != second {
+		t.Errorf("the backup holds %q, not the file that was just replaced", string(b))
+	}
+}
+
 // The control: a file deja wrote and recorded is updated quietly, and a fresh
 // install with no file says nothing about replacing anything.
 func TestInstallDoesNotCryReplacedForItsOwnSkill(t *testing.T) {


### PR DESCRIPTION
A `SKILL.md` at deja's path that deja never wrote is replaced on install, and the only line about it was `guidance updated`. A `.bak` is taken, so nothing is lost — but nothing said so either.

The overwrite itself stays. `skill_marks.go` explains why and the reasoning holds: deja cannot tell its own pre-marks copy from a stranger's file at the same path, and treating every unmarked file as a stranger's would freeze the skill on every machine installed before marks existed. What it can do is report it, in the same voice the recorded-edit case already uses:

```
skill: replaced ~/.claude/skills/deja-history/SKILL.md, which deja has no record of writing — your copy is at ~/.claude/skills/deja-history/SKILL.md.bak
```

Only when the file was non-empty, differs from what deja is writing, and has no mark. A second install says nothing — by then the mark exists.

Fail-before test: `TestInstallReportsReplacingAnUnmarkedSkill`, which also checks the backup holds the user's original. `TestInstallDoesNotCryReplacedForItsOwnSkill` is the control across a first and second install.

Closes #1703.

The repo caught one of my own mistakes on the way: `TestDocCommentsNameWhatTheyDocument` failed because I had inserted the new helper between `skillWasEdited`'s doc comment and its declaration. Good test.
