### PR TITLE
feat(index): say what an incremental run could not read

### DIFF
--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -989,7 +989,7 @@ func TestIndexErrorBranches(t *testing.T) {
 		t.Fatal(err)
 	}
 	old := Manifest{Files: map[string]FileState{changed: {Path: changed, Size: 0}}, Sessions: map[string]SessionMeta{}, Scope: ""}
-	if _, _, err := appendIncremental(filepath.Join(tmp, "missing-index"), "", "", old, old.Files, old.Files); err == nil {
+	if _, _, _, err := appendIncremental(filepath.Join(tmp, "missing-index"), "", "", old, old.Files, old.Files); err == nil {
 		t.Fatal("appendIncremental missing dir returned nil")
 	}
 	if got := canAppendIncremental(nil, nil); got {

--- a/internal/index/coverage_recover4_test.go
+++ b/internal/index/coverage_recover4_test.go
@@ -153,7 +153,7 @@ func TestAppendIncrementalDirectDefensiveBranches(t *testing.T) {
 	old := Manifest{Files: map[string]FileState{}, Sessions: nil}
 	changed := map[string]FileState{unknown: {Path: unknown, Size: 1}}
 	files := map[string]FileState{unknown: {Path: unknown, Size: 1}}
-	if _, _, err := appendIncremental(filepath.Join(tmp, "idx"), "", "", old, files, changed); err != nil {
+	if _, _, _, err := appendIncremental(filepath.Join(tmp, "idx"), "", "", old, files, changed); err != nil {
 		t.Fatalf("appendIncremental defensive branches err=%v", err)
 	}
 	if _, ok := files[unknown]; ok {

--- a/internal/index/incremental_silence_test.go
+++ b/internal/index/incremental_silence_test.go
@@ -68,7 +68,7 @@ func TestAnIncrementalRunSaysWhatItCouldNotRead(t *testing.T) {
 		t.Fatalf("the pass counted %d unreadable lines, so there is nothing for the run to report", got)
 	}
 
-	if !strings.Contains(said, "1 line") {
+	if !strings.Contains(said, "— 1 line skipped") {
 		t.Errorf("the run that read the loss never mentioned it:\n%s", said)
 	}
 }

--- a/internal/index/incremental_silence_test.go
+++ b/internal/index/incremental_silence_test.go
@@ -40,8 +40,8 @@ func TestAnIncrementalRunSaysWhatItCouldNotRead(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := f.WriteString(
-		`{"type":"user","sessionId":"s1","cwd":"/tmp/app","timestamp":"2026-01-02T03:04:06Z","message":{"role":"user","content":"the pool `+"\x1b"+`[31mtimed out"}}`+"\n"+
-			`{"type":"assistant","sessionId":"s1","cwd":"/tmp/app","timestamp":"2026-01-02T03:04:07Z","message":{"role":"assistant","content":"raised it to 40"}}`+"\n"); err != nil {
+		`{"type":"user","sessionId":"s1","cwd":"/tmp/app","timestamp":"2026-01-02T03:04:06Z","message":{"role":"user","content":"the pool ` + "\x1b" + `[31mtimed out"}}` + "\n" +
+			`{"type":"assistant","sessionId":"s1","cwd":"/tmp/app","timestamp":"2026-01-02T03:04:07Z","message":{"role":"assistant","content":"raised it to 40"}}` + "\n"); err != nil {
 		t.Fatal(err)
 	}
 	if err := f.Close(); err != nil {

--- a/internal/index/incremental_silence_test.go
+++ b/internal/index/incremental_silence_test.go
@@ -1,0 +1,74 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The clause that names what a build could not read (#1993) lives in
+// harnessNarration, which only a full pass calls. After the first build every
+// run a person sees is the append path, and that one counted the loss into the
+// manifest and said nothing (#2007).
+func TestAnIncrementalRunSaysWhatItCouldNotRead(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	proj := filepath.Join(tmp, "claude", "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(proj, "s1.jsonl")
+	if err := os.WriteFile(path, []byte(
+		`{"type":"user","sessionId":"s1","cwd":"/tmp/app","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"why does pgbouncer time out"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two more turns, one of them carrying a raw escape inside the JSON string,
+	// which makes the line invalid JSON.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(
+		`{"type":"user","sessionId":"s1","cwd":"/tmp/app","timestamp":"2026-01-02T03:04:06Z","message":{"role":"user","content":"the pool `+"\x1b"+`[31mtimed out"}}`+"\n"+
+			`{"type":"assistant","sessionId":"s1","cwd":"/tmp/app","timestamp":"2026-01-02T03:04:07Z","message":{"role":"assistant","content":"raised it to 40"}}`+"\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	if err := Ensure(dir, "", false, &out); err != nil {
+		t.Fatal(err)
+	}
+	said := out.String()
+
+	// The premise: this has to be the append path, not a rebuild that happens
+	// to narrate. Without it the case would pass on the line #1993 already
+	// covers.
+	if !strings.Contains(said, "updated 1 file") {
+		t.Fatalf("this did not take the append path, so it does not measure what it is about:\n%s", said)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := m.IngestHealth["claude"].MalformedLines; got != 1 {
+		t.Fatalf("the pass counted %d unreadable lines, so there is nothing for the run to report", got)
+	}
+
+	if !strings.Contains(said, "1 line") {
+		t.Errorf("the run that read the loss never mentioned it:\n%s", said)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -658,6 +658,16 @@ func harnessNarration(name string, ss []model.Session, skipped string, unreadabl
 	return line
 }
 
+// totalMalformed is malformedByHarness summed: the incremental line names the
+// pass, not a store.
+func totalMalformed() int {
+	n := 0
+	for _, c := range malformedByHarness() {
+		n += c
+	}
+	return n
+}
+
 // malformedByHarness folds the per-file malformed counts the parsers reported
 // this run into per-store totals, without draining them: the manifest fold that
 // doctor reads from runs later and takes the same numbers.
@@ -2024,7 +2034,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		return nil
 	}
 	if len(removed) == 0 && canAppendIncremental(changed, old.Files) {
-		filesTouched, messages, err := appendIncremental(dir, harness, scope, old, files, changed)
+		filesTouched, messages, unreadable, err := appendIncremental(dir, harness, scope, old, files, changed)
 		if IsCorrupt(err) {
 			if progress != nil {
 				fmt.Fprintf(progress, "deja: index damaged (%v), rebuilding ...\n", err)
@@ -2035,7 +2045,15 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 			return fmt.Errorf("append: %w", err)
 		}
 		if progress != nil {
-			fmt.Fprintf(progress, "deja: updated %d file%s (%d new message%s)\n", filesTouched, pluralS(filesTouched), messages, pluralS(messages))
+			line := fmt.Sprintf("deja: updated %d file%s (%d new message%s)", filesTouched, pluralS(filesTouched), messages, pluralS(messages))
+			// After the first build every run a person sees is this one, so a
+			// clause that lives only in the full pass is a clause nobody reads
+			// (#2007). Same counters, summed across the stores this pass
+			// touched — the line is about the pass rather than one store.
+			if unreadable > 0 {
+				line += fmt.Sprintf(" — %d line%s skipped, deja could not read %s", unreadable, pluralS(unreadable), pluralThem(unreadable))
+			}
+			fmt.Fprintln(progress, line)
 		}
 		return nil
 	}
@@ -2328,7 +2346,7 @@ func canAppendIncremental(changed map[string]FileState, old map[string]FileState
 	return true
 }
 
-func appendIncremental(dir, harness, scope string, old Manifest, files map[string]FileState, changed map[string]FileState) (int, int, error) {
+func appendIncremental(dir, harness, scope string, old Manifest, files map[string]FileState, changed map[string]FileState) (filesTouched, messages, unreadable int, err error) {
 	// This pass's counts, like the two full paths: an incremental that nobody
 	// read between builds otherwise reported its own colliding ids plus the
 	// ones before it (#1850).
@@ -2337,7 +2355,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	lastIngestFiles = len(changed)
 	rf, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	// The log is being APPENDED to, so ids must continue where the existing
 	// records left off. Starting a fresh table would hand id 0 to a new
@@ -2346,7 +2364,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	rw, err := newRecordWriter(rf, tbl)
 	if err != nil {
 		_ = rf.Close()
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	defer func() { _ = rw.Close() }()
 	buckets := bucketPostings{}
@@ -2376,7 +2394,6 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	if m.Sessions == nil {
 		m.Sessions = map[string]SessionMeta{}
 	}
-	filesTouched, messages := 0, 0
 	// Sorted, not map order: two sessions can claim the same harness:id, and
 	// which one wins decided the project a whole conversation was filed under
 	// — differently on every run (#698).
@@ -2460,7 +2477,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 				}
 				off, err := rw.write(Record{Key: key, SourcePath: s.Path, Role: msg.Role, Text: text, Time: msg.Time})
 				if err != nil {
-					return filesTouched, messages, err
+					return filesTouched, messages, 0, err
 				}
 				messages++
 				seen := map[string]bool{}
@@ -2471,7 +2488,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 					seen[tok] = true
 					data, err := loadBucket(tok)
 					if err != nil {
-						return filesTouched, messages, err
+						return filesTouched, messages, 0, err
 					}
 					data[tok] = append(data[tok], posting{Off: off, Sid: meta.Ord})
 				}
@@ -2479,17 +2496,20 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 		}
 	}
 	if err := rw.Close(); err != nil {
-		return filesTouched, messages, err
+		return filesTouched, messages, 0, err
 	}
 	if err := writeBucketsConcurrent(filepath.Join(dir, "buckets"), buckets); err != nil {
-		return filesTouched, messages, err
+		return filesTouched, messages, 0, err
 	}
 	setOpencodeLastUpdated(m.Files, m.Sessions)
 	m.RecordStrings = tbl.strs
+	// Read before writeManifest: the fold in there drains the counters, and the
+	// caller prints its line after this returns (#2007).
+	unreadable = totalMalformed()
 	if err := writeManifest(dir, m); err != nil {
-		return filesTouched, messages, err
+		return filesTouched, messages, unreadable, err
 	}
-	return filesTouched, messages, nil
+	return filesTouched, messages, unreadable, nil
 }
 
 func sameFile(a, b FileState) bool {


### PR DESCRIPTION
Fixes #2007. A transcript grows by two lines, one of them invalid JSON:

```
first build:  deja: claude: 1 session, 1 message
incremental:  deja: updated 1 file (1 new message)
ingest health claude   malformed=1
```

Two lines arrived, one message landed, and the run that read the loss said nothing — the clause from #1993 lives in `harnessNarration`, which only a full pass calls. After the first build, the append path is every run a person sees.

```
deja: updated 1 file (1 new message) — 1 line skipped, deja could not read it
```

`appendIncremental` returns the count now, because it has to be read before `writeManifest` — the fold in there drains the counters, and the line is printed after the call returns.
