### PR TITLE
fix(mcp): refuse a batch as an invalid request instead of claiming it did not parse

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -41,18 +41,32 @@ func isNotification(id json.RawMessage) bool {
 	return len(id) == 0 || string(id) == "null"
 }
 
+// parseBatch reports whether a frame is an array of requests, and returns them.
+// A frame that only starts like one — a truncated `[` — is not a batch and
+// keeps its parse error.
+func parseBatch(frame string) ([]json.RawMessage, bool) {
+	if !strings.HasPrefix(frame, "[") {
+		return nil, false
+	}
+	var elems []json.RawMessage
+	if err := json.Unmarshal([]byte(frame), &elems); err != nil {
+		return nil, false
+	}
+	return elems, true
+}
+
 // batchID returns the id of the first request in a batch, so the refusal can
 // be matched to something the client sent rather than coming back as null.
 // A batch whose first element carries no id gets a null id, as before.
-func batchID(frame string) json.RawMessage {
-	var reqs []rpcRequest
-	if err := json.Unmarshal([]byte(frame), &reqs); err != nil || len(reqs) == 0 {
+func batchID(elems []json.RawMessage) json.RawMessage {
+	if len(elems) == 0 {
 		return nil
 	}
-	if isNotification(reqs[0].ID) {
+	var first rpcRequest
+	if err := json.Unmarshal(elems[0], &first); err != nil || isNotification(first.ID) {
 		return nil
 	}
-	return reqs[0].ID
+	return first.ID
 }
 
 const mcpMaxFrame = 10 * 1024 * 1024
@@ -68,12 +82,12 @@ func serveMCP(dir string, r io.Reader, w io.Writer) error {
 			writeRPCError(enc, nil, -32700, "parse error")
 		} else if trimmed := strings.TrimSpace(string(line)); trimmed != "" {
 			var req rpcRequest
-			if strings.HasPrefix(trimmed, "[") {
+			if batch, isBatch := parseBatch(trimmed); isBatch {
 				// A batch is valid JSON, and answering -32700 told a client its
 				// bytes were corrupt when they were not — with a null id, so it
 				// could not tell which of its requests died either. deja serves
 				// one request per frame; the refusal says so (#1795).
-				writeRPCError(enc, batchID(trimmed), -32600, "batch requests are not supported — send one request per line")
+				writeRPCError(enc, batchID(batch), -32600, "batch requests are not supported — send one request per line")
 			} else if uerr := json.Unmarshal([]byte(trimmed), &req); uerr != nil {
 				writeRPCError(enc, nil, -32700, "parse error")
 			} else if req.JSONRPC != "" && req.JSONRPC != "2.0" {

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -55,18 +55,27 @@ func parseBatch(frame string) ([]json.RawMessage, bool) {
 	return elems, true
 }
 
-// batchID returns the id of the first request in a batch, so the refusal can
-// be matched to something the client sent rather than coming back as null.
-// A batch whose first element carries no id gets a null id, as before.
-func batchID(elems []json.RawMessage) json.RawMessage {
-	if len(elems) == 0 {
-		return nil
+// batchReply says whether a batch is owed an answer and which id to put on it.
+// The id is the first request in the array that carries one, so the refusal can
+// be matched to something the client sent. A batch of nothing but notifications
+// is owed no answer — the spec forbids replying to one, inside a batch or out
+// of it — while an empty or malformed array is an invalid request like any
+// other and gets the refusal with a null id.
+func batchReply(elems []json.RawMessage) (json.RawMessage, bool) {
+	notificationsOnly := len(elems) > 0
+	for _, elem := range elems {
+		var req rpcRequest
+		if !bytes.HasPrefix(bytes.TrimSpace(elem), []byte("{")) || json.Unmarshal(elem, &req) != nil {
+			// Not a request object at all, so it asked for nothing and is not
+			// a notification either: the array is malformed and says so.
+			notificationsOnly = false
+			continue
+		}
+		if !isNotification(req.ID) {
+			return req.ID, true
+		}
 	}
-	var first rpcRequest
-	if err := json.Unmarshal(elems[0], &first); err != nil || isNotification(first.ID) {
-		return nil
-	}
-	return first.ID
+	return nil, !notificationsOnly
 }
 
 const mcpMaxFrame = 10 * 1024 * 1024
@@ -86,8 +95,13 @@ func serveMCP(dir string, r io.Reader, w io.Writer) error {
 				// A batch is valid JSON, and answering -32700 told a client its
 				// bytes were corrupt when they were not — with a null id, so it
 				// could not tell which of its requests died either. deja serves
-				// one request per frame; the refusal says so (#1795).
-				writeRPCError(enc, batchID(batch), -32600, "batch requests are not supported — send one request per line")
+				// one request per frame; the refusal says so (#1795). A batch
+				// carrying nothing but notifications gets no reply at all, as a
+				// notification does on its own line: the spec forbids answering
+				// one, inside a batch or out of it.
+				if id, answer := batchReply(batch); answer {
+					writeRPCError(enc, id, -32600, "batch requests are not supported — send one request per line")
+				}
 			} else if uerr := json.Unmarshal([]byte(trimmed), &req); uerr != nil {
 				writeRPCError(enc, nil, -32700, "parse error")
 			} else if req.JSONRPC != "" && req.JSONRPC != "2.0" {

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -41,6 +41,20 @@ func isNotification(id json.RawMessage) bool {
 	return len(id) == 0 || string(id) == "null"
 }
 
+// batchID returns the id of the first request in a batch, so the refusal can
+// be matched to something the client sent rather than coming back as null.
+// A batch whose first element carries no id gets a null id, as before.
+func batchID(frame string) json.RawMessage {
+	var reqs []rpcRequest
+	if err := json.Unmarshal([]byte(frame), &reqs); err != nil || len(reqs) == 0 {
+		return nil
+	}
+	if isNotification(reqs[0].ID) {
+		return nil
+	}
+	return reqs[0].ID
+}
+
 const mcpMaxFrame = 10 * 1024 * 1024
 
 func serveMCP(dir string, r io.Reader, w io.Writer) error {
@@ -54,8 +68,20 @@ func serveMCP(dir string, r io.Reader, w io.Writer) error {
 			writeRPCError(enc, nil, -32700, "parse error")
 		} else if trimmed := strings.TrimSpace(string(line)); trimmed != "" {
 			var req rpcRequest
-			if uerr := json.Unmarshal([]byte(trimmed), &req); uerr != nil {
+			if strings.HasPrefix(trimmed, "[") {
+				// A batch is valid JSON, and answering -32700 told a client its
+				// bytes were corrupt when they were not — with a null id, so it
+				// could not tell which of its requests died either. deja serves
+				// one request per frame; the refusal says so (#1795).
+				writeRPCError(enc, batchID(trimmed), -32600, "batch requests are not supported — send one request per line")
+			} else if uerr := json.Unmarshal([]byte(trimmed), &req); uerr != nil {
 				writeRPCError(enc, nil, -32700, "parse error")
+			} else if req.JSONRPC != "" && req.JSONRPC != "2.0" {
+				// The member that says which protocol the frame speaks. An
+				// absent one is still served — clients in the wild omit it and
+				// the request is unambiguous — but "1.0" asks for a protocol
+				// this server does not speak and used to be answered anyway.
+				writeRPCError(enc, req.ID, -32600, "unsupported jsonrpc version "+req.JSONRPC+" — this server speaks 2.0")
 			} else if !isNotification(req.ID) {
 				result, code, msg := handleMCP(dir, req)
 				if code != 0 {

--- a/cmd/deja/mcp_frame_shape_test.go
+++ b/cmd/deja/mcp_frame_shape_test.go
@@ -112,15 +112,22 @@ func TestAMissingJSONRPCVersionIsStillServed(t *testing.T) {
 func TestOnlyARealArrayCountsAsABatch(t *testing.T) {
 	hermeticEnv(t)
 	for frame, want := range map[string]int{
-		"[":                          -32700,
-		`"[not a batch"`:             -32700,
-		"[]":                         -32600,
-		"[1,2,3]":                    -32600,
-		`[{"jsonrpc":"2.0","id":7}]`: -32600,
+		"[":                                   -32700,
+		`"[not a batch"`:                      -32700,
+		"[]":                                  -32600,
+		"[1,2,3]":                             -32600,
+		`[{"jsonrpc":"2.0","id":7}]`:          -32600,
+		`[{"jsonrpc":"2.0","method":"ping"}]`: 0,
 	} {
 		var out bytes.Buffer
 		if err := serveMCP(t.TempDir(), strings.NewReader(frame+"\n"), &out); err != nil {
 			t.Fatal(err)
+		}
+		if want == 0 {
+			if strings.TrimSpace(out.String()) != "" {
+				t.Errorf("%s was answered: %s", frame, out.String())
+			}
+			continue
 		}
 		frames := decodeRPCFrames(t, out.String())
 		if len(frames) != 1 {
@@ -145,5 +152,33 @@ func TestABatchRefusalCarriesAStringID(t *testing.T) {
 	frames := decodeRPCFrames(t, out.String())
 	if id, _ := frames[0]["id"].(string); id != "abc" {
 		t.Errorf("refusal came back with id %v, want \"abc\"", frames[0]["id"])
+	}
+}
+
+// The spec forbids replying to a notification, inside a batch or out of it, so
+// a batch of nothing but notifications is answered with silence. A batch that
+// mixes them still gets the refusal, on the id of the first real request.
+func TestABatchOfNotificationsIsAnsweredWithSilence(t *testing.T) {
+	hermeticEnv(t)
+	quiet := `[{"jsonrpc":"2.0","method":"ping"},{"jsonrpc":"2.0","method":"ping"}]` + "\n"
+	var out bytes.Buffer
+	if err := serveMCP(t.TempDir(), strings.NewReader(quiet), &out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(out.String()) != "" {
+		t.Errorf("a batch of notifications was answered: %s", out.String())
+	}
+
+	mixed := `[{"jsonrpc":"2.0","method":"ping"},{"jsonrpc":"2.0","id":"b","method":"ping"}]` + "\n"
+	out.Reset()
+	if err := serveMCP(t.TempDir(), strings.NewReader(mixed), &out); err != nil {
+		t.Fatal(err)
+	}
+	frames := decodeRPCFrames(t, out.String())
+	if len(frames) != 1 {
+		t.Fatalf("want one reply to a mixed batch, got %d", len(frames))
+	}
+	if id, _ := frames[0]["id"].(string); id != "b" {
+		t.Errorf("the refusal came back with id %v, want the request that asked for an answer", frames[0]["id"])
 	}
 }

--- a/cmd/deja/mcp_frame_shape_test.go
+++ b/cmd/deja/mcp_frame_shape_test.go
@@ -106,3 +106,44 @@ func TestAMissingJSONRPCVersionIsStillServed(t *testing.T) {
 		t.Fatalf("a frame without the version member was refused: %s", out.String())
 	}
 }
+
+// A frame that only starts like an array is truncated JSON, not a batch, and
+// keeps its parse error; an array of anything else is still a batch.
+func TestOnlyARealArrayCountsAsABatch(t *testing.T) {
+	hermeticEnv(t)
+	for frame, want := range map[string]int{
+		"[":                          -32700,
+		`"[not a batch"`:             -32700,
+		"[]":                         -32600,
+		"[1,2,3]":                    -32600,
+		`[{"jsonrpc":"2.0","id":7}]`: -32600,
+	} {
+		var out bytes.Buffer
+		if err := serveMCP(t.TempDir(), strings.NewReader(frame+"\n"), &out); err != nil {
+			t.Fatal(err)
+		}
+		frames := decodeRPCFrames(t, out.String())
+		if len(frames) != 1 {
+			t.Fatalf("%s: want one reply, got %d", frame, len(frames))
+		}
+		e, _ := frames[0]["error"].(map[string]any)
+		if code, _ := e["code"].(float64); int(code) != want {
+			t.Errorf("%s answered %v, want %d", frame, e["code"], want)
+		}
+	}
+}
+
+// The refusal carries the first request's id whatever type it is, so a client
+// with string ids can match it too.
+func TestABatchRefusalCarriesAStringID(t *testing.T) {
+	hermeticEnv(t)
+	var out bytes.Buffer
+	in := `[{"jsonrpc":"2.0","id":"abc","method":"ping"},{"jsonrpc":"2.0","id":"def","method":"ping"}]` + "\n"
+	if err := serveMCP(t.TempDir(), strings.NewReader(in), &out); err != nil {
+		t.Fatal(err)
+	}
+	frames := decodeRPCFrames(t, out.String())
+	if id, _ := frames[0]["id"].(string); id != "abc" {
+		t.Errorf("refusal came back with id %v, want \"abc\"", frames[0]["id"])
+	}
+}

--- a/cmd/deja/mcp_frame_shape_test.go
+++ b/cmd/deja/mcp_frame_shape_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// decodeRPCFrames reads the server's replies, one JSON object per line.
+func decodeRPCFrames(t *testing.T, out string) []map[string]any {
+	t.Helper()
+	var frames []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var f map[string]any
+		if err := json.Unmarshal([]byte(line), &f); err != nil {
+			t.Fatalf("reply is not JSON: %q", line)
+		}
+		frames = append(frames, f)
+	}
+	return frames
+}
+
+// A batch is valid JSON, so answering "parse error" tells a client its bytes
+// were corrupt when they were not. deja does not run batches; the reply has to
+// say that instead (#1795).
+func TestABatchIsRefusedAsInvalidNotAsUnparseable(t *testing.T) {
+	hermeticEnv(t)
+	in := `[{"jsonrpc":"2.0","id":2,"method":"ping","params":{}},{"jsonrpc":"2.0","id":3,"method":"ping","params":{}}]` + "\n"
+	var out bytes.Buffer
+	if err := serveMCP(t.TempDir(), strings.NewReader(in), &out); err != nil {
+		t.Fatal(err)
+	}
+	frames := decodeRPCFrames(t, out.String())
+	if len(frames) != 1 {
+		t.Fatalf("want one reply to a batch, got %d: %s", len(frames), out.String())
+	}
+	e, ok := frames[0]["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("a batch was served rather than refused: %s", out.String())
+	}
+	if code, _ := e["code"].(float64); int(code) != -32600 {
+		t.Errorf("a batch is refused with code %v, want -32600 invalid request", e["code"])
+	}
+	if msg, _ := e["message"].(string); !strings.Contains(strings.ToLower(msg), "batch") {
+		t.Errorf("the refusal does not say what deja will not do: %q", msg)
+	}
+}
+
+// A frame that really is not JSON keeps its parse error — the control that the
+// change above did not turn every bad frame into "invalid request".
+func TestCorruptBytesStillParseError(t *testing.T) {
+	hermeticEnv(t)
+	var out bytes.Buffer
+	if err := serveMCP(t.TempDir(), strings.NewReader("{not json\n"), &out); err != nil {
+		t.Fatal(err)
+	}
+	frames := decodeRPCFrames(t, out.String())
+	if len(frames) != 1 {
+		t.Fatalf("want one reply, got %d", len(frames))
+	}
+	e, _ := frames[0]["error"].(map[string]any)
+	if code, _ := e["code"].(float64); int(code) != -32700 {
+		t.Errorf("corrupt bytes answered with %v, want -32700 parse error", e["code"])
+	}
+}
+
+// The version member is the one field that says which protocol the frame
+// speaks. Serving "1.0" as if it were "2.0" answers a request nobody made.
+func TestAWrongJSONRPCVersionIsRefused(t *testing.T) {
+	hermeticEnv(t)
+	var out bytes.Buffer
+	in := `{"jsonrpc":"1.0","id":4,"method":"ping","params":{}}` + "\n"
+	if err := serveMCP(t.TempDir(), strings.NewReader(in), &out); err != nil {
+		t.Fatal(err)
+	}
+	frames := decodeRPCFrames(t, out.String())
+	if len(frames) != 1 {
+		t.Fatalf("want one reply, got %d: %s", len(frames), out.String())
+	}
+	e, ok := frames[0]["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("jsonrpc 1.0 was served: %s", out.String())
+	}
+	if code, _ := e["code"].(float64); int(code) != -32600 {
+		t.Errorf("jsonrpc 1.0 refused with %v, want -32600", e["code"])
+	}
+	if id, _ := frames[0]["id"].(float64); int(id) != 4 {
+		t.Errorf("the refusal came back with id %v, so a client cannot match it to the request", frames[0]["id"])
+	}
+}
+
+// A frame that omits the member entirely is still served: clients in the wild
+// do it and the request is unambiguous. Pinned so the leniency is deliberate.
+func TestAMissingJSONRPCVersionIsStillServed(t *testing.T) {
+	hermeticEnv(t)
+	var out bytes.Buffer
+	if err := serveMCP(t.TempDir(), strings.NewReader(`{"id":5,"method":"ping","params":{}}`+"\n"), &out); err != nil {
+		t.Fatal(err)
+	}
+	frames := decodeRPCFrames(t, out.String())
+	if len(frames) != 1 || frames[0]["error"] != nil {
+		t.Fatalf("a frame without the version member was refused: %s", out.String())
+	}
+}


### PR DESCRIPTION
Closes #1795.

A JSON-RPC batch got `-32700 parse error` with a null id — the frame parsed fine, and the client could not tell "deja does not do batches" from "your bytes were corrupt", nor which request died. It is now `-32600` with a sentence, carrying the id of the first request in the array so the refusal can be matched to something the client sent. `{"jsonrpc":"1.0"}` was served as if it were 2.0 and is now refused the same way.

A frame that omits `jsonrpc` entirely is still served — clients in the wild omit it and the request is unambiguous. That leniency is now pinned by a test rather than being an accident.

Before / after on the same four frames:

```
{"error":{"code":-32700,"message":"parse error"},"id":null,"jsonrpc":"2.0"}
{"id":4,"jsonrpc":"2.0","result":{}}

{"error":{"code":-32600,"message":"batch requests are not supported — send one request per line"},"id":2,"jsonrpc":"2.0"}
{"error":{"code":-32600,"message":"unsupported jsonrpc version 1.0 — this server speaks 2.0"},"id":4,"jsonrpc":"2.0"}
```

Not doing: running the array. No harness we install into sends one, 2025-06-18 removed batching from MCP, and a half-supported batch path is worse than a clear refusal. If a client turns up that needs it, the refusal is the thing to change.

Tests fail before the fix: `TestABatchIsRefusedAsInvalidNotAsUnparseable`, `TestAWrongJSONRPCVersionIsRefused`. Control that corrupt bytes keep their parse error: `TestCorruptBytesStillParseError`. Leniency pinned by `TestAMissingJSONRPCVersionIsStillServed`.

The two refusal sentences are wording — yours to change.