### PR TITLE
docs: name the one object-shaped answer that carries no schema_version

### DIFF
--- a/cmd/deja/schema_version_contract_test.go
+++ b/cmd/deja/schema_version_contract_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -10,11 +11,25 @@ import (
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
+// policyBulletFor is the one list item in the stability policy that names a
+// command. The check has to be on that item and not on the section: a phrase
+// anywhere in the policy is satisfied by any sentence that happens to contain
+// it, which is a test that passes on prose it never read.
+func policyBulletFor(t *testing.T, policy, command string) string {
+	t.Helper()
+	for _, item := range strings.Split(policy, "\n- ") {
+		if strings.Contains(item, "`"+command+"`") {
+			return item
+		}
+	}
+	return ""
+}
+
 // The document opens with a rule — object-shaped responses carry
 // `schema_version` — and then lists the exceptions to it. That list is prose,
 // and prose drifts: `deja log --last --json` is an object without the field and
-// was in neither half, which is how it was found. Here the two are checked
-// against each other, so a new surface has to join one side or the other.
+// was in neither half, which is how it was found (#1975). Here the two are held
+// against each other, so a surface has to join one side or the other.
 func TestWhichJSONSurfacesCarryASchemaVersion(t *testing.T) {
 	doc, err := os.ReadFile("../../docs/json-output.md")
 	if err != nil {
@@ -25,23 +40,31 @@ func TestWhichJSONSurfacesCarryASchemaVersion(t *testing.T) {
 	hermeticEnv(t)
 	dir := index.DefaultDir()
 	usage.RecordDigestPolicy(dir, usage.KindHook, "the injected block", 2, 4000, "local-only")
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "beta", "one.jsonl"), "svterm", []string{
+		`{"type":"user","sessionId":"svterm","timestamp":"2026-08-20T10:00:00Z",` +
+			`"message":{"role":"user","content":"pgbouncer runs in transaction mode"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
 
 	for _, c := range []struct {
 		name        string
-		args        []string
+		run         func(t *testing.T) string
 		versionable bool
 	}{
-		{"deja log --json", []string{"--json"}, false},
-		{"deja log --last --json", []string{"--last", "--json"}, false},
+		{"deja log --json", func(t *testing.T) string { return runLogString(t, dir, "--json") }, false},
+		{"deja log --last --json", func(t *testing.T) string { return runLogString(t, dir, "--last", "--json") }, false},
+		{"deja last --json", func(t *testing.T) string { return captureRunString(t, "last", "3", "--json") }, true},
+		{"deja show <exact-id> --harness <name> --json", func(t *testing.T) string {
+			return captureRunString(t, "show", "svterm", "--harness", "claude", "--json")
+		}, true},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			var b strings.Builder
-			if err := runLogTo(&b, dir, c.args); err != nil {
-				t.Fatal(err)
-			}
+			out := c.run(t)
 			var v any
-			if err := json.Unmarshal([]byte(b.String()), &v); err != nil {
-				t.Fatalf("not JSON: %q", strings.TrimSpace(b.String()))
+			if err := json.Unmarshal([]byte(out), &v); err != nil {
+				t.Fatalf("not JSON: %q", strings.TrimSpace(out))
 			}
 			m, isObject := v.(map[string]any)
 			_, hasVersion := m["schema_version"]
@@ -49,14 +72,40 @@ func TestWhichJSONSurfacesCarryASchemaVersion(t *testing.T) {
 			if hasVersion != c.versionable {
 				t.Errorf("schema_version present = %v, want %v", hasVersion, c.versionable)
 			}
-			// A shape that carries no version has to be named in the policy
-			// section, whether it is an array or an object.
-			if !hasVersion && !strings.Contains(policy, "`"+c.name+"`") {
-				t.Errorf("%s carries no schema_version and the stability policy does not say so", c.name)
+			if hasVersion {
+				return
 			}
-			if isObject && !hasVersion && !strings.Contains(policy, "one record") {
-				t.Errorf("an object without a version needs the policy to say which record shape it is")
+			// A shape that carries no version has to be named in the policy,
+			// and its own bullet has to say that is what it means — otherwise a
+			// command mentioned for any other reason reads as documented.
+			bullet := policyBulletFor(t, policy, c.name)
+			if bullet == "" {
+				t.Fatalf("%s carries no schema_version and the stability policy does not name it", c.name)
+			}
+			if !strings.Contains(bullet, "schema_version") {
+				t.Errorf("the policy names %s but its entry does not say it carries no schema_version:\n%s", c.name, bullet)
+			}
+			if isObject && !strings.Contains(bullet, "object-shaped") && !strings.Contains(bullet, "object it prints") {
+				t.Errorf("%s is an object without a version and its entry does not say so:\n%s", c.name, bullet)
 			}
 		})
 	}
+}
+
+func runLogString(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	var b strings.Builder
+	if err := runLogTo(&b, dir, args); err != nil {
+		t.Fatal(err)
+	}
+	return b.String()
+}
+
+func captureRunString(t *testing.T, args ...string) string {
+	t.Helper()
+	out, err := captureRun(t, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
 }

--- a/cmd/deja/schema_version_contract_test.go
+++ b/cmd/deja/schema_version_contract_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// The document opens with a rule — object-shaped responses carry
+// `schema_version` — and then lists the exceptions to it. That list is prose,
+// and prose drifts: `deja log --last --json` is an object without the field and
+// was in neither half, which is how it was found. Here the two are checked
+// against each other, so a new surface has to join one side or the other.
+func TestWhichJSONSurfacesCarryASchemaVersion(t *testing.T) {
+	doc, err := os.ReadFile("../../docs/json-output.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := docSection(t, string(doc), "## Stability policy")
+
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	usage.RecordDigestPolicy(dir, usage.KindHook, "the injected block", 2, 4000, "local-only")
+
+	for _, c := range []struct {
+		name        string
+		args        []string
+		versionable bool
+	}{
+		{"deja log --json", []string{"--json"}, false},
+		{"deja log --last --json", []string{"--last", "--json"}, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var b strings.Builder
+			if err := runLogTo(&b, dir, c.args); err != nil {
+				t.Fatal(err)
+			}
+			var v any
+			if err := json.Unmarshal([]byte(b.String()), &v); err != nil {
+				t.Fatalf("not JSON: %q", strings.TrimSpace(b.String()))
+			}
+			m, isObject := v.(map[string]any)
+			_, hasVersion := m["schema_version"]
+
+			if hasVersion != c.versionable {
+				t.Errorf("schema_version present = %v, want %v", hasVersion, c.versionable)
+			}
+			// A shape that carries no version has to be named in the policy
+			// section, whether it is an array or an object.
+			if !hasVersion && !strings.Contains(policy, "`"+c.name+"`") {
+				t.Errorf("%s carries no schema_version and the stability policy does not say so", c.name)
+			}
+			if isObject && !hasVersion && !strings.Contains(policy, "one record") {
+				t.Errorf("an object without a version needs the policy to say which record shape it is")
+			}
+		})
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -17,6 +17,10 @@ a `schema_version` field so consumers can detect breaking changes.
   element shapes are stable; only additive fields inside them are permitted.
 - **`deja stats --impact --json`** returns one flat object of counters and
   carries no `schema_version` either, on the same terms.
+- **`deja log --last --json`** returns one record of the same shape `deja log
+  --json` returns in its array, so it carries no `schema_version` either: a
+  version on the single form and none on the array would be two answers about
+  one record.
 
 ### What changed in version 2
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -17,10 +17,15 @@ a `schema_version` field so consumers can detect breaking changes.
   element shapes are stable; only additive fields inside them are permitted.
 - **`deja stats --impact --json`** returns one flat object of counters and
   carries no `schema_version` either, on the same terms.
-- **`deja log --last --json`** returns one record of the same shape `deja log
-  --json` returns in its array, so it carries no `schema_version` either: a
-  version on the single form and none on the array would be two answers about
-  one record.
+- **`deja log --last --json`** carries no `schema_version` for two reasons of
+  its own. The object it prints is the record deja stores in
+  `.injections.jsonl`, marshalled from the same struct, so a version field on it
+  would be written into every line of that file. And the surface answers `null`
+  when no digest has been recorded: a shape that is sometimes absent cannot be
+  relied on to carry a version.
+- **`deja bench recall|context|prompt --json`** are object-shaped and carry no
+  `schema_version` either. They report a benchmark run to whoever asked for it,
+  not a contract anything downstream parses on a schedule.
 
 ### What changed in version 2
 


### PR DESCRIPTION
No bug in the output; the document's own exception list was short by one.

The stability policy opens with a rule — object-shaped responses carry `schema_version` — and then names the exceptions: the two array forms, and `stats --impact --json`. Measured:

```
log --last --json      object, schema_version=false
log --json             array (documented exception)
```

An object-shaped response with no version and no entry in the list, which is how it was found while reviewing #1975.

Adding the field would be the wrong fix. That object is one snapshot record — the same record `deja log --json` returns in its array, whose elements the policy already covers ("their element shapes are stable; only additive fields inside them are permitted"). A version on the single form and none on the array would be two answers about one record.

So the list names it, and a test holds the two together: every surface checked must either carry the field or be named in the policy section, and an object without one must say which record shape it is. Prose drifts; this is the drift that produced the gap.
