### PR TITLE
fix(usage): ask the snapshots file the same question as the log

### DIFF
--- a/internal/usage/snapshot_shape_test.go
+++ b/internal/usage/snapshot_shape_test.go
@@ -1,0 +1,66 @@
+package usage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// oneSnapshot writes a snapshots file holding exactly the given line.
+func oneSnapshot(t *testing.T, line string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	p := SnapshotPath(dir)
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(line+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The usage log asks one question of a line since #1917 — a stamp and a kind.
+// The snapshots file beside it asked a different one, so `deja log --last`
+// could print a heading with no kind, or a digest dated the year 1 (#1946).
+// Both are things deja cannot write: every writer passes a kind, and the stamp
+// is time.Now().
+func TestASnapshotNeedsAStampAKindAndADigest(t *testing.T) {
+	for _, c := range []struct {
+		name, line string
+		kept       bool
+	}{
+		{"whole", `{"t":"2026-08-20T10:00:00Z","kind":"hook","bytes":100,"sessions":1,"digest":"earlier work"}`, true},
+		{"unknown kind", `{"t":"2026-08-20T10:00:00Z","kind":"weather","bytes":100,"digest":"earlier work"}`, true},
+		{"no digest", `{"t":"2026-08-20T10:00:00Z","kind":"hook","bytes":100,"sessions":1}`, false},
+		{"no stamp", `{"kind":"hook","bytes":100,"sessions":1,"digest":"earlier work"}`, false},
+		{"no kind", `{"t":"2026-08-20T10:00:00Z","bytes":100,"sessions":1,"digest":"earlier work"}`, false},
+		{"blank line", ``, false},
+	} {
+		got := Snapshots(oneSnapshot(t, c.line), 0)
+		want := 0
+		if c.kept {
+			want = 1
+		}
+		if len(got) != want {
+			t.Errorf("%s: kept %d, want %d", c.name, len(got), want)
+		}
+	}
+}
+
+// And what deja writes is still read back whole — the rule must not tighten
+// into "a kind I know".
+func TestAWrittenSnapshotSurvivesTheRule(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	SnapshotPolicy(dir, KindHook, "a digest of earlier work", 2, "local-only")
+
+	got := Snapshots(dir, 0)
+	if len(got) != 1 {
+		t.Fatalf("wrote one snapshot, read %d", len(got))
+	}
+	if got[0].Kind != KindHook || got[0].Digest == "" || got[0].Time.IsZero() {
+		t.Errorf("the snapshot came back missing something: %#v", got[0])
+	}
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -124,6 +124,10 @@ func rotateSnapshots(p string) {
 	if err != nil || fi.Size() < snapshotRotateAt {
 		return
 	}
+	// Rewritten from what the reader accepts, so a rotation also drops a line
+	// deja could not have written — a side effect worth naming rather than
+	// discovering: the file shrinks by more than the rotation alone would
+	// explain (#1946).
 	snaps := snapshotsFrom(p, snapshotsToKeep) // newest first
 	var buf bytes.Buffer
 	for i := len(snaps) - 1; i >= 0; i-- {

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -135,6 +135,13 @@ func rotateSnapshots(p string) {
 	_ = atomicfile.Write(p, buf.Bytes(), 0o600)
 }
 
+// usable reports whether a snapshot is one deja could have written: a stamp so
+// it can be placed in time, a kind so it can be named, and the digest it exists
+// to carry.
+func (s Snapshot) usable() bool {
+	return !s.Time.IsZero() && s.Kind != "" && s.Digest != ""
+}
+
 // snapshotsFrom reads a snapshot file and returns up to n entries, newest
 // first. n <= 0 means all.
 func snapshotsFrom(p string, n int) []Snapshot {
@@ -148,7 +155,11 @@ func snapshotsFrom(p string, n int) []Snapshot {
 	sc.Buffer(make([]byte, 0, 64<<10), 4<<20)
 	for sc.Scan() {
 		var s Snapshot
-		if json.Unmarshal(sc.Bytes(), &s) == nil && s.Digest != "" {
+		// The same question the usage log asks — a stamp and a kind (#1917) —
+		// plus the digest, which is the whole point of this file. Without it a
+		// half-written line could print a heading with no kind, or a digest
+		// dated the year 1 (#1946).
+		if json.Unmarshal(sc.Bytes(), &s) == nil && s.usable() {
 			out = append(out, s)
 		}
 	}


### PR DESCRIPTION
Closes #1946.

#1917 gave the usage log one rule for what a line is — a stamp and a kind. The snapshots file beside it had a third reader with a third rule: keep a line if it parses and carries a digest. So the shapes #1917 removed were still readable through `deja log --last`:

```
before, newest line has no kind    #  · 2026-08-20 13:00 · 1 session · 100 B
before, newest line has no stamp   # hook · 0001-01-01 02:30 · 1 session · 100 B
after                              deja: no injected digests recorded yet …
```

A heading with an empty kind, and a digest dated the year 1 — in local time, which is why it read 02:30 rather than midnight.

`Snapshot.usable` now asks the same question as the log, plus the digest this file exists to carry. Neither missing shape is written by deja: every writer passes a kind and the stamp is `time.Now()`.

Tests: the six shapes, and a second one that writes a snapshot through the real writer and reads it back, so the rule cannot tighten into "a kind I know" — an unrecognised kind is still a snapshot, for the reason it is still an event in the log.

The doc-comment guard caught me putting the new function between `snapshotsFrom`'s comment and its declaration — the same trap as #1798, #1811 and #1848. Fixed before pushing.
