### PR TITLE
test(nfcfold): tie the composition table to the block the scan looks for

### DIFF
--- a/internal/nfcfold/mark_range_test.go
+++ b/internal/nfcfold/mark_range_test.go
@@ -1,0 +1,28 @@
+package nfcfold
+
+import "testing"
+
+// hasCombining scans one block, U+0300–U+036F, and Compose can only act on a
+// mark the table knows. The two have to describe the same set: a table entry
+// keyed on a mark outside that block would never be reached, because the scan
+// returns early and hands the string back untouched.
+//
+// Today every entry is inside it, which is what makes the narrow scan correct
+// rather than lucky. This says so, so that adding U+0483 or a mark from the
+// extended blocks fails here instead of quietly doing nothing (#1835).
+func TestEveryMarkTheTableUsesIsOneTheScanLooksFor(t *testing.T) {
+	seen := 0
+	for pair := range compose {
+		if mark := pair[1]; !hasCombining(string(mark)) {
+			t.Errorf("the table composes %U with %U, which hasCombining does not look for", pair[0], mark)
+		}
+		seen++
+	}
+	if seen == 0 {
+		t.Fatal("the composition table is empty, so this proves nothing")
+	}
+	// And the scan is not vacuous the other way: ordinary text has no mark.
+	if hasCombining("laptop") || hasCombining("数据分片") {
+		t.Error("hasCombining reports a mark in text that has none")
+	}
+}


### PR DESCRIPTION
Closes #1835.

No behaviour change. The review of #1825 asked what `hasCombining`'s single block misses; the answer, measured against the table, is nothing — all 29 marks it composes are inside U+0300–U+036F, and a mark outside has no entry, so scanning for it would find nothing to do.

The two live in different files with nothing connecting them, though, so an entry added on U+0483 would make `Compose` hand the string straight back and do nothing at all — silently. This walks the table and asserts each mark is one the scan looks for.

Control: adding `{0x0413, 0x0483}` to the table makes it fail with `the table composes U+0413 with U+0483, which hasCombining does not look for`.
