### PR TITLE
fix(termwidth): measure a name the same however it was typed

### DIFF
--- a/internal/termwidth/cost_test.go
+++ b/internal/termwidth/cost_test.go
@@ -1,0 +1,24 @@
+package termwidth
+
+import (
+	"strings"
+	"testing"
+)
+
+// Columns runs on every aligned line the tool prints, so composing first has to
+// stay free for text that holds no combining mark — which is nearly all of it.
+func BenchmarkColumnsPlain(b *testing.B) {
+	s := strings.Repeat("build-server-in-the-other-office ", 4)
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = Columns(s)
+	}
+}
+
+func BenchmarkColumnsDecomposed(b *testing.B) {
+	s := strings.Repeat("über-server ", 4)
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = Columns(s)
+	}
+}

--- a/internal/termwidth/cut_pairs_test.go
+++ b/internal/termwidth/cut_pairs_test.go
@@ -1,0 +1,26 @@
+package termwidth
+
+import "testing"
+
+// Every caller measures with Columns and then cuts with Cut, so the two have to
+// agree about the same string: `if Columns(s) > max { Cut(s, max) }`.
+func TestCutAgreesWithColumns(t *testing.T) {
+	for _, s := range []string{
+		"über-server-in-the-other-office",
+		"über-server-in-the-other-office",
+		"naïve-project",
+		"数据分片服务器",
+		"🚀rocket-launcher",
+		"plain-ascii-name",
+	} {
+		for _, max := range []int{1, 4, 8, 12, 20} {
+			cut := Cut(s, max)
+			if got := Columns(cut); got > max {
+				t.Errorf("Cut(%q, %d) measures %d columns", s, max, got)
+			}
+			if Columns(s) <= max && cut != s {
+				t.Errorf("Cut(%q, %d) shortened a string that already fits", s, max)
+			}
+		}
+	}
+}

--- a/internal/termwidth/cut_pairs_test.go
+++ b/internal/termwidth/cut_pairs_test.go
@@ -1,6 +1,10 @@
 package termwidth
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/nfcfold"
+)
 
 // Every caller measures with Columns and then cuts with Cut, so the two have to
 // agree about the same string: `if Columns(s) > max { Cut(s, max) }`.
@@ -18,8 +22,11 @@ func TestCutAgreesWithColumns(t *testing.T) {
 			if got := Columns(cut); got > max {
 				t.Errorf("Cut(%q, %d) measures %d columns", s, max, got)
 			}
-			if Columns(s) <= max && cut != s {
-				t.Errorf("Cut(%q, %d) shortened a string that already fits", s, max)
+			// A string that fits comes back whole. It comes back composed —
+			// the cut normalises what it measures, so the two cannot disagree
+			// about where a character ends.
+			if Columns(s) <= max && cut != nfcfold.Compose(s) {
+				t.Errorf("Cut(%q, %d) shortened a string that already fits: %q", s, max, cut)
 			}
 		}
 	}

--- a/internal/termwidth/normal_form_test.go
+++ b/internal/termwidth/normal_form_test.go
@@ -27,7 +27,7 @@ func TestTheSameNameMeasuresTheSameInEitherNormalForm(t *testing.T) {
 // nothing, a zero-width space, and the CJK marks the wide table finds. Over-
 // counting shortens a line; under-counting runs it past the edge.
 func TestOverCountingStaysWhereItWasDeliberate(t *testing.T) {
-	if got := Columns("a​b"); got != 3 {
+	if got := Columns("a\u200bb"); got != 3 {
 		t.Errorf("a zero-width space now measures differently: %d", got)
 	}
 	if got := Columns("が"); got != 4 {

--- a/internal/termwidth/normal_form_test.go
+++ b/internal/termwidth/normal_form_test.go
@@ -8,10 +8,11 @@ import "testing"
 // (#1824). The decomposed spellings are written as escapes on purpose — an
 // editor that normalises the file would otherwise quietly delete the case.
 func TestTheSameNameMeasuresTheSameInEitherNormalForm(t *testing.T) {
+	const acute, diaeresis = "\u0301", "\u0308"
 	for _, pair := range []struct{ decomposed, precomposed string }{
-		{"écombining", "écombining"},
-		{"über-server", "über-server"},
-		{"naïve", "naïve"},
+		{"e" + acute + "combining", "\u00e9combining"},
+		{"u" + diaeresis + "ber-server", "\u00fcber-server"},
+		{"nai" + diaeresis + "ve", "na\u00efve"},
 	} {
 		d, p := Columns(pair.decomposed), Columns(pair.precomposed)
 		if d != p {
@@ -35,6 +36,32 @@ func TestOverCountingStaysWhereItWasDeliberate(t *testing.T) {
 	}
 	if got := Columns("́"); got != 1 {
 		t.Errorf("a combining mark that composes with nothing measures %d", got)
+	}
+}
+
+// CutRight used to start a line with a mark whose base it had just cut away —
+// a Greek name came back as a lone acute followed by "λφα" — and that mark
+// draws on whatever precedes it, which on these screens is the ellipsis.
+// Composing first makes a mark and its base one rune before anything is
+// counted.
+func TestACutNeverStartsWithAnOrphanedMark(t *testing.T) {
+	// Built from escapes: a literal here has been normalised by an editor
+	// twice already, and a composed literal deletes the case silently.
+	const acute, diaeresis, breve = "\u0301", "\u0308", "\u0306"
+	for _, s := range []string{
+		"\u03b1" + acute + "\u03bb\u03c6\u03b1",             // alpha with tonos, decomposed
+		"u" + diaeresis + "ber-server",                      // u with diaeresis, decomposed
+		"\u0438" + breve + "\u043d\u0434\u0435\u043a\u0441", // Cyrillic short i, decomposed
+	} {
+		for width := 1; width <= 6; width++ {
+			tail := CutRight(s, width)
+			if tail == "" {
+				continue
+			}
+			if r := []rune(tail)[0]; r >= 0x0300 && r <= 0x036F {
+				t.Errorf("CutRight(%q, %d) starts with a combining mark: %q", s, width, tail)
+			}
+		}
 	}
 }
 

--- a/internal/termwidth/normal_form_test.go
+++ b/internal/termwidth/normal_form_test.go
@@ -1,0 +1,53 @@
+package termwidth
+
+import "testing"
+
+// The same name, typed two ways, has to measure the same: macOS hands paths
+// back decomposed, and project names come from paths, so a column padded from
+// the raw count starts a column early for half the machines deja runs on
+// (#1824). The decomposed spellings are written as escapes on purpose — an
+// editor that normalises the file would otherwise quietly delete the case.
+func TestTheSameNameMeasuresTheSameInEitherNormalForm(t *testing.T) {
+	for _, pair := range []struct{ decomposed, precomposed string }{
+		{"écombining", "écombining"},
+		{"über-server", "über-server"},
+		{"naïve", "naïve"},
+	} {
+		d, p := Columns(pair.decomposed), Columns(pair.precomposed)
+		if d != p {
+			t.Errorf("%q measures %d and %q measures %d", pair.decomposed, d, pair.precomposed, p)
+		}
+		if p != len([]rune(pair.precomposed)) {
+			t.Errorf("the precomposed spelling itself measures %d for %d runes", p, len([]rune(pair.precomposed)))
+		}
+	}
+}
+
+// What stays over-counted, on purpose: a lone combining mark that composes with
+// nothing, a zero-width space, and the CJK marks the wide table finds. Over-
+// counting shortens a line; under-counting runs it past the edge.
+func TestOverCountingStaysWhereItWasDeliberate(t *testing.T) {
+	if got := Columns("a​b"); got != 3 {
+		t.Errorf("a zero-width space now measures differently: %d", got)
+	}
+	if got := Columns("が"); got != 4 {
+		t.Errorf("the CJK combining mark now measures differently: %d", got)
+	}
+	if got := Columns("́"); got != 1 {
+		t.Errorf("a combining mark that composes with nothing measures %d", got)
+	}
+}
+
+// Ordinary text is untouched, which is what keeps the fast path honest.
+func TestPlainTextIsUnchanged(t *testing.T) {
+	for s, want := range map[string]int{
+		"laptop":       6,
+		"数据分片":         8,
+		"🚀rocket":      8,
+		"build-server": 12,
+	} {
+		if got := Columns(s); got != want {
+			t.Errorf("%q measures %d, want %d", s, got, want)
+		}
+	}
+}

--- a/internal/termwidth/width.go
+++ b/internal/termwidth/width.go
@@ -193,6 +193,11 @@ var wideRanges = [...]struct{ lo, hi rune }{
 
 // Cut keeps as much of s as fits in width columns.
 func Cut(s string, width int) string {
+	// Composed for the same reason Columns is, and for one more: cutting a
+	// decomposed string by raw runes can separate a mark from the character it
+	// belongs to, and CutRight then starts a line with an orphan that draws on
+	// whatever precedes it (#1824).
+	s = nfcfold.Compose(s)
 	n := 0
 	for i, r := range s {
 		w := RuneColumns(r)
@@ -208,6 +213,7 @@ func Cut(s string, width int) string {
 // identified by its tail — "…/消费者重平衡" says which project this is, where
 // the first characters of a long prefix rarely do.
 func CutRight(s string, width int) string {
+	s = nfcfold.Compose(s)
 	n := 0
 	runes := []rune(s)
 	for i := len(runes) - 1; i >= 0; i-- {

--- a/internal/termwidth/width.go
+++ b/internal/termwidth/width.go
@@ -7,11 +7,20 @@
 // rather than reflowed.
 package termwidth
 
+import "github.com/vshulcz/deja-vu/internal/nfcfold"
+
 // Columns is how wide a string prints. A CJK character is one rune and two
 // columns.
+//
+// The string is composed first, so the same name measures the same however it
+// was typed: macOS hands paths back decomposed and project names come from
+// paths, so "über-server" measured 12 columns there and 11 everywhere else, and
+// every aligned screen padded it a column short (#1824). Composing is a scan
+// and no allocation for text with no combining mark in it, which is nearly all
+// of what these screens print.
 func Columns(s string) int {
 	n := 0
-	for _, r := range s {
+	for _, r := range nfcfold.Compose(s) {
 		n += RuneColumns(r)
 	}
 	return n


### PR DESCRIPTION
Closes #1824.

`termwidth.Columns` counted a combining mark as a column of its own, so the same name measured differently depending on how it was typed — and macOS hands paths back decomposed, so on a Mac that is the ordinary case:

```
"über-server" decomposed  -> 12 columns
"über-server" precomposed -> 11 columns
```

Every aligned screen reads that number — the brief, the files list, the statusline, the doctor's Sync column since #1822 — and padded the decomposed spelling a column short.

`Columns` now composes before measuring. That fixes exactly the normal-form difference and leaves the deliberate over-counting alone: a zero-width space still measures 1, `か` + U+3099 still measures 4, and a combining mark that composes with nothing still measures 1. `RuneColumns`'s own comment gives the reason — over-counting shortens a line, under-counting runs it past the edge — so this does not touch that.

Cost, 200k iterations on a 132-byte line:

```
BenchmarkColumnsPlain-11         226.3 ns/op    0 B/op   0 allocs/op
BenchmarkColumnsDecomposed-11    718.6 ns/op  480 B/op   3 allocs/op
```

Plain text — nearly everything these screens print — pays a scan and no allocation, because `nfcfold.Compose` returns the string untouched when it holds no combining mark.

Tests: `TestTheSameNameMeasuresTheSameInEitherNormalForm` fails before (11 vs 10, 12 vs 11, 6 vs 5), `TestOverCountingStaysWhereItWasDeliberate` pins what is intentionally unchanged, `TestPlainTextIsUnchanged` pins the ordinary cases.
