### PR TITLE
test(atomicfile): cover WriteStream, which had none

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         shell: bash
         run: |
           declare -A floor=(
-            [cmd/deja]=88 [internal/atomicfile]=47 [internal/bench]=100
+            [cmd/deja]=88 [internal/atomicfile]=77 [internal/bench]=100
             [internal/cjkfold]=100 [internal/digest]=90 [internal/embed]=93
             [internal/index]=90 [internal/mark]=98 [internal/model]=100
             [internal/nfcfold]=100 [internal/peers]=76 [internal/policy]=100

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -2,6 +2,8 @@ package atomicfile
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -183,5 +185,126 @@ func TestStaleTempsAreSwept(t *testing.T) {
 	// belongs to another writer mid-flight.
 	if _, err := os.Stat(fresh); err != nil {
 		t.Errorf("a live temp file was swept: %v", err)
+	}
+}
+
+// WriteStream carries the embedding sidecar, megabytes of vectors that would
+// cost twice the memory to buffer and hand over whole. It had no test of its
+// own at all — 0% of the function — while Write beside it had five.
+func TestWriteStreamPublishesWhatItWroteAndKeepsTheMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sidecar.bin")
+	body := bytes.Repeat([]byte("vector"), 4096)
+
+	if err := WriteStream(path, 0o640, func(w io.Writer) error {
+		for off := 0; off < len(body); off += 512 {
+			end := off + 512
+			if end > len(body) {
+				end = len(body)
+			}
+			if _, err := w.Write(body[off:end]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("published %d bytes, wrote %d", len(got), len(body))
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && fi.Mode().Perm() != 0o640 {
+		t.Errorf("mode = %v, want 640 — CreateTemp makes 600 and the chmod is what fixes it", fi.Mode().Perm())
+	}
+	leftTemps(t, dir)
+}
+
+// A writer that gives up halfway must leave the old file alone. This is the
+// whole reason the sidecar is written through this package: a half-written one
+// is worse than yesterday's, because it parses as a shorter index.
+func TestWriteStreamPublishesNothingWhenTheWriterFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sidecar.bin")
+	if err := os.WriteFile(path, []byte("the previous sidecar"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	boom := errors.New("out of vectors")
+	err := WriteStream(path, 0o600, func(w io.Writer) error {
+		if _, werr := w.Write(bytes.Repeat([]byte("half"), 1024)); werr != nil {
+			return werr
+		}
+		return boom
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want the writer's own error", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "the previous sidecar" {
+		t.Errorf("the failed write replaced the file with %q", got)
+	}
+	leftTemps(t, dir)
+}
+
+// Same rule as Write: a rename that cannot land leaves nothing on the way.
+func TestWriteStreamLeavesNoTempWhenTheRenameFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "occupied")
+	if err := os.MkdirAll(filepath.Join(path, "child"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteStream(path, 0o600, func(w io.Writer) error {
+		_, err := w.Write([]byte("x"))
+		return err
+	}); err == nil {
+		t.Fatal("replacing a non-empty directory reported success")
+	}
+	leftTemps(t, dir)
+}
+
+// leftTemps fails if this package left one of its temp files behind.
+func leftTemps(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Errorf("left %s behind", e.Name())
+		}
+	}
+}
+
+// And the same on a directory that is not there: the caller decides whether to
+// make it, so nothing is created on the way.
+func TestWriteStreamToAMissingDirectoryFailsCleanly(t *testing.T) {
+	dir := t.TempDir()
+	called := false
+	err := WriteStream(filepath.Join(dir, "gone", "sidecar.bin"), 0o600, func(w io.Writer) error {
+		called = true
+		return nil
+	})
+	if err == nil {
+		t.Error("writing into a missing directory reported success")
+	}
+	if called {
+		t.Error("the writer ran even though there was nowhere to write")
+	}
+	if entries, err := os.ReadDir(dir); err == nil && len(entries) != 0 {
+		t.Errorf("the failed write left %d entries behind", len(entries))
 	}
 }

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -86,15 +86,7 @@ func TestWriteLeavesNoTempAndKeepsTheMode(t *testing.T) {
 	if err := Write(path, []byte("one\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, e := range entries {
-		if strings.Contains(e.Name(), ".tmp") {
-			t.Errorf("a temp file survived the write: %s", e.Name())
-		}
-	}
+	leftTemps(t, dir)
 	fi, err := os.Stat(path)
 	if err != nil {
 		t.Fatal(err)
@@ -132,15 +124,7 @@ func TestAFailedRenameLeavesNoTemp(t *testing.T) {
 	if err := Write(path, []byte("x"), 0o600); err == nil {
 		t.Fatal("replacing a non-empty directory reported success")
 	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, e := range entries {
-		if strings.Contains(e.Name(), ".tmp") {
-			t.Errorf("the failed rename left %s behind", e.Name())
-		}
-	}
+	leftTemps(t, dir)
 }
 
 // A destination whose directory does not exist fails and leaves nothing: the
@@ -229,8 +213,9 @@ func TestWriteStreamPublishesWhatItWroteAndKeepsTheMode(t *testing.T) {
 }
 
 // A writer that gives up halfway must leave the old file alone. This is the
-// whole reason the sidecar is written through this package: a half-written one
-// is worse than yesterday's, because it parses as a shorter index.
+// whole reason the sidecar is written through this package: its header carries
+// the vector count, so a half-written one decodes as nothing at all — worse
+// than yesterday's, which decodes.
 func TestWriteStreamPublishesNothingWhenTheWriterFails(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sidecar.bin")
@@ -275,20 +260,6 @@ func TestWriteStreamLeavesNoTempWhenTheRenameFails(t *testing.T) {
 	leftTemps(t, dir)
 }
 
-// leftTemps fails if this package left one of its temp files behind.
-func leftTemps(t *testing.T, dir string) {
-	t.Helper()
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, e := range entries {
-		if strings.Contains(e.Name(), ".tmp") {
-			t.Errorf("left %s behind", e.Name())
-		}
-	}
-}
-
 // And the same on a directory that is not there: the caller decides whether to
 // make it, so nothing is created on the way.
 func TestWriteStreamToAMissingDirectoryFailsCleanly(t *testing.T) {
@@ -306,5 +277,19 @@ func TestWriteStreamToAMissingDirectoryFailsCleanly(t *testing.T) {
 	}
 	if entries, err := os.ReadDir(dir); err == nil && len(entries) != 0 {
 		t.Errorf("the failed write left %d entries behind", len(entries))
+	}
+}
+
+// leftTemps fails if this package left one of its temp files behind.
+func leftTemps(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Errorf("left %s behind", e.Name())
+		}
 	}
 }


### PR DESCRIPTION
`internal/atomicfile` was the lowest-covered package deja ships, and the reason turned out to be one function:

```
publish      100.0%
sweepStale    87.5%
Write         65.0%
WriteStream    0.0%
```

`WriteStream` is the path the embedding sidecar takes — megabytes of vectors, written through this package precisely because a half-written one is worse than yesterday's: it parses, just shorter. It had no test at all, while `Write` beside it had five.

Four now, mirroring what `Write` is held to: it publishes exactly what the writer wrote and applies the mode (`CreateTemp` makes 0600, the chmod is what fixes it), a writer that gives up halfway leaves the previous file untouched, a rename that cannot land leaves no temp behind, and a missing directory fails before the writer is ever called.

47.2% to 77.4%; the floor moves with it. What is still uncovered in both functions is the same set — `CreateTemp`, `Close` and `Chmod` failing — which needs a filesystem that fails on command rather than a test.

No behaviour change, and nothing surprised: the tests pass as written against the current code.
