### PR TITLE
mcp: answer ping and resources/templates/list

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -142,6 +142,18 @@ func handleMCP(dir string, req rpcRequest) (any, int, string) {
 				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"text": map[string]any{"type": "string", "description": "A durable fact, decision, or conclusion to remember."}, "project": map[string]any{"type": "string", "description": "Optional project name; defaults to notes."}, "tags": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Optional navigation tags, searchable as #tag."}}, "required": []string{"text"}},
 			},
 		}}, 0, ""
+	case "ping":
+		// Part of the spec at the version we claim, and both sides must
+		// answer it with an empty result. A host that pings for keepalive
+		// is entitled to read an error as a stale connection and drop the
+		// server, so this cannot fall through to -32601.
+		return map[string]any{}, 0, ""
+	case "resources/templates/list":
+		// We declare a resources capability, so clients ask for its
+		// templates. deja exposes concrete session resources and no URI
+		// templates, and the empty list is the shape that says so —
+		// an error here reads as a broken capability.
+		return map[string]any{"resourceTemplates": []map[string]any{}}, 0, ""
 	case "resources/list":
 		return mcpResourcesList(dir)
 	case "resources/read":

--- a/cmd/deja/mcp_contract_test.go
+++ b/cmd/deja/mcp_contract_test.go
@@ -314,3 +314,65 @@ func TestRecallReturnsTheDecisionNotOnlyTheQuestion(t *testing.T) {
 		t.Fatalf("recall dropped the question:\n%s", got)
 	}
 }
+
+// TestMCPPingAndResourceTemplates covers #1720: neither `ping` nor
+// `resources/templates/list` had a case in handleMCP, so both fell through
+// to -32601. A host that pings for keepalive reads that error as a stale
+// connection and drops the server, and we declare a resources capability,
+// so clients ask for its templates as a matter of course.
+func TestMCPPingAndResourceTemplates(t *testing.T) {
+	hermeticEnv(t)
+
+	resp := driveMCP(t,
+		`{"jsonrpc":"2.0","id":1,"method":"ping"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"resources/templates/list","params":{}}`,
+	)
+	if len(resp) != 2 {
+		t.Fatalf("got %d responses, want 2: %#v", len(resp), resp)
+	}
+
+	for _, r := range resp {
+		if e, ok := r["error"]; ok {
+			t.Fatalf("response %v carried an error: %#v", r["id"], e)
+		}
+	}
+
+	ping, ok := resp[0]["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("ping result is not an object: %#v", resp[0])
+	}
+	if len(ping) != 0 {
+		t.Errorf("ping result = %#v, want an empty object", ping)
+	}
+
+	templates, ok := resp[1]["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("resources/templates/list result is not an object: %#v", resp[1])
+	}
+	list, ok := templates["resourceTemplates"].([]any)
+	if !ok {
+		t.Fatalf("result has no resourceTemplates array: %#v", templates)
+	}
+	if len(list) != 0 {
+		t.Errorf("resourceTemplates = %#v, want an empty array", list)
+	}
+}
+
+// TestMCPUndeclaredMethodStillErrors is the control for the case above: the
+// fix must add exactly the two spec methods, not turn the default branch
+// into a catch-all that answers anything.
+func TestMCPUndeclaredMethodStillErrors(t *testing.T) {
+	hermeticEnv(t)
+
+	resp := driveMCP(t, `{"jsonrpc":"2.0","id":1,"method":"prompts/list","params":{}}`)
+	if len(resp) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resp))
+	}
+	e, ok := resp[0]["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("prompts/list did not error: %#v", resp[0])
+	}
+	if code, _ := e["code"].(float64); code != -32601 {
+		t.Errorf("prompts/list error code = %v, want -32601", e["code"])
+	}
+}


### PR DESCRIPTION
Closes #1720.

`handleMCP` had no case for either method, so both fell through to the `-32601` default:

```
ping                       ERROR {'code': -32601, 'message': 'method not found'}
resources/templates/list   ERROR {'code': -32601, 'message': 'method not found'}
```

`ping` is in the spec at the version we claim (`2024-11-05`) and both sides must answer it with an empty result — a host using it for keepalive is entitled to read the error as a stale connection and drop the server. We declare a `resources` capability, so clients ask for its templates as a matter of course; deja exposes concrete session resources and no URI templates, and the empty list is the shape that says so.

## One deviation from the issue text

The issue writes the expected payload as `{"resources_templates":[]}`. I used **`resourceTemplates`**, the key the MCP schema defines and what clients actually read — `resources_templates` would parse as a result with no template list at all, leaving the client no better off than with the error. I took that for a slip in the probe script rather than an intended shape; say the word if you meant otherwise.

## Tests

- `TestMCPPingAndResourceTemplates` (new) — drives both methods through `driveMCP`, i.e. `serveMCP` over the real stdio framing, asserting neither carries an `error`, that `ping` returns an empty object, and that `resourceTemplates` is present and empty. Fails on `main` with the exact `-32601` from the issue.
- `TestMCPUndeclaredMethodStillErrors` (new) — the control: `prompts/list` must still return `-32601`, since we declare no prompts capability. Without it, a fix that turned the default branch into a catch-all would pass the test above.

Hermetic via the existing `hermeticEnv(t)`; neither method touches the index, so no store seeding is needed.

## Verification

```text
go test ./... -race -count=1     # all pass
go vet ./...                     # clean
go build ./cmd/deja              # ok
gofmt -s -l cmd/deja/            # no output

go test ./cmd/deja/ -coverprofile=coverage.out
ok  github.com/vshulcz/deja-vu/cmd/deja  65.377s  coverage: 89.8% of statements
go tool cover -func=coverage.out | tail -1
total: (statements) 89.9%
```

`cmd/deja` floor is 88; this stays above it.

## Notes for reviewers

I did not touch the `initialize` capabilities block. Answering `ping` needs no declaration, and `resources/templates/list` is covered by the `resources` capability we already send.

The branch is based on `884ac6b` rather than current `main`: my token lacks the `workflow` scope, so I cannot push a branch that carries the newer `.github/workflows/hol-plugin-scanner.yml`. The change itself touches only `cmd/deja/mcp.go` and `cmd/deja/mcp_contract_test.go`, so it should rebase cleanly — tell me if you'd rather I find another way to get it onto the current tip.