### PR TITLE
test(usage): measure what a record weighs instead of guessing

### DIFF
--- a/cmd/deja/answer_budget_room_test.go
+++ b/cmd/deja/answer_budget_room_test.go
@@ -16,11 +16,6 @@ import (
 // A budget raised past this line is not wrong on its own; what is wrong is
 // raising it and leaving the log's threshold where it was.
 func TestEveryAnswerFitsTheRoomTheLogHas(t *testing.T) {
-	// The frame, the header and a trailing note ride along with the body: blame
-	// is documented as ending up about its note's length over budget, so the
-	// room has to cover more than the number itself.
-	const overhead = 2048
-
 	for _, c := range []struct {
 		name   string
 		budget int
@@ -32,9 +27,9 @@ func TestEveryAnswerFitsTheRoomTheLogHas(t *testing.T) {
 		{"handoff", handoffBudget},
 		{"deja vu", promptHookBudget},
 	} {
-		if c.budget+overhead > usage.RecordRoom {
-			t.Errorf("%s answers in %d bytes and the log has room for %d: raise usage.snapshotRotateAt, not the budget",
-				c.name, c.budget, usage.RecordRoom)
+		if usage.RecordSize(c.budget) > usage.RecordRoom {
+			t.Errorf("%s answers in %d bytes, which is %d on disk against %d of room: raise the log's threshold, not the budget",
+				c.name, c.budget, usage.RecordSize(c.budget), usage.RecordRoom)
 		}
 	}
 }

--- a/internal/search/control_bytes_test.go
+++ b/internal/search/control_bytes_test.go
@@ -1,7 +1,6 @@
 package search
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -9,6 +8,8 @@ import (
 // on that. The one this file was written for: a control byte is six bytes in
 // JSON, so a digest carrying them would weigh three times what
 // `usage.RecordSize` says, and the injection log's own bound would be wrong.
+// This holds SafeText and SafeLine to it; that every digest is built through
+// one of them is about two dozen call sites and is not what this proves.
 // The older one is why the stripping is there at all — an escape byte
 // recolours a terminal and a carriage return rewinds a line.
 func TestControlBytesDoNotSurviveIntoServedText(t *testing.T) {
@@ -44,5 +45,5 @@ func hasControlByte(s string) bool {
 			return true
 		}
 	}
-	return strings.Contains(s, "\x00")
+	return false
 }

--- a/internal/search/control_bytes_test.go
+++ b/internal/search/control_bytes_test.go
@@ -1,0 +1,48 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// Control bytes never reach the text deja hands an agent, and two things rest
+// on that. The one this file was written for: a control byte is six bytes in
+// JSON, so a digest carrying them would weigh three times what
+// `usage.RecordSize` says, and the injection log's own bound would be wrong.
+// The older one is why the stripping is there at all — an escape byte
+// recolours a terminal and a carriage return rewinds a line.
+func TestControlBytesDoNotSurviveIntoServedText(t *testing.T) {
+	for _, c := range []struct{ name, in string }{
+		{"an escape sequence", "before\x1b[31mafter"},
+		{"a bell", "before\x07after"},
+		{"a start-of-heading byte", "before\x01after"},
+		{"a null byte", "before\x00after"},
+		{"a carriage return", "before\rafter"},
+		{"a vertical tab", "before\x0bafter"},
+		{"a delete byte", "before\x7fafter"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := SafeText(c.in); hasControlByte(got) {
+				t.Errorf("SafeText kept a control byte: %q", got)
+			}
+			if got := SafeLine(c.in); hasControlByte(got) {
+				t.Errorf("SafeLine kept a control byte: %q", got)
+			}
+		})
+	}
+}
+
+// hasControlByte ignores the two a transcript is made of: a newline separates
+// turns, and a tab is ordinary in pasted output. Both cost two bytes in JSON,
+// which is the bound `usage.RecordSize` is built on.
+func hasControlByte(s string) bool {
+	for _, r := range s {
+		if r == '\n' || r == '\t' {
+			continue
+		}
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return strings.Contains(s, "\x00")
+}

--- a/internal/usage/record_size_test.go
+++ b/internal/usage/record_size_test.go
@@ -1,0 +1,61 @@
+package usage
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// `RecordSize` says an answer doubles at worst. That rests on escaping being
+// two bytes per character, which holds for the newlines and quotes a digest is
+// full of — and not for a control byte, which costs six. The bound is only true
+// because control bytes never reach a digest, and this is the arithmetic half
+// of that claim: the sanitising half lives in internal/search.
+func TestWhatARecordWeighs(t *testing.T) {
+	const budget = 8192
+	for _, c := range []struct {
+		name   string
+		body   string
+		within bool
+	}{
+		{"plain text", strings.Repeat("the pgbouncer pool kept timing out ", 234), true},
+		{"a digest full of newlines", strings.Repeat("- session `abc`\n  user: something happened\n", 195), true},
+		{"every byte a newline", strings.Repeat("\n", budget), true},
+		{"every byte a quote", strings.Repeat(`"`, budget), true},
+		{"cyrillic", strings.Repeat("отладка ", 1024), true},
+		// The case the bound does not cover, kept here so the reason is on the
+		// record: six bytes each, and RecordSize would be wrong by 3x.
+		{"control bytes, which cannot reach here", strings.Repeat("\x01", budget), false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			b, err := json.Marshal(Snapshot{
+				Time: time.Now().UTC(), Kind: KindBlame, Sessions: 3,
+				Bytes: len(c.body), Policy: "local+imported",
+				Terms: []string{"pgbouncer", "pool"}, Into: "agent-session-1",
+				Digest: c.body,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			within := len(b) <= RecordSize(len(c.body))
+			if within != c.within {
+				t.Errorf("record is %d bytes for a body of %d; RecordSize says %d",
+					len(b), len(c.body), RecordSize(len(c.body)))
+			}
+		})
+	}
+}
+
+// And the room holds the largest answer deja serves, at that bound.
+func TestTheLargestAnswerFitsTheRoomWithEscaping(t *testing.T) {
+	const largest = 8192 // blame and recall_context, the widest budgets today
+	if got := RecordSize(largest); got > RecordRoom {
+		t.Errorf("the largest answer weighs %d against %d of room", got, RecordRoom)
+	}
+	// Not by so much that the check is vacuous: an answer twice as wide would
+	// not fit, which is the change this is here to catch.
+	if RecordSize(2*largest) <= RecordRoom {
+		t.Errorf("a budget of %d would still pass, so this bound constrains nothing", 2*largest)
+	}
+}

--- a/internal/usage/record_size_test.go
+++ b/internal/usage/record_size_test.go
@@ -1,17 +1,18 @@
 package usage
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 )
 
-// `RecordSize` says an answer doubles at worst. That rests on escaping being
-// two bytes per character, which holds for the newlines and quotes a digest is
-// full of — and not for a control byte, which costs six. The bound is only true
-// because control bytes never reach a digest, and this is the arithmetic half
-// of that claim: the sanitising half lives in internal/search.
+// `RecordSize` says a record is three times its answer at worst. Two of those
+// bytes are the newlines and quotes a digest is full of; the third is a byte
+// that is not valid UTF-8, written as the replacement character, which nothing
+// strips. Two classes are kept out of the multiplier instead of allowed for:
+// control bytes, which SafeText removes, and the angle brackets and ampersands
+// encoding/json would escape to six bytes each — the writer turns that escaping
+// off, because they are ordinary text (#1982).
 func TestWhatARecordWeighs(t *testing.T) {
 	const budget = 8192
 	for _, c := range []struct {
@@ -24,12 +25,15 @@ func TestWhatARecordWeighs(t *testing.T) {
 		{"every byte a newline", strings.Repeat("\n", budget), true},
 		{"every byte a quote", strings.Repeat(`"`, budget), true},
 		{"cyrillic", strings.Repeat("отладка ", 1024), true},
-		// The case the bound does not cover, kept here so the reason is on the
-		// record: six bytes each, and RecordSize would be wrong by 3x.
+		{"angle brackets, as code has them", strings.Repeat("<T> & Vec<U> ", 630), true},
+		{"a shell pipeline", strings.Repeat("cat a.txt | grep x > out.txt && ", 256), true},
+		{"bytes that are not valid UTF-8", strings.Repeat("\xff", budget), true},
+		// The one class the bound does not cover, kept so the reason is on the
+		// record: six bytes each, and RecordSize would be wrong by twice.
 		{"control bytes, which cannot reach here", strings.Repeat("\x01", budget), false},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			b, err := json.Marshal(Snapshot{
+			b, err := marshalSnapshot(Snapshot{
 				Time: time.Now().UTC(), Kind: KindBlame, Sessions: 3,
 				Bytes: len(c.body), Policy: "local+imported",
 				Terms: []string{"pgbouncer", "pool"}, Into: "agent-session-1",

--- a/internal/usage/record_size_test.go
+++ b/internal/usage/record_size_test.go
@@ -63,3 +63,24 @@ func TestTheLargestAnswerFitsTheRoomWithEscaping(t *testing.T) {
 		t.Errorf("a budget of %d would still pass, so this bound constrains nothing", 2*largest)
 	}
 }
+
+// A record's size must not depend on which Go release built deja. An invalid
+// byte is written as the replacement character, and 1.25 escapes that as six
+// bytes where 1.27 writes it raw as three — so the digest is coerced to valid
+// UTF-8 before it is marshalled, and the answer is three either way (#1982).
+func TestARecordIsTheSameSizeOnEveryToolchain(t *testing.T) {
+	body := strings.Repeat("\xff", 8192)
+	b, err := marshalSnapshot(Snapshot{
+		Time: time.Now().UTC(), Kind: KindBlame, Sessions: 1,
+		Bytes: len(body), Digest: body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), `\ufffd`) {
+		t.Errorf("the record carries escaped replacement characters, which cost six bytes each")
+	}
+	if len(b) > RecordSize(len(body)) {
+		t.Errorf("record is %d bytes for a body of %d; the bound says %d", len(b), len(body), RecordSize(len(body)))
+	}
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -48,6 +48,21 @@ const (
 // be held to it.
 const RecordRoom = snapshotRotateAt / snapshotsToKeep
 
+// RecordSize is what an answer of n bytes weighs once it is a line in this log:
+// the JSON envelope around it, plus what escaping costs.
+//
+// Escaping is a multiplier rather than a constant, which is what makes this a
+// function. Measured against a budget of 8192: plain text costs 168 bytes, a
+// real digest with its newlines 558, and text that is all newlines or all
+// quotes doubles — each of those is two bytes in JSON. A control byte costs six
+// (), but SafeText and SafeLine strip control bytes before any of this
+// text becomes a digest, so the doubling is the bound that applies.
+//
+// The envelope is the record's own fields — the stamp, the kind, the policy
+// name, the terms, the receiving session — and 512 covers them with room for
+// the longest of each.
+func RecordSize(n int) int { return 2*n + 512 }
+
 // SnapshotPath returns the injection-snapshot log for an index dir; a sibling
 // file like the usage log, so it survives full rebuilds.
 func SnapshotPath(indexDir string) string {

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -279,6 +279,12 @@ func Events(indexDir string, n int) []Event {
 // 26 kB this log holds, which is the state #1971 is about. The escaping exists
 // so a document can be embedded in HTML; this file is read by deja (#1982).
 func marshalSnapshot(s Snapshot) ([]byte, error) {
+	// Coerced to valid UTF-8 first, and not only for tidiness: an invalid byte
+	// is written as the replacement character, and whether that costs three
+	// bytes or six depends on the Go release — 1.25 escapes it, 1.27 writes it
+	// raw. A record whose size depends on the toolchain is not a record with a
+	// bound, and a transcript picks up invalid bytes from any truncated paste.
+	s.Digest = strings.ToValidUTF8(s.Digest, "\ufffd")
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -54,14 +54,21 @@ const RecordRoom = snapshotRotateAt / snapshotsToKeep
 // Escaping is a multiplier rather than a constant, which is what makes this a
 // function. Measured against a budget of 8192: plain text costs 168 bytes, a
 // real digest with its newlines 558, and text that is all newlines or all
-// quotes doubles — each of those is two bytes in JSON. A control byte costs six
-// (), but SafeText and SafeLine strip control bytes before any of this
-// text becomes a digest, so the doubling is the bound that applies.
+// quotes doubles, since each is two bytes in JSON. Three, not two, because a
+// byte that is not valid UTF-8 is written as the replacement character and
+// costs three — a truncated binary paste in a transcript is enough, and nothing
+// strips it.
+//
+// Two things are kept out of the multiplier rather than allowed for. Control
+// bytes would cost six each as \u00XX escapes, and SafeText strips them before
+// any of this text becomes a digest. So would <, > and & under encoding/json's
+// default HTML escaping — and those are ordinary text nobody should strip, so
+// the writer turns that escaping off instead (#1982).
 //
 // The envelope is the record's own fields — the stamp, the kind, the policy
-// name, the terms, the receiving session — and 512 covers them with room for
-// the longest of each.
-func RecordSize(n int) int { return 2*n + 512 }
+// name, the terms, the receiving session — measured at 168 typical and 344 with
+// a long policy name, eight terms and a 128-character session id.
+func RecordSize(n int) int { return 3*n + 512 }
 
 // SnapshotPath returns the injection-snapshot log for an index dir; a sibling
 // file like the usage log, so it survives full rebuilds.
@@ -137,7 +144,7 @@ func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policy
 	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
 		return
 	}
-	b, err := json.Marshal(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions,
+	b, err := marshalSnapshot(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions,
 		Bytes: len(digest), Policy: policyName, Terms: terms, Into: into, Digest: digest})
 	if err != nil {
 		return
@@ -182,7 +189,7 @@ func rotateSnapshots(p string, incoming int) {
 	for {
 		buf.Reset()
 		for i := len(snaps) - 1; i >= 0; i-- {
-			if b, err := json.Marshal(snaps[i]); err == nil {
+			if b, err := marshalSnapshot(snaps[i]); err == nil {
 				buf.Write(append(b, '\n'))
 			}
 		}
@@ -264,4 +271,20 @@ func Events(indexDir string, n int) []Event {
 		out = out[:n]
 	}
 	return out
+}
+
+// marshalSnapshot writes one record without encoding/json's HTML escaping. That
+// escaping turns <, > and & into six bytes each, and a digest is often code: an
+// answer at the widest budget made of angle brackets weighed 49 kB against the
+// 26 kB this log holds, which is the state #1971 is about. The escaping exists
+// so a document can be embedded in HTML; this file is read by deja (#1982).
+func marshalSnapshot(s Snapshot) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(s); err != nil {
+		return nil, err
+	}
+	// Encode appends a newline; the callers add their own.
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
 }


### PR DESCRIPTION
The 2 kB allowance in #1974 was a guess, and it described the wrong thing. Measured, against the 8192-byte budget it was guarding:

```
plain text                   body= 8190 record=  8358 overhead=  168 (1.02x)
a real digest with newlines  body= 8385 record=  8943 overhead=  558 (1.07x)
every byte a newline         body= 8192 record= 16552 overhead= 8360 (2.02x)
every byte a quote           body= 8192 record= 16552 overhead= 8360 (2.02x)
control bytes                body= 8192 record= 49320 overhead=41128 (6.02x)
cyrillic                     body=15360 record= 15529 overhead=  169 (1.01x)
```

The overhead is not a constant. JSON escaping is a multiplier: a newline and a quote are two bytes each, and a control byte is six. A fixed allowance is the right shape only for the frame, which is 154 bytes and never moves.

So `usage.RecordSize(n)` is `2n + 512` and the guard uses it. At the widest budget that is 16.9 kB against 26.2 kB of room — and a budget twice as wide would not fit, which the test asserts so the bound is not vacuous.

The doubling holds only because control bytes never reach a digest: at six bytes each the model would be wrong by three times. That is `SafeText` and `SafeLine`, and it was pinned for a different reason — an escape byte recolours a terminal — so this adds the case that says why the arithmetic depends on it too, across escape, bell, SOH, NUL, carriage return, vertical tab and delete.

No behaviour change: nothing is over the line today, and nothing here moves a budget or a threshold.
