### PR TITLE
fix(usage): one week for every counter that shows one

### DIFF
--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -483,7 +483,8 @@ func questionStemFor(text string) string {
 // only signal that separates memory that was used from memory that was merely
 // served, so the impact panel reads it too (#1062).
 func AgentCredits(ss []model.Session, now time.Time) (total, week int) {
-	weekCut := now.Add(-7 * 24 * time.Hour)
+	// The same week the status bar and the brief mean (#1920).
+	weekCut := usage.WeekCut(now)
 	for _, s := range ss {
 		for _, msg := range s.Messages {
 			if msg.Role != "assistant" || !strings.Contains(msg.Text, "deja-vu recalled") {

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -280,26 +280,21 @@ func TodayDemand(indexDir string) (recalls, bytes, injected int) {
 	return recalls, bytes, injected
 }
 
-// weekCut is when "this week" opens: seven calendar days back, the same wall
+// WeekCut is when "this week" opens: seven calendar days back, the same wall
 // time. Not 168 hours — in a zone with daylight saving those differ by an hour
 // for one week in each direction, and the status bar prints the week counters
 // beside the déjà-vu count, so one of them counted an event the other did not
 // (#1920). The day counters here cut at local midnight and the brief cuts at
 // seven calendar days, so this is the rule the rest of deja already speaks.
-func weekCut(now time.Time) time.Time {
-	return now.AddDate(0, 0, -7)
-}
-
-// WeekCut is that rule for the other packages measuring the same week.
 func WeekCut(now time.Time) time.Time {
-	return weekCut(now)
+	return now.AddDate(0, 0, -7)
 }
 
 // DejaVuWeek counts this week's déjà vu moments — prompts the user's own
 // history already answered.
 func DejaVuWeek(indexDir string) int {
 	now := time.Now()
-	cut := weekCut(now)
+	cut := WeekCut(now)
 	n := 0
 	for _, e := range read(Path(indexDir)) {
 		if e.Kind == KindDejaVu && e.Time.After(cut) && !ahead(e.Time, now) && e.Sessions > 0 {
@@ -365,7 +360,7 @@ func Totals(indexDir string) Summary {
 // deliveries deja pushed unprompted.
 func Week(indexDir string) (recalls, bytes, injected, injectedBytes int) {
 	now := time.Now()
-	cut := weekCut(now)
+	cut := WeekCut(now)
 	for _, e := range read(Path(indexDir)) {
 		if e.Time.Before(cut) || ahead(e.Time, now) || e.Empty {
 			continue

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -280,11 +280,26 @@ func TodayDemand(indexDir string) (recalls, bytes, injected int) {
 	return recalls, bytes, injected
 }
 
+// weekCut is when "this week" opens: seven calendar days back, the same wall
+// time. Not 168 hours — in a zone with daylight saving those differ by an hour
+// for one week in each direction, and the status bar prints the week counters
+// beside the déjà-vu count, so one of them counted an event the other did not
+// (#1920). The day counters here cut at local midnight and the brief cuts at
+// seven calendar days, so this is the rule the rest of deja already speaks.
+func weekCut(now time.Time) time.Time {
+	return now.AddDate(0, 0, -7)
+}
+
+// WeekCut is that rule for the other packages measuring the same week.
+func WeekCut(now time.Time) time.Time {
+	return weekCut(now)
+}
+
 // DejaVuWeek counts this week's déjà vu moments — prompts the user's own
 // history already answered.
 func DejaVuWeek(indexDir string) int {
 	now := time.Now()
-	cut := now.AddDate(0, 0, -7)
+	cut := weekCut(now)
 	n := 0
 	for _, e := range read(Path(indexDir)) {
 		if e.Kind == KindDejaVu && e.Time.After(cut) && !ahead(e.Time, now) && e.Sessions > 0 {
@@ -350,7 +365,7 @@ func Totals(indexDir string) Summary {
 // deliveries deja pushed unprompted.
 func Week(indexDir string) (recalls, bytes, injected, injectedBytes int) {
 	now := time.Now()
-	cut := now.Add(-7 * 24 * time.Hour)
+	cut := weekCut(now)
 	for _, e := range read(Path(indexDir)) {
 		if e.Time.Before(cut) || ahead(e.Time, now) || e.Empty {
 			continue

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -280,8 +280,9 @@ func TodayDemand(indexDir string) (recalls, bytes, injected int) {
 	return recalls, bytes, injected
 }
 
-// WeekCut is when "this week" opens: seven calendar days back, the same wall
-// time. Not 168 hours — in a zone with daylight saving those differ by an hour
+// WeekCut is when "this week" opens: seven calendar days back, at the same wall
+// time — or, in the hour a spring-forward removes, at the time the clock
+// actually reached, since 02:30 did not happen that day. Not 168 hours — in a zone with daylight saving those differ by an hour
 // for one week in each direction, and the status bar prints the week counters
 // beside the déjà-vu count, so one of them counted an event the other did not
 // (#1920). The day counters here cut at local midnight and the brief cuts at

--- a/internal/usage/week_test.go
+++ b/internal/usage/week_test.go
@@ -36,22 +36,46 @@ func TestTheWeekIsSevenCalendarDays(t *testing.T) {
 	}
 }
 
-// And the two counters that read it agree, which is the thing that was wrong.
-func TestTheWeekCountersShareOneCut(t *testing.T) {
+// The hour the two rules disagreed about, asserted rather than skipped past.
+// After the autumn change the fixed-hours cut lands an hour later than the
+// calendar one, so an event in between is inside this week by the rule deja
+// keeps and outside it by the rule it dropped — which is the event that used to
+// be in one counter and not the other.
+func TestTheHourTheOldRuleWouldHaveMissed(t *testing.T) {
 	ny, err := time.LoadLocation("America/New_York")
 	if err != nil {
 		t.Skip("no tzdata: ", err)
 	}
 	now := time.Date(2026, 11, 3, 12, 0, 0, 0, ny)
-	if !WeekCut(now).Equal(WeekCut(now)) {
-		t.Fatal("WeekCut is not a function of its argument")
+	fixed := now.Add(-7 * 24 * time.Hour)
+	cut := WeekCut(now)
+	if !cut.Before(fixed) {
+		t.Fatalf("this week has no clock change in it: cut=%s fixed=%s", cut, fixed)
 	}
-	// An event in the hour the two rules disagreed about.
-	inTheGap := now.AddDate(0, 0, -7).Add(30 * time.Minute)
-	if inTheGap.Before(WeekCut(now)) {
+	event := cut.Add(30 * time.Minute)
+	if event.Before(cut) {
 		t.Errorf("an event half an hour into the week is outside it")
 	}
-	if fixed := now.Add(-7 * 24 * time.Hour); !inTheGap.Before(fixed) {
-		t.Skip("this week has no clock change, so there is no gap to test")
+	if !event.Before(fixed) {
+		t.Errorf("the event is not in the hour the two rules disagreed about: %s", event)
+	}
+}
+
+// And in spring the disagreement runs the other way: the fixed-hours cut opens
+// an hour early, so it counted an event from the week before.
+func TestTheHourTheOldRuleWouldHaveAdded(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skip("no tzdata: ", err)
+	}
+	now := time.Date(2026, 3, 10, 12, 0, 0, 0, ny)
+	fixed := now.Add(-7 * 24 * time.Hour)
+	cut := WeekCut(now)
+	if !fixed.Before(cut) {
+		t.Fatalf("this week has no clock change in it: cut=%s fixed=%s", cut, fixed)
+	}
+	event := fixed.Add(30 * time.Minute)
+	if !event.Before(cut) {
+		t.Errorf("an event before this week's start is counted inside it: %s", event)
 	}
 }

--- a/internal/usage/week_test.go
+++ b/internal/usage/week_test.go
@@ -24,7 +24,7 @@ func TestTheWeekIsSevenCalendarDays(t *testing.T) {
 		{"after the spring change", time.Date(2026, 3, 10, 12, 0, 0, 0, ny)},
 		{"an ordinary week", time.Date(2026, 8, 25, 12, 0, 0, 0, ny)},
 	} {
-		cut := weekCut(c.now)
+		cut := WeekCut(c.now)
 		if got, want := cut.Format("2006-01-02 15:04"), c.now.AddDate(0, 0, -7).Format("2006-01-02 15:04"); got != want {
 			t.Errorf("%s: week opens at %s, want the same wall time seven days back (%s)", c.what, got, want)
 		}
@@ -43,12 +43,12 @@ func TestTheWeekCountersShareOneCut(t *testing.T) {
 		t.Skip("no tzdata: ", err)
 	}
 	now := time.Date(2026, 11, 3, 12, 0, 0, 0, ny)
-	if !weekCut(now).Equal(weekCut(now)) {
-		t.Fatal("weekCut is not a function of its argument")
+	if !WeekCut(now).Equal(WeekCut(now)) {
+		t.Fatal("WeekCut is not a function of its argument")
 	}
 	// An event in the hour the two rules disagreed about.
 	inTheGap := now.AddDate(0, 0, -7).Add(30 * time.Minute)
-	if inTheGap.Before(weekCut(now)) {
+	if inTheGap.Before(WeekCut(now)) {
 		t.Errorf("an event half an hour into the week is outside it")
 	}
 	if fixed := now.Add(-7 * 24 * time.Hour); !inTheGap.Before(fixed) {

--- a/internal/usage/week_test.go
+++ b/internal/usage/week_test.go
@@ -1,0 +1,57 @@
+package usage
+
+import (
+	"testing"
+	"time"
+)
+
+// deja had two ways of saying "a week ago" and showed them side by side: the
+// status bar's week counters cut at a fixed 168 hours while its déjà-vu count
+// cut seven calendar days back. In a zone with daylight saving those differ by
+// an hour for one week in each direction, so an event inside that hour was in
+// one number and not the other (#1920). The day counters beside them use local
+// midnight, which is calendar, and so does the brief.
+func TestTheWeekIsSevenCalendarDays(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skip("no tzdata: ", err)
+	}
+	for _, c := range []struct {
+		what string
+		now  time.Time
+	}{
+		{"after the autumn change", time.Date(2026, 11, 3, 12, 0, 0, 0, ny)},
+		{"after the spring change", time.Date(2026, 3, 10, 12, 0, 0, 0, ny)},
+		{"an ordinary week", time.Date(2026, 8, 25, 12, 0, 0, 0, ny)},
+	} {
+		cut := weekCut(c.now)
+		if got, want := cut.Format("2006-01-02 15:04"), c.now.AddDate(0, 0, -7).Format("2006-01-02 15:04"); got != want {
+			t.Errorf("%s: week opens at %s, want the same wall time seven days back (%s)", c.what, got, want)
+		}
+		// The wall clock, not 168 hours: that is what makes it the same week
+		// the day counters and the brief are talking about.
+		if h, m := cut.Hour(), cut.Minute(); h != 12 || m != 0 {
+			t.Errorf("%s: week opens at %02d:%02d, not the hour it is now", c.what, h, m)
+		}
+	}
+}
+
+// And the two counters that read it agree, which is the thing that was wrong.
+func TestTheWeekCountersShareOneCut(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skip("no tzdata: ", err)
+	}
+	now := time.Date(2026, 11, 3, 12, 0, 0, 0, ny)
+	if !weekCut(now).Equal(weekCut(now)) {
+		t.Fatal("weekCut is not a function of its argument")
+	}
+	// An event in the hour the two rules disagreed about.
+	inTheGap := now.AddDate(0, 0, -7).Add(30 * time.Minute)
+	if inTheGap.Before(weekCut(now)) {
+		t.Errorf("an event half an hour into the week is outside it")
+	}
+	if fixed := now.Add(-7 * 24 * time.Hour); !inTheGap.Before(fixed) {
+		t.Skip("this week has no clock change, so there is no gap to test")
+	}
+}


### PR DESCRIPTION
Closes #1920.

deja had two ways of saying "a week ago" and printed them on the same line. In a zone with daylight saving they differ by an hour, one week in each direction:

```
now=2026-11-03 12:00 EST   168h → 2026-10-27 13:00 EDT   seven days → 2026-10-27 12:00 EDT
now=2026-03-10 12:00 EDT   168h → 2026-03-03 11:00 EST   seven days → 2026-03-03 12:00 EST
now=2026-08-25 12:00 EDT   168h → 2026-08-18 12:00 EDT   seven days → 2026-08-18 12:00 EDT
```

`Week` cut at 168 hours, `DejaVuWeek` at seven calendar days, and the status bar shows both — so after a clock change one of them counted an event the other did not. `internal/stats` cut at 168 hours too, while the brief's "this week" and the day counters (local midnight) were already calendar.

`weekCut` says it once, calendar, and the counters read it. `usage.WeekCut` is the same rule for `internal/stats`.

Tests: the cut keeps the wall clock across both changes and an ordinary week, and an event half an hour into the week is inside it. They skip rather than fail where the machine has no tzdata, since that is not something this change can fix.
