### PR TITLE
fix(mcp): let blame answer from the snapshot while a rebuild runs

### DIFF
--- a/cmd/deja/blame_stale_test.go
+++ b/cmd/deja/blame_stale_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"github.com/vshulcz/deja-vu/internal/model"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,4 +68,50 @@ func TestBlameSaysWhenItServedASnapshot(t *testing.T) {
 	if quiet := string(mustMarshalBlame(nil, 0, false)); strings.Contains(quiet, "refresh") {
 		t.Errorf("an ordinary answer carries the note: %s", quiet)
 	}
+}
+
+// The note must not cost a session: the payload is trimmed to its budget on the
+// hits alone, and the note is added afterwards.
+func TestTheRefreshNoteDoesNotCostASession(t *testing.T) {
+	hits := make([]search.BlameHit, 0, 40)
+	for i := range 40 {
+		hits = append(hits, search.BlameHit{
+			Session:  model.Session{ID: "s", Harness: "claude", Project: "proj", Title: strings.Repeat("x", 300)},
+			Count:    i,
+			Snippets: []string{strings.Repeat("y", 300)},
+		})
+	}
+	quiet := countBlameSessions(t, blameBodyFor(hits, false))
+	noisy := countBlameSessions(t, blameBodyFor(hits, true))
+	if noisy != quiet {
+		t.Errorf("the note cost %d session(s): %d against %d", quiet-noisy, noisy, quiet)
+	}
+}
+
+// blameBodyFor runs the same trim-then-note sequence blameTextResult does.
+func blameBodyFor(hits []search.BlameHit, refreshing bool) []byte {
+	body := mustMarshalBlame(hits, 0, false)
+	for len(body) > blameMCPBudget && len(hits) > 1 {
+		hits = hits[:max(len(hits)*3/4, 1)]
+		body = mustMarshalBlame(hits, 0, false)
+	}
+	if refreshing {
+		body = mustMarshalBlame(hits, 0, true)
+	}
+	return body
+}
+
+func countBlameSessions(t *testing.T, body []byte) int {
+	t.Helper()
+	var rows []map[string]any
+	if err := json.Unmarshal(body, &rows); err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for _, r := range rows {
+		if _, ok := r["session"]; ok {
+			n++
+		}
+	}
+	return n
 }

--- a/cmd/deja/blame_stale_test.go
+++ b/cmd/deja/blame_stale_test.go
@@ -43,18 +43,23 @@ func TestBlameReadsWithoutWaitingForARebuild(t *testing.T) {
 	_ = tmp
 	// And the tool no longer declines while a rebuild is in flight: that is
 	// what buildingNowForBlockingTool is for, and blame is not one of those
-	// any more.
+	// any more. The case has to be there for this to mean anything.
 	src, err := os.ReadFile("mcp.go")
 	if err != nil {
 		t.Fatal(err)
 	}
+	found := false
 	for _, block := range strings.Split(string(src), "case \"") {
 		if !strings.HasPrefix(block, "blame\"") {
 			continue
 		}
+		found = true
 		if strings.Contains(block, "buildingNowForBlockingTool") {
 			t.Error("blame still declines while a rebuild runs")
 		}
+	}
+	if !found {
+		t.Fatal("no blame case in mcp.go, so this proved nothing")
 	}
 }
 
@@ -85,6 +90,11 @@ func TestTheRefreshNoteDoesNotCostASession(t *testing.T) {
 	noisy := countBlameSessions(t, blameBodyFor(hits, true))
 	if noisy != quiet {
 		t.Errorf("the note cost %d session(s): %d against %d", quiet-noisy, noisy, quiet)
+	}
+	// What it does cost is its own length, and no more.
+	over := len(blameBodyFor(hits, true)) - blameMCPBudget
+	if note := len(`{"note":"index refresh running in the background — the very newest sessions may not appear yet"},`); over > note {
+		t.Errorf("the payload is %d bytes over the budget, more than the note's %d", over, note)
 	}
 }
 

--- a/cmd/deja/blame_stale_test.go
+++ b/cmd/deja/blame_stale_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// The reading tools answer from the snapshot while a rebuild runs (#1733).
+// blame was left out because its path takes the blocking EnsureForSearch — and
+// blame is the tool an agent calls before editing a file, so "ask again then"
+// means the edit happens without the history (#1784).
+func TestBlameReadsWithoutWaitingForARebuild(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"b1","cwd":"/w","timestamp":"2026-08-24T01:00:00Z","message":{"role":"user","content":"zapfizzle editing parser.go here"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "a.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The agent-facing path must not be the blocking one.
+	hits, _, _, err := findBlameHitsStale(dir, search.BlameTarget{Stem: "parser.go", Base: "parser.go"}, search.BlameOptions{All: true}, policy.ActivationMCP, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Error("blame found nothing on a store that mentions the file")
+	}
+	_ = tmp
+	// And the tool no longer declines while a rebuild is in flight: that is
+	// what buildingNowForBlockingTool is for, and blame is not one of those
+	// any more.
+	src, err := os.ReadFile("mcp.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, block := range strings.Split(string(src), "case \"") {
+		if !strings.HasPrefix(block, "blame\"") {
+			continue
+		}
+		if strings.Contains(block, "buildingNowForBlockingTool") {
+			t.Error("blame still declines while a rebuild runs")
+		}
+	}
+}
+
+// And the answer says so: recall prints the sentence in prose, blame answers in
+// JSON, so the note goes in the payload rather than nowhere.
+func TestBlameSaysWhenItServedASnapshot(t *testing.T) {
+	body := string(mustMarshalBlame(nil, 0, true))
+	if !strings.Contains(body, "index refresh running in the background") {
+		t.Errorf("a snapshot answer says nothing about the refresh: %s", body)
+	}
+	if quiet := string(mustMarshalBlame(nil, 0, false)); strings.Contains(quiet, "refresh") {
+		t.Errorf("an ordinary answer carries the note: %s", quiet)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1955,18 +1955,41 @@ func runBlame(dir string, args []string) error {
 }
 
 func findBlameHits(dir string, target search.BlameTarget, o search.BlameOptions, activation string, progress io.Writer) ([]search.BlameHit, int, error) {
+	hits, hidden, _, err := blameHits(dir, target, o, activation, progress, false)
+	return hits, hidden, err
+}
+
+// findBlameHitsStale is findBlameHits for a caller that must not wait: it
+// serves the snapshot on disk while a rebuild runs, the way recall does, and
+// hands the rebuild to the detached warmup. blame is the tool an agent calls
+// before editing a file, so declining for the length of a refresh means the
+// edit happens without the history (#1784). The CLI keeps the blocking path —
+// someone typed it and is watching the progress (#1306).
+func findBlameHitsStale(dir string, target search.BlameTarget, o search.BlameOptions, activation string, progress io.Writer) ([]search.BlameHit, int, bool, error) {
+	return blameHits(dir, target, o, activation, progress, true)
+}
+
+func blameHits(dir string, target search.BlameTarget, o search.BlameOptions, activation string, progress io.Writer, stale bool) ([]search.BlameHit, int, bool, error) {
 	query := search.Options{Query: target.Stem, Harness: o.Harness, Project: o.Project, Since: o.Since, All: true}
-	if err := index.EnsureForSearch(dir, query, false, progress); err != nil {
-		return nil, 0, err
+	refreshing := false
+	if stale {
+		var err error
+		if refreshing, err = index.EnsureForSearchStale(dir, query, progress); err != nil {
+			return nil, 0, false, err
+		} else if refreshing {
+			requestWarmup(dir)
+		}
+	} else if err := index.EnsureForSearch(dir, query, false, progress); err != nil {
+		return nil, 0, false, err
 	}
 	result, err := index.SearchWithRecoveryDetailed(dir, query, progress)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 	all := search.Blame(withFileTouchers(dir, result.Sessions, target), target, o)
 	hits := policyFilterBlame(activation, all)
 	attachBlameLifecycles(hits)
-	return hits, len(all) - len(hits), nil
+	return hits, len(all) - len(hits), refreshing, nil
 }
 
 // blameToucherCap bounds how many extra sessions a blame reads from the

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -480,7 +480,9 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 	// 300 sessions touched one file (#1071); a cap that an argument can turn
 	// off is not a cap.
 	// Trimmed without the note, then rebuilt with it: a session must not be
-	// dropped to make room for a sentence about the index.
+	// dropped to make room for a sentence about the index. The answer can end
+	// up the note's length over the budget, which is about a hundred bytes and
+	// worth more than the session it would otherwise cost.
 	body := mustMarshalBlame(hits, 0, false)
 	for len(body) > blameMCPBudget && len(hits) > 1 {
 		hits = hits[:max(len(hits)*3/4, 1)]

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -305,11 +305,12 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 				return "", err
 			}
 		}
-		// blame reaches index.EnsureForSearch through findBlameHits, which
-		// blocks and can run the whole build inside this call. The CLI keeps
-		// that — someone typed it and watches the progress — but an agent gets
-		// the same sentence as every other tool (#1306).
-		if line := buildingNowForBlockingTool(dir); line != "" {
+		// The agent-facing blame reads without waiting, the way recall does:
+		// it is the tool called before editing a file, so declining for the
+		// length of a refresh means the edit happens without the history
+		// (#1784). Only a store deja cannot answer from at all still gets the
+		// sentence (#1306).
+		if line := buildingNowForAgent(dir); line != "" {
 			return line, nil
 		}
 		text, hits, err := blameTextResult(dir, search.BlameOptions{Harness: a.Harness, Project: a.Project, Since: since, All: a.All}, a.Path, int(a.Limit))
@@ -457,7 +458,7 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 	if err != nil {
 		return "", 0, err
 	}
-	hits, _, err := findBlameHits(dir, target, o, policy.ActivationMCP, mcpProgress())
+	hits, _, refreshing, err := findBlameHitsStale(dir, target, o, policy.ActivationMCP, mcpProgress())
 	if err != nil {
 		return "", 0, err
 	}
@@ -478,16 +479,16 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 	// used to skip the truncation above and hand back 162 KB from a store where
 	// 300 sessions touched one file (#1071); a cap that an argument can turn
 	// off is not a cap.
-	body := mustMarshalBlame(hits, 0)
+	body := mustMarshalBlame(hits, 0, refreshing)
 	for len(body) > blameMCPBudget && len(hits) > 1 {
 		hits = hits[:max(len(hits)*3/4, 1)]
-		body = mustMarshalBlame(hits, 0)
+		body = mustMarshalBlame(hits, 0, refreshing)
 	}
 	if omitted := found - len(hits); omitted > 0 {
 		// Silently returning the top slice let an agent conclude it had seen
 		// every session that touched the file. Say what was left out and what
 		// to do about it.
-		body = mustMarshalBlame(hits, omitted)
+		body = mustMarshalBlame(hits, omitted, refreshing)
 	}
 	return string(body), len(hits), nil
 }
@@ -519,8 +520,14 @@ type blameSessionJSON struct {
 	Touched []string  `json:"touched,omitempty"`
 }
 
-func mustMarshalBlame(hits []search.BlameHit, omitted int) []byte {
-	out := make([]any, 0, len(hits)+1)
+func mustMarshalBlame(hits []search.BlameHit, omitted int, refreshing bool) []byte {
+	out := make([]any, 0, len(hits)+2)
+	if refreshing {
+		// The answer is the snapshot on disk while a rebuild adds to it — the
+		// same thing recall says in prose, said here in the shape this tool
+		// answers in (#1784).
+		out = append(out, map[string]any{"note": "index refresh running in the background — the very newest sessions may not appear yet"})
+	}
 	for _, h := range hits {
 		out = append(out, blameHitJSON{
 			Session: blameSessionJSON{

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -479,10 +479,15 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 	// used to skip the truncation above and hand back 162 KB from a store where
 	// 300 sessions touched one file (#1071); a cap that an argument can turn
 	// off is not a cap.
-	body := mustMarshalBlame(hits, 0, refreshing)
+	// Trimmed without the note, then rebuilt with it: a session must not be
+	// dropped to make room for a sentence about the index.
+	body := mustMarshalBlame(hits, 0, false)
 	for len(body) > blameMCPBudget && len(hits) > 1 {
 		hits = hits[:max(len(hits)*3/4, 1)]
-		body = mustMarshalBlame(hits, 0, refreshing)
+		body = mustMarshalBlame(hits, 0, false)
+	}
+	if refreshing {
+		body = mustMarshalBlame(hits, 0, true)
 	}
 	if omitted := found - len(hits); omitted > 0 {
 		// Silently returning the top slice let an agent conclude it had seen

--- a/cmd/deja/mcp_blame_test.go
+++ b/cmd/deja/mcp_blame_test.go
@@ -26,7 +26,7 @@ func TestMCPBlameLeavesTheTranscriptBehind(t *testing.T) {
 		Title: "pool exhaustion", Count: 3, Score: 1.5, Tier: "exact",
 		Snippets: []string{"we chose transaction pooling"},
 	}}
-	out := mustMarshalBlame(hits, 0)
+	out := mustMarshalBlame(hits, 0, false)
 	if len(out) > 4096 {
 		t.Fatalf("blame answered %d bytes for one hit; the transcript is still in there", len(out))
 	}


### PR DESCRIPTION
Closes #1784.

Since #1734 the reading tools answer from the snapshot during a refresh; blame still declined, because its path takes the blocking `EnsureForSearch`. blame is the tool an agent calls *before editing a file*, so "ask again then" meant the edit happened without the history.

```
before  blame   0.01s  deja is indexing this machine's history. Recall comes online in a few seconds; ask again then.
after   blame   0.43s  10 sessions, and the payload opens with
                       {"note":"index refresh running in the background — the very newest sessions may not appear yet"}
```

`findBlameHitsStale` is the agent-facing path — `EnsureForSearchStale`, hand the rebuild to the detached warmup, answer from disk. `deja blame` on the command line keeps the blocking call, which is the distinction #1306 drew: someone typed it and is watching the progress.

The note goes in the payload rather than in prose, because blame answers in JSON — recall's sentence in the shape this tool speaks.

Tests: `TestBlameReadsWithoutWaitingForARebuild` (which also fails if the tool goes back to declining) and `TestBlameSaysWhenItServedASnapshot`.

`remember` stays on the blocking path: it writes first and then indexes, which is a different question.