### PR TITLE
fix(index): clear the evicted-files counter per build, and catch the next one

### DIFF
--- a/internal/index/counter_family_test.go
+++ b/internal/index/counter_family_test.go
@@ -1,0 +1,88 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// buildWithFiles writes the named transcripts into a fresh store and builds it,
+// returning the project directory and the index directory so the caller can
+// take files away and build again.
+func buildWithFiles(t *testing.T, ids ...string) (proj, dir string) {
+	t.Helper()
+	home := t.TempDir()
+	setHome(t, home)
+	t.Setenv("USERPROFILE", home)
+	root := filepath.Join(home, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	proj = filepath.Join(root, "-tmp-e")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range ids {
+		line := `{"type":"user","sessionId":"` + id + `","cwd":"/tmp/e","timestamp":"2026-08-01T10:00:00Z","message":{"role":"user","content":"pool exhausted"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, id+".jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir = filepath.Join(home, "idx")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return proj, dir
+}
+
+// The third counter of the family: it says how many indexed files went away
+// with their store, and the command layer turns that into "the history that was
+// here has gone" rather than "nothing to index yet" (#1762). It accumulated
+// across builds like the other two (#1861).
+func TestTheEvictedCounterBelongsToTheLastBuild(t *testing.T) {
+	proj, dir := buildWithFiles(t, "a", "b", "c")
+
+	for _, id := range []string{"a", "b"} {
+		if err := os.Remove(filepath.Join(proj, id+".jsonl")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately not read: the leftover is what the next build must not
+	// inherit.
+	if err := os.Remove(filepath.Join(proj, "c.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := ReportEvictedFiles(); n != 1 {
+		t.Errorf("the second eviction reported %d files, want its own 1", n)
+	}
+}
+
+// The family itself: every counter drained by a Report function has to be
+// cleared where a build starts, or it reports the process rather than the
+// build. Three were found one at a time — emptied and collisions in #1850,
+// evicted in #1861 — and this is what makes the fourth a build failure.
+func TestEveryReportedCounterIsClearedByABuild(t *testing.T) {
+	src, err := os.ReadFile("ingest.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(src)
+
+	drained := regexp.MustCompile(`func Report\w+\(\) int \{\s*return int\((\w+)\.Swap\(0\)\)`)
+	found := drained.FindAllStringSubmatch(body, -1)
+	if len(found) < 3 {
+		t.Fatalf("expected the counter family, found %d — has the shape changed?", len(found))
+	}
+	for _, m := range found {
+		name := m[1]
+		if !strings.Contains(body, name+".Store(0)") {
+			t.Errorf("%s is drained by a Report function but never cleared where a build starts: a second build in one process reports the first one's number too", name)
+		}
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -358,6 +358,9 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	// This build's counts, not the process's: see writeSessionsWithSync (#1850).
 	emptied.Store(0)
 	collisions.Store(0)
+	// A rebuild evicts nothing, but a number left by an earlier build must not
+	// outlive it (#1861).
+	evicted.Store(0)
 	lastIngestFiles = len(files)
 	initialBuild := !HasManifest(dir)
 	writtenMessages := 0
@@ -1910,6 +1913,11 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 }
 
 func updateIndex(dir, harness, scope string, files map[string]FileState, force bool, progress io.Writer) error {
+	// Cleared here rather than beside the other two: this build counts what
+	// went away further down, before the incremental paths reset theirs, so a
+	// reset down there would zero the number this build is about to report
+	// (#1861).
+	evicted.Store(0)
 	old, err := readManifest(dir)
 	if err == nil && !recordsIntact(dir, old) {
 		force = true // records.bin lost its tail to a crash; only a rebuild is safe


### PR DESCRIPTION
Closes #1861.

#1850 fixed two counters that accumulated across builds and cleared a third value that turned out to be assigned rather than accumulated. It missed `evicted`, which accumulates and is drained by `ReportEvictedFiles` the same way:

```
second eviction reports 3 files (its own is 1)
```

`cmd/deja/main.go:394` reads that number to choose a sentence — "nothing to index yet" against "the history that was here has gone" (#1762) — so it is a claim about the user's machine, not a statistic.

The fix is not where the other two went: `evicted.Add` happens inside `updateIndex` *before* the incremental resets #1850 added, so clearing it there would zero the count of the build doing the reporting. It is cleared where `updateIndex` starts, and in the rebuild path beside the others, where nothing evicts but a stale number must not survive.

The second test is what this iteration is actually for: three counters were found one at a time by tripping over them, and the package has a shape — an `atomic.Int64` drained by a `Report*` function. `TestEveryReportedCounterIsClearedByABuild` walks `ingest.go` for that shape and asserts each one is cleared somewhere, so a fourth is a build failure rather than a wrong number on someone's screen. It fails on the base branch naming `evicted`.

`./internal/index` is clean at `-count=2`.
