### PR TITLE
test(usage): measure the shape that costs three bytes a character

### DIFF
--- a/internal/search/control_bytes_test.go
+++ b/internal/search/control_bytes_test.go
@@ -6,8 +6,8 @@ import (
 
 // Control bytes never reach the text deja hands an agent, and two things rest
 // on that. The one this file was written for: a control byte is six bytes in
-// JSON, so a digest carrying them would weigh three times what
-// `usage.RecordSize` says, and the injection log's own bound would be wrong.
+// JSON, so a digest carrying them would weigh twice what
+// `usage.RecordSize` says — six bytes against the three it allows — and the log's own bound would be wrong.
 // This holds SafeText and SafeLine to it; that every digest is built through
 // one of them is about two dozen call sites and is not what this proves.
 // The older one is why the stripping is there at all — an escape byte

--- a/internal/usage/envelope_test.go
+++ b/internal/usage/envelope_test.go
@@ -1,0 +1,46 @@
+package usage
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// `RecordSize` allows 512 bytes for the envelope — the stamp, the kind, the
+// policy name, the terms, the receiving session — and every case that measures
+// the escaping uses a body big enough that 3n swamps that half. This measures
+// the envelope on its own.
+//
+// The terms are the part that grows: a prompt containing one long word puts
+// that word in the record, and `prompt.Terms` treats a path or a hash as a
+// single token (#1988).
+func TestTheEnvelopeFitsWhatItIsAllowed(t *testing.T) {
+	body := "a digest"
+	for _, c := range []struct {
+		name string
+		snap Snapshot
+	}{
+		{"a bare record", Snapshot{Time: time.Now().UTC(), Kind: KindHook, Digest: body}},
+		{"every field at a plausible size", Snapshot{
+			Time: time.Now().UTC(), Kind: KindRecall, Sessions: 99, Bytes: len(body),
+			Policy: "local+imported+promoted+whatever-a-policy-name-can-be",
+			Terms:  []string{"pgbouncer", "transaction", "prepared", "statements", "timeout", "retry"},
+			Into:   strings.Repeat("s", 128), Digest: body,
+		}},
+		{"terms from a prompt holding a long path", Snapshot{
+			Time: time.Now().UTC(), Kind: KindDejaVu, Sessions: 2, Bytes: len(body),
+			Terms: []string{strings.Repeat("pgbouncer/", 400), "timeout"}, Digest: body,
+		}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			b, err := marshalSnapshot(c.snap)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n := len(b); n > RecordSize(len(body)) {
+				t.Errorf("record is %d bytes for a digest of %d; RecordSize says %d",
+					n, len(body), RecordSize(len(body)))
+			}
+		})
+	}
+}

--- a/internal/usage/record_size_test.go
+++ b/internal/usage/record_size_test.go
@@ -28,9 +28,12 @@ func TestWhatARecordWeighs(t *testing.T) {
 		{"angle brackets, as code has them", strings.Repeat("<T> & Vec<U> ", 630), true},
 		{"a shell pipeline", strings.Repeat("cat a.txt | grep x > out.txt && ", 256), true},
 		// One run of invalid bytes is one replacement character — ToValidUTF8
-		// collapses it — so a solid block measures nothing. Alternating is what
-		// costs three per byte, and 2.51x is the worst a body reaches.
+		// collapses it — so a solid block measures nothing. What costs is an
+		// invalid byte beside a character JSON escapes: three out for the one,
+		// two for the other, and 2.5 is the ceiling that gives.
 		{"invalid bytes in one run", strings.Repeat("\xff", budget), true},
+		// A plain letter costs one byte out, so this is 2x — the same as a
+		// newline on its own, and here to show what the neighbour has to be.
 		{"invalid bytes alternating with text", strings.Repeat("\xffa", budget/2), true},
 		{"invalid bytes alternating with newlines", strings.Repeat("\xff\n", budget/2), true},
 		// The one class the bound does not cover, kept so the reason is on the

--- a/internal/usage/record_size_test.go
+++ b/internal/usage/record_size_test.go
@@ -27,7 +27,12 @@ func TestWhatARecordWeighs(t *testing.T) {
 		{"cyrillic", strings.Repeat("отладка ", 1024), true},
 		{"angle brackets, as code has them", strings.Repeat("<T> & Vec<U> ", 630), true},
 		{"a shell pipeline", strings.Repeat("cat a.txt | grep x > out.txt && ", 256), true},
-		{"bytes that are not valid UTF-8", strings.Repeat("\xff", budget), true},
+		// One run of invalid bytes is one replacement character — ToValidUTF8
+		// collapses it — so a solid block measures nothing. Alternating is what
+		// costs three per byte, and 2.51x is the worst a body reaches.
+		{"invalid bytes in one run", strings.Repeat("\xff", budget), true},
+		{"invalid bytes alternating with text", strings.Repeat("\xffa", budget/2), true},
+		{"invalid bytes alternating with newlines", strings.Repeat("\xff\n", budget/2), true},
 		// The one class the bound does not cover, kept so the reason is on the
 		// record: six bytes each, and RecordSize would be wrong by twice.
 		{"control bytes, which cannot reach here", strings.Repeat("\x01", budget), false},

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -54,10 +54,12 @@ const RecordRoom = snapshotRotateAt / snapshotsToKeep
 // Escaping is a multiplier rather than a constant, which is what makes this a
 // function. Measured against a budget of 8192: plain text costs 168 bytes, a
 // real digest with its newlines 558, and text that is all newlines or all
-// quotes doubles, since each is two bytes in JSON. Three, not two, because a
-// byte that is not valid UTF-8 is written as the replacement character and
-// costs three — a truncated binary paste in a transcript is enough, and nothing
-// strips it.
+// quotes doubles, since each is two bytes in JSON. Three, not two, because of
+// what a truncated binary paste does: an invalid byte becomes the replacement
+// character, three bytes, and the worst shape is invalid bytes alternating with
+// newlines — measured at 2.51 times the body. A solid run of invalid bytes is
+// not the worst case and looks like the best one, since ToValidUTF8 collapses a
+// run to a single character.
 //
 // Two things are kept out of the multiplier rather than allowed for. Control
 // bytes would cost six each as \u00XX escapes, and SafeText strips them before

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -57,9 +57,14 @@ const RecordRoom = snapshotRotateAt / snapshotsToKeep
 // quotes doubles, since each is two bytes in JSON. Three, not two, because of
 // what a truncated binary paste does: an invalid byte becomes the replacement
 // character, three bytes, and the worst shape is invalid bytes alternating with
-// newlines — measured at 2.51 times the body. A solid run of invalid bytes is
-// not the worst case and looks like the best one, since ToValidUTF8 collapses a
-// run to a single character.
+// newlines. The ceiling there is exactly 2.5: three bytes out for the invalid
+// byte, two for the cheapest neighbour that stops it collapsing — brute-forced
+// over every one and two byte repeat unit, and nothing beats it. A solid run of
+// invalid bytes is not the worst case and looks like the best one, since
+// ToValidUTF8 collapses a run to a single character.
+//
+// The other 512 is the envelope, which is only a constant because the terms are
+// bounded before they are written (#1988).
 //
 // Two things are kept out of the multiplier rather than allowed for. Control
 // bytes would cost six each as \u00XX escapes, and SafeText strips them before
@@ -287,6 +292,7 @@ func marshalSnapshot(s Snapshot) ([]byte, error) {
 	// raw. A record whose size depends on the toolchain is not a record with a
 	// bound, and a transcript picks up invalid bytes from any truncated paste.
 	s.Digest = strings.ToValidUTF8(s.Digest, "\ufffd")
+	s.Terms = boundTerms(s.Terms)
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
@@ -295,4 +301,37 @@ func marshalSnapshot(s Snapshot) ([]byte, error) {
 	}
 	// Encode appends a newline; the callers add their own.
 	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// termsRoom is what a record carries of the query terms behind a déjà vu
+// firing. They are there so a wrong "you have been here" can be explained
+// afterwards, and a term cut to its first characters still does that — while an
+// uncut one does not fit the envelope RecordSize allows: `prompt.Terms` treats a
+// pasted path or hash as one token, and one such word wrote a record 1.8 times
+// its own bound (#1988).
+const termsRoom = 256
+
+// boundTerms is the terms as the record keeps them: the same terms, each cut so
+// the set fits termsRoom, and nothing dropped — a term that is missing reads as
+// a term that did not match.
+func boundTerms(terms []string) []string {
+	total := 0
+	for _, t := range terms {
+		total += len(t) + 3 // the quotes and the comma
+	}
+	if total <= termsRoom {
+		return terms
+	}
+	each := termsRoom/max(len(terms), 1) - 3
+	if each < 8 {
+		each = 8
+	}
+	out := make([]string, len(terms))
+	for i, t := range terms {
+		if len(t) > each {
+			t = strings.ToValidUTF8(t[:each], "") + "…"
+		}
+		out[i] = t
+	}
+	return out
 }


### PR DESCRIPTION
The question was whether the two constants behind the injection log's size bound can drift apart without a test noticing. They cannot — but the model between them could, and that is what this fixes.

Mutated each in turn:

```
snapshotsToKeep 20 -> 60         CAUGHT
snapshotsToKeep 20 -> 5          CAUGHT
snapshotRotateAt 512k -> 128k    CAUGHT
keepAtLeast 200 -> 400           CAUGHT
EventRoom 4096 -> 16384          CAUGHT

RecordSize 3n -> 2n              passed — nothing noticed
RecordSize envelope 512 -> 0     passed — nothing noticed
```

The constants are held; the model was not. The case that was supposed to justify the third byte is 8192 invalid bytes in a row — and `strings.ToValidUTF8` replaces a *run* with one replacement character, so that case measures 91 bytes for an 8 kB body. 0.01×, proving the opposite of what it claimed.

The number itself is right, and here is what makes it right:

```
all invalid, one run              body=8192 record=    91 (0.01x)
invalid alternating with text     body=8192 record= 16472 (2.01x)
invalid alternating with newline  body=8192 record= 20568 (2.51x)  over 2n
invalid, quote, newline           body=8190 record= 19197 (2.34x)  over 2n
```

Alternating is what costs three bytes a character, because keeping invalid bytes apart is what stops them collapsing into one. 2.51× is the worst a body reaches, so `3n + 512` is the bound and not a guess.

Both shapes are cases now, and weakening the model to `2n + 512` fails on the alternating one. The comment says why a solid run is the best case rather than the worst, which is the thing that fooled me.
