### PR TITLE
fix(doctor): say when the wiring runs a binary that is no longer there

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -807,6 +807,7 @@ func doctorPolicy(w io.Writer, dir string) {
 
 func doctorMCP(w io.Writer) {
 	fmt.Fprintln(w, "MCP wiring:")
+	doctorWiredExe(w)
 	for _, c := range doctorMCPConfigs() {
 		status := "config missing"
 		if doctorExists(c.path) {

--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -188,3 +188,22 @@ func codexHookTrustSection(cfg string) string {
 	}
 	return rest
 }
+
+// doctorWiredExe reports a wiring that points at a binary which is no longer
+// there. Every hook the harnesses run names the executable that installed
+// them, so a deja that moved — a `go install` into a different GOBIN, a brew
+// prefix change, a renamed home — leaves every hook exiting 127 on every
+// prompt while each config file still reads correctly (#1708). The recorded
+// path is checked rather than each harness's own format, which is the one
+// thing all of them have in common.
+func doctorWiredExe(w io.Writer) {
+	st := readWiringState()
+	if st.Exe == "" || len(st.Targets) == 0 {
+		return
+	}
+	if _, err := os.Stat(st.Exe); err == nil {
+		return
+	}
+	fmt.Fprintf(w, "  %-12s the wiring runs %s, which is not there — `deja install --all` re-points it at this binary\n",
+		"binary", shortHome(st.Exe))
+}

--- a/cmd/deja/doctor_exe_test.go
+++ b/cmd/deja/doctor_exe_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The wiring names the binary that installed it. Move that binary — a go
+// install into a different GOBIN, a brew prefix change — and every hook exits
+// 127 on every prompt while doctor reports the machine as wired (#1708).
+func TestDoctorNamesAVanishedBinary(t *testing.T) {
+	hermeticEnv(t)
+	gone := filepath.Join(t.TempDir(), "bin", "deja")
+	recordWiringExe(gone)
+
+	var buf bytes.Buffer
+	doctorWiredExe(&buf)
+	out := buf.String()
+	if !strings.Contains(out, gone) {
+		t.Errorf("doctor does not name the binary the wiring points at:\n%s", out)
+	}
+	if !strings.Contains(out, "deja install") {
+		t.Errorf("doctor does not say what to run:\n%s", out)
+	}
+}
+
+// The control: a binary that is where the wiring says says nothing at all.
+func TestDoctorSaysNothingWhenTheBinaryIsThere(t *testing.T) {
+	hermeticEnv(t)
+	here := filepath.Join(t.TempDir(), "deja")
+	if err := os.WriteFile(here, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	recordWiringExe(here)
+
+	var buf bytes.Buffer
+	doctorWiredExe(&buf)
+	if out := buf.String(); out != "" {
+		t.Errorf("doctor complained about a binary that is present:\n%s", out)
+	}
+}
+
+// And a machine that has never installed says nothing either.
+func TestDoctorSaysNothingWithoutWiring(t *testing.T) {
+	hermeticEnv(t)
+	var buf bytes.Buffer
+	doctorWiredExe(&buf)
+	if out := buf.String(); out != "" {
+		t.Errorf("doctor complained with no wiring recorded:\n%s", out)
+	}
+}
+
+// recordWiringExe writes a wiring record naming exe, the way an install would.
+func recordWiringExe(exe string) {
+	st := wiringState{Version: version, Targets: []string{"claude-code"}, Exe: exe, Home: homeDir()}
+	b, _ := json.MarshalIndent(st, "", "  ")
+	path := wiringStatePath()
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	_ = os.WriteFile(path, b, 0o600)
+}


### PR DESCRIPTION
Move the deja binary after installing and every hook exits 127 on every prompt, while `deja doctor` reports `wired` for each config and exits 0. The rows are true about the files and useless to the reader: the command in them names a path that is gone.

doctor now checks the executable the wiring recorded — one check, in the one place every harness has in common, rather than parsing each config format:

```
MCP wiring:
  binary       the wiring runs ~/bin/deja, which is not there — `deja install --all` re-points it at this binary
  claude-code  wired          guidance written     ~/.claude.json
```

Fail-before test: `TestDoctorNamesAVanishedBinary`, with two controls — a binary that is where the wiring says, and a machine that never installed, both silent.

Closes #1708.

Not done here, and worth a decision of its own: deja does **not** re-point the wiring when it notices. `refreshWiringAfterUpgrade` does that after an upgrade; extending it to "the recorded exe has vanished" means deja writes into a user's config unasked, on a machine where the thing they last did was move a file. The message says what to run instead.
