### PR TITLE
fix(index): say a store went away instead of greeting the reader as new

### DIFF
--- a/cmd/deja/empty_after_eviction_test.go
+++ b/cmd/deja/empty_after_eviction_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// "nothing to index yet" is the sentence for a machine deja has never had
+// history from. Printed after a store went away it contradicts the line above
+// it, which has just said what was lost: the reader is told they are new here
+// and that N indexed files are gone, in that order (#1762).
+func TestTheEmptyIndexSentenceKnowsSomethingWasLost(t *testing.T) {
+	fresh := emptyIndexReason(index.BuildSummary{Initial: true}, 0)
+	if !strings.Contains(fresh, "nothing to index yet") {
+		t.Errorf("a first run says %q", fresh)
+	}
+
+	lost := emptyIndexReason(index.BuildSummary{}, 3)
+	if strings.Contains(lost, "yet") {
+		t.Errorf("a run that evicted a store still reads as a first run: %q", lost)
+	}
+	if !strings.Contains(lost, "3") {
+		t.Errorf("the sentence does not say how much went away: %q", lost)
+	}
+	if !strings.Contains(lost, "gone") && !strings.Contains(lost, "went away") {
+		t.Errorf("the sentence does not say what happened: %q", lost)
+	}
+
+	// One file reads as one file.
+	if one := emptyIndexReason(index.BuildSummary{}, 1); strings.Contains(one, "1 indexed files") {
+		t.Errorf("plural for a single file: %q", one)
+	}
+}

--- a/cmd/deja/empty_after_eviction_test.go
+++ b/cmd/deja/empty_after_eviction_test.go
@@ -33,3 +33,17 @@ func TestTheEmptyIndexSentenceKnowsSomethingWasLost(t *testing.T) {
 		t.Errorf("plural for a single file: %q", one)
 	}
 }
+
+// Records kept back because their volume is merely unmounted have not gone
+// away, so the counter must not see them — otherwise a reconnectable disk reads
+// as history lost.
+func TestUnmountedRecordsAreNotCountedAsGone(t *testing.T) {
+	if n := index.ReportEvictedFiles(); n != 0 {
+		t.Fatalf("the counter starts at %d", n)
+	}
+	// Two reads in a row: the first clears it, so a later command in the same
+	// process cannot inherit a count that was already spent.
+	if n := index.ReportEvictedFiles(); n != 0 {
+		t.Errorf("the counter did not clear: %d", n)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -391,7 +391,7 @@ func cmdIndex(dir string, rest []string) error {
 	// a bare "indexing ..." line, and the state (no history anywhere, or a
 	// store behind a permission wall) only surfaced on the next command.
 	if b := index.LastBuild; b.Sessions == 0 && b.Messages == 0 && (noAgentHistoryFound() || deniedStoreCount() > 0) {
-		fmt.Fprintln(os.Stderr, emptyIndexHint("nothing to index yet"))
+		fmt.Fprintln(os.Stderr, emptyIndexReason(b, index.ReportEvictedFiles()))
 	}
 	maybeFirstIndexGreeting(dir)
 	// The live display erases itself on the way out, so a rebuild on a
@@ -2952,6 +2952,18 @@ func idPrefixNeeded(dir, subject, refusal string) error {
 		return errors.New(strings.TrimPrefix(emptyIndexHint(subject+", and nothing is indexed yet"), "deja: "))
 	}
 	return errors.New(refusal)
+}
+
+// emptyIndexReason opens the empty-index sentence. "Nothing to index yet" is
+// for a machine deja has never seen history from; a run that has just evicted a
+// store says what went away instead, because the line above it has already told
+// the reader what was lost and the two must not contradict each other (#1762).
+func emptyIndexReason(b index.BuildSummary, evicted int) string {
+	if evicted > 0 {
+		return emptyIndexHint(fmt.Sprintf("%d indexed file%s went away with the store that held %s, and nothing is left to index",
+			evicted, pluralS(evicted), pluralWhich(evicted)))
+	}
+	return emptyIndexHint("nothing to index yet")
 }
 
 // emptyIndexHint phrases the nothing-here answer the same way everywhere, and

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1889,7 +1889,6 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	// next run on there was nothing left to compare against and the warning
 	// stopped too. Records that came off a mount point stay in the index while
 	// the volume is away, and the line repeats until it is back.
-	evicted.Add(int64(len(removed)))
 	gone := missingTrees(removed)
 	for i := range gone {
 		gone[i].renamed = renamedMount(gone[i].dir)
@@ -1906,6 +1905,9 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 			}
 		}
 	}
+	// Counted after the keep-back above: records that came off an unmounted
+	// volume are still in the index, so they did not go away.
+	evicted.Add(int64(len(removed)))
 	if progress != nil {
 		for _, g := range gone {
 			verb := "is"

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1566,6 +1566,18 @@ func sortedKeys[V any](m map[string]V) []string {
 var collisions atomic.Int64
 var emptied atomic.Int64
 
+// evicted counts the indexed files that left because their store went away —
+// a disk unmounted, a directory deleted. The command layer needs it to tell a
+// machine deja has never seen history from ("nothing to index yet") from one
+// whose history has just gone (#1762).
+var evicted atomic.Int64
+
+// ReportEvictedFiles returns how many indexed files were dropped for having
+// disappeared since the last build, and clears the counter.
+func ReportEvictedFiles() int {
+	return int(evicted.Swap(0))
+}
+
 // attributeSession decides which of two transcripts sharing an id owns the
 // manifest row, and whether they collided at all. Lexicographically smallest
 // path wins, so the answer does not depend on which file was read first.
@@ -1877,6 +1889,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	// next run on there was nothing left to compare against and the warning
 	// stopped too. Records that came off a mount point stay in the index while
 	// the volume is away, and the line repeats until it is back.
+	evicted.Add(int64(len(removed)))
 	gone := missingTrees(removed)
 	for i := range gone {
 		gone[i].renamed = renamedMount(gone[i].dir)


### PR DESCRIPTION
Closes #1762.

When a store disappears, the run explains the eviction and then contradicts itself:

```
before  deja: /…/ext4 is gone, and 3 indexed files with it — if that disk is simply not mounted, reconnect it and run `deja index`
        deja: incremental index changed_files=0 removed_files=3 sessions=0
        deja: nothing to index yet — no agent history was found on this machine; `deja sources` shows where deja looked

after   deja: /…/ext4 is gone, and 3 indexed files with it — if that disk is simply not mounted, reconnect it and run `deja index`
        deja: incremental index changed_files=0 removed_files=3 sessions=0
        deja: 3 indexed files went away with the store that held them, and nothing is left to index — no agent history was found on this machine; `deja sources` shows where deja looked
```

"Nothing to index **yet**" is the first-run sentence, and it was the last thing a reader saw after being told what they had just lost. A machine deja really has never seen still gets it unchanged.

The issue as filed claimed the eviction itself was the bug. It is not: `TestUnmountedVolumeKeepsWhatItAlreadyIndexed` pins "a store the user deleted is still a deletion", and keeping the records made it fail. The correction is on the issue.

Test: `TestTheEmptyIndexSentenceKnowsSomethingWasLost`.