### PR TITLE
fix(hooks): close a truncated dedup line before appending

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -565,11 +565,18 @@ func rememberInjected(dir, sid string, ss []model.Session) {
 	if fi, err := os.Stat(p); err == nil && fi.Size() > 1<<20 {
 		rotateHookseen(p, sid)
 	}
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	// O_RDWR so the append can read the last byte first: a hook killed before
+	// its newline leaves half a line, and writing onto it costs the record
+	// written after — a session deja then does not know it has shown, which is
+	// this file's whole job (#1967).
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
 	if err != nil {
 		return
 	}
 	defer f.Close()
+	if atomicfile.EndsMidLine(f) {
+		_, _ = f.WriteString("\n")
+	}
 	stamp := time.Now().UTC().Format(time.RFC3339)
 	for _, s := range ss {
 		fmt.Fprintf(f, "%s %s %s\n", sid, s.ID, stamp)
@@ -610,13 +617,16 @@ func rememberInjectedIDs(dir, sid string, ids ...string) {
 	if sid == "" {
 		return
 	}
-	f, err := os.OpenFile(dir+".hookseen", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	f, err := os.OpenFile(dir+".hookseen", os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
 	if err != nil {
 		return
 	}
 	defer f.Close()
 	if fi, err := f.Stat(); err == nil && fi.Size() > 1<<20 {
 		return
+	}
+	if atomicfile.EndsMidLine(f) {
+		_, _ = f.WriteString("\n")
 	}
 	for _, id := range ids {
 		fmt.Fprintf(f, "%s %s\n", sid, id)

--- a/cmd/deja/hookseen_tail_test.go
+++ b/cmd/deja/hookseen_tail_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A hook killed between a dedup line and its newline leaves half a line, and
+// the next hook wrote onto it. The reader takes the first two fields of each
+// line, so the glued line keeps the interrupted record and drops the one
+// appended after it — leaving a session deja does not know it has already
+// shown, which is the whole job of this file (#1967).
+func TestTheDedupFileKeepsWhatWasWrittenAfterAKill(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "idx")
+	rememberInjected(dir, "ses1", []model.Session{{ID: "sessA"}})
+
+	b, err := os.ReadFile(dir + ".hookseen")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir+".hookseen", b[:len(b)-1], 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rememberInjected(dir, "ses2", []model.Session{{ID: "sessB"}})
+
+	if seen := alreadyInjected(dir, "ses2"); !seen["sessB"] {
+		raw, _ := os.ReadFile(dir + ".hookseen")
+		t.Errorf("the session shown to ses2 is not recorded, so it will be shown again:\n%s", raw)
+	}
+	// And the interrupted record still counts for the session it belonged to.
+	if seen := alreadyInjected(dir, "ses1"); !seen["sessA"] {
+		t.Error("the record the kill interrupted was lost as well")
+	}
+}
+
+// The other writer of the same file: block fingerprints rather than sessions.
+func TestTheDedupFileKeepsAFingerprintWrittenAfterAKill(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "idx")
+	rememberInjectedIDs(dir, "ses1", "fingerprint-a")
+
+	b, err := os.ReadFile(dir + ".hookseen")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir+".hookseen", b[:len(b)-1], 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rememberInjectedIDs(dir, "ses2", "fingerprint-b")
+
+	if seen := alreadyInjected(dir, "ses2"); !seen["fingerprint-b"] {
+		raw, _ := os.ReadFile(dir + ".hookseen")
+		t.Errorf("the block shown to ses2 is not recorded, so the same words go out again:\n%s", raw)
+	}
+}

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -12,6 +12,11 @@
 //
 // The index's own writers are excluded from this by `lockDir`, which is why
 // they can keep their fixed temp names.
+//
+// The same writers append rather than replace when the file is a log, and they
+// share the other half of the problem: a record left unterminated by a killed
+// process. EndsMidLine is here for them — it writes nothing, but the callers
+// are the same set and the reason is the same one.
 package atomicfile
 
 import (

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -130,3 +130,24 @@ func Write(path string, b []byte, perm os.FileMode) error {
 	}
 	return nil
 }
+
+// EndsMidLine reports whether a line-oriented file's last byte is anything but
+// a newline — a record whose writer was killed before it finished. A caller
+// appending to such a file writes onto that line unless it closes it first, and
+// the glued line then parses as neither record: measured on the usage log
+// (#1901), the injection snapshots (#1965) and the hook dedup file (#1967).
+//
+// The file must be open for reading; O_WRONLY silently reports a clean end. A
+// file that cannot be read is treated as ending cleanly, because none of these
+// writers may fail a recall over their own bookkeeping.
+func EndsMidLine(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil || fi.Size() == 0 {
+		return false
+	}
+	var last [1]byte
+	if _, err := f.ReadAt(last[:], fi.Size()-1); err != nil {
+		return false
+	}
+	return last[0] != '\n'
+}

--- a/internal/atomicfile/endsmidline_test.go
+++ b/internal/atomicfile/endsmidline_test.go
@@ -1,0 +1,62 @@
+package atomicfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The question every append-only writer here asks before it writes: did the
+// last one finish? Three of them got it wrong in turn — the usage log (#1901),
+// the injection snapshots (#1965) and the hook dedup file (#1967) — so it lives
+// in one place now.
+func TestEndsMidLine(t *testing.T) {
+	dir := t.TempDir()
+	for _, c := range []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"a file that does not exist yet", "", false},
+		{"a whole line", "one\n", false},
+		{"a line cut before its newline", "one", true},
+		{"whole lines then half of one", "one\ntwo\nthr", true},
+		{"a trailing blank line", "one\n\n", false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			p := filepath.Join(dir, c.name)
+			if c.body != "" {
+				if err := os.WriteFile(p, []byte(c.body), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = f.Close() }()
+			if got := EndsMidLine(f); got != c.want {
+				t.Errorf("EndsMidLine(%q) = %v, want %v", c.body, got, c.want)
+			}
+		})
+	}
+}
+
+// A descriptor opened write-only cannot answer the question, and says the file
+// ends cleanly rather than failing — the callers are bookkeeping, and none of
+// them may break a recall. Worth pinning because it is the trap: the fix for
+// all three files was as much the open mode as the check.
+func TestEndsMidLineOnAWriteOnlyDescriptorSaysClean(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "half")
+	if err := os.WriteFile(p, []byte("cut"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(p, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	if EndsMidLine(f) {
+		t.Error("a write-only descriptor reported a truncated tail it cannot read")
+	}
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -131,7 +131,7 @@ func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policy
 	// cost every later one too: appended onto the partial line, the new digest
 	// parsed as nothing either, and `deja log --last` reported no injection at
 	// all on a machine that had just served two (#1965).
-	if endsMidLine(f) {
+	if atomicfile.EndsMidLine(f) {
 		b = append([]byte{'\n'}, b...)
 	}
 	_, _ = f.Write(append(b, '\n'))

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -224,25 +224,10 @@ func recordFull(indexDir, kind string, bytes, sessions int, empty bool, raw int6
 	// one too: appended onto the partial line, so that line no longer parsed
 	// either and a recall deja had just served went missing from every count
 	// (#1901). One byte of reading closes the line first.
-	if endsMidLine(f) {
+	if atomicfile.EndsMidLine(f) {
 		b = append([]byte{'\n'}, b...)
 	}
 	_, _ = f.Write(append(b, '\n'))
-}
-
-// endsMidLine reports whether the log's last byte is anything but a newline.
-// A file that cannot be read is treated as ending cleanly: a usage event must
-// never be the reason a recall fails.
-func endsMidLine(f *os.File) bool {
-	fi, err := f.Stat()
-	if err != nil || fi.Size() == 0 {
-		return false
-	}
-	var last [1]byte
-	if _, err := f.ReadAt(last[:], fi.Size()-1); err != nil {
-		return false
-	}
-	return last[0] != '\n'
 }
 
 // InjectedToday returns session-start context bytes injected since local midnight.


### PR DESCRIPTION
Fixes #1967, and puts the check that fixes it in one place.

A hook killed between a dedup line and its newline leaves half a line, and the next hook wrote straight onto it:

```
ses1 sessA 2026-08-25T23:54:45Zses2 sessB 2026-08-25T23:54:45Z
ses3 fingerprint-c

alreadyInjected(ses1) = map[sessA:true]
alreadyInjected(ses2) = map[]              <- lost
alreadyInjected(ses3) = map[fingerprint-c:true]
```

`alreadyInjected` takes the first two fields of each line, so the glued line keeps the interrupted record and drops the one appended after it. `ses2` is then a session deja does not know it has already shown, and the per-prompt hook shows it again — the state `rememberInjected`'s own comment describes: "permanently broke dedup — the per-prompt hook then re-injected the same sessions turn after turn".

One record lost rather than the whole file, because `strings.Fields` tolerates the glue. That is the difference from #1965, not an absence of the same defect.

This is the third file with it — the usage log (#1901), the injection snapshots (#1965), this one — so the check is now `atomicfile.EndsMidLine`, in the package whose comment already opens with "for the writers that are not behind a lock", and the two earlier callers use it instead of their own copy. Its own tests pin the trap the fix keeps hitting: a write-only descriptor cannot read the last byte and reports a clean end, so the open mode is half the fix.

Both writers of `.hookseen` are covered, sessions and block fingerprints, and both tests fail on base.
