### PR TITLE
fix(index): tell a run that waited for another build where the index stands

### DIFF
--- a/cmd/deja/index_waiter_test.go
+++ b/cmd/deja/index_waiter_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// A run that waits behind another build finishes with the index current and
+// nothing printed by the build itself — so the command owes the closing line
+// the same run would print when nothing was in flight (#1751).
+func TestAnIndexRunThatBuiltNothingStillSaysWhereItStands(t *testing.T) {
+	var out bytes.Buffer
+	w := &countingWriter{w: &out}
+	if _, err := w.Write([]byte("deja: incremental index changed_files=1\n")); err != nil {
+		t.Fatal(err)
+	}
+	if w.n == 0 {
+		t.Error("the writer did not count what the build printed")
+	}
+
+	quiet := &countingWriter{w: &bytes.Buffer{}}
+	if quiet.n != 0 {
+		t.Error("a build that printed nothing counted output")
+	}
+	if line := indexQuietOutcome(quiet.n, 760); !strings.Contains(line, "up to date") || !strings.Contains(line, "760") {
+		t.Errorf("a silent build ends with %q", line)
+	}
+	if line := indexQuietOutcome(w.n, 760); line != "" {
+		t.Errorf("a build that reported its work adds a second summary: %q", line)
+	}
+}

--- a/cmd/deja/index_waiter_test.go
+++ b/cmd/deja/index_waiter_test.go
@@ -23,10 +23,12 @@ func TestAnIndexRunThatBuiltNothingStillSaysWhereItStands(t *testing.T) {
 	if quiet.n != 0 {
 		t.Error("a build that printed nothing counted output")
 	}
-	if line := indexQuietOutcome(quiet.n, 760); !strings.Contains(line, "up to date") || !strings.Contains(line, "760") {
-		t.Errorf("a silent build ends with %q", line)
+	if line := indexQuietOutcome(true, 760); !strings.Contains(line, "up to date") || !strings.Contains(line, "760") {
+		t.Errorf("a silent build over a current index ends with %q", line)
 	}
-	if line := indexQuietOutcome(w.n, 760); line != "" {
-		t.Errorf("a build that reported its work adds a second summary: %q", line)
+	// A store that changed again while the other build was finishing: the run
+	// still says where things stand rather than claiming to be current.
+	if line := indexQuietOutcome(false, 760); strings.Contains(line, "up to date") || !strings.Contains(line, "760") {
+		t.Errorf("a silent build over a stale index ends with %q", line)
 	}
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -266,11 +266,12 @@ func (c *countingWriter) Write(p []byte) (int, error) {
 }
 
 // indexQuietOutcome is the line an index run ends with when the build itself
-// said nothing — another deja had already done the work. Empty when the build
-// reported, so nothing is said twice.
-func indexQuietOutcome(printed, sessions int) string {
-	if printed > 0 {
-		return ""
+// said nothing — another deja had already done the work. It reports what is
+// actually on disk: a store can change again in the moment between the build
+// finishing and this line, and claiming "up to date" there would be a guess.
+func indexQuietOutcome(fresh bool, sessions int) string {
+	if !fresh {
+		return fmt.Sprintf("deja: another deja finished the build (%d session%s indexed); newer sessions are not in it yet", sessions, pluralS(sessions))
 	}
 	return fmt.Sprintf("deja: index is up to date (%d session%s)", sessions, pluralS(sessions))
 }
@@ -336,8 +337,8 @@ func cmdIndex(dir string, rest []string) error {
 		return ensureError(dir, err)
 	}
 	clearWarmupSentinel()
-	if _, n := index.UpToDate(dir, ""); progress.n == 0 {
-		fmt.Fprintln(os.Stderr, indexQuietOutcome(progress.n, n))
+	if fresh, n := index.UpToDate(dir, ""); progress.n == 0 {
+		fmt.Fprintln(os.Stderr, indexQuietOutcome(fresh, n))
 	}
 	// Two transcripts can carry the same harness:id — two files with the same
 	// name in different projects. Both stay searchable, but one manifest row

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -253,6 +253,28 @@ func cmdWarmup(dir string, _ []string) error {
 	return nil
 }
 
+// countingWriter passes writes through and remembers whether there were any.
+type countingWriter struct {
+	w io.Writer
+	n int
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.n += n
+	return n, err
+}
+
+// indexQuietOutcome is the line an index run ends with when the build itself
+// said nothing — another deja had already done the work. Empty when the build
+// reported, so nothing is said twice.
+func indexQuietOutcome(printed, sessions int) string {
+	if printed > 0 {
+		return ""
+	}
+	return fmt.Sprintf("deja: index is up to date (%d session%s)", sessions, pluralS(sessions))
+}
+
 func cmdIndex(dir string, rest []string) error {
 	force := false
 	for _, a := range rest {
@@ -300,7 +322,12 @@ func cmdIndex(dir string, rest []string) error {
 	prepareFirstIndexGreeting(dir)
 	// The detached warmup publishes its progress so hooks can tell the user
 	// memory is on its way; an interactive run draws the live display.
-	build := func() error { return index.Ensure(dir, "", force, os.Stderr) }
+	// Counted, because a run that waited for another build prints nothing of
+	// its own: Ensure finds the index current under the lock and returns. The
+	// command then owed a closing line and had none, leaving "waiting for it
+	// to finish" as the last thing on screen (#1751).
+	progress := &countingWriter{w: os.Stderr}
+	build := func() error { return index.Ensure(dir, "", force, progress) }
 	if err := withWarmupStatus(dir, func() error { return withBuildProgress(build) }); err != nil {
 		// The command whose whole job is building the index used to pass the
 		// syscall through — `mkdir /…/index.db.tmp: permission denied` names
@@ -309,6 +336,9 @@ func cmdIndex(dir string, rest []string) error {
 		return ensureError(dir, err)
 	}
 	clearWarmupSentinel()
+	if _, n := index.UpToDate(dir, ""); progress.n == 0 {
+		fmt.Fprintln(os.Stderr, indexQuietOutcome(progress.n, n))
+	}
 	// Two transcripts can carry the same harness:id — two files with the same
 	// name in different projects. Both stay searchable, but one manifest row
 	// holds them, so one project name covers both. Silence was the worst part


### PR DESCRIPTION
Closes #1751.

A second `deja index` fails the pre-lock freshness check, enters the build path, blocks inside `Ensure`, and by the time it holds the lock the index is current — so `Ensure` returns silently and the command had no closing line. "waiting for it to finish" was the last thing on screen.

The build's progress writer is counted now; a build that printed nothing ends with the same line the command prints when nothing was in flight.

```
before  run 1: deja: another deja is building the index — waiting for it to finish
                (end of output)

after   run 1: deja: another deja is building the index — waiting for it to finish
               deja: index is up to date (960 sessions)
        run 2: deja: incremental index changed_files=100 removed_files=0 sessions=100
                (unchanged — a build that reported its work adds nothing)
```

Test: `TestAnIndexRunThatBuiltNothingStillSaysWhereItStands` over `countingWriter` and `indexQuietOutcome`.