### PR TITLE
fix(peers): stop two syncs at once from losing machines

### DIFF
--- a/internal/peers/lock.go
+++ b/internal/peers/lock.go
@@ -1,0 +1,62 @@
+package peers
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// lockWait is how long a sync waits for another one to finish writing the
+	// list. The file is small and written once per exchange, so a wait this
+	// long only happens when something is wrong.
+	lockWait = 2 * time.Second
+	// lockStale is when a lock is treated as left behind by a process that
+	// died. Nothing holds this lock across a network call — it is taken around
+	// a read, an edit and a write of one small file.
+	lockStale = 30 * time.Second
+	// lockPoll is how often the wait looks again.
+	lockPoll = 5 * time.Millisecond
+)
+
+// withLock serialises a read-modify-write of the peers file.
+//
+// Record reads the whole list, edits it and writes it back, so two syncs
+// finishing at once kept only the last writer's row — and a lost row is a
+// machine deja stops syncing with, silently (#1883).
+//
+// A sync is never failed for want of the lock: waiting is bounded, a lock left
+// by a dead process is taken over, and a directory that cannot hold one at all
+// (a read-only config mount) runs the write unlocked, which is what deja did
+// before this existed.
+func withLock(fn func() error) error {
+	path := Path() + ".lock"
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fn()
+	}
+	deadline := time.Now().Add(lockWait)
+	for {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			f.Close()
+			defer os.Remove(path)
+			return fn()
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			return fn()
+		}
+		if fi, serr := os.Stat(path); serr == nil && time.Since(fi.ModTime()) > lockStale {
+			_ = os.Remove(path)
+			continue
+		}
+		if time.Now().After(deadline) {
+			// Better a write that races than a sync that refuses to record what
+			// it just did: the exchange has already happened by the time this
+			// runs.
+			return fn()
+		}
+		time.Sleep(lockPoll)
+	}
+}

--- a/internal/peers/lock.go
+++ b/internal/peers/lock.go
@@ -40,8 +40,8 @@ func withLock(fn func() error) error {
 	for {
 		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 		if err == nil {
-			f.Close()
-			defer os.Remove(path)
+			_ = f.Close()
+			defer func() { _ = os.Remove(path) }()
 			return fn()
 		}
 		if !errors.Is(err, fs.ErrExist) {

--- a/internal/peers/peers.go
+++ b/internal/peers/peers.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vshulcz/deja-vu/internal/atomicfile"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
@@ -184,6 +185,15 @@ func Record(host string, pulled bool, when time.Time, err error) error {
 	if host == "" {
 		return nil
 	}
+	// Locked around the read, the edit and the write: without it two syncs
+	// finishing at once each wrote back the list they had read, and the second
+	// one dropped the first one's machine (#1883).
+	return withLock(func() error {
+		return recordLocked(host, pulled, when, err)
+	})
+}
+
+func recordLocked(host string, pulled bool, when time.Time, err error) error {
 	list := Load()
 	i := -1
 	for k := range list {
@@ -218,6 +228,17 @@ func Record(host string, pulled bool, when time.Time, err error) error {
 // Forget drops a host from the list. Reports whether it was there.
 func Forget(host string) (bool, error) {
 	host = strings.TrimSpace(host)
+	var found bool
+	err := withLock(func() error {
+		var ferr error
+		found, ferr = forgetLocked(host)
+		return ferr
+	})
+	return found, err
+}
+
+// forgetLocked is Forget with the list already held.
+func forgetLocked(host string) (bool, error) {
 	list := Load()
 	out := list[:0:0]
 	found := false
@@ -246,11 +267,11 @@ func save(list []Peer) error {
 	}
 	// Written whole through a temp file: a sync interrupted midway must not
 	// leave a half-written list that Load then silently reads as no peers.
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, append(b, '\n'), 0o600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	// atomicfile rather than a temp of our own, because ours was named for the
+	// file rather than for the writer — two syncs wrote into the one temp and
+	// renamed it in turn, so one of them could publish a list holding half of
+	// each, or fail outright on a temp the other had already renamed (#1883).
+	return atomicfile.Write(path, append(b, '\n'), 0o600)
 }
 
 // trimError keeps a failure short enough to sit on one line of a report. The

--- a/internal/peers/race_test.go
+++ b/internal/peers/race_test.go
@@ -1,0 +1,73 @@
+package peers
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Record reads the list, edits it and writes it back. Nothing serialised the
+// three steps, so two syncs finishing at once — two terminals, or a hook beside
+// a `deja sync` — kept only the last writer's row. A lost row is a machine deja
+// stops syncing with, and nothing says so (#1883).
+func TestConcurrentRecordsKeepEveryMachine(t *testing.T) {
+	writePeers(t, `{"peers":[]}`)
+	hosts := []string{"laptop", "server", "mini", "build-box", "desktop"}
+	when := time.Date(2026, 8, 25, 10, 0, 0, 0, time.UTC)
+
+	var wg sync.WaitGroup
+	errs := make([]error, len(hosts))
+	for i, h := range hosts {
+		wg.Add(1)
+		go func(i int, h string) {
+			defer wg.Done()
+			errs[i] = Record(h, false, when, nil)
+		}(i, h)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("%s: %v", hosts[i], err)
+		}
+	}
+
+	got := Load()
+	if len(got) != len(hosts) {
+		var names []string
+		for _, p := range got {
+			names = append(names, p.Host)
+		}
+		t.Fatalf("%d machines survived %d concurrent records: %s", len(got), len(hosts), strings.Join(names, ", "))
+	}
+	for _, p := range got {
+		if !p.LastPush.Equal(when) {
+			t.Errorf("%s kept no exchange: %#v", p.Host, p)
+		}
+	}
+}
+
+// A row written by one sync must survive another sync recording a different
+// machine — the read-modify-write case, rather than a fresh file.
+func TestARecordDoesNotDropTheRowsItDidNotWrite(t *testing.T) {
+	writePeers(t, `{"peers":[{"host":"laptop","last_push":"2026-08-20T10:00:00Z"}]}`)
+	when := time.Date(2026, 8, 25, 10, 0, 0, 0, time.UTC)
+	var wg sync.WaitGroup
+	for _, h := range []string{"server", "mini"} {
+		wg.Add(1)
+		go func(h string) {
+			defer wg.Done()
+			_ = Record(h, true, when, nil)
+		}(h)
+	}
+	wg.Wait()
+	seen := map[string]bool{}
+	for _, p := range Load() {
+		seen[p.Host] = true
+	}
+	for _, want := range []string{"laptop", "server", "mini"} {
+		if !seen[want] {
+			t.Errorf("%s is gone from the list", want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1883.

`Record` reads the list, edits it and writes it back, with nothing serialising the three steps. Four records at once against an empty file, twenty rounds:

```
before   rounds=20 lost=20      (round 0 kept nothing, most kept the last writer's row)
after    rounds=20 lost=0       (three runs)
```

A lost row is a machine deja stops syncing with — `deja sync` walks this file — and nothing says so, which is the one thing the peers file exists to prevent.

Two changes:

- `withLock` around the read-modify-write. A sync is never failed for want of the lock: the wait is bounded at 2s, a lock left by a dead process is taken over after 30s, and a directory that cannot hold one (a read-only config mount) runs the write unlocked, exactly as before. The exchange has already happened by the time this runs, so refusing to record it would be the worse answer.
- `save` writes through `atomicfile` instead of a temp named after the file. Two writers shared `peers.json.tmp`, so one could publish a list holding half of each — or fail outright on a temp the other had already renamed, which is what the first failing run showed (`rename …/peers.json.tmp …: no such file or directory`).

Both tests fail on the base branch: the concurrent one on the lost rows (and on that rename error), and the read-modify-write one because a row written earlier disappears.

Not covered: this serialises writers that can see each other's lock file. Two machines writing the same peers file over a network mount is not something the lock claims to handle.
