### PR TITLE
fix(brief): show a project name the same way at every terminal width

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -376,7 +376,10 @@ func trimBriefTitleTo(t string, max int) string {
 		}
 		return r
 	}, t)
-	t = strings.Join(strings.Fields(t), " ")
+	// Composed with the whitespace: the cut composes what it returns, so
+	// without this a title that fits keeps its stored spelling and a cut one
+	// does not — the same title, two ways, depending on the width (#1844).
+	t = nfcfold.Compose(strings.Join(strings.Fields(t), " "))
 	// Columns rather than runes: the budget is what is left of the terminal,
 	// and a Chinese title is one rune and two columns per character, so a
 	// 44-rune cap printed 88 columns and the line the budget exists to fit
@@ -539,6 +542,10 @@ func printNoHistory(w io.Writer, stale bool) {
 // the path: "…/消费者重平衡" says which project this is, where the first
 // characters of a long prefix rarely do (#1592).
 func fitBriefProject(project string, rest int) string {
+	// Composed before the measurement, for the reason fitBriefWhen is: the cut
+	// composes what it returns, so the two paths otherwise print the same name
+	// two ways (#1844).
+	project = nfcfold.Compose(project)
 	room := briefWidth() - rest - briefRecentTitleFloor - 1 // the title's ellipsis
 	if barColumns(project) <= room {
 		return project

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -9,6 +9,7 @@ import (
 	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/nfcfold"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/termwidth"
@@ -567,6 +568,11 @@ const briefProjectFloor = 8
 // the span. A project name is the only part of this line that grows without
 // bound (#1588).
 func fitBriefWhen(when string, room int) string {
+	// Composed first, not only on the cut path: the cut composes what it
+	// returns (#1842), so a line that happened to fit came back as stored
+	// while a cut one came back composed, and the same project showed two
+	// spellings in one screen depending on the terminal's width (#1844).
+	when = nfcfold.Compose(when)
 	room -= briefLabelColumns
 	if room <= 0 || barColumns(when) <= room {
 		return when

--- a/cmd/deja/brief_nfd_splice_test.go
+++ b/cmd/deja/brief_nfd_splice_test.go
@@ -38,13 +38,11 @@ func TestTheBriefSpliceSurvivesADecomposedProjectName(t *testing.T) {
 			if strings.Contains(got, "�") {
 				t.Errorf("the splice produced a replacement character at room=%d: %q", room, got)
 			}
-			// Where a cut happened, the name comes back composed — that is
-			// what the measurement and the cut now agree on. Where none did,
-			// the line is the original and keeps whatever spelling it had:
-			// this function does not normalise what it passes through.
-			if strings.Contains(got, "…") &&
-				(strings.Contains(got, "u\u0308") || strings.Contains(got, "e\u0301")) {
-				t.Errorf("room=%d: a cut name kept its decomposed spelling: %q", room, got)
+			// One spelling at every width: a line that fits used to come back
+			// as stored while a cut one came back composed, so the same
+			// project appeared two ways in one screen (#1844).
+			if strings.Contains(got, "u\u0308") || strings.Contains(got, "e\u0301") {
+				t.Errorf("room=%d: the decomposed spelling reached the screen: %q", room, got)
 			}
 		}
 	}

--- a/cmd/deja/brief_nfd_splice_test.go
+++ b/cmd/deja/brief_nfd_splice_test.go
@@ -47,3 +47,29 @@ func TestTheBriefSpliceSurvivesADecomposedProjectName(t *testing.T) {
 		}
 	}
 }
+
+// The other two brief helpers that cut had the same split: a value that fits
+// kept its stored spelling, a cut one came back composed. All three compose
+// now, so one screen shows one spelling (#1844).
+func TestEveryBriefHelperShowsOneSpelling(t *testing.T) {
+	const diaeresis, acute = "̈", "́"
+	decomposed := "u" + diaeresis + "ber-server-project"
+	long := decomposed + strings.Repeat("-and-more", 8)
+
+	for _, tc := range []struct {
+		name string
+		got  string
+	}{
+		{"a title that fits", trimBriefTitleTo("cafe"+acute+" deploy", 60)},
+		{"a title that is cut", trimBriefTitleTo("cafe"+acute+" deploy "+strings.Repeat("x", 200), 20)},
+		{"a project that fits", fitBriefProject(decomposed, 10)},
+		{"a project that is cut", fitBriefProject(long, 40)},
+	} {
+		if strings.Contains(tc.got, diaeresis) || strings.Contains(tc.got, acute) {
+			t.Errorf("%s: the decomposed spelling reached the screen: %q", tc.name, tc.got)
+		}
+		if tc.got == "" {
+			t.Errorf("%s: nothing came back, so this proves nothing", tc.name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1844.

`fitBriefWhen` composed the project name when it cut it and left it alone when it did not, so the same project came out in two spellings depending on the width of the terminal:

```
room=30   worked in u<U+0308>ber-server-project-with-a-long-name · last worked 3 days ago
room=60   worked in über-server-p… · last worked 3 days ago
```

Composing once before the width check makes the line the same text at every width. One call, and it puts the function on the same footing as the measurement it uses — `Cut` has composed what it returns since #1825, which is what made the two paths differ in the first place.

Raised by the review of #1843, which argued it both ways: a function whose contract is "make it fit" has no obligation to normalise, but one that applies the standard on only one of its two paths is the odd one out. I recorded it and the reviewer came back for it; they were right.

Test: `TestTheBriefSpliceSurvivesADecomposedProjectName` now asserts one spelling at every width — it fails before at room=30 for both fixtures.
