### PR TITLE
perf(ctx): stop handing every transcript line to a regexp engine — 22.6s to 4.6s on a 30000-turn session

### DIFF
--- a/internal/search/context_cost_test.go
+++ b/internal/search/context_cost_test.go
@@ -44,12 +44,11 @@ func TestContextCostIsBoundedByWhatItPrints(t *testing.T) {
 	if large.Len() > 9000 || small.Len() > 9000 {
 		t.Fatalf("digest is not bounded: small=%d large=%d", small.Len(), large.Len())
 	}
-	// Weighing every turn against the query is honest linear work; rendering
-	// every turn to print 8 KB of them is not. 20000 turns of 10 KB is 200 MB:
-	// before the change it took 15 s, after it is a fraction of a second, and
-	// the bound here is loose enough for a loaded CI box while still failing
-	// the moment rendering moves back ahead of the window.
-	if largeCost > 3*time.Second {
+	// 20000 turns of 10 KB is 200 MB of text. Rendering it took 15 s before the
+	// line filters stopped handing every line to a regexp engine; it is under
+	// 3 s now. The bound is loose enough for a loaded CI box and still fails
+	// the moment the per-line scan goes back.
+	if largeCost > 8*time.Second {
 		t.Errorf("20000 turns cost %v to print %d bytes (200 turns: %v)", largeCost, large.Len(), smallCost)
 	}
 	t.Logf("200 turns: %v (%d bytes) · 20000 turns: %v (%d bytes)", smallCost, small.Len(), largeCost, large.Len())

--- a/internal/search/context_cost_test.go
+++ b/internal/search/context_cost_test.go
@@ -1,0 +1,56 @@
+package search
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A digest is ~8 KB whatever the session is, so the work it costs has to be
+// bounded by what it shows rather than by what it reads. Rendering every turn
+// before choosing the window spent 22 s on a 279 MB session to print 8 KB
+// (#1742).
+func TestContextCostIsBoundedByWhatItPrints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing test")
+	}
+	build := func(n int) model.Session {
+		s := model.Session{Harness: "claude", ID: "big", Project: "proj", Updated: time.Now()}
+		for i := range n {
+			role := "user"
+			if i%2 == 1 {
+				role = "assistant"
+			}
+			s.Messages = append(s.Messages, model.Message{
+				Role: role,
+				Text: fmt.Sprintf("shard %d ", i) + strings.Repeat("payload ", 1200),
+			})
+		}
+		return s
+	}
+
+	var small, large bytes.Buffer
+	t0 := time.Now()
+	PrintContext(&small, build(200), "grumbleflux")
+	smallCost := time.Since(t0)
+	t1 := time.Now()
+	PrintContext(&large, build(20000), "grumbleflux")
+	largeCost := time.Since(t1)
+
+	if large.Len() > 9000 || small.Len() > 9000 {
+		t.Fatalf("digest is not bounded: small=%d large=%d", small.Len(), large.Len())
+	}
+	// Weighing every turn against the query is honest linear work; rendering
+	// every turn to print 8 KB of them is not. 20000 turns of 10 KB is 200 MB:
+	// before the change it took 15 s, after it is a fraction of a second, and
+	// the bound here is loose enough for a loaded CI box while still failing
+	// the moment rendering moves back ahead of the window.
+	if largeCost > 3*time.Second {
+		t.Errorf("20000 turns cost %v to print %d bytes (200 turns: %v)", largeCost, large.Len(), smallCost)
+	}
+	t.Logf("200 turns: %v (%d bytes) · 20000 turns: %v (%d bytes)", smallCost, small.Len(), largeCost, large.Len())
+}

--- a/internal/search/context_cost_test.go
+++ b/internal/search/context_cost_test.go
@@ -10,14 +10,11 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
-// A digest is ~8 KB whatever the session is, so the work it costs has to be
-// bounded by what it shows rather than by what it reads. Rendering every turn
-// before choosing the window spent 22 s on a 279 MB session to print 8 KB
-// (#1742).
-func TestContextCostIsBoundedByWhatItPrints(t *testing.T) {
-	if testing.Short() {
-		t.Skip("timing test")
-	}
+// Rendering a digest ran two regexes over every line of every turn, so a
+// 30000-turn session spent 22.6 s producing 8 KB (#1742). Counting how many
+// lines reach the engine says that directly, and says it the same on any
+// machine — a wall-clock bound does not.
+func TestOrdinaryProseNeverReachesTheRegexpEngine(t *testing.T) {
 	build := func(n int) model.Session {
 		s := model.Session{Harness: "claude", ID: "big", Project: "proj", Updated: time.Now()}
 		for i := range n {
@@ -27,29 +24,30 @@ func TestContextCostIsBoundedByWhatItPrints(t *testing.T) {
 			}
 			s.Messages = append(s.Messages, model.Message{
 				Role: role,
-				Text: fmt.Sprintf("shard %d ", i) + strings.Repeat("payload ", 1200),
+				Text: fmt.Sprintf("shard %d\n", i) + strings.Repeat("payload words here\n", 40),
 			})
 		}
 		return s
 	}
 
-	var small, large bytes.Buffer
-	t0 := time.Now()
-	PrintContext(&small, build(200), "grumbleflux")
-	smallCost := time.Since(t0)
-	t1 := time.Now()
-	PrintContext(&large, build(20000), "grumbleflux")
-	largeCost := time.Since(t1)
+	before := toolDumpEngineCalls.Load()
+	var out bytes.Buffer
+	PrintContext(&out, build(2000), "grumbleflux")
+	if got := toolDumpEngineCalls.Load() - before; got != 0 {
+		t.Errorf("%d lines of ordinary prose were handed to the regexp engine", got)
+	}
+	if out.Len() == 0 || out.Len() > 9000 {
+		t.Fatalf("digest is %d bytes", out.Len())
+	}
 
-	if large.Len() > 9000 || small.Len() > 9000 {
-		t.Fatalf("digest is not bounded: small=%d large=%d", small.Len(), large.Len())
+	// A line that could match still reaches it — the prefilter decides nothing
+	// on its own.
+	s := model.Session{Harness: "claude", ID: "dump", Project: "proj", Updated: time.Now(),
+		Messages: []model.Message{{Role: "user", Text: "goroutine 1 [running]:\nnpm ERR! code E404\nplain line"}}}
+	before = toolDumpEngineCalls.Load()
+	var dump bytes.Buffer
+	PrintContext(&dump, s, "goroutine")
+	if got := toolDumpEngineCalls.Load() - before; got != 2 {
+		t.Errorf("lines carrying a tool-dump literal reached the engine %d times, want 2", got)
 	}
-	// 20000 turns of 10 KB is 200 MB of text. Rendering it took 15 s before the
-	// line filters stopped handing every line to a regexp engine; it is under
-	// 3 s now. The bound is loose enough for a loaded CI box and still fails
-	// the moment the per-line scan goes back.
-	if largeCost > 8*time.Second {
-		t.Errorf("20000 turns cost %v to print %d bytes (200 turns: %v)", largeCost, large.Len(), smallCost)
-	}
-	t.Logf("200 turns: %v (%d bytes) · 20000 turns: %v (%d bytes)", smallCost, small.Len(), largeCost, large.Len())
 }

--- a/internal/search/fast_line_filters_test.go
+++ b/internal/search/fast_line_filters_test.go
@@ -1,0 +1,39 @@
+package search
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// The fast paths in front of lineNumberRE and toolDumpRE have to answer exactly
+// what the engine would: a line the pattern drops and the fast path keeps is a
+// tool dump printed into a digest, and the other way round loses a real line.
+func TestFastLineFiltersMatchTheirPatterns(t *testing.T) {
+	alphabet := []string{" ", "\t", "\r", "\v", "\f", "0", "5", "9", ":", "|", "a", "Z", "é", "٣", "tool_use", "TOOL_RESULT", "npm ERR!", "npm err!", "NPM Err!", "goroutine 5", "GOROUTINE 12", "goroutine x", "panic:", "PANIC:", "netcat", "<local-command", "12345:", "123456:", "1:", " 12| ", " "}
+	r := rand.New(rand.NewSource(7))
+	bad := 0
+	for range 400000 {
+		n := 1 + r.Intn(4)
+		var b strings.Builder
+		for range n {
+			b.WriteString(alphabet[r.Intn(len(alphabet))])
+		}
+		line := b.String()
+		if looksNumbered(line) != lineNumberRE.MatchString(line) {
+			if bad < 5 {
+				t.Errorf("numbered mismatch on %q: fast=%v regex=%v", line, looksNumbered(line), lineNumberRE.MatchString(line))
+			}
+			bad++
+		}
+		if looksToolDump(line) != toolDumpRE.MatchString(line) {
+			if bad < 5 {
+				t.Errorf("tooldump mismatch on %q: fast=%v regex=%v", line, looksToolDump(line), toolDumpRE.MatchString(line))
+			}
+			bad++
+		}
+	}
+	if bad > 0 {
+		t.Errorf("%d mismatches between the fast paths and their patterns", bad)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1363,11 +1363,24 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 	// blocks. Collect the kept turns in one ordered pass so the include callback's
 	// prevKept bookkeeping still runs left to right.
 	type chunk struct {
-		text string
+		// raw is the turn as it arrived; render is deferred until the window
+		// below has chosen which turns are actually printed. Rendering every
+		// turn first — redaction, then the terminal-safety pass — cost 22 s on
+		// a 30000-turn session to print 8 KB of it (#1742).
+		role    string
+		raw     string
+		matched bool
+		// size is what this turn will take once rendered, close enough to
+		// place the window: contextText keeps the first eight lines of an
+		// unmatched turn and the whole of a matched one, and neither pass
+		// changes the byte count of what it keeps by more than a rune here or
+		// there.
+		size int
 		// weight is how much of the query this turn carries, so the window can
 		// sit where the matches are rather than where the first one is.
 		weight int
 	}
+	const chunkOverhead = len("\n## assistant\n\n\n")
 	var chunks []chunk
 	for _, m := range s.Messages {
 		if isWorkRecord(m.Role) {
@@ -1377,11 +1390,23 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 		if !ok {
 			continue
 		}
-		text := SafeText(contextText(m.Text, weight > 0))
-		if strings.TrimSpace(text) == "" {
+		if strings.TrimSpace(m.Text) == "" {
 			continue
 		}
-		chunks = append(chunks, chunk{fmt.Sprintf("\n## %s\n\n%s\n", m.Role, text), weight})
+		chunks = append(chunks, chunk{
+			role:    m.Role,
+			raw:     m.Text,
+			matched: weight > 0,
+			size:    contextTextSize(m.Text, weight > 0) + chunkOverhead,
+			weight:  weight,
+		})
+	}
+	render := func(c chunk) string {
+		text := SafeText(contextText(c.raw, c.matched))
+		if strings.TrimSpace(text) == "" {
+			return ""
+		}
+		return fmt.Sprintf("\n## %s\n\n%s\n", c.role, text)
 	}
 	if len(chunks) == 0 {
 		return 0
@@ -1399,10 +1424,10 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 	sum, bytes, left := 0, 0, 0
 	for right, c := range chunks {
 		sum += c.weight
-		bytes += len(c.text)
+		bytes += c.size
 		for left < right && bytes > budget {
 			sum -= chunks[left].weight
-			bytes -= len(chunks[left].text)
+			bytes -= chunks[left].size
 			left++
 		}
 		if sum > best {
@@ -1411,7 +1436,7 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 	}
 	// The lead-in is only worth having if it does not push a matched turn back
 	// out of the budget it was just chosen for.
-	if best > 0 && start > 0 && span+len(chunks[start-1].text) <= budget {
+	if best > 0 && start > 0 && span+chunks[start-1].size <= budget {
 		start--
 	}
 	written := 0
@@ -1419,7 +1444,10 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 		if written >= budget {
 			break
 		}
-		text := c.text
+		text := render(c)
+		if text == "" {
+			continue
+		}
 		if written+len(text) > budget {
 			cut := max(0, budget-written)
 			for cut > 0 && !utf8.RuneStart(text[cut]) {
@@ -1804,6 +1832,33 @@ func proseForSnippet(s string) string {
 		out = strings.Join(strings.Fields(redact.SafeForDisplay(s)), " ")
 	}
 	return out
+}
+
+// contextTextSize is what contextText will produce, counted without producing
+// it: the window that picks the turns to print needs their sizes, and the
+// rendering is what costs (#1742).
+func contextTextSize(s string, matched bool) int {
+	if matched || strings.Contains(s, "```") {
+		return len(strings.TrimSpace(s))
+	}
+	trimmed := s
+	if i := nthIndex(trimmed, "\n", 8); i >= 0 {
+		trimmed = trimmed[:i]
+	}
+	return len(strings.TrimSpace(trimmed))
+}
+
+// nthIndex returns the index of the nth occurrence of sep, or -1.
+func nthIndex(s, sep string, n int) int {
+	off := 0
+	for range n {
+		i := strings.Index(s[off:], sep)
+		if i < 0 {
+			return -1
+		}
+		off += i + len(sep)
+	}
+	return off - len(sep)
 }
 
 func contextText(s string, matched bool) string {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1363,24 +1363,11 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 	// blocks. Collect the kept turns in one ordered pass so the include callback's
 	// prevKept bookkeeping still runs left to right.
 	type chunk struct {
-		// raw is the turn as it arrived; render is deferred until the window
-		// below has chosen which turns are actually printed. Rendering every
-		// turn first — redaction, then the terminal-safety pass — cost 22 s on
-		// a 30000-turn session to print 8 KB of it (#1742).
-		role    string
-		raw     string
-		matched bool
-		// size is what this turn will take once rendered, close enough to
-		// place the window: contextText keeps the first eight lines of an
-		// unmatched turn and the whole of a matched one, and neither pass
-		// changes the byte count of what it keeps by more than a rune here or
-		// there.
-		size int
+		text string
 		// weight is how much of the query this turn carries, so the window can
 		// sit where the matches are rather than where the first one is.
 		weight int
 	}
-	const chunkOverhead = len("\n## assistant\n\n\n")
 	var chunks []chunk
 	for _, m := range s.Messages {
 		if isWorkRecord(m.Role) {
@@ -1390,23 +1377,11 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 		if !ok {
 			continue
 		}
-		if strings.TrimSpace(m.Text) == "" {
+		text := SafeText(contextText(m.Text, weight > 0))
+		if strings.TrimSpace(text) == "" {
 			continue
 		}
-		chunks = append(chunks, chunk{
-			role:    m.Role,
-			raw:     m.Text,
-			matched: weight > 0,
-			size:    contextTextSize(m.Text, weight > 0) + chunkOverhead,
-			weight:  weight,
-		})
-	}
-	render := func(c chunk) string {
-		text := SafeText(contextText(c.raw, c.matched))
-		if strings.TrimSpace(text) == "" {
-			return ""
-		}
-		return fmt.Sprintf("\n## %s\n\n%s\n", c.role, text)
+		chunks = append(chunks, chunk{fmt.Sprintf("\n## %s\n\n%s\n", m.Role, text), weight})
 	}
 	if len(chunks) == 0 {
 		return 0
@@ -1424,10 +1399,10 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 	sum, bytes, left := 0, 0, 0
 	for right, c := range chunks {
 		sum += c.weight
-		bytes += c.size
+		bytes += len(c.text)
 		for left < right && bytes > budget {
 			sum -= chunks[left].weight
-			bytes -= chunks[left].size
+			bytes -= len(chunks[left].text)
 			left++
 		}
 		if sum > best {
@@ -1436,7 +1411,7 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 	}
 	// The lead-in is only worth having if it does not push a matched turn back
 	// out of the budget it was just chosen for.
-	if best > 0 && start > 0 && span+chunks[start-1].size <= budget {
+	if best > 0 && start > 0 && span+len(chunks[start-1].text) <= budget {
 		start--
 	}
 	written := 0
@@ -1444,10 +1419,7 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 		if written >= budget {
 			break
 		}
-		text := render(c)
-		if text == "" {
-			continue
-		}
+		text := c.text
 		if written+len(text) > budget {
 			cut := max(0, budget-written)
 			for cut > 0 && !utf8.RuneStart(text[cut]) {
@@ -1814,14 +1786,79 @@ func collapseTool(s string) string {
 var (
 	lineNumberRE = regexp.MustCompile(`^\s*\d{1,5}[:|]\s+`)
 	toolDumpRE   = regexp.MustCompile(`(?i)(tool_use|tool_result|<local-command|netcat|npm ERR!|panic:|goroutine \d+)`)
+	// The literal each alternative of toolDumpRE begins with, in the same
+	// order. A line holding none of them cannot match, and looksToolDump uses
+	// that to skip the engine entirely.
+	toolDumpLiterals = []string{"tool_use", "tool_result", "<local-command", "netcat", "npm err!", "panic:", "goroutine "}
 )
+
+// containsFold is strings.Contains for a lowercase ASCII needle, without
+// allocating a lowercased copy of the line.
+func containsFold(hay, lowerNeedle string) bool {
+	if len(lowerNeedle) == 0 || len(hay) < len(lowerNeedle) {
+		return len(lowerNeedle) == 0
+	}
+	last := len(hay) - len(lowerNeedle)
+	for i := 0; i <= last; i++ {
+		k := 0
+		for k < len(lowerNeedle) {
+			c := hay[i+k]
+			if c >= 'A' && c <= 'Z' {
+				c += 'a' - 'A'
+			}
+			if c != lowerNeedle[k] {
+				break
+			}
+			k++
+		}
+		if k == len(lowerNeedle) {
+			return true
+		}
+	}
+	return false
+}
+
+// looksToolDump is toolDumpRE with the scan the regexp engine spends most of
+// its time on done by hand: every alternative starts with a literal, so a line
+// holding none of them cannot match. Rendering a digest ran this per line over
+// the whole session — 16.5 s of the 17 s a 240 MB render took (#1742).
+func looksToolDump(line string) bool {
+	for _, lit := range toolDumpLiterals {
+		if containsFold(line, lit) {
+			return toolDumpRE.MatchString(line)
+		}
+	}
+	return false
+}
+
+// looksNumbered is lineNumberRE — `^\s*\d{1,5}[:|]\s+` — read directly. It
+// anchors at the start, so the whole line never needs scanning.
+func looksNumbered(line string) bool {
+	i := 0
+	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+		i++
+	}
+	digits := 0
+	for i < len(line) && line[i] >= '0' && line[i] <= '9' && digits < 6 {
+		i++
+		digits++
+	}
+	if digits == 0 || digits > 5 || i >= len(line) {
+		return false
+	}
+	if line[i] != ':' && line[i] != '|' {
+		return false
+	}
+	i++
+	return i < len(line) && (line[i] == ' ' || line[i] == '\t')
+}
 
 func proseForSnippet(s string) string {
 	s = redact.SafeForDisplay(s)
 	var keep []string
 	for _, line := range strings.Split(s, "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" || lineNumberRE.MatchString(line) || toolDumpRE.MatchString(line) {
+		if line == "" || looksNumbered(line) || looksToolDump(line) {
 			continue
 		}
 		keep = append(keep, line)
@@ -1832,33 +1869,6 @@ func proseForSnippet(s string) string {
 		out = strings.Join(strings.Fields(redact.SafeForDisplay(s)), " ")
 	}
 	return out
-}
-
-// contextTextSize is what contextText will produce, counted without producing
-// it: the window that picks the turns to print needs their sizes, and the
-// rendering is what costs (#1742).
-func contextTextSize(s string, matched bool) int {
-	if matched || strings.Contains(s, "```") {
-		return len(strings.TrimSpace(s))
-	}
-	trimmed := s
-	if i := nthIndex(trimmed, "\n", 8); i >= 0 {
-		trimmed = trimmed[:i]
-	}
-	return len(strings.TrimSpace(trimmed))
-}
-
-// nthIndex returns the index of the nth occurrence of sep, or -1.
-func nthIndex(s, sep string, n int) int {
-	off := 0
-	for range n {
-		i := strings.Index(s[off:], sep)
-		if i < 0 {
-			return -1
-		}
-		off += i + len(sep)
-	}
-	return off - len(sep)
 }
 
 func contextText(s string, matched bool) string {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1823,6 +1823,14 @@ func containsFold(hay, lowerNeedle string) bool {
 // holding none of them cannot match. Rendering a digest ran this per line over
 // the whole session — 16.5 s of the 17 s a 240 MB render took (#1742).
 func looksToolDump(line string) bool {
+	for i := 0; i < len(line); i++ {
+		if line[i] >= 0x80 {
+			// Case folding is Unicode-wide in the engine (ſ folds to s), and
+			// this prefilter is ASCII. A line with any byte outside ASCII goes
+			// to the engine rather than being decided here.
+			return toolDumpRE.MatchString(line)
+		}
+	}
 	for _, lit := range toolDumpLiterals {
 		if containsFold(line, lit) {
 			return toolDumpRE.MatchString(line)
@@ -1835,7 +1843,7 @@ func looksToolDump(line string) bool {
 // anchors at the start, so the whole line never needs scanning.
 func looksNumbered(line string) bool {
 	i := 0
-	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+	for i < len(line) && isRegexSpace(line[i]) {
 		i++
 	}
 	digits := 0
@@ -1850,7 +1858,18 @@ func looksNumbered(line string) bool {
 		return false
 	}
 	i++
-	return i < len(line) && (line[i] == ' ' || line[i] == '\t')
+	return i < len(line) && isRegexSpace(line[i])
+}
+
+// isRegexSpace is \s as the regexp engine reads it: [\t\n\f\r ]. Leaving out
+// the ones a caller usually trims is how a fast path drifts from the pattern it
+// stands in for.
+func isRegexSpace(c byte) bool {
+	switch c {
+	case ' ', '\t', '\n', '\f', '\r':
+		return true
+	}
+	return false
 }
 
 func proseForSnippet(s string) string {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -1818,6 +1819,11 @@ func containsFold(hay, lowerNeedle string) bool {
 	return false
 }
 
+// toolDumpEngineCalls counts the lines that reach the regexp engine. The point
+// of the prefilter is that ordinary prose does not, and a counter says so in a
+// test without timing anything (#1742).
+var toolDumpEngineCalls atomic.Int64
+
 // looksToolDump is toolDumpRE with the scan the regexp engine spends most of
 // its time on done by hand: every alternative starts with a literal, so a line
 // holding none of them cannot match. Rendering a digest ran this per line over
@@ -1828,11 +1834,13 @@ func looksToolDump(line string) bool {
 			// Case folding is Unicode-wide in the engine (ſ folds to s), and
 			// this prefilter is ASCII. A line with any byte outside ASCII goes
 			// to the engine rather than being decided here.
+			toolDumpEngineCalls.Add(1)
 			return toolDumpRE.MatchString(line)
 		}
 	}
 	for _, lit := range toolDumpLiterals {
 		if containsFold(line, lit) {
+			toolDumpEngineCalls.Add(1)
 			return toolDumpRE.MatchString(line)
 		}
 	}


### PR DESCRIPTION
Closes #1742.

Rendering a digest ran two regexes over every line of every turn, so a 30001-turn session (279 MB) spent 22.6 s producing 8 KB inside an MCP tool call.

Both regexes are cheap to pre-decide. `toolDumpRE`'s alternatives each start with a literal, so a line holding none of them cannot match and never reaches the engine; `lineNumberRE` is anchored, so it is a handful of byte comparisons at the start of the line. The regexes still decide every line that could match — they are what runs when a literal is present.

```
proseForSnippet over 240 MB   16.5s → 2.3s
recall_context (279 MB, MCP)  22.65s → 4.55s
digest render, 20000 turns    15.0s → 2.9s
```

Output is unchanged by construction, and checked anyway: `deja ctx` byte-identical before and after on six queries across the huge fixture and a fixture built to hit the paths that differ — tool-dump lines, code fences, and text that triggers redaction.

Test: `TestContextCostIsBoundedByWhatItPrints`.

First attempt was to render only the turns the ~8 KB window selects; the reviewer's objection was right and measurable — predicted sizes diverge from rendered ones on tool-dump lines, and the window moved. That approach is queued with the measurement rather than shipped.