### PR TITLE
test(index): stand where the swap-window wait is instead of racing a goroutine against it

### DIFF
--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -481,7 +481,7 @@ func Damaged(dir string) bool {
 	if !RebuildInProgress(dir) {
 		return true
 	}
-	time.Sleep(swapWindowWait)
+	waitOutSwapWindow()
 	m2, err := readManifest(dir)
 	if err != nil {
 		// The manifest went away under us, which is the swap itself rather than

--- a/internal/index/swap_stat_test.go
+++ b/internal/index/swap_stat_test.go
@@ -3,6 +3,7 @@ package index
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -140,4 +141,24 @@ func damagedFixture(t *testing.T) (dir string, records []byte) {
 		t.Fatal(err)
 	}
 	return dir, body
+}
+
+// Both retry loops take the same pause by the same name: a test that stands
+// where the wait is has to see every path that waits, or the next one to grow a
+// direct time.Sleep is the one that goes back to racing the scheduler (#1782).
+func TestEveryRetryLoopTakesTheSamePause(t *testing.T) {
+	src, err := os.ReadFile("swap_window.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The definition of the pause is allowed to sleep; nothing else is.
+	for i, line := range strings.Split(string(src), "\n") {
+		if !strings.Contains(line, "time.Sleep(swapWindowWait)") {
+			continue
+		}
+		if strings.Contains(line, "var waitOutSwapWindow") {
+			continue
+		}
+		t.Errorf("swap_window.go:%d sleeps directly instead of going through waitOutSwapWindow: %s", i+1, strings.TrimSpace(line))
+	}
 }

--- a/internal/index/swap_stat_test.go
+++ b/internal/index/swap_stat_test.go
@@ -75,17 +75,27 @@ func TestDamagedRereadsAPairThatDisagreed(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer unlock()
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		time.Sleep(5 * time.Millisecond)
-		_ = os.WriteFile(path, body, 0o600)
-	}()
+	// The store agrees with its manifest again by the time the second read
+	// happens. Standing where the wait is rather than racing a goroutine
+	// against it: on a loaded runner a 5 ms sleep can land after the 20 ms
+	// window and the test failed on a store that behaved exactly as designed
+	// (#1782).
+	restored := false
+	old := waitOutSwapWindow
+	waitOutSwapWindow = func() {
+		restored = true
+		if err := os.WriteFile(path, body, 0o600); err != nil {
+			t.Error(err)
+		}
+	}
+	defer func() { waitOutSwapWindow = old }()
+
 	if Damaged(dir) {
 		t.Error("a store that agrees with its manifest a moment later was called damaged")
 	}
-	wg.Wait()
+	if !restored {
+		t.Error("the second read never happened, so this proved nothing")
+	}
 }
 
 // And a store that is really short stays damaged: the second read is a second

--- a/internal/index/swap_window.go
+++ b/internal/index/swap_window.go
@@ -79,7 +79,7 @@ func statIndexFile(path string) (os.FileInfo, error) {
 		if !inFlight {
 			return nil, err
 		}
-		time.Sleep(swapWindowWait)
+		waitOutSwapWindow()
 	}
 	return nil, err
 }

--- a/internal/index/swap_window.go
+++ b/internal/index/swap_window.go
@@ -24,6 +24,12 @@ const (
 	swapWindowWait  = 20 * time.Millisecond
 )
 
+// waitOutSwapWindow is the pause a reader takes before looking again. It is a
+// variable so a test can stand where the pause is instead of racing a
+// goroutine against it: the point of those tests is what the second read sees,
+// not which goroutine the scheduler picks (#1782).
+var waitOutSwapWindow = func() { time.Sleep(swapWindowWait) }
+
 // openIndexFile is os.Open for a file inside the index directory.
 func openIndexFile(path string) (*os.File, error) {
 	f, err := os.Open(path)
@@ -47,7 +53,7 @@ func openIndexFile(path string) (*os.File, error) {
 		if !inFlight {
 			return nil, err
 		}
-		time.Sleep(swapWindowWait)
+		waitOutSwapWindow()
 	}
 	return nil, err
 }


### PR DESCRIPTION
Closes #1782.

`TestDamagedRereadsAPairThatDisagreed` restored the truncated file from a goroutine sleeping 5 ms and relied on that landing inside the 20 ms `swapWindowWait` before `Damaged` looks again. On a loaded runner the goroutine can be starved past the window, and the test then fails on a store behaving exactly as designed — it did once on ubuntu during BUG-HUNT 85, on a branch that touched only `cmd/deja`.

The pause is a variable now (`waitOutSwapWindow`), so the test restores the file *inside* it and asserts the second read happened at all. Production behaviour is unchanged: the variable holds the same `time.Sleep(swapWindowWait)`.

```
before, with the restore moved to 25 ms (what starvation does to 5 ms):   FAIL
after,  same 25 ms delay inside the wait:                                 ok
```

`TestRealDamageSurvivesTheReread` beside it never depended on the scheduler and is untouched.