### PR TITLE
fix(remember): keep one copy of a note instead of charging every later recall for the same fact

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -423,8 +423,14 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Project) == "" {
 			a.Project = "notes"
 		}
-		if err := notesWriteError(sources.AppendNoteTagged(a.Project, a.Text, a.Tags, time.Now())); err != nil {
-			return "", err
+		switch err := sources.AppendNoteTagged(a.Project, a.Text, a.Tags, time.Now()); {
+		case errors.Is(err, sources.ErrNoteExists):
+			// Not an error to the agent: the fact it wanted stored is stored.
+			// Saying so stops it retrying, and stops one fact costing a line of
+			// every later recall (#1736).
+			return fmt.Sprintf("Already remembered under %s.", strings.TrimSpace(a.Project)), nil
+		case err != nil:
+			return "", notesWriteError(err)
 		}
 		// The note is on disk either way; what is left is making it findable.
 		// On upgrade day that meant rebuilding the whole index inside the call

--- a/cmd/deja/remember.go
+++ b/cmd/deja/remember.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -51,6 +52,10 @@ func runRemember(dir string, args []string) error {
 	}
 	now := time.Now()
 	if err := sources.AppendNoteTagged(project, text, tags, now); err != nil {
+		if errors.Is(err, sources.ErrNoteExists) {
+			fmt.Fprintf(os.Stderr, "deja: already remembered under %s\n", project)
+			return nil
+		}
 		return notesWriteError(err)
 	}
 	if err := index.EnsureForSearch(dir, search.Options{All: true}, false, os.Stderr); err != nil {

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -87,7 +87,12 @@ const maxNoteLine = 4 << 20
 // (#1736), so the write is refused and the caller says so.
 var ErrNoteExists = errors.New("note already remembered")
 
-// noteAlreadyStored reports whether this exact note is on file already. It
+// noteAlreadyStored reports whether this exact note is on file already. The
+// answer is advisory: two processes checking at once can both write, and a
+// read error reads as "not a duplicate" so a save is never lost to one. A
+// duplicate that slips through costs a repeated line, a refused save costs the
+// fact.
+// It
 // reads the file rather than an index: a note written a second ago has not
 // been indexed yet, and back-to-back saves are exactly the case this exists
 // for. Promoted notes are skipped — those carry provenance and a lifecycle,

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -1,6 +1,8 @@
 package sources
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -75,6 +77,45 @@ func AppendNote(project, text string, now time.Time) error {
 	return AppendNoteTagged(project, text, nil, now)
 }
 
+// maxNoteLine bounds one line of the scan below. A note longer than this is
+// not compared — it is written, and the duplicate check simply does not claim
+// to cover it.
+const maxNoteLine = 4 << 20
+
+// ErrNoteExists says the note is already on file: same project, same text.
+// Appending it again cost the agent a line of every later recall for one fact
+// (#1736), so the write is refused and the caller says so.
+var ErrNoteExists = errors.New("note already remembered")
+
+// noteAlreadyStored reports whether this exact note is on file already. It
+// reads the file rather than an index: a note written a second ago has not
+// been indexed yet, and back-to-back saves are exactly the case this exists
+// for. Promoted notes are skipped — those carry provenance and a lifecycle,
+// and a `remember` is not a correction to one.
+func noteAlreadyStored(path, project, text string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), maxNoteLine)
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var n note
+		if json.Unmarshal(line, &n) != nil || n.Kind != "" {
+			continue
+		}
+		if n.Project == project && strings.TrimSpace(n.Text) == text {
+			return true
+		}
+	}
+	return false
+}
+
 func AppendNoteTagged(project, text string, tags []string, now time.Time) error {
 	project = strings.TrimSpace(project)
 	if project == "" {
@@ -86,6 +127,9 @@ func AppendNoteTagged(project, text string, tags []string, now time.Time) error 
 	path := NotesFile()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
+	}
+	if noteAlreadyStored(path, project, strings.TrimSpace(text)) {
+		return ErrNoteExists
 	}
 	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("notes file is a symlink")

--- a/internal/sources/notes_dedup_test.go
+++ b/internal/sources/notes_dedup_test.go
@@ -1,0 +1,41 @@
+package sources
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The same conclusion saved twice — a long session, or two agents on one
+// machine — used to land twice and cost the agent a line of every later recall
+// for one fact (#1736).
+func TestRememberingTheSameNoteTwiceIsANoOp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	when := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
+
+	if err := AppendNote("api", "pgbouncer needs prepared statements off", when); err != nil {
+		t.Fatal(err)
+	}
+	err := AppendNote("api", "pgbouncer needs prepared statements off", when.Add(time.Minute))
+	if !errors.Is(err, ErrNoteExists) {
+		t.Errorf("a duplicate was accepted: %v", err)
+	}
+	// Same text, different project, is a different note.
+	if err := AppendNote("web", "pgbouncer needs prepared statements off", when); err != nil {
+		t.Errorf("another project was refused: %v", err)
+	}
+	// A near-duplicate is not a duplicate.
+	if err := AppendNote("api", "pgbouncer needs prepared statements off for now", when); err != nil {
+		t.Errorf("a longer note was refused: %v", err)
+	}
+	b, err := os.ReadFile(NotesFile())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(strings.TrimSpace(string(b)), "\n") + 1; n != 3 {
+		t.Errorf("notes file holds %d rows, want 3:\n%s", n, b)
+	}
+}


### PR DESCRIPTION
Closes #1736.

`remember` appended unconditionally, so the same conclusion saved twice printed twice in every later recall — three identical lines out of a 420-byte page in the repro. The write is now refused for an identical note under the same project (`sources.ErrNoteExists`), and both callers say so instead of failing: MCP answers `Already remembered under api.`, the CLI writes one line to stderr and exits 0.

The check reads `notes.jsonl` rather than the index — a note written a second ago is not indexed yet, and back-to-back saves are the case this exists for. Promoted notes (`kind` set) are skipped: those carry provenance and a lifecycle, and a `remember` is not a correction to one.

```
before  first note → Remembered · duplicate → Remembered · third → Remembered   (3 rows, 3 lines in recall)
after   first note → Remembered · duplicate → Already remembered · third → Already remembered   (1 row, 1 line)
```

Test: `TestRememberingTheSameNoteTwiceIsANoOp` — it also pins that the same text under another project, and a longer note, are still different notes.

Wording of "Already remembered under X." is yours to change; the mechanism is what the issue is about.