### PR TITLE
fix(doctor): say when a peer's stamp is ahead of this machine's clock

### DIFF
--- a/cmd/deja/doctor_json_contract_test.go
+++ b/cmd/deja/doctor_json_contract_test.go
@@ -54,6 +54,7 @@ func TestDoctorJSONKeysMatchTheDocumentedContract(t *testing.T) {
 		// doctorSyncReport / doctorPeerReport
 		"sync": true, "peers": true, "host": true,
 		"last_push": true, "last_pull": true, "sessions_from_there": true,
+		"stamped_ahead": true,
 		// index.HarnessIngest
 		"malformed_lines": true, "clipped_messages": true,
 		"failed_files": true, "last_error": true,

--- a/cmd/deja/doctor_peers.go
+++ b/cmd/deja/doctor_peers.go
@@ -75,6 +75,12 @@ func peerLine(p peers.Peer, sessions int, now time.Time) string {
 	switch {
 	case p.Last().IsZero():
 		line = "never exchanged"
+	case index.StampedAhead(p.Last(), now):
+		// The age would be negative, and everything under a minute reads as
+		// "just now" — so the peer that most needs looking at read as the one
+		// that just synced (#1855).
+		line = "last exchange stamped " + p.Last().Local().Format("2006-01-02") +
+			", later than this machine's clock — one of the two is wrong"
 	default:
 		line = "last exchange " + doctorAgo(now.Sub(p.Last()))
 	}

--- a/cmd/deja/doctor_peers.go
+++ b/cmd/deja/doctor_peers.go
@@ -68,6 +68,22 @@ const (
 	doctorPeerColumnMax = 32
 )
 
+// peerStampedAhead reports a stamp this machine's clock cannot account for.
+//
+// A minute of slack rather than the bare `t.After(now)` the session side uses:
+// a peer's timestamps are written by deja itself from time.Now(), so a file
+// copied from a machine a few hundred milliseconds ahead — or an NTP step
+// landing between the write and the read — would otherwise put "one of the two
+// clocks is wrong" against a peer that is perfectly healthy. A minute is also
+// the granularity the line already speaks in, since everything under it reads
+// as "just now" (#1855).
+func peerStampedAhead(t, now time.Time) bool {
+	return index.StampedAhead(t, now.Add(peerClockSlack))
+}
+
+// peerClockSlack is how far ahead a stamp may be before it is worth a sentence.
+const peerClockSlack = time.Minute
+
 // peerLine is one machine's state in one line: how long since memory moved,
 // which way it has not moved, and how much of this index came from there.
 func peerLine(p peers.Peer, sessions int, now time.Time) string {
@@ -75,7 +91,7 @@ func peerLine(p peers.Peer, sessions int, now time.Time) string {
 	switch {
 	case p.Last().IsZero():
 		line = "never exchanged"
-	case index.StampedAhead(p.Last(), now):
+	case peerStampedAhead(p.Last(), now):
 		// The age would be negative, and everything under a minute reads as
 		// "just now" — so the peer that most needs looking at read as the one
 		// that just synced (#1855).

--- a/cmd/deja/doctor_peers_ahead_test.go
+++ b/cmd/deja/doctor_peers_ahead_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A stamp in the future made the age negative, and everything under a minute
+// reads as "just now" — so a peer seventy years out looked like the healthiest
+// machine on the screen whose whole purpose is to show a sync that stopped
+// (#1855). deja says this about sessions already (index.StampedAhead, #1753).
+func TestAPeerStampedAheadIsNotReportedAsJustSynced(t *testing.T) {
+	tmp := hermeticEnv(t)
+	path := filepath.Join(tmp, "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", path)
+	ahead := time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339)
+	body := `{"peers":[{"host":"laptop","last_push":"` + ahead + `"}]}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var text strings.Builder
+	doctorPeers(&text, t.TempDir(), time.Now())
+	if strings.Contains(text.String(), "just now") {
+		t.Errorf("a stamp in the future reads as a sync that just happened:\n%s", text.String())
+	}
+	if !strings.Contains(text.String(), "clock") {
+		t.Errorf("the line does not say why the date cannot be trusted:\n%s", text.String())
+	}
+
+	var out strings.Builder
+	if err := runDoctor(&out, []string{"--json", "--offline"}, stubLookup("1.0.0", false), index.DefaultDir()); err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		Sync struct {
+			Peers []struct {
+				Host    string `json:"host"`
+				Ahead   bool   `json:"stamped_ahead"`
+				LastPsh string `json:"last_push"`
+			} `json:"peers"`
+		} `json:"sync"`
+	}
+	if err := json.Unmarshal([]byte(out.String()), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Sync.Peers) != 1 {
+		t.Fatalf("want one peer, got %#v", report.Sync.Peers)
+	}
+	if !report.Sync.Peers[0].Ahead {
+		t.Errorf("--json does not say the stamp is ahead of this machine's clock: %#v", report.Sync.Peers[0])
+	}
+	// The stamp itself is still reported as written — the reader may need it.
+	if report.Sync.Peers[0].LastPsh == "" {
+		t.Errorf("the stamp was dropped rather than flagged: %#v", report.Sync.Peers[0])
+	}
+}
+
+// The control: an ordinary peer says neither, on either surface.
+func TestAnOrdinaryPeerIsNotFlaggedAsAhead(t *testing.T) {
+	tmp := hermeticEnv(t)
+	path := filepath.Join(tmp, "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", path)
+	when := time.Now().Add(-3 * time.Hour).UTC().Format(time.RFC3339)
+	if err := os.WriteFile(path, []byte(`{"peers":[{"host":"laptop","last_push":"`+when+`"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var text strings.Builder
+	doctorPeers(&text, t.TempDir(), time.Now())
+	if strings.Contains(text.String(), "clock") {
+		t.Errorf("an ordinary peer was flagged:\n%s", text.String())
+	}
+	if !strings.Contains(text.String(), "hours ago") {
+		t.Errorf("an ordinary peer lost its age:\n%s", text.String())
+	}
+	if got := collectDoctorSync(t.TempDir()); len(got.Peers) != 1 || got.Peers[0].Ahead {
+		t.Errorf("an ordinary peer is flagged in --json: %#v", got.Peers)
+	}
+}

--- a/cmd/deja/doctor_peers_ahead_test.go
+++ b/cmd/deja/doctor_peers_ahead_test.go
@@ -83,3 +83,27 @@ func TestAnOrdinaryPeerIsNotFlaggedAsAhead(t *testing.T) {
 		t.Errorf("an ordinary peer is flagged in --json: %#v", got.Peers)
 	}
 }
+
+// The slack: a peers file written by a machine a moment ahead, or an NTP step
+// landing between the write and the read, must not put "one of the two clocks
+// is wrong" against a healthy peer. A real skew still does (#1855).
+func TestTheClockSentenceHasSlackForJitter(t *testing.T) {
+	now := time.Date(2026, 8, 25, 9, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name  string
+		delta time.Duration
+		want  bool
+	}{
+		{"a second behind", -time.Second, false},
+		{"exactly now", 0, false},
+		{"a millisecond ahead", time.Millisecond, false},
+		{"thirty seconds ahead", 30 * time.Second, false},
+		{"a minute ahead", time.Minute, false},
+		{"two minutes ahead", 2 * time.Minute, true},
+		{"two days ahead", 48 * time.Hour, true},
+	} {
+		if got := peerStampedAhead(now.Add(tc.delta), now); got != tc.want {
+			t.Errorf("%s: flagged=%v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -115,6 +115,12 @@ type doctorPeerReport struct {
 	// LastError is why the most recent exchange failed. Bounded, unlike Host:
 	// nothing acts on this string, and a remote can make it arbitrarily long.
 	LastError string `json:"last_error,omitempty"`
+	// Ahead marks a stamp later than this machine's clock. The age of such a
+	// stamp is negative, and everything under a minute reads as "just now", so
+	// a peer seventy years out looked like the healthiest machine on the
+	// screen that exists to show a stopped sync (#1855). Same rule as sessions
+	// (index.StampedAhead, #1753).
+	Ahead bool `json:"stamped_ahead,omitempty"`
 }
 
 // collectDoctorSync reads the peers file and what arrived from each machine.
@@ -146,6 +152,7 @@ func collectDoctorSync(dir string) doctorSyncReport {
 		if !p.LastPull.IsZero() {
 			row.LastPull = p.LastPull.UTC().Format(time.RFC3339)
 		}
+		row.Ahead = index.StampedAhead(p.Last(), time.Now())
 		out.Peers = append(out.Peers, row)
 	}
 	return out

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -152,7 +152,7 @@ func collectDoctorSync(dir string) doctorSyncReport {
 		if !p.LastPull.IsZero() {
 			row.LastPull = p.LastPull.UTC().Format(time.RFC3339)
 		}
-		row.Ahead = index.StampedAhead(p.Last(), time.Now())
+		row.Ahead = peerStampedAhead(p.Last(), time.Now())
 		out.Peers = append(out.Peers, row)
 	}
 	return out

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -361,6 +361,11 @@ is a broken sync that reads as a working one. `last_error` is why the most
 recent exchange failed and is absent once one succeeds. Both `host` and
 `last_error` are written elsewhere — a config file, another machine — so they
 are bounded and stripped of control characters before they are reported.
+`stamped_ahead` appears only when the newer of the two timestamps is later than
+this machine's clock: the age would be negative and the row would otherwise read
+as a sync that just happened, so a consumer should treat that peer's dates as
+unusable for "how long since" rather than as healthy — the rule recall applies
+to sessions stamped ahead.
 
 ## `deja blame <path> --json`
 


### PR DESCRIPTION
Closes #1855.

A peer whose last exchange is stamped in the future read as the healthiest machine on the screen that exists to show a sync has stopped: the age is negative and everything under a minute is "just now".

```
  laptop       last exchange just now, nothing received yet
```

Now:

```
  desk         last exchange 23 hours ago, nothing received yet
  laptop       last exchange stamped 2099-01-01, later than this machine's clock — one of the two is wrong, nothing received yet

{'host': 'laptop', 'last_push': '2099-01-01T10:00:00Z', 'sessions_from_there': 0, 'stamped_ahead': True}
```

Same rule deja already applies to sessions — `index.StampedAhead`, whose sentence on the recall page says a date ahead of the clock cannot place a session against the others (#1753). The stamp itself is still reported as written: `--json` flags it rather than dropping it, since the reader may need the value to work out which of the two clocks is wrong.

`stamped_ahead` is additive, so `schema_version` stays 2; `docs/json-output.md`, the example and the contract test move with it.

Tests: `TestAPeerStampedAheadIsNotReportedAsJustSynced` over both surfaces, with `TestAnOrdinaryPeerIsNotFlaggedAsAhead` as the control that a normal peer keeps its age and gains no flag.
