### PR TITLE
fix(statusline): let the filename give way so the memory half fits the bar

### DIFF
--- a/cmd/deja/statusline_fit_test.go
+++ b/cmd/deja/statusline_fit_test.go
@@ -66,3 +66,29 @@ func TestAnOrdinaryMemorySegmentIsNotTrimmed(t *testing.T) {
 		t.Errorf("a segment that fits carries an ellipsis: %q", got)
 	}
 }
+
+// The budgets are columns of allowance, not columns of line: a title shorter
+// than its budget gives nothing back when the budget is cut. Subtracting the
+// overflow in one step therefore left bars over-width while both parts were
+// still above their floors — 57 of 2496 measured. This walks the grid and
+// allows an over-width segment only where even both floors would not fit.
+func TestNoBarIsLeftOverWidthWhileThePartsCanStillGiveWay(t *testing.T) {
+	when := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	titles := []string{"retry", strings.Repeat("word ", 12), strings.Repeat("計", 30)}
+	for width := 20; width <= 120; width += 4 {
+		for nameLen := 5; nameLen <= 80; nameLen += 5 {
+			for _, title := range titles {
+				m := fileMemory{Path: "/p/" + strings.Repeat("n", nameLen) + ".go", Sessions: 3, Title: title, Last: when}
+				got := memorySegment(m, width)
+				if barColumns(got) <= width {
+					continue
+				}
+				atFloor := "deja · " + statuslineMemoryLineWithin(m, statuslineMinTitle, statuslineMinName)
+				if barColumns(atFloor) <= width {
+					t.Fatalf("width=%d name=%d: %d columns, though the floors fit in %d: %q",
+						width, nameLen, barColumns(got), barColumns(atFloor), got)
+				}
+			}
+		}
+	}
+}

--- a/cmd/deja/statusline_fit_test.go
+++ b/cmd/deja/statusline_fit_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The memory half is the one withFileMemory says has to survive, so it is
+// fitted before any of the usage numbers are appended. Only the title was
+// elastic: the filename was fixed at 28 columns, so a long path put the segment
+// past the bar however far the title had been cut, and a bar has no horizontal
+// scroll (#1880, the shape of #1076).
+func TestTheMemorySegmentFitsWhereTheFloorsAllowIt(t *testing.T) {
+	when := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	long := fileMemory{Path: "/p/" + strings.Repeat("n", 60) + ".go", Sessions: 3, Title: "retry", Last: when}
+	wide := fileMemory{Path: "/p/parser.go", Sessions: 3, Title: strings.Repeat("計", 40), Last: when}
+	for _, c := range []struct {
+		name  string
+		mem   fileMemory
+		width int
+	}{
+		{"long name, short title", long, 60},
+		{"long name, long title", fileMemory{Path: long.Path, Sessions: 3, Title: strings.Repeat("word ", 12), Last: when}, 60},
+		{"wide script title", wide, 60},
+	} {
+		if got := memorySegment(c.mem, c.width); barColumns(got) > c.width {
+			t.Errorf("%s: %d columns on a %d-column bar: %q", c.name, barColumns(got), c.width, got)
+		}
+	}
+}
+
+// Below both floors the segment is still over-width, and that is the older
+// decision: a title cut to a stub in quotation marks says less than the count
+// form, which is what TestStatuslineNarrowBarKeepsAReadableTitle pins. What
+// this asserts is that the filename gives way as far as it may, so the segment
+// is no wider than the floors require.
+func TestOnATooNarrowBarTheFilenameStillGivesWay(t *testing.T) {
+	m := fileMemory{
+		Path:     "/p/" + strings.Repeat("n", 60) + ".go",
+		Sessions: 3,
+		Title:    "retry",
+		Last:     time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC),
+	}
+	got := memorySegment(m, 40)
+	fixedName := "deja · " + statuslineMemoryLineWithin(m, statuslineMinTitle, statuslineMaxName)
+	if barColumns(got) >= barColumns(fixedName) {
+		t.Errorf("the filename did not give way: %q is not narrower than %q", got, fixedName)
+	}
+	// The title floor still holds, so the segment says what the session was
+	// about rather than showing a stub.
+	open, close := strings.Index(got, "“"), strings.Index(got, "”")
+	if open < 0 || close < open {
+		t.Errorf("the quoted title is gone: %q", got)
+	}
+}
+
+// An ordinary bar is unchanged: the fitting only takes away when it has to.
+func TestAnOrdinaryMemorySegmentIsNotTrimmed(t *testing.T) {
+	m := fileMemory{Path: "/p/parser.go", Sessions: 3, Title: "retry loop", Last: time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)}
+	got := memorySegment(m, 80)
+	if !strings.Contains(got, "parser.go") || !strings.Contains(got, "retry loop") {
+		t.Errorf("a segment that fits was trimmed anyway: %q", got)
+	}
+	if strings.Contains(got, "…") {
+		t.Errorf("a segment that fits carries an ellipsis: %q", got)
+	}
+}

--- a/cmd/deja/statusline_memory.go
+++ b/cmd/deja/statusline_memory.go
@@ -41,6 +41,9 @@ const (
 	// statuslineMaxName bounds the filename for the same reason: a 200-char
 	// path put a 226-rune line on a bar that has no horizontal scroll.
 	statuslineMaxName = 28
+	// statuslineMinName is how far the filename gives way on a narrow bar
+	// before the segment is cut outright. Below this a name says nothing.
+	statuslineMinName = 10
 )
 
 // readStatuslineInput consumes the payload without ever blocking. An
@@ -196,14 +199,22 @@ func statuslineMemoryLine(m fileMemory) string {
 	return statuslineMemoryLineTo(m, statuslineMaxTitle)
 }
 
-// statuslineMemoryLineTo bounds the title to maxTitle runes. maxTitle <= 0
-// drops the title and falls through to the count form, which is what a bar too
-// narrow to hold any of it gets.
+// statuslineMemoryLineTo bounds the title to maxTitle columns — the unit
+// safeForStatusline works in, since the bound exists to keep the bar inside the
+// terminal. maxTitle <= 0 drops the title and falls through to the count form,
+// which is what a bar too narrow to hold any of it gets.
 func statuslineMemoryLineTo(m fileMemory, maxTitle int) string {
+	return statuslineMemoryLineWithin(m, maxTitle, statuslineMaxName)
+}
+
+// statuslineMemoryLineWithin is that with the filename bounded too. The
+// filename is the second elastic part: at 28 columns it alone could put the
+// segment past a narrow bar however far the title was cut (#1880).
+func statuslineMemoryLineWithin(m fileMemory, maxTitle, maxName int) string {
 	// The path comes from a tool call and is recorded verbatim, exactly like
 	// the title: a filename can carry a carriage return or an escape just as
 	// easily, and it reaches the same bar.
-	name := safeForStatusline(filepath.Base(m.Path), statuslineMaxName)
+	name := safeForStatusline(filepath.Base(m.Path), maxName)
 	when := ""
 	if !m.Last.IsZero() {
 		// A meta with no timestamp would otherwise put "Jan 1 0001" on the bar.
@@ -254,6 +265,43 @@ func safeForStatusline(s string, max int) string {
 	return s
 }
 
+// memorySegment renders the memory half to fit a bar of the given width.
+//
+// The title gives way first, down to statuslineMinTitle: it is the longest
+// elastic part and the one a reader can lose the tail of and still recognise.
+// Then the filename, down to statuslineMinName — it was fixed at 28 columns,
+// so a long path put the segment past a narrow bar however far the title had
+// been cut (#1880).
+//
+// A bar too narrow for both floors still gets an over-width segment, and that
+// is the older decision this keeps: the title has a floor because a stub in
+// quotation marks says less than the count form, and
+// TestStatuslineNarrowBarKeepsAReadableTitle pins it. What changes here is that
+// the segment is no wider than those floors require.
+func memorySegment(m fileMemory, width int) string {
+	const prefix = "deja · "
+	line := func(title, name int) string {
+		return prefix + statuslineMemoryLineWithin(m, title, name)
+	}
+	mem := line(statuslineMaxTitle, statuslineMaxName)
+	if barColumns(mem) <= width {
+		return mem
+	}
+	title := statuslineMaxTitle - (barColumns(mem) - width)
+	if title < statuslineMinTitle {
+		title = statuslineMinTitle
+	}
+	mem = line(title, statuslineMaxName)
+	if barColumns(mem) <= width {
+		return mem
+	}
+	name := statuslineMaxName - (barColumns(mem) - width)
+	if name < statuslineMinName {
+		name = statuslineMinName
+	}
+	return line(title, name)
+}
+
 // withFileMemory puts the memory ahead of the usage numbers when there is
 // one. The numbers are about deja; the memory is about the reader's own work,
 // and on a line that gets truncated the useful half should survive.
@@ -277,14 +325,7 @@ func withFileMemory(dir string, in transcriptSource, usage string) string {
 	// The memory segment is fitted first, because the comment above is the
 	// rule: it is the half that has to survive. The title is its elastic part,
 	// with a floor so a long filename cannot cut it to a stub.
-	mem := "deja · " + statuslineMemoryLineTo(m, statuslineMaxTitle)
-	if over := barColumns(mem) - width; over > 0 {
-		budget := statuslineMaxTitle - over
-		if budget < statuslineMinTitle {
-			budget = statuslineMinTitle
-		}
-		mem = "deja · " + statuslineMemoryLineTo(m, budget)
-	}
+	mem := memorySegment(m, width)
 	// Then as much of the usage as still fits. Appending it whole is what put
 	// it past the edge; dropping it is the trade this function already
 	// documents, and half of it beats a line that runs off.

--- a/cmd/deja/statusline_memory.go
+++ b/cmd/deja/statusline_memory.go
@@ -283,23 +283,22 @@ func memorySegment(m fileMemory, width int) string {
 	line := func(title, name int) string {
 		return prefix + statuslineMemoryLineWithin(m, title, name)
 	}
-	mem := line(statuslineMaxTitle, statuslineMaxName)
-	if barColumns(mem) <= width {
-		return mem
+	title, name := statuslineMaxTitle, statuslineMaxName
+	mem := line(title, name)
+	// A column of budget is not a column of line: a title shorter than its
+	// budget gives nothing back when the budget is cut, so subtracting the
+	// overflow in one step left 57 of 2496 measured bars over-width while both
+	// parts were still above their floors. Stepping down converges on the
+	// narrowest form the floors allow, and the loop is bounded by the budgets.
+	for barColumns(mem) > width && title > statuslineMinTitle {
+		title--
+		mem = line(title, name)
 	}
-	title := statuslineMaxTitle - (barColumns(mem) - width)
-	if title < statuslineMinTitle {
-		title = statuslineMinTitle
+	for barColumns(mem) > width && name > statuslineMinName {
+		name--
+		mem = line(title, name)
 	}
-	mem = line(title, statuslineMaxName)
-	if barColumns(mem) <= width {
-		return mem
-	}
-	name := statuslineMaxName - (barColumns(mem) - width)
-	if name < statuslineMinName {
-		name = statuslineMinName
-	}
-	return line(title, name)
+	return mem
 }
 
 // withFileMemory puts the memory ahead of the usage numbers when there is


### PR DESCRIPTION
Closes #1880.

`withFileMemory` fits the memory half before appending any usage numbers, because that is the half it says has to survive. Only the title was elastic, though: the filename sat at 28 columns whatever happened, and cutting a five-column title by twelve removes five.

```
case                     width   before   after
long name, short title   60      64       60
long name, long title    60      72       60
narrow bar, long name    40      64       46
```

The filename now gives way after the title reaches its floor, down to a floor of its own.

What has not changed is the older decision underneath: a bar too narrow for both floors still gets an over-width segment, because a title cut to a stub inside quotation marks says less than the count form. `TestStatuslineNarrowBarKeepsAReadableTitle` pins that, and an earlier draft of this fix clamped the segment to the width and broke it — the 40-column row above is 46 for that reason, not by omission.

The fitting moved into `memorySegment`, which is what the tests drive. `statuslineMemoryLineTo`'s comment said it bounds the title "to maxTitle runes"; `safeForStatusline` bounds in columns and always has, so the comment now says columns.

Both new tests fail with the filename pass removed — the fit test on the two 60-column rows, and the narrow-bar test because the segment is then exactly as wide as one rendered with the fixed name.
