### PR TITLE
fix(usage): close a truncated line before appending the next event

### DIFF
--- a/internal/usage/truncated_tail_test.go
+++ b/internal/usage/truncated_tail_test.go
@@ -1,0 +1,65 @@
+package usage
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A process killed between the record and its newline costs that record — the
+// log is appended without a lock by design and `read` drops a line that does
+// not parse. It cost one more: the next event was appended onto the partial
+// line, so that line failed to parse too and the recall just served went
+// missing from every count (#1901).
+func TestARecordAfterATruncatedTailSurvives(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	p := Path(dir)
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	good := `{"t":"2026-08-20T10:00:00Z","kind":"recall","bytes":100,"sessions":1}`
+	partial := `{"t":"2026-08-21T10:00:00Z","kind":"recall","byte`
+	if err := os.WriteFile(p, []byte(good+"\n"+partial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	RecordResult(dir, KindRecall, 200, 1, false)
+
+	tot := Totals(dir)
+	if tot.Recalls != 2 {
+		body, _ := os.ReadFile(p)
+		t.Fatalf("counted %d recalls, want the old one and the new one:\n%s", tot.Recalls, body)
+	}
+	if tot.Bytes != 300 {
+		t.Errorf("counted %d bytes, want 100 + 200", tot.Bytes)
+	}
+	// The partial record itself stays lost — that is the trade the log makes —
+	// but it must not take a second line with it.
+	body, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), `"byte{`) {
+		t.Errorf("the new record was appended onto the partial line:\n%s", body)
+	}
+}
+
+// The ordinary case is unchanged: no stray blank line, no doubled newline.
+func TestAnOrdinaryRecordAddsOneLine(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	RecordResult(dir, KindRecall, 100, 1, false)
+	RecordResult(dir, KindRecall, 200, 1, false)
+	body, err := os.ReadFile(Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lines := strings.Split(strings.TrimSuffix(string(body), "\n"), "\n"); len(lines) != 2 {
+		t.Errorf("two records wrote %d lines:\n%s", len(lines), body)
+	}
+	if strings.Contains(string(body), "\n\n") {
+		t.Errorf("a blank line crept in:\n%s", body)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -154,7 +154,9 @@ func recordFull(indexDir, kind string, bytes, sessions int, empty bool, raw int6
 		return
 	}
 	rotate(p)
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	// O_RDWR rather than O_WRONLY: the append needs to read the last byte to
+	// know whether the previous record finished (#1901).
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
 	if err != nil {
 		return
 	}
@@ -163,7 +165,30 @@ func recordFull(indexDir, kind string, bytes, sessions int, empty bool, raw int6
 	if err != nil {
 		return
 	}
+	// A process killed between a record and its newline costs that record, which
+	// is the trade this log makes for writing without a lock. It cost the next
+	// one too: appended onto the partial line, so that line no longer parsed
+	// either and a recall deja had just served went missing from every count
+	// (#1901). One byte of reading closes the line first.
+	if endsMidLine(f) {
+		b = append([]byte{'\n'}, b...)
+	}
 	_, _ = f.Write(append(b, '\n'))
+}
+
+// endsMidLine reports whether the log's last byte is anything but a newline.
+// A file that cannot be read is treated as ending cleanly: a usage event must
+// never be the reason a recall fails.
+func endsMidLine(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil || fi.Size() == 0 {
+		return false
+	}
+	var last [1]byte
+	if _, err := f.ReadAt(last[:], fi.Size()-1); err != nil {
+		return false
+	}
+	return last[0] != '\n'
 }
 
 // InjectedToday returns session-start context bytes injected since local midnight.


### PR DESCRIPTION
Closes #1901.

The usage log is appended without a lock by design, and `read` drops a line that does not parse — so a process killed between a record and its newline costs that record. That is the trade. It cost one more: the next event was appended onto the partial line, so that line stopped parsing too.

```
before   events readable 1 -> record a recall -> events readable 1   (totals: recalls=1 bytes=100)
after    events readable 1 -> record a recall -> events readable 2   (totals: recalls=2 bytes=300)
```

The recall that went missing had already been served; every count reading this file was short by it — `deja stats`, the status bar, `--impact`.

The append now reads the last byte and closes the line first, which needed the file opened `O_RDWR` rather than `O_WRONLY`. A file it cannot stat or read is treated as ending cleanly: a usage event must never be the reason a recall fails.

Tests: the truncated-tail case fails on the base branch, and a second one keeps the ordinary path honest — two records, two lines, no blank line.
