### PR TITLE
docs(json): say what a week and a day mean in the stats numbers

### DIFF
--- a/cmd/deja/week_docs_test.go
+++ b/cmd/deja/week_docs_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// `deja stats --json` reports four week figures and the document never said
+// what a week is; the rules lived only in Go, and until #1921 deja itself did
+// not agree with them (#1939). This holds the sentence against the code it
+// describes rather than against itself.
+func TestTheStatsSectionSaysWhatAWeekIs(t *testing.T) {
+	doc, err := os.ReadFile("../../docs/json-output.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	section := docSection(t, string(doc), "## `deja stats --json`")
+	prose := strings.Join(strings.Fields(section), " ")
+
+	for _, want := range []struct{ what, phrase string }{
+		{"a week is seven calendar days", "seven calendar days"},
+		{"a day starts at local midnight", "local midnight"},
+		{"the wall clock is what is kept across a change", "wall clock"},
+	} {
+		if !strings.Contains(prose, want.phrase) {
+			t.Errorf("the stats section does not say %s (looked for %q)", want.what, want.phrase)
+		}
+	}
+
+	// And the sentence has to keep describing what WeekCut does: seven calendar
+	// days at the same wall time, not a fixed number of hours.
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skip("no tzdata: ", err)
+	}
+	now := time.Date(2026, 11, 3, 12, 0, 0, 0, ny)
+	if cut := usage.WeekCut(now); cut.Hour() != now.Hour() {
+		t.Errorf("WeekCut no longer keeps the wall clock (%s from %s), so the documented sentence is wrong",
+			cut.Format("15:04 MST"), now.Format("15:04 MST"))
+	}
+	if cut, fixed := usage.WeekCut(now), now.Add(-7*24*time.Hour); cut.Equal(fixed) {
+		t.Error("WeekCut and a fixed 168 hours agree here, so this test proves nothing about the rule")
+	}
+}

--- a/cmd/deja/week_docs_test.go
+++ b/cmd/deja/week_docs_test.go
@@ -38,9 +38,9 @@ func TestTheStatsSectionSaysWhatAWeekIs(t *testing.T) {
 		t.Skip("no tzdata: ", err)
 	}
 	now := time.Date(2026, 11, 3, 12, 0, 0, 0, ny)
-	if cut := usage.WeekCut(now); cut.Hour() != now.Hour() {
+	if cut := usage.WeekCut(now); cut.Format("15:04:05") != now.Format("15:04:05") {
 		t.Errorf("WeekCut no longer keeps the wall clock (%s from %s), so the documented sentence is wrong",
-			cut.Format("15:04 MST"), now.Format("15:04 MST"))
+			cut.Format("15:04:05 MST"), now.Format("15:04:05 MST"))
 	}
 	if cut, fixed := usage.WeekCut(now), now.Add(-7*24*time.Hour); cut.Equal(fixed) {
 		t.Error("WeekCut and a fixed 168 hours agree here, so this test proves nothing about the rule")

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -262,6 +262,17 @@ digests distilled and `since` is the oldest event still in the usage log; both
 are omitted when zero, so a store with no recall history yet shows neither.
 
 
+`week_recalls`, `week_bytes`, `week_injected` and `week_agent_credits` cover
+seven calendar days back from now, at the same wall clock — not a fixed 168
+hours. Across a clock change that means the week runs an hour longer in autumn
+and an hour shorter in spring, and in the hour a spring-forward removes it opens
+at the time the clock actually reached. A day, where deja counts one, runs from
+local midnight. Both are the reader's own timezone, not UTC.
+
+The distinction is not pedantry: deja itself had two rules for a week until
+#1921, and the two numbers on the status bar disagreed for one week in each
+direction.
+
 Optional fields are omitted when zero or empty — `sidecar_size`, for one,
 appears only after `deja embed` has built a semantic sidecar. The heatmap grid used by
 `--card` is intentionally excluded from `--json` output.

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -265,13 +265,13 @@ are omitted when zero, so a store with no recall history yet shows neither.
 `week_recalls`, `week_bytes`, `week_injected` and `week_agent_credits` cover
 seven calendar days back from now, at the same wall clock — not a fixed 168
 hours. Across a clock change that means the week runs an hour longer in autumn
-and an hour shorter in spring, and in the hour a spring-forward removes it opens
-at the time the clock actually reached. A day, where deja counts one, runs from
-local midnight. Both are the reader's own timezone, not UTC.
+and an hour shorter in spring; and where a spring-forward removed the wall time
+the week would have started at, it starts at the time the clock reached instead.
+A day, where deja counts one, runs from local midnight. Both are the reader's own
+timezone, not UTC.
 
-The distinction is not pedantry: deja itself had two rules for a week until
-#1921, and the two numbers on the status bar disagreed for one week in each
-direction.
+deja had two rules for a week until #1921, and the two numbers on the status bar
+disagreed for one week in each direction, so the definition is worth stating.
 
 Optional fields are omitted when zero or empty — `sidecar_size`, for one,
 appears only after `deja embed` has built a semantic sidecar. The heatmap grid used by


### PR DESCRIPTION
Closes #1939.

`deja stats --json` reports `week_recalls`, `week_bytes`, `week_injected` and `week_agent_credits`, and nothing said what a week is. The keys were in the example and the key list; no sentence defined the window, and `docs/` did not mention "week" or "today" anywhere else.

The rules lived only in Go: seven calendar days back at the same wall clock (`usage.WeekCut`), a day from local midnight, and across a clock change the week keeps the wall clock — 169 hours in autumn, 167 in spring, and in the hour a spring-forward removes it opens at the time the clock actually reached. All in the reader's own timezone.

Worth saying in the document rather than only in the code, because deja itself had two rules for a week until #1921 and the two numbers on the status bar disagreed for one week in each direction.

`TestTheStatsSectionSaysWhatAWeekIs` fails on the base branch on all three phrases. It also checks the sentence against `WeekCut` itself — that the cut keeps the wall clock, and that it differs from a fixed 168 hours on the date it uses — so the prose cannot outlive the rule it describes. That second assertion is there because a doc test that only greps the document proves the document says something, not that the something is true.
