### PR TITLE
chore(sync): drop the export helper the push path stopped using in #215

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -869,7 +869,7 @@ func TestSyncSSHAdditionalBranches(t *testing.T) {
 	if err := index.EnsureForSearch(index.DefaultDir(), search.Options{All: true}, false, io.Discard); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := exportBatches(index.DefaultDir(), t.TempDir(), true); err != nil {
+	if _, err := index.ExportFull(index.DefaultDir(), t.TempDir()); err != nil {
 		t.Fatal(err)
 	}
 	sshRunner = func(name string, args ...string) (string, error) {

--- a/cmd/deja/sync_export_path_test.go
+++ b/cmd/deja/sync_export_path_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+// The ssh push settles watermarks only after the remote acknowledges the batch
+// (#215), and namespaces them per peer (#982). `index.Export` does neither — it
+// advances the unnamed watermark as it writes. Nothing on the ssh path may
+// reach for it: `exportBatches` did, kept alive by one test line for a year
+// after its caller went away (#1891), and wiring it back would have undone both
+// rules with nothing on any surface saying so.
+func TestTheSSHPathTakesNoUnnamedWatermark(t *testing.T) {
+	src, err := os.ReadFile("sync_ssh.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// index.Export( exactly — not ExportFull, which ignores watermarks by
+	// design, nor ExportDeferred, which is the acknowledged-delivery form.
+	unnamed := regexp.MustCompile(`index\.Export\(`)
+	if m := unnamed.FindString(string(src)); m != "" {
+		t.Errorf("the ssh path exports under the unnamed watermark: %s", m)
+	}
+}

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -294,13 +294,6 @@ func syncSSHPull(dir, host string, full bool) error {
 	return nil
 }
 
-func exportBatches(dir, out string, full bool) (int, error) {
-	if full {
-		return index.ExportFull(dir, out)
-	}
-	return index.Export(dir, out)
-}
-
 func sshCapture(host, cmd string) (string, error) {
 	out, err := sshRunner("ssh", append(sshOpts(), host, cmd)...)
 	s := strings.TrimSpace(out)


### PR DESCRIPTION
Closes #1891.

`exportBatches` lost its caller in #215, when the ssh push moved to `ExportDeferred` so watermarks settle only after the remote acknowledges the batch. It stayed for a year because one line of `coverage_extra_test.go` called it.

What it does matters more than that it was unused: it exports through `index.Export`, the unnamed watermark. Wiring it back would have undone acknowledged delivery (#215) and per-peer watermarks (#982) at once, with nothing on any surface saying so. Removed; the test line calls `index.ExportFull` directly, which is what it was covering through the wrapper.

`TestTheSSHPathTakesNoUnnamedWatermark` walks `sync_ssh.go` for `index.Export(` — not `ExportFull`, which ignores watermarks by design, nor `ExportDeferred`. It fails on the base branch.

No behaviour change: nothing called the function.
