### PR TITLE
fix(stats): say which window the impact numbers cover

### DIFF
--- a/cmd/deja/stats_impact.go
+++ b/cmd/deja/stats_impact.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -40,18 +41,30 @@ func runStatsImpact(w io.Writer, dir string, jsonOut bool) error {
 
 func printImpact(w io.Writer, r usage.ImpactReport, credits int, jsonOut bool) error {
 	if jsonOut {
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(struct {
-			usage.ImpactReport
-			CreditedAloud int `json:"credited_aloud"`
-		}{r, credits})
+		// Marshalled apart and joined rather than embedded: ImpactReport writes
+		// its own JSON (so a window it never opened is absent rather than year
+		// 1), and an embedded type's marshaller answers for the whole outer
+		// struct — which silently dropped credited_aloud.
+		b, err := json.MarshalIndent(r, "", "  ")
+		if err != nil {
+			return err
+		}
+		body := strings.TrimRight(string(b), "}\n")
+		_, err = fmt.Fprintf(w, "%s,\n  \"credited_aloud\": %d\n}\n", body, credits)
+		return err
 	}
 	if r.Recalls == 0 && r.Injections == 0 {
 		fmt.Fprintln(w, "deja: no recall activity recorded yet — impact numbers appear once agents start recalling")
 		return nil
 	}
-	fmt.Fprintln(w, "deja impact — measured on this machine, nothing modeled")
+	// The window, not a lifetime: the usage log is rewritten past 1MB keeping
+	// 14 days, so these counts drop by half when that happens and nothing here
+	// said why (#1889). `deja stats` has named its window since #763.
+	if r.Since.IsZero() {
+		fmt.Fprintln(w, "deja impact — measured on this machine, nothing modeled")
+	} else {
+		fmt.Fprintf(w, "deja impact — measured on this machine since %s, nothing modeled\n", r.Since.Local().Format("Jan 2"))
+	}
 	// pluralS on all three counts: n=1 is this screen's commonest state — the
 	// first recall on a machine — and it read "1 agent-initiated recalls"
 	// (#1652). The verbs are already invariant.

--- a/cmd/deja/stats_impact.go
+++ b/cmd/deja/stats_impact.go
@@ -49,7 +49,9 @@ func printImpact(w io.Writer, r usage.ImpactReport, credits int, jsonOut bool) e
 		if err != nil {
 			return err
 		}
-		body := strings.TrimRight(string(b), "}\n")
+		// Exactly one closing brace, not every trailing one: a cutset would eat
+		// the brace of a nested value too, the day this report grows one.
+		body := strings.TrimRight(strings.TrimSuffix(strings.TrimRight(string(b), " \n\t"), "}"), " \n\t")
 		_, err = fmt.Fprintf(w, "%s,\n  \"credited_aloud\": %d\n}\n", body, credits)
 		return err
 	}

--- a/cmd/deja/stats_impact_credits_test.go
+++ b/cmd/deja/stats_impact_credits_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -94,5 +95,30 @@ func TestStatsCreditLineSingular(t *testing.T) {
 			}
 		}
 		t.Fatalf("no credit line in:\n%s", out)
+	}
+}
+
+// The report and the credit count are marshalled apart and joined, because an
+// embedded type's MarshalJSON answers for the whole outer struct. Joining is
+// string surgery, so this pins the result: valid JSON, both keys, and no stray
+// whitespace where the comma goes.
+func TestImpactJSONIsWellFormedAfterTheJoin(t *testing.T) {
+	var out strings.Builder
+	r := usage.ImpactReport{Recalls: 3, Injections: 1, ServedBytes: 100, RawBytes: 1000, Since: time.Date(2026, 8, 12, 9, 0, 0, 0, time.UTC)}
+	if err := printImpact(&out, r, 2, true); err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid([]byte(out.String())) {
+		t.Fatalf("not valid JSON:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "\n,") {
+		t.Errorf("the join left a comma on its own line:\n%s", out.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["credited_aloud"] != float64(2) || got["since"] == nil || got["recalls"] != float64(3) {
+		t.Errorf("keys lost in the join: %v", got)
 	}
 }

--- a/internal/usage/impact_window_test.go
+++ b/internal/usage/impact_window_test.go
@@ -1,0 +1,88 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeImpactLog writes events at the given ages in days, all recalls.
+func writeImpactLog(t *testing.T, ages ...int) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	p := Path(dir)
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	var b strings.Builder
+	for i, age := range ages {
+		e := Event{
+			Time: now.Add(-time.Duration(age) * 24 * time.Hour), Kind: KindRecall,
+			Bytes: 100, Sessions: 1, RawBytes: 1000, SessionIDs: []string{string(rune('a' + i))},
+		}
+		raw, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b.Write(raw)
+		b.WriteByte('\n')
+	}
+	if err := os.WriteFile(p, []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The impact screen reads as everything that has happened on this machine,
+// while the log it counts is rewritten past 1MB keeping 14 days — so the
+// figures are a window whose start moves silently, and one rotation halved
+// them. `deja stats` has said which window it means since #763; this is the
+// same fact on the screen that most looks like a lifetime total (#1889).
+func TestImpactCarriesTheWindowItCounted(t *testing.T) {
+	dir := writeImpactLog(t, 20, 10, 1)
+	r := Impact(dir)
+	if r.Recalls != 3 {
+		t.Fatalf("counted %d recalls, want 3", r.Recalls)
+	}
+	if r.Since.IsZero() {
+		t.Fatal("the report does not say when its window opens")
+	}
+	if age := time.Since(r.Since).Hours() / 24; age < 19 || age > 21 {
+		t.Errorf("the window opens %.0f days ago, want the oldest event at 20", age)
+	}
+}
+
+// A log with nothing in it says nothing rather than year 1 (the shape of
+// #1874).
+func TestAnEmptyImpactLogHasNoWindow(t *testing.T) {
+	dir := writeImpactLog(t)
+	r := Impact(dir)
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "since") {
+		t.Errorf("an empty log reports a window: %s", b)
+	}
+}
+
+// And a log with events carries it in the machine form too.
+func TestImpactJSONCarriesTheWindow(t *testing.T) {
+	dir := writeImpactLog(t, 5, 2)
+	b, err := json.Marshal(Impact(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := out["since"]; !ok {
+		t.Errorf("--impact --json does not say which window it counted: %s", b)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -414,7 +414,27 @@ type ImpactReport struct {
 	ServedBytes   int   `json:"served_bytes"`   // digest bytes actually returned
 	RawBytes      int64 `json:"raw_bytes"`      // source transcripts those digests distilled
 	ReusedTwice   int   `json:"reused_twice"`   // sessions agents recalled 2+ times
-	DejaVuMoments int   `json:"dejavu_moments"` // prompts matched to prior work, all time
+	DejaVuMoments int   `json:"dejavu_moments"` // prompts matched to prior work
+	// Since is the oldest event still in the log. The log is rewritten past
+	// 1MB keeping the last 14 days, so every count above is a window and not a
+	// lifetime — one rotation over a 30-day log halved them (#1889). The same
+	// fact `deja stats` has carried since #763.
+	Since time.Time `json:"-"`
+}
+
+// MarshalJSON writes Since only when there is one, for the reason Summary's
+// does: `omitempty` does nothing to a struct, so the tag alone would print
+// January of year 1 on a machine with no recall history (#1874).
+func (r ImpactReport) MarshalJSON() ([]byte, error) {
+	type plain ImpactReport
+	out := struct {
+		plain
+		Since *time.Time `json:"since,omitempty"`
+	}{plain: plain(r)}
+	if !r.Since.IsZero() {
+		out.Since = &r.Since
+	}
+	return json.Marshal(out)
 }
 
 // Impact counts across the whole usage log.
@@ -422,6 +442,9 @@ func Impact(indexDir string) ImpactReport {
 	var r ImpactReport
 	worn := map[string]int{}
 	for _, e := range read(Path(indexDir)) {
+		if r.Since.IsZero() || e.Time.Before(r.Since) {
+			r.Since = e.Time
+		}
 		switch e.Kind {
 		case KindRecall, KindContext:
 			if e.Empty {


### PR DESCRIPTION
Closes #1889.

`deja stats --impact` reads as everything that has happened on this machine — the header says "measured on this machine, nothing modeled", the counts carry no period, and `DejaVuMoments` was commented "all time". The usage log is rewritten past 1 MB keeping 14 days, so one rotation over a 30-day log takes the numbers down by half and nothing on the screen says why:

```
recalls        4000  ->  1872
served bytes   2.0MB ->  936KB
oldest event   2026-07-27 -> 2026-08-12
```

`deja stats` has named its window since #763 ("Recalls served 101 since Jun 22"). This is that half for the screen that most looks like a lifetime total:

```
deja impact — measured on this machine since Jul 27, nothing modeled
  recalls served     30 agent-initiated recalls returned matches
```

and `"since": "2026-07-27T13:43:31Z"` in `--impact --json`, absent when the log holds nothing (the shape of #1874 — `omitempty` does nothing to a `time.Time`).

One thing worth knowing: the JSON wrapper embedded `ImpactReport` to add `credited_aloud`, and an embedded type's `MarshalJSON` answers for the whole outer struct, so adding one here silently dropped that key. The two are now marshalled apart and joined; `TestImpactJSONIncludesCreditedAloud` already covered it and caught it.

Wording is yours: "measured on this machine since Jul 2" is what I picked, and the alternative is to leave the header alone and put the window on a line of its own.
