### PR TITLE
docs(json): describe stats --impact --json and pin its keys

### DIFF
--- a/cmd/deja/impact_contract_test.go
+++ b/cmd/deja/impact_contract_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// `deja stats --impact --json` is a machine surface that was documented
+// nowhere, and it grew `since` in #1890 while `credited_aloud` vanished for one
+// commit in the same change. `stats --json` has had its keys pinned to the
+// document since #1710; this is that pin for the screen beside it (#1898).
+func TestImpactJSONKeysMatchTheDocumentedContract(t *testing.T) {
+	doc, err := os.ReadFile("../../docs/json-output.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	section := string(doc)
+	i := strings.Index(section, "## `deja stats --impact --json`")
+	if i < 0 {
+		t.Fatal("docs/json-output.md does not describe `deja stats --impact --json`")
+	}
+	section = section[i:]
+	if end := strings.Index(section[3:], "\n## "); end > 0 {
+		section = section[:end+3]
+	}
+
+	var out strings.Builder
+	full := usage.ImpactReport{
+		Recalls: 3, Injections: 2, ServedBytes: 100, RawBytes: 1000,
+		ReusedTwice: 1, DejaVuMoments: 1, Since: time.Date(2026, 8, 12, 9, 0, 0, 0, time.UTC),
+	}
+	if err := printImpact(&out, full, 2, true); err != nil {
+		t.Fatal(err)
+	}
+	var emitted map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &emitted); err != nil {
+		t.Fatalf("%v: %s", err, out.String())
+	}
+	for k := range emitted {
+		if !strings.Contains(section, "`"+k+"`") {
+			t.Errorf("--impact --json emits %q, missing from its section of docs/json-output.md", k)
+		}
+	}
+	// And the other way: a key the document names must still be emitted, so a
+	// field that leaves the struct cannot leave the document behind.
+	for _, k := range []string{"recalls", "injections", "served_bytes", "raw_bytes",
+		"reused_twice", "dejavu_moments", "since", "credited_aloud"} {
+		if !strings.Contains(section, "`"+k+"`") {
+			continue
+		}
+		if _, ok := emitted[k]; !ok {
+			t.Errorf("docs/json-output.md names %q, no longer emitted", k)
+		}
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -15,6 +15,8 @@ a `schema_version` field so consumers can detect breaking changes.
 - **`deja blame --json`** and **`deja log --json`** return a top-level JSON
   array rather than an envelope, so neither carries `schema_version`. Their
   element shapes are stable; only additive fields inside them are permitted.
+- **`deja stats --impact --json`** returns one flat object of counters and
+  carries no `schema_version` either, on the same terms.
 
 ### What changed in version 2
 
@@ -378,6 +380,40 @@ ahead counts: a peers file is written by deja itself, so a copy
 from a machine a moment ahead — or an NTP step landing between the write and the
 read — is not a clock worth reporting, while a session's stamp comes from a
 transcript deja did not write.
+
+## `deja stats --impact --json`
+
+What deja has actually served on this machine, measured from the usage log:
+
+```json
+{
+  "recalls": 30,
+  "injections": 4,
+  "served_bytes": 15000,
+  "raw_bytes": 150000,
+  "reused_twice": 2,
+  "dejavu_moments": 1,
+  "since": "2026-07-27T14:33:13Z",
+  "credited_aloud": 3
+}
+```
+
+No envelope and no `schema_version`, for the same reason as `blame` and `log`:
+the shape is one flat object of counters, and a consumer reads the keys it knows.
+Additive fields are permitted; a rename is a breaking change and would be called
+one.
+
+`recalls` counts agent-initiated recalls that returned matches, `injections`
+session starts that began with project memory. `served_bytes` is what the
+digests actually returned and `raw_bytes` the source transcripts they were
+distilled from, so the ratio is how much reading deja saved. `reused_twice` is
+sessions agents recalled two or more times, `dejavu_moments` prompts matched to
+prior work, and `credited_aloud` the recalls an agent said out loud.
+
+`since` is the oldest event still in the usage log, and it is the period every
+count above belongs to: the log is rewritten past 1MB keeping the last 14 days,
+so these are a window and not a lifetime total. It is absent when the log holds
+nothing, which is the one case where the counts are all zero anyway.
 
 ## `deja blame <path> --json`
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -410,10 +410,12 @@ distilled from, so the ratio is how much reading deja saved. `reused_twice` is
 sessions agents recalled two or more times, `dejavu_moments` prompts matched to
 prior work, and `credited_aloud` the recalls an agent said out loud.
 
-`since` is the oldest event still in the usage log, and it is the period every
-count above belongs to: the log is rewritten past 1MB keeping the last 14 days,
-so these are a window and not a lifetime total. It is absent when the log holds
-nothing, which is the one case where the counts are all zero anyway.
+`since` is the oldest event still in the usage log, so no count above covers
+more than the period from then to now. On a quiet machine that is every event
+there has ever been; once the log grows past 1MB it is rewritten keeping the
+last 14 days, and from then on the figures are a window whose start moves. Read
+`since` rather than assuming either. It is absent when the log holds nothing,
+which is the one case where the counts are all zero anyway.
 
 ## `deja blame <path> --json`
 


### PR DESCRIPTION
Closes #1898.

`deja stats --impact --json` is a machine surface documented nowhere — not in `docs/json-output.md`, not in the README, not in `deja help`. It grew `since` last night in #1890, and `credited_aloud` vanished for one commit in that same change before a test caught it.

Now described beside the others: the object, what each counter means, that `since` is the window the counts belong to rather than a lifetime, and that it is absent when the log holds nothing. The stability policy already named the two shapes that return no envelope (`blame`, `log`); this is the third and says so on the same terms.

`TestImpactJSONKeysMatchTheDocumentedContract` pins the key set to that section in both directions, the way `TestStatsJSONKeysMatchTheDocumentedContract` has since #1710. It fails on the base branch — there is no section to read.

No behaviour change.
