### PR TITLE
fix(log): answer --last --json in JSON when there is no digest

### DIFF
--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -42,6 +42,14 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 	if last {
 		snaps := usage.Snapshots(dir, 1)
 		if len(snaps) == 0 {
+			// `--json` answers in JSON, including when the answer is that
+			// there is nothing: this shape is one object, and null is how a
+			// missing object is spelled. The sentence went out under the flag
+			// too, so a script polling this got a parse error (#1975).
+			if jsonOut {
+				fmt.Fprintln(w, "null")
+				return nil
+			}
 			fmt.Fprintln(w, "deja: no injected digests recorded yet — they appear after a hook or MCP recall fires")
 			return nil
 		}

--- a/cmd/deja/log_last_json_test.go
+++ b/cmd/deja/log_last_json_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// `--json` has to answer in JSON, including when the answer is that there is
+// nothing. The array form beside this one is `[]` and never null for the reason
+// the document gives — it is the output a script polls — while `--last --json`
+// returned the human sentence and a parse error with it (#1975).
+func TestTheLastDigestAnswersInJSONWhenThereIsNone(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+
+	for _, c := range []struct{ name, body string }{
+		{"no file at all", ""},
+		{"one truncated line", `{"t":"2026-08-25T10:00:00Z","kind":"hook","digest":"the block`},
+		{"a line with no digest", `{"t":"2026-08-25T10:00:00Z","kind":"hook","bytes":10}`},
+		{"blank lines only", "\n\n\n"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if c.body == "" {
+				_ = os.Remove(usage.SnapshotPath(dir))
+			} else if err := os.WriteFile(usage.SnapshotPath(dir), []byte(c.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var b strings.Builder
+			if err := runLogTo(&b, dir, []string{"--last", "--json"}); err != nil {
+				t.Fatal(err)
+			}
+			var v any
+			if err := json.Unmarshal([]byte(b.String()), &v); err != nil {
+				t.Fatalf("not JSON: %q", strings.TrimSpace(b.String()))
+			}
+			if v != nil {
+				t.Errorf("want null for a digest that is not there, got %#v", v)
+			}
+		})
+	}
+}
+
+// The human form is unchanged: a person reading the screen gets the sentence,
+// not the word null.
+func TestTheLastDigestStillSaysSoInWords(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	_ = os.Remove(usage.SnapshotPath(dir))
+
+	var b strings.Builder
+	if err := runLogTo(&b, dir, []string{"--last"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), "no injected digests recorded yet") {
+		t.Errorf("the human form changed: %q", b.String())
+	}
+}
+
+// And a digest that is there still comes back whole, so the branch above did
+// not take the ordinary answer with it.
+func TestTheLastDigestIsStillReturned(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	usage.RecordDigestPolicy(dir, usage.KindHook, "the injected block", 2, 4000, "local-only")
+
+	var b strings.Builder
+	if err := runLogTo(&b, dir, []string{"--last", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var got usage.Snapshot
+	if err := json.Unmarshal([]byte(b.String()), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Digest != "the injected block" {
+		t.Errorf("digest = %q", got.Digest)
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -494,7 +494,9 @@ one from something that is not deja, is skipped rather than shown with a missing
 half. The same rule decides what the counters in `stats --json` read, so the two
 never disagree about whether something happened.
 
-`deja log --last --json` is a different shape: one object, the most recent
+`deja log --last --json` is `null` when no digest has been recorded — one object
+is the shape, and that is how a missing one is spelled. It is a different shape
+from the array above: one object, the most recent
 injected digest itself. It carries `t` and `kind` as above, the `digest` text,
 `bytes`, and — each omitted when empty — `sessions`, the `policy` that allowed
 the injection, the `terms` behind a déjà vu firing, and `into`, the agent session

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -494,13 +494,12 @@ one from something that is not deja, is skipped rather than shown with a missing
 half. The same rule decides what the counters in `stats --json` read, so the two
 never disagree about whether something happened.
 
-`deja log --last --json` is `null` when no digest has been recorded — one object
-is the shape, and that is how a missing one is spelled. It is a different shape
-from the array above: one object, the most recent
+`deja log --last --json` is a different shape: one object, the most recent
 injected digest itself. It carries `t` and `kind` as above, the `digest` text,
 `bytes`, and — each omitted when empty — `sessions`, the `policy` that allowed
 the injection, the `terms` behind a déjà vu firing, and `into`, the agent session
-it went to.
+it went to. It is `null` when no digest has been recorded: one object is the
+shape, and that is how a missing one is spelled.
 
 ## `deja blame <path> --json`
 


### PR DESCRIPTION
Fixes #1975 — the mechanical half. The wording half is left for you there.

`deja log --last --json` printed a human sentence when there was nothing to show:

```
log --json          json ok: []
log --last --json   NOT JSON: "deja: no injected digests recorded yet — they appear after a hook or MCP recall fires"
```

The sentence went out before the `jsonOut` branch was reached, so the flag never got a say, and a script polling that surface got a parse error rather than an answer. The array form beside it gets this right and the document says why: `[]` and never null, "because this is the output a script polls".

`null` now, which is how a missing object is spelled for a shape the document already calls "one object". The human form is untouched, and there is a test for each — plus one that the ordinary answer still comes back whole, since the branch sits in front of it.

The same sentence still comes back for every shape of nothing: no file, a truncated line, a line with no digest, blank lines only. That conflation — a file deja cannot read reported as a file that was never written — is the one #1960 fixed for the vector sidecar, and whether this screen should draw the same distinction, in what words, is the half left in the issue.
