### PR TITLE
docs(json): the peer host is reported as written, not bounded

### DIFF
--- a/cmd/deja/doctor_sync_prose_test.go
+++ b/cmd/deja/doctor_sync_prose_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The Sync section of docs/json-output.md described both strings a peer row
+// carries as bounded. Only the error is: a host is a name deja is handed back
+// to act on — `deja sync ssh <host>` — and a bounded name names no machine
+// (#1839). The encoder escapes a control byte on its own, which is why the text
+// report needs a bound and this does not.
+//
+// This pins the two halves the paragraph describes against what deja emits,
+// which is the check the section has not had while it grew (#1869).
+func TestTheSyncSectionDescribesWhatTheRowsCarry(t *testing.T) {
+	tmp := hermeticEnv(t)
+	path := filepath.Join(tmp, "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", path)
+	host := "box" + strings.Repeat("y", 400) + "\x1b[31m"
+	body, err := json.Marshal(map[string]any{"peers": []map[string]string{{
+		"host":       host,
+		"last_push":  "2026-08-20T10:00:00Z",
+		"last_error": "boom " + strings.Repeat("z", 400),
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	if err := runDoctor(&out, []string{"--json", "--offline"}, stubLookup("1.0.0", false), index.DefaultDir()); err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		Sync struct {
+			Peers []struct {
+				Host      string `json:"host"`
+				LastError string `json:"last_error"`
+			} `json:"peers"`
+		} `json:"sync"`
+	}
+	if err := json.Unmarshal([]byte(out.String()), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Sync.Peers) != 1 {
+		t.Fatalf("want one peer, got %#v", report.Sync.Peers)
+	}
+	row := report.Sync.Peers[0]
+	if row.Host != host {
+		t.Errorf("the host was altered, so what the JSON hands back is not a name to sync with: %q", row.Host)
+	}
+	if len(row.LastError) > 260 {
+		t.Errorf("the error is unbounded at %d bytes; a remote writes it", len(row.LastError))
+	}
+	// The escape reaches the reader as an escape sequence in the JSON string,
+	// never as a raw byte a terminal would act on.
+	if strings.Contains(out.String(), "\x1b") {
+		t.Error("a control byte was written into the JSON unescaped")
+	}
+
+	doc, err := os.ReadFile("../../docs/json-output.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Line breaks are the document's own layout: the claim is about the words.
+	prose := strings.Join(strings.Fields(string(doc)), " ")
+	if strings.Contains(prose, "Both `host` and `last_error` are written elsewhere") {
+		t.Error("docs/json-output.md still says both strings are bounded; the host is reported as written")
+	}
+}

--- a/cmd/deja/doctor_sync_prose_test.go
+++ b/cmd/deja/doctor_sync_prose_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/termwidth"
 )
 
 // The Sync section of docs/json-output.md described both strings a peer row
@@ -57,13 +58,24 @@ func TestTheSyncSectionDescribesWhatTheRowsCarry(t *testing.T) {
 	if row.Host != host {
 		t.Errorf("the host was altered, so what the JSON hands back is not a name to sync with: %q", row.Host)
 	}
-	if len(row.LastError) > 260 {
-		t.Errorf("the error is unbounded at %d bytes; a remote writes it", len(row.LastError))
+	// In columns, which is the bound safeForStatusline applies: a byte count
+	// would call a 200-column line of CJK unbounded and a bound written in
+	// bytes correct.
+	if cols := termwidth.Columns(row.LastError); cols > 201 {
+		t.Errorf("the error is unbounded at %d columns; a remote writes it", cols)
 	}
 	// The escape reaches the reader as an escape sequence in the JSON string,
 	// never as a raw byte a terminal would act on.
 	if strings.Contains(out.String(), "\x1b") {
 		t.Error("a control byte was written into the JSON unescaped")
+	}
+
+	// The same bound with a wide script: two columns to the rune, so a bound
+	// that counted bytes or runes would cut in the wrong place — and a test
+	// fed only ASCII could not tell the three apart.
+	wide := strings.Repeat("計", 400)
+	if got := termwidth.Columns(safeForStatusline(wide, 200)); got > 201 {
+		t.Errorf("a wide-script error came back %d columns wide", got)
 	}
 
 	doc, err := os.ReadFile("../../docs/json-output.md")

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -361,9 +361,12 @@ is a broken sync that reads as a working one. A row carrying neither is a
 machine named once and never reached — the text report says "never exchanged"
 for it — and it is still a row, which is what distinguishes it from a deja too
 old to report peers at all: that one has no `sync` key. `last_error` is why the most
-recent exchange failed and is absent once one succeeds. Both `host` and
-`last_error` are written elsewhere — a config file, another machine — so they
-are bounded and stripped of control characters before they are reported.
+recent exchange failed and is absent once one succeeds. `last_error` is written by
+another machine and can be made arbitrarily long, so it is bounded before it is
+reported. `host` is not: it is a name to act on — `deja sync ssh <host>` — and a
+bounded name names no machine, so it is reported exactly as the config file
+spells it, however long. Neither can carry a raw control byte into a terminal:
+the JSON encoder escapes those in any string.
 `stamped_ahead` appears when the newer of the two timestamps is more than a
 minute later than this machine's clock: the age would be negative and the row
 would otherwise read as a sync that just happened, so a consumer should treat


### PR DESCRIPTION
Closes #1869.

The Sync section said "Both `host` and `last_error` … are bounded and stripped of control characters before they are reported". Only the error is. The host is reported exactly as the config file spells it — that was the review's call on #1839: a name deja hands back for `deja sync ssh <host>` is not a name once it is truncated, and the JSON encoder escapes a control byte on its own.

```
$ deja doctor --json --offline     # peers.json holds a 409-char host with ESC in it
host len    409
error len   201
```

The paragraph now says which of the two is bounded and why the other is not.

The test is the part worth reading: `TestTheSyncSectionDescribesWhatTheRowsCarry` puts an oversized host and an oversized error through `doctor --json` and asserts the host arrives byte for byte, the error is cut, and no raw escape reaches the output — then checks the paragraph does not still make the old claim. The section has grown three times in five iterations with nothing checking its prose against emitted values, only its key names.

No behaviour change.
