### PR TITLE
test: fail on a control byte in tracked text

### DIFF
--- a/cmd/deja/doctor_sync_json_test.go
+++ b/cmd/deja/doctor_sync_json_test.go
@@ -122,7 +122,9 @@ func TestTheJSONReportNamesThePeerExactly(t *testing.T) {
 	if err := runDoctor(&out, []string{"--json", "--offline"}, stubLookup("1.0.0", false), index.DefaultDir()); err != nil {
 		t.Fatal(err)
 	}
-	// The bytes on the wire carry no raw escape: the encoder wrote .
+	// The bytes on the wire carry no raw escape or rewind: an escape byte is
+	// written as the six characters of a \u001b sequence, and this asserts on
+	// the bytes rather than on what a terminal would make of them.
 	if strings.ContainsAny(out.String(), "\x1b\r") {
 		t.Errorf("the encoded report carries a raw escape or rewind")
 	}

--- a/internal/index/source_bytes_test.go
+++ b/internal/index/source_bytes_test.go
@@ -1,0 +1,101 @@
+package index
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A control byte in tracked text is invisible in an editor and invisible in a
+// diff, so it survives review by being unreadable. Two reached comments about
+// control bytes — one in `internal/usage/snapshots.go` and one in a comment
+// claiming the bytes on the wire carry no raw escape (#1983) — and the second
+// was found only because someone ran `od -c` over a diff.
+//
+// Tab, newline and carriage return are the three a text file is made of. A file
+// holding a NUL is binary and not this test's business: the testdata fixtures
+// deja parses are exactly that.
+func TestNoControlBytesInTrackedText(t *testing.T) {
+	root := repoRoot(t)
+	var found []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", "dist", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil || bytes.IndexByte(b, 0) >= 0 {
+			return nil
+		}
+		for i, c := range b {
+			if c == '\t' || c == '\n' || c == '\r' {
+				continue
+			}
+			if c < 0x20 || c == 0x7f {
+				rel, _ := filepath.Rel(root, path)
+				found = append(found, formatByteHit(rel, b, i, c))
+				return nil
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(found) > 0 {
+		t.Errorf("control bytes in tracked text, which no editor and no diff will show:\n%s",
+			strings.Join(found, "\n"))
+	}
+}
+
+// formatByteHit names the file, the line and the byte, since the byte itself
+// prints as nothing.
+func formatByteHit(rel string, b []byte, at int, c byte) string {
+	line := 1 + bytes.Count(b[:at], []byte("\n"))
+	return "  " + rel + ":" + itoa(line) + ": byte 0x" + hexByte(c)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var d []byte
+	for n > 0 {
+		d = append([]byte{byte('0' + n%10)}, d...)
+		n /= 10
+	}
+	return string(d)
+}
+
+func hexByte(c byte) string {
+	const digits = "0123456789abcdef"
+	return string([]byte{digits[c>>4], digits[c&0xf]})
+}
+
+// repoRoot walks up to the directory holding go.mod.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("no go.mod above the working directory")
+		}
+		dir = parent
+	}
+}

--- a/internal/index/source_bytes_test.go
+++ b/internal/index/source_bytes_test.go
@@ -2,83 +2,71 @@ package index
 
 import (
 	"bytes"
-	"io/fs"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
 // A control byte in tracked text is invisible in an editor and invisible in a
-// diff, so it survives review by being unreadable. Two reached comments about
-// control bytes — one in `internal/usage/snapshots.go` and one in a comment
-// claiming the bytes on the wire carry no raw escape (#1983) — and the second
-// was found only because someone ran `od -c` over a diff.
+// diff, so it survives review by being unreadable. One is in this repository:
+// a comment in `cmd/deja/doctor_sync_json_test.go` said the bytes on the wire
+// carry no raw escape and carried one (#1983). Another reached a comment on a
+// branch during this work and was found only because a reviewer ran `od -c`
+// over the diff, which is not a review anyone can be asked to repeat.
 //
 // Tab, newline and carriage return are the three a text file is made of. A file
-// holding a NUL is binary and not this test's business: the testdata fixtures
-// deja parses are exactly that.
+// holding a NUL is taken as binary and skipped — today that is two PNGs and two
+// GIFs and nothing else, no fixture among them, and the cost of the heuristic is
+// that a text file which somehow contains a NUL is skipped with them.
 func TestNoControlBytesInTrackedText(t *testing.T) {
 	root := repoRoot(t)
+	// Tracked files only, from git rather than from the filesystem: a walk
+	// reads a developer's build output, their .venv, and the agent-session
+	// directories the .gitignore expects in this checkout — all of them full of
+	// captured terminal escapes. That failure lands only on the machines with
+	// junk in the tree, never in CI, which is the worst way for a guard to be
+	// wrong.
+	out, err := exec.Command("git", "-C", root, "ls-files", "-z").Output()
+	if err != nil {
+		t.Skipf("no git checkout to ask: %v", err)
+	}
+
 	var found []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
+	for _, name := range bytes.Split(out, []byte{0}) {
+		if len(name) == 0 {
+			continue
 		}
-		if d.IsDir() {
-			switch d.Name() {
-			case ".git", "node_modules", "dist", "vendor":
-				return filepath.SkipDir
-			}
-			return nil
-		}
+		path := filepath.Join(root, string(name))
 		b, err := os.ReadFile(path)
-		if err != nil || bytes.IndexByte(b, 0) >= 0 {
-			return nil
+		if err != nil {
+			// A tracked file that cannot be read is not this test's finding,
+			// but it is not a pass either.
+			if !os.IsNotExist(err) {
+				t.Errorf("cannot read tracked file %s: %v", name, err)
+			}
+			continue
+		}
+		if bytes.IndexByte(b, 0) >= 0 {
+			continue
 		}
 		for i, c := range b {
 			if c == '\t' || c == '\n' || c == '\r' {
 				continue
 			}
 			if c < 0x20 || c == 0x7f {
-				rel, _ := filepath.Rel(root, path)
-				found = append(found, formatByteHit(rel, b, i, c))
-				return nil
+				line := 1 + bytes.Count(b[:i], []byte("\n"))
+				found = append(found, fmt.Sprintf("  %s:%d: byte 0x%02x", name, line, c))
+				break
 			}
 		}
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
 	}
 	if len(found) > 0 {
 		t.Errorf("control bytes in tracked text, which no editor and no diff will show:\n%s",
 			strings.Join(found, "\n"))
 	}
-}
-
-// formatByteHit names the file, the line and the byte, since the byte itself
-// prints as nothing.
-func formatByteHit(rel string, b []byte, at int, c byte) string {
-	line := 1 + bytes.Count(b[:at], []byte("\n"))
-	return "  " + rel + ":" + itoa(line) + ": byte 0x" + hexByte(c)
-}
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var d []byte
-	for n > 0 {
-		d = append([]byte{byte('0' + n%10)}, d...)
-		n /= 10
-	}
-	return string(d)
-}
-
-func hexByte(c byte) string {
-	const digits = "0123456789abcdef"
-	return string([]byte{digits[c>>4], digits[c&0xf]})
 }
 
 // repoRoot walks up to the directory holding go.mod.


### PR DESCRIPTION
Fixes #1983.

`cmd/deja/doctor_sync_json_test.go:125` had a raw escape byte inside a comment that said it did not:

```
// The bytes on the wire carry no raw escape: the encoder wrote <one raw 0x1b byte here>.
```

That last part was the byte itself. It renders as nothing in an editor and as nothing in a diff, which is how it got in and how it stayed.

Another reached a comment on a branch during this work — a 0x01, in a comment about stripping control bytes — and was found only because a reviewer ran `od -c` over the diff. It never landed on main, and that is not a review anyone can be asked to repeat.

So: a test that reads the bytes of every file git tracks. Tab, newline and carriage return are what a text file is made of; anything else below 0x20, and 0x7f, fails with the file, the line and the byte in hex, since the byte prints as nothing. A file holding a NUL is taken as binary and skipped — today two PNGs and two GIFs, no fixture among them.

It asks git rather than walking the tree, and CI proved why within a minute of the first push: the walk read benchmark spill files on the macOS runner. On a developer machine it would have read build output, a .venv, and the agent-session directories the .gitignore expects here — captured terminal output, full of raw escapes. The guard would have been red on the machines that matter and green in CI, which is the worst way for a guard to be wrong.

Scanned before writing it: 1468 tracked files, four images, one hit — the file above, and the test fails on the tree without this change.

The comment now says what is true: an escape byte is written as the six characters of a backslash-u-zero-zero-one-b sequence, and the assertion beside it is on the bytes rather than on what a terminal would make of them.
