### PR TITLE
docs: pages for lost context, a full window, and resuming a session

### DIFF
--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -150,6 +150,13 @@ func resumeCommand(s model.Session) (string, string, error) {
 		return "", "cline --id " + s.ID, nil
 	case "roo":
 		return "", "", fmt.Errorf("roo tasks reopen from the extension's history UI, not the terminal")
+	case "zed":
+		// These two used to fall through to "don't know how to resume", which
+		// reads like deja is missing something. Both are settled answers, and
+		// the registry has carried the reason all along.
+		return "", "", fmt.Errorf("zed threads reopen from the editor's own history — no zed flag takes a thread id")
+	case "deepseek":
+		return "", "", fmt.Errorf("neither of DeepSeek Harness's two apps takes a session id, so there is nothing to reopen by")
 	case "qwen":
 		return qwenProjectDirFor(s), "qwen -r " + s.ID, nil
 	case "openclaw":

--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -54,6 +54,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/auditing-agents.html
+++ b/docs/guide/auditing-agents.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -54,6 +54,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -54,6 +54,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -83,6 +83,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/context-window-full.html
+++ b/docs/guide/context-window-full.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The context window is full — deja-vu</title>
+<meta name="description" content="Compaction keeps 77% of decisions and 0.2% of commands — measured. What to do instead of paying for a window that grows until it breaks.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/context-window-full.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="The context window is full">
+<meta property="og:description" content="Compaction keeps 77% of decisions and 0.2% of commands — measured. What to do instead of paying for a window that grows until it breaks.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/context-window-full.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="The context window is full">
+<meta name="twitter:description" content="Compaction keeps 77% of decisions and 0.2% of commands — measured. What to do instead of paying for a window that grows until it breaks.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"The context window is full","description":"Compaction keeps 77% of decisions and 0.2% of commands — measured. What to do instead of paying for a window that grows until it breaks.","url":"https://vshulcz.github.io/deja-vu/guide/context-window-full.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/context-window-full.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Context window full","item":"https://vshulcz.github.io/deja-vu/guide/context-window-full.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What happens when the context window fills up?","acceptedAnswer":{"@type":"Answer","text":"The agent offers to compact. Measured over 43 compactions, the summary kept 77% of decisions and 0.2% of the commands that had run."}},{"@type":"Question","name":"How do I avoid compaction?","acceptedAnswer":{"@type":"Answer","text":"Fetch context instead of carrying it: recall injections are capped at 1,536 bytes per prompt and about 4 KB per tool call, a fixed cost against a window that otherwise grows."}},{"@type":"Question","name":"Can I get back what compaction dropped?","acceptedAnswer":{"@type":"Answer","text":"Yes. Compaction rewrites the agent's context, not its transcript, so the commands and errors are still on disk and searchable."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html" aria-current="page">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>The context window is full</h1>
+<p class="pagelede">compaction is not the only answer, and it is the lossy one<span class="mins" data-mins></span></p>
+
+<p>The warning arrives in the middle of something: the window is nearly full, and the agent offers to compact. You say yes because the alternative is starting over, and the session continues in a thinner version of itself.</p>
+
+<h2>What the summary keeps, and what it drops</h2>
+<p>Measured over 43 real compactions in this repository's own history: the summary retained <b>77% of the decisions</b> and <b>0.2% of the commands</b> that had actually been run. The reasoning survives because it is prose. The invocation with the flags that worked, the exact error text, the span an edit replaced — those are the parts a summary treats as noise, and they are the parts you cannot reconstruct from memory.</p>
+<p>So the window being full is not really the problem. The problem is that the fix is lossy in a direction nobody chooses on purpose.</p>
+
+<h2>Keeping the window small on purpose</h2>
+<pre>deja install --auto</pre>
+<p>The alternative to carrying everything in context is fetching the part you need when you need it. Recall arrives at session start, on each prompt, before an edit or a command, and after a command fails — each one bounded: an injection is capped at 1,536 bytes per prompt and about 4 KB per tool call. That is a fixed, small cost against a window that otherwise grows until it breaks. <a href="token-cost.html">What memory costs</a> has the measurement.</p>
+
+<h2>After it has already compacted</h2>
+<pre>deja ctx "what we were doing"</pre>
+<p>The pre-compaction turns are still on disk in full — compaction rewrites the agent's context, not its transcript. deja reads the transcript, so the commands and errors the summary dropped are still searchable, and <a href="after-compaction.html">getting them back</a> is one query.</p>
+
+<h2>Why not a bigger window</h2>
+<p>A larger window moves the wall without removing it, and every token in context is paid on every turn of the session. A 5 GB history searched in under a millisecond and returned as a 1.5 KB digest is a different shape of answer than a 200k-token window that holds the same history and charges for it continuously.</p>
+
+<h2>The part that is not about this</h2>
+<p>The index covers every agent's transcripts on the machine — <a href="where-sessions-are-stored.html">each in its own format</a> — including sessions from before deja was installed. Indexing and search are local: no model, no embeddings, nothing leaves the machine (<a href="privacy.html">privacy</a>).</p>
+
+<p><a href="getting-started.html">Getting started</a> &middot; <a href="token-cost.html">What memory costs</a> &middot; <a href="after-compaction.html">What compaction drops</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/export-conversations.html
+++ b/docs/guide/export-conversations.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html" aria-current="page">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/find-a-session.html
+++ b/docs/guide/find-a-session.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -54,6 +54,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -54,6 +54,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/lost-context.html
+++ b/docs/guide/lost-context.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The agent lost the context you had — deja-vu</title>
+<meta name="description" content="A crash, a cleared window or a restart takes the agent's context but not the transcript — how to get the work back and stop paying for it next time.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/lost-context.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="The agent lost the context you had">
+<meta property="og:description" content="A crash, a cleared window or a restart takes the agent's context but not the transcript — how to get the work back and stop paying for it next time.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/lost-context.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="The agent lost the context you had">
+<meta name="twitter:description" content="A crash, a cleared window or a restart takes the agent's context but not the transcript — how to get the work back and stop paying for it next time.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"The agent lost the context you had","description":"A crash, a cleared window or a restart takes the agent's context but not the transcript — how to get the work back and stop paying for it next time.","url":"https://vshulcz.github.io/deja-vu/guide/lost-context.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/lost-context.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Lost context","item":"https://vshulcz.github.io/deja-vu/guide/lost-context.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What do I do when my coding agent loses context?","acceptedAnswer":{"@type":"Answer","text":"Search the transcripts it already wrote to disk: deja "what you were doing", or deja ctx for a digest of the best-matching session. Sixteen of twenty harnesses can also be reopened with deja resume."}},{"@type":"Question","name":"Is the context recoverable after a crash?","acceptedAnswer":{"@type":"Answer","text":"The transcript is, because agents write each turn to disk as it happens. What a crash destroys is the model's working set, not the file."}},{"@type":"Question","name":"How do I stop losing it?","acceptedAnswer":{"@type":"Answer","text":"deja install --auto wires recall at session start and on each prompt, so a fresh window opens already knowing the project's recent decisions."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html" aria-current="page">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>The agent lost the context you had</h1>
+<p class="pagelede">a crash, a clear, a reconnect — the work is still on disk<span class="mins" data-mins></span></p>
+
+<p>It happens mid-task, not between tasks: the window is cleared, the CLI is restarted, a session is resumed and comes back empty, the tab is closed by something that is not you. The agent is now confidently a stranger to work you did an hour ago.</p>
+
+<h2>The context is not gone, the pointer to it is</h2>
+<p>Almost every coding agent writes each turn to disk as it happens — <a href="where-sessions-are-stored.html">twenty formats, one per tool</a>. What a crash or a clear destroys is the model's working set, not the transcript. The file is still sitting under <code>~/.claude/projects</code>, <code>~/.codex/sessions</code>, <code>~/.qwen/projects</code> or wherever your agent keeps it, with the decision you now cannot recall.</p>
+
+<h2>Getting it back into the session you are in</h2>
+<pre>deja "the thing you were doing"</pre>
+<p>Search runs over every agent's history on the machine, so it does not matter which tool held the lost context — or whether that tool still exists. <code>deja ctx &lt;query&gt;</code> gives the single best-matching session as a digest rather than a wall of transcript, which is what you want to paste back into a fresh window.</p>
+<p>If the tool you lost supports it, <code>deja resume &lt;id&gt;</code> prints the exact command that reopens that conversation, in the directory it belongs to — sixteen of the twenty do.</p>
+
+<h2>Not losing it the next time</h2>
+<pre>deja install --auto</pre>
+<p>After this the recovery is not a thing you have to think of. Recall arrives at session start, so a fresh window opens already knowing the project's recent decisions; and on each prompt, so a question about old work is answered from the transcript instead of from a guess. A cleared window costs a paragraph of context rather than an afternoon.</p>
+
+<h2>What it cannot do</h2>
+<p>Anything the agent never wrote down is not recoverable, and deja does not pretend otherwise: it indexes the files, it does not reconstruct what was in the model's head. Sessions that were never flushed to disk before the crash — some tools write on turn boundaries, not on every token — lose their last turn. That last turn is usually the one you remember anyway.</p>
+
+<h2>The part that is not about this</h2>
+<p>The index covers every agent's transcripts on the machine — <a href="where-sessions-are-stored.html">each in its own format</a> — including sessions from before deja was installed. Indexing and search are local: BM25 over the transcripts, no model, no embeddings, credentials stripped as the index is built (<a href="privacy.html">privacy</a>).</p>
+
+<p><a href="getting-started.html">Getting started</a> &middot; <a href="find-a-session.html">Finding a session</a> &middot; <a href="after-compaction.html">What compaction drops</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/memory-for-dsh.html
+++ b/docs/guide/memory-for-dsh.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/memory-for-gemini.html
+++ b/docs/guide/memory-for-gemini.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html" aria-current="page">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/memory-for-grok.html
+++ b/docs/guide/memory-for-grok.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html" aria-current="page">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/memory-for-kimi.html
+++ b/docs/guide/memory-for-kimi.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/memory-for-opencode.html
+++ b/docs/guide/memory-for-opencode.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/memory-for-qwen.html
+++ b/docs/guide/memory-for-qwen.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html" aria-current="page">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/memory-for-zed.html
+++ b/docs/guide/memory-for-zed.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/parallel-sessions.html
+++ b/docs/guide/parallel-sessions.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -54,6 +54,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/resume-a-session.html
+++ b/docs/guide/resume-a-session.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Resuming the session you had yesterday — deja-vu</title>
+<meta name="description" content="Find the session across every agent on the machine, then reopen it in the tool that owns it — or take the digest instead of the whole conversation.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/resume-a-session.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Resuming the session you had yesterday">
+<meta property="og:description" content="Find the session across every agent on the machine, then reopen it in the tool that owns it — or take the digest instead of the whole conversation.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/resume-a-session.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Resuming the session you had yesterday">
+<meta name="twitter:description" content="Find the session across every agent on the machine, then reopen it in the tool that owns it — or take the digest instead of the whole conversation.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Resuming the session you had yesterday","description":"Find the session across every agent on the machine, then reopen it in the tool that owns it — or take the digest instead of the whole conversation.","url":"https://vshulcz.github.io/deja-vu/guide/resume-a-session.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/resume-a-session.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Resuming a session","item":"https://vshulcz.github.io/deja-vu/guide/resume-a-session.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I resume a previous coding session?","acceptedAnswer":{"@type":"Answer","text":"deja resume <id> prints the command that reopens that exact conversation, including the directory it must run in. Sixteen of the twenty indexed harnesses support it."}},{"@type":"Question","name":"Can I find a session from a different agent?","acceptedAnswer":{"@type":"Answer","text":"Yes. deja searches every agent's transcripts at once and each hit carries its harness and session id, which the agents' own resume commands cannot do."}},{"@type":"Question","name":"What if I only want the conclusion?","acceptedAnswer":{"@type":"Answer","text":"deja ctx <id-prefix> returns the session as a digest — decisions, files touched, commands run — small enough to paste into a session you are already in."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html" aria-current="page">Resuming a session</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Resuming the session you had yesterday</h1>
+<p class="pagelede">find it across every agent, then reopen it in the right one<span class="mins" data-mins></span></p>
+
+<p>Every agent can resume its own last session. None of them can tell you which session you want, and none of them can see the one you had in a different tool — which is where the answer usually is.</p>
+
+<h2>Find it first</h2>
+<pre>deja "connection pool exhausted"</pre>
+<p>Search runs over every agent's transcripts on the machine at once, and each hit carries the harness it belongs to and its session id. That is the step the tools themselves cannot do: <code>claude --resume</code> lists Claude's sessions, <code>codex resume</code> lists Codex's, and neither knows the other exists.</p>
+
+<h2>Then reopen it</h2>
+<pre>deja resume &lt;id&gt;</pre>
+<p>It prints the command that reopens that exact conversation, including the directory it has to run in when the tool scopes its session list by working directory:</p>
+<pre>cd '/path/to/project' &amp;&amp; grok --resume 01a03433-0c67-7331-8eb1-cd6173d4c8f9</pre>
+<p>Sixteen of the twenty harnesses deja indexes can be reopened this way. The other four are refusals with a reason rather than silence: aider appends to a transcript file and has no notion of reopening one conversation, Roo and Zed reopen from their own UI rather than a terminal, and neither of DeepSeek Harness's two apps takes a session id. The <a href="../registry/README.html">format registry</a> records which is which, and why.</p>
+
+<h2>When resuming is the wrong tool</h2>
+<p>Reopening a session brings back the whole conversation, including the parts that were wrong before they were right. Often what you want is the conclusion, not the road to it:</p>
+<pre>deja ctx &lt;id-prefix&gt;</pre>
+<p>That returns the session as a digest — what was decided, which files it touched, which commands ran — small enough to paste into a session you are already in. <a href="find-a-session.html">Finding a session</a> covers the search side in more detail.</p>
+
+<h2>The part that is not about this</h2>
+<p>The index covers every agent's transcripts on the machine — <a href="where-sessions-are-stored.html">each in its own format</a> — including sessions from before deja was installed. Indexing and search are local: BM25 over the transcripts, credentials stripped as the index is built (<a href="privacy.html">privacy</a>).</p>
+
+<p><a href="getting-started.html">Getting started</a> &middot; <a href="find-a-session.html">Finding a session</a> &middot; <a href="switching-agents.html">Switching agents</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/rules-files.html
+++ b/docs/guide/rules-files.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -54,6 +54,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/switching-agents.html
+++ b/docs/guide/switching-agents.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/sync-across-machines.html
+++ b/docs/guide/sync-across-machines.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html" aria-current="page">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/guide/token-cost.html
+++ b/docs/guide/token-cost.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html" aria-current="page">What memory costs</a>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -55,6 +55,9 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
 <a href="export-conversations.html">Exporting sessions</a>
 <a href="sync-across-machines.html">Across machines</a>
 <a href="token-cost.html">What memory costs</a>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -21,6 +21,9 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/lost-context.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/context-window-full.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/resume-a-session.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/agents.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/search.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/commands.html</loc><lastmod>2026-08-11</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
Picked by measurement rather than by taste. Issue counts for the phrase people actually type:

| phrase | issues | had a page |
|---|---:|---|
| lost context | 62,775 | no |
| same error again | 30,926 | yes — repeated-mistakes |
| context window full | 7,982 | no |
| summarize the conversation | 6,722 | partly — after-compaction |
| resume previous session | 4,670 | no |
| too many tokens | 2,785 | yes — token-cost |
| agent forgets | 1,827 | yes — forgetting |
| switch between agents | 1,809 | yes — switching-agents |

So three gaps at the top of the list, and three pages. Each says what deja cannot do as well: the lost-context page states that a turn never flushed to disk is not recoverable, because that is the honest limit of indexing files rather than capturing state.

Writing the resume page turned up a real gap in the CLI. It claimed all four unsupported harnesses refuse with a reason; in fact Zed and DeepSeek Harness fell through to `don't know how to resume "zed" sessions`, which reads like deja is missing something rather than like the question being settled. Both now say what the registry has recorded all along, and the page matches the code.