### PR TITLE
ship the Gemini manifest in the release archive

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,12 @@ archives:
       # writes the skill too; shipping it here means it can be read, or copied
       # by hand on a machine where deja cannot write ~/.agents (#1320).
       - skills/deja-search/SKILL.md
+      # `gemini extensions install <repo-url>` resolves to the release asset for
+      # the platform, unpacks it and reads the manifest from the top of the
+      # archive — so leaving these two behind fails the install outright:
+      # "Configuration file not found at .../gemini-extension.json".
+      - gemini-extension.json
+      - GEMINI.md
 
 checksum:
   name_template: checksums.txt

--- a/cmd/deja/release_archive_test.go
+++ b/cmd/deja/release_archive_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// `gemini extensions install https://github.com/vshulcz/deja-vu` does not clone
+// the repository: it resolves the release asset for the platform, unpacks it and
+// reads gemini-extension.json from the top of that archive. Until v0.18.0 the
+// manifest lived only in git, so the command every gallery visitor is shown
+// ended at "Configuration file not found" — the listing worked and the install
+// did not, which is the worst of the two failures because nothing reports it.
+//
+// The same holds for GEMINI.md: the manifest names it as contextFileName, and an
+// extension whose context file is missing installs and then teaches nothing.
+func TestReleaseArchiveCarriesTheGeminiExtension(t *testing.T) {
+	cfg := string(repoFile(t, ".goreleaser.yaml"))
+	_, archives, ok := strings.Cut(cfg, "\narchives:")
+	if !ok {
+		t.Fatal(".goreleaser.yaml has no archives section")
+	}
+	// Stop at the next top-level key so a filename appearing elsewhere in the
+	// file cannot pass for a shipped one.
+	if end := strings.Index(archives, "\nchecksum:"); end >= 0 {
+		archives = archives[:end]
+	}
+	for _, want := range []string{"gemini-extension.json", "GEMINI.md"} {
+		if !strings.Contains(archives, want) {
+			t.Errorf("the release archive does not carry %s, so `gemini extensions install` fails on the published asset", want)
+		}
+	}
+}


### PR DESCRIPTION
`gemini extensions install https://github.com/vshulcz/deja-vu` resolves the release asset for the platform and reads `gemini-extension.json` from the top of it. The manifest landed on main after v0.18.0 was tagged, so it is in no published archive and the install ends at:

```
Configuration file not found at /var/folders/.../gemini-extension5DAHzR/gemini-extension.json
```

We are already listed in the Gemini gallery, so that is the command visitors get. Adds the manifest and GEMINI.md to the archive, with a test that fails if either goes missing again. Takes effect at the next release.