### PR TITLE
feat(recall): say when a hit is the other machine's copy of a session this one holds

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -704,6 +704,18 @@ func wholeSessionForMCP(dir string, s model.Session) (model.Session, bool, error
 // needs precisely when the answer was too big to fit.
 const recallCountLineReserve = 160
 
+// twinSessionsFor pairs each session with the same session as it exists on
+// another machine, so a page holding both copies can say so. One manifest read
+// per page; empty when the index cannot be read, which costs a marker rather
+// than an answer.
+func twinSessionsFor(dir string) map[string]string {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return nil
+	}
+	return index.TwinSessions(metas)
+}
+
 func recallTextResult(dir, q, harness string, limit, offset, budget int) (string, int, int64, []string, error) {
 	if limit <= 0 {
 		limit = 5
@@ -765,6 +777,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	// attempts and none of the 5 clean ones.
 	total := len(hits)
 	attachLifecycles(dir, hits)
+	twins := twinSessionsFor(dir)
 	demoted := demoteRejected(hits)
 	if offset > 0 {
 		if offset >= total {
@@ -826,6 +839,16 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		// excerpts show which path was dropped.
 		if h.Session.GaveUp && h.Lifecycle == "" {
 			fmt.Fprintln(&hb, "[this session abandoned one approach partway — check the excerpts for which, the rest may still hold]")
+		}
+		// Sync keeps both copies when a session id is on two machines, and
+		// nothing connected them: one session's two histories read as two
+		// unrelated sessions, sometimes disagreeing with each other (#1775).
+		if twin := twins[h.Session.Harness+":"+h.Session.ID]; twin != "" {
+			if strings.HasPrefix(h.Session.ID, "imported-") {
+				fmt.Fprintf(&hb, "[another machine's copy of %s, which this machine has too — the two may not say the same thing]\n", twin)
+			} else {
+				fmt.Fprintf(&hb, "[this machine's copy; %s is the same session as it arrived from another machine — the two may not say the same thing]\n", twin)
+			}
 		}
 		if h.Superseded != "" {
 			fmt.Fprintf(&hb, "[earlier attempt — a newer session in this project covers the same ground, updated %s]\n", h.Superseded)

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -708,7 +708,7 @@ const recallCountLineReserve = 160
 // another machine, so a page holding both copies can say so. One manifest read
 // per page; empty when the index cannot be read, which costs a marker rather
 // than an answer.
-func twinSessionsFor(dir string) map[string]string {
+func twinSessionsFor(dir string) map[string][]string {
 	metas, err := index.AllMeta(dir)
 	if err != nil {
 		return nil
@@ -843,11 +843,13 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 		// Sync keeps both copies when a session id is on two machines, and
 		// nothing connected them: one session's two histories read as two
 		// unrelated sessions, sometimes disagreeing with each other (#1775).
-		if twin := twins[h.Session.Harness+":"+h.Session.ID]; twin != "" {
-			if strings.HasPrefix(h.Session.ID, "imported-") {
-				fmt.Fprintf(&hb, "[another machine's copy of %s, which this machine has too — the two may not say the same thing]\n", twin)
+		if twin := twins[h.Session.Harness+":"+h.Session.ID]; len(twin) > 0 {
+			// OrigID is the fact; an "imported-" id is only the convention
+			// sync mints, and a harness could name a local session that way.
+			if h.Session.OrigID != "" {
+				fmt.Fprintf(&hb, "[another machine's copy of %s, which this machine has too — the two may not say the same thing]\n", joinCapped(twin, 3))
 			} else {
-				fmt.Fprintf(&hb, "[this machine's copy; %s is the same session as it arrived from another machine — the two may not say the same thing]\n", twin)
+				fmt.Fprintf(&hb, "[this machine's copy; the same session arrived from elsewhere as %s — they may not say the same thing]\n", joinCapped(twin, 3))
 			}
 		}
 		if h.Superseded != "" {

--- a/cmd/deja/recall_twin_test.go
+++ b/cmd/deja/recall_twin_test.go
@@ -62,6 +62,9 @@ func TestRecallNamesTheOtherMachinesCopy(t *testing.T) {
 	}
 	// Each copy is named from its own side rather than with one hedged
 	// sentence on both.
+	if n := strings.Count(text, "may not say the same thing"); n != 2 {
+		t.Errorf("the marker appears %d times, want one per copy:\n%s", n, text)
+	}
 	if !strings.Contains(text, "another machine's copy") || !strings.Contains(text, "this machine's copy") {
 		t.Errorf("the two copies are not told apart:\n%s", text)
 	}

--- a/cmd/deja/recall_twin_test.go
+++ b/cmd/deja/recall_twin_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A page that holds both copies of one session — this machine's and the one
+// that arrived by sync — has to say they are the same session, or the reader
+// is looking at two answers to one question with no way to tell (#1775).
+func TestRecallNamesTheOtherMachinesCopy(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(id, ts, text string) string {
+		return `{"type":"user","sessionId":"` + id + `","cwd":"/w","timestamp":"` + ts + `","message":{"role":"user","content":"` + text + `"}}` + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(root, "s.jsonl"),
+		[]byte(line("dup-2", "2026-08-20T01:00:00Z", "quazzle local copy: the limit is five")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The same session as it arrived from another machine.
+	imported := filepath.Join(tmp, "batch")
+	if err := os.MkdirAll(imported, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(index.SyncRecord{
+		Harness: "claude", SessionID: "dup-2", Project: "proj",
+		Role: "user", Text: "quazzle other machine: the limit is nine",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(imported, "deja-sync-elsewhere-1.jsonl"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", imported); err != nil {
+		t.Fatal(err)
+	}
+
+	text, _, _, _, err := recallTextResult(dir, "quazzle limit", "", 5, 0, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "five") || !strings.Contains(text, "nine") {
+		t.Fatalf("the fixture is wrong, both copies should be on the page:\n%s", text)
+	}
+	if !strings.Contains(text, "the same session") {
+		t.Errorf("the page does not say the two are one session:\n%s", text)
+	}
+	// Each copy is named from its own side rather than with one hedged
+	// sentence on both.
+	if !strings.Contains(text, "another machine's copy") || !strings.Contains(text, "this machine's copy") {
+		t.Errorf("the two copies are not told apart:\n%s", text)
+	}
+}

--- a/internal/index/twin.go
+++ b/internal/index/twin.go
@@ -1,0 +1,34 @@
+package index
+
+// TwinSessions pairs a session with the same session as it exists on another
+// machine. Sync keeps both copies when an id is on two machines — neither
+// overwrites the other, which is right — and the imported row keeps the id it
+// had there (#1049). Nothing connected the two, so a reader saw one session's
+// two histories as two unrelated sessions, sometimes with contradictory
+// conclusions (#1775).
+//
+// The pairing is by harness and id: the same id under another harness is
+// another session, and an import whose origin is not on this machine has no
+// counterpart to name.
+func TwinSessions(metas []SessionMeta) map[string]string {
+	local := make(map[string]string, len(metas))
+	for _, m := range metas {
+		if m.OrigID == "" {
+			local[m.Harness+":"+m.ID] = m.Harness + ":" + m.ID
+		}
+	}
+	out := map[string]string{}
+	for _, m := range metas {
+		if m.OrigID == "" {
+			continue
+		}
+		origin := m.Harness + ":" + m.OrigID
+		if _, ok := local[origin]; !ok {
+			continue
+		}
+		imported := m.Harness + ":" + m.ID
+		out[imported] = origin
+		out[origin] = imported
+	}
+	return out
+}

--- a/internal/index/twin.go
+++ b/internal/index/twin.go
@@ -1,5 +1,7 @@
 package index
 
+import "sort"
+
 // TwinSessions pairs a session with the same session as it exists on another
 // machine. Sync keeps both copies when an id is on two machines — neither
 // overwrites the other, which is right — and the imported row keeps the id it
@@ -10,14 +12,14 @@ package index
 // The pairing is by harness and id: the same id under another harness is
 // another session, and an import whose origin is not on this machine has no
 // counterpart to name.
-func TwinSessions(metas []SessionMeta) map[string]string {
+func TwinSessions(metas []SessionMeta) map[string][]string {
 	local := make(map[string]string, len(metas))
 	for _, m := range metas {
 		if m.OrigID == "" {
 			local[m.Harness+":"+m.ID] = m.Harness + ":" + m.ID
 		}
 	}
-	out := map[string]string{}
+	out := map[string][]string{}
 	for _, m := range metas {
 		if m.OrigID == "" {
 			continue
@@ -26,9 +28,14 @@ func TwinSessions(metas []SessionMeta) map[string]string {
 		if _, ok := local[origin]; !ok {
 			continue
 		}
+		// Several machines can hold one session, so the local copy names all
+		// of them; each import names the one it came from.
 		imported := m.Harness + ":" + m.ID
-		out[imported] = origin
-		out[origin] = imported
+		out[imported] = []string{origin}
+		out[origin] = append(out[origin], imported)
+	}
+	for k := range out {
+		sort.Strings(out[k])
 	}
 	return out
 }

--- a/internal/index/twin_test.go
+++ b/internal/index/twin_test.go
@@ -16,12 +16,23 @@ func TestTwinsAcrossMachinesFindEachOther(t *testing.T) {
 	}
 	twins := TwinSessions(metas)
 
-	if got := twins["claude:dup-2"]; got != "claude:imported-d5b1285ecbfe" {
+	if got := twins["claude:dup-2"]; len(got) != 1 || got[0] != "claude:imported-d5b1285ecbfe" {
 		t.Errorf("the local copy points at %q", got)
 	}
-	if got := twins["claude:imported-d5b1285ecbfe"]; got != "claude:dup-2" {
+	if got := twins["claude:imported-d5b1285ecbfe"]; len(got) != 1 || got[0] != "claude:dup-2" {
 		t.Errorf("the imported copy points at %q", got)
 	}
+	// Two other machines holding one session are both named, rather than one
+	// of them silently winning the map.
+	three := TwinSessions([]SessionMeta{
+		{ID: "dup-3", Harness: "claude"},
+		{ID: "imported-aaa", Harness: "claude", OrigID: "dup-3"},
+		{ID: "imported-bbb", Harness: "claude", OrigID: "dup-3"},
+	})
+	if got := three["claude:dup-3"]; len(got) != 2 {
+		t.Errorf("the local copy names %q, want both imports", got)
+	}
+
 	// A session with no counterpart, an import whose origin is not here, and
 	// the same id under another harness are all left alone.
 	for _, key := range []string{"claude:other", "claude:imported-elsewhere", "codex:dup-2"} {

--- a/internal/index/twin_test.go
+++ b/internal/index/twin_test.go
@@ -1,0 +1,32 @@
+package index
+
+import "testing"
+
+// Sync keeps both copies when a session id exists on two machines, and the
+// imported row keeps the id it had there (#1049). Nothing connected the two, so
+// a reader saw one session's two histories as two unrelated sessions with
+// contradictory conclusions (#1775).
+func TestTwinsAcrossMachinesFindEachOther(t *testing.T) {
+	metas := []SessionMeta{
+		{ID: "dup-2", Harness: "claude", Project: "proj"},
+		{ID: "imported-d5b1285ecbfe", Harness: "claude", Project: "imported:proj", OrigID: "dup-2"},
+		{ID: "other", Harness: "claude", Project: "proj"},
+		{ID: "imported-elsewhere", Harness: "claude", Project: "imported:proj", OrigID: "never-here"},
+		{ID: "dup-2", Harness: "codex", Project: "proj"},
+	}
+	twins := TwinSessions(metas)
+
+	if got := twins["claude:dup-2"]; got != "claude:imported-d5b1285ecbfe" {
+		t.Errorf("the local copy points at %q", got)
+	}
+	if got := twins["claude:imported-d5b1285ecbfe"]; got != "claude:dup-2" {
+		t.Errorf("the imported copy points at %q", got)
+	}
+	// A session with no counterpart, an import whose origin is not here, and
+	// the same id under another harness are all left alone.
+	for _, key := range []string{"claude:other", "claude:imported-elsewhere", "codex:dup-2"} {
+		if got, ok := twins[key]; ok {
+			t.Errorf("%s was paired with %q", key, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1775.

Sync keeps both copies when a session id exists on two machines — neither overwrites the other, which is right — and the imported row keeps the id it had there (#1049). Nothing connected them, so an agent saw one session's two histories as two unrelated sessions, sometimes disagreeing:

```
1. [claude] imported:proj · imported-d5b1285ecbfe · updated 2026-08-25 (today)      "the limit is nine"
2. [claude] proj · dup-2 · updated 2026-08-24 (1d ago)                              "the limit is five"
```

Now each copy names the other, from its own side:

```
1. [claude] imported:proj · imported-d5b1285ecbfe · …
[another machine's copy of claude:dup-2, which this machine has too — the two may not say the same thing]
2. [claude] proj · dup-2 · …
[this machine's copy; claude:imported-d5b1285ecbfe is the same session as it arrived from another machine — …]
```

`index.TwinSessions` does the pairing by harness and origin id: the same id under another harness is another session, and an import whose origin is not on this machine has no counterpart to name. One manifest read per page.

The marker sits with the ones already there — `[earlier attempt …]`, `[this session abandoned one approach partway]`, `[stamped later than this machine's clock …]` — on the agent-facing page, which is the reader that cannot ask a human. `deja search` renders its own listing and is unchanged.

Ranking was checked both ways and is sound: recency decides which copy leads, in both directions.

Tests: `TestTwinsAcrossMachinesFindEachOther` and `TestRecallNamesTheOtherMachinesCopy`.