### PR TITLE
fix(completion): give deja show its own flag completions

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -140,7 +140,14 @@ _deja_completion() {
                 COMPREPLY=( $(compgen -d -- "$cur") )
             fi
             ;;
-        check|ctx|embed|hook-precompact|hook-prompt|mcp|share|show|sources|statusline|update|version|warmup)
+        show)
+            if [[ "$prev" == "--harness" ]]; then
+                COMPREPLY=( $(compgen -W "$harnesses" -- "$cur") )
+            else
+                COMPREPLY=( $(compgen -W "--json --harness --offset --limit" -- "$cur") )
+            fi
+            ;;
+        check|ctx|embed|hook-precompact|hook-prompt|mcp|share|sources|statusline|update|version|warmup)
             COMPREPLY=()
             ;;
         *)
@@ -262,7 +269,10 @@ _deja() {
         _arguments '--pull[pull from the remote]' '--full[transfer all records]' '1:host:'
       fi
       ;;
-    check|ctx|embed|hook-precompact|hook-prompt|mcp|share|show|sources|statusline|update|version|warmup)
+    show)
+      _arguments '--json[print JSON]' '--harness=[filter by harness]:harness:($harnesses)' '--offset=[skip leading messages]:count:' '--limit=[cap messages printed]:count:' '1:session ID prefix:'
+      ;;
+    check|ctx|embed|hook-precompact|hook-prompt|mcp|share|sources|statusline|update|version|warmup)
       ;;
     *)
       _arguments '--json[print JSON]' '--re[interpret query as a regular expression]' '--all[include all results]' '--no-embed[skip semantic reranking]' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(%ROLES%)' '--session=[only one session]:id:' '--rebuild[force a full rebuild]'
@@ -315,6 +325,10 @@ complete -c deja -n '__fish_seen_subcommand_from hook-context' -l plain
 complete -c deja -n '__fish_seen_subcommand_from index' -l rebuild
 complete -c deja -n '__fish_seen_subcommand_from install uninstall' -a '%INSTALL_TARGETS% --all --auto'
 complete -c deja -n '__fish_seen_subcommand_from install uninstall' -l no-guidance
+complete -c deja -n '__fish_seen_subcommand_from show' -l json
+complete -c deja -n '__fish_seen_subcommand_from show' -l harness -r -a '%HARNESSES%'
+complete -c deja -n '__fish_seen_subcommand_from show' -l offset -r
+complete -c deja -n '__fish_seen_subcommand_from show' -l limit -r
 complete -c deja -n '__fish_seen_subcommand_from last' -l harness -r -a '%HARNESSES%'
 complete -c deja -n '__fish_seen_subcommand_from last' -l project -r
 complete -c deja -n '__fish_seen_subcommand_from last' -l since -r
@@ -413,7 +427,11 @@ Register-ArgumentCompleter -Native -CommandName deja -ScriptBlock {
                 elseif ($action -eq 'ssh') { @('--pull', '--full') }
                 else { @() }
             }
-            { $_ -in @('check', 'ctx', 'embed', 'hook-precompact', 'hook-prompt', 'mcp', 'share', 'show', 'sources', 'statusline', 'update', 'version', 'warmup') } { @() }
+            'show' {
+                if ($previous -eq '--harness') { $harnesses }
+                else { @('--json', '--harness', '--offset', '--limit') }
+            }
+            { $_ -in @('check', 'ctx', 'embed', 'hook-precompact', 'hook-prompt', 'mcp', 'share', 'sources', 'statusline', 'update', 'version', 'warmup') } { @() }
             default { $defaultOptions }
         }
     }


### PR DESCRIPTION
Closes #1926.

## The change

`show` had its own flags but sat in every shell's "commands with no flags" bucket, so Tab after it offered nothing. It now has its own case in all four generators, matching how `last` is handled:

| Shell | Change |
|---|---|
| bash | own `show)` case; removed from the `check\|ctx\|…` bucket |
| zsh | own `show)` case with `_arguments`; removed from the bucket |
| powershell | own `'show'` branch; removed from the `$_ -in @(…)` list |
| fish | four `__fish_seen_subcommand_from show` rules (fish had none at all) |

bash, zsh and powershell also complete harness names after `--harness`, the way they already do for `last` — the flag takes a value from a known set, so offering the bare flag and then nothing would be a half-finished completion.

## Verified

Built the binary and ran `deja completion <shell>` for all four, checking each names all four flags — and that `show` no longer appears in any no-flag bucket:

```
  bash        --json=ok --harness=ok --offset=ok --limit=ok    (bucket: removed)
  zsh         --json=ok --harness=ok --offset=ok --limit=ok    (bucket: removed)
  powershell  --json=ok --harness=ok --offset=ok --limit=ok    (bucket: removed)
  fish        --json=ok --harness=ok --offset=ok --limit=ok
```

One note on that check: fish declares options as `-l json`, not `--json`, so a naive grep for `--json` reports fish as missing even when the rules are correct. My first pass did exactly that and I had to correct it — flagging it in case the same trap shows up in a CI assertion for the sibling issues.

`go build ./...`, `go test ./cmd/deja/` and `go vet ./cmd/deja/` all pass.

## Scope

Only `show`. The sibling issues (#1925 `last`, #1927 `forget`, #1928 `remember --tag`) are the same shape and I'm happy to take them, but kept separate so each stays reviewable.
