### PR TITLE
warmup: name the phase before it is written

### DIFF
--- a/cmd/deja/warmup_status.go
+++ b/cmd/deja/warmup_status.go
@@ -121,17 +121,29 @@ func readWarmupStatus(dir string) *warmupStatus {
 	return &st
 }
 
+// phaseName is the phase to show. A status file can exist with its phase not
+// yet written, and every caller wraps this fragment in a parenthetical or a
+// sentence, so an empty phase renders as "()" — a sentence deja wrote about
+// itself, with nothing in it. Both fragments substitute the same word rather
+// than each guarding separately, so they cannot drift apart again.
+func (s *warmupStatus) phaseName() string {
+	if s.Phase == "" {
+		return "starting"
+	}
+	return s.Phase
+}
+
 // progress is the bare "phase 42%" fragment, for callers that supply their
 // own sentence.
 func (s *warmupStatus) progress() string {
 	if s.Total <= 0 {
-		return s.Phase
+		return s.phaseName()
 	}
 	p := 100 * s.Done / s.Total
 	if p > 100 {
 		p = 100
 	}
-	return fmt.Sprintf("%s %d%%", s.Phase, p)
+	return fmt.Sprintf("%s %d%%", s.phaseName(), p)
 }
 
 // line is the one-sentence status a host can show its user. It names what is
@@ -146,11 +158,7 @@ func (s *warmupStatus) line() string {
 		}
 		pct = fmt.Sprintf(" %d%%", p)
 	}
-	phase := s.Phase
-	if phase == "" {
-		phase = "starting"
-	}
-	return fmt.Sprintf("deja: indexing your history (%s%s) — recall comes online in a few seconds", phase, pct)
+	return fmt.Sprintf("deja: indexing your history (%s%s) — recall comes online in a few seconds", s.phaseName(), pct)
 }
 
 // publishBuildProgress installs the file sink for the work that happens before

--- a/cmd/deja/warmup_status_test.go
+++ b/cmd/deja/warmup_status_test.go
@@ -249,3 +249,40 @@ func TestOpencodePluginIndexesBeforeCompaction(t *testing.T) {
 		t.Fatalf("compaction hook does not index:\n%s", src)
 	}
 }
+
+// TestWarmupProgressNamesAnUnwrittenPhase covers #1731: a status file that
+// exists but has not had its phase written yet left progress() returning "",
+// and every caller wraps that fragment in a parenthetical — so the sentence
+// handed to an agent was "deja is indexing this machine's history ()."
+func TestWarmupProgressNamesAnUnwrittenPhase(t *testing.T) {
+	tests := []struct {
+		name string
+		st   warmupStatus
+		want string
+	}{
+		{name: "phase not yet written, no total", st: warmupStatus{}, want: "starting"},
+		{name: "phase not yet written, with total", st: warmupStatus{Done: 1, Total: 4}, want: "starting 25%"},
+		{name: "phase written, no total", st: warmupStatus{Phase: "finding transcripts…"}, want: "finding transcripts…"},
+		{name: "phase written, with total", st: warmupStatus{Phase: "indexing messages", Done: 1, Total: 4}, want: "indexing messages 25%"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.st.progress(); got != tt.want {
+				t.Errorf("progress() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWarmupSentencesNeverShowAnEmptyParenthetical is the property the fix
+// exists to protect, asserted on the rendered sentences rather than on the
+// fragment: no surface may hand a user or an agent "()".
+func TestWarmupSentencesNeverShowAnEmptyParenthetical(t *testing.T) {
+	st := &warmupStatus{}
+	for _, got := range []string{st.progress(), st.line()} {
+		if got == "" || strings.Contains(got, "()") {
+			t.Errorf("rendered %q with an unwritten phase, want a named phase", got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1731.

A status file can exist with its phase not yet written. `progress()` returned `s.Phase` unguarded, and every caller wraps that fragment in a parenthetical, so the sentence handed to a model was:

```
deja is indexing this machine's history (). Recall comes online in a few seconds; ask again then.
```

`line()` already substituted `starting` for an empty phase. This moves that substitution into a `phaseName()` helper and routes both fragments through it, so the guard cannot be present on one sentence and missing from the other again — which is exactly how this bug arose.

## Two things wider than the issue text

**It is not only the agent sentence.** `progress()` has five callers, all of which wrap it: `buildingNowForAgent` (`mcp.go:1022`), the statusline (`statusline.go:48`), the still-building recall notice (`warmup_status.go:217`), the MCP instructions block, and `doctor`'s `status building now (%s)` row. Guarding at the one call site the issue names would have left the other four rendering `()`. Fixing `progress()` itself fixes all five, and is why the diff is smaller than the blast radius.

**There is a second shape.** The issue reproduces the empty phase with no total. When the total *is* known and the phase is not yet written, the old code returned `" 25%"`, rendering as `"( 25%)"` — a leading space inside the parenthesis. Same root cause, same fix; the test covers both.

I kept `starting`, the word `line()` already used, rather than dropping the parenthetical — it matches the human-facing sentence and reads as a phase name next to `finding transcripts…`.

## Tests

- `TestWarmupProgressNamesAnUnwrittenPhase` (new, table-driven) — all four combinations of phase written/unwritten × total known/unknown. Two subtests fail on `main`: `progress() = "", want "starting"` and `progress() = " 25%", want "starting 25%"`.
- `TestWarmupSentencesNeverShowAnEmptyParenthetical` (new) — asserts the property on the rendered output of both `progress()` and `line()` rather than on the fragment, so a future caller cannot reintroduce `()` by formatting around the guard.
- `TestWarmupProgressFragment` and `TestWarmupStatusLineReadsLikeASentence` — unchanged, both still pass.

Pure value formatting, no I/O, so no environment setup is needed.

## Verification

```text
go test ./... -race -count=1     # all pass
go vet ./...                     # clean
go build ./cmd/deja              # ok
gofmt -s -l cmd/deja/            # no output

go test ./cmd/deja/ -coverprofile=coverage.out
ok  github.com/vshulcz/deja-vu/cmd/deja  91.708s  coverage: 89.8% of statements
go tool cover -func=coverage.out | tail -1
total: (statements) 89.9%
```

`cmd/deja` floor is 88; this stays above it.

## Note for reviewers

Based on `884ac6b` rather than current `main` for the same reason as #1746: my token lacks the `workflow` scope and cannot push a branch carrying the newer `.github/workflows/hol-plugin-scanner.yml`. This touches only `cmd/deja/warmup_status.go` and its test, so it should rebase cleanly.