### PR TITLE
ci: give peers and stats a coverage floor, and say which floors are tight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,14 +124,20 @@ jobs:
       # A floor per package, set at where each stands today. Raise them as
       # coverage improves; lowering one to make a build pass is the move this
       # gate exists to prevent.
+      #
+      # Some have no room. bench and policy sit exactly on 100, so one uncovered
+      # line fails the build, and usage has half a point — an exported one-line
+      # wrapper with no caller was enough to trip it (#1921). If you are adding
+      # a helper to one of those, add its test in the same commit.
       - name: Per-package coverage floor
         if: runner.os == 'Linux'
         shell: bash
         run: |
           declare -A floor=(
             [cmd/deja]=88 [internal/bench]=100 [internal/digest]=90 [internal/embed]=93
-            [internal/index]=90 [internal/policy]=100 [internal/redact]=94
-            [internal/search]=93 [internal/sources]=87 [internal/usage]=95
+            [internal/index]=90 [internal/peers]=76 [internal/policy]=100
+            [internal/redact]=94 [internal/search]=93 [internal/sources]=87
+            [internal/stats]=91 [internal/usage]=95
           )
           fail=0
           while read -r pkg cov; do


### PR DESCRIPTION
Closes #1943.

Measured every package against its floor:

```
package                 coverage  floor  margin
internal/bench           100.0    100   +0.0
internal/policy          100.0    100   +0.0
internal/usage            95.5     95   +0.5
internal/index            91.0     90   +1.0
internal/search           94.4     93   +1.4
internal/embed            94.8     93   +1.8
internal/sources          89.4     87   +2.4
cmd/deja                  90.9     88   +2.9
internal/redact           97.7     94   +3.7
internal/digest           96.3     90   +6.3
internal/peers            76.4   none
internal/stats            91.9   none
```

Two changes.

`internal/peers` and `internal/stats` now have floors, at where they stand. Peers gates nothing today at 76.4%, after a night that gave it identity folding (#1867), a canonical spelling (#1878), a learned machine name (#1887) and a lock (#1884) — it decides which machines are one machine, and a change there deserves the same gate the index has.

And the comment above the table now says which floors have no room: `bench` and `policy` sit exactly on 100, so one uncovered line fails the build, and `usage` has half a point — an exported one-line wrapper with no caller was enough to trip it in #1921. Anyone adding a helper to those three now learns it before pushing rather than from a red build.

Simulated the gate with the new table against today's coverage: nothing fails. No floor was lowered.
