### PR TITLE
fix(statusline): use the count form on a bar too narrow for the title

### DIFF
--- a/cmd/deja/statusline_count_form_test.go
+++ b/cmd/deja/statusline_count_form_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// `statuslineMinTitle`'s comment says what happens below the floor — "the count
+// form says more than three words and an ellipsis" — and nothing reached it:
+// memorySegment never passed a budget that low, so a bar too narrow for the
+// floored title ran off the edge instead of using the shorter sentence (#1903).
+func TestANarrowBarTakesTheCountFormWhenItFits(t *testing.T) {
+	when := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	m := fileMemory{Path: "/p/parser.go", Sessions: 3, Title: "retry loop in the parser", Last: when}
+
+	floored := "deja · " + statuslineMemoryLineWithin(m, statuslineMinTitle, statuslineMinName)
+	count := "deja · " + statuslineMemoryLineWithin(m, 0, statuslineMinName)
+	if barColumns(count) >= barColumns(floored) {
+		t.Fatalf("this memory does not shorten in the count form (%d against %d), so the test says nothing",
+			barColumns(count), barColumns(floored))
+	}
+
+	// A bar between the two: the count form fits, the title form does not.
+	width := barColumns(count)
+	got := memorySegment(m, width)
+	if barColumns(got) > width {
+		t.Errorf("%d columns on a %d-column bar: %q", barColumns(got), width, got)
+	}
+	if strings.Contains(got, "“") {
+		t.Errorf("the title form was kept though it does not fit: %q", got)
+	}
+	if !strings.Contains(got, "3 earlier sessions") {
+		t.Errorf("the count form is not what was printed: %q", got)
+	}
+}
+
+// Where the title fits, it stays: a count is a statistic, the title is the
+// memory.
+func TestAWideBarKeepsTheTitle(t *testing.T) {
+	m := fileMemory{Path: "/p/parser.go", Sessions: 3, Title: "retry loop in the parser",
+		Last: time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)}
+	got := memorySegment(m, 80)
+	if !strings.Contains(got, "retry loop") {
+		t.Errorf("a bar with room lost the title: %q", got)
+	}
+}
+
+// And where neither form fits, the title stays rather than being traded for a
+// sentence that does not fit either — the decision
+// TestStatuslineNarrowBarKeepsAReadableTitle pins.
+func TestWhenNothingFitsTheTitleSurvives(t *testing.T) {
+	m := fileMemory{Path: "/p/parser.go", Sessions: 3, Title: "retry loop in the parser",
+		Last: time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)}
+	got := memorySegment(m, 20)
+	if !strings.Contains(got, "“") {
+		t.Errorf("a bar too narrow for either form dropped the title: %q", got)
+	}
+}

--- a/cmd/deja/statusline_memory.go
+++ b/cmd/deja/statusline_memory.go
@@ -298,6 +298,17 @@ func memorySegment(m fileMemory, width int) string {
 		name--
 		mem = line(title, name)
 	}
+	if barColumns(mem) <= width {
+		return mem
+	}
+	// Below both floors, the count form — which statuslineMinTitle's comment
+	// has always named as the answer there: a title cut to three words and an
+	// ellipsis says less than "3 earlier sessions". Only when it actually fits,
+	// since for a short title the count form is the wider of the two, and a bar
+	// too narrow for either keeps the title (#1903).
+	if counted := line(0, name); barColumns(counted) <= width {
+		return counted
+	}
 	return mem
 }
 


### PR DESCRIPTION
Closes #1903.

`statuslineMemoryLineTo` has a count form for `maxTitle <= 0`, and `statuslineMinTitle`'s comment has always named it as the answer below the floor: *"the shortest title fragment worth printing. Below it the count form says more than three words and an ellipsis."* Nothing reached it — `memorySegment` never passes a budget that low — so a bar too narrow for the floored title simply ran off the edge.

Measured, both forms at their floors:

```
memory                         floored title   count form
parser.go, long title          52              46
40-char filename, long title   54              48
parser.go, short title         44              45
```

There is a band — a 48-column split pane — where the count form fits and the title form does not. The third row is why it cannot simply replace the other: for a short title the count form is wider.

After, for the first memory:

```
width=52  52  deja · parser.go · 3 earlier: “retry loop i…” 5d ago
width=48  46  deja · parser.go · 3 earlier sessions · 5d ago
width=46  46  deja · parser.go · 3 earlier sessions · 5d ago
width=44  52  deja · parser.go · 3 earlier: “retry loop i…” 5d ago
```

Below 46 neither form fits and the title stays, which is the decision `TestStatuslineNarrowBarKeepsAReadableTitle` pins — the count form is taken only when it actually fits, never as a consolation.

Three tests: the band (which fails on base), the wide bar keeping its title, and the too-narrow bar keeping it too. The first refuses to run if the memory it uses does not actually shorten in the count form, so it cannot pass by accident.
