### PR TITLE
fix(sync): stop calling a push with nothing to send an exchange

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2778,6 +2778,7 @@ Usage:
   deja sync import <dir>
   deja sync                       (exchange with every machine deja knows, both ways)
   deja sync ssh <host> [--pull] [--both] [--full]
+  deja sync forget <host>
   deja last [n] [--json] [--project name] [--harness name] [--from machine|local] [--since duration] [--role user|assistant|tool|files|command|edit]
   deja sources
   deja completion <bash|zsh|fish>

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/vshulcz/deja-vu/internal/peers"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -49,6 +50,21 @@ func runSync(dir string, args []string) error {
 	switch args[0] {
 	case "ssh":
 		return runSyncSSH(dir, args[1:])
+	case "forget":
+		// A machine deja knows is retried by every bare `deja sync`, and a
+		// typo'd hostname is one of those forever — at the cost of the connect
+		// timeout each time. peers.Forget did the work already and nothing
+		// reached it (#1780).
+		host := args[1]
+		found, err := peers.Forget(host)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return fmt.Errorf("deja does not know a machine called %q — `deja doctor` lists the ones it does", host)
+		}
+		fmt.Fprintf(os.Stdout, "deja: %s forgotten — bare `deja sync` will not try it again\n", host)
+		return nil
 	case "export":
 		full := false
 		rest := args[1:]

--- a/cmd/deja/sync_nothing_sent_test.go
+++ b/cmd/deja/sync_nothing_sent_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,5 +45,29 @@ func TestNothingToSendIsNotAnExchange(t *testing.T) {
 		if p.Host == "broken.example" && p.LastError == "" {
 			t.Error("a failure was not recorded")
 		}
+	}
+}
+
+// peers.Forget was written and tested and nothing reached it: a typo'd hostname
+// stayed in the list and every bare `deja sync` retried it, at the cost of the
+// connect timeout each time (#1780).
+func TestSyncForgetRemovesAMachine(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	if err := peers.Record("mini", false, time.Now(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSync(t.TempDir(), []string{"forget", "mini"}); err != nil {
+		t.Fatalf("forgetting a known machine: %v", err)
+	}
+	if list := peers.Load(); len(list) != 0 {
+		t.Errorf("peers = %v", list)
+	}
+	err := runSync(t.TempDir(), []string{"forget", "mini"})
+	if err == nil {
+		t.Fatal("forgetting a machine deja does not know said nothing")
+	}
+	if !strings.Contains(err.Error(), "does not know") {
+		t.Errorf("the refusal reads %q", err)
 	}
 }

--- a/cmd/deja/sync_nothing_sent_test.go
+++ b/cmd/deja/sync_nothing_sent_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/peers"
+)
+
+// "Last exchange just now" has to mean memory moved. A push with nothing to
+// send never opens a connection, so it is not an exchange — and stamping it
+// made doctor say a machine that does not exist was reached a moment ago, in
+// the same line that reported the failure (#1780).
+func TestNothingToSendIsNotAnExchange(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+
+	if err := recordExchange("quiet.example", false, time.Now(), errNothingToSend); err != nil {
+		t.Fatal(err)
+	}
+	list := peers.Load()
+	if len(list) != 1 {
+		t.Fatalf("peers = %v", list)
+	}
+	if !list[0].LastPush.IsZero() {
+		t.Errorf("a push that sent nothing was stamped %v", list[0].LastPush)
+	}
+	if list[0].LastError != "" {
+		t.Errorf("nothing to send is not a failure: %q", list[0].LastError)
+	}
+
+	// A real exchange still stamps, and a real failure still records.
+	if err := recordExchange("quiet.example", false, time.Now(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if peers.Load()[0].LastPush.IsZero() {
+		t.Error("a push that sent something was not stamped")
+	}
+	if err := recordExchange("broken.example", false, time.Now(), errors.New("boom")); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range peers.Load() {
+		if p.Host == "broken.example" && p.LastError == "" {
+			t.Error("a failure was not recorded")
+		}
+	}
+}

--- a/cmd/deja/sync_nothing_sent_test.go
+++ b/cmd/deja/sync_nothing_sent_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -14,8 +15,7 @@ import (
 // made doctor say a machine that does not exist was reached a moment ago, in
 // the same line that reported the failure (#1780).
 func TestNothingToSendIsNotAnExchange(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("DEJA_PEERS_FILE", filepath.Join(t.TempDir(), "peers.json"))
 
 	if err := recordExchange("quiet.example", false, time.Now(), errNothingToSend); err != nil {
 		t.Fatal(err)
@@ -52,8 +52,7 @@ func TestNothingToSendIsNotAnExchange(t *testing.T) {
 // stayed in the list and every bare `deja sync` retried it, at the cost of the
 // connect timeout each time (#1780).
 func TestSyncForgetRemovesAMachine(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("DEJA_PEERS_FILE", filepath.Join(t.TempDir(), "peers.json"))
 	if err := peers.Record("mini", false, time.Now(), nil); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -82,6 +83,22 @@ func syncSSHHost(dir, host string, pull, full, both bool) error {
 	return syncOneWay(dir, host, pull, full)
 }
 
+// errNothingToSend says the push had nothing to send, so no connection was
+// opened. It is not a failure and it is not an exchange: stamping it made
+// doctor report a machine deja never contacted as reached a moment ago (#1780).
+var errNothingToSend = errors.New("nothing new to push")
+
+// recordExchange writes what happened to the peer list, which is where doctor
+// and the bare `deja sync` read a machine's history from.
+func recordExchange(host string, pull bool, when time.Time, err error) error {
+	if errors.Is(err, errNothingToSend) {
+		// Remember the machine — it is one deja knows about now — without
+		// claiming an exchange or a failure.
+		return peers.Record(host, pull, time.Time{}, nil)
+	}
+	return peers.Record(host, pull, when, err)
+}
+
 func syncOneWay(dir, host string, pull, full bool) error {
 	var err error
 	if pull {
@@ -92,8 +109,13 @@ func syncOneWay(dir, host string, pull, full bool) error {
 	// Recorded either way: a peer that has been failing for a week is exactly
 	// what the report exists to show, and it is invisible if only successes
 	// are written down.
-	if rerr := peers.Record(host, pull, time.Now(), err); rerr != nil && err == nil {
+	if rerr := recordExchange(host, pull, time.Now(), err); rerr != nil && err == nil {
 		fmt.Fprintf(os.Stderr, "deja: synced with %s, but could not record it: %v\n", host, rerr)
+	}
+	if errors.Is(err, errNothingToSend) {
+		// Nothing to send is a quiet success for the caller: a machine with no
+		// new work is not a machine that could not be reached.
+		return nil
 	}
 	return err
 }
@@ -153,7 +175,7 @@ func syncSSHPush(dir, host string, full bool) error {
 	fmt.Fprintf(os.Stdout, "deja: exported %d records\n", n)
 	if n == 0 {
 		fmt.Fprintln(os.Stdout, "deja: nothing new to push")
-		return nil
+		return errNothingToSend
 	}
 	batches, err := filepath.Glob(filepath.Join(tmp, "*.jsonl"))
 	if err != nil || len(batches) == 0 {

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -81,6 +81,7 @@
 <tr><td><code>deja install &lt;target|--all|--auto&gt;</code></td><td>Wire MCP recall (and hooks) into your agents.</td></tr>
 <tr><td><code>deja embed</code></td><td>Build the semantic vector sidecar from a local endpoint.</td></tr>
 <tr><td><code>deja sync export/import/ssh</code></td><td>Move redacted memory between machines.</td></tr>
+<tr><td><code>deja sync forget &lt;host&gt;</code></td><td>Drop a machine deja knows, so a bare <code>deja sync</code> stops trying it.</td></tr>
 <tr><td><code>deja promote &lt;id&gt;</code></td><td>Distill a session into a curated note: quoted evidence with provenance and a lifecycle state (<code>--state accepted|rejected|superseded|stale</code>). Corrections append; the note outranks the raw transcript in recall. <code>--to path</code> also appends a Markdown block for repo-visible notes. <code>--tag</code> adds keywords; promoting into ground another accepted note already covers prints a conflict warning naming the older note.</td></tr>
 <tr><td><code>deja view</code></td><td>Browse memory in one self-contained local HTML: sessions with previews, recall audit trail, curated notes. <code>--out path</code>, <code>--no-open</code>.</td></tr>
 <tr><td><code>deja doctor</code></td><td>Diagnose stores, wiring, index and version. <code>--json</code>, <code>--offline</code>. <code>--deep</code> re-parses a sample of source files and resolves postings to prove the index against the sources; exits non-zero on drift.</td></tr>

--- a/internal/peers/peers.go
+++ b/internal/peers/peers.go
@@ -104,6 +104,10 @@ func Record(host string, pulled bool, when time.Time, err error) error {
 		// The failure is recorded, the timestamp is not: "last exchanged
 		// tuesday" has to mean memory actually moved.
 		list[i].LastError = trimError(err.Error())
+	} else if when.IsZero() {
+		// A caller with nothing to report — a push that found nothing to send,
+		// so no connection was opened. The host is remembered; what it did
+		// last time is not overwritten with a zero (#1780).
 	} else {
 		list[i].LastError = ""
 		if pulled {

--- a/internal/peers/peers_test.go
+++ b/internal/peers/peers_test.go
@@ -160,3 +160,34 @@ func TestSaveReplacesTheFileWhole(t *testing.T) {
 		t.Errorf("a second write lost the first host: %+v", list)
 	}
 }
+
+// A push with nothing to send opens no connection: the host is remembered, and
+// what it did last time is left alone rather than overwritten with a zero
+// (#1780).
+func TestRecordingNothingKeepsWhatWasThere(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	when := time.Now().Add(-time.Hour)
+	if err := Record("mini", false, when, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := Record("mini", false, time.Time{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	list := Load()
+	if len(list) != 1 {
+		t.Fatalf("peers = %v", list)
+	}
+	if got := list[0].LastPush; got.Sub(when.UTC()).Abs() > time.Second {
+		t.Errorf("the earlier exchange was overwritten: %v", got)
+	}
+	// A host deja has never reached is remembered with nothing claimed.
+	if err := Record("fresh", false, time.Time{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range Load() {
+		if p.Host == "fresh" && (!p.LastPush.IsZero() || p.LastError != "") {
+			t.Errorf("a host that was never contacted reads as %+v", p)
+		}
+	}
+}

--- a/internal/peers/peers_test.go
+++ b/internal/peers/peers_test.go
@@ -165,8 +165,10 @@ func TestSaveReplacesTheFileWhole(t *testing.T) {
 // what it did last time is left alone rather than overwritten with a zero
 // (#1780).
 func TestRecordingNothingKeepsWhatWasThere(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("USERPROFILE", t.TempDir())
+	// The package's own convention: XDG_CONFIG_HOME decides this path on Linux,
+	// so setting HOME alone leaves every test in the package sharing one real
+	// file — which is how this one first failed on CI and passed here.
+	t.Setenv("DEJA_PEERS_FILE", filepath.Join(t.TempDir(), "peers.json"))
 	when := time.Now().Add(-time.Hour)
 	if err := Record("mini", false, when, nil); err != nil {
 		t.Fatal(err)
@@ -196,8 +198,7 @@ func TestRecordingNothingKeepsWhatWasThere(t *testing.T) {
 // failure stands: clearing it would say the host is fine when deja never
 // contacted it (#1780).
 func TestNothingToSendLeavesAnEarlierFailureStanding(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("DEJA_PEERS_FILE", filepath.Join(t.TempDir(), "peers.json"))
 	if err := Record("mini", false, time.Now(), errors.New("connection refused")); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/peers/peers_test.go
+++ b/internal/peers/peers_test.go
@@ -191,3 +191,28 @@ func TestRecordingNothingKeepsWhatWasThere(t *testing.T) {
 		}
 	}
 }
+
+// A push with nothing to send tells us nothing about the machine, so the last
+// failure stands: clearing it would say the host is fine when deja never
+// contacted it (#1780).
+func TestNothingToSendLeavesAnEarlierFailureStanding(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	if err := Record("mini", false, time.Now(), errors.New("connection refused")); err != nil {
+		t.Fatal(err)
+	}
+	if err := Record("mini", false, time.Time{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	list := Load()
+	if len(list) != 1 || list[0].LastError == "" {
+		t.Errorf("the failure was cleared by a push that never opened a connection: %+v", list)
+	}
+	// A real exchange is what clears it.
+	if err := Record("mini", false, time.Now(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := Load()[0].LastError; got != "" {
+		t.Errorf("a successful exchange left the old failure: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #1780.

`deja sync ssh <host>` with nothing new to send never opens a connection, and recorded the exchange anyway — so doctor said a machine that does not exist was reached a moment ago, in the same line that reported the failure:

```
before  githbu.example last exchange just now, nothing received yet — last attempt failed: … Could not resolve hostname …
after   githbu.example never exchanged
        (and once there is something to send: never exchanged — last attempt failed: … Could not resolve hostname …)
```

`peers.Record` already had the rule in its own comment — "the timestamp is not: 'last exchanged tuesday' has to mean memory actually moved" — and a push of zero records over a connection that was never opened did not move memory. `syncSSHPush` returns `errNothingToSend` now; the host is still remembered as a machine deja knows, without a timestamp and without an error, and the caller still treats it as a quiet success so a machine with no new work is not counted as one that could not be reached.

Test: `TestNothingToSendIsNotAnExchange`, which also pins that a real exchange still stamps and a real failure still records.