### PR TITLE
fix(mcp): decide remember's index refresh with one lock attempt instead of a check and a wait

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -491,11 +491,27 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		// On upgrade day that meant rebuilding the whole index inside the call
 		// (#1309), so the agent is told instead — the detached warmup picks it
 		// up with everything else.
+		// The note is on disk either way; what is left is making it findable.
+		// On upgrade day that meant rebuilding the whole index inside the call
+		// (#1309), so the agent is told instead — the detached warmup picks it
+		// up with everything else.
 		if line := buildingNowForBlockingTool(dir); line != "" {
 			return "Saved. " + line, nil
 		}
-		if err := index.EnsureForSearch(dir, search.Options{All: true}, false, mcpProgress()); err != nil {
+		// The check above cannot cover a rebuild that starts after it: it and a
+		// blocking Ensure ask the same lock a moment apart, and what began in
+		// between was waited out inside the client's call (#1804). One attempt
+		// at the lock decides both.
+		busy, err := index.EnsureForSearchNoWait(dir, search.Options{All: true}, mcpProgress())
+		if err != nil {
 			return "", err
+		}
+		if busy {
+			requestWarmup(dir)
+			if line := buildingNowForBlockingTool(dir); line != "" {
+				return "Saved. " + line, nil
+			}
+			return "Saved. deja is refreshing its index; this note becomes findable when that finishes, in a few seconds.", nil
 		}
 		// The journal is where the user sees what the agent did with their
 		// store; a write belongs there at least as much as a read.

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -491,10 +491,6 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		// On upgrade day that meant rebuilding the whole index inside the call
 		// (#1309), so the agent is told instead — the detached warmup picks it
 		// up with everything else.
-		// The note is on disk either way; what is left is making it findable.
-		// On upgrade day that meant rebuilding the whole index inside the call
-		// (#1309), so the agent is told instead — the detached warmup picks it
-		// up with everything else.
 		if line := buildingNowForBlockingTool(dir); line != "" {
 			return "Saved. " + line, nil
 		}

--- a/cmd/deja/mcp_nonblocking_test.go
+++ b/cmd/deja/mcp_nonblocking_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Every MCP tool answers from the current snapshot while a refresh runs; the
+// one that still called the blocking index.EnsureForSearch was kept off it by a
+// check one lock acquisition earlier, which is not atomic with the call it
+// protects (#1804). The invariant is about the source: no tool served inside
+// handleMCP may take the blocking path at all.
+func TestNoMCPToolTakesTheBlockingIndexPath(t *testing.T) {
+	src, err := os.ReadFile("mcp.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(string(src), "index.EnsureForSearch("); n != 0 {
+		t.Errorf("mcp.go still calls the blocking index.EnsureForSearch %d time(s); a tool that takes it waits out a rebuild inside the client's call", n)
+	}
+	if !strings.Contains(string(src), "index.EnsureForSearchStale(") {
+		t.Error("mcp.go no longer reads through the non-blocking path at all")
+	}
+}
+
+// With the index lock held for longer than any client would wait, remember
+// still answers, still writes the note, and says why it is not findable yet.
+func TestRememberAnswersWhileTheIndexIsLocked(t *testing.T) {
+	dir := seedRecallPage(t)
+	unlock := holdIndexLock(t, dir)
+	defer unlock()
+
+	done := make(chan string, 1)
+	go func() {
+		out, err := callMCPTool(dir, "remember", []byte(`{"text":"the wobble pool cap is 12","project":"proj"}`))
+		if err != nil {
+			done <- "error: " + err.Error()
+			return
+		}
+		done <- out
+	}()
+	select {
+	case out := <-done:
+		if !strings.Contains(out, "emembered") && !strings.Contains(out, "Saved") {
+			t.Errorf("remember answered something else while the index was locked: %q", out)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("remember waited on the index lock instead of answering")
+	}
+
+	notes := os.Getenv("DEJA_NOTES_FILE")
+	body, err := os.ReadFile(notes)
+	if err != nil {
+		t.Fatalf("the note was not written: %v", err)
+	}
+	if !strings.Contains(string(body), "wobble pool cap") {
+		t.Errorf("the note is missing from %s:\n%s", notes, body)
+	}
+}
+
+// holdIndexLock takes the index lock the way another deja process would, so a
+// tool that waits for it waits for this test instead.
+func holdIndexLock(t *testing.T, dir string) func() {
+	t.Helper()
+	f, err := os.OpenFile(dir+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}
+}

--- a/cmd/deja/mcp_nonblocking_test.go
+++ b/cmd/deja/mcp_nonblocking_test.go
@@ -77,3 +77,24 @@ func holdIndexLock(t *testing.T, dir string) func() {
 		_ = f.Close()
 	}
 }
+
+// A read-only index answers every question asked of it. The non-blocking
+// Ensure must not read "cannot write the lock file" as "a rebuild is running",
+// or remember tells the agent to come back later, forever.
+func TestRememberOnAReadOnlyIndexDoesNotPromiseARefresh(t *testing.T) {
+	dir := seedRecallPage(t)
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Skipf("cannot make the index read-only here: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	if os.Geteuid() == 0 {
+		t.Skip("root writes anywhere, so the read-only case cannot be built")
+	}
+	out, err := callMCPTool(dir, "remember", []byte(`{"text":"the wobble pool cap is 12","project":"proj"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "refreshing its index") {
+		t.Errorf("a read-only index was reported as a refresh in flight: %q", out)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -227,16 +227,33 @@ func EnsureForSearchNoWait(dir string, o query.Options, progress io.Writer) (bus
 	}
 	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
-		if errors.Is(err, fs.ErrPermission) && HasManifest(dir) {
-			return false, nil
-		}
 		return false, err
 	}
 	if !ok {
+		// tryLockDir reports "no lock" for two different things: someone else
+		// holds it, and this machine cannot write the lock file at all. Only
+		// the first is a refresh to wait for. A read-only index — a container
+		// mount, a locked-down machine — answers every question asked of it,
+		// and telling the caller to come back later would be a wait that never
+		// ends.
+		if lockUnwritable(dir) && HasManifest(dir) {
+			return false, nil
+		}
 		return true, nil
 	}
 	defer unlock()
 	return false, ensureLocked(dir, o, false, progress)
+}
+
+// lockUnwritable reports an index whose lock file cannot be created or opened
+// for writing, which is how a read-only store presents itself.
+func lockUnwritable(dir string) bool {
+	f, err := os.OpenFile(dir+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return errors.Is(err, fs.ErrPermission)
+	}
+	_ = f.Close()
+	return false
 }
 
 // ensureLocked is the body of an Ensure, with the lock already held.

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -213,6 +213,34 @@ func EnsureForSearch(dir string, o query.Options, force bool, progress io.Writer
 		return err
 	}
 	defer unlock()
+	return ensureLocked(dir, o, force, progress)
+}
+
+// EnsureForSearchNoWait is EnsureForSearch for a caller that must answer inside
+// somebody's tool call: it takes the lock or reports that another process holds
+// it, in one attempt. Checking RebuildInProgress and then calling the blocking
+// Ensure asked the same question twice, a lock acquisition apart, and a rebuild
+// starting in that window was waited out inside the call (#1804).
+func EnsureForSearchNoWait(dir string, o query.Options, progress io.Writer) (busy bool, err error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	unlock, ok, err := tryLockDir(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrPermission) && HasManifest(dir) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !ok {
+		return true, nil
+	}
+	defer unlock()
+	return false, ensureLocked(dir, o, false, progress)
+}
+
+// ensureLocked is the body of an Ensure, with the lock already held.
+func ensureLocked(dir string, o query.Options, force bool, progress io.Writer) error {
 	sweepStaleTmp(dir)
 	prior, priorErr := readManifest(dir)
 	want := currentFilesReusing("", priorFiles(prior, priorErr))


### PR DESCRIPTION
Closes #1804.

`remember` was the last MCP tool that could wait out a rebuild inside a client's call. What stopped it was `RebuildInProgress` — a try-lock — followed by a blocking `EnsureForSearch` on the same lock: the same question asked twice, a lock acquisition apart, so a rebuild starting in that window was waited out.

`index.EnsureForSearchNoWait` takes the lock or reports that someone else holds it, in one attempt, and `EnsureForSearch`'s body moves behind `ensureLocked` so both share it. `remember` keeps the pre-check for the things a lock cannot tell it — an index written by another version, a directory it cannot write — which is what #1309's "don't rebuild inside the call" rests on.

Behaviour is unchanged where it was already right: with the lock held for 10 s a fresh note answers in under a second with "Saved. deja is indexing this machine's history…", and with the lock free the note is indexed inline and findable straight away (`TestMCPToolContract/remember_then_recall_round-trips`, `TestRememberSavesOnUpgradeDayWithoutRebuilding` unchanged).

Tests: `TestNoMCPToolTakesTheBlockingIndexPath` fails before (mcp.go had one `index.EnsureForSearch(`), `TestRememberAnswersWhileTheIndexIsLocked` holds the real lock and asserts the answer and the note on disk.