### PR TITLE
fix(notes): count a note deja cannot read

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1674,8 +1674,8 @@ func pluralS(n int) string {
 	return "s"
 }
 
-// pluralThem keeps "1 line skipped, deja could not read them" off the same
-// first line.
+// pluralThem is pluralS for the pronoun that follows it, so a run never says
+// "1 line skipped, deja could not read them".
 func pluralThem(n int) string {
 	if n == 1 {
 		return "it"

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -650,7 +650,7 @@ func harnessNarration(name string, ss []model.Session, skipped string, unreadabl
 	}
 	line := fmt.Sprintf("deja: %s: %d session%s, %d message%s", label, len(ss), pluralS(len(ss)), msgs, pluralS(msgs))
 	if unreadable > 0 {
-		line += fmt.Sprintf(" — %d line%s could not be read and were skipped", unreadable, pluralS(unreadable))
+		line += fmt.Sprintf(" — %d line%s skipped, deja could not read %s", unreadable, pluralS(unreadable), pluralThem(unreadable))
 	}
 	if skipped != "" {
 		line += " — part of this store could not be read: " + skipped
@@ -1672,6 +1672,15 @@ func pluralS(n int) string {
 		return ""
 	}
 	return "s"
+}
+
+// pluralThem keeps "1 line skipped, deja could not read them" off the same
+// first line.
+func pluralThem(n int) string {
+	if n == 1 {
+		return "it"
+	}
+	return "them"
 }
 
 func sessionTitle(s model.Session) string {

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -262,6 +262,11 @@ func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error
 		text, _ := m["text"].(string)
 		t, parseErr := time.Parse(time.RFC3339Nano, ts)
 		if parseErr != nil || strings.TrimSpace(text) == "" {
+			// Counted, not just skipped: this is the one store a person writes
+			// by hand, holding the one thing deja cannot re-derive, and a
+			// hand-written "2026-01-03" parses as nothing. The promoted branch
+			// below has counted its own refusals since #814 (#2005).
+			diagMalformedLine(path)
 			return
 		}
 		// A note written before deja recorded a project — or by a caller that

--- a/internal/sources/notes_dropped_test.go
+++ b/internal/sources/notes_dropped_test.go
@@ -1,0 +1,50 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A note is the one class of content deja cannot re-derive from anything else,
+// and the notes file is the one store a person can write by hand. A line the
+// parser refuses has to be counted, or it is gone with nothing to find it by:
+// not in the index, not in the run's narration, not in doctor (#2005). The
+// promoted branch has counted its own refusals since #814.
+func TestANoteThatCannotBeReadIsCounted(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	body := strings.Join([]string{
+		`{"ts":"2026-01-02T03:04:05Z","project":"app","text":"pgbouncer pool size is 40"}`,
+		// A date without a time, which is what a person writes by hand.
+		`{"ts":"2026-01-03","project":"app","text":"the retry budget is 3"}`,
+		// No timestamp at all.
+		`{"project":"app","text":"the pool lives in pool.go"}`,
+		// Nothing to keep, but still a line someone wrote.
+		`{"ts":"2026-01-04T03:04:05Z","project":"app","text":"   "}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	DiagSnapshot() // drop whatever another case left behind
+	ss, err := ParseNotesFileFromOffset(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the good note is kept and the other three are not, or the
+	// count below is about something else.
+	msgs := 0
+	for _, s := range ss {
+		msgs += len(s.Messages)
+	}
+	if msgs != 1 {
+		t.Fatalf("four notes in, %d messages out: the fixture is not the one this is about", msgs)
+	}
+
+	malformed, _ := DiagSnapshot()
+	if got := malformed[path]; got != 3 {
+		t.Errorf("three notes were dropped and %d were counted, so a hand-written note can vanish with no trace", got)
+	}
+}


### PR DESCRIPTION
Fixes #2005. Five notes in, one out, and only the promoted-branch refusal counted:

```
deja: notes: 1 session, 1 message — 1 line could not be read and were skipped
five notes written, 1 sessions indexed
```

The plain branch returned on an unparseable `ts` and on empty text without calling `diagMalformedLine`, so a hand-written `"ts":"2026-01-03"` was gone with nothing to find it by. Notes are the one store a person writes by hand and the one thing deja cannot re-derive.

After:

```
deja: notes: 1 session, 1 message — 4 lines skipped, deja could not read them
deja: notes: 1 session, 1 message — 1 line skipped, deja could not read it
```

The second line is also this PR: "1 line could not be read and were skipped" was mine, from #1994. Wording is yours to settle either way.

Counting empty text as unreadable is a judgement call — deja never writes such a line, so it means someone's editor did — but say the word and I'll count only the timestamp case.
