### PR TITLE
fix(view): redact the page it writes instead of trusting what the index kept

### DIFF
--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -208,6 +208,12 @@ func writeViewHTML(dir, out string) (string, int, error) {
 	for i := range notes {
 		notes[i].Title = redactMask(notes[i].Title)
 		notes[i].Text = redactMask(notes[i].Text)
+		// A note's project and tags are what the user typed, so they are text
+		// like the rest rather than structure deja minted.
+		notes[i].Project = redactMask(notes[i].Project)
+		for j := range notes[i].Tags {
+			notes[i].Tags[j] = redactMask(notes[i].Tags[j])
+		}
 	}
 	sj, err := json.Marshal(sessions)
 	if err != nil {

--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -98,7 +98,7 @@ func runView(dir string, args []string) error {
 	if out == "" {
 		out = dir + ".view.html"
 	}
-	path, err := writeViewHTML(dir, out)
+	path, masked, err := writeViewHTMLCounted(dir, out)
 	if err != nil {
 		return err
 	}
@@ -107,11 +107,8 @@ func runView(dir string, args []string) error {
 	// and passed around, so it carries the same redaction floor the other
 	// outbound paths (share, sync export, promote --to) print — but only when it
 	// actually holds masked content, so local browsing stays quiet (#857).
-	// Redaction happens at index time, so the markers are already in the page.
-	if body, rerr := os.ReadFile(path); rerr == nil {
-		if masked := strings.Count(string(body), redact.Marker); masked > 0 {
-			fmt.Fprintf(os.Stderr, "deja: %d secret%s masked in this page. pattern redaction is a floor — review before sharing; rotate anything that leaked.\n", masked, pluralS(masked))
-		}
+	if masked > 0 {
+		fmt.Fprintf(os.Stderr, "deja: %d secret%s masked in this page. pattern redaction is a floor — review before sharing; rotate anything that leaked.\n", masked, pluralS(masked))
 	}
 	if openBrowser {
 		openInBrowser(path)
@@ -119,14 +116,30 @@ func runView(dir string, args []string) error {
 	return nil
 }
 
-func writeViewHTML(dir, out string) (string, error) {
+// redactMask is redact.Text without its counts, for the fields below.
+func redactMask(s string) string {
+	out, _ := redact.Text(s)
+	return out
+}
+
+// writeViewHTMLCounted writes the page and reports how many secrets it took out
+// of it. The other ways out — share, sync export, promote --to — redact what
+// they emit; this one wrote whatever the index held, which is not the same
+// text on an index built by an older deja or before a pattern was fixed, and
+// then counted the markers ingest had written and called them masked here
+// (#1768).
+func writeViewHTMLCounted(dir, out string) (string, int, error) {
+	return writeViewHTML(dir, out)
+}
+
+func writeViewHTML(dir, out string) (string, int, error) {
 	abs, err := filepath.Abs(out)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	metas, err := index.Recent(dir, 0)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	// The page is titles, project names and message previews — the whole of
 	// what the trust policy exists to keep off the screen, and it is written to
@@ -178,31 +191,51 @@ func writeViewHTML(dir, out string) (string, error) {
 			Tags: n.Tags, At: n.At.Format("2006-01-02"),
 		})
 	}
+	// Redact here rather than trusting the index: the page is the artifact
+	// someone opens and passes on, and the index it is built from may have been
+	// written by an older deja or before a pattern was fixed.
+	for i := range sessions {
+		sessions[i].Title = redactMask(sessions[i].Title)
+		sessions[i].Preview = redactMask(sessions[i].Preview)
+		sessions[i].Project = redactMask(sessions[i].Project)
+	}
+	for i := range recalls {
+		recalls[i].Digest = redactMask(recalls[i].Digest)
+		for j := range recalls[i].Terms {
+			recalls[i].Terms[j] = redactMask(recalls[i].Terms[j])
+		}
+	}
+	for i := range notes {
+		notes[i].Title = redactMask(notes[i].Title)
+		notes[i].Text = redactMask(notes[i].Text)
+	}
 	sj, err := json.Marshal(sessions)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	rj, err := json.Marshal(recalls)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	nj, err := json.Marshal(notes)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	page.SessionsJSON = jsonForScript(sj)
 	page.RecallsJSON = jsonForScript(rj)
 	page.NotesJSON = jsonForScript(nj)
 	var b strings.Builder
 	if err := viewTemplate.Execute(&b, page); err != nil {
-		return "", fmt.Errorf("render view: %w", err)
+		return "", 0, fmt.Errorf("render view: %w", err)
 	}
 	if err := os.WriteFile(abs, []byte(b.String()), 0o644); err != nil {
 		// A path on a disk that is gone came back as the bare syscall, which
 		// says nothing about what to change (#1036).
-		return "", fmt.Errorf("cannot write the view to %s — %s", abs, writeFailureReason(err))
+		return "", 0, fmt.Errorf("cannot write the view to %s — %s", abs, writeFailureReason(err))
 	}
-	return abs, nil
+	// The page holds a masked spot for every secret taken out of it, here or at
+	// ingest; counting the finished page reports both without claiming which.
+	return abs, strings.Count(string(page.SessionsJSON)+string(page.RecallsJSON)+string(page.NotesJSON), redact.Marker), nil
 }
 
 // jsonForScript makes embedded JSON safe inside a <script> block.

--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -98,7 +98,7 @@ func runView(dir string, args []string) error {
 	if out == "" {
 		out = dir + ".view.html"
 	}
-	path, masked, err := writeViewHTMLCounted(dir, out)
+	path, masked, err := writeViewHTML(dir, out)
 	if err != nil {
 		return err
 	}
@@ -120,16 +120,6 @@ func runView(dir string, args []string) error {
 func redactMask(s string) string {
 	out, _ := redact.Text(s)
 	return out
-}
-
-// writeViewHTMLCounted writes the page and reports how many secrets it took out
-// of it. The other ways out — share, sync export, promote --to — redact what
-// they emit; this one wrote whatever the index held, which is not the same
-// text on an index built by an older deja or before a pattern was fixed, and
-// then counted the markers ingest had written and called them masked here
-// (#1768).
-func writeViewHTMLCounted(dir, out string) (string, int, error) {
-	return writeViewHTML(dir, out)
 }
 
 func writeViewHTML(dir, out string) (string, int, error) {
@@ -234,14 +224,16 @@ func writeViewHTML(dir, out string) (string, int, error) {
 	if err := viewTemplate.Execute(&b, page); err != nil {
 		return "", 0, fmt.Errorf("render view: %w", err)
 	}
+	// The page holds a masked spot for every secret taken out of it, here or at
+	// ingest; counting the rendered page reports both without claiming which,
+	// and counts what a reader will actually find in the file.
+	masked := strings.Count(b.String(), redact.Marker)
 	if err := os.WriteFile(abs, []byte(b.String()), 0o644); err != nil {
 		// A path on a disk that is gone came back as the bare syscall, which
 		// says nothing about what to change (#1036).
 		return "", 0, fmt.Errorf("cannot write the view to %s — %s", abs, writeFailureReason(err))
 	}
-	// The page holds a masked spot for every secret taken out of it, here or at
-	// ingest; counting the finished page reports both without claiming which.
-	return abs, strings.Count(string(page.SessionsJSON)+string(page.RecallsJSON)+string(page.NotesJSON), redact.Marker), nil
+	return abs, masked, nil
 }
 
 // jsonForScript makes embedded JSON safe inside a <script> block.

--- a/cmd/deja/view_policy_test.go
+++ b/cmd/deja/view_policy_test.go
@@ -61,7 +61,7 @@ func TestViewHonoursTheTrustPolicy(t *testing.T) {
 	}
 
 	out := filepath.Join(t.TempDir(), "view.html")
-	if _, err := writeViewHTML(dir, out); err != nil {
+	if _, _, err := writeViewHTML(dir, out); err != nil {
 		t.Fatal(err)
 	}
 	before := len(viewSessionsEmbedded(t, readFileString(t, out)))
@@ -75,7 +75,7 @@ func TestViewHonoursTheTrustPolicy(t *testing.T) {
 	}
 	t.Setenv("DEJA_POLICY_FILE", policyPath)
 
-	if _, err := writeViewHTML(dir, out); err != nil {
+	if _, _, err := writeViewHTML(dir, out); err != nil {
 		t.Fatal(err)
 	}
 	page := readFileString(t, out)

--- a/cmd/deja/view_redaction_test.go
+++ b/cmd/deja/view_redaction_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/redact"
+)
+
+// The page is a file on disk whose whole purpose is to be looked at and passed
+// around, and `share` and `sync export` both redact on the way out. This one
+// wrote whatever the index held — an index from an older deja, or one built
+// before a pattern was fixed — and then counted the markers ingest had written
+// and called them masked here (#1768).
+func TestTheViewRedactsWhatTheIndexKept(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const secret = "8f14e45fceea167a5a36dedd4bea2543"
+	const token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789"
+	rec := `{"type":"user","sessionId":"v1","cwd":"/w","timestamp":"2026-08-22T01:00:00Z","message":{"role":"user","content":"vexlorb {\"api_key\": \"` + secret + `\"} and ` + token + `"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "a.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_NO_REDACT", "1")
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_NO_REDACT", "")
+
+	out := filepath.Join(tmp, "view.html")
+	path, masked, err := writeViewHTMLCounted(dir, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	page := string(body)
+	if strings.Contains(page, secret) {
+		t.Error("the page carries an api key the index kept")
+	}
+	if strings.Contains(page, token) {
+		t.Error("the page carries a github token the index kept")
+	}
+	if masked < 2 {
+		t.Errorf("the page reports %d masked, and it masked at least two", masked)
+	}
+	if !strings.Contains(page, redact.Marker) {
+		t.Error("nothing in the page says a secret was taken out of it")
+	}
+}

--- a/cmd/deja/view_redaction_test.go
+++ b/cmd/deja/view_redaction_test.go
@@ -35,7 +35,7 @@ func TestTheViewRedactsWhatTheIndexKept(t *testing.T) {
 	t.Setenv("DEJA_NO_REDACT", "")
 
 	out := filepath.Join(tmp, "view.html")
-	path, masked, err := writeViewHTMLCounted(dir, out)
+	path, masked, err := writeViewHTML(dir, out)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/view_test.go
+++ b/cmd/deja/view_test.go
@@ -68,7 +68,7 @@ func TestViewStaysQuietWhenNothingIsMasked(t *testing.T) {
 func TestViewGeneratesSelfContainedHTML(t *testing.T) {
 	dir := viewFixtureIndex(t)
 	out := filepath.Join(t.TempDir(), "view.html")
-	path, err := writeViewHTML(dir, out)
+	path, _, err := writeViewHTML(dir, out)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestViewSaysWhatIsWrongWithThePath(t *testing.T) {
 	if err := index.Ensure(dir, "", false, nil); err != nil {
 		t.Fatal(err)
 	}
-	_, err := writeViewHTML(dir, filepath.Join(tmp, "no-such-dir", "m.html"))
+	_, _, err := writeViewHTML(dir, filepath.Join(tmp, "no-such-dir", "m.html"))
 	if err == nil {
 		t.Fatal("writing into a directory that does not exist did not fail")
 	}


### PR DESCRIPTION
Closes #1768.

`share` and `sync export` redact on the way out; `view` wrote whatever the index held. On an index built by an older deja — or before a pattern was fixed, which #1766 did today — the page carried the secrets in the clear:

```
before  $ deja view --no-open
        deja: view written to ~/.cache/deja/index.db.view.html
        $ grep -cE '8f14e45…|ghp_…|BEGIN RSA PRIVATE|…' index.db.view.html
        4

after   deja: view written to …
        deja: 6 secrets masked in this page. pattern redaction is a floor — review before sharing; rotate anything that leaked.
        $ grep -cE …  →  0
```

Titles, previews, project names, recall digests and terms, and promoted notes all go through `redact.Text` before they reach the page. The count is the markers in the finished page, so it reports what was masked here and what ingest had already masked without claiming which — and a page with none stays quiet, which is what `TestViewNamesTheRedactionFloorWhenThePageHoldsAMaskedSecret` and #857 ask for.

Test: `TestTheViewRedactsWhatTheIndexKept` builds an index with `DEJA_NO_REDACT=1` and asserts the page holds neither the api key nor the token.