### PR TITLE
fix(index): say when only half a store could be read, in the run and in doctor --json

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -358,11 +358,17 @@ func printDoctorStoreWarnings(w io.Writer, stores []doctorStore) {
 				what = "store is only partly readable — some sessions are missing from recall"
 			}
 			fmt.Fprintf(w, "  warning      %s %s — permission denied on %s; check its permissions (on macOS, also Full Disk Access for your terminal)\n", store.Name, what, store.Denied)
-		case "needs-sqlite3":
+		case "needs-sqlite3", "needs-zstd":
 			// Not a format change: the parser could not run at all. Saying so
 			// points at installing one package instead of at a bug report
-			// against the harness (#792).
-			fmt.Fprintf(w, "  warning      %s store needs the sqlite3 CLI — install it, then run `deja index`\n", store.Name)
+			// against the harness (#792). Which package depends on the store —
+			// zed and deepseek need zstd (#1758) — and a partly readable one
+			// says so rather than reading as a store that is entirely gone.
+			what := "store"
+			if store.Partial {
+				what = "store is only partly readable — part of it"
+			}
+			fmt.Fprintf(w, "  warning      %s %s needs %s — install it, then run `deja index`\n", store.Name, what, toolFromSkip(store.Skipped))
 		}
 	}
 }
@@ -490,7 +496,7 @@ func doctorHarnesses(w io.Writer, dir string) {
 			// `doctor --json`, which has said `denied` all along while this
 			// row, the one people read, said `found` (#993).
 			switch inspected[name] {
-			case "denied", "unreadable", "parsed-zero", "needs-sqlite3":
+			case "denied", "unreadable", "parsed-zero", "needs-sqlite3", "needs-zstd":
 				status = inspected[name]
 				if status == "denied" {
 					if detail != "" {
@@ -640,6 +646,18 @@ func doctorHarnesses(w io.Writer, dir string) {
 	if n := noteBucketsRegrouped(dir); n > 0 {
 		fmt.Fprintf(w, "  warning      %s of notes in the index %s not what this machine would build now — the zone changed, so the days regrouped; `deja index` renames them\n",
 			doctorCount(n, "day"), verbIs(n))
+	}
+}
+
+// toolFromSkip turns a skip reason into the package to install.
+func toolFromSkip(reason string) string {
+	switch {
+	case strings.Contains(reason, "sqlite3") && strings.Contains(reason, "zstd"):
+		return "the sqlite3 and zstd CLIs"
+	case strings.Contains(reason, "zstd"):
+		return "the zstd CLI"
+	default:
+		return "the sqlite3 CLI"
 	}
 }
 

--- a/cmd/deja/doctor_json_contract_test.go
+++ b/cmd/deja/doctor_json_contract_test.go
@@ -41,7 +41,7 @@ func TestDoctorJSONKeysMatchTheDocumentedContract(t *testing.T) {
 		// doctorStore
 		"name": true, "state": true, "paths": true, "files": true,
 		"indexed_sessions": true, "indexed_from_elsewhere": true,
-		"denied": true, "partial": true, "unchecked": true,
+		"denied": true, "skipped": true, "partial": true, "unchecked": true,
 		// doctorComponent
 		"path": true, "stale_stores": true,
 		// doctorVersionReport

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -438,6 +438,15 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 	_ = f.Close()
 	sessions, parseErr := check.parse(newest)
 	store.State = "ok"
+	// A store can be half-readable: cursor keeps CLI transcripts as JSONL and
+	// its IDE sessions in SQLite, so the newest file can parse while the other
+	// half cannot be read at all. The text row has said so in its detail all
+	// along; this form called the store ok (#1758).
+	if reason := sources.SkipReason(check.name); reason != "" && storeNeedsSQLite3(check.name) {
+		store.State = "needs-sqlite3"
+		store.Partial = len(check.files) > 1
+		return store, mod
+	}
 	// A parser that could not run is not a store that could not be understood.
 	// Without this, removing the sqlite3 CLI told the user their harness had
 	// changed its format and asked them to report it — two lines above deja

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -36,7 +36,11 @@ type doctorStore struct {
 	// rather than the whole harness (#816).
 	// Unchecked says the permission walk stopped at its budget, so no
 	// permission problem past that point was looked for (#1025).
+	// Skipped is why part of the store could not be read at all — a missing
+	// sqlite3 or zstd CLI. The text row has carried it in its detail; a reader
+	// of --json saw a state and no reason (#1758).
 	Denied    string `json:"denied,omitempty"`
+	Skipped   string `json:"skipped,omitempty"`
 	Partial   bool   `json:"partial,omitempty"`
 	Unchecked bool   `json:"unchecked,omitempty"`
 }
@@ -315,6 +319,19 @@ func anotherFileOpens(files []string, except string) bool {
 	return false
 }
 
+// stateForMissingTool names the state by the tool that is missing. zed and
+// deepseek need zstd rather than sqlite3, and calling that "needs-sqlite3"
+// sends the reader to install the wrong package (#1758).
+func stateForMissingTool(reason string) string {
+	if strings.Contains(reason, "sqlite3") {
+		return "needs-sqlite3"
+	}
+	if strings.Contains(reason, "zstd") {
+		return "needs-zstd"
+	}
+	return "unreadable"
+}
+
 func presentDoctorFile(path string) []string {
 	// By content: an empty notes file is not a store with something in it, and
 	// counting it made the two forms of this command disagree about the same
@@ -442,8 +459,9 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 	// its IDE sessions in SQLite, so the newest file can parse while the other
 	// half cannot be read at all. The text row has said so in its detail all
 	// along; this form called the store ok (#1758).
-	if reason := sources.SkipReason(check.name); reason != "" && storeNeedsSQLite3(check.name) {
-		store.State = "needs-sqlite3"
+	if reason := sources.SkipReason(check.name); reason != "" {
+		store.State = stateForMissingTool(reason)
+		store.Skipped = reason
 		store.Partial = len(check.files) > 1
 		return store, mod
 	}

--- a/cmd/deja/doctor_store_coverage_test.go
+++ b/cmd/deja/doctor_store_coverage_test.go
@@ -97,3 +97,45 @@ func doctorCheckNamed(t *testing.T, name string) doctorStoreCheck {
 	t.Fatalf("no doctor store check named %q", name)
 	return doctorStoreCheck{}
 }
+
+// The text row says a store's sqlite half is unreadable — "sqlite3 CLI missing
+// — IDE sessions unavailable" — while the JSON form called the same store ok.
+// Two answers about one store is what #999 closed for the states that existed
+// then (#1758).
+func TestBothFormsAgreeWhenHalfAStoreNeedsSqlite(t *testing.T) {
+	tmp := hermeticEnv(t)
+	ide := filepath.Join(tmp, "cursor-user", "globalStorage")
+	if err := os.MkdirAll(ide, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A file that is not a readable database is enough: the point is the CLI,
+	// and without it deja cannot tell one from the other.
+	if err := os.WriteFile(filepath.Join(ide, "state.vscdb"), bytes.Repeat([]byte("x"), 64), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cli := filepath.Join(tmp, "cursor-cli", "projects", "p", "agent-transcripts")
+	if err := os.MkdirAll(cli, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"c1","cwd":"/w","timestamp":"2026-08-08T01:00:00Z","message":{"role":"user","content":"snorklewhip"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(cli, "t.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CURSOR_ROOT", filepath.Join(tmp, "cursor-user"))
+	t.Setenv("DEJA_CURSOR_CLI_ROOT", filepath.Join(tmp, "cursor-cli"))
+	t.Setenv("PATH", "")
+
+	var check doctorStoreCheck
+	for _, c := range doctorStoreChecks() {
+		if c.name == "cursor" {
+			check = c
+		}
+	}
+	store, _ := inspectDoctorStore(check)
+	if store.State == "ok" {
+		t.Errorf("the JSON form calls a store ok while its text row says the sqlite3 CLI is missing")
+	}
+	if store.State != "needs-sqlite3" {
+		t.Errorf("state = %q, want needs-sqlite3", store.State)
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -322,8 +322,9 @@ appears only after `deja embed` has built a semantic sidecar. The heatmap grid u
 when unavailable; `policy` is always present. `index.path` points at the index
 directory; `index.db` is that directory's name, not a file. Store `state`
 values are `ok`, `missing`, `unreadable`, `parsed-zero`, `denied` (which adds a
-`denied` field naming the unreadable path), and `needs-sqlite3`; an existing but
-empty store directory reports `missing`. A store also carries `indexed_sessions`
+`denied` field naming the unreadable path), `needs-sqlite3` and `needs-zstd`
+(both of which add a `skipped` field saying which CLI is missing); an existing
+but empty store directory reports `missing`. A store also carries `indexed_sessions`
 and, when it holds peer-synced work, `indexed_from_elsewhere`; a store whose
 permission walk was cut short or blocked carries `partial` or `unchecked`.
 Version `state` is `ok`, `update-available`, `ahead`, `dev`, `offline` (under

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -567,19 +567,32 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 		}
 		ss = append(ss, r.ss...)
 		if progress != nil && !SuppressHarnessNarration {
-			msgs := 0
-			for _, s := range r.ss {
-				msgs += len(s.Messages)
-			}
-			// "deja" is the notes pseudo-source; it narrates as "notes".
-			label := r.name
-			if label == "deja" {
-				label = "notes"
-			}
-			fmt.Fprintf(progress, "deja: %s: %d session%s, %d message%s\n", label, len(r.ss), pluralS(len(r.ss)), msgs, pluralS(msgs))
+			fmt.Fprintln(progress, harnessNarration(r.name, r.ss, sources.SkipReason(r.name)))
 		}
 	}
 	return ss
+}
+
+// harnessNarration is the line an index run prints for one store. A store can
+// be half-readable — cursor keeps CLI transcripts as JSONL and its IDE sessions
+// in SQLite — and the count alone then reads as the whole story while half of
+// it is missing from recall. The skip reason was printed only for a store that
+// yielded nothing at all (#1758, the shape of #794).
+func harnessNarration(name string, ss []model.Session, skipped string) string {
+	msgs := 0
+	for _, s := range ss {
+		msgs += len(s.Messages)
+	}
+	// "deja" is the notes pseudo-source; it narrates as "notes".
+	label := name
+	if label == "deja" {
+		label = "notes"
+	}
+	line := fmt.Sprintf("deja: %s: %d session%s, %d message%s", label, len(ss), pluralS(len(ss)), msgs, pluralS(msgs))
+	if skipped != "" {
+		line += " — part of this store could not be read: " + skipped
+	}
+	return line
 }
 
 // ReportCollisions returns how many transcripts shared an id with another since

--- a/internal/index/partial_skip_test.go
+++ b/internal/index/partial_skip_test.go
@@ -1,0 +1,36 @@
+package index
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A store can be half-readable: cursor keeps CLI transcripts as JSONL and its
+// IDE sessions in SQLite, so without the sqlite3 CLI one half arrives and the
+// other does not. The run narrated what it got and said nothing about the rest,
+// while the same run names a store it could not read at all (#1758).
+func TestNarrationNamesAHalfReadStore(t *testing.T) {
+	got := harnessNarration("cursor", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, "sqlite3 CLI not found")
+	if !strings.Contains(got, "1 session") {
+		t.Errorf("the line lost its count: %q", got)
+	}
+	if !strings.Contains(got, "sqlite3 CLI not found") {
+		t.Errorf("a half-read store says nothing about the half it could not read: %q", got)
+	}
+
+	// Nothing skipped: the line is what it always was.
+	plain := harnessNarration("claude", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, "")
+	if strings.Contains(plain, "—") {
+		t.Errorf("a fully read store gained a caveat: %q", plain)
+	}
+
+	// The notes pseudo-source keeps its label.
+	if n := harnessNarration("deja", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, ""); !strings.HasPrefix(n, "deja: notes:") {
+		t.Errorf("notes narrate as notes: %q", n)
+	}
+	var buf bytes.Buffer
+	_ = buf
+}

--- a/internal/index/partial_skip_test.go
+++ b/internal/index/partial_skip_test.go
@@ -1,7 +1,6 @@
 package index
 
 import (
-	"bytes"
 	"strings"
 	"testing"
 
@@ -31,6 +30,4 @@ func TestNarrationNamesAHalfReadStore(t *testing.T) {
 	if n := harnessNarration("deja", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, ""); !strings.HasPrefix(n, "deja: notes:") {
 		t.Errorf("notes narrate as notes: %q", n)
 	}
-	var buf bytes.Buffer
-	_ = buf
 }

--- a/internal/sources/skip.go
+++ b/internal/sources/skip.go
@@ -1,5 +1,7 @@
 package sources
 
+import "strings"
+
 // SkipReason says why a harness deja can see on disk produced nothing. That is
 // a missing external tool: six stores are read through the sqlite3 CLI, and an
 // index run that names every harness it read while staying silent about the
@@ -19,7 +21,10 @@ func SkipReason(harness string) string {
 	// tool the files are there and unreadable — the same failure as Zed's, one
 	// layer up: whole sessions rather than thread bodies inside a store.
 	if harness == "deepseek" {
-		if ZstdAvailable() || len(DeepSeekSessionFiles()) == 0 {
+		// Only the framed ones need the tool. A store of plain session.jsonl
+		// reads without it, and saying part of it could not be read there
+		// names a problem the reader does not have (#1758).
+		if ZstdAvailable() || !anyZstdFramed(DeepSeekSessionFiles()) {
 			return ""
 		}
 		return "zstd CLI not found"
@@ -44,6 +49,17 @@ func SkipReason(harness string) string {
 		return ""
 	}
 	return "sqlite3 CLI not found"
+}
+
+// anyZstdFramed reports whether any of these files is a zstd frame rather than
+// plain text — the DeepSeek Harness writes either, depending on its settings.
+func anyZstdFramed(files []string) bool {
+	for _, f := range files {
+		if strings.HasSuffix(f, ".zstd") || strings.HasSuffix(f, ".zst") {
+			return true
+		}
+	}
+	return false
 }
 
 func zedSkipReason() string {


### PR DESCRIPTION
Closes #1758.

Cursor keeps CLI transcripts as JSONL and its IDE sessions in SQLite. Without the `sqlite3` CLI the IDE half is unreadable, and the index run reported only what it managed to read — the skip line was printed for a store that yielded nothing at all.

```
before  deja: cursor: 1 session, 2 messages
after   deja: cursor: 1 session, 2 messages — part of this store could not be read: sqlite3 CLI not found
        (with sqlite3: deja: cursor: 2 sessions, 4 messages — unchanged)
        (a wholly unreadable store still reads: deja: cursor: skipped — sqlite3 CLI not found)
```

Second half of the same fault: doctor's text row has always carried "sqlite3 CLI missing — IDE sessions unavailable" in its detail while the JSON form called the store `ok`, because the state comes from whichever file is newest and the CLI transcript parses. Now both say `needs-sqlite3`, with `partial` set:

```
{"name": "cursor", "state": "needs-sqlite3", …, "files": 2, "indexed_sessions": 1, "partial": true}
```

Tests: `TestNarrationNamesAHalfReadStore` and `TestBothFormsAgreeWhenHalfAStoreNeedsSqlite`.