### PR TITLE
fix(forget): say a deleted transcript is gone from this machine, not that it came from another

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -3214,11 +3214,6 @@ func dayWord(n int) string {
 	return fmt.Sprintf("%d days", n)
 }
 
-// unforgetGoneLines says why a lifted tombstone restored nothing. Two causes
-// with two answers: a session deja only ever held in its own index came from
-// another machine and sync import brings it back (#967), while a transcript
-// this machine wrote and then deleted is simply not on disk — telling that
-// reader to import from another machine names one they never had (#1755).
 // pluralIsLifted and pluralTranscript keep the two sentences readable for one
 // key and for several; joinCapped names up to five.
 func pluralIsLifted(n int) string {
@@ -3235,6 +3230,11 @@ func pluralTranscript(n int) string {
 	return "s they"
 }
 
+// unforgetGoneLines says why a lifted tombstone restored nothing. Two causes
+// with two answers: a session deja only ever held in its own index came from
+// another machine and sync import brings it back (#967), while a transcript
+// this machine wrote and then deleted is simply not on disk — telling that
+// reader to import from another machine names one they never had (#1755).
 func unforgetGoneLines(missing []string) []string {
 	var imported, local []string
 	for _, key := range missing {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -3219,6 +3219,22 @@ func dayWord(n int) string {
 // another machine and sync import brings it back (#967), while a transcript
 // this machine wrote and then deleted is simply not on disk — telling that
 // reader to import from another machine names one they never had (#1755).
+// pluralIsLifted and pluralTranscript keep the two sentences readable for one
+// key and for several; joinCapped names up to five.
+func pluralIsLifted(n int) string {
+	if n == 1 {
+		return " is"
+	}
+	return "s are"
+}
+
+func pluralTranscript(n int) string {
+	if n == 1 {
+		return " it"
+	}
+	return "s they"
+}
+
 func unforgetGoneLines(missing []string) []string {
 	var imported, local []string
 	for _, key := range missing {
@@ -3234,10 +3250,11 @@ func unforgetGoneLines(missing []string) []string {
 	}
 	var out []string
 	if len(imported) > 0 {
-		out = append(out, fmt.Sprintf("%s came from another machine and deja held the only copy — the tombstone is lifted, but the records are gone; `deja sync import` brings them back", joinCapped(imported, 5)))
+		out = append(out, fmt.Sprintf("%s came from another machine and deja held the only copy — the tombstone%s lifted, but the records are gone; `deja sync import` brings them back", joinCapped(imported, 5), pluralIsLifted(len(imported))))
 	}
 	if len(local) > 0 {
-		out = append(out, fmt.Sprintf("%s is no longer on this machine — the tombstone is lifted, but the transcript it named is gone, so there is nothing to index", joinCapped(local, 5)))
+		out = append(out, fmt.Sprintf("%s %s no longer on this machine — the tombstone%s lifted, but the transcript%s named %s gone, so there is nothing to index",
+			joinCapped(local, 5), verbIs(len(local)), pluralIsLifted(len(local)), pluralTranscript(len(local)), verbIs(len(local))))
 	}
 	return out
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2429,7 +2429,7 @@ func runForget(dir string, args []string) error {
 		// still on this machine. An imported one lives only in the index, so
 		// forget took the last copy — and the undo reported a restore that did
 		// not happen (#967).
-		back, gone, names := restoredSessions(dir, unforget, lifted, lifting)
+		back, gone, names, missing := restoredSessions(dir, unforget, lifted, lifting)
 		restorePromotedTitles(dir, unforget)
 		if back > 0 {
 			// The ids, not just the count: this is the moment someone checks
@@ -2437,8 +2437,13 @@ func runForget(dir string, args []string) error {
 			// the ambiguity refusal name them a step earlier (#1095, #1014).
 			fmt.Fprintf(os.Stdout, "restored %d session%s and rebuilt the index — %s\n", back, pluralS(back), joinCapped(names, 5))
 		}
-		if gone > 0 {
-			fmt.Fprintf(os.Stdout, "%d of them came from another machine and deja held the only copy — the tombstone is lifted, but the records are gone; `deja sync import` brings them back\n", gone)
+		for _, line := range unforgetGoneLines(missing) {
+			fmt.Fprintln(os.Stdout, line)
+		}
+		if gone > 0 && len(missing) == 0 {
+			// The selector was a prefix rather than whole keys, so which ones
+			// did not come back is not known by name here.
+			fmt.Fprintf(os.Stdout, "%d of them did not come back — the tombstone is lifted, but the records are not in the index; `deja forget --list` shows what is left\n", gone)
 		}
 		return nil
 	}
@@ -3209,13 +3214,41 @@ func dayWord(n int) string {
 	return fmt.Sprintf("%d days", n)
 }
 
+// unforgetGoneLines says why a lifted tombstone restored nothing. Two causes
+// with two answers: a session deja only ever held in its own index came from
+// another machine and sync import brings it back (#967), while a transcript
+// this machine wrote and then deleted is simply not on disk — telling that
+// reader to import from another machine names one they never had (#1755).
+func unforgetGoneLines(missing []string) []string {
+	var imported, local []string
+	for _, key := range missing {
+		id := key
+		if i := strings.IndexByte(key, ':'); i >= 0 {
+			id = key[i+1:]
+		}
+		if strings.HasPrefix(id, "imported-") {
+			imported = append(imported, key)
+			continue
+		}
+		local = append(local, key)
+	}
+	var out []string
+	if len(imported) > 0 {
+		out = append(out, fmt.Sprintf("%s came from another machine and deja held the only copy — the tombstone is lifted, but the records are gone; `deja sync import` brings them back", joinCapped(imported, 5)))
+	}
+	if len(local) > 0 {
+		out = append(out, fmt.Sprintf("%s is no longer on this machine — the tombstone is lifted, but the transcript it named is gone, so there is nothing to index", joinCapped(local, 5)))
+	}
+	return out
+}
+
 // restoredSessions splits what a lifted tombstone actually returned from what
 // it could not: a session whose transcript is on this machine is re-read by the
 // rebuild, while an imported one existed only in the index that forget rewrote.
-func restoredSessions(dir, selector string, lifted int, lifting []string) (back, gone int, names []string) {
+func restoredSessions(dir, selector string, lifted int, lifting []string) (back, gone int, names, missing []string) {
 	metas, err := index.AllMeta(dir)
 	if err != nil {
-		return lifted, 0, lifting
+		return lifted, 0, lifting, nil
 	}
 	// A session counts as back only if its row is in the manifest again: an
 	// imported one lives only in the index, so forget took the last copy and
@@ -3228,7 +3261,9 @@ func restoredSessions(dir, selector string, lifted int, lifting []string) (back,
 		if here[key] {
 			back++
 			names = append(names, key)
+			continue
 		}
+		missing = append(missing, key)
 	}
 	if back == 0 && lifted > 0 {
 		// Selectors that are not whole keys (a bare id, a prefix) still count
@@ -3242,9 +3277,15 @@ func restoredSessions(dir, selector string, lifted int, lifting []string) (back,
 		if back > lifted {
 			back, names = lifted, names[:lifted]
 		}
+		if back > 0 {
+			// The prefix path found them by manifest row, so nothing here is
+			// missing by name.
+			missing = nil
+		}
 	}
 	sort.Strings(names)
-	return back, lifted - back, names
+	sort.Strings(missing)
+	return back, lifted - back, names, missing
 }
 
 // restorePromotedTitles gives a promoted note back the title it borrowed from a

--- a/cmd/deja/unforget_missing_test.go
+++ b/cmd/deja/unforget_missing_test.go
@@ -47,4 +47,15 @@ func TestUnforgetSaysWhyNothingCameBack(t *testing.T) {
 	if got := unforgetGoneLines(nil); len(got) != 0 {
 		t.Errorf("nothing missing still said %q", got)
 	}
+
+	// One key and several read as sentences, not as a count with a plural
+	// bolted on.
+	one := strings.Join(unforgetGoneLines([]string{"claude:ts-01"}), " ")
+	many := strings.Join(unforgetGoneLines([]string{"claude:ts-01", "claude:ts-02"}), " ")
+	if !strings.Contains(one, "claude:ts-01 is no longer") || !strings.Contains(one, "the tombstone is lifted") {
+		t.Errorf("one key reads as %q", one)
+	}
+	if !strings.Contains(many, "claude:ts-01, claude:ts-02 are no longer") || !strings.Contains(many, "the tombstones are lifted") {
+		t.Errorf("two keys read as %q", many)
+	}
 }

--- a/cmd/deja/unforget_missing_test.go
+++ b/cmd/deja/unforget_missing_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Lifting a tombstone restores nothing in two different situations, and they
+// have different answers: a session deja only ever held in its own index came
+// from another machine and `sync import` brings it back, while a transcript
+// this machine wrote and then deleted is simply not on disk — pointing the
+// second at sync import blames a machine the user never had (#1755).
+func TestUnforgetSaysWhyNothingCameBack(t *testing.T) {
+	for _, tc := range []struct {
+		keys []string
+		want []string
+		not  []string
+	}{
+		{
+			keys: []string{"claude:imported-ab12cd34"},
+			want: []string{"another machine", "sync import"},
+			not:  []string{"no longer on this machine"},
+		},
+		{
+			keys: []string{"claude:ts-01"},
+			want: []string{"no longer on this machine"},
+			not:  []string{"another machine", "sync import"},
+		},
+		{
+			keys: []string{"claude:imported-ab12cd34", "claude:ts-01"},
+			want: []string{"another machine", "no longer on this machine"},
+		},
+	} {
+		got := unforgetGoneLines(tc.keys)
+		joined := strings.Join(got, "\n")
+		for _, want := range tc.want {
+			if !strings.Contains(joined, want) {
+				t.Errorf("%v said %q, missing %q", tc.keys, joined, want)
+			}
+		}
+		for _, no := range tc.not {
+			if strings.Contains(joined, no) {
+				t.Errorf("%v said %q, which should not mention %q", tc.keys, joined, no)
+			}
+		}
+	}
+	if got := unforgetGoneLines(nil); len(got) != 0 {
+		t.Errorf("nothing missing still said %q", got)
+	}
+}


### PR DESCRIPTION
Closes #1755.

Lifting a tombstone restores nothing in two different situations, and they had one sentence between them. A session deja only ever held in its own index really did come from another machine, and `sync import` brings it back (#967). A transcript this machine wrote and the user then deleted is simply not on disk — and was told to import it from a machine they never had.

```
before  1 of them came from another machine and deja held the only copy … `deja sync import` brings them back
after   claude:ts-09 is no longer on this machine — the tombstone is lifted, but the transcript it named is gone, so there is nothing to index
```

Imported sessions carry the `imported-` id prefix `sync.go` mints, which is the same marker `ImportedSessionCounts` reads. `restoredSessions` now returns which keys did not come back, so both sentences name them instead of counting them; a prefix selector, which finds rows by manifest rather than by key, keeps a count-only line.

Test: `TestUnforgetSaysWhyNothingCameBack` over the imported case, the local case, and both at once.