### PR TITLE
feat: install deja into Gemini CLI as an extension

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,25 @@
+# deja
+
+This file is loaded in every session the extension is enabled in, so it stays
+short. The detail lives in the tool descriptions.
+
+Search deja before re-deriving past work: when the user refers to an earlier
+session or decision, before debugging an error, and before implementing
+something that may already exist. It searches this machine's own history across
+every AI coding tool used on it, further back than deja itself was installed.
+
+- `recall` — search with the most specific token available: an exact error
+  string, a function name, a file path, a flag.
+- `recall_context` — the full digest of the best-matching session, once a hit
+  looks right and the reasoning behind it matters.
+
+If recalled history genuinely helped, say so in one line: what was recalled and
+how you used it. Say nothing about recalls that did not help.
+
+deja is a binary you install yourself; this extension only points Gemini at it:
+
+    brew install vshulcz/tap/deja-vu
+
+or
+
+    curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ harness supports, aider's read-only context file, and the Windows `cmd /c deja m
 <details>
 <summary>What gets written into each agent's own guidance file</summary>
 
-Install also writes user-level guidance for the harnesses it detects: Claude Code, Codex, opencode, Gemini CLI, Antigravity, Qwen, Kimi Code, pi, Copilot, Cursor, Goose, OpenClaw, Hermes, Roo Code, omp, DeepSeek Harness and Zed each get it in their own guidance file (or under the configured `XDG_CONFIG_HOME`). Re-run rewrites deja's skill or marked block without changing surrounding user content. Use `deja install --all --no-guidance` to opt out; Grok gets `~/.grok/GROK.md`, which it reads only when a project has no `.grok/GROK.md` of its own. Cursor has no user-level instructions file, so it gets a skill at `~/.cursor/skills/` instead, read only when something looks relevant rather than every session.
+Install also writes user-level guidance for the harnesses it detects: Claude Code, Codex, opencode, Gemini CLI, Antigravity, Qwen, Kimi Code, pi, Copilot, Cursor, Goose, OpenClaw, Hermes, Roo Code, omp, DeepSeek Harness and Zed each get it in their own guidance file (or under the configured `XDG_CONFIG_HOME`). Re-run rewrites deja's skill or marked block without changing surrounding user content. Use `deja install --all --no-guidance` to opt out; Grok Build gets the shared skill in `~/.agents/skills`, which is what it reads; the `~/.grok/GROK.md` written beside it is for the unrelated community CLI that shares that directory. Cursor has no user-level instructions file, so it gets a skill at `~/.cursor/skills/` instead, read only when something looks relevant rather than every session.
 
 </details>
 

--- a/cmd/deja/gemini_extension_test.go
+++ b/cmd/deja/gemini_extension_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Gemini can install this repository as an extension directly, and `deja
+// install gemini` writes an extension of its own. Both are the same product, so
+// both must claim the same name: Gemini keys an extension by the name in its
+// manifest and refuses a second install under a name it already has
+// ("Extension "deja" is already installed"). Let the two names drift and a
+// machine ends up with two deja extensions, two MCP servers and every tool
+// listed twice — the fault Zed had until one shared server id made it
+// impossible.
+func TestGeminiExtensionSharesTheInstallerName(t *testing.T) {
+	var manifest struct {
+		Name        string                    `json:"name"`
+		Version     string                    `json:"version"`
+		Description string                    `json:"description"`
+		MCPServers  map[string]map[string]any `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(repoFile(t, "gemini-extension.json"), &manifest); err != nil {
+		t.Fatalf("gemini-extension.json: %v", err)
+	}
+	if manifest.Name != geminiExtensionName {
+		t.Fatalf("manifest name is %q, the installer writes %q — a machine with both gets two deja extensions", manifest.Name, geminiExtensionName)
+	}
+	if manifest.Version == "" || manifest.Description == "" {
+		t.Fatal("the gallery reads version and description; an empty one is a listing that says nothing")
+	}
+	// The gallery crawler wants the manifest at the absolute root, which is why
+	// this file sits beside go.mod rather than under extensions/.
+	server, ok := manifest.MCPServers["deja"]
+	if !ok {
+		t.Fatal("the extension carries no deja MCP server, which is the only thing it is for")
+	}
+	if server["command"] != "deja" {
+		t.Fatalf("MCP command is %v; it has to be the binary on PATH, since an extension ships files rather than binaries", server["command"])
+	}
+}

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -60,6 +60,19 @@ Kimi notifies about updates only for plugins installed from its own
 marketplace, so `deja doctor` reports the installed plugin version against the
 one this deja ships.
 
+Gemini installs this repository itself: `gemini extensions install
+https://github.com/vshulcz/deja-vu` reads `gemini-extension.json` at the
+repository root — the only reason that file is not under `extensions/` — and the
+gallery at geminicli.com crawls repositories tagged `gemini-cli-extension` for
+the same file. It carries the MCP server and `GEMINI.md`; the hooks stay with
+`deja install gemini`, because they only run when `hooksConfig.enabled` is set
+in the user's `settings.json` and an extension cannot write that.
+
+Its `name` is `deja`, the same name the installer's extension uses, and
+`TestGeminiExtensionSharesTheInstallerName` keeps it that way: Gemini keys an
+extension by that name and refuses a second install under a name it already
+has, which is what makes two deja extensions on one machine impossible.
+
 ## Rules that cost us time once
 
 - **Resolve the binary in this order, everywhere:** an explicit setting or

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,14 @@
+{
+  "name": "deja",
+  "version": "0.18.0",
+  "description": "Search the coding sessions already on your disk — Gemini CLI, Claude Code, Codex, Cursor and seventeen more — including work from before deja was installed.",
+  "contextFileName": "GEMINI.md",
+  "mcpServers": {
+    "deja": {
+      "command": "deja",
+      "args": [
+        "mcp"
+      ]
+    }
+  }
+}

--- a/scripts/pinmanifests/main.go
+++ b/scripts/pinmanifests/main.go
@@ -43,8 +43,11 @@ const (
 	// the default branch. It had no version field at all until the directory's
 	// own scanner asked for one.
 	claudePlugin = "claude-plugin/.claude-plugin/plugin.json"
-	releaseAPI   = "https://api.github.com/repos/vshulcz/deja-vu/releases/latest"
-	assetBase    = "https://github.com/vshulcz/deja-vu/releases/download"
+	// The Gemini gallery crawls the manifest at the repository root and shows
+	// its version, and `gemini extensions install` reads the same file.
+	geminiExtension = "gemini-extension.json"
+	releaseAPI      = "https://api.github.com/repos/vshulcz/deja-vu/releases/latest"
+	assetBase       = "https://github.com/vshulcz/deja-vu/releases/download"
 )
 
 type pins struct {
@@ -65,7 +68,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "pinmanifests:", err)
 			os.Exit(1)
 		}
-		fmt.Println("scoop, winget and the codex and claude plugins match the newest release")
+		fmt.Println("scoop, winget and the codex, claude and gemini manifests match the newest release")
 		return
 	}
 
@@ -84,7 +87,7 @@ func main() {
 	if err := write(*root, p); err != nil {
 		fail(err)
 	}
-	fmt.Printf("pinned scoop, winget and the codex and claude plugins to %s\n", p.version)
+	fmt.Printf("pinned scoop, winget and the codex, claude and gemini manifests to %s\n", p.version)
 }
 
 // parse pulls the two Windows hashes out of a checksums file. Both must be
@@ -117,12 +120,13 @@ func parse(version, checksums string) (pins, error) {
 
 func write(root string, p pins) error {
 	for path, render := range map[string]func(pins) ([]byte, error){
-		scoopPath:    renderScoop,
-		versionPath:  renderVersion,
-		localePath:   renderLocale,
-		installer:    renderInstaller,
-		codexPlugin:  renderPluginVersion(codexPlugin),
-		claudePlugin: renderPluginVersion(claudePlugin),
+		scoopPath:       renderScoop,
+		versionPath:     renderVersion,
+		localePath:      renderLocale,
+		installer:       renderInstaller,
+		codexPlugin:     renderPluginVersion(codexPlugin),
+		claudePlugin:    renderPluginVersion(claudePlugin),
+		geminiExtension: renderPluginVersion(geminiExtension),
 	} {
 		body, err := render(p)
 		if err != nil {
@@ -254,12 +258,13 @@ func runCheck(root string) error {
 		return err
 	}
 	for path, render := range map[string]func(pins) ([]byte, error){
-		scoopPath:    renderScoop,
-		versionPath:  renderVersion,
-		localePath:   renderLocale,
-		installer:    renderInstaller,
-		codexPlugin:  renderPluginVersion(codexPlugin),
-		claudePlugin: renderPluginVersion(claudePlugin),
+		scoopPath:       renderScoop,
+		versionPath:     renderVersion,
+		localePath:      renderLocale,
+		installer:       renderInstaller,
+		codexPlugin:     renderPluginVersion(codexPlugin),
+		claudePlugin:    renderPluginVersion(claudePlugin),
+		geminiExtension: renderPluginVersion(geminiExtension),
 	} {
 		want, err := render(p)
 		if err != nil {


### PR DESCRIPTION
A channel with no gatekeeper: `gemini extensions install https://github.com/vshulcz/deja-vu` reads `gemini-extension.json` at the repository root, and the gallery at geminicli.com crawls repositories tagged `gemini-cli-extension` for the same file — daily, no PR and no submission.

Verified on Gemini CLI 0.55.1: installed from this checkout, `gemini mcp list` reports `deja (from deja): deja mcp (stdio) - Connected`, and the extension's `GEMINI.md` loads as a context file.

The name is `deja` — the same name `deja install gemini` gives its own extension — and that is the whole duplicate story: Gemini keys extensions by that name and answers a second install with "Extension \"deja\" is already installed", which I reproduced. A test pins the two names together, the way Zed's shared server id does.

The hooks stay with the CLI install: they only run when `hooksConfig.enabled` is set in the user's `settings.json`, and an extension cannot write that. So the extension carries the MCP server and the context file, and the README says which route gives automatic recall.

Also in here, one line: the README claimed Grok reads `~/.grok/GROK.md` when a project has none of its own. Measured on Grok Build 1.0.5 yesterday — it never reads that file; the shared skill is what reaches it.