### PR TITLE
fix(usage): count an injection that carried no project session

### DIFF
--- a/cmd/deja/statusline_injected_test.go
+++ b/cmd/deja/statusline_injected_test.go
@@ -29,9 +29,12 @@ func TestTheStatuslineCountsTheBlockItInjected(t *testing.T) {
 	if err := runStatusline(dir, strings.NewReader(""), &line); err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(line.String(), "0 B injected") {
-		t.Errorf("the statusline reports nothing injected on a day it injected %d bytes:\n%s",
-			len(out), line.String())
+	// Asserted positively: runStatusline returns early on a warmup, a policy
+	// rule or a quiet week, and every one of those lines would satisfy "does
+	// not say 0 B injected" while saying nothing about the block at all.
+	got := strings.TrimSpace(line.String())
+	if want := "deja · no agent recalls today · 501 B injected"; got != want {
+		t.Errorf("statusline = %q,\n                 want %q", got, want)
 	}
 }
 

--- a/cmd/deja/statusline_injected_test.go
+++ b/cmd/deja/statusline_injected_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// A machine whose project has no history of its own still gets the environment
+// block at every session start, and on such a day that block is the whole of
+// deja's work. The statusline said "0 B injected" through it — the untrue line
+// its own comment cites #1403 for — because `Empty` means no session went in,
+// not that nothing was served (#1962).
+func TestTheStatuslineCountsTheBlockItInjected(t *testing.T) {
+	dir := seedWalls(t, index.FrictionMinSessions)
+	withHookStdin(t, `{"source":"startup","session_id":"ses_env"}`)
+	out := captureStdout(t, func() {
+		if err := runHookContext(dir, true); err != nil {
+			t.Error(err)
+		}
+	})
+	if !strings.Contains(out, "separate sessions") {
+		t.Fatalf("no environment block went out, so there is nothing to count:\n%q", out)
+	}
+
+	var line strings.Builder
+	if err := runStatusline(dir, strings.NewReader(""), &line); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(line.String(), "0 B injected") {
+		t.Errorf("the statusline reports nothing injected on a day it injected %d bytes:\n%s",
+			len(out), line.String())
+	}
+}
+
+// The week that contains today has to contain today's bytes. `injected` there
+// counts hook deliveries deja pushed unprompted, which is what this was.
+func TestTheWeekCountsAnInjectionWithNoProjectSession(t *testing.T) {
+	dir := t.TempDir()
+	usage.RecordResultRaw(dir, usage.KindHook, 501, 0, true, 0)
+
+	_, _, injected, injectedBytes := usage.Week(dir)
+	if injected != 1 || injectedBytes != 501 {
+		t.Errorf("week counted %d injections and %d bytes, want 1 and 501", injected, injectedBytes)
+	}
+	_, _, today := usage.TodayDemand(dir)
+	if today != 501 {
+		t.Errorf("today counted %d injected bytes, want 501", today)
+	}
+}
+
+// And a lookup that found nothing stays out of both, which is the flag's other
+// half: an empty recall serves the sentence saying so, and counting its bytes
+// as memory re-used would be the mirror of the bug above.
+func TestARecallThatMatchedNothingStaysOutOfTheDemandCounts(t *testing.T) {
+	dir := t.TempDir()
+	usage.RecordResultRaw(dir, usage.KindRecall, 211, 0, true, 0)
+
+	if recalls, bytes, _, _ := usage.Week(dir); recalls != 0 || bytes != 0 {
+		t.Errorf("week counted an empty recall: %d recalls, %d bytes", recalls, bytes)
+	}
+	if recalls, bytes, _ := usage.TodayDemand(dir); recalls != 0 || bytes != 0 {
+		t.Errorf("today counted an empty recall: %d recalls, %d bytes", recalls, bytes)
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -272,6 +272,12 @@ the week would have started at, it starts at the time the clock reached instead.
 A day, where deja counts one, runs from local midnight. Both are the reader's own
 timezone, not UTC.
 
+`week_recalls` and `week_bytes` count what an agent asked for and got, so a
+recall that matched nothing is left out. `week_injected` counts what deja pushed
+unprompted, including a session start that carried only the environment block —
+that injection has no project session in it, which is a different thing from
+having served nothing.
+
 deja had two rules for a week until #1921, and the two numbers on the status bar
 disagreed for one week in each direction, so the definition is worth stating.
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -285,7 +285,11 @@ func TodayDemand(indexDir string) (recalls, bytes, injected int) {
 	now := time.Now()
 	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	for _, e := range read(Path(indexDir)) {
-		if e.Time.Before(midnight) || ahead(e.Time, now) || e.Empty {
+		// FoundNothing, not the raw flag: on an injection the flag means no
+		// project session went in, and the environment block goes out with it
+		// — dropping those said "0 B injected" on a day memory had been
+		// arriving since morning (#1962).
+		if e.Time.Before(midnight) || ahead(e.Time, now) || e.FoundNothing() {
 			continue
 		}
 		switch {
@@ -382,7 +386,9 @@ func Week(indexDir string) (recalls, bytes, injected, injectedBytes int) {
 	now := time.Now()
 	cut := WeekCut(now)
 	for _, e := range read(Path(indexDir)) {
-		if e.Time.Before(cut) || ahead(e.Time, now) || e.Empty {
+		// Same rule as the day: the week that contains today has to contain
+		// today's injected bytes (#1962).
+		if e.Time.Before(cut) || ahead(e.Time, now) || e.FoundNothing() {
 			continue
 		}
 		switch {


### PR DESCRIPTION
Fixes #1962.

On a machine whose project has no history of its own, the session start still injects the environment block, and on such a day that block is the whole of deja's work. The statusline said:

```
deja · no recalls yet today · 0 B injected
```

502 bytes had gone out. Its own comment, three lines above that number, says saying this "while memory has been arriving since morning is the kind of untrue line #1403 is about".

Same cause as #1954: `Event.Empty` means no session went into the event, not that nothing was served. `TodayDemand` and `Week` still skipped on the raw flag, so five readers of one event gave three answers:

```
Totals       injections=1 injectedBytes=501
TodayWith    recalls=1 bytes=501 injected=501
Week         recalls=0 bytes=0 injections=0 injectedBytes=0
TodayDemand  recalls=0 bytes=0 injected=0
Impact       injections=0 servedBytes=0
```

Both now skip on `FoundNothing()`, which #1954 added for exactly this distinction. The demand-side numbers are unchanged — a recall that matched nothing still stays out of `recalls` and `bytes`, and there is a test for that half too. `Impact` keeps its own rule: its sentence is "N session starts began with project memory", and this start did not.

`week_injected` and the day are documented as what they now count.
