### PR TITLE
fix(sync): sanitise the directory in every sentence that names it

### DIFF
--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -127,21 +127,21 @@ func runSync(dir string, args []string) error {
 			if p := deniedPath(err); p != "" && !strings.HasPrefix(p, out) &&
 				(errors.Is(err, fs.ErrPermission) || writeFailureReason(err) != err.Error()) {
 				if n > 0 {
-					return fmt.Errorf("%d records are written into %s, but deja could not record that they went: %w; the next export sends them again", n, out, ensureError(dir, err))
+					return fmt.Errorf("%d records are written into %s, but deja could not record that they went: %w; the next export sends them again", n, search.SafeLine(out), ensureError(dir, err))
 				}
 				return ensureError(dir, err)
 			}
 			if parent := filepath.Dir(out); !dirExists(out) && !dirExists(parent) {
-				return fmt.Errorf("cannot write the export into %s — %s is not there; the disk it lives on may have been unmounted", out, parent)
+				return fmt.Errorf("cannot write the export into %s — %s is not there; the disk it lives on may have been unmounted", search.SafeLine(out), search.SafeLine(parent))
 			}
 			if errors.Is(err, fs.ErrPermission) {
-				return fmt.Errorf("cannot write the export into %s — check that directory's permissions, or choose one you can write", out)
+				return fmt.Errorf("cannot write the export into %s — check that directory's permissions, or choose one you can write", search.SafeLine(out))
 			}
 			// A full or vanished disk in the same words as everywhere else
 			// (#906); anything deja does not recognise still comes through
 			// whole rather than being guessed at.
 			if reason := writeFailureReason(err); reason != err.Error() {
-				return fmt.Errorf("cannot write the export into %s — %s", out, reason)
+				return fmt.Errorf("cannot write the export into %s — %s", search.SafeLine(out), reason)
 			}
 			return err
 		}
@@ -149,6 +149,9 @@ func runSync(dir string, args []string) error {
 		// A watermark is per machine, not per destination: the second peer you
 		// hand memory to gets an empty folder and the same "exported 0
 		// records" that means "you are up to date" at the first one (#982).
+		// The path stays as written in the next line: it hands over a command
+		// to paste, and a collapsed path names no directory. Same tension as
+		// the recovery sentence in #1820 and the tombstone id in #1794.
 		if n == 0 && !full && !hasSyncBatches(out) {
 			fmt.Fprintf(os.Stdout, "deja: nothing has changed since the last export, and this folder holds no batch from this machine — `deja sync export %s --full` sends everything\n", out)
 		}

--- a/cmd/deja/sync_export_name_test.go
+++ b/cmd/deja/sync_export_name_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The CLI wrapper has its own family of sentences naming the export directory,
+// and they printed the path raw while the index package's five did not (#1857).
+func TestTheExportSentencesAreSafeToPrint(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"v1","cwd":"/proj","timestamp":"2026-08-22T01:00:00Z","message":{"role":"user","content":"the retry budget question"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "a.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// A parent that cannot be created because a file sits where it would go:
+	// MkdirAll fails, and the sentence names the path.
+	blocker := filepath.Join(tmp, "gone\x1b[31mHACK\rrewound")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Skipf("the filesystem refused the name: %v", err)
+	}
+	odd := filepath.Join(blocker, "batch")
+	err := runSync(dir, []string{"export", odd})
+	if err == nil {
+		t.Fatal("exporting into a missing parent was accepted")
+	}
+	if strings.ContainsAny(err.Error(), "\x1b\r") {
+		t.Errorf("the sentence carries an escape or a rewind: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "batch") {
+		t.Errorf("the sentence no longer names the directory: %q", err.Error())
+	}
+}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -133,7 +133,7 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 		// The import side of the same mistake is worded; this one handed back
 		// `mkdir /…/file: not a directory` (#1112).
 		if fi, statErr := os.Stat(outDir); statErr == nil && !fi.IsDir() {
-			return 0, nil, fmt.Errorf("%s is a file; sync export wants a directory to write the batch into", outDir)
+			return 0, nil, fmt.Errorf("%s is a file; sync export wants a directory to write the batch into", search.SafeLine(outDir))
 		}
 		return 0, nil, err
 	}
@@ -372,14 +372,14 @@ func Import(dir, inDir string) (int, error) {
 		return 0, fmt.Errorf("cannot read %s: %s", search.SafeLine(inDir), search.SafeLine(err.Error()))
 	}
 	if !fi.IsDir() {
-		return 0, fmt.Errorf("%s is a file; sync import wants the directory a `sync export` wrote", inDir)
+		return 0, fmt.Errorf("%s is a file; sync import wants the directory a `sync export` wrote", search.SafeLine(inDir))
 	}
 	// Glob swallows a directory it cannot open, so a locked source imported
 	// "0 records" — the same words an already-imported batch prints, and the
 	// records were there the whole time (#1042).
 	if f, oerr := os.Open(inDir); oerr != nil {
 		if os.IsPermission(oerr) {
-			return 0, fmt.Errorf("cannot read %s — permission denied; check that directory's permissions (on macOS, also Full Disk Access for your terminal)", inDir)
+			return 0, fmt.Errorf("cannot read %s — permission denied; check that directory's permissions (on macOS, also Full Disk Access for your terminal)", search.SafeLine(inDir))
 		}
 		return 0, oerr
 	} else {

--- a/internal/index/sync_dir_name_test.go
+++ b/internal/index/sync_dir_name_test.go
@@ -1,0 +1,76 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Two of the five sentences about the import directory sanitised it and three
+// did not, and the comment on the sanitised pair says why it matters: the path
+// reaches a terminal through main, which prints an error as it is (#1857).
+func TestEverySentenceAboutTheDirectoryIsSafeToPrint(t *testing.T) {
+	base := t.TempDir()
+	const odd = "batch\x1b[31mHACK\rrewound"
+
+	t.Run("a file where the directory should be", func(t *testing.T) {
+		path := filepath.Join(base, odd)
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Skipf("the filesystem refused the name: %v", err)
+		}
+		_, err := Import(filepath.Join(base, "idx"), path)
+		if err == nil {
+			t.Fatal("importing a file was accepted")
+		}
+		assertPrintable(t, err.Error(), "is a file")
+	})
+
+	t.Run("a directory deja may not read", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root reads anything")
+		}
+		dir := filepath.Join(base, odd+"-dir")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(dir, 0o000); err != nil {
+			t.Skipf("cannot drop permissions: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+		_, err := Import(filepath.Join(base, "idx2"), dir)
+		if err == nil {
+			t.Skip("this platform read the directory anyway")
+		}
+		assertPrintable(t, err.Error(), "permission denied")
+	})
+
+	t.Run("a file where the export directory should be", func(t *testing.T) {
+		path := filepath.Join(base, odd+"-export")
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Skipf("the filesystem refused the name: %v", err)
+		}
+		_, _, err := ExportDeferred(filepath.Join(base, "idx3"), path, "peer")
+		if err == nil {
+			t.Skip("the fixture did not reach the sentence")
+		}
+		if strings.Contains(err.Error(), "is a file") {
+			assertPrintable(t, err.Error(), "is a file")
+		}
+	})
+}
+
+// assertPrintable holds one sentence: no escape, no rewind, and still naming
+// what went wrong.
+func assertPrintable(t *testing.T, msg, want string) {
+	t.Helper()
+	if strings.ContainsAny(msg, "\x1b\r") {
+		t.Errorf("the sentence carries an escape or a rewind: %q", msg)
+	}
+	if !strings.Contains(msg, want) {
+		t.Errorf("the sentence no longer says what happened (%q): %q", want, msg)
+	}
+	if !strings.Contains(msg, "batch") {
+		t.Errorf("the sentence no longer names the directory: %q", msg)
+	}
+}


### PR DESCRIPTION
Closes #1857.

Five sentences in `internal/index/sync.go` name the sync directory; two sanitised it and three did not, and the comment on the sanitised pair says exactly why it matters — "the raw syscall error went back — carrying the unsanitised path with it, which is the escape sequence this wording exists to defuse".

```
is-a-file:  escape=true cr=true
  "/…/batch\x1b[31mHACK\rrewound is a file; sync import wants the directory a `sync export` wrote"
unreadable: escape=true cr=true
  "cannot read /…/batch\x1b[31mHACK\rrewound-dir — permission denied; …"
```

All five take `search.SafeLine` now: the two import branches, and the export-side twin at `sync.go:136`.

Lower stakes than #1847, where the name came from another machine — this is the path the user typed, so it takes a deliberately odd argument to hit. What it costs is a reader having to work out which of five sentences about one value follows which rule.

Test: `TestEverySentenceAboutTheDirectoryIsSafeToPrint` covers a file where the directory should be, a directory deja may not read (skipped as root), and the export-side twin; each asserts no escape, no rewind, and that the sentence still says what happened and names the directory. The first two fail before.
