### PR TITLE
fix(npm): the dsh package page rendered in Chinese

### DIFF
--- a/cmd/deja/npm_readme_test.go
+++ b/cmd/deja/npm_readme_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// npm chooses the readme it renders on the package page by looking for README*
+// at the package root, and with two of them it took the translation: the page
+// for dsh-deja served Chinese to everyone, which is a strange thing for an
+// English-speaking user to meet on the page that is supposed to sell the
+// package. One README at the root, translations in a subdirectory.
+func TestPublishedPackagesHaveOneReadmeAtTheRoot(t *testing.T) {
+	for _, pkg := range []string{
+		filepath.Join("..", "..", "extensions", "dsh"),
+		filepath.Join("..", "..", "extensions", "opencode"),
+	} {
+		entries, err := os.ReadDir(pkg)
+		if err != nil {
+			t.Fatalf("%s: %v", pkg, err)
+		}
+		var readmes []string
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasPrefix(strings.ToUpper(e.Name()), "README") {
+				readmes = append(readmes, e.Name())
+			}
+		}
+		if len(readmes) != 1 {
+			t.Errorf("%s has %v at its root; npm picks one of them for the package page and it is not necessarily README.md", filepath.Base(pkg), readmes)
+		}
+
+		// Whatever the allowlist ships has to exist, or the tarball quietly
+		// loses a file that the README links to.
+		b, err := os.ReadFile(filepath.Join(pkg, "package.json"))
+		if err != nil {
+			t.Fatalf("%s: %v", pkg, err)
+		}
+		var manifest struct {
+			Files []string `json:"files"`
+		}
+		if err := json.Unmarshal(b, &manifest); err != nil {
+			t.Fatalf("%s package.json: %v", pkg, err)
+		}
+		for _, f := range manifest.Files {
+			if _, err := os.Stat(filepath.Join(pkg, f)); err != nil {
+				t.Errorf("%s lists %q in files but it is not there", filepath.Base(pkg), f)
+			}
+		}
+	}
+}

--- a/extensions/dsh/README.md
+++ b/extensions/dsh/README.md
@@ -1,6 +1,6 @@
 # dsh-deja
 
-English | [中文](README.zh.md)
+English | [中文](docs/zh.md)
 
 DeepSeek Harness can already search its own sessions — that is what the built-in
 `session-query` subsystem does. This plugin answers the other question: what you

--- a/extensions/dsh/docs/zh.md
+++ b/extensions/dsh/docs/zh.md
@@ -1,6 +1,6 @@
 # dsh-deja
 
-[English](README.md) | 中文
+[English](../README.md) | 中文
 
 DeepSeek Harness 自带的 `session-query` 已经可以检索它自己的会话。这个插件回答的是另一个问题：你在这台机器上**其他**智能体里做过什么。
 

--- a/extensions/dsh/package.json
+++ b/extensions/dsh/package.json
@@ -13,7 +13,7 @@
     "lib.js",
     "cordis.patch.yml",
     "README.md",
-    "README.zh.md",
+    "docs/zh.md",
     "LICENSE"
   ],
   "license": "MIT",


### PR DESCRIPTION
Measuring installs turned up that the harness packages have no organic downloads at all — `dsh-deja` and `opencode-deja` were published on 23 August and have exactly one non-zero day each, the publish-day burst from mirrors. Looking for why, the first thing a prospective user meets is broken.

**https://npmjs.com/package/dsh-deja renders in Chinese.** npm selects the readme it shows by globbing `README*` at the package root, the package ships `README.md` and `README.zh.md`, and it picked the translation:

```
curl -s https://registry.npmjs.org/dsh-deja | jq -r .readme | head -3
# dsh-deja
# [English](README.md) | 中文
```

That is the page every catalogue link, every `npm search` hit and every `dsh plugin` listing lands on. An English-speaking DeepSeek Harness user reads two lines of Chinese and leaves.

The translation moves to `docs/zh.md` — still in the package, still linked both ways — so exactly one `README*` sits at the root and the choice is no longer npm's to make. `npm pack --dry-run` confirms both files ship.

`TestPublishedPackagesHaveOneReadmeAtTheRoot` pins it for both published packages, and also checks that everything named in `files` actually exists, since a missing entry silently drops a file the README links to. Checked by mutation: restoring the second README at the root fails the test.

**This needs a republish to take effect** — the registry keeps the readme captured at publish time, so the fix reaches users with the next release of the package.

Unrelated but noticed while reading: the package README says `dsh plugin --profile web add dsh-deja` while the guide page and `extensions/README.md` say `dsh plugin add dsh-deja`. I have no dsh here to settle which is right, so I have not touched either.