### PR TITLE
fix: an empty id prefix resolves to nothing, in both lookups

### DIFF
--- a/internal/index/empty_prefix_test.go
+++ b/internal/index/empty_prefix_test.go
@@ -1,0 +1,38 @@
+package index
+
+import "testing"
+
+// PrefixMatches has always answered 0 for an empty prefix — "not a question
+// worth answering" — while FindByPrefix resolved it to whichever session sorted
+// first, because every id has "" as a prefix. #853 is the rule that the count
+// and the resolver must agree; this is that same disagreement with the sign
+// flipped, and it reached a user through the MCP resource URI in #1728.
+func TestEmptyPrefixResolvesToNothing(t *testing.T) {
+	dir := askedFixture(t,
+		map[string][]string{
+			"aa1": {"why does the pool exhaust under load?"},
+			"bb1": {"why is the build slow?"},
+		},
+		map[string]string{
+			"aa1": "2026-03-01T10:00:00Z",
+			"bb1": "2026-03-03T10:00:00Z",
+		})
+
+	s, ok, err := FindByPrefix(dir, "")
+	if err != nil {
+		t.Fatalf("empty prefix: %v", err)
+	}
+	if ok {
+		t.Fatalf("an empty prefix opened session %q; every id has \"\" as a prefix, so this is whichever one sorted first", s.ID)
+	}
+
+	// The two answers agree, which is the whole point.
+	if n := PrefixMatches(dir, ""); n != 0 {
+		t.Fatalf("PrefixMatches = %d, want 0", n)
+	}
+
+	// A real prefix is untouched: the guard must not be a refusal of everything.
+	if got, ok, err := FindByPrefix(dir, "aa"); err != nil || !ok || got.ID != "aa1" {
+		t.Fatalf("got %q ok=%v err=%v, want aa1", got.ID, ok, err)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1390,6 +1390,15 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
+	// Every id has "" as a prefix, so an empty one used to resolve to whichever
+	// session sorted first — and PrefixMatches has always answered 0 for it.
+	// That is the disagreement #853 is about, with the sign flipped: the count
+	// says nothing matches and the resolver opens something anyway. It reached a
+	// user through the MCP resource URI (#1728), which is a boundary that can be
+	// guarded, but the shared lookup is where the two answers have to agree.
+	if p == "" {
+		return model.Session{}, false, nil
+	}
 	// Non-blocking: the session-start hook reaches this through the handoff
 	// tip, and a blocking lock made the agent wait out the entire rebuild —
 	// twelve seconds on a real corpus, on the very upgrade that triggers one.

--- a/internal/search/empty_prefix_test.go
+++ b/internal/search/empty_prefix_test.go
@@ -1,0 +1,27 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// This is the lookup the CLI falls back to while the index is unavailable, so
+// an empty prefix has to be refused here too. Guarding only the index copy
+// would make the behaviour depend on whether a rebuild happens to be running.
+func TestEmptyPrefixFindsNothing(t *testing.T) {
+	ss := []model.Session{
+		{ID: "aa1", Harness: "claude", Project: "app"},
+		{ID: "bb1", Harness: "codex", Project: "app"},
+	}
+
+	if s, ok := FindByPrefix(ss, ""); ok {
+		t.Fatalf("an empty prefix returned session %q", s.ID)
+	}
+	if s, ok := FindByPrefix(ss, "bb"); !ok || s.ID != "bb1" {
+		t.Fatalf("got %q ok=%v, want bb1 — the guard must not refuse real prefixes", s.ID, ok)
+	}
+	if _, ok := FindByPrefix(nil, ""); ok {
+		t.Fatal("an empty store has nothing to match either")
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1232,7 +1232,14 @@ func variantDetail(text string, terms []string, variants map[string][]string) st
 	return ""
 }
 
+// FindByPrefix is the fallback the CLI takes when there is no index to read, so
+// it has to answer an empty prefix the same way index.FindByPrefix does: with
+// no match. Otherwise the guard depends on whether a rebuild happens to be
+// running, which is the worst kind of intermittent.
 func FindByPrefix(ss []model.Session, p string) (model.Session, bool) {
+	if p == "" {
+		return model.Session{}, false
+	}
 	for _, s := range mergeSessions(ss) {
 		if strings.HasPrefix(s.ID, p) {
 			return s, true


### PR DESCRIPTION
Follow-up to #1750, where @MsfPablo guarded the MCP resource URI and asked whether the shared lookup should refuse an empty prefix outright. It should, and the reason is stronger than defence in depth.

`PrefixMatches` has always answered `0` for an empty prefix — its test calls it "not a question worth answering" — while `FindByPrefix` resolved it to whichever session sorted first, because every id has `""` as a prefix. The comment above `PrefixMatches` states the invariant this breaks:

> The count and the resolver have to agree, or a reader is told an id matches nothing and then watches it open (#853).

That is exactly this bug with the sign flipped: the count says nothing matches, and the resolver opens something anyway.

Both copies are fixed, because there are two: `internal/search.FindByPrefix` is the fallback the CLI takes when the index is unavailable, so guarding only the index one would make the behaviour depend on whether a rebuild happens to be running.

Each test was checked by removing its own guard: without them, the empty prefix opens `bb1` and `aa1` respectively. Both also assert a real prefix still resolves, so neither guard can be satisfied by refusing everything.