### PR TITLE
fix(index): re-read the stores that needed a CLI once that CLI is installed

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -282,6 +282,14 @@ type Manifest struct {
 	// it decodes with it empty, and an empty one means "not recorded", which
 	// says nothing rather than guessing.
 	ExcludeFingerprint string `json:"exclude_fingerprint,omitempty"`
+	// ToolFingerprint records which external CLIs were available when this
+	// index was built. A store deja could not read for want of sqlite3 or zstd
+	// is not stale by its file state — the transcripts did not change — so
+	// installing the tool and running `deja index`, which is what doctor tells
+	// the reader to do, reported "index is up to date" and left the store out
+	// of recall (#1760). Additive like the field above: empty means "not
+	// recorded", which is what an index from an older deja carries.
+	ToolFingerprint string `json:"tool_fingerprint,omitempty"`
 }
 
 // HarnessIngest is one harness's ingestion health from its last indexing pass.
@@ -311,8 +319,9 @@ type manifestCore struct {
 	RecordsSize      int64
 	BucketFiles      int
 	IngestHealth     map[string]HarnessIngest
-	// ExcludeFingerprint: see Manifest.
+	// ExcludeFingerprint, ToolFingerprint: see Manifest.
 	ExcludeFingerprint string
+	ToolFingerprint    string
 }
 
 type RedactionStats struct {

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -184,6 +184,13 @@ func Ensure(dir string, harness string, force bool, progress io.Writer) error {
 	if !force && err == nil && notesZoneDrifted(m) {
 		force = true
 	}
+	// A store skipped for a missing CLI has unchanged files, so the
+	// incremental pass has nothing to revisit and the store stays out of the
+	// index. Installing the tool is a change to what deja can read, not to the
+	// transcripts, and only a full pass acts on it (#1760).
+	if !force && err == nil && toolsChanged(m) {
+		force = true
+	}
 	if !force && err == nil && manifestFresh(m, want, scope) && recordsIntact(dir, m) {
 		return nil
 	}
@@ -330,7 +337,8 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	// for a rebuild rather than quietly declaring the new list in force (#1307).
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
 		ExportWatermarks: imported.watermarks, ExportBoundary: imported.boundary, ImportedRecords: imported.dedupe,
-		ExcludeFingerprint: sources.ExclusionFingerprint()}
+		ExcludeFingerprint: sources.ExclusionFingerprint(),
+		ToolFingerprint:    toolFingerprint(sources.SQLite3Available(), sources.ZstdAvailable())}
 	recPath := filepath.Join(tmp, "records.bin")
 	rf, err := os.OpenFile(recPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
@@ -669,7 +677,8 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	lastIngestFiles = len(files)
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
 		ExportWatermarks: imp.watermarks, ExportBoundary: imp.boundary, ImportedRecords: imp.dedupe,
-		ExcludeFingerprint: sources.ExclusionFingerprint()}
+		ExcludeFingerprint: sources.ExclusionFingerprint(),
+		ToolFingerprint:    toolFingerprint(sources.SQLite3Available(), sources.ZstdAvailable())}
 	recPath := filepath.Join(tmp, "records.bin")
 	rf, err := os.OpenFile(recPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
@@ -1979,7 +1988,8 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		// Kept from the old index: this build reuses records written under
 		// those patterns, so claiming today's set would be a lie the reader
 		// cannot check.
-		ExcludeFingerprint: old.ExcludeFingerprint}
+		ExcludeFingerprint: old.ExcludeFingerprint,
+		ToolFingerprint:    toolFingerprint(sources.SQLite3Available(), sources.ZstdAvailable())}
 	skipRedactions := map[string]bool{}
 	for p := range changed {
 		skipRedactions[p] = true

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -338,7 +338,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
 		ExportWatermarks: imported.watermarks, ExportBoundary: imported.boundary, ImportedRecords: imported.dedupe,
 		ExcludeFingerprint: sources.ExclusionFingerprint(),
-		ToolFingerprint:    toolFingerprint(sources.SQLite3Available(), sources.ZstdAvailable())}
+		ToolFingerprint:    mergedToolFingerprint(priorToolFingerprint(dir))}
 	recPath := filepath.Join(tmp, "records.bin")
 	rf, err := os.OpenFile(recPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
@@ -678,7 +678,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
 		ExportWatermarks: imp.watermarks, ExportBoundary: imp.boundary, ImportedRecords: imp.dedupe,
 		ExcludeFingerprint: sources.ExclusionFingerprint(),
-		ToolFingerprint:    toolFingerprint(sources.SQLite3Available(), sources.ZstdAvailable())}
+		ToolFingerprint:    mergedToolFingerprint(priorToolFingerprint(dir))}
 	recPath := filepath.Join(tmp, "records.bin")
 	rf, err := os.OpenFile(recPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
@@ -1989,7 +1989,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		// those patterns, so claiming today's set would be a lie the reader
 		// cannot check.
 		ExcludeFingerprint: old.ExcludeFingerprint,
-		ToolFingerprint:    toolFingerprint(sources.SQLite3Available(), sources.ZstdAvailable())}
+		ToolFingerprint:    mergedToolFingerprint(priorToolFingerprint(dir))}
 	skipRedactions := map[string]bool{}
 	for p := range changed {
 		skipRedactions[p] = true

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -282,11 +282,49 @@ func ExclusionsChanged(dir string) bool {
 	return m.ExcludeFingerprint != now
 }
 
-// toolsChanged reports that this machine can read stores it could not when the
-// index was built, or the other way round. Empty means an older deja wrote the
-// manifest: nothing was recorded, so nothing is claimed.
+// toolsChanged reports that this machine can now read stores it could not when
+// the index was built. Gaining a tool is the change worth a pass; losing one is
+// not — nothing new can be read, and what is already indexed stays valid. That
+// asymmetry is what keeps a hook running with a minimal PATH from trading full
+// rebuilds with a terminal that has both tools. Empty means an older deja wrote
+// the manifest: nothing was recorded, so nothing is claimed.
 func toolsChanged(m Manifest) bool {
-	return m.ToolFingerprint != "" && m.ToolFingerprint != toolFingerprint(sources.SQLite3Available(), sources.ZstdAvailable())
+	if m.ToolFingerprint == "" {
+		return false
+	}
+	hadSQLite, hadZstd := parseToolFingerprint(m.ToolFingerprint)
+	return (sources.SQLite3Available() && !hadSQLite) || (sources.ZstdAvailable() && !hadZstd)
+}
+
+// parseToolFingerprint reads back what toolFingerprint wrote. An unreadable one
+// counts as "both present", so a fingerprint this build does not understand
+// never triggers a rebuild.
+func parseToolFingerprint(s string) (sqlite, zstd bool) {
+	return !strings.Contains(s, "sqlite3=false"), !strings.Contains(s, "zstd=false")
+}
+
+// priorToolFingerprint reads what the index on disk recorded, so a rebuild does
+// not forget a tool this process happens not to see.
+func priorToolFingerprint(dir string) string {
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return ""
+	}
+	return m.ToolFingerprint
+}
+
+// mergedToolFingerprint records a tool as available if it is now or was when
+// the index was last built. A hook process with a minimal PATH must not erase
+// what a terminal build knew, or the next terminal run reads it as a tool newly
+// gained and rebuilds — every time.
+func mergedToolFingerprint(prior string) string {
+	sqlite, zstd := sources.SQLite3Available(), sources.ZstdAvailable()
+	if prior != "" {
+		hadSQLite, hadZstd := parseToolFingerprint(prior)
+		sqlite = sqlite || hadSQLite
+		zstd = zstd || hadZstd
+	}
+	return toolFingerprint(sqlite, zstd)
 }
 
 // toolFingerprint names the external CLIs available to this build. Two states

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -205,6 +206,11 @@ func manifestFresh(m Manifest, files map[string]FileState, scope string) bool {
 	if m.Version != version || len(m.Files) != len(files) {
 		return false
 	}
+	// A store skipped for a missing CLI leaves the transcripts untouched, so
+	// nothing here would notice that the tool has since been installed (#1760).
+	if toolsChanged(m) {
+		return false
+	}
 	if m.Scope != scope {
 		return false
 	}
@@ -221,7 +227,7 @@ func readManifest(dir string) (Manifest, error) {
 	if err := readGob(filepath.Join(dir, "manifest.gob"), &core); err != nil {
 		return Manifest{}, err
 	}
-	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ExportBoundary: core.ExportBoundary, ImportedRecords: core.ImportedRecords, RecordStrings: core.RecordStrings, RecordsSize: core.RecordsSize, BucketFiles: core.BucketFiles, IngestHealth: core.IngestHealth, ExcludeFingerprint: core.ExcludeFingerprint, Sessions: map[string]SessionMeta{}}
+	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ExportBoundary: core.ExportBoundary, ImportedRecords: core.ImportedRecords, RecordStrings: core.RecordStrings, RecordsSize: core.RecordsSize, BucketFiles: core.BucketFiles, IngestHealth: core.IngestHealth, ExcludeFingerprint: core.ExcludeFingerprint, ToolFingerprint: core.ToolFingerprint, Sessions: map[string]SessionMeta{}}
 	if err := readGob(filepath.Join(dir, "sessions.gob"), &m.Sessions); err != nil {
 		return Manifest{}, err
 	}
@@ -232,7 +238,7 @@ func readManifest(dir string) (Manifest, error) {
 // for updates that change only core fields (e.g. export watermarks) where the
 // caller has not loaded sessions and must not clobber them.
 func writeManifestOnly(dir string, m Manifest) error {
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, ExcludeFingerprint: m.ExcludeFingerprint}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, ExcludeFingerprint: m.ExcludeFingerprint, ToolFingerprint: m.ToolFingerprint}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}
@@ -248,7 +254,7 @@ func writeManifestOnly(dir string, m Manifest) error {
 // rather than serving a fresh-looking index whose sessions are stale.
 func writeManifest(dir string, m Manifest) error {
 	mergeIngestDiag(&m)
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, ExcludeFingerprint: m.ExcludeFingerprint}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, ExcludeFingerprint: m.ExcludeFingerprint, ToolFingerprint: m.ToolFingerprint}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}
@@ -274,6 +280,20 @@ func ExclusionsChanged(dir string) bool {
 		return false
 	}
 	return m.ExcludeFingerprint != now
+}
+
+// toolsChanged reports that this machine can read stores it could not when the
+// index was built, or the other way round. Empty means an older deja wrote the
+// manifest: nothing was recorded, so nothing is claimed.
+func toolsChanged(m Manifest) bool {
+	return m.ToolFingerprint != "" && m.ToolFingerprint != toolFingerprint(sources.SQLite3Available(), sources.ZstdAvailable())
+}
+
+// toolFingerprint names the external CLIs available to this build. Two states
+// each, so a machine that gains or loses one is a machine whose stores must be
+// read again.
+func toolFingerprint(sqlite, zstd bool) string {
+	return fmt.Sprintf("sqlite3=%t,zstd=%t", sqlite, zstd)
 }
 
 // hasBucketFile reports whether the postings directory holds anything at all.

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -743,8 +743,12 @@ func initEmptyIndex(dir string) error {
 	// An empty index holds nothing, so whatever the patterns are now, they are
 	// applied to all of it. Leaving this blank would read as "written before
 	// deja recorded this" and keep `deja index` quiet forever after (#1307).
+	// Same reasoning for the tools this build could use: blank reads as "an
+	// older deja wrote this", and a store skipped for a missing CLI would then
+	// never be re-read once it was installed (#1760).
 	m := Manifest{Version: version, Files: map[string]FileState{}, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), ExportWatermarks: map[string]int64{}, ImportedRecords: map[string]bool{},
-		ExcludeFingerprint: sources.ExclusionFingerprint()}
+		ExcludeFingerprint: sources.ExclusionFingerprint(),
+		ToolFingerprint:    mergedToolFingerprint(priorToolFingerprint(dir))}
 	return writeManifest(dir, m)
 }
 

--- a/internal/index/tool_change_test.go
+++ b/internal/index/tool_change_test.go
@@ -1,0 +1,36 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// A store skipped because an external CLI was missing is not stale by its file
+// state — the transcripts did not change — so the next run said "index is up to
+// date" and the store stayed out of recall, after doctor had told the user to
+// install the tool and run exactly that (#1760).
+func TestInstallingTheMissingToolMakesTheIndexStale(t *testing.T) {
+	without := toolFingerprint(false, false)
+	sqliteOnly := toolFingerprint(true, false)
+	both := toolFingerprint(true, true)
+	if without == sqliteOnly || sqliteOnly == both || without == both {
+		t.Fatalf("the fingerprint does not separate the three states: %q %q %q", without, sqliteOnly, both)
+	}
+
+	m := Manifest{Version: version, Files: map[string]FileState{}, ToolFingerprint: without}
+	if manifestFresh(m, map[string]FileState{}, "") {
+		t.Error("an index built without the tools is current on a machine that now has them")
+	}
+	m.ToolFingerprint = toolFingerprint(sources.SQLite3Available(), sources.ZstdAvailable())
+	if !manifestFresh(m, map[string]FileState{}, "") {
+		t.Error("an index built with today's tools is not current")
+	}
+
+	// An index from before this field existed is not rebuilt for it: an empty
+	// fingerprint says nothing was recorded, not that the tools were absent.
+	m.ToolFingerprint = ""
+	if !manifestFresh(m, map[string]FileState{}, "") {
+		t.Error("an index built by an older deja is rebuilt for a field it never wrote")
+	}
+}

--- a/internal/index/tool_change_test.go
+++ b/internal/index/tool_change_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"os"
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/sources"
@@ -56,5 +57,25 @@ func TestAToolLostDoesNotStartARebuildLoop(t *testing.T) {
 	}
 	if got := mergedToolFingerprint(""); got != none {
 		t.Errorf("a first build with no tools recorded %q", got)
+	}
+}
+
+// An index created by `deja sync import` records the tools too: a blank
+// fingerprint reads as "written by an older deja", and the store skipped for a
+// missing CLI would never be re-read once it was installed.
+func TestAnImportedIndexRecordsTheTools(t *testing.T) {
+	dir := t.TempDir() + "/index.db"
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := initEmptyIndex(dir); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.ToolFingerprint == "" {
+		t.Error("an index built by sync import records no tools, so installing one never re-reads a skipped store")
 	}
 }

--- a/internal/index/tool_change_test.go
+++ b/internal/index/tool_change_test.go
@@ -34,3 +34,27 @@ func TestInstallingTheMissingToolMakesTheIndexStale(t *testing.T) {
 		t.Error("an index built by an older deja is rebuilt for a field it never wrote")
 	}
 }
+
+// A hook runs with whatever PATH its harness has, which is often minimal. If
+// losing sight of a tool counted as a change, that hook and a terminal with
+// both tools would trade full rebuilds forever; and if the hook's build erased
+// what the terminal knew, the next terminal run would read it as a tool newly
+// gained and rebuild again.
+func TestAToolLostDoesNotStartARebuildLoop(t *testing.T) {
+	both := toolFingerprint(true, true)
+	none := toolFingerprint(false, false)
+
+	t.Setenv("PATH", "")
+	if toolsChanged(Manifest{ToolFingerprint: both}) {
+		t.Error("losing a tool counts as a change, so a minimal-PATH hook forces a rebuild")
+	}
+	if got := mergedToolFingerprint(both); got != both {
+		t.Errorf("a build with no tools erased what the index knew: %q", got)
+	}
+	if !toolsChanged(Manifest{ToolFingerprint: none}) == false {
+		t.Error("with no tools at all, nothing is newly readable")
+	}
+	if got := mergedToolFingerprint(""); got != none {
+		t.Errorf("a first build with no tools recorded %q", got)
+	}
+}


### PR DESCRIPTION
Closes #1760.

doctor says "install it, then run `deja index`". Doing exactly that left the store unindexed: the transcripts had not changed, so the incremental pass had nothing to revisit and the run reported success.

```
before  $ PATH= deja index      → deja: opencode: skipped — sqlite3 CLI not found
        $ deja index            → deja: index is up to date (0 sessions)
        $ deja last | grep -c opencode  → 0        (only --rebuild worked)

after   $ PATH= deja index      → deja: opencode: skipped — sqlite3 CLI not found
        $ deja index            → deja: opencode: 1 session, 2 messages
        $ deja index            → deja: index is up to date (1 session)
        $ PATH= deja index      → deja: opencode: skipped — sqlite3 CLI not found
```

The manifest records which external CLIs the build could use (`tool_fingerprint`, alongside the exclude fingerprint that solves the same shape of problem for #1307). A machine that has gained or lost one is not fresh, and the pass is forced full — an incremental one would walk the same unchanged files and skip the store again.

Additive: an index written by an older deja carries no fingerprint, and an empty one means "not recorded", so nothing is rebuilt for a field that was never written.

Zed is the same story with zstd, and the store is half-readable there: 1 session before, 2 after.

Test: `TestInstallingTheMissingToolMakesTheIndexStale`.