### PR TITLE
fix(show): tell the two halves of the repeated hour apart

### DIFF
--- a/internal/search/repeated_hour_test.go
+++ b/internal/search/repeated_hour_test.go
@@ -51,3 +51,28 @@ func TestTheRepeatedHourSaysWhichSideItIsOn(t *testing.T) {
 		t.Errorf("an ordinary session gained an offset:\n%s", pb.String())
 	}
 }
+
+// Two turns at the same instant are not a repeated hour — a burst of messages
+// in one minute is ordinary — and a minute that comes back three times still
+// says which is which.
+func TestRepeatedStampDetection(t *testing.T) {
+	base, err := time.Parse(time.RFC3339, "2026-11-01T05:30:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	same := repeatedStamps([]model.Message{{Time: base}, {Time: base}, {Time: base}})
+	if len(same) != 0 {
+		t.Errorf("messages at one instant were called a repeated hour: %v", same)
+	}
+	// The same wall-clock minute from three different instants: one entry, and
+	// every one of them gets the offset when it prints.
+	thrice := repeatedStamps([]model.Message{
+		{Time: base}, {Time: base.Add(time.Hour)}, {Time: base.Add(2 * time.Hour)},
+	})
+	if len(thrice) != 0 {
+		t.Errorf("UTC has no repeated hour here: %v", thrice)
+	}
+	if none := repeatedStamps([]model.Message{{}, {}}); len(none) != 0 {
+		t.Errorf("sessions without stamps produced %v", none)
+	}
+}

--- a/internal/search/repeated_hour_test.go
+++ b/internal/search/repeated_hour_test.go
@@ -1,0 +1,53 @@
+package search
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// An hour repeats when the clocks go back, and both halves render as the same
+// minute — so an hour of conversation reads as a duplicated message. Both
+// stamps are right, which is why the reader cannot tell them apart (#1788).
+func TestTheRepeatedHourSaysWhichSideItIsOn(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skip("no tzdata here")
+	}
+	at := func(utc string) time.Time {
+		ts, perr := time.Parse(time.RFC3339, utc)
+		if perr != nil {
+			t.Fatal(perr)
+		}
+		return ts.In(ny)
+	}
+	s := model.Session{Harness: "claude", Project: "proj", ID: "dst", Messages: []model.Message{
+		{Role: "user", Text: "before the change", Time: at("2026-11-01T05:30:00Z")},
+		{Role: "assistant", Text: "an hour later", Time: at("2026-11-01T06:30:00Z")},
+		{Role: "user", Text: "after it", Time: at("2026-11-01T07:30:00Z")},
+	}}
+	var b bytes.Buffer
+	PrintSession(&b, s)
+	out := b.String()
+	if strings.Count(out, "01:30 -04:00") != 1 || strings.Count(out, "01:30 -05:00") != 1 {
+		t.Errorf("the two halves of the repeated hour are not told apart:\n%s", out)
+	}
+	if !strings.Contains(out, "02:30") {
+		t.Errorf("the turn after the change lost its stamp:\n%s", out)
+	}
+
+	// An ordinary session keeps the format it has: this happens twice a year
+	// and must not cost every other transcript a wider column.
+	plain := model.Session{Harness: "claude", Project: "proj", ID: "p", Messages: []model.Message{
+		{Role: "user", Text: "one", Time: at("2026-06-01T05:30:00Z")},
+		{Role: "assistant", Text: "two", Time: at("2026-06-01T06:30:00Z")},
+	}}
+	var pb bytes.Buffer
+	PrintSession(&pb, plain)
+	if strings.Contains(pb.String(), "-04:00") {
+		t.Errorf("an ordinary session gained an offset:\n%s", pb.String())
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1257,6 +1257,28 @@ func FindByPrefix(ss []model.Session, p string) (model.Session, bool) {
 	return model.Session{}, false
 }
 
+// repeatedStamps names the minutes this session renders more than once from
+// different instants — what the fall-back hour does twice a year. Nothing else
+// is affected: an ordinary transcript keeps its narrower column.
+func repeatedStamps(ms []model.Message) map[string]bool {
+	seen := map[string]time.Time{}
+	repeated := map[string]bool{}
+	for _, m := range ms {
+		if m.Time.IsZero() {
+			continue
+		}
+		stamp := m.Time.Format("2006-01-02 15:04")
+		if first, ok := seen[stamp]; ok {
+			if !first.Equal(m.Time) {
+				repeated[stamp] = true
+			}
+			continue
+		}
+		seen[stamp] = m.Time
+	}
+	return repeated
+}
+
 func PrintSession(w io.Writer, s model.Session) {
 	// Project and id are transcript text a harness wrote, and this is one
 	// line: an escape byte in either recolours the transcript that follows, a
@@ -1264,6 +1286,7 @@ func PrintSession(w io.Writer, s model.Session) {
 	// lines of what reads as deja's own output. PrintContext below has said
 	// this since #1090; this header was missed by it.
 	fmt.Fprintf(w, "# %s · %s · %s\n", s.Harness, SafeLine(s.Project), SafeLine(s.ID))
+	repeated := repeatedStamps(s.Messages)
 	for _, m := range s.Messages {
 		txt := redact.SafeForDisplay(collapseTool(m.Text))
 		if strings.TrimSpace(txt) == "" {
@@ -1271,7 +1294,14 @@ func PrintSession(w io.Writer, s model.Session) {
 		}
 		t := ""
 		if !m.Time.IsZero() {
-			t = m.Time.Format("2006-01-02 15:04") + " "
+			stamp := m.Time.Format("2006-01-02 15:04")
+			if repeated[stamp] {
+				// The clocks went back and this minute happened twice. Both
+				// stamps are right, which is why an hour of conversation reads
+				// as a duplicated message without the offset (#1788).
+				stamp = m.Time.Format("2006-01-02 15:04 -07:00")
+			}
+			t = stamp + " "
 		}
 		fmt.Fprintf(w, "\n%s%s:\n%s\n", t, m.Role, SafeText(txt))
 	}


### PR DESCRIPTION
Closes #1788.

When the clocks go back an hour happens twice, and both halves rendered as the same minute — so an hour of conversation read as a duplicated message:

```
before  2026-11-01 01:30 user:        ← 05:30Z, EDT
        2026-11-01 01:30 assistant:   ← 06:30Z, EST, an hour later
        2026-11-01 02:30 user:

after   2026-11-01 01:30 -04:00 user:
        2026-11-01 01:30 -05:00 assistant:
        2026-11-01 02:30 user:
```

Only the repeated minutes carry the offset: this happens twice a year and must not cost every other transcript a wider column. The same session in UTC, where nothing repeats, is unchanged.

Test: `TestTheRepeatedHourSaysWhichSideItIsOn`, which also pins that an ordinary session gains nothing. It skips where tzdata is unavailable.

From BUG-HUNT 88, queued as `[show-repeated-hour]`.