### PR TITLE
docs(sitemap): every entry carries a lastmod, from the registry's own dates

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -31,25 +31,25 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/privacy.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/benchmarks.html</loc><lastmod>2026-07-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/compare.html</loc><lastmod>2026-07-23</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/README.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/aider.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/antigravity.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/claude-code.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/cline.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/codex.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/copilot.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/cursor.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/gemini.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/goose.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/grok.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/hermes.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/kimi.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/openclaw.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/opencode.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/pi.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/qwen.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/roo.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/zed.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/deepseek.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/registry/omp.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/README.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/aider.html</loc><lastmod>2026-07-27</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/antigravity.html</loc><lastmod>2026-07-17</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/claude-code.html</loc><lastmod>2026-07-17</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/cline.html</loc><lastmod>2026-07-28</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/codex.html</loc><lastmod>2026-07-17</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/copilot.html</loc><lastmod>2026-08-14</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/cursor.html</loc><lastmod>2026-07-17</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/gemini.html</loc><lastmod>2026-07-24</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/goose.html</loc><lastmod>2026-07-28</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/grok.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/hermes.html</loc><lastmod>2026-07-28</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/kimi.html</loc><lastmod>2026-07-28</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/openclaw.html</loc><lastmod>2026-07-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/opencode.html</loc><lastmod>2026-07-17</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/pi.html</loc><lastmod>2026-07-19</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/qwen.html</loc><lastmod>2026-07-17</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/roo.html</loc><lastmod>2026-07-27</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/zed.html</loc><lastmod>2026-08-21</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/deepseek.html</loc><lastmod>2026-08-21</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/registry/omp.html</loc><lastmod>2026-08-21</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 </urlset>

--- a/scripts/genregistry/main.go
+++ b/scripts/genregistry/main.go
@@ -52,12 +52,15 @@ func run() error {
 		return err
 	}
 	name := map[string]string{}
+	verified := map[string]string{}
 	for _, h := range reg.Harnesses {
 		name[h.ID] = h.DisplayName
+		verified[h.ID] = h.LastVerified
 	}
 	// One page is filed under a different name than its registry entry.
 	// Everything else matches, and the check below keeps it that way.
 	name["claude-code"] = name["claude"]
+	verified["claude-code"] = verified["claude"]
 
 	paths, err := filepath.Glob(filepath.Join("docs", "registry", "*.md"))
 	if err != nil {
@@ -110,7 +113,7 @@ func run() error {
 		}
 		written = append(written, "registry/"+id+".html")
 	}
-	if err := writeSitemap(written); err != nil {
+	if err := writeSitemap(written, verified); err != nil {
 		return err
 	}
 	fmt.Printf("wrote %d registry pages and the sitemap\n", len(written))
@@ -203,6 +206,7 @@ var pageTemplate = template.Must(template.New("page").Parse(`<!DOCTYPE html>
 <meta name="twitter:image" content="{{.Site}}/assets/og.png">
 <link rel="apple-touch-icon" href="../assets/icon.svg">
 <link rel="sitemap" type="application/xml" href="{{.Site}}/sitemap.xml">
+<link rel="describedby" type="text/markdown" href="{{.Site}}/llms.txt">
 <script type="application/ld+json">{{.Article}}</script>
 <script type="application/ld+json">{{.Crumbs}}</script>
 </head>
@@ -288,7 +292,7 @@ func render(m meta, body string, others []link) string {
 // writeSitemap adds the registry pages to the sitemap, keeping every entry
 // already in it as it stands. The lastmod and priority on the existing pages
 // are hand-set; regenerating the file would quietly drop them.
-func writeSitemap(registryPages []string) error {
+func writeSitemap(registryPages []string, verified map[string]string) error {
 	path := filepath.Join("docs", "sitemap.xml")
 	b, err := os.ReadFile(path)
 	if err != nil {
@@ -302,8 +306,15 @@ func writeSitemap(registryPages []string) error {
 			continue
 		}
 		// A format page changes when the harness changes its files, which is
-		// rare and unannounced; monthly is what the guide pages use.
-		add.WriteString("  <url><loc>" + loc + "</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>\n")
+		// rare and unannounced; monthly is what the guide pages use. The date
+		// is the registry's own last_verified — the day someone last checked
+		// that page against a real store, which is what lastmod means.
+		id := strings.TrimSuffix(strings.TrimPrefix(p, "registry/"), ".html")
+		lastmod := ""
+		if d := verified[id]; d != "" {
+			lastmod = "<lastmod>" + d + "</lastmod>"
+		}
+		add.WriteString("  <url><loc>" + loc + "</loc>" + lastmod + "<changefreq>monthly</changefreq><priority>0.6</priority></url>\n")
 	}
 	if add.Len() == 0 {
 		return nil


### PR DESCRIPTION
Search Console still says it cannot process the sitemap, so I audited the file rather than guessing: served 200 as `application/xml`, no redirects, no BOM, pure ASCII, no CRLF, no unescaped ampersands, valid namespace, 52 URLs all inside the property prefix and all returning 200, and every `changefreq`/`priority`/`lastmod` value valid. Nothing there is malformed, and Google's own "open sitemap" view renders it — so this is their fetch, not our file.

What the audit did find is a real weakness. Twenty-one of the fifty-two entries — every registry page — had **no `lastmod` at all**, because `writeSitemap` appended them with only `changefreq` and `priority`. The registry already records `last_verified` per harness: the day someone last checked that format against a real store. That is precisely what `lastmod` means, and it was being thrown away at the moment of writing the sitemap.

The generator now reads it, and the twenty-one existing entries are backfilled once, since it only appends missing rows by design. 52 of 52 carry a date now.

Also fixed a regression I caused an hour ago: `genregistry` rebuilds registry pages from a template, so regenerating stripped the `rel="describedby"` link to `llms.txt` that #1871 added to every page. The template carries it now, so the next regeneration keeps it.