### PR TITLE
fix(mcp): keep the offset line on a full recall page, so the rest of the matches stay reachable

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -911,13 +911,19 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	// From what was served, not from the limit: the loop also stops on the
 	// token budget, and then this said "2 more" while five were left — the
 	// agent asks for offset=served and the arithmetic has to hold.
+	more := ""
 	if left := total - offset - served; left > 0 {
-		fmt.Fprintf(&b, "\n%d more match(es) — call recall again with offset=%d.\n", left, offset+served)
+		more = fmt.Sprintf("\n%d more match(es) — call recall again with offset=%d.\n", left, offset+served)
 	}
+	// The paging line is the instruction, not the evidence: appending it before
+	// the trim made a full page drop the one thing that says how to reach the
+	// rest, exactly where offset is meant to be used (#1726). Trim the excerpts
+	// to leave room for it instead.
 	out := b.String()
-	if len(out) > budget {
-		out = trimUTF8(out, budget)
+	if len(out)+len(more) > budget {
+		out = trimUTF8(out, budget-len(more))
 	}
+	out += more
 	var raw int64
 	var ids []string
 	for i, h := range hits {

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -921,6 +921,11 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	// to leave room for it instead.
 	out := b.String()
 	if len(out)+len(more) > budget {
+		// A budget smaller than the instruction itself: keep the page and drop
+		// the line rather than trim to a negative length.
+		if len(more) >= budget {
+			more = ""
+		}
 		out = trimUTF8(out, budget-len(more))
 	}
 	out += more
@@ -939,6 +944,9 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 }
 
 func trimUTF8(s string, budget int) string {
+	if budget <= 0 {
+		return ""
+	}
 	if len(s) <= budget {
 		return s
 	}

--- a/cmd/deja/mcp_paging_test.go
+++ b/cmd/deja/mcp_paging_test.go
@@ -53,3 +53,14 @@ func TestFullRecallPageKeepsThePagingLine(t *testing.T) {
 		t.Errorf("a full page dropped the paging line (want %q), tail was:\n%q", want, out[max(0, len(out)-200):])
 	}
 }
+
+// A budget smaller than the paging line itself must not trim to a negative
+// length: the page is what there is room for, the instruction is what goes.
+func TestTinyBudgetDropsTheLineRatherThanPanicking(t *testing.T) {
+	if got := trimUTF8("hello world", -5); got != "" {
+		t.Errorf("trimUTF8 with a negative budget = %q", got)
+	}
+	if got := trimUTF8("hello", 0); got != "" {
+		t.Errorf("trimUTF8 with a zero budget = %q", got)
+	}
+}

--- a/cmd/deja/mcp_paging_test.go
+++ b/cmd/deja/mcp_paging_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A full page is where offset exists to be used, and it was the page that lost
+// the line naming the offset — the excerpts have to give way instead (#1726).
+func TestFullRecallPageKeepsThePagingLine(t *testing.T) {
+	root := t.TempDir()
+	proj := filepath.Join(root, "proj")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "zqxwv widget pipeline stalled. " + strings.Repeat("detail ", 400)
+	for i := range 12 {
+		line := func(role, text string) string {
+			if role == "user" {
+				return fmt.Sprintf(`{"type":"user","sessionId":"sess-%02d","cwd":"/work/zq","timestamp":"2026-08-%02dT03:04:05Z","message":{"role":"user","content":%q}}`, i, i+1, text)
+			}
+			return fmt.Sprintf(`{"type":"assistant","sessionId":"sess-%02d","cwd":"/work/zq","timestamp":"2026-08-%02dT03:05:05Z","message":{"role":"assistant","content":[{"type":"text","text":%q}]}}`, i, i+1, text)
+		}
+		content := line("user", "why does zqxwv fail? "+body) + "\n" + line("assistant", "zqxwv resolved by resharding. "+body) + "\n"
+		if err := os.WriteFile(filepath.Join(proj, fmt.Sprintf("s%02d.jsonl", i)), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(t.TempDir(), "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(t.TempDir(), "opencode.db"))
+	dir := filepath.Join(t.TempDir(), "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+
+	const budget = 4096
+	out, served, _, _, err := recallTextResult(dir, "zqxwv", "", 0, 0, budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) > budget {
+		t.Fatalf("page is %d bytes, over the %d budget", len(out), budget)
+	}
+	if served == 0 || served >= 12 {
+		t.Fatalf("fixture served %d of 12 — it does not fill a page", served)
+	}
+	want := fmt.Sprintf("offset=%d", served)
+	if !strings.Contains(out, "more match(es)") || !strings.Contains(out, want) {
+		t.Errorf("a full page dropped the paging line (want %q), tail was:\n%q", want, out[max(0, len(out)-200):])
+	}
+}


### PR DESCRIPTION
Closes #1726.

The `N more match(es) — call recall again with offset=N` line was appended before the final trim, so a full page cut it away — the page that says "5 of 12 matched" and never says how to get the other seven. The trim now leaves room for it: the excerpts give way, the instruction stays, and the page is still exactly at budget (4096 before and after).

Test: `TestFullRecallPageKeepsThePagingLine` — twelve long matching sessions, fails before on the missing `offset=5`.