### PR TITLE
fix(search): run the co-occurrence rescue when the words never appear together

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -686,7 +686,11 @@ func cmdCtx(dir string, rest []string) error {
 	// Which rung answered, said out loud on stderr as the search screen says
 	// it — stdout stays the context block an agent parses. ctx served an
 	// answer to a word the caller never typed and said nothing about it.
-	if result.Stemmed {
+	if result.Neighbour {
+		printNeighbour(os.Stderr, result.Variants)
+		o.Stemmed = true
+		o.FuzzyVariants = result.Variants
+	} else if result.Stemmed {
 		printStemmed(os.Stderr, result.Variants)
 		o.Stemmed = true
 		o.FuzzyVariants = result.Variants
@@ -962,7 +966,11 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	ss, policyHidden := policyFilterSessionsCounted(policy.ActivationSearch, result.Sessions)
 	o.PolicyWithheld = policyHidden
 	o.Tier = result.Tier
-	if result.Stemmed {
+	if result.Neighbour {
+		printNeighbour(os.Stderr, result.Variants)
+		o.Stemmed = true
+		o.FuzzyVariants = result.Variants
+	} else if result.Stemmed {
 		printStemmed(os.Stderr, result.Variants)
 		o.Stemmed = true
 		o.FuzzyVariants = result.Variants
@@ -1082,6 +1090,24 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	o.Width = printableWidth(os.Stdout)
 	search.Print(os.Stdout, hits, o)
 	return nil
+}
+
+// printNeighbour narrates a co-occurrence swap. It is not a word form: the
+// corpus says these two words keep company, which is a different claim and
+// reads as a typo correction if it borrows the other sentence (#1786).
+func printNeighbour(w io.Writer, variants map[string][]string) {
+	keys := make([]string, 0, len(variants))
+	for token := range variants {
+		keys = append(keys, token)
+	}
+	sort.Strings(keys)
+	for _, token := range keys {
+		for _, variant := range variants[token] {
+			if variant != "" && variant != token {
+				fmt.Fprintf(w, "deja: no session has those words together, so deja tried one this corpus keeps beside %q: %s\n", token, variant)
+			}
+		}
+	}
 }
 
 func printStemmed(w io.Writer, variants map[string][]string) {

--- a/internal/index/cooccur.go
+++ b/internal/index/cooccur.go
@@ -243,7 +243,7 @@ func cooccurSearch(dir string, m Manifest, o query.Options) (SearchResult, error
 			if serr != nil || len(ss) == 0 {
 				continue
 			}
-			return SearchResult{Sessions: ss, Stemmed: true, Variants: variants, Tier: query.TierClose}, nil
+			return SearchResult{Sessions: ss, Stemmed: true, Neighbour: true, Variants: variants, Tier: query.TierClose}, nil
 		}
 	}
 	return SearchResult{}, nil

--- a/internal/index/cooccur_reach_test.go
+++ b/internal/index/cooccur_reach_test.go
@@ -56,10 +56,22 @@ func TestCooccurRescueRunsWhenThePostingsDoNotIntersect(t *testing.T) {
 	// The branch this is about is the one where the ANDed postings do not
 	// intersect — both words are in the index, no session holds both.
 	o := query.Options{Query: "kerberos renewal", All: true}
+	both := map[string]bool{}
 	for _, tok := range []string{"kerberos", "renewal"} {
 		posts, perr := postingsFor(dir, "t"+tok)
 		if perr != nil || len(posts) == 0 {
 			t.Fatalf("%s has no postings, so this is not the branch under test (%v)", tok, perr)
+		}
+		hits, herr := Search(dir, query.Options{Query: tok, All: true})
+		if herr != nil {
+			t.Fatal(herr)
+		}
+		for _, h := range hits {
+			key := h.Harness + ":" + h.ID
+			if both[key] {
+				t.Fatalf("%s is in a session that holds both words, so the postings do intersect", key)
+			}
+			both[key] = true
 		}
 	}
 	direct, err := func() (SearchResult, error) {
@@ -87,4 +99,15 @@ func TestCooccurRescueRunsWhenThePostingsDoNotIntersect(t *testing.T) {
 		t.Errorf("a query that matches directly returned %d (%v)", len(hit), err)
 	}
 	_ = model.Session{}
+}
+
+// A neighbour swap is not a word form, and the two are narrated differently:
+// "login" answered by "jwks" is the corpus keeping company, not a spelling.
+func TestANeighbourSwapSaysItIsOne(t *testing.T) {
+	if !(SearchResult{Neighbour: true}).Neighbour {
+		t.Fatal("the flag does not survive a copy")
+	}
+	if (SearchResult{Stemmed: true}).Neighbour {
+		t.Error("a stem result claims to be a neighbour swap")
+	}
 }

--- a/internal/index/cooccur_reach_test.go
+++ b/internal/index/cooccur_reach_test.go
@@ -53,7 +53,15 @@ func TestCooccurRescueRunsWhenThePostingsDoNotIntersect(t *testing.T) {
 	if n := readCooccur(dir)["kerberos"]; len(n) == 0 {
 		t.Fatalf("the fixture did not teach the map: %v", readCooccur(dir))
 	}
+	// The branch this is about is the one where the ANDed postings do not
+	// intersect — both words are in the index, no session holds both.
 	o := query.Options{Query: "kerberos renewal", All: true}
+	for _, tok := range []string{"kerberos", "renewal"} {
+		posts, perr := postingsFor(dir, "t"+tok)
+		if perr != nil || len(posts) == 0 {
+			t.Fatalf("%s has no postings, so this is not the branch under test (%v)", tok, perr)
+		}
+	}
 	direct, err := func() (SearchResult, error) {
 		m, merr := readManifest(dir)
 		if merr != nil {

--- a/internal/index/cooccur_reach_test.go
+++ b/internal/index/cooccur_reach_test.go
@@ -1,0 +1,82 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// The rescue is for a query whose words are right but never appear together —
+// "login" next to "jwks". That is the state where the postings intersect to
+// nothing, and the chain called the rescue only in the other zero-result
+// branch, so the case it was written for never reached it (#1786).
+func TestCooccurRescueRunsWhenThePostingsDoNotIntersect(t *testing.T) {
+	dir := t.TempDir() + "/index.db"
+	root := t.TempDir()
+	writeSession := func(i int, text string) {
+		line := func(role, body string) string {
+			b, _ := json.Marshal(map[string]any{
+				"type": role, "sessionId": "s" + string(rune('a'+i%26)) + string(rune('a'+i/26)),
+				"cwd": "/w", "timestamp": "2026-08-20T01:00:00Z",
+				"message": map[string]any{"role": role, "content": body},
+			})
+			return string(b)
+		}
+		body := line("user", text) + "\n" + line("assistant", "resolved: "+text) + "\n"
+		if err := os.WriteFile(filepath.Join(root, "s"+string(rune('a'+i%26))+string(rune('a'+i/26))+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	filler := []string{"alpha bravo charlie", "delta echo foxtrot", "golf hotel india", "juliet kilo lima"}
+	for i := range 160 {
+		writeSession(i, filler[i%len(filler)])
+	}
+	for i := 160; i < 170; i++ {
+		writeSession(i, "keytab renewal failed on the build agent")
+	}
+	for i := 170; i < 182; i++ {
+		writeSession(i, "kerberos keytab rotation on the runner")
+	}
+	setHome(t, t.TempDir())
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(t.TempDir(), "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(t.TempDir(), "opencode.db"))
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The map has to know them, or this proves nothing about the chain.
+	if n := readCooccur(dir)["kerberos"]; len(n) == 0 {
+		t.Fatalf("the fixture did not teach the map: %v", readCooccur(dir))
+	}
+	o := query.Options{Query: "kerberos renewal", All: true}
+	direct, err := func() (SearchResult, error) {
+		m, merr := readManifest(dir)
+		if merr != nil {
+			return SearchResult{}, merr
+		}
+		return cooccurSearch(dir, m, o)
+	}()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(direct.Sessions) == 0 {
+		t.Fatal("the rescue itself found nothing, so the fixture is wrong")
+	}
+	ss, err := Search(dir, o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) == 0 {
+		t.Errorf("the rescue finds %d sessions and the search that a user runs returns none", len(direct.Sessions))
+	}
+	// And an ordinary query is unaffected.
+	if hit, err := Search(dir, query.Options{Query: "keytab renewal", All: true}); err != nil || len(hit) == 0 {
+		t.Errorf("a query that matches directly returned %d (%v)", len(hit), err)
+	}
+	_ = model.Session{}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -359,8 +359,13 @@ type SearchResult struct {
 	Sessions []model.Session
 	Fuzzy    bool
 	Stemmed  bool
-	Variants map[string][]string
-	Tier     string
+	// Neighbour says the swap came from the co-occurrence map rather than from
+	// a word form: "login" answered by "jwks" is not a spelling of it, and
+	// calling it a word form reads as a typo correction the reader did not
+	// make (#1786).
+	Neighbour bool
+	Variants  map[string][]string
+	Tier      string
 	// Total is how many sessions the tier matched before its own window
 	// trimmed them, and Capped whether that trimming withheld any. The
 	// relevance tier is the one that needs them: it ranks and truncates

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -157,6 +157,15 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 			} else if result.Fuzzy {
 				return withRelevanceTail(dir, m, o, result)
 			}
+			// Two words that never appear together is the state the
+			// co-occurrence rescue was written for — "login" next to "jwks"
+			// — and it was called only in the other zero-result branch, so
+			// the case it exists for never reached it (#1786).
+			if result, ferr := cooccurSearch(dir, m, o); ferr != nil {
+				return SearchResult{}, fmt.Errorf("cooccur postings: %w", ferr)
+			} else if len(result.Sessions) > 0 {
+				return withRelevanceTail(dir, m, o, result)
+			}
 			// A pasted error that matched no postings is the case the word
 			// ladder cannot win: its identifiers are line numbers and hashes.
 			// The friction hashes the store already keeps answer it exactly.


### PR DESCRIPTION
Closes #1786.

The rescue exists for a query whose words are right but not together — "this user's login lives next to jwks and rotation". That is the state where the ANDed postings intersect to nothing, and the chain called the rescue only in the *other* zero-result branch, the one for postings that intersect but scan to nothing. So the case it was written for never reached it.

```
before  $ deja search "kerberos renewal"
        deja: no matches in 182 indexed sessions …
        deja: on their own: "kerberos" in 12, "renewal" in 10 — no session has them together
        (while cooccurSearch, asked directly, answered with 10 sessions)

after   deja: no exact match, trying word forms: kerberos -> keytab
        [claude] proj · 5d ago · y-160 — 6 matches · stemmed (kerberos->keytab)
          keytab renewal failed on the build agent 160
```

The call goes where the others already are — after stem and fuzzy, before the error-signature pass and the relevance fallback — and through `withRelevanceTail` like the sibling branch, so the tier and the narration are the same.

Test: `TestCooccurRescueRunsWhenThePostingsDoNotIntersect` builds a store that teaches the map `kerberos -> keytab`, asserts the map learned it and that the rescue itself finds the sessions, then asserts the search a user runs returns them; it also pins that a query matching directly is unaffected.

This is also why `[cooccur-staleness]` was hard to demonstrate — the map's staleness rarely mattered because the rescue rarely ran.