### PR TITLE
fix(doctor): name the zed, deepseek and omp stores it reads from

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -626,6 +626,16 @@ func doctorHarnesses(w io.Writer, dir string) {
 	printRow("openclaw", openclawRoot, doctorExists(openclawRoot), doctorCount(len(sources.OpenClawSessionFiles()), "file"))
 	copilotRoot := sources.CopilotRoot()
 	printFiles("copilot", copilotRoot, doctorExists(copilotRoot), sources.CopilotSessionFiles())
+	// omp, deepseek and zed are read by the indexer and were named by nothing
+	// here — a user of one of them had no row to check when their sessions did
+	// not come back (#1738). The registry decides what is indexed, and a test
+	// now holds these rows to it.
+	ompRoot := sources.OmpRoot()
+	printFiles("omp", ompRoot, doctorExists(ompRoot), sources.OmpSessionFiles())
+	dshRoot := sources.DeepSeekRoot()
+	printFiles("deepseek", dshRoot, doctorExists(dshRoot), sources.DeepSeekSessionFiles())
+	zedDB := sources.ZedDB()
+	printRow("zed", zedDB, doctorFilePresent(zedDB), doctorSQLiteDetail(zedDB, sqlite))
 	printRow("deja", sources.NotesFile(), doctorFilePresent(sources.NotesFile()), "notes")
 	if n := noteBucketsRegrouped(dir); n > 0 {
 		fmt.Fprintf(w, "  warning      %s of notes in the index %s not what this machine would build now — the zone changed, so the days regrouped; `deja index` renames them\n",

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -277,8 +277,18 @@ func doctorStoreChecks() []doctorStoreCheck {
 		// (#999).
 		{"cline", []string{sources.ClineSessionsDir()}, sources.ClineSessionFiles(), sources.ParseClineFile},
 		{"roo", sources.RooRoots(), sources.RooTaskFiles(), sources.ParseRooTask},
+		{"deepseek", []string{sources.DeepSeekRoot()}, sources.DeepSeekSessionFiles(), sources.ParseDeepSeekFile},
+		// Zed keeps one SQLite store rather than session files, so the file
+		// list is the database itself — the shape opencode's row uses.
+		{"zed", []string{sources.ZedDB()}, presentDoctorFile(sources.ZedDB()), doctorProbeZed},
 		{"deja", []string{sources.NotesFile()}, presentDoctorFile(sources.NotesFile()), sources.ParseNotesFile},
 	}
+}
+
+// doctorProbeZed reads the thread store the way the indexer does, so the row
+// says what a real read would find rather than that the file exists.
+func doctorProbeZed(path string) ([]model.Session, error) {
+	return sources.ParseZedDB(path)
 }
 
 func presentDoctorFile(path string) []string {

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -216,7 +216,7 @@ func firstDeniedDir(paths []string) (string, bool) {
 // storeNeedsSQLite3 names the harnesses deja reads through the sqlite3 CLI.
 func storeNeedsSQLite3(name string) bool {
 	switch name {
-	case "opencode", "cursor", "grok", "hermes", "goose":
+	case "opencode", "cursor", "grok", "hermes", "goose", "zed":
 		return true
 	}
 	return false

--- a/cmd/deja/doctor_store_coverage_test.go
+++ b/cmd/deja/doctor_store_coverage_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -63,4 +65,35 @@ func TestDoctorNamesEveryStoreTheIndexerReads(t *testing.T) {
 			t.Errorf("doctor --json never names the %s store", h.Name)
 		}
 	}
+}
+
+// The two forms have to agree about why a store cannot be read: the text row
+// names the missing sqlite3 CLI, and the JSON said "unreadable" — the split
+// #999 closed for the stores that existed then.
+func TestZedSaysWhySqliteIsWhatIsMissing(t *testing.T) {
+	tmp := hermeticEnv(t)
+	db := sources.ZedDB()
+	if err := os.MkdirAll(filepath.Dir(db), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(db, bytes.Repeat([]byte("x"), 64), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", "")
+	store, _ := inspectDoctorStore(doctorCheckNamed(t, "zed"))
+	if store.State != "needs-sqlite3" {
+		t.Errorf("zed without the sqlite3 CLI reports %q, while the text row names the CLI", store.State)
+	}
+	_ = tmp
+}
+
+func doctorCheckNamed(t *testing.T, name string) doctorStoreCheck {
+	t.Helper()
+	for _, c := range doctorStoreChecks() {
+		if c.name == name {
+			return c
+		}
+	}
+	t.Fatalf("no doctor store check named %q", name)
+	return doctorStoreCheck{}
 }

--- a/cmd/deja/doctor_store_coverage_test.go
+++ b/cmd/deja/doctor_store_coverage_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// doctor is the surface that answers "where did deja look", so a store it reads
+// and never names is a store whose absence from recall cannot be diagnosed.
+// Both lists are hand-written; the registry is the one that decides what is
+// indexed, so it is what they are checked against (#1738, the shape of #999).
+func TestDoctorNamesEveryStoreTheIndexerReads(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := tmp + "/index.db"
+
+	var text bytes.Buffer
+	if err := runDoctor(&text, nil, stubLookup("1.0.0", true), dir); err != nil {
+		t.Fatal(err)
+	}
+	rows := map[string]bool{}
+	inStores := false
+	for _, line := range strings.Split(text.String(), "\n") {
+		if strings.HasPrefix(line, "Harness stores:") {
+			inStores = true
+			continue
+		}
+		if inStores {
+			if strings.TrimSpace(line) == "" {
+				break
+			}
+			if f := strings.Fields(line); len(f) > 0 {
+				rows[f[0]] = true
+			}
+		}
+	}
+
+	var js bytes.Buffer
+	if err := runDoctor(&js, []string{"--json"}, stubLookup("1.0.0", true), dir); err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		Stores []struct {
+			Name string `json:"name"`
+		} `json:"stores"`
+	}
+	if err := json.Unmarshal(js.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	inJSON := map[string]bool{}
+	for _, s := range report.Stores {
+		inJSON[s.Name] = true
+	}
+
+	for _, h := range sources.Registry() {
+		if !rows[h.Name] {
+			t.Errorf("doctor never names the %s store in its Harness stores block", h.Name)
+		}
+		if !inJSON[h.Name] {
+			t.Errorf("doctor --json never names the %s store", h.Name)
+		}
+	}
+}

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -165,6 +165,24 @@
       "indexed_sessions": 0
     },
     {
+      "name": "deepseek",
+      "state": "missing",
+      "paths": [
+        "<tmp>/home/.dsh/sessions"
+      ],
+      "files": 0,
+      "indexed_sessions": 0
+    },
+    {
+      "name": "zed",
+      "state": "unplugged",
+      "paths": [
+        "<tmp>/zed/threads/threads.db"
+      ],
+      "files": 0,
+      "indexed_sessions": 0
+    },
+    {
       "name": "deja",
       "state": "missing",
       "paths": [


### PR DESCRIPTION
Closes #1738.

`deja sources` lists 21 stores, doctor's text rows printed 18 and its JSON 19 — zed, deepseek and omp were read by the indexer and named by neither surface, so a user of one of them had no row to check when their sessions did not come back. Both lists are hand-written; the registry is what decides what gets indexed, so `TestDoctorNamesEveryStoreTheIndexerReads` now holds both to `sources.Registry()` and the next harness cannot land in one and not the others.

On this machine the new rows read:

```
  omp          found     ~/.omp/agent/sessions  (12 files, 12 indexed sessions)
  deepseek     found     ~/.dsh/sessions  (22 files, 16 indexed sessions)
  zed          found     ~/Library/Application Support/Zed/threads/threads.db  (5.5 MB, 30 indexed sessions)
```

The zed row goes through the SQLite detail the opencode row uses, since Zed keeps one thread store rather than session files, and its JSON probe parses that store the way the indexer does. `testdata/doctor.json` regenerated for the two new JSON entries.