### PR TITLE
fix(doctor): name the transcript it may not open instead of blaming the harness format

### DIFF
--- a/cmd/deja/doctor_denied_file_test.go
+++ b/cmd/deja/doctor_denied_file_test.go
@@ -58,3 +58,51 @@ func TestAnUnreadableFileIsDeniedAndNamed(t *testing.T) {
 	}
 	_ = tmp
 }
+
+// "Partly readable" has to mean something read. A store whose files are all
+// locked is not partly anything.
+func TestAWhollyLockedStoreIsNotCalledPartlyReadable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root reads everything")
+	}
+	hermeticEnv(t)
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var locked []string
+	for _, name := range []string{"a.jsonl", "b.jsonl"} {
+		p := filepath.Join(proj, name)
+		body := `{"type":"user","sessionId":"` + name + `","cwd":"/w","timestamp":"2026-08-08T01:00:00Z","message":{"role":"user","content":"flumberjack"}}` + "\n"
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(p, 0o000); err != nil {
+			t.Skipf("cannot lock a file here: %v", err)
+		}
+		locked = append(locked, p)
+	}
+	t.Cleanup(func() {
+		for _, p := range locked {
+			_ = os.Chmod(p, 0o600)
+		}
+	})
+	if f, err := os.Open(locked[0]); err == nil {
+		_ = f.Close()
+		t.Skip("this filesystem ignores the mode")
+	}
+
+	var check doctorStoreCheck
+	for _, c := range doctorStoreChecks() {
+		if c.name == "claude" {
+			check = c
+		}
+	}
+	store, _ := inspectDoctorStore(check)
+	if store.State != "denied" {
+		t.Errorf("state %q, want denied", store.State)
+	}
+	if store.Partial {
+		t.Error("every file is locked, so the store is not partly readable")
+	}
+}

--- a/cmd/deja/doctor_denied_file_test.go
+++ b/cmd/deja/doctor_denied_file_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A transcript deja is not allowed to open is a permission problem, not a
+// harness that changed its format: the advice, and the path, have to match the
+// fault (#1747).
+func TestAnUnreadableFileIsDeniedAndNamed(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root reads everything")
+	}
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	proj := filepath.Join(root, "-proj")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := func(id, text string) string {
+		return `{"type":"user","sessionId":"` + id + `","cwd":"/w","timestamp":"2026-08-08T01:00:00Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(proj, "readable.jsonl"), []byte(rec("ok1", "flumberjack readable")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	locked := filepath.Join(proj, "locked.jsonl")
+	// Newer than the readable one, so it is the file doctor inspects.
+	if err := os.WriteFile(locked, []byte(rec("locked1", "flumberjack locked")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Skipf("cannot lock a file here: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o600) })
+	if f, err := os.Open(locked); err == nil {
+		_ = f.Close()
+		t.Skip("this filesystem ignores the mode")
+	}
+
+	var check doctorStoreCheck
+	for _, c := range doctorStoreChecks() {
+		if c.name == "claude" {
+			check = c
+		}
+	}
+	store, _ := inspectDoctorStore(check)
+	if store.State != "denied" {
+		t.Errorf("an unreadable transcript reports state %q, want denied", store.State)
+	}
+	if !strings.Contains(store.Denied, "locked.jsonl") {
+		t.Errorf("doctor names %q, not the file it could not read", store.Denied)
+	}
+	if !store.Partial {
+		t.Error("the rest of the store indexed, so this is a partly readable store")
+	}
+	_ = tmp
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -396,10 +396,16 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 	f, err := os.Open(newest)
 	if err != nil {
 		if os.IsPermission(err) {
-			store.State = "unreadable"
-		} else {
-			store.State = "parsed-zero"
+			// A file deja may not open is the same fault as a directory it may
+			// not list, and has the same answer: name it and say it is
+			// permissions. Calling it "unreadable" told the user their harness
+			// had changed its format and asked them to report it (#1747).
+			store.State = "denied"
+			store.Denied = newest
+			store.Partial = len(check.files) > 1
+			return store, mod
 		}
+		store.State = "parsed-zero"
 		return store, mod
 	}
 	_ = f.Close()

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -291,6 +291,30 @@ func doctorProbeZed(path string) ([]model.Session, error) {
 	return sources.ParseZedDB(path)
 }
 
+// anotherFileOpens reports whether any file besides one already known to be
+// unreadable can be opened. Bounded: a store can hold tens of thousands of
+// files and doctor is not an audit — one that opens is enough to know the store
+// is partly readable, and the bound keeps a wholly locked store from costing a
+// syscall each.
+func anotherFileOpens(files []string, except string) bool {
+	const probe = 64
+	tried := 0
+	for _, p := range files {
+		if p == except {
+			continue
+		}
+		if tried >= probe {
+			return false
+		}
+		tried++
+		if f, err := os.Open(p); err == nil {
+			_ = f.Close()
+			return true
+		}
+	}
+	return false
+}
+
 func presentDoctorFile(path string) []string {
 	// By content: an empty notes file is not a store with something in it, and
 	// counting it made the two forms of this command disagree about the same
@@ -402,7 +426,10 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 			// had changed its format and asked them to report it (#1747).
 			store.State = "denied"
 			store.Denied = newest
-			store.Partial = len(check.files) > 1
+			// "Partly readable" has to mean something did read: a store whose
+			// files are all locked is not partly anything, and saying "some
+			// sessions are missing" there understates it.
+			store.Partial = anotherFileOpens(check.files, newest)
 			return store, mod
 		}
 		store.State = "parsed-zero"


### PR DESCRIPTION
Closes #1747.

A transcript at mode 000 landed in the `unreadable` state, whose warning is for a harness that changed its format and asks the user to report it. deja already has the right state for this — `denied`, which names the path and gives the permission advice — but only a *directory* reached it.

```
before  claude       unreadable /…/claude  (2 files, 1 indexed session)
        warning      claude store cannot be read — its format may have changed; please report it
        (and `deja index` had just said "`deja doctor` names it" — it named nothing)

after   claude       denied    /…/claude  (2 files, partly unreadable, 1 indexed session)
        warning      claude store is only partly readable — some sessions are missing from recall — permission denied on /…/proj/locked.jsonl; check its permissions (on macOS, also Full Disk Access for your terminal)
```

`Partial` is set when other files did index, which is what makes the sentence say sessions are missing rather than that the store is gone. The JSON form carries `denied` and `partial` too.

Test: `TestAnUnreadableFileIsDeniedAndNamed` — skips under root and on a filesystem that ignores the mode.