### PR TITLE
fix(index): count the empty transcripts of the last build, not of the process

### DIFF
--- a/internal/index/empty_counter_test.go
+++ b/internal/index/empty_counter_test.go
@@ -96,3 +96,53 @@ func TestTheCollisionCounterBelongsToTheLastBuild(t *testing.T) {
 		t.Errorf("a build with no collisions reported %d", n)
 	}
 }
+
+// An incremental pass is a build too. Two of them with nobody reading in
+// between used to report the first one's colliding ids alongside the second's
+// (#1850) — the reviewer of #1851 found this path after the two full ones were
+// fixed.
+func TestAnIncrementalPassCountsOnlyItsOwn(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+	t.Setenv("USERPROFILE", home)
+	root := filepath.Join(home, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	proj := filepath.Join(root, "-tmp-c")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(id string) string {
+		return `{"type":"user","sessionId":"` + id + `","cwd":"/tmp/c","timestamp":"2026-08-01T10:00:00Z","message":{"role":"user","content":"pool exhausted"}}` + "\n"
+	}
+	pair := func(id string) {
+		t.Helper()
+		for _, half := range []string{"-one.jsonl", "-two.jsonl"} {
+			if err := os.WriteFile(filepath.Join(proj, id+half), []byte(line(id)), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	dir := filepath.Join(home, "idx")
+
+	pair("dupa")
+	pair("dupb")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := ReportCollisions(); n != 2 {
+		t.Fatalf("the full build found %d colliding ids, want the 2 it was given", n)
+	}
+
+	// Two incremental passes, and nothing reads between them.
+	pair("dupc")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	pair("dupd")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := ReportCollisions(); n != 1 {
+		t.Errorf("the last incremental reported %d colliding ids, want its own 1", n)
+	}
+}

--- a/internal/index/empty_counter_test.go
+++ b/internal/index/empty_counter_test.go
@@ -1,0 +1,58 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// buildWithEmpties writes one real transcript and n empty ones into a fresh
+// store, builds it, and returns the index directory.
+func buildWithEmpties(t *testing.T, empties int) string {
+	t.Helper()
+	home := t.TempDir()
+	setHome(t, home)
+	t.Setenv("USERPROFILE", home)
+	root := filepath.Join(home, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	proj := filepath.Join(root, "-tmp-g")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	real := `{"type":"user","sessionId":"real","cwd":"/tmp/g","timestamp":"2026-08-01T10:00:00Z","message":{"role":"user","content":"pool exhausted"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "real.jsonl"), []byte(real), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for i := range empties {
+		id := string(rune('a' + i))
+		body := `{"type":"user","sessionId":"empty` + id + `","cwd":"/tmp/g","timestamp":"2026-08-01T08:00:00Z","message":{"role":"user","content":"   "}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, "empty"+id+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(home, "idx")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The counter says "since the last build" and counted since the last read, so a
+// second build in one process reported its own empty transcripts plus whatever
+// an earlier build had left behind (#1850). One process is one build for the
+// CLI, which is why it never showed there — the test binary and the server's
+// warmup are where several builds share a process.
+func TestTheEmptyCounterBelongsToTheLastBuild(t *testing.T) {
+	buildWithEmpties(t, 2)
+	// Deliberately not read: the leftover is what the next build must not
+	// inherit.
+	buildWithEmpties(t, 1)
+	if n := ReportEmptySessions(); n != 1 {
+		t.Errorf("the second build reported %d empty transcripts, want its own 1", n)
+	}
+	// And a build with none reports none, rather than the previous build's.
+	buildWithEmpties(t, 0)
+	if n := ReportEmptySessions(); n != 0 {
+		t.Errorf("a build with nothing empty reported %d", n)
+	}
+}

--- a/internal/index/empty_counter_test.go
+++ b/internal/index/empty_counter_test.go
@@ -56,3 +56,43 @@ func TestTheEmptyCounterBelongsToTheLastBuild(t *testing.T) {
 		t.Errorf("a build with nothing empty reported %d", n)
 	}
 }
+
+// The collision counter sits beside the empty one and had the same flaw: a
+// second build in one process reported its own colliding ids plus the ones an
+// earlier build had counted (#1850).
+func TestTheCollisionCounterBelongsToTheLastBuild(t *testing.T) {
+	build := func(pairs int) {
+		home := t.TempDir()
+		setHome(t, home)
+		t.Setenv("USERPROFILE", home)
+		root := filepath.Join(home, "claude")
+		t.Setenv("DEJA_CLAUDE_ROOT", root)
+		proj := filepath.Join(root, "-tmp-c")
+		if err := os.MkdirAll(proj, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for i := range pairs {
+			id := "dup" + string(rune('a'+i))
+			line := `{"type":"user","sessionId":"` + id + `","cwd":"/tmp/c","timestamp":"2026-08-01T10:00:00Z","message":{"role":"user","content":"pool exhausted"}}` + "\n"
+			// One id in two files is what makes a collision.
+			for _, half := range []string{"-one.jsonl", "-two.jsonl"} {
+				if err := os.WriteFile(filepath.Join(proj, id+half), []byte(line), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+		if err := Ensure(filepath.Join(home, "idx"), "", false, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	build(2)
+	// Deliberately not read.
+	build(1)
+	if n := ReportCollisions(); n != 1 {
+		t.Errorf("the second build reported %d collisions, want its own 1", n)
+	}
+	build(0)
+	if n := ReportCollisions(); n != 0 {
+		t.Errorf("a build with no collisions reported %d", n)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -355,8 +355,9 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 }
 
 func rebuildWithTombstones(dir string, harness string, scope string, files map[string]FileState, progress io.Writer, dead map[string]bool) error {
-	// This build's count, not the process's: see writeSessionsWithSync (#1850).
+	// This build's counts, not the process's: see writeSessionsWithSync (#1850).
 	emptied.Store(0)
+	collisions.Store(0)
 	lastIngestFiles = len(files)
 	initialBuild := !HasManifest(dir)
 	writtenMessages := 0
@@ -721,12 +722,14 @@ func writeSessions(tmp, dir string, ss []model.Session, files map[string]FileSta
 }
 
 func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string]FileState, scope string, imp importedState) error {
-	// The counter belongs to this build. Draining it only on read made
+	// The counters belong to this build. Draining them only on read made
 	// "since the last build" true only when the last read was the last build:
 	// a second build in one process reported its own empty transcripts plus
-	// whatever an earlier one left behind (#1850). One process is one build
-	// for the CLI, which is why it showed in the test binary first.
+	// whatever an earlier one left behind (#1850), and the collision counter
+	// beside it did the same. One process is one build for the CLI, which is
+	// why it showed in the test binary first.
 	emptied.Store(0)
+	collisions.Store(0)
 	initialBuild := !HasManifest(dir)
 	writtenMessages := 0
 	lastIngestFiles = len(files)

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -355,6 +355,8 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 }
 
 func rebuildWithTombstones(dir string, harness string, scope string, files map[string]FileState, progress io.Writer, dead map[string]bool) error {
+	// This build's count, not the process's: see writeSessionsWithSync (#1850).
+	emptied.Store(0)
 	lastIngestFiles = len(files)
 	initialBuild := !HasManifest(dir)
 	writtenMessages := 0
@@ -704,8 +706,10 @@ func dropEmptySessions(m *Manifest, wrote map[string]bool) {
 	}
 }
 
-// ReportEmptySessions returns how many transcripts held nothing to index since
-// the last build, and clears the counter. The parse count and the indexed
+// ReportEmptySessions returns how many transcripts held nothing to index in the
+// last build, and clears the counter. The build zeroes it as it starts writing,
+// so a caller reads that build's number whether or not anyone read the one
+// before (#1850). The parse count and the indexed
 // count differ by exactly this, and the run is where someone is looking at
 // both numbers.
 func ReportEmptySessions() int {
@@ -717,6 +721,12 @@ func writeSessions(tmp, dir string, ss []model.Session, files map[string]FileSta
 }
 
 func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string]FileState, scope string, imp importedState) error {
+	// The counter belongs to this build. Draining it only on read made
+	// "since the last build" true only when the last read was the last build:
+	// a second build in one process reported its own empty transcripts plus
+	// whatever an earlier one left behind (#1850). One process is one build
+	// for the CLI, which is why it showed in the test binary first.
+	emptied.Store(0)
 	initialBuild := !HasManifest(dir)
 	writtenMessages := 0
 	lastIngestFiles = len(files)

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2006,6 +2006,9 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		return nil
 	}
 	var replacements []model.Session
+	// This pass's counts, like every other build path (#1850).
+	emptied.Store(0)
+	collisions.Store(0)
 	lastIngestFiles = len(changed)
 	for p, f := range changed {
 		ss, err := parseChangedFile(harness, p, old.Files[p])
@@ -2292,6 +2295,11 @@ func canAppendIncremental(changed map[string]FileState, old map[string]FileState
 }
 
 func appendIncremental(dir, harness, scope string, old Manifest, files map[string]FileState, changed map[string]FileState) (int, int, error) {
+	// This pass's counts, like the two full paths: an incremental that nobody
+	// read between builds otherwise reported its own colliding ids plus the
+	// ones before it (#1850).
+	emptied.Store(0)
+	collisions.Store(0)
 	lastIngestFiles = len(changed)
 	rf, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {


### PR DESCRIPTION
Closes #1850.

`ReportEmptySessions` promised "since the last build" and delivered "since the last read": nothing zeroed the counter when a build began, so a second build in one process reported its own empty transcripts plus whatever an earlier one had left behind.

```
$ go test ./internal/index/ -run SessionsWithNothingToIndex -count=2
--- FAIL: TestSessionsWithNothingToIndexAreNotCounted
    empty_transcripts reported = 2, want 1
```

That reproduced on the base branch — it surfaced while answering the review of #1848, where at first it looked like that PR had broken the package. `./internal/index -count=2` and `-count=3` are clean now.

Both build paths zero it as they start writing — `rebuildWithTombstones` and `writeSessionsWithSync` — so a caller reads that build's number whether or not anyone read the one before. The CLI never saw this because one `deja index` run is one process, one build, one read; the test binary and the server's warmup are where several builds share a process.

Test: `TestTheEmptyCounterBelongsToTheLastBuild` builds a store with two empty transcripts, deliberately does not read the counter, builds another with one, and expects 1 — it reports 3 before the fix. It also checks a build with none reports none rather than the previous build's number.
