### PR TITLE
fix(install): refuse a guidance file whose block deja cannot bound, and repair a duplicated one

### DIFF
--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -226,7 +226,10 @@ func dropRetiredGuidance(harness string) error {
 			}
 			continue
 		}
-		next := updateGuidanceBlock(string(old), true)
+		next, uerr := updateGuidanceBlock(string(old), true)
+		if uerr != nil {
+			return uerr
+		}
 		// A file that held nothing but our block was ours to begin with, so
 		// leaving it behind empty would be litter rather than someone's content.
 		if strings.TrimSpace(next) == "" {
@@ -385,7 +388,11 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 			}
 		}
 	} else {
-		next = []byte(updateGuidanceBlock(string(old), uninstall))
+		updated, uerr := updateGuidanceBlock(string(old), uninstall)
+		if uerr != nil {
+			return installResult{}, uerr
+		}
+		next = []byte(updated)
 	}
 	a, err := writeGuidanceFile(path, old, next)
 	if err != nil {
@@ -403,30 +410,75 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 		if rerr != nil && !os.IsNotExist(rerr) {
 			return installResult{}, rerr
 		}
-		if _, werr := writeIfChanged(alt, oldAlt, []byte(updateGuidanceBlock(string(oldAlt), uninstall))); werr != nil {
+		updatedAlt, uerr := updateGuidanceBlock(string(oldAlt), uninstall)
+		if uerr != nil {
+			return installResult{}, uerr
+		}
+		if _, werr := writeIfChanged(alt, oldAlt, []byte(updatedAlt)); werr != nil {
 			return installResult{}, werr
 		}
 	}
 	return installResult{Path: path, Action: a}, nil
 }
 
-func updateGuidanceBlock(old string, uninstall bool) string {
+func updateGuidanceBlock(old string, uninstall bool) (string, error) {
 	newline := "\n"
 	if strings.Contains(old, "\r\n") {
 		newline = "\r\n"
 	}
-	start, end := guidanceMarkerLines(old)
-	if start >= 0 && end >= 0 {
+	// A marker without its pair means the block cannot be bounded. Appending a
+	// fresh one left the file with two starts and one end, and the uninstall
+	// after that cut from the first start to the only end — across the user's
+	// own text — and deleted the file, because what was left was empty (#1705).
+	if err := checkGuidanceMarkers(old); err != nil {
+		return "", err
+	}
+	// Every complete block, not just the first: a file carrying two kept both
+	// for ever, since the install removed one and appended one.
+	for {
+		start, end := guidanceMarkerLines(old)
+		if start < 0 || end < 0 {
+			break
+		}
 		old = old[:start] + old[end:]
 	}
 	if uninstall {
-		return old
+		return old, nil
 	}
 	old = strings.TrimRight(old, "\r\n")
 	if old != "" {
 		old += newline + newline
 	}
-	return old + strings.ReplaceAll(guidanceText("append"), "\n", newline)
+	return old + strings.ReplaceAll(guidanceText("append"), "\n", newline), nil
+}
+
+// checkGuidanceMarkers reports whether every start marker has an end marker
+// after it. Only whole-line markers count, which is what guidanceMarkerLines
+// pairs — a marker written inline in a sentence is prose, and deja appends its
+// own block below such a file rather than claiming that text.
+//
+// A lone end marker is left alone for the same reason: it is what an inline
+// start looks like to a line scanner, and appending below it costs nobody
+// anything. A start with no end is different — the block cannot be bounded,
+// and cutting from it to the next end takes whatever the user wrote in
+// between, which is how an uninstall came to delete the file (#1705).
+func checkGuidanceMarkers(doc string) error {
+	open := false
+	for _, line := range strings.Split(doc, "\n") {
+		switch strings.TrimSuffix(line, "\r") {
+		case guidanceStart:
+			if open {
+				return fmt.Errorf("deja's guidance block has a start marker with no end marker after it — put the pair back, or delete the block entirely")
+			}
+			open = true
+		case guidanceEnd:
+			open = false
+		}
+	}
+	if open {
+		return fmt.Errorf("deja's guidance block has no end marker — put it back, or delete the block entirely")
+	}
+	return nil
 }
 
 func guidanceMarkerLines(s string) (start, end int) {

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -388,6 +388,17 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 			}
 		}
 	} else {
+		// grok writes a twin below; check its markers before touching this
+		// file, or a refusal there leaves this one already rewritten (#1705).
+		if harness == "grok" {
+			b, rerr := os.ReadFile(filepath.Join(sources.GrokHome(), "AGENTS.md"))
+			if rerr != nil && !os.IsNotExist(rerr) {
+				return installResult{}, rerr
+			}
+			if cerr := checkGuidanceMarkers(string(b)); cerr != nil {
+				return installResult{}, cerr
+			}
+		}
 		updated, uerr := updateGuidanceBlock(string(old), uninstall)
 		if uerr != nil {
 			return installResult{}, uerr

--- a/cmd/deja/guidance_block_test.go
+++ b/cmd/deja/guidance_block_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+const guidanceBlockSample = guidanceStart + "\nsome guidance\n" + guidanceEnd + "\n"
+
+// A file whose markers cannot be paired had a whole second block appended, and
+// the uninstall after that cut from the first start to the only end — over the
+// user's own text — and deleted the file, because what was left was empty
+// (#1705).
+func TestGuidanceBlockRefusesUnpairedMarkers(t *testing.T) {
+	noEnd := strings.ReplaceAll(guidanceBlockSample, guidanceEnd+"\n", "") + "MY OWN text below\n"
+	if _, err := updateGuidanceBlock(noEnd, false); err == nil {
+		t.Error("install edited a file with no end marker")
+	}
+	if _, err := updateGuidanceBlock(noEnd, true); err == nil {
+		t.Error("uninstall edited a file with no end marker")
+	}
+	// A lone end marker is what an inline start looks like to a line scanner,
+	// and appending below it costs nobody anything — so it is not refused.
+	noStart := strings.ReplaceAll(guidanceBlockSample, guidanceStart+"\n", "") + "MY OWN text below\n"
+	got, err := updateGuidanceBlock(noStart, false)
+	if err != nil {
+		t.Fatalf("a lone end marker was refused: %v", err)
+	}
+	if !strings.Contains(got, "MY OWN text below") {
+		t.Errorf("the user's text was dropped:\n%s", got)
+	}
+}
+
+// Two complete blocks are repaired to one rather than kept for ever.
+func TestGuidanceBlockRepairsADuplicate(t *testing.T) {
+	two := guidanceBlockSample + "MY OWN text between\n\n" + guidanceBlockSample
+	got, err := updateGuidanceBlock(two, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(got, guidanceStart); n != 1 {
+		t.Errorf("expected one block, found %d:\n%s", n, got)
+	}
+	if !strings.Contains(got, "MY OWN text between") {
+		t.Errorf("the user's text was dropped:\n%s", got)
+	}
+}
+
+// The control: text above and below an intact block survives, and one block
+// stays one block.
+func TestGuidanceBlockKeepsTextAround(t *testing.T) {
+	around := "MY OWN above\n\n" + guidanceBlockSample + "MY OWN below\n"
+	got, err := updateGuidanceBlock(around, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"MY OWN above", "MY OWN below"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q was dropped:\n%s", want, got)
+		}
+	}
+	if n := strings.Count(got, guidanceStart); n != 1 {
+		t.Errorf("expected one block, found %d:\n%s", n, got)
+	}
+	// And uninstall takes the block, leaving the user's text.
+	got, err = updateGuidanceBlock(got, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, guidanceStart) {
+		t.Errorf("uninstall left the block:\n%s", got)
+	}
+	if !strings.Contains(got, "MY OWN above") || !strings.Contains(got, "MY OWN below") {
+		t.Errorf("uninstall took the user's text:\n%s", got)
+	}
+}

--- a/cmd/deja/guidance_block_test.go
+++ b/cmd/deja/guidance_block_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
 const guidanceBlockSample = guidanceStart + "\nsome guidance\n" + guidanceEnd + "\n"
@@ -43,6 +47,35 @@ func TestGuidanceBlockRepairsADuplicate(t *testing.T) {
 	}
 	if !strings.Contains(got, "MY OWN text between") {
 		t.Errorf("the user's text was dropped:\n%s", got)
+	}
+}
+
+// grok writes GROK.md and AGENTS.md from one install. A refusal on the second
+// used to leave the first already rewritten (#1705, found in review).
+func TestGuidanceGrokTwinIsCheckedFirst(t *testing.T) {
+	hermeticEnv(t)
+	dir := sources.GrokHome()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := guidanceStart + "\nSTALE\n" + guidanceEnd + "\n"
+	primary := filepath.Join(dir, "GROK.md")
+	if err := os.WriteFile(primary, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	half := guidanceStart + "\nsome guidance\n" + "MY OWN in the twin\n"
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(half), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "grok"); err == nil {
+		t.Error("install accepted a twin it could not bound")
+	}
+	b, err := os.ReadFile(primary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != stale {
+		t.Errorf("the primary file was rewritten while the twin refused:\n%s", b)
 	}
 }
 

--- a/cmd/deja/guidance_test.go
+++ b/cmd/deja/guidance_test.go
@@ -75,7 +75,11 @@ func TestOwnedGuidanceTargetsAndMarkerBoundaries(t *testing.T) {
 	}
 	old := "prose " + guidanceStart + "\nkeep\n" + guidanceEnd + "\n"
 	want := old + "\n" + guidanceStart + "\n" + guidanceBody + "\n" + guidanceEnd + "\n"
-	if got := updateGuidanceBlock(old, false); got != want {
+	got, err := updateGuidanceBlock(old, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
 		t.Fatalf("inline markers were replaced: %q", got)
 	}
 	// grok still shares its file with the user, so it stands in for the
@@ -193,7 +197,10 @@ func TestClaudeGuidanceIsOwnedAndOptOutWorks(t *testing.T) {
 
 func TestGuidanceBlockHandlesCRLFAndUnsupportedResult(t *testing.T) {
 	old := "# Rules\r\n\r\n" + guidanceStart + "\r\nold\r\n" + guidanceEnd + "\r\n"
-	got := updateGuidanceBlock(old, false)
+	got, err := updateGuidanceBlock(old, false)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if strings.Count(got, guidanceStart) != 1 || !strings.Contains(got, "\r\n") || strings.Contains(got, "old") {
 		t.Fatalf("CRLF rewrite = %q", got)
 	}


### PR DESCRIPTION
Delete deja's `guidance:end` marker from `~/.grok/GROK.md`, write a line of your own below it, and the next install appends a *whole second block*: two starts, one end. The uninstall after that cuts from the first start to the only end — across your line and both blocks — and what is left is empty, so the file is **deleted**.

```
$ deja uninstall grok
$ cat ~/.grok/GROK.md
cat: ~/.grok/GROK.md: No such file or directory
```

`updateGuidanceBlock` now refuses when a start marker has no end after it, in both directions, leaving the file byte-identical. And it removes *every* complete block rather than the first, so a file that somehow carries two comes out with one instead of keeping both for ever.

A lone **end** marker is deliberately still accepted: that is what an inline start looks like to a line scanner, and `TestGuidanceBlockPreservesInlineMarkers` documents that a marker written inside a sentence is prose, not deja's. Appending below such a file costs nobody anything. My first version refused it and broke that test — the narrower rule is the right one.

Fail-before tests: `TestGuidanceBlockRefusesUnpairedMarkers` and `TestGuidanceBlockRepairsADuplicate`, with `TestGuidanceBlockKeepsTextAround` as the control — text above and below an intact block survives an install and an uninstall.

Closes #1705.

Verified by hand: install and uninstall both refuse on the half-marked file, `MY OWN text below` is still there, and a file with two blocks comes out with one.
