### PR TITLE
fix(sync): give ssh a connect timeout so a sleeping machine costs seconds, not minutes

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -450,7 +450,7 @@ func TestSyncSSHErrorBranches(t *testing.T) {
 		t.Fatalf("sshCapture quote err=%v", err)
 	}
 	sshRunner = func(name string, args ...string) (string, error) {
-		if name == "ssh" && args[1] == "mktemp -d" {
+		if name == "ssh" && args[len(args)-1] == "mktemp -d" {
 			return "/tmp/remote", nil
 		}
 		return "boom", os.ErrPermission
@@ -671,7 +671,7 @@ func TestSyncSSHPushMoreErrorBranches(t *testing.T) {
 	old := sshRunner
 	defer func() { sshRunner = old }()
 	sshRunner = func(name string, args ...string) (string, error) {
-		if name == "ssh" && args[1] == "mktemp -d" {
+		if name == "ssh" && args[len(args)-1] == "mktemp -d" {
 			return "", errors.New("mktemp failed")
 		}
 		return "", nil
@@ -682,7 +682,7 @@ func TestSyncSSHPushMoreErrorBranches(t *testing.T) {
 	// Mark exported so a new fixture is available for the remote-import branch.
 	setupLocalIndex(t)
 	sshRunner = func(name string, args ...string) (string, error) {
-		if name == "ssh" && args[1] == "mktemp -d" {
+		if name == "ssh" && args[len(args)-1] == "mktemp -d" {
 			return "/tmp/remote", nil
 		}
 		if name == "ssh" {
@@ -849,13 +849,13 @@ func TestSyncSSHAdditionalBranches(t *testing.T) {
 	defer func() { sshRunner = old }()
 	var cleaned bool
 	sshRunner = func(name string, args ...string) (string, error) {
-		if name == "ssh" && args[1] == "mktemp -d" {
+		if name == "ssh" && args[len(args)-1] == "mktemp -d" {
 			return "/tmp/remote-zero", nil
 		}
-		if name == "ssh" && strings.Contains(args[1], "sync export") {
+		if name == "ssh" && strings.Contains(args[len(args)-1], "sync export") {
 			return "deja: exported 0 records", nil
 		}
-		if name == "ssh" && strings.Contains(args[1], "rm -rf") {
+		if name == "ssh" && strings.Contains(args[len(args)-1], "rm -rf") {
 			cleaned = true
 		}
 		return "", nil
@@ -873,7 +873,7 @@ func TestSyncSSHAdditionalBranches(t *testing.T) {
 		t.Fatal(err)
 	}
 	sshRunner = func(name string, args ...string) (string, error) {
-		if name == "ssh" && args[1] == "mktemp -d" {
+		if name == "ssh" && args[len(args)-1] == "mktemp -d" {
 			return "/tmp/remote", nil
 		}
 		if name == "scp" {

--- a/cmd/deja/coverage_final_test.go
+++ b/cmd/deja/coverage_final_test.go
@@ -196,7 +196,7 @@ func TestSyncSSHPullMkdirTempFailure(t *testing.T) {
 	old := sshRunner
 	defer func() { sshRunner = old }()
 	sshRunner = func(name string, args ...string) (string, error) {
-		if name == "ssh" && args[1] == "mktemp -d" {
+		if name == "ssh" && args[len(args)-1] == "mktemp -d" {
 			return "/tmp/remote", nil
 		}
 		if name == "ssh" {

--- a/cmd/deja/sync_all_test.go
+++ b/cmd/deja/sync_all_test.go
@@ -84,17 +84,17 @@ func TestBareSyncExchangesWithEveryPeerBothWays(t *testing.T) {
 	var pulls, pushes int
 	sshRunner = func(name string, args ...string) (string, error) {
 		if name == "ssh" && len(args) > 1 {
-			hosts = append(hosts, args[0])
+			hosts = append(hosts, sshHostArg(args))
 			switch {
-			case strings.Contains(args[1], "sync export"):
+			case strings.Contains(args[len(args)-1], "sync export"):
 				pulls++
 				return "deja: exported 0 records", nil
-			case strings.Contains(args[1], "sync import"):
+			case strings.Contains(args[len(args)-1], "sync import"):
 				pushes++
 				return "deja: imported 0 records", nil
 			}
 		}
-		if args[len(args)-1] == "mktemp -d" || (len(args) > 1 && args[1] == "mktemp -d") {
+		if args[len(args)-1] == "mktemp -d" || (len(args) > 1 && args[len(args)-1] == "mktemp -d") {
 			return "/tmp/remote-out", nil
 		}
 		return "", nil
@@ -134,8 +134,8 @@ func TestBareSyncKeepsGoingPastAnUnreachableMachine(t *testing.T) {
 	ok := fakeSSHOK()
 	sshRunner = func(name string, args ...string) (string, error) {
 		if len(args) > 0 {
-			reached[args[0]] = true
-			if args[0] == "broken" {
+			reached[sshHostArg(args)] = true
+			if sshHostArg(args) == "broken" {
 				return "no route to host", errors.New("exit status 255")
 			}
 		}
@@ -216,11 +216,11 @@ func fakeSSHOK() func(string, ...string) (string, error) {
 			return "", nil
 		}
 		switch {
-		case args[1] == "mktemp -d":
+		case args[len(args)-1] == "mktemp -d":
 			return "/tmp/remote-out", nil
-		case strings.Contains(args[1], "sync export"):
+		case strings.Contains(args[len(args)-1], "sync export"):
 			return "deja: exported 0 records", nil
-		case strings.Contains(args[1], "sync import"):
+		case strings.Contains(args[len(args)-1], "sync import"):
 			return "deja: imported 0 records", nil
 		}
 		return "", nil

--- a/cmd/deja/sync_pull_peer_test.go
+++ b/cmd/deja/sync_pull_peer_test.go
@@ -23,10 +23,10 @@ func TestSyncPullNamesThisMachineToTheRemote(t *testing.T) {
 	var exportCmd string
 	sshRunner = func(name string, args ...string) (string, error) {
 		switch {
-		case name == "ssh" && args[1] == "mktemp -d":
+		case name == "ssh" && args[len(args)-1] == "mktemp -d":
 			return "/tmp/remote-out", nil
-		case name == "ssh" && strings.Contains(args[1], "sync export"):
-			exportCmd = args[1]
+		case name == "ssh" && strings.Contains(args[len(args)-1], "sync export"):
+			exportCmd = args[len(args)-1]
 			return "deja: exported 0 records", nil
 		}
 		return "", nil
@@ -51,10 +51,10 @@ func TestSyncPullQuotesAnAwkwardMachineName(t *testing.T) {
 	var exportCmd string
 	sshRunner = func(name string, args ...string) (string, error) {
 		switch {
-		case name == "ssh" && args[1] == "mktemp -d":
+		case name == "ssh" && args[len(args)-1] == "mktemp -d":
 			return "/tmp/remote-out", nil
-		case name == "ssh" && strings.Contains(args[1], "sync export"):
-			exportCmd = args[1]
+		case name == "ssh" && strings.Contains(args[len(args)-1], "sync export"):
+			exportCmd = args[len(args)-1]
 			return "deja: exported 0 records", nil
 		}
 		return "", nil
@@ -83,11 +83,11 @@ func TestSyncPullFallsBackWhenTheRemoteIsOlder(t *testing.T) {
 	var commands []string
 	sshRunner = func(name string, args ...string) (string, error) {
 		switch {
-		case name == "ssh" && args[1] == "mktemp -d":
+		case name == "ssh" && args[len(args)-1] == "mktemp -d":
 			return "/tmp/remote-out", nil
-		case name == "ssh" && strings.Contains(args[1], "sync export"):
-			commands = append(commands, args[1])
-			if strings.Contains(args[1], "--peer") {
+		case name == "ssh" && strings.Contains(args[len(args)-1], "sync export"):
+			commands = append(commands, args[len(args)-1])
+			if strings.Contains(args[len(args)-1], "--peer") {
 				return `deja: sync export: unknown flag "--peer" — only --full is accepted`, errors.New("exit status 1")
 			}
 			return "deja: exported 0 records", nil
@@ -115,9 +115,9 @@ func TestSyncPullDoesNotRetryOtherFailures(t *testing.T) {
 	var calls int
 	sshRunner = func(name string, args ...string) (string, error) {
 		switch {
-		case name == "ssh" && args[1] == "mktemp -d":
+		case name == "ssh" && args[len(args)-1] == "mktemp -d":
 			return "/tmp/remote-out", nil
-		case name == "ssh" && strings.Contains(args[1], "sync export"):
+		case name == "ssh" && strings.Contains(args[len(args)-1], "sync export"):
 			calls++
 			return "deja: no sessions indexed yet", errors.New("exit status 1")
 		}

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -29,6 +29,19 @@ var sshRunner = func(name string, args ...string) (string, error) {
 	return stdout.String(), err
 }
 
+// sshConnectTimeout is how long deja waits for a machine to answer. A laptop
+// that is asleep neither answers nor refuses, and ssh's own default left one
+// host waiting 446 seconds with nothing on screen — while `deja sync` walks
+// every machine it knows (#1772).
+const sshConnectTimeout = "10"
+
+// sshOpts are the options every ssh and scp call carries: a connect timeout,
+// and BatchMode so a host that wants a password fails instead of blocking on a
+// prompt nothing is reading.
+func sshOpts() []string {
+	return []string{"-o", "ConnectTimeout=" + sshConnectTimeout, "-o", "BatchMode=yes"}
+}
+
 func runSyncSSH(dir string, args []string) error {
 	host := ""
 	pull, full := false, false
@@ -150,14 +163,14 @@ func syncSSHPush(dir, host string, full bool) error {
 	if err != nil {
 		return err
 	}
-	scpArgs := append([]string{"-q"}, batches...)
+	scpArgs := append(append(sshOpts(), "-q"), batches...)
 	scpArgs = append(scpArgs, host+":"+rtmp+"/")
 	if out, err := sshRunner("scp", scpArgs...); err != nil {
 		return fmt.Errorf("scp: %v: %s", err, strings.TrimSpace(out))
 	}
 	remote := fmt.Sprintf(`d=$(command -v deja || echo "$HOME/.local/bin/deja"); "$d" sync import %s; rc=$?; rm -rf %s; exit $rc`,
 		shellQuote(rtmp), shellQuote(rtmp))
-	out, err := sshRunner("ssh", host, "sh -lc "+shellQuote(remote))
+	out, err := sshRunner("ssh", append(sshOpts(), host, "sh -lc "+shellQuote(remote))...)
 	out = strings.TrimSpace(out)
 	if err != nil {
 		return fmt.Errorf("remote import: %v: %s", err, out)
@@ -191,14 +204,14 @@ func syncSSHPull(dir, host string, full bool) error {
 	remoteCmd := func(c string) string {
 		return fmt.Sprintf(`d=$(command -v deja || echo "$HOME/.local/bin/deja"); "$d" %s %s`, c, shellQuote(rtmp))
 	}
-	out, err := sshRunner("ssh", host, "sh -lc "+shellQuote(remoteCmd(pullCmd)))
+	out, err := sshRunner("ssh", append(sshOpts(), host, "sh -lc "+shellQuote(remoteCmd(pullCmd)))...)
 	out = strings.TrimSpace(out)
 	// A deja too old to know --peer refuses the flag rather than ignoring it,
 	// which is the behaviour that stops a typo from exporting nothing (#745).
 	// Upgrading both machines at once is not something a person does, so fall
 	// back to the shared watermark rather than failing the pull.
 	if err != nil && strings.Contains(out, "unknown flag") && pullCmd != exportCmd {
-		out, err = sshRunner("ssh", host, "sh -lc "+shellQuote(remoteCmd(exportCmd)))
+		out, err = sshRunner("ssh", append(sshOpts(), host, "sh -lc "+shellQuote(remoteCmd(exportCmd)))...)
 		out = strings.TrimSpace(out)
 	}
 	if err != nil {
@@ -221,7 +234,7 @@ func syncSSHPull(dir, host string, full bool) error {
 		return err
 	}
 	defer os.RemoveAll(ltmp)
-	if out, err := sshRunner("scp", "-q", host+":"+rtmp+"/*.jsonl", ltmp+"/"); err != nil {
+	if out, err := sshRunner("scp", append(sshOpts(), "-q", host+":"+rtmp+"/*.jsonl", ltmp+"/")...); err != nil {
 		cleanup()
 		return fmt.Errorf("scp: %v: %s — the remote already advanced its watermark for this batch; recover it with `deja sync ssh %s --pull --full`", err, strings.TrimSpace(out), host)
 	}
@@ -242,7 +255,7 @@ func exportBatches(dir, out string, full bool) (int, error) {
 }
 
 func sshCapture(host, cmd string) (string, error) {
-	out, err := sshRunner("ssh", host, cmd)
+	out, err := sshRunner("ssh", append(sshOpts(), host, cmd)...)
 	s := strings.TrimSpace(out)
 	if err != nil {
 		return "", fmt.Errorf("ssh %s: %v: %s", host, err, s)

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -221,7 +221,7 @@ func syncSSHPull(dir, host string, full bool) error {
 		fmt.Fprintf(os.Stdout, "%s: %s\n", host, out)
 	}
 	cleanup := func() {
-		_, _ = sshRunner("ssh", host, "sh -lc "+shellQuote("rm -rf "+shellQuote(rtmp)))
+		_, _ = sshRunner("ssh", append(sshOpts(), host, "sh -lc "+shellQuote("rm -rf "+shellQuote(rtmp)))...)
 	}
 	if strings.Contains(out, "exported 0 records") {
 		cleanup()

--- a/cmd/deja/sync_ssh_test.go
+++ b/cmd/deja/sync_ssh_test.go
@@ -42,14 +42,14 @@ func TestSyncSSHPullFullAndScpFailure(t *testing.T) {
 	var exportCmd string
 	var cleanup bool
 	sshRunner = func(name string, args ...string) (string, error) {
-		if name == "ssh" && args[1] == "mktemp -d" {
+		if name == "ssh" && args[len(args)-1] == "mktemp -d" {
 			return "/tmp/remote-out", nil
 		}
-		if name == "ssh" && strings.Contains(args[1], "sync export") {
-			exportCmd = args[1]
+		if name == "ssh" && strings.Contains(args[len(args)-1], "sync export") {
+			exportCmd = args[len(args)-1]
 			return "deja: exported 1 records", nil
 		}
-		if name == "ssh" && strings.Contains(args[1], "rm -rf") {
+		if name == "ssh" && strings.Contains(args[len(args)-1], "rm -rf") {
 			cleanup = true
 			return "", nil
 		}
@@ -77,7 +77,7 @@ func TestSyncSSHPush(t *testing.T) {
 	defer func() { sshRunner = old }()
 	sshRunner = func(name string, args ...string) (string, error) {
 		calls = append(calls, append([]string{name}, args...))
-		if name == "ssh" && args[1] == "mktemp -d" {
+		if name == "ssh" && args[len(args)-1] == "mktemp -d" {
 			return "/tmp/remote-batch\n", nil
 		}
 		if name == "ssh" {
@@ -94,7 +94,8 @@ func TestSyncSSHPush(t *testing.T) {
 	if calls[1][0] != "scp" || !strings.HasSuffix(calls[1][len(calls[1])-1], ":/tmp/remote-batch/") {
 		t.Fatalf("bad scp call: %v", calls[1])
 	}
-	if !strings.Contains(calls[2][2], "sync import") || !strings.Contains(calls[2][2], "/tmp/remote-batch") {
+	last := calls[2][len(calls[2])-1]
+	if !strings.Contains(last, "sync import") || !strings.Contains(last, "/tmp/remote-batch") {
 		t.Fatalf("bad remote import call: %v", calls[2])
 	}
 }
@@ -111,7 +112,7 @@ func TestSyncSSHPushNothingNew(t *testing.T) {
 	// First push exports the one record; run it with a runner that accepts it.
 	full := sshRunner
 	sshRunner = func(name string, args ...string) (string, error) {
-		if name == "ssh" && args[1] == "mktemp -d" {
+		if name == "ssh" && args[len(args)-1] == "mktemp -d" {
 			return "/tmp/remote-batch", nil
 		}
 		return "deja: imported 1 records", nil
@@ -136,10 +137,10 @@ func TestSyncSSHPull(t *testing.T) {
 	old := sshRunner
 	defer func() { sshRunner = old }()
 	sshRunner = func(name string, args ...string) (string, error) {
-		if name == "ssh" && args[1] == "mktemp -d" {
+		if name == "ssh" && args[len(args)-1] == "mktemp -d" {
 			return "/tmp/remote-out", nil
 		}
-		if name == "ssh" && strings.Contains(args[1], "sync export") {
+		if name == "ssh" && strings.Contains(args[len(args)-1], "sync export") {
 			return "deja: exported 1 records", nil
 		}
 		if name == "scp" {
@@ -213,7 +214,7 @@ func TestSyncSSHIgnoresStderrBanner(t *testing.T) {
 	old := sshRunner
 	defer func() { sshRunner = old }()
 	sshRunner = func(name string, args ...string) (string, error) {
-		if name == "ssh" && len(args) > 1 && strings.Contains(args[1], "mktemp") {
+		if name == "ssh" && len(args) > 1 && strings.Contains(args[len(args)-1], "mktemp") {
 			// stdout only — the banner went to stderr, which we now drop.
 			return "/tmp/remote-batch\n", nil
 		}
@@ -232,7 +233,7 @@ func TestSyncSSHTakesLastLineOfRemoteOutput(t *testing.T) {
 	defer func() { sshRunner = old }()
 	var target string
 	sshRunner = func(name string, args ...string) (string, error) {
-		if name == "ssh" && len(args) > 1 && strings.Contains(args[1], "mktemp") {
+		if name == "ssh" && len(args) > 1 && strings.Contains(args[len(args)-1], "mktemp") {
 			return "Welcome to prod\n/tmp/remote-batch\n", nil
 		}
 		if name == "scp" {
@@ -255,7 +256,7 @@ func TestSyncSSHRejectsUnusableRemotePath(t *testing.T) {
 	old := sshRunner
 	defer func() { sshRunner = old }()
 	sshRunner = func(name string, args ...string) (string, error) {
-		if name == "ssh" && len(args) > 1 && strings.Contains(args[1], "mktemp") {
+		if name == "ssh" && len(args) > 1 && strings.Contains(args[len(args)-1], "mktemp") {
 			return "/tmp/deja sync/tmp.AbCd\n", nil
 		}
 		return "deja: imported 1 records", nil

--- a/cmd/deja/sync_ssh_timeout_test.go
+++ b/cmd/deja/sync_ssh_timeout_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -13,14 +14,10 @@ func TestSSHCarriesAConnectTimeout(t *testing.T) {
 	old := sshRunner
 	sshRunner = func(name string, args ...string) (string, error) {
 		got = append(got, append([]string{name}, args...))
-		return "", nil
+		return "/tmp/deja-remote", nil
 	}
 	t.Cleanup(func() { sshRunner = old })
 
-	sshRunner = func(name string, args ...string) (string, error) {
-		got = append(got, append([]string{name}, args...))
-		return "/tmp/deja-remote", nil
-	}
 	if _, err := sshCapture("somehost", "mktemp -d"); err != nil {
 		t.Fatal(err)
 	}
@@ -38,4 +35,39 @@ func TestSSHCarriesAConnectTimeout(t *testing.T) {
 	if i, j := strings.Index(line, "somehost"), strings.Index(line, "mktemp -d"); i < 0 || j < 0 || i > j {
 		t.Errorf("the call lost its shape: %s", line)
 	}
+}
+
+// Every ssh and scp deja runs carries the options, including the cleanup call
+// that removes the remote batch directory — a host that has gone away between
+// the transfer and the cleanup would otherwise hold the sync open.
+func TestEverySSHCallCarriesTheOptions(t *testing.T) {
+	src, err := os.ReadFile("sync_ssh.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, line := range strings.Split(string(src), "\n") {
+		if !strings.Contains(line, `sshRunner("ssh"`) && !strings.Contains(line, `sshRunner("scp"`) {
+			continue
+		}
+		if !strings.Contains(line, "sshOpts()") && !strings.Contains(line, "scpArgs") {
+			t.Errorf("sync_ssh.go:%d runs without the options: %s", i+1, strings.TrimSpace(line))
+		}
+	}
+}
+
+// sshHostArg is what a test stub needs to read the host out of an ssh call now
+// that every call carries options: the first argument that is neither an
+// option nor an option's value.
+func sshHostArg(args []string) string {
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-o" {
+			i++
+			continue
+		}
+		if strings.HasPrefix(args[i], "-") {
+			continue
+		}
+		return args[i]
+	}
+	return ""
 }

--- a/cmd/deja/sync_ssh_timeout_test.go
+++ b/cmd/deja/sync_ssh_timeout_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A laptop that is asleep neither answers nor refuses, so ssh waits out the
+// system default — measured at 446 s on one host, and `deja sync` walks every
+// machine it knows (#1772).
+func TestSSHCarriesAConnectTimeout(t *testing.T) {
+	var got [][]string
+	old := sshRunner
+	sshRunner = func(name string, args ...string) (string, error) {
+		got = append(got, append([]string{name}, args...))
+		return "", nil
+	}
+	t.Cleanup(func() { sshRunner = old })
+
+	sshRunner = func(name string, args ...string) (string, error) {
+		got = append(got, append([]string{name}, args...))
+		return "/tmp/deja-remote", nil
+	}
+	if _, err := sshCapture("somehost", "mktemp -d"); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ssh was run %d times", len(got))
+	}
+	line := strings.Join(got[0], " ")
+	if !strings.Contains(line, "ConnectTimeout=") {
+		t.Errorf("ssh runs without a connect timeout: %s", line)
+	}
+	if !strings.Contains(line, "BatchMode=yes") {
+		t.Errorf("ssh can stop on a password prompt nothing is reading: %s", line)
+	}
+	// The host and the command still arrive, in that order.
+	if i, j := strings.Index(line, "somehost"), strings.Index(line, "mktemp -d"); i < 0 || j < 0 || i > j {
+		t.Errorf("the call lost its shape: %s", line)
+	}
+}


### PR DESCRIPTION
Closes #1772.

A laptop that is asleep neither answers nor refuses, so ssh waits out the system default. Measured against 192.0.2.1 (RFC 5737, blackholed):

```
before  446.7s, no output at all
after    10.5s, "Connection to 192.0.2.1 port 22 timed out"
```

Every `ssh` and `scp` call carries `-o ConnectTimeout=10 -o BatchMode=yes` now. BatchMode is the other half: a host that wants a password was blocking on a prompt nothing is reading.

Test: `TestSSHCarriesAConnectTimeout`. The stubs in the existing ssh tests read the remote command by position, so they read it from the end of the argument list now — the calls kept their shape, which that test also pins.

The rest of the round trip was checked in the same session and is sound: export on A and import on B carry all sessions with their turns, a second import of the same directory adds 0, B's export carries none of A's records so nothing echoes back, a self-import is recognised word for word, and a directory of damaged batches imports what it can while naming each file it could not read.