### PR TITLE
fix(brief): say a store was locked instead of no agent ran here

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -529,8 +529,20 @@ func printNoHistory(w io.Writer, stale bool) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "deja reads the session stores your agents already write —")
 	fmt.Fprintln(w, "Claude Code, Codex, opencode, Cursor, Gemini, Copilot and twelve more.")
-	fmt.Fprintln(w, "Nothing was found on this machine, which usually means no agent has")
-	fmt.Fprintln(w, "run here yet, or its store lives somewhere else.")
+	// A store deja is not allowed to open is not a machine no agent has used,
+	// and this is the first screen a new user sees: sending them after a
+	// missing store when the fix is a permission is the worst place to make
+	// that claim. Every other empty answer draws the line through
+	// emptyIndexHint; this screen is written as an introduction rather than an
+	// answer, so it says it in its own shape (#1979).
+	if denied := deniedStoreCount(); denied > 0 {
+		fmt.Fprintf(w, "Nothing was found on this machine — but %d store%s could not be read\n",
+			denied, pluralS(denied))
+		fmt.Fprintln(w, "(permission denied); `deja doctor` names it.")
+	} else {
+		fmt.Fprintln(w, "Nothing was found on this machine, which usually means no agent has")
+		fmt.Fprintln(w, "run here yet, or its store lives somewhere else.")
+	}
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "  deja sources     what was looked for, and where")
 	fmt.Fprintln(w, "  deja doctor      check the setup")

--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -536,9 +536,9 @@ func printNoHistory(w io.Writer, stale bool) {
 	// emptyIndexHint; this screen is written as an introduction rather than an
 	// answer, so it says it in its own shape (#1979).
 	if denied := deniedStoreCount(); denied > 0 {
-		fmt.Fprintf(w, "Nothing was found on this machine — but %d store%s could not be read\n",
+		fmt.Fprintf(w, "Nothing was found on this machine, but %d store%s could not be\n",
 			denied, pluralS(denied))
-		fmt.Fprintln(w, "(permission denied); `deja doctor` names it.")
+		fmt.Fprintf(w, "read (permission denied) — `deja doctor` names %s.\n", pluralWhich(denied))
 	} else {
 		fmt.Fprintln(w, "Nothing was found on this machine, which usually means no agent has")
 		fmt.Fprintln(w, "run here yet, or its store lives somewhere else.")

--- a/cmd/deja/brief_denied_test.go
+++ b/cmd/deja/brief_denied_test.go
@@ -7,8 +7,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-
-	"github.com/vshulcz/deja-vu/internal/index"
 )
 
 // The first screen a new user sees, on a machine whose store deja is not
@@ -20,25 +18,21 @@ func TestTheEmptyScreenSaysAStoreCouldNotBeRead(t *testing.T) {
 	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
 		t.Skip("directory permissions do not deny reads here")
 	}
-	tmp := hermeticEnv(t)
+	hermeticEnv(t)
 	claude := os.Getenv("DEJA_CLAUDE_ROOT")
 	seedClaude(t, claude, "app", "s1", "the pgbouncer pool kept timing out", "we fixed the retry")
-	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
-		t.Fatal(err)
-	}
 
 	proj := filepath.Join(claude, "-app")
 	if err := os.Chmod(proj, 0o000); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(proj, 0o755) })
-	if err := os.RemoveAll(filepath.Join(tmp, "index.db")); err != nil {
-		t.Fatal(err)
-	}
 
 	var b bytes.Buffer
 	printNoHistory(&b, false)
-	out := b.String()
+	// Newlines collapsed: this is wrapped copy, and an assertion that breaks
+	// when a line wraps differently is about the wrapping, not the claim.
+	out := strings.Join(strings.Fields(b.String()), " ")
 
 	if !strings.Contains(out, "could not be read") {
 		t.Errorf("the empty screen does not say a store was unreadable:\n%s", out)
@@ -46,7 +40,7 @@ func TestTheEmptyScreenSaysAStoreCouldNotBeRead(t *testing.T) {
 	if !strings.Contains(out, "deja doctor") {
 		t.Errorf("the empty screen does not point at what names it:\n%s", out)
 	}
-	if strings.Contains(out, "no agent has\nrun here yet") {
+	if strings.Contains(out, "no agent has") {
 		t.Errorf("the empty screen still says no agent ran here:\n%s", out)
 	}
 }
@@ -58,12 +52,47 @@ func TestTheEmptyScreenStillIntroducesDejaOnAQuietMachine(t *testing.T) {
 
 	var b bytes.Buffer
 	printNoHistory(&b, false)
-	out := b.String()
+	out := strings.Join(strings.Fields(b.String()), " ")
 
 	if !strings.Contains(out, "no agent has") {
 		t.Errorf("the introduction changed on an empty machine:\n%s", out)
 	}
 	if strings.Contains(out, "could not be read") {
 		t.Errorf("an empty machine was told a store is unreadable:\n%s", out)
+	}
+}
+
+// Two locked stores are named as two, and the pronoun follows the noun. The
+// helper beside this one has said "them" since the wording was written; this
+// screen's own copy hardcoded "it" (#1979).
+func TestTheEmptyScreenCountsLockedStoresCorrectly(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	hermeticEnv(t)
+	claude := os.Getenv("DEJA_CLAUDE_ROOT")
+	codex := os.Getenv("DEJA_CODEX_ROOT")
+	seedClaude(t, claude, "app", "s1", "the pgbouncer pool kept timing out", "we fixed the retry")
+	if err := os.MkdirAll(filepath.Join(codex, "sessions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codex, "sessions", "s.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{filepath.Join(claude, "-app"), filepath.Join(codex, "sessions")} {
+		if err := os.Chmod(p, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(p, 0o755) })
+	}
+
+	var b bytes.Buffer
+	printNoHistory(&b, false)
+	out := strings.Join(strings.Fields(b.String()), " ")
+	if !strings.Contains(out, "2 stores") {
+		t.Errorf("two locked stores are not counted:\n%s", out)
+	}
+	if strings.Contains(out, "names it") {
+		t.Errorf("two stores, one pronoun:\n%s", out)
 	}
 }

--- a/cmd/deja/brief_denied_test.go
+++ b/cmd/deja/brief_denied_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The first screen a new user sees, on a machine whose store deja is not
+// allowed to read: it told them no agent had run here, which sends them looking
+// for a store that is not missing. Every other surface answers through
+// `emptyIndexHint` and says a store could not be read; this one has no branch
+// of its own, which is #1020's fix having missed a caller (#1979).
+func TestTheEmptyScreenSaysAStoreCouldNotBeRead(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny reads here")
+	}
+	tmp := hermeticEnv(t)
+	claude := os.Getenv("DEJA_CLAUDE_ROOT")
+	seedClaude(t, claude, "app", "s1", "the pgbouncer pool kept timing out", "we fixed the retry")
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	proj := filepath.Join(claude, "-app")
+	if err := os.Chmod(proj, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(proj, 0o755) })
+	if err := os.RemoveAll(filepath.Join(tmp, "index.db")); err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	printNoHistory(&b, false)
+	out := b.String()
+
+	if !strings.Contains(out, "could not be read") {
+		t.Errorf("the empty screen does not say a store was unreadable:\n%s", out)
+	}
+	if !strings.Contains(out, "deja doctor") {
+		t.Errorf("the empty screen does not point at what names it:\n%s", out)
+	}
+	if strings.Contains(out, "no agent has\nrun here yet") {
+		t.Errorf("the empty screen still says no agent ran here:\n%s", out)
+	}
+}
+
+// And on a machine that genuinely has nothing, the introduction is unchanged —
+// it is the one screen written to explain deja rather than to answer.
+func TestTheEmptyScreenStillIntroducesDejaOnAQuietMachine(t *testing.T) {
+	hermeticEnv(t)
+
+	var b bytes.Buffer
+	printNoHistory(&b, false)
+	out := b.String()
+
+	if !strings.Contains(out, "no agent has") {
+		t.Errorf("the introduction changed on an empty machine:\n%s", out)
+	}
+	if strings.Contains(out, "could not be read") {
+		t.Errorf("an empty machine was told a store is unreadable:\n%s", out)
+	}
+}

--- a/cmd/deja/denied_store_surfaces_test.go
+++ b/cmd/deja/denied_store_surfaces_test.go
@@ -11,20 +11,19 @@ import (
 )
 
 // The wording that separates a locked store from an empty machine lives in
-// `emptyIndexHint`, and #1020 pinned the helper. What was not pinned is the two
-// surfaces a person actually types: a query and `deja last` both answer from
-// that helper, and a wiring change would let either call a machine empty while
-// its sessions sit behind a wall doctor can see.
+// `emptyIndexHint`. #1020 pinned the helper, and friction is pinned through a
+// command — but a query and `deja last` each return through
+// `hiddenByOwnSettings` before reaching the helper, a branch friction does not
+// have, and nothing held either of them to it.
 func TestAQueryAndLastNameAStoreTheyCouldNotRead(t *testing.T) {
 	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
 		t.Skip("directory permissions do not deny reads here")
 	}
-	tmp := t.TempDir()
-	claude := filepath.Join(tmp, "claude")
-	t.Setenv("DEJA_CLAUDE_ROOT", claude)
-	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
-	t.Setenv("HOME", tmp)
-	t.Setenv("USERPROFILE", tmp)
+	// hermeticEnv rather than four Setenvs: XDG_CONFIG_HOME leaking from the
+	// machine is enough to fail both cases, because a `deja/exclude` file there
+	// sends the answer through hiddenByOwnSettings before the hint is reached.
+	tmp := hermeticEnv(t)
+	claude := os.Getenv("DEJA_CLAUDE_ROOT")
 
 	seedClaude(t, claude, "app", "s1", "the pgbouncer pool kept timing out", "we fixed the retry")
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {


### PR DESCRIPTION
Fixes #1979, and takes the two findings from #1978 that arrived after I merged it.

Bare `deja`, on a machine whose store deja is not allowed to read:

```
Nothing was found on this machine, which usually means no agent has
run here yet, or its store lives somewhere else.
```

The sessions are there. `deja doctor` says `"state": "denied"` with the path in the same breath, and `deja sources` prints "cannot be read — permission denied on …". This is the first screen a new user sees, and it sends them looking for a store that is not missing when the fix is a permission.

`emptyIndexHint` carries the wording every other empty answer uses — a query, `deja last`, `deja stats`, `deja friction`. `printNoHistory` does not go through it and had no branch of its own: #1020's fix having missed a caller. It says it in its own shape now, because that screen is written as an introduction rather than as an answer.

Also here, from the #1978 review:

- that test built its environment from four `Setenv` calls instead of `hermeticEnv`, so `XDG_CONFIG_HOME` leaked from the machine — and a `deja/exclude` file there sends the answer through `hiddenByOwnSettings` before the hint is reached, failing both cases. Reproduced by the reviewer on a real config.
- its comment said the two surfaces were "pinned nowhere". They were pinned at friction, which drives a command through the same helper. What is not covered there is the `hiddenByOwnSettings` branch that a query and `deja last` return through and friction does not, so the test earns its place for a narrower reason than I claimed. The comment says that now.

The wording of the new sentence is the half I would rather you decided, and it is in the issue: this is the one screen written to explain deja to someone who has just installed it.
