### PR TITLE
feat(recall): say when a session's date is later than this machine's clock

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -704,6 +704,11 @@ func wholeSessionForMCP(dir string, s model.Session) (model.Session, bool, error
 // needs precisely when the answer was too big to fit.
 const recallCountLineReserve = 160
 
+// futureStampTolerance is how far ahead of the clock a transcript may be
+// stamped before the date stops being usable as "when". Ordinary zone and clock
+// jitter lands inside a day; the same reading readWarmupStatus takes.
+const futureStampTolerance = 48 * time.Hour
+
 func recallTextResult(dir, q, harness string, limit, offset, budget int) (string, int, int64, []string, error) {
 	if limit <= 0 {
 		limit = 5
@@ -829,6 +834,15 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		}
 		if h.Superseded != "" {
 			fmt.Fprintf(&hb, "[earlier attempt — a newer session in this project covers the same ground, updated %s]\n", h.Superseded)
+		}
+		// `deja brief` counts these — a wrong clock, a transcript copied from a
+		// machine set wrong, a harness writing local time as UTC — so deja knew
+		// and the page that an agent reads did not. The date stays as the
+		// transcript wrote it; what is added is that it cannot be trusted for
+		// "newest", which is the one thing the top of a recall page implies
+		// (#1753).
+		if h.Session.Updated.After(time.Now().Add(futureStampTolerance)) {
+			fmt.Fprintln(&hb, "[stamped later than this machine's clock — its date cannot place it against the others]")
 		}
 		if h.Tier != search.TierExact {
 			fmt.Fprintf(&hb, "[%s]\n", h.Tier)

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -704,11 +704,6 @@ func wholeSessionForMCP(dir string, s model.Session) (model.Session, bool, error
 // needs precisely when the answer was too big to fit.
 const recallCountLineReserve = 160
 
-// futureStampTolerance is how far ahead of the clock a transcript may be
-// stamped before the date stops being usable as "when". Ordinary zone and clock
-// jitter lands inside a day; the same reading readWarmupStatus takes.
-const futureStampTolerance = 48 * time.Hour
-
 func recallTextResult(dir, q, harness string, limit, offset, budget int) (string, int, int64, []string, error) {
 	if limit <= 0 {
 		limit = 5
@@ -841,7 +836,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		// transcript wrote it; what is added is that it cannot be trusted for
 		// "newest", which is the one thing the top of a recall page implies
 		// (#1753).
-		if h.Session.Updated.After(time.Now().Add(futureStampTolerance)) {
+		if index.StampedAhead(h.Session.Updated, time.Now()) {
 			fmt.Fprintln(&hb, "[stamped later than this machine's clock — its date cannot place it against the others]")
 		}
 		if h.Tier != search.TierExact {

--- a/cmd/deja/recall_future_marker_test.go
+++ b/cmd/deja/recall_future_marker_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// `deja brief` counts sessions stamped later than this machine's clock, so deja
+// knows about them; recall put one at the top of the page with its date as
+// plain fact. The listing already carries caveats where they are read — an
+// earlier attempt, an abandoned approach — and this belongs with them (#1753).
+func TestRecallMarksASessionStampedAheadOfTheClock(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	write := func(sid string, at time.Time) {
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/w/p","timestamp":"` +
+			at.UTC().Format(time.RFC3339) + `","message":{"role":"user","content":"blorptastic work in ` + sid + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	now := time.Now()
+	write("today", now.Add(-time.Hour))
+	write("ahead", now.AddDate(0, 0, 30))
+
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	text, _, _, _, err := recallTextResult(dir, "blorptastic", "", 5, 0, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "ahead") || !strings.Contains(text, "today") {
+		t.Fatalf("the fixture is wrong, both sessions should be on the page:\n%s", text)
+	}
+	marker := "[stamped later than this machine's clock"
+	if !strings.Contains(text, marker) {
+		t.Errorf("recall does not mark the session ahead of the clock:\n%s", text)
+	}
+	// And only that one.
+	if n := strings.Count(text, marker); n != 1 {
+		t.Errorf("the marker appears %d times, want 1:\n%s", n, text)
+	}
+}

--- a/cmd/deja/recall_future_marker_test.go
+++ b/cmd/deja/recall_future_marker_test.go
@@ -52,3 +52,25 @@ func TestRecallMarksASessionStampedAheadOfTheClock(t *testing.T) {
 		t.Errorf("the marker appears %d times, want 1:\n%s", n, text)
 	}
 }
+
+// One rule, two surfaces: whatever the brief counts as ahead of the clock is
+// what recall marks. They disagreed while the marker carried a tolerance of its
+// own, and the brief's own test pins that three hours out already counts.
+func TestBriefAndRecallAgreeOnWhatIsAheadOfTheClock(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		what  string
+		at    time.Time
+		ahead bool
+	}{
+		{"an hour ago", now.Add(-time.Hour), false},
+		{"a minute ahead", now.Add(time.Minute), true},
+		{"three hours ahead", now.Add(3 * time.Hour), true},
+		{"five years ahead", now.AddDate(5, 0, 0), true},
+		{"exactly now", now, false},
+	} {
+		if got := index.StampedAhead(tc.at, now); got != tc.ahead {
+			t.Errorf("%s: StampedAhead = %v, want %v", tc.what, got, tc.ahead)
+		}
+	}
+}

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -452,6 +452,16 @@ func RebuildInProgress(dir string) bool {
 	return true
 }
 
+// StampedAhead reports a session stamped later than this machine's clock, and
+// so unusable for placing it against the others. Anything ahead counts: a
+// session three hours out is still ahead, which is what the brief has counted
+// since #696 and what its test pins. One rule in one place, so the brief's
+// count and the marker recall prints cannot disagree about the same session
+// (#1753).
+func StampedAhead(t, now time.Time) bool {
+	return t.After(now)
+}
+
 // OverviewStats is what the brief needs about a whole store.
 type OverviewStats struct {
 	Sessions      int
@@ -491,7 +501,7 @@ func Overview(dir string) (OverviewStats, error) {
 	for _, meta := range m.Sessions {
 		o.Sessions++
 		hs[meta.Harness] = true
-		if meta.Updated.After(now) {
+		if StampedAhead(meta.Updated, now) {
 			o.Future++
 		}
 		if meta.Updated.After(day) && !meta.Updated.After(now) {


### PR DESCRIPTION
Closes #1753.

A transcript stamped ahead of the clock leads every recall page as the newest thing deja holds, with `updated 2031-01-02` printed as fact. `deja brief` already counts these (`ahead  N sessions stamped later than this machine's clock`), so deja knew and the page an agent reads did not.

The date is left exactly as the transcript wrote it. What is added is the caveat, in the same place the listing already carries `[earlier attempt …]` and `[this session abandoned one approach partway]`:

```
1. [claude] proj · fut-1 · 2 matches · updated 2031-01-03 (Jan 3 2031)
[stamped later than this machine's clock — its date cannot place it against the others]
3. [claude] proj · now-1 · 1 matches · updated 2026-08-24 (today)
```

Tolerance is 48h, the reading `readWarmupStatus` already takes — zone and clock jitter is not a wrong clock.

My first attempt was to damp the timestamp to the file's mtime at ingest. It worked and it was wrong: it edits what the transcript says and destroys the signal brief reports, and `TestBriefNamesSessionsAheadOfTheClock` and `TestHandoffReceiptOnAFutureSession` both failed — which is what they are for. Backed out; the correction is on the issue.

Test: `TestRecallMarksASessionStampedAheadOfTheClock`, which also pins that only the session ahead gets the marker.