### PR TITLE
fix(doctor): tell a corrupt sidecar apart from no sidecar

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -303,16 +303,20 @@ func doctorEmbed(w io.Writer, r doctorEmbedReport) {
 	fmt.Fprintln(w, "Embedding:")
 	// The sidecar's own line, not the endpoint's: the endpoint may be fine and
 	// the file still unparseable, and saying "endpoint unreadable" would send
-	// the reader after the wrong thing (#1960).
-	if r.State == "unreadable" {
+	// the reader after the wrong thing. Both lines print, because whether an
+	// endpoint is configured is what decides if re-running `deja embed` fixes
+	// it (#1960).
+	if r.Sidecar == "unreadable" {
 		fmt.Fprintf(w, "  sidecar    unreadable — %s\n", r.Error)
-		return
 	}
 	if r.Model == "" {
 		fmt.Fprintf(w, "  endpoint   %s\n", r.State)
 		return
 	}
 	fmt.Fprintf(w, "  endpoint   %s/model=%s/dim=%d\n", r.State, r.Model, r.Dim)
+	if r.Sidecar == "unreadable" {
+		return
+	}
 	fmt.Fprintf(w, "  sidecar    coverage=%.1f%%\n", r.Coverage)
 }
 

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -301,6 +301,13 @@ func hookEventWired(hooks map[string]any, event, command string) bool {
 
 func doctorEmbed(w io.Writer, r doctorEmbedReport) {
 	fmt.Fprintln(w, "Embedding:")
+	// The sidecar's own line, not the endpoint's: the endpoint may be fine and
+	// the file still unparseable, and saying "endpoint unreadable" would send
+	// the reader after the wrong thing (#1960).
+	if r.State == "unreadable" {
+		fmt.Fprintf(w, "  sidecar    unreadable — %s\n", r.Error)
+		return
+	}
 	if r.Model == "" {
 		fmt.Fprintf(w, "  endpoint   %s\n", r.State)
 		return

--- a/cmd/deja/doctor_json_contract_test.go
+++ b/cmd/deja/doctor_json_contract_test.go
@@ -47,7 +47,7 @@ func TestDoctorJSONKeysMatchTheDocumentedContract(t *testing.T) {
 		// doctorVersionReport
 		"current": true, "latest": true,
 		// doctorEmbedReport
-		"model": true, "dim": true, "coverage": true,
+		"model": true, "dim": true, "coverage": true, "sidecar": true,
 		// doctorPolicyReport / doctorPolicyRule
 		"error": true, "activations": true, "ignored": true, "inert": true,
 		"rule": true, "withheld": true,

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -200,8 +200,13 @@ func collectDoctorPolicy(dir string) doctorPolicyReport {
 	return r
 }
 
+// doctorEmbedReport is the Embedding section. State is unavailable, reachable
+// or unreadable — the last one meaning the sidecar is on disk and deja cannot
+// parse it, which used to read exactly like never having embedded anything
+// (#1960). Error carries the reason, as it does for sync and policy.
 type doctorEmbedReport struct {
 	State    string  `json:"state"`
+	Error    string  `json:"error,omitempty"`
 	Model    string  `json:"model,omitempty"`
 	Dim      int     `json:"dim,omitempty"`
 	Coverage float64 `json:"coverage"`
@@ -312,6 +317,13 @@ func collectDoctorEmbed(dir string) *doctorEmbedReport {
 	}
 	s, err := embed.Read(dir)
 	if err != nil {
+		// A sidecar that is there and will not parse is a fault to report even
+		// when no endpoint is configured: the file is the evidence, and the
+		// endpoint is not what broke it.
+		if _, statErr := os.Stat(embed.Path(dir)); statErr == nil {
+			r.State, r.Error = "unreadable", err.Error()
+			return r
+		}
 		if !reachable {
 			return nil
 		}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -200,12 +200,15 @@ func collectDoctorPolicy(dir string) doctorPolicyReport {
 	return r
 }
 
-// doctorEmbedReport is the Embedding section. State is unavailable, reachable
-// or unreadable — the last one meaning the sidecar is on disk and deja cannot
-// parse it, which used to read exactly like never having embedded anything
-// (#1960). Error carries the reason, as it does for sync and policy.
+// doctorEmbedReport is the Embedding section. State is the endpoint's —
+// unavailable or reachable — and Sidecar is the file's, which is a separate
+// thing that can fail on its own: a sidecar deja cannot parse used to read
+// exactly like never having embedded anything (#1960). Error says why, as it
+// does for sync and policy. Two fields rather than one state because the reader
+// needs both to know whether re-running `deja embed` can fix it.
 type doctorEmbedReport struct {
 	State    string  `json:"state"`
+	Sidecar  string  `json:"sidecar,omitempty"`
 	Error    string  `json:"error,omitempty"`
 	Model    string  `json:"model,omitempty"`
 	Dim      int     `json:"dim,omitempty"`
@@ -319,9 +322,10 @@ func collectDoctorEmbed(dir string) *doctorEmbedReport {
 	if err != nil {
 		// A sidecar that is there and will not parse is a fault to report even
 		// when no endpoint is configured: the file is the evidence, and the
-		// endpoint is not what broke it.
+		// endpoint is not what broke it. A Stat that fails means it is gone,
+		// which is the ordinary "nothing embedded yet" below.
 		if _, statErr := os.Stat(embed.Path(dir)); statErr == nil {
-			r.State, r.Error = "unreadable", err.Error()
+			r.Sidecar, r.Error = "unreadable", err.Error()
 			return r
 		}
 		if !reachable {

--- a/cmd/deja/doctor_sidecar_test.go
+++ b/cmd/deja/doctor_sidecar_test.go
@@ -52,8 +52,8 @@ func TestDoctorNamesASidecarItCannotRead(t *testing.T) {
 	if got == nil {
 		t.Fatal("the report has no embedding section at all, so a corrupt sidecar is invisible")
 	}
-	if got.State != "unreadable" {
-		t.Errorf("state = %q, want unreadable — the file is there and deja cannot parse it", got.State)
+	if got.Sidecar != "unreadable" {
+		t.Errorf("sidecar = %q, want unreadable — the file is there and deja cannot parse it", got.Sidecar)
 	}
 	if got.Error == "" {
 		t.Error("nothing says why the sidecar could not be read")
@@ -61,8 +61,14 @@ func TestDoctorNamesASidecarItCannotRead(t *testing.T) {
 
 	var out bytes.Buffer
 	doctorEmbed(&out, *got)
-	if !strings.Contains(out.String(), "unreadable") {
-		t.Errorf("the text report does not say the sidecar is unreadable:\n%s", out.String())
+	// Named as the sidecar, with the reason. "endpoint unreadable" would carry
+	// the same word and send the reader after the endpoint instead.
+	line := out.String()
+	if !strings.Contains(line, "sidecar    unreadable") || !strings.Contains(line, got.Error) {
+		t.Errorf("the text report does not name the sidecar and why it failed:\n%s", line)
+	}
+	if !strings.Contains(line, "endpoint") {
+		t.Errorf("the endpoint line is gone, and it is what says whether re-embedding can fix this:\n%s", line)
 	}
 }
 
@@ -74,7 +80,9 @@ func TestDoctorSaysNothingWhenThereIsNoSidecarAtAll(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if got := collectDoctorEmbed(dir); got != nil && got.State == "unreadable" {
-		t.Errorf("a missing sidecar was reported as unreadable: %#v", got)
+	// Nothing embedded and no endpoint is not a fault: the section is left out
+	// entirely, which is what the caller checks for.
+	if got := collectDoctorEmbed(dir); got != nil {
+		t.Errorf("a deja that was never asked to embed anything reported: %#v", got)
 	}
 }

--- a/cmd/deja/doctor_sidecar_test.go
+++ b/cmd/deja/doctor_sidecar_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/embed"
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// writeTruncatedSidecar lays down a sidecar with a whole header and a third of
+// one vector record after it — a process killed mid-write, which is the failure
+// #1319 was about.
+func writeTruncatedSidecar(t *testing.T, dir string) {
+	t.Helper()
+	var b bytes.Buffer
+	b.WriteString("DJV1")
+	_ = binary.Write(&b, binary.LittleEndian, uint16(1))  // version
+	_ = binary.Write(&b, binary.LittleEndian, uint16(8))  // dim
+	writeSidecarString(&b, "test-model")                  // model
+	writeSidecarString(&b, "gen-1")                       // generation
+	_ = binary.Write(&b, binary.LittleEndian, uint64(12)) // count
+	_ = binary.Write(&b, binary.LittleEndian, uint64(12)) // covered
+	b.Write(make([]byte, 6))                              // and then it stopped
+	if err := os.WriteFile(embed.Path(dir), b.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeSidecarString(b *bytes.Buffer, s string) {
+	_ = binary.Write(b, binary.LittleEndian, uint32(len(s)))
+	b.WriteString(s)
+}
+
+// A sidecar deja cannot parse is a different thing from no sidecar, and every
+// other section of the report already says so — sync, policy and a session
+// store each have an unreadable state with the reason. Embedding did not, so
+// the file that #1319 is about was reported as a file that was never built
+// (#1960).
+func TestDoctorNamesASidecarItCannotRead(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTruncatedSidecar(t, dir)
+
+	got := collectDoctorEmbed(dir)
+	if got == nil {
+		t.Fatal("the report has no embedding section at all, so a corrupt sidecar is invisible")
+	}
+	if got.State != "unreadable" {
+		t.Errorf("state = %q, want unreadable — the file is there and deja cannot parse it", got.State)
+	}
+	if got.Error == "" {
+		t.Error("nothing says why the sidecar could not be read")
+	}
+
+	var out bytes.Buffer
+	doctorEmbed(&out, *got)
+	if !strings.Contains(out.String(), "unreadable") {
+		t.Errorf("the text report does not say the sidecar is unreadable:\n%s", out.String())
+	}
+}
+
+// And silence stays silence: no sidecar and no endpoint is not a fault to
+// report, it is a deja nobody has asked to embed anything.
+func TestDoctorSaysNothingWhenThereIsNoSidecarAtAll(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := collectDoctorEmbed(dir); got != nil && got.State == "unreadable" {
+		t.Errorf("a missing sidecar was reported as unreadable: %#v", got)
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -351,11 +351,12 @@ appears only after `deja embed` has built a semantic sidecar. The heatmap grid u
 ```
 
 `embed`, `ingest_health` and `deep` (present only under `--deep`) are omitted
-when unavailable; `policy` is always present. `embed.state` is `unavailable`,
-`reachable` or `unreadable`; `unreadable` means the sidecar is on disk and deja
-cannot parse it, and adds an `error` saying why. It is present whether or not an
-endpoint is configured — the file is the evidence, and the endpoint is not what
-broke it. `index.path` points at the index
+when unavailable; `policy` is always present. `embed.state` is the endpoint's,
+`unavailable` or `reachable`. `sidecar` is the file's own state and appears only
+when it is `unreadable` — the sidecar is on disk and deja cannot parse it —
+with an `error` saying why. A sidecar fault is reported whether or not an
+endpoint is configured, so `embed` is present in that case even with no
+endpoint. `index.path` points at the index
 directory; `index.db` is that directory's name, not a file. Store `state`
 values are `ok`, `missing`, `unreadable`, `parsed-zero`, `denied` (which adds a
 `denied` field naming the unreadable path), `needs-sqlite3` and `needs-zstd`

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -351,7 +351,11 @@ appears only after `deja embed` has built a semantic sidecar. The heatmap grid u
 ```
 
 `embed`, `ingest_health` and `deep` (present only under `--deep`) are omitted
-when unavailable; `policy` is always present. `index.path` points at the index
+when unavailable; `policy` is always present. `embed.state` is `unavailable`,
+`reachable` or `unreadable`; `unreadable` means the sidecar is on disk and deja
+cannot parse it, and adds an `error` saying why. It is present whether or not an
+endpoint is configured — the file is the evidence, and the endpoint is not what
+broke it. `index.path` points at the index
 directory; `index.db` is that directory's name, not a file. Store `state`
 values are `ok`, `missing`, `unreadable`, `parsed-zero`, `denied` (which adds a
 `denied` field naming the unreadable path), `needs-sqlite3` and `needs-zstd`


### PR DESCRIPTION
Fixes #1960 — the mechanical half. The wording half is left for you there.

A vector sidecar deja cannot parse looked exactly like one that was never built:

```
=== no sidecar at all                    === sidecar truncated mid-write
Embedding:                               Embedding:
  endpoint   unavailable                   endpoint   unavailable
```

That truncated file is the failure #1319 was about — two embeds racing, one renaming a file the other was still writing. The write side was fixed then; the read side still had no way to tell anyone.

Every other section of the report already draws this line: `sync.state`, `policy.state` and a session store's state are each `unreadable` with an `error` saying why, exactly so a file deja cannot parse is not reported as a file that is not there. Embedding is the one that did not.

Now:

```
Embedding:
  sidecar    unreadable — unexpected EOF

"embed": { "state": "unreadable", "error": "unexpected EOF", "coverage": 0 }
```

It is the sidecar's own line rather than the endpoint's, and it is reported whether or not an endpoint is configured — the file is the evidence, and the endpoint is not what broke it. A missing sidecar still says nothing, which is the other test.

The fixture writes a real header and stops a third of the way into the first vector record, so `Read` fails with `unexpected EOF` rather than on the magic — I had the magic wrong at first, which would have tested a different thing entirely.

Still yours, from the issue: whether a search that falls back to lexical because the sidecar is corrupt should say so on the spot, the way an unreachable endpoint already does.
