### PR TITLE
test: drive the handoff too

### DIFF
--- a/cmd/deja/digest_control_bytes_test.go
+++ b/cmd/deja/digest_control_bytes_test.go
@@ -133,6 +133,22 @@ func TestNothingServedCarriesAControlByte(t *testing.T) {
 		}
 	})
 
+	t.Run("a handoff", func(t *testing.T) {
+		// The path `internal/digest.MessageText` serves, and the one #1985 left
+		// out for being CLI-shaped: dropping that sanitiser left every other
+		// case here green while a raw escape reached the text a person pastes.
+		out, err := captureRun(t, "handoff", "s1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out, "pgbouncer") {
+			t.Fatalf("the handoff carried none of the session:\n%q", out)
+		}
+		if at := controlByteAt(out); at >= 0 {
+			t.Errorf("the handoff carried byte 0x%02x at %d", out[at], at)
+		}
+	})
+
 	// And the records those paths left behind, which is where the size bound
 	// reads them.
 	snaps := usage.Snapshots(idx, 0)

--- a/cmd/deja/digest_control_bytes_test.go
+++ b/cmd/deja/digest_control_bytes_test.go
@@ -30,7 +30,10 @@ func TestNothingServedCarriesAControlByte(t *testing.T) {
 	}
 	// Colour, a bell, and a rewind — captured terminal output, as a transcript
 	// picks it up.
-	dirty := "the build failed: \x1b[31mERROR\x1b[0m\x07 pgbouncer pool timed out\r and retried"
+	// Names a file, so `blame` has something to answer about: a case that comes
+	// back empty measures nothing, which is how the first version of this test
+	// let blame through (#1985).
+	dirty := "the build failed in parser.go: \x1b[31mERROR\x1b[0m\x07 pgbouncer pool timed out\r and retried"
 	line := func(role string) string {
 		b, err := json.Marshal(map[string]any{
 			"type": role, "sessionId": "s1", "cwd": "/tmp/app",
@@ -61,6 +64,7 @@ func TestNothingServedCarriesAControlByte(t *testing.T) {
 	}{
 		{"recall", `{"query":"pgbouncer"}`, "recall"},
 		{"recall_context", `{"query":"pgbouncer"}`, "recall_context"},
+		{"blame", `{"path":"parser.go"}`, "blame"},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			out, err := callMCPTool(idx, c.tool, json.RawMessage(c.args))

--- a/internal/digest/message_text_test.go
+++ b/internal/digest/message_text_test.go
@@ -6,10 +6,9 @@ import (
 )
 
 // `MessageText` is the third place served text is stripped, after
-// `search.SafeText` and `redact.SafeForDisplay` — and it is the one no path
-// test reaches: the handoff digest is built through it and is CLI-shaped, so
-// dropping the sanitiser here leaves every other guard green while a raw escape
-// reaches the file a person opens (#1985).
+// `search.SafeText` and `redact.SafeForDisplay` — the one the handoff digest
+// is built through. This holds it directly; `TestNothingServedCarriesAControlByte`
+// holds the path (#1985, #1989).
 func TestMessageTextStripsWhatATerminalActsOn(t *testing.T) {
 	in := "the build failed: \x1b[31mERROR\x1b[0m\x07 pgbouncer pool timed out\r and retried"
 


### PR DESCRIPTION
Two writers of a snapshot that the control-byte test did not drive: the handoff digest, and blame — which I had dropped from #1985 rather than fixed.

The handoff, over the same transcript full of captured terminal output:

```
handoff printed 924 bytes, keeps a control byte: false
snapshot kind=handoff  digest=924  keeps a control byte: false
```

It is the path `internal/digest.MessageText` serves, and the reason it had no path test is that `deja handoff` looked CLI-shaped. It is three lines. Worth having for a specific reason: dropping that sanitiser is the sabotage that left every other case in that test green while a raw escape reached the text a person pastes into another agent. It fails here now, and only here.

Blame answered `[]` for that fixture, which is why I dropped it — the fixture never named a file. It does now, and blame answers about it. An empty answer no longer passes: point it at a file nothing mentions and the case fails with `"[]"`.

Eight writers driven: recall, recall_context, blame, the session start, the prompt hook, a `deja://session/…` read, the antigravity hook and the handoff. The ninth line — the session start's environment-block branch — goes through the same writer as its digest branch.

Also corrected: `message_text_test.go` said its subject was the one no path test reaches, which this PR makes untrue.
