### PR TITLE
guide pages for Claude Code, Codex, Cursor and Copilot

### DIFF
--- a/cmd/deja/docs_pages_test.go
+++ b/cmd/deja/docs_pages_test.go
@@ -84,6 +84,12 @@ func TestGuidePagesShareTheirNavigation(t *testing.T) {
 			"memory-for-kimi.html",
 			"memory-for-zed.html",
 			"memory-for-grok.html",
+			// The four biggest audiences arrive on these, so a sidebar that
+			// omits one strands the reader who came from a search for it.
+			"memory-for-claude-code.html",
+			"memory-for-codex.html",
+			"memory-for-cursor.html",
+			"memory-for-copilot.html",
 		} {
 			if name == sibling {
 				continue

--- a/cmd/deja/docs_structured_data_test.go
+++ b/cmd/deja/docs_structured_data_test.go
@@ -37,3 +37,87 @@ func TestGuidePagesCarryValidStructuredData(t *testing.T) {
 		}
 	}
 }
+
+// Valid JSON is not the same as JSON about this page. These pages are written
+// by copying a neighbour, and the two blocks that name the harness are the two
+// nobody rereads: four new pages shipped with another harness's breadcrumb and
+// its three FAQ answers, which is what Google would have published as the rich
+// result for a page about something else.
+func TestGuideStructuredDataDescribesItsOwnPage(t *testing.T) {
+	pages, err := filepath.Glob(filepath.Join("..", "..", "docs", "guide", "*.html"))
+	if err != nil || len(pages) == 0 {
+		t.Fatalf("no guide pages found: %v", err)
+	}
+	// Every harness that has a page of its own. A question on one page naming
+	// another page's harness is the copy that was never finished — a question
+	// naming none of them is just a general one, which is fine.
+	var harnesses []string
+	for _, page := range pages {
+		if rest, ok := strings.CutPrefix(strings.TrimSuffix(filepath.Base(page), ".html"), "memory-for-"); ok {
+			first, _, _ := strings.Cut(rest, "-")
+			harnesses = append(harnesses, first)
+		}
+	}
+
+	block := regexp.MustCompile(`(?s)<script type="application/ld\+json">(.*?)</script>`)
+	for _, page := range pages {
+		name := filepath.Base(page)
+		harness, ok := strings.CutPrefix(strings.TrimSuffix(name, ".html"), "memory-for-")
+		if !ok {
+			continue // only the per-harness pages carry a harness name to get wrong
+		}
+		// claude-code and the like: the first segment is the word both the
+		// breadcrumb and the questions use.
+		harness, _, _ = strings.Cut(harness, "-")
+
+		foreign := func(text string) string {
+			low := strings.ToLower(text)
+			if strings.Contains(low, harness) {
+				return ""
+			}
+			for _, other := range harnesses {
+				if other != harness && strings.Contains(low, other) {
+					return other
+				}
+			}
+			return ""
+		}
+
+		b, err := os.ReadFile(page)
+		if err != nil {
+			t.Fatalf("%s: %v", page, err)
+		}
+		for _, m := range block.FindAllStringSubmatch(string(b), -1) {
+			var doc struct {
+				Type            string `json:"@type"`
+				ItemListElement []struct {
+					Position int    `json:"position"`
+					Name     string `json:"name"`
+				} `json:"itemListElement"`
+				MainEntity []struct {
+					Name string `json:"name"`
+				} `json:"mainEntity"`
+			}
+			if err := json.Unmarshal([]byte(m[1]), &doc); err != nil {
+				continue // the test above already reports a parse failure
+			}
+			switch doc.Type {
+			case "BreadcrumbList":
+				for _, item := range doc.ItemListElement {
+					if item.Position != 2 {
+						continue
+					}
+					if !strings.Contains(strings.ToLower(item.Name), harness) {
+						t.Errorf("%s: breadcrumb reads %q, which does not name %s — the page was copied and this block came with it", name, item.Name, harness)
+					}
+				}
+			case "FAQPage":
+				for _, q := range doc.MainEntity {
+					if other := foreign(q.Name); other != "" {
+						t.Errorf("%s: FAQ asks %q, which is about %s", name, q.Name, other)
+					}
+				}
+			}
+		}
+	}
+}

--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -55,6 +55,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/auditing-agents.html
+++ b/docs/guide/auditing-agents.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -55,6 +55,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -55,6 +55,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -84,6 +84,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/context-window-full.html
+++ b/docs/guide/context-window-full.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html" aria-current="page">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/export-conversations.html
+++ b/docs/guide/export-conversations.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/find-a-session.html
+++ b/docs/guide/find-a-session.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -55,6 +55,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -55,6 +55,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/lost-context.html
+++ b/docs/guide/lost-context.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html" aria-current="page">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/memory-for-claude-code.html
+++ b/docs/guide/memory-for-claude-code.html
@@ -4,13 +4,13 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to Qwen Code — deja-vu</title>
-<meta name="description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
-<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html">
+<title>Adding memory to Claude Code — deja-vu</title>
+<meta name="description" content="How to give Claude Code recall over every coding agent's sessions on this machine — the MCP server, the SessionStart hook and the plugin marketplace.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to Qwen Code">
-<meta property="og:description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
-<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html">
+<meta property="og:title" content="Adding memory to Claude Code">
+<meta property="og:description" content="How to give Claude Code recall over every coding agent's sessions on this machine — the MCP server, the SessionStart hook and the plugin marketplace.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
@@ -25,16 +25,16 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to Qwen Code">
-<meta name="twitter:description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
+<meta name="twitter:title" content="Adding memory to Claude Code">
+<meta name="twitter:description" content="How to give Claude Code recall over every coding agent's sessions on this machine — the MCP server, the SessionStart hook and the plugin marketplace.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
 <link rel="apple-touch-icon" href="../assets/icon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
 <link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to Qwen Code","description":"How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for Qwen Code","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I add memory to Qwen Code?","acceptedAnswer":{"@type":"Answer","text":"Run qwen extensions install https://github.com/vshulcz/deja-vu, or deja install qwen-auto to wire the MCP server and the skill directly."}},{"@type":"Question","name":"Where does Qwen Code keep its sessions?","acceptedAnswer":{"@type":"Answer","text":"Under ~/.qwen/projects/<project>/chats as JSONL, which is what deja indexes."}},{"@type":"Question","name":"Does Qwen Code read Claude-format marketplaces?","acceptedAnswer":{"@type":"Answer","text":"Yes. qwen extensions sources add takes a Claude-format marketplace, and this repository is one."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to Claude Code","description":"How to give Claude Code recall over every coding agent's sessions on this machine — the MCP server, the SessionStart hook and the plugin marketplace.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for Claude Code","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I add memory to Claude Code?","acceptedAnswer":{"@type":"Answer","text":"Run deja install claude-auto to write the MCP server, the /deja command and the SessionStart hook, or add this repository as a plugin marketplace with claude plugin marketplace add vshulcz/deja-vu."}},{"@type":"Question","name":"Where does Claude Code keep its sessions?","acceptedAnswer":{"@type":"Answer","text":"Under ${CLAUDE_CONFIG_DIR:-~/.claude}/projects/ as JSONL, one file per session, which is what deja indexes."}},{"@type":"Question","name":"Will installing both the MCP server and the plugin duplicate the tools?","acceptedAnswer":{"@type":"Answer","text":"No. Claude keys MCP servers by name and every manifest deja ships names this one deja, so the two collapse into a single server."}}]}</script>
 </head>
 <body>
 <div class="glow"></div>
@@ -55,8 +55,8 @@
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
-<a href="memory-for-qwen.html" aria-current="page">Memory for Qwen Code</a>
-<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html" aria-current="page">Memory for Claude Code</a>
 <a href="memory-for-codex.html">Memory for Codex</a>
 <a href="memory-for-cursor.html">Memory for Cursor</a>
 <a href="memory-for-copilot.html">Memory for Copilot CLI</a>
@@ -81,32 +81,35 @@
 <a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
 <article>
 
-<h1>Adding memory to Qwen Code</h1>
-<p class="pagelede">it takes the Gemini extension, and Claude-format marketplaces<span class="mins" data-mins></span></p>
+<h1>Adding memory to Claude Code</h1>
+<p class="pagelede">the MCP server, the hook, and the plugin marketplace<span class="mins" data-mins></span></p>
 
-<p>Qwen Code keeps every session on disk and opens the next one empty. What you worked out last week is still there, and so is the work you did in whichever other agent you had open at the time.</p>
+<p>Claude Code writes every session to disk and starts the next one empty. The work is still there — and so is whatever you did that week in Cursor, Codex or any other agent you had open.</p>
 
-<h2>What Qwen already has</h2>
-<p>Sessions live under <code>~/.qwen/projects/&lt;project&gt;/chats</code> as JSONL. Complete, and unread by anything — including by Qwen's next session.</p>
+<h2>What Claude Code already has</h2>
+<p>Transcripts live under <code>${CLAUDE_CONFIG_DIR:-~/.claude}/projects/</code> as JSONL, one file per session, complete down to the tool calls. Nothing reads them back, including Claude Code's own next session. <a href="../registry/claude-code.html">How Claude's store is read</a> has the format, the quirks and the date it was last checked against a real store.</p>
 
 <h2>Adding recall</h2>
-<pre>qwen extensions install https://github.com/vshulcz/deja-vu</pre>
-<p>Qwen Code shares Gemini CLI's extension format, so the <code>gemini-extension.json</code> at the root of the repository is the whole install. Checked on Qwen Code 0.20.0: it reports the deja MCP server, the context file and the <code>deja-search</code> skill, and installs them under <code>~/.qwen/extensions/deja</code>.</p>
-<p>The CLI install is the other path, and the one that also writes guidance where Qwen reads it:</p>
-<pre>deja install qwen-auto</pre>
-<p>Running both is safe rather than doubled: MCP servers are keyed by name, so the extension's <code>deja</code> and the one in <code>settings.json</code> collapse into a single server rather than listing every tool twice.</p>
-<p>Qwen also reads Claude-format marketplaces, which this repository is:</p>
-<pre>qwen extensions sources add https://github.com/vshulcz/deja-vu</pre>
-<p>Either way it needs the binary, since an extension delivers files rather than runtimes:</p>
+<pre>deja install claude-auto</pre>
+<p>That writes three things: the deja MCP server into <code>~/.claude.json</code>, a <code>/deja</code> command at <code>~/.claude/commands/deja.md</code>, and a SessionStart hook in <code>~/.claude/settings.json</code> so a new session opens already carrying what the last ones settled. The MCP server on its own is <code>deja install claude-code</code>.</p>
+<p>This repository is also a Claude plugin marketplace, if you would rather install it the way Claude Code installs everything else:</p>
+<pre>claude plugin marketplace add vshulcz/deja-vu
+claude plugin install deja-vu@deja-vu</pre>
+<p>Running both is safe rather than doubled. Claude keys MCP servers by name, and every manifest we ship names this one <code>deja</code>, so the two collapse into a single server instead of listing every tool twice.</p>
+<p>Either path needs the binary — a plugin ships files, not runtimes:</p>
 <pre>brew install deja-vu
 # or
 curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
+
+<h2>What the hook actually changes</h2>
+<p>Without it, recall depends on the agent deciding to search. The hook moves the decision earlier: the session opens with what this project already settled, so the first exchange is not spent re-deriving it. <a href="after-compaction.html">After compaction</a> covers the other half — the moment a long session is summarised and the details go.</p>
 
 <h2>The part that is not about this harness</h2>
 <p>The index covers every agent's transcripts on the machine — twenty of them today, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in one tool answers a question asked in another, including sessions from before any of this was installed. That is the reason to index rather than to capture.</p>
 <p>Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>). An injection is capped at 1,536 bytes per prompt and about 4 KB per tool call — <a href="token-cost.html">what memory costs</a> has the measured comparison.</p>
 
-<p><a href="getting-started.html">Getting started</a> · <a href="../registry/qwen.html">How Qwen's store is read</a> · <a href="memory-for-gemini.html">Memory for Gemini CLI</a></p>
+<p><a href="getting-started.html">Getting started</a> · <a href="../registry/claude-code.html">How Claude's store is read</a> · <a href="rules-files.html">When CLAUDE.md grows</a></p>
+
 </article>
 </div>
 <footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>

--- a/docs/guide/memory-for-codex.html
+++ b/docs/guide/memory-for-codex.html
@@ -4,13 +4,13 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to Qwen Code — deja-vu</title>
-<meta name="description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
-<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html">
+<title>Adding memory to Codex CLI — deja-vu</title>
+<meta name="description" content="How to give Codex CLI recall over every coding agent's sessions on this machine — the MCP server, the hook it has to approve, and the plugin marketplace.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to Qwen Code">
-<meta property="og:description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
-<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html">
+<meta property="og:title" content="Adding memory to Codex CLI">
+<meta property="og:description" content="How to give Codex CLI recall over every coding agent's sessions on this machine — the MCP server, the hook it has to approve, and the plugin marketplace.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
@@ -25,16 +25,16 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to Qwen Code">
-<meta name="twitter:description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
+<meta name="twitter:title" content="Adding memory to Codex CLI">
+<meta name="twitter:description" content="How to give Codex CLI recall over every coding agent's sessions on this machine — the MCP server, the hook it has to approve, and the plugin marketplace.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
 <link rel="apple-touch-icon" href="../assets/icon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
 <link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to Qwen Code","description":"How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for Qwen Code","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I add memory to Qwen Code?","acceptedAnswer":{"@type":"Answer","text":"Run qwen extensions install https://github.com/vshulcz/deja-vu, or deja install qwen-auto to wire the MCP server and the skill directly."}},{"@type":"Question","name":"Where does Qwen Code keep its sessions?","acceptedAnswer":{"@type":"Answer","text":"Under ~/.qwen/projects/<project>/chats as JSONL, which is what deja indexes."}},{"@type":"Question","name":"Does Qwen Code read Claude-format marketplaces?","acceptedAnswer":{"@type":"Answer","text":"Yes. qwen extensions sources add takes a Claude-format marketplace, and this repository is one."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to Codex CLI","description":"How to give Codex CLI recall over every coding agent's sessions on this machine — the MCP server, the hook it has to approve, and the plugin marketplace.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for Codex CLI","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I add memory to Codex CLI?","acceptedAnswer":{"@type":"Answer","text":"Run deja install codex-auto to write the MCP server into ~/.codex/config.toml along with the hook, then approve the hook once under /hooks."}},{"@type":"Question","name":"Where does Codex CLI keep its sessions?","acceptedAnswer":{"@type":"Answer","text":"Under ${CODEX_HOME:-~/.codex}/sessions/YYYY/MM/DD/rollout-*.jsonl, with typed prompts in history.jsonl beside them."}},{"@type":"Question","name":"Why does nothing happen after installing the Codex hook?","acceptedAnswer":{"@type":"Answer","text":"Codex does not run a hook it has not been shown. Open Codex once and approve it under /hooks; until then nothing runs, codex exec included."}}]}</script>
 </head>
 <body>
 <div class="glow"></div>
@@ -55,9 +55,9 @@
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
-<a href="memory-for-qwen.html" aria-current="page">Memory for Qwen Code</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="memory-for-claude-code.html">Memory for Claude Code</a>
-<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-codex.html" aria-current="page">Memory for Codex</a>
 <a href="memory-for-cursor.html">Memory for Cursor</a>
 <a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
@@ -81,32 +81,36 @@
 <a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
 <article>
 
-<h1>Adding memory to Qwen Code</h1>
-<p class="pagelede">it takes the Gemini extension, and Claude-format marketplaces<span class="mins" data-mins></span></p>
+<h1>Adding memory to Codex CLI</h1>
+<p class="pagelede">the MCP server, the hook you have to approve, and the marketplace<span class="mins" data-mins></span></p>
 
-<p>Qwen Code keeps every session on disk and opens the next one empty. What you worked out last week is still there, and so is the work you did in whichever other agent you had open at the time.</p>
+<p>Codex CLI records every session and opens the next one empty. The rollout files are still on disk, along with the work you did the same week in whichever other agent was open.</p>
 
-<h2>What Qwen already has</h2>
-<p>Sessions live under <code>~/.qwen/projects/&lt;project&gt;/chats</code> as JSONL. Complete, and unread by anything — including by Qwen's next session.</p>
+<h2>What Codex already has</h2>
+<p>Rollouts live under <code>${CODEX_HOME:-~/.codex}/sessions/YYYY/MM/DD/rollout-*.jsonl</code>, with the prompts you typed in <code>history.jsonl</code> beside them. Complete, and read by nothing. <a href="../registry/codex.html">How Codex's store is read</a> has the format and the quirks it took to parse it.</p>
 
 <h2>Adding recall</h2>
-<pre>qwen extensions install https://github.com/vshulcz/deja-vu</pre>
-<p>Qwen Code shares Gemini CLI's extension format, so the <code>gemini-extension.json</code> at the root of the repository is the whole install. Checked on Qwen Code 0.20.0: it reports the deja MCP server, the context file and the <code>deja-search</code> skill, and installs them under <code>~/.qwen/extensions/deja</code>.</p>
-<p>The CLI install is the other path, and the one that also writes guidance where Qwen reads it:</p>
-<pre>deja install qwen-auto</pre>
-<p>Running both is safe rather than doubled: MCP servers are keyed by name, so the extension's <code>deja</code> and the one in <code>settings.json</code> collapse into a single server rather than listing every tool twice.</p>
-<p>Qwen also reads Claude-format marketplaces, which this repository is:</p>
-<pre>qwen extensions sources add https://github.com/vshulcz/deja-vu</pre>
-<p>Either way it needs the binary, since an extension delivers files rather than runtimes:</p>
+<pre>deja install codex-auto</pre>
+<p>That writes the deja MCP server into <code>~/.codex/config.toml</code> and a hook that carries the recall into the session. The server alone is <code>deja install codex</code>.</p>
+<p>One catch worth knowing before you go looking for a bug: Codex will not run a hook it has not been shown. Open Codex once and approve it under <code>/hooks</code>, otherwise every file on disk looks right and no memory ever arrives — <code>codex exec</code> included.</p>
+<p>This repository is also a Codex plugin marketplace:</p>
+<pre>codex plugin marketplace add https://github.com/vshulcz/deja-vu
+codex plugin add deja-vu@deja-vu</pre>
+<p>Running both is safe rather than doubled: MCP servers are keyed by name and every manifest we ship calls this one <code>deja</code>, so the two resolve to one server rather than listing every tool twice.</p>
+<p>Either path needs the binary, since a plugin ships files and not runtimes:</p>
 <pre>brew install deja-vu
 # or
 curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
+
+<h2>Why this matters more in Codex than most</h2>
+<p>Codex sessions are short and many — a day's work is spread over a dozen rollout files rather than one long thread. That makes the thing you settled on Tuesday hard to find by scrolling and easy to find by search. <a href="find-a-session.html">Finding a session</a> is the command side of that.</p>
 
 <h2>The part that is not about this harness</h2>
 <p>The index covers every agent's transcripts on the machine — twenty of them today, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in one tool answers a question asked in another, including sessions from before any of this was installed. That is the reason to index rather than to capture.</p>
 <p>Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>). An injection is capped at 1,536 bytes per prompt and about 4 KB per tool call — <a href="token-cost.html">what memory costs</a> has the measured comparison.</p>
 
-<p><a href="getting-started.html">Getting started</a> · <a href="../registry/qwen.html">How Qwen's store is read</a> · <a href="memory-for-gemini.html">Memory for Gemini CLI</a></p>
+<p><a href="getting-started.html">Getting started</a> · <a href="../registry/codex.html">How Codex's store is read</a> · <a href="switching-agents.html">Switching agents</a></p>
+
 </article>
 </div>
 <footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>

--- a/docs/guide/memory-for-copilot.html
+++ b/docs/guide/memory-for-copilot.html
@@ -4,13 +4,13 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to Qwen Code — deja-vu</title>
-<meta name="description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
-<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html">
+<title>Adding memory to Copilot CLI — deja-vu</title>
+<meta name="description" content="How to give GitHub Copilot CLI recall over every coding agent's sessions on this machine — where its events live, and the MCP entry it needs.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-copilot.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to Qwen Code">
-<meta property="og:description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
-<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html">
+<meta property="og:title" content="Adding memory to Copilot CLI">
+<meta property="og:description" content="How to give GitHub Copilot CLI recall over every coding agent's sessions on this machine — where its events live, and the MCP entry it needs.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-copilot.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
@@ -25,16 +25,16 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to Qwen Code">
-<meta name="twitter:description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
+<meta name="twitter:title" content="Adding memory to Copilot CLI">
+<meta name="twitter:description" content="How to give GitHub Copilot CLI recall over every coding agent's sessions on this machine — where its events live, and the MCP entry it needs.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
 <link rel="apple-touch-icon" href="../assets/icon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
 <link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to Qwen Code","description":"How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for Qwen Code","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I add memory to Qwen Code?","acceptedAnswer":{"@type":"Answer","text":"Run qwen extensions install https://github.com/vshulcz/deja-vu, or deja install qwen-auto to wire the MCP server and the skill directly."}},{"@type":"Question","name":"Where does Qwen Code keep its sessions?","acceptedAnswer":{"@type":"Answer","text":"Under ~/.qwen/projects/<project>/chats as JSONL, which is what deja indexes."}},{"@type":"Question","name":"Does Qwen Code read Claude-format marketplaces?","acceptedAnswer":{"@type":"Answer","text":"Yes. qwen extensions sources add takes a Claude-format marketplace, and this repository is one."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to Copilot CLI","description":"How to give GitHub Copilot CLI recall over every coding agent's sessions on this machine — where its events live, and the MCP entry it needs.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-copilot.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-copilot.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for Copilot CLI","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-copilot.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I add memory to GitHub Copilot CLI?","acceptedAnswer":{"@type":"Answer","text":"Run deja install copilot, which writes the deja entry into ~/.copilot/mcp-config.json in Copilot's own schema."}},{"@type":"Question","name":"Where does Copilot CLI keep its sessions?","acceptedAnswer":{"@type":"Answer","text":"Under ~/.copilot/session-state/<sessionId>/events.jsonl as a stream of {type, data, timestamp} records."}},{"@type":"Question","name":"Why is the Copilot MCP entry different from other harnesses?","acceptedAnswer":{"@type":"Answer","text":"Copilot's config is not the common mcpServers shape: entries carry a type and a list of enabled tools, so deja writes it in Copilot's own form."}}]}</script>
 </head>
 <body>
 <div class="glow"></div>
@@ -55,11 +55,11 @@
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
-<a href="memory-for-qwen.html" aria-current="page">Memory for Qwen Code</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="memory-for-claude-code.html">Memory for Claude Code</a>
 <a href="memory-for-codex.html">Memory for Codex</a>
 <a href="memory-for-cursor.html">Memory for Cursor</a>
-<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
+<a href="memory-for-copilot.html" aria-current="page">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>
@@ -81,32 +81,31 @@
 <a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
 <article>
 
-<h1>Adding memory to Qwen Code</h1>
-<p class="pagelede">it takes the Gemini extension, and Claude-format marketplaces<span class="mins" data-mins></span></p>
+<h1>Adding memory to Copilot CLI</h1>
+<p class="pagelede">its MCP schema is its own, and the wiring follows it<span class="mins" data-mins></span></p>
 
-<p>Qwen Code keeps every session on disk and opens the next one empty. What you worked out last week is still there, and so is the work you did in whichever other agent you had open at the time.</p>
+<p>Copilot CLI records each session and starts the next one empty. The events are still on disk, next to whatever you did that week in the other agents on the machine.</p>
 
-<h2>What Qwen already has</h2>
-<p>Sessions live under <code>~/.qwen/projects/&lt;project&gt;/chats</code> as JSONL. Complete, and unread by anything — including by Qwen's next session.</p>
+<h2>What Copilot already has</h2>
+<p>Sessions live under <code>~/.copilot/session-state/&lt;sessionId&gt;/events.jsonl</code> as a stream of <code>{type, data, timestamp}</code> records. Complete, and read by nothing. <a href="../registry/copilot.html">How Copilot's store is read</a> has the event shapes and the quirks behind them.</p>
 
 <h2>Adding recall</h2>
-<pre>qwen extensions install https://github.com/vshulcz/deja-vu</pre>
-<p>Qwen Code shares Gemini CLI's extension format, so the <code>gemini-extension.json</code> at the root of the repository is the whole install. Checked on Qwen Code 0.20.0: it reports the deja MCP server, the context file and the <code>deja-search</code> skill, and installs them under <code>~/.qwen/extensions/deja</code>.</p>
-<p>The CLI install is the other path, and the one that also writes guidance where Qwen reads it:</p>
-<pre>deja install qwen-auto</pre>
-<p>Running both is safe rather than doubled: MCP servers are keyed by name, so the extension's <code>deja</code> and the one in <code>settings.json</code> collapse into a single server rather than listing every tool twice.</p>
-<p>Qwen also reads Claude-format marketplaces, which this repository is:</p>
-<pre>qwen extensions sources add https://github.com/vshulcz/deja-vu</pre>
-<p>Either way it needs the binary, since an extension delivers files rather than runtimes:</p>
+<pre>deja install copilot</pre>
+<p>Copilot keeps its MCP servers in <code>~/.copilot/mcp-config.json</code>, and its schema is not the common <code>mcpServers</code> one — entries carry a type and a list of enabled tools, so the entry is written in Copilot's own shape rather than copied from another harness.</p>
+<p>It needs the binary, which that entry calls by name:</p>
 <pre>brew install deja-vu
 # or
 curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
+
+<h2>What you can ask it</h2>
+<p>Once the server is wired, the useful questions are the ones a fresh session cannot answer on its own: what this error meant the last time it appeared, how this project's build is actually invoked here, what was decided about a file and why. <a href="agents.html">Agents &amp; MCP</a> lists the tools and what each is for.</p>
 
 <h2>The part that is not about this harness</h2>
 <p>The index covers every agent's transcripts on the machine — twenty of them today, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in one tool answers a question asked in another, including sessions from before any of this was installed. That is the reason to index rather than to capture.</p>
 <p>Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>). An injection is capped at 1,536 bytes per prompt and about 4 KB per tool call — <a href="token-cost.html">what memory costs</a> has the measured comparison.</p>
 
-<p><a href="getting-started.html">Getting started</a> · <a href="../registry/qwen.html">How Qwen's store is read</a> · <a href="memory-for-gemini.html">Memory for Gemini CLI</a></p>
+<p><a href="getting-started.html">Getting started</a> · <a href="../registry/copilot.html">How Copilot's store is read</a> · <a href="agents.html">Agents &amp; MCP</a></p>
+
 </article>
 </div>
 <footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>

--- a/docs/guide/memory-for-cursor.html
+++ b/docs/guide/memory-for-cursor.html
@@ -4,13 +4,13 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to Qwen Code — deja-vu</title>
-<meta name="description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
-<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html">
+<title>Adding memory to Cursor — deja-vu</title>
+<meta name="description" content="How to give Cursor recall over every coding agent's sessions on this machine — where its SQLite chat store lives, and what deja install cursor-auto writes.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to Qwen Code">
-<meta property="og:description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
-<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html">
+<meta property="og:title" content="Adding memory to Cursor">
+<meta property="og:description" content="How to give Cursor recall over every coding agent's sessions on this machine — where its SQLite chat store lives, and what deja install cursor-auto writes.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
@@ -25,16 +25,16 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to Qwen Code">
-<meta name="twitter:description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
+<meta name="twitter:title" content="Adding memory to Cursor">
+<meta name="twitter:description" content="How to give Cursor recall over every coding agent's sessions on this machine — where its SQLite chat store lives, and what deja install cursor-auto writes.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
 <link rel="apple-touch-icon" href="../assets/icon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
 <link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to Qwen Code","description":"How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for Qwen Code","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I add memory to Qwen Code?","acceptedAnswer":{"@type":"Answer","text":"Run qwen extensions install https://github.com/vshulcz/deja-vu, or deja install qwen-auto to wire the MCP server and the skill directly."}},{"@type":"Question","name":"Where does Qwen Code keep its sessions?","acceptedAnswer":{"@type":"Answer","text":"Under ~/.qwen/projects/<project>/chats as JSONL, which is what deja indexes."}},{"@type":"Question","name":"Does Qwen Code read Claude-format marketplaces?","acceptedAnswer":{"@type":"Answer","text":"Yes. qwen extensions sources add takes a Claude-format marketplace, and this repository is one."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Adding memory to Cursor","description":"How to give Cursor recall over every coding agent's sessions on this machine — where its SQLite chat store lives, and what deja install cursor-auto writes.","url":"https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Memory for Cursor","item":"https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I add memory to Cursor?","acceptedAnswer":{"@type":"Answer","text":"Run deja install cursor-auto, which writes the deja MCP server into ~/.cursor/mcp.json and the hooks that carry recall into a session."}},{"@type":"Question","name":"Where does Cursor keep its chats?","acceptedAnswer":{"@type":"Answer","text":"In SQLite rather than JSONL: state.vscdb under ~/Library/Application Support/Cursor/User on macOS and ~/.config/Cursor/User on Linux."}},{"@type":"Question","name":"Can Cursor recall work done in a terminal agent?","acceptedAnswer":{"@type":"Answer","text":"Yes. deja indexes every agent's transcripts on the machine, so a question asked in Cursor is answered from the session that solved it, whichever tool that was."}}]}</script>
 </head>
 <body>
 <div class="glow"></div>
@@ -55,10 +55,10 @@
 <a href="memory-for-zed.html">Memory for Zed</a>
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
-<a href="memory-for-qwen.html" aria-current="page">Memory for Qwen Code</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
 <a href="memory-for-claude-code.html">Memory for Claude Code</a>
 <a href="memory-for-codex.html">Memory for Codex</a>
-<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-cursor.html" aria-current="page">Memory for Cursor</a>
 <a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
@@ -81,32 +81,31 @@
 <a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
 <article>
 
-<h1>Adding memory to Qwen Code</h1>
-<p class="pagelede">it takes the Gemini extension, and Claude-format marketplaces<span class="mins" data-mins></span></p>
+<h1>Adding memory to Cursor</h1>
+<p class="pagelede">its chats live in SQLite, and the terminal agent beside it is the same history<span class="mins" data-mins></span></p>
 
-<p>Qwen Code keeps every session on disk and opens the next one empty. What you worked out last week is still there, and so is the work you did in whichever other agent you had open at the time.</p>
+<p>Cursor keeps your chats, and opens the next one empty. What you worked out last week is still on disk — along with the work you did in whichever terminal agent you had open beside it.</p>
 
-<h2>What Qwen already has</h2>
-<p>Sessions live under <code>~/.qwen/projects/&lt;project&gt;/chats</code> as JSONL. Complete, and unread by anything — including by Qwen's next session.</p>
+<h2>What Cursor already has</h2>
+<p>The editor stores chats in SQLite rather than JSONL: <code>state.vscdb</code> under <code>~/Library/Application Support/Cursor/User</code> on macOS and <code>~/.config/Cursor/User</code> on Linux, split between <code>globalStorage/</code> and one database per workspace. Nothing reads it back. <a href="../registry/cursor.html">How Cursor's store is read</a> has the schema and what it took to follow it across versions.</p>
 
 <h2>Adding recall</h2>
-<pre>qwen extensions install https://github.com/vshulcz/deja-vu</pre>
-<p>Qwen Code shares Gemini CLI's extension format, so the <code>gemini-extension.json</code> at the root of the repository is the whole install. Checked on Qwen Code 0.20.0: it reports the deja MCP server, the context file and the <code>deja-search</code> skill, and installs them under <code>~/.qwen/extensions/deja</code>.</p>
-<p>The CLI install is the other path, and the one that also writes guidance where Qwen reads it:</p>
-<pre>deja install qwen-auto</pre>
-<p>Running both is safe rather than doubled: MCP servers are keyed by name, so the extension's <code>deja</code> and the one in <code>settings.json</code> collapse into a single server rather than listing every tool twice.</p>
-<p>Qwen also reads Claude-format marketplaces, which this repository is:</p>
-<pre>qwen extensions sources add https://github.com/vshulcz/deja-vu</pre>
-<p>Either way it needs the binary, since an extension delivers files rather than runtimes:</p>
+<pre>deja install cursor-auto</pre>
+<p>That writes the deja MCP server into <code>~/.cursor/mcp.json</code> and the hooks that carry recall into a session. The server on its own is <code>deja install cursor</code>.</p>
+<p>It needs the binary, which the MCP entry calls by name:</p>
 <pre>brew install deja-vu
 # or
 curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
+
+<h2>The editor and the terminal are the same history</h2>
+<p>Cursor is usually not the only agent on the machine — there is a terminal agent open in the same repository, and the two never see each other's work. Indexing both is the point: a question asked in Cursor gets answered from the session where it was actually solved, whichever tool that was. <a href="switching-agents.html">Switching agents</a> is the longer version of that argument.</p>
 
 <h2>The part that is not about this harness</h2>
 <p>The index covers every agent's transcripts on the machine — twenty of them today, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in one tool answers a question asked in another, including sessions from before any of this was installed. That is the reason to index rather than to capture.</p>
 <p>Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>). An injection is capped at 1,536 bytes per prompt and about 4 KB per tool call — <a href="token-cost.html">what memory costs</a> has the measured comparison.</p>
 
-<p><a href="getting-started.html">Getting started</a> · <a href="../registry/qwen.html">How Qwen's store is read</a> · <a href="memory-for-gemini.html">Memory for Gemini CLI</a></p>
+<p><a href="getting-started.html">Getting started</a> · <a href="../registry/cursor.html">How Cursor's store is read</a> · <a href="parallel-sessions.html">Parallel sessions</a></p>
+
 </article>
 </div>
 <footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>

--- a/docs/guide/memory-for-dsh.html
+++ b/docs/guide/memory-for-dsh.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/memory-for-gemini.html
+++ b/docs/guide/memory-for-gemini.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html" aria-current="page">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/memory-for-grok.html
+++ b/docs/guide/memory-for-grok.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html" aria-current="page">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/memory-for-kimi.html
+++ b/docs/guide/memory-for-kimi.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/memory-for-opencode.html
+++ b/docs/guide/memory-for-opencode.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/memory-for-zed.html
+++ b/docs/guide/memory-for-zed.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/parallel-sessions.html
+++ b/docs/guide/parallel-sessions.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -55,6 +55,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/resume-a-session.html
+++ b/docs/guide/resume-a-session.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html" aria-current="page">Resuming a session</a>

--- a/docs/guide/rules-files.html
+++ b/docs/guide/rules-files.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -55,6 +55,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/switching-agents.html
+++ b/docs/guide/switching-agents.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/sync-across-machines.html
+++ b/docs/guide/sync-across-machines.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/token-cost.html
+++ b/docs/guide/token-cost.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -56,6 +56,10 @@
 <a href="memory-for-grok.html">Memory for Grok Build</a>
 <a href="memory-for-gemini.html">Memory for Gemini CLI</a>
 <a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
 <a href="lost-context.html">Lost context</a>
 <a href="context-window-full.html">Context window full</a>
 <a href="resume-a-session.html">Resuming a session</a>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -21,6 +21,10 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-copilot.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/lost-context.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/context-window-full.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/resume-a-session.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>


### PR DESCRIPTION
Guide pages existed for opencode, dsh, Kimi, Zed, Grok, Gemini and Qwen — and not for the four most-used harnesses, which is the first place a reader would look for one.

Each page states where that harness keeps its sessions and what `deja install` writes, checked against the code rather than assumed; the Codex one also names the hook approval step, which is the reason installs there look fine and do nothing.

Generating them from an existing page carried the old harness's breadcrumb and FAQ answers into the copies, which Google would have published as the rich result. Fixed, and a test now fails when a page's structured data names a different harness.
