### PR TITLE
test(usage): pin why the environment block stays out of the impact ratio

### DIFF
--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -430,7 +430,11 @@ one.
 `recalls` counts agent-initiated recalls that returned matches, `injections`
 session starts that began with project memory. `served_bytes` is what the
 digests actually returned and `raw_bytes` the source transcripts they were
-distilled from, so the ratio is how much reading deja saved. `reused_twice` is
+distilled from, so the ratio is how much reading deja saved. The two go
+together: a session start that carried only the environment block is in neither,
+because that block is a summary of what the machine keeps hitting rather than a
+digest of transcripts. `deja stats` counts its bytes, which is the number for
+everything deja handed over. `reused_twice` is
 sessions agents recalled two or more times, `dejavu_moments` prompts matched to
 prior work, and `credited_aloud` the recalls an agent said out loud.
 

--- a/internal/usage/impact_envblock_test.go
+++ b/internal/usage/impact_envblock_test.go
@@ -8,8 +8,7 @@ import (
 // environment block has no transcripts behind it — it is a summary of what this
 // machine keeps hitting, recorded with no raw size — so its bytes would raise
 // that numerator against an unchanged denominator and understate the saving.
-// Counting them was proposed while reviewing #1963; the numbers here are why
-// they stay out.
+// #1963 proposed counting them; these are the numbers that say otherwise.
 func TestTheImpactRatioIgnoresTheEnvironmentBlock(t *testing.T) {
 	dir := t.TempDir()
 	for i := 0; i < 3; i++ {
@@ -33,17 +32,5 @@ func TestTheImpactRatioIgnoresTheEnvironmentBlock(t *testing.T) {
 	// an empty report.
 	if after.ServedBytes != 2700 || after.RawBytes != 27000 {
 		t.Errorf("the recalls stopped counting: served=%d raw=%d", after.ServedBytes, after.RawBytes)
-	}
-}
-
-// A session start that did carry project memory counts, bytes and all — the
-// skip above is about the block, not about session starts.
-func TestASessionStartWithMemoryStillCounts(t *testing.T) {
-	dir := t.TempDir()
-	RecordResultRaw(dir, KindHook, 900, 2, false, 9000)
-
-	r := Impact(dir)
-	if r.Injections != 1 || r.ServedBytes != 900 || r.RawBytes != 9000 {
-		t.Errorf("injections=%d served=%d raw=%d, want 1, 900, 9000", r.Injections, r.ServedBytes, r.RawBytes)
 	}
 }

--- a/internal/usage/impact_envblock_test.go
+++ b/internal/usage/impact_envblock_test.go
@@ -1,0 +1,49 @@
+package usage
+
+import (
+	"testing"
+)
+
+// The impact line reads "N served instead of M of raw transcripts". The
+// environment block has no transcripts behind it — it is a summary of what this
+// machine keeps hitting, recorded with no raw size — so its bytes would raise
+// that numerator against an unchanged denominator and understate the saving.
+// Counting them was proposed while reviewing #1963; the numbers here are why
+// they stay out.
+func TestTheImpactRatioIgnoresTheEnvironmentBlock(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 3; i++ {
+		RecordResultRaw(dir, KindRecall, 900, 2, false, 9000)
+	}
+	before := Impact(dir)
+
+	for i := 0; i < 10; i++ {
+		RecordResultRaw(dir, KindHook, 501, 0, true, 0)
+	}
+	after := Impact(dir)
+
+	if after.ServedBytes != before.ServedBytes || after.RawBytes != before.RawBytes {
+		t.Errorf("ten environment blocks moved the ratio: served %d→%d, raw %d→%d",
+			before.ServedBytes, after.ServedBytes, before.RawBytes, after.RawBytes)
+	}
+	if after.Injections != 0 {
+		t.Errorf("injections = %d; no session start here began with project memory", after.Injections)
+	}
+	// And the real work is still counted, so this is not a test that passes on
+	// an empty report.
+	if after.ServedBytes != 2700 || after.RawBytes != 27000 {
+		t.Errorf("the recalls stopped counting: served=%d raw=%d", after.ServedBytes, after.RawBytes)
+	}
+}
+
+// A session start that did carry project memory counts, bytes and all — the
+// skip above is about the block, not about session starts.
+func TestASessionStartWithMemoryStillCounts(t *testing.T) {
+	dir := t.TempDir()
+	RecordResultRaw(dir, KindHook, 900, 2, false, 9000)
+
+	r := Impact(dir)
+	if r.Injections != 1 || r.ServedBytes != 900 || r.RawBytes != 9000 {
+		t.Errorf("injections=%d served=%d raw=%d, want 1, 900, 9000", r.Injections, r.ServedBytes, r.RawBytes)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -583,6 +583,14 @@ func Impact(indexDir string) ImpactReport {
 			// the environment block, and that event is logged empty. Counting
 			// it made "N session starts began with project memory" claim
 			// memory that was not there.
+			//
+			// The bytes go with the count, which is the part that looks like
+			// an oversight and is not. The block is a summary of what this
+			// machine keeps hitting, not a digest of transcripts, so it is
+			// recorded with no raw size behind it. Adding it to ServedBytes
+			// alone divides a real numerator by an unchanged denominator:
+			// measured on three recalls and ten blocks, "10× less" becomes
+			// "3.5× less", understating the saving deja made. Both stay out.
 			if e.Empty {
 				continue
 			}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -589,8 +589,8 @@ func Impact(indexDir string) ImpactReport {
 			// machine keeps hitting, not a digest of transcripts, so it is
 			// recorded with no raw size behind it. Adding it to ServedBytes
 			// alone divides a real numerator by an unchanged denominator:
-			// measured on three recalls and ten blocks, "10× less" becomes
-			// "3.5× less", understating the saving deja made. Both stay out.
+			// measured on three recalls and ten blocks, a tenfold saving reads
+			// as fourfold, understating what deja did. Both stay out.
 			if e.Empty {
 				continue
 			}


### PR DESCRIPTION
No bug — and the change that was proposed would have made a different number wrong.

Reviewing #1963 turned up that `Impact` skips `ServedBytes` and `RawBytes` along with `Injections++` for an environment-block event, while the comment justifies only the count. That reads like an oversight. It is not.

The block is a summary of what this machine keeps hitting, not a digest of transcripts, so it is recorded with no raw size behind it — `hook_context.go:251` passes `0, 0`. The impact line it would feed says "N served instead of M of raw transcripts". Adding the block's bytes moves that numerator against an unchanged denominator:

```
three recalls (900 B each, from 9 kB of transcripts) and ten blocks (501 B each):

  as it stands:       served=2700  raw=27000  ratio=10.0
  counting the block: served=7710  raw=27000  ratio=3.5
```

Ten blocks a day is an ordinary day on a project with no history of its own, and it would turn "10× less" into the short-sessions message — deja understating its own saving with bytes that never replaced a transcript.

So both fields stay out, and the comment now says why rather than leaving the next reader to work it out or "fix" it. Two tests: ten blocks move neither figure while the recalls still count, and a session start that did carry project memory counts bytes and all — the skip is about the block, not about session starts.

Mutated to the proposed alternative to check the test earns its place: it fails with exactly those numbers.
