### PR TITLE
test(peers): hold the shape that keeps the lock's fallback out of reach

### DIFF
--- a/internal/peers/race_test.go
+++ b/internal/peers/race_test.go
@@ -75,10 +75,15 @@ func TestARecordDoesNotDropTheRowsItDidNotWrite(t *testing.T) {
 
 // The lock waits two seconds and then writes anyway, so that a sync is never
 // failed for want of it (#1884) — which is the old lost-update behaviour if
-// contention ever reaches that far. Measured: the lock is held about 300µs, so
-// sixteen writers queue a few milliseconds in front of each other and nothing
-// comes close. This holds that shape: many writers, many records each, every
-// machine still on the list.
+// contention ever reaches that far. It does not: one uncontended Record takes
+// 298–322µs whether the file holds one row or sixteen, so the writers here
+// queue a few milliseconds in front of each other, and 128 of them measured
+// ~40ms. Reaching two seconds would take thousands at once, on a file deja
+// writes once per exchange.
+//
+// Goroutines rather than processes, which is what a test can do here: this
+// pins that the read-modify-write is serialised, not that the lock file works
+// between processes.
 func TestSustainedContentionKeepsEveryMachine(t *testing.T) {
 	writePeers(t, `{"peers":[]}`)
 	const writers, each = 16, 20

--- a/internal/peers/race_test.go
+++ b/internal/peers/race_test.go
@@ -1,6 +1,7 @@
 package peers
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -68,6 +69,44 @@ func TestARecordDoesNotDropTheRowsItDidNotWrite(t *testing.T) {
 	for _, want := range []string{"laptop", "server", "mini"} {
 		if !seen[want] {
 			t.Errorf("%s is gone from the list", want)
+		}
+	}
+}
+
+// The lock waits two seconds and then writes anyway, so that a sync is never
+// failed for want of it (#1884) — which is the old lost-update behaviour if
+// contention ever reaches that far. Measured: the lock is held about 300µs, so
+// sixteen writers queue a few milliseconds in front of each other and nothing
+// comes close. This holds that shape: many writers, many records each, every
+// machine still on the list.
+func TestSustainedContentionKeepsEveryMachine(t *testing.T) {
+	writePeers(t, `{"peers":[]}`)
+	const writers, each = 16, 20
+	when := time.Date(2026, 8, 25, 10, 0, 0, 0, time.UTC)
+
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		host := fmt.Sprintf("host-%02d", i)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for k := 0; k < each; k++ {
+				if err := Record(host, k%2 == 0, when, nil); err != nil {
+					t.Errorf("%s: %v", host, err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	list := Load()
+	if len(list) != writers {
+		t.Fatalf("%d machines survived %d records from %d writers", len(list), writers*each, writers)
+	}
+	for _, p := range list {
+		if p.LastPush.IsZero() || p.LastPull.IsZero() {
+			t.Errorf("%s lost one of its two directions: %#v", p.Host, p)
 		}
 	}
 }


### PR DESCRIPTION
A measurement and the test that holds its shape. No behaviour change, no issue — nothing is broken.

`withLock` (#1884) waits two seconds for the peers file and then writes anyway, so a sync is never failed for want of the lock. Past that point it is the old lost-update behaviour, documented but never measured. Here is the measurement — one process, N goroutines each recording exchanges in a loop:

```
writers  records  rows kept  wall     per record
2        80       2/2        29ms     357µs
8        320      8/8        107ms    334µs
16       640      16/16      178ms    279µs
64       3840     64/64      1.361s   355µs
128      7680     128/128    3.21s    418µs
```

Nothing was lost at any size, including the run whose wall clock is longer than the wait itself. That is the useful part: a writer waits for the holders ahead of it, not for the whole run. The lock is held about 300µs, so 128 concurrent writers put roughly 40ms in front of any one of them, and reaching two seconds would take on the order of 5000 writers queued at once — on a file deja writes once per exchange.

So the wait does not need to grow. The test keeps the shape that makes that true (sixteen writers, twenty records each, every machine still on the list, both directions intact) and runs in about 60ms; if the lock ever becomes slow enough to matter, this is where it shows.
