### PR TITLE
mcp: refuse a session uri that carries no id

### DIFF
--- a/cmd/deja/mcp_contract_test.go
+++ b/cmd/deja/mcp_contract_test.go
@@ -376,3 +376,52 @@ func TestMCPUndeclaredMethodStillErrors(t *testing.T) {
 		t.Errorf("prompts/list error code = %v, want -32601", e["code"])
 	}
 }
+
+// TestMCPResourceReadRefusesAnEmptySessionRef covers #1728: FindByPrefix
+// matches on strings.HasPrefix, and every id has "" as a prefix, so a URI
+// carrying no id at all returned a full session digest — a whole transcript
+// the agent never asked for, echoed back under the URI it did send.
+func TestMCPResourceReadRefusesAnEmptySessionRef(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	seedClaude(t, claude, "app", "sess-alpha", "the frobnicator crash in parser.go", "fixed the frobnicator")
+	seedClaude(t, claude, "app", "sess-beta", "another frobnicator regression today", "frobnicator again")
+
+	refused := []struct {
+		name string
+		uri  string
+	}{
+		{name: "no id at all", uri: "deja://session/"},
+		{name: "harness prefix only", uri: "deja://session/claude:"},
+	}
+	for _, tt := range refused {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := driveMCP(t, `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"`+tt.uri+`"}}`)
+			e, ok := resp[0]["error"].(map[string]any)
+			if !ok {
+				t.Fatalf("%s was served instead of refused: %#v", tt.uri, resp[0])
+			}
+			if code, _ := e["code"].(float64); code != -32602 {
+				t.Errorf("error code = %v, want -32602", e["code"])
+			}
+		})
+	}
+
+	// Control: a real URI from resources/list must still be served, so the
+	// guard cannot be satisfied by refusing everything.
+	t.Run("a full uri is still served", func(t *testing.T) {
+		list := driveMCP(t, `{"jsonrpc":"2.0","id":2,"method":"resources/list","params":{}}`)
+		resources := list[0]["result"].(map[string]any)["resources"].([]any)
+		uri := resources[0].(map[string]any)["uri"].(string)
+
+		read := driveMCP(t, `{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{"uri":"`+uri+`"}}`)
+		if e, ok := read[0]["error"]; ok {
+			t.Fatalf("real uri %q was refused: %#v", uri, e)
+		}
+		contents := read[0]["result"].(map[string]any)["contents"].([]any)
+		if text := contents[0].(map[string]any)["text"].(string); !strings.Contains(text, "frobnicator") {
+			t.Fatalf("resource text wrong:\n%s", text)
+		}
+	})
+}

--- a/cmd/deja/mcp_resources.go
+++ b/cmd/deja/mcp_resources.go
@@ -83,6 +83,15 @@ func mcpResourceRead(dir, uri string) (any, int, string) {
 	if i := strings.IndexByte(ref, ':'); i >= 0 {
 		id = ref[i+1:]
 	}
+	// Every id has the empty string as a prefix, so an empty ref would make
+	// FindByPrefix return whichever session it reaches first — a whole
+	// transcript the agent never asked for, echoed back under the URI it did
+	// send. `deja://session/` and `deja://session/claude:` both land here.
+	// resources/list only ever emits full URIs, so nothing legitimate
+	// arrives empty; refuse it exactly the way an unknown id is refused.
+	if id == "" {
+		return nil, -32602, fmt.Sprintf("no session matches %q", id)
+	}
 	s, found, err := index.FindByPrefix(dir, id)
 	if err != nil {
 		return nil, -32603, err.Error()


### PR DESCRIPTION
Closes #1728.

`FindByPrefix` matches on `strings.HasPrefix(meta.ID, p)`, and every id has the empty string as a prefix. So `deja://session/` and `deja://session/claude:` — URIs carrying no id at all — returned a full session digest: a whole transcript the agent never asked for, echoed back under the URI it did send, and recorded in `deja log` as a resource served on purpose.

An empty ref is now refused with the same `-32602 no session matches ""` an unknown id already gets.

## Why the guard is here and not in FindByPrefix

`FindByPrefix` has five other callers (`hook_context.go`, `view.go`, two in `main.go`, and the resources path), and they pass an id they already hold or a CLI argument. Prefix-matching the empty string is only dangerous where the input is attacker-shaped, which is this boundary — the URI arrives from the client. Guarding here fixes the reported hole without changing a shared lookup's semantics for callers that are fine.

If you'd rather `FindByPrefix` refuse an empty prefix outright as a matter of principle, that's a one-liner too and arguably the better invariant — I didn't want to change the shared function's contract uninvited.

## Tests

`TestMCPResourceReadRefusesAnEmptySessionRef` (new), driving real stdio through `driveMCP`:

- `deja://session/` → refused with `-32602`. Fails on `main` (served instead of refused).
- `deja://session/claude:` → refused with `-32602`. Fails on `main`.
- **Control**: a full URI taken from `resources/list` is still served and still contains the session text — so the guard cannot be satisfied by refusing everything.

The existing `TestMCPResourcesAndPagination` read path is unchanged and still passes.

## Verification

```text
go test ./... -race -count=1     # all pass
go vet ./...                     # clean
gofmt -s -l cmd/deja/            # no output

go test ./cmd/deja/ -coverprofile=coverage.out
ok  github.com/vshulcz/deja-vu/cmd/deja  78.624s  coverage: 89.8% of statements
go tool cover -func=coverage.out | tail -1
total: (statements) 89.9%
```

`cmd/deja` floor is 88; this stays above it.

## Note for reviewers

Based on `884ac6b` rather than current `main`, same as #1746 and #1748 — my token lacks the `workflow` scope and cannot push a branch carrying the newer `.github/workflows/hol-plugin-scanner.yml`. This touches only `cmd/deja/mcp_resources.go` and `cmd/deja/mcp_contract_test.go`.