### PR TITLE
docs(json): name the kind Claude sets, and pin the optional session keys

### DIFF
--- a/cmd/deja/session_optional_test.go
+++ b/cmd/deja/session_optional_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// #1911 pinned the always-present half of the session object; the optional keys
+// were pinned by nothing, and the document's own example for `kind` named the
+// values Grok passes through while omitting the one both Claude readers set
+// (#1936). Three ordinary sessions reach six of those keys.
+func TestTheOptionalSessionKeysAreDocumentedToo(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sessions := map[string][]string{
+		// Edits a file, then says it backed out of something.
+		"plain": {
+			`{"type":"user","sessionId":"plain","cwd":"/proj","timestamp":"2026-08-20T10:00:00Z","message":{"role":"user","content":"fix the retry loop"}}`,
+			`{"type":"assistant","sessionId":"plain","cwd":"/proj","timestamp":"2026-08-20T10:00:01Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/proj/parser.go"}}]}}`,
+			`{"type":"assistant","sessionId":"plain","cwd":"/proj","timestamp":"2026-08-20T10:00:02Z","message":{"role":"assistant","content":"that did not work, reverted it and tried another way"}}`,
+		},
+		// No user turn, so the title comes from the assistant.
+		"agenty": {
+			`{"type":"assistant","sessionId":"agenty","cwd":"/proj","timestamp":"2026-08-20T11:00:00Z","message":{"role":"assistant","content":"looking at the pool exhaustion first"}}`,
+		},
+		// Spawned by an agent: a sidechain with a parent and an agent name.
+		"child": {
+			`{"type":"user","sessionId":"parent1","isSidechain":true,"agentId":"child1","attributionAgent":"reviewer","cwd":"/proj","timestamp":"2026-08-20T12:00:00Z","message":{"role":"user","content":"review the parser change"}}`,
+			`{"type":"assistant","sessionId":"parent1","isSidechain":true,"agentId":"child1","attributionAgent":"reviewer","cwd":"/proj","timestamp":"2026-08-20T12:00:01Z","message":{"role":"assistant","content":"the retry loop is fine"}}`,
+		},
+	}
+	for name, lines := range sessions {
+		if err := os.WriteFile(filepath.Join(store, name+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "last", "10", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		Sessions []map[string]any `json:"sessions"`
+	}
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatal(err)
+	}
+	emitted := map[string]any{}
+	for _, s := range report.Sessions {
+		for k, v := range s {
+			emitted[k] = v
+		}
+	}
+
+	// The fixture is worth nothing if it stops producing these.
+	for _, want := range []string{"gave_up", "touched", "agent_title", "kind", "parent", "agent"} {
+		if _, ok := emitted[want]; !ok {
+			t.Errorf("the fixture no longer emits %q, so nothing here is being checked", want)
+		}
+	}
+
+	doc, err := os.ReadFile("../../docs/json-output.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	table := docSection(t, string(doc), "### The session object")
+	var missing []string
+	for k := range emitted {
+		// Either form: the table names keys in backticks, the examples quote
+		// them as JSON.
+		if !strings.Contains(table, "`"+k+"`") && !strings.Contains(string(doc), "`"+k+"`") &&
+			!strings.Contains(string(doc), `"`+k+`"`) {
+			missing = append(missing, k)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("deja last --json emits %v, absent from docs/json-output.md", missing)
+	}
+
+	// The value deja actually sets, not only the ones another harness passes
+	// through: a reader meeting "sidechain" must find it in the table.
+	if got, _ := emitted["kind"].(string); got != "" && !strings.Contains(table, "`"+got+"`") {
+		t.Errorf("the session table does not name kind %q, which is what a Claude store produces", got)
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -148,7 +148,7 @@ when empty:
 | `lifecycle` | state of an imported promoted note: `accepted`, `rejected`, `superseded` or `stale` |
 | `lifecycle_note` | the note left with that state |
 | `lifecycle_at` | when that state was set |
-| `kind` | the harness's own word for a session an agent spawned (`subagent`, `subagent_fork`); absent for sessions a person started |
+| `kind` | the harness's own word for a session an agent spawned — `sidechain` from Claude, `subagent` or `subagent_fork` from Grok, and whatever a harness deja has not met yet calls it; absent for sessions a person started |
 | `parent` | the session this one was spawned from, where the harness records the edge itself — deja never infers one |
 | `agent` | name of the agent that ran a spawned session |
 


### PR DESCRIPTION
Closes #1936.

The session table said `kind` carries "the harness's own word for a session an agent spawned (`subagent`, `subagent_fork`)". Those are Grok's values, passed through since #1532. Both Claude readers set `sidechain`, and that is what anyone with a Claude store sees:

```
$ deja last --json
kind=sidechain  parent=parent1  agent=reviewer
```

The row now names all three cases, including a harness deja has not met yet.

Behind it, the wider gap #1911 left: the always-present half of the session object is pinned, the optional half is not. A fixture of three ordinary sessions — one that edits a file and backs out of something, one with no user turn, one spawned by an agent — reaches six of those keys (`gave_up`, `touched`, `agent_title`, `kind`, `parent`, `agent`), and now pins them, together with an assertion that the value in `kind` is itself documented rather than only the field name.

The test also refuses to pass quietly if the fixture stops producing those six, which is how a pin like this usually dies.

Still unpinned, and worth saying: `from` and `orig_id` need an imported session, and `lifecycle`, `lifecycle_note` and `lifecycle_at` need a promoted note that arrived by sync. Those want fixtures of their own.
