### PR TITLE
fix(mcp): answer from the index while a refresh runs instead of sending the agent away

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -1170,14 +1170,14 @@ func buildingNowForAgent(dir string) string {
 // inside the call, so for them a refresh in flight is still a reason to say so
 // rather than to hang.
 func buildingNowForBlockingTool(dir string) string {
-	if line := buildingNowForAgent(dir); line != "" {
-		return line
-	}
 	if st := readWarmupStatus(dir); st != nil {
 		return "deja is indexing this machine's history (" + st.progress() + "). Recall comes online in a few seconds; ask again then."
 	}
 	if index.RebuildInProgress(dir) || warmupJustRequested(dir) {
 		return "deja is indexing this machine's history. Recall comes online in a few seconds; ask again then."
 	}
-	return ""
+	// Everything else these two have to say — an index written by another
+	// version, an index directory nobody can write — is the same sentence the
+	// reading tools get, so it is answered in one place rather than copied.
+	return buildingNowForAgent(dir)
 }

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -309,7 +309,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		// blocks and can run the whole build inside this call. The CLI keeps
 		// that — someone typed it and watches the progress — but an agent gets
 		// the same sentence as every other tool (#1306).
-		if line := buildingNowForAgent(dir); line != "" {
+		if line := buildingNowForBlockingTool(dir); line != "" {
 			return line, nil
 		}
 		text, hits, err := blameTextResult(dir, search.BlameOptions{Harness: a.Harness, Project: a.Project, Since: since, All: a.All}, a.Path, int(a.Limit))
@@ -430,7 +430,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		// On upgrade day that meant rebuilding the whole index inside the call
 		// (#1309), so the agent is told instead — the detached warmup picks it
 		// up with everything else.
-		if line := buildingNowForAgent(dir); line != "" {
+		if line := buildingNowForBlockingTool(dir); line != "" {
 			return "Saved. " + line, nil
 		}
 		if err := index.EnsureForSearch(dir, search.Options{All: true}, false, mcpProgress()); err != nil {
@@ -1126,6 +1126,16 @@ func (n *mcpNumber) UnmarshalJSON(b []byte) error {
 // — an internal path and an errno, handed to a model as a broken tool (#972).
 // Every other surface says the same thing in words.
 func buildingNowForAgent(dir string) string {
+	// A refresh is not an empty index. The snapshot on disk is published by an
+	// atomic swap and stays readable throughout one, which is why readers take
+	// tryLockDir rather than waiting — so answer from it and let recall say a
+	// refresh is running. Sending the agent away for the length of every
+	// refresh cost it the history it has: an agent does not ask again, it
+	// concludes there is none (#1733). The sentence below is for the state it
+	// was written for — nothing to answer from yet.
+	if index.HasManifest(dir) && !indexNeedsRebuild(dir) {
+		return ""
+	}
 	if st := readWarmupStatus(dir); st != nil {
 		return "deja is indexing this machine's history (" + st.progress() + "). Recall comes online in a few seconds; ask again then."
 	}
@@ -1150,5 +1160,24 @@ func buildingNowForAgent(dir string) string {
 	}
 	// Nothing indexed yet and nothing building: this is a first run, and
 	// building it here is how an install with no hooks ever gets an index.
+	return ""
+}
+
+// buildingNowForBlockingTool is buildingNowForAgent for the two tools that
+// still reach a blocking index.EnsureForSearch — blame and remember. Every
+// other tool reads through the non-blocking path and answers from the snapshot
+// while a refresh runs (#1733); these two would wait out the whole rebuild
+// inside the call, so for them a refresh in flight is still a reason to say so
+// rather than to hang.
+func buildingNowForBlockingTool(dir string) string {
+	if line := buildingNowForAgent(dir); line != "" {
+		return line
+	}
+	if st := readWarmupStatus(dir); st != nil {
+		return "deja is indexing this machine's history (" + st.progress() + "). Recall comes online in a few seconds; ask again then."
+	}
+	if index.RebuildInProgress(dir) || warmupJustRequested(dir) {
+		return "deja is indexing this machine's history. Recall comes online in a few seconds; ask again then."
+	}
 	return ""
 }

--- a/cmd/deja/mcp_refresh_serves_test.go
+++ b/cmd/deja/mcp_refresh_serves_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A refresh in flight is not an empty index: the snapshot on disk is published
+// by an atomic swap and is readable throughout. Answering "ask again then" over
+// a complete index sends the agent away for the length of every refresh, and an
+// agent does not ask again — it concludes there is no history (#1733).
+func TestARefreshOverAReadableIndexStillAnswers(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"zeepwock pipeline stalled"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"s1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := buildingNowForAgent(dir); got != "" {
+		t.Fatalf("the fixture is wrong — a quiet built index already claims to be building: %q", got)
+	}
+
+	// A refresh in flight, in both the shapes the code checks for.
+	if err := os.WriteFile(filepath.Join(dir, "warmup.sentinel"),
+		[]byte(strconv.FormatInt(time.Now().UnixNano(), 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := buildingNowForAgent(dir); got != "" {
+		t.Errorf("a refresh over a readable index sends the agent away: %q", got)
+	}
+	st := `{"phase":"reading transcripts","done":2,"total":9,"updated":` + strconv.FormatInt(time.Now().UnixNano(), 10) + `}`
+	if err := os.WriteFile(warmupStatusPath(dir), []byte(st), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := buildingNowForAgent(dir); got != "" {
+		t.Errorf("a published build status over a readable index sends the agent away: %q", got)
+	}
+
+	// And the answer really comes from the index.
+	text, _, _, _, err := recallTextResult(dir, "zeepwock", "", 5, 0, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "zeepwock") {
+		t.Errorf("recall answered nothing useful during a refresh:\n%s", text)
+	}
+
+	// With nothing to answer from, the sentence is still what an agent gets.
+	empty := filepath.Join(t.TempDir(), "index.db")
+	if err := os.MkdirAll(empty, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(empty, "warmup.sentinel"),
+		[]byte(strconv.FormatInt(time.Now().UnixNano(), 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := buildingNowForAgent(empty); !strings.Contains(got, "indexing") {
+		t.Errorf("a first build stopped saying it is building: %q", got)
+	}
+}
+
+// blame and remember still reach a blocking index.EnsureForSearch, so for them
+// a refresh in flight is a reason to say so — waiting it out inside the call is
+// what the sentence was written to avoid (#1306, #1309).
+func TestTheTwoBlockingToolsStillDeclineDuringARefresh(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"zeepwock pipeline stalled"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"s1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := buildingNowForBlockingTool(dir); got != "" {
+		t.Fatalf("a quiet index already declines: %q", got)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "warmup.sentinel"),
+		[]byte(strconv.FormatInt(time.Now().UnixNano(), 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := buildingNowForBlockingTool(dir); !strings.Contains(got, "indexing") {
+		t.Errorf("a blocking tool would wait out the refresh instead of saying so: %q", got)
+	}
+	if got := buildingNowForAgent(dir); got != "" {
+		t.Errorf("the reading tools were dragged back into declining: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #1733.

While a rebuild held the lock, every tool answered "deja is indexing this machine's history — ask again then", with a complete index underneath. The snapshot is published by an atomic swap and stays readable, which is why readers take `tryLockDir` instead of waiting; the MCP layer just never took that path. An agent does not ask again — it concludes there is no history.

The tricky part, and why the early return existed: removing it outright makes `blame` and `remember` **hang for the length of the rebuild**, because both reach a blocking `index.EnsureForSearch` (measured: >8 s against a held lock, while recall answered in 1.7 s). So the sentence stays for those two — `buildingNowForBlockingTool` — and the five tools that read non-blocking now answer. Making blame and remember non-blocking is a separate change; noted on the issue.

```
                before (rebuild in flight)                     after
recall          deja is indexing… ask again then               (index refresh running in the background…) + results
recall_context  deja is indexing… ask again then               # deja context: claude · proj · bg-0027
fix / how       deja is indexing… ask again then               real answers
resources/list  []                                             the listing
blame/remember  deja is indexing… ask again then               unchanged — and it is not a hang
```

Tests: `TestARefreshOverAReadableIndexStillAnswers` (fails before, in both refresh shapes) and `TestTheTwoBlockingToolsStillDeclineDuringARefresh`.