### PR TITLE
strip credentials from uppercase _KEY env assignments

### DIFF
--- a/internal/redact/env_key_test.go
+++ b/internal/redact/env_key_test.go
@@ -1,0 +1,46 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1919 documents `export DEJA_EMBED_KEY=…` as the way to reach an authenticated
+// embedding endpoint, which puts that line in the shell an agent is watching.
+// A key with a provider prefix was already caught and a high-entropy one too,
+// but a plain opaque token named by a variable ending in _KEY was not: every
+// pattern wanted the words api_key, secret, token or password in the name.
+func TestEnvVarKeyIsRedacted(t *testing.T) {
+	for _, tc := range []struct{ name, line, secret string }{
+		{"opaque hex", `export DEJA_EMBED_KEY=9f2b7c4e1a8d6350bb91ee27ac4d0f83`, "9f2b7c4e1a8d6350bb91ee27ac4d0f83"},
+		{"quoted", `export GROQ_KEY='gsk0000aaaa1111bbbb2222cccc'`, "gsk0000aaaa1111bbbb2222cccc"},
+		{"json", `{"VOYAGE_KEY": "pa00000000111111112222222233"}`, "pa00000000111111112222222233"},
+		{"colon form", `DEEPINFRA_KEY: 0123456789abcdef0123456789`, "0123456789abcdef0123456789"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, counts := Text(tc.line)
+			if strings.Contains(out, tc.secret) {
+				t.Fatalf("secret survived ingest:\n  in:  %s\n  out: %s", tc.line, out)
+			}
+			if counts.Total() == 0 {
+				t.Fatal("nothing was counted, so `deja sources` would report a clean store")
+			}
+		})
+	}
+}
+
+// The reason this pattern is case-sensitive. Configuration files are full of
+// lowercase keys whose values are ordinary strings, and redacting those costs
+// recall while protecting nothing.
+func TestLowercaseKeyNamesAreLeftAlone(t *testing.T) {
+	for _, line := range []string{
+		`cache_key: user-profile-v2-20260825`,
+		`  partition_key = "customer_id_and_region"`,
+		`sort_key: created_at_descending_index`,
+	} {
+		out, _ := Text(line)
+		if strings.Contains(out, "[redacted") {
+			t.Errorf("redacted an ordinary configuration value:\n  in:  %s\n  out: %s", line, out)
+		}
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -37,6 +37,16 @@ var (
 	// secret sat in the clear because every pattern here was English-only. The
 	// value class and length floor are the same, so the looseness is unchanged.
 	genericKVRE = regexp.MustCompile(`(?i)\b([\w.-]{0,64}?(?:api[_-]?key|secret|token|passwd|password|authorization))(\\*['"]?\s*[:=]\s*)(\\*['"]?)([A-Za-z0-9/+=._-]{16,})(\\*['"]?)`)
+	// An environment variable holding a credential does not have to say "api" or
+	// "token" in its name: DEJA_EMBED_KEY, GROQ_KEY, VOYAGE_KEY all end in plain
+	// _KEY, which genericKVRE never matched, so an opaque value — one with no
+	// provider prefix and not enough entropy for the last-resort pass — was
+	// indexed in the clear. Measured on `export DEJA_EMBED_KEY=9f2b…f83`.
+	//
+	// Case-sensitive on purpose: this is the shell shape, and matching `_key`
+	// as well would take `cache_key: <16 chars>` out of every YAML file people
+	// paste, which costs recall for no secret.
+	envKeyRE = regexp.MustCompile(`\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*_KEY)(\\*['"]?\s*[:=]\s*)(\\*['"]?)([A-Za-z0-9/+=._-]{16,})(\\*['"]?)`)
 	// The same shape in the languages people actually type in. \b is ASCII-only
 	// in RE2, so a Cyrillic or CJK key word can never sit behind it — these get
 	// their own pattern. A Russian speaker writing "пароль: …" had the secret
@@ -201,6 +211,9 @@ func Text(s string) (string, Counts) {
 	}
 	if kvAssignmentNearby(lower) {
 		s = replaceSubmatch(s, genericKVRE, "credential", counts, func(m []string) string {
+			return m[1] + m[2] + m[3] + "[redacted:credential]" + closingQuote(m[3], m[5])
+		})
+		s = replaceSubmatch(s, envKeyRE, "credential", counts, func(m []string) string {
 			return m[1] + m[2] + m[3] + "[redacted:credential]" + closingQuote(m[3], m[5])
 		})
 		s = replaceSubmatch(s, genericKVIntlRE, "credential", counts, func(m []string) string {


### PR DESCRIPTION
Found while reviewing #1919, which documents `export DEJA_EMBED_KEY=…` — that line lands in a shell an agent is watching, so it gets indexed.

A key with a provider prefix was already caught, and a high-entropy one too. An opaque token in a variable ending in plain `_KEY` was not: every pattern wanted api_key, secret, token or password in the name.

```
export DEJA_EMBED_KEY=9f2b7c4e1a8d6350bb91ee27ac4d0f83   # stored verbatim
```

Case-sensitive on purpose — matching `_key` too would redact `cache_key: …` out of every YAML file people paste, which costs recall and protects nothing. Both directions are pinned by tests.