### PR TITLE
fix(doctor): have --deep say what it compared instead of promising no memory was lost

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -140,7 +140,12 @@ func doctorDeep(w io.Writer, r index.DeepReport) {
 		fmt.Fprintf(w, "  stale    %s changed since last pass — `deja index` will absorb them\n", doctorCount(len(r.Stale), "source"))
 	}
 	if r.Clean() {
-		fmt.Fprintln(w, "  status   index matches sources — no memory lost")
+		// What this pass actually compares is message counts per session, plus
+		// the structure around them: sizes, magic numbers, postings that
+		// resolve. It cannot see a same-length edit inside a record, which
+		// leaves the count identical and the session unreachable — so the line
+		// says what was checked rather than promising nothing was lost (#1712).
+		fmt.Fprintln(w, "  status   every session's message count matches its source, and the records and postings read cleanly")
 		return
 	}
 	for _, f := range r.Findings {

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -140,12 +140,26 @@ func doctorDeep(w io.Writer, r index.DeepReport) {
 		fmt.Fprintf(w, "  stale    %s changed since last pass — `deja index` will absorb them\n", doctorCount(len(r.Stale), "source"))
 	}
 	if r.Clean() {
-		// What this pass actually compares is message counts per session, plus
-		// the structure around them: sizes, magic numbers, postings that
-		// resolve. It cannot see a same-length edit inside a record, which
-		// leaves the count identical and the session unreachable — so the line
-		// says what was checked rather than promising nothing was lost (#1712).
-		fmt.Fprintln(w, "  status   every session's message count matches its source, and the records and postings read cleanly")
+		// What this pass compares is message counts per session, plus the
+		// structure around them: sizes, magic numbers, postings that resolve.
+		// It cannot see a same-length edit inside a record, which leaves the
+		// count identical and the session unreachable — so the line says what
+		// was checked rather than promising nothing was lost (#1712).
+		//
+		// And only what was actually checked: nothing is sampled when every
+		// source is stale, or when the sampled tokens carry no postings, and a
+		// clean report then means "found nothing wrong", not "compared and
+		// agreed".
+		switch {
+		case r.SampledFiles == 0 && r.SampledPostings == 0:
+			fmt.Fprintln(w, "  status   nothing to compare — no source was in sync to re-parse and no sampled token carried postings")
+		case r.SampledFiles == 0:
+			fmt.Fprintln(w, "  status   the sampled postings resolve; no source was in sync to re-parse, so no message count was compared")
+		case r.SampledPostings == 0:
+			fmt.Fprintln(w, "  status   every sampled session's message count matches its source; no sampled token carried postings")
+		default:
+			fmt.Fprintln(w, "  status   every sampled session's message count matches its source, and the sampled postings resolve")
+		}
 		return
 	}
 	for _, f := range r.Findings {

--- a/cmd/deja/doctor_deep_wording_test.go
+++ b/cmd/deja/doctor_deep_wording_test.go
@@ -25,6 +25,38 @@ func TestDeepStatusSaysWhatItCompared(t *testing.T) {
 	}
 }
 
+// A clean report that sampled nothing must not claim a comparison happened:
+// nothing is sampled when every source is stale, or when the sampled tokens
+// carry no postings (found in review on #1713).
+func TestDeepStatusDoesNotClaimAnUnsampledComparison(t *testing.T) {
+	cases := []struct {
+		name    string
+		report  index.DeepReport
+		mustNot string
+		must    string
+	}{
+		{"nothing sampled at all", index.DeepReport{FilesChecked: 3, SessionsIndexed: 3},
+			"matches its source", "nothing to compare"},
+		{"no file re-parsed", index.DeepReport{FilesChecked: 3, SessionsIndexed: 3, SampledPostings: 10},
+			"message count matches", "no source was in sync"},
+		{"no posting carried", index.DeepReport{FilesChecked: 3, SessionsIndexed: 3, SampledFiles: 3},
+			"postings resolve;", "no sampled token carried postings"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			doctorDeep(&buf, c.report)
+			out := buf.String()
+			if strings.Contains(out, c.mustNot) {
+				t.Errorf("claims a comparison that did not happen:\n%s", out)
+			}
+			if !strings.Contains(out, c.must) {
+				t.Errorf("does not say what was skipped:\n%s", out)
+			}
+		})
+	}
+}
+
 // The control: a report with findings still leads with them, unchanged.
 func TestDeepStatusStillLeadsWithFindings(t *testing.T) {
 	var buf bytes.Buffer

--- a/cmd/deja/doctor_deep_wording_test.go
+++ b/cmd/deja/doctor_deep_wording_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// DeepVerify compares per-session message counts and the structure around
+// them; it does not compare content, so a same-length edit inside a record
+// passes every check while the session becomes unreachable. The status line
+// claimed more than that — "index matches sources — no memory lost" is what a
+// reader takes to the bank when deciding whether to rebuild (#1712).
+func TestDeepStatusSaysWhatItCompared(t *testing.T) {
+	var buf bytes.Buffer
+	doctorDeep(&buf, index.DeepReport{FilesChecked: 3, SessionsIndexed: 3, SampledFiles: 3, SampledPostings: 10})
+	out := buf.String()
+	if strings.Contains(out, "no memory lost") {
+		t.Errorf("the status promises more than a count comparison can support:\n%s", out)
+	}
+	if !strings.Contains(out, "count") {
+		t.Errorf("the status does not say what was compared:\n%s", out)
+	}
+}
+
+// The control: a report with findings still leads with them, unchanged.
+func TestDeepStatusStillLeadsWithFindings(t *testing.T) {
+	var buf bytes.Buffer
+	doctorDeep(&buf, index.DeepReport{
+		FilesChecked: 3,
+		Findings:     []index.DeepFinding{{Kind: "torn-log", Detail: "records.bin unreadable"}},
+	})
+	out := buf.String()
+	if !strings.Contains(out, "torn-log") || !strings.Contains(out, "records.bin unreadable") {
+		t.Errorf("a finding was dropped:\n%s", out)
+	}
+	if strings.Contains(out, "count") {
+		t.Errorf("the clean-status wording leaked into a report with findings:\n%s", out)
+	}
+}

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -480,7 +480,7 @@ func TestDoctorDeepCleanAndDrift(t *testing.T) {
 		t.Fatalf("clean deep doctor must exit 0: %v\n%s", err, out.String())
 	}
 	got := out.String()
-	if !strings.Contains(got, "Deep verification:") || !strings.Contains(got, "index matches sources") {
+	if !strings.Contains(got, "Deep verification:") || !strings.Contains(got, "message count matches its source") {
 		t.Fatalf("missing clean deep section:\n%s", got)
 	}
 


### PR DESCRIPTION
`--deep` compares per-session message counts and the structure around them. A same-length edit inside a record leaves the count identical, so the check passes — while the session becomes unreachable by any query, because the postings still key on the old word and the record no longer holds it. The line it printed was:

```
  status   index matches sources — no memory lost
```

That is the sentence a reader takes to the bank when deciding whether to rebuild, and this pass cannot support it. It now says what it checked:

```
  status   every session's message count matches its source, and the records and postings read cleanly
```

Nothing about the checking changes. `--deep` is good at what it does check, and the issue quotes all four cases: truncation, a corrupted length prefix, a garbage bucket, and a healthy index.

Fail-before test: `TestDeepStatusSaysWhatItCompared`, with `TestDeepStatusStillLeadsWithFindings` as the control that a report with findings is untouched. The existing `TestDoctorDeepCleanAndDrift` asserted the old sentence and now asserts the new one.

Closes #1712 — the reporting half.

The larger option is in the issue and is yours to call: store a content hash per session at build time and verify it here, which catches this class outright. It needs care against false alarms on the normalisation the count check already models (`stripSelfRecall`, dedup, clipping), so I have not reached for it inside a wording fix.
