### PR TITLE
chore: Search Console verification file

### DIFF
--- a/docs/google0044e230ee95349f.html
+++ b/docs/google0044e230ee95349f.html
@@ -1,0 +1,1 @@
+google-site-verification: google0044e230ee95349f.html


### PR DESCRIPTION
Verifies `https://vshulcz.github.io/deja-vu/` as a URL-prefix property, so we can finally see which queries show us and whether the 52 pages in the sitemap are indexed at all.

Same shape as the IndexNow key already sitting in `docs/`: a static file GitHub Pages serves from the property root. Neither docs guard looks outside `docs/guide/`, so it changes nothing they check.

macOS blocked reading the copy in ~/Downloads (`Operation not permitted`), so the content is reconstructed from the filename — the format is fixed, and the file this produces is 53 bytes, which matches the downloaded one exactly.