### PR TITLE
fix(usage): rotation keeps the newest events rather than emptying the log

### DIFF
--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -414,8 +414,10 @@ prior work, and `credited_aloud` the recalls an agent said out loud.
 more than the period from then to now. On a quiet machine that is every event
 there has ever been; once the log grows past 1MB it is rewritten keeping the
 last 14 days, and from then on the figures are a window whose start moves. Read
-`since` rather than assuming either. It is absent when the log holds nothing,
-which is the one case where the counts are all zero anyway.
+`since` rather than assuming either — it can also be older than 14 days, since a
+rewrite that would leave nothing keeps the newest few hundred events instead of
+emptying the file. It is absent only when the log holds nothing at all, which is
+the one case where the counts are all zero anyway.
 
 ## `deja blame <path> --json`
 

--- a/internal/usage/rotate_floor_test.go
+++ b/internal/usage/rotate_floor_test.go
@@ -1,0 +1,113 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// agedLog writes a log past the rotation size whose events are all the given
+// number of days old.
+func agedLog(t *testing.T, days int) (dir, path string) {
+	t.Helper()
+	dir = t.TempDir()
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	path = Path(dir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	var b strings.Builder
+	for i := 0; i < 4000; i++ {
+		e := Event{
+			Time: now.Add(-time.Duration(days+i%5) * 24 * time.Hour), Kind: KindRecall,
+			Bytes: 500, Sessions: 2, RawBytes: 5000, SessionIDs: []string{strings.Repeat("x", 200)},
+		}
+		raw, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b.Write(raw)
+		b.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir, path
+}
+
+// Rotation drops what is older than the keep window, and when everything is
+// older than it — a fortnight away from the machine — that used to be the whole
+// file. The first recall on return left zero bytes, and `deja stats --impact`
+// said "no recall activity recorded yet" about a log that had held four
+// thousand events (#1922). Bounding the file is the job; erasing the record is
+// not.
+func TestRotationLeavesTheNewestEventsWhenAllAreOld(t *testing.T) {
+	dir, p := agedLog(t, 21)
+	before := len(read(p))
+	if before == 0 {
+		t.Fatal("the fixture wrote nothing")
+	}
+
+	rotate(p)
+
+	kept := read(p)
+	if len(kept) == 0 {
+		t.Fatalf("rotation left nothing of %d events", before)
+	}
+	if len(kept) >= before {
+		t.Errorf("rotation kept %d of %d — it is meant to bound the file", len(kept), before)
+	}
+	if tot := Totals(dir); tot.Since.IsZero() {
+		t.Error("the window says the log holds nothing, though it holds the newest events")
+	}
+	if imp := Impact(dir); imp.Recalls == 0 {
+		t.Error("the impact screen reports no activity after a rotation that kept events")
+	}
+	// The newest ones, not an arbitrary slice: the last thing that happened is
+	// what a reader wants when the rest has aged out.
+	newest := kept[0].Time
+	for _, e := range kept {
+		if e.Time.After(newest) {
+			newest = e.Time
+		}
+	}
+	if age := time.Since(newest).Hours() / 24; age > 22 {
+		t.Errorf("the newest kept event is %.0f days old, so the oldest were kept instead", age)
+	}
+}
+
+// The ordinary case is unchanged: with events inside the window, only those
+// stay.
+func TestRotationStillDropsWhatIsOutsideTheWindow(t *testing.T) {
+	dir, p := agedLog(t, 0)
+	// Half of them well outside the window.
+	old := Event{Time: time.Now().UTC().Add(-40 * 24 * time.Hour), Kind: KindRecall, Bytes: 1, Sessions: 1}
+	raw, err := json.Marshal(old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(p, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(append(raw, '\n')); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	rotate(p)
+
+	for _, e := range read(p) {
+		if time.Since(e.Time) > 15*24*time.Hour {
+			t.Errorf("an event %s old survived a rotation with fresh events in the file", time.Since(e.Time))
+			break
+		}
+	}
+	if tot := Totals(dir); tot.Recalls == 0 {
+		t.Error("the fresh events were dropped too")
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -129,6 +130,13 @@ func (s Summary) MarshalJSON() ([]byte, error) {
 const (
 	rotateAt   = 1 << 20 // rewrite the log when it grows past 1MB
 	keepWindow = 14 * 24 * time.Hour
+	// keepAtLeast is how many events survive when every one of them is older
+	// than the window — a fortnight away from the machine, and the first recall
+	// on return used to leave the file empty and the impact screen saying no
+	// recall had ever happened (#1922). Bounding the file is the job; erasing
+	// the record is not, and a few hundred events are tens of kilobytes against
+	// a megabyte.
+	keepAtLeast = 200
 )
 
 // ahead reports a timestamp past the end of the reader's day — a clock that
@@ -449,6 +457,16 @@ func rotate(p string) {
 	}
 	if len(keep) == len(all) {
 		return
+	}
+	if len(keep) == 0 && len(all) > 0 {
+		// Newest first, then back into the order the file is read in.
+		byTime := append([]Event(nil), all...)
+		sort.Slice(byTime, func(i, j int) bool { return byTime[i].Time.After(byTime[j].Time) })
+		if len(byTime) > keepAtLeast {
+			byTime = byTime[:keepAtLeast]
+		}
+		sort.Slice(byTime, func(i, j int) bool { return byTime[i].Time.Before(byTime[j].Time) })
+		keep = byTime
 	}
 	// One buffer, then one atomic replace. The temp name used to be derived
 	// from the log's own path, and this is the one writer in deja with no lock

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -131,11 +131,10 @@ const (
 	rotateAt   = 1 << 20 // rewrite the log when it grows past 1MB
 	keepWindow = 14 * 24 * time.Hour
 	// keepAtLeast is how many events survive when every one of them is older
-	// than the window — a fortnight away from the machine, and the first recall
-	// on return used to leave the file empty and the impact screen saying no
-	// recall had ever happened (#1922). Bounding the file is the job; erasing
-	// the record is not, and a few hundred events are tens of kilobytes against
-	// a megabyte.
+	// than the window. Without it, a fortnight away emptied the log on the
+	// first recall back and the impact screen said no recall had ever happened
+	// (#1922). Measured at 59.8 KB, against the megabyte that triggers a
+	// rewrite.
 	keepAtLeast = 200
 )
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -460,12 +460,15 @@ func rotate(p string) {
 	}
 	if len(keep) == 0 && len(all) > 0 {
 		// Newest first, then back into the order the file is read in.
+		// Stable, so two events written in the same second keep the order they
+		// were written in — that order is the only thing separating them, and
+		// `deja log` prints it.
 		byTime := append([]Event(nil), all...)
-		sort.Slice(byTime, func(i, j int) bool { return byTime[i].Time.After(byTime[j].Time) })
+		sort.SliceStable(byTime, func(i, j int) bool { return byTime[i].Time.After(byTime[j].Time) })
 		if len(byTime) > keepAtLeast {
 			byTime = byTime[:keepAtLeast]
 		}
-		sort.Slice(byTime, func(i, j int) bool { return byTime[i].Time.Before(byTime[j].Time) })
+		sort.SliceStable(byTime, func(i, j int) bool { return byTime[i].Time.Before(byTime[j].Time) })
 		keep = byTime
 	}
 	// One buffer, then one atomic replace. The temp name used to be derived


### PR DESCRIPTION
Closes #1922.

Rotation drops what is older than fourteen days. Come back from a fortnight away and every event is older than that, so the first recall on return emptied the file:

```
before  events=4000 recalls=4000 since=2026-07-26
after   bytes=0     events=0     recalls=0        since=—        (was)
after   bytes=59800 events=200   recalls=200      since=2026-08-04 (now)
```

`deja stats --impact` then printed "no recall activity recorded yet — impact numbers appear once agents start recalling" about a log that had held four thousand events, and `deja stats` lost its "Recalls served N since …" line the same way.

Bounding the file is the job; erasing the record is not. When nothing is inside the window, rotation now keeps the newest `keepAtLeast` events — 200, which measured 59.8 KB against the 1 MB threshold that triggers rotation in the first place.

Two tests: everything old keeps the newest (and it really is the newest, not an arbitrary slice — the test checks their age), and the ordinary case still drops what is outside the window when there is anything inside it.
