### PR TITLE
fix(install): the PATH offer was behind a condition curl | sh can never meet

### DIFF
--- a/cmd/deja/install_sh_prompt_test.go
+++ b/cmd/deja/install_sh_prompt_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The documented install is `curl -fsSL … | sh`, which makes stdin the script
+// itself: [ -t 0 ] is false on a real terminal, so a guard written that way puts
+// the PATH offer behind a condition no reader of the README can satisfy. Every
+// one of them gets ACTION REQUIRED and edits a dotfile by hand instead — on
+// macOS, where ~/.local/bin is not on PATH by default, that is the step between
+// installing deja and being able to run it.
+//
+// The offer reads from the controlling terminal instead. No terminal at all —
+// CI, a Dockerfile — still falls through to the message and never blocks.
+func TestInstallerAsksThroughTheControllingTerminal(t *testing.T) {
+	b, err := os.ReadFile("../../install.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Comments are allowed to name the old condition; code is not.
+	var code []string
+	for _, line := range strings.Split(string(b), "\n") {
+		if trimmed := strings.TrimSpace(line); !strings.HasPrefix(trimmed, "#") {
+			code = append(code, line)
+		}
+	}
+	src := strings.Join(code, "\n")
+
+	if strings.Contains(src, "[ -t 0 ]") {
+		t.Error("install.sh gates something on stdin being a terminal; under `curl | sh` it never is")
+	}
+	if !strings.Contains(src, "read -r answer < /dev/tty") {
+		t.Error("the PATH offer does not read from /dev/tty, so a piped install cannot answer it")
+	}
+	// Prompting with no terminal to prompt on would hang a CI install.
+	if !strings.Contains(src, `[ -t 1 ] && [ -r /dev/tty ]`) {
+		t.Error("the offer is not guarded by a writable terminal and a readable /dev/tty")
+	}
+}

--- a/install.sh
+++ b/install.sh
@@ -99,9 +99,14 @@ case ":$PATH:" in
       *) rc="$HOME/.profile" ;;
     esac
     line="export PATH=$dest_dir:\$PATH"
-    if [ "$yes" -eq 0 ] && [ -t 0 ] && [ -t 1 ]; then
+    # stdin is the script itself under the documented `curl … | sh`, so a
+    # guard on stdin being a terminal can never be true for anyone following
+    # the README. The controlling terminal is still there, and reading the
+    # answer from it is what makes the offer reachable at all. No terminal
+    # (CI, a Dockerfile) falls through to the message and never blocks.
+    if [ "$yes" -eq 0 ] && [ -t 1 ] && [ -r /dev/tty ]; then
       printf 'deja install: append %s to %s? [y/N] ' "$line" "$rc"
-      read -r answer
+      read -r answer < /dev/tty
       case "$answer" in
         y|Y|yes|YES)
           printf '%s\n' "$line" >> "$rc"


### PR DESCRIPTION
Walking the install path end to end on a throwaway HOME, looking for where a download stops being a user.

The good news first: `install.sh` finishes in **4 seconds**, `deja install --auto` in under one, and the first thing it prints is the machine's own history — two real lines from the seeded transcripts, then a working search. The promise lands.

The defect is one line earlier. When `~/.local/bin` is not on PATH, the installer offers to append it, guarded by `[ -t 0 ] && [ -t 1 ]`. Under the command we document everywhere — `curl -fsSL … | sh` — **stdin is the script**, so that condition is false on a real terminal and the offer is unreachable for every reader of the README. Measured rather than assumed, with `script` giving a pty so the pipe is the only difference:

```
--- piped into sh, inside a pty (what curl | sh looks like) ---
stdin is NOT a tty      stdout IS a tty      /dev/tty readable
--- run as a file, inside a pty ---
stdin IS a tty          stdout IS a tty      /dev/tty readable
```

So everyone gets `ACTION REQUIRED: add this line to ~/.zshrc` and edits a dotfile by hand — on macOS, where `~/.local/bin` is not on PATH by default and which is 43% of our downloads, that stands between installing deja and being able to type `deja`.

The offer now reads from the controlling terminal, which is present in exactly the case it matters. Verified both directions:

- pty + pipe, answering `y` → `updated …/.zshrc`, and the line is in the file.
- no terminal at all (the CI shape) → prints the message, writes nothing, does not block.

`--yes` still wins over both, and `scripts/e2e.sh` passes. The test asserts the executable condition rather than the file text, since the comment above it names the old form deliberately.