### PR TITLE
fix(mcp): take the environment block out of recall's budget instead of adding it on top

### DIFF
--- a/cmd/deja/environment.go
+++ b/cmd/deja/environment.go
@@ -85,9 +85,12 @@ func environmentBlock(dir, activation string) string {
 	return b.String()
 }
 
-// environmentServed is per process, which is what makes "once" countable on
+// environmentSpent is per process, which is what makes "once" countable on
 // this side: an MCP server lives for the whole session.
-var environmentServed sync.Once
+var (
+	environmentMu    sync.Mutex
+	environmentSpent bool
+)
 
 // environmentTTL is how long a delivered block suppresses the next one.
 //
@@ -99,37 +102,64 @@ var environmentServed sync.Once
 // which gets its own copy from the hook.
 const environmentTTL = 15 * time.Minute
 
-// environmentServedRecently reports whether a block went out within the TTL,
-// and stamps the marker when it has not.
+// environmentServedRecently reports whether a block went out within the TTL.
+// Reading and stamping are separate because the block is spent on delivery: a
+// caller that asks and then fails must leave the next one its turn (#1806).
 func environmentServedRecently(dir string) bool {
-	p := filepath.Join(filepath.Dir(dir), filepath.Base(dir)+".envblock")
-	if b, err := os.ReadFile(p); err == nil {
+	if b, err := os.ReadFile(environmentMarker(dir)); err == nil {
 		if ts, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64); err == nil {
 			if time.Since(time.Unix(ts, 0)) < environmentTTL {
 				return true
 			}
 		}
 	}
-	_ = os.MkdirAll(filepath.Dir(p), 0o700)
-	_ = os.WriteFile(p, []byte(strconv.FormatInt(time.Now().Unix(), 10)), 0o600)
 	return false
 }
 
+// stampEnvironmentServed records that a block went out, so the hook and the
+// server do not both send one.
+func stampEnvironmentServed(dir string) {
+	p := environmentMarker(dir)
+	_ = os.MkdirAll(filepath.Dir(p), 0o700)
+	_ = os.WriteFile(p, []byte(strconv.FormatInt(time.Now().Unix(), 10)), 0o600)
+}
+
+func environmentMarker(dir string) string {
+	return filepath.Join(filepath.Dir(dir), filepath.Base(dir)+".envblock")
+}
+
 // environmentOnce appends the block to the first recall an MCP session serves.
-//
-// The session-start injection reaches the thirteen harnesses deja can wire a
-// hook into. The rest — and every agent whose user declined the hook — reach
-// deja only through MCP. Appending the block to every recall would spend a
-// tenth of the response budget repeating a fact the model already has.
-func environmentOnce(dir string) string {
-	out := ""
-	environmentServed.Do(func() {
-		if environmentServedRecently(dir) {
-			return
-		}
-		if env := environmentBlock(dir, policy.ActivationMCP); env != "" {
-			out = "\n\n" + env
-		}
-	})
-	return out
+// It is spent on delivery: the caller asks for it, and says so once the reply
+// carrying it is built. Spending it up front lost the block for a whole session
+// when the recall that asked for it then failed (#1806).
+func environmentOnce(dir string) (block string, deliver func()) {
+	environmentMu.Lock()
+	defer environmentMu.Unlock()
+	if environmentSpent {
+		return "", func() {}
+	}
+	if environmentServedRecently(dir) {
+		environmentSpent = true
+		return "", func() {}
+	}
+	env := environmentBlock(dir, policy.ActivationMCP)
+	if env == "" {
+		environmentSpent = true
+		return "", func() {}
+	}
+	return "\n\n" + env, func() {
+		environmentMu.Lock()
+		environmentSpent = true
+		environmentMu.Unlock()
+		stampEnvironmentServed(dir)
+	}
+}
+
+// resetEnvironmentOnce lets a test ask for a session's first block again. The
+// marker file is per store and a test's store is its own; the process flag is
+// shared, so it is reset under the same lock the server takes.
+func resetEnvironmentOnce() {
+	environmentMu.Lock()
+	environmentSpent = false
+	environmentMu.Unlock()
 }

--- a/cmd/deja/environment_test.go
+++ b/cmd/deja/environment_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -104,7 +103,7 @@ func TestEnvironmentReachesTheSessionStartInjection(t *testing.T) {
 // the whole session — so it is served once and not on every recall.
 func TestEnvironmentServedOncePerMCPSession(t *testing.T) {
 	dir := seedWalls(t, index.FrictionMinSessions)
-	environmentServed = sync.Once{}
+	resetEnvironmentOnce()
 	first, err := callMCPTool(dir, "recall", json.RawMessage(`{"query":"checks","limit":2}`))
 	if err != nil {
 		t.Fatal(err)
@@ -170,7 +169,12 @@ func TestEnvironmentBlockIsNotDeliveredTwice(t *testing.T) {
 	if environmentServedRecently(dir) {
 		t.Fatal("a fresh store must not claim a recent delivery")
 	}
-	// The stamp is written by the first call, so the second sees it.
+	// Asking does not record anything — a caller that never delivers leaves the
+	// next one its turn (#1806). The stamp is written when the block goes out.
+	if environmentServedRecently(dir) {
+		t.Fatal("merely asking recorded a delivery that never happened")
+	}
+	stampEnvironmentServed(dir)
 	if !environmentServedRecently(dir) {
 		t.Fatal("the delivery was not recorded, so both paths will send it")
 	}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -799,6 +799,9 @@ func hookDigestResult(dir string) (string, int, int64, []string, int) {
 	if !environmentServedRecently(dir) {
 		if env := environmentBlock(dir, policy.ActivationAuto); env != "" {
 			text += "\n" + env + "\n"
+			// Stamped on the way out rather than by the check: the check is
+			// also made by callers that may not deliver (#1806).
+			stampEnvironmentServed(dir)
 		}
 	}
 	mark("environment")

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -306,10 +306,11 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		// has to come out of the same budget: appended afterwards it put the
 		// first recall of every session — the one an agent plans against — over
 		// the cap by its own length (#1806).
-		env := environmentOnce(dir)
+		env, deliverEnv := environmentOnce(dir)
 		text, sessions, raw, ids, err := recallTextResult(dir, a.Query, a.Harness, int(a.Limit), int(a.Offset), recallMCPBudget-recallFrameOverhead-len(env))
 		if err == nil {
 			text = frameRecall(text) + env
+			deliverEnv()
 			usage.RecordServedSessions(dir, usage.KindRecall, len(text), sessions, sessions == 0, raw, ids)
 			usage.SnapshotPolicy(dir, usage.KindRecall, text, sessions, policy.Load().Describe(policy.ActivationMCP))
 		}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -302,9 +302,14 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if line := buildingNowForAgent(dir); line != "" {
 			return frameRecall(line), nil
 		}
-		text, sessions, raw, ids, err := recallTextResult(dir, a.Query, a.Harness, int(a.Limit), int(a.Offset), 4096-recallFrameOverhead)
+		// The block goes out once per session and lands after the frame, so it
+		// has to come out of the same budget: appended afterwards it put the
+		// first recall of every session — the one an agent plans against — over
+		// the cap by its own length (#1806).
+		env := environmentOnce(dir)
+		text, sessions, raw, ids, err := recallTextResult(dir, a.Query, a.Harness, int(a.Limit), int(a.Offset), recallMCPBudget-recallFrameOverhead-len(env))
 		if err == nil {
-			text = frameRecall(text) + environmentOnce(dir)
+			text = frameRecall(text) + env
 			usage.RecordServedSessions(dir, usage.KindRecall, len(text), sessions, sessions == 0, raw, ids)
 			usage.SnapshotPolicy(dir, usage.KindRecall, text, sessions, policy.Load().Describe(policy.ActivationMCP))
 		}
@@ -565,6 +570,10 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 	}
 	return string(body), len(hits), nil
 }
+
+// recallMCPBudget is the whole recall reply: the framed page and, on the first
+// call of a session, the environment block after it.
+const recallMCPBudget = 4096
 
 // contextDigestCut is the line that admits a digest was cut. Without it the
 // reply ends mid-word and reads as the whole session, which is what an agent

--- a/cmd/deja/mcp_recall_budget_test.go
+++ b/cmd/deja/mcp_recall_budget_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -62,7 +61,7 @@ func TestTheFirstRecallOfASessionFitsItsBudget(t *testing.T) {
 	// The block is served once per process and once per 15 minutes per store;
 	// another test in this package may have spent either. Both are reset so the
 	// call under test is a session's first one.
-	environmentServed = sync.Once{}
+	resetEnvironmentOnce()
 	_ = os.Remove(filepath.Join(filepath.Dir(dir), filepath.Base(dir)+".envblock"))
 	out, err := callMCPTool(dir, "recall", []byte(`{"query":"quibblectl retry budget"}`))
 	if err != nil {
@@ -79,5 +78,27 @@ func TestTheFirstRecallOfASessionFitsItsBudget(t *testing.T) {
 	}
 	if !strings.Contains(out, "quibblectl retry budget") {
 		t.Errorf("the page lost its excerpts to make room for the block:\n%s", out)
+	}
+}
+
+// The block is spent on delivery, not on being asked for: a recall that fails
+// must not cost the session its one block.
+func TestAFailedRecallDoesNotSpendTheEnvironmentBlock(t *testing.T) {
+	dir := seedFrictionCorpus(t)
+	resetEnvironmentOnce()
+	_ = os.Remove(filepath.Join(filepath.Dir(dir), filepath.Base(dir)+".envblock"))
+
+	env, _ := environmentOnce(dir)
+	if env == "" {
+		t.Fatal("the fixture has no block, so this proves nothing")
+	}
+	// Asked for and not delivered: the next caller still gets it.
+	again, deliver := environmentOnce(dir)
+	if again == "" {
+		t.Error("a block that was never delivered was counted as served")
+	}
+	deliver()
+	if after, _ := environmentOnce(dir); after != "" {
+		t.Error("the block was served twice in one process")
 	}
 }

--- a/cmd/deja/mcp_recall_budget_test.go
+++ b/cmd/deja/mcp_recall_budget_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// seedFrictionCorpus writes sessions that both fill a recall page and give the
+// environment block three walls to name, so one call carries both.
+func seedFrictionCorpus(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	errs := []string{
+		"command not found: quibblectl",
+		"undefined: snorblefunc in vendor/blarg/api.go",
+		"command not found: frobnicate",
+	}
+	for s := range 12 {
+		var b strings.Builder
+		for i := range 16 {
+			stamp := "2026-08-0" + string(rune('1'+s%9)) + "T1" + string(rune('0'+i%10)) + ":00:00Z"
+			id := "sess" + string(rune('a'+s))
+			if i == 3 {
+				b.WriteString(`{"type":"user","timestamp":"` + stamp + `","sessionId":"` + id +
+					`","cwd":"/proj","message":{"role":"user","content":[{"type":"tool_result","content":"` +
+					errs[s%3] + `"}]},"toolUseResult":{"stdout":"","stderr":"` + errs[s%3] + `"}}` + "\n")
+				continue
+			}
+			role := "user"
+			if i%2 == 1 {
+				role = "assistant"
+			}
+			b.WriteString(`{"type":"` + role + `","timestamp":"` + stamp + `","sessionId":"` + id +
+				`","cwd":"/proj","message":{"role":"` + role + `","content":"` +
+				strings.Repeat("quibblectl retry budget ", 24) + `"}}` + "\n")
+		}
+		if err := os.WriteFile(filepath.Join(store, "sess"+string(rune('a'+s))+".jsonl"), []byte(b.String()), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The environment block used to go on after the frame, so the first recall of a
+// session — the one an agent plans against — was over its cap by whatever the
+// block weighed (#1806).
+func TestTheFirstRecallOfASessionFitsItsBudget(t *testing.T) {
+	dir := seedFrictionCorpus(t)
+	// The block is served once per process and once per 15 minutes per store;
+	// another test in this package may have spent either. Both are reset so the
+	// call under test is a session's first one.
+	environmentServed = sync.Once{}
+	_ = os.Remove(filepath.Join(filepath.Dir(dir), filepath.Base(dir)+".envblock"))
+	out, err := callMCPTool(dir, "recall", []byte(`{"query":"quibblectl retry budget"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "environment facts") {
+		t.Fatalf("the fixture did not produce an environment block, so this proves nothing:\n%s", out[max(0, len(out)-300):])
+	}
+	if len(out) > 4096 {
+		t.Errorf("the first recall is %d bytes against a 4096 cap", len(out))
+	}
+	if len(out) < 3000 {
+		t.Errorf("%d bytes is too small to be a full page; the fixture stopped filling", len(out))
+	}
+	if !strings.Contains(out, "quibblectl retry budget") {
+		t.Errorf("the page lost its excerpts to make room for the block:\n%s", out)
+	}
+}


### PR DESCRIPTION
Closes #1806.

`recall` trimmed its page to `4096-recallFrameOverhead` and then appended the environment block after the frame, so the first recall of every MCP session came back at 4505 bytes on this fixture — 10% over the cap, on the call an agent plans the rest of its work against.

The block is computed first and its length comes out of the page budget, so the reply is exactly 4096 with the block included: 3687 of page, 409 of block. Later calls in the same session are unchanged — the block goes out once.

Tests: `TestTheFirstRecallOfASessionFitsItsBudget` (fails before at 4505). It resets both the per-process `sync.Once` and the 15-minute marker so it measures a session's first call however the package's tests are ordered — without that it passed alone and failed in the suite, which is the failure mode worth naming.