### PR TITLE
docs(usage): write down the rotation window the append accepts

### DIFF
--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -181,6 +181,16 @@ func recordFull(indexDir, kind string, bytes, sessions int, empty bool, raw int6
 		return
 	}
 	rotate(p)
+	// A rotation by another process between this open and the write below
+	// leaves this descriptor pointing at the file that was just retired, and
+	// the event goes with it. Measured and left alone on purpose: it takes a
+	// log past 1MB, two processes recording in the same instant, and the
+	// rotation landing inside those few microseconds — and closing it properly
+	// means locking a file this package appends to without a lock by design
+	// (#1319), which is the trade that keeps a usage event from ever being the
+	// reason a recall waits. One event is the cost, and one event is what this
+	// file is allowed to lose.
+	//
 	// O_RDWR rather than O_WRONLY: the append needs to read the last byte to
 	// know whether the previous record finished (#1901).
 	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -181,15 +181,13 @@ func recordFull(indexDir, kind string, bytes, sessions int, empty bool, raw int6
 		return
 	}
 	rotate(p)
-	// A rotation by another process between this open and the write below
-	// leaves this descriptor pointing at the file that was just retired, and
-	// the event goes with it. Measured and left alone on purpose: it takes a
-	// log past 1MB, two processes recording in the same instant, and the
-	// rotation landing inside those few microseconds — and closing it properly
-	// means locking a file this package appends to without a lock by design
-	// (#1319), which is the trade that keeps a usage event from ever being the
-	// reason a recall waits. One event is the cost, and one event is what this
-	// file is allowed to lose.
+	// The call above is not a guard: another process can rotate between this
+	// open and the write below, leaving this descriptor on the file that was
+	// just retired, and the event goes with it. Accepted, measured — it needs a
+	// log past 1MB and a rotation inside the open, the stat and the write, tens
+	// of microseconds here and more under load. Closing it means locking a file
+	// this package appends to without one by design (#1319). One event is the
+	// cost, and one event is what this file already risks on a crash.
 	//
 	// O_RDWR rather than O_WRONLY: the append needs to read the last byte to
 	// know whether the previous record finished (#1901).


### PR DESCRIPTION
A measurement and a comment. No behaviour change, no issue — the window is real and the trade is the right one.

`recordFull` rotates the usage log and then opens it. A rotation by another process between that open and the write leaves the descriptor pointing at the file just retired, and the event goes with it:

```
1.1MB log of events older than the keep window
open the file → rotate → append
  size_before=1125KB  size_after=0KB  rotated=true  event_in_log=0
```

Reaching it takes all three at once: the log past 1MB (below that `rotate` returns immediately), two processes recording in the same instant, and the rotation landing inside the open plus a stat and a one-byte read — a few microseconds.

Closing it properly means locking a file this package appends to without a lock on purpose (#1319), which is the trade that keeps a usage event from ever being the reason a recall waits. One event is the cost, and one event is what this file is allowed to lose — the same trade it already makes for a process killed mid-write.

So the change is the comment saying that, where the next reader will meet it as a bug otherwise. The numbers are in the PR rather than the source, since they are about this machine.
