### PR TITLE
fix(compact): strip control bytes from the evidence block

### DIFF
--- a/cmd/deja/compact.go
+++ b/cmd/deja/compact.go
@@ -48,9 +48,7 @@ func compactEvidence(dir, sessionID string) string {
 	}
 	// Both lists come from the session's own records, and a record can be a path
 	// or a command the parser lifted out of a tool call — whatever the harness
-	// wrote into the payload, escape bytes included (#2000). Cleaned where the
-	// entry is normalised, so the dedup sees one entry rather than two
-	// spellings of it.
+	// wrote into the payload, escape bytes included (#2000).
 	files := lastDistinct(s.Messages, "files", compactEvidenceFiles,
 		func(text string) []string { return strings.Split(text, "\n") },
 		func(p string) string { return search.SafeLine(trimPath(p)) })
@@ -94,11 +92,18 @@ func lastDistinct(ms []model.Message, role string, limit int, split func(string)
 		}
 		for _, p := range split(ms[i].Text) {
 			p = strings.TrimSpace(p)
-			if p == "" || seen[p] || isScratch(p) {
+			if p == "" || isScratch(p) {
 				continue
 			}
-			seen[p] = true
-			out = append(out, format(p))
+			// Distinct as printed, not as stored: format trims a path to its
+			// last segments and strips control bytes, so two records that
+			// differ only in what it removes are one row, printed twice.
+			f := format(p)
+			if f == "" || seen[f] {
+				continue
+			}
+			seen[f] = true
+			out = append(out, f)
 			if len(out) >= limit {
 				break
 			}

--- a/cmd/deja/compact.go
+++ b/cmd/deja/compact.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
 )
 
 // What a compaction actually costs, measured on 58 transcripts and 43
@@ -45,8 +46,14 @@ func compactEvidence(dir, sessionID string) string {
 	if err != nil || !ok {
 		return ""
 	}
+	// Both lists come from the session's own records, and a record can be a path
+	// or a command the parser lifted out of a tool call — whatever the harness
+	// wrote into the payload, escape bytes included (#2000). Cleaned where the
+	// entry is normalised, so the dedup sees one entry rather than two
+	// spellings of it.
 	files := lastDistinct(s.Messages, "files", compactEvidenceFiles,
-		func(text string) []string { return strings.Split(text, "\n") }, trimPath)
+		func(text string) []string { return strings.Split(text, "\n") },
+		func(p string) string { return search.SafeLine(trimPath(p)) })
 	commands := lastDistinct(s.Messages, "command", compactEvidenceCommands,
 		func(text string) []string {
 			// A multi-line command is a heredoc or a pasted script. Truncated to
@@ -55,7 +62,7 @@ func compactEvidence(dir, sessionID string) string {
 				return nil
 			}
 			return []string{text}
-		}, func(c string) string { return c })
+		}, search.SafeLine)
 	if len(files) == 0 && len(commands) == 0 {
 		return ""
 	}

--- a/cmd/deja/compact_control_bytes_test.go
+++ b/cmd/deja/compact_control_bytes_test.go
@@ -49,6 +49,16 @@ func TestCompactEvidenceStripsControlBytes(t *testing.T) {
 				"input": map[string]any{"file_path": "/tmp/app/pool" + esc + ".go"}},
 			map[string]any{"type": "tool_use", "name": "Bash",
 				"input": map[string]any{"command": "psql -c 'show pool" + esc + "'"}},
+			// The same path twice, once with a stray byte on the end. Cleaning
+			// the entry without deduping on the cleaned spelling printed it as
+			// two identical rows out of a block budgeted at eight. A bare
+			// control byte, not an escape sequence: SafeText replaces the ESC
+			// and leaves the "[31m" behind, which is a different path and
+			// should stay a different row.
+			map[string]any{"type": "tool_use", "name": "Read",
+				"input": map[string]any{"file_path": "/tmp/app/retry.go\u0007"}},
+			map[string]any{"type": "tool_use", "name": "Read",
+				"input": map[string]any{"file_path": "/tmp/app/retry.go"}},
 		}},
 	})
 	if err := os.WriteFile(filepath.Join(dir, "s1.jsonl"), []byte(user+"\n"+asst+"\n"), 0o644); err != nil {
@@ -63,6 +73,9 @@ func TestCompactEvidenceStripsControlBytes(t *testing.T) {
 	// here means the records never arrived rather than that they were stripped.
 	if !strings.Contains(got, "files it touched:") || !strings.Contains(got, "psql") {
 		t.Fatalf("the block is missing the rows this is about:\n%q", got)
+	}
+	if n := strings.Count(got, "retry.go"); n != 1 {
+		t.Errorf("the same path with and without a stray byte is one row, printed %d times:\n%q", n, got)
 	}
 	for _, r := range got {
 		if r != '\n' && r != '\t' && unicode.IsControl(r) {

--- a/cmd/deja/compact_control_bytes_test.go
+++ b/cmd/deja/compact_control_bytes_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode"
+)
+
+// The compaction block is built from a session's own records, and a record can
+// be a path or a command the parser lifted out of a tool call — payloads the
+// serving-path guard never covered, because its dirt is always in the message
+// text (#2000). This block is injected into a context window that was just
+// emptied, and a command row is the string a person is most likely to copy.
+func TestCompactEvidenceStripsControlBytes(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	dir := filepath.Join(claude, "-tmp-app")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	t.Setenv("DEJA_INDEX_TOOL_PATHS", "1")
+	t.Setenv("DEJA_INDEX_COMMANDS", "1")
+
+	esc := "\x1b[31m"
+	rec := func(v any) string {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+	// The escape is written as a \u001b escape in the JSON, the way a harness
+	// writes it. A raw control byte inside a JSON string is invalid JSON and
+	// the line would be dropped before any of this (#1993).
+	user := rec(map[string]any{
+		"type": "user", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": "2026-01-02T03:04:05Z",
+		"message":   map[string]any{"role": "user", "content": "why does pgbouncer time out"},
+	})
+	asst := rec(map[string]any{
+		"type": "assistant", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": "2026-01-02T03:04:06Z",
+		"message": map[string]any{"role": "assistant", "content": []any{
+			map[string]any{"type": "tool_use", "name": "Read",
+				"input": map[string]any{"file_path": "/tmp/app/pool" + esc + ".go"}},
+			map[string]any{"type": "tool_use", "name": "Bash",
+				"input": map[string]any{"command": "psql -c 'show pool" + esc + "'"}},
+		}},
+	})
+	if err := os.WriteFile(filepath.Join(dir, "s1.jsonl"), []byte(user+"\n"+asst+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := captureRun(t, "index"); err != nil {
+		t.Fatalf("index: %v %s", err, out)
+	}
+
+	got := compactEvidence(os.Getenv("DEJA_INDEX_DIR"), "s1")
+	// The premise: the block has to hold both kinds of row, or a clean answer
+	// here means the records never arrived rather than that they were stripped.
+	if !strings.Contains(got, "files it touched:") || !strings.Contains(got, "psql") {
+		t.Fatalf("the block is missing the rows this is about:\n%q", got)
+	}
+	for _, r := range got {
+		if r != '\n' && r != '\t' && unicode.IsControl(r) {
+			t.Errorf("the compaction block carries %q, which reaches the model's context and the terminal that renders it:\n%q", r, got)
+			break
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2000. The claude parser appends four kinds of message — text, tool paths, edit spans, commands. The serving-path guard drives a dirty transcript through every writer, but its dirt is always in the message text. With the escape in the tool payloads instead, one writer passed it through:

```
deja files       escapes=0
deja recall      escapes=0
recall --context escapes=0
compact evidence escapes=2
   "  files it touched: tmp/app/pool\x1b[31m.go"
   "    $ psql -c 'show pool\x1b[31m'"
deja blame       escapes=0
```

`search.SafeLine` on both, applied where each entry is normalised so the dedup sees one entry rather than two spellings. It lands in a context window that was just emptied, and the command row is the string a person is most likely to copy.
