### PR TITLE
docs(json): say that a peer stamped ahead gets a minute of slack

### DIFF
--- a/cmd/deja/doctor_ahead_rule_test.go
+++ b/cmd/deja/doctor_ahead_rule_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A peer's stamps are written by deja itself, so a copy from a machine a few
+// hundred milliseconds ahead is not a broken clock; a session's stamps come
+// from a transcript on some other machine, where anything ahead is unusable.
+// Two rules, on purpose (#1855, #1753) — this pins the band where they differ,
+// so a change to either is a change to a test rather than a silent one.
+func TestThePeerRuleAndTheSessionRuleDifferByTheSlack(t *testing.T) {
+	now := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	inside := now.Add(peerClockSlack / 2)
+	outside := now.Add(peerClockSlack + time.Second)
+
+	if peerStampedAhead(inside, now) {
+		t.Errorf("a peer stamped inside the slack is flagged, so a clock a moment out reads as broken")
+	}
+	if !peerStampedAhead(outside, now) {
+		t.Errorf("a peer stamped past the slack is not flagged")
+	}
+	if !index.StampedAhead(inside, now) {
+		t.Errorf("the session rule has grown a tolerance, so the two rules no longer differ and the doc below is describing nothing")
+	}
+}
+
+// The field is part of a documented contract, and the doc said the session
+// rule, which is the one the peer surface does not use: someone implementing
+// against it disagreed with deja over the whole slack band (#1865).
+func TestTheDocumentedPeerAheadRuleNamesTheSlack(t *testing.T) {
+	src, err := os.ReadFile("../../docs/json-output.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := string(src)
+	i := strings.Index(doc, "`stamped_ahead`")
+	if i < 0 {
+		t.Fatal("docs/json-output.md no longer describes stamped_ahead")
+	}
+	para := doc[i:]
+	if end := strings.Index(para, "\n\n"); end > 0 {
+		para = para[:end]
+	}
+	if !strings.Contains(para, "minute") {
+		t.Errorf("the documented rule does not name the minute of slack the peer surface applies, so a reader implements the session rule:\n%s", para)
+	}
+	if strings.Contains(para, "the rule recall applies to sessions stamped ahead") {
+		t.Errorf("the doc still says a peer is judged by the session rule:\n%s", para)
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -118,8 +118,9 @@ type doctorPeerReport struct {
 	// Ahead marks a stamp later than this machine's clock. The age of such a
 	// stamp is negative, and everything under a minute reads as "just now", so
 	// a peer seventy years out looked like the healthiest machine on the
-	// screen that exists to show a stopped sync (#1855). Same rule as sessions
-	// (index.StampedAhead, #1753).
+	// screen that exists to show a stopped sync (#1855). Not the session rule:
+	// a peer gets peerClockSlack first, for the reason peerStampedAhead gives
+	// (#1865).
 	Ahead bool `json:"stamped_ahead,omitempty"`
 }
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -368,8 +368,8 @@ are bounded and stripped of control characters before they are reported.
 minute later than this machine's clock: the age would be negative and the row
 would otherwise read as a sync that just happened, so a consumer should treat
 that peer's dates as unusable for "how long since" rather than as healthy. The
-minute is the difference from what recall says about a session stamped ahead,
-where anything ahead counts: a peers file is written by deja itself, so a copy
+minute is what makes this different from the rule for a session, where anything
+ahead counts: a peers file is written by deja itself, so a copy
 from a machine a moment ahead — or an NTP step landing between the write and the
 read — is not a clock worth reporting, while a session's stamp comes from a
 transcript deja did not write.

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -364,11 +364,15 @@ old to report peers at all: that one has no `sync` key. `last_error` is why the 
 recent exchange failed and is absent once one succeeds. Both `host` and
 `last_error` are written elsewhere — a config file, another machine — so they
 are bounded and stripped of control characters before they are reported.
-`stamped_ahead` appears only when the newer of the two timestamps is later than
-this machine's clock: the age would be negative and the row would otherwise read
-as a sync that just happened, so a consumer should treat that peer's dates as
-unusable for "how long since" rather than as healthy — the rule recall applies
-to sessions stamped ahead.
+`stamped_ahead` appears when the newer of the two timestamps is more than a
+minute later than this machine's clock: the age would be negative and the row
+would otherwise read as a sync that just happened, so a consumer should treat
+that peer's dates as unusable for "how long since" rather than as healthy. The
+minute is the difference from what recall says about a session stamped ahead,
+where anything ahead counts: a peers file is written by deja itself, so a copy
+from a machine a moment ahead — or an NTP step landing between the write and the
+read — is not a clock worth reporting, while a session's stamp comes from a
+transcript deja did not write.
 
 ## `deja blame <path> --json`
 


### PR DESCRIPTION
Closes #1865.

`stamped_ahead` was documented as the rule recall applies to a session — anything later than this machine's clock — but the peer surface gives a stamp a minute of slack first (#1855). A peer stamped 30s ahead is therefore not flagged and reads as "last exchange just now", which is what the doc says it will not do:

```
$ deja doctor --json --offline     # last_push 30s ahead
"peers":[{"host":"laptop","last_push":"2026-08-25T10:33:07Z","sessions_from_there":0}]
$ deja doctor --json --offline     # 120s ahead
"peers":[{"host":"laptop","last_push":"…","stamped_ahead":true}]
```

The slack is right and stays. What changes is the paragraph, which now names the minute and says why a peer is not judged the way a session is: a peers file is written by deja itself, a transcript is not. The field's comment in `doctor_report.go` said "same rule as sessions" and now points at `peerStampedAhead`.

Tests: `TestTheDocumentedPeerAheadRuleNamesTheSlack` reads the paragraph and fails on the base branch; `TestThePeerRuleAndTheSessionRuleDifferByTheSlack` pins the band where the two rules disagree, including the assertion that the session rule still has no tolerance — without it the doc would be describing a difference that had quietly gone away.

No behaviour change.
