### PR TITLE
test(hooks): pin the receiver both injection paths record

### DIFF
--- a/cmd/deja/hook_context_into_test.go
+++ b/cmd/deja/hook_context_into_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// snapshotsInto is every receiver the injection log recorded, by kind.
+func snapshotsInto(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	b, err := os.ReadFile(usage.SnapshotPath(dir))
+	if err != nil {
+		t.Fatalf("nothing was written to the injection log: %v", err)
+	}
+	got := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		var snap usage.Snapshot
+		if json.Unmarshal([]byte(line), &snap) != nil {
+			continue
+		}
+		got[snap.Kind] = snap.Into
+	}
+	return got
+}
+
+// The session-start hook is the commonest injection there is, and it recorded
+// no receiver at all while holding the id — pinned only at the usage package's
+// own door, so the hook could stop passing it and nothing would say so (#1949).
+// The déjà-vu path has had TestHookPromptRecordsTheSessionItAnswered since the
+// field was added; this is its other half.
+func TestHookContextRecordsTheSessionItStarted(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "startterm", []string{
+		`{"type":"user","sessionId":"startterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	withHookStdin(t, `{"source":"startup","session_id":"ses_from_harness","cwd":"`+cwd+`"}`)
+	if out := runHookContextPlain(t); !strings.Contains(out, "transaction mode") {
+		t.Fatalf("the hook injected nothing, so there is no record to check:\n%q", out)
+	}
+
+	if into := snapshotsInto(t, index.DefaultDir())[usage.KindHook]; into != "ses_from_harness" {
+		t.Errorf("the session-start injection went to %q, not to the session in the payload", into)
+	}
+}
+
+// Both hooks write the same field, and a reader pairing an injection with what
+// the agent did next can only do it if they mean the same string. They take it
+// from the same key of their own payloads, which is the part worth holding: an
+// id one hook derived some other way would look right in the log and pair
+// wrong.
+func TestBothHooksRecordTheSameSessionForOneSession(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "bothterm", []string{
+		`{"type":"user","sessionId":"bothterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	withHookStdin(t, `{"source":"startup","session_id":"ses_both","cwd":"`+cwd+`"}`)
+	if out := runHookContextPlain(t); !strings.Contains(out, "transaction mode") {
+		t.Fatalf("the session-start hook injected nothing:\n%q", out)
+	}
+	var prompt bytes.Buffer
+	in := strings.NewReader(`{"prompt":"do we need pgbouncer here","session_id":"ses_both"}`)
+	if err := runHookPromptMode(index.DefaultDir(), in, &prompt, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(prompt.String(), "transaction mode") {
+		t.Fatalf("the prompt hook injected nothing:\n%q", prompt.String())
+	}
+
+	into := snapshotsInto(t, index.DefaultDir())
+	if into[usage.KindHook] != into[usage.KindDejaVu] {
+		t.Errorf("one session was recorded under two names: session start wrote %q, deja vu wrote %q",
+			into[usage.KindHook], into[usage.KindDejaVu])
+	}
+	if into[usage.KindHook] != "ses_both" {
+		t.Errorf("neither hook recorded the session the harness named: %q", into[usage.KindHook])
+	}
+}
+
+// runHookContextPlain runs the session-start hook with stdout captured.
+func runHookContextPlain(t *testing.T) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	runErr := runHookContext(index.DefaultDir(), true)
+	os.Stdout = old
+	_ = w.Close()
+	var out bytes.Buffer
+	_, _ = io.Copy(&out, r)
+	_ = r.Close()
+	if runErr != nil {
+		t.Fatal(runErr)
+	}
+	return out.String()
+}

--- a/cmd/deja/hook_context_into_test.go
+++ b/cmd/deja/hook_context_into_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,22 +13,35 @@ import (
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
-// snapshotsInto is every receiver the injection log recorded, by kind.
-func snapshotsInto(t *testing.T, dir string) map[string]string {
+// snapshotOnlyInto is the one receiver a kind recorded. Every row of that kind
+// has to agree: keeping the last would let a good row cover a bad one written
+// before it.
+func snapshotOnlyInto(t *testing.T, dir, kind string) string {
 	t.Helper()
 	b, err := os.ReadFile(usage.SnapshotPath(dir))
 	if err != nil {
 		t.Fatalf("nothing was written to the injection log: %v", err)
 	}
-	got := map[string]string{}
+	seen := map[string]bool{}
 	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
 		var snap usage.Snapshot
 		if json.Unmarshal([]byte(line), &snap) != nil {
-			continue
+			t.Fatalf("the injection log has a line deja cannot read back: %s", line)
 		}
-		got[snap.Kind] = snap.Into
+		if snap.Kind == kind {
+			seen[snap.Into] = true
+		}
 	}
-	return got
+	switch len(seen) {
+	case 0:
+		t.Fatalf("the injection log has no %s row at all:\n%s", kind, b)
+	case 1:
+		for into := range seen {
+			return into
+		}
+	}
+	t.Fatalf("%s rows disagree on where they went: %v", kind, seen)
+	return ""
 }
 
 // The session-start hook is the commonest injection there is, and it recorded
@@ -53,13 +65,17 @@ func TestHookContextRecordsTheSessionItStarted(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(cwd)
+	// The hook exports the payload's cwd into the process, so without pinning it
+	// here every later test in this package inherits a project directory that no
+	// longer exists — and the second run below would keep this one's.
+	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
 
 	withHookStdin(t, `{"source":"startup","session_id":"ses_from_harness","cwd":"`+cwd+`"}`)
-	if out := runHookContextPlain(t); !strings.Contains(out, "transaction mode") {
+	if out := captureStdout(t, func() { runHookContextPlain(t) }); !strings.Contains(out, "transaction mode") {
 		t.Fatalf("the hook injected nothing, so there is no record to check:\n%q", out)
 	}
 
-	if into := snapshotsInto(t, index.DefaultDir())[usage.KindHook]; into != "ses_from_harness" {
+	if into := snapshotOnlyInto(t, index.DefaultDir(), usage.KindHook); into != "ses_from_harness" {
 		t.Errorf("the session-start injection went to %q, not to the session in the payload", into)
 	}
 }
@@ -85,9 +101,10 @@ func TestBothHooksRecordTheSameSessionForOneSession(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(cwd)
+	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
 
 	withHookStdin(t, `{"source":"startup","session_id":"ses_both","cwd":"`+cwd+`"}`)
-	if out := runHookContextPlain(t); !strings.Contains(out, "transaction mode") {
+	if out := captureStdout(t, func() { runHookContextPlain(t) }); !strings.Contains(out, "transaction mode") {
 		t.Fatalf("the session-start hook injected nothing:\n%q", out)
 	}
 	var prompt bytes.Buffer
@@ -99,33 +116,22 @@ func TestBothHooksRecordTheSameSessionForOneSession(t *testing.T) {
 		t.Fatalf("the prompt hook injected nothing:\n%q", prompt.String())
 	}
 
-	into := snapshotsInto(t, index.DefaultDir())
-	if into[usage.KindHook] != into[usage.KindDejaVu] {
-		t.Errorf("one session was recorded under two names: session start wrote %q, deja vu wrote %q",
-			into[usage.KindHook], into[usage.KindDejaVu])
+	start := snapshotOnlyInto(t, index.DefaultDir(), usage.KindHook)
+	dejaVu := snapshotOnlyInto(t, index.DefaultDir(), usage.KindDejaVu)
+	if start != dejaVu {
+		t.Errorf("one session was recorded under two names: session start wrote %q, deja vu wrote %q", start, dejaVu)
 	}
-	if into[usage.KindHook] != "ses_both" {
-		t.Errorf("neither hook recorded the session the harness named: %q", into[usage.KindHook])
+	if start != "ses_both" {
+		t.Errorf("neither hook recorded the session the harness named: %q", start)
 	}
 }
 
-// runHookContextPlain runs the session-start hook with stdout captured.
-func runHookContextPlain(t *testing.T) string {
+// runHookContextPlain runs the session-start hook. Stdout is captured by
+// captureStdout around it, which drains the pipe while the hook writes — a
+// digest larger than the pipe buffer would otherwise wedge the test.
+func runHookContextPlain(t *testing.T) {
 	t.Helper()
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
+	if err := runHookContext(index.DefaultDir(), true); err != nil {
+		t.Error(err)
 	}
-	old := os.Stdout
-	os.Stdout = w
-	runErr := runHookContext(index.DefaultDir(), true)
-	os.Stdout = old
-	_ = w.Close()
-	var out bytes.Buffer
-	_, _ = io.Copy(&out, r)
-	_ = r.Close()
-	if runErr != nil {
-		t.Fatal(runErr)
-	}
-	return out.String()
 }


### PR DESCRIPTION
No bug — measured, then pinned.

The question was whether the two writers of `into` record the same kind of id. Driven end to end against one throwaway index, one session id, both hooks:

```
{"t":"…","kind":"hook",  "sessions":1,"bytes":726,"policy":"local+imported","into":"agent-session-777",…}
{"t":"…","kind":"dejavu","sessions":1,"bytes":741,"terms":[…],              "into":"agent-session-777",…}
```

Same string, and by construction: both read `session_id` from their own payload, and `hook_prompt.go:257` already compares that id against the index's own session ids, so it is one namespace.

What was missing is a test. The déjà-vu path has had one since the field was added; the session-start path was pinned only at the usage package's door, so the hook could stop passing the id and nothing would say so — which is how #1949 lived through a release. Two tests here: the session-start hook records the payload's session, and both hooks record the same string for one session. Reverting `hook_context.go:323` to the old call makes both fail, the second with "one session was recorded under two names".
