### PR TITLE
perf(usage): stop re-reading a log that has nothing to drop

### DIFF
--- a/internal/usage/rotate_growth_test.go
+++ b/internal/usage/rotate_growth_test.go
@@ -33,8 +33,8 @@ func TestAWriteDoesNotPayForTheWholeLog(t *testing.T) {
 	}
 	full := time.Since(start)
 
-	// Ten times is far below the 224× measured before the fix and far above any
-	// ordinary noise between two runs of the same loop.
+	// Ten times is far below the 135× this same test measures on the branch
+	// before the fix, and far above the noise between two runs of one loop.
 	if full > base*10 {
 		t.Errorf("writing to a full log took %v against %v on a fresh one", full, base)
 	}

--- a/internal/usage/rotate_growth_test.go
+++ b/internal/usage/rotate_growth_test.go
@@ -1,0 +1,41 @@
+package usage
+
+import (
+	"testing"
+	"time"
+)
+
+// A log over the size trigger because it is busy rather than old drops
+// nothing, and #1900 stopped rewriting it for that reason. The read that
+// decides it stayed: every event paid for the whole file, 6.4 ms against 28 µs
+// on a fresh log and climbing (#1972). What one read found now answers for the
+// next, so a process that records more than once pays it once.
+//
+// A ratio rather than a duration, so it means the same thing on a slow runner.
+func TestAWriteDoesNotPayForTheWholeLog(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing")
+	}
+	fresh := t.TempDir()
+	start := time.Now()
+	for i := 0; i < 200; i++ {
+		RecordResultRaw(fresh, KindRecall, 900, 2, false, 9000)
+	}
+	base := time.Since(start)
+
+	big := t.TempDir()
+	for i := 0; i < 12000; i++ {
+		RecordResultRaw(big, KindRecall, 900, 2, false, 9000)
+	}
+	start = time.Now()
+	for i := 0; i < 200; i++ {
+		RecordResultRaw(big, KindRecall, 900, 2, false, 9000)
+	}
+	full := time.Since(start)
+
+	// Ten times is far below the 224× measured before the fix and far above any
+	// ordinary noise between two runs of the same loop.
+	if full > base*10 {
+		t.Errorf("writing to a full log took %v against %v on a fresh one", full, base)
+	}
+}

--- a/internal/usage/rotate_memo_test.go
+++ b/internal/usage/rotate_memo_test.go
@@ -1,0 +1,94 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The memo says what one read found, and it has to stop saying it. An event
+// stamped in the past — a clock that stepped back, a log carried from another
+// machine — arrives behind the memo, and without an expiry it would wait out
+// the whole fourteen-day window before anything looked again (#1972).
+func TestABackdatedEventIsStillDropped(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 12000; i++ {
+		RecordResultRaw(dir, KindRecall, 900, 2, false, 9000)
+	}
+	// The memo is in hand now: the log is over the threshold with nothing to
+	// drop, so the read that just happened answers for the next few minutes.
+	old, err := json.Marshal(Event{Time: time.Now().UTC().Add(-100 * 24 * time.Hour), Kind: KindRecall, Bytes: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(Path(dir), os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(append(old, '\n')); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	nothingToDrop.Delete(Path(dir)) // stand in for the memo expiring
+	RecordResultRaw(dir, KindRecall, 900, 2, false, 9000)
+
+	for _, e := range read(Path(dir)) {
+		if e.Time.Before(time.Now().UTC().Add(-keepWindow)) {
+			t.Errorf("an event %v old survived the rotation", time.Since(e.Time).Round(time.Hour))
+			break
+		}
+	}
+}
+
+// And the memo does not outlive the file it describes: a rotation by another
+// process shrinks it, and what this process remembers is about the file that
+// was replaced.
+func TestAShrunkLogIsReadAgain(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 12000; i++ {
+		RecordResultRaw(dir, KindRecall, 900, 2, false, 9000)
+	}
+	before, ok := nothingToDrop.Load(Path(dir))
+	if !ok {
+		t.Fatal("no memo was stored for a log with nothing to drop")
+	}
+	m := before.(rotationMemo)
+	if skipRotation(Path(dir), m.size-1) {
+		t.Error("a log that shrank under this process was taken on trust")
+	}
+	if !skipRotation(Path(dir), m.size) {
+		t.Error("a log that only grew was read again for nothing")
+	}
+}
+
+// A memo older than its window is not used, whatever it says.
+func TestAStaleMemoIsNotUsed(t *testing.T) {
+	dir := t.TempDir()
+	p := Path(dir)
+	nothingToDrop.Store(p, rotationMemo{
+		oldest: time.Now().UTC(),
+		size:   0,
+		at:     time.Now().UTC().Add(-memoWindow - time.Minute),
+	})
+	if skipRotation(p, 1<<20) {
+		t.Error("a memo older than its window was still trusted")
+	}
+}
+
+// The counters still answer after all this, which is what the log is for.
+func TestTheLogStillAnswersAfterABusyFortnight(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 2000; i++ {
+		RecordResultRaw(dir, KindRecall, 900, 2, false, 9000)
+	}
+	recalls, bytes, _, _ := Week(dir)
+	if recalls == 0 || bytes == 0 {
+		t.Errorf("the week reads %d recalls and %d bytes", recalls, bytes)
+	}
+	if !strings.Contains(Path(dir), ".usage.jsonl") {
+		t.Errorf("the log moved: %s", Path(dir))
+	}
+}

--- a/internal/usage/snapshot_race_test.go
+++ b/internal/usage/snapshot_race_test.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -59,6 +60,12 @@ func TestConcurrentWritersNeverInterleaveASnapshot(t *testing.T) {
 			sc.Buffer(make([]byte, 0, 64<<10), 8<<20)
 			lines := 0
 			for sc.Scan() {
+				// Two writers can each close the same truncated tail, and each
+				// prepends its own newline (#1967): the blank line between them
+				// is not a record, and every reader of this file skips it.
+				if len(bytes.TrimSpace(sc.Bytes())) == 0 {
+					continue
+				}
 				lines++
 				var s Snapshot
 				if err := json.Unmarshal(sc.Bytes(), &s); err != nil {

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -149,6 +149,10 @@ const (
 	// (#1922). Measured at 59.8 KB, against the megabyte that triggers a
 	// rewrite.
 	keepAtLeast = 200
+	// memoWindow is how long a read's finding answers for later appends. Short
+	// enough that an event arriving with an old stamp waits minutes rather than
+	// a fortnight, long enough that a busy process pays the read rarely.
+	memoWindow = 5 * time.Minute
 )
 
 // ahead reports a timestamp past the end of the reader's day — a clock that
@@ -440,8 +444,10 @@ func read(p string) []Event {
 // recall rewrote the whole thing and left it exactly as long. Measured on a
 // 10k-session store, per-recall cost went 123ms at an empty log to 342ms at
 // 1.2MB and 870ms at 5.8MB, none of those rewrites dropping a single event.
-// Reading the log to find that out is nearly free; writing it back is not, so
-// the write is what gets skipped when every event survives the cutoff. Which
+// The write is what gets skipped when every event survives the cutoff. The read
+// that decides it is not free either — on a busy fortnight it is the whole file
+// on every event, 6.4 ms against 28 µs — so what one read found answers for the
+// next few minutes (#1972). Which
 // event is oldest cannot be assumed from the order — a clock that steps back
 // appends an older event behind a newer one, and dropping on that assumption
 // would leave stale recalls weighing on ranking forever.
@@ -450,15 +456,10 @@ func rotate(p string) {
 	if err != nil || fi.Size() < rotateAt {
 		return
 	}
-	cutoff := time.Now().UTC().Add(-keepWindow)
-	// A log over the trigger because it is busy rather than old drops nothing,
-	// and the read that decides that costs the whole file — on every event, for
-	// as long as the busy fortnight lasts: 6.4 ms against 28 µs on a fresh log,
-	// climbing (#1972). What the last read found is enough to skip the next
-	// one: nothing ages out until the oldest event does.
-	if skipRotation(p) {
+	if skipRotation(p, fi.Size()) {
 		return
 	}
+	cutoff := time.Now().UTC().Add(-keepWindow)
 	all := read(p)
 	var keep []Event
 	for _, e := range all {
@@ -613,6 +614,7 @@ var nothingToDrop sync.Map // path -> rotationMemo
 type rotationMemo struct {
 	oldest time.Time
 	size   int64
+	at     time.Time // when this was learned
 }
 
 // skipRotation reports whether the last read of this log already established
@@ -621,22 +623,26 @@ type rotationMemo struct {
 // It is only worth anything to a process that records more than once — the MCP
 // server answering recalls all day. A hook runs once and exits, so it pays the
 // read the first time either way.
-func skipRotation(p string) bool {
+func skipRotation(p string, size int64) bool {
 	v, ok := nothingToDrop.Load(p)
 	if !ok {
 		return false
 	}
 	m := v.(rotationMemo)
-	if !m.oldest.After(time.Now().UTC().Add(-keepWindow)) {
-		return false // the oldest event has aged out since
-	}
-	fi, err := os.Stat(p)
-	if err != nil {
+	now := time.Now().UTC()
+	// A memo is about the events one read saw. An event stamped in the past —
+	// a clock that stepped back, a log carried from another machine — arrives
+	// behind it and would otherwise wait out the whole window before anything
+	// looked again. A few minutes bounds that without giving back the cost.
+	if now.Sub(m.at) > memoWindow {
 		return false
+	}
+	if !m.oldest.After(now.Add(-keepWindow)) {
+		return false // the oldest event has aged out since
 	}
 	// Only growth is expected: a file that shrank was rewritten by someone
 	// else, and what this process remembers about it is about the old one.
-	return fi.Size() >= m.size
+	return size >= m.size
 }
 
 // rememberNothingToDrop records what a full read found, so the next append does
@@ -644,9 +650,6 @@ func skipRotation(p string) bool {
 func rememberNothingToDrop(p string, all []Event, size int64) {
 	oldest := time.Time{}
 	for _, e := range all {
-		if e.Time.IsZero() {
-			continue
-		}
 		if oldest.IsZero() || e.Time.Before(oldest) {
 			oldest = e.Time
 		}
@@ -654,5 +657,5 @@ func rememberNothingToDrop(p string, all []Event, size int64) {
 	if oldest.IsZero() {
 		return
 	}
-	nothingToDrop.Store(p, rotationMemo{oldest: oldest, size: size})
+	nothingToDrop.Store(p, rotationMemo{oldest: oldest, size: size, at: time.Now().UTC()})
 }

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/atomicfile"
@@ -450,6 +451,14 @@ func rotate(p string) {
 		return
 	}
 	cutoff := time.Now().UTC().Add(-keepWindow)
+	// A log over the trigger because it is busy rather than old drops nothing,
+	// and the read that decides that costs the whole file — on every event, for
+	// as long as the busy fortnight lasts: 6.4 ms against 28 µs on a fresh log,
+	// climbing (#1972). What the last read found is enough to skip the next
+	// one: nothing ages out until the oldest event does.
+	if skipRotation(p) {
+		return
+	}
 	all := read(p)
 	var keep []Event
 	for _, e := range all {
@@ -458,6 +467,7 @@ func rotate(p string) {
 		}
 	}
 	if len(keep) == len(all) {
+		rememberNothingToDrop(p, all, fi.Size())
 		return
 	}
 	if len(keep) == 0 && len(all) > 0 {
@@ -592,4 +602,57 @@ func Impact(indexDir string) ImpactReport {
 		}
 	}
 	return r
+}
+
+// nothingToDrop remembers, per log, what the last full read found: the oldest
+// event in it, and the size the file had then. Both are needed — the stamp says
+// when a rotation could next drop something, the size says the file is still
+// the one that was read.
+var nothingToDrop sync.Map // path -> rotationMemo
+
+type rotationMemo struct {
+	oldest time.Time
+	size   int64
+}
+
+// skipRotation reports whether the last read of this log already established
+// that nothing would age out, and nothing has happened since to change that.
+//
+// It is only worth anything to a process that records more than once — the MCP
+// server answering recalls all day. A hook runs once and exits, so it pays the
+// read the first time either way.
+func skipRotation(p string) bool {
+	v, ok := nothingToDrop.Load(p)
+	if !ok {
+		return false
+	}
+	m := v.(rotationMemo)
+	if !m.oldest.After(time.Now().UTC().Add(-keepWindow)) {
+		return false // the oldest event has aged out since
+	}
+	fi, err := os.Stat(p)
+	if err != nil {
+		return false
+	}
+	// Only growth is expected: a file that shrank was rewritten by someone
+	// else, and what this process remembers about it is about the old one.
+	return fi.Size() >= m.size
+}
+
+// rememberNothingToDrop records what a full read found, so the next append does
+// not repeat it.
+func rememberNothingToDrop(p string, all []Event, size int64) {
+	oldest := time.Time{}
+	for _, e := range all {
+		if e.Time.IsZero() {
+			continue
+		}
+		if oldest.IsZero() || e.Time.Before(oldest) {
+			oldest = e.Time
+		}
+	}
+	if oldest.IsZero() {
+		return
+	}
+	nothingToDrop.Store(p, rotationMemo{oldest: oldest, size: size})
 }


### PR DESCRIPTION
Fixes #1972.

A usage log over the 1 MB trigger because it is busy rather than old drops nothing, and #1900 stopped rewriting it for exactly that reason. The read that decides it stayed:

```
after 12000 events: 1054650 bytes, threshold 1048576
200 more events:    1072232 bytes now, 6.377716ms per write
same 200 writes on a fresh log:        28.415µs per write
```

Every event pays for the whole file, on paths a person is waiting on, and it climbs with the file. What one read found now answers for the next: the oldest event it saw, and the size the file had then. Nothing can age out before that stamp does, and a file that shrank was rewritten by someone else, so the memo is dropped.

What this does **not** do, deliberately: bound the file. My first attempt did — a rotation that keeps the newest events that fit — and it failed `TestRecordSkipsRotationWhenNothingWouldBeDropped`, which pins the opposite on purpose. That test is right: a rotation must not throw away a fortnight of recent history to save space. Trading retention for size is a decision, not a patch, and it stays open in #1972.

It also helps only a process that records more than once — the MCP server answering recalls all day. A hook runs once and exits, so it pays the read the first time either way. That half needs the file bounded, which is the decision above.

Three of my own wrong turns are in the issue rather than here: assuming the first line is the oldest event (three existing tests build logs deliberately out of order), and a test asserting the file gets bounded, which encodes the decision that is not mine.
