### PR TITLE
fix(usage): one rule for what counts as an event in the log

### DIFF
--- a/internal/usage/event_shape_test.go
+++ b/internal/usage/event_shape_test.go
@@ -1,0 +1,76 @@
+package usage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// oneLine writes a log holding exactly the given line.
+func oneLine(t *testing.T, line string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	p := Path(dir)
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(line+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The counters kept a line with a stamp; `deja log` kept one with a kind. So a
+// half-written line was a row on one surface and nothing on the other — and a
+// line with no kind, which no counter has a case for, still set `since`, the
+// window every figure on the impact screen is measured from (#1917).
+func TestBothReadersAgreeOnWhatAnEventIs(t *testing.T) {
+	for _, c := range []struct {
+		name, line string
+		kept       bool
+	}{
+		{"whole", `{"t":"2026-08-20T10:00:00Z","kind":"recall","bytes":100,"sessions":1}`, true},
+		{"unknown kind", `{"t":"2026-08-20T10:00:00Z","kind":"weather","bytes":100}`, true},
+		{"no stamp", `{"kind":"recall","bytes":100,"sessions":1}`, false},
+		{"no kind", `{"t":"2026-08-20T10:00:00Z","bytes":100,"sessions":1}`, false},
+		{"neither", `{"bytes":100,"sessions":1}`, false},
+	} {
+		dir := oneLine(t, c.line)
+		byCounters := len(read(Path(dir)))
+		byLog := len(Events(dir, 0))
+		if byCounters != byLog {
+			t.Errorf("%s: the counters read %d and deja log reads %d", c.name, byCounters, byLog)
+		}
+		want := 0
+		if c.kept {
+			want = 1
+		}
+		if byCounters != want {
+			t.Errorf("%s: kept %d, want %d", c.name, byCounters, want)
+		}
+	}
+}
+
+// A line no counter can count must not decide the period the counts cover.
+func TestALineWithNoKindDoesNotMoveTheWindow(t *testing.T) {
+	dir := oneLine(t, `{"t":"2020-01-01T00:00:00Z","bytes":100,"sessions":1}`)
+	if tot := Totals(dir); !tot.Since.IsZero() {
+		t.Errorf("a kindless line pulled the window back to %s", tot.Since.Format("2006-01-02"))
+	}
+	if imp := Impact(dir); !imp.Since.IsZero() {
+		t.Errorf("the impact screen dates its counts from %s", imp.Since.Format("2006-01-02"))
+	}
+}
+
+// An unknown kind is a different thing: deja may have written it, an older or
+// newer version of itself, so it stays an event even though nothing counts it.
+func TestAnUnknownKindStaysAnEvent(t *testing.T) {
+	dir := oneLine(t, `{"t":"2026-08-20T10:00:00Z","kind":"weather","bytes":100}`)
+	if got := len(Events(dir, 0)); got != 1 {
+		t.Errorf("deja log hides an event it does not recognise: %d", got)
+	}
+	if tot := Totals(dir); tot.Since.IsZero() {
+		t.Error("an unknown kind stopped counting towards the window")
+	}
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -178,7 +178,9 @@ func Events(indexDir string, n int) []Event {
 	sc.Buffer(make([]byte, 0, 64<<10), 4<<20)
 	for sc.Scan() {
 		var e Event
-		if json.Unmarshal(sc.Bytes(), &e) == nil && e.Kind != "" {
+		// The same rule the counters read by, so a line is an event on both
+		// surfaces or on neither (#1917).
+		if json.Unmarshal(sc.Bytes(), &e) == nil && e.usable() {
 			out = append(out, e)
 		}
 	}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -373,6 +373,20 @@ func Today(indexDir string) (recalls int, bytes int) {
 	return recalls, bytes
 }
 
+// usable reports whether a line is an event at all: a stamp, so it can be
+// placed in time, and a kind, so it can be counted or named. The two readers
+// asked for one each — the counters for a stamp, `deja log` for a kind — so a
+// half-written line was a row on one surface and nothing on the other, and a
+// line with no kind, which no counter has a case for, still set `since`, the
+// window every figure on the impact screen is measured from (#1917).
+//
+// An unrecognised kind stays an event: deja may have written it, an older or a
+// newer version of itself, and it belongs in the log the reader browses even
+// though no counter has a case for it.
+func (e Event) usable() bool {
+	return !e.Time.IsZero() && e.Kind != ""
+}
+
 func read(p string) []Event {
 	f, err := os.Open(p)
 	if err != nil {
@@ -384,7 +398,7 @@ func read(p string) []Event {
 	s.Buffer(make([]byte, 4096), 1<<20)
 	for s.Scan() {
 		var e Event
-		if json.Unmarshal(s.Bytes(), &e) == nil && !e.Time.IsZero() {
+		if json.Unmarshal(s.Bytes(), &e) == nil && e.usable() {
 			out = append(out, e)
 		}
 	}


### PR DESCRIPTION
Closes #1917.

The usage log has two readers and they disagreed about what an event is. `read` (the counters) kept a line with a stamp; `Events` (`deja log`) kept one with a kind:

```
line              read  events  recalls  since         →  after
whole             1     1       1        2026-08-20       unchanged
kind, no stamp    0     1       0        —                read=0 events=0
stamp, no kind    1     0       0        2026-08-20       read=0 events=0
unknown kind      1     1       0        2026-08-20       unchanged
```

Two shapes were wrong in opposite directions: a line with a kind and no stamp was a row in `deja log` dated January of year 1, and a line with a stamp and no kind could never be counted — no counter has a case for it — yet it set `since`, the window every figure on `deja stats --impact` is measured from. One such line pulled that window back to whatever date it carried.

Neither shape is written by deja; both come from a hand-edited file, a partial write that happened to parse, or a batch from something else.

`Event.usable` now says it once — a stamp and a kind — and both readers ask it. An *unrecognised* kind stays an event on purpose: deja may have written it, an older or newer version of itself, and it belongs in the log a reader browses even though no counter has a case for it. There is a test for that, so the rule cannot quietly tighten into "a kind I know".
