### PR TITLE
fix(doctor): emit the stale_stores the JSON schema documents, and name the real policy file

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -1019,7 +1019,7 @@ func doctorTOMLWired(path string) bool {
 // index this build cannot read without shipping a manifest writer.
 var indexFormatDirection = index.FormatDirection
 
-func doctorIndex(w io.Writer, idx doctorComponent, dir string) {
+func doctorIndex(w io.Writer, idx doctorIndexReport, dir string) {
 	fmt.Fprintln(w, "Index:")
 	loc := idx.Path
 	if loc == "" {

--- a/cmd/deja/doctor_building_test.go
+++ b/cmd/deja/doctor_building_test.go
@@ -29,7 +29,7 @@ func TestDoctorSaysWhenTheIndexIsBeingBuilt(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	doctorIndex(&out, doctorComponent{State: "missing", Path: dir}, dir)
+	doctorIndex(&out, doctorIndexReport{State: "missing", Path: dir}, dir)
 	got := out.String()
 	if !strings.Contains(got, "building now (reading sessions 42%)") {
 		t.Errorf("doctor does not mention the build in flight:\n%s", got)
@@ -43,7 +43,7 @@ func TestDoctorSaysWhenTheIndexIsBeingBuilt(t *testing.T) {
 		t.Fatal(err)
 	}
 	out.Reset()
-	doctorIndex(&out, doctorComponent{State: "missing", Path: dir}, dir)
+	doctorIndex(&out, doctorIndexReport{State: "missing", Path: dir}, dir)
 	if got := out.String(); !strings.Contains(got, "not built (run `deja warmup`)") {
 		t.Errorf("an index that is really missing lost its advice:\n%s", got)
 	}

--- a/cmd/deja/doctor_damaged_test.go
+++ b/cmd/deja/doctor_damaged_test.go
@@ -29,7 +29,7 @@ func TestDoctorReportsADamagedIndex(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	doctorIndex(&buf, doctorComponent{State: "fresh", Path: dir}, dir)
+	doctorIndex(&buf, doctorIndexReport{State: "fresh", Path: dir}, dir)
 	if strings.Contains(buf.String(), "integrity") {
 		t.Errorf("healthy index reported damage:\n%s", buf.String())
 	}
@@ -38,7 +38,7 @@ func TestDoctorReportsADamagedIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 	buf.Reset()
-	doctorIndex(&buf, doctorComponent{State: "fresh", Path: dir}, dir)
+	doctorIndex(&buf, doctorIndexReport{State: "fresh", Path: dir}, dir)
 	out := buf.String()
 	if !strings.Contains(out, "integrity damaged") {
 		t.Errorf("damaged index reported as healthy:\n%s", out)

--- a/cmd/deja/doctor_format_test.go
+++ b/cmd/deja/doctor_format_test.go
@@ -31,7 +31,7 @@ func TestDoctorNamesAnIndexFromAnOlderFormat(t *testing.T) {
 
 	// A current index says nothing about its format.
 	var out bytes.Buffer
-	doctorIndex(&out, doctorComponent{State: "ok", Path: dir}, dir)
+	doctorIndex(&out, doctorIndexReport{State: "ok", Path: dir}, dir)
 	if got := out.String(); strings.Contains(got, "older deja") {
 		t.Errorf("a current index was called old:\n%s", got)
 	}
@@ -41,7 +41,7 @@ func TestDoctorNamesAnIndexFromAnOlderFormat(t *testing.T) {
 	indexFormatDirection = func(string) int { return -1 }
 	t.Cleanup(func() { indexFormatDirection = saved })
 	out.Reset()
-	doctorIndex(&out, doctorComponent{State: "ok", Path: dir}, dir)
+	doctorIndex(&out, doctorIndexReport{State: "ok", Path: dir}, dir)
 	got := out.String()
 	if !strings.Contains(got, "written by an older deja") {
 		t.Errorf("doctor does not mention the format:\n%s", got)
@@ -62,7 +62,7 @@ func TestDoctorTellsAnOldIndexFromANewOne(t *testing.T) {
 	line := func(direction int) string {
 		indexFormatDirection = func(string) int { return direction }
 		var out bytes.Buffer
-		doctorIndex(&out, doctorComponent{State: "ok", Path: dir}, dir)
+		doctorIndex(&out, doctorIndexReport{State: "ok", Path: dir}, dir)
 		for _, l := range strings.Split(out.String(), "\n") {
 			if strings.Contains(l, "format ") {
 				return l

--- a/cmd/deja/doctor_json_shape_test.go
+++ b/cmd/deja/doctor_json_shape_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// docs/json-output.md is the contract for anyone parsing this. It names the
+// three keys that may be absent — embed, ingest_health, deep — so every other
+// documented field has to be there. stale_stores carried omitempty, so the
+// zero the example shows was the one value never written, and a script reading
+// it raised on every machine with a fresh index (#1710).
+func TestDoctorJSONCarriesEveryDocumentedField(t *testing.T) {
+	hermeticEnv(t)
+	out, err := captureRun(t, "doctor", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("doctor --json is not JSON: %v\n%s", err, out)
+	}
+	for _, key := range []string{"schema_version", "stores", "index", "mcp", "sqlite3", "version", "policy"} {
+		if _, ok := report[key]; !ok {
+			t.Errorf("%q is missing from the report", key)
+		}
+	}
+	idx, _ := report["index"].(map[string]any)
+	if _, ok := idx["stale_stores"]; !ok {
+		t.Errorf("index.stale_stores is documented and absent: %v", idx)
+	}
+}
+
+// The policy path in the docs has to be the file deja actually reads.
+func TestDocsNameThePolicyFileDejaWrites(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("..", "..", "docs", "json-output.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "policy.toml") {
+		t.Error("docs/json-output.md names policy.toml; deja reads and writes policy.json")
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -42,9 +42,21 @@ type doctorStore struct {
 }
 
 type doctorComponent struct {
+	State string `json:"state"`
+	Path  string `json:"path,omitempty"`
+}
+
+// doctorIndexReport is the index component. It carries stale_stores, which
+// docs/json-output.md documents and which the sqlite3 component has no meaning
+// for — sharing one struct put the field in both. omitempty is deliberately
+// absent: the document names the three keys that may be missing and this is
+// not one of them, so with omitempty the zero the example shows was the one
+// value never written, and a script reading it raised on every machine whose
+// index was fresh (#1710).
+type doctorIndexReport struct {
 	State       string `json:"state"`
 	Path        string `json:"path,omitempty"`
-	StaleStores int    `json:"stale_stores,omitempty"`
+	StaleStores int    `json:"stale_stores"`
 }
 
 type doctorVersionReport struct {
@@ -56,7 +68,7 @@ type doctorVersionReport struct {
 type doctorReport struct {
 	SchemaVersion int                            `json:"schema_version"`
 	Stores        []doctorStore                  `json:"stores"`
-	Index         doctorComponent                `json:"index"`
+	Index         doctorIndexReport              `json:"index"`
 	MCP           []doctorMCPStatus              `json:"mcp"`
 	SQLite3       doctorComponent                `json:"sqlite3"`
 	Version       doctorVersionReport            `json:"version"`
@@ -424,8 +436,8 @@ func newestDoctorFile(files []string) (string, time.Time) {
 	return newest, newestMod
 }
 
-func inspectDoctorIndex(dir string, storeMods []time.Time) doctorComponent {
-	result := doctorComponent{State: "missing", Path: dir}
+func inspectDoctorIndex(dir string, storeMods []time.Time) doctorIndexReport {
+	result := doctorIndexReport{State: "missing", Path: dir}
 	if !index.HasManifest(dir) {
 		return result
 	}

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -252,18 +252,18 @@ func TestDoctorIndexStates(t *testing.T) {
 
 func TestDoctorIndexFreshnessOutput(t *testing.T) {
 	var out bytes.Buffer
-	doctorIndex(&out, doctorComponent{State: "ok", Path: "/tmp/index"}, index.DefaultDir())
+	doctorIndex(&out, doctorIndexReport{State: "ok", Path: "/tmp/index"}, index.DefaultDir())
 	if !strings.Contains(out.String(), "freshness up to date") {
 		t.Fatalf("fresh output = %q", out.String())
 	}
 	out.Reset()
-	doctorIndex(&out, doctorComponent{State: "stale", Path: "/tmp/index", StaleStores: 3}, index.DefaultDir())
+	doctorIndex(&out, doctorIndexReport{State: "stale", Path: "/tmp/index", StaleStores: 3}, index.DefaultDir())
 	got := out.String()
 	if !strings.Contains(got, "freshness 3 stores changed since last build") {
 		t.Fatalf("stale output = %q", got)
 	}
 	out.Reset()
-	doctorIndex(&out, doctorComponent{State: "stale", Path: "/tmp/index", StaleStores: 1}, index.DefaultDir())
+	doctorIndex(&out, doctorIndexReport{State: "stale", Path: "/tmp/index", StaleStores: 1}, index.DefaultDir())
 	if !strings.Contains(out.String(), "freshness 1 store changed since last build") {
 		t.Fatalf("singular stale output = %q", out.String())
 	}

--- a/cmd/deja/doctor_unreadable_index_test.go
+++ b/cmd/deja/doctor_unreadable_index_test.go
@@ -30,7 +30,7 @@ func TestDoctorNamesAnUnreadableIndex(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
 
 	var out bytes.Buffer
-	doctorIndex(&out, doctorComponent{State: "missing", Path: dir}, dir)
+	doctorIndex(&out, doctorIndexReport{State: "missing", Path: dir}, dir)
 	got := out.String()
 	if !strings.Contains(got, "unreadable") || !strings.Contains(got, "permission denied") {
 		t.Errorf("a blocked index was not named unreadable:\n%s", got)
@@ -58,7 +58,7 @@ func TestDoctorNamesAnIndexItCannotWrite(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	doctorIndex(&out, doctorComponent{State: "stale-readonly", Path: dir, StaleStores: 2}, dir)
+	doctorIndex(&out, doctorIndexReport{State: "stale-readonly", Path: dir, StaleStores: 2}, dir)
 	got := out.String()
 
 	if !strings.Contains(got, "cannot be written") {

--- a/cmd/deja/first_build_surfaces_test.go
+++ b/cmd/deja/first_build_surfaces_test.go
@@ -35,7 +35,7 @@ func TestFirstBuildIsNotCalledSilenceOrAbsence(t *testing.T) {
 	}
 
 	var report bytes.Buffer
-	doctorIndex(&report, doctorComponent{State: "missing", Path: dir}, dir)
+	doctorIndex(&report, doctorIndexReport{State: "missing", Path: dir}, dir)
 	if !strings.Contains(report.String(), "building now") {
 		t.Errorf("doctor during the first build:\n%s", report.String())
 	}
@@ -48,7 +48,7 @@ func TestFirstBuildIsNotCalledSilenceOrAbsence(t *testing.T) {
 		t.Fatal(err)
 	}
 	report.Reset()
-	doctorIndex(&report, doctorComponent{State: "missing", Path: dir}, dir)
+	doctorIndex(&report, doctorIndexReport{State: "missing", Path: dir}, dir)
 	if !strings.Contains(report.String(), "not built") {
 		t.Errorf("an idle missing index stopped saying so:\n%s", report.String())
 	}

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -176,7 +176,8 @@
   ],
   "index": {
     "state": "missing",
-    "path": "<tmp>/index.db"
+    "path": "<tmp>/index.db",
+    "stale_stores": 0
   },
   "mcp": [
     {

--- a/cmd/deja/unplugged_index_test.go
+++ b/cmd/deja/unplugged_index_test.go
@@ -24,7 +24,7 @@ func TestAnUnpluggedIndexDiskIsNotPermissionsOrAMissingIndex(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	doctorIndex(&out, doctorComponent{State: "missing", Path: dir}, dir)
+	doctorIndex(&out, doctorIndexReport{State: "missing", Path: dir}, dir)
 	if !strings.Contains(out.String(), "not reachable") {
 		t.Errorf("doctor on an unreachable index:\n%s", out.String())
 	}
@@ -45,7 +45,7 @@ func TestAnUnpluggedIndexDiskIsNotPermissionsOrAMissingIndex(t *testing.T) {
 		t.Errorf("a locked directory stopped being a permissions problem: %v", err)
 	}
 	out.Reset()
-	doctorIndex(&out, doctorComponent{State: "missing", Path: real}, real)
+	doctorIndex(&out, doctorIndexReport{State: "missing", Path: real}, real)
 	if !strings.Contains(out.String(), "not built") {
 		t.Errorf("an absent index stopped saying so:\n%s", out.String())
 	}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -304,7 +304,7 @@ appears only after `deja embed` has built a semantic sidecar. The heatmap grid u
   },
   "policy": {
     "state": "active",
-    "path": "/home/user/.config/deja/policy.toml",
+    "path": "/home/user/.config/deja/policy.json",
     "indexed_sessions": 240,
     "activations": {
       "search": {"rule": "allow all", "withheld": 0},


### PR DESCRIPTION
`docs/json-output.md` is the contract for anyone parsing `deja doctor --json`, and it disagreed with the output in two places.

`index.stale_stores` is in the documented example as `0`, and `0` was the one value never emitted: the field carried `omitempty`. A script written against the example raised on every machine whose index is fresh. The document names the three keys that may be absent — `embed`, `ingest_health`, `deep` — and this is not one of them, so the code was wrong, not the doc.

The index now has its own type. `doctorComponent` was shared with `sqlite3`, and simply dropping `omitempty` put a meaningless `stale_stores` in the sqlite3 block — caught by the golden, which is what it is for.

The policy example named `~/.config/deja/policy.toml`. deja reads and writes `policy.json` (`internal/policy.Path`), the text report says so, and this example was the one place a reader would go to learn the filename.

Fail-before tests: `TestDoctorJSONCarriesEveryDocumentedField` over the seven always-present keys plus `index.stale_stores`, and `TestDocsNameThePolicyFileDejaWrites`, which fails while the docs name a file deja does not write.

Closes #1710.

The golden gained the field; the rest of the shape was already right on both a fresh machine and an indexed one, which is in the issue as the control.
