### PR TITLE
feat(index): say how many lines an index run could not read

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -612,6 +612,7 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 		}(i, hr.Name, hr.Load)
 	}
 	wg.Wait()
+	unreadable := malformedByHarness()
 	var ss []model.Session
 	for _, r := range results {
 		if len(r.ss) == 0 {
@@ -626,7 +627,7 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 		}
 		ss = append(ss, r.ss...)
 		if progress != nil && !SuppressHarnessNarration {
-			fmt.Fprintln(progress, harnessNarration(r.name, r.ss, sources.SkipReason(r.name)))
+			fmt.Fprintln(progress, harnessNarration(r.name, r.ss, sources.SkipReason(r.name), unreadable[r.name]))
 		}
 	}
 	return ss
@@ -637,7 +638,7 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 // in SQLite — and the count alone then reads as the whole story while half of
 // it is missing from recall. The skip reason was printed only for a store that
 // yielded nothing at all (#1758, the shape of #794).
-func harnessNarration(name string, ss []model.Session, skipped string) string {
+func harnessNarration(name string, ss []model.Session, skipped string, unreadable int) string {
 	msgs := 0
 	for _, s := range ss {
 		msgs += len(s.Messages)
@@ -648,10 +649,26 @@ func harnessNarration(name string, ss []model.Session, skipped string) string {
 		label = "notes"
 	}
 	line := fmt.Sprintf("deja: %s: %d session%s, %d message%s", label, len(ss), pluralS(len(ss)), msgs, pluralS(msgs))
+	if unreadable > 0 {
+		line += fmt.Sprintf(" — %d line%s could not be read and were skipped", unreadable, pluralS(unreadable))
+	}
 	if skipped != "" {
 		line += " — part of this store could not be read: " + skipped
 	}
 	return line
+}
+
+// malformedByHarness folds the per-file malformed counts the parsers reported
+// this run into per-store totals, without draining them: the manifest fold that
+// doctor reads from runs later and takes the same numbers.
+func malformedByHarness() map[string]int {
+	out := map[string]int{}
+	for p, n := range sources.DiagMalformedCounts() {
+		if h := harnessForPath(p); h != "" {
+			out[h] += n
+		}
+	}
+	return out
 }
 
 // ReportCollisions returns how many transcripts shared an id with another since

--- a/internal/index/malformed_narration_test.go
+++ b/internal/index/malformed_narration_test.go
@@ -56,6 +56,20 @@ func TestAnIndexRunSaysWhatItCouldNotRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// A second store, all of it readable. The count belongs to the store that
+	// lost the lines: a fold that hands every store the run-wide total reads
+	// the same on a one-store fixture, which is what this store is here to
+	// stop.
+	rollout := filepath.Join(tmp, "codex", "sessions", "2026", "01", "01")
+	if err := os.MkdirAll(rollout, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rollout, "rollout-2026-01-01T12-00-00-c1.jsonl"),
+		[]byte(`{"type":"session_meta","timestamp":"2026-01-01T12:00:00Z","payload":{"session_id":"c1","cwd":"/p/app"}}`+"\n"+
+			`{"timestamp":"2026-01-01T12:00:01Z","payload":{"role":"user","content":"a clean codex turn"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	dir := filepath.Join(tmp, "index.db")
 	var out strings.Builder
 	if err := Ensure(dir, "", true, &out); err != nil {
@@ -81,5 +95,13 @@ func TestAnIndexRunSaysWhatItCouldNotRead(t *testing.T) {
 	// unable to tell one bad write from half the store.
 	if !strings.Contains(said, "4 line") {
 		t.Errorf("an index run that dropped 4 unreadable lines never said so:\n%s", said)
+	}
+	if !strings.Contains(said, "deja: codex:") {
+		t.Fatalf("the clean store never narrated, so nothing here checks attribution:\n%s", said)
+	}
+	for _, line := range strings.Split(said, "\n") {
+		if strings.HasPrefix(line, "deja: codex:") && strings.Contains(line, "could not be read") {
+			t.Errorf("the claude store's loss was charged to codex too: %q", line)
+		}
 	}
 }

--- a/internal/index/malformed_narration_test.go
+++ b/internal/index/malformed_narration_test.go
@@ -1,0 +1,85 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A line deja cannot parse is dropped and counted, and until #1993 the index
+// run reported only what survived: ten turns on disk, "6 messages" on screen,
+// and the four that vanished visible only through `deja doctor`. The narration
+// already names a store it could not open; a line it could not parse is the
+// same loss.
+func TestAnIndexRunSaysWhatItCouldNotRead(t *testing.T) {
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "claude", "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+
+	turn := func(role, text string) string {
+		b, err := json.Marshal(map[string]any{
+			"type": role, "sessionId": "s1", "cwd": "/tmp/app",
+			"timestamp": "2026-08-20T10:00:00Z",
+			"message":   map[string]any{"role": role, "content": text},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+	// Ten turns; four carry a raw escape inside the JSON string, which is what
+	// a harness writes when it captures terminal output into a field without
+	// escaping it. A raw control byte inside a JSON string is invalid JSON, so
+	// claude_decode.go drops the whole line.
+	var body strings.Builder
+	for i := 0; i < 10; i++ {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		line := turn(role, "turn about pgbouncer number "+string(rune('0'+i)))
+		if i >= 3 && i <= 6 {
+			line = strings.Replace(line, "turn about", "turn \x1b[31mabout", 1)
+		}
+		body.WriteString(line + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(body.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(tmp, "index.db")
+	var out strings.Builder
+	if err := Ensure(dir, "", true, &out); err != nil {
+		t.Fatal(err)
+	}
+	said := out.String()
+
+	// The premise: four turns really are gone. Without this the case would pass
+	// on a fixture whose lines all parsed, saying nothing about the silence.
+	got, ok, err := FindByIdentity(dir, "claude", "s1")
+	if err != nil || !ok {
+		t.Fatalf("the session did not come back from the index: %v %v", ok, err)
+	}
+	if len(got.Messages) != 6 {
+		t.Fatalf("fixture indexed %d of 10 turns, so it does not measure a drop", len(got.Messages))
+	}
+	if !strings.Contains(said, "6 message") {
+		t.Fatalf("the run did not narrate the claude store at all: %q", said)
+	}
+
+	// The count of what was lost, in the line that reports what was kept. A
+	// mention that omits the number ("some lines were skipped") leaves a person
+	// unable to tell one bad write from half the store.
+	if !strings.Contains(said, "4 line") {
+		t.Errorf("an index run that dropped 4 unreadable lines never said so:\n%s", said)
+	}
+}

--- a/internal/index/partial_skip_test.go
+++ b/internal/index/partial_skip_test.go
@@ -12,7 +12,7 @@ import (
 // other does not. The run narrated what it got and said nothing about the rest,
 // while the same run names a store it could not read at all (#1758).
 func TestNarrationNamesAHalfReadStore(t *testing.T) {
-	got := harnessNarration("cursor", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, "sqlite3 CLI not found")
+	got := harnessNarration("cursor", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, "sqlite3 CLI not found", 0)
 	if !strings.Contains(got, "1 session") {
 		t.Errorf("the line lost its count: %q", got)
 	}
@@ -21,13 +21,13 @@ func TestNarrationNamesAHalfReadStore(t *testing.T) {
 	}
 
 	// Nothing skipped: the line is what it always was.
-	plain := harnessNarration("claude", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, "")
+	plain := harnessNarration("claude", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, "", 0)
 	if strings.Contains(plain, "—") {
 		t.Errorf("a fully read store gained a caveat: %q", plain)
 	}
 
 	// The notes pseudo-source keeps its label.
-	if n := harnessNarration("deja", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, ""); !strings.HasPrefix(n, "deja: notes:") {
+	if n := harnessNarration("deja", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, "", 0); !strings.HasPrefix(n, "deja: notes:") {
 		t.Errorf("notes narrate as notes: %q", n)
 	}
 }

--- a/internal/sources/diag.go
+++ b/internal/sources/diag.go
@@ -26,6 +26,19 @@ func diagFileError(path string, err error) {
 	diagMu.Unlock()
 }
 
+// DiagMalformedCounts returns the malformed-line counts accumulated so far
+// without clearing them. The index narrates each store as it lands, which is
+// before the manifest fold that drains these counters (#1993).
+func DiagMalformedCounts() map[string]int {
+	diagMu.Lock()
+	defer diagMu.Unlock()
+	out := make(map[string]int, len(diagMalformed))
+	for p, n := range diagMalformed {
+		out[p] = n
+	}
+	return out
+}
+
 // DiagSnapshot returns and clears the counters accumulated since the last
 // snapshot: malformed JSONL lines per file, and files whose parse failed
 // outright with the error text.


### PR DESCRIPTION
Fixes #1993. Ten turns on disk, four of them invalid JSON, and the run said "1 session, 6 messages" — the loss reached a person only through `deja doctor`.

The narration already has the sentence for the other half of this ("part of this store could not be read: …"), so the malformed count joins it:

```
deja: claude: 1 session, 6 messages — 4 lines could not be read and were skipped
```

`DiagMalformedCounts` peeks at the per-file counters without draining them, because each store narrates as it lands and the manifest fold that doctor reads from runs later — draining there would have left doctor at zero.

Wording is yours to settle; the mechanism is that the number is available at narration time.
