### PR TITLE
fix(remember): clean and bound a tag where it is written, and where it is echoed

### DIFF
--- a/cmd/deja/remember.go
+++ b/cmd/deja/remember.go
@@ -88,7 +88,10 @@ func runRemember(dir string, args []string) error {
 	}
 	suffix := ""
 	if norm := sources.NormalizeTags(tags); len(norm) > 0 {
-		suffix = " #" + strings.Join(norm, " #")
+		// Cleaned at the source now, but the echo is the line a user checks
+		// what was filed against, and it is one line: bound it the way the
+		// project name beside it is bounded (#1810).
+		suffix = " " + safeForStatusline("#"+strings.Join(norm, " #"), mcpResourceNameMax)
 	}
 	fmt.Fprintf(os.Stdout, "deja: remembered under %s%s\n", projectForEcho(project), suffix)
 	return nil

--- a/cmd/deja/remember_echo_test.go
+++ b/cmd/deja/remember_echo_test.go
@@ -94,3 +94,34 @@ func TestRememberEchoNamesAProjectThatBoundsToNothing(t *testing.T) {
 		t.Errorf("the line does not say why the name is missing: %q", line)
 	}
 }
+
+// The project name has been bounded since #1792; the tags printed beside it
+// were not, so a tag with an escape byte in it still rewrote the line (#1810).
+func TestRememberEchoBoundsTheTagsToo(t *testing.T) {
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(t.TempDir(), "notes.jsonl"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+	out := captureStdout(t, func() {
+		err := runRemember(index.DefaultDir(), []string{
+			"--project", "proj",
+			"--tag", "ok",
+			"--tag", "red\x1b[31mALERT\x1b[0m\rrewound",
+			"--tag", strings.Repeat("w", 400),
+			"the shard limit is 64",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	if strings.ContainsAny(out, "\x1b\r") {
+		t.Errorf("the confirmation carried an escape or a rewind: %q", out)
+	}
+	if len(out) > 200 {
+		t.Errorf("the confirmation is %d bytes of tags: %q", len(out), out[:120])
+	}
+	if !strings.Contains(out, "#ok") {
+		t.Errorf("the tags the note was filed under are gone: %q", out)
+	}
+	if !strings.Contains(out, "under proj ") {
+		t.Errorf("the project and its tags ran together: %q", out)
+	}
+}

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/atomicfile"
 	"github.com/vshulcz/deja-vu/internal/cjkfold"
@@ -57,13 +58,33 @@ func NotesFile() string {
 	return filepath.Join(Home(), ".local", "share", "deja", "notes.jsonl")
 }
 
+// cleanTag removes what a tag cannot carry and cuts it to maxTagLen. A control
+// byte in a tag reached notes.jsonl and every surface reading it, and an escape
+// sequence is not something anyone meant to file a note under.
+func cleanTag(t string) string {
+	t = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
+			return ' '
+		}
+		return r
+	}, t)
+	t = strings.Join(strings.Fields(t), "-")
+	return truncateRunes(t, maxTagLen)
+}
+
+// maxTagLen bounds one tag. The count has been capped at 8 since tags landed;
+// one tag's length was not bounded at all, so a 400-character tag was stored
+// and printed whole (#1810). A handle someone types and searches for is short,
+// and 64 bytes is well past anything anyone writes by hand.
+const maxTagLen = 64
+
 // NormalizeTags lowercases, trims a leading '#', drops empties/dupes and
 // caps the count — tags are navigation handles, not prose.
 func NormalizeTags(tags []string) []string {
 	seen := map[string]bool{}
 	var out []string
 	for _, t := range tags {
-		t = strings.ToLower(strings.TrimPrefix(strings.TrimSpace(t), "#"))
+		t = strings.ToLower(strings.TrimPrefix(strings.TrimSpace(cleanTag(t)), "#"))
 		if t == "" || seen[t] || len(out) >= 8 {
 			continue
 		}

--- a/internal/sources/tags_test.go
+++ b/internal/sources/tags_test.go
@@ -1,0 +1,43 @@
+package sources
+
+import (
+	"strings"
+	"testing"
+)
+
+// A tag is a short handle someone searches for. A control byte in one is not a
+// tag anyone meant to write, and it reached notes.jsonl and every surface that
+// reads it (#1810).
+func TestNormalizeTagsDropsControlBytes(t *testing.T) {
+	got := NormalizeTags([]string{"ok", "red\x1b[31mALERT\x1b[0m\rrewound", "two\nlines"})
+	for _, tag := range got {
+		if strings.ContainsAny(tag, "\x1b\r\n") {
+			t.Errorf("a stored tag carries a control byte: %q", tag)
+		}
+	}
+	if len(got) != 3 {
+		t.Fatalf("tags were dropped rather than cleaned: %q", got)
+	}
+	if got[0] != "ok" {
+		t.Errorf("an ordinary tag was altered: %q", got[0])
+	}
+	if !strings.Contains(got[1], "alert") {
+		t.Errorf("the word the user typed is gone: %q", got[1])
+	}
+}
+
+// The count has been capped at 8 since tags landed; one tag's length was not
+// bounded at all, so a 400-character tag was stored and printed whole.
+func TestNormalizeTagsBoundsOneTag(t *testing.T) {
+	got := NormalizeTags([]string{strings.Repeat("w", 400)})
+	if len(got) != 1 {
+		t.Fatalf("the tag was dropped: %q", got)
+	}
+	if len(got[0]) > maxTagLen {
+		t.Errorf("one tag is %d bytes, cap is %d", len(got[0]), maxTagLen)
+	}
+	// A tag that fits is untouched, so the bound is not paid by ordinary use.
+	if same := NormalizeTags([]string{"retry-budget"}); same[0] != "retry-budget" {
+		t.Errorf("an ordinary tag was cut: %q", same[0])
+	}
+}

--- a/internal/sources/tags_test.go
+++ b/internal/sources/tags_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // A tag is a short handle someone searches for. A control byte in one is not a
@@ -39,5 +40,24 @@ func TestNormalizeTagsBoundsOneTag(t *testing.T) {
 	// A tag that fits is untouched, so the bound is not paid by ordinary use.
 	if same := NormalizeTags([]string{"retry-budget"}); same[0] != "retry-budget" {
 		t.Errorf("an ordinary tag was cut: %q", same[0])
+	}
+}
+
+// A tag with a space in it was never a handle anything could match — the tags
+// are folded into "#tag" tokens in the indexed text, and half a tag matches
+// nothing. Folding the space to a hyphen makes it one, and makes it the same
+// handle as the hyphenated spelling someone else typed.
+func TestATagWithASpaceBecomesOneHandle(t *testing.T) {
+	got := NormalizeTags([]string{"retry budget", "retry-budget"})
+	if len(got) != 1 || got[0] != "retry-budget" {
+		t.Errorf("the two spellings did not fold into one handle: %q", got)
+	}
+	// Multibyte tags survive the cut as valid text, not as half a character.
+	long := NormalizeTags([]string{strings.Repeat("резервирование", 8)})[0]
+	if !utf8.ValidString(long) {
+		t.Errorf("the cut split a character: %q", long)
+	}
+	if len(long) > maxTagLen {
+		t.Errorf("a Cyrillic tag is %d bytes, cap is %d", len(long), maxTagLen)
 	}
 }


### PR DESCRIPTION
Closes #1810.

Two halves of the same gap. `NormalizeTags` capped the *count* at 8 and nothing else: a tag carrying an escape byte went into `notes.jsonl` as typed, and a 400-character tag was stored whole. And `deja remember`'s confirmation printed the tag list raw beside a project name that has been bounded since #1792, so the line was recoloured and rewound.

Now: control and format runes are dropped where a tag is written, whitespace folds to `-`, one tag is cut at 64 bytes, and the echo takes the same 80-column bound as the project beside it.

```
deja: remembered under proj #ok #red^[[31malert^[[0m^Mrewound #wwww…(400)
deja: remembered under proj #ok #red-[31malert-[0m-rewound #wwww…(64, then …)
```

Stored: `['ok', 'red-[31malert-[0m-rewound', 'wwww…(64)']`.

Cutting a tag at 64 bytes changes what is written, so say if you want a different number or no bound at all — it is the one part of this that is a product call rather than a mechanism. Dropping control bytes is not: a tag with an escape sequence in it is not a handle anyone meant to file a note under.

Tests: `TestNormalizeTagsDropsControlBytes`, `TestNormalizeTagsBoundsOneTag` (with a control that an ordinary tag is untouched), `TestRememberEchoBoundsTheTagsToo`. Control that the rest was already right: `deja recall` renders the same note de-escaped and truncated, which is why this only shows on the write and confirm paths.