### PR TITLE
fix(doctor): learn what a peer calls itself, so its sessions are counted

### DIFF
--- a/cmd/deja/doctor_peers.go
+++ b/cmd/deja/doctor_peers.go
@@ -170,13 +170,19 @@ func peerSessionCount(from map[string]int, p peers.Peer) int {
 // attributed — a batch from a third machine already in the index must not
 // rename the peer.
 func learnPeerMachine(dir, host string, before map[string]int) {
-	best, grew := "", 0
+	best, grown := "", 0
 	for name, n := range importsByPeerName(dir) {
-		if d := n - before[peers.Identity(name)]; d > grew {
-			best, grew = name, d
+		if n > before[peers.Identity(name)] {
+			best = name
+			grown++
 		}
 	}
-	if best == "" || peers.Identity(best) == peers.Identity(host) {
+	// Only when one machine grew. A batch can carry records from more than one
+	// origin — a machine that itself imported from a third — and another
+	// process can import while this runs, so picking the largest of several
+	// would sometimes write down a machine this host never sent. Learning
+	// nothing leaves the count at zero, which is what it was.
+	if grown != 1 || peers.Identity(best) == peers.Identity(host) {
 		return
 	}
 	// Best effort: a sync that worked must not fail because a name could not be

--- a/cmd/deja/doctor_peers.go
+++ b/cmd/deja/doctor_peers.go
@@ -48,7 +48,7 @@ func doctorPeers(w io.Writer, dir string, now time.Time) {
 		}
 	}
 	for i, p := range list {
-		state := peerLine(p, from[peers.Identity(p.Host)], now)
+		state := peerLine(p, peerSessionCount(from, p), now)
 		pad := width - termwidth.Columns(names[i])
 		if pad < 0 {
 			fmt.Fprintf(w, "  %s\n  %s %s\n", names[i], strings.Repeat(" ", width), state)
@@ -147,4 +147,39 @@ func importsByPeerName(dir string) map[string]int {
 		out[peers.Identity(name)] += n
 	}
 	return out
+}
+
+// peerSessionCount is what arrived from one machine, by either name it is known
+// under: the alias in the row, or what the machine calls itself, learned from a
+// pull (#1887).
+func peerSessionCount(from map[string]int, p peers.Peer) int {
+	if n := from[peers.Identity(p.Host)]; n > 0 {
+		return n
+	}
+	if p.Machine == "" {
+		return 0
+	}
+	return from[peers.Identity(p.Machine)]
+}
+
+// learnPeerMachine notes what the host deja just pulled from calls itself.
+//
+// The pairing is only ever visible here: the alias is what the connection used,
+// and the origin is stamped on the records that arrived. `before` is the count
+// per machine taken ahead of the import, so only what this exchange brought is
+// attributed — a batch from a third machine already in the index must not
+// rename the peer.
+func learnPeerMachine(dir, host string, before map[string]int) {
+	best, grew := "", 0
+	for name, n := range importsByPeerName(dir) {
+		if d := n - before[peers.Identity(name)]; d > grew {
+			best, grew = name, d
+		}
+	}
+	if best == "" || peers.Identity(best) == peers.Identity(host) {
+		return
+	}
+	// Best effort: a sync that worked must not fail because a name could not be
+	// written down.
+	_ = peers.Learn(host, best)
 }

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -144,7 +144,7 @@ func collectDoctorSync(dir string) doctorSyncReport {
 			// which is the reason the text report needs a bound and this does
 			// not.
 			Host:      p.Host,
-			Sessions:  from[peers.Identity(p.Host)],
+			Sessions:  peerSessionCount(from, p),
 			LastError: safeForStatusline(p.LastError, 200),
 		}
 		if !p.LastPush.IsZero() {

--- a/cmd/deja/peer_machine_test.go
+++ b/cmd/deja/peer_machine_test.go
@@ -130,3 +130,51 @@ func TestAnEmptyPullLearnsNothing(t *testing.T) {
 		t.Fatalf("a pull that brought nothing wrote a name: %#v", list)
 	}
 }
+
+// A pull that brings records from two origins teaches nothing: a batch can
+// carry a third machine's work, and another process can import while this
+// runs, so the safe answer is the count that was there before.
+func TestAnAmbiguousPullLearnsNothing(t *testing.T) {
+	tmp := hermeticEnv(t)
+	peersFile := filepath.Join(tmp, "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", peersFile)
+	if err := os.WriteFile(peersFile, []byte(`{"peers":[{"host":"work"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+
+	before := importsByPeerName(dir)
+	if _, err := index.Import(dir, seedPeerBatch(t, tmp, "build-box", 3)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := index.Import(dir, seedPeerBatch(t, tmp, "someone-else", 2)); err != nil {
+		t.Fatal(err)
+	}
+	learnPeerMachine(dir, "work", before)
+
+	if list := peers.Load(); len(list) != 1 || list[0].Machine != "" {
+		t.Fatalf("a pull carrying two origins wrote a name: %#v", list)
+	}
+}
+
+// A machine renamed, or an alias repointed at another host, is corrected by
+// the next pull rather than kept forever.
+func TestARepointedAliasIsRelearned(t *testing.T) {
+	tmp := hermeticEnv(t)
+	peersFile := filepath.Join(tmp, "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", peersFile)
+	if err := os.WriteFile(peersFile, []byte(`{"peers":[{"host":"work","machine":"build-box"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+
+	before := importsByPeerName(dir)
+	if _, err := index.Import(dir, seedPeerBatch(t, tmp, "test-machine", 2)); err != nil {
+		t.Fatal(err)
+	}
+	learnPeerMachine(dir, "work", before)
+
+	if list := peers.Load(); len(list) != 1 || list[0].Machine != "test-machine" {
+		t.Fatalf("the stale pairing survived: %#v", list)
+	}
+}

--- a/cmd/deja/peer_machine_test.go
+++ b/cmd/deja/peer_machine_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/peers"
+)
+
+// seedPeerBatch writes a batch stamped with the given origin and returns the
+// directory holding it.
+func seedPeerBatch(t *testing.T, tmp, origin string, n int) string {
+	t.Helper()
+	batch := filepath.Join(tmp, "batch-"+origin)
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var lines []string
+	for i := 0; i < n; i++ {
+		rec := map[string]any{
+			"harness": "claude", "session_id": origin + string(rune('a'+i)), "project": "proj",
+			"role": "user", "text": "retry loop", "time": "2026-08-20T10:00:0" + string(rune('0'+i)) + "Z",
+			"origin": origin,
+		}
+		b, err := json.Marshal(rec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines = append(lines, string(b))
+	}
+	if err := os.WriteFile(filepath.Join(batch, "deja-sync-1.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return batch
+}
+
+// The peers row holds the ssh alias someone typed; an imported session is
+// stamped with what the sending machine calls itself. #1876 made the comparison
+// case-insensitive, which does nothing when the two names differ outright —
+// the normal case for anyone with an ssh config. The row then said a machine
+// had sent nothing while its sessions were in the index (#1887).
+func TestAPullLearnsWhatTheMachineCallsItself(t *testing.T) {
+	tmp := hermeticEnv(t)
+	peersFile := filepath.Join(tmp, "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", peersFile)
+	if err := os.WriteFile(peersFile, []byte(`{"peers":[{"host":"work","last_pull":"2026-08-20T10:00:00Z"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+
+	before := importsByPeerName(dir)
+	if _, err := index.Import(dir, seedPeerBatch(t, tmp, "build-box", 3)); err != nil {
+		t.Fatal(err)
+	}
+	learnPeerMachine(dir, "work", before)
+
+	list := peers.Load()
+	if len(list) != 1 || list[0].Machine != "build-box" {
+		t.Fatalf("the pairing was not learned: %#v", list)
+	}
+
+	var text strings.Builder
+	doctorPeers(&text, dir, time.Date(2026, 8, 25, 10, 0, 0, 0, time.UTC))
+	if !strings.Contains(text.String(), "3 sessions from there") {
+		t.Errorf("the row still counts none of what arrived:\n%s", text.String())
+	}
+
+	var out strings.Builder
+	if err := runDoctor(&out, []string{"--json", "--offline"}, stubLookup("1.0.0", false), dir); err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		Sync struct {
+			Peers []struct {
+				Sessions int `json:"sessions_from_there"`
+			} `json:"peers"`
+		} `json:"sync"`
+	}
+	if err := json.Unmarshal([]byte(out.String()), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Sync.Peers) != 1 || report.Sync.Peers[0].Sessions != 3 {
+		t.Errorf("--json counts %#v, want three", report.Sync.Peers)
+	}
+}
+
+// Only what actually arrived in this exchange is attributed to the host: a
+// batch from a third machine sitting in the index must not rename the peer.
+func TestLearningIgnoresWhatWasAlreadyThere(t *testing.T) {
+	tmp := hermeticEnv(t)
+	peersFile := filepath.Join(tmp, "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", peersFile)
+	if err := os.WriteFile(peersFile, []byte(`{"peers":[{"host":"work"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if _, err := index.Import(dir, seedPeerBatch(t, tmp, "old-desktop", 2)); err != nil {
+		t.Fatal(err)
+	}
+
+	before := importsByPeerName(dir)
+	if _, err := index.Import(dir, seedPeerBatch(t, tmp, "build-box", 3)); err != nil {
+		t.Fatal(err)
+	}
+	learnPeerMachine(dir, "work", before)
+
+	list := peers.Load()
+	if len(list) != 1 || list[0].Machine != "build-box" {
+		t.Fatalf("the wrong machine was learned: %#v", list)
+	}
+}
+
+// An exchange that brought nothing new leaves the row alone.
+func TestAnEmptyPullLearnsNothing(t *testing.T) {
+	tmp := hermeticEnv(t)
+	peersFile := filepath.Join(tmp, "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", peersFile)
+	if err := os.WriteFile(peersFile, []byte(`{"peers":[{"host":"work"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	before := importsByPeerName(dir)
+	learnPeerMachine(dir, "work", before)
+	if list := peers.Load(); len(list) != 1 || list[0].Machine != "" {
+		t.Fatalf("a pull that brought nothing wrote a name: %#v", list)
+	}
+}

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -282,10 +282,14 @@ func syncSSHPull(dir, host string, full bool) error {
 		return fmt.Errorf("scp: %v: %s — the remote already advanced its watermark for this batch; recover it with `deja sync ssh %s --pull --full`", err, remoteOutputForEcho(out), host)
 	}
 	cleanup()
+	// Taken before the import so only what this exchange brings is attributed
+	// to this host (#1887).
+	before := importsByPeerName(dir)
 	n, err := index.Import(dir, ltmp)
 	if err != nil {
 		return fmt.Errorf("%w — the remote already advanced its watermark for this batch; recover it with `deja sync ssh %s --pull --full`", err, host)
 	}
+	learnPeerMachine(dir, host, before)
 	fmt.Fprintf(os.Stdout, "deja: imported %d records\n", n)
 	return nil
 }

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -354,7 +354,9 @@ Per-harness `ingest_health` may also carry `clipped_messages` and `last_error`.
 `sync.state` is `ok` or `unreadable`; `unreadable` adds an `error` saying why the peers file could not be parsed, and its `peers` list is empty because deja could read nothing from it — a sync is never stopped by a malformed config, so the report is the only place that failure shows. `sync.peers` is every machine this one knows, and it is always present — an
 empty list means no machines are configured, which a script can tell apart from
 a deja too old to report. Each row carries `host`, `sessions_from_there` (how
-much of this index arrived from it), and `last_push` / `last_pull` as RFC 3339
+much of this index arrived from it — matched by the name the machine calls
+itself, which deja learns from the records a pull brings, since `host` is
+whatever ssh alias was typed), and `last_push` / `last_pull` as RFC 3339
 timestamps, each omitted when that direction has never happened: the two fail
 apart, and a machine that takes what this one sends while sending nothing back
 is a broken sync that reads as a working one. A row carrying neither is a

--- a/internal/peers/peers.go
+++ b/internal/peers/peers.go
@@ -32,6 +32,14 @@ type Peer struct {
 	// succeeds. A peer that has been failing for a week is the thing this file
 	// exists to make visible.
 	LastError string `json:"last_error,omitempty"`
+	// Machine is what the host calls itself, learned from the records that
+	// arrived from it. Host is an ssh alias someone typed, and an imported
+	// session is stamped with the sender's own hostname, so counting what came
+	// from a machine by its alias found nothing whenever the two differ — the
+	// normal case for anyone with an ssh config (#1887). Absent until a pull
+	// has something to learn from, so a file written before this reads
+	// unchanged.
+	Machine string `json:"machine,omitempty"`
 }
 
 // Last is the more recent of the two directions.
@@ -174,6 +182,9 @@ func mergePeers(a, b Peer) Peer {
 	if b.Last().After(a.Last()) {
 		out.LastError = b.LastError
 	}
+	if out.Machine == "" {
+		out.Machine = b.Machine
+	}
 	return out
 }
 
@@ -223,6 +234,29 @@ func recordLocked(host string, pulled bool, when time.Time, err error) error {
 		}
 	}
 	return save(list)
+}
+
+// Learn notes what a host calls itself, so what arrived from it can be counted
+// against its row. Nothing is written when the name is empty or already there.
+func Learn(host, machine string) error {
+	host, machine = strings.TrimSpace(host), strings.TrimSpace(machine)
+	if host == "" || machine == "" {
+		return nil
+	}
+	return withLock(func() error {
+		list := Load()
+		for i := range list {
+			if identity(list[i].Host) != identity(host) {
+				continue
+			}
+			if list[i].Machine == machine {
+				return nil
+			}
+			list[i].Machine = machine
+			return save(list)
+		}
+		return nil
+	})
 }
 
 // Forget drops a host from the list. Reports whether it was there.

--- a/internal/peers/peers.go
+++ b/internal/peers/peers.go
@@ -236,12 +236,23 @@ func recordLocked(host string, pulled bool, when time.Time, err error) error {
 	return save(list)
 }
 
+// machineNameMax bounds a learned name. A hostname's own limit is 253 bytes;
+// this is the same figure deja bounds an exported field to.
+const machineNameMax = 120
+
 // Learn notes what a host calls itself, so what arrived from it can be counted
 // against its row. Nothing is written when the name is empty or already there.
 func Learn(host, machine string) error {
 	host, machine = strings.TrimSpace(host), strings.TrimSpace(machine)
 	if host == "" || machine == "" {
 		return nil
+	}
+	// The name is another machine's word for itself. Import already bounds it,
+	// but this file outlives any one index and is read by every sync, so the
+	// bound is applied where the value is written rather than trusted from
+	// upstream. A name longer than this is not one.
+	if r := []rune(machine); len(r) > machineNameMax {
+		machine = string(r[:machineNameMax])
 	}
 	return withLock(func() error {
 		list := Load()


### PR DESCRIPTION
Closes #1887.

`deja doctor` counts a peer's sessions by name. The row holds the ssh alias someone typed; an imported session is stamped with what the sending machine calls itself. #1876 made that comparison case-insensitive, which covers `laptop` against `Laptop` and does nothing when the names simply differ — the normal case for anyone with an ssh config:

```
$ deja sync import ./batch      # three records stamped origin "build-box"
deja: imported 3 records — 3 sessions from another machine
$ deja doctor
  work         last exchange 5 days ago, nothing sent yet
```

Three sessions arrived and the row says none, dropping the "N sessions from there" clause entirely — so it reads like a machine that has sent nothing, which is the distinction the screen exists to draw.

deja has both halves of the pairing only during an ssh pull: the alias it connected to, and the origin stamped on the records that arrived. `learnPeerMachine` takes the per-machine counts before the import, sees which one grew, and writes it into the row as `machine` — a new optional field, absent until a pull has something to learn from, so an older peers file reads unchanged. Both surfaces then count by either name.

Deliberately not covered: a hand-run `deja sync import` learns nothing, because no alias is involved — deja would be guessing. A machine only ever pushed to still counts zero, which is honest: nothing has arrived from it.

Tests: the pairing is learned and both surfaces count three; a batch from a third machine already in the index does not rename the peer; a pull that brings nothing writes nothing. The first fails with the second lookup removed (checked by neutering it), naming both surfaces.
