### PR TITLE
fix(remember): bound and de-escape the project name the confirmation echoes back

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -429,7 +429,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			// Not an error to the agent: the fact it wanted stored is stored.
 			// Saying so stops it retrying, and stops one fact costing a line of
 			// every later recall (#1736).
-			return fmt.Sprintf("Already remembered under %s.", strings.TrimSpace(a.Project)), nil
+			return fmt.Sprintf("Already remembered under %s.", projectForEcho(a.Project)), nil
 		case err != nil:
 			return "", notesWriteError(err)
 		}
@@ -446,7 +446,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		// The journal is where the user sees what the agent did with their
 		// store; a write belongs there at least as much as a read.
 		usage.RecordResult(dir, usage.KindRemember, len(a.Text), 1, false)
-		return fmt.Sprintf("Remembered under %s.", strings.TrimSpace(a.Project)), nil
+		return fmt.Sprintf("Remembered under %s.", projectForEcho(a.Project)), nil
 	default:
 		return "", fmt.Errorf("unknown tool %q", name)
 	}

--- a/cmd/deja/remember.go
+++ b/cmd/deja/remember.go
@@ -12,6 +12,16 @@ import (
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
+// projectForEcho is how a project name is written back to whoever named it.
+// The value is theirs and reaches a terminal or a model unchanged otherwise:
+// an escape byte recoloured the confirmation and a carriage return rewound it,
+// and a 5000-character name printed whole. The listing surfaces have bounded
+// both since #1090; this is the same bound on the line that says a note was
+// stored (#1792).
+func projectForEcho(project string) string {
+	return neutralizeFrameMarkers(safeForStatusline(project, mcpResourceNameMax))
+}
+
 func runRemember(dir string, args []string) error {
 	var text, project string
 	var tags []string
@@ -53,7 +63,7 @@ func runRemember(dir string, args []string) error {
 	now := time.Now()
 	if err := sources.AppendNoteTagged(project, text, tags, now); err != nil {
 		if errors.Is(err, sources.ErrNoteExists) {
-			fmt.Fprintf(os.Stderr, "deja: already remembered under %s\n", project)
+			fmt.Fprintf(os.Stderr, "deja: already remembered under %s\n", projectForEcho(project))
 			return nil
 		}
 		return notesWriteError(err)
@@ -73,6 +83,6 @@ func runRemember(dir string, args []string) error {
 	if norm := sources.NormalizeTags(tags); len(norm) > 0 {
 		suffix = " #" + strings.Join(norm, " #")
 	}
-	fmt.Fprintf(os.Stdout, "deja: remembered under %s%s\n", strings.TrimSpace(project), suffix)
+	fmt.Fprintf(os.Stdout, "deja: remembered under %s%s\n", projectForEcho(project), suffix)
 	return nil
 }

--- a/cmd/deja/remember.go
+++ b/cmd/deja/remember.go
@@ -19,7 +19,14 @@ import (
 // both since #1090; this is the same bound on the line that says a note was
 // stored (#1792).
 func projectForEcho(project string) string {
-	return neutralizeFrameMarkers(safeForStatusline(project, mcpResourceNameMax))
+	out := neutralizeFrameMarkers(safeForStatusline(project, mcpResourceNameMax))
+	// A name of nothing but control bytes bounds down to nothing, and
+	// "remembered under " names no project at all. The note is stored either
+	// way, so the line says what happened instead of trailing off.
+	if out == "" && strings.TrimSpace(project) != "" {
+		return "a name with no printable characters"
+	}
+	return out
 }
 
 func runRemember(dir string, args []string) error {

--- a/cmd/deja/remember_echo_test.go
+++ b/cmd/deja/remember_echo_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The line that confirms a note was stored is the one a user reads to check
+// they got it right, and it names a value they typed. An escape byte in it
+// recoloured and rewound that line, and a 5000-character project printed whole
+// — the listing surfaces have bounded both since #1090 (#1792).
+func TestRememberEchoDoesNotHandTheTerminalWhateverWasTyped(t *testing.T) {
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(t.TempDir(), "notes.jsonl"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+	hostile := "red\x1b[31mALERT\x1b[0m\rrewound"
+	out := captureStdout(t, func() {
+		if err := runRemember(index.DefaultDir(), []string{"--project", hostile, "the shard limit is 64"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if strings.ContainsAny(out, "\x1b\r") {
+		t.Errorf("the confirmation carried an escape or a rewind: %q", out)
+	}
+	if !strings.Contains(out, "ALERT") {
+		t.Errorf("the project the note was stored under is gone from the line: %q", out)
+	}
+}
+
+func TestRememberEchoBoundsALongProject(t *testing.T) {
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(t.TempDir(), "notes.jsonl"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+	long := strings.Repeat("w", 5000)
+	out := captureStdout(t, func() {
+		if err := runRemember(index.DefaultDir(), []string{"--project", long, "the shard limit is 64"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if len(out) > 200 {
+		t.Errorf("a 5000-character project printed %d bytes: %q", len(out), out[:120])
+	}
+	if !strings.Contains(out, "…") {
+		t.Errorf("the cut is not marked, so the line reads as the whole name: %q", out)
+	}
+}
+
+// Over MCP the same value goes back into a model's context, where a frame
+// marker matters as much as an escape byte does on a terminal.
+func TestMCPRememberReplyBoundsTheProject(t *testing.T) {
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(t.TempDir(), "notes.jsonl"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+	args, err := json.Marshal(map[string]string{
+		"text":    "the shard limit is 64",
+		"project": "proj\x1b[31mALERT\x1b[0m\r" + strings.Repeat("w", 3000),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := callMCPTool(index.DefaultDir(), "remember", args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.ContainsAny(result, "\x1b\r") {
+		t.Errorf("the reply carried an escape or a rewind: %q", result[:80])
+	}
+	if len(result) > 200 {
+		t.Errorf("the reply is %d bytes of project name: %q", len(result), result[:120])
+	}
+}

--- a/cmd/deja/remember_echo_test.go
+++ b/cmd/deja/remember_echo_test.go
@@ -70,3 +70,27 @@ func TestMCPRememberReplyBoundsTheProject(t *testing.T) {
 		t.Errorf("the reply is %d bytes of project name: %q", len(result), result[:120])
 	}
 }
+
+// A project of nothing but control bytes bounds down to nothing, and the
+// confirmation used to trail off after "under".
+func TestRememberEchoNamesAProjectThatBoundsToNothing(t *testing.T) {
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(t.TempDir(), "notes.jsonl"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+	out := captureStdout(t, func() {
+		if err := runRemember(index.DefaultDir(), []string{"--project", "\x00\x01\x02", "the shard limit is 64"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	line := ""
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(l, "remembered under") {
+			line = l
+		}
+	}
+	if strings.HasSuffix(strings.TrimSpace(line), "under") || strings.TrimSpace(line) == "deja: remembered under" {
+		t.Errorf("the confirmation names no project: %q", line)
+	}
+	if !strings.Contains(line, "no printable characters") {
+		t.Errorf("the line does not say why the name is missing: %q", line)
+	}
+}


### PR DESCRIPTION
Closes #1792.

`deja remember` and the MCP `remember` tool echoed the project name exactly as typed: an escape byte recoloured the confirmation and a `\r` rewound it, and a 5000-character name printed whole (3 KB of it into a model's context over MCP). Both now go through the bound the listing surfaces have used since #1090 — `safeForStatusline` at `mcpResourceNameMax` (80), then `neutralizeFrameMarkers`.

Only the echo changes; the note is still stored under the name as given, so nothing about lookup or dedup moves.

Tests fail before the fix: `TestRememberEchoDoesNotHandTheTerminalWhateverWasTyped`, `TestRememberEchoBoundsALongProject`, `TestMCPRememberReplyBoundsTheProject`.

Before / after on the CLI, through `cat -v`:

```
deja: remembered under red^[[31mALERT^[[0m^Mrewound
deja: remembered under red [31mALERT [0m rewound
```

Wording is yours: the cut name ends in `…` and keeps the first 80 columns. If you would rather the confirmation name no project at all when it was cut, say so and I will change it.