### PR TITLE
fix: version and security policy in the plugin bundles

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "deja-vu",
+  "version": "0.18.0",
   "description": "Memory for AI coding agents: your own past sessions, recalled before you ask.",
   "author": {
     "name": "vshulcz",

--- a/claude-plugin/SECURITY.md
+++ b/claude-plugin/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+This bundle is distributed on its own — plugin directories mirror the folder
+rather than the repository — so the policy travels with it.
+
+## Reporting a vulnerability
+
+Report privately via GitHub:
+[Security → Report a vulnerability](https://github.com/vshulcz/deja-vu/security/advisories/new).
+Do not open a public issue for anything you believe is exploitable. Expect an
+initial response within 72 hours.
+
+## What this bundle runs
+
+The hooks and the MCP entry point are shell scripts that locate a `deja` binary
+you installed yourself and exec it. The bundle ships no binary and downloads
+nothing at run time. With no `deja` on the machine, the hooks stay silent and
+the MCP server reports what is missing.
+
+Everything deja reads is already on your disk, and the index it builds stays
+there: no network calls, no telemetry. Credentials are redacted as the index is
+built. Full policy: [the repository's SECURITY.md](https://github.com/vshulcz/deja-vu/blob/main/SECURITY.md).

--- a/codex-plugin/SECURITY.md
+++ b/codex-plugin/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+This bundle is distributed on its own — plugin catalogues mirror the folder
+rather than the repository — so the policy travels with it.
+
+## Reporting a vulnerability
+
+Report privately via GitHub:
+[Security → Report a vulnerability](https://github.com/vshulcz/deja-vu/security/advisories/new).
+Do not open a public issue for anything you believe is exploitable. Expect an
+initial response within 72 hours.
+
+## What this bundle runs
+
+`.mcp.json` starts `deja mcp` from a `deja` you installed yourself. The bundle
+ships no binary and downloads nothing at run time. With no `deja` on the
+machine, the hook stays silent and the MCP server reports what is missing.
+
+Everything deja reads is already on your disk, and the index it builds stays
+there: no network calls, no telemetry. Credentials are redacted as the index is
+built. Full policy: [the repository's SECURITY.md](https://github.com/vshulcz/deja-vu/blob/main/SECURITY.md).

--- a/scripts/pinmanifests/main.go
+++ b/scripts/pinmanifests/main.go
@@ -1,4 +1,4 @@
-// Command pinmanifests rewrites the scoop, winget and Codex plugin manifests for a
+// Command pinmanifests rewrites the scoop, winget and plugin manifests for a
 // release.
 //
 // These files carry a version and the SHA-256 of the two Windows zips, and they
@@ -39,8 +39,12 @@ const (
 	// sat at 0.1.0 from July through 0.17.1 because nothing compared it to
 	// anything.
 	codexPlugin = "codex-plugin/.codex-plugin/plugin.json"
-	releaseAPI  = "https://api.github.com/repos/vshulcz/deja-vu/releases/latest"
-	assetBase   = "https://github.com/vshulcz/deja-vu/releases/download"
+	// Same reasoning for the Claude bundle, which the directory mirrors from
+	// the default branch. It had no version field at all until the directory's
+	// own scanner asked for one.
+	claudePlugin = "claude-plugin/.claude-plugin/plugin.json"
+	releaseAPI   = "https://api.github.com/repos/vshulcz/deja-vu/releases/latest"
+	assetBase    = "https://github.com/vshulcz/deja-vu/releases/download"
 )
 
 type pins struct {
@@ -61,7 +65,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "pinmanifests:", err)
 			os.Exit(1)
 		}
-		fmt.Println("scoop, winget and the codex plugin match the newest release")
+		fmt.Println("scoop, winget and the codex and claude plugins match the newest release")
 		return
 	}
 
@@ -80,7 +84,7 @@ func main() {
 	if err := write(*root, p); err != nil {
 		fail(err)
 	}
-	fmt.Printf("pinned scoop, winget and the codex plugin to %s\n", p.version)
+	fmt.Printf("pinned scoop, winget and the codex and claude plugins to %s\n", p.version)
 }
 
 // parse pulls the two Windows hashes out of a checksums file. Both must be
@@ -113,11 +117,12 @@ func parse(version, checksums string) (pins, error) {
 
 func write(root string, p pins) error {
 	for path, render := range map[string]func(pins) ([]byte, error){
-		scoopPath:   renderScoop,
-		versionPath: renderVersion,
-		localePath:  renderLocale,
-		installer:   renderInstaller,
-		codexPlugin: renderCodexPlugin,
+		scoopPath:    renderScoop,
+		versionPath:  renderVersion,
+		localePath:   renderLocale,
+		installer:    renderInstaller,
+		codexPlugin:  renderPluginVersion(codexPlugin),
+		claudePlugin: renderPluginVersion(claudePlugin),
 	} {
 		body, err := render(p)
 		if err != nil {
@@ -175,20 +180,21 @@ func renderLocale(p pins) ([]byte, error) { return edit(localePath, p) }
 
 func renderInstaller(p pins) ([]byte, error) { return edit(installer, p) }
 
-// renderCodexPlugin rewrites only the version field. The manifest carries
-// descriptions, prompts and pointers that no release derives, so regenerating it
-// from a template here would drop whatever someone adds later — the same reason
-// the winget files are edited rather than rendered.
-func renderCodexPlugin(p pins) ([]byte, error) {
-	b, err := os.ReadFile(codexPlugin)
-	if err != nil {
-		return nil, err
+// renderPluginVersion rewrites only the version field. These manifests carry
+// descriptions, prompts and pointers that no release derives, so regenerating
+// them from a template here would drop whatever someone adds later — the same
+// reason the winget files are edited rather than rendered.
+func renderPluginVersion(path string) func(pins) ([]byte, error) {
+	return func(p pins) ([]byte, error) {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if !jsonVersion.MatchString(string(b)) {
+			return nil, fmt.Errorf("%s has no version field to pin", path)
+		}
+		return []byte(jsonVersion.ReplaceAllString(string(b), `${1}"`+p.version+`"`)), nil
 	}
-	s := jsonVersion.ReplaceAllString(string(b), `${1}"`+p.version+`"`)
-	if !jsonVersion.MatchString(string(b)) {
-		return nil, fmt.Errorf("%s has no version field to pin", codexPlugin)
-	}
-	return []byte(s), nil
 }
 
 var (
@@ -248,11 +254,12 @@ func runCheck(root string) error {
 		return err
 	}
 	for path, render := range map[string]func(pins) ([]byte, error){
-		scoopPath:   renderScoop,
-		versionPath: renderVersion,
-		localePath:  renderLocale,
-		installer:   renderInstaller,
-		codexPlugin: renderCodexPlugin,
+		scoopPath:    renderScoop,
+		versionPath:  renderVersion,
+		localePath:   renderLocale,
+		installer:    renderInstaller,
+		codexPlugin:  renderPluginVersion(codexPlugin),
+		claudePlugin: renderPluginVersion(claudePlugin),
 	} {
 		want, err := render(p)
 		if err != nil {


### PR DESCRIPTION
Preparing the Claude directory submission surfaced two gaps a scanner flags and a reviewer would ask about.

The Claude manifest had no `version` field. Adding one only helps if something keeps it current, so `pinmanifests` now pins both plugin manifests — it already had the Codex one, for the same reason: that manifest sat at 0.1.0 from July through 0.17.1 because nothing compared it to anything.

Directories mirror the plugin folder rather than the repository, so a `SECURITY.md` at the repo root does not travel with the bundle. Both bundles get one, each saying what it actually runs: a script that execs a `deja` you installed yourself, no bundled binary, nothing fetched at run time.

Scanner after this: claude-plugin 100/100, codex-plugin 91/100, no findings above info.