### PR TITLE
fix(mcp): name the phase while a build starts instead of an empty parenthesis

### DIFF
--- a/cmd/deja/warmup_phase_test.go
+++ b/cmd/deja/warmup_phase_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A status file exists before its phase is written, and every agent-facing
+// sentence interpolates progress() into parentheses — so that window read
+// "indexing this machine's history ()". line() has always substituted a word
+// there; progress() did not (#1731).
+func TestBuildingSentenceNeverShowsAnEmptyPhase(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	write := func(st warmupStatus) {
+		st.Updated = time.Now().UnixNano()
+		b, err := json.Marshal(st)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(warmupStatusPath(dir), b, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, st := range []warmupStatus{{}, {Done: 3, Total: 10}} {
+		write(st)
+		got := buildingNowForAgent(dir)
+		if got == "" {
+			t.Fatalf("no sentence at all for %+v", st)
+		}
+		if strings.Contains(got, "()") || strings.Contains(got, "( ") {
+			t.Errorf("%+v renders an empty phase: %q", st, got)
+		}
+	}
+
+	// The phase, when there is one, still reads as before.
+	write(warmupStatus{Phase: "finding transcripts", Done: 1, Total: 4})
+	if got := buildingNowForAgent(dir); !strings.Contains(got, "finding transcripts 25%") {
+		t.Errorf("a real phase went missing: %q", got)
+	}
+}

--- a/cmd/deja/warmup_status.go
+++ b/cmd/deja/warmup_status.go
@@ -124,14 +124,22 @@ func readWarmupStatus(dir string) *warmupStatus {
 // progress is the bare "phase 42%" fragment, for callers that supply their
 // own sentence.
 func (s *warmupStatus) progress() string {
+	// The status file exists before the first phase is written to it, and every
+	// caller drops this into parentheses or a sentence — so that window read
+	// "indexing this machine's history ()" and, with a count already known,
+	// "( 30%)". The word line() has always used for the same gap (#1731).
+	phase := s.Phase
+	if phase == "" {
+		phase = "starting"
+	}
 	if s.Total <= 0 {
-		return s.Phase
+		return phase
 	}
 	p := 100 * s.Done / s.Total
 	if p > 100 {
 		p = 100
 	}
-	return fmt.Sprintf("%s %d%%", s.Phase, p)
+	return fmt.Sprintf("%s %d%%", phase, p)
 }
 
 // line is the one-sentence status a host can show its user. It names what is


### PR DESCRIPTION
Closes #1731.

`progress()` returned `Phase` unguarded, so the window before the first phase is written rendered as `deja is indexing this machine's history ().` — and with a count already known, `( 30%)`. `line()` has always substituted `starting` for the same gap; the fix moves that substitution into `progress()`, which is what the five agent- and human-facing callers interpolate.

```
before  deja is indexing this machine's history ( 30%). Recall comes online in a few seconds; ask again then.
after   deja is indexing this machine's history (starting 30%). Recall comes online in a few seconds; ask again then.
```

Test: `TestBuildingSentenceNeverShowsAnEmptyPhase`, which also pins that a real phase still reads `finding transcripts 25%`.