### PR TITLE
docs(json): describe deja log --json and pin its keys

### DIFF
--- a/cmd/deja/log_contract_test.go
+++ b/cmd/deja/log_contract_test.go
@@ -22,11 +22,9 @@ func TestLogJSONKeysMatchTheDocumentedContract(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(usage.Path(dir)), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	when := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
 	usage.RecordServedSessions(dir, usage.KindRecall, 900, 2, false, 9000, []string{"s1", "s2"})
 	usage.RecordResultRaw(dir, usage.KindHook, 400, 1, false, 4000)
 	usage.RecordResult(dir, usage.KindRecall, 0, 0, true)
-	_ = when
 	_ = tmp
 
 	out, err := captureRun(t, "log", "--json")

--- a/cmd/deja/log_contract_test.go
+++ b/cmd/deja/log_contract_test.go
@@ -100,3 +100,41 @@ func TestLogJSONIsAnArrayNewestFirst(t *testing.T) {
 		t.Errorf("the array is oldest first: %s then %s", events[0].Time, events[1].Time)
 	}
 }
+
+// `--last` is a different shape and the document describes it in prose; that
+// prose named Go field names rather than JSON keys until this test existed.
+func TestLogLastJSONKeysMatchTheDocumentedContract(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := os.MkdirAll(filepath.Dir(usage.Path(dir)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	usage.SnapshotPolicy(dir, usage.KindHook, "a digest of earlier work", 2, "local-only")
+
+	out, err := captureRun(t, "log", "--last", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snap map[string]any
+	if err := json.Unmarshal([]byte(out), &snap); err != nil {
+		t.Fatalf("%v: %s", err, out)
+	}
+	doc, err := os.ReadFile("../../docs/json-output.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	section := docSection(t, string(doc), "## `deja log --json`")
+	var missing []string
+	for k := range snap {
+		if !strings.Contains(section, "`"+k+"`") {
+			missing = append(missing, k)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("deja log --last --json emits %v, absent from the section", missing)
+	}
+	if len(snap) < 4 {
+		t.Errorf("the snapshot emitted %d keys, too few to say anything: %v", len(snap), snap)
+	}
+}

--- a/cmd/deja/log_contract_test.go
+++ b/cmd/deja/log_contract_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// `deja log --json` is the surface a script polls to see what deja fed an
+// agent, and the document named it twice without saying what it emits (#1924).
+// Pinned the way stats (#1710), impact (#1900) and show/last (#1911) are.
+func TestLogJSONKeysMatchTheDocumentedContract(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := os.MkdirAll(filepath.Dir(usage.Path(dir)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	when := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
+	usage.RecordServedSessions(dir, usage.KindRecall, 900, 2, false, 9000, []string{"s1", "s2"})
+	usage.RecordResultRaw(dir, usage.KindHook, 400, 1, false, 4000)
+	usage.RecordResult(dir, usage.KindRecall, 0, 0, true)
+	_ = when
+	_ = tmp
+
+	out, err := captureRun(t, "log", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var events []map[string]any
+	if err := json.Unmarshal([]byte(out), &events); err != nil {
+		t.Fatalf("%v: %s", err, out)
+	}
+	if len(events) != 3 {
+		t.Fatalf("wrote three events, read %d: %s", len(events), out)
+	}
+
+	doc, err := os.ReadFile("../../docs/json-output.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	section := docSection(t, string(doc), "## `deja log --json`")
+
+	keys := map[string]bool{}
+	for _, e := range events {
+		for k := range e {
+			keys[k] = true
+		}
+	}
+	var missing []string
+	for k := range keys {
+		if !strings.Contains(section, "`"+k+"`") {
+			missing = append(missing, k)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("deja log --json emits %v, absent from its section of docs/json-output.md", missing)
+	}
+}
+
+// The two shapes the document has to keep straight: the array is newest first
+// and is never null, which #733 settled for the script that polls it.
+func TestLogJSONIsAnArrayNewestFirst(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := os.MkdirAll(filepath.Dir(usage.Path(dir)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	empty, err := captureRun(t, "log", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(empty) != "[]" {
+		t.Errorf("an empty log emits %q, not an empty array", strings.TrimSpace(empty))
+	}
+
+	usage.RecordResult(dir, usage.KindRecall, 100, 1, false)
+	time.Sleep(2 * time.Millisecond)
+	usage.RecordResult(dir, usage.KindHook, 200, 1, false)
+
+	out, err := captureRun(t, "log", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var events []usage.Event
+	if err := json.Unmarshal([]byte(out), &events); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("read %d events", len(events))
+	}
+	if events[0].Time.Before(events[1].Time) {
+		t.Errorf("the array is oldest first: %s then %s", events[0].Time, events[1].Time)
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -451,7 +451,9 @@ have written it, and the log keeps what it was given.
 
 `bytes` is the size of the text that changed hands — what deja served, or, for
 `remember`, the note the agent wrote — and `raw` the size of the transcripts
-behind a served digest, both omitted when zero. `sessions` counts what the digest held, `ids` names them for a
+behind a served digest, which is omitted when there is none. `bytes` is always
+there, zero included: a recall that served nothing is a fact, not a missing
+field. `sessions` counts what the digest held, `ids` names them for a
 recall, and `empty` marks an answer that found nothing — a recall that returned
 no sessions is still a recall, and the count of those is what
 `empty_result_rate` is made of.

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -461,8 +461,10 @@ half. The same rule decides what the counters in `stats --json` read, so the two
 never disagree about whether something happened.
 
 `deja log --last --json` is a different shape: one object, the most recent
-injected digest itself, with `kind`, `time`, `sessions`, `bytes`, `policy` and
-the `digest` text.
+injected digest itself. It carries `t` and `kind` as above, the `digest` text,
+`bytes`, and — each omitted when empty — `sessions`, the `policy` that allowed
+the injection, the `terms` behind a déjà vu firing, and `into`, the agent session
+it went to.
 
 ## `deja blame <path> --json`
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -449,8 +449,9 @@ writes rather than serves; `search` and `handoff` are the reader's own commands.
 A kind this list does not name may still appear: another version of deja may
 have written it, and the log keeps what it was given.
 
-`bytes` is what was served and `raw` the size of the transcripts behind it, both
-omitted when zero. `sessions` counts what the digest held, `ids` names them for a
+`bytes` is the size of the text that changed hands — what deja served, or, for
+`remember`, the note the agent wrote — and `raw` the size of the transcripts
+behind a served digest, both omitted when zero. `sessions` counts what the digest held, `ids` names them for a
 recall, and `empty` marks an answer that found nothing — a recall that returned
 no sessions is still a recall, and the count of those is what
 `empty_result_rate` is made of.

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -419,6 +419,51 @@ rewrite that would leave nothing keeps the newest few hundred events instead of
 emptying the file. It is absent only when the log holds nothing at all, which is
 the one case where the counts are all zero anyway.
 
+## `deja log --json`
+
+What deja actually fed the agents, newest first:
+
+```json
+[
+  { "t": "2026-08-24T12:00:00Z", "kind": "recall", "bytes": 0, "empty": true },
+  { "t": "2026-08-24T11:00:00Z", "kind": "hook", "bytes": 400, "sessions": 1, "raw": 4000 },
+  {
+    "t": "2026-08-24T10:00:00Z",
+    "kind": "recall",
+    "bytes": 900,
+    "sessions": 2,
+    "raw": 9000,
+    "ids": ["s1", "s2"]
+  }
+]
+```
+
+A top-level array, so no `schema_version`, on the same terms as `blame`. It is
+`[]` and never `null` when there is nothing to report: this is the output a
+script polls, and `null` raises where an empty list iterates zero times.
+
+`t` is when it happened and `kind` is what deja did — `recall`, `recall_context`
+and `blame` are answers to an agent that asked; `hook`, `dejavu` and `tool` are
+memory offered unasked; `resource` is a read of `deja://session/…`; `remember`
+writes rather than serves; `search` and `handoff` are the reader's own commands.
+A kind this list does not name may still appear: another version of deja may
+have written it, and the log keeps what it was given.
+
+`bytes` is what was served and `raw` the size of the transcripts behind it, both
+omitted when zero. `sessions` counts what the digest held, `ids` names them for a
+recall, and `empty` marks an answer that found nothing — a recall that returned
+no sessions is still a recall, and the count of those is what
+`empty_result_rate` is made of.
+
+A line needs both `t` and `kind` to appear here at all: a half-written line, or
+one from something that is not deja, is skipped rather than shown with a missing
+half. The same rule decides what the counters in `stats --json` read, so the two
+never disagree about whether something happened.
+
+`deja log --last --json` is a different shape: one object, the most recent
+injected digest itself, with `kind`, `time`, `sessions`, `bytes`, `policy` and
+the `digest` text.
+
 ## `deja blame <path> --json`
 
 Returns a JSON array of blame hits (same stability rules as exact search):


### PR DESCRIPTION
Closes #1924.

`deja log --json` was named twice in the document — once in the stability policy, once in passing beside `blame` — and described nowhere. It is the output a script polls to see what deja fed an agent:

```json
[
  { "t": "2026-08-24T12:00:00Z", "kind": "recall", "bytes": 0, "empty": true },
  { "t": "2026-08-24T11:00:00Z", "kind": "hook", "bytes": 400, "sessions": 1, "raw": 4000 },
  { "t": "2026-08-24T10:00:00Z", "kind": "recall", "bytes": 900, "sessions": 2, "raw": 9000,
    "ids": ["s1", "s2"] }
]
```

The new section says what each key is, which kinds appear and that an unrecognised one may too, that the array is newest first and is `[]` rather than `null` when empty (#733 settled that for the script that polls it), and what `--last` returns instead. It also carries the rule from #1918 that nothing else states: a line needs both `t` and `kind` to appear at all, and that is the same rule the counters read by, so the two cannot disagree about whether something happened.

`TestLogJSONKeysMatchTheDocumentedContract` pins the emitted keys to that section — it fails on the base branch because there is no section to read — and a second test holds the two properties a reader would otherwise have to discover: newest first, and an empty array rather than null.

Verified the pin by mutation: removing the `ids` mention from the section turns it red naming that key.
