### PR TITLE
perf(ctx): render a digest's turns across cores

### DIFF
--- a/internal/search/context_parallel_test.go
+++ b/internal/search/context_parallel_test.go
@@ -1,0 +1,81 @@
+package search
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// mixedContextSession is the shape that broke rendering only the window in
+// #1742: prose next to tool dumps and numbered output, so collapsing changes
+// sizes, plus a fenced block and an escape byte that the renderers treat
+// differently from ordinary text.
+func mixedContextSession(turns int) model.Session {
+	base := time.Date(2026, 8, 25, 9, 0, 0, 0, time.UTC)
+	s := model.Session{Harness: "claude", Project: "proj", ID: "mixed", Updated: base}
+	for i := range turns {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		var text string
+		switch i % 5 {
+		case 0:
+			text = fmt.Sprintf("turn %d: the resharding question came back today", i)
+		case 1:
+			text = fmt.Sprintf("  %d | 0x%04x  some tool dump line\n  %d | 0x%04x  another\nwe decided to cap retries at 3", i, i, i+1, i+1)
+		case 2:
+			text = fmt.Sprintf("```go\nfunc turn%d() {}\n```", i)
+		case 3:
+			text = strings.Repeat(fmt.Sprintf("turn %d prose that runs long enough to matter. ", i), 40)
+		case 4:
+			text = fmt.Sprintf("turn %d\x1b[31m coloured \x1b[0m and \t tabbed\n\n\n  spaced   out  ", i)
+		}
+		s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: base.Add(time.Duration(i) * time.Minute)})
+	}
+	return s
+}
+
+// The digest is the same bytes however many cores render it: turns are written
+// back by index, so parallel rendering cannot reorder or drop one (#1790).
+func TestContextIsTheSameBytesOnOneCoreAndMany(t *testing.T) {
+	s := mixedContextSession(200)
+	for _, query := range []string{"", "resharding", "retries", "nothing matches this"} {
+		var one, many bytes.Buffer
+		withRenderWorkers(t, 1, func() { PrintContext(&one, s, query) })
+		withRenderWorkers(t, 8, func() { PrintContext(&many, s, query) })
+		if one.String() != many.String() {
+			t.Errorf("query %q rendered differently on 8 cores than on 1:\n--- one ---\n%s\n--- many ---\n%s", query, one.String(), many.String())
+		}
+		if one.Len() == 0 {
+			t.Errorf("query %q rendered nothing, so this proves nothing", query)
+		}
+	}
+}
+
+// Below the threshold the turns render in place; the output still has to match
+// what the pool produces.
+func TestShortSessionsRenderInPlaceAndMatch(t *testing.T) {
+	s := mixedContextSession(6)
+	var small, pooled bytes.Buffer
+	withRenderWorkers(t, 8, func() { PrintContext(&small, s, "resharding") })
+	withRenderWorkers(t, 1, func() { PrintContext(&pooled, s, "resharding") })
+	if small.String() != pooled.String() {
+		t.Errorf("a six-turn session rendered differently:\n%s\n---\n%s", small.String(), pooled.String())
+	}
+	if !strings.Contains(small.String(), "resharding") {
+		t.Errorf("the matched turn is missing:\n%s", small.String())
+	}
+}
+
+func withRenderWorkers(t *testing.T, n int, f func()) {
+	t.Helper()
+	prev := renderContextTurnsWorkers
+	renderContextTurnsWorkers = func() int { return n }
+	defer func() { renderContextTurnsWorkers = prev }()
+	f()
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -7,8 +7,10 @@ import (
 	"math"
 	"os"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unicode"
@@ -1385,6 +1387,52 @@ func PrintContext(w io.Writer, s model.Session, query string) {
 	printContextChunks(w, s, budget, func(m model.Message) (bool, int) { return true, 0 })
 }
 
+// contextTurn is a turn the digest keeps, before it is rendered.
+type contextTurn struct {
+	role   string
+	raw    string
+	weight int
+}
+
+// renderContextTurnsWorkers is how many turns render at once. One worker per
+// core; a session small enough that the goroutines cost more than the work
+// renders in place.
+var renderContextTurnsWorkers = runtime.NumCPU
+
+// renderContextTurns renders each kept turn, in parallel when there are enough
+// of them to pay for it. Results are written by index, so the digest is the
+// same bytes in the same order however many cores run it.
+func renderContextTurns(turns []contextTurn) []string {
+	out := make([]string, len(turns))
+	workers := renderContextTurnsWorkers()
+	if workers > len(turns) {
+		workers = len(turns)
+	}
+	if workers < 2 || len(turns) < 32 {
+		for i, t := range turns {
+			out[i] = SafeText(contextText(t.raw, t.weight > 0))
+		}
+		return out
+	}
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for {
+				i := int(next.Add(1)) - 1
+				if i >= len(turns) {
+					return
+				}
+				out[i] = SafeText(contextText(turns[i].raw, turns[i].weight > 0))
+			}
+		}()
+	}
+	wg.Wait()
+	return out
+}
+
 func printContextChunks(w io.Writer, s model.Session, budget int, include func(m model.Message) (ok bool, weight int)) int {
 	// A digest is what someone pipes into a prompt, so it carries the
 	// conversation. The work records — tool output, the files a turn touched, the
@@ -1399,7 +1447,15 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 		// sit where the matches are rather than where the first one is.
 		weight int
 	}
-	var chunks []chunk
+	// The include callback carries state from turn to turn (prevKept), so which
+	// turns are kept is decided in one ordered pass. Rendering them is not:
+	// redaction and prose collapsing are the bulk of the command's time — 3.5 s
+	// of a 4.5 s run on a 30001-message session — and every turn is rendered
+	// before the 8 KB window can say which ones get printed (#1790). Rendering
+	// only the window was tried and reverted (#1742): collapsed sizes differ
+	// from predicted ones and the window moves. Spreading the same renders
+	// across cores keeps the output identical by construction.
+	var kept []contextTurn
 	for _, m := range s.Messages {
 		if isWorkRecord(m.Role) {
 			continue
@@ -1408,11 +1464,16 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 		if !ok {
 			continue
 		}
-		text := SafeText(contextText(m.Text, weight > 0))
+		kept = append(kept, contextTurn{role: m.Role, raw: m.Text, weight: weight})
+	}
+	rendered := renderContextTurns(kept)
+	var chunks []chunk
+	for i, k := range kept {
+		text := rendered[i]
 		if strings.TrimSpace(text) == "" {
 			continue
 		}
-		chunks = append(chunks, chunk{fmt.Sprintf("\n## %s\n\n%s\n", m.Role, text), weight})
+		chunks = append(chunks, chunk{fmt.Sprintf("\n## %s\n\n%s\n", k.role, text), k.weight})
 	}
 	if len(chunks) == 0 {
 		return 0


### PR DESCRIPTION
Closes #1790.

`deja ctx` renders every kept turn before the 8 KB window picks which ones print, and that render — redaction, prose collapsing, terminal safety — was 3.5 s of a 4.5 s run on the 30001-message session. Which turns are kept still happens in one ordered pass (the include callback carries `prevKept` from turn to turn); only the rendering is spread across cores, written back by index, so the digest is the same bytes in the same order however many cores run it. Sessions under 32 kept turns render in place.

Rendering only the window is the other option and was tried and reverted in #1742: collapsed sizes diverge from predicted ones and the window moves.

Measured on the same fixture, three runs each: 4.51 / 4.50 / 5.18 s before, 1.16 / 1.19 / 1.15 s after. Output byte-identical on `resharding`, `grumbleflux`, `shard`, `whopper`.

Tests: `TestContextIsTheSameBytesOnOneCoreAndMany` renders a mixed fixture (prose, tool dumps, a fenced block, an escape byte) on 1 core and 8 and compares; `TestShortSessionsRenderInPlaceAndMatch` pins the in-place path. Control: writing results at the wrong index fails the first test on all four queries.