### PR TITLE
grant discussions:write to the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      # The release opens a discussion (#1559), and GitHub answers a token that
+      # may not create one with a 404 naming the category instead of the
+      # permission: "Discussion could not be created. Make sure you passed a
+      # valid category name." The category was always valid — v0.19.0 published
+      # its binaries and then failed the run on this line.
+      discussions: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Memory for AI coding agents: your own past sessions, recalled before you ask.",
   "author": {
     "name": "vshulcz",

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Recall your own past coding sessions, across every AI tool you use.",
   "author": {
     "name": "vshulcz",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Search the coding sessions already on your disk — Gemini CLI, Claude Code, Codex, Cursor and seventeen more — including work from before deja was installed.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {

--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.18.0",
+    "version": "0.19.0",
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_amd64.zip",
-            "hash": "e2c5a442afb3f208aa1389be031b2ac595de3c79b1179856fb843a1f1b042391"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.0/deja-vu_0.19.0_windows_amd64.zip",
+            "hash": "c37de2f355a51daafb97d7667a1786dfdd954816f81011175f8a5757f9f996ce"
         },
         "arm64": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_arm64.zip",
-            "hash": "f814fe2117f69ae1d2cc2202e6c3d37e90ef7cde705c3e3c6de1dfdfa4743b25"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.0/deja-vu_0.19.0_windows_arm64.zip",
+            "hash": "2534207efaead35dca0b899c8eb32a9dd13b6cbad8436bf68c2313fc8a03adfc"
         }
     },
     "bin": "deja.exe",

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.18.0
+PackageVersion: 0.19.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_amd64.zip
-  InstallerSha256: E2C5A442AFB3F208AA1389BE031B2AC595DE3C79B1179856FB843A1F1B042391
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.0/deja-vu_0.19.0_windows_amd64.zip
+  InstallerSha256: C37DE2F355A51DAAFB97D7667A1786DFDD954816F81011175F8A5757F9F996CE
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_arm64.zip
-  InstallerSha256: F814FE2117F69AE1D2CC2202E6C3D37E90EF7CDE705C3E3C6DE1DFDFA4743B25
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.0/deja-vu_0.19.0_windows_arm64.zip
+  InstallerSha256: 2534207EFAEAD35DCA0B899C8EB32A9DD13B6CBAD8436BF68C2313FC8A03ADFC
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.18.0
+PackageVersion: 0.19.0
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.18.0/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.19.0/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.18.0
+PackageVersion: 0.19.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "deja-vu",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Search the coding sessions already on your disk — Claude Code, Codex, Cursor, opencode and seventeen more — including work from before deja was installed.",
   "author": {
     "name": "vshulcz",


### PR DESCRIPTION
#1559 asked every release to open a discussion. The job never had permission to create one, and GitHub reports that as a 404 about the category name:

```
could not update existing release: 404 Discussion could not be created.
Make sure you passed a valid category name.
```

The category exists — this is the first release since #1559 landed, so the setting had never actually run. v0.19.0 published its fifteen binaries and then took the run red on this line, which stopped the manifest pinning, the Homebrew bump and the npm publish behind it.