### PR TITLE
fix(index): follow a store directory that is a symlink instead of calling it empty

### DIFF
--- a/internal/sources/cursor.go
+++ b/internal/sources/cursor.go
@@ -82,7 +82,8 @@ func CursorDBs() []string {
 func CursorTranscripts() []string {
 	root := filepath.Join(CursorCLIRoot(), "projects")
 	var out []string
-	_ = filepath.WalkDir(resolvedRoot(root), func(p string, d os.DirEntry, err error) error {
+	walked, under := walkRoot(root)
+	_ = filepath.WalkDir(walked, func(p string, d os.DirEntry, err error) error {
 		// Regular files only: a FIFO matching the glob would block the
 		// parser's Open forever (same hang walkFiles guards against).
 		if err != nil || !d.Type().IsRegular() {
@@ -95,7 +96,7 @@ func CursorTranscripts() []string {
 			return nil
 		}
 		if cursorPathHasDir(p, "agent-transcripts") {
-			out = append(out, p)
+			out = append(out, under(p))
 		}
 		return nil
 	})

--- a/internal/sources/cursor.go
+++ b/internal/sources/cursor.go
@@ -82,7 +82,7 @@ func CursorDBs() []string {
 func CursorTranscripts() []string {
 	root := filepath.Join(CursorCLIRoot(), "projects")
 	var out []string
-	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+	_ = filepath.WalkDir(resolvedRoot(root), func(p string, d os.DirEntry, err error) error {
 		// Regular files only: a FIFO matching the glob would block the
 		// parser's Open forever (same hang walkFiles guards against).
 		if err != nil || !d.Type().IsRegular() {

--- a/internal/sources/gemini.go
+++ b/internal/sources/gemini.go
@@ -44,11 +44,12 @@ func GeminiChatFiles() []string {
 			continue
 		}
 		chats := filepath.Join(root, e.Name(), "chats")
-		_ = filepath.WalkDir(resolvedRoot(chats), func(p string, d os.DirEntry, err error) error {
+		walked, under := walkRoot(chats)
+		_ = filepath.WalkDir(walked, func(p string, d os.DirEntry, err error) error {
 			// Regular files only: a FIFO matching the glob would block the
 			// parser's Open forever (same hang walkFiles guards against).
 			if err == nil && d.Type().IsRegular() && (strings.HasSuffix(p, ".json") || strings.HasSuffix(p, ".jsonl")) {
-				out = append(out, p)
+				out = append(out, under(p))
 			}
 			return nil
 		})

--- a/internal/sources/gemini.go
+++ b/internal/sources/gemini.go
@@ -44,7 +44,7 @@ func GeminiChatFiles() []string {
 			continue
 		}
 		chats := filepath.Join(root, e.Name(), "chats")
-		_ = filepath.WalkDir(chats, func(p string, d os.DirEntry, err error) error {
+		_ = filepath.WalkDir(resolvedRoot(chats), func(p string, d os.DirEntry, err error) error {
 			// Regular files only: a FIFO matching the glob would block the
 			// parser's Open forever (same hang walkFiles guards against).
 			if err == nil && d.Type().IsRegular() && (strings.HasSuffix(p, ".json") || strings.HasSuffix(p, ".jsonl")) {

--- a/internal/sources/symlink_root_test.go
+++ b/internal/sources/symlink_root_test.go
@@ -1,0 +1,70 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A store reached through a symlink is the store: people put ~/.claude in a
+// dotfiles repo, on an external disk, in a synced folder. Walking the link
+// itself found nothing and every surface called the store found and empty
+// (#1744).
+func TestASymlinkedStoreRootIsWalked(t *testing.T) {
+	tmp := t.TempDir()
+	real := filepath.Join(tmp, "real", "proj")
+	if err := os.MkdirAll(real, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"s1","cwd":"/w","timestamp":"2026-08-07T01:00:00Z","message":{"role":"user","content":"quibbleknot"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(real, "a.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(tmp, "link")
+	if err := os.Symlink(filepath.Join(tmp, "real"), link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	direct := walkFiles(filepath.Join(tmp, "real"), func(p string) bool { return filepath.Ext(p) == ".jsonl" })
+	if len(direct) != 1 {
+		t.Fatalf("the fixture is wrong: the real path yielded %v", direct)
+	}
+	through := walkFiles(link, func(p string) bool { return filepath.Ext(p) == ".jsonl" })
+	if len(through) != 1 {
+		t.Errorf("a symlinked store root yielded %v, while its real path yielded %v", through, direct)
+	}
+}
+
+// A link inside a store still is not followed — that is what keeps a FIFO from
+// hanging the build and a link from walking out of the store — and a loop does
+// not stop the walk.
+func TestLinksInsideAStoreAreStillSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	store := filepath.Join(tmp, "store", "proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"s1","cwd":"/w","timestamp":"2026-08-07T01:00:00Z","message":{"role":"user","content":"quibbleknot"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "a.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(tmp, "outside.jsonl")
+	if err := os.WriteFile(outside, []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(store, "linked.jsonl")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	loop := filepath.Join(tmp, "store", "loop")
+	if err := os.MkdirAll(loop, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(loop, filepath.Join(loop, "self")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	got := walkFiles(filepath.Join(tmp, "store"), func(p string) bool { return filepath.Ext(p) == ".jsonl" })
+	if len(got) != 1 {
+		t.Errorf("walk returned %v, want only the real file", got)
+	}
+}

--- a/internal/sources/symlink_root_test.go
+++ b/internal/sources/symlink_root_test.go
@@ -99,3 +99,56 @@ func TestWalkReportsPathsUnderTheConfiguredRoot(t *testing.T) {
 		t.Errorf("the reported path does not open: %v", err)
 	}
 }
+
+// cursor and gemini walk a path built under their configured root, so a link
+// *at* that path — ~/.cursor/projects pointing elsewhere, a chats directory
+// moved off the disk — is the case they have to follow. A link higher up was
+// never broken for them: the walk starts below it and the path resolves on the
+// way in.
+func TestCursorAndGeminiFollowASymlinkedWalkRoot(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
+
+	cursorRoot := filepath.Join(tmp, "cursor")
+	if err := os.MkdirAll(cursorRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realProjects := filepath.Join(tmp, "projects-elsewhere", "p", "agent-transcripts")
+	if err := os.MkdirAll(realProjects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realProjects, "t.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(tmp, "projects-elsewhere"), filepath.Join(cursorRoot, "projects")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	t.Setenv("DEJA_CURSOR_CLI_ROOT", cursorRoot)
+	got := CursorTranscripts()
+	want := filepath.Join(cursorRoot, "projects", "p", "agent-transcripts", "t.jsonl")
+	if len(got) != 1 || got[0] != want {
+		t.Errorf("cursor through a symlinked projects directory: %v, want [%s]", got, want)
+	}
+
+	geminiRoot := filepath.Join(tmp, "gemini")
+	if err := os.MkdirAll(filepath.Join(geminiRoot, "tmp", "hash"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realChats := filepath.Join(tmp, "chats-elsewhere")
+	if err := os.MkdirAll(realChats, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realChats, "c.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realChats, filepath.Join(geminiRoot, "tmp", "hash", "chats")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	t.Setenv("DEJA_GEMINI_ROOT", geminiRoot)
+	gots := GeminiChatFiles()
+	wantG := filepath.Join(geminiRoot, "tmp", "hash", "chats", "c.json")
+	if len(gots) != 1 || gots[0] != wantG {
+		t.Errorf("gemini through a symlinked chats directory: %v, want [%s]", gots, wantG)
+	}
+}

--- a/internal/sources/symlink_root_test.go
+++ b/internal/sources/symlink_root_test.go
@@ -68,3 +68,34 @@ func TestLinksInsideAStoreAreStillSkipped(t *testing.T) {
 		t.Errorf("walk returned %v, want only the real file", got)
 	}
 }
+
+// The paths that come back are the ones the user configured. Everything
+// downstream keys on them — the kind predicates test strings.HasPrefix against
+// the root, the manifest records them, the incremental pass looks them up — and
+// two spellings of one file lose the file: the first attempt at #1744 walked
+// the target and reported its paths, and the next incremental run indexed the
+// store back down to nothing.
+func TestWalkReportsPathsUnderTheConfiguredRoot(t *testing.T) {
+	tmp := t.TempDir()
+	real := filepath.Join(tmp, "real", "proj")
+	if err := os.MkdirAll(real, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(real, "a.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(tmp, "link")
+	if err := os.Symlink(filepath.Join(tmp, "real"), link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	got := walkFiles(link, func(p string) bool { return filepath.Ext(p) == ".jsonl" })
+	if len(got) != 1 {
+		t.Fatalf("walk returned %v", got)
+	}
+	if want := filepath.Join(link, "proj", "a.jsonl"); got[0] != want {
+		t.Errorf("walk reported %q, want %q — the configured root", got[0], want)
+	}
+	if _, err := os.Stat(got[0]); err != nil {
+		t.Errorf("the reported path does not open: %v", err)
+	}
+}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -292,7 +292,22 @@ func resolvedRoot(root string) string {
 
 func walkFiles(root string, pred func(string) bool) []string {
 	var out []string
-	_ = filepath.WalkDir(resolvedRoot(root), func(p string, d os.DirEntry, err error) error {
+	// Walk the target, report paths under the configured root: everything
+	// downstream — the kind predicates that test strings.HasPrefix against the
+	// root, the manifest, the incremental offsets — keys on the path the user
+	// configured, and handing it two spellings of one file loses the file.
+	walked := resolvedRoot(root)
+	under := func(p string) string {
+		if walked == root {
+			return p
+		}
+		rel, err := filepath.Rel(walked, p)
+		if err != nil {
+			return p
+		}
+		return filepath.Join(root, rel)
+	}
+	_ = filepath.WalkDir(walked, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			// A directory the process cannot read takes its sessions out of
 			// recall. Dropping the error here left the index run with nothing
@@ -308,8 +323,8 @@ func walkFiles(root string, pred func(string) bool) []string {
 		// no writer and never returns, so one such file in a scanned store
 		// froze indexing for good. IsRegular already excludes symlinks and
 		// directories, so it subsumes the checks it replaces.
-		if d.Type().IsRegular() && pred(p) {
-			out = append(out, p)
+		if q := under(p); d.Type().IsRegular() && pred(q) {
+			out = append(out, q)
 		}
 		return nil
 	})

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -268,9 +268,31 @@ func keepRegular(paths []string) []string {
 	return out
 }
 
+// resolvedRoot follows a store root that is itself a symlink. People keep
+// ~/.claude in a dotfiles repo, on an external disk, in a synced folder;
+// WalkDir lstats its root, so the walk saw a symlink rather than a directory
+// and descended nowhere — the store indexed nothing while every surface called
+// it found and empty (#1744). Only the root: a link inside a store is still
+// skipped, which is what keeps a FIFO from hanging the build and a link from
+// walking out of the store.
+func resolvedRoot(root string) string {
+	fi, err := os.Lstat(root)
+	if err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		return root
+	}
+	target, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return root
+	}
+	if st, err := os.Stat(target); err != nil || !st.IsDir() {
+		return root
+	}
+	return target
+}
+
 func walkFiles(root string, pred func(string) bool) []string {
 	var out []string
-	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+	_ = filepath.WalkDir(resolvedRoot(root), func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			// A directory the process cannot read takes its sessions out of
 			// recall. Dropping the error here left the index run with nothing

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -290,23 +290,32 @@ func resolvedRoot(root string) string {
 	return target
 }
 
-func walkFiles(root string, pred func(string) bool) []string {
-	var out []string
-	// Walk the target, report paths under the configured root: everything
-	// downstream — the kind predicates that test strings.HasPrefix against the
-	// root, the manifest, the incremental offsets — keys on the path the user
-	// configured, and handing it two spellings of one file loses the file.
+// walkRoot returns the directory to walk for a configured root and a function
+// putting each walked path back under that root. Walking the target is what
+// makes a symlinked store readable; reporting the configured spelling is what
+// keeps it usable, since the kind predicates test strings.HasPrefix against the
+// root and the manifest and the incremental pass key on the same string.
+func walkRoot(root string) (string, func(string) string) {
 	walked := resolvedRoot(root)
-	under := func(p string) string {
-		if walked == root {
-			return p
-		}
+	if walked == root {
+		return root, func(p string) string { return p }
+	}
+	return walked, func(p string) string {
 		rel, err := filepath.Rel(walked, p)
 		if err != nil {
 			return p
 		}
 		return filepath.Join(root, rel)
 	}
+}
+
+func walkFiles(root string, pred func(string) bool) []string {
+	var out []string
+	// Walk the target, report paths under the configured root: everything
+	// downstream — the kind predicates that test strings.HasPrefix against the
+	// root, the manifest, the incremental offsets — keys on the path the user
+	// configured, and handing it two spellings of one file loses the file.
+	walked, under := walkRoot(root)
 	_ = filepath.WalkDir(walked, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			// A directory the process cannot read takes its sessions out of


### PR DESCRIPTION
Closes #1744.

`filepath.WalkDir` lstats its root, so a store kept behind a symlink — dotfiles repo, external disk, synced folder — was visited as one symlink entry and never descended into. deja indexed nothing and said `found … (0 files)`.

Only the root is resolved. A link *inside* a store is still skipped: that is what keeps a FIFO from hanging the build and a link from walking out of the store, and `TestLinksInsideAStoreAreStillSkipped` pins it, loop included.

```
before  deja: index is up to date (0 sessions)   ·  doctor: claude found /…/claude-link (0 files)
after   deja: claude: 1 session, 1 message       ·  doctor: claude found /…/claude-link (1 file, 1 indexed session)
```

`cursor.go` and `gemini.go` walk their own roots and get the same treatment.

Tests: `TestASymlinkedStoreRootIsWalked` (fails before) and `TestLinksInsideAStoreAreStillSkipped`.