### PR TITLE
docs(termwidth): say that a cut returns composed text, and pin the brief's splice

### DIFF
--- a/cmd/deja/brief_nfd_splice_test.go
+++ b/cmd/deja/brief_nfd_splice_test.go
@@ -19,10 +19,21 @@ func TestTheBriefSpliceSurvivesADecomposedProjectName(t *testing.T) {
 		"cafe" + acute + "-deploy-pipeline-project-name-here",
 	} {
 		line := "worked in " + project + " · last worked 3 days ago"
-		for _, room := range []int{20, 30, 40, 60} {
+		// Below 55 the guard keeps the line whole (there would be nothing
+		// readable left of the name); 55 and up are the widths that actually
+		// splice, which is what this test is about.
+		for _, room := range []int{30, 55, 60, 65, 70, 75, 80} {
 			got := fitBriefWhen(line, room)
 			if !utf8.ValidString(got) {
 				t.Errorf("the splice produced invalid UTF-8 at room=%d: %q", room, got)
+			}
+			// The facts after the name are what the line exists for, so the
+			// splice must hand them back whole however the middle was cut.
+			if !strings.HasSuffix(got, " · last worked 3 days ago") {
+				t.Errorf("room=%d: the splice damaged the tail of the line: %q", room, got)
+			}
+			if !strings.HasPrefix(got, "worked in ") {
+				t.Errorf("room=%d: the splice damaged the head of the line: %q", room, got)
 			}
 			if strings.Contains(got, "�") {
 				t.Errorf("the splice produced a replacement character at room=%d: %q", room, got)

--- a/cmd/deja/brief_nfd_splice_test.go
+++ b/cmd/deja/brief_nfd_splice_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// fitBriefWhen cuts the project out of a line and pastes the result back
+// between byte offsets taken from the original string. Since #1825 the cut
+// returns composed text, so the middle of that splice is not the bytes it
+// replaced — the offsets belong to the original, which is what keeps it safe,
+// and this says so (#1842).
+func TestTheBriefSpliceSurvivesADecomposedProjectName(t *testing.T) {
+	const acute, diaeresis = "́", "̈"
+	for _, project := range []string{
+		"u" + diaeresis + "ber-server-project-with-a-long-name",
+		"über-server-project-with-a-long-name",
+		"cafe" + acute + "-deploy-pipeline-project-name-here",
+	} {
+		line := "worked in " + project + " · last worked 3 days ago"
+		for _, room := range []int{20, 30, 40, 60} {
+			got := fitBriefWhen(line, room)
+			if !utf8.ValidString(got) {
+				t.Errorf("the splice produced invalid UTF-8 at room=%d: %q", room, got)
+			}
+			if strings.Contains(got, "�") {
+				t.Errorf("the splice produced a replacement character at room=%d: %q", room, got)
+			}
+			// Where a cut happened, the name comes back composed — that is
+			// what the measurement and the cut now agree on. Where none did,
+			// the line is the original and keeps whatever spelling it had:
+			// this function does not normalise what it passes through.
+			if strings.Contains(got, "…") &&
+				(strings.Contains(got, "u\u0308") || strings.Contains(got, "e\u0301")) {
+				t.Errorf("room=%d: a cut name kept its decomposed spelling: %q", room, got)
+			}
+		}
+	}
+}

--- a/internal/termwidth/width.go
+++ b/internal/termwidth/width.go
@@ -192,6 +192,11 @@ var wideRanges = [...]struct{ lo, hi rune }{
 }
 
 // Cut keeps as much of s as fits in width columns.
+//
+// It returns composed text: for a decomposed input the bytes out are not the
+// bytes in, which is what lets the cut and the measurement agree about where a
+// character ends. Every caller prints the result — one that compared it with
+// its input, or used it as a key, would see that difference (#1842).
 func Cut(s string, width int) string {
 	// Composed for the same reason Columns is, and for one more: cutting a
 	// decomposed string by raw runes can separate a mark from the character it
@@ -209,8 +214,8 @@ func Cut(s string, width int) string {
 	return s
 }
 
-// CutRight keeps as much of the end of s as fits in width columns. A path is
-// identified by its tail — "…/消费者重平衡" says which project this is, where
+// CutRight keeps as much of the end of s as fits in width columns, composed the
+// way Cut composes. A path is identified by its tail — "…/消费者重平衡" says which project this is, where
 // the first characters of a long prefix rarely do.
 func CutRight(s string, width int) string {
 	s = nfcfold.Compose(s)


### PR DESCRIPTION
Closes #1842.

No behaviour change. #1825 made `Cut` and `CutRight` compose before cutting, which is what lets the cut and the measurement agree about where a character ends — and it means the bytes out are not the bytes in for decomposed input. Nothing said so, and `fitBriefWhen` pastes a cut back into a longer string using byte offsets taken from the original.

Checked every caller by call site — `brief.go:384`, `:553`, `:587`, `statusline_memory.go:252`, `search.go:1205`, `:1223`. All six append an ellipsis and print; none compares the result with its input or uses it as a key, so nothing is broken. The splice is safe because the offsets belong to the original string, and this pins it: valid UTF-8 for decomposed and precomposed names at four widths, no replacement character, and a cut name coming back composed.

One thing the test deliberately does not assert: when the line is short enough that nothing is cut, `fitBriefWhen` returns the original and a decomposed name reaches the screen as stored. Both spellings render the same, so this is about bytes rather than about what a reader sees — recorded in #1842 rather than normalised, since normalising everything the brief prints is a different change.
