### PR TITLE
test(hooks): hold the session start to one project across worktrees

### DIFF
--- a/cmd/deja/hook_worktree_test.go
+++ b/cmd/deja/hook_worktree_test.go
@@ -22,14 +22,14 @@ func TestASessionStartedInAWorktreeGetsTheProjectsMemory(t *testing.T) {
 	}
 	withStatsStores(t)
 	tmp := t.TempDir()
-	main := filepath.Join(tmp, "checkout")
+	repo := filepath.Join(tmp, "checkout")
 	side := filepath.Join(tmp, "checkout-fix")
-	if err := os.MkdirAll(main, 0o755); err != nil {
+	if err := os.MkdirAll(repo, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	git := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", append([]string{"-C", main}, args...)...)
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
 		cmd.Env = append(os.Environ(),
 			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
 		if out, err := cmd.CombinedOutput(); err != nil {
@@ -37,7 +37,7 @@ func TestASessionStartedInAWorktreeGetsTheProjectsMemory(t *testing.T) {
 		}
 	}
 	git("init", "-q")
-	if err := os.WriteFile(filepath.Join(main, "a.txt"), []byte("x"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(repo, "a.txt"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	git("add", ".")
@@ -47,7 +47,7 @@ func TestASessionStartedInAWorktreeGetsTheProjectsMemory(t *testing.T) {
 	// The sessions were worked in the main checkout.
 	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
 	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "checkout", "one.jsonl"), "wtterm", []string{
-		`{"type":"user","sessionId":"wtterm","cwd":"` + main + `","timestamp":"` + old +
+		`{"type":"user","sessionId":"wtterm","cwd":"` + filepath.ToSlash(repo) + `","timestamp":"` + old +
 			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
 	})
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
@@ -55,13 +55,16 @@ func TestASessionStartedInAWorktreeGetsTheProjectsMemory(t *testing.T) {
 	}
 
 	for _, where := range []struct{ name, dir string }{
-		{"the main checkout", main},
+		{"the main checkout", repo},
 		{"a linked worktree", side},
 	} {
 		t.Run(where.name, func(t *testing.T) {
 			t.Setenv("CLAUDE_PROJECT_DIR", where.dir)
 			t.Chdir(where.dir)
-			withHookStdin(t, `{"source":"startup","session_id":"ses_wt","cwd":"`+where.dir+`"}`)
+			// A Windows path in a JSON string is a run of invalid escapes, and
+			// the payload would not parse at all — the same reason
+			// hook_cwd_test.go does this.
+			withHookStdin(t, `{"source":"startup","session_id":"ses_wt","cwd":"`+filepath.ToSlash(where.dir)+`"}`)
 			out := captureStdout(t, func() {
 				if err := runHookContext(index.DefaultDir(), true); err != nil {
 					t.Error(err)

--- a/cmd/deja/hook_worktree_test.go
+++ b/cmd/deja/hook_worktree_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Work done in a linked worktree is work on the same project, and the session
+// start there has to open with the same memory. `ProjectNameCandidates` knows
+// that (internal/digest), but nothing held the hook itself to it — and the hook
+// is where the project is decided: it reads CLAUDE_PROJECT_DIR, or the payload's
+// cwd, and everything downstream follows that one string.
+func TestASessionStartedInAWorktreeGetsTheProjectsMemory(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	withStatsStores(t)
+	tmp := t.TempDir()
+	main := filepath.Join(tmp, "checkout")
+	side := filepath.Join(tmp, "checkout-fix")
+	if err := os.MkdirAll(main, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", main}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	git("init", "-q")
+	if err := os.WriteFile(filepath.Join(main, "a.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", ".")
+	git("commit", "-q", "-m", "seed")
+	git("worktree", "add", "-q", side, "-b", "fix")
+
+	// The sessions were worked in the main checkout.
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "checkout", "one.jsonl"), "wtterm", []string{
+		`{"type":"user","sessionId":"wtterm","cwd":"` + main + `","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, where := range []struct{ name, dir string }{
+		{"the main checkout", main},
+		{"a linked worktree", side},
+	} {
+		t.Run(where.name, func(t *testing.T) {
+			t.Setenv("CLAUDE_PROJECT_DIR", where.dir)
+			t.Chdir(where.dir)
+			withHookStdin(t, `{"source":"startup","session_id":"ses_wt","cwd":"`+where.dir+`"}`)
+			out := captureStdout(t, func() {
+				if err := runHookContext(index.DefaultDir(), true); err != nil {
+					t.Error(err)
+				}
+			})
+			if !strings.Contains(out, "transaction mode") {
+				t.Errorf("a session started in %s opened with no memory of the project:\n%q", where.name, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
No bug — measured, then pinned.

The question was `adoptHookCWD`, which exports `CLAUDE_PROJECT_DIR` for the whole process and never puts it back. In production that costs nothing: every hook is its own process and the export dies with it. It only bites tests sharing one process, which #1953 already pinned.

The case where the precedence could actually hurt is a linked worktree — the session runs in one checkout while the project's history was recorded in another. Driven end to end on a real repo with a worktree, both open with the same memory:

```
=== session-start hook run FROM THE MAIN CHECKOUT
✓ recalled from claude session · 3 days ago
  - Session: **…/repo** `m3`

=== session-start hook run FROM THE LINKED WORKTREE (same repo)
✓ recalled from claude session · 3 days ago
  - Session: **…/repo** `m3`
```

`ProjectNameCandidates` is what makes that true and has its own test in `internal/digest`. The hook is where the project is actually decided — it reads the environment, or the payload's cwd, and everything downstream follows that one string — and nothing held it to the same rule. This is that test, both checkouts through `runHookContext` itself.

It is not free-passing: stub `gitWorktreeRoots` to return nothing and the worktree subtest fails with an empty digest, while the main checkout keeps working.
