### PR TITLE
docs: link the guide from the README, which is the page Google crawls most

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,20 @@ deja uninstall --all
 rm -rf ~/.cache/deja
 ```
 
+## Guides
+
+Written for the situation rather than the feature:
+
+- [The agent lost the context you had](https://vshulcz.github.io/deja-vu/guide/lost-context.html) — after a crash, a clear, or a session that came back empty
+- [The context window is full](https://vshulcz.github.io/deja-vu/guide/context-window-full.html) — what compaction keeps, measured, and what to do instead
+- [Resuming yesterday's session](https://vshulcz.github.io/deja-vu/guide/resume-a-session.html) — find it across every agent, reopen it in the one that owns it
+- [The agent repeats a mistake you already fixed](https://vshulcz.github.io/deja-vu/guide/repeated-mistakes.html)
+- [Finding the session where you solved it](https://vshulcz.github.io/deja-vu/guide/find-a-session.html)
+- [Why agents forget between sessions](https://vshulcz.github.io/deja-vu/guide/forgetting.html) · [Where each agent keeps its history](https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html)
+- [What compaction drops](https://vshulcz.github.io/deja-vu/guide/after-compaction.html) · [Switching agents](https://vshulcz.github.io/deja-vu/guide/switching-agents.html) · [Auditing an agent](https://vshulcz.github.io/deja-vu/guide/auditing-agents.html) · [Exporting a conversation](https://vshulcz.github.io/deja-vu/guide/export-conversations.html) · [Across machines](https://vshulcz.github.io/deja-vu/guide/sync-across-machines.html) · [What memory costs](https://vshulcz.github.io/deja-vu/guide/token-cost.html)
+
+Per harness: [opencode](https://vshulcz.github.io/deja-vu/guide/memory-for-opencode.html) · [DeepSeek Harness](https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html) · [Kimi Code](https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html) · [Zed](https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html) · [Grok Build](https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html) · [Gemini CLI](https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html) · [Qwen Code](https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html)
+
 ## Try it on your own history
 
 ```sh


### PR DESCRIPTION
The home page of the site is indexed — Search Console's URL inspection confirms it — so crawling is not the problem. Discovery of the *rest* of the site is: Google reaches a page either from the sitemap or by following links, and only **4 of 30** guide pages were reachable from the README, which is the most-crawled page we own (Google is our top referrer to the repository).

A `Guides` section before the closing call to action, written as situations rather than features: the three new problem pages first, then the older ones on one line, then the per-harness pages on another. **24 of 30** are linked now, and every link resolves to a page this repository publishes — checked rather than eyeballed.

The six left out are navigational or niche (`getting-started`, `privacy`, `harnesses`, `search`, `parallel-sessions`, `rules-files`); three of those are already linked from the header and the install section, and stuffing the rest in would cost more in readability than it buys in crawl paths.

This matters more than the sitemap right now: the sitemap submission still reports "couldn't fetch", while links are a path Google already follows every time it recrawls the repository.