### PR TITLE
fix(usage): count a blame and a resource read on both screens

### DIFF
--- a/internal/usage/kinds_test.go
+++ b/internal/usage/kinds_test.go
@@ -1,0 +1,77 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// oneEvent writes a log holding a single event of the given kind.
+func oneEvent(t *testing.T, kind string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	p := Path(dir)
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	e := Event{
+		Time: time.Now().UTC().Add(-time.Hour), Kind: kind,
+		Bytes: 100, Sessions: 1, RawBytes: 1000, SessionIDs: []string{"s1"},
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, append(b, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// What deja served an agent is one question, and the two screens that answer it
+// walked the log with different rules: a blame was a recall to `deja stats` and
+// nothing to `deja stats --impact`, so its bytes were missing from the ratio the
+// impact screen prints (#1907). #1569 aligned five counters here; Impact was not
+// among them.
+func TestTheTwoScreensCountTheSameServings(t *testing.T) {
+	for _, kind := range []string{KindRecall, KindContext, KindBlame, KindResource} {
+		dir := oneEvent(t, kind)
+		tot := Totals(dir)
+		imp := Impact(dir)
+		if tot.Recalls != 1 {
+			t.Errorf("%s: stats counts %d recalls, want 1", kind, tot.Recalls)
+		}
+		if imp.Recalls != 1 {
+			t.Errorf("%s: impact counts %d recalls, want 1", kind, imp.Recalls)
+		}
+		if imp.ServedBytes != 100 || imp.RawBytes != 1000 {
+			t.Errorf("%s: impact served %d of %d raw, want 100 of 1000 — the distilled ratio is short by it",
+				kind, imp.ServedBytes, imp.RawBytes)
+		}
+	}
+}
+
+// A read of deja://session/… hands the agent a whole session, which is why the
+// kind exists — and nothing counted it at all.
+func TestAResourceReadIsCountedAsServed(t *testing.T) {
+	dir := oneEvent(t, KindResource)
+	if tot := Totals(dir); tot.Recalls != 1 || tot.Bytes != 100 {
+		t.Errorf("stats counts a resource read as %d recalls, %d bytes", tot.Recalls, tot.Bytes)
+	}
+}
+
+// The kinds that write rather than serve stay uncounted on both screens.
+func TestWritingKindsAreNotServings(t *testing.T) {
+	for _, kind := range []string{KindRemember, KindSearch, KindHandoff} {
+		dir := oneEvent(t, kind)
+		if tot := Totals(dir); tot.Recalls != 0 || tot.Injections != 0 {
+			t.Errorf("%s: stats counts it as served: %#v", kind, tot)
+		}
+		if imp := Impact(dir); imp.Recalls != 0 || imp.Injections != 0 {
+			t.Errorf("%s: impact counts it as served: %#v", kind, imp)
+		}
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -48,6 +48,33 @@ const (
 	KindTool = "tool"
 )
 
+// servedKinds are the events that hand an agent memory it asked for: the two
+// recall tools, a blame — "the largest thing the server hands over", which is
+// why #682 gave it a kind of its own — and a read of deja://session/…, which
+// hands over a whole session in the same frame recall_context uses.
+//
+// Named once because the counters drifted: #1569 aligned five of them and left
+// Impact behind, so a blame was a recall on `deja stats` and nothing on
+// `deja stats --impact`, whose distilled ratio was then short by its bytes
+// (#1907).
+func servedKind(kind string) bool {
+	switch kind {
+	case KindRecall, KindContext, KindBlame, KindResource:
+		return true
+	}
+	return false
+}
+
+// injectedKinds are the events where deja offers memory unasked: the
+// session-start hook, the per-prompt recall and the PreToolUse line.
+func injectedKind(kind string) bool {
+	switch kind {
+	case KindHook, KindDejaVu, KindTool:
+		return true
+	}
+	return false
+}
+
 type Event struct {
 	Time     time.Time `json:"t"`
 	Kind     string    `json:"kind"`
@@ -206,11 +233,11 @@ func TodayWithInjections(indexDir string) (recalls, bytes, injected int) {
 		if e.Time.Before(midnight) || ahead(e.Time, now) {
 			continue
 		}
-		switch e.Kind {
-		case KindRecall, KindContext, KindBlame:
+		switch {
+		case servedKind(e.Kind):
 			recalls++
 			bytes += e.Bytes
-		case KindHook, KindDejaVu, KindTool:
+		case injectedKind(e.Kind):
 			recalls++
 			bytes += e.Bytes
 			injected += e.Bytes
@@ -234,11 +261,11 @@ func TodayDemand(indexDir string) (recalls, bytes, injected int) {
 		if e.Time.Before(midnight) || ahead(e.Time, now) || e.Empty {
 			continue
 		}
-		switch e.Kind {
-		case KindRecall, KindContext, KindBlame:
+		switch {
+		case servedKind(e.Kind):
 			recalls++
 			bytes += e.Bytes
-		case KindHook, KindDejaVu, KindTool:
+		case injectedKind(e.Kind):
 			injected += e.Bytes
 		}
 	}
@@ -268,8 +295,7 @@ func TodayRaw(indexDir string) int64 {
 		if e.Time.Before(midnight) || ahead(e.Time, now) {
 			continue
 		}
-		switch e.Kind {
-		case KindRecall, KindContext, KindBlame, KindHook, KindDejaVu, KindTool:
+		if servedKind(e.Kind) || injectedKind(e.Kind) {
 			raw += e.RawBytes
 		}
 	}
@@ -284,8 +310,8 @@ func Totals(indexDir string) Summary {
 		if out.Since.IsZero() || (!e.Time.IsZero() && e.Time.Before(out.Since)) {
 			out.Since = e.Time
 		}
-		switch e.Kind {
-		case KindRecall, KindContext, KindBlame:
+		switch {
+		case servedKind(e.Kind):
 			out.Recalls++
 			out.RecallSessions += e.Sessions
 			out.Bytes += e.Bytes
@@ -293,7 +319,7 @@ func Totals(indexDir string) Summary {
 			if e.Empty {
 				empty++
 			}
-		case KindHook, KindDejaVu, KindTool:
+		case injectedKind(e.Kind):
 			out.Injections++
 			out.InjectedSessions += e.Sessions
 			out.InjectedBytes += e.Bytes
@@ -321,11 +347,11 @@ func Week(indexDir string) (recalls, bytes, injected, injectedBytes int) {
 		if e.Time.Before(cut) || ahead(e.Time, now) || e.Empty {
 			continue
 		}
-		switch e.Kind {
-		case KindRecall, KindContext, KindBlame:
+		switch {
+		case servedKind(e.Kind):
 			recalls++
 			bytes += e.Bytes
-		case KindHook, KindDejaVu, KindTool:
+		case injectedKind(e.Kind):
 			injected++
 			injectedBytes += e.Bytes
 		}
@@ -470,8 +496,8 @@ func Impact(indexDir string) ImpactReport {
 		if r.Since.IsZero() || e.Time.Before(r.Since) {
 			r.Since = e.Time
 		}
-		switch e.Kind {
-		case KindRecall, KindContext:
+		switch {
+		case servedKind(e.Kind):
 			if e.Empty {
 				continue
 			}
@@ -481,7 +507,7 @@ func Impact(indexDir string) ImpactReport {
 			for _, id := range e.SessionIDs {
 				worn[id]++
 			}
-		case KindHook:
+		case e.Kind == KindHook:
 			// A session start with no project session to show still injects
 			// the environment block, and that event is logged empty. Counting
 			// it made "N session starts began with project memory" claim
@@ -492,7 +518,7 @@ func Impact(indexDir string) ImpactReport {
 			r.Injections++
 			r.ServedBytes += e.Bytes
 			r.RawBytes += e.RawBytes
-		case KindDejaVu:
+		case e.Kind == KindDejaVu:
 			r.DejaVuMoments++
 		}
 	}


### PR DESCRIPTION
Closes #1907.

`deja stats` and `deja stats --impact` walked the same usage log with different kind sets, so they disagreed about the same day:

```
kind        stats                  impact                 after (both)
blame       recalls=1 bytes=100    recalls=0 served=0     recalls=1 served=100
resource    nothing                nothing                recalls=1 served=100
```

#682 gave `blame` a kind of its own because it is "the largest thing the server hands over — whole sessions rather than budgeted snippets — so leaving it out understated what the agent was given", and #1569 aligned five counters here on one pair of kind sets. `Impact` was not among them, so a blame was a recall on one screen and nothing on the other — and its bytes were missing from the "context distilled" ratio, which is the one figure on that screen about how much reading deja saved.

`resource` was counted by neither, though its own comment says leaving it out "understated what was served the same way blame did before #682".

`servedKind` and `injectedKind` now name the two sets once, and every counter here reads them — the drift is what made this worth fixing rather than patching Impact alone.

Unchanged, and yours to decide (asked in the issue): `tool` and `dejavu` are injections to `deja stats` while the impact screen says "N session starts began with project memory", and neither is a session start. Counting them there makes that sentence false; leaving them out keeps deja's most frequent injection surface off the screen, which `KindTool`'s comment says must not happen. I did not guess.
