### PR TITLE
fix(hooks): recall the fix for an error even when the tool log runs past 1 MiB

### DIFF
--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -57,15 +57,31 @@ type toolAfterInput struct {
 
 func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
 	var input toolAfterInput
-	_ = json.NewDecoder(bytes.NewReader(readHookPayload(stdin, hookStdinWait))).Decode(&input)
+	raw := readHookPayload(stdin, hookStdinWait)
+	_ = json.NewDecoder(bytes.NewReader(raw)).Decode(&input)
 	adoptHookCWD(input.CWD)
 	if !planIndexReady(dir) {
 		return nil
 	}
-	if !isCommandTool(input.ToolName) {
+	// A payload the decoder could not read at all has no tool name either, and
+	// the gate below would drop it before the salvage a few lines down. Only
+	// that case: a payload that decoded and names another tool is still not
+	// ours.
+	truncated := input.ToolName == "" && len(bytes.TrimSpace(raw)) > 0
+	if !truncated && !isCommandTool(input.ToolName) {
 		return nil
 	}
 	out := toolResponseText(input.ToolResponse)
+	if out == "" {
+		// readHookPayload stops at 1 MiB, so a verbose build cuts the JSON
+		// mid-string and the decode yields nothing at all — not a truncated
+		// payload, an empty one. The error is usually the first line of that
+		// output, and this hook exists for exactly the failing `make` or
+		// `pytest -v` whose log runs past a megabyte (#1716). What arrived is
+		// still worth reading: pull the output back out of the cut JSON rather
+		// than throwing away a megabyte that begins with the error.
+		out = clampOutput(salvageToolOutput(string(raw)))
+	}
 	if out == "" {
 		return nil
 	}
@@ -129,6 +145,101 @@ func toolResponseText(raw json.RawMessage) string {
 		}
 	}
 	return clampOutput(b.String())
+}
+
+// salvageToolOutput pulls the tool's output out of a payload the decoder could
+// not read. Scanning the raw bytes does not work: the JSON prefix is glued to
+// the first line of the output, and a line holding a quote is dropped as source
+// rather than error — correctly, for real tool output. So find where the value
+// starts, unescape what follows, and hand back that.
+func salvageToolOutput(raw string) string {
+	for _, key := range []string{`"stderr"`, `"error"`, `"output"`, `"stdout"`, `"content"`, `"result"`} {
+		i := strings.Index(raw, key)
+		if i < 0 {
+			continue
+		}
+		v, ok := jsonStringAfter(raw[i+len(key):])
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// jsonStringAfter reads the string value that follows a key: the colon, any
+// whitespace a pretty-printed payload puts there, then the quoted value. The
+// value ends at the first unescaped quote, or at the end of what arrived when
+// the payload was cut mid-string — which is the case this exists for.
+func jsonStringAfter(s string) (string, bool) {
+	s = strings.TrimLeft(s, " \t\r\n")
+	if !strings.HasPrefix(s, ":") {
+		return "", false
+	}
+	s = strings.TrimLeft(s[1:], " \t\r\n")
+	if !strings.HasPrefix(s, `"`) {
+		return "", false
+	}
+	s = s[1:]
+	if end := unescapedQuote(s); end >= 0 {
+		s = s[:end]
+	}
+	s = unescapeJSONString(s)
+	return s, true
+}
+
+// unescapeJSONString undoes the escapes a tool log actually carries, in one
+// left-to-right pass so an escaped backslash cannot be re-read as an escape.
+// A cut value can end on a lone backslash; that one is dropped.
+func unescapeJSONString(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] != '\\' || i+1 >= len(s) {
+			if s[i] != '\\' {
+				b.WriteByte(s[i])
+			}
+			continue
+		}
+		i++
+		switch s[i] {
+		case 'n':
+			b.WriteByte('\n')
+		case 't':
+			b.WriteByte('\t')
+		case 'r':
+			b.WriteByte('\r')
+		case '"', '\\', '/':
+			b.WriteByte(s[i])
+		default:
+			b.WriteByte('\\')
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
+}
+
+// unescapedQuote returns the index of the first quote not preceded by an odd
+// number of backslashes, or -1.
+func unescapedQuote(s string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] != '"' {
+			continue
+		}
+		back := 0
+		for j := i - 1; j >= 0 && s[j] == '\\'; j-- {
+			back++
+		}
+		if back%2 == 0 {
+			return i
+		}
+	}
+	return -1
 }
 
 func clampOutput(s string) string {

--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -63,12 +63,16 @@ func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
 	if !planIndexReady(dir) {
 		return nil
 	}
-	// A payload the decoder could not read at all has no tool name either, and
-	// the gate below would drop it before the salvage a few lines down. Only
-	// that case: a payload that decoded and names another tool is still not
-	// ours.
-	truncated := input.ToolName == "" && len(bytes.TrimSpace(raw)) > 0
-	if !truncated && !isCommandTool(input.ToolName) {
+	// A payload the decoder could not read has no tool name either, and the
+	// gate below would drop it before the salvage a few lines down. Read the
+	// name straight out of the raw bytes instead — a payload that names another
+	// tool is still not ours, cut or not.
+	name := input.ToolName
+	truncated := name == "" && len(bytes.TrimSpace(raw)) > 0
+	if truncated {
+		name, _ = jsonStringAfter(after(string(raw), `"tool_name"`))
+	}
+	if !isCommandTool(name) {
 		return nil
 	}
 	out := toolResponseText(input.ToolResponse)
@@ -80,7 +84,7 @@ func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
 		// `pytest -v` whose log runs past a megabyte (#1716). What arrived is
 		// still worth reading: pull the output back out of the cut JSON rather
 		// than throwing away a megabyte that begins with the error.
-		out = clampOutput(salvageToolOutput(string(raw)))
+		out = clampOutput(salvageToolOutput(after(string(raw), `"tool_response"`)))
 	}
 	if out == "" {
 		return nil
@@ -145,6 +149,17 @@ func toolResponseText(raw json.RawMessage) string {
 		}
 	}
 	return clampOutput(b.String())
+}
+
+// after returns what follows key, or "" when the key is not there. Scoping the
+// salvage this way keeps it from mining the command in tool_input, which can
+// hold any of the keys below.
+func after(s, key string) string {
+	i := strings.Index(s, key)
+	if i < 0 {
+		return ""
+	}
+	return s[i+len(key):]
 }
 
 // salvageToolOutput pulls the tool's output out of a payload the decoder could

--- a/cmd/deja/hook_tool_after_big_test.go
+++ b/cmd/deja/hook_tool_after_big_test.go
@@ -77,3 +77,32 @@ func TestSalvagedOutputUnescapes(t *testing.T) {
 		}
 	}
 }
+
+// Letting a cut payload past the tool-name gate must not let every tool past
+// it: the name is read out of the raw bytes, and a read of someone else's file
+// is not a command that failed.
+func TestToolAfterStillIgnoresOtherToolsWhenCut(t *testing.T) {
+	const knownErr = "panic: sql: database is closed"
+	seedFixPair(t, knownErr, "make clean && make CGO_ENABLED=0")
+	dir := os.Getenv("DEJA_INDEX_DIR")
+
+	obj := map[string]any{
+		"hook_event_name": "PostToolUse",
+		"tool_name":       "Read",
+		"tool_input":      map[string]string{"file_path": "/work/app/log.txt"},
+		"tool_response":   map[string]string{"content": knownErr + "\n" + strings.Repeat("x", 1200<<10)},
+		"session_id":      "other-tool",
+		"cwd":             "/work/app",
+	}
+	b, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := runHookToolAfter(dir, bytes.NewReader(b), &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("a cut payload from a non-command tool got answered:\n%q", out.String())
+	}
+}

--- a/cmd/deja/hook_tool_after_big_test.go
+++ b/cmd/deja/hook_tool_after_big_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// bigToolAfterPayload is a PostToolUse payload whose stderr begins with err and
+// is padded past the stdin bound.
+func bigToolAfterPayload(t *testing.T, err, cwd string, size int) []byte {
+	t.Helper()
+	obj := map[string]any{
+		"hook_event_name": "PostToolUse",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]string{"command": "make deploy ENV=staging"},
+		"tool_response":   map[string]string{"stderr": err + "\n"},
+		"session_id":      "big",
+		"cwd":             cwd,
+	}
+	base, _ := json.Marshal(obj)
+	pad := size - len(base)
+	if pad < 0 {
+		pad = 0
+	}
+	obj["tool_response"] = map[string]string{"stderr": err + "\n" + strings.Repeat("x", pad)}
+	b, merr := json.Marshal(obj)
+	if merr != nil {
+		t.Fatal(merr)
+	}
+	return b
+}
+
+// readHookPayload stops at 1 MiB, so a bigger payload is cut mid-string and the
+// decode yields nothing — the hook then answers nothing, even though the error
+// it knows is the first line of the output (#1716). A failing verbose build is
+// exactly where this hook earns its keep.
+func TestToolAfterUsesWhatArrivedFromAHugePayload(t *testing.T) {
+	const knownErr = "panic: sql: database is closed"
+	seedFixPair(t, knownErr, "make clean && make CGO_ENABLED=0")
+	dir := os.Getenv("DEJA_INDEX_DIR")
+
+	var small, big bytes.Buffer
+	if err := runHookToolAfter(dir, bytes.NewReader(bigToolAfterPayload(t, knownErr, "/work/app", 900<<10)), &small); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(small.String(), "what followed it") {
+		t.Fatalf("the control did not recall at all, fixture is wrong:\n%s", small.String())
+	}
+	if err := runHookToolAfter(dir, bytes.NewReader(bigToolAfterPayload(t, knownErr, "/work/app", 1200<<10)), &big); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(big.String(), "what followed it") {
+		t.Errorf("a payload over the stdin bound lost the recall:\n%q", big.String())
+	}
+}
+
+// A salvaged value is raw JSON text, so the escapes have to come back out
+// correctly — an escaped backslash must not be re-read as the start of the next
+// escape, and a value cut mid-escape must not swallow the byte after it.
+func TestSalvagedOutputUnescapes(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want string
+	}{
+		{`{"stderr":"a\nb"}`, "a\nb"},
+		{`{"stderr": "spaced"}`, "spaced"},
+		{`{"stderr":"C:\\src\\n"}`, `C:\src\n`},
+		{`{"stderr":"say \"hi\""}`, `say "hi"`},
+		{`{"stderr":"cut off here, no end quote`, "cut off here, no end quote"},
+		{`{"stdout":"","stderr":"second key wins"}`, "second key wins"},
+	} {
+		if got := salvageToolOutput(tc.raw); got != tc.want {
+			t.Errorf("salvageToolOutput(%s) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1716.

`readHookPayload` stops at 1 MiB, so a verbose build cuts the payload mid-string and the decode returns an empty struct — no tool name, no output — and `hook-tool-after` returned silently even though the error was the first line of the log.

The salvage extracts the JSON string value after `"stderr"`/`"error"`/`"output"`/… rather than scanning raw bytes: the JSON prefix is glued to the first output line, and `isFriction` drops any line holding a quote, so a raw scan finds nothing. A truncated payload is let past the tool-name gate only when the decode produced no name at all; a payload that decoded and names another tool is still ignored.

Test: `TestToolAfterUsesWhatArrivedFromAHugePayload` (fails before — silent at 1200 KiB, recalls at 900 KiB) and `TestSalvagedOutputUnescapes` for the escape handling.