### PR TITLE
fix(usage): keep the injection log under its rotation threshold

### DIFF
--- a/internal/usage/snapshot_race_test.go
+++ b/internal/usage/snapshot_race_test.go
@@ -16,14 +16,27 @@ import (
 // them into a line that parses as neither — the shape #1319 was about, and the
 // one the reader's own filtering would hide rather than report.
 //
-// They cannot: one write to a regular file is not split. Pinned across three
-// sizes because the answer is about the size, and 64 kB is past any buffer this
-// code has.
+// They cannot here: one write of a whole record reaches the file whole, on the
+// systems this runs on. Not a guarantee — os.File.Write loops on short writes,
+// and a network filesystem promises nothing about an append — which is why this
+// is measured rather than assumed.
+//
+// Sizes stay under the rotation threshold on purpose: past it, a rotation
+// rewrites the file from the lines the reader accepts and would delete the torn
+// line before the assertion ever saw it (#1971).
 func TestConcurrentWritersNeverInterleaveASnapshot(t *testing.T) {
 	for _, size := range []int{200, 4096, 64 << 10} {
 		t.Run(fmt.Sprintf("%d bytes", size), func(t *testing.T) {
 			dir := t.TempDir()
-			const writers, each = 16, 8
+			// writers × each × size stays well under snapshotRotateAt, so no
+			// rotation can delete the evidence.
+			writers, each := 16, 8
+			switch {
+			case size > 4096:
+				writers, each = 4, 2
+			case size > 200:
+				writers, each = 8, 4
+			}
 			var wg sync.WaitGroup
 			for w := 0; w < writers; w++ {
 				wg.Add(1)
@@ -60,9 +73,49 @@ func TestConcurrentWritersNeverInterleaveASnapshot(t *testing.T) {
 			if err := sc.Err(); err != nil {
 				t.Fatal(err)
 			}
-			if lines == 0 {
-				t.Fatal("nothing was written")
+			if lines != writers*each {
+				t.Fatalf("file holds %d lines, wrote %d — a rotation would hide a torn line by deleting it", lines, writers*each)
 			}
 		})
+	}
+}
+
+// Above the cliff every write rotates, and every record appended while a
+// rotation rebuilds is rewritten away. Twenty records of 26 kB or more exceed
+// the 512 kB threshold, so the file never drops back under it — and a whole
+// session read through `deja://session/…` is recorded here unbudgeted, which is
+// how a real store gets there (#1971).
+func TestARotationLeavesTheFileUnderItsOwnThreshold(t *testing.T) {
+	dir := t.TempDir()
+	big := strings.Repeat("y", 40<<10)
+	for i := 0; i < snapshotsToKeep+4; i++ {
+		RecordDigestPolicy(dir, KindHook, big, 1, 0, "local-only")
+	}
+	fi, err := os.Stat(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size() >= snapshotRotateAt {
+		t.Errorf("the log is %d bytes after a rotation, over its own %d threshold: every write from here rotates",
+			fi.Size(), snapshotRotateAt)
+	}
+}
+
+// And the newest digest survives the rotation that shrinks the file, which is
+// the record `deja log --last` exists to show.
+func TestTheNewestDigestSurvivesARotationOfBigRecords(t *testing.T) {
+	dir := t.TempDir()
+	big := strings.Repeat("y", 40<<10)
+	for i := 0; i < snapshotsToKeep+4; i++ {
+		RecordDigestPolicy(dir, KindHook, big, 1, 0, "local-only")
+	}
+	RecordDigestPolicy(dir, KindHook, "the one just served", 1, 0, "local-only")
+
+	got := Snapshots(dir, 0)
+	if len(got) == 0 {
+		t.Fatal("the log is empty")
+	}
+	if got[0].Digest != "the one just served" {
+		t.Errorf("newest digest is %d bytes of the wrong record", len(got[0].Digest))
 	}
 }

--- a/internal/usage/snapshot_race_test.go
+++ b/internal/usage/snapshot_race_test.go
@@ -1,0 +1,68 @@
+package usage
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// A digest is kilobytes, not the ~100 bytes a usage event is, and the injection
+// log takes the whole record in one Write on an append descriptor with no lock.
+// The question is whether two agents starting together can interleave two of
+// them into a line that parses as neither — the shape #1319 was about, and the
+// one the reader's own filtering would hide rather than report.
+//
+// They cannot: one write to a regular file is not split. Pinned across three
+// sizes because the answer is about the size, and 64 kB is past any buffer this
+// code has.
+func TestConcurrentWritersNeverInterleaveASnapshot(t *testing.T) {
+	for _, size := range []int{200, 4096, 64 << 10} {
+		t.Run(fmt.Sprintf("%d bytes", size), func(t *testing.T) {
+			dir := t.TempDir()
+			const writers, each = 16, 8
+			var wg sync.WaitGroup
+			for w := 0; w < writers; w++ {
+				wg.Add(1)
+				go func(w int) {
+					defer wg.Done()
+					body := strings.Repeat(string(rune('a'+w)), size)
+					for i := 0; i < each; i++ {
+						RecordDigestPolicy(dir, KindHook, body, 1, 0, "local-only")
+					}
+				}(w)
+			}
+			wg.Wait()
+
+			f, err := os.Open(SnapshotPath(dir))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = f.Close() }()
+			sc := bufio.NewScanner(f)
+			sc.Buffer(make([]byte, 0, 64<<10), 8<<20)
+			lines := 0
+			for sc.Scan() {
+				lines++
+				var s Snapshot
+				if err := json.Unmarshal(sc.Bytes(), &s); err != nil {
+					t.Fatalf("line %d holds no whole record: %v", lines, err)
+				}
+				// One writer's letter, repeated, and nothing else: a record
+				// carrying part of another's would still parse.
+				if len(s.Digest) != size || strings.Count(s.Digest, s.Digest[:1]) != size {
+					t.Fatalf("line %d holds %d bytes of mixed digest", lines, len(s.Digest))
+				}
+			}
+			if err := sc.Err(); err != nil {
+				t.Fatal(err)
+			}
+			if lines == 0 {
+				t.Fatal("nothing was written")
+			}
+		})
+	}
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -114,7 +114,13 @@ func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policy
 	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
 		return
 	}
-	rotateSnapshots(p)
+	b, err := json.Marshal(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions,
+		Bytes: len(digest), Policy: policyName, Terms: terms, Into: into, Digest: digest})
+	if err != nil {
+		return
+	}
+	// The record's own size decides how much room the rotation has to leave.
+	rotateSnapshots(p, len(b)+1)
 	// O_RDWR rather than O_WRONLY: the append needs to read the last byte, for
 	// the reason the usage log opens the same way (#1901).
 	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
@@ -122,11 +128,6 @@ func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policy
 		return
 	}
 	defer func() { _ = f.Close() }()
-	b, err := json.Marshal(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions,
-		Bytes: len(digest), Policy: policyName, Terms: terms, Into: into, Digest: digest})
-	if err != nil {
-		return
-	}
 	// A process killed between a record and its newline costs that record. It
 	// cost every later one too: appended onto the partial line, the new digest
 	// parsed as nothing either, and `deja log --last` reported no injection at
@@ -137,7 +138,7 @@ func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policy
 	_, _ = f.Write(append(b, '\n'))
 }
 
-func rotateSnapshots(p string) {
+func rotateSnapshots(p string, incoming int) {
 	fi, err := os.Stat(p)
 	if err != nil || fi.Size() < snapshotRotateAt {
 		return
@@ -147,11 +148,27 @@ func rotateSnapshots(p string) {
 	// discovering: the file shrinks by more than the rotation alone would
 	// explain (#1946).
 	snaps := snapshotsFrom(p, snapshotsToKeep) // newest first
+	// Keeping a fixed count says nothing about the size that triggered this. A
+	// read of `deja://session/…` records a whole session here, unbudgeted, and
+	// twenty of those sit above the threshold for good: the file then rotates on
+	// every write, and every record appended while a rotation rebuilds is
+	// rewritten away — measured at half of two concurrent injections (#1971).
+	// Dropping the oldest until the rebuild fits leaves the next write with
+	// nothing to do.
 	var buf bytes.Buffer
-	for i := len(snaps) - 1; i >= 0; i-- {
-		if b, err := json.Marshal(snaps[i]); err == nil {
-			buf.Write(append(b, '\n'))
+	for {
+		buf.Reset()
+		for i := len(snaps) - 1; i >= 0; i-- {
+			if b, err := json.Marshal(snaps[i]); err == nil {
+				buf.Write(append(b, '\n'))
+			}
 		}
+		// One record over the threshold is kept anyway: a log holding the last
+		// digest and nothing else is still a log, and holding none is not.
+		if buf.Len()+incoming < snapshotRotateAt || len(snaps) <= 1 {
+			break
+		}
+		snaps = snaps[:len(snaps)-1] // drop the oldest
 	}
 	// Same shared-temp-name defect as the usage log above (#1319).
 	_ = atomicfile.Write(p, buf.Bytes(), 0o600)


### PR DESCRIPTION
No bug, one guard, and a correction to my own issue.

The question was whether two agents starting together can interleave two multi-kilobyte snapshot records into a line that parses as neither. They cannot: sixteen writers at 200 B, 4 kB and 64 kB, repeated and under `-race`, produce no torn line. Worth a test because the reader silently drops anything that would have proved otherwise — a tear would show up as digests quietly missing, not as an error.

While measuring it I reported #1969, claiming every concurrent writer loses its newest record. That was my probe, not deja: I built the survivor set keyed on nine characters of each digest and looked it up with a seven-character key, so every lookup missed. Corrected, the loss is one writer's record in one run out of twelve — the trade `usage.go:191` already documents and bounds at one event.

I also wrote two fixes against the wrong model — carrying the tail across a rotation, and re-appending when the file was replaced under the descriptor — and measured them at one in twelve, unchanged. Neither is here. The issue carries the correction and is closed.
