### PR TITLE
fix(remember): keep checking for duplicates past an oversized note

### DIFF
--- a/internal/sources/note_dedupe_test.go
+++ b/internal/sources/note_dedupe_test.go
@@ -52,3 +52,49 @@ func TestOneHugeNoteDoesNotDisableTheDuplicateCheck(t *testing.T) {
 		t.Errorf("the oversized note was not written whole: file is %d bytes", len(body))
 	}
 }
+
+// The cap is on a note's content: a line of exactly maxNoteLine bytes is still
+// compared, and one byte more is skipped. Counting the newline made the
+// boundary one byte tight.
+func TestTheLineCapCountsTheNoteNotItsNewline(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		fill    int
+		compare bool
+	}{
+		{"one under", -1, true},
+		{"exactly the cap", 0, true},
+		{"one over", 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "notes.jsonl")
+			t.Setenv("DEJA_NOTES_FILE", path)
+			// A note whose JSON line lands exactly on the cap.
+			body := strings.Repeat("z", 64)
+			if err := AppendNote("proj", body, time.Now()); err != nil {
+				t.Fatal(err)
+			}
+			line, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pad := maxNoteLine - len(strings.TrimRight(string(line), "\n")) + tc.fill
+			if pad < 0 {
+				t.Skip("the stored line is already past the cap")
+			}
+			grown := strings.Repeat("z", 64+pad)
+			path2 := filepath.Join(t.TempDir(), "notes2.jsonl")
+			t.Setenv("DEJA_NOTES_FILE", path2)
+			if err := AppendNote("proj", grown, time.Now()); err != nil {
+				t.Fatal(err)
+			}
+			err = AppendNote("proj", grown, time.Now())
+			if tc.compare && err != ErrNoteExists {
+				t.Errorf("a line at the cap was not compared: %v", err)
+			}
+			if !tc.compare && err != nil {
+				t.Errorf("a line past the cap should be written without comparison: %v", err)
+			}
+		})
+	}
+}

--- a/internal/sources/note_dedupe_test.go
+++ b/internal/sources/note_dedupe_test.go
@@ -1,0 +1,54 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The duplicate check reads the file line by line. A note longer than the
+// scan's buffer is not compared — that much is by design — but it used to stop
+// the scan, so every note written after it was never compared either, and one
+// oversized note turned the check off for the whole store (#1812).
+func TestOneHugeNoteDoesNotDisableTheDuplicateCheck(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", path)
+	now := time.Now()
+
+	huge := strings.Repeat("the shard limit is 64. ", 240000) // ~5.5 MB
+	if err := AppendNote("proj", huge, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := AppendNote("proj", "the retry cap is three", now); err != nil {
+		t.Fatal(err)
+	}
+	err := AppendNote("proj", "the retry cap is three", now)
+	if err == nil {
+		t.Fatal("a note already on file was written again after an oversized one")
+	}
+	if err != ErrNoteExists {
+		t.Fatalf("want ErrNoteExists, got %v", err)
+	}
+
+	// The control: without the oversized note in front, the same duplicate is
+	// refused — so the assertion above is not vacuous.
+	plain := filepath.Join(t.TempDir(), "plain.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", plain)
+	if err := AppendNote("proj", "the retry cap is three", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := AppendNote("proj", "the retry cap is three", now); err != ErrNoteExists {
+		t.Fatalf("the control does not hold: %v", err)
+	}
+
+	// And the oversized note itself is still written, unchanged.
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) < len(huge) {
+		t.Errorf("the oversized note was not written whole: file is %d bytes", len(body))
+	}
+}

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -124,22 +124,52 @@ func noteAlreadyStored(path, project, text string) bool {
 		return false
 	}
 	defer func() { _ = f.Close() }()
-	sc := bufio.NewScanner(f)
-	sc.Buffer(make([]byte, 0, 64*1024), maxNoteLine)
-	for sc.Scan() {
-		line := bytes.TrimSpace(sc.Bytes())
-		if len(line) == 0 {
+	br := bufio.NewReaderSize(f, 64*1024)
+	for {
+		line, tooLong, err := readNoteLine(br, maxNoteLine)
+		if tooLong {
+			// A note past the cap is not compared — that is what the cap says
+			// — but it used to end the scan, so every note after it went
+			// uncompared too and one oversized note turned the check off for
+			// the whole store (#1812). notes.jsonl is append-only, so that
+			// oversized line sits in front of everything written later.
+			if err != nil {
+				return false
+			}
 			continue
 		}
-		var n note
-		if json.Unmarshal(line, &n) != nil || n.Kind != "" {
-			continue
+		line = bytes.TrimSpace(line)
+		if len(line) > 0 {
+			var n note
+			if json.Unmarshal(line, &n) == nil && n.Kind == "" &&
+				n.Project == project && strings.TrimSpace(n.Text) == text {
+				return true
+			}
 		}
-		if n.Project == project && strings.TrimSpace(n.Text) == text {
-			return true
+		if err != nil {
+			return false
 		}
 	}
-	return false
+}
+
+// readNoteLine reads one line, reporting a line past max rather than buffering
+// it: the caller skips it and carries on down the file.
+func readNoteLine(br *bufio.Reader, max int) (line []byte, tooLong bool, err error) {
+	var buf []byte
+	for {
+		chunk, e := br.ReadSlice('\n')
+		if len(buf)+len(chunk) > max {
+			tooLong = true
+			buf = nil
+		}
+		if !tooLong {
+			buf = append(buf, chunk...)
+		}
+		if e == bufio.ErrBufferFull {
+			continue
+		}
+		return buf, tooLong, e
+	}
 }
 
 func AppendNoteTagged(project, text string, tags []string, now time.Time) error {

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -158,7 +158,10 @@ func readNoteLine(br *bufio.Reader, max int) (line []byte, tooLong bool, err err
 	var buf []byte
 	for {
 		chunk, e := br.ReadSlice('\n')
-		if len(buf)+len(chunk) > max {
+		// The cap is on the line's content; the newline that ends it is not
+		// part of the note, and counting it made a line of exactly max bytes
+		// look one byte too long.
+		if len(buf)+len(bytes.TrimSuffix(chunk, []byte("\n"))) > max {
 			tooLong = true
 			buf = nil
 		}


### PR DESCRIPTION
Closes #1812.

`bufio.Scanner` stops at the first line longer than its buffer, and `sc.Err()` was never read — so one note past `maxNoteLine` ended the duplicate scan, and since notes.jsonl is append-only, every note written after it was compared against nothing. The user kept seeing "Remembered under proj." while the store filled with copies.

The scan now skips a line past the cap and carries on. A note that long is still not compared — that part is what the cap says — and it is still written whole.

```
id 2 'Remembered under proj.'      # 5.5 MB note
id 3 'Remembered under proj.'      # small note
id 4 'Remembered under proj.'      # the same small note — accepted (before)
id 4 'Already remembered under proj.'                          # (after)
```

Test: `TestOneHugeNoteDoesNotDisableTheDuplicateCheck`, with a control that the same duplicate is refused without the oversized note in front, and an assertion that the big note itself is still written whole.

Not fixed here: nothing bounds how big one note may be, which is the open product call in the queue (a single `remember` accepting 3 MB, iteration 79). This only stops one such note from disabling the check for everything else.