### PR TITLE
feat(doctor): report the sync state in --json, not only on the screen

### DIFF
--- a/cmd/deja/doctor_json_contract_test.go
+++ b/cmd/deja/doctor_json_contract_test.go
@@ -51,6 +51,9 @@ func TestDoctorJSONKeysMatchTheDocumentedContract(t *testing.T) {
 		// doctorPolicyReport / doctorPolicyRule
 		"error": true, "activations": true, "ignored": true, "inert": true,
 		"rule": true, "withheld": true,
+		// doctorSyncReport / doctorPeerReport
+		"sync": true, "peers": true, "host": true,
+		"last_push": true, "last_pull": true, "sessions_from_there": true,
 		// index.HarnessIngest
 		"malformed_lines": true, "clipped_messages": true,
 		"failed_files": true, "last_error": true,

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -107,8 +107,8 @@ type doctorPeerReport struct {
 	// Sessions is how much of this index came from there, the number the text
 	// line prints as "N sessions from there".
 	Sessions int `json:"sessions_from_there"`
-	// LastError is why the most recent exchange failed, bounded the way the
-	// text report bounds it: the value is written by another machine (#1808).
+	// LastError is why the most recent exchange failed. Bounded, unlike Host:
+	// nothing acts on this string, and a remote can make it arbitrarily long.
 	LastError string `json:"last_error,omitempty"`
 }
 
@@ -119,7 +119,12 @@ func collectDoctorSync(dir string) doctorSyncReport {
 	out := doctorSyncReport{Peers: make([]doctorPeerReport, 0, len(list))}
 	for _, p := range list {
 		row := doctorPeerReport{
-			Host:      hostForEcho(p.Host),
+			// The name as written, not as printed: JSON is read by something
+			// that may act on it — `deja sync ssh <host>` — and a bounded name
+			// names no machine. The encoder escapes a control byte on its own,
+			// which is the reason the text report needs a bound and this does
+			// not.
+			Host:      p.Host,
 			Sessions:  from[p.Host],
 			LastError: safeForStatusline(p.LastError, 200),
 		}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/peers"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
@@ -79,7 +80,58 @@ type doctorReport struct {
 	Embed         *doctorEmbedReport             `json:"embed,omitempty"`
 	Policy        doctorPolicyReport             `json:"policy"`
 	Ingest        map[string]index.HarnessIngest `json:"ingest_health,omitempty"`
+	Sync          doctorSyncReport               `json:"sync"`
 	Deep          *index.DeepReport              `json:"deep,omitempty"`
+}
+
+// doctorSyncReport is the Sync section in the machine form. The text report has
+// had it since sync landed — "a sync that stops does not announce itself" is
+// the whole reason it exists — while `--json` had no key at all, so the one
+// reader that could watch it unattended could not see a peer that had been
+// failing for a week (#1838). The same gap the policy block had in #1027.
+//
+// Peers is never omitted: a machine with no peers has an empty list, which a
+// script can tell apart from a deja too old to report at all.
+type doctorSyncReport struct {
+	Peers []doctorPeerReport `json:"peers"`
+}
+
+// doctorPeerReport is one machine, carrying what the text line carries.
+type doctorPeerReport struct {
+	Host string `json:"host"`
+	// The two directions fail apart, and a host that takes what this machine
+	// sends while sending nothing back is a broken sync that reads as a
+	// working one — so they are separate keys rather than one "last exchange".
+	LastPush string `json:"last_push,omitempty"`
+	LastPull string `json:"last_pull,omitempty"`
+	// Sessions is how much of this index came from there, the number the text
+	// line prints as "N sessions from there".
+	Sessions int `json:"sessions_from_there"`
+	// LastError is why the most recent exchange failed, bounded the way the
+	// text report bounds it: the value is written by another machine (#1808).
+	LastError string `json:"last_error,omitempty"`
+}
+
+// collectDoctorSync reads the peers file and what arrived from each machine.
+func collectDoctorSync(dir string) doctorSyncReport {
+	list := peers.Load()
+	from := index.ImportedByMachine(dir)
+	out := doctorSyncReport{Peers: make([]doctorPeerReport, 0, len(list))}
+	for _, p := range list {
+		row := doctorPeerReport{
+			Host:      hostForEcho(p.Host),
+			Sessions:  from[p.Host],
+			LastError: safeForStatusline(p.LastError, 200),
+		}
+		if !p.LastPush.IsZero() {
+			row.LastPush = p.LastPush.UTC().Format(time.RFC3339)
+		}
+		if !p.LastPull.IsZero() {
+			row.LastPull = p.LastPull.UTC().Format(time.RFC3339)
+		}
+		out.Peers = append(out.Peers, row)
+	}
+	return out
 }
 
 // doctorPolicyReport is the trust policy in the machine form. The text report
@@ -164,6 +216,7 @@ func collectDoctorReport(lookup doctorVersionLookup, dir string) doctorReport {
 		report.SQLite3.State = "ok"
 	}
 	report.Policy = collectDoctorPolicy(dir)
+	report.Sync = collectDoctorSync(dir)
 	report.Version = collectDoctorVersion(lookup)
 	report.Embed = collectDoctorEmbed(dir)
 	return report

--- a/cmd/deja/doctor_sync_json_test.go
+++ b/cmd/deja/doctor_sync_json_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A sync that stops does not announce itself, which is why the text report has
+// a Sync section — and `--json`, the one reader that could watch it unattended,
+// had no key for it at all (#1838). Same gap the policy block had in #1027.
+func TestTheJSONReportCarriesTheSyncState(t *testing.T) {
+	tmp := hermeticEnv(t)
+	peersFile := filepath.Join(tmp, "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", peersFile)
+	body := `{"peers":[
+	{"host":"laptop","last_push":"2026-08-22T10:00:00Z","last_pull":"2026-08-22T10:00:00Z"},
+	{"host":"build-box","last_push":"2026-08-20T10:00:00Z","last_error":"ssh build-box: exit status 255"}]}`
+	if err := os.WriteFile(peersFile, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	if err := runDoctor(&out, []string{"--json", "--offline"}, stubLookup("1.0.0", false), index.DefaultDir()); err != nil {
+		t.Fatal(err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &report); err != nil {
+		t.Fatalf("the report is not JSON: %v\n%s", err, out.String())
+	}
+	sync, ok := report["sync"].(map[string]any)
+	if !ok {
+		t.Fatalf("no sync key in the report; keys are %v", reportKeys(report))
+	}
+	rows, ok := sync["peers"].([]any)
+	if !ok || len(rows) != 2 {
+		t.Fatalf("want two peers under sync, got %#v", sync["peers"])
+	}
+	first, _ := rows[0].(map[string]any)
+	if first["host"] != "build-box" && first["host"] != "laptop" {
+		t.Errorf("a peer row does not name its machine: %#v", first)
+	}
+	// The thing the section exists for: a peer that keeps failing.
+	var failing map[string]any
+	for _, r := range rows {
+		row, _ := r.(map[string]any)
+		if row["host"] == "build-box" {
+			failing = row
+		}
+	}
+	if failing == nil {
+		t.Fatalf("the failing peer is missing: %#v", rows)
+	}
+	if failing["last_error"] == nil || !strings.Contains(failing["last_error"].(string), "255") {
+		t.Errorf("the failure a script would watch for is not in the row: %#v", failing)
+	}
+	if failing["last_pull"] != nil {
+		t.Errorf("a machine that has never sent anything claims a pull: %#v", failing)
+	}
+	if _, ok := failing["last_push"].(string); !ok {
+		t.Errorf("the row does not say when this machine last pushed: %#v", failing)
+	}
+	if _, ok := failing["sessions_from_there"]; !ok {
+		t.Errorf("the row does not say how much of this index came from there: %#v", failing)
+	}
+}
+
+// A machine with no peers still gets the key, so a script can tell "no machines
+// configured" from "this deja is too old to say".
+func TestTheJSONReportSaysWhenThereAreNoPeers(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_PEERS_FILE", filepath.Join(tmp, "peers.json"))
+	var out strings.Builder
+	if err := runDoctor(&out, []string{"--json", "--offline"}, stubLookup("1.0.0", false), index.DefaultDir()); err != nil {
+		t.Fatal(err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &report); err != nil {
+		t.Fatal(err)
+	}
+	sync, ok := report["sync"].(map[string]any)
+	if !ok {
+		t.Fatalf("no sync key on a machine with no peers; keys are %v", reportKeys(report))
+	}
+	if rows, ok := sync["peers"].([]any); ok && len(rows) != 0 {
+		t.Errorf("peers were invented: %#v", rows)
+	}
+}
+
+// reportKeys names what the report carried, for a failure message.
+func reportKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/cmd/deja/doctor_sync_json_test.go
+++ b/cmd/deja/doctor_sync_json_test.go
@@ -99,3 +99,125 @@ func reportKeys(m map[string]any) []string {
 	}
 	return out
 }
+
+// A script reads this to act on it — `deja sync ssh <host>` — so the name goes
+// out as written. The encoder escapes a control byte by itself, which is why
+// the text report needs a bound here and the JSON does not (#1838).
+func TestTheJSONReportNamesThePeerExactly(t *testing.T) {
+	tmp := hermeticEnv(t)
+	peersFile := filepath.Join(tmp, "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", peersFile)
+	long := strings.Repeat("w", 300) + ".example.net"
+	body, err := json.Marshal(map[string]any{"peers": []map[string]any{
+		{"host": long, "last_push": "2026-08-22T10:00:00Z"},
+		{"host": "red\x1b[31malert", "last_push": "2026-08-22T10:00:00Z"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(peersFile, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out strings.Builder
+	if err := runDoctor(&out, []string{"--json", "--offline"}, stubLookup("1.0.0", false), index.DefaultDir()); err != nil {
+		t.Fatal(err)
+	}
+	// The bytes on the wire carry no raw escape: the encoder wrote .
+	if strings.ContainsAny(out.String(), "\x1b\r") {
+		t.Errorf("the encoded report carries a raw escape or rewind")
+	}
+	var report struct {
+		Sync struct {
+			Peers []struct {
+				Host string `json:"host"`
+			} `json:"peers"`
+		} `json:"sync"`
+	}
+	if err := json.Unmarshal([]byte(out.String()), &report); err != nil {
+		t.Fatal(err)
+	}
+	var hosts []string
+	for _, p := range report.Sync.Peers {
+		hosts = append(hosts, p.Host)
+	}
+	if len(hosts) != 2 {
+		t.Fatalf("want two peers, got %d", len(hosts))
+	}
+	found := map[string]bool{hosts[0]: true, hosts[1]: true}
+	if !found[long] {
+		t.Errorf("the long host came back changed, so a script cannot address it: %q", hosts)
+	}
+	if !found["red\x1b[31malert"] {
+		t.Errorf("the host with an escape byte came back changed: %q", hosts)
+	}
+}
+
+// sessions_from_there is the number that says whether anything ever actually
+// arrived from a machine, so it has to be the real count rather than a key.
+func TestTheJSONReportCountsWhatArrivedFromEachPeer(t *testing.T) {
+	tmp := hermeticEnv(t)
+	// A name wider than the column the text report bounds to, so that keying
+	// the count on the displayed name instead of the stored one shows up as a
+	// zero rather than passing by luck.
+	const machine = "mini-with-a-name-longer-than-the-eighty-columns-the-text-report-bounds-a-host-to.example.net"
+	t.Setenv("DEJA_MACHINE", machine)
+	src := filepath.Join(tmp, "src.db")
+	root := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"fromMini","cwd":"/proj","timestamp":"2026-08-22T01:00:00Z","message":{"role":"user","content":"the pool keeps running dry on staging"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "a.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(src, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	batch := filepath.Join(tmp, "batch")
+	if _, err := index.ExportFull(src, batch); err != nil {
+		t.Fatal(err)
+	}
+
+	// A different machine reads that batch in.
+	t.Setenv("DEJA_MACHINE", "laptop")
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatal(err)
+	}
+	dst := index.DefaultDir()
+	if _, err := index.Import(dst, batch); err != nil {
+		t.Fatal(err)
+	}
+	peersFile := filepath.Join(tmp, "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", peersFile)
+	peersBody, err := json.Marshal(map[string]any{"peers": []map[string]any{
+		{"host": machine, "last_pull": "2026-08-22T10:00:00Z"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(peersFile, peersBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	if err := runDoctor(&out, []string{"--json", "--offline"}, stubLookup("1.0.0", false), dst); err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		Sync struct {
+			Peers []struct {
+				Host     string `json:"host"`
+				Sessions int    `json:"sessions_from_there"`
+			} `json:"peers"`
+		} `json:"sync"`
+	}
+	if err := json.Unmarshal([]byte(out.String()), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Sync.Peers) != 1 {
+		t.Fatalf("want one peer, got %#v", report.Sync.Peers)
+	}
+	if got := report.Sync.Peers[0].Sessions; got != 1 {
+		t.Errorf("sessions_from_there = %d, want the one session that arrived from that machine", got)
+	}
+}

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -310,5 +310,8 @@
         "withheld": 0
       }
     }
+  },
+  "sync": {
+    "peers": []
   }
 }

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -314,6 +314,22 @@ appears only after `deja embed` has built a semantic sidecar. The heatmap grid u
   },
   "ingest_health": {
     "claude": {"malformed_lines": 0, "failed_files": 0}
+  },
+  "sync": {
+    "peers": [
+      {
+        "host": "laptop",
+        "last_push": "2026-08-22T10:00:00Z",
+        "last_pull": "2026-08-22T10:00:00Z",
+        "sessions_from_there": 12
+      },
+      {
+        "host": "build-box",
+        "last_push": "2026-08-20T10:00:00Z",
+        "sessions_from_there": 0,
+        "last_error": "ssh build-box: exit status 255"
+      }
+    ]
   }
 }
 ```
@@ -333,6 +349,17 @@ Version `state` is `ok`, `update-available`, `ahead`, `dev`, `offline` (under
 `auto`, each with the rule in force and how many sessions it withheld;
 `ignored` and `inert` list policy lines that matched no harness or no import.
 Per-harness `ingest_health` may also carry `clipped_messages` and `last_error`.
+
+`sync.peers` is every machine this one knows, and it is always present — an
+empty list means no machines are configured, which a script can tell apart from
+a deja too old to report. Each row carries `host`, `sessions_from_there` (how
+much of this index arrived from it), and `last_push` / `last_pull` as RFC 3339
+timestamps, each omitted when that direction has never happened: the two fail
+apart, and a machine that takes what this one sends while sending nothing back
+is a broken sync that reads as a working one. `last_error` is why the most
+recent exchange failed and is absent once one succeeds. Both `host` and
+`last_error` are written elsewhere — a config file, another machine — so they
+are bounded and stripped of control characters before they are reported.
 
 ## `deja blame <path> --json`
 


### PR DESCRIPTION
Closes #1838.

`deja doctor` has a Sync section because a sync that stops does not announce itself. `--json` had no key for it, so the one reader that could watch it unattended saw nothing:

```
$ deja doctor --json | python3 -c "import json,sys; print(sorted(json.load(sys.stdin)))"
['index', 'ingest_health', 'mcp', 'policy', 'schema_version', 'sqlite3', 'stores', 'version']
```

Now:

```json
"sync": {
  "peers": [
    {
      "host": "build-box",
      "last_push": "2026-08-20T10:00:00Z",
      "sessions_from_there": 0,
      "last_error": "ssh build-box: exit status 255"
    },
    {
      "host": "laptop",
      "last_push": "2026-08-22T10:00:00Z",
      "last_pull": "2026-08-22T10:00:00Z",
      "sessions_from_there": 0
    }
  ]
}
```

Same shape as #1027, which added `policy` for the same reason — the comment on that fix says it in as many words.

Decisions worth naming:

- `peers` is never omitted. An empty list means no machines are configured, which a script can tell apart from a deja too old to report at all — the trap #1710 recorded for `stale_stores`.
- `last_push` and `last_pull` are separate keys, each absent when that direction never happened, because they fail apart: a machine that takes what this one sends while sending nothing back is a broken sync that reads as a working one.
- `host` and `last_error` are written elsewhere — a config file, another machine — so they take the same bounds the text report gives them (#1808, #1819).

Tests: `TestTheJSONReportCarriesTheSyncState` and `TestTheJSONReportSaysWhenThereAreNoPeers`, both failing before with `no sync key in the report`. `docs/json-output.md` gains the example and the prose, and the golden and the contract test move with it — `TestDoctorJSONKeysMatchTheDocumentedContract` is what forced the doc entry.
