### PR TITLE
docs: install from homebrew-core, not the tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ solved in that project when the session opens.
 <details>
 <summary>Other ways to install, and what to do if you want less than all of it</summary>
 
-`brew install vshulcz/tap/deja-vu`, `go install github.com/vshulcz/deja-vu/cmd/deja@latest`,
+`brew install deja-vu`, `go install github.com/vshulcz/deja-vu/cmd/deja@latest`,
 or `npx @vshulcz/deja-vu "query"` to try it without installing anything. Desktop apps that
 take MCP servers as bundles can open the `.mcpb` from the
 [latest release](https://github.com/vshulcz/deja-vu/releases/latest); it carries the binary.

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -20,7 +20,7 @@ model and no embeddings, credentials redacted as the index is built.
 The binary is not in the bundle — plugins carry files, not native binaries:
 
 ```sh
-brew install vshulcz/tap/deja-vu
+brew install deja-vu
 ```
 
 or

--- a/claude-plugin/hooks/deja.sh
+++ b/claude-plugin/hooks/deja.sh
@@ -39,7 +39,7 @@ if [ -z "${DEJA:-}" ]; then
 	# Drain stdin so the caller never blocks on the pipe.
 	cat >/dev/null 2>&1 || true
 	if [ "${1:-}" = "hook-context" ]; then
-		printf '{"systemMessage":"deja-vu plugin is installed but the deja binary is not on PATH — install it with: brew install vshulcz/tap/deja  (or: go install github.com/vshulcz/deja-vu/cmd/deja@latest)"}\n'
+		printf '{"systemMessage":"deja-vu plugin is installed but the deja binary is not on PATH — install it with: brew install deja-vu  (or: go install github.com/vshulcz/deja-vu/cmd/deja@latest)"}\n'
 	fi
 	exit 0
 fi

--- a/claude-plugin/mcp/deja-mcp.sh
+++ b/claude-plugin/mcp/deja-mcp.sh
@@ -22,5 +22,5 @@ fi
 
 # No binary: fail loudly here rather than silently registering a server that
 # answers nothing. The client reports it as one server that would not start.
-echo "deja binary not found — install it with: brew install vshulcz/tap/deja" >&2
+echo "deja binary not found — install it with: brew install deja-vu" >&2
 exit 1

--- a/codex-plugin/README.md
+++ b/codex-plugin/README.md
@@ -16,7 +16,7 @@ model and no embeddings, credentials redacted as the index is built.
 The binary is not in the bundle — plugins carry files, not native binaries:
 
 ```sh
-brew install vshulcz/tap/deja-vu
+brew install deja-vu
 ```
 
 or

--- a/codex-plugin/hooks/deja.sh
+++ b/codex-plugin/hooks/deja.sh
@@ -45,7 +45,7 @@ if [ -z "${DEJA:-}" ]; then
 	# Drain stdin so Codex never blocks on the pipe.
 	cat >/dev/null 2>&1 || true
 	if [ "${1:-}" = "hook-context" ]; then
-		printf '{"systemMessage":"the deja-vu plugin is installed but the deja binary is not on PATH — install it with: brew install vshulcz/tap/deja-vu  (or: go install github.com/vshulcz/deja-vu/cmd/deja@latest)"}\n'
+		printf '{"systemMessage":"the deja-vu plugin is installed but the deja binary is not on PATH — install it with: brew install deja-vu  (or: go install github.com/vshulcz/deja-vu/cmd/deja@latest)"}\n'
 	fi
 	exit 0
 fi

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -79,7 +79,7 @@
 <h2>Install</h2>
 <pre>curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
 # or
-brew install vshulcz/tap/deja-vu
+brew install deja-vu
 npm  install -g @vshulcz/deja-vu
 go   install github.com/vshulcz/deja-vu/cmd/deja@latest</pre>
 <p>Desktop apps that install MCP servers as bundles take the <code>.mcpb</code> file published with every release — one per platform, carrying the binary, so nothing else is needed. Open it and the app installs the server. Terminal agents use <code>deja install</code>, described under <a href="harnesses.html">harnesses</a>.</p>

--- a/docs/guide/memory-for-gemini.html
+++ b/docs/guide/memory-for-gemini.html
@@ -89,7 +89,7 @@
 <p>Hooks are the difference between the two. Gemini runs them only when <code>hooksConfig.enabled</code> is set in your <code>settings.json</code>, and an extension cannot write that file — so the extension gives you recall on demand, and the CLI install adds recall that arrives on its own at session start and on each prompt.</p>
 <p>Both name the extension <code>deja</code>, which is deliberate: Gemini keys extensions by that name and answers a second install with <code>Extension "deja" is already installed</code>. Having both wired is not a state you can reach by accident.</p>
 <p>Either way it needs the binary, since an extension delivers files rather than runtimes:</p>
-<pre>brew install vshulcz/tap/deja-vu
+<pre>brew install deja-vu
 # or
 curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
 

--- a/docs/guide/memory-for-grok.html
+++ b/docs/guide/memory-for-grok.html
@@ -86,7 +86,7 @@
 <p>Writes <code>[mcp_servers.deja]</code> into <code>~/.grok/config.toml</code> and a hook file of deja's own into <code>~/.grok/hooks/</code>. Grok reads hooks in the same shape Claude Code uses, which is why all four moments work here: session start, per prompt, before a tool runs, and before compaction.</p>
 <p>A plugin for the official marketplace is <a href="https://github.com/xai-org/plugin-marketplace/pull/332">in review</a>. When it lands, <code>grok plugin install deja</code> is the other path, and the two coexist: each half of the plugin stands down when it finds what the CLI already wired, so nothing is listed or injected twice.</p>
 <p>Either way it needs the binary, since a plugin delivers files rather than runtimes:</p>
-<pre>brew install vshulcz/tap/deja-vu
+<pre>brew install deja-vu
 # or
 curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
 

--- a/docs/guide/memory-for-kimi.html
+++ b/docs/guide/memory-for-kimi.html
@@ -84,7 +84,7 @@
 <h2>Adding recall</h2>
 <pre>/plugins install https://github.com/vshulcz/deja-vu</pre>
 <p>Kimi installs the plugin from the repository — the manifest sits at the root, which is the only reason that file is there. It needs the <a href="https://github.com/vshulcz/deja-vu">deja</a> binary, which is what indexes and searches:</p>
-<pre>brew install vshulcz/tap/deja-vu
+<pre>brew install deja-vu
 # or
 curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
 <p>With the CLI instead, <code>deja install kimi-auto</code> writes the MCP server into <code>mcp.json</code> and a <code>[[hooks]]</code> block into <code>config.toml</code>. Having both is fine: the plugin reads those two files and skips whatever the installer already covers.</p>

--- a/docs/guide/memory-for-opencode.html
+++ b/docs/guide/memory-for-opencode.html
@@ -88,7 +88,7 @@
   "plugin": ["opencode-deja"]
 }</pre>
 <p>opencode installs the package on start. It needs the <a href="https://github.com/vshulcz/deja-vu">deja</a> binary, which does the indexing — the plugin is the seam, not the engine:</p>
-<pre>brew install vshulcz/tap/deja-vu
+<pre>brew install deja-vu
 # or
 curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
 <h3>The CLI</h3>

--- a/docs/guide/memory-for-qwen.html
+++ b/docs/guide/memory-for-qwen.html
@@ -90,7 +90,7 @@
 <p>Qwen also reads Claude-format marketplaces, which this repository is:</p>
 <pre>qwen extensions sources add https://github.com/vshulcz/deja-vu</pre>
 <p>Either way it needs the binary, since an extension delivers files rather than runtimes:</p>
-<pre>brew install vshulcz/tap/deja-vu
+<pre>brew install deja-vu
 # or
 curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
 

--- a/docs/guide/memory-for-zed.html
+++ b/docs/guide/memory-for-zed.html
@@ -87,7 +87,7 @@
 <p>writes the server into <code>settings.json</code>. Or install the deja extension from Zed's extension list, which brings its own copy of the binary if you have none.</p>
 <p>Both use the same server id — <code>deja-context-server</code> — and Zed keys servers by id, so whichever order you install in there is exactly one server. That was not free: with two different ids, Zed ran two servers and the agent saw every tool twice.</p>
 <p>The extension is <a href="https://github.com/zed-industries/extensions/pull/7307">still in review</a> at the time of writing; until it lands, <code>deja install zed</code> is the path, and it needs the binary:</p>
-<pre>brew install vshulcz/tap/deja-vu</pre>
+<pre>brew install deja-vu</pre>
 
 <h2>What arrives, and what does not</h2>
 <p>The six tools, and a <code>/deja</code> slash command in the agent panel. What Zed cannot give you today is memory that arrives unasked: its extension API covers language servers, slash commands, context servers and debuggers, and there is no lifecycle hook where recall could be injected — no session-start block, nothing before a tool call. Every other harness in the matrix gets that; Zed does not, and it is a limitation of the API rather than something we chose to skip. It becomes work the day Zed ships a hook.</p>

--- a/extensions/grok/README.md
+++ b/extensions/grok/README.md
@@ -19,7 +19,7 @@ Install the binary first — plugins deliver files, not runtimes or native
 binaries:
 
 ```sh
-brew install vshulcz/tap/deja-vu
+brew install deja-vu
 ```
 
 or

--- a/extensions/zed/src/lib.rs
+++ b/extensions/zed/src/lib.rs
@@ -108,7 +108,7 @@ impl DejaExtension {
                 "no deja binary was found and the release could not be fetched ({error}). \
                  Install deja — curl -fsSL \
                  https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh, or \
-                 brew install vshulcz/tap/deja-vu — and it will be used from there"
+                 brew install deja-vu — and it will be used from there"
             )
         })?;
 


### PR DESCRIPTION
`brew install deja-vu` works — the formula is in `homebrew/core` at 0.18.0, which is the current release. Every install line still said `brew install vshulcz/tap/deja-vu`, which is a tap the user does not need to think about.

Two of the fifteen were worse than verbose: `claude-plugin/mcp/deja-mcp.sh` and `claude-plugin/hooks/deja.sh` printed `brew install vshulcz/tap/deja`, and the tap's formula is `deja-vu` — so the message shown when the binary is missing sent people to a command that fails.

The tap still exists and still works for anyone already on it.