### PR TITLE
docs: the home page had no robots meta, unlike every guide page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,7 @@
 <title>deja-vu — memory for coding agents</title>
 <meta name="theme-color" content="#0b0f10">
 <meta name="description" content="Persistent memory for coding agents, built from the history they already wrote — including everything from before you installed it. Claude Code, Codex and 18 more agents.">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
 <meta property="og:type" content="website">


### PR DESCRIPTION
Found while working out why Search Console has never crawled the site: every guide page carries `<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">` and `docs/index.html` carried none.

Absent means index, so this was never a blocker. What it did cost is the two hints: `max-snippet:-1` and `max-image-preview:large` are how a page tells Google it may quote at length and show a large preview — which is exactly what an AI answer or a rich result does with a source. The home page is the one URL a crawler reaches first and the one most likely to be quoted.