### PR TITLE
fix: resume Grok Build sessions

### DIFF
--- a/cmd/deja/capability_drift_test.go
+++ b/cmd/deja/capability_drift_test.go
@@ -238,6 +238,11 @@ func TestCapabilityRegistryMatchesCode(t *testing.T) {
 func plausibleSession(t *testing.T, harness string) model.Session {
 	t.Helper()
 	s := model.Session{ID: "abc123", Harness: harness, Project: "p", Path: "/tmp/x.jsonl"}
+	if harness == "grok" {
+		// Grok Build sessions are directories of updates.jsonl; the other rows
+		// under this harness come from the grok-dev database and cannot resume.
+		s.Path = filepath.Join(t.TempDir(), "sessions", "workspace%2Fp", "abc123", "updates.jsonl")
+	}
 	if harness == "openclaw" {
 		dir := filepath.Join(t.TempDir(), "agents", "main", "sessions")
 		if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -102,8 +102,12 @@ func guidancePath(harness string) string {
 		// system prompt, so the agent would never find it on its own.
 		return filepath.Join(sources.HermesHome(), "skills", "deja-history", "SKILL.md")
 	case "grok":
-		// grok reads <cwd>/.grok/GROK.md first and only falls back to the
-		// home copy, so this never shadows a project's own instructions.
+		// This file is for @vibe-kit/grok-cli, which reads <cwd>/.grok/GROK.md
+		// first and only falls back to the home copy, so it never shadows a
+		// project's own instructions. Grok Build ignores it — its home rules are
+		// Agents.md, AGENTS.md, Claude.md and CLAUDE.md, and `grok inspect` on
+		// 1.0.5 lists those and not this. What reaches Grok Build is the shared
+		// skill written alongside it, which the same command lists.
 		return filepath.Join(sources.GrokHome(), "GROK.md")
 	case "opencode":
 		// opencode reads skills from its config directory, which is the cheaper

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -135,7 +135,14 @@ func resumeCommand(s model.Session) (string, string, error) {
 		}
 		return "", "", fmt.Errorf("cursor IDE chats reopen from the Cursor UI, not the terminal")
 	case "grok":
-		return "", "", fmt.Errorf("grok has no session resume — start grok in %s to continue", sources.GrokCWDForSession(s.Path))
+		// Grok Build resumes by session id and scopes its session list by the
+		// working directory, so this has to run in the original project. The
+		// grok-dev store is a different product sharing ~/.grok: its rows come
+		// out of grok.db and there is no CLI to hand them to.
+		if !strings.HasSuffix(s.Path, "updates.jsonl") {
+			return "", "", fmt.Errorf("session %s comes from the grok-dev store, which has no terminal resume", digest.Short(s.ID))
+		}
+		return sources.GrokCWDForSession(s.Path), "grok --resume " + s.ID, nil
 	case "cline":
 		if strings.HasPrefix(s.ID, "cline-task-") {
 			return "", "", fmt.Errorf("legacy Cline VS Code tasks reopen from the extension's history UI, not the terminal")

--- a/cmd/deja/resume_test.go
+++ b/cmd/deja/resume_test.go
@@ -34,7 +34,8 @@ func TestResumeCommandPerHarness(t *testing.T) {
 		{"codex rollout", model.Session{Harness: "codex", ID: "uuid-1", Project: "my-app"}, "", "codex resume uuid-1", ""},
 		{"codex history entry", model.Session{Harness: "codex", ID: "uuid-2", Project: "history"}, "", "", "nothing to resume"},
 		{"opencode with dir", model.Session{Harness: "opencode", ID: "ses_1", Project: "my-app", Path: real}, real, "opencode -s ses_1", ""},
-		{"grok has no resume", model.Session{Harness: "grok", ID: "019f-grok", Project: "my-app", Path: grokPath}, "", "", "grok has no session resume"},
+		{"grok build session", model.Session{Harness: "grok", ID: "019f-grok", Project: "my-app", Path: grokPath}, real, "grok --resume 019f-grok", ""},
+		{"grok-dev row", model.Session{Harness: "grok", ID: "019f-dev", Project: "my-app", Path: filepath.Join(tmp, "grok.db")}, "", "", "grok-dev store"},
 		{"imported", model.Session{Harness: "claude", ID: "imported-9f5", Project: "imported:my-app"}, "", "", "another machine"},
 		{"unknown harness", model.Session{Harness: "mystery", ID: "x"}, "", "", "don't know how"},
 	}

--- a/docs/guide/memory-for-grok.html
+++ b/docs/guide/memory-for-grok.html
@@ -89,7 +89,7 @@
 curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
 
 <h2>One thing to know about the name</h2>
-<p>There is a community CLI that shares the name <code>grok</code> and the <code>~/.grok</code> directory, and it is a different product. deja reads xAI's Grok Build store; where a capability could not be verified against Grok Build itself — <code>resume</code> is the one — the <a href="../registry/grok.html">registry page</a> says so and names what was checked instead of guessing.</p>
+<p>There is a community CLI that shares the name <code>grok</code> and the <code>~/.grok</code> directory, and it is a different product. deja reads xAI's Grok Build store, and <code>deja resume</code> prints a <code>grok --resume</code> for its sessions and refuses for the community CLI's, which has no terminal resume. Where something still could not be checked against a running Grok Build, the <a href="../registry/grok.html">registry page</a> says so and names what was tried instead of guessing.</p>
 
 <h2>The part that is not about this harness</h2>
 <p>The index covers every agent's transcripts on the machine — twenty of them today, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in one tool answers a question asked in another, including sessions from before any of this was installed. That is the reason to index rather than to capture.</p>

--- a/docs/registry/grok.html
+++ b/docs/registry/grok.html
@@ -76,6 +76,14 @@
 <p>working directory, since Grok Build scopes its session list by directory.</p>
 <p>Rows that came out of <code>grok.db</code> belong to the other product and get an error</p>
 <p>instead.</p>
+<ul>
+<li>Grok Build reads deja&#39;s wiring three ways at once: <code>[mcp_servers.deja]</code> in</li>
+</ul>
+<p><code>config.toml</code>, <code>~/.grok/hooks/deja.json</code> in Claude Code&#39;s hook shape, and the</p>
+<p>shared skill in <code>~/.agents/skills</code>. It also scans <code>~/.claude.json</code> and</p>
+<p><code>~/.cursor/mcp.json</code>, so a machine wired for those has deja in Grok already.</p>
+<p><code>~/.grok/GROK.md</code> is the exception: that file is for the other product, and</p>
+<p>Grok Build&#39;s home rules are <code>Agents.md</code>, <code>AGENTS.md</code>, <code>Claude.md</code>, <code>CLAUDE.md</code>.</p>
 <p><strong>Last verified:</strong> 2026-08-24 against Grok Build 1.0.5 (macos-aarch64)</p>
 
 <hr>

--- a/docs/registry/grok.html
+++ b/docs/registry/grok.html
@@ -71,8 +71,12 @@
 <li><code>generated_title</code> takes precedence over <code>session_summary</code>.</li>
 <li>Missing summary files fall back to directory IDs and the <code>.cwd</code> or URL-decoded path.</li>
 <li>Path encoding is ambiguous when upstream leaves separators or percent escapes in different forms.</li>
+<li><code>deja resume</code> prints <code>grok --resume &lt;id&gt;</code> and runs it in the recovered</li>
 </ul>
-<p><strong>Last verified:</strong> 2026-07-27</p>
+<p>working directory, since Grok Build scopes its session list by directory.</p>
+<p>Rows that came out of <code>grok.db</code> belong to the other product and get an error</p>
+<p>instead.</p>
+<p><strong>Last verified:</strong> 2026-08-24 against Grok Build 1.0.5 (macos-aarch64)</p>
 
 <hr>
 <p>deja reads this format and nineteen others, and turns what it finds into memory your

--- a/docs/registry/grok.md
+++ b/docs/registry/grok.md
@@ -52,4 +52,11 @@ session asked for it is not written down, and deja does not guess.
   Rows that came out of `grok.db` belong to the other product and get an error
   instead.
 
+- Grok Build reads deja's wiring three ways at once: `[mcp_servers.deja]` in
+  `config.toml`, `~/.grok/hooks/deja.json` in Claude Code's hook shape, and the
+  shared skill in `~/.agents/skills`. It also scans `~/.claude.json` and
+  `~/.cursor/mcp.json`, so a machine wired for those has deja in Grok already.
+  `~/.grok/GROK.md` is the exception: that file is for the other product, and
+  Grok Build's home rules are `Agents.md`, `AGENTS.md`, `Claude.md`, `CLAUDE.md`.
+
 **Last verified:** 2026-08-24 against Grok Build 1.0.5 (macos-aarch64)

--- a/docs/registry/grok.md
+++ b/docs/registry/grok.md
@@ -47,5 +47,9 @@ session asked for it is not written down, and deja does not guess.
 - `generated_title` takes precedence over `session_summary`.
 - Missing summary files fall back to directory IDs and the `.cwd` or URL-decoded path.
 - Path encoding is ambiguous when upstream leaves separators or percent escapes in different forms.
+- `deja resume` prints `grok --resume <id>` and runs it in the recovered
+  working directory, since Grok Build scopes its session list by directory.
+  Rows that came out of `grok.db` belong to the other product and get an error
+  instead.
 
-**Last verified:** 2026-07-27
+**Last verified:** 2026-08-24 against Grok Build 1.0.5 (macos-aarch64)

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -243,13 +243,7 @@
     "handoff": "exec",
     "prereq": "sqlite3 (grok-dev store)"
    },
-   "gaps": {
-    "plugin_mcp_path": {
-     "state": "unknown",
-     "why": "the plugin ships `.mcp.json` with `${GROK_PLUGIN_ROOT}` in its args, and nothing observed so far shows Grok expanding it there. The binary's only variable-expansion module is `xai-grok-hooks/src/env_expand.rs` and the docs introduce both plugin variables under plugin hooks, so a plugin-only install may be handing the launcher a literal path. Deciding it needs a signed-in session: `grok mcp doctor` and `grok inspect` ignore plugin servers, and `session/new` over ACP stops at `Authentication required` before any plugin server attaches.",
-     "source": "Grok Build 1.0.5 on macOS: mcp doctor, inspect, ACP session/new, binary strings"
-    }
-   }
+   "gaps": {}
   },
   {
    "id": "hermes",

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -232,22 +232,22 @@
     "fixtures/registry/grok/sessions/workspace%2Fregistry-demo/registry-grok/updates.jsonl"
    ],
    "parser_source": "internal/sources/grok.go",
-   "last_verified": "2026-07-27",
+   "last_verified": "2026-08-24",
    "display_name": "Grok Build",
    "capabilities": {
     "mcp": true,
     "auto": true,
     "skill": true,
     "command": true,
-    "resume": false,
+    "resume": true,
     "handoff": "exec",
     "prereq": "sqlite3 (grok-dev store)"
    },
    "gaps": {
-    "resume": {
+    "plugin_mcp_path": {
      "state": "unknown",
-     "why": "unanswered on purpose: the `grok` on this machine is the community CLI, a different product that shares the name and the ~/.grok directory, and its help has no resume flag. That says nothing about xAI's Grok Build, which is what this row is about, and no second source was available to check.",
-     "source": "community grok 1.0.1 --help; not Grok Build"
+     "why": "the plugin ships `.mcp.json` with `${GROK_PLUGIN_ROOT}` in its args, and nothing observed so far shows Grok expanding it there. The binary's only variable-expansion module is `xai-grok-hooks/src/env_expand.rs` and the docs introduce both plugin variables under plugin hooks, so a plugin-only install may be handing the launcher a literal path. Deciding it needs a signed-in session: `grok mcp doctor` and `grok inspect` ignore plugin servers, and `session/new` over ACP stops at `Authentication required` before any plugin server attaches.",
+     "source": "Grok Build 1.0.5 on macOS: mcp doctor, inspect, ACP session/new, binary strings"
     }
    }
   },

--- a/extensions/grok/README.md
+++ b/extensions/grok/README.md
@@ -73,12 +73,13 @@ missing instead of pretending the history is empty.
 ## Unverified here
 
 `${GROK_PLUGIN_ROOT}` is what Grok's own plugin guide documents for hook
-commands, and it is used the same way in `.mcp.json` above. That second use is
-not something this machine could check against a running Grok Build — the `grok`
-CLI installed here is the community project that shares the name and the
-`~/.grok` directory, not xAI's Grok Build. If the variable is not expanded for
-MCP servers, the server fails to start and the CLI-wired path still works; say
-so in an issue and it will be fixed rather than guessed at again.
+commands, and it is used the same way in `.mcp.json` above. The hook use is
+confirmed on Grok Build 1.0.5; the `.mcp.json` use is not. Grok's plugin guide
+introduces both variables under plugin *hooks*, and neither `grok mcp doctor`
+nor `grok inspect` reports plugin MCP servers, so there is no offline way to
+read back the argv a plugin server would be launched with. If the variable is
+not expanded there, the server fails to start and the CLI-wired path still
+works; say so in an issue and it will be fixed rather than guessed at again.
 
 ## License
 

--- a/extensions/grok/README.md
+++ b/extensions/grok/README.md
@@ -70,16 +70,17 @@ plugin release froze.
 Without deja anywhere, the hook stays silent and the MCP server says what is
 missing instead of pretending the history is empty.
 
-## Unverified here
+## Standing down without looking broken
 
-`${GROK_PLUGIN_ROOT}` is what Grok's own plugin guide documents for hook
-commands, and it is used the same way in `.mcp.json` above. The hook use is
-confirmed on Grok Build 1.0.5; the `.mcp.json` use is not. Grok's plugin guide
-introduces both variables under plugin *hooks*, and neither `grok mcp doctor`
-nor `grok inspect` reports plugin MCP servers, so there is no offline way to
-read back the argv a plugin server would be launched with. If the variable is
-not expanded there, the server fails to start and the CLI-wired path still
-works; say so in an issue and it will be fixed rather than guessed at again.
+`${GROK_PLUGIN_ROOT}` expands in `.mcp.json` as well as in hook commands —
+measured on Grok Build 1.0.5 by launching a plugin server that wrote its own
+argument back to a file, since neither `grok mcp doctor` nor `grok inspect`
+reports plugin MCP servers.
+
+When `deja install grok` already wired the CLI copy, this one answers the
+handshake and lists no tools. Exiting instead would be reported as
+`handshake failed: connection closed` and sit in the plugin UI as a broken
+server, which is a worse thing to leave behind than an idle one.
 
 ## License
 

--- a/extensions/grok/bin/deja-mcp.mjs
+++ b/extensions/grok/bin/deja-mcp.mjs
@@ -16,15 +16,77 @@ if (installerOwns("mcp")) {
       "This plugin's copy stays out of the way so the tools are not listed twice — " +
       "run `deja uninstall grok` to let the plugin own it instead.\n",
   )
-  process.exit(0)
+  standDown()
+} else {
+  start()
 }
 
-const child = spawn(resolveDeja(), ["mcp"], { stdio: "inherit" })
-child.on("error", (err) => {
-  process.stderr.write(
-    `deja could not start: ${err.message}. Install it with: ` +
-      "curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh\n",
-  )
-  process.exit(1)
-})
-child.on("close", (code) => process.exit(code ?? 0))
+// Standing down by exiting looks like a crash from the outside: Grok Build 1.0.5
+// reports `handshake failed: connection closed: initialize response` and the
+// server sits in the UI as broken. So answer the handshake and offer nothing —
+// the tools come from the CLI-wired copy, and this one is visibly idle rather
+// than visibly failing.
+function standDown() {
+  let buf = ""
+  process.stdin.setEncoding("utf8")
+  process.stdin.on("data", (chunk) => {
+    buf += chunk
+    let i
+    while ((i = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, i)
+      buf = buf.slice(i + 1)
+      if (line.trim()) reply(line)
+    }
+  })
+  process.stdin.on("end", () => process.exit(0))
+}
+
+function reply(line) {
+  let msg
+  try {
+    msg = JSON.parse(line)
+  } catch {
+    return
+  }
+  if (msg.id === undefined) return // a notification wants no answer
+  let result
+  switch (msg.method) {
+    case "initialize":
+      result = {
+        protocolVersion: msg.params?.protocolVersion ?? "2024-11-05",
+        capabilities: { tools: {} },
+        serverInfo: { name: "deja (plugin, standing down)", version: "0.1.0" },
+      }
+      break
+    case "tools/list":
+      result = { tools: [] }
+      break
+    case "resources/list":
+      result = { resources: [] }
+      break
+    case "prompts/list":
+      result = { prompts: [] }
+      break
+    case "ping":
+      result = {}
+      break
+    default:
+      process.stdout.write(
+        JSON.stringify({ jsonrpc: "2.0", id: msg.id, error: { code: -32601, message: "not served: deja is wired through the CLI" } }) + "\n",
+      )
+      return
+  }
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result }) + "\n")
+}
+
+function start() {
+  const child = spawn(resolveDeja(), ["mcp"], { stdio: "inherit" })
+  child.on("error", (err) => {
+    process.stderr.write(
+      `deja could not start: ${err.message}. Install it with: ` +
+        "curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh\n",
+    )
+    process.exit(1)
+  })
+  child.on("close", (code) => process.exit(code ?? 0))
+}


### PR DESCRIPTION
Installed xAI's Grok Build (1.0.5) in place of the community `grok` CLI and checked the row against the real thing, with a signed-in session.

`grok --resume <id>` exists and the session list is scoped by working directory, so `deja resume` now prints that command and cds into the recovered cwd — verified by resuming a real session and having it answer from its own history. Rows that came from `grok.db` are the other product and still get an error.

The plugin's MCP server used to exit when `deja install grok` had already wired the CLI copy. Grok reports that as `handshake failed: connection closed` and leaves a broken server in the UI, so it now answers the handshake and lists no tools (`tool_count=0`, no error). `${GROK_PLUGIN_ROOT}` does expand in `.mcp.json` — measured by having a plugin server write its own argument back — so the registry loses that open question too.

Also confirmed live: the four hooks load with their matchers, recall reaches the model through both the hook and the MCP tools, and Grok Build picks up deja from `~/.claude.json` and `~/.cursor/mcp.json` as well. `~/.grok/GROK.md` is not read by Grok Build; the shared skill is what reaches it, and the comment that said otherwise is fixed.