### PR TITLE
test(usage): pin the record size this log can hold

### DIFF
--- a/cmd/deja/answer_budget_room_test.go
+++ b/cmd/deja/answer_budget_room_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// Every answer deja snapshots lands in one injection log, and that log holds a
+// record of `usage.RecordRoom` before it starts rotating on every write — at
+// which point half of two concurrent injections is rewritten away (#1971). The
+// budgets that decide a record's size live here and in internal/search, which
+// that package cannot import, so this is where the two meet.
+//
+// A budget raised past this line is not wrong on its own; what is wrong is
+// raising it and leaving the log's threshold where it was.
+func TestEveryAnswerFitsTheRoomTheLogHas(t *testing.T) {
+	// The frame, the header and a trailing note ride along with the body: blame
+	// is documented as ending up about its note's length over budget, so the
+	// room has to cover more than the number itself.
+	const overhead = 2048
+
+	for _, c := range []struct {
+		name   string
+		budget int
+	}{
+		{"recall", recallMCPBudget},
+		{"recall_context", contextMCPBudget},
+		{"blame", blameMCPBudget},
+		{"resource", search.ContextBudget},
+		{"handoff", handoffBudget},
+		{"deja vu", promptHookBudget},
+	} {
+		if c.budget+overhead > usage.RecordRoom {
+			t.Errorf("%s answers in %d bytes and the log has room for %d: raise usage.snapshotRotateAt, not the budget",
+				c.name, c.budget, usage.RecordRoom)
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1330,6 +1330,11 @@ func isWorkRecord(role string) bool {
 	return false
 }
 
+// ContextBudget is how much of a session PrintContext prints. The whole
+// transcript would be tens of times an answer's size, and it is one
+// recall_context away when an agent genuinely needs it.
+const ContextBudget = 8000
+
 func PrintContext(w io.Writer, s model.Session, query string) {
 	// Project and id are transcript text a harness wrote, and this is one line:
 	// an escape byte in either recolours the header and a carriage return
@@ -1352,7 +1357,7 @@ func PrintContext(w io.Writer, s model.Session, query string) {
 	fmt.Fprintln(w)
 	qlow := strings.ToLower(query)
 	terms, phrases := QueryParts(query)
-	budget := 8000
+	budget := ContextBudget
 	// The reply to an included turn comes with it. Every user turn was kept
 	// and every assistant turn had to match, but the decision lives in the
 	// answer and is worded nothing like the question: `ctx "http client"`

--- a/internal/usage/snapshot_budget_test.go
+++ b/internal/usage/snapshot_budget_test.go
@@ -5,30 +5,15 @@ import (
 	"testing"
 )
 
-// The rotation keeps a fixed count, so what keeps the file under its own
-// threshold is the size of a record — and that comes from budgets in another
-// package. Twenty of the largest writer today is about 164 kB against 512 kB:
+// The rotation keeps a fixed count, so the size of one record is what decides
+// whether the file stays under its threshold — and the budgets that set that
+// size live in packages this one cannot import. `RecordRoom` is the line
+// between them; `cmd/deja` holds the budgets to it.
 //
-//	recall / recall_context   4096 (2048 under a narrowing policy)
-//	blame                     8192
-//	resource                  8000
-//	déjà vu                   1536
-//	handoff                   6144
-//	tool                       480
-//
-// Above `snapshotRotateAt / snapshotsToKeep` the file sits over the threshold
-// for good, every write rotates, and half of two concurrent injections is
-// rewritten away — measured in #1971, which is also where a rotation learned to
-// drop the oldest until the rebuild fits. This is the other half: a budget that
-// grows past this line silently puts the log back in that state, and the number
-// to raise then is the threshold, not the budget.
-func TestARecordThisLogCanHoldWithoutRotatingEveryTime(t *testing.T) {
-	const perRecord = snapshotRotateAt / snapshotsToKeep
-	if perRecord < 8192 {
-		t.Fatalf("a record of the largest budgeted answer (8192) no longer fits: %d bytes each", perRecord)
-	}
-
-	// Twenty at the largest budget, and the file is still under the threshold.
+// Here: twenty records at the largest budget today fit, which is what the line
+// is for. Above it the file sits over the threshold for good and half of two
+// concurrent injections is rewritten away (#1971).
+func TestTwentyOfTheLargestAnswerStillFit(t *testing.T) {
 	dir := t.TempDir()
 	big := strings.Repeat("b", 8192)
 	for i := 0; i < snapshotsToKeep; i++ {
@@ -36,22 +21,5 @@ func TestARecordThisLogCanHoldWithoutRotatingEveryTime(t *testing.T) {
 	}
 	if got := len(Snapshots(dir, 0)); got != snapshotsToKeep {
 		t.Errorf("the log holds %d of %d records at the largest budget", got, snapshotsToKeep)
-	}
-}
-
-// And a record over that line does not take the log with it: the rotation drops
-// the oldest until the rebuild fits, so the next write is not rotating again.
-func TestALogOfOversizedRecordsStaysUnderTheThreshold(t *testing.T) {
-	dir := t.TempDir()
-	huge := strings.Repeat("h", 64<<10)
-	for i := 0; i < snapshotsToKeep+4; i++ {
-		RecordDigestPolicy(dir, KindResource, huge, 1, 0, "local-only")
-	}
-	got := Snapshots(dir, 0)
-	if len(got) == 0 {
-		t.Fatal("the log is empty")
-	}
-	if got[0].Digest != huge {
-		t.Errorf("the newest record is %d bytes, not the one just written", len(got[0].Digest))
 	}
 }

--- a/internal/usage/snapshot_budget_test.go
+++ b/internal/usage/snapshot_budget_test.go
@@ -1,0 +1,57 @@
+package usage
+
+import (
+	"strings"
+	"testing"
+)
+
+// The rotation keeps a fixed count, so what keeps the file under its own
+// threshold is the size of a record — and that comes from budgets in another
+// package. Twenty of the largest writer today is about 164 kB against 512 kB:
+//
+//	recall / recall_context   4096 (2048 under a narrowing policy)
+//	blame                     8192
+//	resource                  8000
+//	déjà vu                   1536
+//	handoff                   6144
+//	tool                       480
+//
+// Above `snapshotRotateAt / snapshotsToKeep` the file sits over the threshold
+// for good, every write rotates, and half of two concurrent injections is
+// rewritten away — measured in #1971, which is also where a rotation learned to
+// drop the oldest until the rebuild fits. This is the other half: a budget that
+// grows past this line silently puts the log back in that state, and the number
+// to raise then is the threshold, not the budget.
+func TestARecordThisLogCanHoldWithoutRotatingEveryTime(t *testing.T) {
+	const perRecord = snapshotRotateAt / snapshotsToKeep
+	if perRecord < 8192 {
+		t.Fatalf("a record of the largest budgeted answer (8192) no longer fits: %d bytes each", perRecord)
+	}
+
+	// Twenty at the largest budget, and the file is still under the threshold.
+	dir := t.TempDir()
+	big := strings.Repeat("b", 8192)
+	for i := 0; i < snapshotsToKeep; i++ {
+		RecordDigestPolicy(dir, KindBlame, big, 1, 0, "local-only")
+	}
+	if got := len(Snapshots(dir, 0)); got != snapshotsToKeep {
+		t.Errorf("the log holds %d of %d records at the largest budget", got, snapshotsToKeep)
+	}
+}
+
+// And a record over that line does not take the log with it: the rotation drops
+// the oldest until the rebuild fits, so the next write is not rotating again.
+func TestALogOfOversizedRecordsStaysUnderTheThreshold(t *testing.T) {
+	dir := t.TempDir()
+	huge := strings.Repeat("h", 64<<10)
+	for i := 0; i < snapshotsToKeep+4; i++ {
+		RecordDigestPolicy(dir, KindResource, huge, 1, 0, "local-only")
+	}
+	got := Snapshots(dir, 0)
+	if len(got) == 0 {
+		t.Fatal("the log is empty")
+	}
+	if got[0].Digest != huge {
+		t.Errorf("the newest record is %d bytes, not the one just written", len(got[0].Digest))
+	}
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -40,6 +40,14 @@ const (
 	snapshotRotateAt = 512 << 10
 )
 
+// RecordRoom is the largest record this log holds without rotating on every
+// write: the rotation keeps a fixed count, so the count and the threshold
+// together decide the size. Above it the file sits over the threshold for good,
+// and half of two concurrent injections is rewritten away (#1971). Exported so
+// the packages that set the budgets — none of which this one can import — can
+// be held to it.
+const RecordRoom = snapshotRotateAt / snapshotsToKeep
+
 // SnapshotPath returns the injection-snapshot log for an index dir; a sibling
 // file like the usage log, so it survives full rebuilds.
 func SnapshotPath(indexDir string) string {


### PR DESCRIPTION
No bug, one guard, and a correction to my own issue.

The question was how big a record a read of `deja://session/…` leaves in the injection log — the queue item and #1971 both say "a whole session, `search.PrintContext` with no budget". It has one. `search.go:1355` sets `budget := 8000`, and the measurement agrees: a 600-turn session answers in 8213 bytes, and the same session with turns sixteen times longer answers in 8213 bytes.

Every writer of that log is budgeted:

| path | cap |
|---|---|
| recall / recall_context | 4096, 2048 under a narrowing policy |
| blame | 8192 |
| resource | 8000 |
| déjà vu | 1536 |
| handoff | 6144 |
| tool | 480 |

Twenty of the largest is about 164 kB against the 512 kB threshold, so the cliff fixed in #1971 is not reachable through any of them today. That fix still stands — it costs nothing, and the file's own guarantee should not rest on six numbers in another package staying where they are — but the account of how a store gets there was wrong, and the issue now carries the correction.

What is missing is the line between the two: `snapshotRotateAt / snapshotsToKeep` is the record size this log can hold without rotating on every write, and nothing said so. A test does now, with the budgets listed and the number to raise named — the threshold, not the budget. Its sibling holds the other half: a record over that line does not take the log with it.
