### PR TITLE
fix(sync): bound the ssh capture's error like the rest of the sync path

### DIFF
--- a/cmd/deja/sync_remote_error_test.go
+++ b/cmd/deja/sync_remote_error_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -158,5 +159,32 @@ func TestAFailingSSHCaptureCannotWriteOnThisTerminal(t *testing.T) {
 	// The control: what the remote said is still in it.
 	if !strings.Contains(msg, "no space") {
 		t.Errorf("the remote's own report is gone: %q", msg[:min(len(msg), 120)])
+	}
+}
+
+// ssh writes host-key notices and server banners to stderr — text the machine
+// at the other end controls — and the runner folds stderr into its error, so it
+// reaches this terminal too (#1833).
+func TestTheRunnersStderrIsBoundedToo(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the fixture runs a POSIX shell")
+	}
+	// The redirection wraps the whole group: applying it to the last command
+	// only sends the banner to stdout, where the runner drops it, and the test
+	// then passes against unfixed code.
+	hostile := `{ printf 'banner\033[31m\rHACKED '; i=0; while [ $i -lt 400 ]; do printf 'padding '; i=$((i+1)); done; } >&2; exit 1`
+	_, err := sshRunner("sh", "-c", hostile)
+	if err == nil {
+		t.Fatal("the fixture did not fail")
+	}
+	msg := err.Error()
+	if strings.ContainsAny(msg, "\x1b\r") {
+		t.Errorf("the runner's error carries an escape or a rewind: %q", msg[:min(len(msg), 90)])
+	}
+	if len(msg) > remoteEchoMax+200 {
+		t.Errorf("the runner's error is %d bytes", len(msg))
+	}
+	if !strings.Contains(msg, "banner") {
+		t.Errorf("what the other end said is gone: %q", msg[:min(len(msg), 120)])
 	}
 }

--- a/cmd/deja/sync_remote_error_test.go
+++ b/cmd/deja/sync_remote_error_test.go
@@ -120,3 +120,43 @@ func TestAFailingScpCannotWriteOnThisTerminalEither(t *testing.T) {
 		t.Errorf("what the remote said is gone: %q", err.Error())
 	}
 }
+
+// sshCapture is the first thing a pull does, so a remote whose mktemp fails is
+// the most likely of the three failures — and it built its error from the raw
+// host and the raw output (#1833).
+func TestAFailingSSHCaptureCannotWriteOnThisTerminal(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_PEERS_FILE", filepath.Join(tmp, "peers.json"))
+	root := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"v1","cwd":"/proj","timestamp":"2026-08-22T01:00:00Z","message":{"role":"user","content":"the retry budget question"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "a.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	old := sshRunner
+	t.Cleanup(func() { sshRunner = old })
+	sshRunner = func(name string, args ...string) (string, error) {
+		return "mktemp: no space\x1b[31m\rHACKED " + strings.Repeat("padding ", 300), errors.New("exit status 1")
+	}
+	err := syncSSHHost(dir, "peer\x1b[31mX", true, false, false)
+	if err == nil {
+		t.Fatal("the fixture did not fail, so there is no error to inspect")
+	}
+	msg := err.Error()
+	if strings.ContainsAny(msg, "\x1b\r") {
+		t.Errorf("the error carries an escape or a rewind: %q", msg[:min(len(msg), 100)])
+	}
+	if len(msg) > remoteEchoMax+200 {
+		t.Errorf("the error is %d bytes of remote output", len(msg))
+	}
+	// The control: what the remote said is still in it.
+	if !strings.Contains(msg, "no space") {
+		t.Errorf("the remote's own report is gone: %q", msg[:min(len(msg), 120)])
+	}
+}

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -283,7 +283,7 @@ func sshCapture(host, cmd string) (string, error) {
 	out, err := sshRunner("ssh", append(sshOpts(), host, cmd)...)
 	s := strings.TrimSpace(out)
 	if err != nil {
-		return "", fmt.Errorf("ssh %s: %v: %s", host, err, s)
+		return "", fmt.Errorf("ssh %s: %v: %s", hostForEcho(host), err, remoteOutputForEcho(s))
 	}
 	// A remote that still prints something conversational on stdout (motd,
 	// profile chatter) leaves the useful value on the last line.

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -295,10 +295,10 @@ func sshCapture(host, cmd string) (string, error) {
 	// it bare is safe for a path with shell metacharacters. Reject it with a
 	// message that points at the cause instead of failing obscurely later.
 	if s == "" || strings.ContainsAny(s, "'\"\n") {
-		return "", fmt.Errorf("ssh %s: unexpected output %q", host, s)
+		return "", fmt.Errorf("ssh %s: unexpected output %q", hostForEcho(host), s)
 	}
 	if strings.ContainsAny(s, " \t*?$;`&|<>()") {
-		return "", fmt.Errorf("ssh %s: remote temp path %q contains characters scp cannot carry — set TMPDIR on %s to a plain path", host, s, host)
+		return "", fmt.Errorf("ssh %s: remote temp path %q contains characters scp cannot carry — set TMPDIR on %s to a plain path", hostForEcho(host), s, hostForEcho(host))
 	}
 	return s, nil
 }

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -25,7 +25,11 @@ var sshRunner = func(name string, args ...string) (string, error) {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil && strings.TrimSpace(stderr.String()) != "" {
-		return stdout.String(), fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+		// The comment above says what stderr holds — host-key notices and
+		// server banners — which is text the machine at the other end writes.
+		// It reaches this terminal through the error, so it takes the same
+		// bound as the remote's stdout (#1833).
+		return stdout.String(), fmt.Errorf("%w: %s", err, remoteOutputForEcho(strings.TrimSpace(stderr.String())))
 	}
 	return stdout.String(), err
 }


### PR DESCRIPTION
Closes #1833.

`sshCapture` was the one sync error #1819 and #1820 did not reach: it built its message from the raw host and the raw remote output, and `main` prints an error exactly as it is.

```
length=2459 escape=true cr=true
head="ssh peer\x1b[31mX: exit status 1: mktemp: no space\x1b[31m\rHACKED padding padding …"
```

It now uses the same two bounds as the rest of the file — `hostForEcho` for the name, `remoteOutputForEcho` for the output. Nothing here is a command to paste, so unlike the recovery sentence in #1820 the host has no reason to stay raw.

This is the first thing `deja sync ssh <host> --pull` does, so it is the most likely of the remote failures rather than the least.

Test: `TestAFailingSSHCaptureCannotWriteOnThisTerminal` fails before (2459 bytes, escape and rewind present), with a control that the remote's own report — "no space" — survives the bound.

The rest of the sweep the queue asked for, recorded in the issue rather than changed: `install_sync_timer.go` quotes launchctl/systemctl from this machine's own service manager, `mcp.go`'s `want a number, got %s` echoes a JSON value back to a model inside a size-bounded frame, and `update.go` quotes an HTTP status line.
