### PR TITLE
repin the Windows manifests to the rebuilt 0.19.0 archives

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.0/deja-vu_0.19.0_windows_amd64.zip",
-            "hash": "c37de2f355a51daafb97d7667a1786dfdd954816f81011175f8a5757f9f996ce"
+            "hash": "c64f1b538f38774114e6f704807908de39c2f4eb41531f319d61925f1847ad57"
         },
         "arm64": {
             "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.0/deja-vu_0.19.0_windows_arm64.zip",
-            "hash": "2534207efaead35dca0b899c8eb32a9dd13b6cbad8436bf68c2313fc8a03adfc"
+            "hash": "2e06405f2cf509d6eb20a1099fcef5ac0e02d19f525f1e3a1bd5dfe66eac7119"
         }
     },
     "bin": "deja.exe",

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -9,9 +9,9 @@ UpgradeBehavior: install
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.0/deja-vu_0.19.0_windows_amd64.zip
-  InstallerSha256: C37DE2F355A51DAAFB97D7667A1786DFDD954816F81011175F8A5757F9F996CE
+  InstallerSha256: C64F1B538F38774114E6F704807908DE39C2F4EB41531F319D61925F1847AD57
 - Architecture: arm64
   InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.0/deja-vu_0.19.0_windows_arm64.zip
-  InstallerSha256: 2534207EFAEAD35DCA0B899C8EB32A9DD13B6CBAD8436BF68C2313FC8A03ADFC
+  InstallerSha256: 2E06405F2CF509D6EB20A1099FCEF5AC0E02D19F525F1E3A1BD5DFE66EAC7119
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
v0.19.0 was published twice: the first run failed after uploading its binaries, so the release was deleted and the tag moved. The rebuild produced different zip checksums, and the manifests still carried the first run's.