### PR TITLE
fix(json): drop a timestamp that was never set instead of writing year 1

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -650,9 +650,28 @@ type blameSessionJSON struct {
 	Project string    `json:"project,omitempty"`
 	Path    string    `json:"path,omitempty"`
 	Title   string    `json:"title,omitempty"`
-	Started time.Time `json:"started,omitempty"`
-	Updated time.Time `json:"updated,omitempty"`
+	Started time.Time `json:"-"`
+	Updated time.Time `json:"-"`
 	Touched []string  `json:"touched,omitempty"`
+}
+
+// MarshalJSON drops a stamp the harness never wrote. `omitempty` does nothing
+// to a struct, so a session with no start time told the agent it began in
+// January of year 1 (#1874).
+func (s blameSessionJSON) MarshalJSON() ([]byte, error) {
+	type plain blameSessionJSON
+	out := struct {
+		plain
+		Started *time.Time `json:"started,omitempty"`
+		Updated *time.Time `json:"updated,omitempty"`
+	}{plain: plain(s)}
+	if !s.Started.IsZero() {
+		out.Started = &s.Started
+	}
+	if !s.Updated.IsZero() {
+		out.Updated = &s.Updated
+	}
+	return json.Marshal(out)
 }
 
 func mustMarshalBlame(hits []search.BlameHit, omitted int, refreshing bool) []byte {

--- a/cmd/deja/zero_time_json_test.go
+++ b/cmd/deja/zero_time_json_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// `omitempty` does nothing to a struct, and time.Time is one: a field tagged
+// that way is always written, and a zero time reads as January of year 1. The
+// document promises `recall.since` is absent on a store with no recall history
+// (#1874).
+func TestStatsOmitsTheRecallWindowItNeverOpened(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"s1","cwd":"/proj","timestamp":"2026-08-20T10:00:00Z","message":{"role":"user","content":"fix the parser"}}`
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "stats", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		Recall map[string]any `json:"recall"`
+	}
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("%v: %s", err, out)
+	}
+	if v, ok := report.Recall["since"]; ok {
+		t.Errorf("a store that has served no recall reports a window opening at %v", v)
+	}
+	// The control: the block itself is still there, so the absence above is an
+	// omitted field and not a missing section.
+	if _, ok := report.Recall["recalls_served"]; !ok {
+		t.Errorf("the recall block is gone entirely: %v", report.Recall)
+	}
+}
+
+// The same tag on the same type is elsewhere in the emitted JSON. This walks
+// for it rather than waiting to meet the next one: a new field written this way
+// is a documented omission that never happens.
+func TestNoEmittedTimestampReliesOnOmitemptyAloneToVanish(t *testing.T) {
+	// internal/peers is deja's own file rather than a reported contract, and a
+	// year-1 stamp there parses back to a zero time.Time, so nothing reads it
+	// wrong. Recorded here so the exception is a decision rather than a gap.
+	allowed := map[string]bool{
+		"../../internal/peers/peers.go": true,
+	}
+	// A pointer is the fix, not the flaw: *time.Time with omitempty does
+	// vanish. Only the bare struct is the bug.
+	tagged := regexp.MustCompile(`[^*\w.]time\.Time\s+` + "`" + `json:"[^"]*,omitempty"`)
+	var found []string
+	roots := []string{".", "../../internal"}
+	for _, root := range roots {
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return err
+			}
+			if allowed[filepath.ToSlash(path)] {
+				return nil
+			}
+			src, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if m := tagged.FindString(string(src)); m != "" {
+				found = append(found, path+": "+m)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(found) > 0 {
+		t.Errorf("these fields are written even when the time is zero, which reads as year 1:\n%s", strings.Join(found, "\n"))
+	}
+}

--- a/internal/stats/json_contract_test.go
+++ b/internal/stats/json_contract_test.go
@@ -1,9 +1,13 @@
 package stats
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
 // collectJSONKeys gathers every json field name a type marshals, recursing
@@ -55,6 +59,21 @@ func TestStatsJSONKeysMatchTheDocumentedContract(t *testing.T) {
 	}
 	emitted := map[string]bool{}
 	collectJSONKeys(reflect.TypeOf(Report{}), emitted)
+	// usage.Summary writes its own JSON so a zero timestamp does not print as
+	// year 1 (#1874), and a key written that way is invisible to the tag walk
+	// above. Marshal a filled one and take the keys from the output.
+	filled := usage.Summary{Since: time.Unix(1, 0).UTC()}
+	b, err := json.Marshal(filled)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var written map[string]any
+	if err := json.Unmarshal(b, &written); err != nil {
+		t.Fatal(err)
+	}
+	for k := range written {
+		emitted[k] = true
+	}
 
 	for k := range emitted {
 		if !documented[k] {

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -80,7 +80,23 @@ type Summary struct {
 	// 1MB keeping the last 14 days, so a count with no period attached reads
 	// as a lifetime total and then falls by orders of magnitude when that
 	// happens (#763).
-	Since time.Time `json:"since,omitempty"`
+	Since time.Time `json:"-"`
+}
+
+// MarshalJSON writes Since only when there is one. `omitempty` does nothing to
+// a struct, and time.Time is one, so the tag alone wrote January of year 1 on
+// every store that had served no recall — a date a reader subtracts from, and
+// one the document says is not there at all (#1874).
+func (s Summary) MarshalJSON() ([]byte, error) {
+	type plain Summary
+	out := struct {
+		plain
+		Since *time.Time `json:"since,omitempty"`
+	}{plain: plain(s)}
+	if !s.Since.IsZero() {
+		out.Since = &s.Since
+	}
+	return json.Marshal(out)
 }
 
 const (


### PR DESCRIPTION
Closes #1874.

Auditing the rest of `docs/json-output.md` against emitted values (the `show` window, the `stats` omissions) turned up one sentence that is not true. The document says `recall.since` is omitted when there is no recall history; `omitempty` does nothing to a struct, and `time.Time` is one:

```
$ deja stats --json          # fresh store
"recall": { …, "since": "0001-01-01T00:00:00Z" }
```

A reader that branches on the key being absent instead gets a date it will subtract from.

The same tag on the same type is in `blameSessionJSON` (`started`, `updated`), where a session whose harness records no start stamp told an agent it began in year 1. Both types now write their own JSON and leave the field out when the time is zero. `internal/peers` keeps the tags on purpose — that file is deja's own and a year-1 stamp parses back to a zero `time.Time`, so nothing reads it wrong; the walk below records the exception.

Tests:

- `TestStatsOmitsTheRecallWindowItNeverOpened` — a store that has served no recall, through the real command, with the block's presence as the control.
- `TestNoEmittedTimestampReliesOnOmitemptyAloneToVanish` — walks `cmd/deja` and `internal` for a bare `time.Time` tagged `,omitempty`. Both fail on the base branch, the walk naming both files.

`TestStatsJSONKeysMatchTheDocumentedContract` reflects over struct tags, which cannot see a key a custom marshaler writes, so it now also takes the keys from a marshalled `usage.Summary`.
