### PR TITLE
perf(search): build the query side of the record check once

### DIFF
--- a/internal/index/query_side_test.go
+++ b/internal/index/query_side_test.go
@@ -48,11 +48,14 @@ func seedQuerySideCorpus(t *testing.T, sessions int) string {
 //
 // Measured as a ratio against the plain query on the same corpus, so the
 // assertion does not depend on the machine or on how much the reader's Go
-// version allocates elsewhere.
+// version allocates elsewhere. The threshold is 1.3 because the two searches
+// allocate the same amount once the query side is shared — the ratio is 1.0
+// here and 2.14 on the branch before this — and because -race and a low GOGC
+// move both sides together (checked).
 func TestTheQuerySideIsNotRebuiltForEveryRecord(t *testing.T) {
 	dir := seedQuerySideCorpus(t, 40)
 	allocs := func(q string) float64 {
-		return testing.AllocsPerRun(2, func() {
+		return testing.AllocsPerRun(5, func() {
 			if _, err := Search(dir, query.Options{Query: q, All: true}); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/index/query_side_test.go
+++ b/internal/index/query_side_test.go
@@ -1,0 +1,85 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	query "github.com/vshulcz/deja-vu/internal/query"
+)
+
+// seedQuerySideCorpus writes sessions whose text is decomposed (NFD), the form
+// a macOS path hands back, and returns the index dir.
+func seedQuerySideCorpus(t *testing.T, sessions int) string {
+	t.Helper()
+	tmp := t.TempDir()
+	claude := filepath.Join(tmp, "claude", "-proj")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const word = "cafe\u0301" // e + combining acute, written as escapes on purpose
+	for s := 0; s < sessions; s++ {
+		var lines []string
+		for i := 0; i < 20; i++ {
+			text := fmt.Sprintf("the %s parser retried %d times before the pool was exhausted", word, i)
+			lines = append(lines, fmt.Sprintf(`{"type":"user","sessionId":"s%d","cwd":"/proj","timestamp":"2026-08-20T10:%02d:00Z","message":{"role":"user","content":%q}}`, s, i%60, text))
+		}
+		if err := os.WriteFile(filepath.Join(claude, fmt.Sprintf("s%d.jsonl", s)), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The per-record check ran the query side — parts, composed form, CJK-folded
+// form — for every record it looked at, so a decomposed query, which takes the
+// retry path on every record, allocated more than twice what the same search
+// allocated with an ASCII query (49385 against 22984 over 120 sessions). The
+// query does not change between records (#1885).
+//
+// Measured as a ratio against the plain query on the same corpus, so the
+// assertion does not depend on the machine or on how much the reader's Go
+// version allocates elsewhere.
+func TestTheQuerySideIsNotRebuiltForEveryRecord(t *testing.T) {
+	dir := seedQuerySideCorpus(t, 40)
+	allocs := func(q string) float64 {
+		return testing.AllocsPerRun(2, func() {
+			if _, err := Search(dir, query.Options{Query: q, All: true}); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+	plain := allocs("pool exhausted")
+	decomposed := allocs("cafe\u0301 parser")
+	if plain == 0 {
+		t.Fatal("the plain search allocated nothing, so the ratio below says nothing")
+	}
+	if ratio := decomposed / plain; ratio > 1.3 {
+		t.Errorf("a decomposed query allocates %.2fx the plain one (%v against %v): the query side is being rebuilt per record",
+			ratio, decomposed, plain)
+	}
+}
+
+// The retry paths still do what they are for: a query typed in one normal form
+// finds text stored in the other.
+func TestADecomposedQueryStillFindsComposedText(t *testing.T) {
+	dir := seedQuerySideCorpus(t, 2)
+	for _, q := range []string{"cafe\u0301 parser", "caf\u00e9 parser"} {
+		got, err := Search(dir, query.Options{Query: q, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) == 0 {
+			t.Errorf("%+q found nothing", q)
+		}
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1834,6 +1834,10 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		}
 		s.Messages = append(s.Messages, model.Message{Role: r.Role, Text: r.Text, Time: r.Time})
 	}
+	// Built once: the query side of the check does not change between records,
+	// and this loop runs over every record a query without postings reaches
+	// (#1885).
+	matcher := newRecordMatcher(o, variants)
 	if len(offsets) > 0 {
 		f, err := openIndexFile(filepath.Join(dir, "records.bin"))
 		if err != nil {
@@ -1842,7 +1846,7 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		defer func() { _ = f.Close() }()
 		offsets = sortedUniqueOffsets(offsets)
 		if err := eachRecordAt(f, offsets, tablesFromManifest(m), func(r Record) {
-			if recordMatchesQueryVariants(r, o, variants) {
+			if matcher.matches(r) {
 				add(r)
 			}
 		}); err != nil {
@@ -1850,7 +1854,7 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		}
 	} else {
 		if err := eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
-			if recordMatchesQueryVariants(r, o, variants) {
+			if matcher.matches(r) {
 				add(r)
 			}
 		}); err != nil {
@@ -3009,23 +3013,68 @@ func recordMatchesQuery(r Record, o query.Options) bool {
 }
 
 func recordMatchesQueryVariants(r Record, o query.Options, variants map[string][]string) bool {
+	return newRecordMatcher(o, variants).matches(r)
+}
+
+// recordMatcher is the query side of the verification check, built once.
+//
+// The check runs per record — for a query with no postings, that is every
+// record in the store — and everything derived from the query is the same
+// every time: the parts, the composed form, the CJK-folded form and their
+// parts. Rebuilding them per record doubled the cost of a decomposed query
+// (4.1 ms against 1.9 ms over 120 sessions, and 49385 allocations against
+// 22984), since such a query takes the retry path on every record (#1885).
+type recordMatcher struct {
+	regex    bool
+	matchAll bool
+	variants map[string][]string
+
+	terms, phrases []string
+
+	// nfc is the query composed, kept apart so a record can be tested against
+	// it without composing the query again.
+	nfc        string
+	nfcDiffers bool
+	nfcTerms   []string
+	nfcPhrases []string
+	cjk        string
+	cjkDiffers bool
+	cjkTerms   []string
+	cjkPhrases []string
+}
+
+func newRecordMatcher(o query.Options, variants map[string][]string) recordMatcher {
+	m := recordMatcher{regex: o.Regex, variants: variants}
 	if o.Regex {
+		return m
+	}
+	m.terms, m.phrases = query.QueryParts(o.Query)
+	if len(m.terms) == 0 && len(m.phrases) == 0 {
+		m.matchAll = true
+		return m
+	}
+	m.nfc = nfcfold.Compose(o.Query)
+	m.nfcDiffers = m.nfc != o.Query
+	m.nfcTerms, m.nfcPhrases = query.QueryParts(m.nfc)
+	m.cjk = cjkfold.String(o.Query)
+	m.cjkDiffers = m.cjk != o.Query
+	m.cjkTerms, m.cjkPhrases = query.QueryParts(m.cjk)
+	return m
+}
+
+func (m recordMatcher) matches(r Record) bool {
+	if m.regex || m.matchAll {
 		return true
 	}
-	terms, phrases := query.QueryParts(o.Query)
-	if len(terms) == 0 && len(phrases) == 0 {
-		return true
-	}
-	if query.MatchesParts(r.Text, terms, phrases, variants) {
+	if query.MatchesParts(r.Text, m.terms, m.phrases, m.variants) {
 		return true
 	}
 	// The postings that pointed here folded NFD to NFC (tokens); this surface
 	// check runs on the raw bytes, where the same accented word in the other
 	// normalization would not substring-match. Retry both composed, mirroring
 	// the CJK retry below (#1098).
-	if nfcfold.Compose(r.Text) != r.Text || nfcfold.Compose(o.Query) != o.Query {
-		nterms, nphrases := query.QueryParts(nfcfold.Compose(o.Query))
-		if query.MatchesParts(nfcfold.Compose(r.Text), nterms, nphrases, variants) {
+	if composed := nfcfold.Compose(r.Text); m.nfcDiffers || composed != r.Text {
+		if query.MatchesParts(composed, m.nfcTerms, m.nfcPhrases, m.variants) {
 			return true
 		}
 	}
@@ -3034,13 +3083,10 @@ func recordMatchesQueryVariants(r Record, o query.Options, variants map[string][
 	// verification step compares surface text, which would then reject the
 	// very record the postings pointed at — retry it on both sides folded.
 	folded := cjkfold.String(r.Text)
-	if folded == r.Text {
-		if q := cjkfold.String(o.Query); q == o.Query {
-			return false
-		}
+	if folded == r.Text && !m.cjkDiffers {
+		return false
 	}
-	fterms, fphrases := query.QueryParts(cjkfold.String(o.Query))
-	return query.MatchesParts(folded, fterms, fphrases, variants)
+	return query.MatchesParts(folded, m.cjkTerms, m.cjkPhrases, m.variants)
 }
 
 // bucket shards a token by its opening characters. It used to slice two


### PR DESCRIPTION
Closes #1885.

`recordMatchesQueryVariants` runs once per record — for a query with no postings, that is every record in the store — and everything it derived from the *query* was rebuilt each time: `QueryParts`, `nfcfold.Compose` (twice on the retry path, plus the parts of the result), `cjkfold.String` (twice, plus its parts). None of it depends on the record.

120 sessions × 20 messages, `Search(dir, {All:true})`:

```
                       before                    after
ASCII query            1.91–2.01 ms  22984       1.30–1.32 ms  6205
NFD corpus             2.05–2.18 ms  22984       1.49–1.54 ms  6205
NFD query              4.11–4.35 ms  49385       1.78–1.83 ms  6208
```

A decomposed query took the retry path on every record, so it paid for the rebuild twice over. The record side — composing the record's own text, folding it for CJK — stays where it is, and the composed text is now computed once in that branch rather than twice.

`recordMatcher` holds the query side; the two scan loops build it once. `recordMatchesQuery`/`recordMatchesQueryVariants` remain as wrappers, so the other callers and the tests are untouched.

Tests: `TestTheQuerySideIsNotRebuiltForEveryRecord` compares allocations of a decomposed query against a plain one on the same corpus — a ratio, so it does not depend on the machine. It reports 2.14x on the base branch and fails; it is 1.0x now. `TestADecomposedQueryStillFindsComposedText` keeps the retry paths honest, with both normal forms written as escapes.

The benchmark used for the numbers is not committed.
