### PR TITLE
docs(architecture): say which machines deja treats as one

### DIFF
--- a/cmd/deja/sync_docs_test.go
+++ b/cmd/deja/sync_docs_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The Sync format section described the watermark as it was before #982 — per
+// source path — while it has been per peer and source since, and folded by
+// peers.Identity since #1878. The rules that decide whether two exports are for
+// the same machine were written down in Go comments and nowhere a reader would
+// look (#1915).
+//
+// A prose check rather than a key check: this section has no keys, and what it
+// has to get right is which of the two names a watermark is filed under.
+func TestTheSyncSectionDescribesTheWatermarkItHas(t *testing.T) {
+	doc, err := os.ReadFile("../../docs/ARCHITECTURE.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	i := strings.Index(string(doc), "## Sync format")
+	if i < 0 {
+		t.Fatal("docs/ARCHITECTURE.md no longer has a Sync format section")
+	}
+	section := string(doc)[i:]
+	if end := strings.Index(section[3:], "\n## "); end > 0 {
+		section = section[:end+3]
+	}
+	prose := strings.Join(strings.Fields(section), " ")
+
+	for _, want := range []struct{ what, phrase string }{
+		{"the watermark is per peer as well as per source", "per peer"},
+		{"the peers file is named", "peers.json"},
+		{"one machine, whatever case its name is typed in", "case"},
+		{"a pull learns what the machine calls itself", "learns"},
+	} {
+		if !strings.Contains(prose, want.phrase) {
+			t.Errorf("the Sync format section does not say %s (looked for %q)", want.what, want.phrase)
+		}
+	}
+	if strings.Contains(prose, "The export watermark is per source path (falling back") {
+		t.Error("the section still describes the pre-#982 watermark")
+	}
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -106,9 +106,19 @@ counts are blended with recency and an absolute project-root match receives a bo
 {"harness":"claude","session_id":"abc123","project":"api","role":"assistant","text":"fixed by ...","time":"2026-07-14T12:00:00Z"}
 ```
 
-The export watermark is per source path (falling back to session key for synthetic records) and is stored in `manifest.gob` as the max exported record timestamp. Re-running export emits only records with a newer timestamp for that source. Text is redacted again during export.
+The export watermark is per peer and source path (falling back to session key for synthetic records) and is stored in `manifest.gob` as the max exported record timestamp. Re-running export emits only records with a newer timestamp for that source and that peer, so what one machine has already received says nothing about what another still needs. An export with no peer named keeps the bare source key, which is what manifests written before per-peer watermarks carry. Text is redacted again during export.
 
 `deja sync import <dir>` reads all `*.jsonl` batches, appends records to the local index, updates touched token buckets, and writes imported session metadata with the original harness and an `imported:` project prefix. Imported IDs are namespaced (`imported-<hash>`) so they do not clobber local sessions from the same harness. The manifest stores dedupe keys of `harness:session_id:time`, making re-import idempotent. Imported records live only in the index, so full rebuilds replay them from the old `records.bin` before regenerating from sources, and exports skip them to avoid echoing history back to its origin.
+
+### Which machines are one machine
+
+The machines this one syncs with live in `peers.json` beside `policy.json`, outside the index, since who you sync with outlives any one rebuild. A bare `deja sync` walks that file and exchanges with every row, both ways.
+
+A host is matched the way ssh matches it: case-insensitively, but only after the last `@`. `box` and `BOX` are one machine; `Root@box` and `root@box` are two logins on it. That rule decides three things at once — which row an exchange is recorded against, which rows a `deja sync forget` removes, and which watermark an export advances, so one machine cannot be sent its whole history twice under two spellings.
+
+A run uses the spelling already stored for a host rather than the one typed, for the same reason.
+
+The name a machine calls itself is not the alias you type at it, and an imported session is stamped with the former. A pull learns the pairing and records it on the peer's row, and `deja doctor` then counts what arrived from a machine under either name. A machine only ever pushed to has nothing to learn from, so it counts nothing — which is honest: nothing has arrived from it.
 
 `deja sync ssh <host>` wraps the same export/import in one command: export to a temp dir, scp the batches, run the remote import (system ssh/scp, remote binary from PATH or `~/.local/bin/deja`).
 


### PR DESCRIPTION
Closes #1915.

`docs/ARCHITECTURE.md` described the export watermark as it was before #982:

> The export watermark is per source path (falling back to session key for synthetic records) …

It is per peer *and* source; the bare source key is the older shape, kept so pre-#982 manifests still read. Since #1878 the peer half is folded by `peers.Identity`, so `Laptop` and `laptop` share one watermark rather than each being sent the machine's whole history.

That paragraph was also the only place in `docs/` touching any of this. Four rules decided in the last day — the peers file and what a bare `deja sync` does with it (#1780), what counts as one machine (#1867), which spelling a run uses (#1878), and the name a pull learns so `doctor` can count by either (#1887) — lived in Go comments. They are now a short section beside the format they govern, since what they decide is whether two exports are for the same machine.

`TestTheSyncSectionDescribesTheWatermarkItHas` reads that section for what it must say and fails on the base branch on all five checks, including the old sentence still being there. A prose check rather than a key check, because the section has no keys — what it has to get right is which of the two names a watermark is filed under.

No behaviour change.
