### PR TITLE
feat(completion): support PowerShell

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -11,11 +11,11 @@ import (
 // runCompletion writes a shell-specific script so the binary stays dependency-free.
 func runCompletion(args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("completion needs bash, zsh, or fish")
+		return fmt.Errorf("completion needs bash, zsh, fish, or powershell")
 	}
 	script, ok := completionScripts[args[0]]
 	if !ok {
-		return fmt.Errorf("unknown shell %q; want bash, zsh, or fish", args[0])
+		return fmt.Errorf("unknown shell %q; want bash, zsh, fish, powershell, or pwsh", args[0])
 	}
 	// Every list a shell offers is substituted rather than duplicated per shell:
 	// three hand-maintained copies is how this one fell seven harnesses behind.
@@ -30,9 +30,11 @@ func runCompletion(args []string) error {
 }
 
 var completionScripts = map[string]string{
-	"bash": bashCompletion,
-	"zsh":  zshCompletion,
-	"fish": fishCompletion,
+	"bash":       bashCompletion,
+	"zsh":        zshCompletion,
+	"fish":       fishCompletion,
+	"powershell": powershellCompletion,
+	"pwsh":       powershellCompletion,
 }
 
 const bashCompletion = `# bash completion for deja
@@ -75,7 +77,7 @@ _deja_completion() {
             fi
             ;;
         completion)
-            COMPREPLY=( $(compgen -W "bash zsh fish" -- "$cur") )
+            COMPREPLY=( $(compgen -W "bash zsh fish powershell pwsh" -- "$cur") )
             ;;
         doctor)
             COMPREPLY=( $(compgen -W "--json --offline --deep" -- "$cur") )
@@ -211,7 +213,7 @@ _deja() {
       fi
       ;;
     completion)
-      _values 'shell' bash zsh fish
+      _values 'shell' bash zsh fish powershell pwsh
       ;;
     doctor)
       _arguments '--json[print JSON]' '--offline[skip version check]' '--deep[verify index against sources]'
@@ -281,7 +283,7 @@ complete -c deja -n '__deja_needs_command' -l role -r -a 'user assistant tool'
 complete -c deja -n '__deja_needs_command' -l session -r
 complete -c deja -n '__deja_needs_command' -l rebuild
 
-complete -c deja -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish'
+complete -c deja -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish powershell pwsh'
 complete -c deja -n '__fish_seen_subcommand_from blame' -l all
 complete -c deja -n '__fish_seen_subcommand_from blame' -l json
 complete -c deja -n '__fish_seen_subcommand_from blame' -l harness -r -a '%HARNESSES%'
@@ -328,4 +330,97 @@ complete -c deja -n '__fish_seen_subcommand_from export' -F
 complete -c deja -n '__fish_seen_subcommand_from import' -F
 complete -c deja -n '__fish_seen_subcommand_from ssh' -l pull
 complete -c deja -n '__fish_seen_subcommand_from ssh' -l full
+`
+
+const powershellCompletion = `# PowerShell completion for deja
+Register-ArgumentCompleter -Native -CommandName deja -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $commands = @(
+        'blame', 'bench', 'check', 'completion', 'ctx', 'doctor', 'embed',
+        'files', 'fix', 'forget', 'friction', 'handoff', 'help', 'how',
+        'index', 'install', 'last', 'log', 'mcp', 'promote', 'remember',
+        'restore', 'resume', 'search', 'share', 'show', 'sources', 'stats',
+        'statusline', 'sync', 'uninstall', 'update', 'version', 'view', 'warmup'
+    )
+    $harnesses = @('%HARNESSES%' -split ' ' | Where-Object { $_ })
+    $installTargets = @('%INSTALL_TARGETS%' -split ' ' | Where-Object { $_ }) + @('--all', '--auto')
+    $handoffTargets = @('%HANDOFF_TARGETS%' -split ' ' | Where-Object { $_ })
+    $defaultOptions = @(
+        '--json', '--re', '--all', '--no-embed', '--harness', '--project',
+        '--since', '--role', '--session', '--rebuild'
+    )
+
+    $elements = @($commandAst.CommandElements | ForEach-Object { $_.Extent.Text })
+    $hasCurrentWord = -not [string]::IsNullOrEmpty($wordToComplete)
+    $completingCommand = $elements.Count -le 1 -or ($elements.Count -eq 2 -and $hasCurrentWord)
+
+    if ($completingCommand) {
+        $candidates = $commands + @('--version', '-version') + $defaultOptions
+    } else {
+        $command = $elements[1]
+        $action = if ($elements.Count -gt 2) { $elements[2] } else { '' }
+        $argumentPosition = if ($hasCurrentWord) { $elements.Count - 2 } else { $elements.Count - 1 }
+        $previous = if ($hasCurrentWord -and $elements.Count -gt 1) {
+            $elements[$elements.Count - 2]
+        } elseif ($elements.Count -gt 0) {
+            $elements[$elements.Count - 1]
+        } else {
+            ''
+        }
+
+        $candidates = switch ($command) {
+            'blame' {
+                if ($previous -eq '--harness') { $harnesses }
+                else { @('--all', '--json', '--harness', '--project', '--since') }
+            }
+            'bench' {
+                if ($argumentPosition -eq 1) { @('recall', 'context') }
+                elseif ($action -eq 'recall') { @('--json') }
+                else { @('--json', '--seed') }
+            }
+            'completion' { @('bash', 'zsh', 'fish', 'powershell', 'pwsh') }
+            'doctor' { @('--json', '--offline', '--deep') }
+            'forget' { @('--list', '--dry-run', '--session', '--project', '--before', '--unforget') }
+            'handoff' {
+                if ($previous -eq '--to') { $handoffTargets }
+                else { @('--to', '--exec') }
+            }
+            'hook-context' { @('--plain') }
+            'index' { @('--rebuild', '-rebuild') }
+            { $_ -in @('install', 'uninstall') } { $installTargets + @('--no-guidance') }
+            'last' {
+                if ($previous -eq '--harness') { $harnesses }
+                elseif ($previous -eq '--role') { @('user', 'assistant', 'tool') }
+                else { @('--harness', '--project', '--since', '--role') }
+            }
+            'remember' { @('--project') }
+            'resume' { @('--exec') }
+            'stats' {
+                if ($previous -eq '--harness') { $harnesses }
+                elseif ($previous -eq '--role') { @('user', 'assistant', 'tool') }
+                else { @('--json', '--impact', '--html', '--redaction', '--card', '--harness', '--project', '--since', '--role') }
+            }
+            'sync' {
+                if ($argumentPosition -eq 1) { @('export', 'import', 'ssh') }
+                elseif ($action -eq 'export') { @('--full') }
+                elseif ($action -eq 'ssh') { @('--pull', '--full') }
+                else { @() }
+            }
+            { $_ -in @('check', 'ctx', 'embed', 'hook-precompact', 'hook-prompt', 'mcp', 'share', 'show', 'sources', 'statusline', 'update', 'version', 'warmup') } { @() }
+            default { $defaultOptions }
+        }
+    }
+
+    $candidates |
+        Where-Object {
+            $_ -and $_.StartsWith($wordToComplete, [System.StringComparison]::OrdinalIgnoreCase)
+        } |
+        Sort-Object -Unique |
+        ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new(
+                $_, $_, [System.Management.Automation.CompletionResultType]::ParameterValue, $_
+            )
+        }
+}
 `

--- a/cmd/deja/completion_coverage_test.go
+++ b/cmd/deja/completion_coverage_test.go
@@ -18,9 +18,10 @@ func TestCompletionsListEveryUserFacingCommand(t *testing.T) {
 		"warmup-status": true, "mcp": true,
 	}
 	shells := map[string]string{
-		"bash": bashCompletion,
-		"zsh":  zshCompletion,
-		"fish": fishCompletion,
+		"bash":       bashCompletion,
+		"zsh":        zshCompletion,
+		"fish":       fishCompletion,
+		"powershell": powershellCompletion,
 	}
 	names := make([]string, 0, len(commands))
 	for name := range commands {

--- a/cmd/deja/completion_lists_test.go
+++ b/cmd/deja/completion_lists_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
+var completionTestShells = []string{"bash", "zsh", "fish", "powershell"}
+
 func emittedCompletion(t *testing.T, shell string) string {
 	t.Helper()
 	out, err := captureRun(t, "completion", shell)
@@ -29,7 +31,7 @@ func TestCompletionOffersEveryHarness(t *testing.T) {
 	// every harness name also appears among the install targets, so looking for
 	// them one at a time passes on a completion that offers none of them.
 	want := strings.Join(names, " ")
-	for _, shell := range []string{"bash", "zsh", "fish"} {
+	for _, shell := range completionTestShells {
 		if script := emittedCompletion(t, shell); !strings.Contains(script, want) {
 			t.Errorf("%s completion does not offer the registry's harnesses", shell)
 		}
@@ -44,7 +46,7 @@ func TestCompletionOffersEveryHandoffTarget(t *testing.T) {
 		t.Fatalf("handoffTargets returned %d, so this test proves nothing", len(targets))
 	}
 	want := strings.Join(targets, " ")
-	for _, shell := range []string{"bash", "zsh", "fish"} {
+	for _, shell := range completionTestShells {
 		if script := emittedCompletion(t, shell); !strings.Contains(script, want) {
 			t.Errorf("%s completion does not offer every handoff target", shell)
 		}
@@ -54,10 +56,9 @@ func TestCompletionOffersEveryHandoffTarget(t *testing.T) {
 // And nothing is left holding a placeholder: a substitution that stops matching
 // would otherwise ship the marker to the reader's shell.
 func TestCompletionSubstitutesEveryPlaceholder(t *testing.T) {
-	for _, shell := range []string{"bash", "zsh", "fish"} {
-		if script := emittedCompletion(t, shell); strings.Contains(script, "%") &&
-			strings.Contains(script, "%HARNESSES%") || strings.Contains(script, "%HANDOFF_TARGETS%") ||
-			strings.Contains(script, "%INSTALL_TARGETS%") {
+	for _, shell := range completionTestShells {
+		if script := emittedCompletion(t, shell); strings.Contains(script, "%HARNESSES%") ||
+			strings.Contains(script, "%HANDOFF_TARGETS%") || strings.Contains(script, "%INSTALL_TARGETS%") {
 			t.Errorf("%s completion still carries a placeholder", shell)
 		}
 	}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2617,7 +2617,7 @@ Usage:
   deja sync ssh <host> [--pull] [--both] [--full]
   deja last [n] [--json] [--project name] [--harness name] [--from machine|local] [--since duration] [--role user|assistant|tool|files|command|edit]
   deja sources
-  deja completion <bash|zsh|fish>
+  deja completion <bash|zsh|fish|powershell>
   deja forget --session <id-prefix> [--project <substring>] [--before <duration|date>] [--dry-run] [--all-matches]
   deja forget --list | --unforget <id>
   deja doctor [--json] [--deep] [--offline]

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -124,6 +124,7 @@ func TestCompletionScripts(t *testing.T) {
 		{"bash", []string{"complete -F _deja_completion deja", "install_targets=", "compgen -f"}},
 		{"zsh", []string{"#compdef deja", "compdef _deja deja", "install_targets="}},
 		{"fish", []string{"complete -c deja", "__fish_seen_subcommand_from blame", "-F"}},
+		{"powershell", []string{"Register-ArgumentCompleter -Native -CommandName deja", "$installTargets =", "CompletionResult"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.shell, func(t *testing.T) {
@@ -136,17 +137,28 @@ func TestCompletionScripts(t *testing.T) {
 					t.Errorf("completion output missing %q", want)
 				}
 			}
-			for _, want := range []string{"blame", "stats", "sync", "harness", "claude-code", "fish"} {
+			for _, want := range []string{"blame", "stats", "sync", "harness", "claude-code", "fish", "powershell"} {
 				if !strings.Contains(out, want) {
 					t.Errorf("completion output missing %q", want)
 				}
 			}
 		})
 	}
-	for _, args := range [][]string{{"completion"}, {"completion", "powershell"}} {
+	for _, args := range [][]string{{"completion"}, {"completion", "nu"}} {
 		if _, err := captureRun(t, args...); err == nil {
 			t.Fatalf("run(%q) succeeded, want error", args)
 		}
+	}
+	powershell, err := captureRun(t, "completion", "powershell")
+	if err != nil {
+		t.Fatalf("run completion powershell: %v", err)
+	}
+	pwsh, err := captureRun(t, "completion", "pwsh")
+	if err != nil {
+		t.Fatalf("run completion pwsh: %v", err)
+	}
+	if powershell != pwsh {
+		t.Error("pwsh alias returned a different completion script")
 	}
 }
 
@@ -174,6 +186,30 @@ func TestCompletionScriptsParseWhenShellIsAvailable(t *testing.T) {
 				t.Fatalf("%s rejected completion script: %v\n%s", tc.shell, err, out)
 			}
 		})
+	}
+}
+
+func TestPowerShellCompletionScriptParsesWhenAvailable(t *testing.T) {
+	tested := false
+	for _, candidate := range []string{"pwsh", "powershell"} {
+		shell, err := exec.LookPath(candidate)
+		if err != nil {
+			continue
+		}
+		tested = true
+		t.Run(candidate, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "deja-completion.ps1")
+			if err := os.WriteFile(path, []byte(powershellCompletion), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cmd := exec.Command(shell, "-NoProfile", "-NonInteractive", "-File", path)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("PowerShell rejected completion script: %v\n%s", err, out)
+			}
+		})
+	}
+	if !tested {
+		t.Skip("PowerShell is not installed")
 	}
 }
 

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -96,7 +96,7 @@
 <tr><td><code>deja resume &lt;id&gt;</code></td><td>Reopen a session in the agent that wrote it. Prints the command; <code>--exec</code> runs it. Where the harness scopes its session list to one project, the command carries the <code>cd</code> that makes the id resolve; where a harness has no way to reopen a conversation from a terminal, it says so rather than printing something that would start a new one. The <a href="harnesses.html">matrix</a> has the column.</td></tr>
 <tr><td><code>deja warmup</code></td><td>Build or refresh the index without searching — for a shell profile or a provisioning script.</td></tr>
 <tr><td><code>deja statusline</code></td><td>One line for an agent's status bar: today's sessions and what deja has served, and — when the host pipes its session payload — the file this session is working on most with what earlier sessions decided about it. Silent when no earlier session touched it.</td></tr>
-<tr><td><code>deja completion &lt;bash|zsh|fish&gt;</code></td><td>Print a completion script for your shell.</td></tr>
+<tr><td><code>deja completion &lt;bash|zsh|fish|powershell&gt;</code></td><td>Print a completion script for your shell. <code>pwsh</code> is accepted as an alias for PowerShell.</td></tr>
 <tr><td><code>deja uninstall &lt;target|--all&gt;</code></td><td>Remove deja's wiring from an agent. Other servers in shared config files are left alone.</td></tr>
 <tr><td><code>deja version</code></td><td>Print the version.</td></tr>
 <tr><td><code>deja sources</code></td><td>Discovered stores per harness, with redaction counts.</td></tr>


### PR DESCRIPTION
## Summary

- add native PowerShell completion for commands, subcommands, and common flags
- populate harness, install, and handoff candidates from the same runtime lists used by the existing shells
- accept `pwsh` as an alias and expose PowerShell in the existing completions, CLI help, and command guide

Closes #1577

## Test plan

- `go test ./cmd/deja -run 'TestCompletion|TestPowerShellCompletion' -count=1`
- `go vet ./...`
- `go build ./cmd/deja`
- sourced the generated script and verified `TabExpansion2` results in PowerShell 7 and Windows PowerShell 5.1

## Notes

`deja completion pwsh` emits the same script as `deja completion powershell`.