### PR TITLE
fix(usage): close a truncated snapshot line before appending

### DIFF
--- a/internal/usage/snapshot_tail_test.go
+++ b/internal/usage/snapshot_tail_test.go
@@ -31,23 +31,36 @@ func TestASnapshotAfterAnInterruptedWriteIsStillReadable(t *testing.T) {
 	if got[0].Digest != "the second digest" {
 		t.Errorf("newest digest is %q, want the one just served", got[0].Digest)
 	}
-	// The interrupted record itself is gone, which is the cost of the kill and
-	// not of the write after it.
+	// The interrupted record survives too: what the kill cost it was the
+	// newline, not the JSON, and the write after it no longer takes it down.
 	if len(got) != 2 {
-		t.Logf("readable snapshots: %d (the interrupted line may or may not survive)", len(got))
+		t.Errorf("readable snapshots: %d, want both", len(got))
 	}
 }
 
-// The same file, rotated in the same run: rotation rewrites from what the
-// reader accepts, so a partial tail must not take the rest of the file with it.
+// The same file, rotated by the write that follows a partial tail. Rotation
+// rewrites from what the reader accepts, so it is the second place a
+// half-written line could take the rest of the file with it — and it turns out
+// to be the one place that already healed it: the rewrite terminates every
+// line, so the write after a rotation never glued anything. A guard on a path
+// that was right, not a repeat of the one above.
 func TestRotationSurvivesAPartialTail(t *testing.T) {
 	dir := t.TempDir()
 	big := make([]byte, 4096)
 	for i := range big {
 		big[i] = 'x'
 	}
-	for i := 0; i < 300; i++ {
+	// Past the rotation threshold, measured rather than assumed: 300 records of
+	// this size sat under it, and the test then rotated nothing.
+	for {
 		RecordDigestPolicy(dir, KindHook, string(big), 2, 4000, "local-only")
+		fi, err := os.Stat(SnapshotPath(dir))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Size() >= 512<<10 {
+			break
+		}
 	}
 	b, err := os.ReadFile(SnapshotPath(dir))
 	if err != nil {
@@ -56,19 +69,25 @@ func TestRotationSurvivesAPartialTail(t *testing.T) {
 	if err := os.WriteFile(SnapshotPath(dir), b[:len(b)-1], 0o600); err != nil {
 		t.Fatal(err)
 	}
+	before, err := os.Stat(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	RecordDigestPolicy(dir, KindHook, "after the rotation", 2, 4000, "local-only")
 
+	after, err := os.Stat(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Size() >= before.Size() {
+		t.Fatalf("no rotation happened: %d bytes before, %d after", before.Size(), after.Size())
+	}
 	got := Snapshots(dir, 0)
 	if len(got) == 0 {
 		t.Fatal("the rotation emptied the file")
 	}
 	if got[0].Digest != "after the rotation" {
-		t.Errorf("newest digest is %q, want the one just served", got[0].Digest)
-	}
-	for _, s := range got {
-		if !s.usable() {
-			t.Errorf("rotation kept a line the reader will not accept: %#v", s)
-		}
+		t.Errorf("newest digest is %d bytes of the wrong record", len(got[0].Digest))
 	}
 }

--- a/internal/usage/snapshot_tail_test.go
+++ b/internal/usage/snapshot_tail_test.go
@@ -1,0 +1,74 @@
+package usage
+
+import (
+	"os"
+	"testing"
+)
+
+// A process killed between a snapshot record and its newline costs that record.
+// It cost every later one too: the next digest was appended onto the partial
+// line, so one line held two objects and parsed as neither, and `deja log
+// --last` reported nothing on a machine that had just served two (#1965). The
+// usage log closed this in #1901; its sibling had not.
+func TestASnapshotAfterAnInterruptedWriteIsStillReadable(t *testing.T) {
+	dir := t.TempDir()
+	RecordDigestPolicy(dir, KindHook, "the first digest", 2, 4000, "local-only")
+
+	b, err := os.ReadFile(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(SnapshotPath(dir), b[:len(b)-1], 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	RecordDigestPolicy(dir, KindHook, "the second digest", 2, 4000, "local-only")
+
+	got := Snapshots(dir, 0)
+	if len(got) == 0 {
+		t.Fatal("one interrupted write lost every digest in the file")
+	}
+	if got[0].Digest != "the second digest" {
+		t.Errorf("newest digest is %q, want the one just served", got[0].Digest)
+	}
+	// The interrupted record itself is gone, which is the cost of the kill and
+	// not of the write after it.
+	if len(got) != 2 {
+		t.Logf("readable snapshots: %d (the interrupted line may or may not survive)", len(got))
+	}
+}
+
+// The same file, rotated in the same run: rotation rewrites from what the
+// reader accepts, so a partial tail must not take the rest of the file with it.
+func TestRotationSurvivesAPartialTail(t *testing.T) {
+	dir := t.TempDir()
+	big := make([]byte, 4096)
+	for i := range big {
+		big[i] = 'x'
+	}
+	for i := 0; i < 300; i++ {
+		RecordDigestPolicy(dir, KindHook, string(big), 2, 4000, "local-only")
+	}
+	b, err := os.ReadFile(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(SnapshotPath(dir), b[:len(b)-1], 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	RecordDigestPolicy(dir, KindHook, "after the rotation", 2, 4000, "local-only")
+
+	got := Snapshots(dir, 0)
+	if len(got) == 0 {
+		t.Fatal("the rotation emptied the file")
+	}
+	if got[0].Digest != "after the rotation" {
+		t.Errorf("newest digest is %q, want the one just served", got[0].Digest)
+	}
+	for _, s := range got {
+		if !s.usable() {
+			t.Errorf("rotation kept a line the reader will not accept: %#v", s)
+		}
+	}
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -115,7 +115,9 @@ func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policy
 		return
 	}
 	rotateSnapshots(p)
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	// O_RDWR rather than O_WRONLY: the append needs to read the last byte, for
+	// the reason the usage log opens the same way (#1901).
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
 	if err != nil {
 		return
 	}
@@ -124,6 +126,13 @@ func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policy
 		Bytes: len(digest), Policy: policyName, Terms: terms, Into: into, Digest: digest})
 	if err != nil {
 		return
+	}
+	// A process killed between a record and its newline costs that record. It
+	// cost every later one too: appended onto the partial line, the new digest
+	// parsed as nothing either, and `deja log --last` reported no injection at
+	// all on a machine that had just served two (#1965).
+	if endsMidLine(f) {
+		b = append([]byte{'\n'}, b...)
 	}
 	_, _ = f.Write(append(b, '\n'))
 }


### PR DESCRIPTION
Fixes #1965.

A process killed between a snapshot record and its newline leaves half a line. The next injection appended straight onto it, so one line held two objects and parsed as neither — and the reader drops what it cannot parse, so both digests went:

```
one injection recorded, killed before the newline, then the next injection:

  after the kill:            1 snapshot readable
  after the next injection:  0 readable
```

`deja log --last` then reports no injected digests on a machine that has just served two.

This is #1901 in the sibling file. The usage log closes a truncated line before appending — one byte of reading — and its own comment says why: "It cost the next one too… a recall deja had just served went missing from every count." The snapshot log is the file deja reads the injected *text* back out of, where losing a record is not an approximation but the difference between the digest and nothing, and it never got the same byte.

Same fix, same shape: `O_RDWR` so the descriptor can be read, `endsMidLine` before the write.

Two tests. The second is the rotation half of the queue item that found this: a partial tail plus a rotation in the same run, since rotation rewrites from what the reader accepts. Both fail on base — the second returns a digest from before the rotation as the newest.
