### PR TITLE
fix(sync): bound and de-escape peer names on the screens that report them

### DIFF
--- a/cmd/deja/doctor_peers.go
+++ b/cmd/deja/doctor_peers.go
@@ -25,7 +25,7 @@ func doctorPeers(w io.Writer, dir string, now time.Time) {
 	}
 	from := index.ImportedByMachine(dir)
 	for _, p := range list {
-		fmt.Fprintf(w, "  %-12s %s\n", p.Host, peerLine(p, from[p.Host], now))
+		fmt.Fprintf(w, "  %-12s %s\n", hostForEcho(p.Host), peerLine(p, from[p.Host], now))
 	}
 }
 
@@ -51,7 +51,9 @@ func peerLine(p peers.Peer, sessions int, now time.Time) string {
 		line += fmt.Sprintf(", %s from there", doctorCount(sessions, "session"))
 	}
 	if p.LastError != "" {
-		line += " — last attempt failed: " + p.LastError
+		// The stored error usually quotes the host back, so it carries whatever
+		// the name carried.
+		line += " — last attempt failed: " + safeForStatusline(p.LastError, 200)
 	}
 	return line
 }

--- a/cmd/deja/peers_echo.go
+++ b/cmd/deja/peers_echo.go
@@ -1,0 +1,18 @@
+package main
+
+// hostForEcho is how a peer's name is written to a screen. The name comes from
+// a config file — typed once, or shared with a team — and reached the terminal
+// exactly as stored: an escape byte recoloured the line a user reads when sync
+// is misbehaving, a carriage return rewound it, and a 300-character host filled
+// three lines of one `deja sync` run (#1808). The same bound the listing
+// surfaces have used since #1090.
+//
+// The name is not altered anywhere it is used as an address: ssh still gets the
+// host as written, and `deja sync forget` still matches on it.
+func hostForEcho(host string) string {
+	out := neutralizeFrameMarkers(safeForStatusline(host, mcpResourceNameMax))
+	if out == "" && host != "" {
+		return "a name with no printable characters"
+	}
+	return out
+}

--- a/cmd/deja/peers_echo.go
+++ b/cmd/deja/peers_echo.go
@@ -1,5 +1,7 @@
 package main
 
+import "github.com/vshulcz/deja-vu/internal/search"
+
 // hostForEcho is how a peer's name is written to a screen. The name comes from
 // a config file — typed once, or shared with a team — and reached the terminal
 // exactly as stored: an escape byte recoloured the line a user reads when sync
@@ -13,6 +15,24 @@ func hostForEcho(host string) string {
 	out := neutralizeFrameMarkers(safeForStatusline(host, mcpResourceNameMax))
 	if out == "" && host != "" {
 		return "a name with no printable characters"
+	}
+	return out
+}
+
+// remoteEchoMax bounds what a peer's own deja is allowed to write on this
+// screen. Its lines are short — "deja: exported 5 records" — so anything past
+// this is not the report it claims to be.
+const remoteEchoMax = 2000
+
+// remoteOutputForEcho is how the other machine's output reaches this terminal.
+// It arrives over ssh from a deja this one does not control, and was printed
+// raw: an escape byte in it recoloured the local screen and a carriage return
+// rewound it, which is the #1090 class with the text coming from somewhere else
+// entirely (#1808).
+func remoteOutputForEcho(out string) string {
+	out = search.SafeText(out)
+	if len(out) > remoteEchoMax {
+		out = trimUTF8(out, remoteEchoMax) + " …"
 	}
 	return out
 }

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -63,7 +63,7 @@ func runSync(dir string, args []string) error {
 		if !found {
 			return fmt.Errorf("deja does not know a machine called %q — `deja doctor` lists the ones it does", host)
 		}
-		fmt.Fprintf(os.Stdout, "deja: %s forgotten — bare `deja sync` will not try it again\n", host)
+		fmt.Fprintf(os.Stdout, "deja: %s forgotten — bare `deja sync` will not try it again\n", hostForEcho(host))
 		return nil
 	case "export":
 		full := false

--- a/cmd/deja/sync_host_echo_test.go
+++ b/cmd/deja/sync_host_echo_test.go
@@ -69,3 +69,22 @@ func TestForgetStillMatchesTheHostAsWritten(t *testing.T) {
 }
 
 func peersLoadForTest() []peers.Peer { return peers.Load() }
+
+// The other machine's deja writes on this screen, and it is a machine this one
+// does not control: its output reached the terminal raw.
+func TestRemoteOutputCannotRewriteTheLocalScreen(t *testing.T) {
+	hostile := "deja: exported 3 records\x1b[31m\rHACKED" + strings.Repeat(" padding", 400)
+	got := remoteOutputForEcho(hostile)
+	if strings.ContainsAny(got, "\x1b\r") {
+		t.Errorf("remote output carried an escape or a rewind: %q", got[:60])
+	}
+	if len(got) > remoteEchoMax+8 {
+		t.Errorf("remote output printed %d bytes", len(got))
+	}
+	if !strings.Contains(got, "exported 3 records") {
+		t.Errorf("the report itself was lost: %q", got[:60])
+	}
+	if short := remoteOutputForEcho("deja: exported 3 records"); short != "deja: exported 3 records" {
+		t.Errorf("an ordinary report was altered: %q", short)
+	}
+}

--- a/cmd/deja/sync_host_echo_test.go
+++ b/cmd/deja/sync_host_echo_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/peers"
+)
+
+// hostileHostsFile writes a peers file holding a host with an escape byte and
+// one long enough to fill a screen, and points deja at it.
+func hostileHostsFile(t *testing.T) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "peers.json")
+	body, err := json.Marshal(map[string]any{"peers": []map[string]any{
+		{"host": "build\x1b[31mALERT\x1b[0m\rrewound", "last_push": time.Now().Add(-48 * time.Hour).Format(time.RFC3339)},
+		{"host": strings.Repeat("w", 300), "last_push": time.Now().Add(-72 * time.Hour).Format(time.RFC3339)},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_PEERS_FILE", path)
+}
+
+// A host name is printed on the screen someone reads when sync is misbehaving;
+// an escape byte in it rewrites that screen (#1808).
+func TestTheDoctorDoesNotHandTheTerminalAPeerName(t *testing.T) {
+	hermeticEnv(t)
+	hostileHostsFile(t)
+	var b strings.Builder
+	doctorPeers(&b, t.TempDir(), time.Now())
+	out := b.String()
+	if strings.ContainsAny(out, "\x1b\r") {
+		t.Errorf("the doctor's Sync section carried an escape or a rewind:\n%q", out)
+	}
+	if !strings.Contains(out, "ALERT") {
+		t.Errorf("the host deja is talking to is gone from the line:\n%s", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if len(line) > 400 {
+			t.Errorf("one peer line is %d bytes:\n%s", len(line), line[:120])
+		}
+	}
+}
+
+// The name is bounded on screen and nowhere else: ssh is still handed the host
+// as written, and `deja sync forget` still matches on it.
+func TestForgetStillMatchesTheHostAsWritten(t *testing.T) {
+	hermeticEnv(t)
+	hostileHostsFile(t)
+	long := strings.Repeat("w", 300)
+	out, err := captureRunStderr(t, "sync", "forget", long)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = out
+	for _, p := range peersLoadForTest() {
+		if p.Host == long {
+			t.Errorf("forget did not match the host it was given in full")
+		}
+	}
+}
+
+func peersLoadForTest() []peers.Peer { return peers.Load() }

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -110,7 +110,7 @@ func syncOneWay(dir, host string, pull, full bool) error {
 	// what the report exists to show, and it is invisible if only successes
 	// are written down.
 	if rerr := recordExchange(host, pull, time.Now(), err); rerr != nil && err == nil {
-		fmt.Fprintf(os.Stderr, "deja: synced with %s, but could not record it: %v\n", host, rerr)
+		fmt.Fprintf(os.Stderr, "deja: synced with %s, but could not record it: %v\n", hostForEcho(host), rerr)
 	}
 	if errors.Is(err, errNothingToSend) {
 		// Nothing to send is a quiet success for the caller: a machine with no
@@ -201,7 +201,7 @@ func syncSSHPush(dir, host string, full bool) error {
 		return fmt.Errorf("delivered, but recording watermarks failed (next push may resend; harmless — import dedupes): %w", err)
 	}
 	if out != "" {
-		fmt.Fprintf(os.Stdout, "%s: %s\n", host, out)
+		fmt.Fprintf(os.Stdout, "%s: %s\n", hostForEcho(host), remoteOutputForEcho(out))
 	}
 	return nil
 }
@@ -240,7 +240,7 @@ func syncSSHPull(dir, host string, full bool) error {
 		return fmt.Errorf("remote export: %v: %s", err, out)
 	}
 	if out != "" {
-		fmt.Fprintf(os.Stdout, "%s: %s\n", host, out)
+		fmt.Fprintf(os.Stdout, "%s: %s\n", hostForEcho(host), remoteOutputForEcho(out))
 	}
 	cleanup := func() {
 		_, _ = sshRunner("ssh", append(sshOpts(), host, "sh -lc "+shellQuote("rm -rf "+shellQuote(rtmp)))...)

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -132,11 +132,11 @@ func runSyncAll(dir string, full bool) error {
 	}
 	var failed int
 	for _, p := range list {
-		fmt.Fprintf(os.Stdout, "deja: %s\n", p.Host)
+		fmt.Fprintf(os.Stdout, "deja: %s\n", hostForEcho(p.Host))
 		if err := syncSSHHost(dir, p.Host, false, full, true); err != nil {
 			// One unreachable laptop must not stop the server from getting
 			// what the desktop did.
-			fmt.Fprintf(os.Stderr, "deja: %s: %v\n", p.Host, err)
+			fmt.Fprintf(os.Stderr, "deja: %s: %s\n", hostForEcho(p.Host), safeForStatusline(err.Error(), 200))
 			failed++
 		}
 	}


### PR DESCRIPTION
Closes #1808.

`deja sync` and `deja doctor` printed a peer host exactly as the peers file holds it, so an escape byte recoloured and rewound the line a user reads when sync is misbehaving, and a 300-character host filled three lines of one run. Both now go through the bound the listing surfaces have used since #1090, and so does the stored `last_error`, which usually quotes the host back.

Before / after through `cat -v`:

```
deja: build^[[31mALERT^[[0m^Mrewound
deja: build [31mALERT [0m rewound
```

The name is bounded on screen and nowhere else: ssh is handed the host as written and `deja sync forget <host>` still matches on it in full — `TestForgetStillMatchesTheHostAsWritten` covers that, and `TestTheDoctorDoesNotHandTheTerminalAPeerName` fails before the fix.

`doctor --json` was already safe (the encoder escapes both), and `peers.trimError` was already rune-safe — the plain-text surfaces were the ones with nothing.