### PR TITLE
fix(sync): treat one machine named twice as one machine

### DIFF
--- a/internal/peers/duplicate_test.go
+++ b/internal/peers/duplicate_test.go
@@ -1,0 +1,95 @@
+package peers
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writePeers points deja at a peers file with the given body.
+func writePeers(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", path)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// One machine named twice used to be two rows: the second was frozen, because
+// Record stops at the first match, so it showed "failed 235 days ago" beside
+// the same machine reporting a sync this morning — and a bare `deja sync`
+// opened two connections to it (#1853).
+func TestOneMachineNamedTwiceIsOneMachine(t *testing.T) {
+	writePeers(t, `{"peers":[
+	{"host":"laptop","last_push":"2026-08-24T10:00:00Z"},
+	{"host":"laptop","last_push":"2026-01-01T10:00:00Z","last_error":"stale copy"}]}`)
+
+	list := Load()
+	if len(list) != 1 {
+		t.Fatalf("the same host came back %d times: %#v", len(list), list)
+	}
+	// The newer exchange wins, and the error belongs to it — the stale row's
+	// failure is not news about a machine that has synced since.
+	if got := list[0].LastPush.Format("2006-01-02"); got != "2026-08-24" {
+		t.Errorf("the folded row kept the older push: %s", got)
+	}
+	if list[0].LastError != "" {
+		t.Errorf("the folded row inherited an error from an exchange it is newer than: %q", list[0].LastError)
+	}
+}
+
+// The other direction: the newer row is the one that failed, so its error is
+// what the reader needs to see.
+func TestFoldingKeepsTheNewerFailure(t *testing.T) {
+	writePeers(t, `{"peers":[
+	{"host":"laptop","last_push":"2026-01-01T10:00:00Z"},
+	{"host":"laptop","last_push":"2026-08-24T10:00:00Z","last_error":"ssh laptop: exit status 255"}]}`)
+
+	list := Load()
+	if len(list) != 1 {
+		t.Fatalf("the same host came back %d times", len(list))
+	}
+	if list[0].LastError == "" {
+		t.Errorf("the newest exchange failed and the row says nothing: %#v", list[0])
+	}
+}
+
+// A recorded exchange leaves one row, whichever copy it started from, and the
+// file it writes back holds one too.
+func TestRecordingLeavesOneRowPerMachine(t *testing.T) {
+	writePeers(t, `{"peers":[
+	{"host":"laptop","last_push":"2026-08-24T10:00:00Z"},
+	{"host":"laptop","last_push":"2026-01-01T10:00:00Z","last_error":"stale copy"}]}`)
+
+	if err := Record("laptop", false, time.Now(), nil); err != nil {
+		t.Fatal(err)
+	}
+	list := Load()
+	if len(list) != 1 {
+		t.Fatalf("recording left %d rows for one machine: %#v", len(list), list)
+	}
+	if list[0].LastError != "" {
+		t.Errorf("a successful exchange left an error behind: %q", list[0].LastError)
+	}
+	if err := Record("laptop", false, time.Now(), errors.New("boom")); err != nil {
+		t.Fatal(err)
+	}
+	list = Load()
+	if len(list) != 1 || list[0].LastError == "" {
+		t.Errorf("a failure did not land on the one row: %#v", list)
+	}
+}
+
+// The control: two different machines stay two machines.
+func TestFoldingKeepsDistinctMachinesApart(t *testing.T) {
+	writePeers(t, `{"peers":[
+	{"host":"laptop","last_push":"2026-08-24T10:00:00Z"},
+	{"host":"build-box","last_push":"2026-08-23T10:00:00Z"}]}`)
+	if list := Load(); len(list) != 2 {
+		t.Errorf("two machines came back as %d: %#v", len(list), list)
+	}
+}

--- a/internal/peers/peers.go
+++ b/internal/peers/peers.go
@@ -85,10 +85,21 @@ func Snapshot() ([]Peer, string) {
 		return nil, err.Error()
 	}
 	out := f.Peers[:0:0]
+	seen := map[string]int{}
 	for _, p := range f.Peers {
 		if p.Host = strings.TrimSpace(p.Host); p.Host == "" {
 			continue
 		}
+		// One machine named twice was two rows, and Record only ever updated
+		// the first: the other showed a months-old failure beside the same
+		// machine reporting a sync this morning, and a bare `deja sync` opened
+		// two connections to it (#1853). A file can hold the same host twice
+		// through a hand-edit or a restored backup; deja never writes one.
+		if at, ok := seen[p.Host]; ok {
+			out[at] = mergePeers(out[at], p)
+			continue
+		}
+		seen[p.Host] = len(out)
 		out = append(out, p)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Host < out[j].Host })
@@ -106,6 +117,23 @@ func Snapshot() ([]Peer, string) {
 func Problem() string {
 	_, why := Snapshot()
 	return why
+}
+
+// mergePeers folds two rows for one machine. Each direction keeps its newest
+// timestamp, and the error belongs to whichever exchange happened last: an old
+// failure is not news about a machine that has synced since.
+func mergePeers(a, b Peer) Peer {
+	out := a
+	if b.LastPush.After(out.LastPush) {
+		out.LastPush = b.LastPush
+	}
+	if b.LastPull.After(out.LastPull) {
+		out.LastPull = b.LastPull
+	}
+	if b.Last().After(a.Last()) {
+		out.LastError = b.LastError
+	}
+	return out
 }
 
 // Record notes an exchange with a host: which way it went, and whether it


### PR DESCRIPTION
Closes #1853.

A peers file naming one machine twice produced a row nothing could ever update — `Record` stops at the first match — so the doctor showed a months-old failure beside the same machine reporting a sync this morning, and a bare `deja sync` opened two connections to it.

```
Load returns 2 rows
   host="laptop" push=2026-08-24 err=""
   host="laptop" push=2026-01-01 err="stale copy"
after a failure:
   host="laptop" push=2026-08-25 err="boom"
   host="laptop" push=2026-01-01 err="stale copy"     ← untouched
```

`Load` folds duplicates now, so all three symptoms go at once and the next `Record` writes the folded list back — the file heals itself. Each direction keeps its newest timestamp and the error belongs to whichever exchange happened last: an old failure is not news about a machine that has synced since, and a *newer* failure survives, which the second test covers.

```
Sync:
  laptop       last exchange 23 hours ago, nothing received yet

{'state': 'ok', 'peers': [{'host': 'laptop', 'last_push': '2026-08-24T10:00:00Z', …}]}
```

deja never writes such a file: `Record` appends a host only when no row matches. It comes from a hand-edit, a merged config or a restored backup — the same ways the malformed file in #1840 arrives.

Tests: `TestOneMachineNamedTwiceIsOneMachine`, `TestFoldingKeepsTheNewerFailure`, `TestRecordingLeavesOneRowPerMachine`, and `TestFoldingKeepsDistinctMachinesApart` as the control that two machines stay two.
