### PR TITLE
feat: carry the Agent Plugins manifests at the root

### DIFF
--- a/cmd/deja/agent_plugin_test.go
+++ b/cmd/deja/agent_plugin_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+// The Agent Plugins manifest schema is closed: an unknown top-level field is a
+// schema violation, and the name has its own grammar. Both are the kind of thing
+// a directory rejects on submission rather than a reviewer catching by eye, so
+// they are pinned here.
+//
+// https://open-plugins.com/plugin-authors/manifest
+func TestAgentPluginManifestIsPortable(t *testing.T) {
+	var manifest map[string]any
+	if err := json.Unmarshal(repoFile(t, "plugin.json"), &manifest); err != nil {
+		t.Fatalf("plugin.json: %v", err)
+	}
+
+	allowed := map[string]bool{
+		"$schema": true, "name": true, "version": true, "description": true,
+		"author": true, "homepage": true, "repository": true, "license": true,
+		"keywords": true, "extensions": true,
+	}
+	for key := range manifest {
+		if !allowed[key] {
+			t.Errorf("%q is not a portable top-level field; client-specific data belongs under extensions", key)
+		}
+	}
+	for _, required := range []string{"$schema", "name"} {
+		if manifest[required] == nil {
+			t.Errorf("%q is required", required)
+		}
+	}
+
+	// 1–64 characters, lowercase ASCII letters, digits, hyphens and periods,
+	// starting and ending alphanumeric, with no doubled separator.
+	name, _ := manifest["name"].(string)
+	ok := regexp.MustCompile(`^[a-z0-9]([a-z0-9.-]{0,62}[a-z0-9])?$`).MatchString(name)
+	if !ok || regexp.MustCompile(`--|\.\.`).MatchString(name) {
+		t.Errorf("plugin name %q does not satisfy the Agent Plugins grammar", name)
+	}
+}
+
+// Skills are discovered at a fixed depth: an immediate child of skills/ whose
+// SKILL.md is a regular file. A skill nested one level deeper is not found, and
+// nothing else in this repository would notice.
+func TestAgentPluginSkillsAreDiscoverable(t *testing.T) {
+	root := filepath.Join("..", "..")
+	entries, err := os.ReadDir(filepath.Join(root, "skills"))
+	if err != nil {
+		t.Fatalf("skills/: %v", err)
+	}
+	found := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(root, "skills", e.Name(), "SKILL.md"))
+		if err != nil || !info.Mode().IsRegular() {
+			t.Errorf("skills/%s has no SKILL.md at the top level, so no client will discover it", e.Name())
+			continue
+		}
+		found++
+	}
+	if found == 0 {
+		t.Fatal("no skill is discoverable, which makes the plugin manifest a promise of nothing")
+	}
+}
+
+// mcp.json is a closed document too: only $schema and mcpServers, and a stdio
+// command is one executable token rather than a shell line.
+func TestAgentPluginMCPDocument(t *testing.T) {
+	var doc map[string]any
+	if err := json.Unmarshal(repoFile(t, "mcp.json"), &doc); err != nil {
+		t.Fatalf("mcp.json: %v", err)
+	}
+	for key := range doc {
+		if key != "$schema" && key != "mcpServers" {
+			t.Errorf("%q is not allowed at the top level of mcp.json", key)
+		}
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	server, ok := servers["deja"].(map[string]any)
+	if !ok {
+		t.Fatal("mcp.json declares no deja server")
+	}
+	if server["type"] != "stdio" {
+		t.Errorf("transport is %v, want stdio", server["type"])
+	}
+	cmd, _ := server["command"].(string)
+	if cmd != "deja" {
+		t.Errorf("command is %q; it has to be one executable token resolved on PATH, not a shell command", cmd)
+	}
+}

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -73,6 +73,15 @@ Its `name` is `deja`, the same name the installer's extension uses, and
 extension by that name and refuses a second install under a name it already
 has, which is what makes two deja extensions on one machine impossible.
 
+`plugin.json` and `mcp.json` at the repository root are the [Agent
+Plugins](https://open-plugins.com) manifests — a vendor-neutral format for the
+parts that are the same everywhere, a manifest plus `skills/` plus MCP servers.
+They cost nothing to carry because `skills/deja-search/` was already where the
+standard puts skills, and they are what cursor.directory auto-detects from a
+repository URL. Both documents are closed schemas: an unknown top-level field is
+a violation, so `TestAgentPluginManifestIsPortable` and its two neighbours pin
+the fields, the name grammar and the one-token stdio command.
+
 Qwen Code takes the same file. `qwen extensions install <repo>` reads
 `gemini-extension.json` and installs the MCP server, `GEMINI.md` and the
 `deja-search` skill under `~/.qwen/extensions/deja` — checked on Qwen Code

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "deja": {
+      "type": "stdio",
+      "command": "deja",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "deja-vu",
+  "version": "0.18.0",
+  "description": "Search the coding sessions already on your disk — Claude Code, Codex, Cursor, opencode and seventeen more — including work from before deja was installed.",
+  "author": {
+    "name": "vshulcz",
+    "url": "https://github.com/vshulcz"
+  },
+  "homepage": "https://github.com/vshulcz/deja-vu",
+  "repository": "https://github.com/vshulcz/deja-vu",
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "recall",
+    "sessions",
+    "search",
+    "history"
+  ]
+}

--- a/scripts/pinmanifests/main.go
+++ b/scripts/pinmanifests/main.go
@@ -46,8 +46,12 @@ const (
 	// The Gemini gallery crawls the manifest at the repository root and shows
 	// its version, and `gemini extensions install` reads the same file.
 	geminiExtension = "gemini-extension.json"
-	releaseAPI      = "https://api.github.com/repos/vshulcz/deja-vu/releases/latest"
-	assetBase       = "https://github.com/vshulcz/deja-vu/releases/download"
+	// The Agent Plugins manifest at the root: cursor.directory reads it
+	// straight from the default branch, so its version is the one a
+	// listing shows.
+	agentPlugin = "plugin.json"
+	releaseAPI  = "https://api.github.com/repos/vshulcz/deja-vu/releases/latest"
+	assetBase   = "https://github.com/vshulcz/deja-vu/releases/download"
 )
 
 type pins struct {
@@ -68,7 +72,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "pinmanifests:", err)
 			os.Exit(1)
 		}
-		fmt.Println("scoop, winget and the codex, claude and gemini manifests match the newest release")
+		fmt.Println("scoop, winget and the plugin manifests match the newest release")
 		return
 	}
 
@@ -87,7 +91,7 @@ func main() {
 	if err := write(*root, p); err != nil {
 		fail(err)
 	}
-	fmt.Printf("pinned scoop, winget and the codex, claude and gemini manifests to %s\n", p.version)
+	fmt.Printf("pinned scoop, winget and the plugin manifests to %s\n", p.version)
 }
 
 // parse pulls the two Windows hashes out of a checksums file. Both must be
@@ -127,6 +131,7 @@ func write(root string, p pins) error {
 		codexPlugin:     renderPluginVersion(codexPlugin),
 		claudePlugin:    renderPluginVersion(claudePlugin),
 		geminiExtension: renderPluginVersion(geminiExtension),
+		agentPlugin:     renderPluginVersion(agentPlugin),
 	} {
 		body, err := render(p)
 		if err != nil {
@@ -265,6 +270,7 @@ func runCheck(root string) error {
 		codexPlugin:     renderPluginVersion(codexPlugin),
 		claudePlugin:    renderPluginVersion(claudePlugin),
 		geminiExtension: renderPluginVersion(geminiExtension),
+		agentPlugin:     renderPluginVersion(agentPlugin),
 	} {
 		want, err := render(p)
 		if err != nil {


### PR DESCRIPTION
Cursor's community directory takes a submission as a GitHub URL and auto-detects components that follow the [Agent Plugins](https://open-plugins.com) standard — a vendor-neutral 1.0.0 format for a manifest, `skills/`, and MCP servers. `cursor/community-plugins` is ★3980 and was pushed today, so this is a live surface rather than an aspirational one.

The cost is two files, because `skills/deja-search/` is already exactly where the standard looks:

- `plugin.json` — identity and metadata, version pinned by `pinmanifests` like the Codex, Claude and Gemini manifests, since the directory reads it from the default branch.
- `mcp.json` — one stdio server, `deja mcp`, resolved on PATH.

Both are **closed** schemas: an unknown top-level field is a schema violation, and the plugin name has its own grammar. That is the sort of thing a directory rejects at submission rather than a reviewer catching, so three tests pin the portable field set, the name grammar and the one-executable-token rule for a stdio command. Checked each by mutation — adding a `skills` key, a name of `Deja--VU`, and a command of `deja mcp` each fail their test.