### PR TITLE
fix(doctor): count a machine's sessions whichever case it spells its name in

### DIFF
--- a/cmd/deja/doctor_peer_count_test.go
+++ b/cmd/deja/doctor_peer_count_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The count beside a machine is looked up by name, and the two names come from
+// different places: the peers row is the ssh alias someone typed, while the
+// stamp on an imported session is what the sending machine calls itself. macOS
+// hands back a capitalised hostname, so `ssh laptop` against a host named
+// `Laptop` reported none of the sessions it had sent (#1876).
+func TestTheSessionCountFindsTheMachineInEitherCase(t *testing.T) {
+	tmp := hermeticEnv(t)
+	peersFile := filepath.Join(tmp, "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", peersFile)
+	if err := os.WriteFile(peersFile, []byte(`{"peers":[{"host":"laptop","last_pull":"2026-08-20T10:00:00Z"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	batch := filepath.Join(tmp, "batch")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var lines []string
+	for i := 0; i < 3; i++ {
+		rec := map[string]any{
+			"harness": "claude", "session_id": "remote" + string(rune('a'+i)), "project": "proj",
+			"role": "user", "text": "retry loop", "time": "2026-08-20T10:00:0" + string(rune('0'+i)) + "Z",
+			"origin": "Laptop",
+		}
+		b, err := json.Marshal(rec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines = append(lines, string(b))
+	}
+	if err := os.WriteFile(filepath.Join(batch, "deja-sync-1.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if n, err := index.Import(dir, batch); err != nil || n != 3 {
+		t.Fatalf("import: %d records, %v", n, err)
+	}
+
+	var text strings.Builder
+	doctorPeers(&text, dir, time.Date(2026, 8, 25, 10, 0, 0, 0, time.UTC))
+	if !strings.Contains(text.String(), "3 sessions from there") {
+		t.Errorf("the row does not count the sessions that machine sent:\n%s", text.String())
+	}
+
+	var out strings.Builder
+	if err := runDoctor(&out, []string{"--json", "--offline"}, stubLookup("1.0.0", false), dir); err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		Sync struct {
+			Peers []struct {
+				Host     string `json:"host"`
+				Sessions int    `json:"sessions_from_there"`
+			} `json:"peers"`
+		} `json:"sync"`
+	}
+	if err := json.Unmarshal([]byte(out.String()), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Sync.Peers) != 1 || report.Sync.Peers[0].Sessions != 3 {
+		t.Errorf("--json counts %#v, want three sessions from laptop", report.Sync.Peers)
+	}
+}

--- a/cmd/deja/doctor_peers.go
+++ b/cmd/deja/doctor_peers.go
@@ -33,7 +33,7 @@ func doctorPeers(w io.Writer, dir string, now time.Time) {
 		fmt.Fprintf(w, "  %-12s no other machines yet — `deja sync ssh <host>` once, then `deja sync` keeps them all in step\n", "peers")
 		return
 	}
-	from := index.ImportedByMachine(dir)
+	from := importsByPeerName(dir)
 	// The column is padded by what the terminal draws, not by how many runes
 	// the name has: %-12s gave a 32-character name no padding at all and
 	// treated a CJK name as one column per character (#1821). A name wider
@@ -48,7 +48,7 @@ func doctorPeers(w io.Writer, dir string, now time.Time) {
 		}
 	}
 	for i, p := range list {
-		state := peerLine(p, from[p.Host], now)
+		state := peerLine(p, from[peers.Identity(p.Host)], now)
 		pad := width - termwidth.Columns(names[i])
 		if pad < 0 {
 			fmt.Fprintf(w, "  %s\n  %s %s\n", names[i], strings.Repeat(" ", width), state)
@@ -132,4 +132,19 @@ func doctorAgo(d time.Duration) string {
 	default:
 		return fmt.Sprintf("%s ago", doctorCount(int(d.Hours()/24), "day"))
 	}
+}
+
+// importsByPeerName counts imported sessions under the same rule the peers
+// list uses for identity. The stamp on an imported session is what the sending
+// machine calls itself — a hostname, capitalised on macOS — while the row it
+// belongs to is an ssh alias someone typed, so an exact lookup reported none of
+// the sessions a machine had sent (#1876). A genuinely different name — alias
+// `work`, hostname `build-box` — is still a miss, and nothing here can fix
+// that.
+func importsByPeerName(dir string) map[string]int {
+	out := map[string]int{}
+	for name, n := range index.ImportedByMachine(dir) {
+		out[peers.Identity(name)] += n
+	}
+	return out
 }

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -127,7 +127,7 @@ type doctorPeerReport struct {
 // collectDoctorSync reads the peers file and what arrived from each machine.
 func collectDoctorSync(dir string) doctorSyncReport {
 	list, why := peers.Snapshot()
-	from := index.ImportedByMachine(dir)
+	from := importsByPeerName(dir)
 	out := doctorSyncReport{State: "ok", Peers: make([]doctorPeerReport, 0, len(list))}
 	if why != "" {
 		// Error is unbounded on purpose, unlike a peer's LastError beside it:
@@ -144,7 +144,7 @@ func collectDoctorSync(dir string) doctorSyncReport {
 			// which is the reason the text report needs a bound and this does
 			// not.
 			Host:      p.Host,
-			Sessions:  from[p.Host],
+			Sessions:  from[peers.Identity(p.Host)],
 			LastError: safeForStatusline(p.LastError, 200),
 		}
 		if !p.LastPush.IsZero() {

--- a/internal/peers/peers.go
+++ b/internal/peers/peers.go
@@ -135,6 +135,15 @@ func identity(host string) string {
 	return host[:at+1] + strings.ToLower(host[at+1:])
 }
 
+// Identity is that rule for a caller outside this package: anything keyed by a
+// machine name has to agree with the list about which names are one machine.
+// `deja doctor` counts imported sessions by the name the sending machine calls
+// itself, which is a hostname — capitalised on macOS — against an ssh alias
+// that usually is not (#1876).
+func Identity(host string) string {
+	return identity(strings.TrimSpace(host))
+}
+
 // Canonical is how a host named on the command line should be spelled for the
 // rest of a run: the spelling deja already stored for that machine, if it knows
 // it. Watermarks are namespaced by the peer string, so `deja sync ssh laptop`


### PR DESCRIPTION
Closes #1876.

#1867 folded case inside `internal/peers`. The count beside each machine in `deja doctor` is looked up outside it, with the raw string, and the two names come from different places: the row is the ssh alias someone typed, the stamp on an imported session is what the sending machine calls itself. macOS capitalises a hostname, so `ssh laptop` against a host named `Laptop` reported none of the sessions it had sent.

```
before  laptop   last exchange 5 days ago, nothing sent yet
        "sessions_from_there": 0
after   laptop   last exchange 5 days ago, nothing sent yet, 3 sessions from there
        "sessions_from_there": 3
```

The text row dropped the clause entirely, so it read like a machine that had sent nothing — which is what someone opens `deja doctor` to find out.

`peers.Identity` exports the rule the list already uses, and both surfaces count through one helper. A genuinely different name — alias `work`, hostname `build-box` — is still a miss, and nothing here can fix that; the comment says so.

`TestTheSessionCountFindsTheMachineInEitherCase` imports a real batch stamped `Laptop` against a row written `laptop` and checks both surfaces. It fails on the base branch on both.
