### PR TITLE
fix(index): count clipped messages against the file that holds them

### DIFF
--- a/internal/index/health_carry_test.go
+++ b/internal/index/health_carry_test.go
@@ -336,12 +336,22 @@ func TestAClipSurvivesAPassOverAnotherFile(t *testing.T) {
 		t.Errorf("the long message is still in the other file and the count is %d", got)
 	}
 
-	// And the file that holds it, re-read: counted once, not once more.
-	if err := os.WriteFile(a, []byte(turn("a", "2026-01-02T03:04:05Z", "user", long)), 0o644); err != nil {
+	// And the file that holds it, re-read by the merge path: counted once, not
+	// once more. Shorter than it was so the pass cannot append, still long
+	// enough to be clipped.
+	shorter := long[:len(long)-1000]
+	if len(shorter) < maxIndexedText {
+		t.Fatalf("the re-read fixture is %d bytes, under the %d that gets it clipped", len(shorter), maxIndexedText)
+	}
+	if err := os.WriteFile(a, []byte(turn("a", "2026-01-02T03:04:05Z", "user", shorter)), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := Ensure(dir, "", true, nil); err != nil {
+	out.Reset()
+	if err := Ensure(dir, "", false, &out); err != nil {
 		t.Fatal(err)
+	}
+	if said := out.String(); !strings.Contains(said, "incremental index") {
+		t.Fatalf("the re-read did not take the merge path: %q", said)
 	}
 	if got := clippedFor(t, dir, "claude"); got != 1 {
 		t.Errorf("one long message, count says %d", got)

--- a/internal/index/health_carry_test.go
+++ b/internal/index/health_carry_test.go
@@ -286,3 +286,64 @@ func TestAFileThatOpensAgainStopsBeingReportedUnreadable(t *testing.T) {
 		t.Errorf("deja read the file and still reports %d unreadable", got)
 	}
 }
+
+func clippedFor(t *testing.T, dir, harness string) int {
+	t.Helper()
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m.IngestHealth[harness].ClippedMessages
+}
+
+// Clips were the last ingest number kept per harness, so a pass over some other
+// file reset them to what it found — nothing — while the long message sat where
+// it always had (#2022).
+func TestAClipSurvivesAPassOverAnotherFile(t *testing.T) {
+	dir, proj, turn := healthFixture(t)
+	long := strings.Repeat("pgbouncer pool timed out and the retry took a second ", 1600)
+	if len(long) < maxIndexedText {
+		t.Fatalf("the fixture message is %d bytes, under the %d that gets it clipped", len(long), maxIndexedText)
+	}
+	a := filepath.Join(proj, "a.jsonl")
+	b := filepath.Join(proj, "b.jsonl")
+	if err := os.WriteFile(a, []byte(turn("a", "2026-01-02T03:04:05Z", "user", long)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte(turn("b", "2026-01-02T03:04:05Z", "user", "a short question")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := clippedFor(t, dir, "claude"); got != 1 {
+		t.Fatalf("the build clipped %d messages, so this measures nothing", got)
+	}
+
+	// b rewritten shorter. A rewrite that only grows is still an append, and
+	// the append path keeps the old manifest — this is the path that does not.
+	if err := os.WriteFile(b, []byte(turn("b", "2026-01-02T03:04:05Z", "user", "short")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out strings.Builder
+	if err := Ensure(dir, "", false, &out); err != nil {
+		t.Fatal(err)
+	}
+	if said := out.String(); !strings.Contains(said, "incremental index") {
+		t.Fatalf("this was not the merge path, so it does not measure what it is about: %q", said)
+	}
+	if got := clippedFor(t, dir, "claude"); got != 1 {
+		t.Errorf("the long message is still in the other file and the count is %d", got)
+	}
+
+	// And the file that holds it, re-read: counted once, not once more.
+	if err := os.WriteFile(a, []byte(turn("a", "2026-01-02T03:04:05Z", "user", long)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := clippedFor(t, dir, "claude"); got != 1 {
+		t.Errorf("one long message, count says %d", got)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -315,6 +315,10 @@ type HarnessIngest struct {
 type FileIngest struct {
 	Malformed int    `json:"malformed,omitempty"`
 	Error     string `json:"error,omitempty"`
+	// Clipped counts messages stored short of what this file holds. Here for
+	// the same reason as the other two: a pass that reads one transcript must
+	// not speak for what another one holds (#2022).
+	Clipped int `json:"clipped,omitempty"`
 }
 
 type manifestCore struct {

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -73,6 +73,12 @@ func mergeIngestDiag(m *Manifest) {
 	// Whatever this pass read, it read whole: its files start from nothing and
 	// take what the parsers just reported.
 	for p := range passParsed {
+		// The clip count for this pass was recorded during redaction, which
+		// runs before this fold, so it is not something to start over.
+		if e, ok := m.IngestFiles[p]; ok && e.Clipped > 0 {
+			m.IngestFiles[p] = FileIngest{Clipped: e.Clipped}
+			continue
+		}
 		delete(m.IngestFiles, p)
 	}
 	for p, n := range malformed {
@@ -93,7 +99,7 @@ func mergeIngestDiag(m *Manifest) {
 		}
 		if e, ok := m.IngestFiles[p]; ok && e.Error != "" {
 			e.Error = ""
-			if e.Malformed == 0 {
+			if e.Malformed == 0 && e.Clipped == 0 {
 				delete(m.IngestFiles, p)
 			} else {
 				m.IngestFiles[p] = e
@@ -113,23 +119,16 @@ func mergeIngestDiag(m *Manifest) {
 	if len(m.IngestFiles) == 0 {
 		m.IngestFiles = nil
 	}
-	m.IngestHealth = healthFromFiles(m.IngestFiles, m.IngestHealth)
+	m.IngestHealth = healthFromFiles(m.IngestFiles)
 	// The set belongs to the pass that recorded it. Left standing, it deleted
 	// those files' entries again on the next manifest write in the process —
 	// and `deja sync` writes one, from Import, right after a pass.
 	passParsed, passRead = nil, nil
 }
 
-// healthFromFiles sums the per-file counts per harness. The clip count is not
-// per file — it is recorded during redaction, before this fold — so it is
-// carried from what the pass already put there.
-func healthFromFiles(files map[string]FileIngest, prior map[string]HarnessIngest) map[string]HarnessIngest {
+// healthFromFiles sums the per-file counts per harness.
+func healthFromFiles(files map[string]FileIngest) map[string]HarnessIngest {
 	out := map[string]HarnessIngest{}
-	for h, e := range prior {
-		if e.ClippedMessages > 0 {
-			out[h] = HarnessIngest{ClippedMessages: e.ClippedMessages}
-		}
-	}
 	for p, e := range files {
 		h := harnessForPath(p)
 		if h == "" {
@@ -137,6 +136,7 @@ func healthFromFiles(files map[string]FileIngest, prior map[string]HarnessIngest
 		}
 		cur := out[h]
 		cur.MalformedLines += e.Malformed
+		cur.ClippedMessages += e.Clipped
 		if e.Error != "" {
 			cur.FailedFiles++
 			cur.LastError = e.Error
@@ -1997,9 +1997,15 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 
 // copyIngestFiles hands the new manifest its own map: the old one belongs to
 // the manifest this build read, which is still in use while the build runs.
-func copyIngestFiles(old map[string]FileIngest) map[string]FileIngest {
+// The files this pass will re-read arrive with their clip count zeroed: the
+// pass records its own as it goes, and adding it to what the last pass found
+// counted one long message twice.
+func copyIngestFiles(old map[string]FileIngest, reread map[string]FileState) map[string]FileIngest {
 	out := make(map[string]FileIngest, len(old))
 	for p, e := range old {
+		if _, ok := reread[p]; ok {
+			e.Clipped = 0
+		}
 		out[p] = e
 	}
 	return out
@@ -2229,7 +2235,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		// doctor forgot a store's unreadable file because an unrelated
 		// transcript changed (#2015). A store this pass re-read starts over,
 		// because a file rewritten clean has to be able to clear its count.
-		IngestFiles: copyIngestFiles(old.IngestFiles)}
+		IngestFiles: copyIngestFiles(old.IngestFiles, changed)}
 	skipRedactions := map[string]bool{}
 	for p := range changed {
 		skipRedactions[p] = true
@@ -3055,25 +3061,30 @@ func filePrefixHash(path string, n int64) uint64 {
 	return h.Sum64()
 }
 
-// countClipped records messages stored short of the transcript. The caller
-// holds the lock where one is needed; redactForIngest runs single-threaded.
+// countClipped records messages stored short of the transcript, against the
+// file that holds them. The caller holds the lock where one is needed;
+// redactForIngest runs single-threaded.
 func countClipped(m *Manifest, sourcePath string, n int) {
 	if m == nil || n == 0 {
 		return
 	}
-	h := harnessForPath(sourcePath)
-	if h == "" {
-		if _, ok := m.Files[sources.OpencodeDB()]; ok {
-			h = "opencode"
+	p := sourcePath
+	if harnessForPath(p) == "" {
+		// opencode sessions carry their project dir as Path; the store on
+		// record is the database file.
+		if db := sources.OpencodeDB(); db != "" {
+			if _, ok := m.Files[db]; ok {
+				p = db
+			}
 		}
 	}
-	if h == "" {
+	if harnessForPath(p) == "" {
 		return
 	}
-	if m.IngestHealth == nil {
-		m.IngestHealth = map[string]HarnessIngest{}
+	if m.IngestFiles == nil {
+		m.IngestFiles = map[string]FileIngest{}
 	}
-	e := m.IngestHealth[h]
-	e.ClippedMessages += n
-	m.IngestHealth[h] = e
+	e := m.IngestFiles[p]
+	e.Clipped += n
+	m.IngestFiles[p] = e
 }


### PR DESCRIPTION
Fixes #2022. Two claude files, `a` holding a message past `maxIndexedText`, `b` touched afterwards:

```
build: a clipped, b fine           clipped=1
after b is rewritten (merge path)  clipped=0
after b is appended to             clipped=0
after a is appended to             clipped=0
```

The long message never left the disk. Clips were the last ingest number kept per harness, so a merge pass reset them to what it found — nothing.

They move where the other two went in #2017: `FileIngest.Clipped`, and the per-harness number is the sum. Two ordering details the other counters did not have, because clips are recorded during redaction rather than by the diag channel:

- a file the merge path will re-read arrives with its carried clip count zeroed, or this pass's count would be added to the last pass's;
- the fold leaves the clip count alone when it starts a re-read file over, since that number is already this pass's.

Worth knowing for anyone writing a fixture here: a rewrite that only grows the file is still an append, so reaching the merge path takes a rewrite that shrinks it. My first probe measured the append path three times without noticing.
