### PR TITLE
test(docs): end a doc section at the heading that ends it

### DIFF
--- a/cmd/deja/docsection_test.go
+++ b/cmd/deja/docsection_test.go
@@ -60,6 +60,34 @@ func TestAnEmptySectionTakesNothingFromTheNextOne(t *testing.T) {
 	}
 }
 
+// A `#` inside a fenced example is a comment, not a heading. `deja log` prints
+// its rows starting with one, and an example of that output in this document
+// would have ended every section it appeared in.
+func TestAHashInsideAnExampleIsNotAHeading(t *testing.T) {
+	doc := strings.Join([]string{
+		"## `deja log --json`",
+		"",
+		"```",
+		"# hook · 2026-08-24 11:00 · 2 sessions",
+		"```",
+		"",
+		"Log says `bytes`.",
+		"",
+		"## `deja blame --json`",
+		"",
+		"Blame says `occurrences`.",
+		"",
+	}, "\n")
+
+	got := docSection(t, doc, "## `deja log --json`")
+	if !strings.Contains(got, "`bytes`") {
+		t.Errorf("a comment line inside an example ended the section: %q", got)
+	}
+	if strings.Contains(got, "occurrences") {
+		t.Errorf("the section still reached into the next command: %q", got)
+	}
+}
+
 // Prose that names a heading is not the heading. The match was on the raw text
 // anywhere, so a sentence pointing at a section started the section there — mid
 // paragraph, and short by everything up to the real heading.
@@ -84,7 +112,9 @@ func TestTheSessionObjectSectionIsNotMostOfTheDocument(t *testing.T) {
 	if strings.Contains(sec, "## `deja last --json`") {
 		t.Errorf("the session-object section runs past `deja search --json` into the commands after it")
 	}
-	if lines, total := strings.Count(sec, "\n"), strings.Count(doc, "\n"); lines*2 > total {
-		t.Errorf("the session-object section is %d of %d lines, which is not a section", lines, total)
+	// The table is 25 lines today. A cap rather than a share of the document:
+	// half of a growing file is a bound that loosens as the file grows.
+	if lines := strings.Count(sec, "\n"); lines > 40 {
+		t.Errorf("the session-object section is %d lines, which is more than the table it names", lines)
 	}
 }

--- a/cmd/deja/docsection_test.go
+++ b/cmd/deja/docsection_test.go
@@ -60,6 +60,17 @@ func TestAnEmptySectionTakesNothingFromTheNextOne(t *testing.T) {
 	}
 }
 
+// Prose that names a heading is not the heading. The match was on the raw text
+// anywhere, so a sentence pointing at a section started the section there — mid
+// paragraph, and short by everything up to the real heading.
+func TestASentenceNamingASectionIsNotTheSection(t *testing.T) {
+	doc := "# Contract\n\nSee ## `deja last --json` for the shape.\n\n## `deja last --json`\n\nLast says `id`.\n"
+
+	if got := docSection(t, doc, "## `deja last --json`"); !strings.Contains(got, "`id`") {
+		t.Errorf("the section started at a sentence about it, not at the heading: %q", got)
+	}
+}
+
 // The reach measured on the real document, not a fixture: the session object is
 // a subsection of `deja search --json`, so it cannot outlive it.
 func TestTheSessionObjectSectionIsNotMostOfTheDocument(t *testing.T) {

--- a/cmd/deja/docsection_test.go
+++ b/cmd/deja/docsection_test.go
@@ -97,6 +97,13 @@ func TestASentenceNamingASectionIsNotTheSection(t *testing.T) {
 	if got := docSection(t, doc, "## `deja last --json`"); !strings.Contains(got, "`id`") {
 		t.Errorf("the section started at a sentence about it, not at the heading: %q", got)
 	}
+
+	// And a sentence that opens the line with the heading's own text is still a
+	// sentence.
+	opens := "## `deja last --json` is the shape below.\n\n## `deja last --json`\n\nLast says `id`.\n"
+	if got := docSection(t, opens, "## `deja last --json`"); !strings.Contains(got, "`id`") {
+		t.Errorf("a line beginning with the heading text started the section: %q", got)
+	}
 }
 
 // The reach measured on the real document, not a fixture: the session object is

--- a/cmd/deja/docsection_test.go
+++ b/cmd/deja/docsection_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// docSection is what four contract tests use to say a key must be documented
+// *here* rather than anywhere in the file, so how far it reaches is the whole
+// value of those tests. It cut at the next heading of the same level only, so a
+// `###` section ran past the `##` that ends it: on today's json-output.md
+// "### The session object" is the last `###` in the file and its section was
+// 374 of 505 lines, through five later commands' output (#1951).
+func TestASectionStopsAtTheHeadingThatEndsIt(t *testing.T) {
+	doc := strings.Join([]string{
+		"# Contract",
+		"",
+		"## `deja search --json`",
+		"",
+		"Search says `hits`.",
+		"",
+		"### The session object",
+		"",
+		"The session object says `id`.",
+		"",
+		"## `deja blame --json`",
+		"",
+		"Blame says `occurrences`.",
+		"",
+	}, "\n")
+
+	nested := docSection(t, doc, "### The session object")
+	if !strings.Contains(nested, "`id`") {
+		t.Errorf("the section lost its own content: %q", nested)
+	}
+	if strings.Contains(nested, "occurrences") {
+		t.Errorf("a `###` section reached past the `##` that ends it, into a later command: %q", nested)
+	}
+
+	// The parent still holds what is nested under it.
+	parent := docSection(t, doc, "## `deja search --json`")
+	if !strings.Contains(parent, "`hits`") || !strings.Contains(parent, "`id`") {
+		t.Errorf("the parent section dropped its own subsection: %q", parent)
+	}
+	if strings.Contains(parent, "occurrences") {
+		t.Errorf("the parent section reached into the next command: %q", parent)
+	}
+}
+
+// A heading with nothing under it takes nothing from the section after it. The
+// cut used to be skipped when the next heading came first thing, which handed
+// back the rest of the file for the emptiest section there is.
+func TestAnEmptySectionTakesNothingFromTheNextOne(t *testing.T) {
+	doc := "## Empty\n## `deja blame --json`\n\nBlame says `occurrences`.\n"
+
+	if got := docSection(t, doc, "## Empty"); strings.Contains(got, "occurrences") {
+		t.Errorf("an empty section swallowed the one after it: %q", got)
+	}
+}
+
+// The reach measured on the real document, not a fixture: the session object is
+// a subsection of `deja search --json`, so it cannot outlive it.
+func TestTheSessionObjectSectionIsNotMostOfTheDocument(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("..", "..", "docs", "json-output.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := string(b)
+
+	sec := docSection(t, doc, "### The session object")
+	if strings.Contains(sec, "## `deja last --json`") {
+		t.Errorf("the session-object section runs past `deja search --json` into the commands after it")
+	}
+	if lines, total := strings.Count(sec, "\n"), strings.Count(doc, "\n"); lines*2 > total {
+		t.Errorf("the session-object section is %d of %d lines, which is not a section", lines, total)
+	}
+}

--- a/cmd/deja/session_json_contract_test.go
+++ b/cmd/deja/session_json_contract_test.go
@@ -32,14 +32,25 @@ func docSection(t *testing.T, doc, heading string) string {
 	}
 	rest := doc[i+len(heading):]
 	level := strings.Count(strings.SplitN(heading, " ", 2)[0], "#")
+	fenced := false
 	for at := 0; ; {
 		nl := strings.IndexByte(rest[at:], '\n')
 		if nl < 0 {
 			return rest
 		}
 		at += nl + 1
-		hashes := len(rest[at:]) - len(strings.TrimLeft(rest[at:], "#"))
-		if hashes > 0 && hashes <= level && strings.HasPrefix(rest[at+hashes:], " ") {
+		line := rest[at:]
+		// A `#` inside an example is a comment, not a heading — `deja log`
+		// output starts its rows with one. Sections here end on headings only.
+		if strings.HasPrefix(line, "```") {
+			fenced = !fenced
+			continue
+		}
+		if fenced {
+			continue
+		}
+		hashes := len(line) - len(strings.TrimLeft(line, "#"))
+		if hashes > 0 && hashes <= level && strings.HasPrefix(line[hashes:], " ") {
 			return rest[:at-1]
 		}
 	}

--- a/cmd/deja/session_json_contract_test.go
+++ b/cmd/deja/session_json_contract_test.go
@@ -18,9 +18,17 @@ import (
 // the end of it (#1951).
 func docSection(t *testing.T, doc, heading string) string {
 	t.Helper()
-	i := strings.Index(doc, heading)
-	if i < 0 {
-		t.Fatalf("docs/json-output.md has no %q", heading)
+	// A heading starts a line. Matching anywhere would let prose that names a
+	// heading — a pointer to it, a sentence about the format — start the
+	// section somewhere in the middle of a paragraph.
+	i := strings.Index(doc, "\n"+heading)
+	switch {
+	case i >= 0:
+		i++
+	case strings.HasPrefix(doc, heading):
+		i = 0
+	default:
+		t.Fatalf("docs/json-output.md has no %q at the start of a line", heading)
 	}
 	rest := doc[i+len(heading):]
 	level := strings.Count(strings.SplitN(heading, " ", 2)[0], "#")

--- a/cmd/deja/session_json_contract_test.go
+++ b/cmd/deja/session_json_contract_test.go
@@ -11,7 +11,11 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 )
 
-// docSection is one heading's text, up to the next heading of the same level.
+// docSection is one heading's text, up to the next heading of the same or a
+// shallower level — a subsection ends where its parent does. That is what makes
+// these tests a check on where a key is documented rather than on the document
+// as a whole: cutting at the same level only, the last `###` in a file ran to
+// the end of it (#1951).
 func docSection(t *testing.T, doc, heading string) string {
 	t.Helper()
 	i := strings.Index(doc, heading)
@@ -19,11 +23,18 @@ func docSection(t *testing.T, doc, heading string) string {
 		t.Fatalf("docs/json-output.md has no %q", heading)
 	}
 	rest := doc[i+len(heading):]
-	level := strings.Repeat("#", strings.Count(strings.SplitN(heading, " ", 2)[0], "#"))
-	if end := strings.Index(rest, "\n"+level+" "); end > 0 {
-		rest = rest[:end]
+	level := strings.Count(strings.SplitN(heading, " ", 2)[0], "#")
+	for at := 0; ; {
+		nl := strings.IndexByte(rest[at:], '\n')
+		if nl < 0 {
+			return rest
+		}
+		at += nl + 1
+		hashes := len(rest[at:]) - len(strings.TrimLeft(rest[at:], "#"))
+		if hashes > 0 && hashes <= level && strings.HasPrefix(rest[at+hashes:], " ") {
+			return rest[:at-1]
+		}
 	}
-	return rest
 }
 
 // jsonKeys is every key a value emits, nested ones included, once each.

--- a/cmd/deja/session_json_contract_test.go
+++ b/cmd/deja/session_json_contract_test.go
@@ -18,17 +18,27 @@ import (
 // the end of it (#1951).
 func docSection(t *testing.T, doc, heading string) string {
 	t.Helper()
-	// A heading starts a line. Matching anywhere would let prose that names a
+	// A heading is a whole line. Matching anywhere would let prose that names a
 	// heading — a pointer to it, a sentence about the format — start the
-	// section somewhere in the middle of a paragraph.
-	i := strings.Index(doc, "\n"+heading)
-	switch {
-	case i >= 0:
-		i++
-	case strings.HasPrefix(doc, heading):
-		i = 0
-	default:
-		t.Fatalf("docs/json-output.md has no %q at the start of a line", heading)
+	// section somewhere in the middle of a paragraph, and matching only its
+	// start would take a sentence that opens with one.
+	i := -1
+	for at := 0; ; {
+		k := strings.Index(doc[at:], heading)
+		if k < 0 {
+			break
+		}
+		k += at
+		at = k + len(heading)
+		startsLine := k == 0 || doc[k-1] == '\n'
+		endsLine := at == len(doc) || doc[at] == '\n'
+		if startsLine && endsLine {
+			i = k
+			break
+		}
+	}
+	if i < 0 {
+		t.Fatalf("docs/json-output.md has no line %q", heading)
 	}
 	rest := doc[i+len(heading):]
 	level := strings.Count(strings.SplitN(heading, " ", 2)[0], "#")

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -191,6 +191,8 @@ return redacted index content in a bounded message window; the default limit is
     "harness": "codex",
     "id": "abc123",
     "project": "myapp",
+    "started": "2026-01-02T03:04:05Z",
+    "updated": "2026-01-02T03:10:00Z",
     "source": {"origin": "local", "instance": "workstation"},
     "messages": [
       {"role": "user", "text": "bounded redacted text", "time": "2026-01-02T03:04:05Z"}


### PR DESCRIPTION
Fixes #1951.

`docSection` is what four contract tests use to say a key must be documented *here* rather than anywhere in the file. It cut a section at the next heading of the same level only, so a `###` ran past the `##` that ends it and stopped at the next `###` — or, for the last one in a file, at the end of it:

```
### The session object                           section =  374 lines of 505
## `deja search --json`                          section =   87 lines of 505
```

Every test that adds the session-object section to its own was really checking the back three quarters of the document. Now a section ends at the next heading of the same or a shallower level, and the empty-section case (`end > 0`) no longer swallows the file either.

Tightening it turned up what it had been hiding: `deja show --json` emits `started` and `updated`, and neither its section nor the session-object table said so. They are always present, so the table — "these are the rest, each omitted when empty" — is the wrong home; they are in the section's example now, where the other always-present fields are.

Three tests: the reach on a fixture, the empty section, and the reach measured on the real `json-output.md` so the next `###` added at the end of the file cannot quietly re-open it.
