### PR TITLE
fix(index): clear the skip counters when a pass starts

### DIFF
--- a/internal/index/aborted_pass_count_test.go
+++ b/internal/index/aborted_pass_count_test.go
@@ -6,20 +6,14 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
 )
 
-// The malformed-line counters used to be drained in one place: the manifest
-// fold, inside writeManifest. A pass that died before it left its count behind
-// for whoever parsed next, so one bad line on disk was reported as two — with
-// the manifest agreeing, which is the worst shape for a number a person is
-// meant to act on (#2010).
-func TestAnAbortedPassDoesNotLendItsCountToTheNextOne(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("directory permissions do not stop a write on windows")
-	}
-	if os.Geteuid() == 0 {
-		t.Skip("root writes through a read-only directory")
-	}
+// abortedPassIndex leaves an index behind whose last pass died between the
+// parse and the manifest write, with exactly one unreadable line on disk.
+func abortedPassIndex(t *testing.T) string {
+	t.Helper()
 	tmp := t.TempDir()
 	setHome(t, tmp)
 	t.Setenv("USERPROFILE", tmp)
@@ -70,15 +64,35 @@ func TestAnAbortedPassDoesNotLendItsCountToTheNextOne(t *testing.T) {
 	if err := os.Chmod(buckets, 0o700); err != nil {
 		t.Fatal(err)
 	}
+	return dir
+}
+
+func skipWhereADirectoryCannotBeMadeUnwritable(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions do not stop a write on windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root writes through a read-only directory")
+	}
+}
+
+// The malformed-line counters used to be cleared in one place: the manifest
+// fold, inside writeManifest. A pass that died before it left its count behind
+// for whoever parsed next, so one bad line on disk was reported as two — with
+// the manifest agreeing, which is the worst shape for a number a person is
+// meant to act on (#2010).
+func TestAnAbortedPassDoesNotLendItsCountToTheNextOne(t *testing.T) {
+	skipWhereADirectoryCannotBeMadeUnwritable(t)
+	dir := abortedPassIndex(t)
 
 	var out strings.Builder
 	if err := Ensure(dir, "", false, &out); err != nil {
 		t.Fatal(err)
 	}
 	said := out.String()
-
-	if strings.Contains(said, "2 lines") {
-		t.Errorf("one unreadable line on disk, and the run reports the dead pass's count as well:\n%s", said)
+	if !strings.Contains(said, "— 1 line skipped") {
+		t.Errorf("one unreadable line on disk, and the run does not report exactly one:\n%s", said)
 	}
 	m, err := readManifest(dir)
 	if err != nil {
@@ -86,5 +100,25 @@ func TestAnAbortedPassDoesNotLendItsCountToTheNextOne(t *testing.T) {
 	}
 	if got := m.IngestHealth["claude"].MalformedLines; got != 1 {
 		t.Errorf("one unreadable line on disk, manifest says %d", got)
+	}
+}
+
+// The same leak by the path a recall takes. An aborted pass leaves records.bin
+// short, so the next search finds the index damaged and rebuilds — through
+// rebuildForSearch, which never passes through updateIndex, which is where the
+// first fix for this put the drain.
+func TestASearchRebuildDoesNotInheritADeadPassCount(t *testing.T) {
+	skipWhereADirectoryCannotBeMadeUnwritable(t)
+	dir := abortedPassIndex(t)
+
+	if err := EnsureForSearch(dir, query.Options{}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := m.IngestHealth["claude"].MalformedLines; got != 1 {
+		t.Errorf("one unreadable line on disk, the search rebuild recorded %d", got)
 	}
 }

--- a/internal/index/aborted_pass_count_test.go
+++ b/internal/index/aborted_pass_count_test.go
@@ -1,0 +1,90 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The malformed-line counters used to be drained in one place: the manifest
+// fold, inside writeManifest. A pass that died before it left its count behind
+// for whoever parsed next, so one bad line on disk was reported as two — with
+// the manifest agreeing, which is the worst shape for a number a person is
+// meant to act on (#2010).
+func TestAnAbortedPassDoesNotLendItsCountToTheNextOne(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions do not stop a write on windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root writes through a read-only directory")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	proj := filepath.Join(tmp, "claude", "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	turn := func(ts, role, text string) string {
+		return `{"type":"` + role + `","sessionId":"s1","cwd":"/tmp/app","timestamp":"` + ts +
+			`","message":{"role":"` + role + `","content":"` + text + `"}}` + "\n"
+	}
+	path := filepath.Join(proj, "s1.jsonl")
+	if err := os.WriteFile(path, []byte(turn("2026-01-02T03:04:05Z", "user", "why does pgbouncer time out")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// One unreadable line and one good one: without the good one the pass has
+	// no buckets to write and so never reaches the failure below.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(
+		turn("2026-01-02T03:04:06Z", "user", "the pool \x1b[31mtimed out") +
+			turn("2026-01-02T03:04:07Z", "assistant", "raised the pool to 40")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Kill the pass after the parse and before the manifest is written.
+	buckets := filepath.Join(dir, "buckets")
+	if err := os.Chmod(buckets, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err == nil {
+		t.Fatal("the pass was supposed to fail before writing the manifest, so this measures nothing")
+	}
+	if err := os.Chmod(buckets, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	if err := Ensure(dir, "", false, &out); err != nil {
+		t.Fatal(err)
+	}
+	said := out.String()
+
+	if strings.Contains(said, "2 lines") {
+		t.Errorf("one unreadable line on disk, and the run reports the dead pass's count as well:\n%s", said)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := m.IngestHealth["claude"].MalformedLines; got != 1 {
+		t.Errorf("one unreadable line on disk, manifest says %d", got)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1954,6 +1954,11 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	// reset down there would zero the number this build is about to report
 	// (#1861).
 	evicted.Store(0)
+	// The parsers' skip counters belong to the pass that parsed. They used to
+	// be cleared only by the manifest fold, so a pass that died before writing
+	// left its count for the next one to report: one bad line on disk, "2 lines
+	// skipped" on screen, with the manifest agreeing (#2010).
+	sources.DiagSnapshot()
 	old, err := readManifest(dir)
 	if err == nil && !recordsIntact(dir, old) {
 		force = true // records.bin lost its tail to a crash; only a rebuild is safe

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -356,6 +356,7 @@ func rebuild(dir string, harness string, scope string, files map[string]FileStat
 
 func rebuildWithTombstones(dir string, harness string, scope string, files map[string]FileState, progress io.Writer, dead map[string]bool) error {
 	// This build's counts, not the process's: see writeSessionsWithSync (#1850).
+	beginPass()
 	emptied.Store(0)
 	collisions.Store(0)
 	// A rebuild evicts nothing, but a number left by an earlier build must not
@@ -1954,9 +1955,10 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 // before writing left its count for the next one to report: one bad line on
 // disk, "2 lines skipped" on screen, with the manifest agreeing (#2010).
 //
-// Called at both places a pass parses — this one and rebuildForSearch, which a
-// recall reaches directly after an index is found damaged, without passing
-// through updateIndex at all.
+// Called at every place a pass parses: this one, rebuildForSearch — which a
+// recall reaches directly once an index is found damaged, without passing
+// through updateIndex at all — and rebuildWithTombstones, which forget and
+// unforget call for themselves.
 func beginPass() {
 	sources.DiagSnapshot()
 }

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -699,6 +699,7 @@ func markShared(sessions map[string]SessionMeta, key string) {
 }
 
 func rebuildForSearch(dir string, o query.Options, scope string, files map[string]FileState, progress io.Writer) error {
+	beginPass()
 	tmp := dir + ".tmp"
 	_ = os.RemoveAll(tmp)
 	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o700); err != nil {
@@ -1948,17 +1949,25 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 	}
 }
 
+// beginPass clears the parsers' skip counters, which belong to the pass that
+// parsed. They used to be cleared only by the manifest fold, so a pass that died
+// before writing left its count for the next one to report: one bad line on
+// disk, "2 lines skipped" on screen, with the manifest agreeing (#2010).
+//
+// Called at both places a pass parses — this one and rebuildForSearch, which a
+// recall reaches directly after an index is found damaged, without passing
+// through updateIndex at all.
+func beginPass() {
+	sources.DiagSnapshot()
+}
+
 func updateIndex(dir, harness, scope string, files map[string]FileState, force bool, progress io.Writer) error {
 	// Cleared here rather than beside the other two: this build counts what
 	// went away further down, before the incremental paths reset theirs, so a
 	// reset down there would zero the number this build is about to report
 	// (#1861).
 	evicted.Store(0)
-	// The parsers' skip counters belong to the pass that parsed. They used to
-	// be cleared only by the manifest fold, so a pass that died before writing
-	// left its count for the next one to report: one bad line on disk, "2 lines
-	// skipped" on screen, with the manifest agreeing (#2010).
-	sources.DiagSnapshot()
+	beginPass()
 	old, err := readManifest(dir)
 	if err == nil && !recordsIntact(dir, old) {
 		force = true // records.bin lost its tail to a crash; only a rebuild is safe


### PR DESCRIPTION
Fixes #2010. One unreadable line on disk, a pass killed between the parse and `writeManifest`, then the next pass:

```
aborted pass: err=append: open .../buckets/tp.bin.tmp: permission denied
next pass:    deja: claude: 1 session, 2 messages — 2 lines skipped, deja could not read them
manifest claude malformed=2
```

The counters were cleared only by the manifest fold, so a pass that never got there left its count for whoever parsed next — and the manifest agreed with the wrong number.

The drain moves to the top of `updateIndex`: the counters belong to the pass that parsed, not to whoever gets far enough to write. After it, the same sequence reports 1.

The other half of the issue — a `writeManifest` failure losing the count — resolves itself: the manifest it failed to write is the reason the next pass re-reads the same tail and counts it again.

The test needs a good line alongside the bad one, or the pass has no buckets to write and never reaches the failure. It skips on windows (directory permissions don't stop a write) and as root.
