### PR TITLE
fix(sync): one machine, one watermark, whichever case the name was typed in

### DIFF
--- a/cmd/deja/export_peer_case_test.go
+++ b/cmd/deja/export_peer_case_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A watermark is namespaced by the peer string an export was given, and one
+// machine spelled two ways got two of them: the second export sent the same
+// records again and reported them as work delivered (#1878). ssh has treated
+// the two spellings as one machine since #1867.
+func TestOneMachineSettlesUnderOneWatermarkWhicheverCase(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var lines []string
+	for i := 0; i < 4; i++ {
+		lines = append(lines, `{"type":"user","sessionId":"s`+string(rune('a'+i))+`","cwd":"/proj","timestamp":"2026-08-20T10:0`+string(rune('0'+i))+`:00Z","message":{"role":"user","content":"retry loop"}}`)
+	}
+	if err := os.WriteFile(filepath.Join(store, "s.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := captureRun(t, "sync", "export", filepath.Join(tmp, "one"), "--peer", "laptop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(first, "exported 4 records") {
+		t.Fatalf("the first export did not send the history: %s", first)
+	}
+	again, err := captureRun(t, "sync", "export", filepath.Join(tmp, "two"), "--peer", "Laptop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(again, "exported 0 records") {
+		t.Errorf("the same machine spelled differently was sent everything again: %s", again)
+	}
+
+	// The control: a different machine still receives the history, so the
+	// watermarks are folded rather than shared.
+	other, err := captureRun(t, "sync", "export", filepath.Join(tmp, "three"), "--peer", "build-box")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(other, "exported 4 records") {
+		t.Errorf("a machine that has received nothing was told it was up to date: %s", other)
+	}
+}

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -114,7 +114,11 @@ func runSync(dir string, args []string) error {
 		if full {
 			n, err = index.ExportFull(dir, out)
 		} else {
-			n, err = index.ExportTo(dir, out, peer)
+			// Folded, so one machine settles under one watermark whichever way
+			// the name was spelled — a pull runs this on the remote with that
+			// machine's hostname, capitalised on macOS, while the alias someone
+			// types by hand usually is not (#1878).
+			n, err = index.ExportTo(dir, out, peers.Identity(peer))
 		}
 		if err != nil {
 			// `open …/deja-sync-b9849e838232-1785639771368128000.jsonl:

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -182,7 +182,10 @@ func syncSSHPush(dir, host string, full bool) error {
 		n, err = index.ExportFull(dir, tmp)
 		commit = func() error { return nil }
 	} else {
-		n, commit, err = index.ExportDeferred(dir, tmp, host)
+		// The connection takes the host as stored; the watermark takes the
+		// folded name, so a push and a hand-run `sync export --peer` settle the
+		// same machine rather than two (#1878).
+		n, commit, err = index.ExportDeferred(dir, tmp, peers.Identity(host))
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
Closes #1878.

A watermark is namespaced by the peer string an export was given, taken as typed. Since #1867 `Laptop` and `laptop` are one machine everywhere else:

```
before  --peer laptop  exported 6      --peer laptop  exported 0      --peer Laptop  exported 6
after   --peer laptop  exported 6      --peer laptop  exported 0      --peer Laptop  exported 0
```

The two sync paths could split the same pair of machines between them: a push hands `ExportDeferred` the host as stored, while a pull runs `sync export --peer <hostname>` on the remote — and a hostname is capitalised on macOS while the alias someone types is not. Nothing is corrupted (import dedupes), but "exported 6 records" after those records already arrived is the sentence a reader trusts to mean the other side did not have them.

Both places where a peer name enters an export now fold it with `peers.Identity`. The connection still uses the stored spelling; only the watermark key folds.

Upgrade note: a machine whose watermark was stored under a capitalised name starts from an empty watermark once, so the next push re-sends its history. Import dedupes it.

`TestOneMachineSettlesUnderOneWatermarkWhicheverCase` fails on the base branch, with a second machine as the control so the fold cannot be mistaken for one shared watermark.

Left for you, from the issue: `--peer` accepts a name deja has never heard of, so a typo opens a private watermark and reports success. Exporting for a machine you have never ssh'd to is legitimate, so whether the command should say "deja does not know a machine called X" is your call.
