### PR TITLE
fix(peers): treat a host name the way ssh does, case and all

### DIFF
--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -55,7 +55,9 @@ func runSync(dir string, args []string) error {
 		// typo'd hostname is one of those forever — at the cost of the connect
 		// timeout each time. peers.Forget did the work already and nothing
 		// reached it (#1780).
-		host := args[1]
+		// Under the spelling deja stored, not the one typed: the line reports
+		// which row is gone, and "LAPTOP forgotten" names no row (#1867).
+		host := peers.Canonical(args[1])
 		found, err := peers.Forget(host)
 		if err != nil {
 			return err

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -78,6 +78,11 @@ func runSyncSSH(dir string, args []string) error {
 // syncSSHHost runs one exchange and records it, so the next `deja sync` knows
 // this host without being told again.
 func syncSSHHost(dir, host string, pull, full, both bool) error {
+	// One machine, one spelling, for the whole run: the watermark is keyed by
+	// this string, and a second spelling of a known host pushed it everything
+	// it already had (#1867). ssh matches a host without regard to case, so
+	// this connects to the same machine either way.
+	host = peers.Canonical(host)
 	if both {
 		if err := syncOneWay(dir, host, false, full); err != nil {
 			return err

--- a/internal/peers/case_test.go
+++ b/internal/peers/case_test.go
@@ -1,0 +1,97 @@
+package peers
+
+import (
+	"testing"
+	"time"
+)
+
+// ssh lowercases a host before it matches it, and a DNS name is
+// case-insensitive (RFC 4343), so `Laptop` and `laptop` are one machine.
+// Comparing byte for byte made them two: deja opened two connections to it,
+// gave each row its own watermark — so the second pushed everything the first
+// had delivered — and reported the machine twice, with the stale row's failure
+// beside the fresh row's success. That is #1853's harm, reached this time by
+// deja's own writes rather than a hand-edit (#1867).
+func TestOneMachineNamedInTwoCasesIsOneRow(t *testing.T) {
+	writePeers(t, `{"peers":[{"host":"Laptop","last_push":"2026-08-20T10:00:00Z"}]}`)
+
+	when := time.Date(2026, 8, 25, 9, 0, 0, 0, time.UTC)
+	if err := Record("laptop", false, when, nil); err != nil {
+		t.Fatal(err)
+	}
+	list := Load()
+	if len(list) != 1 {
+		t.Fatalf("a second spelling of one machine made a second row: %#v", list)
+	}
+	// The spelling stays as it was written: it is what the report prints and
+	// what `sessions_from_there` is counted against.
+	if list[0].Host != "Laptop" {
+		t.Errorf("the stored spelling changed to %q", list[0].Host)
+	}
+	if !list[0].LastPush.Equal(when) {
+		t.Errorf("the exchange landed on neither row: %#v", list[0])
+	}
+}
+
+// A file can hold both spellings already — deja wrote them before this rule.
+func TestBothSpellingsInTheFileFoldToOneRow(t *testing.T) {
+	writePeers(t, `{"peers":[
+		{"host":"Laptop","last_push":"2026-08-20T10:00:00Z"},
+		{"host":"laptop","last_push":"2026-08-25T09:00:00Z"}
+	]}`)
+	list := Load()
+	if len(list) != 1 {
+		t.Fatalf("want one machine, got %#v", list)
+	}
+	if got := list[0].LastPush.UTC().Format(time.RFC3339); got != "2026-08-25T09:00:00Z" {
+		t.Errorf("the folded row kept the older stamp: %s", got)
+	}
+}
+
+// `deja sync forget` is how a typo'd host stops being retried by every bare
+// sync, and it matched only the spelling that was written.
+func TestForgetMatchesAnySpellingOfTheHost(t *testing.T) {
+	writePeers(t, `{"peers":[{"host":"Laptop","last_push":"2026-08-20T10:00:00Z"}]}`)
+	found, err := Forget("LAPTOP")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("forget did not find the machine under another spelling")
+	}
+	if list := Load(); len(list) != 0 {
+		t.Errorf("the row survived: %#v", list)
+	}
+}
+
+// The watermark is keyed by the peer string, so a run has to use the spelling
+// the machine is stored under or it pushes everything again.
+func TestCanonicalGivesTheStoredSpelling(t *testing.T) {
+	writePeers(t, `{"peers":[{"host":"Laptop","last_push":"2026-08-20T10:00:00Z"}]}`)
+	if got := Canonical("LAPTOP"); got != "Laptop" {
+		t.Errorf("Canonical = %q, want the stored spelling", got)
+	}
+	// A machine deja has never heard of keeps the name as typed — there is no
+	// other spelling to prefer, and the name is what ssh is handed.
+	if got := Canonical(" mini "); got != "mini" {
+		t.Errorf("Canonical of an unknown host = %q, want it as typed", got)
+	}
+}
+
+// The user half of user@host is an account name, not a hostname: Root@box and
+// root@box are two logins, and folding the whole string would merge them.
+func TestTheUserHalfOfAnAddressKeepsItsCase(t *testing.T) {
+	writePeers(t, `{"peers":[{"host":"Root@box","last_push":"2026-08-20T10:00:00Z"}]}`)
+	if err := Record("root@box", false, time.Date(2026, 8, 25, 9, 0, 0, 0, time.UTC), nil); err != nil {
+		t.Fatal(err)
+	}
+	if list := Load(); len(list) != 2 {
+		t.Fatalf("two accounts on one host were merged into one row: %#v", list)
+	}
+	if err := Record("root@BOX", false, time.Date(2026, 8, 25, 10, 0, 0, 0, time.UTC), nil); err != nil {
+		t.Fatal(err)
+	}
+	if list := Load(); len(list) != 2 {
+		t.Fatalf("the host half was not folded: %#v", list)
+	}
+}

--- a/internal/peers/peers.go
+++ b/internal/peers/peers.go
@@ -94,12 +94,15 @@ func Snapshot() ([]Peer, string) {
 		// the first: the other showed a months-old failure beside the same
 		// machine reporting a sync this morning, and a bare `deja sync` opened
 		// two connections to it (#1853). A file can hold the same host twice
-		// through a hand-edit or a restored backup; deja never writes one.
-		if at, ok := seen[p.Host]; ok {
+		// through a hand-edit or a restored backup, and — until #1867 — through
+		// deja's own writes, when the two syncs spelled the host differently.
+		// The row keeps the spelling it was written with: that is what the
+		// report prints and what sessions_from_there is counted against.
+		if at, ok := seen[identity(p.Host)]; ok {
 			out[at] = mergePeers(out[at], p)
 			continue
 		}
-		seen[p.Host] = len(out)
+		seen[identity(p.Host)] = len(out)
 		out = append(out, p)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Host < out[j].Host })
@@ -117,6 +120,34 @@ func Snapshot() ([]Peer, string) {
 func Problem() string {
 	_, why := Snapshot()
 	return why
+}
+
+// identity is what makes two names one machine. ssh lowercases a host before
+// it matches it and a DNS name is case-insensitive (RFC 4343), so `Laptop` and
+// `laptop` are one machine — comparing byte for byte gave it two rows, two
+// connections from a bare `deja sync`, and a watermark each, so the second
+// pushed everything the first had already delivered (#1867).
+//
+// Only the part after the last @: the half before it is an account name, and
+// `Root@box` and `root@box` are two logins.
+func identity(host string) string {
+	at := strings.LastIndex(host, "@")
+	return host[:at+1] + strings.ToLower(host[at+1:])
+}
+
+// Canonical is how a host named on the command line should be spelled for the
+// rest of a run: the spelling deja already stored for that machine, if it knows
+// it. Watermarks are namespaced by the peer string, so `deja sync ssh laptop`
+// against a row written `Laptop` had a watermark of its own and pushed
+// everything the machine already had (#1867).
+func Canonical(host string) string {
+	host = strings.TrimSpace(host)
+	for _, p := range Load() {
+		if identity(p.Host) == identity(host) {
+			return p.Host
+		}
+	}
+	return host
 }
 
 // mergePeers folds two rows for one machine. Each direction keeps its newest
@@ -147,7 +178,7 @@ func Record(host string, pulled bool, when time.Time, err error) error {
 	list := Load()
 	i := -1
 	for k := range list {
-		if list[k].Host == host {
+		if identity(list[k].Host) == identity(host) {
 			i = k
 			break
 		}
@@ -182,7 +213,7 @@ func Forget(host string) (bool, error) {
 	out := list[:0:0]
 	found := false
 	for _, p := range list {
-		if p.Host == host {
+		if identity(p.Host) == identity(host) {
 			found = true
 			continue
 		}


### PR DESCRIPTION
Closes #1867.

`Laptop` and `laptop` are one machine to ssh — OpenSSH lowercases before it matches a `Host` pattern, and a DNS name is case-insensitive — and were two to deja, which compared byte for byte. deja wrote both rows itself: two syncs spelling the host differently each missed the other in `Record`.

Before:

```
$ deja doctor
  Laptop       last exchange 5 days ago, nothing received yet
  laptop       last exchange 1 hour ago, nothing received yet
$ deja sync forget LAPTOP
deja: deja does not know a machine called "LAPTOP" — `deja doctor` lists the ones it does
```

After: one row (`Laptop`, last exchange 1 hour ago), and `forget` finds it under any spelling. That is #1853's harm — two connections from a bare `deja sync`, a stale row's failure beside a fresh row's success — reached without a hand-edit.

The other half is the watermark: it is keyed by the peer string, so `deja sync ssh laptop` against a row written `Laptop` had a watermark of its own and pushed the machine everything it already had. `peers.Canonical` gives back the stored spelling and `syncSSHHost` uses it for the whole run.

Only the part after the last `@` folds: `Root@box` and `root@box` are two accounts, and a test pins that they stay two rows while `root@BOX` folds into `root@box`.

Tests fail on the base branch — four of them, one per surface (dedupe on read, `Record`, `Forget`, the user half).

Wording question for you: `deja sync forget` now echoes the stored spelling ("deja: Laptop forgotten") rather than what was typed. Say if you'd rather it echo the typed name.
