### PR TITLE
fix(index): keep what deja could not read per file

### DIFF
--- a/internal/index/health_carry_test.go
+++ b/internal/index/health_carry_test.go
@@ -1,0 +1,88 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The health map is how doctor answers "what could deja not read" — and the
+// answer has to outlive an unrelated pass, because the lines it counts are
+// still on disk. The merge path built a fresh manifest and carried five fields
+// forward but not this one, so the whole map went at the next pass that took it
+// (#2015).
+func TestTheHealthMapSurvivesAnUnrelatedPass(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	proj := filepath.Join(tmp, "claude", "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	turn := func(id, ts, role, text string) string {
+		return `{"type":"` + role + `","sessionId":"` + id + `","cwd":"/tmp/app","timestamp":"` + ts +
+			`","message":{"role":"` + role + `","content":"` + text + `"}}` + "\n"
+	}
+	// The second line carries a raw escape, which makes it invalid JSON.
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(
+		turn("s1", "2026-01-02T03:04:05Z", "user", "why does pgbouncer time out")+
+			turn("s1", "2026-01-02T03:04:06Z", "user", "the pool \x1b[31mtimed out")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the build that read the bad line recorded it. Without this
+	// the assertions below would hold on a store that never lost anything.
+	if got := m.IngestHealth["claude"].MalformedLines; got != 1 {
+		t.Fatalf("the build recorded %d unreadable lines, so there is nothing to carry", got)
+	}
+
+	// A new session in the same store — a change that does not touch the file
+	// holding the bad line. This is the merge path.
+	if err := os.WriteFile(filepath.Join(proj, "s2.jsonl"), []byte(
+		turn("s2", "2026-02-02T03:04:05Z", "user", "unrelated question about retries")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, err = readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Sessions) != 2 {
+		t.Fatalf("the pass indexed %d sessions, so it was not the merge path this is about", len(m.Sessions))
+	}
+	if got := m.IngestHealth["claude"].MalformedLines; got != 1 {
+		t.Errorf("the unreadable line is still on disk and the count is %d: doctor has forgotten it", got)
+	}
+
+	// The other half: a file rewritten without its bad line clears its own
+	// count, or carrying counts forward would make them permanent.
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(
+		turn("s1", "2026-01-02T03:04:05Z", "user", "why does pgbouncer time out")+
+			turn("s1", "2026-01-02T03:04:06Z", "user", "the pool timed out")+
+			turn("s1", "2026-01-02T03:04:07Z", "assistant", "raised it to 40")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, err = readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := m.IngestHealth["claude"].MalformedLines; got != 0 {
+		t.Errorf("the bad line is gone from the file and the count is still %d", got)
+	}
+}

--- a/internal/index/health_carry_test.go
+++ b/internal/index/health_carry_test.go
@@ -3,6 +3,7 @@ package index
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -84,5 +85,150 @@ func TestTheHealthMapSurvivesAnUnrelatedPass(t *testing.T) {
 	}
 	if got := m.IngestHealth["claude"].MalformedLines; got != 0 {
 		t.Errorf("the bad line is gone from the file and the count is still %d", got)
+	}
+}
+
+// healthFixture is one claude store and the paths to build it with.
+func healthFixture(t *testing.T) (dir, proj string, turn func(id, ts, role, text string) string) {
+	t.Helper()
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	proj = filepath.Join(tmp, "claude", "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	turn = func(id, ts, role, text string) string {
+		return `{"type":"` + role + `","sessionId":"` + id + `","cwd":"/tmp/app","timestamp":"` + ts +
+			`","message":{"role":"` + role + `","content":"` + text + `"}}` + "\n"
+	}
+	return filepath.Join(tmp, "index.db"), proj, turn
+}
+
+func malformedFor(t *testing.T, dir, harness string) int {
+	t.Helper()
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m.IngestHealth[harness].MalformedLines
+}
+
+// The append path reads the tail, not the file, so what it finds adds to the
+// file's count. Treating the file as re-read dropped every bad line already
+// indexed — which is every live session, since a session that continues is
+// exactly what this path is for.
+func TestAppendingToASessionKeepsItsEarlierCount(t *testing.T) {
+	dir, proj, turn := healthFixture(t)
+	path := filepath.Join(proj, "s1.jsonl")
+	if err := os.WriteFile(path, []byte(
+		turn("s1", "2026-01-02T03:04:05Z", "user", "why does pgbouncer time out")+
+			turn("s1", "2026-01-02T03:04:06Z", "user", "the pool \x1b[31mtimed out")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := malformedFor(t, dir, "claude"); got != 1 {
+		t.Fatalf("the build recorded %d, so the appends below measure nothing", got)
+	}
+
+	grow := func(ts, text string) {
+		t.Helper()
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.WriteString(turn("s1", ts, "assistant", text)); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := Ensure(dir, "", false, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	grow("2026-01-02T03:05:00Z", "raised the pool to 40")
+	if got := malformedFor(t, dir, "claude"); got != 1 {
+		t.Errorf("the session continued and the count went to %d, but the bad line is still in the file", got)
+	}
+	grow("2026-01-02T03:06:00Z", "and it \x1b[31mstill timed out")
+	if got := malformedFor(t, dir, "claude"); got != 2 {
+		t.Errorf("two bad lines in the file, count says %d", got)
+	}
+}
+
+// A manifest written without a parse — Import writes one, and `deja sync` runs
+// it in the same process right after an index pass — must not take the pass's
+// files with it.
+func TestAManifestWrittenWithoutAParseKeepsTheCounts(t *testing.T) {
+	dir, proj, turn := healthFixture(t)
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(
+		turn("s1", "2026-01-02T03:04:05Z", "user", "why does pgbouncer time out")+
+			turn("s1", "2026-01-02T03:04:06Z", "user", "the pool \x1b[31mtimed out")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := malformedFor(t, dir, "claude"); got != 1 {
+		t.Fatalf("the build recorded %d, so this measures nothing", got)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+	if got := malformedFor(t, dir, "claude"); got != 1 {
+		t.Errorf("a manifest write that parsed nothing left the count at %d", got)
+	}
+}
+
+// The clip count is this pass's — it is recorded during redaction, before the
+// fold — so seeding the new manifest with the old total made every re-read of a
+// clipped file add to it: one long message counted as two, then three.
+func TestAClippedMessageIsCountedOncePerPass(t *testing.T) {
+	dir, proj, turn := healthFixture(t)
+	path := filepath.Join(proj, "s1.jsonl")
+	long := strings.Repeat("pgbouncer pool timed out and the retry took a second ", 1600)
+	if len(long) < maxIndexedText {
+		t.Fatalf("the fixture message is %d bytes, under the %d that gets it clipped", len(long), maxIndexedText)
+	}
+	if err := os.WriteFile(path, []byte(turn("s1", "2026-01-02T03:04:05Z", "user", long)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	clipped := func() int {
+		t.Helper()
+		m, err := readManifest(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return m.IngestHealth["claude"].ClippedMessages
+	}
+	if got := clipped(); got != 1 {
+		t.Fatalf("the build clipped %d messages, so this measures nothing", got)
+	}
+	for i, tail := range []string{"first answer", "second answer", "third answer"} {
+		if err := os.WriteFile(path, []byte(
+			turn("s1", "2026-01-02T03:04:05Z", "user", long)+
+				turn("s1", "2026-01-02T03:04:06Z", "assistant", tail)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := Ensure(dir, "", false, nil); err != nil {
+			t.Fatal(err)
+		}
+		if got := clipped(); got != 1 {
+			t.Fatalf("one long message in the file, rewrite %d says %d clipped", i+1, got)
+		}
 	}
 }

--- a/internal/index/health_carry_test.go
+++ b/internal/index/health_carry_test.go
@@ -3,6 +3,7 @@ package index
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -230,5 +231,58 @@ func TestAClippedMessageIsCountedOncePerPass(t *testing.T) {
 		if got := clipped(); got != 1 {
 			t.Fatalf("one long message in the file, rewrite %d says %d clipped", i+1, got)
 		}
+	}
+}
+
+// A file that failed to open once and then reads fine has to stop being
+// reported: transcripts are append-only, so the append path is the one that
+// reads it again, and it is the path that cannot clear an entry by re-reading.
+// Left alone, a permission blip stayed in doctor until a forced rebuild.
+func TestAFileThatOpensAgainStopsBeingReportedUnreadable(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("file permissions do not stop a read here")
+	}
+	dir, proj, turn := healthFixture(t)
+	path := filepath.Join(proj, "s1.jsonl")
+	if err := os.WriteFile(path, []byte(turn("s1", "2026-01-02T03:04:05Z", "user", "why does pgbouncer time out")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	failed := func() int {
+		t.Helper()
+		m, err := readManifest(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return m.IngestHealth["claude"].FailedFiles
+	}
+	if got := failed(); got != 1 {
+		t.Fatalf("the unreadable file was reported %d times, so this measures nothing", got)
+	}
+
+	// The blip passes and the session carries on, which is an append.
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(turn("s1", "2026-01-02T03:05:00Z", "assistant", "raised the pool to 40")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := failed(); got != 0 {
+		t.Errorf("deja read the file and still reports %d unreadable", got)
 	}
 }

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -275,6 +275,11 @@ type Manifest struct {
 	// that last touched it: malformed JSONL lines and files that failed to
 	// parse. Silent loss must be diagnosable (`deja doctor --json`).
 	IngestHealth map[string]HarnessIngest `json:"ingest_health,omitempty"`
+	// IngestFiles is the same story per file, and it is the one that survives:
+	// a store's counts are the sum of its files, so a pass that re-reads one
+	// transcript cannot forget what a different one could not read (#2015).
+	// Sparse — only files with something to report are in it.
+	IngestFiles map[string]FileIngest `json:"ingest_files,omitempty"`
 	// ExcludeFingerprint identifies the exclusion patterns in force when this
 	// index was built. They apply at ingest, so a pattern added later leaves
 	// what is already indexed searchable and exportable — silently, until this
@@ -304,6 +309,14 @@ type HarnessIngest struct {
 	LastError       string `json:"last_error,omitempty"`
 }
 
+// FileIngest is what one file cost the last pass that read it: lines it could
+// not parse, and the error if the file itself would not open. Held per file so
+// that re-reading one transcript cannot erase what another one reported.
+type FileIngest struct {
+	Malformed int    `json:"malformed,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
 type manifestCore struct {
 	Version          int
 	Files            map[string]FileState
@@ -319,6 +332,7 @@ type manifestCore struct {
 	RecordsSize      int64
 	BucketFiles      int
 	IngestHealth     map[string]HarnessIngest
+	IngestFiles      map[string]FileIngest
 	// ExcludeFingerprint, ToolFingerprint: see Manifest.
 	ExcludeFingerprint string
 	ToolFingerprint    string

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -99,6 +99,10 @@ func mergeIngestDiag(m *Manifest) {
 		m.IngestFiles = nil
 	}
 	m.IngestHealth = healthFromFiles(m.IngestFiles, m.IngestHealth)
+	// The set belongs to the pass that recorded it. Left standing, it deleted
+	// those files' entries again on the next manifest write in the process —
+	// and `deja sync` writes one, from Import, right after a pass.
+	passParsed = nil
 }
 
 // healthFromFiles sums the per-file counts per harness. The clip count is not
@@ -2193,7 +2197,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		// doctor forgot a store's unreadable file because an unrelated
 		// transcript changed (#2015). A store this pass re-read starts over,
 		// because a file rewritten clean has to be able to clear its count.
-		IngestHealth: old.IngestHealth, IngestFiles: copyIngestFiles(old.IngestFiles)}
+		IngestFiles: copyIngestFiles(old.IngestFiles)}
 	skipRedactions := map[string]bool{}
 	for p := range changed {
 		skipRedactions[p] = true
@@ -2429,7 +2433,10 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	emptied.Store(0)
 	collisions.Store(0)
 	lastIngestFiles = len(changed)
-	parsedThisPass(changed)
+	// Deliberately not parsedThisPass: this path reads the appended tail, not
+	// the file, so what it finds adds to the file's count instead of replacing
+	// it. Marking the file re-read dropped every bad line in the part already
+	// indexed — which is every live session.
 	rf, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return 0, 0, 0, err

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -60,50 +60,74 @@ func IngestHealth(dir string) map[string]HarnessIngest {
 	return m.IngestHealth
 }
 
-// mergeIngestDiag folds the sources side-channel counters into the manifest,
-// keyed by harness. Harnesses untouched this pass keep their previous entry.
+// mergeIngestDiag folds the sources side-channel counters into the manifest.
+// The counts live per file, because that is what they are about: a pass that
+// re-reads one transcript must not erase what a different one reported, and a
+// file rewritten without its bad line must be able to clear its own count
+// (#2015). The per-harness map every reader asks for is the sum.
 func mergeIngestDiag(m *Manifest) {
 	malformed, failed := sources.DiagSnapshot()
-	if len(malformed) == 0 && len(failed) == 0 {
-		return
+	if m.IngestFiles == nil {
+		m.IngestFiles = map[string]FileIngest{}
 	}
-	if m.IngestHealth == nil {
-		m.IngestHealth = map[string]HarnessIngest{}
-	}
-	touched := map[string]bool{}
-	for p := range malformed {
-		touched[harnessForPath(p)] = true
-	}
-	for p := range failed {
-		touched[harnessForPath(p)] = true
-	}
-	for h := range touched {
-		if h == "" {
-			continue
-		}
-		// The clip count for this pass is recorded during redaction, which
-		// runs before this fold; resetting the whole entry threw it away.
-		m.IngestHealth[h] = HarnessIngest{ClippedMessages: m.IngestHealth[h].ClippedMessages}
+	// Whatever this pass read, it read whole: its files start from nothing and
+	// take what the parsers just reported.
+	for p := range passParsed {
+		delete(m.IngestFiles, p)
 	}
 	for p, n := range malformed {
-		h := harnessForPath(p)
-		if h == "" {
-			continue
-		}
-		e := m.IngestHealth[h]
-		e.MalformedLines += n
-		m.IngestHealth[h] = e
+		e := m.IngestFiles[p]
+		e.Malformed += n
+		m.IngestFiles[p] = e
 	}
 	for p, msg := range failed {
+		e := m.IngestFiles[p]
+		e.Error = msg
+		m.IngestFiles[p] = e
+	}
+	// A file deja no longer walks has nothing left to report. Kept for a file
+	// that failed to open, which is exactly the file a walk may not see.
+	for p, e := range m.IngestFiles {
+		if e.Error != "" {
+			continue
+		}
+		if _, ok := m.Files[p]; !ok {
+			delete(m.IngestFiles, p)
+		}
+	}
+	if len(m.IngestFiles) == 0 {
+		m.IngestFiles = nil
+	}
+	m.IngestHealth = healthFromFiles(m.IngestFiles, m.IngestHealth)
+}
+
+// healthFromFiles sums the per-file counts per harness. The clip count is not
+// per file — it is recorded during redaction, before this fold — so it is
+// carried from what the pass already put there.
+func healthFromFiles(files map[string]FileIngest, prior map[string]HarnessIngest) map[string]HarnessIngest {
+	out := map[string]HarnessIngest{}
+	for h, e := range prior {
+		if e.ClippedMessages > 0 {
+			out[h] = HarnessIngest{ClippedMessages: e.ClippedMessages}
+		}
+	}
+	for p, e := range files {
 		h := harnessForPath(p)
 		if h == "" {
 			continue
 		}
-		e := m.IngestHealth[h]
-		e.FailedFiles++
-		e.LastError = msg
-		m.IngestHealth[h] = e
+		cur := out[h]
+		cur.MalformedLines += e.Malformed
+		if e.Error != "" {
+			cur.FailedFiles++
+			cur.LastError = e.Error
+		}
+		out[h] = cur
 	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // UpToDate reports whether Ensure would do nothing, and how many sessions the
@@ -363,6 +387,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	// outlive it (#1861).
 	evicted.Store(0)
 	lastIngestFiles = len(files)
+	parsedThisPass(files)
 	initialBuild := !HasManifest(dir)
 	writtenMessages := 0
 	imported := importedSessions(dir)
@@ -765,6 +790,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	initialBuild := !HasManifest(dir)
 	writtenMessages := 0
 	lastIngestFiles = len(files)
+	parsedThisPass(files)
 	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
 		ExportWatermarks: imp.watermarks, ExportBoundary: imp.boundary, ImportedRecords: imp.dedupe,
 		ExcludeFingerprint: sources.ExclusionFingerprint(),
@@ -1950,6 +1976,16 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 	}
 }
 
+// copyIngestFiles hands the new manifest its own map: the old one belongs to
+// the manifest this build read, which is still in use while the build runs.
+func copyIngestFiles(old map[string]FileIngest) map[string]FileIngest {
+	out := make(map[string]FileIngest, len(old))
+	for p, e := range old {
+		out[p] = e
+	}
+	return out
+}
+
 // beginPass clears the parsers' skip counters, which belong to the pass that
 // parsed. They used to be cleared only by the manifest fold, so a pass that died
 // before writing left its count for the next one to report: one bad line on
@@ -1961,6 +1997,23 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 // unforget call for themselves.
 func beginPass() {
 	sources.DiagSnapshot()
+	passParsed = nil
+}
+
+// passParsed is the set of files the pass in progress re-read. Package state
+// for the same reason lastIngestFiles is: a pass holds the directory lock, so
+// only one is ever in flight.
+var passParsed map[string]bool
+
+// parsedThisPass records which files a pass read, so the fold can start their
+// counts over rather than adding to what an earlier pass left (#2015).
+func parsedThisPass(files map[string]FileState) {
+	if passParsed == nil {
+		passParsed = map[string]bool{}
+	}
+	for p := range files {
+		passParsed[p] = true
+	}
 }
 
 func updateIndex(dir, harness, scope string, files map[string]FileState, force bool, progress io.Writer) error {
@@ -2078,6 +2131,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	emptied.Store(0)
 	collisions.Store(0)
 	lastIngestFiles = len(changed)
+	parsedThisPass(changed)
 	for p, f := range changed {
 		ss, err := parseChangedFile(harness, p, old.Files[p])
 		if err != nil {
@@ -2133,7 +2187,13 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		// those patterns, so claiming today's set would be a lie the reader
 		// cannot check.
 		ExcludeFingerprint: old.ExcludeFingerprint,
-		ToolFingerprint:    mergedToolFingerprint(priorToolFingerprint(dir))}
+		ToolFingerprint:    mergedToolFingerprint(priorToolFingerprint(dir)),
+		// What deja could not read is about the files, not about the pass that
+		// happened to notice: the lines are still there. Dropping the map meant
+		// doctor forgot a store's unreadable file because an unrelated
+		// transcript changed (#2015). A store this pass re-read starts over,
+		// because a file rewritten clean has to be able to clear its count.
+		IngestHealth: old.IngestHealth, IngestFiles: copyIngestFiles(old.IngestFiles)}
 	skipRedactions := map[string]bool{}
 	for p := range changed {
 		skipRedactions[p] = true
@@ -2369,6 +2429,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	emptied.Store(0)
 	collisions.Store(0)
 	lastIngestFiles = len(changed)
+	parsedThisPass(changed)
 	rf, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return 0, 0, 0, err

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -85,6 +85,21 @@ func mergeIngestDiag(m *Manifest) {
 		e.Error = msg
 		m.IngestFiles[p] = e
 	}
+	// A file this pass read is a file that opens. Only the error goes: the bad
+	// lines it counted are still in the part already indexed.
+	for p := range passRead {
+		if failed[p] != "" {
+			continue
+		}
+		if e, ok := m.IngestFiles[p]; ok && e.Error != "" {
+			e.Error = ""
+			if e.Malformed == 0 {
+				delete(m.IngestFiles, p)
+			} else {
+				m.IngestFiles[p] = e
+			}
+		}
+	}
 	// A file deja no longer walks has nothing left to report. Kept for a file
 	// that failed to open, which is exactly the file a walk may not see.
 	for p, e := range m.IngestFiles {
@@ -102,7 +117,7 @@ func mergeIngestDiag(m *Manifest) {
 	// The set belongs to the pass that recorded it. Left standing, it deleted
 	// those files' entries again on the next manifest write in the process —
 	// and `deja sync` writes one, from Import, right after a pass.
-	passParsed = nil
+	passParsed, passRead = nil, nil
 }
 
 // healthFromFiles sums the per-file counts per harness. The clip count is not
@@ -2002,12 +2017,29 @@ func copyIngestFiles(old map[string]FileIngest) map[string]FileIngest {
 func beginPass() {
 	sources.DiagSnapshot()
 	passParsed = nil
+	passRead = nil
 }
 
 // passParsed is the set of files the pass in progress re-read. Package state
 // for the same reason lastIngestFiles is: a pass holds the directory lock, so
 // only one is ever in flight.
 var passParsed map[string]bool
+
+// passRead is the files a pass read without the open failing. The append path
+// cannot use parsedThisPass — it reads a tail, so its counts add — but a file
+// it read is a file that opens, and an error recorded when it did not has to
+// go, or a permission blip stayed in doctor until a forced rebuild (#2015).
+var passRead map[string]bool
+
+// readThisPass records a file a pass opened and parsed.
+func readThisPass(files map[string]FileState) {
+	if passRead == nil {
+		passRead = map[string]bool{}
+	}
+	for p := range files {
+		passRead[p] = true
+	}
+}
 
 // parsedThisPass records which files a pass read, so the fold can start their
 // counts over rather than adding to what an earlier pass left (#2015).
@@ -2433,6 +2465,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	emptied.Store(0)
 	collisions.Store(0)
 	lastIngestFiles = len(changed)
+	readThisPass(changed)
 	// Deliberately not parsedThisPass: this path reads the appended tail, not
 	// the file, so what it finds adds to the file's count instead of replacing
 	// it. Marking the file re-read dropped every bad line in the part already

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -227,7 +227,7 @@ func readManifest(dir string) (Manifest, error) {
 	if err := readGob(filepath.Join(dir, "manifest.gob"), &core); err != nil {
 		return Manifest{}, err
 	}
-	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ExportBoundary: core.ExportBoundary, ImportedRecords: core.ImportedRecords, RecordStrings: core.RecordStrings, RecordsSize: core.RecordsSize, BucketFiles: core.BucketFiles, IngestHealth: core.IngestHealth, ExcludeFingerprint: core.ExcludeFingerprint, ToolFingerprint: core.ToolFingerprint, Sessions: map[string]SessionMeta{}}
+	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ExportBoundary: core.ExportBoundary, ImportedRecords: core.ImportedRecords, RecordStrings: core.RecordStrings, RecordsSize: core.RecordsSize, BucketFiles: core.BucketFiles, IngestHealth: core.IngestHealth, IngestFiles: core.IngestFiles, ExcludeFingerprint: core.ExcludeFingerprint, ToolFingerprint: core.ToolFingerprint, Sessions: map[string]SessionMeta{}}
 	if err := readGob(filepath.Join(dir, "sessions.gob"), &m.Sessions); err != nil {
 		return Manifest{}, err
 	}
@@ -238,7 +238,7 @@ func readManifest(dir string) (Manifest, error) {
 // for updates that change only core fields (e.g. export watermarks) where the
 // caller has not loaded sessions and must not clobber them.
 func writeManifestOnly(dir string, m Manifest) error {
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, ExcludeFingerprint: m.ExcludeFingerprint, ToolFingerprint: m.ToolFingerprint}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, IngestFiles: m.IngestFiles, ExcludeFingerprint: m.ExcludeFingerprint, ToolFingerprint: m.ToolFingerprint}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}
@@ -254,7 +254,7 @@ func writeManifestOnly(dir string, m Manifest) error {
 // rather than serving a fresh-looking index whose sessions are stale.
 func writeManifest(dir string, m Manifest) error {
 	mergeIngestDiag(&m)
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, ExcludeFingerprint: m.ExcludeFingerprint, ToolFingerprint: m.ToolFingerprint}
+	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, IngestFiles: m.IngestFiles, ExcludeFingerprint: m.ExcludeFingerprint, ToolFingerprint: m.ToolFingerprint}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}


### PR DESCRIPTION
Fixes #2015. A session whose second line is unreadable, then passes over the same store:

```
after the build that saw it        claude{malformed:1 failed:0 clipped:0}
after an unrelated file appears    (empty)
after a no-op pass                 (empty)
after a full rebuild               claude{malformed:1 failed:0 clipped:0}
```

The bad line never left the disk.

Carrying the map forward on the merge path is not enough on its own: the counts are per harness, so resetting the stores a pass re-read still loses a store's count when an unrelated *file in the same store* changes — which is the case in the issue. And carrying without resetting makes a count that a fixed file can never clear; I measured both while trying the smaller fix.

So the counts move to where they belong — the file:

```
IngestFiles map[string]FileIngest   // sparse: only files with something to report
```

A pass starts its own files over and leaves the rest alone; the per-harness map every reader asks for is the sum. `IngestHealth(dir)` is unchanged for callers.

```
after the build that saw it        malformed=1
after an unrelated file appears    malformed=1
after the file is rewritten clean  malformed=0
```

A file that failed to open keeps its entry even when the walk stops seeing it — that is exactly the file a walk may not see.
