### PR TITLE
ci: run the HOL plugin scanner on the Codex bundle

### DIFF
--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -1,0 +1,42 @@
+# The Codex plugin catalog (hashgraph-online/awesome-codex-plugins) will not
+# take a submission unless this scanner is running on the plugin's own repo, so
+# the run is the entry ticket as much as it is a check. It scans the bundle
+# under codex-plugin/, not the repository root, which is a Go module.
+name: hol-plugin-scanner
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'codex-plugin/**'
+      - '.github/workflows/hol-plugin-scanner.yml'
+  pull_request:
+    paths:
+      - 'codex-plugin/**'
+      - '.github/workflows/hol-plugin-scanner.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hol-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: HOL Plugin Scanner
+        uses: hashgraph-online/ai-plugin-scanner-action@917a3c09b5ec5c2cc264779485da3c0b5ea6a69f # v1.2.99
+        with:
+          plugin_dir: codex-plugin
+          mode: scan
+          min_score: 80
+          fail_on_severity: high
+          format: sarif
+          upload_sarif: true


### PR DESCRIPTION
Entry requirement for hashgraph-online/awesome-codex-plugins — they check the scanner is running on the plugin's own repo before reviewing a submission. Scans `codex-plugin/`, not the repo root.

Local run on 2.2.121: 88/100, no critical or high findings.