### PR TITLE
chore(dsh): 0.20.4, to republish with the English package page

### DIFF
--- a/extensions/dsh/package.json
+++ b/extensions/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-deja",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "Brings the session history of nineteen other coding agents into DeepSeek Harness: recall, session digest and per-file history tools over a local index, plus optional automatic recall before each step.",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
The readme fix in #1837 only reaches npmjs.com through a publish — the registry keeps the readme captured at publish time, so `dsh-deja` still renders in Chinese until a new version goes out.

Patch bump so the version in git matches what is on the registry after publishing. No code change: the diff is one line, and `npm pack --dry-run` shows the same seven files with `README.md` at the root and the translation under `docs/`.