### PR TITLE
fix(sync): bound the batch file name an import error reports

### DIFF
--- a/internal/index/import_name_test.go
+++ b/internal/index/import_name_test.go
@@ -1,0 +1,57 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The batch file's name comes from the sending machine — scp copies whatever
+// matched over there — and the import built its errors out of it raw, so a
+// name with an escape byte in it rewrote the screen of whoever was watching a
+// sync fail (#1847).
+func TestAnImportErrorDoesNotHandTheTerminalAPeersFileName(t *testing.T) {
+	dir := t.TempDir()
+	batch := filepath.Join(dir, "batch")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	name := "deja-sync-\x1b[31mHACK\rrewound-" + strings.Repeat("w", 120) + ".jsonl"
+	if err := os.WriteFile(filepath.Join(batch, name), []byte("{not a record}\n"), 0o644); err != nil {
+		t.Skipf("the filesystem refused the name: %v", err)
+	}
+
+	_, err := Import(filepath.Join(dir, "index.db"), batch)
+	if err == nil {
+		t.Fatal("a batch of nonsense imported cleanly, so there is no error to inspect")
+	}
+	msg := err.Error()
+	if strings.ContainsAny(msg, "\x1b\r") {
+		t.Errorf("the error carries an escape or a rewind: %q", msg[:min(len(msg), 120)])
+	}
+	// The control: the reader can still tell which file failed.
+	if !strings.Contains(msg, "deja-sync-") || !strings.Contains(msg, ".jsonl") {
+		t.Errorf("the error no longer names the file at all: %q", msg[:min(len(msg), 120)])
+	}
+}
+
+// An ordinary batch name is untouched, so the bound is not paid by every sync.
+func TestAnOrdinaryBatchNameIsReportedAsItIs(t *testing.T) {
+	dir := t.TempDir()
+	batch := filepath.Join(dir, "batch")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const name = "deja-sync-9f2a1b-20260825T090000Z.jsonl"
+	if err := os.WriteFile(filepath.Join(batch, name), []byte("{not a record}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Import(filepath.Join(dir, "index.db"), batch)
+	if err == nil {
+		t.Fatal("a batch of nonsense imported cleanly")
+	}
+	if !strings.Contains(err.Error(), name) {
+		t.Errorf("an ordinary name was altered: %q", err.Error())
+	}
+}

--- a/internal/index/import_name_test.go
+++ b/internal/index/import_name_test.go
@@ -55,3 +55,33 @@ func TestAnOrdinaryBatchNameIsReportedAsItIs(t *testing.T) {
 		t.Errorf("an ordinary name was altered: %q", err.Error())
 	}
 }
+
+// The count and the list have to agree: one file whose name carries the
+// separator used to read as three entries under a sentence that said one
+// (#1847).
+func TestOneFileCannotReadAsSeveral(t *testing.T) {
+	dir := t.TempDir()
+	batch := filepath.Join(dir, "batch")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const name = "one.jsonl; two.jsonl; three.jsonl"
+	if err := os.WriteFile(filepath.Join(batch, name), []byte("{not a record}\n"), 0o644); err != nil {
+		t.Skipf("the filesystem refused the name: %v", err)
+	}
+	_, err := Import(filepath.Join(dir, "index.db"), batch)
+	if err == nil {
+		t.Fatal("a batch of nonsense imported cleanly")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "from 1 file") {
+		t.Fatalf("the fixture did not produce the single-file sentence: %q", msg)
+	}
+	// One quoted name, whatever it contains.
+	if strings.Count(msg, `"`) != 2 {
+		t.Errorf("the name is not delimited, so it can read as several: %q", msg)
+	}
+	if !strings.Contains(msg, `"one.jsonl; two.jsonl; three.jsonl"`) {
+		t.Errorf("the name was altered rather than delimited: %q", msg)
+	}
+}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -709,6 +709,16 @@ func restoreMap[V any](live, saved map[string]V) {
 	}
 }
 
+// batchName is how a batch file is named on screen. The name comes from the
+// machine that sent it — scp copies whatever matched over there — and these
+// sentences reach a terminal through main, which prints an error as it is, so
+// an escape byte in a name rewrote the line of whoever was watching a sync
+// fail (#1847). The directory beside it has been sanitised since it was first
+// printed; the file was not.
+func batchName(path string) string {
+	return search.SafeLine(filepath.Base(path))
+}
+
 // skippedError reports the files an import could not read, after the ones it
 // could are already in. Callers print the count they imported and this
 // alongside it.
@@ -717,9 +727,9 @@ func skippedError(skipped []string) error {
 		return nil
 	}
 	if len(skipped) == 1 {
-		return fmt.Errorf("nothing was imported from 1 file: %s", skipped[0])
+		return fmt.Errorf("nothing was imported from 1 file: %s", search.SafeLine(skipped[0]))
 	}
-	return fmt.Errorf("nothing was imported from %d files: %s", len(skipped), strings.Join(skipped, "; "))
+	return fmt.Errorf("nothing was imported from %d files: %s", len(skipped), search.SafeLine(strings.Join(skipped, "; ")))
 }
 
 func initEmptyIndex(dir string) error {
@@ -794,9 +804,9 @@ func readSyncFile(path string, fn func(SyncRecord) error) error {
 			// file is still refused whole: a half-imported transfer is worse
 			// than one the reader can retry (#891).
 			if !next && torn {
-				return fmt.Errorf("%s looks truncated at line %d — the transfer may have been cut off; fetch the batch again", filepath.Base(path), line)
+				return fmt.Errorf("%s looks truncated at line %d — the transfer may have been cut off; fetch the batch again", batchName(path), line)
 			}
-			return fmt.Errorf("%s line %d is not a record deja wrote: %w", filepath.Base(path), line, err)
+			return fmt.Errorf("%s line %d is not a record deja wrote: %w", batchName(path), line, err)
 		}
 		// Metadata from a batch is another machine's text: it lands in the
 		// project label and the harness tag, which are rendered into result

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -804,9 +804,9 @@ func readSyncFile(path string, fn func(SyncRecord) error) error {
 			// file is still refused whole: a half-imported transfer is worse
 			// than one the reader can retry (#891).
 			if !next && torn {
-				return fmt.Errorf("%s looks truncated at line %d — the transfer may have been cut off; fetch the batch again", batchName(path), line)
+				return fmt.Errorf("%q looks truncated at line %d — the transfer may have been cut off; fetch the batch again", batchName(path), line)
 			}
-			return fmt.Errorf("%s line %d is not a record deja wrote: %w", batchName(path), line, err)
+			return fmt.Errorf("%q line %d is not a record deja wrote: %w", batchName(path), line, err)
 		}
 		// Metadata from a batch is another machine's text: it lands in the
 		// project label and the harness tag, which are rendered into result

--- a/internal/index/sync_partial_test.go
+++ b/internal/index/sync_partial_test.go
@@ -46,7 +46,9 @@ func TestImportKeepsGoingPastAFileItCannotRead(t *testing.T) {
 		t.Error("the good file was held hostage to the broken one")
 	}
 	got := err.Error()
-	if !strings.Contains(got, "a-broken.jsonl line 2") {
+	// The name is quoted since #1847, so one carrying "; " cannot read as
+	// several files under a sentence that says one.
+	if !strings.Contains(got, `"a-broken.jsonl" line 2`) {
 		t.Errorf("error does not say where: %q", got)
 	}
 	if !strings.Contains(got, "nothing was imported from 1 file") {


### PR DESCRIPTION
Closes #1847.

The sync path bounds the peer's stdout (#1819, #1833). One layer deeper, `index.Import` built its errors out of the batch file's *name*, and the name comes from the sending machine — scp copies whatever `*.jsonl` matched over there:

```
len=288 escape=true cr=true
msg="nothing was imported from 1 file: deja-sync-\x1b[31mHACK\rrewound-wwwww…w.jsonl line 1 is n…"
```

`main` prints an error as it is, so that reaches the terminal of whoever is watching a sync fail.

Four sentences take the same `search.SafeLine` the directory beside them has taken since it was first printed — the two "nothing was imported from …" and the two per-line ones. An ordinary batch name is untouched, which the second test pins.

Found by walking the call graph rather than grepping: iteration #1833's sweep stopped at the sync package's own errors and never followed `index.Import` out of it.

Tests: `TestAnImportErrorDoesNotHandTheTerminalAPeersFileName` (fails before, with a control that the reader can still tell which file failed) and `TestAnOrdinaryBatchNameIsReportedAsItIs`.
