### PR TITLE
fix(usage): record where a session-start digest went

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -248,7 +248,7 @@ func runHookContext(dir string, plain bool) error {
 		// does not depend on the digest having found anything.
 		if env := environmentBlock(dir, policy.ActivationAuto); env != "" {
 			out := frameRecall(env)
-			usage.RecordDigestPolicy(dir, usage.KindHook, out, 0, 0, policy.Load().Describe(policy.ActivationAuto))
+			usage.RecordDigestPolicyInto(dir, usage.KindHook, out, input.SessionID, 0, 0, policy.Load().Describe(policy.ActivationAuto))
 			if plain {
 				fmt.Fprintln(os.Stdout, out)
 				return nil

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -320,7 +320,7 @@ func runHookContext(dir string, plain bool) error {
 	}
 	digest = frameRecall(digest)
 	polName := policy.Load().Describe(policy.ActivationAuto)
-	usage.RecordDigestPolicy(dir, usage.KindHook, digest, sessions, raw, polName)
+	usage.RecordDigestPolicyInto(dir, usage.KindHook, digest, input.SessionID, sessions, raw, polName)
 	if plain {
 		fmt.Fprintln(os.Stdout, digest)
 		return nil

--- a/internal/usage/into_test.go
+++ b/internal/usage/into_test.go
@@ -1,54 +1,46 @@
 package usage
 
 import (
-	"encoding/json"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 )
 
-// The injection log said what was injected and never to whom, so the only way
-// to tell whether a recall was used was the sentence the block asks the agent
-// to say. Measured on a real store, that sentence follows 22 of 1218
-// injections — a measure of reporting, not of use. With the receiving session
-// recorded, a reader can pair an injection with what the agent did next.
-func TestSnapshotRecordsWhoReceivedIt(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "index.db")
-	RecordDigestInto(dir, KindDejaVu, "a block worth reading", "ses_1234", 2, 900,
-		[]string{"pgbouncer"}, "claude:abc")
+// `into` exists so the log says to whom a digest went, not only what went — the
+// comment on the field measures why: the agent's own "deja-vu recalled" line
+// appeared after 22 of 1218 injections, which counts reporting rather than use.
+// The déjà-vu hook recorded it and the session-start hook did not, so the field
+// meant two different things depending on which path wrote it (#1949).
+func TestASessionStartDigestRecordsWhoItWentTo(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEJA_INDEX_DIR", dir)
 
-	b, err := os.ReadFile(SnapshotPath(dir))
-	if err != nil {
-		t.Fatal(err)
+	RecordDigestPolicyInto(dir, KindHook, "a digest of earlier work", "agent-session-1", 2, 4000, "local-only")
+
+	got := Snapshots(dir, 0)
+	if len(got) != 1 {
+		t.Fatalf("wrote one snapshot, read %d", len(got))
 	}
-	line := strings.TrimSpace(string(b))
-	if line == "" {
-		t.Fatal("nothing was written to the injection log")
+	if got[0].Into != "agent-session-1" {
+		t.Errorf("the snapshot does not say where it went: %#v", got[0])
 	}
-	var got Snapshot
-	if err := json.Unmarshal([]byte(line), &got); err != nil {
-		t.Fatal(err)
-	}
-	if got.Into != "ses_1234" {
-		t.Errorf("into = %q, want the agent session that received the block", got.Into)
-	}
-	if got.Kind != KindDejaVu || got.Sessions != 2 {
-		t.Errorf("the rest of the record changed: %+v", got)
+	// And it still records the counting event, as the policy form always has.
+	if tot := Totals(dir); tot.Injections != 1 || tot.Bytes == 0 {
+		t.Errorf("the counting half was lost: %#v", tot)
 	}
 }
 
-// A caller that does not know the session still writes a usable record, and the
-// field is omitted rather than written empty — older readers see what they saw.
-func TestSnapshotWithoutAReceiverOmitsTheField(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "index.db")
-	RecordDigestTerms(dir, KindDejaVu, "a block", 1, 100, nil)
+// The old form still exists and still writes no destination, so a caller that
+// genuinely does not know one is not made to invent it.
+func TestADigestWithNoKnownDestinationSaysNothing(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEJA_INDEX_DIR", dir)
 
-	b, err := os.ReadFile(SnapshotPath(dir))
-	if err != nil {
-		t.Fatal(err)
+	RecordDigestPolicy(dir, KindHook, "a digest of earlier work", 2, 4000, "local-only")
+
+	got := Snapshots(dir, 0)
+	if len(got) != 1 {
+		t.Fatalf("wrote one snapshot, read %d", len(got))
 	}
-	if strings.Contains(string(b), "\"into\"") {
-		t.Errorf("empty receiver was written out: %s", strings.TrimSpace(string(b)))
+	if got[0].Into != "" {
+		t.Errorf("a caller with no destination recorded one anyway: %q", got[0].Into)
 	}
 }

--- a/internal/usage/into_test.go
+++ b/internal/usage/into_test.go
@@ -1,14 +1,61 @@
 package usage
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
-// `into` exists so the log says to whom a digest went, not only what went — the
-// comment on the field measures why: the agent's own "deja-vu recalled" line
-// appeared after 22 of 1218 injections, which counts reporting rather than use.
-// The déjà-vu hook recorded it and the session-start hook did not, so the field
-// meant two different things depending on which path wrote it (#1949).
+// The injection log said what was injected and never to whom, so the only way
+// to tell whether a recall was used was the sentence the block asks the agent
+// to say. Measured on a real store, that sentence follows 22 of 1218
+// injections — a measure of reporting, not of use. With the receiving session
+// recorded, a reader can pair an injection with what the agent did next.
+func TestSnapshotRecordsWhoReceivedIt(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	RecordDigestInto(dir, KindDejaVu, "a block worth reading", "ses_1234", 2, 900,
+		[]string{"pgbouncer"}, "claude:abc")
+
+	b, err := os.ReadFile(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := strings.TrimSpace(string(b))
+	if line == "" {
+		t.Fatal("nothing was written to the injection log")
+	}
+	var got Snapshot
+	if err := json.Unmarshal([]byte(line), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Into != "ses_1234" {
+		t.Errorf("into = %q, want the agent session that received the block", got.Into)
+	}
+	if got.Kind != KindDejaVu || got.Sessions != 2 {
+		t.Errorf("the rest of the record changed: %+v", got)
+	}
+}
+
+// A caller that does not know the session still writes a usable record, and the
+// field is omitted rather than written empty — older readers see what they saw.
+func TestSnapshotWithoutAReceiverOmitsTheField(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	RecordDigestTerms(dir, KindDejaVu, "a block", 1, 100, nil)
+
+	b, err := os.ReadFile(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "\"into\"") {
+		t.Errorf("empty receiver was written out: %s", strings.TrimSpace(string(b)))
+	}
+}
+
+// The déjà-vu hook recorded the receiver and the session-start hook did not,
+// though it holds the id and uses it two lines away — so the same field meant
+// two different things depending on which path wrote it (#1949).
 func TestASessionStartDigestRecordsWhoItWentTo(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("DEJA_INDEX_DIR", dir)
@@ -29,18 +76,23 @@ func TestASessionStartDigestRecordsWhoItWentTo(t *testing.T) {
 }
 
 // The old form still exists and still writes no destination, so a caller that
-// genuinely does not know one is not made to invent it.
+// genuinely does not know one is not made to invent it. A harness that sends no
+// session_id reaches the same place through the new form: the field is omitted,
+// not filled with a placeholder.
 func TestADigestWithNoKnownDestinationSaysNothing(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("DEJA_INDEX_DIR", dir)
 
 	RecordDigestPolicy(dir, KindHook, "a digest of earlier work", 2, 4000, "local-only")
+	RecordDigestPolicyInto(dir, KindHook, "another digest", "", 2, 4000, "local-only")
 
 	got := Snapshots(dir, 0)
-	if len(got) != 1 {
-		t.Fatalf("wrote one snapshot, read %d", len(got))
+	if len(got) != 2 {
+		t.Fatalf("wrote two snapshots, read %d", len(got))
 	}
-	if got[0].Into != "" {
-		t.Errorf("a caller with no destination recorded one anyway: %q", got[0].Into)
+	for _, s := range got {
+		if s.Into != "" {
+			t.Errorf("a caller with no destination recorded one anyway: %q", s.Into)
+		}
 	}
 }

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -74,8 +74,17 @@ func RecordDigestInto(indexDir, kind, digest, into string, sessions int, raw int
 // RecordDigestPolicy is RecordDigest plus the name of the policy that allowed
 // the injection, kept with the snapshot for `deja log`.
 func RecordDigestPolicy(indexDir, kind, digest string, sessions int, raw int64, policyName string) {
+	RecordDigestPolicyInto(indexDir, kind, digest, "", sessions, raw, policyName)
+}
+
+// RecordDigestPolicyInto is RecordDigestPolicy for a caller that knows which
+// agent session received the digest. Without it the log says what was injected
+// and never to whom, which is the whole reason Into exists — and the
+// session-start hook, the commonest injection there is, was recording nothing
+// while holding the id (#1949).
+func RecordDigestPolicyInto(indexDir, kind, digest, into string, sessions int, raw int64, policyName string) {
 	RecordResultRaw(indexDir, kind, len(digest), sessions, sessions == 0, raw)
-	snapshotWrite(indexDir, kind, digest, sessions, policyName)
+	snapshotWriteInto(indexDir, kind, digest, into, sessions, policyName, nil)
 }
 
 // SnapshotOnly stores the digest text without writing a counting event, for


### PR DESCRIPTION
Part of #1949 — the mechanical half. The wording half is left for you there.

`Snapshot.Into` exists so the log says to whom a digest went, and its comment gives the reason with a measurement: the agent's own "deja-vu recalled" line appears after 22 of 1218 injections, so counting that sentence measures reporting rather than use.

The field was not doing that job. It was written on one path — the déjà-vu hook (`hook_prompt.go:346`) — while the session-start hook, the commonest injection there is, recorded nothing, though it holds `input.SessionID` and uses it two lines away. Nothing in `cmd/` reads the field, and `deja log --last` does not print it.

This fixes the first part: `RecordDigestPolicyInto` takes the destination and the session-start hook passes the id it already has. `RecordDigestPolicy` stays and still writes nothing, so a caller that genuinely has no destination is not made to invent one — there is a test for each.

Still open in #1949, and yours: whether `deja log --last` should name the session it went to, on a line that currently reads

```
# hook · 2026-08-24 11:00 · 2 sessions · 4.0 KB · policy: local-only
```

If the answer is no, the field's comment should stop claiming the job — I would rather that were written down than measured again by the next person.
