### PR TITLE
test(usage): state the room one event has, and hold the writers to it

### DIFF
--- a/cmd/deja/usage_event_room_test.go
+++ b/cmd/deja/usage_event_room_test.go
@@ -23,12 +23,13 @@ func TestARealEventFitsItsRoom(t *testing.T) {
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp)
 
-	// Sixty sessions, each with a name as long as the longest a real store
-	// produces — a codex or gemini transcript filename.
-	long := strings.Repeat("the pgbouncer pool kept timing out in transaction mode ", 4)
+	// Shaped for the worst case rather than around it: an event grows with the
+	// number of ids, an answer holds more sessions when each says less, and an
+	// id is as long as a filename may be. Long turns would cut the answer to a
+	// handful of sessions and measure nothing.
 	for i := 0; i < 60; i++ {
-		id := strings.Repeat("a", 60) + string(rune('a'+i%26)) + string(rune('a'+(i/26)%26))
-		seedClaude(t, claude, "app", id, "turn "+long, "reply "+long)
+		id := strings.Repeat("a", 246) + string(rune('a'+i%26)) + string(rune('a'+(i/26)%26))
+		seedClaude(t, claude, "app", id, "pgbouncer timed out", "we retried")
 	}
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
 		t.Fatal(err)
@@ -43,17 +44,27 @@ func TestARealEventFitsItsRoom(t *testing.T) {
 		t.Fatal(err)
 	}
 	var widest int
+	var carried int
 	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		var e usage.Event
+		if json.Unmarshal([]byte(line), &e) != nil {
+			continue
+		}
 		if len(line) > widest {
-			widest = len(line)
+			widest, carried = len(line), len(e.SessionIDs)
 		}
 	}
 	if widest == 0 {
 		t.Fatal("nothing was recorded, so this proves nothing")
 	}
-	if widest > usage.EventRoom {
-		t.Errorf("a recall wrote an event of %d bytes against %d of room: %d ids at 62 characters",
-			widest, usage.EventRoom, 60)
+	// The ids are what grows, so the count is what the failure has to name: the
+	// number of sessions seeded says nothing about how many the answer held.
+	if carried < 2 {
+		t.Fatalf("the widest event carried %d ids, so it measures nothing", carried)
 	}
-	t.Logf("widest event: %d bytes of %d", widest, usage.EventRoom)
+	if widest > usage.EventRoom {
+		t.Errorf("a recall wrote an event of %d bytes against %d of room, carrying %d ids of 248 characters",
+			widest, usage.EventRoom, carried)
+	}
+	t.Logf("widest event: %d bytes of %d, carrying %d ids", widest, usage.EventRoom, carried)
 }

--- a/cmd/deja/usage_event_room_test.go
+++ b/cmd/deja/usage_event_room_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// `usage.EventRoom` is how large one event may be for the log's own rotation to
+// leave it under its threshold — the relationship `internal/usage` states. This
+// is the half that holds the writers to it: a real recall over a store with
+// many sessions, whose ids are what makes an event grow.
+func TestARealEventFitsItsRoom(t *testing.T) {
+	tmp := t.TempDir()
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	// Sixty sessions, each with a name as long as the longest a real store
+	// produces — a codex or gemini transcript filename.
+	long := strings.Repeat("the pgbouncer pool kept timing out in transaction mode ", 4)
+	for i := 0; i < 60; i++ {
+		id := strings.Repeat("a", 60) + string(rune('a'+i%26)) + string(rune('a'+(i/26)%26))
+		seedClaude(t, claude, "app", id, "turn "+long, "reply "+long)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := callMCPTool(index.DefaultDir(), "recall", json.RawMessage(`{"query":"pgbouncer","limit":100}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := os.ReadFile(usage.Path(index.DefaultDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var widest int
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		if len(line) > widest {
+			widest = len(line)
+		}
+	}
+	if widest == 0 {
+		t.Fatal("nothing was recorded, so this proves nothing")
+	}
+	if widest > usage.EventRoom {
+		t.Errorf("a recall wrote an event of %d bytes against %d of room: %d ids at 62 characters",
+			widest, usage.EventRoom, 60)
+	}
+	t.Logf("widest event: %d bytes of %d", widest, usage.EventRoom)
+}

--- a/internal/usage/event_room_test.go
+++ b/internal/usage/event_room_test.go
@@ -16,7 +16,11 @@ import (
 // it: how much an event can carry. Only `ids` grows, and it grows with the
 // sessions an answer holds, which its own byte budget bounds. This states the
 // room each event has; `TestARealEventFitsItsRoom` in cmd/deja holds the
-// writers to it.
+// writers to it, measured at 2.9 kB for the widest a writer produces.
+//
+// The fallback is the branch this bounds. The ordinary rotation — keep what is
+// inside the window — has no size rule, and the comment on EventRoom says what
+// that leaves open.
 func TestTheKeptEventsFitTheLogTheyAreKeptIn(t *testing.T) {
 	if keepAtLeast*EventRoom >= rotateAt {
 		t.Errorf("%d events of %d bytes is %d, and the log rotates at %d: a rotation would leave it over its own threshold",
@@ -28,8 +32,8 @@ func TestTheKeptEventsFitTheLogTheyAreKeptIn(t *testing.T) {
 // written, not on the fields before they are marshalled.
 func TestAnEventAtItsRoomIsWithinIt(t *testing.T) {
 	dir := t.TempDir()
-	// A widest answer's worth of session ids, at the longest a real store
-	// produces: 70 characters, which is a codex or gemini transcript name.
+	// Wider than any writer produces: a filename's worth of id, twenty times
+	// over, against the eleven a real recall carried.
 	ids := make([]string, 20)
 	for i := range ids {
 		ids[i] = strings.Repeat("a", 70)

--- a/internal/usage/event_room_test.go
+++ b/internal/usage/event_room_test.go
@@ -1,0 +1,50 @@
+package usage
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// When every event is older than the window it keeps, the rotation falls back
+// to the newest `keepAtLeast`. Those have to fit under `rotateAt`, or the
+// rotation leaves the file over its own threshold and the next write rotates
+// again — the state #1971 measured in the injection log, where half of two
+// concurrent injections was rewritten away.
+//
+// The relationship is between three numbers in this file and one thing outside
+// it: how much an event can carry. Only `ids` grows, and it grows with the
+// sessions an answer holds, which its own byte budget bounds. This states the
+// room each event has; `TestARealEventFitsItsRoom` in cmd/deja holds the
+// writers to it.
+func TestTheKeptEventsFitTheLogTheyAreKeptIn(t *testing.T) {
+	if keepAtLeast*EventRoom >= rotateAt {
+		t.Errorf("%d events of %d bytes is %d, and the log rotates at %d: a rotation would leave it over its own threshold",
+			keepAtLeast, EventRoom, keepAtLeast*EventRoom, rotateAt)
+	}
+}
+
+// And an event of that size really is that size — the bound is on the record as
+// written, not on the fields before they are marshalled.
+func TestAnEventAtItsRoomIsWithinIt(t *testing.T) {
+	dir := t.TempDir()
+	// A widest answer's worth of session ids, at the longest a real store
+	// produces: 70 characters, which is a codex or gemini transcript name.
+	ids := make([]string, 20)
+	for i := range ids {
+		ids[i] = strings.Repeat("a", 70)
+	}
+	RecordServedSessions(dir, KindRecall, 4096, len(ids), false, 40960, ids)
+
+	events := read(Path(dir))
+	if len(events) != 1 {
+		t.Fatalf("wrote one event, read %d", len(events))
+	}
+	b, err := json.Marshal(events[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := len(b); n > EventRoom {
+		t.Errorf("an event carrying %d ids is %d bytes against %d of room", len(ids), n, EventRoom)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -149,6 +149,12 @@ const (
 	// (#1922). Measured at 59.8 KB, against the megabyte that triggers a
 	// rewrite.
 	keepAtLeast = 200
+	// EventRoom is how large one event may be for the fallback above to leave
+	// the file under its threshold: keepAtLeast of them have to fit in
+	// rotateAt, with room to spare. Measured, a widest answer's ids come to
+	// about 1.4 kB, so this is set where the check is meaningful rather than
+	// where today's events happen to sit.
+	EventRoom = 4096
 	// memoWindow is how long a read's finding answers for later appends. Short
 	// enough that an event arriving with an old stamp waits minutes rather than
 	// a fortnight, long enough that a busy process pays the read rarely.

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -151,9 +151,15 @@ const (
 	keepAtLeast = 200
 	// EventRoom is how large one event may be for the fallback above to leave
 	// the file under its threshold: keepAtLeast of them have to fit in
-	// rotateAt, with room to spare. Measured, a widest answer's ids come to
-	// about 1.4 kB, so this is set where the check is meaningful rather than
-	// where today's events happen to sit.
+	// rotateAt. A recall over short sessions with filename-length ids writes
+	// 2.9 kB of it, which is the widest a writer produces today.
+	//
+	// It bounds that fallback and not the ordinary rotation, which keeps
+	// whatever is inside the window and can leave the file over the threshold
+	// with no size rule at all. That state is transient — the next write finds
+	// nothing to drop and stops re-reading (#1972) — and closing it properly is
+	// the retention question that issue leaves open. The injection log took the
+	// other road in #1971 and drops the oldest until the rebuild fits.
 	EventRoom = 4096
 	// memoWindow is how long a read's finding answers for later appends. Short
 	// enough that an event arriving with an old stamp waits minutes rather than


### PR DESCRIPTION
No bug: the usage log's own numbers hold, with a factor to spare. This states the relationship between them and holds the writers to it.

When every event is older than the fourteen days it keeps, the rotation falls back to the newest 200. Those have to fit under the 1 MB that triggered the rotation — or it leaves the file over its own threshold and the next write rotates again, which is what #1971 measured in the injection log.

Measured, one event by what it carries:

```
an ordinary recall             106 bytes
a recall over many sessions   7898 bytes   (200 ids of 36)
ids as long as a path        15247 bytes   (50 ids of 300)
```

Only `ids` grows, and it grows with the sessions an answer holds, which the answer's own byte budget bounds. Real session ids are 35 to 42 characters for Claude and up to 70 for a codex or gemini transcript name, so a widest answer carries on the order of a kilobyte of them.

Driven rather than argued: a recall with `limit: 100` over sixty sessions whose ids are 62 characters writes an event of **420 bytes**, against the 4096 this now states as the room. 200 of those is 800 kB against a megabyte.

Two tests: the arithmetic between the three constants, and a real recall held to the bound. Neither is a free pass — raise `keepAtLeast` past 256 and the first fails; make an answer carry its ids unbounded and the second does.
