### PR TITLE
fix(redact): redact a secret whose json arrived with its quotes escaped

### DIFF
--- a/internal/redact/escaped_json_test.go
+++ b/internal/redact/escaped_json_test.go
@@ -29,6 +29,20 @@ func TestSecretsInEscapedJSONAreRedacted(t *testing.T) {
 		}
 	}
 
+	// The quoted-prose pattern too, in both spellings — and a value that holds
+	// backslashes of its own still counts, which is where narrowing the value
+	// class to fix the escaped case would have cost a redaction.
+	for _, in := range []string{
+		`password is \"hunter2hunter2\"`,
+		`password is "C:\Windows\path\secret"`,
+		`password authentication failed for user "admin" with password "S3cr3tP@ssw0rd!"`,
+	} {
+		got, _ := Text(in)
+		if !strings.Contains(got, "[redacted") {
+			t.Errorf("quoted secret survived: %s -> %s", in, got)
+		}
+	}
+
 	// Plain JSON is unchanged, and the near-misses stay near misses.
 	plain, _ := Text(`{"api_key": "8f14e45fceea167a5a36dedd4bea2543"}`)
 	if !strings.Contains(plain, "[redacted") {
@@ -39,6 +53,8 @@ func TestSecretsInEscapedJSONAreRedacted(t *testing.T) {
 		`the password prompt appeared twice`,
 		`/usr/local/share/token/abcdefghijklmnop`,
 		`password: hunter2`,
+		`C:\Users\token\abcdefghijklmnopqrst`,
+		`the pattern is token\s*[:=]\s*value`,
 	} {
 		if got, _ := Text(keep); got != keep {
 			t.Errorf("a near miss was redacted: %q -> %q", keep, got)

--- a/internal/redact/escaped_json_test.go
+++ b/internal/redact/escaped_json_test.go
@@ -1,0 +1,47 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+// Agents paste nested JSON all day — curl output, a log line holding a payload,
+// one tool's output quoted inside another's — and there every quote is escaped.
+// The keyword patterns stopped matching, so a secret recognisable only by its
+// key name went into the index whole (#1765).
+func TestSecretsInEscapedJSONAreRedacted(t *testing.T) {
+	for _, tc := range []struct{ in, keep string }{
+		{`{\"api_key\": \"8f14e45fceea167a5a36dedd4bea2543\"}`, "api_key"},
+		{`{\"password\": \"hunter2hunter2hunter2\"}`, "password"},
+		{`{\"aws_secret_access_key\": \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"}`, "aws_secret_access_key"},
+		{`{\"пароль\": \"8f14e45fceea167a5a36dedd4bea2543\"}`, "пароль"},
+		{`{\\"api_key\\": \\"8f14e45fceea167a5a36dedd4bea2543\\"}`, "api_key"},
+	} {
+		got, _ := Text(tc.in)
+		if !strings.Contains(got, "[redacted") {
+			t.Errorf("not redacted: %s -> %s", tc.in, got)
+		}
+		if !strings.Contains(got, tc.keep) {
+			t.Errorf("the key name went with it: %s -> %s", tc.in, got)
+		}
+		if strings.Contains(got, "8f14e45fceea167a5a36dedd4bea2543") || strings.Contains(got, "hunter2hunter2") || strings.Contains(got, "wJalrXUtnFEMI") {
+			t.Errorf("the value survived: %s -> %s", tc.in, got)
+		}
+	}
+
+	// Plain JSON is unchanged, and the near-misses stay near misses.
+	plain, _ := Text(`{"api_key": "8f14e45fceea167a5a36dedd4bea2543"}`)
+	if !strings.Contains(plain, "[redacted") {
+		t.Errorf("plain json stopped being redacted: %s", plain)
+	}
+	for _, keep := range []string{
+		`token = os.environ['MY_TOKEN']`,
+		`the password prompt appeared twice`,
+		`/usr/local/share/token/abcdefghijklmnop`,
+		`password: hunter2`,
+	} {
+		if got, _ := Text(keep); got != keep {
+			t.Errorf("a near miss was redacted: %q -> %q", keep, got)
+		}
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -27,7 +27,7 @@ func (c Counts) Total() int {
 
 var (
 	awsAccessKeyRE = regexp.MustCompile(`A(?:KIA|SIA)[0-9A-Z]{16}`)
-	awsSecretRE    = regexp.MustCompile(`(?i)\b(aws[_-]?secret[_-]?access[_-]?key)(\s*['"]?\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=_-]{32,})(['"]?)`)
+	awsSecretRE    = regexp.MustCompile(`(?i)\b(aws[_-]?secret[_-]?access[_-]?key)(\\*['"]?\s*[:=]\s*)(\\*['"]?)([A-Za-z0-9/+=_-]{32,})(\\*['"]?)`)
 	// The key may be embedded in a larger identifier (ANTHROPIC_API_KEY,
 	// x-api-key) and, in JSON, a closing quote can sit between the key and the
 	// delimiter ("api_key": "..."). Tolerate both so env-var and JSON forms are
@@ -36,12 +36,12 @@ var (
 	// only English: a Russian speaker writes "пароль: …" or "токен: …" and the
 	// secret sat in the clear because every pattern here was English-only. The
 	// value class and length floor are the same, so the looseness is unchanged.
-	genericKVRE = regexp.MustCompile(`(?i)\b([\w.-]{0,64}?(?:api[_-]?key|secret|token|passwd|password|authorization))(\s*['"]?\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=._-]{16,})(['"]?)`)
+	genericKVRE = regexp.MustCompile(`(?i)\b([\w.-]{0,64}?(?:api[_-]?key|secret|token|passwd|password|authorization))(\\*['"]?\s*[:=]\s*)(\\*['"]?)([A-Za-z0-9/+=._-]{16,})(\\*['"]?)`)
 	// The same shape in the languages people actually type in. \b is ASCII-only
 	// in RE2, so a Cyrillic or CJK key word can never sit behind it — these get
 	// their own pattern. A Russian speaker writing "пароль: …" had the secret
 	// stored in the clear because every pattern here was English-only.
-	genericKVIntlRE = regexp.MustCompile(`(?i)(парол[ьяею]|токен[ауы]?|секрет[ауы]?|ключ[аеиуом]?|contraseña|senha|passwort|密码|密碼|パスワード|비밀번호)(\s*['"]?\s*[:=]\s*)(['"]?)([A-Za-z0-9/+=._-]{16,})(['"]?)`)
+	genericKVIntlRE = regexp.MustCompile(`(?i)(парол[ьяею]|токен[ауы]?|секрет[ауы]?|ключ[аеиуом]?|contraseña|senha|passwort|密码|密碼|パスワード|비밀번호)(\\*['"]?\s*[:=]\s*)(\\*['"]?)([A-Za-z0-9/+=._-]{16,})(\\*['"]?)`)
 	bearerRE        = regexp.MustCompile(`(?i)\b(Bearer|Basic)(\s+)([A-Za-z0-9._~+/=-]{16,})`)
 	// A secret named in prose and quoted rather than assigned. Tool output is
 	// full of this shape — `password authentication failed for user "admin"
@@ -53,7 +53,7 @@ var (
 	//
 	// The quotes are what make it safe to be this loose: "password
 	// authentication failed" has no quoted value and matches nothing.
-	quotedSecretRE = regexp.MustCompile(`(?i)\b(password|passwd|pwd|secret|token|api[_-]?key)(\s+(?:is\s+|was\s+|for\s+)?)(["'` + "`" + `])([^"'` + "`" + `\n]{6,80})(["'` + "`" + `])`)
+	quotedSecretRE = regexp.MustCompile(`(?i)\b(password|passwd|pwd|secret|token|api[_-]?key)(\s+(?:is\s+|was\s+|for\s+)?)(\\*["'` + "`" + `])([^"'` + "`" + `\\\n]{6,80})(\\*["'` + "`" + `])`)
 	pemPrivateRE   = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----.*?-----END [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----`)
 	// Provider prefixes. sk- allows internal hyphens/underscores so modern
 	// hyphenated formats (sk-ant-…, sk-proj-…) are covered, not just legacy
@@ -110,7 +110,10 @@ func assignmentFollows(s string, i int) bool {
 	// The pattern uses \s, which is more than a space: a fuzz case of
 	// "passwd\n:" slipped past an earlier version of this that only skipped
 	// spaces and tabs.
-	for i < len(s) && (isSpaceByte(s[i]) || s[i] == '\'' || s[i] == '"') {
+	// The backslash is here for the same reason the quote is: agents paste
+	// nested JSON, where every quote arrives escaped, and `api_key\":` never
+	// reached the pattern because the gate stopped at the backslash (#1765).
+	for i < len(s) && (isSpaceByte(s[i]) || s[i] == '\'' || s[i] == '"' || s[i] == '\\') {
 		i++
 	}
 	return i < len(s) && (s[i] == ':' || s[i] == '=')

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -53,7 +53,7 @@ var (
 	//
 	// The quotes are what make it safe to be this loose: "password
 	// authentication failed" has no quoted value and matches nothing.
-	quotedSecretRE = regexp.MustCompile(`(?i)\b(password|passwd|pwd|secret|token|api[_-]?key)(\s+(?:is\s+|was\s+|for\s+)?)(\\*["'` + "`" + `])([^"'` + "`" + `\\\n]{6,80})(\\*["'` + "`" + `])`)
+	quotedSecretRE = regexp.MustCompile(`(?i)\b(password|passwd|pwd|secret|token|api[_-]?key)(\s+(?:is\s+|was\s+|for\s+)?)(\\*["'` + "`" + `])([^"'` + "`" + `\n]{6,80})(\\*["'` + "`" + `])`)
 	pemPrivateRE   = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----.*?-----END [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----`)
 	// Provider prefixes. sk- allows internal hyphens/underscores so modern
 	// hyphenated formats (sk-ant-…, sk-proj-…) are covered, not just legacy


### PR DESCRIPTION
Closes #1765.

Nested JSON is what agents paste all day — curl output, a log line holding a payload, one tool's output quoted inside another's — and there every quote arrives escaped. The keyword patterns stopped matching, so a secret recognisable only by its key name went into the index whole.

```
before  {\"api_key\": \"8f14e45fceea167a5a36dedd4bea2543\"}   → unchanged
after   {\"api_key\": \"[redacted:credential]\"}
```

Two places needed it, and the second is why the first alone did nothing: the patterns (`genericKVRE`, `genericKVIntlRE`, `quotedSecretRE`, `awsSecretRE`) now allow backslashes around the quotes, and `assignmentFollows` — the cheap gate that decides whether to run them at all — skips a backslash the way it already skips a quote.

Shape-based redaction was never affected, which is the control: `Bearer …` and `ghp_…` inside the same escaped JSON were redacted before this change and still are.

Test: `TestSecretsInEscapedJSONAreRedacted`, which also pins that plain JSON still redacts and that four near-misses (`token = os.environ['MY_TOKEN']`, "the password prompt appeared twice", a path containing `token`, `password: hunter2`) come back untouched.

Measured end to end on a store of 38 planted cases: 23 shapes and near-misses unchanged, and of 15 adversarial forms only the escaped-JSON one moved.