### PR TITLE
fix(mcp): answer ping instead of method-not-found, so a host keepalive does not read the server as dead

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -142,6 +142,16 @@ func handleMCP(dir string, req rpcRequest) (any, int, string) {
 				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"text": map[string]any{"type": "string", "description": "A durable fact, decision, or conclusion to remember."}, "project": map[string]any{"type": "string", "description": "Optional project name; defaults to notes."}, "tags": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Optional navigation tags, searchable as #tag."}}, "required": []string{"text"}},
 			},
 		}}, 0, ""
+	case "ping":
+		// Part of the protocol at the version above, and a keepalive: a host
+		// that gets an error here is entitled to decide the server is gone.
+		// The result is empty by definition.
+		return map[string]any{}, 0, ""
+	case "resources/templates/list":
+		// We declare a resources capability, so clients ask what templates it
+		// has. deja publishes fixed session URIs rather than templates, so the
+		// honest answer is an empty list in the protocol's own shape.
+		return map[string]any{"resourceTemplates": []map[string]any{}}, 0, ""
 	case "resources/list":
 		return mcpResourcesList(dir)
 	case "resources/read":

--- a/cmd/deja/mcp_ping_test.go
+++ b/cmd/deja/mcp_ping_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// ping is part of the protocol version this server claims, and a host that
+// uses it for keepalive is entitled to read an error as a dead server. The
+// templates list goes with it: we declare a resources capability, so clients
+// ask what templates it has (#1720).
+func TestMCPAnswersPingAndResourceTemplates(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("DEJA_INDEX_DIR", t.TempDir()+"/index.db")
+
+	in := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"ping"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"ping","params":{}}`,
+		`{"jsonrpc":"2.0","id":3,"method":"resources/templates/list","params":{}}`,
+	}, "\n") + "\n"
+
+	var out bytes.Buffer
+	if err := serveMCP(index.DefaultDir(), strings.NewReader(in), &out); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("got %d responses: %q", len(lines), out.String())
+	}
+	for _, line := range lines {
+		var resp struct {
+			ID     int             `json:"id"`
+			Error  json.RawMessage `json:"error"`
+			Result json.RawMessage `json:"result"`
+		}
+		if err := json.Unmarshal([]byte(line), &resp); err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.Error) > 0 {
+			t.Errorf("id %d answered with an error: %s", resp.ID, resp.Error)
+			continue
+		}
+		if resp.ID == 3 && !bytes.Contains(resp.Result, []byte("resourceTemplates")) {
+			t.Errorf("templates list is not in the shape the protocol defines: %s", resp.Result)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1720.

`ping` belongs to the protocol version this server claims (`2024-11-05`) and both sides must answer it; we fell through to `-32601`, which a host using it for keepalive may read as a stale connection. `resources/templates/list` goes with it: we declare a `resources` capability, so clients ask for its templates — deja publishes fixed `deja://session/…` URIs and no templates, so the answer is an empty `resourceTemplates` list rather than an error.

Test: `TestMCPAnswersPingAndResourceTemplates` — all three requests answered with an error before the change.