### PR TITLE
fix(doctor): line the Sync column up by what the terminal draws

### DIFF
--- a/cmd/deja/doctor_peers.go
+++ b/cmd/deja/doctor_peers.go
@@ -3,10 +3,12 @@ package main
 import (
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/peers"
+	"github.com/vshulcz/deja-vu/internal/termwidth"
 )
 
 // doctorPeers reports the machines this one exchanges memory with, and when
@@ -24,10 +26,39 @@ func doctorPeers(w io.Writer, dir string, now time.Time) {
 		return
 	}
 	from := index.ImportedByMachine(dir)
-	for _, p := range list {
-		fmt.Fprintf(w, "  %-12s %s\n", hostForEcho(p.Host), peerLine(p, from[p.Host], now))
+	// The column is padded by what the terminal draws, not by how many runes
+	// the name has: %-12s gave a 32-character name no padding at all and
+	// treated a CJK name as one column per character (#1821). A name wider
+	// than the column keeps its whole self and puts its state on the next
+	// line, indented to where every other state starts.
+	names := make([]string, len(list))
+	width := doctorPeerColumn
+	for i, p := range list {
+		names[i] = hostForEcho(p.Host)
+		if c := termwidth.Columns(names[i]); c > width && c <= doctorPeerColumnMax {
+			width = c
+		}
+	}
+	for i, p := range list {
+		state := peerLine(p, from[p.Host], now)
+		pad := width - termwidth.Columns(names[i])
+		if pad < 0 {
+			fmt.Fprintf(w, "  %s\n  %s %s\n", names[i], strings.Repeat(" ", width), state)
+			continue
+		}
+		fmt.Fprintf(w, "  %s%s %s\n", names[i], strings.Repeat(" ", pad), state)
 	}
 }
+
+const (
+	// doctorPeerColumn is the narrowest the name column gets, so a machine
+	// called "laptop" does not sit alone against the left margin.
+	doctorPeerColumn = 12
+	// doctorPeerColumnMax is how far the column may grow for a long name
+	// before that name gets a line of its own: past this the state would be
+	// pushed off an ordinary terminal.
+	doctorPeerColumnMax = 32
+)
 
 // peerLine is one machine's state in one line: how long since memory moved,
 // which way it has not moved, and how much of this index came from there.

--- a/cmd/deja/doctor_peers_width_test.go
+++ b/cmd/deja/doctor_peers_width_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/termwidth"
+)
+
+// writeMixedPeers points deja at a peers file holding the names that break a
+// column padded by runes: an ordinary one, a long one, a CJK one, and one
+// bounded to 80 columns since #1808.
+func writeMixedPeers(t *testing.T) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "peers.json")
+	body := `{"peers":[
+	{"host":"laptop","last_push":"2026-08-24T10:00:00Z","last_pull":"2026-08-24T10:00:00Z"},
+	{"host":"build-server-in-the-other-office","last_push":"2026-08-23T10:00:00Z"},
+	{"host":"数据分片服务器","last_push":"2026-08-22T10:00:00Z"},
+	{"host":"` + strings.Repeat("w", 300) + `","last_push":"2026-08-21T10:00:00Z"}]}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_PEERS_FILE", path)
+}
+
+// The Sync section is a column, and what it holds is a name someone typed. It
+// was padded with %-12s: a 32-character name got no padding at all, a CJK name
+// was padded as if each character were one column wide, and an 80-column name
+// pushed the state off the screen (#1821).
+func TestTheSyncSectionLinesUpWhateverThePeerIsCalled(t *testing.T) {
+	hermeticEnv(t)
+	writeMixedPeers(t)
+	var b strings.Builder
+	doctorPeers(&b, t.TempDir(), time.Date(2026, 8, 25, 9, 0, 0, 0, time.UTC))
+
+	var starts []int
+	for _, line := range strings.Split(strings.TrimRight(b.String(), "\n"), "\n") {
+		if !strings.HasPrefix(line, "  ") || strings.HasPrefix(line, "Sync") {
+			continue
+		}
+		i := strings.Index(line, "last exchange")
+		if i < 0 {
+			continue
+		}
+		starts = append(starts, termwidth.Columns(line[:i]))
+	}
+	if len(starts) != 4 {
+		t.Fatalf("want a state line per peer, got %d:\n%s", len(starts), b.String())
+	}
+	for _, at := range starts[1:] {
+		if at != starts[0] {
+			t.Errorf("the states start at different columns %v:\n%s", starts, b.String())
+			break
+		}
+	}
+	// The control: every name is still on the screen, so the column was not
+	// bought by throwing the names away.
+	for _, want := range []string{"laptop", "build-server-in-the-other-office", "数据分片服务器"} {
+		if !strings.Contains(b.String(), want) {
+			t.Errorf("%q is missing from the section:\n%s", want, b.String())
+		}
+	}
+}


### PR DESCRIPTION
Closes #1821.

The Sync section's column was `%-12s`, which pads by runes: a 32-character name got no padding, a CJK name was padded as if each character were one column wide, and an 80-column name pushed the state off the screen.

It now pads by what the terminal draws (`termwidth.Columns`, the idiom `files.go:280` already uses), grows the column to the widest name up to 32 columns, and gives a name wider than that a line of its own with the state indented underneath — so nothing is truncated to buy the alignment.

```
  build-server-in-the-other-office last exchange 1 day ago, nothing received yet
  laptop       last exchange 19 hours ago
  数据分片服务器      last exchange 2 days ago, nothing received yet

  build-server-in-the-other-office last exchange 1 day ago, nothing received yet
  laptop                           last exchange 19 hours ago
  wwww…(80 columns)…w
                                   last exchange 3 days ago, nothing received yet
  数据分片服务器                   last exchange 2 days ago, nothing received yet
```

Test: `TestTheSyncSectionLinesUpWhateverThePeerIsCalled` measures where each state begins in terminal columns and fails before at `[35 15 84 22]`, with a control that every name is still on the screen.
