### PR TITLE
test(kimi): compare the two manifests whole instead of five keys of them

### DIFF
--- a/cmd/deja/kimi_plugin_test.go
+++ b/cmd/deja/kimi_plugin_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -102,12 +104,12 @@ func TestKimiManifestsAgree(t *testing.T) {
 	if plugin["version"] != kimiPluginVersion {
 		t.Fatalf("kimiPluginVersion is %q, the manifest says %v", kimiPluginVersion, plugin["version"])
 	}
-	for _, key := range []string{"name", "version", "description", "license", "sessionStart"} {
-		a, _ := json.Marshal(plugin[key])
-		b, _ := json.Marshal(root[key])
-		if string(a) != string(b) {
-			t.Fatalf("%s differs between the two manifests: %s vs %s", key, a, b)
-		}
+	// Whole, not key by key: the two differ only in where they point, and a
+	// list of keys to compare is a list of keys someone forgets to extend —
+	// `interface` is what Kimi's /plugins browser shows, and it went unchecked
+	// (#1777).
+	if diff := manifestDiffIgnoringPaths(plugin, root); diff != "" {
+		t.Fatalf("the two manifests disagree beyond their paths: %s", diff)
 	}
 	// The root manifest addresses the same files from one directory up.
 	if root["skills"] != "./extensions/kimi/skills/" || root["commands"] != "./extensions/kimi/commands/" {
@@ -118,4 +120,58 @@ func TestKimiManifestsAgree(t *testing.T) {
 			t.Fatalf("root manifest points at %s, which is not there: %v", rel, err)
 		}
 	}
+}
+
+// manifestDiffIgnoringPaths compares the two Kimi manifests after rewriting the
+// root one's paths to the packaged form. The prefix is the one intended
+// difference: a GitHub install reads the repo, the zip carries the plugin
+// directory itself.
+func manifestDiffIgnoringPaths(plugin, root map[string]any) string {
+	a, err := json.Marshal(plugin)
+	if err != nil {
+		return err.Error()
+	}
+	b, err := json.Marshal(root)
+	if err != nil {
+		return err.Error()
+	}
+	want := strings.ReplaceAll(string(b), "./extensions/kimi/", "./")
+	if want == string(a) {
+		return ""
+	}
+	return diffJSONMaps(string(a), want)
+}
+
+// diffJSONMaps names the keys that differ, so a failure says what to fix rather
+// than printing two manifests.
+func diffJSONMaps(a, b string) string {
+	var ma, mb map[string]json.RawMessage
+	if json.Unmarshal([]byte(a), &ma) != nil || json.Unmarshal([]byte(b), &mb) != nil {
+		return "the manifests are not both objects"
+	}
+	var out []string
+	for k, va := range ma {
+		vb, ok := mb[k]
+		if !ok {
+			out = append(out, k+" is only in the packaged manifest")
+			continue
+		}
+		if string(va) != string(vb) {
+			out = append(out, fmt.Sprintf("%s: packaged %s, root %s", k, clampForDiff(string(va)), clampForDiff(string(vb))))
+		}
+	}
+	for k := range mb {
+		if _, ok := ma[k]; !ok {
+			out = append(out, k+" is only in the root manifest")
+		}
+	}
+	sort.Strings(out)
+	return strings.Join(out, "; ")
+}
+
+func clampForDiff(s string) string {
+	if len(s) > 80 {
+		return s[:80] + "…"
+	}
+	return s
 }

--- a/cmd/deja/kimi_plugin_test.go
+++ b/cmd/deja/kimi_plugin_test.go
@@ -108,6 +108,14 @@ func TestKimiManifestsAgree(t *testing.T) {
 	// list of keys to compare is a list of keys someone forgets to extend —
 	// `interface` is what Kimi's /plugins browser shows, and it went unchecked
 	// (#1777).
+	// The rewrite below is a string replacement, so it is only honest while the
+	// prefix appears in paths and nowhere else — a description mentioning it
+	// would be rewritten too, and the comparison would pass on a difference.
+	for _, key := range []string{"description", "homepage", "keywords", "interface", "author"} {
+		if b, _ := json.Marshal(root[key]); strings.Contains(string(b), "extensions/kimi") {
+			t.Fatalf("%s mentions the path prefix, which the comparison rewrites: %s", key, b)
+		}
+	}
 	if diff := manifestDiffIgnoringPaths(plugin, root); diff != "" {
 		t.Fatalf("the two manifests disagree beyond their paths: %s", diff)
 	}
@@ -123,7 +131,9 @@ func TestKimiManifestsAgree(t *testing.T) {
 }
 
 // manifestDiffIgnoringPaths compares the two Kimi manifests after rewriting the
-// root one's paths to the packaged form. The prefix is the one intended
+// root one's paths to the packaged form. Key order and number forms do not
+// matter: encoding/json sorts a map's keys and normalises 1.0 to 1, so the two
+// files can be formatted differently and still compare equal. The prefix is the one intended
 // difference: a GitHub install reads the repo, the zip carries the plugin
 // directory itself.
 func manifestDiffIgnoringPaths(plugin, root map[string]any) string {


### PR DESCRIPTION
Closes #1777.

The plugin ships as two manifests — the repo root one a `/plugins install <github url>` reads, and `extensions/kimi/kimi.plugin.json` in the release zip — and `TestKimiManifestsAgree` compared five keys of them. Everything else could drift: `interface` is what Kimi's `/plugins` browser shows, so the two front doors could advertise different things and the suite stayed green.

They are compared whole now, after rewriting the root manifest's `./extensions/kimi/` prefix to `./` — the one intended difference. A failure names the keys rather than printing two manifests.

Before and after, changing only the packaged copy:

```
keywords + "drifted"                 before: ok     after: FAIL
interface.displayName changed        before: ok     after: FAIL
homepage changed                     before: ok     after: FAIL
```

The rest of the packaging check is sound and was verified in the same session: `pinmanifests -check` says scoop, winget and the Codex plugin match the newest release, against the live API, all at 0.18.0; the Codex plugin's manifest points at files that all exist; `server.json` and the mcpb manifest carry placeholder versions because their workflows stamp the release version at publish time.