### PR TITLE
fix(log): stop calling an injection that sent bytes an empty result

### DIFF
--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -78,7 +78,11 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 	}
 	for _, e := range events {
 		mark := ""
-		if e.Empty {
+		// Empty means no session went into the event, not that nothing was
+		// served: a session start on a checkout with no sessions of its own
+		// still injects the environment block, and marking that row put
+		// "(empty result)" beside the bytes it sent (#1954).
+		if e.Empty && e.Bytes == 0 {
 			mark = "  (empty result)"
 		}
 		sess := ""

--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -78,11 +78,7 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 	}
 	for _, e := range events {
 		mark := ""
-		// Empty means no session went into the event, not that nothing was
-		// served: a session start on a checkout with no sessions of its own
-		// still injects the environment block, and marking that row put
-		// "(empty result)" beside the bytes it sent (#1954).
-		if e.Empty && e.Bytes == 0 {
+		if e.FoundNothing() {
 			mark = "  (empty result)"
 		}
 		sess := ""

--- a/cmd/deja/log_empty_test.go
+++ b/cmd/deja/log_empty_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -38,17 +39,25 @@ func TestTheLogDoesNotCallAnInjectionWithBytesEmpty(t *testing.T) {
 	}
 }
 
-// The mark still belongs on the event it was written for: a recall that found
-// nothing serves nothing, and saying so is the whole point of the flag.
-func TestTheLogStillMarksAResultThatServedNothing(t *testing.T) {
-	dir := t.TempDir()
-	usage.RecordResultRaw(dir, usage.KindSearch, 0, 0, true, 0)
+// The mark still belongs on the event it was written for, and that event is
+// not a zero-byte one: a recall that matched nothing serves the sentence saying
+// so, so it carries bytes and the flag together. A rule reading the bytes
+// instead of the kind would drop the mark exactly where it is the point.
+func TestTheLogStillMarksARecallThatMatchedNothing(t *testing.T) {
+	dir := seedWalls(t, index.FrictionMinSessions)
+	text, err := callMCPTool(dir, "recall", json.RawMessage(`{"query":"nothing here matches this at all"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text == "" {
+		t.Fatal("an empty recall answers with the sentence saying so; it answered with nothing")
+	}
 
 	var b strings.Builder
 	if err := runLogTo(&b, dir, nil); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(b.String(), "(empty result)") {
-		t.Errorf("a search that served nothing is no longer marked:\n%s", b.String())
+		t.Errorf("a recall that matched nothing is no longer marked:\n%s", b.String())
 	}
 }

--- a/cmd/deja/log_empty_test.go
+++ b/cmd/deja/log_empty_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// A session start on a checkout with no sessions of its own still injects the
+// environment block — the "this machine keeps hitting X" list. The event is
+// logged empty because no project session went into it, and the log used that
+// flag to print "(empty result)" beside the bytes the block actually sent
+// (#1954).
+func TestTheLogDoesNotCallAnInjectionWithBytesEmpty(t *testing.T) {
+	dir := seedWalls(t, index.FrictionMinSessions)
+	withHookStdin(t, `{"source":"startup","session_id":"ses_env"}`)
+	out := captureStdout(t, func() {
+		if err := runHookContext(dir, true); err != nil {
+			t.Error(err)
+		}
+	})
+	if !strings.Contains(out, "separate sessions") {
+		t.Fatalf("the environment block did not go out, so there is no injection to report:\n%q", out)
+	}
+
+	var b strings.Builder
+	if err := runLogTo(&b, dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	line := b.String()
+	if !strings.Contains(line, usage.KindHook) {
+		t.Fatalf("the log has no injection row:\n%s", line)
+	}
+	if strings.Contains(line, "(empty result)") {
+		t.Errorf("the log calls an injection that sent bytes an empty result:\n%s", line)
+	}
+}
+
+// The mark still belongs on the event it was written for: a recall that found
+// nothing serves nothing, and saying so is the whole point of the flag.
+func TestTheLogStillMarksAResultThatServedNothing(t *testing.T) {
+	dir := t.TempDir()
+	usage.RecordResultRaw(dir, usage.KindSearch, 0, 0, true, 0)
+
+	var b strings.Builder
+	if err := runLogTo(&b, dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), "(empty result)") {
+		t.Errorf("a search that served nothing is no longer marked:\n%s", b.String())
+	}
+}

--- a/cmd/deja/log_test.go
+++ b/cmd/deja/log_test.go
@@ -31,10 +31,7 @@ func TestLogListsEventsAndLastDigest(t *testing.T) {
 	hermeticEnv(t)
 	dir := index.DefaultDir()
 	usage.RecordDigest(dir, usage.KindHook, "the injected context body", 3, 1024)
-	// A recall that found nothing serves nothing: 42 bytes and empty together
-	// is a shape no caller writes, and the log now takes the bytes at their
-	// word (#1954).
-	usage.RecordResult(dir, usage.KindRecall, 0, 0, true)
+	usage.RecordResult(dir, usage.KindRecall, 42, 0, true)
 
 	var out bytes.Buffer
 	if err := runLogTo(&out, dir, nil); err != nil {

--- a/cmd/deja/log_test.go
+++ b/cmd/deja/log_test.go
@@ -31,7 +31,10 @@ func TestLogListsEventsAndLastDigest(t *testing.T) {
 	hermeticEnv(t)
 	dir := index.DefaultDir()
 	usage.RecordDigest(dir, usage.KindHook, "the injected context body", 3, 1024)
-	usage.RecordResult(dir, usage.KindRecall, 42, 0, true)
+	// A recall that found nothing serves nothing: 42 bytes and empty together
+	// is a shape no caller writes, and the log now takes the bytes at their
+	// word (#1954).
+	usage.RecordResult(dir, usage.KindRecall, 0, 0, true)
 
 	var out bytes.Buffer
 	if err := runLogTo(&out, dir, nil); err != nil {

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -467,9 +467,12 @@ have written it, and the log keeps what it was given.
 behind a served digest, which is omitted when there is none. `bytes` is always
 there, zero included: a recall that served nothing is a fact, not a missing
 field. `sessions` counts what the digest held, `ids` names them for a
-recall, and `empty` marks an answer that found nothing — a recall that returned
+recall, and `empty` marks an event no session went into — a recall that returned
 no sessions is still a recall, and the count of those is what
-`empty_result_rate` is made of.
+`empty_result_rate` is made of. It does not mean nothing was served: a session
+start on a checkout with no sessions of its own injects the environment block,
+which is about the machine rather than the project, so that event is `empty`
+and carries its `bytes`.
 
 A line needs both `t` and `kind` to appear here at all: a half-written line, or
 one from something that is not deja, is skipped rather than shown with a missing

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -81,7 +81,11 @@ type Event struct {
 	Kind     string    `json:"kind"`
 	Bytes    int       `json:"bytes"`
 	Sessions int       `json:"sessions,omitempty"`
-	Empty    bool      `json:"empty,omitempty"`
+	// Empty means no session went into the event, which is not the same as
+	// serving nothing: a session start on a checkout with no sessions of its
+	// own still injects the environment block, and that event carries its
+	// bytes (#1954).
+	Empty bool `json:"empty,omitempty"`
 	// RawBytes is the size of the source transcripts the served digest was
 	// distilled from — what the agent would have had to replay without deja.
 	RawBytes int64 `json:"raw,omitempty"`

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -76,6 +76,14 @@ func injectedKind(kind string) bool {
 	return false
 }
 
+// FoundNothing reports whether a lookup came back with nothing, which is what
+// `deja log` marks. Not the same as the Empty flag: on an injection the flag
+// says no project session went in, and a session start on a checkout with no
+// sessions of its own still injects the environment block — bytes and all
+// (#1954). On a lookup the flag does mean the answer found nothing, which is
+// why an empty recall still serves the sentence that says so.
+func (e Event) FoundNothing() bool { return e.Empty && !injectedKind(e.Kind) }
+
 type Event struct {
 	Time     time.Time `json:"t"`
 	Kind     string    `json:"kind"`


### PR DESCRIPTION
Fixes #1954 — the mechanical half. The wording half is left for you there.

A session start on a checkout with no sessions of its own still injects the environment block. The event is logged `empty` because no project session went into it, and `deja log` turned that flag into a mark beside the bytes the block sent:

```
2026-08-26 00:26  hook           501 B  (empty result)
```

The flag is right; the sentence is not. Three readers of that one event, before this:

```
Totals   injections=1 injectedBytes=501 injectedSessions=0
Impact   injections=0 servedBytes=0      (skipped on purpose, comment says why)
deja log 501 B (empty result)
```

`Impact` is right to skip it — the block is about the machine, not the project, and counting it made "N session starts began with project memory" claim memory that was not there. `deja log` reports on the injection itself, and 501 bytes did go out, so the mark now follows the bytes: an event that served nothing keeps it, an event that served something does not.

`Event.Empty` had no comment saying which of the two it meant, and `json-output.md` said "an answer that found nothing". Both say what it is now.

One existing fixture changed: `log_test.go` recorded a recall of 42 bytes with `empty: true`, a shape no caller writes — a recall that found nothing serves nothing. It records a real empty recall and still asserts the mark.

Still yours, from the issue: an injection carrying the environment block and no project sessions may deserve a word of its own on that line rather than no mark at all. That word is yours.
