### PR TITLE
docs: memory pages for Gemini CLI and Qwen Code

### DIFF
--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -52,6 +52,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/auditing-agents.html
+++ b/docs/guide/auditing-agents.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -52,6 +52,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -52,6 +52,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -81,6 +81,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/export-conversations.html
+++ b/docs/guide/export-conversations.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html" aria-current="page">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/find-a-session.html
+++ b/docs/guide/find-a-session.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -52,6 +52,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -52,6 +52,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/memory-for-dsh.html
+++ b/docs/guide/memory-for-dsh.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/memory-for-gemini.html
+++ b/docs/guide/memory-for-gemini.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Adding memory to Gemini CLI — deja-vu</title>
+<meta name="description" content="How to give Gemini CLI recall over every coding agent's sessions on this machine — one extension install, and what the CLI install adds on top.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Adding memory to Gemini CLI">
+<meta property="og:description" content="How to give Gemini CLI recall over every coding agent's sessions on this machine — one extension install, and what the CLI install adds on top.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Adding memory to Gemini CLI">
+<meta name="twitter:description" content="How to give Gemini CLI recall over every coding agent's sessions on this machine — one extension install, and what the CLI install adds on top.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to Gemini CLI","description":"How to give Gemini CLI recall over every coding agent's sessions on this machine — one extension install, and what the CLI install adds on top.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for Gemini CLI","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I add memory to Gemini CLI?","acceptedAnswer":{"@type":"Answer","text":"Run gemini extensions install https://github.com/vshulcz/deja-vu, or deja install gemini-auto if you want the hooks as well."}},{"@type":"Question","name":"Where does Gemini CLI keep its sessions?","acceptedAnswer":{"@type":"Answer","text":"Under ~/.gemini/tmp/<project-hash>/chats as JSON or JSONL, which is what deja indexes."}},{"@type":"Question","name":"Can Gemini CLI recall without being asked?","acceptedAnswer":{"@type":"Answer","text":"Yes, but only through the CLI install: hooks run when hooksConfig.enabled is set in settings.json, and an extension cannot write that."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html" aria-current="page">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Adding memory to Gemini CLI</h1>
+<p class="pagelede">one command, because Gemini installs a repository directly<span class="mins" data-mins></span></p>
+
+<p>Gemini CLI writes every chat to disk and starts the next one without them. The answer to today's question is often in one of those files — or in whatever other agent you used last week.</p>
+
+<h2>What Gemini already has</h2>
+<p>Chats live under <code>~/.gemini/tmp/&lt;project-hash&gt;/chats</code> as JSON or JSONL. Complete, and read by nothing: the directory name is a hash of the working directory, which is why Gemini itself can only list the sessions of the project you are standing in.</p>
+
+<h2>Adding recall</h2>
+<pre>gemini extensions install https://github.com/vshulcz/deja-vu</pre>
+<p>That reads <code>gemini-extension.json</code> at the root of the repository and wires the deja MCP server plus a short context file. Measured on Gemini CLI 0.55.1: <code>gemini mcp list</code> then reports <code>deja (from deja): deja mcp (stdio) - Connected</code>.</p>
+<p>The other path also wires the hooks:</p>
+<pre>deja install gemini-auto</pre>
+<p>Hooks are the difference between the two. Gemini runs them only when <code>hooksConfig.enabled</code> is set in your <code>settings.json</code>, and an extension cannot write that file — so the extension gives you recall on demand, and the CLI install adds recall that arrives on its own at session start and on each prompt.</p>
+<p>Both name the extension <code>deja</code>, which is deliberate: Gemini keys extensions by that name and answers a second install with <code>Extension "deja" is already installed</code>. Having both wired is not a state you can reach by accident.</p>
+<p>Either way it needs the binary, since an extension delivers files rather than runtimes:</p>
+<pre>brew install vshulcz/tap/deja-vu
+# or
+curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
+
+<h2>Qwen Code takes the same file</h2>
+<p>Qwen Code is close enough to Gemini CLI that the same manifest serves it: <code>qwen extensions install https://github.com/vshulcz/deja-vu</code> installs the same MCP server, context file and <code>deja-search</code> skill. <a href="memory-for-qwen.html">Memory for Qwen Code</a> has that side.</p>
+
+<h2>The part that is not about this harness</h2>
+<p>The index covers every agent's transcripts on the machine — twenty of them today, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in one tool answers a question asked in another, including sessions from before any of this was installed. That is the reason to index rather than to capture.</p>
+<p>Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>). An injection is capped at 1,536 bytes per prompt and about 4 KB per tool call — <a href="token-cost.html">what memory costs</a> has the measured comparison.</p>
+
+<p><a href="getting-started.html">Getting started</a> · <a href="../registry/gemini.html">How Gemini's store is read</a> · <a href="memory-for-qwen.html">Memory for Qwen Code</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/memory-for-grok.html
+++ b/docs/guide/memory-for-grok.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html" aria-current="page">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/memory-for-kimi.html
+++ b/docs/guide/memory-for-kimi.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html" aria-current="page">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/memory-for-opencode.html
+++ b/docs/guide/memory-for-opencode.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/memory-for-qwen.html
+++ b/docs/guide/memory-for-qwen.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Adding memory to Qwen Code — deja-vu</title>
+<meta name="description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Adding memory to Qwen Code">
+<meta property="og:description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Adding memory to Qwen Code">
+<meta name="twitter:description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to Qwen Code","description":"How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for Qwen Code","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I add memory to Qwen Code?","acceptedAnswer":{"@type":"Answer","text":"Run qwen extensions install https://github.com/vshulcz/deja-vu, or deja install qwen-auto to wire the MCP server and the skill directly."}},{"@type":"Question","name":"Where does Qwen Code keep its sessions?","acceptedAnswer":{"@type":"Answer","text":"Under ~/.qwen/projects/<project>/chats as JSONL, which is what deja indexes."}},{"@type":"Question","name":"Does Qwen Code read Claude-format marketplaces?","acceptedAnswer":{"@type":"Answer","text":"Yes. qwen extensions sources add takes a Claude-format marketplace, and this repository is one."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html" aria-current="page">Memory for Qwen Code</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Adding memory to Qwen Code</h1>
+<p class="pagelede">it takes the Gemini extension, and Claude-format marketplaces<span class="mins" data-mins></span></p>
+
+<p>Qwen Code keeps every session on disk and opens the next one empty. What you worked out last week is still there, and so is the work you did in whichever other agent you had open at the time.</p>
+
+<h2>What Qwen already has</h2>
+<p>Sessions live under <code>~/.qwen/projects/&lt;project&gt;/chats</code> as JSONL. Complete, and unread by anything — including by Qwen's next session.</p>
+
+<h2>Adding recall</h2>
+<pre>qwen extensions install https://github.com/vshulcz/deja-vu</pre>
+<p>Qwen Code shares Gemini CLI's extension format, so the <code>gemini-extension.json</code> at the root of the repository is the whole install. Checked on Qwen Code 0.20.0: it reports the deja MCP server, the context file and the <code>deja-search</code> skill, and installs them under <code>~/.qwen/extensions/deja</code>.</p>
+<p>The CLI install is the other path, and the one that also writes guidance where Qwen reads it:</p>
+<pre>deja install qwen-auto</pre>
+<p>Running both is safe rather than doubled: MCP servers are keyed by name, so the extension's <code>deja</code> and the one in <code>settings.json</code> collapse into a single server rather than listing every tool twice.</p>
+<p>Qwen also reads Claude-format marketplaces, which this repository is:</p>
+<pre>qwen extensions sources add https://github.com/vshulcz/deja-vu</pre>
+<p>Either way it needs the binary, since an extension delivers files rather than runtimes:</p>
+<pre>brew install vshulcz/tap/deja-vu
+# or
+curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
+
+<h2>The part that is not about this harness</h2>
+<p>The index covers every agent's transcripts on the machine — twenty of them today, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in one tool answers a question asked in another, including sessions from before any of this was installed. That is the reason to index rather than to capture.</p>
+<p>Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>). An injection is capped at 1,536 bytes per prompt and about 4 KB per tool call — <a href="token-cost.html">what memory costs</a> has the measured comparison.</p>
+
+<p><a href="getting-started.html">Getting started</a> · <a href="../registry/qwen.html">How Qwen's store is read</a> · <a href="memory-for-gemini.html">Memory for Gemini CLI</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/memory-for-zed.html
+++ b/docs/guide/memory-for-zed.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html" aria-current="page">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/parallel-sessions.html
+++ b/docs/guide/parallel-sessions.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -52,6 +52,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/rules-files.html
+++ b/docs/guide/rules-files.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -52,6 +52,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/switching-agents.html
+++ b/docs/guide/switching-agents.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/sync-across-machines.html
+++ b/docs/guide/sync-across-machines.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html" aria-current="page">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/token-cost.html
+++ b/docs/guide/token-cost.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html" aria-current="page">What memory costs</a>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -53,6 +53,8 @@
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -19,6 +19,8 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/agents.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/search.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/commands.html</loc><lastmod>2026-08-11</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -73,6 +73,16 @@ Its `name` is `deja`, the same name the installer's extension uses, and
 extension by that name and refuses a second install under a name it already
 has, which is what makes two deja extensions on one machine impossible.
 
+Qwen Code takes the same file. `qwen extensions install <repo>` reads
+`gemini-extension.json` and installs the MCP server, `GEMINI.md` and the
+`deja-search` skill under `~/.qwen/extensions/deja` — checked on Qwen Code
+0.20.0 — and `qwen mcp list` then shows one `deja` server rather than two,
+because MCP servers are keyed by name and `deja install qwen` writes the same
+one into `settings.json`. Qwen also reads Claude-format marketplaces, so
+`qwen extensions sources add <repo>` finds `.claude-plugin/marketplace.json`
+here and lists the plugin. Nothing extra ships for any of that; it is the same
+two files the Gemini install uses.
+
 ## Rules that cost us time once
 
 - **Resolve the binary in this order, everywhere:** an explicit setting or


### PR DESCRIPTION
Two harnesses that now install in one command, and had no page saying so.

Gemini reads `gemini-extension.json` from the repository root; Qwen Code shares that format, so the same file installs there too — verified on Gemini CLI 0.55.1 (`gemini mcp list` reports the server connected) and Qwen Code 0.20.0 (extension, context file and `deja-search` skill land under `~/.qwen/extensions/deja`, and `qwen mcp list` shows one server, not two). Qwen also reads Claude-format marketplaces, which this repository is.

Each page says plainly what the extension route does not give you: hooks need `hooksConfig.enabled` in the user's own `settings.json`, which an extension cannot write, so automatic recall still comes from `deja install`.

Sidebar and sitemap regenerated for the whole guide set, which is the bulk of the diff.