### PR TITLE
perf(main): stop parsing every store to count its files

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -3063,8 +3063,14 @@ func deniedStoreCount() int {
 // opposed to an index that merely has not been built yet.
 func noAgentHistoryFound() bool {
 	for _, check := range doctorStoreChecks() {
-		store, _ := inspectDoctorStore(check)
-		if store.Files == 0 {
+		// The count, not the inspection. `store.Files` is `len(check.files)`
+		// and nothing else ever sets it (doctor_report.go:471), so asking
+		// `inspectDoctorStore` for it paid a stat per path, a listing per
+		// directory, and the newest file of the store opened and run through
+		// that store's parser — SQLite for opencode and cursor — to learn a
+		// number already in hand. Measured on a real home, 514 ms against
+		// 6.6 ms for the same answer (#1991).
+		if len(check.files) == 0 {
 			continue
 		}
 		// By content, not by existence: an empty notes file — one `deja

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -3024,6 +3024,12 @@ func emptyIndexReason(b index.BuildSummary, evicted int) string {
 // so telling someone to run `deja index` sends them to do again what just
 // happened, and they are left where they started. When no agent history was
 // found at all, the useful next step is finding out where deja looked.
+// Both questions below walk every store — stat each path, list each directory,
+// and open the newest file (doctor_report.go:530) — and on a machine with
+// history the first returns at the first store that has some, which is why
+// answering them from one shared walk is slower rather than faster: measured on
+// 21 stores, 0.4 ms as it stands against 1.0 ms for a walk that always
+// completes. The two walks only both happen when there is no history at all.
 func emptyIndexHint(what string) string {
 	if noAgentHistoryFound() {
 		// "no agent history was found" is a claim about the machine, and it

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -3024,12 +3024,16 @@ func emptyIndexReason(b index.BuildSummary, evicted int) string {
 // so telling someone to run `deja index` sends them to do again what just
 // happened, and they are left where they started. When no agent history was
 // found at all, the useful next step is finding out where deja looked.
-// Both questions below walk every store — stat each path, list each directory,
-// and open the newest file (doctor_report.go:530) — and on a machine with
-// history the first returns at the first store that has some, which is why
-// answering them from one shared walk is slower rather than faster: measured on
-// 21 stores, 0.4 ms as it stands against 1.0 ms for a walk that always
-// completes. The two walks only both happen when there is no history at all.
+// Both questions below enumerate every store and then inspect them — a stat per
+// path, a listing per directory, and the newest file opened when nothing
+// refused (doctor_report.go:530). The first stops at the first store that has
+// any history, so answering both from one completed walk trades that
+// short-circuit away and measured slower rather than faster.
+//
+// The whole path is a fraction of a millisecond on 21 stores, and the spread
+// between runs is wider than the difference, so it is not worth restructuring
+// in either direction — which is the thing worth writing down, since the
+// obvious tidy-up is the slower one.
 func emptyIndexHint(what string) string {
 	if noAgentHistoryFound() {
 		// "no agent history was found" is a claim about the machine, and it

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -3024,16 +3024,6 @@ func emptyIndexReason(b index.BuildSummary, evicted int) string {
 // so telling someone to run `deja index` sends them to do again what just
 // happened, and they are left where they started. When no agent history was
 // found at all, the useful next step is finding out where deja looked.
-// Both questions below enumerate every store and then inspect them — a stat per
-// path, a listing per directory, and the newest file opened when nothing
-// refused (doctor_report.go:530). The first stops at the first store that has
-// any history, so answering both from one completed walk trades that
-// short-circuit away and measured slower rather than faster.
-//
-// The whole path is a fraction of a millisecond on 21 stores, and the spread
-// between runs is wider than the difference, so it is not worth restructuring
-// in either direction — which is the thing worth writing down, since the
-// obvious tidy-up is the slower one.
 func emptyIndexHint(what string) string {
 	if noAgentHistoryFound() {
 		// "no agent history was found" is a claim about the machine, and it

--- a/cmd/deja/store_files_cost_test.go
+++ b/cmd/deja/store_files_cost_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// `noAgentHistoryFound` reads one field of the inspection — `store.Files`,
+// which is `len(check.files)` set at doctor_report.go:471 and never mutated —
+// and pays a stat per path, a listing per directory, and the newest file of
+// every store opened and run through that store's parser to get it. On a real
+// home that measured 514 ms against 6.6 ms for the same answer (#1991).
+//
+// A ratio rather than a duration, so it means the same thing on a slow runner,
+// and against the enumeration rather than the clock, so it does not become a
+// flake when a machine is busy.
+func TestTheEmptyScreenDoesNotParseEveryStore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing")
+	}
+	hermeticEnv(t)
+	claude := os.Getenv("DEJA_CLAUDE_ROOT")
+	// Files big enough that parsing them is not free: the sandbox is why this
+	// cost was invisible to my first measurement, so the fixture has to put it
+	// back.
+	long := make([]byte, 4<<20)
+	for i := range long {
+		long[i] = 'x'
+	}
+	for i := 0; i < 4; i++ {
+		seedClaude(t, claude, "app", string(rune('a'+i)), "the pgbouncer pool kept timing out "+string(long), "we retried")
+	}
+
+	start := time.Now()
+	checks := doctorStoreChecks()
+	enumerate := time.Since(start)
+
+	start = time.Now()
+	answer := noAgentHistoryFound()
+	asked := time.Since(start)
+
+	if answer {
+		t.Fatal("the fixture has history, so this measures nothing")
+	}
+	// Four times the enumeration, plus a millisecond or two of slack for a
+	// loaded runner: far above the spread between runs, far below the cost of
+	// reading and parsing a store's newest file.
+	if asked > 4*enumerate+2*time.Millisecond {
+		t.Errorf("the question took %v against %v to enumerate the stores: it is parsing them", asked, enumerate)
+	}
+	t.Logf("enumerate %v, answer %v (%d stores)", enumerate, asked, len(checks))
+
+	if _, err := os.Stat(filepath.Join(claude, "-app")); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Fixes #1991. What started as a comment recording a negative result turned into a real fix, because the negative result was measured wrong.

`noAgentHistoryFound` called `inspectDoctorStore` for every store and read exactly one field of the answer: `store.Files`. That field is `len(check.files)`, set at `doctor_report.go:471` and never mutated anywhere. Everything the inspection did to produce it — a stat per path, a listing per directory, the newest file opened and run through that store's own parser, SQLite for opencode and cursor — was discarded.

On a real home directory with 21 stores, measured by the reviewer of this PR: **514 ms against 6.6 ms** for the same answer. It runs on bare `deja` and on every empty answer that goes through `emptyIndexHint`.

The test that pins it compares the question against the enumeration that precedes it rather than against the clock, so it means the same thing on a loaded runner. On this branch: 10.7 ms before, 150 µs after, against 500 µs to enumerate.

My own first measurement said microseconds and was an artefact of `hermeticEnv`, which points every store root at an empty temp directory — nothing to parse, so the cost disappears. The fixture now writes files big enough to put it back.

`install.go:415` reads `State` and `Paths` as well, so it needs the inspection. `install.go:259` reads only the count, but a full index build follows it immediately, so there is nothing to win there and I have left it alone.

The comment this PR started as is gone: it reasoned about which of two walks to share, and there is one walk now.
