### PR TITLE
chore(scoop): canonical key order and checksums-based autoupdate

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,14 +1,20 @@
 {
+    "version": "0.18.0",
+    "description": "Persistent memory for coding agents",
+    "homepage": "https://github.com/vshulcz/deja-vu",
+    "license": "MIT",
     "architecture": {
         "64bit": {
-            "hash": "e2c5a442afb3f208aa1389be031b2ac595de3c79b1179856fb843a1f1b042391",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_amd64.zip"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_amd64.zip",
+            "hash": "e2c5a442afb3f208aa1389be031b2ac595de3c79b1179856fb843a1f1b042391"
         },
         "arm64": {
-            "hash": "f814fe2117f69ae1d2cc2202e6c3d37e90ef7cde705c3e3c6de1dfdfa4743b25",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_arm64.zip"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_arm64.zip",
+            "hash": "f814fe2117f69ae1d2cc2202e6c3d37e90ef7cde705c3e3c6de1dfdfa4743b25"
         }
     },
+    "bin": "deja.exe",
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
@@ -17,12 +23,9 @@
             "arm64": {
                 "url": "https://github.com/vshulcz/deja-vu/releases/download/v$version/deja-vu_$version_windows_arm64.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
         }
-    },
-    "bin": "deja.exe",
-    "checkver": "github",
-    "description": "Persistent memory for coding agents",
-    "homepage": "https://github.com/vshulcz/deja-vu",
-    "license": "MIT",
-    "version": "0.18.0"
+    }
 }

--- a/scripts/pinmanifests/main.go
+++ b/scripts/pinmanifests/main.go
@@ -144,29 +144,59 @@ func write(root string, p pins) error {
 	return nil
 }
 
+// scoopManifest is a struct rather than a map because Scoop's own bucket
+// tooling formats manifests in this key order, and a map marshals alphabetical.
+// A submission that arrives sorted differently comes back from their formatter
+// as a diff on every line.
+type scoopManifest struct {
+	Version      string               `json:"version"`
+	Description  string               `json:"description"`
+	Homepage     string               `json:"homepage"`
+	License      string               `json:"license"`
+	Architecture map[string]scoopArch `json:"architecture"`
+	Bin          string               `json:"bin"`
+	Checkver     string               `json:"checkver"`
+	Autoupdate   scoopAutoupdate      `json:"autoupdate"`
+}
+
+type scoopArch struct {
+	URL  string `json:"url"`
+	Hash string `json:"hash,omitempty"`
+}
+
+type scoopAutoupdate struct {
+	Architecture map[string]scoopArch `json:"architecture"`
+	// Without this the updater can raise the version but has nothing to put in
+	// the hash fields. goreleaser publishes checksums.txt beside the archives,
+	// which is $baseurl here, and that is the shape the bucket's own manifests
+	// use.
+	Hash map[string]string `json:"hash"`
+}
+
 func renderScoop(p pins) ([]byte, error) {
-	m := map[string]any{
-		"version":     p.version,
-		"description": "Persistent memory for coding agents",
-		"homepage":    "https://github.com/vshulcz/deja-vu",
-		"license":     "MIT",
-		"architecture": map[string]any{
-			"64bit": map[string]any{
-				"url":  fmt.Sprintf("%s/v%s/deja-vu_%s_windows_amd64.zip", assetBase, p.version, p.version),
-				"hash": p.amd64,
+	m := scoopManifest{
+		Version:     p.version,
+		Description: "Persistent memory for coding agents",
+		Homepage:    "https://github.com/vshulcz/deja-vu",
+		License:     "MIT",
+		Architecture: map[string]scoopArch{
+			"64bit": {
+				URL:  fmt.Sprintf("%s/v%s/deja-vu_%s_windows_amd64.zip", assetBase, p.version, p.version),
+				Hash: p.amd64,
 			},
-			"arm64": map[string]any{
-				"url":  fmt.Sprintf("%s/v%s/deja-vu_%s_windows_arm64.zip", assetBase, p.version, p.version),
-				"hash": p.arm64,
+			"arm64": {
+				URL:  fmt.Sprintf("%s/v%s/deja-vu_%s_windows_arm64.zip", assetBase, p.version, p.version),
+				Hash: p.arm64,
 			},
 		},
-		"bin":      "deja.exe",
-		"checkver": "github",
-		"autoupdate": map[string]any{
-			"architecture": map[string]any{
-				"64bit": map[string]any{"url": assetBase + "/v$version/deja-vu_$version_windows_amd64.zip"},
-				"arm64": map[string]any{"url": assetBase + "/v$version/deja-vu_$version_windows_arm64.zip"},
+		Bin:      "deja.exe",
+		Checkver: "github",
+		Autoupdate: scoopAutoupdate{
+			Architecture: map[string]scoopArch{
+				"64bit": {URL: assetBase + "/v$version/deja-vu_$version_windows_amd64.zip"},
+				"arm64": {URL: assetBase + "/v$version/deja-vu_$version_windows_arm64.zip"},
 			},
+			Hash: map[string]string{"url": "$baseurl/checksums.txt"},
 		},
 	}
 	b, err := json.MarshalIndent(m, "", "    ")


### PR DESCRIPTION
Preparing a submission to `ScoopInstaller/Extras` — the bucket most Windows developers already have — surfaced two things in our own manifest.

The renderer built it from a Go map, so it marshalled alphabetically. Scoop's bucket tooling formats manifests in a fixed key order (version, description, homepage, license, architecture, bin, checkver, autoupdate), and a submission that arrives sorted differently comes back from their formatter as a diff on every line. It is a struct now, so the order is the type.

More substantially, `autoupdate` had no `hash` source. Their updater can raise the version from `checkver`, but with nothing to read hashes from it cannot complete the bump. goreleaser already publishes `checksums.txt` beside the archives — that is `$baseurl` — which is exactly the shape the bucket's own manifests use, e.g. lazygit.

Regenerated from the live 0.18.0 release rather than edited by hand, so the file and the renderer cannot disagree; `pinmanifests -check` passes.

We do not meet the **Main** bucket criteria (≥500 stars *and* 150 forks — we have 704 and 56), which is what Extras exists for.