### PR TITLE
fix(mcp): hold recall_context to the ~8KB it promises, and say when a digest is cut

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -328,7 +328,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		}
 		text, sessions, raw, ids, err := recallContextResult(dir, a.Query, a.Harness)
 		if err == nil {
-			text = frameRecall(text)
+			text = frameRecall(fitContextDigest(text, contextMCPBudget-recallFrameOverhead))
 			usage.RecordServedSessions(dir, usage.KindContext, len(text), sessions, sessions == 0, raw, ids)
 			usage.SnapshotPolicy(dir, usage.KindContext, text, sessions, policy.Load().Describe(policy.ActivationMCP))
 		}
@@ -557,6 +557,39 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 // blameMCPBudget bounds one blame answer. Higher than recall's ~4 KB because a
 // hit is a whole session rather than a snippet, and well under what an agent
 // can absorb from one tool call.
+// contextDigestCut is the line that admits a digest was cut. Without it the
+// reply ends mid-word and reads as the whole session, which is what an agent
+// then tells the user it saw.
+const contextDigestCut = "\n[digest trimmed to fit the ~8KB budget — call recall_context again for another session, or deja ctx <id> for the whole one]\n"
+
+// fitContextDigest trims a digest to budget, cutting at a line boundary where
+// one is near enough and saying that it cut. The marker is reserved before the
+// trim, the way recall reserves its paging line (#1726), so the thing that
+// explains the cut is not itself the thing that gets cut.
+func fitContextDigest(text string, budget int) string {
+	if len(text) <= budget {
+		return text
+	}
+	if budget <= len(contextDigestCut) {
+		return trimUTF8(text, budget)
+	}
+	body := trimUTF8(text, budget-len(contextDigestCut))
+	// Back up to the last line break if one is close, so the digest does not
+	// end in the middle of a sentence it will not finish.
+	if i := strings.LastIndexByte(body, '\n'); i > len(body)-400 && i > 0 {
+		body = body[:i]
+	}
+	return body + contextDigestCut
+}
+
+// contextMCPBudget is the whole framed recall_context reply, matching the
+// "~8KB" its tool description promises an agent. recall has been exact since it
+// passed 4096-recallFrameOverhead; this path passed no budget at all, so the
+// digest header — which carries a project name and a session id, neither of
+// them bounded — pushed an ordinary reply to 8221 bytes and a long-named one to
+// 8335 (#1797).
+const contextMCPBudget = 8192
+
 const blameMCPBudget = 8192
 
 // blameHitJSON is what the MCP blame tool returns: the same shape as the CLI's

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -554,9 +554,6 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 	return string(body), len(hits), nil
 }
 
-// blameMCPBudget bounds one blame answer. Higher than recall's ~4 KB because a
-// hit is a whole session rather than a snippet, and well under what an agent
-// can absorb from one tool call.
 // contextDigestCut is the line that admits a digest was cut. Without it the
 // reply ends mid-word and reads as the whole session, which is what an agent
 // then tells the user it saw.
@@ -590,6 +587,9 @@ func fitContextDigest(text string, budget int) string {
 // 8335 (#1797).
 const contextMCPBudget = 8192
 
+// blameMCPBudget bounds one blame answer. Higher than recall's ~4 KB because a
+// hit is a whole session rather than a snippet, and well under what an agent
+// can absorb from one tool call.
 const blameMCPBudget = 8192
 
 // blameHitJSON is what the MCP blame tool returns: the same shape as the CLI's

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -328,7 +328,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		}
 		text, sessions, raw, ids, err := recallContextResult(dir, a.Query, a.Harness)
 		if err == nil {
-			text = frameRecall(fitContextDigest(text, contextMCPBudget-recallFrameOverhead))
+			text = frameRecall(fitContextDigest(text, a.Query, contextMCPBudget-recallFrameOverhead))
 			usage.RecordServedSessions(dir, usage.KindContext, len(text), sessions, sessions == 0, raw, ids)
 			usage.SnapshotPolicy(dir, usage.KindContext, text, sessions, policy.Load().Describe(policy.ActivationMCP))
 		}
@@ -563,7 +563,7 @@ const contextDigestCut = "\n[digest trimmed to fit the ~8KB budget — call reca
 // one is near enough and saying that it cut. The marker is reserved before the
 // trim, the way recall reserves its paging line (#1726), so the thing that
 // explains the cut is not itself the thing that gets cut.
-func fitContextDigest(text string, budget int) string {
+func fitContextDigest(text, query string, budget int) string {
 	if len(text) <= budget {
 		return text
 	}
@@ -572,11 +572,30 @@ func fitContextDigest(text string, budget int) string {
 	}
 	body := trimUTF8(text, budget-len(contextDigestCut))
 	// Back up to the last line break if one is close, so the digest does not
-	// end in the middle of a sentence it will not finish.
+	// end in the middle of a sentence it will not finish — but never at the
+	// cost of the words the digest was asked for. A match sitting in that last
+	// line is the answer; ending mid-word is only untidy.
 	if i := strings.LastIndexByte(body, '\n'); i > len(body)-400 && i > 0 {
-		body = body[:i]
+		if shorter := body[:i]; keepsQuery(shorter, body, query) {
+			body = shorter
+		}
 	}
 	return body + contextDigestCut
+}
+
+// keepsQuery reports whether the shorter body still carries a query word that
+// the longer one did. A query whose words are nowhere in either is no reason to
+// keep the ragged ending.
+func keepsQuery(shorter, longer, query string) bool {
+	for _, word := range strings.Fields(strings.ToLower(query)) {
+		if len(word) < 3 {
+			continue
+		}
+		if strings.Contains(strings.ToLower(longer), word) && !strings.Contains(strings.ToLower(shorter), word) {
+			return false
+		}
+	}
+	return true
 }
 
 // contextMCPBudget is the whole framed recall_context reply, matching the

--- a/cmd/deja/mcp_context_cap_test.go
+++ b/cmd/deja/mcp_context_cap_test.go
@@ -129,3 +129,29 @@ func shortContextSession(t *testing.T) string {
 	}
 	return dir
 }
+
+// The backup to a line break is tidiness; the matched turn is the answer. A
+// digest whose only match sits in the last line must not lose it to the cut.
+func TestTheBackupNeverDropsTheMatch(t *testing.T) {
+	filler := strings.Repeat("filler line that says nothing\n", 300)
+	// One long last line whose match sits near its start: the trim keeps the
+	// match, and the backup to the previous line break would throw it away.
+	tail := "the wobbleshard verdict is that it holds " + strings.Repeat("and then some more words about it ", 14) + "\n"
+	full := filler + tail
+	budget := len(full) - 200
+
+	out := fitContextDigest(full, "wobbleshard verdict", budget)
+	if !strings.Contains(out, "wobbleshard") {
+		t.Errorf("the backup dropped the line carrying the query:\n%s", out[max(0, len(out)-160):])
+	}
+	if len(out) > budget {
+		t.Errorf("the guard broke the budget: %d > %d", len(out), budget)
+	}
+
+	// The control: nothing at stake in that last line, so it is still tidied
+	// away at the line break rather than left ragged.
+	plain := fitContextDigest(filler+strings.Repeat("another filler line ", 25)+"\n", "wobbleshard", budget)
+	if !strings.HasSuffix(plain, contextDigestCut) || strings.Contains(strings.TrimSuffix(plain, contextDigestCut), "another filler") {
+		t.Errorf("the line-break backup stopped happening when nothing was at stake:\n%q", plain[max(0, len(plain)-200):])
+	}
+}

--- a/cmd/deja/mcp_context_cap_test.go
+++ b/cmd/deja/mcp_context_cap_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// seedContextDigestSession writes a session long enough that the digest hits
+// its budget, in a project and under an id the caller names — the header
+// carries both, and neither was bounded.
+func seedContextDigestSession(t *testing.T, project, id string) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-"+project)
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	var b strings.Builder
+	for i := range 400 {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		text := strings.Repeat("резервирование шардов ", 12)
+		if i%3 == 0 {
+			text = strings.Repeat(fmt.Sprintf("wobbleshard budget note %d ", i), 12)
+		}
+		line, err := json.Marshal(map[string]any{
+			"type":      role,
+			"timestamp": base.Add(time.Duration(i) * time.Minute).Format(time.RFC3339),
+			"sessionId": id,
+			"cwd":       "/" + project,
+			"message":   map[string]any{"role": role, "content": text},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		b.Write(line)
+		b.WriteByte('\n')
+	}
+	if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// recall_context documents ~8KB and had no cap: the body budget lives inside
+// PrintContext, and the header, the tier prefix and the frame were all added on
+// top of it. recall at the same layer is exact because it trims before framing
+// (#1797).
+func TestRecallContextFitsTheBudgetItDocuments(t *testing.T) {
+	for _, tc := range []struct{ name, project, id string }{
+		{"ordinary", "proj", "wobble"},
+		{"long names", strings.Repeat("p", 180), strings.Repeat("w", 120)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := seedContextDigestSession(t, tc.project, tc.id)
+			framed, err := callMCPTool(dir, "recall_context", []byte(`{"query":"резервирование шардов"}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(framed) > contextMCPBudget {
+				t.Errorf("recall_context returned %d bytes, budget is %d", len(framed), contextMCPBudget)
+			}
+			if len(framed) < contextMCPBudget/2 {
+				t.Errorf("%d bytes is too little to prove a cap was applied rather than the session being short", len(framed))
+			}
+			if !strings.Contains(framed, "шард") {
+				t.Errorf("the digest lost the words it matched on")
+			}
+		})
+	}
+}
+
+// A cut digest says it was cut. Without the line the reply ends mid-word and
+// reads as the whole session — which is what an agent then tells the user it
+// saw.
+func TestATrimmedDigestSaysItWasTrimmed(t *testing.T) {
+	dir := seedContextDigestSession(t, "proj", "wobble")
+	framed, err := callMCPTool(dir, "recall_context", []byte(`{"query":"резервирование шардов"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(framed, "digest trimmed") {
+		t.Errorf("a digest at the budget does not say it was cut:\n%s", framed[len(framed)-200:])
+	}
+	if strings.Count(framed, "digest trimmed") != 1 {
+		t.Errorf("the marker appears %d times", strings.Count(framed, "digest trimmed"))
+	}
+
+	// The control: a session that fits gets no marker.
+	short := shortContextSession(t)
+	framed, err = callMCPTool(short, "recall_context", []byte(`{"query":"pool exhausted"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(framed, "digest trimmed") {
+		t.Errorf("a digest well inside the budget claims it was cut:\n%s", framed)
+	}
+}
+
+// shortContextSession seeds one session small enough to fit whole.
+func shortContextSession(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"the pool exhausted again"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"short","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "short.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}


### PR DESCRIPTION
Closes #1797.

`recall_context` passed no budget at all: `PrintContext` bounds the body at 8000, and the header, the tier prefix and the frame went on top. An ordinary session came back at 8221 bytes; a session in a project with a 180-character path came back at 8335, and nothing bounded that — the header carries the project name and the session id. `recall` at the same layer has been exact since it started passing `4096-recallFrameOverhead`; this is the same shape.

Measured on the same two fixtures: 8221 → 8192, 8335 → 8192.

The trim would otherwise end a digest mid-word, so it cuts at a line boundary when one is within 400 bytes and appends a line saying the digest was trimmed and how to get the rest. The marker is reserved before the trim, the way recall reserves its paging line (#1726), so the thing that explains the cut cannot itself be cut.

Tests: `TestRecallContextFitsTheBudgetItDocuments` (both fixtures; fails before at 8217/8507), `TestATrimmedDigestSaysItWasTrimmed` with a control that a short session gets no marker.

The marker's wording is yours. It is also half of the queued question about truncation markers on the recall side — this only covers the digest.